### PR TITLE
feat(eve): lifecycle - expose callback context

### DIFF
--- a/.changeset/dynamic-lifecycle-context.md
+++ b/.changeset/dynamic-lifecycle-context.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Expose message snapshots and cancellation signals in hook contexts. Dynamic resolvers receive the latest durable message snapshot across lifecycle events, and durable tools fail closed when replay functions are unavailable.

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -35,10 +35,18 @@ helpers documented in [Session context](./session-context):
 
 ```ts
 interface HookContext extends SessionContext {
+  readonly abortSignal: AbortSignal;
   readonly agent: { readonly name: string; readonly nodeId?: string };
   readonly channel: { readonly kind?: string; readonly continuationToken?: string };
+  readonly messages: readonly ModelMessage[];
 }
 ```
+
+`messages` contains the latest durable model history available when the hook runs. Events that
+do not produce a new snapshot reuse the previous one, so the history may lag the event and may
+be empty for a new session. `abortSignal` tracks cancellation of the active turn. Hooks that run
+while settling a cancelled turn receive an already-aborted signal; use an independent signal or
+timeout for cleanup I/O that must continue after cancellation.
 
 That means a hook can access the current sandbox and release its backing
 compute at an application-defined boundary:

--- a/packages/eve/extension-contracts/compatibility/hook/v11.ts
+++ b/packages/eve/extension-contracts/compatibility/hook/v11.ts
@@ -1,0 +1,13 @@
+import { defineHook } from "#public/hooks/index.js";
+
+export default defineHook({
+  events: {
+    "approval.candidate"(event, ctx) {
+      console.info("approval candidate", {
+        candidateId: event.data.candidateId,
+        outcome: event.data.outcome,
+        sessionId: ctx.session.id,
+      });
+    },
+  },
+});

--- a/packages/eve/extension-contracts/reports/hook/v12.json
+++ b/packages/eve/extension-contracts/reports/hook/v12.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "hook",
+  "epoch": 12,
+  "sha256": "8c1c6e56147f1af064a4bb9d946b0aaaec0c018573009e33f4a8b5d3c30c30b7",
+  "exports": ["defineHook"]
+}

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -29,8 +29,8 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
   },
   connection: { current: 5, supported: [1, 2, 3, 4, 5], dropped: {} },
   hook: {
-    current: 11,
-    supported: [10, 11],
+    current: 12,
+    supported: [10, 11, 12],
     dropped: {
       1: "Model identity moved from session.started runtime metadata to step.started call attribution.",
       2: "Model identity moved from session.started runtime metadata to step.started call attribution.",

--- a/packages/eve/src/context/build-dynamic-tools.ts
+++ b/packages/eve/src/context/build-dynamic-tools.ts
@@ -32,26 +32,26 @@ function lookupStepFunction(stepId: string): ((...args: unknown[]) => unknown) |
   }
 }
 
-function replayTools(metadata: readonly DurableDynamicToolMetadata[]): HarnessToolDefinition[] {
+export function replayDurableTools(
+  metadata: readonly DurableDynamicToolMetadata[],
+): HarnessToolDefinition[] {
   const tools: HarnessToolDefinition[] = [];
 
   for (const m of metadata) {
     if (!m.executeStepFnName || !m.closureVars) {
-      log.warn(
-        `Dynamic tool "${m.name}" has no registered step function — ` +
-          "skipping on this step. The bundler transform may not have processed this tool file.",
+      throw new Error(
+        `Dynamic tool "${m.name}" cannot be replayed because its durable execute metadata is incomplete.`,
       );
-      continue;
     }
 
     const stepFn = lookupStepFunction(m.executeStepFnName);
     if (!stepFn) {
-      log.warn(
-        `Dynamic tool "${m.name}" references step function "${m.executeStepFnName}" ` +
-          "which is not registered — skipping on this step.",
+      throw new Error(
+        `Dynamic tool "${m.name}" cannot be replayed because execute function "${m.executeStepFnName}" is not registered.`,
       );
-      continue;
     }
+
+    const toModelOutput = buildReplayedModelOutput(m);
 
     tools.push({
       description: m.description,
@@ -63,10 +63,26 @@ function replayTools(metadata: readonly DurableDynamicToolMetadata[]): HarnessTo
       name: m.name,
       approval: buildReplayedApproval(m),
       outputSchema: toOutputSchema(m.outputSchema),
+      toModelOutput,
     });
   }
 
   return tools;
+}
+
+function buildReplayedModelOutput(
+  metadata: DurableDynamicToolMetadata,
+): HarnessToolDefinition["toModelOutput"] | undefined {
+  if (metadata.toModelOutputStepFnName === undefined) return undefined;
+
+  const toModelOutputStepFn = lookupStepFunction(metadata.toModelOutputStepFnName);
+  if (toModelOutputStepFn === null) {
+    throw new Error(
+      `Dynamic tool "${metadata.name}" cannot be replayed because model-output function "${metadata.toModelOutputStepFnName}" is not registered.`,
+    );
+  }
+
+  return (output: unknown) => toModelOutputStepFn(metadata.closureVars ?? {}, output);
 }
 
 function buildReplayedApproval(
@@ -137,7 +153,7 @@ export function buildDynamicTools(ctx: {
   get<T>(key: ContextKey<T>): T | undefined;
 }): readonly HarnessToolDefinition[] {
   const step = ctx.get(LiveStepToolsKey) ?? [];
-  const turn = replayTools(ctx.get(TurnDynamicToolMetadataKey) ?? []);
-  const session = replayTools(ctx.get(SessionDynamicToolMetadataKey) ?? []);
+  const turn = replayDurableTools(ctx.get(TurnDynamicToolMetadataKey) ?? []);
+  const session = replayDurableTools(ctx.get(SessionDynamicToolMetadataKey) ?? []);
   return [...step, ...turn, ...session];
 }

--- a/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
@@ -17,11 +17,25 @@ vi.mock("#context/build-callback-context.js", () => ({
 // Import after mock so the module picks up the mock
 const {
   replayDynamicSessionTools,
-  dispatchDynamicToolEvent,
-  refreshDynamicSessionToolsForRuntimeRevision,
+  dispatchDynamicToolEvent: dispatchRuntimeDynamicToolEvent,
+  refreshDynamicSessionToolsForRuntimeRevision: refreshRuntimeDynamicSessionTools,
 } = await import("#context/dynamic-tool-lifecycle.js");
 const { buildDynamicTools, buildResponseAuthorizationTools } =
   await import("#context/build-dynamic-tools.js");
+
+const testAbortSignal = new AbortController().signal;
+const dispatchDynamicToolEvent = (
+  input: Omit<Parameters<typeof dispatchRuntimeDynamicToolEvent>[0], "abortSignal"> & {
+    readonly abortSignal?: AbortSignal;
+  },
+) =>
+  dispatchRuntimeDynamicToolEvent({
+    ...input,
+    abortSignal: input.abortSignal ?? testAbortSignal,
+  });
+const refreshDynamicSessionToolsForRuntimeRevision = (
+  input: Omit<Parameters<typeof refreshRuntimeDynamicSessionTools>[0], "abortSignal">,
+) => refreshRuntimeDynamicSessionTools({ ...input, abortSignal: testAbortSignal });
 
 import { ContextContainer } from "#context/container.js";
 import {
@@ -207,7 +221,7 @@ function getOrCreateStepRegistry(sym: symbol): Map<string, Function> {
 }
 
 describe("replayDynamicSessionTools", () => {
-  it("skips metadata entries without executeStepFnName", () => {
+  it("fails metadata entries without executeStepFnName", () => {
     const metadata: DurableDynamicToolMetadata[] = [
       {
         name: "missing-fn",
@@ -219,11 +233,12 @@ describe("replayDynamicSessionTools", () => {
       },
     ];
 
-    const tools = replayDynamicSessionTools(metadata, []);
-    expect(tools).toHaveLength(0);
+    expect(() => replayDynamicSessionTools(metadata, [])).toThrow(
+      /execute metadata is incomplete/u,
+    );
   });
 
-  it("skips metadata entries without closureVars", () => {
+  it("fails metadata entries without closureVars", () => {
     const metadata: DurableDynamicToolMetadata[] = [
       {
         name: "no-vars",
@@ -236,11 +251,12 @@ describe("replayDynamicSessionTools", () => {
       },
     ];
 
-    const tools = replayDynamicSessionTools(metadata, []);
-    expect(tools).toHaveLength(0);
+    expect(() => replayDynamicSessionTools(metadata, [])).toThrow(
+      /execute metadata is incomplete/u,
+    );
   });
 
-  it("skips entries where step function is not registered", () => {
+  it("fails entries where step function is not registered", () => {
     const metadata: DurableDynamicToolMetadata[] = [
       {
         name: "unregistered",
@@ -253,8 +269,9 @@ describe("replayDynamicSessionTools", () => {
       },
     ];
 
-    const tools = replayDynamicSessionTools(metadata, []);
-    expect(tools).toHaveLength(0);
+    expect(() => replayDynamicSessionTools(metadata, [])).toThrow(
+      /execute function .* is not registered/u,
+    );
   });
 
   it("reconstructs tool with registered step function and closure vars", async () => {
@@ -388,7 +405,7 @@ describe("replayDynamicSessionTools", () => {
     }
   });
 
-  it("skips only the broken entries — valid ones still work", () => {
+  it("fails the replay when any entry is broken", () => {
     const registrySym = Symbol.for("@workflow/core//registeredSteps");
     const registry = getOrCreateStepRegistry(registrySym);
 
@@ -417,10 +434,9 @@ describe("replayDynamicSessionTools", () => {
         },
       ];
 
-      const tools = replayDynamicSessionTools(metadata, []);
-      // Only the valid tool should be reconstructed
-      expect(tools).toHaveLength(1);
-      expect(tools[0]!.name).toBe("valid");
+      expect(() => replayDynamicSessionTools(metadata, [])).toThrow(
+        /execute function .* is not registered/u,
+      );
     } finally {
       registry.delete(validStepId);
     }
@@ -506,6 +522,47 @@ function createReplayableTool(
 }
 
 describe("dispatchDynamicToolEvent", () => {
+  it("allows framework resolvers to build their callback context", async () => {
+    const ctx = createCtx();
+    const handler = vi.fn(() => ({ current_tool: createReplayableTool() }));
+    const abortSignal = new AbortController().signal;
+    const resolver: ResolvedDynamicToolResolver = {
+      ...createResolver("framework", ["turn.started"], handler),
+      buildContext: ({ abortSignal: signal, messages }) => ({ signal, messages }),
+    };
+    const messages = [{ role: "user", content: "hello" }] as const;
+
+    await dispatchDynamicToolEvent({
+      abortSignal,
+      ctx,
+      resolvers: [resolver],
+      messages,
+      event: makeEvent("turn.started"),
+    });
+
+    expect(handler).toHaveBeenCalledWith(makeEvent("turn.started"), {
+      signal: abortSignal,
+      messages,
+    });
+  });
+
+  it("skips a framework resolver when its callback context is inactive", async () => {
+    const handler = vi.fn(() => ({ current_tool: createReplayableTool() }));
+    const resolver: ResolvedDynamicToolResolver = {
+      ...createResolver("framework", ["turn.started"], handler),
+      buildContext: () => null,
+    };
+
+    await dispatchDynamicToolEvent({
+      ctx: createCtx(),
+      resolvers: [resolver],
+      messages: [],
+      event: makeEvent("turn.started"),
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
   it("replaces session tools with the current deployment's resolver output", async () => {
     const ctx = createCtx();
     const oldResolver = createResolver("old", ["session.started"], () => ({
@@ -1036,7 +1093,7 @@ describe("dispatchDynamicToolEvent", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Framework dynamic tools — no bundler transform, auto-registered
+// Framework dynamic tools
 // ---------------------------------------------------------------------------
 
 function createFrameworkTool(
@@ -1051,113 +1108,61 @@ function createFrameworkTool(
 }
 
 describe("framework dynamic tools (no bundler transform)", () => {
-  it("session-scoped framework tool is replayable across steps", async () => {
+  it("replays durable tools in-process and fails when their callback is unavailable", async () => {
     const ctx = createCtx();
-    const executeFn = vi.fn(() => ({ data: "from-framework" }));
-    const resolver = createResolver("fwk", ["session.started"], () => ({
-      search: createFrameworkTool("framework search", executeFn),
-    }));
-
-    await dispatchDynamicToolEvent({
-      ctx,
-      resolvers: [resolver],
-      messages: [],
-      event: makeEvent("session.started"),
-    });
-
-    const metadata = ctx.get(SessionDynamicToolMetadataKey);
-    expect(metadata).toHaveLength(1);
-    expect(metadata![0]!.executeStepFnName).toBe("eve:framework-dynamic:fwk:search");
-    expect(metadata![0]!.closureVars).toEqual({});
-
-    const tools = buildDynamicTools(ctx);
-    expect(tools).toHaveLength(1);
-    expect(tools[0]!.name).toBe("search");
-
-    // Simulate step boundary — virtual context cleared, durable survives
-    ctx.clearVirtualContext();
-
-    const replayedTools = buildDynamicTools(ctx);
-    expect(replayedTools).toHaveLength(1);
-    expect(replayedTools[0]!.name).toBe("search");
-
-    // Execute the replayed tool — the original closure is invoked
-    await replayedTools[0]!.execute!({ query: "test" }, executeOptions);
-    expect(executeFn).toHaveBeenCalledWith({ query: "test" });
-  });
-
-  it("turn-scoped framework tool is replayable", async () => {
-    const ctx = createCtx();
-    const executeFn = vi.fn(() => ({ result: "turn-tool" }));
-    const resolver = createResolver("helper", ["turn.started"], () => ({
-      assist: createFrameworkTool("turn helper", executeFn),
-    }));
-
-    await dispatchDynamicToolEvent({
-      ctx,
-      resolvers: [resolver],
-      messages: [],
-      event: makeEvent("turn.started"),
-    });
-
-    const metadata = ctx.get(TurnDynamicToolMetadataKey);
-    expect(metadata).toHaveLength(1);
-    expect(metadata![0]!.executeStepFnName).toBe("eve:framework-dynamic:helper:assist");
-
-    ctx.clearVirtualContext();
-
-    const tools = buildDynamicTools(ctx);
-    expect(tools).toHaveLength(1);
-    expect(tools[0]!.name).toBe("assist");
-
-    await tools[0]!.execute!({ action: "help" }, executeOptions);
-    expect(executeFn).toHaveBeenCalledWith({ action: "help" });
-  });
-
-  it("framework and authored tools coexist in session scope", async () => {
-    const ctx = createCtx();
-    const frameworkResolver = createResolver("fwk", ["session.started"], () => ({
+    const resolver = createResolver("framework", ["session.started"], () => ({
       search: createFrameworkTool("framework search"),
     }));
-    const authoredResolver = createResolver("authored", ["session.started"], () => ({
-      query: createReplayableTool("authored query"),
-    }));
 
     await dispatchDynamicToolEvent({
       ctx,
-      resolvers: [frameworkResolver, authoredResolver],
-      messages: [],
       event: makeEvent("session.started"),
+      messages: [],
+      resolvers: [resolver],
     });
 
-    const metadata = ctx.get(SessionDynamicToolMetadataKey);
-    expect(metadata).toHaveLength(2);
-
-    ctx.clearVirtualContext();
-
-    const tools = buildDynamicTools(ctx);
-    expect(tools).toHaveLength(2);
-    expect(tools.map((t) => t.name).sort()).toEqual(["query", "search"]);
+    expect(buildDynamicTools(ctx).map(({ name }) => name)).toEqual(["search"]);
+    testRegistry.delete("eve:framework-dynamic:framework:search");
+    expect(() => buildDynamicTools(ctx)).toThrow(/execute function .* is not registered/u);
   });
 
-  it("single-entry framework tool uses slug as name", async () => {
+  it("preserves model-output projection and fails when it cannot be replayed", async () => {
     const ctx = createCtx();
-    const resolver = createResolver("analytics", ["session.started"], () =>
-      createFrameworkTool("single tool"),
-    );
-
-    await dispatchDynamicToolEvent({
-      ctx,
-      resolvers: [resolver],
-      messages: [],
-      event: makeEvent("session.started"),
+    const executeStepId = `test-step-${++stepCounter}`;
+    testRegistry.set(executeStepId, () => ({ private: "hidden", public: "ready" }));
+    const entry = defineTool({
+      description: "Summarize model output",
+      inputSchema: { type: "object" },
+      execute: () => ({ private: "hidden", public: "ready" }),
+      toModelOutput: (output) => ({ type: "text", value: output.public }),
     });
+    Object.assign(entry, {
+      __executeStepFn: { stepId: executeStepId },
+      __closureVars: {},
+    });
+    const resolver = createResolver("turn_tools", ["turn.started"], () => ({ summarize: entry }));
+    const modelOutputStepId = "eve:dynamic-tool-model-output:turn_tools:summarize";
 
-    ctx.clearVirtualContext();
+    try {
+      await dispatchDynamicToolEvent({
+        ctx,
+        event: makeEvent("turn.started"),
+        messages: [{ content: "compacted", role: "user" }],
+        resolvers: [resolver],
+      });
 
-    const tools = buildDynamicTools(ctx);
-    expect(tools).toHaveLength(1);
-    expect(tools[0]!.name).toBe("analytics");
+      expect(ctx.get(TurnDynamicToolMetadataKey)).toHaveLength(1);
+      const [tool] = buildDynamicTools(ctx);
+      await expect(
+        Promise.resolve(tool?.toModelOutput?.({ private: "hidden", public: "ready" })),
+      ).resolves.toEqual({ type: "text", value: "ready" });
+
+      testRegistry.delete(modelOutputStepId);
+      expect(() => buildDynamicTools(ctx)).toThrow(/model-output function .* is not registered/u);
+    } finally {
+      testRegistry.delete(executeStepId);
+      testRegistry.delete(modelOutputStepId);
+    }
   });
 
   it("propagates approval from a step-scoped entry into the harness tool", async () => {
@@ -1199,6 +1204,12 @@ describe("framework dynamic tools (no bundler transform)", () => {
       approval: approvalFn,
       execute: async (): Promise<unknown> => ({ ok: true }),
     });
+    const executeStepId = `test-step-${++stepCounter}`;
+    testRegistry.set(executeStepId, () => ({ ok: true }));
+    Object.assign(entry, {
+      __executeStepFn: { stepId: executeStepId },
+      __closureVars: {},
+    });
     const resolver = createResolver("session_guard", ["session.started"], () => ({
       guarded: entry,
     }));
@@ -1223,6 +1234,8 @@ describe("framework dynamic tools (no bundler transform)", () => {
       "user-approval",
     );
     expect(approvalFn).toHaveBeenCalledExactlyOnceWith(approvalCtx);
+    testRegistry.delete(executeStepId);
+    testRegistry.delete("eve:dynamic-tool-approval:session_guard:guarded");
   });
 
   it("replays turn metadata written before request/response policy naming", async () => {
@@ -1253,6 +1266,8 @@ describe("framework dynamic tools (no bundler transform)", () => {
 
   it("uses the first dynamic definition for response authorization", () => {
     const ctx = createCtx();
+    const executeStepId = `test-step-${++stepCounter}`;
+    testRegistry.set(executeStepId, () => null);
     ctx.set(LiveStepToolsKey, [
       {
         approval: {
@@ -1269,9 +1284,10 @@ describe("framework dynamic tools (no bundler transform)", () => {
       {
         approvalResponseStepFnName: "session-authorizer",
         approvalStepFnName: "session-policy",
+        closureVars: {},
         description: "session",
         entryKey: "session:guarded",
-        executeStepFnName: "session-execute",
+        executeStepFnName: executeStepId,
         inputSchema: { type: "object" },
         name: "guarded",
         resolverSlug: "session",
@@ -1284,6 +1300,7 @@ describe("framework dynamic tools (no bundler transform)", () => {
     });
 
     expect(tools.get("guarded")?.description).toBe("step");
+    testRegistry.delete(executeStepId);
   });
 
   it("replays response authorization from session-scoped dynamic tools", async () => {
@@ -1359,6 +1376,12 @@ describe("framework dynamic tools (no bundler transform)", () => {
       outputSchema,
       execute: async (): Promise<unknown> => ({ ok: true }),
     });
+    const executeStepId = `test-step-${++stepCounter}`;
+    testRegistry.set(executeStepId, () => ({ ok: true }));
+    Object.assign(entry, {
+      __executeStepFn: { stepId: executeStepId },
+      __closureVars: {},
+    });
     const resolver = createResolver("connection", ["session.started"], () => ({ typed: entry }));
 
     await dispatchDynamicToolEvent({
@@ -1376,6 +1399,7 @@ describe("framework dynamic tools (no bundler transform)", () => {
     const tools = buildDynamicTools(ctx);
     expect(tools).toHaveLength(1);
     expect(serializeOutputSchema(tools[0]!.outputSchema as ToolSchema)).toEqual(outputSchema);
+    testRegistry.delete(executeStepId);
   });
 
   it("leaves approval undefined when a step-scoped entry omits it", async () => {
@@ -1394,43 +1418,5 @@ describe("framework dynamic tools (no bundler transform)", () => {
     const tools = buildDynamicTools(ctx);
     expect(tools).toHaveLength(1);
     expect(tools[0]!.approval).toBeUndefined();
-  });
-
-  it("re-dispatch updates the registered step function", async () => {
-    const ctx = createCtx();
-    let callCount = 0;
-    const resolver = createResolver("counter", ["session.started"], () => {
-      callCount++;
-      const current = callCount;
-      return {
-        count: createFrameworkTool(`v${current}`, () => ({ version: current })),
-      };
-    });
-
-    await dispatchDynamicToolEvent({
-      ctx,
-      resolvers: [resolver],
-      messages: [],
-      event: makeEvent("session.started"),
-    });
-
-    ctx.clearVirtualContext();
-    let tools = buildDynamicTools(ctx);
-    const result1 = await tools[0]!.execute!({}, executeOptions);
-    expect(result1).toEqual({ version: 1 });
-
-    // Re-dispatch overwrites the resolver's slot
-    await dispatchDynamicToolEvent({
-      ctx,
-      resolvers: [resolver],
-      messages: [],
-      event: makeEvent("session.started"),
-    });
-
-    ctx.clearVirtualContext();
-    tools = buildDynamicTools(ctx);
-    expect(tools[0]!.description).toBe("v2");
-    const result2 = await tools[0]!.execute!({}, executeOptions);
-    expect(result2).toEqual({ version: 2 });
   });
 });

--- a/packages/eve/src/context/dynamic-tool-lifecycle.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.ts
@@ -7,7 +7,7 @@ import {
   type ApprovalResponseContext,
 } from "#public/definitions/approval.js";
 import type { DynamicToolEntry } from "#shared/dynamic-tool-definition.js";
-import type { UnstampedMessageStreamEvent, SessionStartedStreamEvent } from "#protocol/message.js";
+import type { SessionStartedStreamEvent, UnstampedMessageStreamEvent } from "#protocol/message.js";
 import {
   ALLOWED_DYNAMIC_TOOL_EVENTS,
   isBrandedToolEntry,
@@ -21,7 +21,7 @@ import {
   toOutputSchema,
 } from "#shared/tool-schema.js";
 import { toErrorMessage } from "#shared/errors.js";
-import type { ContextContainer } from "#context/container.js";
+import type { AlsContext } from "#context/container.js";
 import type { ContextKey } from "#context/key.js";
 import {
   SessionDynamicToolMetadataKey,
@@ -32,6 +32,7 @@ import {
 import type { DurableDynamicToolMetadata } from "#context/keys.js";
 import { buildResolveContext } from "#context/dynamic-resolve-context.js";
 import { createToolExecuteWithAuth } from "#execution/tool-auth.js";
+import { replayDurableTools } from "#context/build-dynamic-tools.js";
 
 const log = createLogger("dynamic-tools");
 
@@ -99,39 +100,7 @@ export function replayDynamicSessionTools(
   metadata: readonly DurableDynamicToolMetadata[],
   _resolvers: readonly ResolvedDynamicToolResolver[],
 ): readonly HarnessToolDefinition[] {
-  const tools: HarnessToolDefinition[] = [];
-
-  for (const m of metadata) {
-    if (!m.executeStepFnName || !m.closureVars) {
-      log.warn(
-        `Dynamic tool "${m.name}" has no registered step function — ` +
-          "skipping on this step. The bundler transform may not have processed this tool file.",
-      );
-      continue;
-    }
-
-    const stepFn = lookupStepFunction(m.executeStepFnName);
-    if (!stepFn) {
-      log.warn(
-        `Dynamic tool "${m.name}" references step function "${m.executeStepFnName}" ` +
-          "which is not registered — skipping on this step.",
-      );
-      continue;
-    }
-
-    tools.push({
-      description: m.description,
-      execute: createToolExecuteWithAuth({
-        scope: m.name,
-        execute: (input, ctx) => stepFn(m.closureVars, input, ctx),
-      }),
-      inputSchema: toInputSchema(m.inputSchema),
-      name: m.name,
-      outputSchema: toOutputSchema(m.outputSchema),
-    });
-  }
-
-  return tools;
+  return replayDurableTools(metadata);
 }
 
 // ---------------------------------------------------------------------------
@@ -147,15 +116,6 @@ function getStepRegistry(): Map<string, Function> {
     g[key] = registry;
   }
   return registry;
-}
-
-function lookupStepFunction(stepId: string): ((...args: unknown[]) => unknown) | null {
-  try {
-    const fn = getStepRegistry().get(stepId);
-    return fn ? (fn as (...args: unknown[]) => unknown) : null;
-  } catch {
-    return null;
-  }
 }
 
 function registerStepFunction(stepId: string, fn: Function): void {
@@ -232,17 +192,22 @@ function readDynamicToolResult(
 }
 
 async function resolveToolsFromEvent(
-  ctx: ContextContainer,
+  ctx: AlsContext,
   resolvers: readonly ResolvedDynamicToolResolver[],
   event: UnstampedMessageStreamEvent,
   messages: readonly ModelMessage[],
+  abortSignal: AbortSignal,
 ): Promise<ResolveResult> {
   const outcomes = await Promise.allSettled(
     resolvers.map(async (resolver) => {
       const handler = resolver.events[event.type];
       if (handler === undefined) return null;
 
-      const resolveCtx = buildResolveContext(ctx, messages);
+      const resolveCtx =
+        resolver.buildContext === undefined
+          ? buildResolveContext(ctx, messages)
+          : resolver.buildContext({ abortSignal, messages });
+      if (resolveCtx === null) return null;
       const rawResult = await handler(event, resolveCtx);
       if (rawResult === null || rawResult === undefined) return null;
       const { entries, isSingle } = readDynamicToolResult(resolver, rawResult);
@@ -295,20 +260,17 @@ async function resolveToolsFromEvent(
       let serializedClosureVars =
         closureVars !== undefined ? safeSerialize(closureVars) : undefined;
 
-      // Framework tools skip the bundler AST transform, so they carry
-      // no __executeStepFn/__closureVars. Register the live execute
-      // closure in the step registry so session/turn-scoped metadata
-      // can replay them the same way as authored tools.
-      if (executeStepFnName === undefined) {
-        const syntheticId = `eve:framework-dynamic:${resolver.slug}:${entryKey}`;
+      if (executeStepFnName === undefined || serializedClosureVars === undefined) {
+        executeStepFnName = `eve:framework-dynamic:${resolver.slug}:${entryKey}`;
         const originalExecute = entry.execute.bind(entry);
-        registerStepFunction(syntheticId, (_closureVars: unknown, input: unknown, ctx: unknown) =>
-          originalExecute(
-            input as Record<string, unknown>,
-            ctx as Parameters<typeof entry.execute>[1],
-          ),
+        registerStepFunction(
+          executeStepFnName,
+          (_closureVars: unknown, input: unknown, context: unknown) =>
+            originalExecute(
+              input as Record<string, unknown>,
+              context as Parameters<typeof entry.execute>[1],
+            ),
         );
-        executeStepFnName = syntheticId;
         serializedClosureVars = {};
       }
 
@@ -333,6 +295,15 @@ async function resolveToolsFromEvent(
         }
       }
 
+      let toModelOutputStepFnName: string | undefined;
+      if (entry.toModelOutput !== undefined) {
+        toModelOutputStepFnName = `eve:dynamic-tool-model-output:${resolver.slug}:${entryKey}`;
+        const originalToModelOutput = entry.toModelOutput.bind(entry);
+        registerStepFunction(toModelOutputStepFnName, (_closureVars: unknown, output: unknown) =>
+          originalToModelOutput(output),
+        );
+      }
+
       metadata.push({
         name,
         description: entry.description,
@@ -344,6 +315,7 @@ async function resolveToolsFromEvent(
         approvalStepFnName,
         approvalResponseStepFnName,
         closureVars: serializedClosureVars,
+        toModelOutputStepFnName,
       });
     }
   }
@@ -356,7 +328,7 @@ async function resolveToolsFromEvent(
 // ---------------------------------------------------------------------------
 
 const resolvedStepTools = new WeakMap<
-  ContextContainer,
+  AlsContext,
   { readonly coordinate: string; readonly tools: readonly HarnessToolDefinition[] }
 >();
 
@@ -368,7 +340,8 @@ const resolvedStepTools = new WeakMap<
  */
 /** Resolves step-scoped tools once for one internal policy/model pass. */
 export async function resolveStepDynamicTools(input: {
-  readonly ctx: ContextContainer;
+  readonly abortSignal: AbortSignal;
+  readonly ctx: AlsContext;
   readonly resolvers: readonly ResolvedDynamicToolResolver[];
   readonly event: UnstampedMessageStreamEvent;
   readonly messages: readonly ModelMessage[];
@@ -392,7 +365,13 @@ export async function resolveStepDynamicTools(input: {
   const { liveTools } =
     matching.length === 0
       ? { liveTools: [] }
-      : await resolveToolsFromEvent(input.ctx, matching, input.event, input.messages);
+      : await resolveToolsFromEvent(
+          input.ctx,
+          matching,
+          input.event,
+          input.messages,
+          input.abortSignal,
+        );
   input.ctx.setVirtualContext(LiveStepToolsKey, liveTools);
   if (coordinate !== undefined) {
     resolvedStepTools.set(input.ctx, { coordinate, tools: liveTools });
@@ -400,12 +379,13 @@ export async function resolveStepDynamicTools(input: {
 }
 
 export async function dispatchDynamicToolEvent(input: {
-  readonly ctx: ContextContainer;
+  readonly abortSignal: AbortSignal;
+  readonly ctx: AlsContext;
   readonly resolvers: readonly ResolvedDynamicToolResolver[];
   readonly event: UnstampedMessageStreamEvent;
   readonly messages: readonly ModelMessage[];
 }): Promise<void> {
-  const { ctx, resolvers, event, messages } = input;
+  const { abortSignal, ctx, resolvers, event, messages } = input;
 
   if (!ALLOWED_DYNAMIC_TOOL_EVENTS.has(event.type)) return;
 
@@ -422,7 +402,7 @@ export async function dispatchDynamicToolEvent(input: {
     return;
   }
 
-  const { metadata } = await resolveToolsFromEvent(ctx, matching, event, messages);
+  const { metadata } = await resolveToolsFromEvent(ctx, matching, event, messages, abortSignal);
 
   // Session/turn: store durable metadata for cross-step replay via
   // the bundler's registered step functions.
@@ -446,7 +426,8 @@ export async function dispatchDynamicToolEvent(input: {
  * still observe exactly one `session.started` event for the session.
  */
 export async function refreshDynamicSessionToolsForRuntimeRevision(input: {
-  readonly ctx: ContextContainer;
+  readonly abortSignal: AbortSignal;
+  readonly ctx: AlsContext;
   readonly resolvers: readonly ResolvedDynamicToolResolver[];
   readonly event: SessionStartedStreamEvent;
   readonly messages: readonly ModelMessage[];
@@ -462,7 +443,13 @@ export async function refreshDynamicSessionToolsForRuntimeRevision(input: {
   const { metadata } =
     matching.length === 0
       ? { metadata: [] }
-      : await resolveToolsFromEvent(input.ctx, matching, input.event, input.messages);
+      : await resolveToolsFromEvent(
+          input.ctx,
+          matching,
+          input.event,
+          input.messages,
+          input.abortSignal,
+        );
 
   input.ctx.set(SessionDynamicToolMetadataKey, metadata);
   input.ctx.set(SessionDynamicToolRuntimeRevisionKey, input.runtimeRevision);

--- a/packages/eve/src/context/hook-lifecycle.integration.test.ts
+++ b/packages/eve/src/context/hook-lifecycle.integration.test.ts
@@ -67,6 +67,8 @@ describe("dispatchStreamEventHooks", () => {
         events: {
           "session.completed": async (_event, hookContext) => {
             expect(hookContext.channel.continuationToken).toBe("test:continuation");
+            expect(hookContext.messages).toEqual([{ content: "ready", role: "user" }]);
+            expect(hookContext.abortSignal).toBe(abortController.signal);
             calls.push("typed");
           },
         },
@@ -80,10 +82,13 @@ describe("dispatchStreamEventHooks", () => {
       }),
     ]);
     const ctx = buildCtx();
+    const abortController = new AbortController();
 
     await contextStorage.run(ctx, () =>
       dispatchStreamEventHooks({
+        abortSignal: abortController.signal,
         ctx,
+        messages: [{ content: "ready", role: "user" }],
         registry,
         event: stampTestEvent({ type: "session.completed" }),
       }),
@@ -102,7 +107,9 @@ describe("dispatchStreamEventHooks", () => {
     await expect(
       contextStorage.run(ctx, () =>
         dispatchStreamEventHooks({
+          abortSignal: abortController.signal,
           ctx,
+          messages: [],
           registry: brokenRegistry,
           event: stampTestEvent({ type: "session.completed" }),
         }),

--- a/packages/eve/src/context/hook-lifecycle.ts
+++ b/packages/eve/src/context/hook-lifecycle.ts
@@ -17,6 +17,8 @@ export async function dispatchStreamEventHooks(input: {
   readonly ctx: ContextContainer;
   readonly registry: RuntimeHookRegistry;
   readonly event: MessageStreamEvent;
+  readonly abortSignal: AbortSignal;
+  readonly messages: readonly import("ai").ModelMessage[];
 }): Promise<void> {
   const typed = input.registry.streamEventsByType.get(input.event.type) ?? [];
   const wildcard = input.registry.streamEventsWildcard;
@@ -25,7 +27,7 @@ export async function dispatchStreamEventHooks(input: {
     return;
   }
 
-  const hookCtx = buildHookContext(input.ctx);
+  const hookCtx = buildHookContext(input.ctx, input.abortSignal, input.messages);
   for (const entry of typed) {
     await entry.handler(input.event, hookCtx);
   }
@@ -35,7 +37,11 @@ export async function dispatchStreamEventHooks(input: {
 }
 
 /** Builds the {@link HookContext} surfaced to one handler. */
-function buildHookContext(ctx: ContextContainer): HookContext {
+function buildHookContext(
+  ctx: ContextContainer,
+  abortSignal: AbortSignal,
+  messages: HookContext["messages"],
+): HookContext {
   const bundle = ctx.require(BundleKey);
   const channelAdapter = ctx.get(ChannelKey);
   const continuationToken = ctx.get(ContinuationTokenKey);
@@ -44,6 +50,7 @@ function buildHookContext(ctx: ContextContainer): HookContext {
 
   return {
     ...callbackCtx,
+    abortSignal,
     agent: {
       name: bundle.turnAgent.id,
       nodeId: bundle.nodeId,
@@ -52,5 +59,6 @@ function buildHookContext(ctx: ContextContainer): HookContext {
       kind,
       continuationToken,
     },
+    messages,
   };
 }

--- a/packages/eve/src/context/keys.ts
+++ b/packages/eve/src/context/keys.ts
@@ -160,6 +160,7 @@ export interface DurableDynamicToolMetadata {
   readonly executeStepFnName?: string;
   readonly approvalStepFnName?: string;
   readonly approvalResponseStepFnName?: string;
+  readonly toModelOutputStepFnName?: string;
   readonly closureVars?: Record<string, unknown>;
 }
 

--- a/packages/eve/src/execution/node-step.test.ts
+++ b/packages/eve/src/execution/node-step.test.ts
@@ -306,6 +306,7 @@ describe("createExecutionNodeStep", () => {
       nodeId: undefined,
     };
     const step = createExecutionNodeStep({
+      abortSignal: new AbortController().signal,
       createRuntime: () => createNoopRuntime(),
       mode: "task",
       modelResolutionScope,
@@ -368,6 +369,7 @@ describe("createExecutionNodeStep", () => {
       }),
     );
     const step = createExecutionNodeStep({
+      abortSignal: new AbortController().signal,
       createRuntime,
       mode: "task",
       modelResolutionScope: {

--- a/packages/eve/src/execution/node-step.ts
+++ b/packages/eve/src/execution/node-step.ts
@@ -53,7 +53,7 @@ export type CreateRuntime = (config: {
  */
 export interface CreateExecutionNodeStepInput {
   /** Cancellation signal forwarded to the tool-loop harness. */
-  readonly abortSignal?: AbortSignal;
+  readonly abortSignal: AbortSignal;
   /**
    * Session-level capabilities propagated from the runtime. The
    * harness passes this through to `buildToolSet` so `ask_question`

--- a/packages/eve/src/execution/settle-cancelled-turn-step.ts
+++ b/packages/eve/src/execution/settle-cancelled-turn-step.ts
@@ -30,6 +30,7 @@ import { clearPendingRuntimeActionBatch } from "#harness/runtime-actions.js";
 import { createInstrumentationHandleEvent } from "#harness/instrumentation-native-events.js";
 import { getInstrumentationRuntime } from "#harness/instrumentation-runtime.js";
 import { clearPendingWorkflowInterrupt } from "#harness/workflow-interrupt-state.js";
+import { TurnCancelledError } from "#harness/turn-cancellation.js";
 import {
   encodeMessageStreamEvent,
   type UnstampedMessageStreamEvent,
@@ -86,6 +87,7 @@ export async function settleCancelledTurnStep(input: {
     !stoppedAtDescendantLimit;
 
   if (!alreadyEpilogued) {
+    const abortSignal = AbortSignal.abort(new TurnCancelledError());
     const writer = input.parentWritable.getWriter();
     try {
       const scoped = await withContextScope(ctx, session, async (enrichedSession) => {
@@ -96,8 +98,10 @@ export async function settleCancelledTurnStep(input: {
           const stamped = stampMessageStreamEvent(transformed);
           await writer.write(encodeMessageStreamEvent(stamped));
           await dispatchStreamEventHooks({
+            abortSignal,
             ctx,
             event: stamped,
+            messages: enrichedSession.history,
             registry: bundle.hookRegistry,
           });
         };

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -154,6 +154,9 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
   "use step";
 
   let input = rawInput;
+  // Older durable turn inputs predate cancellation. Normalize that wire shape
+  // once so every lifecycle below receives one step-owned signal.
+  const abortSignal = input.abortSignal ?? AbortSignal.any([]);
 
   let durableSession = await readDurableSession(input.sessionState);
   const ctx = await deserializeContext(input.serializedContext);
@@ -348,6 +351,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
           runtimeRevision: dynamicRuntimeRevision,
         }),
         refreshDynamicSessionToolsForRuntimeRevision({
+          abortSignal,
           ctx,
           resolvers: dynamicToolResolvers,
           event: refreshEvent,
@@ -362,6 +366,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
   }
 
   const writer = input.parentWritable.getWriter();
+  let lifecycleMessages: readonly import("ai").ModelMessage[] = initialSession.history;
 
   // Stamp once: the persisted chunk and the hooks below must agree on the id.
   const emit = async (event: UnstampedMessageStreamEvent): Promise<MessageStreamEvent> => {
@@ -376,14 +381,21 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
     event: UnstampedMessageStreamEvent,
     messages?: readonly import("ai").ModelMessage[],
   ): Promise<void> => {
+    if (messages !== undefined) lifecycleMessages = messages;
     const emitted = await emit(event);
-    await dispatchStreamEventHooks({ ctx, registry: hookRegistry, event: emitted });
+    await dispatchStreamEventHooks({
+      abortSignal,
+      ctx,
+      event: emitted,
+      messages: lifecycleMessages,
+      registry: hookRegistry,
+    });
     if (emitted.type !== "step.started") {
       await dispatchDynamicModelEvent({
         ctx,
         dynamicModel: effectiveAgent.turnAgent.dynamicModel,
         event: emitted,
-        messages: messages ?? [],
+        messages: lifecycleMessages,
         scope: {
           moduleMap: bundle.moduleMap,
           nodeId: bundle.nodeId,
@@ -394,26 +406,27 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
       ctx,
       resolvers: dynamicSubagentResolvers,
       event: emitted,
-      messages: messages ?? [],
+      messages: lifecycleMessages,
       persistentSessions: persistentSubagentSessions,
     });
     await dispatchDynamicToolEvent({
+      abortSignal,
       ctx,
       resolvers: dynamicToolResolvers,
       event: emitted,
-      messages: messages ?? [],
+      messages: lifecycleMessages,
     });
     await dispatchDynamicSkillEvent({
       ctx,
       resolvers: dynamicSkillResolvers,
       event: emitted,
-      messages: messages ?? [],
+      messages: lifecycleMessages,
     });
     await dispatchDynamicInstructionEvent({
       ctx,
       resolvers: dynamicInstructionsResolvers,
       event: emitted,
-      messages: messages ?? [],
+      messages: lifecycleMessages,
     });
   };
 
@@ -424,7 +437,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
     // A signal already aborted at entry (cancellation during an in-line
     // runtime-action wait) must settle before the park-resume stages run,
     // or the pending batch would re-park and later re-dispatch.
-    throwIfTurnAborted(input.abortSignal);
+    throwIfTurnAborted(abortSignal);
     stepResult = await runStep(ctx, initialSession, async (enrichedSession) => {
       let schemaSession = resolveEffectiveOutputSchema({
         agentOutputSchema: effectiveAgent.turnAgent.outputSchema,
@@ -471,7 +484,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
         });
 
         const step = createExecutionNodeStep({
-          abortSignal: input.abortSignal,
+          abortSignal,
           capabilities,
           clearOnly: input.input?.kind === "clear",
           compactOnly: input.input?.kind === "compact",

--- a/packages/eve/src/harness/emission.ts
+++ b/packages/eve/src/harness/emission.ts
@@ -212,12 +212,14 @@ export async function emitTurnEpilogue(
   emitFn: HarnessEmitFn,
   state: HarnessEmissionState,
   mode: RunMode,
+  messages?: readonly ModelMessage[],
 ): Promise<HarnessEmissionState> {
   await emitFn(
     createTurnCompletedEvent({
       sequence: state.sequence,
       turnId: state.turnId,
     }),
+    messages,
   );
 
   if (mode === "conversation") {

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -2627,6 +2627,7 @@ async function emitStructuredResult(
   emissionState: ReturnType<typeof getHarnessEmissionState>,
   structured: JsonValue,
   mode: RunMode,
+  messages: readonly ModelMessage[],
 ): Promise<ReturnType<typeof getHarnessEmissionState>> {
   await emit(
     createResultCompletedEvent({
@@ -2636,7 +2637,7 @@ async function emitStructuredResult(
       turnId: emissionState.turnId,
     }),
   );
-  return emitTurnEpilogue(emit, emissionState, mode);
+  return emitTurnEpilogue(emit, emissionState, mode, messages);
 }
 
 /**
@@ -2658,7 +2659,7 @@ async function finishTaskTurn(input: {
 
   if (schema === undefined) {
     if (emit) {
-      emissionState = await emitTurnEpilogue(emit, emissionState, "task");
+      emissionState = await emitTurnEpilogue(emit, emissionState, "task", session.history);
       session = setHarnessEmissionState(session, emissionState);
     }
     return { next: { done: true, output: stepOutput ?? "" }, session };
@@ -2680,7 +2681,13 @@ async function finishTaskTurn(input: {
 
   session = persistStructuredAssistantTurn(session, history, structured);
   if (emit) {
-    emissionState = await emitStructuredResult(emit, emissionState, structured, "task");
+    emissionState = await emitStructuredResult(
+      emit,
+      emissionState,
+      structured,
+      "task",
+      session.history,
+    );
     session = setHarnessEmissionState(session, emissionState);
   }
   return { next: { done: true, output: structured }, session };
@@ -2705,7 +2712,7 @@ async function finishConversationTurn(input: {
 
   if (schema === undefined) {
     if (emit) {
-      emissionState = await emitTurnEpilogue(emit, emissionState, "conversation");
+      emissionState = await emitTurnEpilogue(emit, emissionState, "conversation", session.history);
       session = setHarnessEmissionState(session, emissionState);
     }
     const settledTurn = { output: stepOutput ?? "" } satisfies SettledTurn;
@@ -2730,7 +2737,13 @@ async function finishConversationTurn(input: {
 
   session = persistStructuredAssistantTurn(session, history, structured);
   if (emit) {
-    emissionState = await emitStructuredResult(emit, emissionState, structured, "conversation");
+    emissionState = await emitStructuredResult(
+      emit,
+      emissionState,
+      structured,
+      "conversation",
+      session.history,
+    );
     session = setHarnessEmissionState(session, emissionState);
   }
   const settledTurn = { output: structured } satisfies SettledTurn;
@@ -2965,6 +2978,7 @@ async function maybeCompact(input: {
         turnId: emissionState.turnId,
         usageInputTokens: getInputTokenCount(messages, session.compaction),
       }),
+      messages,
     );
   }
 
@@ -2993,6 +3007,7 @@ async function maybeCompact(input: {
         sessionId: session.sessionId,
         turnId: emissionState.turnId,
       }),
+      messages,
     );
   }
 

--- a/packages/eve/src/internal/workflow-bundle/dynamic-capability-transform-plugin.test.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-capability-transform-plugin.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { createDynamicCapabilityTransformPlugin } from "./dynamic-capability-transform-plugin.js";
+
+describe("dynamic capability transform plugin", () => {
+  it("transforms defineDynamic tools outside the tools directory", async () => {
+    const plugin = createDynamicCapabilityTransformPlugin();
+    const result = await plugin.transform(
+      `
+        export default defineDynamic({
+          events: {
+            "turn.started": async () => {
+              return {
+                save: defineTool({
+                  description: "Save",
+                  inputSchema: { type: "object" },
+                  execute() { return "saved"; },
+                }),
+              };
+            },
+          },
+        });
+      `,
+      "/agent/lib/provider.ts",
+    );
+
+    expect(result?.code).toContain("__executeStepFn");
+    await expect(plugin.transform(result!.code, "/agent/lib/provider.ts")).resolves.toBeNull();
+  });
+});

--- a/packages/eve/src/internal/workflow-bundle/dynamic-capability-transform-plugin.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-capability-transform-plugin.ts
@@ -9,9 +9,9 @@ export function createDynamicCapabilityTransformPlugin(
 ) {
   return {
     async transform(code: string, id: string) {
-      const normalizedId = id.replaceAll("\\", "/");
       const transformDynamicTools =
-        options.dynamicTools !== false && normalizedId.includes("/tools/");
+        options.dynamicTools !== false && code.includes("defineDynamic");
+      const normalizedId = id.replaceAll("\\", "/");
       const transformDynamicRemoteAgents =
         options.dynamicRemoteAgents !== false && normalizedId.includes("/subagents/");
       if (!transformDynamicTools && !transformDynamicRemoteAgents) {

--- a/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.ts
@@ -346,6 +346,9 @@ function walkForExecuteProps(
     (node.arguments[0] as AstNode).type === "ObjectExpression"
   ) {
     const toolArg = node.arguments[0] as AstNode;
+    if (findProperty(toolArg, "__executeStepFn")) {
+      return;
+    }
     for (const prop of toolArg.properties ?? []) {
       if (
         prop.type === "Property" &&

--- a/packages/eve/src/public/definitions/hook.ts
+++ b/packages/eve/src/public/definitions/hook.ts
@@ -1,3 +1,5 @@
+import type { ModelMessage } from "ai";
+
 import type { HandleMessageStreamEvent } from "../../protocol/message.js";
 import type { SessionContext } from "./callback-context.js";
 import type { ExactDefinition } from "./exact.js";
@@ -67,6 +69,8 @@ export type HookEvent<TKey extends HookEventKey = HookEventType> = TKey extends 
  * `ctx` is always the last argument.
  */
 export interface HookContext extends SessionContext {
+  /** Aborts when the active turn is cancelled. */
+  readonly abortSignal: AbortSignal;
   readonly agent: {
     readonly name: string;
     readonly nodeId?: string;
@@ -75,6 +79,8 @@ export interface HookContext extends SessionContext {
     readonly kind?: string;
     readonly continuationToken?: string;
   };
+  /** Durable model history selected for this lifecycle point. */
+  readonly messages: readonly ModelMessage[];
 }
 
 /**

--- a/packages/eve/src/runtime/types.ts
+++ b/packages/eve/src/runtime/types.ts
@@ -1,3 +1,5 @@
+import type { ModelMessage } from "ai";
+
 import type { ChannelAdapter } from "#channel/adapter.js";
 import type { CompiledChannel } from "#channel/compiled-channel.js";
 import type { NormalizedChannelCorsOptions } from "#channel/cors.js";
@@ -359,6 +361,10 @@ export interface ResolvedDynamicToolResolver extends Readonly<ModuleSourceRef> {
   readonly events: Readonly<
     Record<string, (event: unknown, ctx: unknown) => unknown | Promise<unknown>>
   >;
+  readonly buildContext?: (input: {
+    readonly abortSignal: AbortSignal;
+    readonly messages: readonly ModelMessage[];
+  }) => unknown | null;
   /**
    * Mount namespace when this resolver comes from an extension. Names of tools
    * the resolver produces are prefixed with `${extensionNamespace}__`.

--- a/packages/eve/src/shared/dynamic-tool-definition.ts
+++ b/packages/eve/src/shared/dynamic-tool-definition.ts
@@ -10,11 +10,6 @@ import type { ToolContext } from "#public/definitions/tool.js";
 import type { SessionAuth } from "#context/keys.js";
 import type { UnstampedMessageStreamEvent } from "#protocol/message.js";
 
-/**
- * Stream event types allowed for dynamic tool resolvers. Dispatch
- * supports any event; this extract restricts the public surface until
- * more events are validated.
- */
 export type DynamicToolEventName = Extract<
   UnstampedMessageStreamEvent["type"],
   "session.started" | "turn.started" | "step.started"

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -13,14 +13,14 @@ Memory is a path-authored slot that lets an agent carry provider-defined context
 eve owns only two pieces:
 
 1. **Authored identity.** Each memory file is a named slot with path-derived identity.
-2. **Scope.** eve resolves and locks a trusted partition for that slot, then supplies the same partition to every provider hook and provider-defined tool in the turn.
+2. **Scope.** eve resolves and locks a trusted partition for that slot, then supplies the same partition to every provider event handler and provider-defined tool in the turn.
 
 The provider owns everything else: storage, recall, capture, model tools, formatting, extraction, ranking, limits, retention, and any record or document model. A hosted semantic service and a pair of bounded text files can therefore implement the same memory slot without pretending to share lower-level semantics.
 
 ```text
-turn start       eve scope + visible session ---> provider recall ---> transient context
+turn prepared    eve scope + visible session ---> provider events ---> transient context
                  eve scope + visible session ---> provider tools  ---> scoped model tools
-turn completed   eve scope + settled session ---> provider capture
+turn completed   eve scope + settled session ---> provider events ---> provider side effects
 ```
 
 This document defines that authoring boundary and its observable lifecycle. Provider packaging, vendor configuration, and provider-specific persistence remain follow-up work.
@@ -50,7 +50,7 @@ export default defineMemory({
 
 `provider` supplies the memory behavior. `scope` resolves the provider partition for the current turn. Descriptions, prompts, tool policy, and storage options belong to provider configuration rather than `defineMemory`.
 
-The same provider instance may back several slots. For example, `user.ts` may resolve `[userId]` while `workspace.ts` resolves `[workspaceId]`. Their path identities, scope keys, recalled context, tools, and capture invocations remain separate.
+The same provider instance may back several slots. For example, `user.ts` may resolve `[userId]` while `workspace.ts` resolves `[workspaceId]`. Their path identities, scope keys, context contributions, tools, and event invocations remain separate.
 
 Local directory-form subagents may declare their own memory slots. Graph-node identity keeps root and subagent slots isolated even when they use the same path, scope parts, and provider.
 
@@ -77,47 +77,69 @@ interface MemoryScope {
 
 The key gives providers one collision-resistant partition identifier. The parts remain available when a vendor needs to map the partition onto its own user, workspace, or container concepts. Both are absent from model-facing schemas.
 
-eve resolves scope after admitting the turn and locks it through capture. Returning `null` makes the slot unavailable for that turn: eve does not invoke its provider hooks or lower its tools. Missing values never fall back to a broader partition. Changing the meaning or order of scope parts is a provider data migration.
+eve resolves scope after admitting the turn and locks it through the completed-turn handler. Returning `null` makes the slot unavailable for that turn: eve does not invoke its provider handlers or lower its tools. Missing values never fall back to a broader partition. Changing the meaning or order of scope parts is a provider data migration.
 
 eve guarantees that every invocation for one slot receives the same locked value. The provider is responsible for actually applying that value to downstream storage and service calls; eve cannot enforce isolation inside provider code or an external service.
 
 ## Provider contract
 
-`MemoryProvider` is a public extension point with three semantic hooks. This is the intended shape; exact callback-context and tool-definition type names will be fixed by the implementation plan:
+`MemoryProvider` is a public extension point with separate, constrained event and tool maps. It follows the same event-keyed shape as eve's other dynamic APIs without naming or prescribing recall and capture operations. This is the intended shape; exact event and callback-context type names will be fixed by the implementation plan:
 
 ```ts
 import type { ModelMessage } from "ai";
 import type { ToolDefinition } from "eve/tools";
 
-interface MemoryProviderInvocation {
-  /** Path-derived slot identity, such as "memory" or "user". */
-  readonly slot: string;
-  readonly scope: MemoryScope;
-  readonly session: {
-    readonly id: string;
-    /** Current ModelMessage history selected for this lifecycle point. */
-    readonly messages: readonly ModelMessage[];
+interface MemoryProviderContext extends MemoryCallbackContext {
+  readonly memory: {
+    /** Path-derived slot identity, such as "memory" or "user". */
+    readonly slot: string;
+    readonly scope: MemoryScope;
   };
+  /** Current ModelMessage history selected for this lifecycle point. */
+  readonly messages: readonly ModelMessage[];
   readonly abortSignal: AbortSignal;
 }
 
-type MemoryProviderTools = Readonly<Record<string, ToolDefinition>>;
+interface MemoryTurnPreparedResult {
+  /** Provider-formatted text appended as transient turn context. */
+  readonly context?: string;
+}
+
+type MemoryProviderToolSet = Readonly<Record<string, ToolDefinition>>;
+
+interface MemoryProviderEvents {
+  readonly "turn.prepared"?: (
+    event: TurnPreparedEvent,
+    context: MemoryProviderContext,
+  ) => MemoryTurnPreparedResult | null | Promise<MemoryTurnPreparedResult | null>;
+
+  readonly "turn.completed"?: (
+    event: TurnCompletedEvent,
+    context: MemoryProviderContext,
+  ) => void | Promise<void>;
+}
+
+interface MemoryProviderTools {
+  readonly "turn.prepared"?: (
+    event: TurnPreparedEvent,
+    context: MemoryProviderContext,
+  ) => MemoryProviderToolSet | null | Promise<MemoryProviderToolSet | null>;
+
+  readonly "step.started"?: (
+    event: StepStartedEvent,
+    context: MemoryProviderContext,
+  ) => MemoryProviderToolSet | null | Promise<MemoryProviderToolSet | null>;
+}
 
 interface MemoryProvider {
-  recall?(input: MemoryProviderInvocation, context: MemoryCallbackContext): Promise<string | null>;
-
-  tools?(
-    input: MemoryProviderInvocation,
-    context: MemoryCallbackContext,
-  ): Promise<MemoryProviderTools | null>;
-
-  capture?(input: MemoryProviderInvocation, context: MemoryCallbackContext): Promise<void>;
+  readonly events?: MemoryProviderEvents;
+  readonly tools?: MemoryProviderTools;
 }
 ```
 
-Hooks are independently optional. A provider may contribute only context, only tools, only capture, or any combination. eve does not infer missing behavior or add default tools.
+Both maps and every handler within them are optional. A provider may contribute only context, only tools, only completed-turn side effects, or any combination. eve does not infer missing behavior or add default tools.
 
-Every hook also receives the ordinary authored callback context for session, auth, channel, and runtime access. The invocation carries the memory-specific slot, scope, message history, and cancellation signal explicitly so provider behavior does not depend on ambient model input.
+Every handler receives an ordinary typed eve event and authored callback context extended with the path-derived slot, locked scope, message snapshot, and cancellation signal. Scope does not depend on ambient model input.
 
 `defineMemoryProvider(...)` validates and brands a custom implementation but does not implement storage or impose a data model:
 
@@ -126,47 +148,53 @@ import { defineMemoryProvider } from "eve/memory";
 import { service } from "./service";
 
 export const memory = defineMemoryProvider({
-  async recall(input) {
-    return await service.recall(input.scope, input.session.messages);
+  events: {
+    async "turn.prepared"(_event, ctx) {
+      return {
+        context: await service.recall(ctx.memory.scope, ctx.messages),
+      };
+    },
+    async "turn.completed"(_event, ctx) {
+      await service.capture(ctx.memory.scope, ctx.messages);
+    },
   },
-  async tools(input) {
-    return service.toolsFor(input.scope);
-  },
-  async capture(input) {
-    await service.capture(input.scope, input.session.messages);
+  tools: {
+    async "turn.prepared"(_event, ctx) {
+      return service.toolsFor(ctx.memory.scope);
+    },
   },
 });
 ```
 
-The provider decides what each hook means. `recall` need not search, `capture` need not run a model, and tools need not manipulate memory.
+The provider decides what each handler means. A prepared-turn handler need not search, a completed-turn handler need not persist, and tools need not manipulate memory.
 
 ## Lifecycle
 
-### Turn start
+### Turn preparation
 
-After turn admission and compaction, eve resolves each slot's scope and invokes its `recall` and `tools` hooks once. Their session history includes the newest admitted input and every model-visible user, assistant, and tool message retained after compaction.
+After turn admission and compaction, eve resolves each slot's scope and dispatches `turn.prepared` to its `events` and `tools` maps. This is a new provider-resolution event rather than the existing stream `turn.started`: its name reflects that the newest input has been admitted and the model history has already been compacted. The event context includes that input and every model-visible user, assistant, and tool message retained after compaction.
 
-A non-empty `recall` result becomes one transient user-context message appended at the prompt tail. Results from several slots appear in stable slot-path order. Providers own all formatting and attribution within their returned text.
+The event handler runs before the tool resolver for the same slot. A non-empty `context` result becomes one transient user-context message appended at the prompt tail. Results from several slots appear in stable slot-path order. Providers own all formatting and attribution within their returned text.
 
 Recalled context is not a system instruction. Keeping it at the prompt tail leaves authored instructions and the prior conversation prefix stable for prompt caching. It also remains transient: eve does not write it to durable session history, include it in later capture input, or restore it on replay as conversation authored by the user.
 
-Provider tools are available for every model step in the turn. A provider returns tool keys such as `forget` or `propose`; eve lowers them as `<memory-slot>__<provider-tool>`, for example `user__forget`. Qualification is unconditional, so adding another memory slot never renames an existing tool or creates a collision when two slots use the same provider.
+Tools returned from `tools["turn.prepared"]` are available for every model step in the turn. A provider may additionally resolve `tools["step.started"]` before each model call; its most recent result owns that provider's tool set, and `null` clears it. A provider returns tool keys such as `forget` or `propose`; eve lowers them as `<memory-slot>__<provider-tool>`, for example `user__forget`. Qualification is unconditional, so adding another memory slot never renames an existing tool or creates a collision when two slots use the same provider.
 
 The model never supplies slot identity or scope. eve binds the resolved invocation to each lowered executor, and provider code uses that bound scope for its service or storage call. Provider tools otherwise use the ordinary tool contract, including schemas, approvals, results, and authorization access. A provider may expose tools unrelated to conventional memory CRUD.
 
 ### Turn completion
 
-After `turn.completed`, eve invokes `capture` for every slot that resolved at turn start. The hook receives the same locked scope and the complete settled durable model history, including assistant tool calls and tool results. It does not receive transient recalled context.
+After `turn.completed`, eve dispatches the event to `events["turn.completed"]` for every slot that resolved during turn preparation. The handler receives the same locked scope and the complete settled durable model history, including assistant tool calls and tool results. It does not receive transient context returned by `events["turn.prepared"]`.
 
-eve awaits capture before emitting `session.waiting` in conversation mode or `session.completed` in task mode. A caller that starts the next turn after the ready boundary therefore observes settled provider state. Capture does not run for failed, cancelled, abandoned, deferred, or adapter-consumed turns, nor for manual clear or compaction boundaries that did not complete a turn.
+eve awaits the completed-turn handlers before emitting `session.waiting` in conversation mode or `session.completed` in task mode. A caller that starts the next turn after the ready boundary therefore observes acknowledged provider state. The handler does not run for failed, cancelled, abandoned, deferred, or adapter-consumed turns, nor for manual clear or compaction boundaries that did not complete a turn.
 
-The provider decides whether capture stores the whole session, extracts selected details, rewrites a document, queues its own downstream work, or does nothing. eve does not run a capture model or inspect what the provider persists.
+The provider decides whether the handler stores the whole session, extracts selected details, rewrites a document, queues its own downstream work, or does nothing. eve does not run a capture model or inspect what the provider persists.
 
 ### Failures
 
-A `recall` or `tools` failure fails the turn. Memory is an authored capability, so silently running with a different prompt or tool set would violate the agent definition.
+A `turn.prepared` event-handler or tool-resolution failure fails the turn. A `step.started` tool-resolution failure fails that step. Memory is an authored capability, so silently running with a different prompt or tool set would violate the agent definition.
 
-A `capture` failure occurs after the response and cannot change that completed response. eve emits content-free diagnostics and continues to `session.waiting` or `session.completed`. Providers that acknowledge capture before their own asynchronous persistence completes own the resulting eventual consistency and retry behavior.
+A `turn.completed` handler failure occurs after the response and cannot change that completed response. eve emits content-free diagnostics and continues to `session.waiting` or `session.completed`. Providers that acknowledge the event before their own asynchronous persistence completes own the resulting eventual consistency and retry behavior.
 
 ## Reference providers
 
@@ -174,17 +202,17 @@ V1 includes two reference providers to prove that the framework boundary does no
 
 ### Supermemory
 
-The Supermemory provider sends the resolved scope and visible session history to Supermemory during recall. Supermemory decides what is relevant and returns the fully formatted text that eve injects. eve does not understand Supermemory profiles, containers, documents, search, or extraction.
+On `turn.prepared`, the Supermemory provider sends the resolved scope and visible session history to Supermemory. Supermemory decides what is relevant, and the handler returns the fully formatted text that eve injects. eve does not understand Supermemory profiles, containers, documents, search, or extraction.
 
-The provider chooses its tool set. It may expose scoped search, save, forget, profile, or proposal tools, or another capability entirely. eve only qualifies and scope-binds the returned definitions.
+The provider's tool map may expose scoped search, save, forget, profile, or proposal tools, or another capability entirely. eve only qualifies and scope-binds the returned definitions.
 
-After a completed turn, the provider sends the settled session to Supermemory. Supermemory decides what to persist and how to update its own memory representation. eve does not translate the session into framework records or validate the resulting writes.
+On `turn.completed`, the provider sends the settled session to Supermemory. Supermemory decides what to persist and how to update its own memory representation. eve does not translate the session into framework records or validate the resulting writes.
 
 ### Blob documents
 
-The blob provider stores bounded `USER.md`- and `MEMORY.md`-style text documents under the resolved scope. Recall reads the documents and returns their provider-formatted contents directly; it requires no search, embeddings, or record schema.
+The blob provider stores bounded `USER.md`- and `MEMORY.md`-style text documents under the resolved scope. Its `turn.prepared` handler reads the documents and returns their provider-formatted contents directly; it requires no search, embeddings, or record schema.
 
-The provider owns any tools for editing, consolidating, or clearing those documents. Its capture hook may rewrite them from the completed session and enforce provider-configured size limits. File layout, truncation or consolidation policy, concurrency, and blob-store behavior remain internal to the provider.
+The provider owns any tools for editing, consolidating, or clearing those documents. Its `turn.completed` handler may rewrite them from the settled session and enforce provider-configured size limits. File layout, truncation or consolidation policy, concurrency, and blob-store behavior remain internal to the provider.
 
 This provider demonstrates that simple bounded text can participate in the same lifecycle as a hosted semantic service without eve standardizing either implementation.
 
@@ -193,10 +221,10 @@ This provider demonstrates that simple bounded text can participate in the same 
 - Memory slots have path-derived identity and an explicit authored scope.
 - Scope is resolved from trusted runtime context, locked for the turn, and never accepted from model input.
 - The same provider can back several slots without sharing eve scope keys or colliding model tools.
-- Recall sees the post-compaction visible session including the newest input and contributes transient tail context in deterministic slot order.
-- Provider tools are unconditionally slot-qualified and bound to the same locked scope as recall and capture.
-- Capture sees the completed durable session without recalled transient context and settles before the next ready boundary.
-- Recall and tool-resolution failures fail the turn; capture failures cannot rewrite the completed response or suppress the ready boundary.
+- `events["turn.prepared"]` sees the post-compaction visible session including the newest input and may contribute transient tail context in deterministic slot order.
+- Provider tools are unconditionally slot-qualified and bound to the same locked scope as provider event handlers.
+- `events["turn.completed"]` sees the completed durable session without prepared-turn transient context and settles before the next ready boundary.
+- Prepared-turn event and tool-resolution failures fail the active turn or step; completed-turn event failures cannot rewrite the response or suppress the ready boundary.
 - Providers, not eve, define persistence, consistency after provider acknowledgment, retention, erasure, and administrative behavior.
 
 ## Non-goals
@@ -211,7 +239,7 @@ This provider demonstrates that simple bounded text can participate in the same 
 
 ## Implementation contract follow-up
 
-Before V1 implementation lands, follow-up plans must fix the exact public type names, callback context, scope-part encoding, tool-factory and durable-replay mechanics, diagnostic events, cancellation behavior, provider packaging, and tests for lifecycle ordering and isolation. Supermemory and blob storage each need a provider-specific plan for configuration and operational behavior without expanding the core memory contract.
+Before V1 implementation lands, follow-up plans must fix the exact public type names, introduce the `turn.prepared` resolution point, define event/tool-map compilation and durable-replay mechanics, specify scope-part encoding, diagnostics and cancellation, and add tests for lifecycle ordering and isolation. Supermemory and blob storage each need a provider-specific plan for configuration and operational behavior without expanding the core memory contract.
 
 ## Primary references
 

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -8,8 +8,7 @@ last_updated: "2026-08-01"
 
 ## Summary
 
-Add memory to eve as a first-class agent slot: durable cross-session knowledge that an agent can
-recall, remember, and forget. Remembering a replacement revises an existing record.
+Add memory to eve as a first-class agent slot: durable cross-session knowledge that an agent can recall, remember, and forget. Remembering a replacement revises an existing record.
 
 Declaring a resolved memory collection enables one coherent capability. eve:
 
@@ -19,20 +18,13 @@ Declaring a resolved memory collection enables one coherent capability. eve:
 - captures durable claims from accepted turns; and
 - enforces scope, provenance, approval, budget, revision, and erasure semantics.
 
-These behaviors are intrinsic. No configuration can create read-only, write-only, tools-off, or
-recall-disabled memory collections, and no flag disables capture; the one code-level escape hatch is
-`prepareSource`, which may skip any source for a collection. Data that should not be mutable by the
-agent belongs in instructions, RAG, application state, or an external system of record instead.
+These behaviors are intrinsic. No configuration can create read-only, write-only, tools-off, or recall-disabled memory collections, and no flag disables capture; the one code-level escape hatch is `prepareSource`, which may skip any source for a collection. Data that should not be mutable by the agent belongs in instructions, RAG, application state, or an external system of record instead.
 
-eve owns the slot grammar, trusted scope derivation, recall and mutation lifecycle, canonical public
-model, context rendering, and first-party provider integration. Applications own credentials,
-databases, stable environment identity, deployment preparation, retention, and authorization inputs.
+eve owns the slot grammar, trusted scope derivation, recall and mutation lifecycle, canonical public model, context rendering, and first-party provider integration. Applications own credentials, databases, stable environment identity, deployment preparation, retention, and authorization inputs.
 
 ## Boundary and invariants
 
-One memory file defines a **collection**: one purpose, provider, and subject scope. At runtime, its
-scope definition resolves one subject for the turn. A `user` collection can therefore contain many
-isolated users; the file is not itself one user.
+One memory file defines a **collection**: one purpose, provider, and subject scope. At runtime, its scope definition resolves one subject for the turn. A `user` collection can therefore contain many isolated users; the file is not itself one user.
 
 | Capability                                                        | Owner                                       | Memory |
 | ----------------------------------------------------------------- | ------------------------------------------- | ------ |
@@ -46,24 +38,15 @@ isolated users; the file is not itself one user.
 The design has eight invariants:
 
 1. A declared and resolved collection always provides the complete memory capability.
-2. Trusted runtime identity derives scope, and a channel-attested private audience gates disclosure;
-   model input controls neither.
-3. A versioned application, environment, graph-node, and collection-path namespace isolates every
-   collection while surviving redeploys in the same environment.
-4. Automatic and explicit recall are bounded, attributed, untrusted, and transient to the active
-   turn.
-5. Model-proposed memories require citations to eligible source text. eve verifies citation
-   integrity; semantic entailment remains an evaluation target rather than a security guarantee.
-6. Model mutations are idempotent and read-your-writes. Capture begins only from an accepted completed
-   turn and never changes that turn's response outcome.
-7. Forget and purge make content unreachable through every live memory operation. Payload-free
-   barriers prevent replay from recreating erased content.
-8. Canonical writes are durable and read-your-writes. Embeddings and indexes are rebuildable
-   projections that may lag only when stale candidates are revalidated against canonical state.
+2. Trusted runtime identity derives scope, and a channel-attested private audience gates disclosure; model input controls neither.
+3. A versioned application, environment, graph-node, and collection-path namespace isolates every collection while surviving redeploys in the same environment.
+4. Automatic and explicit recall are bounded, attributed, untrusted, and transient to the active turn.
+5. Model-proposed memories require citations to eligible source text. eve verifies citation integrity; semantic entailment remains an evaluation target rather than a security guarantee.
+6. Model mutations are idempotent and read-your-writes. Capture begins only from an accepted completed turn and never changes that turn's response outcome.
+7. Forget and purge make content unreachable through every live memory operation. Payload-free barriers prevent replay from recreating erased content.
+8. Canonical writes are durable and read-your-writes. Embeddings and indexes are rebuildable projections that may lag only when stale candidates are revalidated against canonical state.
 
-Records are atomic text claims with optional occurrence time, expiry, and citations. V1 does not
-impose `fact`, `preference`, or `episode` kinds because those labels do not yet produce distinct
-behavior.
+Records are atomic text claims with optional occurrence time, expiry, and citations. V1 does not impose `fact`, `preference`, or `episode` kinds because those labels do not yet produce distinct behavior.
 
 ## Authoring API
 
@@ -76,18 +59,9 @@ agent/memory/              # XOR with the flat file
   preferences.ts           # collection named "preferences"
 ```
 
-Every module default-exports `defineMemory(...)`. Identity comes from the path; there is no `name`
-field. The named directory is non-recursive and module-only. Invalid nesting and flat-file/directory
-collisions fail discovery. Collection slugs are lowercase snake case (`[a-z][a-z0-9_]*`) with a
-48-character maximum, so generated mutation tool names stay within eve's 64-character tool-name limit
-and never mix separator styles. Generated memory tool names are reserved: an authored tool that
-collides with `memory_recall` or a generated `memory_remember_*`/`memory_forget_*` name fails
-discovery, like subagent/tool name collisions. Shared code belongs in `agent/lib/`.
+Every module default-exports `defineMemory(...)`. Identity comes from the path; there is no `name` field. The named directory is non-recursive and module-only. Invalid nesting and flat-file/directory collisions fail discovery. Collection slugs are lowercase snake case (`[a-z][a-z0-9_]*`) with a 48-character maximum, so generated mutation tool names stay within eve's 64-character tool-name limit and never mix separator styles. Generated memory tool names are reserved: an authored tool that collides with `memory_recall` or a generated `memory_remember_*`/`memory_forget_*` name fails discovery, like subagent/tool name collisions. Shared code belongs in `agent/lib/`.
 
-Local directory-form subagents may declare the same slot. The graph node ID namespaces each
-collection, so declared subagents never share memory implicitly. The built-in `agent` tool invokes the
-root node and uses the root's collections. Single-file and remote subagents do not own local memory
-slots.
+Local directory-form subagents may declare the same slot. The graph node ID namespaces each collection, so declared subagents never share memory implicitly. The built-in `agent` tool invokes the root node and uses the root's collections. Single-file and remote subagents do not own local memory slots.
 
 ### Definition
 
@@ -104,8 +78,7 @@ export default defineMemory({
 });
 ```
 
-This collection automatically recalls, exposes all memory tools, and captures durable claims. Forget
-always requires approval.
+This collection automatically recalls, exposes all memory tools, and captures durable claims. Forget always requires approval.
 
 The public definition stays intentionally small:
 
@@ -137,8 +110,7 @@ type MemorySourcePreparer = (
 ) => string | null | Promise<string | null>;
 ```
 
-`MemoryProvider` and `MemoryScopeDefinition` are opaque eve values. V1 has no public custom provider,
-scope-resolver, extractor, embedder, tag schema, collection weight, tool toggle, or token-budget API.
+`MemoryProvider` and `MemoryScopeDefinition` are opaque eve values. V1 has no public custom provider, scope-resolver, extractor, embedder, tag schema, collection weight, tool toggle, or token-budget API.
 
 ### Capture configuration
 
@@ -160,42 +132,21 @@ capture: {
 },
 ```
 
-- `model` selects the capture-only model. It accepts a Gateway ID or direct AI SDK `LanguageModel`,
-  but not dynamic selection because a durable intent must pin one replayable model. Omission uses the
-  agent's compiled static model.
-- `reasoning` sets provider-agnostic AI SDK reasoning effort. With no model override, omission inherits
-  the agent setting. An overridden model uses its provider default unless set explicitly.
-- `modelOptions` forwards provider-specific options only to capture calls. With no model override,
-  omission inherits agent options and an explicit value replaces them. An overridden model inherits
-  no options.
-- `instructions` supplements eve's versioned extraction policy. It cannot expand eligible sources,
-  bypass citations, or weaken hard limits.
-- `prepareSource` is a capture-only minimization and redaction hook. It receives bounded normalized
-  inbound text and trusted collection, source, time, auth, and abort context. It returns transformed
-  text or `null` to skip capture for that source and collection. It does not alter response input,
-  automatic recall, or explicit remember citations. An unconditional `null` is the sanctioned
-  code-level way to run a collection without automatic capture; explicit remember and application
-  writes still work.
+- `model` selects the capture-only model. It accepts a Gateway ID or direct AI SDK `LanguageModel`, but not dynamic selection because a durable intent must pin one replayable model. Omission uses the agent's compiled static model.
+- `reasoning` sets provider-agnostic AI SDK reasoning effort. With no model override, omission inherits the agent setting. An overridden model uses its provider default unless set explicitly.
+- `modelOptions` forwards provider-specific options only to capture calls. With no model override, omission inherits agent options and an explicit value replaces them. An overridden model inherits no options.
+- `instructions` supplements eve's versioned extraction policy. It cannot expand eligible sources, bypass citations, or weaken hard limits.
+- `prepareSource` is a capture-only minimization and redaction hook. It receives bounded normalized inbound text and trusted collection, source, time, auth, and abort context. It returns transformed text or `null` to skip capture for that source and collection. It does not alter response input, automatic recall, or explicit remember citations. An unconditional `null` is the sanctioned code-level way to run a collection without automatic capture; explicit remember and application writes still work.
 
-V1 capture accepts only authored inbound text. It excludes assistant output, imported threads,
-channel/client context, instructions, reasoning, tool traffic, approvals, attachments, abandoned
-attempts, and uncommitted output.
+V1 capture accepts only authored inbound text. It excludes assistant output, imported threads, channel/client context, instructions, reasoning, tool traffic, approvals, attachments, abandoned attempts, and uncommitted output.
 
-**Recording action outcomes.** Assistant output is ineligible as capture source and citation evidence
-because it can be attacker-influenced through prompt injection. The sanctioned path for durable action
-memory — "the agent booked the 3pm flight" — is an application write: the tool that performs the
-action records the outcome through `ctx.getMemory(...)`, which commits with `origin: "application"`
-and needs no model citation.
+**Recording action outcomes.** Assistant output is ineligible as capture source and citation evidence because it can be attacker-influenced through prompt injection. The sanctioned path for durable action memory — "the agent booked the 3pm flight" — is an application write: the tool that performs the action records the outcome through `ctx.getMemory(...)`, which commits with `origin: "application"` and needs no model citation.
 
 ## Model tools
 
-Memory tools are intrinsic framework operations, not ordinary authored tools. They cannot be disabled,
-replaced, or independently configured. This deliberately diverges from the `disableTool()` sentinel
-available for framework default tools: declaring the collection is the opt-in, and the slot always
-carries its complete capability.
+Memory tools are intrinsic framework operations, not ordinary authored tools. They cannot be disabled, replaced, or independently configured. This deliberately diverges from the `disableTool()` sentinel available for framework default tools: declaring the collection is the opt-in, and the slot always carries its complete capability.
 
-The shared tool is `memory_recall`. The flat slot contributes `memory_remember` and `memory_forget`;
-named collections contribute `memory_remember_<collection>` and `memory_forget_<collection>`.
+The shared tool is `memory_recall`. The flat slot contributes `memory_remember` and `memory_forget`; named collections contribute `memory_remember_<collection>` and `memory_forget_<collection>`.
 
 ```ts
 interface MemoryRecallToolInput {
@@ -259,21 +210,11 @@ interface MemoryForgetToolResult {
 }
 ```
 
-`memory_recall` searches every resolved collection when `collection` is omitted. eve owns
-cross-collection allocation, rank fusion, deterministic ties, diversity, and the cumulative per-turn
-result budget. A partial recall returns usable memories plus sanitized collection failures; failure of
-every selected collection fails the tool. Provider scores and messages never reach the model.
+`memory_recall` searches every resolved collection when `collection` is omitted. eve owns cross-collection allocation, rank fusion, deterministic ties, diversity, and the cumulative per-turn result budget. A partial recall returns usable memories plus sanitized collection failures; failure of every selected collection fails the tool. Provider scores and messages never reach the model.
 
-Every framework-normalized source is rendered with a source handle. A remember citation is
-`{ sourceHandle, quote }`; the normalized quote must occur in that source. `supersedes` references the
-current memory handle. Recalled memory, assistant output, imported context, and tool results are
-ineligible evidence.
+Every framework-normalized source is rendered with a source handle. A remember citation is `{ sourceHandle, quote }`; the normalized quote must occur in that source. `supersedes` references the current memory handle. Recalled memory, assistant output, imported context, and tool results are ineligible evidence.
 
-Remember and forget are idempotent framework side effects. eve checkpoints a stable operation ID and
-exact request before execution, reports success only after the provider commits, and makes the result
-visible to later model steps. Replay returns the original result while its content remains live; after
-forget or purge it returns payload-free `erased` or `purged`. A later-abandoned response does not roll
-back a completed mutation.
+Remember and forget are idempotent framework side effects. eve checkpoints a stable operation ID and exact request before execution, reports success only after the provider commits, and makes the result visible to later model steps. Replay returns the original result while its content remains live; after forget or purge it returns payload-free `erased` or `purged`. A later-abandoned response does not roll back a completed mutation.
 
 Expected tool failures use stable codes:
 
@@ -281,29 +222,18 @@ Expected tool failures use stable codes:
 - `memory_revision_conflict`: the addressed revision or purge generation is stale;
 - `memory_handle_invalid`: the handle is malformed, tampered, or belongs to another scope;
 - `memory_citation_invalid`: the source handle or quote failed validation;
-- `memory_approval_unavailable`: the session cannot request the required forget approval because it
-  lacks the input capability; erase through the application or admin surface instead; and
+- `memory_approval_unavailable`: the session cannot request the required forget approval because it lacks the input capability; erase through the application or admin surface instead; and
 - `memory_recall_unavailable`: every selected collection failed, with sanitized collection codes.
 
-Forget approval rides the existing tool-approval pipeline. In a session that cannot park for input,
-`memory_forget` returns `memory_approval_unavailable` as an expected tool failure; it never parks a
-task turn or fails the turn.
+Forget approval rides the existing tool-approval pipeline. In a session that cannot park for input, `memory_forget` returns `memory_approval_unavailable` as an expected tool failure; it never parks a task turn or fails the turn.
 
-The failed `memory_recall_unavailable` result carries the same sanitized `failures` entries as a
-partial success and no provider messages or scores.
+The failed `memory_recall_unavailable` result carries the same sanitized `failures` entries as a partial success and no provider messages or scores.
 
-Memory content never enters durable transcript history: history stores payload-free placeholders that
-preserve call/result pairing, and validated transient turn content supplies the payloads, so erasure
-reaches every live surface. Workflow journals may retain normalized source envelopes under world
-retention.
+Memory content never enters durable transcript history: history stores payload-free placeholders that preserve call/result pairing, and validated transient turn content supplies the payloads, so erasure reaches every live surface. Workflow journals may retain normalized source envelopes under world retention.
 
 ## Application control
 
-Application code never uses a provider directly. `MemoryClient` is subject-bound: eve creates it only
-from matching current auth and private audience, and every method retains that sealed scope. A separate
-`MemoryAdminClient` is available only through the explicit trusted-operator route surface for data
-access, rectification, and erasure workflows. Public IDs, revision tokens, handles, and cursors are
-opaque strings.
+Application code never uses a provider directly. `MemoryClient` is subject-bound: eve creates it only from matching current auth and private audience, and every method retains that sealed scope. A separate `MemoryAdminClient` is available only through the explicit trusted-operator route surface for data access, rectification, and erasure workflows. Public IDs, revision tokens, handles, and cursors are opaque strings.
 
 ```ts
 interface MemoryRecordCitation {
@@ -416,39 +346,19 @@ type MemoryAdminClient = Omit<MemoryClient, "recall"> & {
 };
 ```
 
-Every method resolves to a plain value. Expected failures throw `MemoryOperationError` with a stable
-machine-readable `code` and a `retryable` flag, following the connection-error convention: guards
-match on `name` and `code` rather than `instanceof` because bundlers can duplicate class instances.
-`revision_conflict`, `idempotency_conflict`, `invalid_cursor`, and `export_invalidated` are never
-retryable; `unavailable` is the sanitized provider or deadline failure and is retryable. Benign
-outcomes — `not_found`, replay against erased content — are status values, not errors.
+Every method resolves to a plain value. Expected failures throw `MemoryOperationError` with a stable machine-readable `code` and a `retryable` flag, following the connection-error convention: guards match on `name` and `code` rather than `instanceof` because bundlers can duplicate class instances. `revision_conflict`, `idempotency_conflict`, `invalid_cursor`, and `export_invalidated` are never retryable; `unavailable` is the sanitized provider or deadline failure and is retryable. Benign outcomes — `not_found`, replay against erased content — are status values, not errors.
 
-A correction is a full replacement and requires both record ID and expected revision. Forget without
-an expected revision erases the current logical record; with one, a stale target throws
-`revision_conflict`. Application writes need no model citation, but framework bounds and encoding rules
-still apply. Public timestamps are RFC 3339 instants; limits must be finite positive integers and are
-clamped to eve's versioned maximum.
+A correction is a full replacement and requires both record ID and expected revision. Forget without an expected revision erases the current logical record; with one, a stale target throws `revision_conflict`. Application writes need no model citation, but framework bounds and encoding rules still apply. Public timestamps are RFC 3339 instants; limits must be finite positive integers and are clamped to eve's versioned maximum.
 
-An occurrence-time filter excludes records without `occurredAt`; without a filter those records remain
-eligible. `list` orders live records by `observedAt` descending and record ID ascending. Expired records
-are absent from recall, `get`, and `list`, but retained expired and superseded revisions remain in
-`exportRecords` until retention or erasure removes them.
+An occurrence-time filter excludes records without `occurredAt`; without a filter those records remain eligible. `list` orders live records by `observedAt` descending and record ID ascending. Expired records are absent from recall, `get`, and `list`, but retained expired and superseded revisions remain in `exportRecords` until retention or erasure removes them.
 
-An idempotency key binds scope, method, and normalized request. Exact replay returns the original
-result only while its content remains live. After forget or purge, replay returns payload-free
-`erased` or `purged`; it never returns deleted content or recreates the write. Changed input throws
-`idempotency_conflict`.
+An idempotency key binds scope, method, and normalized request. Exact replay returns the original result only while its content remains live. After forget or purge, replay returns payload-free `erased` or `purged`; it never returns deleted content or recreates the write. Changed input throws `idempotency_conflict`.
 
-Cursors bind collection, scope, purge generation, snapshot, and order. Invalid, expired, wrong-scope,
-or pre-purge cursors throw `invalid_cursor` rather than restarting. Export iterates one snapshot. If
-forget or purge changes retained content, the next iterator operation rejects with `export_invalidated`;
-only clean iterator completion means the export is complete. Sanitized provider availability failures
-throw `unavailable`; raw database errors and physical keys remain internal.
+Cursors bind collection, scope, purge generation, snapshot, and order. Invalid, expired, wrong-scope, or pre-purge cursors throw `invalid_cursor` rather than restarting. Export iterates one snapshot. If forget or purge changes retained content, the next iterator operation rejects with `export_invalidated`; only clean iterator completion means the export is complete. Sanitized provider availability failures throw `unavailable`; raw database errors and physical keys remain internal.
 
 ## Trusted scope and namespace
 
-V1 has one scope definition: `byPrincipal()`. It uses `auth.current`, requires
-`principalType: "user"`, and resolves this versioned tuple:
+V1 has one scope definition: `byPrincipal()`. It uses `auth.current`, requires `principalType: "user"`, and resolves this versioned tuple:
 
 ```ts
 type CanonicalMemoryPrincipalV1 = readonly [
@@ -460,13 +370,9 @@ type CanonicalMemoryPrincipalV1 = readonly [
 ];
 ```
 
-`issuer` is preferred when present; otherwise eve uses `authenticator`. Required strings must be
-non-empty. Attributes, display names, `subject`, and `auth.initiator` never define identity.
+`issuer` is preferred when present; otherwise eve uses `authenticator`. Required strings must be non-empty. Attributes, display names, `subject`, and `auth.initiator` never define identity.
 
-The local provider has one dev-only exception: the trusted dev host may inject a branded memory
-principal projection for the existing `local-dev` caller. This does not change `SessionAuthContext`,
-does not make the caller a `user` for connections or governance, and cannot exist outside the local
-provider capability described below.
+The local provider has one dev-only exception: the trusted dev host may inject a branded memory principal projection for the existing `local-dev` caller. This does not change `SessionAuthContext`, does not make the caller a `user` for connections or governance, and cannot exist outside the local provider capability described below.
 
 ```ts
 declare const deliveryAudienceBrand: unique symbol;
@@ -476,26 +382,11 @@ interface DeliveryAudience {
 }
 ```
 
-The unique-symbol brand provides TypeScript opacity only. Runtime unforgeability comes from a sealed
-token created and validated by module-private channel-runtime identity; copied, deserialized, payload-
-authored, and merely shape-compatible objects fail validation. Built-in channels attach the token
-internally. Trusted custom-channel route handlers receive `attestPrivateAudience(auth)` and may call it
-only after enforcing that every response path is restricted to that principal. The sealed value binds
-registered channel identity and the same principal tuple. Local subagents inherit the sealed root-turn
-audience and cannot remint it.
+The unique-symbol brand provides TypeScript opacity only. Runtime unforgeability comes from a sealed token created and validated by module-private channel-runtime identity; copied, deserialized, payload-authored, and merely shape-compatible objects fail validation. Built-in channels attach the token internally. Trusted custom-channel route handlers receive `attestPrivateAudience(auth)` and may call it only after enforcing that every response path is restricted to that principal. The sealed value binds registered channel identity and the same principal tuple. Local subagents inherit the sealed root-turn audience and cannot remint it.
 
-A collection resolves only when current principal and private audience match exactly. Missing,
-anonymous, non-user, shared, unknown, or mismatched identity makes the collection unavailable: no
-automatic recall, tools, capture, outbox, or application client. It never falls back to another scope.
-Unavailability is fail-closed but never fail-silent: eve emits a content-free resolution diagnostic (a
-trace event and a dev-time notice) naming the collection and the failed condition, and `/info`
-descriptors report per-collection resolution state for the current caller.
+A collection resolves only when current principal and private audience match exactly. Missing, anonymous, non-user, shared, unknown, or mismatched identity makes the collection unavailable: no automatic recall, tools, capture, outbox, or application client. It never falls back to another scope. Unavailability is fail-closed but never fail-silent: eve emits a content-free resolution diagnostic (a trace event and a dev-time notice) naming the collection and the failed condition, and `/info` descriptors report per-collection resolution state for the current caller.
 
-Before memory ships, eve delivery must preserve one immutable envelope per source containing source
-ID, order, provenance, auth, audience, and fingerprints. Payloads cannot mint attestations. Coalescing
-may combine model input only after compatible envelopes are grouped and never across auth or audience
-fingerprints. Built-in channels must enforce private destination ownership on send, continue, stream,
-cancel, and reset paths before they attest privacy.
+Before memory ships, eve delivery must preserve one immutable envelope per source containing source ID, order, provenance, auth, audience, and fingerprints. Payloads cannot mint attestations. Coalescing may combine model input only after compatible envelopes are grouped and never across auth or audience fingerprints. Built-in channels must enforce private destination ownership on send, continue, stream, cancel, and reset paths before they attest privacy.
 
 Canonical provider keys derive from this tuple and are passed as keyed opaque digests:
 
@@ -511,29 +402,13 @@ type CanonicalMemoryScopeV1 = readonly [
 ];
 ```
 
-`applicationId` and `environmentId` are stable provider configuration. Vercel integrations may derive
-them from project and target environment. Self-hosted applications must provide them explicitly;
-hostname, working directory, `NODE_ENV`, Git SHA, build path, and deployment ID are invalid fallbacks.
-`applicationId` is the sole stable root identity; package and display-name changes do not affect
-memory. `graphNodeId` is the root sentinel or path-derived local-subagent address. Redeployments in one
-environment share memory. Production, preview, development, different application IDs, nodes, paths,
-and app roots do not share implicitly. Node and collection path renames intentionally require
-migration.
+`applicationId` and `environmentId` are stable provider configuration. Vercel integrations may derive them from project and target environment. Self-hosted applications must provide them explicitly; hostname, working directory, `NODE_ENV`, Git SHA, build path, and deployment ID are invalid fallbacks. `applicationId` is the sole stable root identity; package and display-name changes do not affect memory. `graphNodeId` is the root sentinel or path-derived local-subagent address. Redeployments in one environment share memory. Production, preview, development, different application IDs, nodes, paths, and app roots do not share implicitly. Node and collection path renames intentionally require migration.
 
 ### V1 scope trade-off
 
-V1 memory exists only for authenticated `user` principals. Agents behind `none()` auth (anonymous
-callers), service and `runtime` principals, schedule-driven turns, and unknown identities never
-resolve a collection: a declared slot compiles, tools and capture stay absent, and the resolution
-diagnostic above is the only observable. The `local-dev` projection is the sole dev-time exception.
+V1 memory exists only for authenticated `user` principals. Agents behind `none()` auth (anonymous callers), service and `runtime` principals, schedule-driven turns, and unknown identities never resolve a collection: a declared slot compiles, tools and capture stay absent, and the resolution diagnostic above is the only observable. The `local-dev` projection is the sole dev-time exception.
 
-This is deliberate. Cross-subject disclosure is the dominant memory risk, and trusted identity is the
-only safe scope key, so V1 refuses to guess a subject. An agent-global `byAgent()` scope was
-considered and deferred: it has no cross-subject disclosure boundary, but every caller reads and
-writes one shared store, so persisted prompt injection from any caller reaches every caller, and
-neither citations nor approval isolate subjects within it. Shared and global scopes wait for the
-shared-scope disclosure semantics in the final delivery phase rather than shipping with weaker
-guarantees than the private scope.
+This is deliberate. Cross-subject disclosure is the dominant memory risk, and trusted identity is the only safe scope key, so V1 refuses to guess a subject. An agent-global `byAgent()` scope was considered and deferred: it has no cross-subject disclosure boundary, but every caller reads and writes one shared store, so persisted prompt injection from any caller reaches every caller, and neither citations nor approval isolate subjects within it. Shared and global scopes wait for the shared-scope disclosure semantics in the final delivery phase rather than shipping with weaker guarantees than the private scope.
 
 ### Application addressing
 
@@ -545,8 +420,7 @@ interface SessionContext {
 }
 ```
 
-Unknown collections throw; unavailable principal scope returns `null`. Route handlers can enumerate
-and address root and local-subagent collections:
+Unknown collections throw; unavailable principal scope returns `null`. Route handlers can enumerate and address root and local-subagent collections:
 
 ```ts
 type MemoryNodeAddress =
@@ -587,27 +461,13 @@ interface RouteHandlerArgs {
 }
 ```
 
-Enumeration is root first, then local node ID and collection name. Node IDs are opaque values obtained
-from enumeration, not constructed by applications. Remote subagents own memory remotely.
+Enumeration is root first, then local node ID and collection name. Node IDs are opaque values obtained from enumeration, not constructed by applications. Remote subagents own memory remotely.
 
-`getMemory(...)` requires a verified principal and an attested private audience — a handler lacking
-either has nothing to pass and must not call it — and returns `null` only when that auth does not
-resolve the collection's scope. The subject binding covers the entire client, including mutations,
-because its results may flow into that response.
+`getMemory(...)` requires a verified principal and an attested private audience — a handler lacking either has nothing to pass and must not call it — and returns `null` only when that auth does not resolve the collection's scope. The subject binding covers the entire client, including mutations, because its results may flow into that response.
 
-`getMemoryAdmin(...)` requires no subject audience and never impersonates the subject. A
-`MemoryPrincipalAddress` canonicalizes exactly as scope resolution would — `issuer` is the authority
-when present, otherwise `authenticator` — and admin lookups match only that canonical tuple, with no
-fuzzy or cross-authority matching, so an operator must supply the same authority the records were
-written under. Unknown addresses and malformed principal addresses throw; the call never returns
-`null` because admin access does not depend on subject scope resolution. The application must
-authorize the operator before the call; eve records the operator fingerprint, reason, target,
-operation, and outcome. Admin clients are never exposed to model tools, callbacks, dynamic resolvers,
-or serialized payloads.
+`getMemoryAdmin(...)` requires no subject audience and never impersonates the subject. A `MemoryPrincipalAddress` canonicalizes exactly as scope resolution would — `issuer` is the authority when present, otherwise `authenticator` — and admin lookups match only that canonical tuple, with no fuzzy or cross-authority matching, so an operator must supply the same authority the records were written under. Unknown addresses and malformed principal addresses throw; the call never returns `null` because admin access does not depend on subject scope resolution. The application must authorize the operator before the call; eve records the operator fingerprint, reason, target, operation, and outcome. Admin clients are never exposed to model tools, callbacks, dynamic resolvers, or serialized payloads.
 
-Aggregate data-subject export and purge iterate descriptors and acquire one admin client per
-collection. Arbitrary future custom scopes must register enumerable subject mappings. `/info` may
-expose descriptors for inspection, never subjects or content.
+Aggregate data-subject export and purge iterate descriptors and acquire one admin client per collection. Arbitrary future custom scopes must register enumerable subject mappings. `/info` may expose descriptors for inspection, never subjects or content.
 
 ## Sources and lifecycle
 
@@ -620,22 +480,11 @@ eve maintains two immutable views instead of overloading “prepared source”:
 | Framework-normalized source | Once per accepted authored source | Recall query, response source handles, explicit citations   |
 | Capture-prepared source     | Per source and collection         | Capture model, capture validation, capture-origin citations |
 
-Framework normalization identifies authored text before adapters merge model messages, converts it to
-well-formed NFC Unicode, normalizes line endings, removes blank parts, joins ordered text parts, and
-applies a versioned UTF-8 bound. It preserves case, punctuation, and remaining whitespace. Each source
-retains its ID, normalization version, digest, order, provenance, trusted time, auth, and audience
-fingerprints.
+Framework normalization identifies authored text before adapters merge model messages, converts it to well-formed NFC Unicode, normalizes line endings, removes blank parts, joins ordered text parts, and applies a versioned UTF-8 bound. It preserves case, punctuation, and remaining whitespace. Each source retains its ID, normalization version, digest, order, provenance, trusted time, auth, and audience fingerprints.
 
-`prepareSource` transforms only the second view. Returning `null` skips capture for that collection;
-it does not suppress recall or invalidate explicit source handles. Response-model handles bind the
-normalized digest. Model-tool citations bind normalized byte offsets; capture citations bind the
-prepared digest, preparation fingerprint, and prepared byte offsets. Recall returns stored immutable
-citations and never reruns preparation.
+`prepareSource` transforms only the second view. Returning `null` skips capture for that collection; it does not suppress recall or invalidate explicit source handles. Response-model handles bind the normalized digest. Model-tool citations bind normalized byte offsets; capture citations bind the prepared digest, preparation fingerprint, and prepared byte offsets. Recall returns stored immutable citations and never reruns preparation.
 
-Normalized source envelopes live in the world/session journal under world retention. Memory providers
-retain only revision-owned cited excerpts and payload-free source receipts, not complete source
-objects. Memory erasure does not claim physical deletion from world journals, transcripts, telemetry,
-or model-provider retention.
+Normalized source envelopes live in the world/session journal under world retention. Memory providers retain only revision-owned cited excerpts and payload-free source receipts, not complete source objects. Memory erasure does not claim physical deletion from world journals, transcripts, telemetry, or model-provider retention.
 
 ### Turn lifecycle
 
@@ -657,13 +506,9 @@ commit terminal turn checkpoint + capture outbox
 settle response -> prepare per collection -> dispatch capture
 ```
 
-This requires new execution primitives before the public API ships. eve must own model retries, disable
-nested SDK retries, preserve source provenance through coalescing, and commit terminal classification
-with durable session state. Stream events remain append-only and may already be visible; capture
-eligibility derives only from the durable checkpoint.
+This requires new execution primitives before the public API ships. eve must own model retries, disable nested SDK retries, preserve source provenance through coalescing, and commit terminal classification with durable session state. Stream events remain append-only and may already be visible; capture eligibility derives only from the durable checkpoint.
 
-The checkpoint records the durable protocol outcome and accepted sources. It is internal execution
-machinery, not public API; it appears here only to define capture eligibility:
+The checkpoint records the durable protocol outcome and accepted sources. It is internal execution machinery, not public API; it appears here only to define capture eligibility:
 
 ```ts
 interface TurnTerminalCheckpoint {
@@ -684,55 +529,27 @@ interface TurnTerminalCheckpoint {
 | Adapter consumes delivery without a turn    | No checkpoint | Never                                |
 | Workflow replay                             | Same outcome  | Idempotent using the same source IDs |
 
-A completed checkpoint creates no outbox for an unresolved collection. For a resolved collection, no
-authored text or a `null`/blank prepared source produces an internal `skipped` status. Capture retries
-transient failures; exhausted retries become `failed`, and stale generation or definition becomes
-`obsolete`. These content-free statuses appear in traces and diagnostics only. V1 exposes no capture
-polling or freshness barrier. A following turn may not observe capture; callers needing read-after-write
-use explicit remember or an application write.
+A completed checkpoint creates no outbox for an unresolved collection. For a resolved collection, no authored text or a `null`/blank prepared source produces an internal `skipped` status. Capture retries transient failures; exhausted retries become `failed`, and stale generation or definition becomes `obsolete`. These content-free statuses appear in traces and diagnostics only. V1 exposes no capture polling or freshness barrier. A following turn may not observe capture; callers needing read-after-write use explicit remember or an application write.
 
 ### Recall
 
-Recall runs after compaction and before the first response-model request. Its query uses the latest
-framework-normalized input plus a bounded visible window for coreference. It combines relevant and
-recent candidates under one token and wall-clock budget.
+Recall runs after compaction and before the first response-model request. Its query uses the latest framework-normalized input plus a bounded visible window for coreference. It combines relevant and recent candidates under one token and wall-clock budget.
 
-Transient provider and deadline failures do not fail the turn. Successful collections still
-contribute; each failed collection contributes only a content-free `unavailable` status and emits a
-diagnostic. If every collection fails, the response model still runs with that status rather than an
-empty-memory result. Scope, generation, expiry, signature, and canonical-integrity checks remain
-fail-closed for disclosure: invalid content is never supplied.
+Transient provider and deadline failures do not fail the turn. Successful collections still contribute; each failed collection contributes only a content-free `unavailable` status and emits a diagnostic. If every collection fails, the response model still runs with that status rather than an empty-memory result. Scope, generation, expiry, signature, and canonical-integrity checks remain fail-closed for disclosure: invalid content is never supplied.
 
-The explicit recall tool uses the same partial-success representation. When every explicitly selected
-collection fails, the tool returns `memory_recall_unavailable` so the model can react inside the loop;
-automatic recall instead places the equivalent status before the first model call. This preserves agent
-availability without representing an outage as “the user has no memories.”
+The explicit recall tool uses the same partial-success representation. When every explicitly selected collection fails, the tool returns `memory_recall_unavailable` so the model can react inside the loop; automatic recall instead places the equivalent status before the first model call. This preserves agent availability without representing an outage as “the user has no memories.”
 
-The contribution is a length-delimited data block attributed by collection name, purpose, handle,
-revision time, and available citation. A fixed trusted instruction identifies it as untrusted data. It
-does not change eve permission or approval gates, although stored prompt injection can still influence
-the model.
+The contribution is a length-delimited data block attributed by collection name, purpose, handle, revision time, and available citation. A fixed trusted instruction identifies it as untrusted data. It does not change eve permission or approval gates, although stored prompt injection can still influence the model.
 
-Immediately before each eve-owned model request, eve rechecks scope, purge generation, expiry,
-definition fingerprint, and exact revisions. An unrelated write causes rehydration rather than whole-
-collection invalidation. A projection can nominate candidates only; canonical rehydration prevents
-superseded, expired, erased, or purged content from reappearing.
+Immediately before each eve-owned model request, eve rechecks scope, purge generation, expiry, definition fingerprint, and exact revisions. An unrelated write causes rehydration rather than whole-collection invalidation. A projection can nominate candidates only; canonical rehydration prevents superseded, expired, erased, or purged content from reappearing.
 
 ### Capture
 
-For every collection resolved at turn admission, a completed checkpoint creates a payload-free outbox
-entry that references accepted normalized sources and pins collection, scope, purge generation,
-provider fingerprint and incarnation, preparation fingerprint, model and extraction versions, source
-sequence, audience, time, and provenance. It never reruns scope resolution. A provider-incarnation
-mismatch is terminal `obsolete` and cannot adopt a replacement store.
+For every collection resolved at turn admission, a completed checkpoint creates a payload-free outbox entry that references accepted normalized sources and pins collection, scope, purge generation, provider fingerprint and incarnation, preparation fingerprint, model and extraction versions, source sequence, audience, time, and provenance. It never reruns scope resolution. A provider-incarnation mismatch is terminal `obsolete` and cannot adopt a replacement store.
 
-Capture executes as a durable, idempotent workflow against one strong canonical snapshot: the pinned
-model proposes add, supersede, or no-op operations with exact citations, and eve verifies preparation
-hashes, byte offsets, bounds, and revision expectations before committing the exact proposal with a
-replay receipt. Conflicts re-propose against fresh state rather than blindly retrying.
+Capture executes as a durable, idempotent workflow against one strong canonical snapshot: the pinned model proposes add, supersede, or no-op operations with exact citations, and eve verifies preparation hashes, byte offsets, bounds, and revision expectations before committing the exact proposal with a replay receipt. Conflicts re-propose against fresh state rather than blindly retrying.
 
-Each scope has a monotonic source sequence. A delayed older turn may add a historical event but cannot
-supersede state learned from a newer source.
+Each scope has a monotonic source sequence. A delayed older turn may add a historical event but cannot supersede state learned from a newer source.
 
 ## Canonical model and erasure
 
@@ -747,43 +564,23 @@ supersede state learned from a newer source.
 | Erasure receipts      | Payload-free deletion evidence            | operation, target or generation, key version, time              |
 | Admin audit events    | Trusted-operator accountability           | operator fingerprint, reason, target, operation, outcome, time  |
 
-`observedAt` is canonical commit time, `occurredAt` is optional event time, and `expiresAt` excludes a
-record at or after its deadline according to the provider's trusted clock. Recall, `get`, and `list`
-exclude expired records; export includes retained expired revisions until retention or erasure removes
-them.
+`observedAt` is canonical commit time, `occurredAt` is optional event time, and `expiresAt` excludes a record at or after its deadline according to the provider's trusted clock. Recall, `get`, and `list` exclude expired records; export includes retained expired revisions until retention or erasure removes them.
 
-Corrections append a revision under one logical ID and require the current revision token. CAS ensures
-one current revision. Stale remember and forget handles conflict rather than changing newer data. V1
-has no implicit decay, confidence score, autonomous inference, or graph relation.
+Corrections append a revision under one logical ID and require the current revision token. CAS ensures one current revision. Stale remember and forget handles conflict rather than changing newer data. V1 has no implicit decay, confidence score, autonomous inference, or graph relation.
 
-Forget removes one logical record, its revisions, and revision-owned evidence from live operations.
-It does not find semantically duplicated claims; scope purge is the complete live-memory erasure
-operation. Payload-free receipts and generation barriers remain for at least the maximum replay and
-idempotency horizon. Accepted mutation receipts shed content when their target is erased and resolve
-future replay to `erased` or `purged`. Receipts are pseudonymous operational data, not literally
-data-free.
+Forget removes one logical record, its revisions, and revision-owned evidence from live operations. It does not find semantically duplicated claims; scope purge is the complete live-memory erasure operation. Payload-free receipts and generation barriers remain for at least the maximum replay and idempotency horizon. Accepted mutation receipts shed content when their target is erased and resolve future replay to `erased` or `purged`. Receipts are pseudonymous operational data, not literally data-free.
 
-Restoring an older database requires replaying a separately retained erasure ledger before traffic
-resumes. Physical database remnants, replicas, backups, workflow journals, transcripts, telemetry, and
-model-provider retention remain governed by their own policies.
+Restoring an older database requires replaying a separately retained erasure ledger before traffic resumes. Physical database remnants, replicas, backups, workflow journals, transcripts, telemetry, and model-provider retention remain governed by their own policies.
 
 ## Provider boundary
 
-V1 publicly exposes only opaque first-party `MemoryProvider` values. A provider owns persistence,
-within-collection retrieval, projections, readiness, and migration. eve owns scope, canonical public
-semantics, citations, handles, tools, idempotency orchestration, deadlines, cross-collection fusion,
-budgets, rendering, and final disclosure validation.
+V1 publicly exposes only opaque first-party `MemoryProvider` values. A provider owns persistence, within-collection retrieval, projections, readiness, and migration. eve owns scope, canonical public semantics, citations, handles, tools, idempotency orchestration, deadlines, cross-collection fusion, budgets, rendering, and final disclosure validation.
 
-The internal protocol must prove namespace isolation, durable canonical writes, strong formation
-reads, revision CAS, expiry, erase, purge barriers, bounded snapshot export, stale-projection
-rehydration, readiness, cancellation, limits, fingerprints, retention horizons, and race behavior.
-Public third-party support waits for production evidence and a branded provider API plus conformance
-kit.
+The internal protocol must prove namespace isolation, durable canonical writes, strong formation reads, revision CAS, expiry, erase, purge barriers, bounded snapshot export, stale-projection rehydration, readiness, cancellation, limits, fingerprints, retention horizons, and race behavior. Public third-party support waits for production evidence and a branded provider API plus conformance kit.
 
 ### PostgreSQL reference provider
 
-PostgreSQL owns both document and query embedding. `defineMemory` never accepts an embedding model;
-managed future providers may embed upstream or use a different retrieval strategy entirely.
+PostgreSQL owns both document and query embedding. `defineMemory` never accepts an embedding model; managed future providers may embed upstream or use a different retrieval strategy entirely.
 
 ```ts
 interface MemoryEmbeddingCallOptions {
@@ -848,43 +645,15 @@ export const memory = postgresMemory({
 });
 ```
 
-`memoryNamespace` must derive the current stable application and target environment. Never hardcode an
-environment name in shared source: preview and production must resolve different values, and a missing
-or ambiguous value fails provider readiness. The Vercel integration owns this derivation for the
-majority path: a first-party helper resolves `applicationId` from the project and `environmentId` from
-the target environment, so a Vercel-deployed application writes no namespace code. Self-hosted
-applications provide both explicitly.
+`memoryNamespace` must derive the current stable application and target environment. Never hardcode an environment name in shared source: preview and production must resolve different values, and a missing or ambiguous value fails provider readiness. The Vercel integration owns this derivation for the majority path: a first-party helper resolves `applicationId` from the project and `environmentId` from the target environment, so a Vercel-deployed application writes no namespace code. Self-hosted applications provide both explicitly.
 
-The embedding model accepts a Gateway ID or direct AI SDK `EmbeddingModel`. Query and document call
-options may separately provide provider options for role-specific APIs. `modelRevision` defaults to the
-Gateway ID when `model` is a string; a direct `EmbeddingModel` instance, mutable alias, middleware, or
-custom endpoint requires an explicit revision because eve cannot derive a stable identity from it.
-Dimensions are required and verified because AI SDK models do not report them reliably.
+The embedding model accepts a Gateway ID or direct AI SDK `EmbeddingModel`. Query and document call options may separately provide provider options for role-specific APIs. `modelRevision` defaults to the Gateway ID when `model` is a string; a direct `EmbeddingModel` instance, mutable alias, middleware, or custom endpoint requires an explicit revision because eve cannot derive a stable identity from it. Dimensions are required and verified because AI SDK models do not report them reliably.
 
-Retrieval strategy is a provider implementation choice, not an author knob. V1 uses hybrid recall —
-lexical, vector, and recency lanes fused deterministically within the collection — over canonical
-rows; eve rehydrates canonical state and fuses collections. A canonical write is durable and
-read-your-writes even when its embedding has not yet committed; embeddings are rebuildable projections
-that commit only while they still match canonical state. Query-embedding failure is an operational
-recall failure, never an empty result; automatic recall reports the collection as `unavailable` under
-the policy above. Stable PostgreSQL memory has no lexical-only mode.
+Retrieval strategy is a provider implementation choice, not an author knob. V1 uses hybrid recall — lexical, vector, and recency lanes fused deterministically within the collection — over canonical rows; eve rehydrates canonical state and fuses collections. A canonical write is durable and read-your-writes even when its embedding has not yet committed; embeddings are rebuildable projections that commit only while they still match canonical state. Query-embedding failure is an operational recall failure, never an empty result; automatic recall reports the collection as `unavailable` under the policy above. Stable PostgreSQL memory has no lexical-only mode.
 
-Every retrieval-affecting choice — model identity and revision, dimensions, call options,
-preprocessing, ranking, and fusion version — is covered by one projection fingerprint. Changing any of
-them builds a side-by-side projection generation and activates it atomically only after backfill.
-Runtime readiness verifies schema, pgvector, the active fingerprint, and completed backfill before a
-session uses memory.
+Every retrieval-affecting choice — model identity and revision, dimensions, call options, preprocessing, ranking, and fusion version — is covered by one projection fingerprint. Changing any of them builds a side-by-side projection generation and activates it atomically only after backfill. Runtime readiness verifies schema, pgvector, the active fingerprint, and completed backfill before a session uses memory.
 
-`PostgresMemoryDatabase` and `PostgresMemoryProvider` are opaque branded values. `pgDatabase(pool)`
-accepts the structural lease contract above, never closes it, and adds no `pg` runtime dependency.
-Connections and queries must honor the supplied abort signal, including blocked acquisition and
-in-flight cancellation. `preparePostgresMemory(...)` runs migrations, canary validation, backfill, and
-projection activation; applications invoke it from a deploy-time step — a build command on Vercel, a
-migration job self-hosted — before new code serves traffic. eve never migrates implicitly: `eve dev`
-and `eve start` fail readiness rather than migrate on demand, and a failed prepare rejects without
-changing the active generation. Namespace migration freezes old writers and preserves purge
-generations and receipts. PostgreSQL erasure guarantees live logical unreachability, not immediate
-sanitization of MVCC pages, WAL, replicas, snapshots, or backups.
+`PostgresMemoryDatabase` and `PostgresMemoryProvider` are opaque branded values. `pgDatabase(pool)` accepts the structural lease contract above, never closes it, and adds no `pg` runtime dependency. Connections and queries must honor the supplied abort signal, including blocked acquisition and in-flight cancellation. `preparePostgresMemory(...)` runs migrations, canary validation, backfill, and projection activation; applications invoke it from a deploy-time step — a build command on Vercel, a migration job self-hosted — before new code serves traffic. eve never migrates implicitly: `eve dev` and `eve start` fail readiness rather than migrate on demand, and a failed prepare rejects without changing the active generation. Namespace migration freezes old writers and preserves purge generations and receipts. PostgreSQL erasure guarantees live logical unreachability, not immediate sanitization of MVCC pages, WAL, replicas, snapshots, or backups.
 
 ### Test and local providers
 
@@ -903,10 +672,7 @@ export default defineMemory({
 });
 ```
 
-The controller provides a fixed controllable clock, queued `snapshot()` and `reset()` operations, and
-an opaque provider. It performs no filesystem, network, wall-clock, random, or timer access. It enforces
-the real canonical, CAS, idempotency, expiry, citation, erase, purge, and cursor semantics rather than
-acting as a permissive fake.
+The controller provides a fixed controllable clock, queued `snapshot()` and `reset()` operations, and an opaque provider. It performs no filesystem, network, wall-clock, random, or timer access. It enforces the real canonical, CAS, idempotency, expiry, citation, erase, purge, and cursor semantics rather than acting as a permissive fake.
 
 Local development selects an explicit provider; eve never silently substitutes it for PostgreSQL:
 
@@ -916,102 +682,27 @@ import { localMemory } from "eve/memory/local";
 export const memory = localMemory();
 ```
 
-`localMemory()` uses `DatabaseSync` directly from Node's built-in `node:sqlite`, adding no package,
-ORM, native addon, or database adapter. It stores canonical state in
-`.eve/memory/v1/local.sqlite`, enables WAL, and commits mutations with SQLite transactions. The path is
-rooted at the authored app rather than a generated snapshot, so memory survives hot reloads, worker
-replacement, `/new`, and `eve dev` restarts. Schema readiness gates generation activation; migrations
-require quiesced dev workers, and transactions fence the schema version and store incarnation.
+`localMemory()` uses `DatabaseSync` directly from Node's built-in `node:sqlite`, adding no package, ORM, native addon, or database adapter. It stores canonical state in `.eve/memory/v1/local.sqlite`, enables WAL, and commits mutations with SQLite transactions. The path is rooted at the authored app rather than a generated snapshot, so memory survives hot reloads, worker replacement, `/new`, and `eve dev` restarts. Schema readiness gates generation activation; migrations require quiesced dev workers, and transactions fence the schema version and store incarnation.
 
-The local provider stores no embeddings or search projection. It loads a bounded live scope and uses a
-shared versioned deterministic JavaScript ranker with lexical, fuzzy, and recent lanes. This is for
-lifecycle development and predictable tests, not evidence of production recall quality.
+The local provider stores no embeddings or search projection. It loads a bounded live scope and uses a shared versioned deterministic JavaScript ranker with lexical, fuzzy, and recent lanes. This is for lifecycle development and predictable tests, not evidence of production recall quality.
 
-The loopback dev channel retains its existing `local-dev` auth identity. The trusted dev host supplies
-a separate module-private memory principal and private audience, with session ownership enforced on all
-lifecycle routes. This does not make the synthetic caller a user for connections, permissions, or
-authored callbacks.
+The loopback dev channel retains its existing `local-dev` auth identity. The trusted dev host supplies a separate module-private memory principal and private audience, with session ownership enforced on all lifecycle routes. This does not make the synthetic caller a user for connections, permissions, or authored callbacks.
 
-Local inspection and reset are available through `eve memory path|ls|show|recall|reset`. These
-commands operate on the local provider's SQLite store only; they never connect to a production
-provider. Content is redacted from framework traces by default. The provider creates app-local ignore
-protection for `.eve/memory`, and build/deployment adapters hard-exclude it. Corruption fails closed
-and explicit reset quarantines the database, WAL, and SHM before creating a new incarnation.
+Local inspection and reset are available through `eve memory path|ls|show|recall|reset`. These commands operate on the local provider's SQLite store only; they never connect to a production provider. Content is redacted from framework traces by default. The provider creates app-local ignore protection for `.eve/memory`, and build/deployment adapters hard-exclude it. Corruption fails closed and explicit reset quarantines the database, WAL, and SHM before creating a new incarnation.
 
-The test and local providers are rejected by `eve build` and `eve start`; mounting additionally requires
-a module-private test or `eve dev` runtime capability rather than an environment variable. There is no
-production escape hatch or automatic migration to PostgreSQL.
-
-## Delivery plan
-
-1. **Source provenance (standalone).** Add sealed per-source envelopes, framework normalization, and
-   fingerprint-grouped coalescing. This fixes an existing attribution defect — batch coalescing keeps
-   only the most recent delivery's auth — and changes core delivery behavior for all agents: model
-   input is grouped by compatible envelopes and never merged across auth or audience fingerprints. It
-   lands independently of memory.
-2. **Lifecycle proof.** Add transient turn overlays, eve-owned model attempts, checkpointed mutations,
-   terminal outcomes, and the capture outbox. The overlay/placeholder-history mechanism is the
-   highest-risk component and gates on dedicated failure-mode tests across compaction, replay, and
-   streaming before anything depends on it. No public memory API.
-3. **Private retrieval proof.** Add PostgreSQL canonical storage, embedding configuration, lexical and
-   vector projections, fingerprint generations, hybrid fusion, readiness, and quality evaluation. No
-   public memory API.
-4. **Complete private principal memory.** Add the slot, `byPrincipal()`, intrinsic tools, capture,
-   application clients, node enumeration, erase, purge, export, local/test providers, diagnostics,
-   migration, restore, and race tests.
-5. **Public V1.** Ship only after hybrid quality, latency, cost, failure, erasure, migration, and restore
-   gates pass.
-6. **Advanced scopes and providers.** Add shared and agent-global scopes and custom resolvers, then
-   stabilize the public provider protocol from production evidence.
-
-Integration packages may export providers and, after V1, scope definitions, but do not contribute
-memory slots. The consuming agent owns collection paths, credentials, scope, and capture configuration.
-
-## Verification and evaluation
-
-Deterministic tests cover namespace/principal isolation, private audiences, source provenance,
-normalization, token/deadline budgets, transient history, checkpointed mutations, capture eligibility,
-idempotency, CAS, citation offsets, stale ordering, expiry, erase, purge, restore barriers, projection
-lag, and PostgreSQL races.
-
-Scenario tests prove that one user can remember, recall, correct, export, forget, and purge across
-sessions and redeploys in one environment while another never observes or mutates the content. They
-cover root and local-subagent collections, explicit tools, capture, retries, application writes, and
-the immediately-following-turn freshness caveat.
-
-Quality gates report formation and retrieval separately: extraction precision/recall, entailment,
-duplication, correction, temporal accuracy, Recall@k, NDCG, abstention, answer improvement/harm, prompt
-injection, secret capture, p50/p95 latency, capture lag, tokens, cost, and failure rate. Failed requests
-remain in headline metrics. LoCoMo, LongMemEval, BEAM, and MemoryBench inform quality under pinned
-models, datasets, and context budgets but do not replace isolation, deletion, concurrency, provenance,
-and prompt-structure tests.
+The test and local providers are rejected by `eve build` and `eve start`; mounting additionally requires a module-private test or `eve dev` runtime capability rather than an environment variable. There is no production escape hatch or automatic migration to PostgreSQL.
 
 ## Out of scope
 
-- Read-only, write-only, recall-disabled, or tool-disabled memory collections, and configuration
-  flags that disable capture (`prepareSource` is the code-level per-source skip).
+- Read-only, write-only, recall-disabled, or tool-disabled memory collections, and configuration flags that disable capture (`prepareSource` is the code-level per-source skip).
 - A mutable `MEMORY.md` canonical store or model-managed memory filesystem.
 - A hosted memory service, transcript store, RAG store, or application system of record.
 - Capturing assistant output, reasoning, tool payloads, attachments, or imported context in V1.
 - Shared scopes, multiple scopes per collection, or implicit sharing in V1.
-- Tags, typed record kinds, profiles, graph relations, confidence, autonomous inference, decay, or
-  autonomous instruction modification.
+- Tags, typed record kinds, profiles, graph relations, confidence, autonomous inference, decay, or autonomous instruction modification.
 - Public custom extractor, embedder, or provider interfaces in V1.
 - Raw-source retention and reprocessing as a provider feature.
-- Physical sanitization guarantees for database remnants, replicas, backups, workflow journals,
-  transcripts, logs, telemetry, or model-provider retention.
-
-## Questions the experiment should answer
-
-- How often do users invoke remember explicitly versus relying on capture?
-- How much desired durable memory originates in assistant output or tool results, and does the
-  application-write path close that gap?
-- Does bounded conversational query context materially improve retrieval?
-- Does a small query-independent preference lane improve personalization without profile complexity?
-- Which capture-source preparation controls are practical?
-- What hybrid candidate depths and reranking meet quality gates at acceptable latency and cost?
-- Which use cases ultimately justify tags, typed records, custom extractors, or graph relations?
-- Which future scope conventions can support aggregate data-subject erasure?
+- Physical sanitization guarantees for database remnants, replicas, backups, workflow journals, transcripts, logs, telemetry, or model-provider retention.
 
 ## Primary references
 

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -60,10 +60,12 @@ Local directory-form subagents may declare their own memory slots. Graph-node id
 
 ## Scope
 
-The low-level scope definition returns one ordered tuple of opaque, trusted identifiers or `null`:
+The low-level scope definition returns, or asynchronously resolves, one ordered tuple of opaque, trusted identifiers or `null`:
 
 ```ts
-type MemoryScopeDefinition = (context: MemoryScopeContext) => readonly MemoryScopePart[] | null;
+type MemoryScopeDefinition = (
+  context: MemoryScopeContext,
+) => readonly MemoryScopePart[] | null | Promise<readonly MemoryScopePart[] | null>;
 ```
 
 Scope parts come from trusted auth, application, or channel context. They cannot come from model input or unattested message fields. Parts have no built-in entity types, and no position has special meaning. `[userId, channelId]` means only that both values participate in the provider partition. `byPrincipal()` is sugar for the common authenticated-principal tuple.
@@ -81,7 +83,7 @@ interface MemoryScope {
 
 The key gives providers one collision-resistant partition identifier. The parts remain available when a vendor needs to map the partition onto its own user, workspace, or container concepts. Both are absent from model-facing schemas.
 
-eve resolves scope after admitting the turn but before any automatic compaction, then locks it through the completed-turn handler. For standalone manual compaction, eve resolves and locks scope for that operation from the session's trusted runtime context. Returning `null` makes the slot unavailable for the entire turn or manual operation: eve does not invoke its provider handlers or lower its tools. Missing values never fall back to a broader partition. Changing the meaning or order of scope parts is a provider data migration.
+eve awaits scope after admitting the turn but before any automatic compaction, then locks it through the completed-turn handler. This allows a resolver to consult an external authorization or tenancy service without exposing that lookup to the model. For standalone manual compaction, eve resolves and locks scope for that operation from the session's trusted runtime context. Returning `null` makes the slot unavailable for the entire turn or manual operation: eve does not invoke its provider handlers or lower its tools. Missing values never fall back to a broader partition. Changing the meaning or order of scope parts is a provider data migration.
 
 eve guarantees that every invocation for one slot within the turn or manual operation receives the same locked value. If a memory tool pauses for approval, eve retains that value for the pending invocation and accepts the approval response only from the principal that initiated it. A response from another principal fails before the tool is resolved or executed. The provider is responsible for actually applying the scope value to downstream storage and service calls; eve cannot enforce isolation inside provider code or an external service.
 

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -18,9 +18,9 @@ eve owns only two pieces:
 The provider owns everything else: storage, recall, capture, model tools, formatting, extraction, ranking, limits, retention, and any record or document model. A hosted semantic service and a pair of bounded text files can therefore implement the same memory slot without pretending to share lower-level semantics.
 
 ```text
-turn prepared    eve scope + visible session ---> provider events ---> transient context
-                 eve scope + visible session ---> provider tools  ---> scoped model tools
-turn completed   eve scope + settled session ---> provider events ---> provider side effects
+turn prepared    scope + session ---> events ---> transient context
+                 scope + session ---> tools  ---> scoped model tools
+turn completed   scope + session ---> events ---> provider side effects
 ```
 
 This document defines that authoring boundary and its observable lifecycle. Provider packaging, vendor configuration, and provider-specific persistence remain follow-up work.

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -8,357 +8,216 @@ last_updated: "2026-08-05"
 
 ## Proposal
 
-Memory lets an agent carry useful knowledge across sessions. Unlike conversation history, memory is a durable, scoped collection of claims that the agent can recall, add, revise, and erase.
+Memory is a path-authored slot that lets an agent carry provider-defined context and behavior across sessions. Its presence in the agent filesystem makes memory an explicit framework capability without requiring eve to define what a memory is or how one works.
 
-Declaring a resolved memory collection enables one lifecycle:
+eve owns only two pieces:
+
+1. **Authored identity.** Each memory file is a named slot with path-derived identity.
+2. **Scope.** eve resolves and locks a trusted partition for that slot, then supplies the same partition to every provider hook and provider-defined tool in the turn.
+
+The provider owns everything else: storage, recall, capture, model tools, formatting, extraction, ranking, limits, retention, and any record or document model. A hosted semantic service and a pair of bounded text files can therefore implement the same memory slot without pretending to share lower-level semantics.
 
 ```text
-before response   collection ---- automatic recall ----> turn context
-during response   response model -- remember / forget --> collection
-after completion  authored input -------- capture ------> collection
-application       trusted outcome -------- direct write --> collection
+turn start       eve scope + visible session ---> provider recall ---> transient context
+                 eve scope + visible session ---> provider tools  ---> scoped model tools
+turn completed   eve scope + settled session ---> provider capture
 ```
 
-Capture is the automatic ingestion path. It runs after a completed turn and extracts durable claims from user-authored input. Without capture, the agent remembers only when the response model chooses to call a tool or application code writes a record.
-
-The proposal treats a collection as one coherent opt-in: automatic recall, model tools, capture, application access, and erasure semantics ship together. Data that should not be mutable by the agent belongs in instructions, RAG, application state, or an external system of record instead.
-
-This document focuses on the authoring model, provider boundary, and observable behavior. Exact error catalogs, workflow machinery, and provider-specific implementation details are deferred until the product decisions are accepted.
-
-## Questions for review
-
-These are the main decisions this proposal asks the team to evaluate:
-
-| Question                                                     | Proposed direction                                                                                                                                                                                    |
-| ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Should ordinary conversation create memory automatically?    | Yes. A post-turn capture pass learns durable claims that the response model did not explicitly remember.                                                                                              |
-| Should a resolved collection separate read and write access? | No in V1. Resolving a collection enables recall, remember, forget, and capture together. Recall-only contexts are a plausible future need, but this proposal does not introduce per-operation policy. |
-| Should model-facing forget require approval?                 | Open. V1 defines erasure behavior independently from whether the product requires confirmation or approval before invoking it.                                                                        |
-| How should memory be partitioned?                            | A scope function returns one ordered tuple of opaque, trusted runtime identifiers. The tuple is only a partition key; its parts have no built-in ownership, privacy, or audience semantics.           |
-| Can the model choose a different scope?                      | No. eve resolves and locks each collection's scope for the turn. Automatic recall, model operations, and capture can access only that partition.                                                      |
-| Should application and administrative access ship in V1?     | Yes. Applications need to record trusted outcomes, and operators need partition-level inspection, correction, export, and purge.                                                                      |
-| Can authors implement custom providers in V1?                | Yes. `MemoryProvider` is a public V1 extension point. eve ships PostgreSQL for production plus explicit local and test providers, while other providers implement the same contract.                  |
-
-## What belongs in memory
-
-Memory is for reusable knowledge that should outlive the session but is not the application's source of truth.
-
-| Information                                                      | Owner                                       |
-| ---------------------------------------------------------------- | ------------------------------------------- |
-| Active-turn and per-session state                                | eve messages, compaction, and `defineState` |
-| Conversation archive and transcript search                       | Session/world storage or an application API |
-| External documents and product knowledge                         | RAG or a knowledge integration              |
-| Cross-session facts, preferences, events, and reusable knowledge | Memory                                      |
-| Balances, permissions, order status, and other application truth | Application system of record                |
-| Trusted instructions, skills, and autonomous self-modification   | Instructions, skills, and evaluation        |
-
-The core terms are:
-
-- A **collection** is one authored memory file with one purpose, provider, and scope definition. It may contain records for many isolated partitions.
-- A **record** is one atomic text claim with an eve-assigned origin: `capture`, `model`, or `application`. Replacing its content creates a new revision under the same logical record.
-- A **scope tuple** is the ordered composite key that selects one isolated partition. Its parts are opaque, stable identifiers obtained from trusted runtime context, such as `[userId, channelId]` or `[workspaceId]`.
-
-Origin answers how the current revision was created without claiming that the record is correct or authoritative. Capture considers only user-authored input from a completed turn, but that restriction is an internal lifecycle rule rather than durable evidence attached to the record. Model writes may still be mistaken, user input may be incorrect, and application-written memory remains a reusable account rather than the application's system of record. All recalled memory is therefore untrusted data regardless of origin.
-
-V1 does not classify records as facts, preferences, or episodes because those labels do not yet change behavior.
+This document defines that authoring boundary and its observable lifecycle. Provider packaging, vendor configuration, and provider-specific persistence remain follow-up work.
 
 ## Authoring experience
 
-### Collection files
-
-An agent may declare one flat collection or a directory of named collections:
+An agent may declare one flat memory slot or a directory of named slots:
 
 ```text
-agent/memory.ts            # one collection named "memory"
+agent/memory.ts            # one slot named "memory"
 agent/memory/              # XOR with the flat file
-  user.ts                  # collection named "user"
-  workspace.ts             # collection named "workspace"
+  user.ts                  # slot named "user"
+  workspace.ts             # slot named "workspace"
 ```
 
-Each module default-exports `defineMemory(...)`. Collection identity comes from its path rather than a `name` field. `user.ts` and `workspace.ts` may use the same provider while their collection paths and resolved tuples keep their records isolated. Local directory-form subagents may declare their own collections; graph-node identity keeps them isolated from the root and from one another.
+Each module default-exports `defineMemory(...)`. Identity comes from the path rather than a `name` field. A slot configures only its provider and scope:
 
 ```ts title="agent/memory/user.ts"
 import { byPrincipal, defineMemory } from "eve/memory";
 import { memory } from "../lib/memory";
 
 export default defineMemory({
-  description: "Stable facts and preferences for the current user.",
   provider: memory,
   scope: byPrincipal(),
 });
 ```
 
-`description` tells the model what belongs in the collection. `provider` chooses persistence. `scope` resolves one partition for the current turn. Declaring the collection enables the complete lifecycle.
+`provider` supplies the memory behavior. `scope` resolves the provider partition for the current turn. Descriptions, prompts, tool policy, and storage options belong to provider configuration rather than `defineMemory`.
 
-The imported `memory` value is a `MemoryProvider`. An application can use the PostgreSQL provider shipped by eve or implement the public provider contract described below. Collection definitions do not configure storage or retrieval themselves.
+The same provider instance may back several slots. For example, `user.ts` may resolve `[userId]` while `workspace.ts` resolves `[workspaceId]`. Their path identities, scope keys, recalled context, tools, and capture invocations remain separate.
 
-### Scope
+Local directory-form subagents may declare their own memory slots. Graph-node identity keeps root and subagent slots isolated even when they use the same path, scope parts, and provider.
 
-The low-level scope type is a function that returns one ordered tuple of opaque, trusted identifiers or `null`:
+## Scope
+
+The low-level scope definition returns one ordered tuple of opaque, trusted identifiers or `null`:
 
 ```ts
 type MemoryScopeDefinition = (context: MemoryScopeContext) => readonly MemoryScopePart[] | null;
 ```
 
-Scope parts have no built-in entity types, and no position has special meaning. `[userId, channelId]` means only that both values identify the partition. `byPrincipal()` is sugar for the common single-part tuple using the current authenticated principal; this proposal does not name other helpers.
+Scope parts come from trusted auth, application, or channel context. They cannot come from model input or unattested message fields. Parts have no built-in entity types, and no position has special meaning. `[userId, channelId]` means only that both values participate in the provider partition. `byPrincipal()` is sugar for the common authenticated-principal tuple.
 
-Scope resolves independently for each collection. On one Slack turn, `user.ts` could resolve `[userId, channelId]` while `workspace.ts` resolves `[workspaceId]`; both collections can participate in that turn without sharing records.
+For each resolved slot, eve creates this scope value:
 
-The contents of `MemoryScopeContext` are intentionally not designed in this proposal. It will expose stable identifiers from trusted runtime context and some form of channel access for values such as a Slack workspace, user, channel, or thread. Memory does not interpret those values. A continuation token is not automatically a scope part because it may be more specific or less stable than the partition the author wants.
+```ts
+interface MemoryScope {
+  /** Stable eve namespace derived from application, environment, graph node, slot, and parts. */
+  readonly key: string;
+  /** The ordered values returned by the authored scope definition. */
+  readonly parts: readonly MemoryScopePart[];
+}
+```
 
-Returning `null` leaves the collection unavailable for that turn. Scope parts cannot come from model input or unattested message fields.
+The key gives providers one collision-resistant partition identifier. The parts remain available when a vendor needs to map the partition onto its own user, workspace, or container concepts. Both are absent from model-facing schemas.
 
-## Lifecycle
+eve resolves scope after admitting the turn and locks it through capture. Returning `null` makes the slot unavailable for that turn: eve does not invoke its provider hooks or lower its tools. Missing values never fall back to a broader partition. Changing the meaning or order of scope parts is a provider data migration.
 
-| Phase                        | Behavior                                                                                    | Why                                                                                            |
-| ---------------------------- | ------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| Before the response          | eve recalls relevant and recent records into transient turn context.                        | Existing memory must be present before it can improve the response.                            |
-| During the model loop        | The model may recall with a new query, remember a claim, revise a claim, or request forget. | Explicit actions provide immediate and deliberate control.                                     |
-| After a completed turn       | Capture proposes additions, replacements, or no-ops from that turn's user-authored input.   | Routine conversation can create memory without delaying the response.                          |
-| During an application action | Trusted code may write the durable outcome directly.                                        | Action results should come from the system that performed the action, not assistant narration. |
-
-### Recall
-
-Automatic recall runs after compaction and before the first response-model request. Its query uses the latest normalized input plus a bounded visible window for references such as “that restaurant.” The result combines relevant and recent records under a turn budget.
-
-The model may also recall later with a new query and optional collection. Omitting the collection searches every resolved collection.
-
-Recalled memories are attributed to their collection and presented as untrusted data. They do not change permissions, and their payloads do not enter durable transcript history. A collection outage does not fail the turn; successful collections still contribute and failures remain distinguishable from an empty result.
-
-### Explicit remember and application writes
-
-Explicit remember is for knowledge that must be durable and visible immediately. The model writes a claim through a collection-bound tool. It revises a claim by addressing the current recalled record; stale revisions conflict rather than overwriting newer knowledge. eve marks these revisions with the `model` origin.
-
-Application code can write through scope-bound memory access. This is the path for trusted action outcomes such as “the 3pm flight was booked.” eve marks these revisions with the `application` origin, but the application system remains the source of truth; memory is only a reusable account of the outcome.
-
-### Capture
-
-Capture is a background extraction pass created only by a successfully completed turn. Failed, cancelled, abandoned, deferred, or adapter-consumed turns are not eligible. It uses the exact collection scopes locked for the completed turn rather than resolving them again against later runtime state.
-
-Capture uses a separate model invocation after the turn. Its configuration surface is deferred until implementation demonstrates a concrete need.
-
-For each eligible collection, the capture invocation compares user-authored input with current memory and proposes an addition, replacement, or no-op. eve marks committed revisions with the `capture` origin.
-
-V1 capture excludes assistant output, reasoning, tool traffic, imported context, and attachments. This prevents assistant- or tool-produced content from becoming durable automatically. Trusted action outcomes use application writes instead.
-
-Capture does not delay or change the completed response. Its writes are eventually consistent, so the next turn may not see them. Callers needing immediate durability use explicit remember or an application write.
-
-### Forget and purge
-
-Forget removes one logical record and its revisions from every live memory operation.
-
-An administrative purge removes every record in the addressed collection partition. Broader administrative selectors are separate from the scope tuple and deferred. Erased content cannot return through recall, stale indexes, application reads, or workflow replay.
-
-These are live logical erasure guarantees. Database remnants, replicas, backups, journals, transcripts, telemetry, and model-provider retention remain governed by their own policies.
-
-## Scope and isolation
-
-Long-lived memory creates a cross-session disclosure risk, so model-controlled input never chooses scope parts.
-
-Scope parts come from trusted auth, application, or channel context and include enough authority to remain stable and collision-free. Display names and model-visible attributes do not define them. The memory system treats every part as an opaque identifier rather than inferring whether it represents a user, workspace, channel, or another entity.
-
-eve resolves each collection's scope from the admitted turn and locks it for that turn. Automatic recall, model operations, and capture use only the locked collection and tuple; their schemas never accept an alternate scope. A tuple does not itself express ownership, access policy, or response audience.
-
-Missing required parts or a `null` scope result makes that collection unavailable. eve emits content-free diagnostics rather than silently falling back to a different partition.
-
-The provider namespace also includes stable application, environment, graph-node, and collection-path identity. Redeployments in one environment share memory, while different environments, subagents, collections, and resolved tuples do not. Changing the order or meaning of scope parts requires migration.
-
-Collection authors decide what a partition represents through the collection's purpose and scope definition. Shared memory remains origin-labeled and untrusted, and must never become an instruction or permission source. V1 still excludes memory without an explicit scope tuple.
-
-## Framework capabilities
-
-### Model capabilities
-
-| Capability | Purpose                                 |
-| ---------- | --------------------------------------- |
-| Recall     | Search one or all resolved collections. |
-| Remember   | Create or replace a claim.              |
-| Forget     | Erase one recalled record.              |
-
-These are framework-provided, collection-aware operations rather than authored tools. Mutations are collection-bound so the model never supplies a scope. Their exact names, schemas, record references, and errors belong in the implementation contract.
-
-### Application access
-
-Application code needs a scope-bound way to record trusted outcomes during a turn. Routes outside a bound turn may also need partition-level inspection and correction after independently authorizing the caller and resolving the target tuple. The exact client types and method inventory are deferred until these callers are implemented.
-
-The exact route-facing channel access is likewise deferred with the channel scope API.
-
-Operator-authorized administration can inspect, correct, export, and purge an addressed collection partition without impersonating a turn. Operator identity, reason, target, operation, and outcome are audited. Broader selectors and the exact administration API are deferred.
-
-## Observable guarantees
-
-- Each model operation remains bound to the collection scopes locked for its turn; unavailable or invalid scope fails closed.
-- eve records whether each revision was created by capture, an explicit model operation, or application code. Origin is informational and does not establish correctness or authority.
-- Explicit model and application writes are idempotent, commit before reporting success, and are visible to later steps in the same turn.
-- Capture starts only after a completed turn, never changes that turn's outcome, and may become visible later.
-- Superseded, erased, and purged records are absent from live operations.
-- Canonical records are authoritative. Embeddings and search indexes are rebuildable projections and cannot resurrect stale content.
+eve guarantees that every invocation for one slot receives the same locked value. The provider is responsible for actually applying that value to downstream storage and service calls; eve cannot enforce isolation inside provider code or an external service.
 
 ## Provider contract
 
-`MemoryProvider` is a public V1 extension point. eve ships a PostgreSQL provider, but a collection can use any conforming provider. The provider owns canonical persistence and retrieval within one collection partition. eve owns collection discovery, trusted scope resolution, origin assignment, model operations, cross-collection behavior, budgets, rendering, and final disclosure validation.
-
-The public contract should have this shape; exact field names and error types will be fixed by the implementation plan:
+`MemoryProvider` is a public extension point with three semantic hooks. This is the intended shape; exact callback-context and tool-definition type names will be fixed by the implementation plan:
 
 ```ts
-type MemoryOrigin = "capture" | "model" | "application";
+import type { ModelMessage } from "ai";
+import type { ToolDefinition } from "eve/tools";
 
-interface MemoryRecord {
-  readonly id: string;
-  readonly revision: string;
-  readonly content: string;
-  readonly origin: MemoryOrigin;
-  readonly createdAt: string;
-  readonly updatedAt: string;
+interface MemoryProviderInvocation {
+  /** Path-derived slot identity, such as "memory" or "user". */
+  readonly slot: string;
+  readonly scope: MemoryScope;
+  readonly session: {
+    readonly id: string;
+    /** Current ModelMessage history selected for this lifecycle point. */
+    readonly messages: readonly ModelMessage[];
+  };
+  readonly abortSignal: AbortSignal;
 }
 
-interface MemoryProviderPartition {
-  /** Stable, collision-resistant value created by eve. */
-  readonly key: string;
-}
-
-interface MemoryProviderRequest {
-  /** Framework-created stable storage key; providers treat it as opaque. */
-  readonly partition: MemoryProviderPartition;
-  readonly signal: AbortSignal;
-}
+type MemoryProviderTools = Readonly<Record<string, ToolDefinition>>;
 
 interface MemoryProvider {
-  ready(input: MemoryProviderRequest): Promise<void>;
+  recall?(input: MemoryProviderInvocation, context: MemoryCallbackContext): Promise<string | null>;
 
-  recall(
-    input: MemoryProviderRequest & { readonly query: string; readonly limit: number },
-  ): Promise<{ readonly records: readonly MemoryRecord[]; readonly truncated: boolean }>;
-  get(input: MemoryProviderRequest & { readonly recordId: string }): Promise<MemoryRecord | null>;
-  list(
-    input: MemoryProviderRequest & { readonly cursor?: string; readonly limit: number },
-  ): Promise<{
-    readonly records: readonly MemoryRecord[];
-    readonly cursor?: string;
-  }>;
+  tools?(
+    input: MemoryProviderInvocation,
+    context: MemoryCallbackContext,
+  ): Promise<MemoryProviderTools | null>;
 
-  write(
-    input: MemoryProviderRequest & {
-      readonly operationId: string;
-      readonly content: string;
-      readonly origin: MemoryOrigin;
-      readonly replace?: {
-        readonly recordId: string;
-        readonly expectedRevision: string;
-      };
-    },
-  ): Promise<MemoryRecord>;
-  erase(
-    input: MemoryProviderRequest & {
-      readonly operationId: string;
-      readonly recordId: string;
-      readonly expectedRevision?: string;
-    },
-  ): Promise<{ readonly erased: boolean }>;
-  purge(input: MemoryProviderRequest & { readonly operationId: string }): Promise<void>;
+  capture?(input: MemoryProviderInvocation, context: MemoryCallbackContext): Promise<void>;
 }
 ```
 
-Every operation receives an opaque partition key produced by eve from stable application, environment, graph-node, collection-path, and resolved-scope identity. It also receives an abort signal and operation-specific limits or deadlines. The model and authored application code never construct the partition key.
+Hooks are independently optional. A provider may contribute only context, only tools, only capture, or any combination. eve does not infer missing behavior or add default tools.
 
-`recall` receives a plain-text query and returns ranked current records. `get` and `list` provide canonical reads for application access, validation, inspection, and export. `write` creates or replaces a record and receives the content, eve-assigned origin, an eve-assigned operation ID for idempotency, and the expected revision when replacing a record. `erase` removes one logical record and its revisions; `purge` removes the addressed partition. Provider record IDs, revision tokens, and cursors pass through eve but remain semantically opaque.
+Every hook also receives the ordinary authored callback context for session, auth, channel, and runtime access. The invocation carries the memory-specific slot, scope, message history, and cancellation signal explicitly so provider behavior does not depend on ambient model input.
 
-A provider must implement:
-
-- durable canonical records and read-your-writes behavior;
-- strict isolation by the supplied partition key;
-- atomic replacement using the expected revision;
-- idempotent mutation replay using the supplied operation key;
-- bounded ranked recall plus canonical `get` and paginated `list` reads;
-- live erasure and purge barriers that prevent stale work or indexes from restoring content;
-- readiness, cancellation, bounded inputs and outputs, and stable unavailable-versus-empty behavior.
-
-Provider-specific deployment APIs may add schema migration, index preparation, backfill, or operational controls. The runtime `ready` method checks that the provider can safely serve the active configuration; eve does not require every provider to use a database or have a migration phase. Public provider conformance tests exercise the observable semantics above without prescribing a storage or retrieval architecture.
-
-Custom providers use an eve helper that validates and brands the implementation:
+`defineMemoryProvider(...)` validates and brands a custom implementation but does not implement storage or impose a data model:
 
 ```ts title="agent/lib/memory.ts"
 import { defineMemoryProvider } from "eve/memory";
-import { store } from "./store";
+import { service } from "./service";
 
 export const memory = defineMemoryProvider({
-  async ready(input) {
-    await store.assertReady(input);
-  },
   async recall(input) {
-    return await store.recall(input);
+    return await service.recall(input.scope, input.session.messages);
   },
-  async get(input) {
-    return await store.get(input);
+  async tools(input) {
+    return service.toolsFor(input.scope);
   },
-  async list(input) {
-    return await store.list(input);
-  },
-  async write(input) {
-    return await store.write(input);
-  },
-  async erase(input) {
-    return await store.erase(input);
-  },
-  async purge(input) {
-    return await store.purge(input);
+  async capture(input) {
+    await service.capture(input.scope, input.session.messages);
   },
 });
 ```
 
-The helper does not implement storage. It gives eve a stable protocol boundary while leaving the database, hosted memory service, or other backend entirely to the provider.
+The provider decides what each hook means. `recall` need not search, `capture` need not run a model, and tools need not manipulate memory.
 
-### Embeddings and vectors
+## Lifecycle
 
-eve neither requires nor creates embeddings or vectors. On write, eve gives the provider canonical record text. On recall, eve gives the provider a plain-text query. The provider decides whether and when to create embeddings, where to store vectors, and how to rank results.
+### Turn start
 
-A provider may use SQL filtering, full-text search, embeddings, a vector database, hybrid retrieval, an external memory service, or another strategy. It may embed records synchronously on write, asynchronously after write, lazily, or not at all. Embedding models, credentials, dimensions, preprocessing, vector indexes, backfills, cost, and query-embedding failures are provider-owned concerns. They do not appear in `defineMemory` or the base `MemoryProvider` contract.
+After turn admission and compaction, eve resolves each slot's scope and invokes its `recall` and `tools` hooks once. Their session history includes the newest admitted input and every model-visible user, assistant, and tool message retained after compaction.
 
-Embeddings and search indexes are derived projections. Canonical records and revisions remain authoritative, and a provider must not return superseded, erased, or purged content through a stale projection. A retrieval or query-embedding failure is reported as unavailable rather than as an empty result.
+A non-empty `recall` result becomes one transient user-context message appended at the prompt tail. Results from several slots appear in stable slot-path order. Providers own all formatting and attribution within their returned text.
 
-### First-party providers
+Recalled context is not a system instruction. Keeping it at the prompt tail leaves authored instructions and the prior conversation prefix stable for prompt caching. It also remains transient: eve does not write it to durable session history, include it in later capture input, or restore it on replay as conversation authored by the user.
 
-PostgreSQL is eve's production provider. Stable application and environment identity are required so deployments cannot accidentally share or split memory. Provider-specific options may configure PostgreSQL retrieval, including embeddings and vector indexing, without adding those concepts to the framework contract:
+Provider tools are available for every model step in the turn. A provider returns tool keys such as `forget` or `propose`; eve lowers them as `<memory-slot>__<provider-tool>`, for example `user__forget`. Qualification is unconditional, so adding another memory slot never renames an existing tool or creates a collision when two slots use the same provider.
 
-```ts title="agent/lib/memory.ts"
-import { pgDatabase, postgresMemory } from "eve/memory/postgres";
-import { pool } from "./database";
+The model never supplies slot identity or scope. eve binds the resolved invocation to each lowered executor, and provider code uses that bound scope for its service or storage call. Provider tools otherwise use the ordinary tool contract, including schemas, approvals, results, and authorization access. A provider may expose tools unrelated to conventional memory CRUD.
 
-export const memory = postgresMemory({
-  database: pgDatabase(pool),
-  embedding: {
-    model: "openai/text-embedding-3-small",
-    dimensions: 1536,
-  },
-});
-```
+### Turn completion
 
-An explicit local provider supports persistent development memory without embeddings, and a deterministic test provider supports isolated tests. Their factory names, storage choices, and control surfaces are implementation details. Neither is available in production. Their existence demonstrates that conformance depends on memory behavior, not on vectors or a specific retrieval algorithm.
+After `turn.completed`, eve invokes `capture` for every slot that resolved at turn start. The hook receives the same locked scope and the complete settled durable model history, including assistant tool calls and tool results. It does not receive transient recalled context.
+
+eve awaits capture before emitting `session.waiting` in conversation mode or `session.completed` in task mode. A caller that starts the next turn after the ready boundary therefore observes settled provider state. Capture does not run for failed, cancelled, abandoned, deferred, or adapter-consumed turns, nor for manual clear or compaction boundaries that did not complete a turn.
+
+The provider decides whether capture stores the whole session, extracts selected details, rewrites a document, queues its own downstream work, or does nothing. eve does not run a capture model or inspect what the provider persists.
+
+### Failures
+
+A `recall` or `tools` failure fails the turn. Memory is an authored capability, so silently running with a different prompt or tool set would violate the agent definition.
+
+A `capture` failure occurs after the response and cannot change that completed response. eve emits content-free diagnostics and continues to `session.waiting` or `session.completed`. Providers that acknowledge capture before their own asynchronous persistence completes own the resulting eventual consistency and retry behavior.
+
+## Reference providers
+
+V1 includes two reference providers to prove that the framework boundary does not encode one memory architecture. Package names, credentials, deployment configuration, and service-specific controls belong in provider-specific plans.
+
+### Supermemory
+
+The Supermemory provider sends the resolved scope and visible session history to Supermemory during recall. Supermemory decides what is relevant and returns the fully formatted text that eve injects. eve does not understand Supermemory profiles, containers, documents, search, or extraction.
+
+The provider chooses its tool set. It may expose scoped search, save, forget, profile, or proposal tools, or another capability entirely. eve only qualifies and scope-binds the returned definitions.
+
+After a completed turn, the provider sends the settled session to Supermemory. Supermemory decides what to persist and how to update its own memory representation. eve does not translate the session into framework records or validate the resulting writes.
+
+### Blob documents
+
+The blob provider stores bounded `USER.md`- and `MEMORY.md`-style text documents under the resolved scope. Recall reads the documents and returns their provider-formatted contents directly; it requires no search, embeddings, or record schema.
+
+The provider owns any tools for editing, consolidating, or clearing those documents. Its capture hook may rewrite them from the completed session and enforce provider-configured size limits. File layout, truncation or consolidation policy, concurrency, and blob-store behavior remain internal to the provider.
+
+This provider demonstrates that simple bounded text can participate in the same lifecycle as a hosted semantic service without eve standardizing either implementation.
+
+## Observable guarantees
+
+- Memory slots have path-derived identity and an explicit authored scope.
+- Scope is resolved from trusted runtime context, locked for the turn, and never accepted from model input.
+- The same provider can back several slots without sharing eve scope keys or colliding model tools.
+- Recall sees the post-compaction visible session including the newest input and contributes transient tail context in deterministic slot order.
+- Provider tools are unconditionally slot-qualified and bound to the same locked scope as recall and capture.
+- Capture sees the completed durable session without recalled transient context and settles before the next ready boundary.
+- Recall and tool-resolution failures fail the turn; capture failures cannot rewrite the completed response or suppress the ready boundary.
+- Providers, not eve, define persistence, consistency after provider acknowledgment, retention, erasure, and administrative behavior.
 
 ## Non-goals
 
-- Read-only, write-only, recall-disabled, tool-disabled, or otherwise partial collections.
-- A mutable `MEMORY.md`, model-managed memory filesystem, eve-operated hosted memory service, transcript store, RAG store, or application system of record. A custom provider may connect to an external memory service.
-- Capturing assistant output, reasoning, tool payloads, attachments, or imported context.
-- Memory without an explicit scope tuple, multiple simultaneous tuples for one collection in a turn, or implicit sharing between collections.
-- Tags, typed record kinds, profiles, graph relations, confidence, autonomous inference, decay, or instruction modification.
-- Framework-level custom extractor or standalone embedder interfaces. Providers may expose their own provider-specific extraction or embedding configuration.
-- Physical sanitization guarantees for database remnants, replicas, backups, journals, transcripts, logs, telemetry, or model-provider retention.
+- A framework record, revision, origin, citation, CRUD, query, ranking, embedding, vector, or canonical-storage model.
+- Framework-provided recall, remember, forget, purge, export, application-write, or administrative APIs.
+- A built-in capture model, extractor, formatter, token budget, retention policy, or erasure guarantee.
+- Cross-provider search, mutation, record reconciliation, or behavioral conformance beyond the lifecycle contract.
+- Memory without an explicit scope tuple or model-selected alternate scopes.
+- Preventing a faulty or malicious provider from ignoring the supplied scope, disclosing data, or persisting unintended content.
+- Standardizing provider package layout, vendor credentials, migrations, inspection tools, or deployment operations in this proposal.
 
 ## Implementation contract follow-up
 
-Before V1 implementation lands, follow-up plans must define exact tool, client, and provider schemas; error codes; handles; cursors; limits; normalization; checkpoint and replay machinery; canonical tables; the provider conformance suite; PostgreSQL indexing and migration; and local inspection commands. Those details must satisfy the observable guarantees above without expanding the V1 product surface.
+Before V1 implementation lands, follow-up plans must fix the exact public type names, callback context, scope-part encoding, tool-factory and durable-replay mechanics, diagnostic events, cancellation behavior, provider packaging, and tests for lifecycle ordering and isolation. Supermemory and blob storage each need a provider-specific plan for configuration and operational behavior without expanding the core memory contract.
 
 ## Primary references
 
 - [Supermemory: how it works](https://supermemory.ai/docs/concepts/how-it-works)
-- [Zep context types](https://help.getzep.com/context-types.md)
-- [Graphiti](https://github.com/getzep/graphiti)
-- [Mem0: how memory works](https://docs.mem0.ai/core-concepts/how-it-works)
-- [LangMem conceptual guide](https://langchain-ai.github.io/langmem/concepts/conceptual_guide/)
-- [AI SDK embeddings](https://ai-sdk.dev/docs/ai-sdk-core/embeddings)
-- [PostgreSQL full-text search](https://www.postgresql.org/docs/current/textsearch-indexes.html)
-- [pgvector](https://github.com/pgvector/pgvector)
+- [Hermes Agent memory](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/memory.md)
+- [eve dynamic capabilities](../docs/guides/dynamic-capabilities.md)
 - [eve project layout](../docs/reference/project-layout.md)
-- [eve state](../docs/guides/state.md)
+- [eve prompt caching](../packages/eve/src/harness/prompt-cache.ts)
 - [eve turn execution](../packages/eve/src/execution/workflow-steps.ts)

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -1,6 +1,6 @@
 ---
 issue: https://github.com/vercel/eve/issues/1510
-status: proposed
+status: implemented
 last_updated: "2026-08-12"
 ---
 
@@ -15,19 +15,41 @@ eve owns only two pieces:
 1. **Authored identity.** Each memory file is a named slot with path-derived identity.
 2. **Scope.** eve resolves and locks a trusted partition for that slot, then supplies the same partition to every provider event handler and provider-defined tool in the lifecycle operation.
 
-The provider owns everything else: storage, recall, capture, model tools, formatting, extraction, ranking, limits, retention, and any record or document model. A hosted semantic service and a pair of bounded text files can therefore implement the same memory slot without pretending to share lower-level semantics.
+The provider owns everything else: storage, recall, capture, model tools, formatting, extraction, ranking, limits, retention, and any record or document model. A hosted semantic service and a bounded text file can therefore implement the same memory slot without pretending to share lower-level semantics.
 
 ```text
-session started        scope + session      ---> events ---> durable user message or side effects
-turn started           scope + session      ---> events ---> durable user message or side effects
-message received       scope + session      ---> events ---> durable user message or side effects
-compaction requested   scope + pre-session  ---> events ---> durable user message or side effects
-compaction completed   scope + post-session ---> events ---> durable user message or side effects
+session started        scope + session      ---> events ---> durable user messages or side effects
+turn started           scope + session      ---> events ---> durable user messages or side effects
+message received       scope + session      ---> events ---> durable user messages or side effects
+compaction requested   scope + pre-session  ---> events ---> durable user messages or side effects
+compaction completed   scope + post-session ---> events ---> durable user messages or side effects
 step started           scope + session      ---> tools  ---> scoped model tools
-turn completed         scope + session      ---> events ---> durable user message or side effects
+turn completed         scope + session      ---> events ---> durable user messages or side effects
 ```
 
-This document defines that authoring boundary and its observable lifecycle. Provider packaging, vendor configuration, and provider-specific persistence remain follow-up work.
+This document is the final V1 authoring contract implemented by the stack. Provider packaging, vendor configuration, and provider-specific persistence remain separate from the core contract.
+
+## Public API at a glance
+
+| Import path              | Public surface                                                                                                                                                   |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `eve/memory`             | `defineMemory`, `defineMemoryProvider`, memory-specific `defineDynamic`, `byPrincipal`, and the scope, provider, context, event-result, and memory-message types |
+| `eve/memory/file`        | `fileMemory`, `inMemory`, `FileMemoryOptions`, `MemoryDocumentBackend`, document input/result types, and `MemoryDocumentConflictError`                           |
+| `eve/memory/file/vercel` | `vercelBlob` and `VercelBlobBackendOptions`                                                                                                                      |
+
+The smallest complete slot uses the built-in file provider and authenticated-principal scope:
+
+```ts title="agent/memory/user.ts"
+import { byPrincipal, defineMemory } from "eve/memory";
+import { fileMemory } from "eve/memory/file";
+
+export default defineMemory({
+  provider: fileMemory(),
+  scope: byPrincipal(),
+});
+```
+
+For `agent/memory/user.ts`, eve derives the slot name `user`. `fileMemory()` recalls that principal's indexed memory when the session starts and after compaction, and its provider tools become `user__save_memory` and `user__remove_memory`.
 
 ## Authoring experience
 
@@ -43,32 +65,42 @@ agent/memory/              # XOR with the flat file
 Each module default-exports `defineMemory(...)`. Identity comes from the path rather than a `name` field. A slot configures only its provider and scope:
 
 ```ts title="agent/memory/user.ts"
-import { byPrincipal, defineMemory } from "eve/memory";
-import { memory } from "../lib/memory";
+import { defineMemory } from "eve/memory";
+import { customMemory } from "../lib/custom-memory";
 
 export default defineMemory({
-  provider: memory,
-  scope: byPrincipal(),
+  provider: customMemory,
+  async scope(ctx) {
+    const principal = ctx.session.auth.current;
+    const workspaceId = await resolveWorkspaceId(principal, {
+      signal: ctx.abortSignal,
+    });
+    return workspaceId === null ? null : [workspaceId];
+  },
 });
 ```
 
 `provider` supplies the memory behavior. `scope` resolves the provider partition for the current turn. Descriptions, prompts, tool policy, and storage options belong to provider configuration rather than `defineMemory`.
 
-The same provider instance may back several slots. For example, `user.ts` may resolve `[userId]` while `workspace.ts` resolves `[workspaceId]`. Their path identities, scope keys, context contributions, tools, and event invocations remain separate.
+The same provider instance may back several slots. For example, `user.ts` may resolve `[userId]` while `workspace.ts` resolves `[workspaceId]`. Their path identities, scope keys, memory messages, tools, and event invocations remain separate.
 
 Local directory-form subagents may declare their own memory slots. Graph-node identity keeps root and subagent slots isolated even when they use the same path, scope parts, and provider.
 
 ## Scope
 
-The low-level scope definition returns, or asynchronously resolves, one ordered tuple of opaque, trusted identifiers or `null`:
+The low-level scope definition returns, or asynchronously resolves, one ordered tuple of opaque, trusted identifiers or `null`. Its context includes the session helpers and an `abortSignal` for cancelling external lookups:
 
 ```ts
+interface MemoryScopeContext extends SessionContext {
+  readonly abortSignal: AbortSignal;
+}
+
 type MemoryScopeDefinition = (
   context: MemoryScopeContext,
 ) => readonly MemoryScopePart[] | null | Promise<readonly MemoryScopePart[] | null>;
 ```
 
-Scope parts come from trusted auth, application, or channel context. They cannot come from model input or unattested message fields. Parts have no built-in entity types, and no position has special meaning. `[userId, channelId]` means only that both values participate in the provider partition. `byPrincipal()` is sugar for the common authenticated-principal tuple.
+Scope parts come from trusted auth, application, or channel context. They cannot come from model input or unattested message fields. Parts have no built-in entity types, and no position has special meaning. `[userId, channelId]` means only that both values participate in the provider partition. `byPrincipal()` disables the slot for unauthenticated callers and otherwise returns `[principalType, authenticator, principalId]`.
 
 For each resolved slot, eve creates this scope value:
 
@@ -89,65 +121,72 @@ eve guarantees that every invocation for one slot within the turn or manual oper
 
 ## Provider contract
 
-`MemoryProvider` is a public extension point with separate, constrained event and tool maps. It follows the same event-keyed shape as eve's other dynamic APIs without naming or prescribing recall and capture operations. This is the intended shape; exact event and callback-context type names will be fixed by the implementation plan:
+`MemoryProvider` is a public extension point with constrained lifecycle hooks and dynamic tools. It uses eve's existing event-keyed primitives without naming or prescribing recall and capture operations. Omitting generic exact-definition plumbing, the final public contract is:
 
 ```ts
 import type { ModelMessage } from "ai";
+import type { SessionContext } from "eve/context";
 import type { ToolDefinition } from "eve/tools";
 
-interface MemoryProviderContext extends MemoryCallbackContext {
+interface MemoryProviderContext extends SessionContext {
+  readonly abortSignal: AbortSignal;
+  /** Complete durable model history selected for this lifecycle point. */
+  readonly messages: readonly ModelMessage[];
   readonly memory: {
     /** Path-derived slot identity, such as "memory" or "user". */
     readonly slot: string;
     readonly scope: MemoryScope;
   };
-  /** Current ModelMessage history selected for this lifecycle point. */
-  readonly messages: readonly ModelMessage[];
-  readonly abortSignal: AbortSignal;
 }
 
-type MemoryMessage = string;
-type MemoryMessageResult = MemoryMessage | null | void;
-
 type MemoryProviderToolSet = Readonly<Record<string, ToolDefinition>>;
+
+interface MemoryMessage {
+  readonly content: string;
+}
+
+type MemoryEventResult = MemoryMessage | readonly MemoryMessage[] | null | void;
 
 interface MemoryProviderEvents {
   readonly "session.started"?: (
     event: SessionStartedEvent,
     context: MemoryProviderContext,
-  ) => MemoryMessageResult | Promise<MemoryMessageResult>;
+  ) => MemoryEventResult | Promise<MemoryEventResult>;
 
   readonly "turn.started"?: (
     event: TurnStartedEvent,
     context: MemoryProviderContext,
-  ) => MemoryMessageResult | Promise<MemoryMessageResult>;
+  ) => MemoryEventResult | Promise<MemoryEventResult>;
 
   readonly "message.received"?: (
     event: MessageReceivedEvent,
     context: MemoryProviderContext,
-  ) => MemoryMessageResult | Promise<MemoryMessageResult>;
+  ) => MemoryEventResult | Promise<MemoryEventResult>;
 
   readonly "compaction.requested"?: (
     event: CompactionRequestedEvent,
     context: MemoryProviderContext,
-  ) => MemoryMessageResult | Promise<MemoryMessageResult>;
+  ) => MemoryEventResult | Promise<MemoryEventResult>;
 
   readonly "compaction.completed"?: (
     event: CompactionCompletedEvent,
     context: MemoryProviderContext,
-  ) => MemoryMessageResult | Promise<MemoryMessageResult>;
+  ) => MemoryEventResult | Promise<MemoryEventResult>;
 
   readonly "turn.completed"?: (
     event: TurnCompletedEvent,
     context: MemoryProviderContext,
-  ) => MemoryMessageResult | Promise<MemoryMessageResult>;
+  ) => MemoryEventResult | Promise<MemoryEventResult>;
 }
 
 interface MemoryProviderTools {
-  readonly "step.started"?: (
-    event: StepStartedEvent,
-    context: MemoryProviderContext,
-  ) => MemoryProviderToolSet | null | Promise<MemoryProviderToolSet | null>;
+  readonly kind: "eve:dynamic";
+  readonly events: {
+    readonly "step.started"?: (
+      event: StepStartedEvent,
+      context: MemoryProviderContext,
+    ) => MemoryProviderToolSet | null | Promise<MemoryProviderToolSet | null>;
+  };
 }
 
 interface MemoryProvider {
@@ -156,34 +195,136 @@ interface MemoryProvider {
 }
 ```
 
-Both maps and every handler within them are optional. A provider may contribute only memory messages, only tools, only completed-turn side effects, or any combination. eve does not infer missing behavior or add default tools.
+Both maps and every handler within them are optional. All six provider event handlers share `MemoryEventResult`, so every event may vend memory messages; none is restricted to side effects. A provider may contribute only memory messages, only tools, only completed-turn side effects, or any combination. eve does not infer missing behavior or add default tools.
 
 Every handler receives an ordinary typed eve event and authored callback context extended with the path-derived slot, locked scope, message snapshot, and cancellation signal. Scope does not depend on ambient model input.
 
-`defineMemoryProvider(...)` validates and brands a custom implementation but does not implement storage or impose a data model:
+`defineMemoryProvider(...)` is an identity-with-types helper. It does not implement storage or impose a data model. This example shows the single-message and array return forms, a side-effect-only event, and a dynamic provider tool:
 
-```ts title="agent/lib/memory.ts"
-import { defineMemoryProvider } from "eve/memory";
+```ts title="agent/lib/custom-memory.ts"
+import { defineDynamic, defineMemoryProvider } from "eve/memory";
+import { defineTool } from "eve/tools";
+import { z } from "zod";
 import { service } from "./service";
 
-export const memory = defineMemoryProvider({
+export const customMemory = defineMemoryProvider({
   events: {
+    async "session.started"(_event, ctx) {
+      const content = await service.profile(ctx.memory.scope);
+      return content === null ? null : { content };
+    },
     async "message.received"(event, ctx) {
-      return service.recall(ctx.memory.scope, event.data.message, ctx.messages);
+      const memories = await service.recall(ctx.memory.scope, event.data.message, ctx.messages);
+      return memories.map((content) => ({ content }));
     },
     async "turn.completed"(_event, ctx) {
       await service.capture(ctx.memory.scope, ctx.messages);
     },
   },
-  tools: {
-    async "step.started"(_event, ctx) {
-      return service.toolsFor(ctx.memory.scope);
+  tools: defineDynamic({
+    events: {
+      "step.started"(_event, ctx) {
+        const scope = ctx.memory.scope;
+        return {
+          forget: defineTool({
+            description: "Forget one saved preference.",
+            inputSchema: z.object({ key: z.string() }),
+            execute: ({ key }) => service.forget(scope, key),
+          }),
+        };
+      },
     },
-  },
+  }),
 });
 ```
 
-The provider decides what each handler means. A turn handler need not recall, a compaction handler need not extract, a completed-turn handler need not persist, and tools need not manipulate memory.
+Returning `{ content }` materializes one message. Returning an array materializes each item as a separate message in array order. Returning `null`, `undefined`, or no value materializes nothing, so the `turn.completed` handler above performs only its provider-owned side effect. The provider decides what each event means: a turn handler need not recall, a compaction handler need not extract, a completed-turn handler need not persist, and tools need not manipulate memory.
+
+## Built-in file memory
+
+`fileMemory()` is the reference bounded-document provider:
+
+```ts
+interface FileMemoryOptions {
+  readonly backend?: MemoryDocumentBackend;
+  /** Defaults to 100. */
+  readonly memoryLimit?: number;
+}
+
+function fileMemory(options?: FileMemoryOptions): MemoryProvider;
+```
+
+It stores one indexed `MEMORY.md`-style document per scope. `session.started` recalls the document once when the session opens, and `compaction.completed` recalls the latest document after every successful automatic or manual compaction. The recalled context is returned as a `MemoryMessage`, so eve persists it as ordinary user history. It is not repeated on every turn.
+
+The provider exposes `save_memory({ text })`, which returns `{ index }`, and `remove_memory({ index })`. The slot name qualifies both tools. The document preserves indexes for surviving entries, normalizes saved text to one line, treats identical saves and missing removals as idempotent, and conditionally replaces the document so concurrent operations preserve unrelated memories. The provider retries write conflicts and enforces `memoryLimit`; it does not run a hidden capture model or save complete transcripts.
+
+Calling `fileMemory()` without a backend uses this lazy, process-cached selection:
+
+| Runtime                                                          | Default backend                                                                        |
+| ---------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Vercel with non-empty `BLOB_STORE_ID` or `BLOB_READ_WRITE_TOKEN` | Private Vercel Blob through `vercelBlob()`                                             |
+| Vercel without either Blob variable                              | Error on the first storage operation; attach a store or pass `fileMemory({ backend })` |
+| Non-Vercel with `NODE_ENV=production`                            | Error on the first storage operation; pass an explicit durable backend                 |
+| Non-Vercel development or test                                   | Process-local `inMemory()`                                                             |
+
+`BLOB_STORE_ID` uses Vercel OIDC from request context; authors do not need to require a `VERCEL_OIDC_TOKEN` environment variable. The Vercel check also requires a configured Blob store, so merely setting `VERCEL` never falls back to ephemeral storage.
+
+Tests and non-Vercel development can choose the process-local backend explicitly:
+
+```ts title="agent/memory/user.ts"
+import { byPrincipal, defineMemory } from "eve/memory";
+import { fileMemory, inMemory } from "eve/memory/file";
+
+const backend = inMemory();
+
+export default defineMemory({
+  provider: fileMemory({ backend, memoryLimit: 200 }),
+  scope: byPrincipal(),
+});
+```
+
+Vercel Blob can also be pinned or customized explicitly. `vercelBlob()` accepts `prefix`, `token`, `storeId`, and `oidcToken` overrides:
+
+```ts title="agent/memory/user.ts"
+import { byPrincipal, defineMemory } from "eve/memory";
+import { fileMemory } from "eve/memory/file";
+import { vercelBlob } from "eve/memory/file/vercel";
+
+export default defineMemory({
+  provider: fileMemory({
+    backend: vercelBlob({
+      prefix: "my-agent/memory/files",
+      token: process.env.BLOB_READ_WRITE_TOKEN,
+    }),
+  }),
+  scope: byPrincipal(),
+});
+```
+
+Portable stores implement one optimistic read/replace seam:
+
+```ts
+interface MemoryDocument {
+  readonly content: string;
+  readonly version: string;
+}
+
+interface MemoryDocumentBackend {
+  readonly read: (input: {
+    readonly key: string;
+    readonly signal: AbortSignal;
+  }) => Promise<MemoryDocument | null>;
+
+  readonly write: (input: {
+    readonly content: string;
+    readonly expectedVersion: string | null;
+    readonly key: string;
+    readonly signal: AbortSignal;
+  }) => Promise<MemoryDocument>;
+}
+```
+
+`expectedVersion: null` means create-only. A stale conditional write must throw `MemoryDocumentConflictError`, which lets `fileMemory()` reread the document and reapply the individual save or remove operation. KV stores, database rows, and object stores can implement this contract without becoming part of eve's memory model.
 
 ## Lifecycle
 
@@ -191,7 +332,32 @@ The provider decides what each handler means. A turn handler need not recall, a 
 
 eve dispatches the existing `compaction.requested` event before each automatic or manual compaction pass. Each resolved slot receives the complete durable message history about to be compacted, before any message is summarized or removed. eve awaits the handlers in stable slot-path order before starting compaction, allowing a provider to extract, snapshot, persist, or vend information that the checkpoint may omit. Returned memory messages do not alter eve's compaction input or algorithm; eve appends them after a successful pass.
 
-After the compacted checkpoint has been written to durable history, eve dispatches `compaction.completed`. Each handler receives the settled post-compaction durable history and may return a memory message to append after the checkpoint. The event occurs only after successful compaction; a failed summarization preserves the prior history and does not emit it. Provider tools are not resolved at either boundary because compaction does not invoke the agent model.
+After the compacted checkpoint has been written to durable history, eve dispatches `compaction.completed`. Each handler receives the settled post-compaction durable history and may return memory messages to append after the checkpoint. The event occurs only after successful compaction; a failed summarization preserves the prior history and does not emit it. Provider tools are not resolved at either boundary because compaction does not invoke the agent model.
+
+Both compaction boundaries are ordinary public lifecycle events: they are emitted in the session stream and available to hooks as well as memory providers. Memory adds no private compaction callback or synthetic `turn.prepared` event.
+
+```ts
+interface CompactionRequestedStreamEvent {
+  readonly type: "compaction.requested";
+  readonly data: {
+    readonly modelId: string;
+    readonly sequence: number;
+    readonly sessionId: string;
+    readonly turnId: string;
+    readonly usageInputTokens: number | null;
+  };
+}
+
+interface CompactionCompletedStreamEvent {
+  readonly type: "compaction.completed";
+  readonly data: {
+    readonly modelId: string;
+    readonly sequence: number;
+    readonly sessionId: string;
+    readonly turnId: string;
+  };
+}
+```
 
 Both snapshots include memory messages that were already materialized into durable history. Memory messages returned by the opening `session.started`, `turn.started`, and `message.received` handlers remain pending until the turn's initial compaction decision finishes, so newly recalled messages are not immediately summarized before the first model call. Messages returned from either compaction event append after a successful automatic or manual pass.
 
@@ -199,13 +365,13 @@ Both snapshots include memory messages that were already materialized into durab
 
 eve dispatches memory providers through existing session and compaction events. A provider may recall once on `session.started`, on every `turn.started`, in response to `message.received`, after compaction, or at another supported lifecycle boundary. No memory-only lifecycle event is added.
 
-A non-empty string returned from any provider event handler becomes one ordinary `role: "user"` model message. eve appends messages in event order and stable slot-path order at the next durable boundary: opening-event messages after the initial compaction decision, compaction-event messages after the pass, and completed-turn messages to the settled history for the next turn. Providers own all formatting and attribution within their returned text.
+A provider event returns one `MemoryMessage`, an ordered array of messages, or no result. Each non-empty `content` becomes a separate ordinary `role: "user"` model message. eve appends messages in returned order, event order, and stable slot-path order at the next durable boundary: opening-event messages after the initial compaction decision, compaction-event messages after the pass, and completed-turn messages to the settled history for the next turn. Providers own all formatting and attribution within their returned content.
 
 Memory messages are durable session history. Every later model step and turn sees the same message until compaction or context clearing removes it, so each request extends the previous prompt prefix for stable prompt caching. The messages also appear in later provider message snapshots and compaction input. They remain distinct from dynamic instructions, which eve hoists into the system prompt without writing them to model history.
 
 eve materializes each event result once. Model retries, tool-loop steps, workflow step replay, and approval resume reuse the message already in history instead of appending the same event result again. Memory messages are model context rather than new channel input, so materializing one does not emit another `message.received` event. eve does not compare or deduplicate content returned by different events.
 
-eve resolves `tools["step.started"]` before each model call. Its most recent result owns that provider's tool set, and `null` clears it. A provider returns tool keys such as `forget` or `propose`; eve lowers them as `<memory-slot>__<provider-tool>`, for example `user__forget`. Qualification is unconditional, so adding another memory slot never renames an existing tool or creates a collision when two slots use the same provider.
+eve resolves `tools.events["step.started"]` before each model call. Its most recent result owns that provider's tool set, and `null` clears it. These resolvers use eve's ordinary `defineDynamic` lifecycle. A provider returns tool keys such as `forget` or `propose`; eve qualifies them as `<memory-slot>__<provider-tool>`, for example `user__forget`. Qualification is unconditional, so adding another memory slot never renames an existing tool or creates a collision when two slots use the same provider.
 
 The model never supplies slot identity or scope. eve binds the resolved invocation to each lowered executor, and provider code uses that bound scope for its service or storage call. Provider tools otherwise use the ordinary tool contract, including schemas, approvals, results, and authorization access. A provider may expose tools unrelated to conventional memory CRUD.
 
@@ -213,7 +379,7 @@ The model never supplies slot identity or scope. eve binds the resolved invocati
 
 After `turn.completed`, eve dispatches the event to `events["turn.completed"]` for every resolved slot. The handler receives the same locked scope and the complete settled durable model history, including materialized memory messages, assistant tool calls, and tool results. A returned memory message appends after that snapshot and is available on the next turn.
 
-eve awaits the completed-turn handlers before emitting `session.waiting` in conversation mode or `session.completed` in task mode. A caller that starts the next turn after the ready boundary therefore observes acknowledged provider state. The handler does not run for failed, cancelled, abandoned, deferred, or adapter-consumed turns, nor for manual clear or compaction boundaries that did not complete a turn.
+eve awaits the completed-turn handlers before emitting `session.waiting` in conversation mode or `session.completed` in task mode. A caller that starts the next turn after the ready boundary therefore observes acknowledged provider state. The handler does not run for failed, cancelled, input-deferred, or adapter-consumed turns, nor for manual clear or compaction boundaries that did not complete a turn.
 
 The provider decides whether the handler stores the whole session, extracts selected details, rewrites a document, queues its own downstream work, or does nothing. eve does not run a capture model or inspect what the provider persists.
 
@@ -225,23 +391,23 @@ A `compaction.requested` handler failure aborts the compaction before durable hi
 
 A `turn.completed` handler failure likewise occurs after the response and cannot change that completed response. eve emits content-free diagnostics and continues to `session.waiting` or `session.completed`. Providers that acknowledge an event before their own asynchronous persistence completes own the resulting eventual consistency and retry behavior.
 
-## Reference providers
+## Reference architectures
 
-V1 includes two reference providers to prove that the framework boundary does not encode one memory architecture. Package names, credentials, deployment configuration, and service-specific controls belong in provider-specific plans.
+The contract supports both hosted semantic services and bounded text documents without encoding either architecture in the core. `fileMemory()` implements the bounded-document architecture; hosted service integrations remain provider-specific follow-up work.
 
 ### Supermemory
 
-On `message.received`, the Supermemory provider sends the resolved scope, incoming message, and visible session history to Supermemory. Supermemory decides what is relevant, and the handler returns the fully formatted text that eve persists as a user message. eve does not understand Supermemory profiles, containers, documents, search, or extraction.
+On `message.received`, the Supermemory provider sends the resolved scope, incoming message, and visible session history to Supermemory. Supermemory decides what is relevant, and the handler returns the fully formatted content in a `MemoryMessage` that eve persists as a user message. eve does not understand Supermemory profiles, containers, documents, search, or extraction.
 
 The provider's tool map may expose scoped search, save, forget, profile, or proposal tools, or another capability entirely. eve only qualifies and scope-binds the returned definitions.
 
 On `turn.completed`, the provider sends the settled session to Supermemory. Supermemory decides what to persist and how to update its own memory representation. eve does not translate the session into framework records or validate the resulting writes.
 
-### Blob documents
+### File memory
 
-The blob provider stores bounded `USER.md`- and `MEMORY.md`-style text documents under the resolved scope. Its `session.started` handler reads the documents and returns their provider-formatted contents directly, while `compaction.completed` refreshes that materialized snapshot after compaction. It requires no incoming message, search, embeddings, or record schema.
+The file-memory provider above stores one bounded `MEMORY.md`-style text document under the resolved scope. Its `session.started` handler reads the document and returns indexed memories in a `MemoryMessage`, while `compaction.completed` refreshes that materialized snapshot after compaction. It requires no incoming message, search, embeddings, or record schema.
 
-The provider owns any tools for editing, consolidating, or clearing those documents. Its `turn.completed` handler may rewrite them from the settled session and enforce provider-configured size limits. File layout, truncation or consolidation policy, concurrency, and blob-store behavior remain internal to the provider.
+Its scoped tools save one memory or remove one index without giving the model the complete document. The versioned backend seam supports Blob, KV, database, and process-local storage without changing the provider or core memory contract.
 
 This provider demonstrates that simple bounded text can participate in the same lifecycle as a hosted semantic service without eve standardizing either implementation.
 
@@ -251,7 +417,7 @@ This provider demonstrates that simple bounded text can participate in the same 
 - Scope is resolved from trusted runtime context, locked for the turn, and never accepted from model input.
 - The same provider can back several slots without sharing eve scope keys or colliding model tools.
 - `events["compaction.requested"]` sees the complete pre-compaction durable history, while `events["compaction.completed"]` sees the successfully checkpointed durable history.
-- Every supported provider event may contribute one durable user message in deterministic event and slot order.
+- Every supported provider event may contribute one or more durable user messages in deterministic returned, event, and slot order.
 - Materialized memory messages remain in later model requests, provider snapshots, and compaction input until compaction or context clearing removes them.
 - Provider tools are unconditionally slot-qualified and bound to the same locked scope as provider event handlers.
 - `events["turn.completed"]` sees the completed durable session including memory messages and settles before the next ready boundary.
@@ -268,9 +434,9 @@ This provider demonstrates that simple bounded text can participate in the same 
 - Preventing a faulty or malicious provider from ignoring the supplied scope, disclosing data, or persisting unintended content.
 - Standardizing provider package layout, vendor credentials, migrations, inspection tools, or deployment operations in this proposal.
 
-## Implementation contract follow-up
+## Implementation contract
 
-Before V1 implementation lands, follow-up plans must fix the exact public type names, connect provider handlers to the existing session and compaction events, define event/tool-map compilation and durable message replay mechanics, specify scope-part encoding, diagnostics and cancellation, and add tests for lifecycle ordering and isolation. Supermemory and blob storage each need a provider-specific plan for configuration and operational behavior without expanding the core memory contract.
+V1 fixes the public type names, connects provider handlers to existing session and compaction events, compiles event and tool maps, materializes durable memory messages, specifies scope-part encoding and cancellation behavior, and covers lifecycle ordering and isolation. Provider-specific storage plans define configuration and operational behavior without expanding the core memory contract.
 
 ## Primary references
 

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -1,0 +1,1028 @@
+---
+issue: https://github.com/vercel/eve/issues/1510
+status: proposed
+last_updated: "2026-08-01"
+---
+
+# First-class memory
+
+## Summary
+
+Add memory to eve as a first-class agent slot: durable cross-session knowledge that an agent can
+recall, remember, and forget. Remembering a replacement revises an existing record.
+
+Declaring a resolved memory collection enables one coherent capability. eve:
+
+- recalls relevant memories automatically before the response;
+- makes every collection searchable through one shared recall tool;
+- contributes collection-bound remember and forget tools;
+- captures durable claims from accepted turns; and
+- enforces scope, provenance, approval, budget, revision, and erasure semantics.
+
+These behaviors are intrinsic. No configuration can create read-only, write-only, tools-off, or
+recall-disabled memory collections, and no flag disables capture; the one code-level escape hatch is
+`prepareSource`, which may skip any source for a collection. Data that should not be mutable by the
+agent belongs in instructions, RAG, application state, or an external system of record instead.
+
+eve owns the slot grammar, trusted scope derivation, recall and mutation lifecycle, canonical public
+model, context rendering, and first-party provider integration. Applications own credentials,
+databases, stable environment identity, deployment preparation, retention, and authorization inputs.
+
+## Boundary and invariants
+
+One memory file defines a **collection**: one purpose, provider, and subject scope. At runtime, its
+scope definition resolves one subject for the turn. A `user` collection can therefore contain many
+isolated users; the file is not itself one user.
+
+| Capability                                                        | Owner                                       | Memory |
+| ----------------------------------------------------------------- | ------------------------------------------- | ------ |
+| Active-turn and per-session state                                 | eve messages, compaction, and `defineState` | No     |
+| Conversation archive and transcript search                        | Session/world storage or an application API | No     |
+| External documents and product knowledge                          | RAG or a knowledge integration              | No     |
+| Cross-session facts, preferences, events, and reusable knowledge  | Memory slot                                 | Yes    |
+| Application truth such as balances, permissions, and order status | Application system of record                | No     |
+| Trusted instructions, skills, and autonomous self-modification    | Instructions, skills, and evaluation        | No     |
+
+The design has eight invariants:
+
+1. A declared and resolved collection always provides the complete memory capability.
+2. Trusted runtime identity derives scope, and a channel-attested private audience gates disclosure;
+   model input controls neither.
+3. A versioned application, environment, graph-node, and collection-path namespace isolates every
+   collection while surviving redeploys in the same environment.
+4. Automatic and explicit recall are bounded, attributed, untrusted, and transient to the active
+   turn.
+5. Model-proposed memories require citations to eligible source text. eve verifies citation
+   integrity; semantic entailment remains an evaluation target rather than a security guarantee.
+6. Model mutations are idempotent and read-your-writes. Capture begins only from an accepted completed
+   turn and never changes that turn's response outcome.
+7. Forget and purge make content unreachable through every live memory operation. Payload-free
+   barriers prevent replay from recreating erased content.
+8. Canonical writes are durable and read-your-writes. Embeddings and indexes are rebuildable
+   projections that may lag only when stale candidates are revalidated against canonical state.
+
+Records are atomic text claims with optional occurrence time, expiry, and citations. V1 does not
+impose `fact`, `preference`, or `episode` kinds because those labels do not yet produce distinct
+behavior.
+
+## Authoring API
+
+### Slot grammar
+
+```text
+agent/memory.ts            # one collection named "memory"
+agent/memory/              # XOR with the flat file
+  user.ts                  # collection named "user"
+  preferences.ts           # collection named "preferences"
+```
+
+Every module default-exports `defineMemory(...)`. Identity comes from the path; there is no `name`
+field. The named directory is non-recursive and module-only. Invalid nesting and flat-file/directory
+collisions fail discovery. Collection slugs are lowercase snake case (`[a-z][a-z0-9_]*`) with a
+48-character maximum, so generated mutation tool names stay within eve's 64-character tool-name limit
+and never mix separator styles. Generated memory tool names are reserved: an authored tool that
+collides with `memory_recall` or a generated `memory_remember_*`/`memory_forget_*` name fails
+discovery, like subagent/tool name collisions. Shared code belongs in `agent/lib/`.
+
+Local directory-form subagents may declare the same slot. The graph node ID namespaces each
+collection, so declared subagents never share memory implicitly. The built-in `agent` tool invokes the
+root node and uses the root's collections. Single-file and remote subagents do not own local memory
+slots.
+
+### Definition
+
+Every collection requires three author decisions: purpose, persistence, and scope.
+
+```ts title="agent/memory.ts"
+import { byPrincipal, defineMemory } from "eve/memory";
+import { memory } from "./lib/memory";
+
+export default defineMemory({
+  description: "Stable facts and preferences for the authenticated user.",
+  provider: memory,
+  scope: byPrincipal(),
+});
+```
+
+This collection automatically recalls, exposes all memory tools, and captures durable claims. Forget
+always requires approval.
+
+The public definition stays intentionally small:
+
+```ts
+interface MemoryDefinition {
+  readonly description: string;
+  readonly provider: MemoryProvider;
+  readonly scope: MemoryScopeDefinition;
+  readonly capture?: {
+    readonly model?: AgentStaticModelDefinition;
+    readonly reasoning?: AgentReasoningDefinition;
+    readonly modelOptions?: AgentModelOptionsDefinition;
+    readonly instructions?: string;
+    readonly prepareSource?: MemorySourcePreparer;
+  };
+}
+
+interface MemorySourcePrepareContext {
+  readonly collection: string;
+  readonly sourceId: string;
+  readonly observedAt: string;
+  readonly auth: SessionAuthContext;
+  readonly signal: AbortSignal;
+}
+
+type MemorySourcePreparer = (
+  text: string,
+  context: MemorySourcePrepareContext,
+) => string | null | Promise<string | null>;
+```
+
+`MemoryProvider` and `MemoryScopeDefinition` are opaque eve values. V1 has no public custom provider,
+scope-resolver, extractor, embedder, tag schema, collection weight, tool toggle, or token-budget API.
+
+### Capture configuration
+
+Capture is intrinsic. Omit `capture` to use eve's defaults; the block only configures capture:
+
+```ts
+capture: {
+  model: "anthropic/claude-sonnet-5",
+  reasoning: "low",
+  modelOptions: {
+    providerOptions: {
+      gateway: { serviceTier: "flex" },
+    },
+  },
+  instructions: "Prefer durable preferences over one-time requests.",
+  prepareSource(text, context) {
+    return text;
+  },
+},
+```
+
+- `model` selects the capture-only model. It accepts a Gateway ID or direct AI SDK `LanguageModel`,
+  but not dynamic selection because a durable intent must pin one replayable model. Omission uses the
+  agent's compiled static model.
+- `reasoning` sets provider-agnostic AI SDK reasoning effort. With no model override, omission inherits
+  the agent setting. An overridden model uses its provider default unless set explicitly.
+- `modelOptions` forwards provider-specific options only to capture calls. With no model override,
+  omission inherits agent options and an explicit value replaces them. An overridden model inherits
+  no options.
+- `instructions` supplements eve's versioned extraction policy. It cannot expand eligible sources,
+  bypass citations, or weaken hard limits.
+- `prepareSource` is a capture-only minimization and redaction hook. It receives bounded normalized
+  inbound text and trusted collection, source, time, auth, and abort context. It returns transformed
+  text or `null` to skip capture for that source and collection. It does not alter response input,
+  automatic recall, or explicit remember citations. An unconditional `null` is the sanctioned
+  code-level way to run a collection without automatic capture; explicit remember and application
+  writes still work.
+
+V1 capture accepts only authored inbound text. It excludes assistant output, imported threads,
+channel/client context, instructions, reasoning, tool traffic, approvals, attachments, abandoned
+attempts, and uncommitted output.
+
+**Recording action outcomes.** Assistant output is ineligible as capture source and citation evidence
+because it can be attacker-influenced through prompt injection. The sanctioned path for durable action
+memory — "the agent booked the 3pm flight" — is an application write: the tool that performs the
+action records the outcome through `ctx.getMemory(...)`, which commits with `origin: "application"`
+and needs no model citation.
+
+## Model tools
+
+Memory tools are intrinsic framework operations, not ordinary authored tools. They cannot be disabled,
+replaced, or independently configured. This deliberately diverges from the `disableTool()` sentinel
+available for framework default tools: declaring the collection is the opt-in, and the slot always
+carries its complete capability.
+
+The shared tool is `memory_recall`. The flat slot contributes `memory_remember` and `memory_forget`;
+named collections contribute `memory_remember_<collection>` and `memory_forget_<collection>`.
+
+```ts
+interface MemoryRecallToolInput {
+  readonly query: string;
+  readonly collection?: string;
+  readonly occurredAfter?: string;
+  readonly occurredBefore?: string;
+  readonly limit?: number;
+}
+
+interface MemoryRememberToolInput {
+  readonly content: string;
+  readonly citation: {
+    readonly sourceHandle: string;
+    readonly quote: string;
+  };
+  readonly occurredAt?: string;
+  readonly expiresAt?: string;
+  readonly supersedes?: string;
+}
+
+interface MemoryForgetToolInput {
+  readonly handle: string;
+}
+```
+
+Mutation tools are collection-bound, so the model never chooses a write scope.
+
+Model-facing records use signed short-lived handles rather than canonical IDs:
+
+```ts
+interface MemoryToolRecord {
+  readonly collection: string;
+  readonly handle: string;
+  readonly content: string;
+  readonly observedAt: string;
+  readonly occurredAt?: string;
+  readonly expiresAt?: string;
+  readonly citations: readonly { readonly quote: string }[];
+}
+
+interface MemoryRecallToolResult {
+  readonly memories: readonly MemoryToolRecord[];
+  readonly failures: readonly {
+    readonly collection: string;
+    readonly code: "deadline_exceeded" | "unavailable";
+    readonly retryable: boolean;
+  }[];
+  readonly truncated: boolean;
+}
+
+type MemoryRememberToolResult =
+  | {
+      readonly status: "created" | "revised";
+      readonly memory: MemoryToolRecord;
+    }
+  | { readonly status: "erased" | "purged" };
+
+interface MemoryForgetToolResult {
+  readonly status: "erased" | "purged";
+}
+```
+
+`memory_recall` searches every resolved collection when `collection` is omitted. eve owns
+cross-collection allocation, rank fusion, deterministic ties, diversity, and the cumulative per-turn
+result budget. A partial recall returns usable memories plus sanitized collection failures; failure of
+every selected collection fails the tool. Provider scores and messages never reach the model.
+
+Every framework-normalized source is rendered with a source handle. A remember citation is
+`{ sourceHandle, quote }`; the normalized quote must occur in that source. `supersedes` references the
+current memory handle. Recalled memory, assistant output, imported context, and tool results are
+ineligible evidence.
+
+Remember and forget are idempotent framework side effects. eve checkpoints a stable operation ID and
+exact request before execution, reports success only after the provider commits, and makes the result
+visible to later model steps. Replay returns the original result while its content remains live; after
+forget or purge it returns payload-free `erased` or `purged`. A later-abandoned response does not roll
+back a completed mutation.
+
+Expected tool failures use stable codes:
+
+- `memory_handle_expired`: recall again for a fresh handle;
+- `memory_revision_conflict`: the addressed revision or purge generation is stale;
+- `memory_handle_invalid`: the handle is malformed, tampered, or belongs to another scope;
+- `memory_citation_invalid`: the source handle or quote failed validation;
+- `memory_approval_unavailable`: the session cannot request the required forget approval because it
+  lacks the input capability; erase through the application or admin surface instead; and
+- `memory_recall_unavailable`: every selected collection failed, with sanitized collection codes.
+
+Forget approval rides the existing tool-approval pipeline. In a session that cannot park for input,
+`memory_forget` returns `memory_approval_unavailable` as an expected tool failure; it never parks a
+task turn or fails the turn.
+
+The failed `memory_recall_unavailable` result carries the same sanitized `failures` entries as a
+partial success and no provider messages or scores.
+
+Memory content never enters durable transcript history: history stores payload-free placeholders that
+preserve call/result pairing, and validated transient turn content supplies the payloads, so erasure
+reaches every live surface. Workflow journals may retain normalized source envelopes under world
+retention.
+
+## Application control
+
+Application code never uses a provider directly. `MemoryClient` is subject-bound: eve creates it only
+from matching current auth and private audience, and every method retains that sealed scope. A separate
+`MemoryAdminClient` is available only through the explicit trusted-operator route surface for data
+access, rectification, and erasure workflows. Public IDs, revision tokens, handles, and cursors are
+opaque strings.
+
+```ts
+interface MemoryRecordCitation {
+  readonly sourceView: "normalized" | "capture-prepared";
+  readonly sourceId: string;
+  readonly quote: string;
+}
+
+interface MemoryRevision {
+  readonly revision: string;
+  readonly content: string;
+  readonly origin: "capture" | "model-tool" | "application";
+  readonly observedAt: string;
+  readonly occurredAt?: string;
+  readonly expiresAt?: string;
+  readonly citations: readonly MemoryRecordCitation[];
+}
+
+interface MemoryRecord extends MemoryRevision {
+  readonly recordId: string;
+}
+
+interface MemoryRecallInput {
+  readonly query: string;
+  readonly occurredAfter?: string;
+  readonly occurredBefore?: string;
+  readonly limit?: number;
+}
+
+interface MemoryRecallResult {
+  readonly records: readonly MemoryRecord[];
+  readonly truncated: boolean;
+}
+
+interface MemoryListInput {
+  readonly cursor?: string;
+  readonly limit?: number;
+}
+
+interface MemoryPage {
+  readonly records: readonly MemoryRecord[];
+  readonly cursor: string | null;
+}
+
+type MemoryRememberInput =
+  | {
+      readonly content: string;
+      readonly occurredAt?: string;
+      readonly expiresAt?: string;
+    }
+  | {
+      readonly recordId: string;
+      readonly expectedRevision: string;
+      readonly content: string;
+      readonly occurredAt?: string;
+      readonly expiresAt?: string;
+    };
+
+interface MemoryMutationOptions {
+  readonly idempotencyKey: string;
+  readonly signal?: AbortSignal;
+}
+
+type MemoryErrorCode =
+  | "revision_conflict"
+  | "idempotency_conflict"
+  | "invalid_cursor"
+  | "export_invalidated"
+  | "unavailable";
+
+declare class MemoryOperationError extends Error {
+  readonly name: "MemoryOperationError";
+  readonly code: MemoryErrorCode;
+  readonly retryable: boolean;
+}
+
+type MemoryRememberResult =
+  | { readonly status: "created" | "revised"; readonly record: MemoryRecord }
+  | { readonly status: "erased" | "purged" };
+
+type MemoryForgetResult =
+  | { readonly status: "erased"; readonly erasedAt: string }
+  | { readonly status: "not_found" | "purged" };
+
+interface MemoryClient {
+  recall(input: MemoryRecallInput, options?: { signal?: AbortSignal }): Promise<MemoryRecallResult>;
+  get(
+    input: { readonly recordId: string },
+    options?: { signal?: AbortSignal },
+  ): Promise<MemoryRecord | null>;
+  list(input?: MemoryListInput, options?: { signal?: AbortSignal }): Promise<MemoryPage>;
+  remember(
+    input: MemoryRememberInput,
+    options: MemoryMutationOptions,
+  ): Promise<MemoryRememberResult>;
+  forget(
+    input: { readonly recordId: string; readonly expectedRevision?: string },
+    options: MemoryMutationOptions,
+  ): Promise<MemoryForgetResult>;
+}
+
+type MemoryAdminClient = Omit<MemoryClient, "recall"> & {
+  exportRecords(options?: { signal?: AbortSignal }): AsyncIterable<{
+    readonly recordId: string;
+    readonly revisions: readonly MemoryRevision[];
+  }>;
+  purge(
+    options: MemoryMutationOptions,
+  ): Promise<{ readonly status: "purged"; readonly purgeId: string; readonly purgedAt: string }>;
+};
+```
+
+Every method resolves to a plain value. Expected failures throw `MemoryOperationError` with a stable
+machine-readable `code` and a `retryable` flag, following the connection-error convention: guards
+match on `name` and `code` rather than `instanceof` because bundlers can duplicate class instances.
+`revision_conflict`, `idempotency_conflict`, `invalid_cursor`, and `export_invalidated` are never
+retryable; `unavailable` is the sanitized provider or deadline failure and is retryable. Benign
+outcomes — `not_found`, replay against erased content — are status values, not errors.
+
+A correction is a full replacement and requires both record ID and expected revision. Forget without
+an expected revision erases the current logical record; with one, a stale target throws
+`revision_conflict`. Application writes need no model citation, but framework bounds and encoding rules
+still apply. Public timestamps are RFC 3339 instants; limits must be finite positive integers and are
+clamped to eve's versioned maximum.
+
+An occurrence-time filter excludes records without `occurredAt`; without a filter those records remain
+eligible. `list` orders live records by `observedAt` descending and record ID ascending. Expired records
+are absent from recall, `get`, and `list`, but retained expired and superseded revisions remain in
+`exportRecords` until retention or erasure removes them.
+
+An idempotency key binds scope, method, and normalized request. Exact replay returns the original
+result only while its content remains live. After forget or purge, replay returns payload-free
+`erased` or `purged`; it never returns deleted content or recreates the write. Changed input throws
+`idempotency_conflict`.
+
+Cursors bind collection, scope, purge generation, snapshot, and order. Invalid, expired, wrong-scope,
+or pre-purge cursors throw `invalid_cursor` rather than restarting. Export iterates one snapshot. If
+forget or purge changes retained content, the next iterator operation rejects with `export_invalidated`;
+only clean iterator completion means the export is complete. Sanitized provider availability failures
+throw `unavailable`; raw database errors and physical keys remain internal.
+
+## Trusted scope and namespace
+
+V1 has one scope definition: `byPrincipal()`. It uses `auth.current`, requires
+`principalType: "user"`, and resolves this versioned tuple:
+
+```ts
+type CanonicalMemoryPrincipalV1 = readonly [
+  version: 1,
+  principalType: "user",
+  authorityKind: "issuer" | "authenticator",
+  authority: string,
+  principalId: string,
+];
+```
+
+`issuer` is preferred when present; otherwise eve uses `authenticator`. Required strings must be
+non-empty. Attributes, display names, `subject`, and `auth.initiator` never define identity.
+
+The local provider has one dev-only exception: the trusted dev host may inject a branded memory
+principal projection for the existing `local-dev` caller. This does not change `SessionAuthContext`,
+does not make the caller a `user` for connections or governance, and cannot exist outside the local
+provider capability described below.
+
+```ts
+declare const deliveryAudienceBrand: unique symbol;
+
+interface DeliveryAudience {
+  readonly [deliveryAudienceBrand]: true;
+}
+```
+
+The unique-symbol brand provides TypeScript opacity only. Runtime unforgeability comes from a sealed
+token created and validated by module-private channel-runtime identity; copied, deserialized, payload-
+authored, and merely shape-compatible objects fail validation. Built-in channels attach the token
+internally. Trusted custom-channel route handlers receive `attestPrivateAudience(auth)` and may call it
+only after enforcing that every response path is restricted to that principal. The sealed value binds
+registered channel identity and the same principal tuple. Local subagents inherit the sealed root-turn
+audience and cannot remint it.
+
+A collection resolves only when current principal and private audience match exactly. Missing,
+anonymous, non-user, shared, unknown, or mismatched identity makes the collection unavailable: no
+automatic recall, tools, capture, outbox, or application client. It never falls back to another scope.
+Unavailability is fail-closed but never fail-silent: eve emits a content-free resolution diagnostic (a
+trace event and a dev-time notice) naming the collection and the failed condition, and `/info`
+descriptors report per-collection resolution state for the current caller.
+
+Before memory ships, eve delivery must preserve one immutable envelope per source containing source
+ID, order, provenance, auth, audience, and fingerprints. Payloads cannot mint attestations. Coalescing
+may combine model input only after compatible envelopes are grouped and never across auth or audience
+fingerprints. Built-in channels must enforce private destination ownership on send, continue, stream,
+cancel, and reset paths before they attest privacy.
+
+Canonical provider keys derive from this tuple and are passed as keyed opaque digests:
+
+```ts
+type CanonicalMemoryScopeV1 = readonly [
+  protocol: "eve-memory",
+  version: 1,
+  applicationId: string,
+  environmentId: string,
+  graphNodeId: string,
+  collectionPath: string,
+  principal: CanonicalMemoryPrincipalV1,
+];
+```
+
+`applicationId` and `environmentId` are stable provider configuration. Vercel integrations may derive
+them from project and target environment. Self-hosted applications must provide them explicitly;
+hostname, working directory, `NODE_ENV`, Git SHA, build path, and deployment ID are invalid fallbacks.
+`applicationId` is the sole stable root identity; package and display-name changes do not affect
+memory. `graphNodeId` is the root sentinel or path-derived local-subagent address. Redeployments in one
+environment share memory. Production, preview, development, different application IDs, nodes, paths,
+and app roots do not share implicitly. Node and collection path renames intentionally require
+migration.
+
+### V1 scope trade-off
+
+V1 memory exists only for authenticated `user` principals. Agents behind `none()` auth (anonymous
+callers), service and `runtime` principals, schedule-driven turns, and unknown identities never
+resolve a collection: a declared slot compiles, tools and capture stay absent, and the resolution
+diagnostic above is the only observable. The `local-dev` projection is the sole dev-time exception.
+
+This is deliberate. Cross-subject disclosure is the dominant memory risk, and trusted identity is the
+only safe scope key, so V1 refuses to guess a subject. An agent-global `byAgent()` scope was
+considered and deferred: it has no cross-subject disclosure boundary, but every caller reads and
+writes one shared store, so persisted prompt injection from any caller reaches every caller, and
+neither citations nor approval isolate subjects within it. Shared and global scopes wait for the
+shared-scope disclosure semantics in the final delivery phase rather than shipping with weaker
+guarantees than the private scope.
+
+### Application addressing
+
+In-turn callbacks stay bound to their current graph node:
+
+```ts
+interface SessionContext {
+  getMemory(collection: string): Promise<MemoryClient | null>;
+}
+```
+
+Unknown collections throw; unavailable principal scope returns `null`. Route handlers can enumerate
+and address root and local-subagent collections:
+
+```ts
+type MemoryNodeAddress =
+  { readonly kind: "root" } | { readonly kind: "local-subagent"; readonly nodeId: string };
+
+interface MemoryCollectionAddress {
+  readonly node: MemoryNodeAddress;
+  readonly collection: string;
+}
+
+interface MemoryCollectionDescriptor {
+  readonly address: MemoryCollectionAddress;
+  readonly description: string;
+}
+
+interface MemoryPrincipalAddress {
+  readonly authenticator: string;
+  readonly issuer?: string;
+  readonly principalId: string;
+}
+
+interface RouteHandlerArgs {
+  attestPrivateAudience(auth: SessionAuthContext): DeliveryAudience;
+  listMemoryCollections(): readonly MemoryCollectionDescriptor[];
+  getMemory(input: {
+    readonly address: MemoryCollectionAddress;
+    readonly auth: SessionAuthContext;
+    readonly audience: DeliveryAudience;
+  }): Promise<MemoryClient | null>;
+  getMemoryAdmin(input: {
+    readonly address: MemoryCollectionAddress;
+    readonly principal: MemoryPrincipalAddress;
+    readonly operator: {
+      readonly auth: SessionAuthContext;
+      readonly reason: string;
+    };
+  }): Promise<MemoryAdminClient>;
+}
+```
+
+Enumeration is root first, then local node ID and collection name. Node IDs are opaque values obtained
+from enumeration, not constructed by applications. Remote subagents own memory remotely.
+
+`getMemory(...)` requires a verified principal and an attested private audience — a handler lacking
+either has nothing to pass and must not call it — and returns `null` only when that auth does not
+resolve the collection's scope. The subject binding covers the entire client, including mutations,
+because its results may flow into that response.
+
+`getMemoryAdmin(...)` requires no subject audience and never impersonates the subject. A
+`MemoryPrincipalAddress` canonicalizes exactly as scope resolution would — `issuer` is the authority
+when present, otherwise `authenticator` — and admin lookups match only that canonical tuple, with no
+fuzzy or cross-authority matching, so an operator must supply the same authority the records were
+written under. Unknown addresses and malformed principal addresses throw; the call never returns
+`null` because admin access does not depend on subject scope resolution. The application must
+authorize the operator before the call; eve records the operator fingerprint, reason, target,
+operation, and outcome. Admin clients are never exposed to model tools, callbacks, dynamic resolvers,
+or serialized payloads.
+
+Aggregate data-subject export and purge iterate descriptors and acquire one admin client per
+collection. Arbitrary future custom scopes must register enumerable subject mappings. `/info` may
+expose descriptors for inspection, never subjects or content.
+
+## Sources and lifecycle
+
+### Source views
+
+eve maintains two immutable views instead of overloading “prepared source”:
+
+| View                        | Created                           | Consumers                                                   |
+| --------------------------- | --------------------------------- | ----------------------------------------------------------- |
+| Framework-normalized source | Once per accepted authored source | Recall query, response source handles, explicit citations   |
+| Capture-prepared source     | Per source and collection         | Capture model, capture validation, capture-origin citations |
+
+Framework normalization identifies authored text before adapters merge model messages, converts it to
+well-formed NFC Unicode, normalizes line endings, removes blank parts, joins ordered text parts, and
+applies a versioned UTF-8 bound. It preserves case, punctuation, and remaining whitespace. Each source
+retains its ID, normalization version, digest, order, provenance, trusted time, auth, and audience
+fingerprints.
+
+`prepareSource` transforms only the second view. Returning `null` skips capture for that collection;
+it does not suppress recall or invalidate explicit source handles. Response-model handles bind the
+normalized digest. Model-tool citations bind normalized byte offsets; capture citations bind the
+prepared digest, preparation fingerprint, and prepared byte offsets. Recall returns stored immutable
+citations and never reruns preparation.
+
+Normalized source envelopes live in the world/session journal under world retention. Memory providers
+retain only revision-owned cited excerpts and payload-free source receipts, not complete source
+objects. Memory erasure does not claim physical deletion from world journals, transcripts, telemetry,
+or model-provider retention.
+
+### Turn lifecycle
+
+```text
+accept + seal per-source envelopes
+        |
+framework-normalize authored text
+        |
+compact and commit placeholder history
+        |
+recall + commit transient turn overlay
+        |
+validate + materialize -> one response-model attempt
+        |
+execute checkpointed memory tools during the loop
+        |
+commit terminal turn checkpoint + capture outbox
+        |
+settle response -> prepare per collection -> dispatch capture
+```
+
+This requires new execution primitives before the public API ships. eve must own model retries, disable
+nested SDK retries, preserve source provenance through coalescing, and commit terminal classification
+with durable session state. Stream events remain append-only and may already be visible; capture
+eligibility derives only from the durable checkpoint.
+
+The checkpoint records the durable protocol outcome and accepted sources. It is internal execution
+machinery, not public API; it appears here only to define capture eligibility:
+
+```ts
+interface TurnTerminalCheckpoint {
+  readonly sessionId: string;
+  readonly turnId: string;
+  readonly sequence: number;
+  readonly outcome: "completed" | "failed" | "cancelled";
+  readonly acceptedSourceIds: readonly string[];
+}
+```
+
+| Turn path                                   | Outcome       | Capture                              |
+| ------------------------------------------- | ------------- | ------------------------------------ |
+| Normal response or completed HITL boundary  | `completed`   | Eligible authored normalized text    |
+| Authorization, runtime action, or task wait | No checkpoint | Deferred                             |
+| Recoverable or terminal turn failure        | `failed`      | Never                                |
+| Cancellation before completion              | `cancelled`   | Never                                |
+| Adapter consumes delivery without a turn    | No checkpoint | Never                                |
+| Workflow replay                             | Same outcome  | Idempotent using the same source IDs |
+
+A completed checkpoint creates no outbox for an unresolved collection. For a resolved collection, no
+authored text or a `null`/blank prepared source produces an internal `skipped` status. Capture retries
+transient failures; exhausted retries become `failed`, and stale generation or definition becomes
+`obsolete`. These content-free statuses appear in traces and diagnostics only. V1 exposes no capture
+polling or freshness barrier. A following turn may not observe capture; callers needing read-after-write
+use explicit remember or an application write.
+
+### Recall
+
+Recall runs after compaction and before the first response-model request. Its query uses the latest
+framework-normalized input plus a bounded visible window for coreference. It combines relevant and
+recent candidates under one token and wall-clock budget.
+
+Transient provider and deadline failures do not fail the turn. Successful collections still
+contribute; each failed collection contributes only a content-free `unavailable` status and emits a
+diagnostic. If every collection fails, the response model still runs with that status rather than an
+empty-memory result. Scope, generation, expiry, signature, and canonical-integrity checks remain
+fail-closed for disclosure: invalid content is never supplied.
+
+The explicit recall tool uses the same partial-success representation. When every explicitly selected
+collection fails, the tool returns `memory_recall_unavailable` so the model can react inside the loop;
+automatic recall instead places the equivalent status before the first model call. This preserves agent
+availability without representing an outage as “the user has no memories.”
+
+The contribution is a length-delimited data block attributed by collection name, purpose, handle,
+revision time, and available citation. A fixed trusted instruction identifies it as untrusted data. It
+does not change eve permission or approval gates, although stored prompt injection can still influence
+the model.
+
+Immediately before each eve-owned model request, eve rechecks scope, purge generation, expiry,
+definition fingerprint, and exact revisions. An unrelated write causes rehydration rather than whole-
+collection invalidation. A projection can nominate candidates only; canonical rehydration prevents
+superseded, expired, erased, or purged content from reappearing.
+
+### Capture
+
+For every collection resolved at turn admission, a completed checkpoint creates a payload-free outbox
+entry that references accepted normalized sources and pins collection, scope, purge generation,
+provider fingerprint and incarnation, preparation fingerprint, model and extraction versions, source
+sequence, audience, time, and provenance. It never reruns scope resolution. A provider-incarnation
+mismatch is terminal `obsolete` and cannot adopt a replacement store.
+
+Capture executes as a durable, idempotent workflow against one strong canonical snapshot: the pinned
+model proposes add, supersede, or no-op operations with exact citations, and eve verifies preparation
+hashes, byte offsets, bounds, and revision expectations before committing the exact proposal with a
+replay receipt. Conflicts re-propose against fresh state rather than blindly retrying.
+
+Each scope has a monotonic source sequence. A delayed older turn may add a historical event but cannot
+supersede state learned from a newer source.
+
+## Canonical model and erasure
+
+| Record                | Purpose                                   | Core fields                                                     |
+| --------------------- | ----------------------------------------- | --------------------------------------------------------------- |
+| `MemoryScopeVersion`  | Resurrection and cache invalidation       | purge generation, content revision, source sequence             |
+| `MemorySourceReceipt` | Accepted-source identity and replay guard | source ID, keyed digest, clocks, preparation/provenance version |
+| `MemoryCitation`      | Revision-owned evidence                   | source view/digest, version, byte offsets, quote                |
+| `MemoryRevision`      | Immutable assertion revision              | IDs, content, origin, times, citations                          |
+| `MemoryRecord`        | Current canonical view                    | current revision and derived expiry state                       |
+| `MemoryHit`           | Provider recall result                    | canonical candidate ID and provider rank signals                |
+| Erasure receipts      | Payload-free deletion evidence            | operation, target or generation, key version, time              |
+| Admin audit events    | Trusted-operator accountability           | operator fingerprint, reason, target, operation, outcome, time  |
+
+`observedAt` is canonical commit time, `occurredAt` is optional event time, and `expiresAt` excludes a
+record at or after its deadline according to the provider's trusted clock. Recall, `get`, and `list`
+exclude expired records; export includes retained expired revisions until retention or erasure removes
+them.
+
+Corrections append a revision under one logical ID and require the current revision token. CAS ensures
+one current revision. Stale remember and forget handles conflict rather than changing newer data. V1
+has no implicit decay, confidence score, autonomous inference, or graph relation.
+
+Forget removes one logical record, its revisions, and revision-owned evidence from live operations.
+It does not find semantically duplicated claims; scope purge is the complete live-memory erasure
+operation. Payload-free receipts and generation barriers remain for at least the maximum replay and
+idempotency horizon. Accepted mutation receipts shed content when their target is erased and resolve
+future replay to `erased` or `purged`. Receipts are pseudonymous operational data, not literally
+data-free.
+
+Restoring an older database requires replaying a separately retained erasure ledger before traffic
+resumes. Physical database remnants, replicas, backups, workflow journals, transcripts, telemetry, and
+model-provider retention remain governed by their own policies.
+
+## Provider boundary
+
+V1 publicly exposes only opaque first-party `MemoryProvider` values. A provider owns persistence,
+within-collection retrieval, projections, readiness, and migration. eve owns scope, canonical public
+semantics, citations, handles, tools, idempotency orchestration, deadlines, cross-collection fusion,
+budgets, rendering, and final disclosure validation.
+
+The internal protocol must prove namespace isolation, durable canonical writes, strong formation
+reads, revision CAS, expiry, erase, purge barriers, bounded snapshot export, stale-projection
+rehydration, readiness, cancellation, limits, fingerprints, retention horizons, and race behavior.
+Public third-party support waits for production evidence and a branded provider API plus conformance
+kit.
+
+### PostgreSQL reference provider
+
+PostgreSQL owns both document and query embedding. `defineMemory` never accepts an embedding model;
+managed future providers may embed upstream or use a different retrieval strategy entirely.
+
+```ts
+interface MemoryEmbeddingCallOptions {
+  readonly providerOptions?: Record<string, JsonObject>;
+}
+
+interface PostgresMemoryEmbeddingDefinition {
+  readonly model: string | EmbeddingModel;
+  readonly modelRevision?: string;
+  readonly dimensions: number;
+  readonly documentOptions?: MemoryEmbeddingCallOptions;
+  readonly queryOptions?: MemoryEmbeddingCallOptions;
+}
+
+interface PostgresMemoryDefinition {
+  readonly database: PostgresMemoryDatabase;
+  readonly namespace: {
+    readonly applicationId: string;
+    readonly environmentId: string;
+  };
+  readonly embedding: PostgresMemoryEmbeddingDefinition;
+}
+
+interface PostgresMemoryConnection {
+  query<Row extends Record<string, unknown> = Record<string, unknown>>(
+    text: string,
+    values?: readonly unknown[],
+    options?: { readonly signal?: AbortSignal },
+  ): Promise<{ readonly rows: readonly Row[] }>;
+  release(): void;
+}
+
+interface PostgresMemoryPool {
+  connect(options?: { readonly signal?: AbortSignal }): Promise<PostgresMemoryConnection>;
+}
+
+declare function pgDatabase(pool: PostgresMemoryPool): PostgresMemoryDatabase;
+declare function postgresMemory(definition: PostgresMemoryDefinition): PostgresMemoryProvider;
+
+declare function preparePostgresMemory(
+  provider: PostgresMemoryProvider,
+  options?: { readonly signal?: AbortSignal },
+): Promise<{
+  readonly status: "ready";
+  readonly schemaVersion: number;
+  readonly projectionFingerprint: string;
+}>;
+```
+
+```ts title="agent/lib/memory.ts"
+import { pgDatabase, postgresMemory } from "eve/memory/postgres";
+import { pool } from "./database";
+import { memoryNamespace } from "./environment";
+
+export const memory = postgresMemory({
+  database: pgDatabase(pool),
+  namespace: memoryNamespace,
+  embedding: {
+    model: "openai/text-embedding-3-small",
+    dimensions: 1536,
+  },
+});
+```
+
+`memoryNamespace` must derive the current stable application and target environment. Never hardcode an
+environment name in shared source: preview and production must resolve different values, and a missing
+or ambiguous value fails provider readiness. The Vercel integration owns this derivation for the
+majority path: a first-party helper resolves `applicationId` from the project and `environmentId` from
+the target environment, so a Vercel-deployed application writes no namespace code. Self-hosted
+applications provide both explicitly.
+
+The embedding model accepts a Gateway ID or direct AI SDK `EmbeddingModel`. Query and document call
+options may separately provide provider options for role-specific APIs. `modelRevision` defaults to the
+Gateway ID when `model` is a string; a direct `EmbeddingModel` instance, mutable alias, middleware, or
+custom endpoint requires an explicit revision because eve cannot derive a stable identity from it.
+Dimensions are required and verified because AI SDK models do not report them reliably.
+
+Retrieval strategy is a provider implementation choice, not an author knob. V1 uses hybrid recall —
+lexical, vector, and recency lanes fused deterministically within the collection — over canonical
+rows; eve rehydrates canonical state and fuses collections. A canonical write is durable and
+read-your-writes even when its embedding has not yet committed; embeddings are rebuildable projections
+that commit only while they still match canonical state. Query-embedding failure is an operational
+recall failure, never an empty result; automatic recall reports the collection as `unavailable` under
+the policy above. Stable PostgreSQL memory has no lexical-only mode.
+
+Every retrieval-affecting choice — model identity and revision, dimensions, call options,
+preprocessing, ranking, and fusion version — is covered by one projection fingerprint. Changing any of
+them builds a side-by-side projection generation and activates it atomically only after backfill.
+Runtime readiness verifies schema, pgvector, the active fingerprint, and completed backfill before a
+session uses memory.
+
+`PostgresMemoryDatabase` and `PostgresMemoryProvider` are opaque branded values. `pgDatabase(pool)`
+accepts the structural lease contract above, never closes it, and adds no `pg` runtime dependency.
+Connections and queries must honor the supplied abort signal, including blocked acquisition and
+in-flight cancellation. `preparePostgresMemory(...)` runs migrations, canary validation, backfill, and
+projection activation; applications invoke it from a deploy-time step — a build command on Vercel, a
+migration job self-hosted — before new code serves traffic. eve never migrates implicitly: `eve dev`
+and `eve start` fail readiness rather than migrate on demand, and a failed prepare rejects without
+changing the active generation. Namespace migration freezes old writers and preserves purge
+generations and receipts. PostgreSQL erasure guarantees live logical unreachability, not immediate
+sanitization of MVCC pages, WAL, replicas, snapshots, or backups.
+
+### Test and local providers
+
+Tests create an isolated deterministic provider explicitly:
+
+```ts
+import { byPrincipal, defineMemory } from "eve/memory";
+import { createTestMemory } from "eve/memory/testing";
+
+const testMemory = createTestMemory();
+
+export default defineMemory({
+  description: "Stable user preferences.",
+  provider: testMemory.provider,
+  scope: byPrincipal(),
+});
+```
+
+The controller provides a fixed controllable clock, queued `snapshot()` and `reset()` operations, and
+an opaque provider. It performs no filesystem, network, wall-clock, random, or timer access. It enforces
+the real canonical, CAS, idempotency, expiry, citation, erase, purge, and cursor semantics rather than
+acting as a permissive fake.
+
+Local development selects an explicit provider; eve never silently substitutes it for PostgreSQL:
+
+```ts title="agent/lib/memory.ts"
+import { localMemory } from "eve/memory/local";
+
+export const memory = localMemory();
+```
+
+`localMemory()` uses `DatabaseSync` directly from Node's built-in `node:sqlite`, adding no package,
+ORM, native addon, or database adapter. It stores canonical state in
+`.eve/memory/v1/local.sqlite`, enables WAL, and commits mutations with SQLite transactions. The path is
+rooted at the authored app rather than a generated snapshot, so memory survives hot reloads, worker
+replacement, `/new`, and `eve dev` restarts. Schema readiness gates generation activation; migrations
+require quiesced dev workers, and transactions fence the schema version and store incarnation.
+
+The local provider stores no embeddings or search projection. It loads a bounded live scope and uses a
+shared versioned deterministic JavaScript ranker with lexical, fuzzy, and recent lanes. This is for
+lifecycle development and predictable tests, not evidence of production recall quality.
+
+The loopback dev channel retains its existing `local-dev` auth identity. The trusted dev host supplies
+a separate module-private memory principal and private audience, with session ownership enforced on all
+lifecycle routes. This does not make the synthetic caller a user for connections, permissions, or
+authored callbacks.
+
+Local inspection and reset are available through `eve memory path|ls|show|recall|reset`. These
+commands operate on the local provider's SQLite store only; they never connect to a production
+provider. Content is redacted from framework traces by default. The provider creates app-local ignore
+protection for `.eve/memory`, and build/deployment adapters hard-exclude it. Corruption fails closed
+and explicit reset quarantines the database, WAL, and SHM before creating a new incarnation.
+
+The test and local providers are rejected by `eve build` and `eve start`; mounting additionally requires
+a module-private test or `eve dev` runtime capability rather than an environment variable. There is no
+production escape hatch or automatic migration to PostgreSQL.
+
+## Delivery plan
+
+1. **Source provenance (standalone).** Add sealed per-source envelopes, framework normalization, and
+   fingerprint-grouped coalescing. This fixes an existing attribution defect — batch coalescing keeps
+   only the most recent delivery's auth — and changes core delivery behavior for all agents: model
+   input is grouped by compatible envelopes and never merged across auth or audience fingerprints. It
+   lands independently of memory.
+2. **Lifecycle proof.** Add transient turn overlays, eve-owned model attempts, checkpointed mutations,
+   terminal outcomes, and the capture outbox. The overlay/placeholder-history mechanism is the
+   highest-risk component and gates on dedicated failure-mode tests across compaction, replay, and
+   streaming before anything depends on it. No public memory API.
+3. **Private retrieval proof.** Add PostgreSQL canonical storage, embedding configuration, lexical and
+   vector projections, fingerprint generations, hybrid fusion, readiness, and quality evaluation. No
+   public memory API.
+4. **Complete private principal memory.** Add the slot, `byPrincipal()`, intrinsic tools, capture,
+   application clients, node enumeration, erase, purge, export, local/test providers, diagnostics,
+   migration, restore, and race tests.
+5. **Public V1.** Ship only after hybrid quality, latency, cost, failure, erasure, migration, and restore
+   gates pass.
+6. **Advanced scopes and providers.** Add shared and agent-global scopes and custom resolvers, then
+   stabilize the public provider protocol from production evidence.
+
+Integration packages may export providers and, after V1, scope definitions, but do not contribute
+memory slots. The consuming agent owns collection paths, credentials, scope, and capture configuration.
+
+## Verification and evaluation
+
+Deterministic tests cover namespace/principal isolation, private audiences, source provenance,
+normalization, token/deadline budgets, transient history, checkpointed mutations, capture eligibility,
+idempotency, CAS, citation offsets, stale ordering, expiry, erase, purge, restore barriers, projection
+lag, and PostgreSQL races.
+
+Scenario tests prove that one user can remember, recall, correct, export, forget, and purge across
+sessions and redeploys in one environment while another never observes or mutates the content. They
+cover root and local-subagent collections, explicit tools, capture, retries, application writes, and
+the immediately-following-turn freshness caveat.
+
+Quality gates report formation and retrieval separately: extraction precision/recall, entailment,
+duplication, correction, temporal accuracy, Recall@k, NDCG, abstention, answer improvement/harm, prompt
+injection, secret capture, p50/p95 latency, capture lag, tokens, cost, and failure rate. Failed requests
+remain in headline metrics. LoCoMo, LongMemEval, BEAM, and MemoryBench inform quality under pinned
+models, datasets, and context budgets but do not replace isolation, deletion, concurrency, provenance,
+and prompt-structure tests.
+
+## Out of scope
+
+- Read-only, write-only, recall-disabled, or tool-disabled memory collections, and configuration
+  flags that disable capture (`prepareSource` is the code-level per-source skip).
+- A mutable `MEMORY.md` canonical store or model-managed memory filesystem.
+- A hosted memory service, transcript store, RAG store, or application system of record.
+- Capturing assistant output, reasoning, tool payloads, attachments, or imported context in V1.
+- Shared scopes, multiple scopes per collection, or implicit sharing in V1.
+- Tags, typed record kinds, profiles, graph relations, confidence, autonomous inference, decay, or
+  autonomous instruction modification.
+- Public custom extractor, embedder, or provider interfaces in V1.
+- Raw-source retention and reprocessing as a provider feature.
+- Physical sanitization guarantees for database remnants, replicas, backups, workflow journals,
+  transcripts, logs, telemetry, or model-provider retention.
+
+## Questions the experiment should answer
+
+- How often do users invoke remember explicitly versus relying on capture?
+- How much desired durable memory originates in assistant output or tool results, and does the
+  application-write path close that gap?
+- Does bounded conversational query context materially improve retrieval?
+- Does a small query-independent preference lane improve personalization without profile complexity?
+- Which capture-source preparation controls are practical?
+- What hybrid candidate depths and reranking meet quality gates at acceptable latency and cost?
+- Which use cases ultimately justify tags, typed records, custom extractors, or graph relations?
+- Which future scope conventions can support aggregate data-subject erasure?
+
+## Primary references
+
+- [Supermemory: how it works](https://supermemory.ai/docs/concepts/how-it-works)
+- [Zep context types](https://help.getzep.com/context-types.md)
+- [Graphiti](https://github.com/getzep/graphiti)
+- [Mem0: how memory works](https://docs.mem0.ai/core-concepts/how-it-works)
+- [LangMem conceptual guide](https://langchain-ai.github.io/langmem/concepts/conceptual_guide/)
+- [AI SDK embeddings](https://ai-sdk.dev/docs/ai-sdk-core/embeddings)
+- [PostgreSQL full-text search](https://www.postgresql.org/docs/current/textsearch-indexes.html)
+- [pgvector](https://github.com/pgvector/pgvector)
+- [eve project layout](../docs/reference/project-layout.md)
+- [eve state](../docs/guides/state.md)
+- [eve turn execution](../packages/eve/src/execution/workflow-steps.ts)

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -18,12 +18,13 @@ eve owns only two pieces:
 The provider owns everything else: storage, recall, capture, model tools, formatting, extraction, ranking, limits, retention, and any record or document model. A hosted semantic service and a pair of bounded text files can therefore implement the same memory slot without pretending to share lower-level semantics.
 
 ```text
+session started        scope + session      ---> events ---> durable user message or side effects
 turn started           scope + session      ---> events ---> durable user message or side effects
 message received       scope + session      ---> events ---> durable user message or side effects
-compaction requested   scope + pre-session  ---> events ---> provider side effects
-compaction completed   scope + post-session ---> events ---> provider side effects
+compaction requested   scope + pre-session  ---> events ---> durable user message or side effects
+compaction completed   scope + post-session ---> events ---> durable user message or side effects
 step started           scope + session      ---> tools  ---> scoped model tools
-turn completed         scope + session      ---> events ---> provider side effects
+turn completed         scope + session      ---> events ---> durable user message or side effects
 ```
 
 This document defines that authoring boundary and its observable lifecycle. Provider packaging, vendor configuration, and provider-specific persistence remain follow-up work.
@@ -109,6 +110,11 @@ type MemoryMessageResult = MemoryMessage | null | void;
 type MemoryProviderToolSet = Readonly<Record<string, ToolDefinition>>;
 
 interface MemoryProviderEvents {
+  readonly "session.started"?: (
+    event: SessionStartedEvent,
+    context: MemoryProviderContext,
+  ) => MemoryMessageResult | Promise<MemoryMessageResult>;
+
   readonly "turn.started"?: (
     event: TurnStartedEvent,
     context: MemoryProviderContext,
@@ -122,17 +128,17 @@ interface MemoryProviderEvents {
   readonly "compaction.requested"?: (
     event: CompactionRequestedEvent,
     context: MemoryProviderContext,
-  ) => void | Promise<void>;
+  ) => MemoryMessageResult | Promise<MemoryMessageResult>;
 
   readonly "compaction.completed"?: (
     event: CompactionCompletedEvent,
     context: MemoryProviderContext,
-  ) => void | Promise<void>;
+  ) => MemoryMessageResult | Promise<MemoryMessageResult>;
 
   readonly "turn.completed"?: (
     event: TurnCompletedEvent,
     context: MemoryProviderContext,
-  ) => void | Promise<void>;
+  ) => MemoryMessageResult | Promise<MemoryMessageResult>;
 }
 
 interface MemoryProviderTools {
@@ -181,21 +187,21 @@ The provider decides what each handler means. A turn handler need not recall, a 
 
 ### Compaction
 
-eve dispatches the existing `compaction.requested` event before each automatic or manual compaction pass. Each resolved slot receives the complete durable message history about to be compacted, before any message is summarized or removed. eve awaits the handlers in stable slot-path order before starting compaction, allowing a provider to extract, snapshot, or persist information that the checkpoint may omit. Handlers are side-effect-only and cannot alter eve's compaction input or algorithm.
+eve dispatches the existing `compaction.requested` event before each automatic or manual compaction pass. Each resolved slot receives the complete durable message history about to be compacted, before any message is summarized or removed. eve awaits the handlers in stable slot-path order before starting compaction, allowing a provider to extract, snapshot, persist, or vend information that the checkpoint may omit. Returned memory messages do not alter eve's compaction input or algorithm; eve appends them after a successful pass.
 
-After the compacted checkpoint has been written to durable history, eve dispatches `compaction.completed`. Each handler receives the settled post-compaction durable history. The event occurs only after successful compaction; a failed summarization preserves the prior history and does not emit it. Provider tools are not resolved at either boundary because compaction does not invoke the agent model.
+After the compacted checkpoint has been written to durable history, eve dispatches `compaction.completed`. Each handler receives the settled post-compaction durable history and may return a memory message to append after the checkpoint. The event occurs only after successful compaction; a failed summarization preserves the prior history and does not emit it. Provider tools are not resolved at either boundary because compaction does not invoke the agent model.
 
-Both snapshots include memory messages that were already materialized into durable history. Memory messages returned by the opening `turn.started` and `message.received` handlers remain pending until the turn's initial compaction decision finishes, so a newly recalled message is not immediately summarized before the first model call.
+Both snapshots include memory messages that were already materialized into durable history. Memory messages returned by the opening `session.started`, `turn.started`, and `message.received` handlers remain pending until the turn's initial compaction decision finishes, so newly recalled messages are not immediately summarized before the first model call. Messages returned from either compaction event append after a successful automatic or manual pass.
 
 ### Memory messages
 
-eve dispatches memory providers through the existing `turn.started` and `message.received` session events. A provider that does not need the incoming message can recall on `turn.started`. A provider that does need it can recall on `message.received`, whose event data contains the accepted message and structured parts. No memory-only lifecycle event is added.
+eve dispatches memory providers through existing session and compaction events. A provider may recall once on `session.started`, on every `turn.started`, in response to `message.received`, after compaction, or at another supported lifecycle boundary. No memory-only lifecycle event is added.
 
-A non-empty string returned from either handler becomes one ordinary `role: "user"` model message. eve appends those messages after the turn's initial compaction decision in event order and stable slot-path order. Providers own all formatting and attribution within their returned text.
+A non-empty string returned from any provider event handler becomes one ordinary `role: "user"` model message. eve appends messages in event order and stable slot-path order at the next durable boundary: opening-event messages after the initial compaction decision, compaction-event messages after the pass, and completed-turn messages to the settled history for the next turn. Providers own all formatting and attribution within their returned text.
 
 Memory messages are durable session history. Every later model step and turn sees the same message until compaction or context clearing removes it, so each request extends the previous prompt prefix for stable prompt caching. The messages also appear in later provider message snapshots and compaction input. They remain distinct from dynamic instructions, which eve hoists into the system prompt without writing them to model history.
 
-eve materializes each returned string once. Model retries, tool-loop steps, workflow step replay, and approval resume reuse the message already in history instead of calling the handler again or appending a duplicate. Memory messages are model context rather than new channel input, so materializing one does not emit another `message.received` event.
+eve materializes each event result once. Model retries, tool-loop steps, workflow step replay, and approval resume reuse the message already in history instead of appending the same event result again. Memory messages are model context rather than new channel input, so materializing one does not emit another `message.received` event. eve does not compare or deduplicate content returned by different events.
 
 eve resolves `tools["step.started"]` before each model call. Its most recent result owns that provider's tool set, and `null` clears it. A provider returns tool keys such as `forget` or `propose`; eve lowers them as `<memory-slot>__<provider-tool>`, for example `user__forget`. Qualification is unconditional, so adding another memory slot never renames an existing tool or creates a collision when two slots use the same provider.
 
@@ -203,7 +209,7 @@ The model never supplies slot identity or scope. eve binds the resolved invocati
 
 ### Turn completion
 
-After `turn.completed`, eve dispatches the event to `events["turn.completed"]` for every slot that resolved at turn start. The handler receives the same locked scope and the complete settled durable model history, including materialized memory messages, assistant tool calls, and tool results.
+After `turn.completed`, eve dispatches the event to `events["turn.completed"]` for every resolved slot. The handler receives the same locked scope and the complete settled durable model history, including materialized memory messages, assistant tool calls, and tool results. A returned memory message appends after that snapshot and is available on the next turn.
 
 eve awaits the completed-turn handlers before emitting `session.waiting` in conversation mode or `session.completed` in task mode. A caller that starts the next turn after the ready boundary therefore observes acknowledged provider state. The handler does not run for failed, cancelled, abandoned, deferred, or adapter-consumed turns, nor for manual clear or compaction boundaries that did not complete a turn.
 
@@ -211,7 +217,7 @@ The provider decides whether the handler stores the whole session, extracts sele
 
 ### Failures
 
-A `turn.started` or `message.received` memory-handler failure fails the turn. A `step.started` tool-resolution failure fails that step. Memory is an authored capability, so silently running with a different prompt or tool set would violate the agent definition.
+A `session.started`, `turn.started`, or `message.received` memory-handler failure fails the turn. A `step.started` tool-resolution failure fails that step. Memory is an authored capability, so silently running with a different prompt or tool set would violate the agent definition.
 
 A `compaction.requested` handler failure aborts the compaction before durable history changes. Automatic compaction fails the active turn or step; manual compaction emits a diagnostic and returns to `session.waiting` with the previous history. A `compaction.completed` handler failure occurs after the durable checkpoint and cannot roll it back; eve emits a diagnostic and continues the active turn or ready boundary.
 
@@ -231,7 +237,7 @@ On `turn.completed`, the provider sends the settled session to Supermemory. Supe
 
 ### Blob documents
 
-The blob provider stores bounded `USER.md`- and `MEMORY.md`-style text documents under the resolved scope. Its `turn.started` handler reads the documents and returns their provider-formatted contents directly; it requires no incoming message, search, embeddings, or record schema.
+The blob provider stores bounded `USER.md`- and `MEMORY.md`-style text documents under the resolved scope. Its `session.started` handler reads the documents and returns their provider-formatted contents directly, while `compaction.completed` refreshes that materialized snapshot after compaction. It requires no incoming message, search, embeddings, or record schema.
 
 The provider owns any tools for editing, consolidating, or clearing those documents. Its `turn.completed` handler may rewrite them from the settled session and enforce provider-configured size limits. File layout, truncation or consolidation policy, concurrency, and blob-store behavior remain internal to the provider.
 
@@ -243,7 +249,7 @@ This provider demonstrates that simple bounded text can participate in the same 
 - Scope is resolved from trusted runtime context, locked for the turn, and never accepted from model input.
 - The same provider can back several slots without sharing eve scope keys or colliding model tools.
 - `events["compaction.requested"]` sees the complete pre-compaction durable history, while `events["compaction.completed"]` sees the successfully checkpointed durable history.
-- `events["turn.started"]` and `events["message.received"]` may each contribute one durable user message in deterministic event and slot order.
+- Every supported provider event may contribute one durable user message in deterministic event and slot order.
 - Materialized memory messages remain in later model requests, provider snapshots, and compaction input until compaction or context clearing removes them.
 - Provider tools are unconditionally slot-qualified and bound to the same locked scope as provider event handlers.
 - `events["turn.completed"]` sees the completed durable session including memory messages and settles before the next ready boundary.

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -6,54 +6,41 @@ last_updated: "2026-08-05"
 
 # First-class memory
 
-## Summary
+## Proposal
 
-Memory lets an agent carry useful knowledge across sessions. Unlike conversation
-history, memory is a durable, subject-scoped collection of claims that the agent
-can recall, add, revise, and erase.
+Memory lets an agent carry useful knowledge across sessions. Unlike conversation history, memory is a durable, scoped collection of claims that the agent can recall, add, revise, and erase.
 
-Declaring a resolved memory collection enables the complete memory lifecycle:
-
-1. **Recall** finds relevant existing memories before a response and through a
-   model tool.
-2. **Remember** creates or revises a memory when the model or application knows
-   something should persist.
-3. **Capture** examines accepted user-authored input after a completed turn and
-   extracts cited durable claims for future turns.
-4. **Forget** erases a record, while an administrative purge erases the
-   subject's entire collection.
-
-Capture is the automatic ingestion path. Without it, an agent remembers only
-when the response model happens to call `memory_remember` or application code
-writes a record. Routine facts and preferences would therefore be lost even
-though the user clearly stated them. Capture closes that gap without delaying
-or changing the response: it runs after the turn completes, considers only
-eligible authored input, and must cite the text supporting every proposed
-memory.
+Declaring a resolved memory collection enables one lifecycle:
 
 ```text
 before response   collection ---- automatic recall ----> turn context
 during response   response model -- remember / forget --> collection
 after completion  authored input -------- capture ------> collection
-application       trusted outcome ------ MemoryClient --> collection
+application       trusted outcome -------- direct write --> collection
 ```
 
-A collection is one coherent capability. There are no read-only, write-only,
-tools-off, or recall-disabled variants. Capture has no feature flag, although a
-collection's `prepareSource` hook may skip any source. Data that should not be
-mutable by the agent belongs in instructions, RAG, application state, or an
-external system of record instead.
+Capture is the automatic ingestion path. It runs after a completed turn and extracts cited durable claims from user-authored input. Without capture, the agent remembers only when the response model chooses to call a tool or application code writes a record.
 
-eve owns the slot grammar, trusted scope derivation, lifecycle, canonical public
-model, context rendering, and first-party provider integration. Applications
-own credentials, databases, stable environment identity, deployment
-preparation, retention, and operator authorization.
+The proposal treats a collection as one coherent opt-in: automatic recall, model tools, capture, application access, and erasure semantics ship together. Data that should not be mutable by the agent belongs in instructions, RAG, application state, or an external system of record instead.
+
+This document focuses on the authoring model and observable behavior. Exact schemas, error catalogs, workflow machinery, and provider internals are deferred until the product decisions are accepted.
+
+## Questions for review
+
+These are the main decisions this proposal asks the team to evaluate:
+
+| Question                                                  | Proposed direction                                                                                                                                            |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Should ordinary conversation create memory automatically? | Yes. A post-turn capture pass learns durable claims that the response model did not explicitly remember.                                                      |
+| Should collections expose partial capabilities?           | No. Declaring a collection enables recall, remember, forget, capture, and application access together.                                                        |
+| How should memory be partitioned?                         | A scope function returns one ordered tuple of trusted runtime parts. V1 requires an authenticated user principal first and may append channel-provided parts. |
+| When may personal memory be disclosed?                    | Only when trusted auth resolves the same principal and the channel attests that the response audience is private to that principal.                           |
+| Should application and administrative access ship in V1?  | Yes. Applications need to record trusted outcomes, and operators need subject export, correction, and purge.                                                  |
+| Which providers are public in V1?                         | First-party PostgreSQL for production plus explicit local and test providers. A public custom-provider protocol is deferred.                                  |
 
 ## What belongs in memory
 
-Memory is for reusable knowledge that should outlive the session but is not the
-application's source of truth. This boundary prevents the memory store from
-becoming a transcript database, knowledge base, or authorization system.
+Memory is for reusable knowledge that should outlive the session but is not the application's source of truth.
 
 | Information                                                      | Owner                                       |
 | ---------------------------------------------------------------- | ------------------------------------------- |
@@ -64,35 +51,20 @@ becoming a transcript database, knowledge base, or authorization system.
 | Balances, permissions, order status, and other application truth | Application system of record                |
 | Trusted instructions, skills, and autonomous self-modification   | Instructions, skills, and evaluation        |
 
-One memory file defines a **collection**: one purpose, provider, and subject
-scope. A collection may hold records for many isolated subjects; a `user`
-collection is not itself one user. Records are atomic text claims with optional
-occurrence time, expiry, and citations. V1 does not label records as facts,
-preferences, or episodes because those labels do not yet change behavior.
+The core terms are:
 
-The design makes these commitments:
+- A **collection** is one authored memory file with one purpose, provider, and scope definition. It may contain records for many isolated users and partitions.
+- A **record** is one atomic text claim with citations. Replacing its content creates a new revision under the same logical record.
+- A **scope tuple** is the ordered set of trusted runtime identities that selects one isolated partition, such as `[principal]` or `[principal, workspace, channel]`.
+- A **subject** is the authenticated user represented by the first scope part. Administrative export and purge span every partition for that subject.
 
-- Trusted runtime identity determines the subject. Model input never selects a
-  scope, and memory is disclosed only to a channel-attested private audience.
-- Application, environment, graph node, collection path, and subject jointly
-  isolate storage while allowing redeployments in one environment to share it.
-- Recall is bounded, attributed, treated as untrusted data, and transient to the
-  current turn.
-- Model-proposed writes cite eligible source text. eve verifies the citation;
-  whether the claim is semantically entailed remains an evaluation concern.
-- Writes are idempotent and read-your-writes. Automatic capture starts only
-  after a completed turn and never changes that turn's outcome.
-- Erased content cannot reappear through recall, replay, stale indexes, or
-  application reads. Canonical state is authoritative; embeddings and indexes
-  are rebuildable projections.
+V1 does not classify records as facts, preferences, or episodes because those labels do not yet change behavior.
 
-## Authoring API
+## Authoring experience
 
-The author chooses only the collection's purpose, persistence provider, and
-scope. Declaring it opts into automatic recall, capture, and all memory tools;
-forget always requires approval.
+### Collection files
 
-### Slot grammar
+An agent may declare one flat collection or a directory of named collections:
 
 ```text
 agent/memory.ts            # one collection named "memory"
@@ -101,22 +73,7 @@ agent/memory/              # XOR with the flat file
   preferences.ts           # collection named "preferences"
 ```
 
-Each module default-exports `defineMemory(...)`. Identity comes from the path,
-so there is no `name` field. The named directory is non-recursive and accepts
-modules only; shared code belongs in `agent/lib/`. Invalid nesting and
-flat-file/directory collisions fail discovery.
-
-Collection slugs use lowercase snake case (`[a-z][a-z0-9_]*`) and are at most
-48 characters. This keeps generated mutation tool names within eve's
-64-character tool-name limit. Authored tools may not collide with
-`memory_recall` or generated `memory_remember_*` and `memory_forget_*` names.
-
-Local directory-form subagents may declare the same slot. Their graph node ID
-namespaces each collection, so subagents do not share memory implicitly. The
-built-in `agent` tool uses the root node's collections. Single-file and remote
-subagents do not own local memory slots.
-
-### Collection definition
+Each module default-exports `defineMemory(...)`. Collection identity comes from its path rather than a `name` field. Local directory-form subagents may declare their own collections; graph-node identity keeps them isolated from the root and from one another.
 
 ```ts title="agent/memory.ts"
 import { byPrincipal, defineMemory } from "eve/memory";
@@ -129,510 +86,131 @@ export default defineMemory({
 });
 ```
 
-`description` tells the model what belongs in the collection. `provider`
-chooses persistence. `scope` determines the subject from trusted runtime
-identity. `MemoryProvider` and `MemoryScopeDefinition` are opaque eve values.
+`description` tells the model what belongs in the collection. `provider` chooses persistence. `scope` resolves one partition for the current turn. Declaring the collection enables the complete lifecycle; forget always requires approval.
 
-V1 exposes no custom provider, scope resolver, extractor, embedder, tag schema,
-collection weight, tool toggle, or token-budget API.
+### Scope
 
-### Capture configuration
-
-The optional `capture` block tunes automatic extraction; omitting it uses eve's
-defaults. It does not turn capture on.
+The low-level scope type is a function that returns one ordered tuple of trusted parts or `null`:
 
 ```ts
-capture: {
-  model: "anthropic/claude-sonnet-5",
-  reasoning: "low",
-  instructions: "Prefer durable preferences over one-time requests.",
-  prepareSource(text) {
-    return redactSensitiveText(text);
-  },
-},
+type MemoryScopeDefinition = (context: MemoryScopeContext) => readonly MemoryScopePart[] | null;
 ```
 
-| Option          | Purpose                                                                                                                                                                                             |
-| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `model`         | Pins a capture-only Gateway model ID or AI SDK `LanguageModel`. Dynamic selection is not allowed because replay must use one durable model choice. Omission uses the agent's compiled static model. |
-| `reasoning`     | Sets capture reasoning effort. It inherits the agent setting only when capture also uses the agent model.                                                                                           |
-| `modelOptions`  | Sets capture provider options. When capture uses the agent model, omission inherits the agent's options and an explicit value replaces them. An overridden model inherits no options.               |
-| `instructions`  | Adds collection-specific guidance without expanding eligible sources, bypassing citations, or weakening limits.                                                                                     |
-| `prepareSource` | Minimizes or redacts one normalized source for this collection. Returning `null` skips its capture.                                                                                                 |
-
-`prepareSource` receives trusted collection, source, time, auth, and abort
-context. Its result affects only capture; it does not change response input,
-automatic recall, or citations made by the explicit remember tool. Returning
-`null` unconditionally is the sanctioned way to run a collection without
-automatic capture while preserving explicit and application writes.
-
-## Memory lifecycle
-
-The lifecycle separates retrieving knowledge, deliberately changing it, and
-learning opportunistically from completed turns. That separation gives callers
-a fast response path, a guaranteed write path when needed, and a best-effort
-automatic path for ordinary conversation.
-
-### Recall: make existing memory useful
-
-Recall supplies relevant cross-session context. Merely storing records would
-not help the agent unless eve retrieved them at the right time and clearly
-distinguished them from trusted instructions.
-
-Automatic recall runs after compaction and before the first response-model
-request. Its query combines the latest normalized input with a bounded visible
-window for references such as “that restaurant.” It selects relevant and recent
-records under one wall-clock and token budget, then renders a length-delimited
-data block with collection, purpose, handle, revision time, and available
-citation. A fixed trusted instruction labels the block as untrusted data.
-Memory content does not change eve's permission or approval gates, although
-stored prompt injection can still influence model behavior.
-
-The model can also call `memory_recall` later in the turn with a new query,
-optional collection, occurrence-time range, and result limit. Omitting the
-collection searches every resolved collection using eve-owned rank fusion,
-diversity, deterministic tie-breaking, and a cumulative per-turn budget.
-
-Recall is availability-tolerant but disclosure-strict. A failed collection
-contributes only a sanitized `deadline_exceeded` or `unavailable` status while
-successful collections still return results. If all automatic recall fails,
-the response still runs with an outage status rather than pretending the
-subject has no memories. If all explicit recall fails, the tool returns
-`memory_recall_unavailable` so the model can react.
-
-Before every eve-owned model request, eve revalidates scope, purge generation,
-expiry, definition, and exact canonical revisions. Retrieval projections may
-nominate candidates, but cannot resurrect superseded, expired, erased, or
-purged content. Recalled payloads live only in the transient turn overlay, not
-durable transcript history.
-
-### Explicit remember: guarantee a write
-
-Explicit remember is for knowledge that must be available immediately or whose
-durability is part of the current task. It avoids waiting for capture and makes
-the new value visible to later model steps in the same turn.
-
-The model writes through a collection-bound tool, so it never chooses the
-subject or write scope. A proposed memory must quote an eligible normalized
-source handle from the current turn. To revise a record, the model supplies the
-current memory handle as `supersedes`; stale handles conflict rather than
-overwriting newer knowledge.
-
-Application code can create and revise records without a model citation because
-it is already inside the trusted application boundary. A revision is a full
-replacement under the same logical record ID and requires the expected current
-revision. Both model and application mutations are idempotent, commit before
-reporting success, and provide read-your-writes behavior.
-
-### Capture: learn from ordinary conversation
-
-Capture is a post-turn extraction workflow. It exists so a user can say “I am
-vegetarian” naturally without also asking the agent to remember it or relying
-on the response model to decide that a memory tool call is warranted.
-
-For each collection resolved when the turn begins, capture proceeds as follows:
-
-1. A durable `completed` turn checkpoint records the accepted authored source
-   IDs. Failed, cancelled, abandoned, deferred, or adapter-consumed turns are
-   ineligible.
-2. `prepareSource` minimizes or rejects each source for that collection.
-3. The pinned capture model compares the prepared text with current canonical
-   memory and proposes an add, supersede, or no-op with exact citations.
-4. eve validates source hashes, citation offsets, bounds, purge generation, and
-   revision expectations before committing the proposal idempotently.
-
-Capture retains the subject and private audience sealed at turn admission; it
-never resolves later background work against new auth. A revision conflict
-causes a new proposal against fresh canonical state rather than a blind write
-retry.
-
-V1 accepts only authored inbound text. It excludes assistant output, imported
-threads, channel/client context, instructions, reasoning, tool traffic,
-approvals, attachments, abandoned attempts, and uncommitted output. This keeps
-attacker-influenced assistant or tool output from becoming its own evidence.
-
-Action outcomes such as “the agent booked the 3pm flight” therefore use an
-application write from the tool that performed the action. Application truth
-still belongs in its system of record; the memory is only a reusable account of
-the outcome.
-
-Capture runs after the response settles and transient failures are retried. It
-cannot fail or alter the completed response, and V1 provides no polling or
-freshness barrier. The next turn may not see a captured claim yet. Callers that
-need immediate durability use explicit remember or an application write.
-
-Capture preserves source order. A delayed older turn may add a historical event
-but cannot supersede state learned from a newer source. Replays reuse the same
-source IDs and exact proposal receipt; definition, purge-generation, or
-provider-incarnation changes make stale work obsolete rather than redirecting
-it to a new store.
-
-### Forget and purge: make memory reversible
-
-Memory must support correction and deletion because it stores personal,
-model-generated knowledge. `memory_forget` erases one logical record and always
-uses the existing tool-approval flow. If the session cannot request approval,
-the tool returns `memory_approval_unavailable`; it does not park or fail the
-turn. Applications may erase through a subject-bound client, while trusted
-operator workflows may purge the subject's entire collection.
-
-Forget removes the record, every revision, and revision-owned evidence from all
-live operations. Purge is the complete operation when semantically duplicated
-claims may exist. Payload-free erasure receipts and generation barriers remain
-long enough to prevent workflow or idempotency replay from recreating content.
-A replay against erased content returns only `erased` or `purged`.
-The remaining receipts contain no memory payload, but are still pseudonymous
-operational data governed by retention policy.
-
-This is a live logical unreachability guarantee, not a promise to sanitize MVCC
-pages, WAL, replicas, backups, workflow journals, transcripts, telemetry, or
-model-provider retention. Restoring an older database requires replaying a
-separately retained erasure ledger before serving traffic.
-
-## Model tools
-
-Tools let the response model search beyond automatic context and deliberately
-manage memory during a turn. They are framework operations rather than ordinary
-authored tools, so declaring a collection always contributes the full set.
-
-| Tool                                                | Important inputs                                                                         | Result                                                                                          |
-| --------------------------------------------------- | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `memory_recall`                                     | Query, optional collection and occurrence range, limit.                                  | Memories, sanitized per-collection failures, and whether the result was truncated.              |
-| `memory_remember` or `memory_remember_<collection>` | Content, source handle and quote, optional occurrence/expiry time and superseded handle. | `created` or `revised` with the live record; replay after erasure returns `erased` or `purged`. |
-| `memory_forget` or `memory_forget_<collection>`     | Current memory handle.                                                                   | `erased` or `purged`.                                                                           |
-
-The flat slot uses unsuffixed mutation names; directory collections use their
-collection suffix. Mutation tools are collection-bound. Model-facing records
-contain a signed short-lived handle rather than a canonical ID, plus collection,
-content, observation and optional occurrence/expiry times, and citation quotes.
-
-Every normalized authored source is shown to the model with a source handle.
-Remember accepts a quote only when it occurs in that source. Recalled memory,
-assistant output, imported context, and tool results are not eligible evidence.
-`supersedes` and forget handles must identify the current revision in the same
-sealed scope.
-
-Expected failures have stable codes:
-
-| Code                          | Meaning                                                                              |
-| ----------------------------- | ------------------------------------------------------------------------------------ |
-| `memory_handle_expired`       | Recall again to obtain a fresh handle.                                               |
-| `memory_revision_conflict`    | The referenced revision or purge generation is stale.                                |
-| `memory_handle_invalid`       | The handle is malformed, tampered with, or belongs to another scope.                 |
-| `memory_citation_invalid`     | The source handle or quote failed validation.                                        |
-| `memory_approval_unavailable` | The session cannot request forget approval; use an application or admin surface.     |
-| `memory_recall_unavailable`   | Every selected collection failed; the result includes sanitized collection failures. |
-
-Model mutations use checkpointed operation IDs. Exact replay returns the
-original result while it remains live, changed input conflicts, and a later
-abandoned response does not roll back an already committed mutation. Durable
-history stores payload-free call/result placeholders; validated transient turn
-state supplies live memory content.
-
-## Application control
-
-Application access covers cases the model should not own: recording successful
-tool actions, building subject data views, correcting records, and satisfying
-export or erasure requests. Applications use eve clients rather than accessing
-providers directly, preserving the same scope and revision semantics as model
-tools.
-
-`ctx.getMemory(collection)` returns a subject-bound `MemoryClient` for the
-current graph node. An unknown collection throws; a collection unresolved for
-the current principal returns `null`. The client supports `recall`, `get`,
-`list`, `remember`, and `forget`. The subject binding is sealed into the client,
-including mutations, so it cannot be redirected by method input.
-
-| Operation  | Input and behavior                                                                                     |
-| ---------- | ------------------------------------------------------------------------------------------------------ |
-| `recall`   | Query, optional occurrence range, and limit; returns records plus a truncation flag.                   |
-| `get`      | Record ID; returns the current live record or `null`.                                                  |
-| `list`     | Optional cursor and limit; returns one ordered page of live records.                                   |
-| `remember` | New content, or record ID plus expected revision and replacement content; requires an idempotency key. |
-| `forget`   | Record ID and optional expected revision; requires an idempotency key.                                 |
-
-```ts
-const memory = await ctx.getMemory("user");
-
-await memory?.remember({ content: "The 3pm flight was booked." }, { idempotencyKey: bookingId });
-```
-
-Route handlers can enumerate root and local-subagent collection descriptors,
-then acquire one of two clients:
-
-- `getMemory({ address, auth, audience })` requires verified subject auth and a
-  matching private-audience attestation. It returns `null` when that auth does
-  not resolve the collection.
-- `getMemoryAdmin({ address, principal, operator })` is the explicit trusted
-  operator path. It never impersonates the subject, requires the application to
-  authorize the operator, and records operator fingerprint, reason, target,
-  operation, and outcome.
-
-The admin client adds snapshot export and full-scope purge, but not semantic
-recall. Aggregate subject export and purge enumerate collections and acquire an
-admin client for each. Node IDs and public record IDs, revision tokens, handles,
-and cursors are opaque; applications obtain node addresses from enumeration
-rather than constructing them.
-
-An admin principal address supplies an authenticator, optional issuer, and
-principal ID. It must match the same exact authority tuple used when the record
-was written; there is no fuzzy or cross-authority lookup. Unknown collection
-addresses and malformed principal addresses throw rather than returning
-`null`.
-
-Observable client semantics are:
-
-- Corrections replace the full record and require its ID plus expected
-  revision. Forget may optionally require an expected revision.
-- Application writes need no model citation, but bounds, encoding, and expiry
-  rules still apply.
-- `recall`, `get`, and `list` exclude expired records. `list` orders live records
-  by observation time descending, then record ID ascending.
-- Idempotency keys bind scope, method, and normalized request. Changed input
-  returns `idempotency_conflict`; replay after erasure is payload-free.
-- Cursors bind collection, scope, purge generation, snapshot, and order. Invalid,
-  expired, wrong-scope, or pre-purge cursors return `invalid_cursor`.
-- Export reads one snapshot. Concurrent forget or purge invalidates it; only a
-  clean iterator completion means the export is complete.
-- Expected failures expose a stable `MemoryOperationError` name, machine code,
-  and retryability rather than provider errors. Only sanitized availability
-  failures are retryable.
-
-## Trusted scope and namespace
-
-Long-lived memory creates a cross-session disclosure risk: if subject identity
-or delivery privacy came from model-controlled input, one caller could read or
-write another caller's records. eve therefore resolves scope only from trusted
-runtime identity and independently verifies that the response destination is
-private to that same subject.
-
-### Principal scope
-
-V1 provides only `byPrincipal()`. It reads `auth.current`, requires a `user`
-principal, and constructs identity from:
-
-- protocol version;
-- authority type: `issuer` when present, otherwise `authenticator`;
-- the non-empty authority value; and
-- the non-empty principal ID.
-
-Display names, attributes, `subject`, `auth.initiator`, and authored payloads do
-not affect identity. A collection resolves only when the current principal and
-a sealed private-audience attestation match exactly. The attestation is minted
-by the channel runtime after it verifies every response path is restricted to
-that principal; it cannot be copied from or constructed by a payload. Local
-subagents inherit the root turn's attestation and cannot mint another.
-
-Missing, anonymous, non-user, shared, unknown, or mismatched identity leaves the
-collection unresolved. Automatic recall, tools, capture, outbox work, and the
-application client are all absent; eve never falls back to another scope. A
-content-free trace event, development notice, and `/info` resolution descriptor
-make this fail-closed outcome visible without exposing memory content.
-
-Before memory ships, delivery must preserve an immutable envelope for each
-source: source ID, order, provenance, auth, audience, and fingerprints.
-Coalescing may combine model input only after grouping compatible envelopes and
-never across auth or audience fingerprints. Built-in channels enforce private
-destination ownership on every lifecycle route before attesting privacy.
-
-V1 deliberately excludes anonymous, service, runtime, schedule, shared, and
-agent-global scopes. A shared store would let persisted prompt injection from
-any caller influence every caller. Shared scopes should ship only with explicit
-shared-scope disclosure semantics, not weaker guarantees than private memory.
-
-The local development host is the sole exception: it may project the existing
-`local-dev` caller into a module-private memory principal and audience. This
-does not turn that caller into a user for connections, permissions, governance,
-or authored callbacks, and it cannot exist outside the local provider runtime.
-
-### Storage namespace
-
-The provider receives an opaque digest of a versioned namespace. Each component
-exists to prevent an otherwise plausible collision:
-
-| Component       | Isolation behavior                                                     |
-| --------------- | ---------------------------------------------------------------------- |
-| Application ID  | Stable root identity; display or package renames do not change memory. |
-| Environment ID  | Separates production, preview, development, and other targets.         |
-| Graph node ID   | Separates the root agent from each local subagent.                     |
-| Collection path | Separates independently authored collections.                          |
-| Principal tuple | Separates subjects and authentication authorities.                     |
-
-Application and environment IDs come from stable provider configuration.
-Vercel integrations may derive them from project and target environment;
-self-hosted applications provide them explicitly. Hostname, working directory,
-`NODE_ENV`, Git SHA, build path, and deployment ID are not stable fallbacks.
-
-Redeployments in the same environment share memory. Different applications,
-environments, nodes, collection paths, and principals do not share implicitly.
-Renaming a graph node or collection path requires migration.
-
-## Sources, provenance, and turn ordering
-
-Memory claims need durable evidence, but capture-specific redaction must not
-silently change what the response model saw. eve therefore keeps two immutable
-views of eligible authored text.
-
-| View                        | Created                                | Used by                                                                |
-| --------------------------- | -------------------------------------- | ---------------------------------------------------------------------- |
-| Framework-normalized source | Once for each accepted authored source | Recall query, response source handles, and explicit remember citations |
-| Capture-prepared source     | Once per source and collection         | Capture model, capture validation, and capture-origin citations        |
-
-Framework normalization identifies authored text before adapters merge model
-messages, converts it to well-formed NFC Unicode, normalizes line endings,
-removes blank parts, joins ordered text parts, and applies a versioned UTF-8
-bound. It retains source ID, digest, order, provenance, trusted time, auth, and
-audience fingerprints.
-
-`prepareSource` creates the second view. Response-model handles bind the
-normalized digest; capture citations bind the prepared digest and preparation
-fingerprint. Recall returns immutable stored excerpts and never reruns source
-preparation.
-
-```text
-accept and seal source envelopes
-        |
-normalize authored text
-        |
-compact history -> automatic recall -> response-model loop
-                                      |        |
-                              memory tools   terminal checkpoint
-                                                  |
-                                      prepare per collection
-                                                  |
-                                          capture outbox
-```
-
-The terminal checkpoint is internal machinery required to distinguish a
-completed turn from streaming output that was later cancelled or failed. A
-normal response and a completed human-input boundary are capture-eligible;
-authorization or task waits are deferred; failed and cancelled turns are not.
-Workflow replay preserves the same classification and source IDs.
-
-Normalized source envelopes remain in the world/session journal under world
-retention. Memory providers retain only cited excerpts and payload-free source
-receipts, not complete source objects. Memory erasure therefore does not claim
-to remove original text from journals, transcripts, telemetry, or provider
-retention.
-
-## Canonical records and consistency
-
-The canonical store makes mutation and erasure authoritative; retrieval indexes
-only help find candidates. This distinction is necessary because an eventually
-updated embedding must never make a stale record visible again.
-
-Each logical record points to one current immutable revision. A revision stores
-content, origin (`capture`, `model-tool`, or `application`), observation time,
-optional occurrence and expiry times, and citations. Corrections append a
-revision under the same logical ID using compare-and-swap. V1 has no implicit
-decay, confidence score, autonomous inference, or graph relation.
-
-`observedAt` is trusted commit time. `occurredAt` describes when the claim's
-event happened. `expiresAt` removes it from live operations at the deadline.
-Occurrence-time filtering excludes records without `occurredAt`; without a
-filter those records remain eligible. Retained expired and superseded revisions
-appear only in administrative export until retention or erasure removes them.
-
-Each scope also maintains a purge generation, content revision, and monotonic
-source sequence. Source receipts prevent duplicate capture, revision tokens
-provide compare-and-swap, and erasure receipts prevent resurrection. Canonical
-writes are durable and read-your-writes even while embeddings or indexes lag.
-
-## Provider boundary
-
-Providers persist canonical state and retrieve candidates within one
-collection. eve retains the security- and product-defining behavior so changing
-providers cannot change public memory semantics.
-
-Providers own persistence, projections, readiness, migration, and
-within-collection ranking. eve owns scope, public records, citations, handles,
-tools, idempotency, deadlines, cross-collection fusion, budgets, rendering, and
-final disclosure validation. V1 exposes only opaque first-party
-`MemoryProvider` values. A public custom-provider API waits for production
-evidence and a conformance kit.
-
-### PostgreSQL reference provider
-
-PostgreSQL is the production reference provider. It stores canonical records
-and owns document and query embedding so the collection definition remains
-independent of a retrieval strategy.
-
-```ts title="agent/lib/memory.ts"
-import { pgDatabase, postgresMemory } from "eve/memory/postgres";
-import { pool } from "./database";
-import { memoryNamespace } from "./environment";
-
-export const memory = postgresMemory({
-  database: pgDatabase(pool),
-  namespace: memoryNamespace,
-  embedding: {
-    model: "openai/text-embedding-3-small",
-    dimensions: 1536,
-  },
-});
-```
-
-The namespace supplies stable application and environment IDs. The Vercel
-integration derives these for the common path; self-hosted applications provide
-both. Missing or ambiguous identity fails readiness, and shared source must not
-hardcode an environment name.
-
-Embedding configuration accepts a Gateway ID or AI SDK `EmbeddingModel`,
-required dimensions, separate document/query provider options, and a model
-revision when eve cannot derive a stable identity. Retrieval uses deterministic
-hybrid lexical, vector, and recency lanes. A query-embedding failure is an
-availability failure, never an empty result.
-
-Every retrieval-affecting choice contributes to one projection fingerprint.
-Changing it builds and backfills a side-by-side generation, then activates it
-atomically. Embeddings commit only while they still match canonical state;
-recall rehydrates candidates from canonical rows.
-
-`pgDatabase(pool)` wraps a structural connection-lease contract. It neither
-adds a `pg` runtime dependency nor closes the caller's pool. Acquisition and
-queries honor abort signals. Applications run
-`preparePostgresMemory(provider)` at deploy time for migrations, validation,
-backfill, and projection activation. `eve dev` and `eve start` check readiness
-but never migrate implicitly. Failed preparation leaves the active generation
-unchanged.
-
-### Test and local providers
-
-`createTestMemory()` returns an opaque deterministic provider plus a controller
-with a fixed clock and queued `snapshot()` and `reset()` operations. It performs
-no filesystem, network, wall-clock, random, or timer access, but enforces the
-same canonical, revision, idempotency, expiry, citation, erase, purge, and cursor
-semantics as production.
-
-`localMemory()` is an explicit development provider; eve never substitutes it
-for PostgreSQL. It uses Node's built-in `DatabaseSync` and stores canonical
-state in `.eve/memory/v1/local.sqlite`, surviving hot reloads, worker
-replacement, `/new`, and `eve dev` restarts. A bounded deterministic JavaScript
-ranker supplies lexical, fuzzy, and recency retrieval without embeddings.
-
-Local inspection and reset use `eve memory path|ls|show|recall|reset`. The store
-is ignored and excluded from builds, content is trace-redacted by default, and
-reset quarantines corrupt database files before creating a new incarnation.
-Test and local providers require private test or development runtime capability
-and are rejected by `eve build` and `eve start`; there is no production escape
-hatch.
-
-## Out of scope
-
-- Partial-capability collections or configuration flags that disable capture.
-  `prepareSource` remains the code-level per-source skip.
-- A mutable `MEMORY.md` canonical store or model-managed memory filesystem.
-- A hosted memory service, transcript store, RAG store, or application system
-  of record.
-- Capturing assistant output, reasoning, tool payloads, attachments, or imported
-  context in V1.
-- Shared or multiple scopes per collection, and implicit sharing.
-- Tags, typed record kinds, profiles, graph relations, confidence, autonomous
-  inference, decay, or autonomous instruction modification.
-- Public custom extractor, embedder, or provider interfaces in V1.
-- Raw-source retention and reprocessing as a provider feature.
-- Physical sanitization guarantees for database remnants, replicas, backups,
-  workflow journals, transcripts, logs, telemetry, or model-provider retention.
+V1 requires the authenticated user principal as the first part. `byPrincipal()` is sugar for returning `[principal]`. Later parts may partition the user's memory more narrowly.
+
+The contents of `MemoryScopeContext` are intentionally not designed in this proposal. It will expose the trusted principal and some form of channel access for stable, attested parts such as a Slack workspace, channel, or thread. A continuation token is not automatically a scope part because it may be more specific or less stable than the partition the author wants.
+
+Returning `null` leaves the collection unavailable for that turn. Scope parts cannot come from model input or unattested message fields.
+
+## Lifecycle
+
+| Phase                        | Behavior                                                                                    | Why                                                                                            |
+| ---------------------------- | ------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Before the response          | eve recalls relevant and recent records into transient turn context.                        | Existing memory must be present before it can improve the response.                            |
+| During the model loop        | The model may recall with a new query, remember a claim, revise a claim, or request forget. | Explicit actions provide immediate and deliberate control.                                     |
+| After a completed turn       | Capture proposes cited additions, replacements, or no-ops from eligible authored input.     | Routine conversation can create memory without delaying the response.                          |
+| During an application action | Trusted code may write the durable outcome directly.                                        | Action results should come from the system that performed the action, not assistant narration. |
+
+### Recall
+
+Automatic recall runs after compaction and before the first response-model request. Its query uses the latest normalized input plus a bounded visible window for references such as “that restaurant.” The result combines relevant and recent records under a turn budget.
+
+The model may also recall later with a new query and optional collection. Omitting the collection searches every resolved collection.
+
+Recalled memories are attributed to their collection and presented as untrusted data. They do not change permissions or approval requirements, and their payloads do not enter durable transcript history. A collection outage does not fail the turn; successful collections still contribute and failures remain distinguishable from an empty result.
+
+### Explicit remember and application writes
+
+Explicit remember is for knowledge that must be durable and visible immediately. The model writes through a collection-bound tool and cites an eligible source quote from the current turn. It revises a claim by addressing the current recalled record; stale revisions conflict rather than overwriting newer knowledge.
+
+Application code can write through scope-bound memory access without a model citation. This is the path for trusted action outcomes such as “the 3pm flight was booked.” The application system remains the source of truth; memory is only a reusable account of the outcome.
+
+### Capture
+
+Capture is a background extraction pass created only by a successfully completed turn. Failed, cancelled, abandoned, deferred, or adapter-consumed turns are not eligible. It pins the exact scope and audience resolved at admission rather than evaluating later auth or channel state.
+
+Capture uses a separate model invocation after the turn. Its configuration surface is deferred until implementation demonstrates a concrete need.
+
+For each eligible collection, the capture invocation compares user-authored input with current memory and proposes an addition, replacement, or no-op with exact citations. eve validates the cited source before committing.
+
+V1 capture excludes assistant output, reasoning, tool traffic, approvals, imported context, and attachments. Assistant or tool output may be attacker-influenced and cannot serve as its own evidence; trusted action outcomes use application writes instead.
+
+Capture does not delay or change the completed response. Its writes are eventually consistent, so the next turn may not see them. Callers needing immediate durability use explicit remember or an application write.
+
+### Forget and purge
+
+Forget removes one logical record and its revisions from every live memory operation. The model-facing forget tool always uses the existing approval flow; if the session cannot request approval, the model must direct the user to an application or administrative surface.
+
+An administrative purge removes every record in the subject's collection across all scope partitions. Erased content cannot return through recall, stale indexes, application reads, or workflow replay.
+
+These are live logical erasure guarantees. Database remnants, replicas, backups, journals, transcripts, telemetry, and model-provider retention remain governed by their own policies.
+
+## Scope and privacy
+
+Long-lived memory creates a cross-session disclosure risk, so model-controlled input never chooses the user principal or response audience.
+
+The principal scope part comes from `auth.current` and requires `principalType: "user"`. Its identity includes the authenticator or issuer and the principal ID; display names, attributes, `subject`, and `auth.initiator` do not define identity. Additional parts from the future channel accessor only partition that principal's storage.
+
+A collection resolves only when its tuple begins with the current principal and the channel attests that every response path is private to that principal. Partitioning personal memory by Slack channel does not make a public Slack reply private; a public destination still leaves the collection unresolved.
+
+Missing required parts, anonymous or non-user auth, a `null` scope result, or a mismatched audience makes recall, tools, capture, and application access unavailable. eve emits content-free diagnostics rather than silently falling back to a broader scope.
+
+The provider namespace also includes stable application, environment, graph-node, and collection-path identity. Redeployments in one environment share memory, while different environments, subagents, collections, and resolved tuples do not. Changing the order or meaning of scope parts requires migration.
+
+V1 excludes shared, anonymous, service, runtime, schedule, and agent-global memory. Shared memory needs a separate disclosure and persisted-prompt-injection design.
+
+## Framework capabilities
+
+### Model capabilities
+
+| Capability | Purpose                                            |
+| ---------- | -------------------------------------------------- |
+| Recall     | Search one or all resolved collections.            |
+| Remember   | Create or replace a cited claim in one collection. |
+| Forget     | Erase one recalled record after approval.          |
+
+These are framework-provided, collection-aware operations rather than authored tools. Mutations are collection-bound so the model never supplies a scope. Their exact names, schemas, record references, and errors belong in the implementation contract.
+
+### Application access
+
+Application code needs a scope-bound way to record trusted outcomes during a turn. Subject-facing routes may also need inspection and correction when they can provide matching auth, audience, and scope context. The exact client types and method inventory are deferred until these callers are implemented.
+
+The exact route-facing channel access is likewise deferred with the channel scope API.
+
+Operator-authorized administration addresses a principal rather than impersonating it. It can inspect, correct, export, and purge every partition for that subject in a collection. Operator identity, reason, target, operation, and outcome are audited. The exact administration API is deferred.
+
+## Observable guarantees
+
+- Scope and private audience are revalidated before disclosure; unavailable or invalid memory fails closed.
+- Model-proposed writes cite eligible authored text. eve validates citation integrity, while semantic entailment remains an evaluation concern.
+- Explicit model and application writes are idempotent, commit before reporting success, and are visible to later steps in the same turn.
+- Capture starts only after a completed turn, never changes that turn's outcome, and may become visible later.
+- Superseded, erased, and purged records are absent from live operations.
+- Canonical records are authoritative. Embeddings and search indexes are rebuildable projections and cannot resurrect stale content.
+
+## Provider strategy
+
+Providers own persistence, within-collection retrieval, projections, readiness, and migration. eve owns public records, scope, citations, model operations, cross-collection behavior, budgets, rendering, and final disclosure validation.
+
+PostgreSQL is the first production provider. Stable application and environment identity are required so deployments cannot accidentally share or split memory. Retrieval, indexing, and deployment preparation are implementation concerns.
+
+An explicit local provider supports persistent development memory, and a deterministic test provider supports isolated tests. Their factory names, storage choices, and control surfaces are deferred. Neither is available in production.
+
+V1 exposes opaque first-party providers only. A public custom-provider API waits for production evidence and a conformance kit.
+
+## Non-goals
+
+- Read-only, write-only, recall-disabled, tool-disabled, or otherwise partial collections.
+- A mutable `MEMORY.md`, model-managed memory filesystem, hosted memory service, transcript store, RAG store, or application system of record.
+- Capturing assistant output, reasoning, tool payloads, attachments, or imported context.
+- Scope tuples without an authenticated user principal, multiple simultaneous tuples for one collection in a turn, or implicit sharing.
+- Tags, typed record kinds, profiles, graph relations, confidence, autonomous inference, decay, or instruction modification.
+- Public custom extractor, embedder, or provider interfaces.
+- Physical sanitization guarantees for database remnants, replicas, backups, journals, transcripts, logs, telemetry, or model-provider retention.
+
+## Deferred implementation work
+
+Follow-up implementation plans should define exact tool and client schemas, error codes, handles, cursors, limits, normalization, source envelopes, checkpoint and replay machinery, canonical tables, provider conformance, PostgreSQL indexing and migration, and local inspection commands. Those details must satisfy the observable guarantees above without expanding the V1 product surface.
 
 ## Primary references
 

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -1,7 +1,7 @@
 ---
 issue: https://github.com/vercel/eve/issues/1510
 status: proposed
-last_updated: "2026-08-11"
+last_updated: "2026-08-12"
 ---
 
 # First-class memory
@@ -18,9 +18,10 @@ eve owns only two pieces:
 The provider owns everything else: storage, recall, capture, model tools, formatting, extraction, ranking, limits, retention, and any record or document model. A hosted semantic service and a pair of bounded text files can therefore implement the same memory slot without pretending to share lower-level semantics.
 
 ```text
+turn started           scope + session      ---> events ---> durable user message or side effects
+message received       scope + session      ---> events ---> durable user message or side effects
 compaction requested   scope + pre-session  ---> events ---> provider side effects
 compaction completed   scope + post-session ---> events ---> provider side effects
-turn prepared          scope + session      ---> events ---> transient context
 step started           scope + session      ---> tools  ---> scoped model tools
 turn completed         scope + session      ---> events ---> provider side effects
 ```
@@ -102,14 +103,22 @@ interface MemoryProviderContext extends MemoryCallbackContext {
   readonly abortSignal: AbortSignal;
 }
 
-interface MemoryTurnPreparedResult {
-  /** Provider-formatted text appended as transient turn context. */
-  readonly context?: string;
-}
+type MemoryMessage = string;
+type MemoryMessageResult = MemoryMessage | null | void;
 
 type MemoryProviderToolSet = Readonly<Record<string, ToolDefinition>>;
 
 interface MemoryProviderEvents {
+  readonly "turn.started"?: (
+    event: TurnStartedEvent,
+    context: MemoryProviderContext,
+  ) => MemoryMessageResult | Promise<MemoryMessageResult>;
+
+  readonly "message.received"?: (
+    event: MessageReceivedEvent,
+    context: MemoryProviderContext,
+  ) => MemoryMessageResult | Promise<MemoryMessageResult>;
+
   readonly "compaction.requested"?: (
     event: CompactionRequestedEvent,
     context: MemoryProviderContext,
@@ -119,11 +128,6 @@ interface MemoryProviderEvents {
     event: CompactionCompletedEvent,
     context: MemoryProviderContext,
   ) => void | Promise<void>;
-
-  readonly "turn.prepared"?: (
-    event: TurnPreparedEvent,
-    context: MemoryProviderContext,
-  ) => MemoryTurnPreparedResult | null | Promise<MemoryTurnPreparedResult | null>;
 
   readonly "turn.completed"?: (
     event: TurnCompletedEvent,
@@ -144,7 +148,7 @@ interface MemoryProvider {
 }
 ```
 
-Both maps and every handler within them are optional. A provider may contribute only context, only tools, only completed-turn side effects, or any combination. eve does not infer missing behavior or add default tools.
+Both maps and every handler within them are optional. A provider may contribute only memory messages, only tools, only completed-turn side effects, or any combination. eve does not infer missing behavior or add default tools.
 
 Every handler receives an ordinary typed eve event and authored callback context extended with the path-derived slot, locked scope, message snapshot, and cancellation signal. Scope does not depend on ambient model input.
 
@@ -156,10 +160,8 @@ import { service } from "./service";
 
 export const memory = defineMemoryProvider({
   events: {
-    async "turn.prepared"(_event, ctx) {
-      return {
-        context: await service.recall(ctx.memory.scope, ctx.messages),
-      };
+    async "message.received"(event, ctx) {
+      return service.recall(ctx.memory.scope, event.data.message, ctx.messages);
     },
     async "turn.completed"(_event, ctx) {
       await service.capture(ctx.memory.scope, ctx.messages);
@@ -173,7 +175,7 @@ export const memory = defineMemoryProvider({
 });
 ```
 
-The provider decides what each handler means. A compaction handler need not extract, a prepared-turn handler need not search, a completed-turn handler need not persist, and tools need not manipulate memory.
+The provider decides what each handler means. A turn handler need not recall, a compaction handler need not extract, a completed-turn handler need not persist, and tools need not manipulate memory.
 
 ## Lifecycle
 
@@ -183,15 +185,17 @@ eve dispatches the existing `compaction.requested` event before each automatic o
 
 After the compacted checkpoint has been written to durable history, eve dispatches `compaction.completed`. Each handler receives the settled post-compaction durable history. The event occurs only after successful compaction; a failed summarization preserves the prior history and does not emit it. Provider tools are not resolved at either boundary because compaction does not invoke the agent model.
 
-Both snapshots exclude transient provider context. If compaction occurs later in a multi-step turn, eve keeps the prepared-turn context separate from the compaction input and reapplies it to the remaining model steps without writing it into the checkpoint.
+Both snapshots include memory messages that were already materialized into durable history. Memory messages returned by the opening `turn.started` and `message.received` handlers remain pending until the turn's initial compaction decision finishes, so a newly recalled message is not immediately summarized before the first model call.
 
-### Turn preparation
+### Memory messages
 
-After turn admission and any required initial compaction, eve dispatches `turn.prepared` to the `events` map of each slot whose scope resolved at turn start. This is a new provider-resolution event rather than the existing stream `turn.started`: its name reflects that the newest input has been admitted and the model history has already been compacted. The event context includes that input and every model-visible user, assistant, and tool message retained after compaction.
+eve dispatches memory providers through the existing `turn.started` and `message.received` session events. A provider that does not need the incoming message can recall on `turn.started`. A provider that does need it can recall on `message.received`, whose event data contains the accepted message and structured parts. No memory-only lifecycle event is added.
 
-The event handler runs before the tool resolver for the same slot. A non-empty `context` result becomes one transient user-context message appended at the prompt tail. Results from several slots appear in stable slot-path order. Providers own all formatting and attribution within their returned text.
+A non-empty string returned from either handler becomes one ordinary `role: "user"` model message. eve appends those messages after the turn's initial compaction decision in event order and stable slot-path order. Providers own all formatting and attribution within their returned text.
 
-Recalled context is not a system instruction. Keeping it at the prompt tail leaves authored instructions and the prior conversation prefix stable for prompt caching. It also remains transient: eve does not write it to durable session history, include it in later capture input, or restore it on replay as conversation authored by the user.
+Memory messages are durable session history. Every later model step and turn sees the same message until compaction or context clearing removes it, so each request extends the previous prompt prefix for stable prompt caching. The messages also appear in later provider message snapshots and compaction input. They remain distinct from dynamic instructions, which eve hoists into the system prompt without writing them to model history.
+
+eve materializes each returned string once. Model retries, tool-loop steps, workflow step replay, and approval resume reuse the message already in history instead of calling the handler again or appending a duplicate. Memory messages are model context rather than new channel input, so materializing one does not emit another `message.received` event.
 
 eve resolves `tools["step.started"]` before each model call. Its most recent result owns that provider's tool set, and `null` clears it. A provider returns tool keys such as `forget` or `propose`; eve lowers them as `<memory-slot>__<provider-tool>`, for example `user__forget`. Qualification is unconditional, so adding another memory slot never renames an existing tool or creates a collision when two slots use the same provider.
 
@@ -199,7 +203,7 @@ The model never supplies slot identity or scope. eve binds the resolved invocati
 
 ### Turn completion
 
-After `turn.completed`, eve dispatches the event to `events["turn.completed"]` for every slot that resolved during turn preparation. The handler receives the same locked scope and the complete settled durable model history, including assistant tool calls and tool results. It does not receive transient context returned by `events["turn.prepared"]`.
+After `turn.completed`, eve dispatches the event to `events["turn.completed"]` for every slot that resolved at turn start. The handler receives the same locked scope and the complete settled durable model history, including materialized memory messages, assistant tool calls, and tool results.
 
 eve awaits the completed-turn handlers before emitting `session.waiting` in conversation mode or `session.completed` in task mode. A caller that starts the next turn after the ready boundary therefore observes acknowledged provider state. The handler does not run for failed, cancelled, abandoned, deferred, or adapter-consumed turns, nor for manual clear or compaction boundaries that did not complete a turn.
 
@@ -207,7 +211,7 @@ The provider decides whether the handler stores the whole session, extracts sele
 
 ### Failures
 
-A `turn.prepared` event-handler failure fails the turn. A `step.started` tool-resolution failure fails that step. Memory is an authored capability, so silently running with a different prompt or tool set would violate the agent definition.
+A `turn.started` or `message.received` memory-handler failure fails the turn. A `step.started` tool-resolution failure fails that step. Memory is an authored capability, so silently running with a different prompt or tool set would violate the agent definition.
 
 A `compaction.requested` handler failure aborts the compaction before durable history changes. Automatic compaction fails the active turn or step; manual compaction emits a diagnostic and returns to `session.waiting` with the previous history. A `compaction.completed` handler failure occurs after the durable checkpoint and cannot roll it back; eve emits a diagnostic and continues the active turn or ready boundary.
 
@@ -219,7 +223,7 @@ V1 includes two reference providers to prove that the framework boundary does no
 
 ### Supermemory
 
-On `turn.prepared`, the Supermemory provider sends the resolved scope and visible session history to Supermemory. Supermemory decides what is relevant, and the handler returns the fully formatted text that eve injects. eve does not understand Supermemory profiles, containers, documents, search, or extraction.
+On `message.received`, the Supermemory provider sends the resolved scope, incoming message, and visible session history to Supermemory. Supermemory decides what is relevant, and the handler returns the fully formatted text that eve persists as a user message. eve does not understand Supermemory profiles, containers, documents, search, or extraction.
 
 The provider's tool map may expose scoped search, save, forget, profile, or proposal tools, or another capability entirely. eve only qualifies and scope-binds the returned definitions.
 
@@ -227,7 +231,7 @@ On `turn.completed`, the provider sends the settled session to Supermemory. Supe
 
 ### Blob documents
 
-The blob provider stores bounded `USER.md`- and `MEMORY.md`-style text documents under the resolved scope. Its `turn.prepared` handler reads the documents and returns their provider-formatted contents directly; it requires no search, embeddings, or record schema.
+The blob provider stores bounded `USER.md`- and `MEMORY.md`-style text documents under the resolved scope. Its `turn.started` handler reads the documents and returns their provider-formatted contents directly; it requires no incoming message, search, embeddings, or record schema.
 
 The provider owns any tools for editing, consolidating, or clearing those documents. Its `turn.completed` handler may rewrite them from the settled session and enforce provider-configured size limits. File layout, truncation or consolidation policy, concurrency, and blob-store behavior remain internal to the provider.
 
@@ -239,11 +243,11 @@ This provider demonstrates that simple bounded text can participate in the same 
 - Scope is resolved from trusted runtime context, locked for the turn, and never accepted from model input.
 - The same provider can back several slots without sharing eve scope keys or colliding model tools.
 - `events["compaction.requested"]` sees the complete pre-compaction durable history, while `events["compaction.completed"]` sees the successfully checkpointed durable history.
-- `events["turn.prepared"]` sees the post-compaction visible session including the newest input and may contribute transient tail context in deterministic slot order.
-- Transient prepared-turn context appears in neither compaction snapshot nor durable history.
+- `events["turn.started"]` and `events["message.received"]` may each contribute one durable user message in deterministic event and slot order.
+- Materialized memory messages remain in later model requests, provider snapshots, and compaction input until compaction or context clearing removes them.
 - Provider tools are unconditionally slot-qualified and bound to the same locked scope as provider event handlers.
-- `events["turn.completed"]` sees the completed durable session without prepared-turn transient context and settles before the next ready boundary.
-- Prepared-turn event and tool-resolution failures fail the active turn or step; completed-turn event failures cannot rewrite the response or suppress the ready boundary.
+- `events["turn.completed"]` sees the completed durable session including memory messages and settles before the next ready boundary.
+- Memory-event and tool-resolution failures fail the active turn or step; completed-turn event failures cannot rewrite the response or suppress the ready boundary.
 - Providers, not eve, define persistence, consistency after provider acknowledgment, retention, erasure, and administrative behavior.
 
 ## Non-goals
@@ -258,7 +262,7 @@ This provider demonstrates that simple bounded text can participate in the same 
 
 ## Implementation contract follow-up
 
-Before V1 implementation lands, follow-up plans must fix the exact public type names, introduce the `turn.prepared` resolution point, connect provider handlers to the existing compaction events, define event/tool-map compilation and durable-replay mechanics, specify scope-part encoding, diagnostics and cancellation, and add tests for lifecycle ordering and isolation. Supermemory and blob storage each need a provider-specific plan for configuration and operational behavior without expanding the core memory contract.
+Before V1 implementation lands, follow-up plans must fix the exact public type names, connect provider handlers to the existing session and compaction events, define event/tool-map compilation and durable message replay mechanics, specify scope-part encoding, diagnostics and cancellation, and add tests for lifecycle ordering and isolation. Supermemory and blob storage each need a provider-specific plan for configuration and operational behavior without expanding the core memory contract.
 
 ## Primary references
 

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -1,54 +1,96 @@
 ---
 issue: https://github.com/vercel/eve/issues/1510
 status: proposed
-last_updated: "2026-08-01"
+last_updated: "2026-08-05"
 ---
 
 # First-class memory
 
 ## Summary
 
-Add memory to eve as a first-class agent slot: durable cross-session knowledge that an agent can recall, remember, and forget. Remembering a replacement revises an existing record.
+Memory lets an agent carry useful knowledge across sessions. Unlike conversation
+history, memory is a durable, subject-scoped collection of claims that the agent
+can recall, add, revise, and erase.
 
-Declaring a resolved memory collection enables one coherent capability. eve:
+Declaring a resolved memory collection enables the complete memory lifecycle:
 
-- recalls relevant memories automatically before the response;
-- makes every collection searchable through one shared recall tool;
-- contributes collection-bound remember and forget tools;
-- captures durable claims from accepted turns; and
-- enforces scope, provenance, approval, budget, revision, and erasure semantics.
+1. **Recall** finds relevant existing memories before a response and through a
+   model tool.
+2. **Remember** creates or revises a memory when the model or application knows
+   something should persist.
+3. **Capture** examines accepted user-authored input after a completed turn and
+   extracts cited durable claims for future turns.
+4. **Forget** erases a record, while an administrative purge erases the
+   subject's entire collection.
 
-These behaviors are intrinsic. No configuration can create read-only, write-only, tools-off, or recall-disabled memory collections, and no flag disables capture; the one code-level escape hatch is `prepareSource`, which may skip any source for a collection. Data that should not be mutable by the agent belongs in instructions, RAG, application state, or an external system of record instead.
+Capture is the automatic ingestion path. Without it, an agent remembers only
+when the response model happens to call `memory_remember` or application code
+writes a record. Routine facts and preferences would therefore be lost even
+though the user clearly stated them. Capture closes that gap without delaying
+or changing the response: it runs after the turn completes, considers only
+eligible authored input, and must cite the text supporting every proposed
+memory.
 
-eve owns the slot grammar, trusted scope derivation, recall and mutation lifecycle, canonical public model, context rendering, and first-party provider integration. Applications own credentials, databases, stable environment identity, deployment preparation, retention, and authorization inputs.
+```text
+before response   collection ---- automatic recall ----> turn context
+during response   response model -- remember / forget --> collection
+after completion  authored input -------- capture ------> collection
+application       trusted outcome ------ MemoryClient --> collection
+```
 
-## Boundary and invariants
+A collection is one coherent capability. There are no read-only, write-only,
+tools-off, or recall-disabled variants. Capture has no feature flag, although a
+collection's `prepareSource` hook may skip any source. Data that should not be
+mutable by the agent belongs in instructions, RAG, application state, or an
+external system of record instead.
 
-One memory file defines a **collection**: one purpose, provider, and subject scope. At runtime, its scope definition resolves one subject for the turn. A `user` collection can therefore contain many isolated users; the file is not itself one user.
+eve owns the slot grammar, trusted scope derivation, lifecycle, canonical public
+model, context rendering, and first-party provider integration. Applications
+own credentials, databases, stable environment identity, deployment
+preparation, retention, and operator authorization.
 
-| Capability                                                        | Owner                                       | Memory |
-| ----------------------------------------------------------------- | ------------------------------------------- | ------ |
-| Active-turn and per-session state                                 | eve messages, compaction, and `defineState` | No     |
-| Conversation archive and transcript search                        | Session/world storage or an application API | No     |
-| External documents and product knowledge                          | RAG or a knowledge integration              | No     |
-| Cross-session facts, preferences, events, and reusable knowledge  | Memory slot                                 | Yes    |
-| Application truth such as balances, permissions, and order status | Application system of record                | No     |
-| Trusted instructions, skills, and autonomous self-modification    | Instructions, skills, and evaluation        | No     |
+## What belongs in memory
 
-The design has eight invariants:
+Memory is for reusable knowledge that should outlive the session but is not the
+application's source of truth. This boundary prevents the memory store from
+becoming a transcript database, knowledge base, or authorization system.
 
-1. A declared and resolved collection always provides the complete memory capability.
-2. Trusted runtime identity derives scope, and a channel-attested private audience gates disclosure; model input controls neither.
-3. A versioned application, environment, graph-node, and collection-path namespace isolates every collection while surviving redeploys in the same environment.
-4. Automatic and explicit recall are bounded, attributed, untrusted, and transient to the active turn.
-5. Model-proposed memories require citations to eligible source text. eve verifies citation integrity; semantic entailment remains an evaluation target rather than a security guarantee.
-6. Model mutations are idempotent and read-your-writes. Capture begins only from an accepted completed turn and never changes that turn's response outcome.
-7. Forget and purge make content unreachable through every live memory operation. Payload-free barriers prevent replay from recreating erased content.
-8. Canonical writes are durable and read-your-writes. Embeddings and indexes are rebuildable projections that may lag only when stale candidates are revalidated against canonical state.
+| Information                                                      | Owner                                       |
+| ---------------------------------------------------------------- | ------------------------------------------- |
+| Active-turn and per-session state                                | eve messages, compaction, and `defineState` |
+| Conversation archive and transcript search                       | Session/world storage or an application API |
+| External documents and product knowledge                         | RAG or a knowledge integration              |
+| Cross-session facts, preferences, events, and reusable knowledge | Memory                                      |
+| Balances, permissions, order status, and other application truth | Application system of record                |
+| Trusted instructions, skills, and autonomous self-modification   | Instructions, skills, and evaluation        |
 
-Records are atomic text claims with optional occurrence time, expiry, and citations. V1 does not impose `fact`, `preference`, or `episode` kinds because those labels do not yet produce distinct behavior.
+One memory file defines a **collection**: one purpose, provider, and subject
+scope. A collection may hold records for many isolated subjects; a `user`
+collection is not itself one user. Records are atomic text claims with optional
+occurrence time, expiry, and citations. V1 does not label records as facts,
+preferences, or episodes because those labels do not yet change behavior.
+
+The design makes these commitments:
+
+- Trusted runtime identity determines the subject. Model input never selects a
+  scope, and memory is disclosed only to a channel-attested private audience.
+- Application, environment, graph node, collection path, and subject jointly
+  isolate storage while allowing redeployments in one environment to share it.
+- Recall is bounded, attributed, treated as untrusted data, and transient to the
+  current turn.
+- Model-proposed writes cite eligible source text. eve verifies the citation;
+  whether the claim is semantically entailed remains an evaluation concern.
+- Writes are idempotent and read-your-writes. Automatic capture starts only
+  after a completed turn and never changes that turn's outcome.
+- Erased content cannot reappear through recall, replay, stale indexes, or
+  application reads. Canonical state is authoritative; embeddings and indexes
+  are rebuildable projections.
 
 ## Authoring API
+
+The author chooses only the collection's purpose, persistence provider, and
+scope. Declaring it opts into automatic recall, capture, and all memory tools;
+forget always requires approval.
 
 ### Slot grammar
 
@@ -59,13 +101,22 @@ agent/memory/              # XOR with the flat file
   preferences.ts           # collection named "preferences"
 ```
 
-Every module default-exports `defineMemory(...)`. Identity comes from the path; there is no `name` field. The named directory is non-recursive and module-only. Invalid nesting and flat-file/directory collisions fail discovery. Collection slugs are lowercase snake case (`[a-z][a-z0-9_]*`) with a 48-character maximum, so generated mutation tool names stay within eve's 64-character tool-name limit and never mix separator styles. Generated memory tool names are reserved: an authored tool that collides with `memory_recall` or a generated `memory_remember_*`/`memory_forget_*` name fails discovery, like subagent/tool name collisions. Shared code belongs in `agent/lib/`.
+Each module default-exports `defineMemory(...)`. Identity comes from the path,
+so there is no `name` field. The named directory is non-recursive and accepts
+modules only; shared code belongs in `agent/lib/`. Invalid nesting and
+flat-file/directory collisions fail discovery.
 
-Local directory-form subagents may declare the same slot. The graph node ID namespaces each collection, so declared subagents never share memory implicitly. The built-in `agent` tool invokes the root node and uses the root's collections. Single-file and remote subagents do not own local memory slots.
+Collection slugs use lowercase snake case (`[a-z][a-z0-9_]*`) and are at most
+48 characters. This keeps generated mutation tool names within eve's
+64-character tool-name limit. Authored tools may not collide with
+`memory_recall` or generated `memory_remember_*` and `memory_forget_*` names.
 
-### Definition
+Local directory-form subagents may declare the same slot. Their graph node ID
+namespaces each collection, so subagents do not share memory implicitly. The
+built-in `agent` tool uses the root node's collections. Single-file and remote
+subagents do not own local memory slots.
 
-Every collection requires three author decisions: purpose, persistence, and scope.
+### Collection definition
 
 ```ts title="agent/memory.ts"
 import { byPrincipal, defineMemory } from "eve/memory";
@@ -78,557 +129,433 @@ export default defineMemory({
 });
 ```
 
-This collection automatically recalls, exposes all memory tools, and captures durable claims. Forget always requires approval.
+`description` tells the model what belongs in the collection. `provider`
+chooses persistence. `scope` determines the subject from trusted runtime
+identity. `MemoryProvider` and `MemoryScopeDefinition` are opaque eve values.
 
-The public definition stays intentionally small:
-
-```ts
-interface MemoryDefinition {
-  readonly description: string;
-  readonly provider: MemoryProvider;
-  readonly scope: MemoryScopeDefinition;
-  readonly capture?: {
-    readonly model?: AgentStaticModelDefinition;
-    readonly reasoning?: AgentReasoningDefinition;
-    readonly modelOptions?: AgentModelOptionsDefinition;
-    readonly instructions?: string;
-    readonly prepareSource?: MemorySourcePreparer;
-  };
-}
-
-interface MemorySourcePrepareContext {
-  readonly collection: string;
-  readonly sourceId: string;
-  readonly observedAt: string;
-  readonly auth: SessionAuthContext;
-  readonly signal: AbortSignal;
-}
-
-type MemorySourcePreparer = (
-  text: string,
-  context: MemorySourcePrepareContext,
-) => string | null | Promise<string | null>;
-```
-
-`MemoryProvider` and `MemoryScopeDefinition` are opaque eve values. V1 has no public custom provider, scope-resolver, extractor, embedder, tag schema, collection weight, tool toggle, or token-budget API.
+V1 exposes no custom provider, scope resolver, extractor, embedder, tag schema,
+collection weight, tool toggle, or token-budget API.
 
 ### Capture configuration
 
-Capture is intrinsic. Omit `capture` to use eve's defaults; the block only configures capture:
+The optional `capture` block tunes automatic extraction; omitting it uses eve's
+defaults. It does not turn capture on.
 
 ```ts
 capture: {
   model: "anthropic/claude-sonnet-5",
   reasoning: "low",
-  modelOptions: {
-    providerOptions: {
-      gateway: { serviceTier: "flex" },
-    },
-  },
   instructions: "Prefer durable preferences over one-time requests.",
-  prepareSource(text, context) {
-    return text;
+  prepareSource(text) {
+    return redactSensitiveText(text);
   },
 },
 ```
 
-- `model` selects the capture-only model. It accepts a Gateway ID or direct AI SDK `LanguageModel`, but not dynamic selection because a durable intent must pin one replayable model. Omission uses the agent's compiled static model.
-- `reasoning` sets provider-agnostic AI SDK reasoning effort. With no model override, omission inherits the agent setting. An overridden model uses its provider default unless set explicitly.
-- `modelOptions` forwards provider-specific options only to capture calls. With no model override, omission inherits agent options and an explicit value replaces them. An overridden model inherits no options.
-- `instructions` supplements eve's versioned extraction policy. It cannot expand eligible sources, bypass citations, or weaken hard limits.
-- `prepareSource` is a capture-only minimization and redaction hook. It receives bounded normalized inbound text and trusted collection, source, time, auth, and abort context. It returns transformed text or `null` to skip capture for that source and collection. It does not alter response input, automatic recall, or explicit remember citations. An unconditional `null` is the sanctioned code-level way to run a collection without automatic capture; explicit remember and application writes still work.
+| Option          | Purpose                                                                                                                                                                                             |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `model`         | Pins a capture-only Gateway model ID or AI SDK `LanguageModel`. Dynamic selection is not allowed because replay must use one durable model choice. Omission uses the agent's compiled static model. |
+| `reasoning`     | Sets capture reasoning effort. It inherits the agent setting only when capture also uses the agent model.                                                                                           |
+| `modelOptions`  | Sets capture provider options. When capture uses the agent model, omission inherits the agent's options and an explicit value replaces them. An overridden model inherits no options.               |
+| `instructions`  | Adds collection-specific guidance without expanding eligible sources, bypassing citations, or weakening limits.                                                                                     |
+| `prepareSource` | Minimizes or redacts one normalized source for this collection. Returning `null` skips its capture.                                                                                                 |
 
-V1 capture accepts only authored inbound text. It excludes assistant output, imported threads, channel/client context, instructions, reasoning, tool traffic, approvals, attachments, abandoned attempts, and uncommitted output.
+`prepareSource` receives trusted collection, source, time, auth, and abort
+context. Its result affects only capture; it does not change response input,
+automatic recall, or citations made by the explicit remember tool. Returning
+`null` unconditionally is the sanctioned way to run a collection without
+automatic capture while preserving explicit and application writes.
 
-**Recording action outcomes.** Assistant output is ineligible as capture source and citation evidence because it can be attacker-influenced through prompt injection. The sanctioned path for durable action memory — "the agent booked the 3pm flight" — is an application write: the tool that performs the action records the outcome through `ctx.getMemory(...)`, which commits with `origin: "application"` and needs no model citation.
+## Memory lifecycle
+
+The lifecycle separates retrieving knowledge, deliberately changing it, and
+learning opportunistically from completed turns. That separation gives callers
+a fast response path, a guaranteed write path when needed, and a best-effort
+automatic path for ordinary conversation.
+
+### Recall: make existing memory useful
+
+Recall supplies relevant cross-session context. Merely storing records would
+not help the agent unless eve retrieved them at the right time and clearly
+distinguished them from trusted instructions.
+
+Automatic recall runs after compaction and before the first response-model
+request. Its query combines the latest normalized input with a bounded visible
+window for references such as “that restaurant.” It selects relevant and recent
+records under one wall-clock and token budget, then renders a length-delimited
+data block with collection, purpose, handle, revision time, and available
+citation. A fixed trusted instruction labels the block as untrusted data.
+Memory content does not change eve's permission or approval gates, although
+stored prompt injection can still influence model behavior.
+
+The model can also call `memory_recall` later in the turn with a new query,
+optional collection, occurrence-time range, and result limit. Omitting the
+collection searches every resolved collection using eve-owned rank fusion,
+diversity, deterministic tie-breaking, and a cumulative per-turn budget.
+
+Recall is availability-tolerant but disclosure-strict. A failed collection
+contributes only a sanitized `deadline_exceeded` or `unavailable` status while
+successful collections still return results. If all automatic recall fails,
+the response still runs with an outage status rather than pretending the
+subject has no memories. If all explicit recall fails, the tool returns
+`memory_recall_unavailable` so the model can react.
+
+Before every eve-owned model request, eve revalidates scope, purge generation,
+expiry, definition, and exact canonical revisions. Retrieval projections may
+nominate candidates, but cannot resurrect superseded, expired, erased, or
+purged content. Recalled payloads live only in the transient turn overlay, not
+durable transcript history.
+
+### Explicit remember: guarantee a write
+
+Explicit remember is for knowledge that must be available immediately or whose
+durability is part of the current task. It avoids waiting for capture and makes
+the new value visible to later model steps in the same turn.
+
+The model writes through a collection-bound tool, so it never chooses the
+subject or write scope. A proposed memory must quote an eligible normalized
+source handle from the current turn. To revise a record, the model supplies the
+current memory handle as `supersedes`; stale handles conflict rather than
+overwriting newer knowledge.
+
+Application code can create and revise records without a model citation because
+it is already inside the trusted application boundary. A revision is a full
+replacement under the same logical record ID and requires the expected current
+revision. Both model and application mutations are idempotent, commit before
+reporting success, and provide read-your-writes behavior.
+
+### Capture: learn from ordinary conversation
+
+Capture is a post-turn extraction workflow. It exists so a user can say “I am
+vegetarian” naturally without also asking the agent to remember it or relying
+on the response model to decide that a memory tool call is warranted.
+
+For each collection resolved when the turn begins, capture proceeds as follows:
+
+1. A durable `completed` turn checkpoint records the accepted authored source
+   IDs. Failed, cancelled, abandoned, deferred, or adapter-consumed turns are
+   ineligible.
+2. `prepareSource` minimizes or rejects each source for that collection.
+3. The pinned capture model compares the prepared text with current canonical
+   memory and proposes an add, supersede, or no-op with exact citations.
+4. eve validates source hashes, citation offsets, bounds, purge generation, and
+   revision expectations before committing the proposal idempotently.
+
+Capture retains the subject and private audience sealed at turn admission; it
+never resolves later background work against new auth. A revision conflict
+causes a new proposal against fresh canonical state rather than a blind write
+retry.
+
+V1 accepts only authored inbound text. It excludes assistant output, imported
+threads, channel/client context, instructions, reasoning, tool traffic,
+approvals, attachments, abandoned attempts, and uncommitted output. This keeps
+attacker-influenced assistant or tool output from becoming its own evidence.
+
+Action outcomes such as “the agent booked the 3pm flight” therefore use an
+application write from the tool that performed the action. Application truth
+still belongs in its system of record; the memory is only a reusable account of
+the outcome.
+
+Capture runs after the response settles and transient failures are retried. It
+cannot fail or alter the completed response, and V1 provides no polling or
+freshness barrier. The next turn may not see a captured claim yet. Callers that
+need immediate durability use explicit remember or an application write.
+
+Capture preserves source order. A delayed older turn may add a historical event
+but cannot supersede state learned from a newer source. Replays reuse the same
+source IDs and exact proposal receipt; definition, purge-generation, or
+provider-incarnation changes make stale work obsolete rather than redirecting
+it to a new store.
+
+### Forget and purge: make memory reversible
+
+Memory must support correction and deletion because it stores personal,
+model-generated knowledge. `memory_forget` erases one logical record and always
+uses the existing tool-approval flow. If the session cannot request approval,
+the tool returns `memory_approval_unavailable`; it does not park or fail the
+turn. Applications may erase through a subject-bound client, while trusted
+operator workflows may purge the subject's entire collection.
+
+Forget removes the record, every revision, and revision-owned evidence from all
+live operations. Purge is the complete operation when semantically duplicated
+claims may exist. Payload-free erasure receipts and generation barriers remain
+long enough to prevent workflow or idempotency replay from recreating content.
+A replay against erased content returns only `erased` or `purged`.
+The remaining receipts contain no memory payload, but are still pseudonymous
+operational data governed by retention policy.
+
+This is a live logical unreachability guarantee, not a promise to sanitize MVCC
+pages, WAL, replicas, backups, workflow journals, transcripts, telemetry, or
+model-provider retention. Restoring an older database requires replaying a
+separately retained erasure ledger before serving traffic.
 
 ## Model tools
 
-Memory tools are intrinsic framework operations, not ordinary authored tools. They cannot be disabled, replaced, or independently configured. This deliberately diverges from the `disableTool()` sentinel available for framework default tools: declaring the collection is the opt-in, and the slot always carries its complete capability.
+Tools let the response model search beyond automatic context and deliberately
+manage memory during a turn. They are framework operations rather than ordinary
+authored tools, so declaring a collection always contributes the full set.
 
-The shared tool is `memory_recall`. The flat slot contributes `memory_remember` and `memory_forget`; named collections contribute `memory_remember_<collection>` and `memory_forget_<collection>`.
+| Tool                                                | Important inputs                                                                         | Result                                                                                          |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `memory_recall`                                     | Query, optional collection and occurrence range, limit.                                  | Memories, sanitized per-collection failures, and whether the result was truncated.              |
+| `memory_remember` or `memory_remember_<collection>` | Content, source handle and quote, optional occurrence/expiry time and superseded handle. | `created` or `revised` with the live record; replay after erasure returns `erased` or `purged`. |
+| `memory_forget` or `memory_forget_<collection>`     | Current memory handle.                                                                   | `erased` or `purged`.                                                                           |
 
-```ts
-interface MemoryRecallToolInput {
-  readonly query: string;
-  readonly collection?: string;
-  readonly occurredAfter?: string;
-  readonly occurredBefore?: string;
-  readonly limit?: number;
-}
+The flat slot uses unsuffixed mutation names; directory collections use their
+collection suffix. Mutation tools are collection-bound. Model-facing records
+contain a signed short-lived handle rather than a canonical ID, plus collection,
+content, observation and optional occurrence/expiry times, and citation quotes.
 
-interface MemoryRememberToolInput {
-  readonly content: string;
-  readonly citation: {
-    readonly sourceHandle: string;
-    readonly quote: string;
-  };
-  readonly occurredAt?: string;
-  readonly expiresAt?: string;
-  readonly supersedes?: string;
-}
+Every normalized authored source is shown to the model with a source handle.
+Remember accepts a quote only when it occurs in that source. Recalled memory,
+assistant output, imported context, and tool results are not eligible evidence.
+`supersedes` and forget handles must identify the current revision in the same
+sealed scope.
 
-interface MemoryForgetToolInput {
-  readonly handle: string;
-}
-```
+Expected failures have stable codes:
 
-Mutation tools are collection-bound, so the model never chooses a write scope.
+| Code                          | Meaning                                                                              |
+| ----------------------------- | ------------------------------------------------------------------------------------ |
+| `memory_handle_expired`       | Recall again to obtain a fresh handle.                                               |
+| `memory_revision_conflict`    | The referenced revision or purge generation is stale.                                |
+| `memory_handle_invalid`       | The handle is malformed, tampered with, or belongs to another scope.                 |
+| `memory_citation_invalid`     | The source handle or quote failed validation.                                        |
+| `memory_approval_unavailable` | The session cannot request forget approval; use an application or admin surface.     |
+| `memory_recall_unavailable`   | Every selected collection failed; the result includes sanitized collection failures. |
 
-Model-facing records use signed short-lived handles rather than canonical IDs:
-
-```ts
-interface MemoryToolRecord {
-  readonly collection: string;
-  readonly handle: string;
-  readonly content: string;
-  readonly observedAt: string;
-  readonly occurredAt?: string;
-  readonly expiresAt?: string;
-  readonly citations: readonly { readonly quote: string }[];
-}
-
-interface MemoryRecallToolResult {
-  readonly memories: readonly MemoryToolRecord[];
-  readonly failures: readonly {
-    readonly collection: string;
-    readonly code: "deadline_exceeded" | "unavailable";
-    readonly retryable: boolean;
-  }[];
-  readonly truncated: boolean;
-}
-
-type MemoryRememberToolResult =
-  | {
-      readonly status: "created" | "revised";
-      readonly memory: MemoryToolRecord;
-    }
-  | { readonly status: "erased" | "purged" };
-
-interface MemoryForgetToolResult {
-  readonly status: "erased" | "purged";
-}
-```
-
-`memory_recall` searches every resolved collection when `collection` is omitted. eve owns cross-collection allocation, rank fusion, deterministic ties, diversity, and the cumulative per-turn result budget. A partial recall returns usable memories plus sanitized collection failures; failure of every selected collection fails the tool. Provider scores and messages never reach the model.
-
-Every framework-normalized source is rendered with a source handle. A remember citation is `{ sourceHandle, quote }`; the normalized quote must occur in that source. `supersedes` references the current memory handle. Recalled memory, assistant output, imported context, and tool results are ineligible evidence.
-
-Remember and forget are idempotent framework side effects. eve checkpoints a stable operation ID and exact request before execution, reports success only after the provider commits, and makes the result visible to later model steps. Replay returns the original result while its content remains live; after forget or purge it returns payload-free `erased` or `purged`. A later-abandoned response does not roll back a completed mutation.
-
-Expected tool failures use stable codes:
-
-- `memory_handle_expired`: recall again for a fresh handle;
-- `memory_revision_conflict`: the addressed revision or purge generation is stale;
-- `memory_handle_invalid`: the handle is malformed, tampered, or belongs to another scope;
-- `memory_citation_invalid`: the source handle or quote failed validation;
-- `memory_approval_unavailable`: the session cannot request the required forget approval because it lacks the input capability; erase through the application or admin surface instead; and
-- `memory_recall_unavailable`: every selected collection failed, with sanitized collection codes.
-
-Forget approval rides the existing tool-approval pipeline. In a session that cannot park for input, `memory_forget` returns `memory_approval_unavailable` as an expected tool failure; it never parks a task turn or fails the turn.
-
-The failed `memory_recall_unavailable` result carries the same sanitized `failures` entries as a partial success and no provider messages or scores.
-
-Memory content never enters durable transcript history: history stores payload-free placeholders that preserve call/result pairing, and validated transient turn content supplies the payloads, so erasure reaches every live surface. Workflow journals may retain normalized source envelopes under world retention.
+Model mutations use checkpointed operation IDs. Exact replay returns the
+original result while it remains live, changed input conflicts, and a later
+abandoned response does not roll back an already committed mutation. Durable
+history stores payload-free call/result placeholders; validated transient turn
+state supplies live memory content.
 
 ## Application control
 
-Application code never uses a provider directly. `MemoryClient` is subject-bound: eve creates it only from matching current auth and private audience, and every method retains that sealed scope. A separate `MemoryAdminClient` is available only through the explicit trusted-operator route surface for data access, rectification, and erasure workflows. Public IDs, revision tokens, handles, and cursors are opaque strings.
+Application access covers cases the model should not own: recording successful
+tool actions, building subject data views, correcting records, and satisfying
+export or erasure requests. Applications use eve clients rather than accessing
+providers directly, preserving the same scope and revision semantics as model
+tools.
+
+`ctx.getMemory(collection)` returns a subject-bound `MemoryClient` for the
+current graph node. An unknown collection throws; a collection unresolved for
+the current principal returns `null`. The client supports `recall`, `get`,
+`list`, `remember`, and `forget`. The subject binding is sealed into the client,
+including mutations, so it cannot be redirected by method input.
+
+| Operation  | Input and behavior                                                                                     |
+| ---------- | ------------------------------------------------------------------------------------------------------ |
+| `recall`   | Query, optional occurrence range, and limit; returns records plus a truncation flag.                   |
+| `get`      | Record ID; returns the current live record or `null`.                                                  |
+| `list`     | Optional cursor and limit; returns one ordered page of live records.                                   |
+| `remember` | New content, or record ID plus expected revision and replacement content; requires an idempotency key. |
+| `forget`   | Record ID and optional expected revision; requires an idempotency key.                                 |
 
 ```ts
-interface MemoryRecordCitation {
-  readonly sourceView: "normalized" | "capture-prepared";
-  readonly sourceId: string;
-  readonly quote: string;
-}
+const memory = await ctx.getMemory("user");
 
-interface MemoryRevision {
-  readonly revision: string;
-  readonly content: string;
-  readonly origin: "capture" | "model-tool" | "application";
-  readonly observedAt: string;
-  readonly occurredAt?: string;
-  readonly expiresAt?: string;
-  readonly citations: readonly MemoryRecordCitation[];
-}
-
-interface MemoryRecord extends MemoryRevision {
-  readonly recordId: string;
-}
-
-interface MemoryRecallInput {
-  readonly query: string;
-  readonly occurredAfter?: string;
-  readonly occurredBefore?: string;
-  readonly limit?: number;
-}
-
-interface MemoryRecallResult {
-  readonly records: readonly MemoryRecord[];
-  readonly truncated: boolean;
-}
-
-interface MemoryListInput {
-  readonly cursor?: string;
-  readonly limit?: number;
-}
-
-interface MemoryPage {
-  readonly records: readonly MemoryRecord[];
-  readonly cursor: string | null;
-}
-
-type MemoryRememberInput =
-  | {
-      readonly content: string;
-      readonly occurredAt?: string;
-      readonly expiresAt?: string;
-    }
-  | {
-      readonly recordId: string;
-      readonly expectedRevision: string;
-      readonly content: string;
-      readonly occurredAt?: string;
-      readonly expiresAt?: string;
-    };
-
-interface MemoryMutationOptions {
-  readonly idempotencyKey: string;
-  readonly signal?: AbortSignal;
-}
-
-type MemoryErrorCode =
-  | "revision_conflict"
-  | "idempotency_conflict"
-  | "invalid_cursor"
-  | "export_invalidated"
-  | "unavailable";
-
-declare class MemoryOperationError extends Error {
-  readonly name: "MemoryOperationError";
-  readonly code: MemoryErrorCode;
-  readonly retryable: boolean;
-}
-
-type MemoryRememberResult =
-  | { readonly status: "created" | "revised"; readonly record: MemoryRecord }
-  | { readonly status: "erased" | "purged" };
-
-type MemoryForgetResult =
-  | { readonly status: "erased"; readonly erasedAt: string }
-  | { readonly status: "not_found" | "purged" };
-
-interface MemoryClient {
-  recall(input: MemoryRecallInput, options?: { signal?: AbortSignal }): Promise<MemoryRecallResult>;
-  get(
-    input: { readonly recordId: string },
-    options?: { signal?: AbortSignal },
-  ): Promise<MemoryRecord | null>;
-  list(input?: MemoryListInput, options?: { signal?: AbortSignal }): Promise<MemoryPage>;
-  remember(
-    input: MemoryRememberInput,
-    options: MemoryMutationOptions,
-  ): Promise<MemoryRememberResult>;
-  forget(
-    input: { readonly recordId: string; readonly expectedRevision?: string },
-    options: MemoryMutationOptions,
-  ): Promise<MemoryForgetResult>;
-}
-
-type MemoryAdminClient = Omit<MemoryClient, "recall"> & {
-  exportRecords(options?: { signal?: AbortSignal }): AsyncIterable<{
-    readonly recordId: string;
-    readonly revisions: readonly MemoryRevision[];
-  }>;
-  purge(
-    options: MemoryMutationOptions,
-  ): Promise<{ readonly status: "purged"; readonly purgeId: string; readonly purgedAt: string }>;
-};
+await memory?.remember({ content: "The 3pm flight was booked." }, { idempotencyKey: bookingId });
 ```
 
-Every method resolves to a plain value. Expected failures throw `MemoryOperationError` with a stable machine-readable `code` and a `retryable` flag, following the connection-error convention: guards match on `name` and `code` rather than `instanceof` because bundlers can duplicate class instances. `revision_conflict`, `idempotency_conflict`, `invalid_cursor`, and `export_invalidated` are never retryable; `unavailable` is the sanitized provider or deadline failure and is retryable. Benign outcomes — `not_found`, replay against erased content — are status values, not errors.
+Route handlers can enumerate root and local-subagent collection descriptors,
+then acquire one of two clients:
 
-A correction is a full replacement and requires both record ID and expected revision. Forget without an expected revision erases the current logical record; with one, a stale target throws `revision_conflict`. Application writes need no model citation, but framework bounds and encoding rules still apply. Public timestamps are RFC 3339 instants; limits must be finite positive integers and are clamped to eve's versioned maximum.
+- `getMemory({ address, auth, audience })` requires verified subject auth and a
+  matching private-audience attestation. It returns `null` when that auth does
+  not resolve the collection.
+- `getMemoryAdmin({ address, principal, operator })` is the explicit trusted
+  operator path. It never impersonates the subject, requires the application to
+  authorize the operator, and records operator fingerprint, reason, target,
+  operation, and outcome.
 
-An occurrence-time filter excludes records without `occurredAt`; without a filter those records remain eligible. `list` orders live records by `observedAt` descending and record ID ascending. Expired records are absent from recall, `get`, and `list`, but retained expired and superseded revisions remain in `exportRecords` until retention or erasure removes them.
+The admin client adds snapshot export and full-scope purge, but not semantic
+recall. Aggregate subject export and purge enumerate collections and acquire an
+admin client for each. Node IDs and public record IDs, revision tokens, handles,
+and cursors are opaque; applications obtain node addresses from enumeration
+rather than constructing them.
 
-An idempotency key binds scope, method, and normalized request. Exact replay returns the original result only while its content remains live. After forget or purge, replay returns payload-free `erased` or `purged`; it never returns deleted content or recreates the write. Changed input throws `idempotency_conflict`.
+An admin principal address supplies an authenticator, optional issuer, and
+principal ID. It must match the same exact authority tuple used when the record
+was written; there is no fuzzy or cross-authority lookup. Unknown collection
+addresses and malformed principal addresses throw rather than returning
+`null`.
 
-Cursors bind collection, scope, purge generation, snapshot, and order. Invalid, expired, wrong-scope, or pre-purge cursors throw `invalid_cursor` rather than restarting. Export iterates one snapshot. If forget or purge changes retained content, the next iterator operation rejects with `export_invalidated`; only clean iterator completion means the export is complete. Sanitized provider availability failures throw `unavailable`; raw database errors and physical keys remain internal.
+Observable client semantics are:
+
+- Corrections replace the full record and require its ID plus expected
+  revision. Forget may optionally require an expected revision.
+- Application writes need no model citation, but bounds, encoding, and expiry
+  rules still apply.
+- `recall`, `get`, and `list` exclude expired records. `list` orders live records
+  by observation time descending, then record ID ascending.
+- Idempotency keys bind scope, method, and normalized request. Changed input
+  returns `idempotency_conflict`; replay after erasure is payload-free.
+- Cursors bind collection, scope, purge generation, snapshot, and order. Invalid,
+  expired, wrong-scope, or pre-purge cursors return `invalid_cursor`.
+- Export reads one snapshot. Concurrent forget or purge invalidates it; only a
+  clean iterator completion means the export is complete.
+- Expected failures expose a stable `MemoryOperationError` name, machine code,
+  and retryability rather than provider errors. Only sanitized availability
+  failures are retryable.
 
 ## Trusted scope and namespace
 
-V1 has one scope definition: `byPrincipal()`. It uses `auth.current`, requires `principalType: "user"`, and resolves this versioned tuple:
+Long-lived memory creates a cross-session disclosure risk: if subject identity
+or delivery privacy came from model-controlled input, one caller could read or
+write another caller's records. eve therefore resolves scope only from trusted
+runtime identity and independently verifies that the response destination is
+private to that same subject.
 
-```ts
-type CanonicalMemoryPrincipalV1 = readonly [
-  version: 1,
-  principalType: "user",
-  authorityKind: "issuer" | "authenticator",
-  authority: string,
-  principalId: string,
-];
-```
+### Principal scope
 
-`issuer` is preferred when present; otherwise eve uses `authenticator`. Required strings must be non-empty. Attributes, display names, `subject`, and `auth.initiator` never define identity.
+V1 provides only `byPrincipal()`. It reads `auth.current`, requires a `user`
+principal, and constructs identity from:
 
-The local provider has one dev-only exception: the trusted dev host may inject a branded memory principal projection for the existing `local-dev` caller. This does not change `SessionAuthContext`, does not make the caller a `user` for connections or governance, and cannot exist outside the local provider capability described below.
+- protocol version;
+- authority type: `issuer` when present, otherwise `authenticator`;
+- the non-empty authority value; and
+- the non-empty principal ID.
 
-```ts
-declare const deliveryAudienceBrand: unique symbol;
+Display names, attributes, `subject`, `auth.initiator`, and authored payloads do
+not affect identity. A collection resolves only when the current principal and
+a sealed private-audience attestation match exactly. The attestation is minted
+by the channel runtime after it verifies every response path is restricted to
+that principal; it cannot be copied from or constructed by a payload. Local
+subagents inherit the root turn's attestation and cannot mint another.
 
-interface DeliveryAudience {
-  readonly [deliveryAudienceBrand]: true;
-}
-```
+Missing, anonymous, non-user, shared, unknown, or mismatched identity leaves the
+collection unresolved. Automatic recall, tools, capture, outbox work, and the
+application client are all absent; eve never falls back to another scope. A
+content-free trace event, development notice, and `/info` resolution descriptor
+make this fail-closed outcome visible without exposing memory content.
 
-The unique-symbol brand provides TypeScript opacity only. Runtime unforgeability comes from a sealed token created and validated by module-private channel-runtime identity; copied, deserialized, payload-authored, and merely shape-compatible objects fail validation. Built-in channels attach the token internally. Trusted custom-channel route handlers receive `attestPrivateAudience(auth)` and may call it only after enforcing that every response path is restricted to that principal. The sealed value binds registered channel identity and the same principal tuple. Local subagents inherit the sealed root-turn audience and cannot remint it.
+Before memory ships, delivery must preserve an immutable envelope for each
+source: source ID, order, provenance, auth, audience, and fingerprints.
+Coalescing may combine model input only after grouping compatible envelopes and
+never across auth or audience fingerprints. Built-in channels enforce private
+destination ownership on every lifecycle route before attesting privacy.
 
-A collection resolves only when current principal and private audience match exactly. Missing, anonymous, non-user, shared, unknown, or mismatched identity makes the collection unavailable: no automatic recall, tools, capture, outbox, or application client. It never falls back to another scope. Unavailability is fail-closed but never fail-silent: eve emits a content-free resolution diagnostic (a trace event and a dev-time notice) naming the collection and the failed condition, and `/info` descriptors report per-collection resolution state for the current caller.
+V1 deliberately excludes anonymous, service, runtime, schedule, shared, and
+agent-global scopes. A shared store would let persisted prompt injection from
+any caller influence every caller. Shared scopes should ship only with explicit
+shared-scope disclosure semantics, not weaker guarantees than private memory.
 
-Before memory ships, eve delivery must preserve one immutable envelope per source containing source ID, order, provenance, auth, audience, and fingerprints. Payloads cannot mint attestations. Coalescing may combine model input only after compatible envelopes are grouped and never across auth or audience fingerprints. Built-in channels must enforce private destination ownership on send, continue, stream, cancel, and reset paths before they attest privacy.
+The local development host is the sole exception: it may project the existing
+`local-dev` caller into a module-private memory principal and audience. This
+does not turn that caller into a user for connections, permissions, governance,
+or authored callbacks, and it cannot exist outside the local provider runtime.
 
-Canonical provider keys derive from this tuple and are passed as keyed opaque digests:
+### Storage namespace
 
-```ts
-type CanonicalMemoryScopeV1 = readonly [
-  protocol: "eve-memory",
-  version: 1,
-  applicationId: string,
-  environmentId: string,
-  graphNodeId: string,
-  collectionPath: string,
-  principal: CanonicalMemoryPrincipalV1,
-];
-```
+The provider receives an opaque digest of a versioned namespace. Each component
+exists to prevent an otherwise plausible collision:
 
-`applicationId` and `environmentId` are stable provider configuration. Vercel integrations may derive them from project and target environment. Self-hosted applications must provide them explicitly; hostname, working directory, `NODE_ENV`, Git SHA, build path, and deployment ID are invalid fallbacks. `applicationId` is the sole stable root identity; package and display-name changes do not affect memory. `graphNodeId` is the root sentinel or path-derived local-subagent address. Redeployments in one environment share memory. Production, preview, development, different application IDs, nodes, paths, and app roots do not share implicitly. Node and collection path renames intentionally require migration.
+| Component       | Isolation behavior                                                     |
+| --------------- | ---------------------------------------------------------------------- |
+| Application ID  | Stable root identity; display or package renames do not change memory. |
+| Environment ID  | Separates production, preview, development, and other targets.         |
+| Graph node ID   | Separates the root agent from each local subagent.                     |
+| Collection path | Separates independently authored collections.                          |
+| Principal tuple | Separates subjects and authentication authorities.                     |
 
-### V1 scope trade-off
+Application and environment IDs come from stable provider configuration.
+Vercel integrations may derive them from project and target environment;
+self-hosted applications provide them explicitly. Hostname, working directory,
+`NODE_ENV`, Git SHA, build path, and deployment ID are not stable fallbacks.
 
-V1 memory exists only for authenticated `user` principals. Agents behind `none()` auth (anonymous callers), service and `runtime` principals, schedule-driven turns, and unknown identities never resolve a collection: a declared slot compiles, tools and capture stay absent, and the resolution diagnostic above is the only observable. The `local-dev` projection is the sole dev-time exception.
+Redeployments in the same environment share memory. Different applications,
+environments, nodes, collection paths, and principals do not share implicitly.
+Renaming a graph node or collection path requires migration.
 
-This is deliberate. Cross-subject disclosure is the dominant memory risk, and trusted identity is the only safe scope key, so V1 refuses to guess a subject. An agent-global `byAgent()` scope was considered and deferred: it has no cross-subject disclosure boundary, but every caller reads and writes one shared store, so persisted prompt injection from any caller reaches every caller, and neither citations nor approval isolate subjects within it. Shared and global scopes wait for the shared-scope disclosure semantics in the final delivery phase rather than shipping with weaker guarantees than the private scope.
+## Sources, provenance, and turn ordering
 
-### Application addressing
+Memory claims need durable evidence, but capture-specific redaction must not
+silently change what the response model saw. eve therefore keeps two immutable
+views of eligible authored text.
 
-In-turn callbacks stay bound to their current graph node:
+| View                        | Created                                | Used by                                                                |
+| --------------------------- | -------------------------------------- | ---------------------------------------------------------------------- |
+| Framework-normalized source | Once for each accepted authored source | Recall query, response source handles, and explicit remember citations |
+| Capture-prepared source     | Once per source and collection         | Capture model, capture validation, and capture-origin citations        |
 
-```ts
-interface SessionContext {
-  getMemory(collection: string): Promise<MemoryClient | null>;
-}
-```
+Framework normalization identifies authored text before adapters merge model
+messages, converts it to well-formed NFC Unicode, normalizes line endings,
+removes blank parts, joins ordered text parts, and applies a versioned UTF-8
+bound. It retains source ID, digest, order, provenance, trusted time, auth, and
+audience fingerprints.
 
-Unknown collections throw; unavailable principal scope returns `null`. Route handlers can enumerate and address root and local-subagent collections:
-
-```ts
-type MemoryNodeAddress =
-  { readonly kind: "root" } | { readonly kind: "local-subagent"; readonly nodeId: string };
-
-interface MemoryCollectionAddress {
-  readonly node: MemoryNodeAddress;
-  readonly collection: string;
-}
-
-interface MemoryCollectionDescriptor {
-  readonly address: MemoryCollectionAddress;
-  readonly description: string;
-}
-
-interface MemoryPrincipalAddress {
-  readonly authenticator: string;
-  readonly issuer?: string;
-  readonly principalId: string;
-}
-
-interface RouteHandlerArgs {
-  attestPrivateAudience(auth: SessionAuthContext): DeliveryAudience;
-  listMemoryCollections(): readonly MemoryCollectionDescriptor[];
-  getMemory(input: {
-    readonly address: MemoryCollectionAddress;
-    readonly auth: SessionAuthContext;
-    readonly audience: DeliveryAudience;
-  }): Promise<MemoryClient | null>;
-  getMemoryAdmin(input: {
-    readonly address: MemoryCollectionAddress;
-    readonly principal: MemoryPrincipalAddress;
-    readonly operator: {
-      readonly auth: SessionAuthContext;
-      readonly reason: string;
-    };
-  }): Promise<MemoryAdminClient>;
-}
-```
-
-Enumeration is root first, then local node ID and collection name. Node IDs are opaque values obtained from enumeration, not constructed by applications. Remote subagents own memory remotely.
-
-`getMemory(...)` requires a verified principal and an attested private audience — a handler lacking either has nothing to pass and must not call it — and returns `null` only when that auth does not resolve the collection's scope. The subject binding covers the entire client, including mutations, because its results may flow into that response.
-
-`getMemoryAdmin(...)` requires no subject audience and never impersonates the subject. A `MemoryPrincipalAddress` canonicalizes exactly as scope resolution would — `issuer` is the authority when present, otherwise `authenticator` — and admin lookups match only that canonical tuple, with no fuzzy or cross-authority matching, so an operator must supply the same authority the records were written under. Unknown addresses and malformed principal addresses throw; the call never returns `null` because admin access does not depend on subject scope resolution. The application must authorize the operator before the call; eve records the operator fingerprint, reason, target, operation, and outcome. Admin clients are never exposed to model tools, callbacks, dynamic resolvers, or serialized payloads.
-
-Aggregate data-subject export and purge iterate descriptors and acquire one admin client per collection. Arbitrary future custom scopes must register enumerable subject mappings. `/info` may expose descriptors for inspection, never subjects or content.
-
-## Sources and lifecycle
-
-### Source views
-
-eve maintains two immutable views instead of overloading “prepared source”:
-
-| View                        | Created                           | Consumers                                                   |
-| --------------------------- | --------------------------------- | ----------------------------------------------------------- |
-| Framework-normalized source | Once per accepted authored source | Recall query, response source handles, explicit citations   |
-| Capture-prepared source     | Per source and collection         | Capture model, capture validation, capture-origin citations |
-
-Framework normalization identifies authored text before adapters merge model messages, converts it to well-formed NFC Unicode, normalizes line endings, removes blank parts, joins ordered text parts, and applies a versioned UTF-8 bound. It preserves case, punctuation, and remaining whitespace. Each source retains its ID, normalization version, digest, order, provenance, trusted time, auth, and audience fingerprints.
-
-`prepareSource` transforms only the second view. Returning `null` skips capture for that collection; it does not suppress recall or invalidate explicit source handles. Response-model handles bind the normalized digest. Model-tool citations bind normalized byte offsets; capture citations bind the prepared digest, preparation fingerprint, and prepared byte offsets. Recall returns stored immutable citations and never reruns preparation.
-
-Normalized source envelopes live in the world/session journal under world retention. Memory providers retain only revision-owned cited excerpts and payload-free source receipts, not complete source objects. Memory erasure does not claim physical deletion from world journals, transcripts, telemetry, or model-provider retention.
-
-### Turn lifecycle
+`prepareSource` creates the second view. Response-model handles bind the
+normalized digest; capture citations bind the prepared digest and preparation
+fingerprint. Recall returns immutable stored excerpts and never reruns source
+preparation.
 
 ```text
-accept + seal per-source envelopes
+accept and seal source envelopes
         |
-framework-normalize authored text
+normalize authored text
         |
-compact and commit placeholder history
-        |
-recall + commit transient turn overlay
-        |
-validate + materialize -> one response-model attempt
-        |
-execute checkpointed memory tools during the loop
-        |
-commit terminal turn checkpoint + capture outbox
-        |
-settle response -> prepare per collection -> dispatch capture
+compact history -> automatic recall -> response-model loop
+                                      |        |
+                              memory tools   terminal checkpoint
+                                                  |
+                                      prepare per collection
+                                                  |
+                                          capture outbox
 ```
 
-This requires new execution primitives before the public API ships. eve must own model retries, disable nested SDK retries, preserve source provenance through coalescing, and commit terminal classification with durable session state. Stream events remain append-only and may already be visible; capture eligibility derives only from the durable checkpoint.
+The terminal checkpoint is internal machinery required to distinguish a
+completed turn from streaming output that was later cancelled or failed. A
+normal response and a completed human-input boundary are capture-eligible;
+authorization or task waits are deferred; failed and cancelled turns are not.
+Workflow replay preserves the same classification and source IDs.
 
-The checkpoint records the durable protocol outcome and accepted sources. It is internal execution machinery, not public API; it appears here only to define capture eligibility:
+Normalized source envelopes remain in the world/session journal under world
+retention. Memory providers retain only cited excerpts and payload-free source
+receipts, not complete source objects. Memory erasure therefore does not claim
+to remove original text from journals, transcripts, telemetry, or provider
+retention.
 
-```ts
-interface TurnTerminalCheckpoint {
-  readonly sessionId: string;
-  readonly turnId: string;
-  readonly sequence: number;
-  readonly outcome: "completed" | "failed" | "cancelled";
-  readonly acceptedSourceIds: readonly string[];
-}
-```
+## Canonical records and consistency
 
-| Turn path                                   | Outcome       | Capture                              |
-| ------------------------------------------- | ------------- | ------------------------------------ |
-| Normal response or completed HITL boundary  | `completed`   | Eligible authored normalized text    |
-| Authorization, runtime action, or task wait | No checkpoint | Deferred                             |
-| Recoverable or terminal turn failure        | `failed`      | Never                                |
-| Cancellation before completion              | `cancelled`   | Never                                |
-| Adapter consumes delivery without a turn    | No checkpoint | Never                                |
-| Workflow replay                             | Same outcome  | Idempotent using the same source IDs |
+The canonical store makes mutation and erasure authoritative; retrieval indexes
+only help find candidates. This distinction is necessary because an eventually
+updated embedding must never make a stale record visible again.
 
-A completed checkpoint creates no outbox for an unresolved collection. For a resolved collection, no authored text or a `null`/blank prepared source produces an internal `skipped` status. Capture retries transient failures; exhausted retries become `failed`, and stale generation or definition becomes `obsolete`. These content-free statuses appear in traces and diagnostics only. V1 exposes no capture polling or freshness barrier. A following turn may not observe capture; callers needing read-after-write use explicit remember or an application write.
+Each logical record points to one current immutable revision. A revision stores
+content, origin (`capture`, `model-tool`, or `application`), observation time,
+optional occurrence and expiry times, and citations. Corrections append a
+revision under the same logical ID using compare-and-swap. V1 has no implicit
+decay, confidence score, autonomous inference, or graph relation.
 
-### Recall
+`observedAt` is trusted commit time. `occurredAt` describes when the claim's
+event happened. `expiresAt` removes it from live operations at the deadline.
+Occurrence-time filtering excludes records without `occurredAt`; without a
+filter those records remain eligible. Retained expired and superseded revisions
+appear only in administrative export until retention or erasure removes them.
 
-Recall runs after compaction and before the first response-model request. Its query uses the latest framework-normalized input plus a bounded visible window for coreference. It combines relevant and recent candidates under one token and wall-clock budget.
-
-Transient provider and deadline failures do not fail the turn. Successful collections still contribute; each failed collection contributes only a content-free `unavailable` status and emits a diagnostic. If every collection fails, the response model still runs with that status rather than an empty-memory result. Scope, generation, expiry, signature, and canonical-integrity checks remain fail-closed for disclosure: invalid content is never supplied.
-
-The explicit recall tool uses the same partial-success representation. When every explicitly selected collection fails, the tool returns `memory_recall_unavailable` so the model can react inside the loop; automatic recall instead places the equivalent status before the first model call. This preserves agent availability without representing an outage as “the user has no memories.”
-
-The contribution is a length-delimited data block attributed by collection name, purpose, handle, revision time, and available citation. A fixed trusted instruction identifies it as untrusted data. It does not change eve permission or approval gates, although stored prompt injection can still influence the model.
-
-Immediately before each eve-owned model request, eve rechecks scope, purge generation, expiry, definition fingerprint, and exact revisions. An unrelated write causes rehydration rather than whole-collection invalidation. A projection can nominate candidates only; canonical rehydration prevents superseded, expired, erased, or purged content from reappearing.
-
-### Capture
-
-For every collection resolved at turn admission, a completed checkpoint creates a payload-free outbox entry that references accepted normalized sources and pins collection, scope, purge generation, provider fingerprint and incarnation, preparation fingerprint, model and extraction versions, source sequence, audience, time, and provenance. It never reruns scope resolution. A provider-incarnation mismatch is terminal `obsolete` and cannot adopt a replacement store.
-
-Capture executes as a durable, idempotent workflow against one strong canonical snapshot: the pinned model proposes add, supersede, or no-op operations with exact citations, and eve verifies preparation hashes, byte offsets, bounds, and revision expectations before committing the exact proposal with a replay receipt. Conflicts re-propose against fresh state rather than blindly retrying.
-
-Each scope has a monotonic source sequence. A delayed older turn may add a historical event but cannot supersede state learned from a newer source.
-
-## Canonical model and erasure
-
-| Record                | Purpose                                   | Core fields                                                     |
-| --------------------- | ----------------------------------------- | --------------------------------------------------------------- |
-| `MemoryScopeVersion`  | Resurrection and cache invalidation       | purge generation, content revision, source sequence             |
-| `MemorySourceReceipt` | Accepted-source identity and replay guard | source ID, keyed digest, clocks, preparation/provenance version |
-| `MemoryCitation`      | Revision-owned evidence                   | source view/digest, version, byte offsets, quote                |
-| `MemoryRevision`      | Immutable assertion revision              | IDs, content, origin, times, citations                          |
-| `MemoryRecord`        | Current canonical view                    | current revision and derived expiry state                       |
-| `MemoryHit`           | Provider recall result                    | canonical candidate ID and provider rank signals                |
-| Erasure receipts      | Payload-free deletion evidence            | operation, target or generation, key version, time              |
-| Admin audit events    | Trusted-operator accountability           | operator fingerprint, reason, target, operation, outcome, time  |
-
-`observedAt` is canonical commit time, `occurredAt` is optional event time, and `expiresAt` excludes a record at or after its deadline according to the provider's trusted clock. Recall, `get`, and `list` exclude expired records; export includes retained expired revisions until retention or erasure removes them.
-
-Corrections append a revision under one logical ID and require the current revision token. CAS ensures one current revision. Stale remember and forget handles conflict rather than changing newer data. V1 has no implicit decay, confidence score, autonomous inference, or graph relation.
-
-Forget removes one logical record, its revisions, and revision-owned evidence from live operations. It does not find semantically duplicated claims; scope purge is the complete live-memory erasure operation. Payload-free receipts and generation barriers remain for at least the maximum replay and idempotency horizon. Accepted mutation receipts shed content when their target is erased and resolve future replay to `erased` or `purged`. Receipts are pseudonymous operational data, not literally data-free.
-
-Restoring an older database requires replaying a separately retained erasure ledger before traffic resumes. Physical database remnants, replicas, backups, workflow journals, transcripts, telemetry, and model-provider retention remain governed by their own policies.
+Each scope also maintains a purge generation, content revision, and monotonic
+source sequence. Source receipts prevent duplicate capture, revision tokens
+provide compare-and-swap, and erasure receipts prevent resurrection. Canonical
+writes are durable and read-your-writes even while embeddings or indexes lag.
 
 ## Provider boundary
 
-V1 publicly exposes only opaque first-party `MemoryProvider` values. A provider owns persistence, within-collection retrieval, projections, readiness, and migration. eve owns scope, canonical public semantics, citations, handles, tools, idempotency orchestration, deadlines, cross-collection fusion, budgets, rendering, and final disclosure validation.
+Providers persist canonical state and retrieve candidates within one
+collection. eve retains the security- and product-defining behavior so changing
+providers cannot change public memory semantics.
 
-The internal protocol must prove namespace isolation, durable canonical writes, strong formation reads, revision CAS, expiry, erase, purge barriers, bounded snapshot export, stale-projection rehydration, readiness, cancellation, limits, fingerprints, retention horizons, and race behavior. Public third-party support waits for production evidence and a branded provider API plus conformance kit.
+Providers own persistence, projections, readiness, migration, and
+within-collection ranking. eve owns scope, public records, citations, handles,
+tools, idempotency, deadlines, cross-collection fusion, budgets, rendering, and
+final disclosure validation. V1 exposes only opaque first-party
+`MemoryProvider` values. A public custom-provider API waits for production
+evidence and a conformance kit.
 
 ### PostgreSQL reference provider
 
-PostgreSQL owns both document and query embedding. `defineMemory` never accepts an embedding model; managed future providers may embed upstream or use a different retrieval strategy entirely.
-
-```ts
-interface MemoryEmbeddingCallOptions {
-  readonly providerOptions?: Record<string, JsonObject>;
-}
-
-interface PostgresMemoryEmbeddingDefinition {
-  readonly model: string | EmbeddingModel;
-  readonly modelRevision?: string;
-  readonly dimensions: number;
-  readonly documentOptions?: MemoryEmbeddingCallOptions;
-  readonly queryOptions?: MemoryEmbeddingCallOptions;
-}
-
-interface PostgresMemoryDefinition {
-  readonly database: PostgresMemoryDatabase;
-  readonly namespace: {
-    readonly applicationId: string;
-    readonly environmentId: string;
-  };
-  readonly embedding: PostgresMemoryEmbeddingDefinition;
-}
-
-interface PostgresMemoryConnection {
-  query<Row extends Record<string, unknown> = Record<string, unknown>>(
-    text: string,
-    values?: readonly unknown[],
-    options?: { readonly signal?: AbortSignal },
-  ): Promise<{ readonly rows: readonly Row[] }>;
-  release(): void;
-}
-
-interface PostgresMemoryPool {
-  connect(options?: { readonly signal?: AbortSignal }): Promise<PostgresMemoryConnection>;
-}
-
-declare function pgDatabase(pool: PostgresMemoryPool): PostgresMemoryDatabase;
-declare function postgresMemory(definition: PostgresMemoryDefinition): PostgresMemoryProvider;
-
-declare function preparePostgresMemory(
-  provider: PostgresMemoryProvider,
-  options?: { readonly signal?: AbortSignal },
-): Promise<{
-  readonly status: "ready";
-  readonly schemaVersion: number;
-  readonly projectionFingerprint: string;
-}>;
-```
+PostgreSQL is the production reference provider. It stores canonical records
+and owns document and query embedding so the collection definition remains
+independent of a retrieval strategy.
 
 ```ts title="agent/lib/memory.ts"
 import { pgDatabase, postgresMemory } from "eve/memory/postgres";
@@ -645,64 +572,67 @@ export const memory = postgresMemory({
 });
 ```
 
-`memoryNamespace` must derive the current stable application and target environment. Never hardcode an environment name in shared source: preview and production must resolve different values, and a missing or ambiguous value fails provider readiness. The Vercel integration owns this derivation for the majority path: a first-party helper resolves `applicationId` from the project and `environmentId` from the target environment, so a Vercel-deployed application writes no namespace code. Self-hosted applications provide both explicitly.
+The namespace supplies stable application and environment IDs. The Vercel
+integration derives these for the common path; self-hosted applications provide
+both. Missing or ambiguous identity fails readiness, and shared source must not
+hardcode an environment name.
 
-The embedding model accepts a Gateway ID or direct AI SDK `EmbeddingModel`. Query and document call options may separately provide provider options for role-specific APIs. `modelRevision` defaults to the Gateway ID when `model` is a string; a direct `EmbeddingModel` instance, mutable alias, middleware, or custom endpoint requires an explicit revision because eve cannot derive a stable identity from it. Dimensions are required and verified because AI SDK models do not report them reliably.
+Embedding configuration accepts a Gateway ID or AI SDK `EmbeddingModel`,
+required dimensions, separate document/query provider options, and a model
+revision when eve cannot derive a stable identity. Retrieval uses deterministic
+hybrid lexical, vector, and recency lanes. A query-embedding failure is an
+availability failure, never an empty result.
 
-Retrieval strategy is a provider implementation choice, not an author knob. V1 uses hybrid recall — lexical, vector, and recency lanes fused deterministically within the collection — over canonical rows; eve rehydrates canonical state and fuses collections. A canonical write is durable and read-your-writes even when its embedding has not yet committed; embeddings are rebuildable projections that commit only while they still match canonical state. Query-embedding failure is an operational recall failure, never an empty result; automatic recall reports the collection as `unavailable` under the policy above. Stable PostgreSQL memory has no lexical-only mode.
+Every retrieval-affecting choice contributes to one projection fingerprint.
+Changing it builds and backfills a side-by-side generation, then activates it
+atomically. Embeddings commit only while they still match canonical state;
+recall rehydrates candidates from canonical rows.
 
-Every retrieval-affecting choice — model identity and revision, dimensions, call options, preprocessing, ranking, and fusion version — is covered by one projection fingerprint. Changing any of them builds a side-by-side projection generation and activates it atomically only after backfill. Runtime readiness verifies schema, pgvector, the active fingerprint, and completed backfill before a session uses memory.
-
-`PostgresMemoryDatabase` and `PostgresMemoryProvider` are opaque branded values. `pgDatabase(pool)` accepts the structural lease contract above, never closes it, and adds no `pg` runtime dependency. Connections and queries must honor the supplied abort signal, including blocked acquisition and in-flight cancellation. `preparePostgresMemory(...)` runs migrations, canary validation, backfill, and projection activation; applications invoke it from a deploy-time step — a build command on Vercel, a migration job self-hosted — before new code serves traffic. eve never migrates implicitly: `eve dev` and `eve start` fail readiness rather than migrate on demand, and a failed prepare rejects without changing the active generation. Namespace migration freezes old writers and preserves purge generations and receipts. PostgreSQL erasure guarantees live logical unreachability, not immediate sanitization of MVCC pages, WAL, replicas, snapshots, or backups.
+`pgDatabase(pool)` wraps a structural connection-lease contract. It neither
+adds a `pg` runtime dependency nor closes the caller's pool. Acquisition and
+queries honor abort signals. Applications run
+`preparePostgresMemory(provider)` at deploy time for migrations, validation,
+backfill, and projection activation. `eve dev` and `eve start` check readiness
+but never migrate implicitly. Failed preparation leaves the active generation
+unchanged.
 
 ### Test and local providers
 
-Tests create an isolated deterministic provider explicitly:
+`createTestMemory()` returns an opaque deterministic provider plus a controller
+with a fixed clock and queued `snapshot()` and `reset()` operations. It performs
+no filesystem, network, wall-clock, random, or timer access, but enforces the
+same canonical, revision, idempotency, expiry, citation, erase, purge, and cursor
+semantics as production.
 
-```ts
-import { byPrincipal, defineMemory } from "eve/memory";
-import { createTestMemory } from "eve/memory/testing";
+`localMemory()` is an explicit development provider; eve never substitutes it
+for PostgreSQL. It uses Node's built-in `DatabaseSync` and stores canonical
+state in `.eve/memory/v1/local.sqlite`, surviving hot reloads, worker
+replacement, `/new`, and `eve dev` restarts. A bounded deterministic JavaScript
+ranker supplies lexical, fuzzy, and recency retrieval without embeddings.
 
-const testMemory = createTestMemory();
-
-export default defineMemory({
-  description: "Stable user preferences.",
-  provider: testMemory.provider,
-  scope: byPrincipal(),
-});
-```
-
-The controller provides a fixed controllable clock, queued `snapshot()` and `reset()` operations, and an opaque provider. It performs no filesystem, network, wall-clock, random, or timer access. It enforces the real canonical, CAS, idempotency, expiry, citation, erase, purge, and cursor semantics rather than acting as a permissive fake.
-
-Local development selects an explicit provider; eve never silently substitutes it for PostgreSQL:
-
-```ts title="agent/lib/memory.ts"
-import { localMemory } from "eve/memory/local";
-
-export const memory = localMemory();
-```
-
-`localMemory()` uses `DatabaseSync` directly from Node's built-in `node:sqlite`, adding no package, ORM, native addon, or database adapter. It stores canonical state in `.eve/memory/v1/local.sqlite`, enables WAL, and commits mutations with SQLite transactions. The path is rooted at the authored app rather than a generated snapshot, so memory survives hot reloads, worker replacement, `/new`, and `eve dev` restarts. Schema readiness gates generation activation; migrations require quiesced dev workers, and transactions fence the schema version and store incarnation.
-
-The local provider stores no embeddings or search projection. It loads a bounded live scope and uses a shared versioned deterministic JavaScript ranker with lexical, fuzzy, and recent lanes. This is for lifecycle development and predictable tests, not evidence of production recall quality.
-
-The loopback dev channel retains its existing `local-dev` auth identity. The trusted dev host supplies a separate module-private memory principal and private audience, with session ownership enforced on all lifecycle routes. This does not make the synthetic caller a user for connections, permissions, or authored callbacks.
-
-Local inspection and reset are available through `eve memory path|ls|show|recall|reset`. These commands operate on the local provider's SQLite store only; they never connect to a production provider. Content is redacted from framework traces by default. The provider creates app-local ignore protection for `.eve/memory`, and build/deployment adapters hard-exclude it. Corruption fails closed and explicit reset quarantines the database, WAL, and SHM before creating a new incarnation.
-
-The test and local providers are rejected by `eve build` and `eve start`; mounting additionally requires a module-private test or `eve dev` runtime capability rather than an environment variable. There is no production escape hatch or automatic migration to PostgreSQL.
+Local inspection and reset use `eve memory path|ls|show|recall|reset`. The store
+is ignored and excluded from builds, content is trace-redacted by default, and
+reset quarantines corrupt database files before creating a new incarnation.
+Test and local providers require private test or development runtime capability
+and are rejected by `eve build` and `eve start`; there is no production escape
+hatch.
 
 ## Out of scope
 
-- Read-only, write-only, recall-disabled, or tool-disabled memory collections, and configuration flags that disable capture (`prepareSource` is the code-level per-source skip).
+- Partial-capability collections or configuration flags that disable capture.
+  `prepareSource` remains the code-level per-source skip.
 - A mutable `MEMORY.md` canonical store or model-managed memory filesystem.
-- A hosted memory service, transcript store, RAG store, or application system of record.
-- Capturing assistant output, reasoning, tool payloads, attachments, or imported context in V1.
-- Shared scopes, multiple scopes per collection, or implicit sharing in V1.
-- Tags, typed record kinds, profiles, graph relations, confidence, autonomous inference, decay, or autonomous instruction modification.
+- A hosted memory service, transcript store, RAG store, or application system
+  of record.
+- Capturing assistant output, reasoning, tool payloads, attachments, or imported
+  context in V1.
+- Shared or multiple scopes per collection, and implicit sharing.
+- Tags, typed record kinds, profiles, graph relations, confidence, autonomous
+  inference, decay, or autonomous instruction modification.
 - Public custom extractor, embedder, or provider interfaces in V1.
 - Raw-source retention and reprocessing as a provider feature.
-- Physical sanitization guarantees for database remnants, replicas, backups, workflow journals, transcripts, logs, telemetry, or model-provider retention.
+- Physical sanitization guarantees for database remnants, replicas, backups,
+  workflow journals, transcripts, logs, telemetry, or model-provider retention.
 
 ## Primary references
 

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -126,6 +126,7 @@ eve guarantees that every invocation for one slot within the turn or manual oper
 ```ts
 import type { ModelMessage } from "ai";
 import type { SessionContext } from "eve/context";
+import type { HookEventMap } from "eve/hooks";
 import type { ToolDefinition } from "eve/tools";
 
 interface MemoryProviderContext extends SessionContext {
@@ -147,43 +148,25 @@ interface MemoryMessage {
 
 type MemoryEventResult = MemoryMessage | readonly MemoryMessage[] | null | void;
 
+type MemoryEventHandler<TEvent> = (
+  event: TEvent,
+  context: MemoryProviderContext,
+) => MemoryEventResult | Promise<MemoryEventResult>;
+
 interface MemoryProviderEvents {
-  readonly "session.started"?: (
-    event: SessionStartedEvent,
-    context: MemoryProviderContext,
-  ) => MemoryEventResult | Promise<MemoryEventResult>;
-
-  readonly "turn.started"?: (
-    event: TurnStartedEvent,
-    context: MemoryProviderContext,
-  ) => MemoryEventResult | Promise<MemoryEventResult>;
-
-  readonly "message.received"?: (
-    event: MessageReceivedEvent,
-    context: MemoryProviderContext,
-  ) => MemoryEventResult | Promise<MemoryEventResult>;
-
-  readonly "compaction.requested"?: (
-    event: CompactionRequestedEvent,
-    context: MemoryProviderContext,
-  ) => MemoryEventResult | Promise<MemoryEventResult>;
-
-  readonly "compaction.completed"?: (
-    event: CompactionCompletedEvent,
-    context: MemoryProviderContext,
-  ) => MemoryEventResult | Promise<MemoryEventResult>;
-
-  readonly "turn.completed"?: (
-    event: TurnCompletedEvent,
-    context: MemoryProviderContext,
-  ) => MemoryEventResult | Promise<MemoryEventResult>;
+  readonly "session.started"?: MemoryEventHandler<HookEventMap["session.started"]>;
+  readonly "turn.started"?: MemoryEventHandler<HookEventMap["turn.started"]>;
+  readonly "message.received"?: MemoryEventHandler<HookEventMap["message.received"]>;
+  readonly "compaction.requested"?: MemoryEventHandler<HookEventMap["compaction.requested"]>;
+  readonly "compaction.completed"?: MemoryEventHandler<HookEventMap["compaction.completed"]>;
+  readonly "turn.completed"?: MemoryEventHandler<HookEventMap["turn.completed"]>;
 }
 
 interface MemoryProviderTools {
   readonly kind: "eve:dynamic";
   readonly events: {
     readonly "step.started"?: (
-      event: StepStartedEvent,
+      event: HookEventMap["step.started"],
       context: MemoryProviderContext,
     ) => MemoryProviderToolSet | null | Promise<MemoryProviderToolSet | null>;
   };

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -1,7 +1,7 @@
 ---
 issue: https://github.com/vercel/eve/issues/1510
 status: proposed
-last_updated: "2026-08-05"
+last_updated: "2026-08-11"
 ---
 
 # First-class memory
@@ -13,14 +13,16 @@ Memory is a path-authored slot that lets an agent carry provider-defined context
 eve owns only two pieces:
 
 1. **Authored identity.** Each memory file is a named slot with path-derived identity.
-2. **Scope.** eve resolves and locks a trusted partition for that slot, then supplies the same partition to every provider event handler and provider-defined tool in the turn.
+2. **Scope.** eve resolves and locks a trusted partition for that slot, then supplies the same partition to every provider event handler and provider-defined tool in the lifecycle operation.
 
 The provider owns everything else: storage, recall, capture, model tools, formatting, extraction, ranking, limits, retention, and any record or document model. A hosted semantic service and a pair of bounded text files can therefore implement the same memory slot without pretending to share lower-level semantics.
 
 ```text
-turn prepared    scope + session ---> events ---> transient context
-                 scope + session ---> tools  ---> scoped model tools
-turn completed   scope + session ---> events ---> provider side effects
+compaction requested   scope + pre-session  ---> events ---> provider side effects
+compaction completed   scope + post-session ---> events ---> provider side effects
+turn prepared          scope + session      ---> events ---> transient context
+step started           scope + session      ---> tools  ---> scoped model tools
+turn completed         scope + session      ---> events ---> provider side effects
 ```
 
 This document defines that authoring boundary and its observable lifecycle. Provider packaging, vendor configuration, and provider-specific persistence remain follow-up work.
@@ -77,9 +79,9 @@ interface MemoryScope {
 
 The key gives providers one collision-resistant partition identifier. The parts remain available when a vendor needs to map the partition onto its own user, workspace, or container concepts. Both are absent from model-facing schemas.
 
-eve resolves scope after admitting the turn and locks it through the completed-turn handler. Returning `null` makes the slot unavailable for that turn: eve does not invoke its provider handlers or lower its tools. Missing values never fall back to a broader partition. Changing the meaning or order of scope parts is a provider data migration.
+eve resolves scope after admitting the turn but before any automatic compaction, then locks it through the completed-turn handler. For standalone manual compaction, eve resolves and locks scope for that operation from the session's trusted runtime context. Returning `null` makes the slot unavailable for the entire turn or manual operation: eve does not invoke its provider handlers or lower its tools. Missing values never fall back to a broader partition. Changing the meaning or order of scope parts is a provider data migration.
 
-eve guarantees that every invocation for one slot receives the same locked value. The provider is responsible for actually applying that value to downstream storage and service calls; eve cannot enforce isolation inside provider code or an external service.
+eve guarantees that every invocation for one slot within the turn or manual operation receives the same locked value. If a memory tool pauses for approval, eve retains that value for the pending invocation and accepts the approval response only from the principal that initiated it. A response from another principal fails before the tool is resolved or executed. The provider is responsible for actually applying the scope value to downstream storage and service calls; eve cannot enforce isolation inside provider code or an external service.
 
 ## Provider contract
 
@@ -108,6 +110,16 @@ interface MemoryTurnPreparedResult {
 type MemoryProviderToolSet = Readonly<Record<string, ToolDefinition>>;
 
 interface MemoryProviderEvents {
+  readonly "compaction.requested"?: (
+    event: CompactionRequestedEvent,
+    context: MemoryProviderContext,
+  ) => void | Promise<void>;
+
+  readonly "compaction.completed"?: (
+    event: CompactionCompletedEvent,
+    context: MemoryProviderContext,
+  ) => void | Promise<void>;
+
   readonly "turn.prepared"?: (
     event: TurnPreparedEvent,
     context: MemoryProviderContext,
@@ -120,11 +132,6 @@ interface MemoryProviderEvents {
 }
 
 interface MemoryProviderTools {
-  readonly "turn.prepared"?: (
-    event: TurnPreparedEvent,
-    context: MemoryProviderContext,
-  ) => MemoryProviderToolSet | null | Promise<MemoryProviderToolSet | null>;
-
   readonly "step.started"?: (
     event: StepStartedEvent,
     context: MemoryProviderContext,
@@ -159,26 +166,34 @@ export const memory = defineMemoryProvider({
     },
   },
   tools: {
-    async "turn.prepared"(_event, ctx) {
+    async "step.started"(_event, ctx) {
       return service.toolsFor(ctx.memory.scope);
     },
   },
 });
 ```
 
-The provider decides what each handler means. A prepared-turn handler need not search, a completed-turn handler need not persist, and tools need not manipulate memory.
+The provider decides what each handler means. A compaction handler need not extract, a prepared-turn handler need not search, a completed-turn handler need not persist, and tools need not manipulate memory.
 
 ## Lifecycle
 
+### Compaction
+
+eve dispatches the existing `compaction.requested` event before each automatic or manual compaction pass. Each resolved slot receives the complete durable message history about to be compacted, before any message is summarized or removed. eve awaits the handlers in stable slot-path order before starting compaction, allowing a provider to extract, snapshot, or persist information that the checkpoint may omit. Handlers are side-effect-only and cannot alter eve's compaction input or algorithm.
+
+After the compacted checkpoint has been written to durable history, eve dispatches `compaction.completed`. Each handler receives the settled post-compaction durable history. The event occurs only after successful compaction; a failed summarization preserves the prior history and does not emit it. Provider tools are not resolved at either boundary because compaction does not invoke the agent model.
+
+Both snapshots exclude transient provider context. If compaction occurs later in a multi-step turn, eve keeps the prepared-turn context separate from the compaction input and reapplies it to the remaining model steps without writing it into the checkpoint.
+
 ### Turn preparation
 
-After turn admission and compaction, eve resolves each slot's scope and dispatches `turn.prepared` to its `events` and `tools` maps. This is a new provider-resolution event rather than the existing stream `turn.started`: its name reflects that the newest input has been admitted and the model history has already been compacted. The event context includes that input and every model-visible user, assistant, and tool message retained after compaction.
+After turn admission and any required initial compaction, eve dispatches `turn.prepared` to the `events` map of each slot whose scope resolved at turn start. This is a new provider-resolution event rather than the existing stream `turn.started`: its name reflects that the newest input has been admitted and the model history has already been compacted. The event context includes that input and every model-visible user, assistant, and tool message retained after compaction.
 
 The event handler runs before the tool resolver for the same slot. A non-empty `context` result becomes one transient user-context message appended at the prompt tail. Results from several slots appear in stable slot-path order. Providers own all formatting and attribution within their returned text.
 
 Recalled context is not a system instruction. Keeping it at the prompt tail leaves authored instructions and the prior conversation prefix stable for prompt caching. It also remains transient: eve does not write it to durable session history, include it in later capture input, or restore it on replay as conversation authored by the user.
 
-Tools returned from `tools["turn.prepared"]` are available for every model step in the turn. A provider may additionally resolve `tools["step.started"]` before each model call; its most recent result owns that provider's tool set, and `null` clears it. A provider returns tool keys such as `forget` or `propose`; eve lowers them as `<memory-slot>__<provider-tool>`, for example `user__forget`. Qualification is unconditional, so adding another memory slot never renames an existing tool or creates a collision when two slots use the same provider.
+eve resolves `tools["step.started"]` before each model call. Its most recent result owns that provider's tool set, and `null` clears it. A provider returns tool keys such as `forget` or `propose`; eve lowers them as `<memory-slot>__<provider-tool>`, for example `user__forget`. Qualification is unconditional, so adding another memory slot never renames an existing tool or creates a collision when two slots use the same provider.
 
 The model never supplies slot identity or scope. eve binds the resolved invocation to each lowered executor, and provider code uses that bound scope for its service or storage call. Provider tools otherwise use the ordinary tool contract, including schemas, approvals, results, and authorization access. A provider may expose tools unrelated to conventional memory CRUD.
 
@@ -192,9 +207,11 @@ The provider decides whether the handler stores the whole session, extracts sele
 
 ### Failures
 
-A `turn.prepared` event-handler or tool-resolution failure fails the turn. A `step.started` tool-resolution failure fails that step. Memory is an authored capability, so silently running with a different prompt or tool set would violate the agent definition.
+A `turn.prepared` event-handler failure fails the turn. A `step.started` tool-resolution failure fails that step. Memory is an authored capability, so silently running with a different prompt or tool set would violate the agent definition.
 
-A `turn.completed` handler failure occurs after the response and cannot change that completed response. eve emits content-free diagnostics and continues to `session.waiting` or `session.completed`. Providers that acknowledge the event before their own asynchronous persistence completes own the resulting eventual consistency and retry behavior.
+A `compaction.requested` handler failure aborts the compaction before durable history changes. Automatic compaction fails the active turn or step; manual compaction emits a diagnostic and returns to `session.waiting` with the previous history. A `compaction.completed` handler failure occurs after the durable checkpoint and cannot roll it back; eve emits a diagnostic and continues the active turn or ready boundary.
+
+A `turn.completed` handler failure likewise occurs after the response and cannot change that completed response. eve emits content-free diagnostics and continues to `session.waiting` or `session.completed`. Providers that acknowledge an event before their own asynchronous persistence completes own the resulting eventual consistency and retry behavior.
 
 ## Reference providers
 
@@ -221,7 +238,9 @@ This provider demonstrates that simple bounded text can participate in the same 
 - Memory slots have path-derived identity and an explicit authored scope.
 - Scope is resolved from trusted runtime context, locked for the turn, and never accepted from model input.
 - The same provider can back several slots without sharing eve scope keys or colliding model tools.
+- `events["compaction.requested"]` sees the complete pre-compaction durable history, while `events["compaction.completed"]` sees the successfully checkpointed durable history.
 - `events["turn.prepared"]` sees the post-compaction visible session including the newest input and may contribute transient tail context in deterministic slot order.
+- Transient prepared-turn context appears in neither compaction snapshot nor durable history.
 - Provider tools are unconditionally slot-qualified and bound to the same locked scope as provider event handlers.
 - `events["turn.completed"]` sees the completed durable session without prepared-turn transient context and settles before the next ready boundary.
 - Prepared-turn event and tool-resolution failures fail the active turn or step; completed-turn event failures cannot rewrite the response or suppress the ready boundary.
@@ -239,7 +258,7 @@ This provider demonstrates that simple bounded text can participate in the same 
 
 ## Implementation contract follow-up
 
-Before V1 implementation lands, follow-up plans must fix the exact public type names, introduce the `turn.prepared` resolution point, define event/tool-map compilation and durable-replay mechanics, specify scope-part encoding, diagnostics and cancellation, and add tests for lifecycle ordering and isolation. Supermemory and blob storage each need a provider-specific plan for configuration and operational behavior without expanding the core memory contract.
+Before V1 implementation lands, follow-up plans must fix the exact public type names, introduce the `turn.prepared` resolution point, connect provider handlers to the existing compaction events, define event/tool-map compilation and durable-replay mechanics, specify scope-part encoding, diagnostics and cancellation, and add tests for lifecycle ordering and isolation. Supermemory and blob storage each need a provider-specific plan for configuration and operational behavior without expanding the core memory contract.
 
 ## Primary references
 

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -19,24 +19,25 @@ after completion  authored input -------- capture ------> collection
 application       trusted outcome -------- direct write --> collection
 ```
 
-Capture is the automatic ingestion path. It runs after a completed turn and extracts cited durable claims from user-authored input. Without capture, the agent remembers only when the response model chooses to call a tool or application code writes a record.
+Capture is the automatic ingestion path. It runs after a completed turn and extracts durable claims from user-authored input. Without capture, the agent remembers only when the response model chooses to call a tool or application code writes a record.
 
 The proposal treats a collection as one coherent opt-in: automatic recall, model tools, capture, application access, and erasure semantics ship together. Data that should not be mutable by the agent belongs in instructions, RAG, application state, or an external system of record instead.
 
-This document focuses on the authoring model and observable behavior. Exact schemas, error catalogs, workflow machinery, and provider internals are deferred until the product decisions are accepted.
+This document focuses on the authoring model, provider boundary, and observable behavior. Exact error catalogs, workflow machinery, and provider-specific implementation details are deferred until the product decisions are accepted.
 
 ## Questions for review
 
 These are the main decisions this proposal asks the team to evaluate:
 
-| Question                                                  | Proposed direction                                                                                                                                            |
-| --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Should ordinary conversation create memory automatically? | Yes. A post-turn capture pass learns durable claims that the response model did not explicitly remember.                                                      |
-| Should collections expose partial capabilities?           | No. Declaring a collection enables recall, remember, forget, capture, and application access together.                                                        |
-| How should memory be partitioned?                         | A scope function returns one ordered tuple of trusted runtime parts. V1 requires an authenticated user principal first and may append channel-provided parts. |
-| When may personal memory be disclosed?                    | Only when trusted auth resolves the same principal and the channel attests that the response audience is private to that principal.                           |
-| Should application and administrative access ship in V1?  | Yes. Applications need to record trusted outcomes, and operators need subject export, correction, and purge.                                                  |
-| Which providers are public in V1?                         | First-party PostgreSQL for production plus explicit local and test providers. A public custom-provider protocol is deferred.                                  |
+| Question                                                     | Proposed direction                                                                                                                                                                                    |
+| ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Should ordinary conversation create memory automatically?    | Yes. A post-turn capture pass learns durable claims that the response model did not explicitly remember.                                                                                              |
+| Should a resolved collection separate read and write access? | No in V1. Resolving a collection enables recall, remember, forget, and capture together. Recall-only contexts are a plausible future need, but this proposal does not introduce per-operation policy. |
+| Should model-facing forget require approval?                 | Open. V1 defines erasure behavior independently from whether the product requires confirmation or approval before invoking it.                                                                        |
+| How should memory be partitioned?                            | A scope function returns one ordered tuple of opaque, trusted runtime identifiers. The tuple is only a partition key; its parts have no built-in ownership, privacy, or audience semantics.           |
+| Can the model choose a different scope?                      | No. eve resolves and locks each collection's scope for the turn. Automatic recall, model operations, and capture can access only that partition.                                                      |
+| Should application and administrative access ship in V1?     | Yes. Applications need to record trusted outcomes, and operators need partition-level inspection, correction, export, and purge.                                                                      |
+| Can authors implement custom providers in V1?                | Yes. `MemoryProvider` is a public V1 extension point. eve ships PostgreSQL for production plus explicit local and test providers, while other providers implement the same contract.                  |
 
 ## What belongs in memory
 
@@ -53,10 +54,11 @@ Memory is for reusable knowledge that should outlive the session but is not the 
 
 The core terms are:
 
-- A **collection** is one authored memory file with one purpose, provider, and scope definition. It may contain records for many isolated users and partitions.
-- A **record** is one atomic text claim with citations. Replacing its content creates a new revision under the same logical record.
-- A **scope tuple** is the ordered set of trusted runtime identities that selects one isolated partition, such as `[principal]` or `[principal, workspace, channel]`.
-- A **subject** is the authenticated user represented by the first scope part. Administrative export and purge span every partition for that subject.
+- A **collection** is one authored memory file with one purpose, provider, and scope definition. It may contain records for many isolated partitions.
+- A **record** is one atomic text claim with an eve-assigned origin: `capture`, `model`, or `application`. Replacing its content creates a new revision under the same logical record.
+- A **scope tuple** is the ordered composite key that selects one isolated partition. Its parts are opaque, stable identifiers obtained from trusted runtime context, such as `[userId, channelId]` or `[workspaceId]`.
+
+Origin answers how the current revision was created without claiming that the record is correct or authoritative. Capture considers only user-authored input from a completed turn, but that restriction is an internal lifecycle rule rather than durable evidence attached to the record. Model writes may still be mistaken, user input may be incorrect, and application-written memory remains a reusable account rather than the application's system of record. All recalled memory is therefore untrusted data regardless of origin.
 
 V1 does not classify records as facts, preferences, or episodes because those labels do not yet change behavior.
 
@@ -70,35 +72,39 @@ An agent may declare one flat collection or a directory of named collections:
 agent/memory.ts            # one collection named "memory"
 agent/memory/              # XOR with the flat file
   user.ts                  # collection named "user"
-  preferences.ts           # collection named "preferences"
+  workspace.ts             # collection named "workspace"
 ```
 
-Each module default-exports `defineMemory(...)`. Collection identity comes from its path rather than a `name` field. Local directory-form subagents may declare their own collections; graph-node identity keeps them isolated from the root and from one another.
+Each module default-exports `defineMemory(...)`. Collection identity comes from its path rather than a `name` field. `user.ts` and `workspace.ts` may use the same provider while their collection paths and resolved tuples keep their records isolated. Local directory-form subagents may declare their own collections; graph-node identity keeps them isolated from the root and from one another.
 
-```ts title="agent/memory.ts"
+```ts title="agent/memory/user.ts"
 import { byPrincipal, defineMemory } from "eve/memory";
-import { memory } from "./lib/memory";
+import { memory } from "../lib/memory";
 
 export default defineMemory({
-  description: "Stable facts and preferences for the authenticated user.",
+  description: "Stable facts and preferences for the current user.",
   provider: memory,
   scope: byPrincipal(),
 });
 ```
 
-`description` tells the model what belongs in the collection. `provider` chooses persistence. `scope` resolves one partition for the current turn. Declaring the collection enables the complete lifecycle; forget always requires approval.
+`description` tells the model what belongs in the collection. `provider` chooses persistence. `scope` resolves one partition for the current turn. Declaring the collection enables the complete lifecycle.
+
+The imported `memory` value is a `MemoryProvider`. An application can use the PostgreSQL provider shipped by eve or implement the public provider contract described below. Collection definitions do not configure storage or retrieval themselves.
 
 ### Scope
 
-The low-level scope type is a function that returns one ordered tuple of trusted parts or `null`:
+The low-level scope type is a function that returns one ordered tuple of opaque, trusted identifiers or `null`:
 
 ```ts
 type MemoryScopeDefinition = (context: MemoryScopeContext) => readonly MemoryScopePart[] | null;
 ```
 
-V1 requires the authenticated user principal as the first part. `byPrincipal()` is sugar for returning `[principal]`. Later parts may partition the user's memory more narrowly.
+Scope parts have no built-in entity types, and no position has special meaning. `[userId, channelId]` means only that both values identify the partition. `byPrincipal()` is sugar for the common single-part tuple using the current authenticated principal; this proposal does not name other helpers.
 
-The contents of `MemoryScopeContext` are intentionally not designed in this proposal. It will expose the trusted principal and some form of channel access for stable, attested parts such as a Slack workspace, channel, or thread. A continuation token is not automatically a scope part because it may be more specific or less stable than the partition the author wants.
+Scope resolves independently for each collection. On one Slack turn, `user.ts` could resolve `[userId, channelId]` while `workspace.ts` resolves `[workspaceId]`; both collections can participate in that turn without sharing records.
+
+The contents of `MemoryScopeContext` are intentionally not designed in this proposal. It will expose stable identifiers from trusted runtime context and some form of channel access for values such as a Slack workspace, user, channel, or thread. Memory does not interpret those values. A continuation token is not automatically a scope part because it may be more specific or less stable than the partition the author wants.
 
 Returning `null` leaves the collection unavailable for that turn. Scope parts cannot come from model input or unattested message fields.
 
@@ -108,7 +114,7 @@ Returning `null` leaves the collection unavailable for that turn. Scope parts ca
 | ---------------------------- | ------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | Before the response          | eve recalls relevant and recent records into transient turn context.                        | Existing memory must be present before it can improve the response.                            |
 | During the model loop        | The model may recall with a new query, remember a claim, revise a claim, or request forget. | Explicit actions provide immediate and deliberate control.                                     |
-| After a completed turn       | Capture proposes cited additions, replacements, or no-ops from eligible authored input.     | Routine conversation can create memory without delaying the response.                          |
+| After a completed turn       | Capture proposes additions, replacements, or no-ops from that turn's user-authored input.   | Routine conversation can create memory without delaying the response.                          |
 | During an application action | Trusted code may write the durable outcome directly.                                        | Action results should come from the system that performed the action, not assistant narration. |
 
 ### Recall
@@ -117,100 +123,231 @@ Automatic recall runs after compaction and before the first response-model reque
 
 The model may also recall later with a new query and optional collection. Omitting the collection searches every resolved collection.
 
-Recalled memories are attributed to their collection and presented as untrusted data. They do not change permissions or approval requirements, and their payloads do not enter durable transcript history. A collection outage does not fail the turn; successful collections still contribute and failures remain distinguishable from an empty result.
+Recalled memories are attributed to their collection and presented as untrusted data. They do not change permissions, and their payloads do not enter durable transcript history. A collection outage does not fail the turn; successful collections still contribute and failures remain distinguishable from an empty result.
 
 ### Explicit remember and application writes
 
-Explicit remember is for knowledge that must be durable and visible immediately. The model writes through a collection-bound tool and cites an eligible source quote from the current turn. It revises a claim by addressing the current recalled record; stale revisions conflict rather than overwriting newer knowledge.
+Explicit remember is for knowledge that must be durable and visible immediately. The model writes a claim through a collection-bound tool. It revises a claim by addressing the current recalled record; stale revisions conflict rather than overwriting newer knowledge. eve marks these revisions with the `model` origin.
 
-Application code can write through scope-bound memory access without a model citation. This is the path for trusted action outcomes such as “the 3pm flight was booked.” The application system remains the source of truth; memory is only a reusable account of the outcome.
+Application code can write through scope-bound memory access. This is the path for trusted action outcomes such as “the 3pm flight was booked.” eve marks these revisions with the `application` origin, but the application system remains the source of truth; memory is only a reusable account of the outcome.
 
 ### Capture
 
-Capture is a background extraction pass created only by a successfully completed turn. Failed, cancelled, abandoned, deferred, or adapter-consumed turns are not eligible. It pins the exact scope and audience resolved at admission rather than evaluating later auth or channel state.
+Capture is a background extraction pass created only by a successfully completed turn. Failed, cancelled, abandoned, deferred, or adapter-consumed turns are not eligible. It uses the exact collection scopes locked for the completed turn rather than resolving them again against later runtime state.
 
 Capture uses a separate model invocation after the turn. Its configuration surface is deferred until implementation demonstrates a concrete need.
 
-For each eligible collection, the capture invocation compares user-authored input with current memory and proposes an addition, replacement, or no-op with exact citations. eve validates the cited source before committing.
+For each eligible collection, the capture invocation compares user-authored input with current memory and proposes an addition, replacement, or no-op. eve marks committed revisions with the `capture` origin.
 
-V1 capture excludes assistant output, reasoning, tool traffic, approvals, imported context, and attachments. Assistant or tool output may be attacker-influenced and cannot serve as its own evidence; trusted action outcomes use application writes instead.
+V1 capture excludes assistant output, reasoning, tool traffic, imported context, and attachments. This prevents assistant- or tool-produced content from becoming durable automatically. Trusted action outcomes use application writes instead.
 
 Capture does not delay or change the completed response. Its writes are eventually consistent, so the next turn may not see them. Callers needing immediate durability use explicit remember or an application write.
 
 ### Forget and purge
 
-Forget removes one logical record and its revisions from every live memory operation. The model-facing forget tool always uses the existing approval flow; if the session cannot request approval, the model must direct the user to an application or administrative surface.
+Forget removes one logical record and its revisions from every live memory operation.
 
-An administrative purge removes every record in the subject's collection across all scope partitions. Erased content cannot return through recall, stale indexes, application reads, or workflow replay.
+An administrative purge removes every record in the addressed collection partition. Broader administrative selectors are separate from the scope tuple and deferred. Erased content cannot return through recall, stale indexes, application reads, or workflow replay.
 
 These are live logical erasure guarantees. Database remnants, replicas, backups, journals, transcripts, telemetry, and model-provider retention remain governed by their own policies.
 
-## Scope and privacy
+## Scope and isolation
 
-Long-lived memory creates a cross-session disclosure risk, so model-controlled input never chooses the user principal or response audience.
+Long-lived memory creates a cross-session disclosure risk, so model-controlled input never chooses scope parts.
 
-The principal scope part comes from `auth.current` and requires `principalType: "user"`. Its identity includes the authenticator or issuer and the principal ID; display names, attributes, `subject`, and `auth.initiator` do not define identity. Additional parts from the future channel accessor only partition that principal's storage.
+Scope parts come from trusted auth, application, or channel context and include enough authority to remain stable and collision-free. Display names and model-visible attributes do not define them. The memory system treats every part as an opaque identifier rather than inferring whether it represents a user, workspace, channel, or another entity.
 
-A collection resolves only when its tuple begins with the current principal and the channel attests that every response path is private to that principal. Partitioning personal memory by Slack channel does not make a public Slack reply private; a public destination still leaves the collection unresolved.
+eve resolves each collection's scope from the admitted turn and locks it for that turn. Automatic recall, model operations, and capture use only the locked collection and tuple; their schemas never accept an alternate scope. A tuple does not itself express ownership, access policy, or response audience.
 
-Missing required parts, anonymous or non-user auth, a `null` scope result, or a mismatched audience makes recall, tools, capture, and application access unavailable. eve emits content-free diagnostics rather than silently falling back to a broader scope.
+Missing required parts or a `null` scope result makes that collection unavailable. eve emits content-free diagnostics rather than silently falling back to a different partition.
 
 The provider namespace also includes stable application, environment, graph-node, and collection-path identity. Redeployments in one environment share memory, while different environments, subagents, collections, and resolved tuples do not. Changing the order or meaning of scope parts requires migration.
 
-V1 excludes shared, anonymous, service, runtime, schedule, and agent-global memory. Shared memory needs a separate disclosure and persisted-prompt-injection design.
+Collection authors decide what a partition represents through the collection's purpose and scope definition. Shared memory remains origin-labeled and untrusted, and must never become an instruction or permission source. V1 still excludes memory without an explicit scope tuple.
 
 ## Framework capabilities
 
 ### Model capabilities
 
-| Capability | Purpose                                            |
-| ---------- | -------------------------------------------------- |
-| Recall     | Search one or all resolved collections.            |
-| Remember   | Create or replace a cited claim in one collection. |
-| Forget     | Erase one recalled record after approval.          |
+| Capability | Purpose                                 |
+| ---------- | --------------------------------------- |
+| Recall     | Search one or all resolved collections. |
+| Remember   | Create or replace a claim.              |
+| Forget     | Erase one recalled record.              |
 
 These are framework-provided, collection-aware operations rather than authored tools. Mutations are collection-bound so the model never supplies a scope. Their exact names, schemas, record references, and errors belong in the implementation contract.
 
 ### Application access
 
-Application code needs a scope-bound way to record trusted outcomes during a turn. Subject-facing routes may also need inspection and correction when they can provide matching auth, audience, and scope context. The exact client types and method inventory are deferred until these callers are implemented.
+Application code needs a scope-bound way to record trusted outcomes during a turn. Routes outside a bound turn may also need partition-level inspection and correction after independently authorizing the caller and resolving the target tuple. The exact client types and method inventory are deferred until these callers are implemented.
 
 The exact route-facing channel access is likewise deferred with the channel scope API.
 
-Operator-authorized administration addresses a principal rather than impersonating it. It can inspect, correct, export, and purge every partition for that subject in a collection. Operator identity, reason, target, operation, and outcome are audited. The exact administration API is deferred.
+Operator-authorized administration can inspect, correct, export, and purge an addressed collection partition without impersonating a turn. Operator identity, reason, target, operation, and outcome are audited. Broader selectors and the exact administration API are deferred.
 
 ## Observable guarantees
 
-- Scope and private audience are revalidated before disclosure; unavailable or invalid memory fails closed.
-- Model-proposed writes cite eligible authored text. eve validates citation integrity, while semantic entailment remains an evaluation concern.
+- Each model operation remains bound to the collection scopes locked for its turn; unavailable or invalid scope fails closed.
+- eve records whether each revision was created by capture, an explicit model operation, or application code. Origin is informational and does not establish correctness or authority.
 - Explicit model and application writes are idempotent, commit before reporting success, and are visible to later steps in the same turn.
 - Capture starts only after a completed turn, never changes that turn's outcome, and may become visible later.
 - Superseded, erased, and purged records are absent from live operations.
 - Canonical records are authoritative. Embeddings and search indexes are rebuildable projections and cannot resurrect stale content.
 
-## Provider strategy
+## Provider contract
 
-Providers own persistence, within-collection retrieval, projections, readiness, and migration. eve owns public records, scope, citations, model operations, cross-collection behavior, budgets, rendering, and final disclosure validation.
+`MemoryProvider` is a public V1 extension point. eve ships a PostgreSQL provider, but a collection can use any conforming provider. The provider owns canonical persistence and retrieval within one collection partition. eve owns collection discovery, trusted scope resolution, origin assignment, model operations, cross-collection behavior, budgets, rendering, and final disclosure validation.
 
-PostgreSQL is the first production provider. Stable application and environment identity are required so deployments cannot accidentally share or split memory. Retrieval, indexing, and deployment preparation are implementation concerns.
+The public contract should have this shape; exact field names and error types will be fixed by the implementation plan:
 
-An explicit local provider supports persistent development memory, and a deterministic test provider supports isolated tests. Their factory names, storage choices, and control surfaces are deferred. Neither is available in production.
+```ts
+type MemoryOrigin = "capture" | "model" | "application";
 
-V1 exposes opaque first-party providers only. A public custom-provider API waits for production evidence and a conformance kit.
+interface MemoryRecord {
+  readonly id: string;
+  readonly revision: string;
+  readonly content: string;
+  readonly origin: MemoryOrigin;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+interface MemoryProviderPartition {
+  /** Stable, collision-resistant value created by eve. */
+  readonly key: string;
+}
+
+interface MemoryProviderRequest {
+  /** Framework-created stable storage key; providers treat it as opaque. */
+  readonly partition: MemoryProviderPartition;
+  readonly signal: AbortSignal;
+}
+
+interface MemoryProvider {
+  ready(input: MemoryProviderRequest): Promise<void>;
+
+  recall(
+    input: MemoryProviderRequest & { readonly query: string; readonly limit: number },
+  ): Promise<{ readonly records: readonly MemoryRecord[]; readonly truncated: boolean }>;
+  get(input: MemoryProviderRequest & { readonly recordId: string }): Promise<MemoryRecord | null>;
+  list(
+    input: MemoryProviderRequest & { readonly cursor?: string; readonly limit: number },
+  ): Promise<{
+    readonly records: readonly MemoryRecord[];
+    readonly cursor?: string;
+  }>;
+
+  write(
+    input: MemoryProviderRequest & {
+      readonly operationId: string;
+      readonly content: string;
+      readonly origin: MemoryOrigin;
+      readonly replace?: {
+        readonly recordId: string;
+        readonly expectedRevision: string;
+      };
+    },
+  ): Promise<MemoryRecord>;
+  erase(
+    input: MemoryProviderRequest & {
+      readonly operationId: string;
+      readonly recordId: string;
+      readonly expectedRevision?: string;
+    },
+  ): Promise<{ readonly erased: boolean }>;
+  purge(input: MemoryProviderRequest & { readonly operationId: string }): Promise<void>;
+}
+```
+
+Every operation receives an opaque partition key produced by eve from stable application, environment, graph-node, collection-path, and resolved-scope identity. It also receives an abort signal and operation-specific limits or deadlines. The model and authored application code never construct the partition key.
+
+`recall` receives a plain-text query and returns ranked current records. `get` and `list` provide canonical reads for application access, validation, inspection, and export. `write` creates or replaces a record and receives the content, eve-assigned origin, an eve-assigned operation ID for idempotency, and the expected revision when replacing a record. `erase` removes one logical record and its revisions; `purge` removes the addressed partition. Provider record IDs, revision tokens, and cursors pass through eve but remain semantically opaque.
+
+A provider must implement:
+
+- durable canonical records and read-your-writes behavior;
+- strict isolation by the supplied partition key;
+- atomic replacement using the expected revision;
+- idempotent mutation replay using the supplied operation key;
+- bounded ranked recall plus canonical `get` and paginated `list` reads;
+- live erasure and purge barriers that prevent stale work or indexes from restoring content;
+- readiness, cancellation, bounded inputs and outputs, and stable unavailable-versus-empty behavior.
+
+Provider-specific deployment APIs may add schema migration, index preparation, backfill, or operational controls. The runtime `ready` method checks that the provider can safely serve the active configuration; eve does not require every provider to use a database or have a migration phase. Public provider conformance tests exercise the observable semantics above without prescribing a storage or retrieval architecture.
+
+Custom providers use an eve helper that validates and brands the implementation:
+
+```ts title="agent/lib/memory.ts"
+import { defineMemoryProvider } from "eve/memory";
+import { store } from "./store";
+
+export const memory = defineMemoryProvider({
+  async ready(input) {
+    await store.assertReady(input);
+  },
+  async recall(input) {
+    return await store.recall(input);
+  },
+  async get(input) {
+    return await store.get(input);
+  },
+  async list(input) {
+    return await store.list(input);
+  },
+  async write(input) {
+    return await store.write(input);
+  },
+  async erase(input) {
+    return await store.erase(input);
+  },
+  async purge(input) {
+    return await store.purge(input);
+  },
+});
+```
+
+The helper does not implement storage. It gives eve a stable protocol boundary while leaving the database, hosted memory service, or other backend entirely to the provider.
+
+### Embeddings and vectors
+
+eve neither requires nor creates embeddings or vectors. On write, eve gives the provider canonical record text. On recall, eve gives the provider a plain-text query. The provider decides whether and when to create embeddings, where to store vectors, and how to rank results.
+
+A provider may use SQL filtering, full-text search, embeddings, a vector database, hybrid retrieval, an external memory service, or another strategy. It may embed records synchronously on write, asynchronously after write, lazily, or not at all. Embedding models, credentials, dimensions, preprocessing, vector indexes, backfills, cost, and query-embedding failures are provider-owned concerns. They do not appear in `defineMemory` or the base `MemoryProvider` contract.
+
+Embeddings and search indexes are derived projections. Canonical records and revisions remain authoritative, and a provider must not return superseded, erased, or purged content through a stale projection. A retrieval or query-embedding failure is reported as unavailable rather than as an empty result.
+
+### First-party providers
+
+PostgreSQL is eve's production provider. Stable application and environment identity are required so deployments cannot accidentally share or split memory. Provider-specific options may configure PostgreSQL retrieval, including embeddings and vector indexing, without adding those concepts to the framework contract:
+
+```ts title="agent/lib/memory.ts"
+import { pgDatabase, postgresMemory } from "eve/memory/postgres";
+import { pool } from "./database";
+
+export const memory = postgresMemory({
+  database: pgDatabase(pool),
+  embedding: {
+    model: "openai/text-embedding-3-small",
+    dimensions: 1536,
+  },
+});
+```
+
+An explicit local provider supports persistent development memory without embeddings, and a deterministic test provider supports isolated tests. Their factory names, storage choices, and control surfaces are implementation details. Neither is available in production. Their existence demonstrates that conformance depends on memory behavior, not on vectors or a specific retrieval algorithm.
 
 ## Non-goals
 
 - Read-only, write-only, recall-disabled, tool-disabled, or otherwise partial collections.
-- A mutable `MEMORY.md`, model-managed memory filesystem, hosted memory service, transcript store, RAG store, or application system of record.
+- A mutable `MEMORY.md`, model-managed memory filesystem, eve-operated hosted memory service, transcript store, RAG store, or application system of record. A custom provider may connect to an external memory service.
 - Capturing assistant output, reasoning, tool payloads, attachments, or imported context.
-- Scope tuples without an authenticated user principal, multiple simultaneous tuples for one collection in a turn, or implicit sharing.
+- Memory without an explicit scope tuple, multiple simultaneous tuples for one collection in a turn, or implicit sharing between collections.
 - Tags, typed record kinds, profiles, graph relations, confidence, autonomous inference, decay, or instruction modification.
-- Public custom extractor, embedder, or provider interfaces.
+- Framework-level custom extractor or standalone embedder interfaces. Providers may expose their own provider-specific extraction or embedding configuration.
 - Physical sanitization guarantees for database remnants, replicas, backups, journals, transcripts, logs, telemetry, or model-provider retention.
 
-## Deferred implementation work
+## Implementation contract follow-up
 
-Follow-up implementation plans should define exact tool and client schemas, error codes, handles, cursors, limits, normalization, source envelopes, checkpoint and replay machinery, canonical tables, provider conformance, PostgreSQL indexing and migration, and local inspection commands. Those details must satisfy the observable guarantees above without expanding the V1 product surface.
+Before V1 implementation lands, follow-up plans must define exact tool, client, and provider schemas; error codes; handles; cursors; limits; normalization; checkpoint and replay machinery; canonical tables; the provider conformance suite; PostgreSQL indexing and migration; and local inspection commands. Those details must satisfy the observable guarantees above without expanding the V1 product surface.
 
 ## Primary references
 


### PR DESCRIPTION
### Summary

Related to #1510. Stacked on #1581.

Exposes durable message snapshots and active-turn cancellation to hooks and framework-owned dynamic resolvers on eve's existing events. It also lets framework capabilities use the dynamic tool lifecycle with fail-closed replay and usage-based `defineDynamic` transforms.

The former `turn.prepared` protocol, hook, harness, and context path are removed completely. This PR contains no memory API or provider behavior; #1700 builds memory directly on session, turn, message, compaction, and step events. After incorporating the approval lifecycle now on `main`, the hook capability advances to epoch 12 while retaining compatible epoch 10 and 11 extensions; epochs 1–9 remain dropped for the existing model-attribution incompatibility.

### Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm guard:invariants`
- `pnpm docs:check`
- `pnpm test:unit`
- `pnpm test:integration`

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
