### PR TITLE
docs: sync templates from eve-examples

### DIFF
--- a/apps/docs/app/[lang]/templates/[slug]/page.tsx
+++ b/apps/docs/app/[lang]/templates/[slug]/page.tsx
@@ -127,30 +127,19 @@ const TemplateDetailPage = async ({ params }: { params: Promise<PageParams> }) =
             <h2 className="m-0 text-heading-24 text-gray-1000" id="github-heading">
               GitHub
             </h2>
-            <dl className="mt-6 grid gap-6 sm:grid-cols-2 lg:grid-cols-1">
+            <dl className="mt-6">
               <div>
-                <dt className="font-medium text-gray-1000 text-label-14">Owner</dt>
-                <dd className="mt-2 text-copy-14">
-                  <a
-                    className="rounded-sm font-medium text-gray-900 underline decoration-gray-400 underline-offset-4 outline-none transition-colors hover:text-gray-1000 hover:decoration-gray-1000 focus-visible:ring-2 focus-visible:ring-blue-700 focus-visible:ring-offset-2 focus-visible:ring-offset-background-100 motion-reduce:transition-none"
-                    href={`https://github.com/${entry.githubOwner}`}
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    {entry.githubOwner}
-                  </a>
-                </dd>
-              </div>
-              <div>
-                <dt className="font-medium text-gray-1000 text-label-14">Repository</dt>
+                <dt className="font-medium text-gray-1000 text-label-14">Source</dt>
                 <dd className="mt-2 text-copy-14">
                   <a
                     className="break-words rounded-sm font-medium text-gray-900 underline decoration-gray-400 underline-offset-4 outline-none transition-colors hover:text-gray-1000 hover:decoration-gray-1000 focus-visible:ring-2 focus-visible:ring-blue-700 focus-visible:ring-offset-2 focus-visible:ring-offset-background-100 motion-reduce:transition-none"
-                    href={`https://github.com/${entry.githubOwner}/${entry.githubRepo}`}
+                    href={entry.sourceRevisionHref}
                     rel="noopener noreferrer"
                     target="_blank"
                   >
-                    {entry.githubRepo}
+                    {[entry.githubOwner, entry.githubRepo, entry.githubPathPrefix]
+                      .filter(Boolean)
+                      .join("/")}
                   </a>
                 </dd>
               </div>

--- a/apps/docs/app/[lang]/templates/[slug]/page.tsx
+++ b/apps/docs/app/[lang]/templates/[slug]/page.tsx
@@ -127,9 +127,22 @@ const TemplateDetailPage = async ({ params }: { params: Promise<PageParams> }) =
             <h2 className="m-0 text-heading-24 text-gray-1000" id="github-heading">
               GitHub
             </h2>
-            <dl className="mt-6">
+            <dl className="mt-6 grid gap-6 sm:grid-cols-2 lg:grid-cols-1">
               <div>
-                <dt className="font-medium text-gray-1000 text-label-14">Source</dt>
+                <dt className="font-medium text-gray-1000 text-label-14">Owner</dt>
+                <dd className="mt-2 text-copy-14">
+                  <a
+                    className="rounded-sm font-medium text-gray-900 underline decoration-gray-400 underline-offset-4 outline-none transition-colors hover:text-gray-1000 hover:decoration-gray-1000 focus-visible:ring-2 focus-visible:ring-blue-700 focus-visible:ring-offset-2 focus-visible:ring-offset-background-100 motion-reduce:transition-none"
+                    href={`https://github.com/${entry.githubOwner}`}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    {entry.githubOwner}
+                  </a>
+                </dd>
+              </div>
+              <div>
+                <dt className="font-medium text-gray-1000 text-label-14">Repository</dt>
                 <dd className="mt-2 text-copy-14">
                   <a
                     className="break-words rounded-sm font-medium text-gray-900 underline decoration-gray-400 underline-offset-4 outline-none transition-colors hover:text-gray-1000 hover:decoration-gray-1000 focus-visible:ring-2 focus-visible:ring-blue-700 focus-visible:ring-offset-2 focus-visible:ring-offset-background-100 motion-reduce:transition-none"
@@ -137,9 +150,7 @@ const TemplateDetailPage = async ({ params }: { params: Promise<PageParams> }) =
                     rel="noopener noreferrer"
                     target="_blank"
                   >
-                    {[entry.githubOwner, entry.githubRepo, entry.githubPathPrefix]
-                      .filter(Boolean)
-                      .join("/")}
+                    {entry.githubRepo}
                   </a>
                 </dd>
               </div>

--- a/apps/docs/app/[lang]/templates/[slug]/template-readme.tsx
+++ b/apps/docs/app/[lang]/templates/[slug]/template-readme.tsx
@@ -4,7 +4,7 @@ import { createCodePlugin } from "@streamdown/code";
 import { geistShikiTheme } from "@vercel/geistdocs/shiki-theme";
 import { useMemo } from "react";
 import { type Components, Streamdown } from "streamdown";
-import { resolveReadmeHref } from "@/lib/templates/readme-links";
+import { createResolveReadmeLinksPlugin, resolveReadmeHref } from "@/lib/templates/readme-links";
 
 interface TemplateReadmeProps {
   readme: string;
@@ -15,6 +15,10 @@ export const TemplateReadme = ({ readme, sourceRevisionHref }: TemplateReadmePro
   const codePlugin = useMemo(
     () => createCodePlugin({ themes: [geistShikiTheme, geistShikiTheme] }),
     [],
+  );
+  const remarkPlugins = useMemo(
+    () => [createResolveReadmeLinksPlugin(sourceRevisionHref)],
+    [sourceRevisionHref],
   );
   const components = useMemo<Partial<Components>>(
     () => ({
@@ -63,6 +67,7 @@ export const TemplateReadme = ({ readme, sourceRevisionHref }: TemplateReadmePro
       disallowedElements={["img"]}
       mode="static"
       plugins={{ code: codePlugin }}
+      remarkPlugins={remarkPlugins}
       shikiTheme={[geistShikiTheme, geistShikiTheme]}
     >
       {readme}

--- a/apps/docs/app/[lang]/templates/[slug]/template-readme.tsx
+++ b/apps/docs/app/[lang]/templates/[slug]/template-readme.tsx
@@ -3,7 +3,7 @@
 import { createCodePlugin } from "@streamdown/code";
 import { geistShikiTheme } from "@vercel/geistdocs/shiki-theme";
 import { useMemo } from "react";
-import { type Components, Streamdown } from "streamdown";
+import { type Components, defaultRemarkPlugins, Streamdown } from "streamdown";
 import { createResolveReadmeLinksPlugin, resolveReadmeHref } from "@/lib/templates/readme-links";
 
 interface TemplateReadmeProps {
@@ -17,7 +17,10 @@ export const TemplateReadme = ({ readme, sourceRevisionHref }: TemplateReadmePro
     [],
   );
   const remarkPlugins = useMemo(
-    () => [createResolveReadmeLinksPlugin(sourceRevisionHref)],
+    () => [
+      ...Object.values(defaultRemarkPlugins),
+      createResolveReadmeLinksPlugin(sourceRevisionHref),
+    ],
     [sourceRevisionHref],
   );
   const components = useMemo<Partial<Components>>(

--- a/apps/docs/lib/templates/compose.test.ts
+++ b/apps/docs/lib/templates/compose.test.ts
@@ -52,6 +52,24 @@ describe("composeTemplateEntries", () => {
     expect(entry).not.toHaveProperty("github");
   });
 
+  it("includes a monorepo path in the pinned source URL", () => {
+    const monorepoEntry: TemplateManifestEntry = {
+      ...manifestEntry,
+      github: {
+        owner: "vercel",
+        repo: "eve-examples",
+        ref: "main",
+        pathPrefix: "example-template",
+      },
+    };
+
+    const [entry] = composeTemplateEntries([monorepoEntry], generated);
+
+    expect(entry.sourceRevisionHref).toBe(
+      "https://github.com/vercel/eve-examples/tree/0123456789abcdef0123456789abcdef01234567/example-template",
+    );
+  });
+
   it("throws when a manifest slug has no generated data", () => {
     expect(() => composeTemplateEntries([manifestEntry], { templates: {} })).toThrow(
       /No generated data for template "example"/,

--- a/apps/docs/lib/templates/compose.test.ts
+++ b/apps/docs/lib/templates/compose.test.ts
@@ -46,6 +46,7 @@ describe("composeTemplateEntries", () => {
       "https://github.com/vercel-labs/example/tree/0123456789abcdef0123456789abcdef01234567",
     );
     expect(entry.githubOwner).toBe("vercel-labs");
+    expect(entry.githubPathPrefix).toBeUndefined();
     expect(entry.githubRepo).toBe("example");
     expect(entry.readme).toBe(generated.templates.example.readme);
     expect(entry.files).toEqual(generated.templates.example.files);
@@ -68,6 +69,7 @@ describe("composeTemplateEntries", () => {
     expect(entry.sourceRevisionHref).toBe(
       "https://github.com/vercel/eve-examples/tree/0123456789abcdef0123456789abcdef01234567/example-template",
     );
+    expect(entry.githubPathPrefix).toBe("example-template");
   });
 
   it("throws when a manifest slug has no generated data", () => {

--- a/apps/docs/lib/templates/compose.test.ts
+++ b/apps/docs/lib/templates/compose.test.ts
@@ -46,7 +46,6 @@ describe("composeTemplateEntries", () => {
       "https://github.com/vercel-labs/example/tree/0123456789abcdef0123456789abcdef01234567",
     );
     expect(entry.githubOwner).toBe("vercel-labs");
-    expect(entry.githubPathPrefix).toBeUndefined();
     expect(entry.githubRepo).toBe("example");
     expect(entry.readme).toBe(generated.templates.example.readme);
     expect(entry.files).toEqual(generated.templates.example.files);
@@ -69,7 +68,6 @@ describe("composeTemplateEntries", () => {
     expect(entry.sourceRevisionHref).toBe(
       "https://github.com/vercel/eve-examples/tree/0123456789abcdef0123456789abcdef01234567/example-template",
     );
-    expect(entry.githubPathPrefix).toBe("example-template");
   });
 
   it("throws when a manifest slug has no generated data", () => {

--- a/apps/docs/lib/templates/compose.ts
+++ b/apps/docs/lib/templates/compose.ts
@@ -20,7 +20,6 @@ export interface TemplateEntry {
   model: string;
   readme: string;
   githubOwner: string;
-  githubPathPrefix?: string;
   githubRepo: string;
   slug: string;
   source: TemplateSource;
@@ -100,7 +99,6 @@ export const composeTemplateEntries = (
       ...curated,
       files,
       githubOwner: entry.github.owner,
-      githubPathPrefix: entry.github.pathPrefix,
       githubRepo: entry.github.repo,
       readme: data.readme,
       sourceRevision: data.sourceRevision,

--- a/apps/docs/lib/templates/compose.ts
+++ b/apps/docs/lib/templates/compose.ts
@@ -20,6 +20,7 @@ export interface TemplateEntry {
   model: string;
   readme: string;
   githubOwner: string;
+  githubPathPrefix?: string;
   githubRepo: string;
   slug: string;
   source: TemplateSource;
@@ -99,6 +100,7 @@ export const composeTemplateEntries = (
       ...curated,
       files,
       githubOwner: entry.github.owner,
+      githubPathPrefix: entry.github.pathPrefix,
       githubRepo: entry.github.repo,
       readme: data.readme,
       sourceRevision: data.sourceRevision,

--- a/apps/docs/lib/templates/manifest.ts
+++ b/apps/docs/lib/templates/manifest.ts
@@ -47,16 +47,21 @@ export const templateManifest: TemplateManifestEntry[] = [
     slug: "eve-chat-template",
     title: "Chat",
     setupPrompt:
-      "Set up the eve chat template in my current workspace using https://github.com/vercel-labs/eve-chat-template/tree/main as the source. Copy the project files, install its dependencies, and follow the repository README to configure it. Preserve the existing project if the workspace is not empty, and tell me about any required environment variables or manual setup steps.",
+      "Set up the eve chat template in my current workspace using https://github.com/vercel/eve-examples/tree/main/eve-chat-template as the source. Copy the project files, install its dependencies, and follow the repository README to configure it. Preserve the existing project if the workspace is not empty, and tell me about any required environment variables or manual setup steps.",
     description:
       "A persisted Next.js chat template for eve, built with shadcn/ui, Tailwind CSS, Streamdown, Better Auth, Drizzle, Neon, and Upstash Redis.",
     demoHref: "https://eve-chat-template.labs.vercel.dev",
-    sourceHref: "https://github.com/vercel-labs/eve-chat-template/tree/main",
+    sourceHref: "https://github.com/vercel/eve-examples/tree/main/eve-chat-template",
     category: "Chat",
     model: "anthropic/claude-sonnet-5",
     integrations: ["Web chat", "Slack"],
     source: "Vercel Templates",
-    github: { owner: "vercel-labs", repo: "eve-chat-template", ref: "main" },
+    github: {
+      owner: "vercel",
+      repo: "eve-examples",
+      ref: "main",
+      pathPrefix: "eve-chat-template",
+    },
     files: [
       "agent/agent.ts",
       "agent/channels/eve.ts",
@@ -97,15 +102,20 @@ export const templateManifest: TemplateManifestEntry[] = [
     slug: "eve-slack-agent",
     title: "Slack",
     setupPrompt:
-      "Set up the eve Slack agent template in my current workspace using https://github.com/vercel-labs/eve-slack-agent-template/tree/main as the source. Copy the project files, install its dependencies, and follow the repository README to configure it. Preserve the existing project if the workspace is not empty, and tell me about any required environment variables or manual setup steps.",
+      "Set up the eve Slack agent template in my current workspace using https://github.com/vercel/eve-examples/tree/main/eve-slack-agent-template as the source. Copy the project files, install its dependencies, and follow the repository README to configure it. Preserve the existing project if the workspace is not empty, and tell me about any required environment variables or manual setup steps.",
     description:
       "A Slack agent template with webhook handling, Vercel Connect, a starter agent, and an example tool ready to deploy on Vercel.",
-    sourceHref: "https://github.com/vercel-labs/eve-slack-agent-template/tree/main",
+    sourceHref: "https://github.com/vercel/eve-examples/tree/main/eve-slack-agent-template",
     category: "Collaboration",
     model: "anthropic/claude-sonnet-5",
     integrations: ["Slack"],
     source: "Vercel Templates",
-    github: { owner: "vercel-labs", repo: "eve-slack-agent-template", ref: "main" },
+    github: {
+      owner: "vercel",
+      repo: "eve-examples",
+      ref: "main",
+      pathPrefix: "eve-slack-agent-template",
+    },
     files: [
       "agent/agent.ts",
       "agent/channels/slack.ts",

--- a/apps/docs/lib/templates/readme-links.test.ts
+++ b/apps/docs/lib/templates/readme-links.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveReadmeHref, sanitizeReadmeHref } from "./readme-links";
+import {
+  createResolveReadmeLinksPlugin,
+  resolveReadmeHref,
+  sanitizeReadmeHref,
+} from "./readme-links";
 
 const sourceRevisionHref =
   "https://github.com/vercel/eve/tree/0123456789abcdef/apps/fixtures/weather-agent";
@@ -27,6 +31,22 @@ describe("resolveReadmeHref", () => {
 
   it("rejects relative links when the source is not a pinned GitHub tree", () => {
     expect(resolveReadmeHref("docs/setup.md", "https://example.com/template")).toBeUndefined();
+  });
+});
+
+describe("createResolveReadmeLinksPlugin", () => {
+  it("resolves links before the markdown renderer sanitizes relative URLs", () => {
+    const tree = {
+      type: "root",
+      children: [
+        { type: "link", url: "docs/setup.md", children: [{ type: "text", value: "Setup" }] },
+        { type: "paragraph", children: [{ type: "text", value: "No link" }] },
+      ],
+    };
+
+    createResolveReadmeLinksPlugin(sourceRevisionHref)()(tree);
+
+    expect(tree.children[0].url).toBe(`${sourceRevisionHref}/docs/setup.md`);
   });
 });
 

--- a/apps/docs/lib/templates/readme-links.ts
+++ b/apps/docs/lib/templates/readme-links.ts
@@ -1,5 +1,18 @@
 const SAFE_ABSOLUTE_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
 
+interface MarkdownNode {
+  type?: unknown;
+  url?: unknown;
+  children?: unknown;
+}
+
+export const createResolveReadmeLinksPlugin =
+  (sourceRevisionHref: string) =>
+  () =>
+  (tree: unknown): void => {
+    resolveMarkdownLinks(tree, sourceRevisionHref);
+  };
+
 export const resolveReadmeHref = (
   href: string | undefined,
   sourceRevisionHref: string,
@@ -70,6 +83,22 @@ const getGitHubBases = (
     directory: url.toString(),
     repository: new URL(`/${owner}/${repo}/tree/${revision}`, url.origin).toString(),
   };
+};
+
+const resolveMarkdownLinks = (value: unknown, sourceRevisionHref: string): void => {
+  if (!value || typeof value !== "object") {
+    return;
+  }
+
+  const node = value as MarkdownNode;
+  if (node.type === "link" && typeof node.url === "string") {
+    node.url = resolveReadmeHref(node.url, sourceRevisionHref);
+  }
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      resolveMarkdownLinks(child, sourceRevisionHref);
+    }
+  }
 };
 
 const stripAsciiControlCharacters = (value: string): string => {


### PR DESCRIPTION
### Summary

Closes #1906. The Chat and Slack gallery entries now sync from their subdirectories in `vercel/eve-examples`, including source actions, setup prompts, and pinned revision URLs. The GitHub repository link retains the compact owner/repository presentation while targeting the pinned template directory. README-relative links are resolved before Streamdown sanitization while preserving its default GFM plugins.

### Validation

- `pnpm --filter eve-docs templates:sync`
- `pnpm --filter eve-docs test:unit` (139 tests)
- `pnpm --filter eve-docs exec tsc --noEmit`
- `pnpm --filter eve-docs build`
- `pnpm --filter eve-docs exec next build`
- Inspected the local Chat and Slack pages for pinned `eve-examples` source URLs, GFM tables, and the Chat README's relative setup link

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
