### PR TITLE
fix(registry): publish requirements with Eve releases

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -13,7 +13,7 @@
     "test:unit": "vitest run --config vitest.config.ts",
     "render:eve-5": "NODE_OPTIONS=--loader=./scripts/wgsl-node-loader.mjs tsx scripts/render-eve-5.ts",
     "registry:build": "tsx scripts/prepare-registry-output.ts && shadcn build",
-    "registry:check": "pnpm run registry:build && pnpm run registry:validate && pnpm run registry:validate:channels && pnpm run registry:validate:instrumentation && tsc --project registry/tsconfig.json",
+    "registry:check": "node --test ../../scripts/materialize-registry-release-requirements.test.mjs ../../scripts/validate-public-registry-requirements.test.mjs && node ../../scripts/validate-public-registry-requirements.mjs && pnpm run registry:build && pnpm run registry:validate && pnpm run registry:validate:channels && pnpm run registry:validate:instrumentation && tsc --project registry/tsconfig.json",
     "registry:validate": "tsx scripts/validate-connection-registry.ts",
     "registry:validate:channels": "tsx scripts/validate-channel-registry.ts",
     "registry:validate:instrumentation": "tsx scripts/validate-instrumentation-registry.ts",

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -1200,7 +1200,7 @@
             "bin": "eve",
             "args": ["integration", "setup", "slack"]
           },
-          "requires": ">=0.31.4",
+          "requires": ">=0.27.8",
           "docs": "/docs/channels/slack",
           "implementation": "native"
         }
@@ -1221,7 +1221,7 @@
             "bin": "eve",
             "args": ["integration", "setup", "discord"]
           },
-          "requires": ">=0.31.4",
+          "requires": ">=0.30.0",
           "docs": "/docs/channels/discord",
           "implementation": "native"
         }
@@ -1308,7 +1308,7 @@
             "bin": "eve",
             "args": ["integration", "setup", "github"]
           },
-          "requires": ">=0.31.4",
+          "requires": ">=0.30.7",
           "docs": "/docs/channels/github",
           "implementation": "native"
         }
@@ -1328,7 +1328,7 @@
             "bin": "eve",
             "args": ["integration", "setup", "linear"]
           },
-          "requires": ">=0.31.4",
+          "requires": ">=0.30.6",
           "docs": "/docs/channels/linear",
           "implementation": "native"
         }
@@ -1348,7 +1348,7 @@
             "bin": "eve",
             "args": ["integration", "setup", "web"]
           },
-          "requires": ">=0.31.4",
+          "requires": ">=0.27.8",
           "docs": "/docs/channels/eve",
           "implementation": "native"
         }
@@ -1852,7 +1852,7 @@
             "bin": "eve",
             "args": ["integration", "setup", "photon"]
           },
-          "requires": ">=0.31.4",
+          "requires": ">=0.29.0",
           "docs": "/docs/channels/photon",
           "implementation": "native"
         }

--- a/apps/docs/registry.staged-requirements.json
+++ b/apps/docs/registry.staged-requirements.json
@@ -1,0 +1,10 @@
+{
+  "items": [
+    "channel/slack",
+    "channel/discord",
+    "channel/github",
+    "channel/linear-agent",
+    "channel/web",
+    "channel/photon-imessage"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test:scenario": "turbo run test:scenario",
     "test:unit": "turbo run test:unit",
     "typecheck": "turbo run typecheck",
-    "version-packages": "changeset version",
+    "version-packages": "changeset version && node ./scripts/materialize-registry-release-requirements.mjs",
     "release": "pnpm build && node ./scripts/assert-changeset-publish-packages.mjs && changeset publish",
     "test:tui": "pnpm --filter eve run test:tui",
     "update:extension-contracts": "node ./scripts/extension-capability-contracts.mjs"

--- a/scripts/materialize-registry-release-requirements.mjs
+++ b/scripts/materialize-registry-release-requirements.mjs
@@ -1,0 +1,67 @@
+import { readFile, rm, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const registryPath = join("apps", "docs", "registry.json");
+const requirementsPath = join("apps", "docs", "registry.staged-requirements.json");
+const evePackagePath = join("packages", "eve", "package.json");
+const versionPattern = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/u;
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function materializeRegistryRequirements(registry, requirements, eveVersion) {
+  if (!isRecord(registry) || !Array.isArray(registry.items)) {
+    throw new Error("registry must contain an items array");
+  }
+  if (!isRecord(requirements) || !Array.isArray(requirements.items)) {
+    throw new Error("registry release requirements must contain an items array");
+  }
+  if (typeof eveVersion !== "string" || !versionPattern.test(eveVersion)) {
+    throw new Error(`invalid eve release version: ${String(eveVersion)}`);
+  }
+
+  const known = new Map(registry.items.filter(isRecord).map((item) => [item.name, item]));
+  for (const name of requirements.items) {
+    if (typeof name !== "string") throw new Error("registry release item names must be strings");
+    const item = known.get(name);
+    if (item === undefined)
+      throw new Error(`registry release requirement names unknown item ${name}`);
+    if (!isRecord(item.meta) || !isRecord(item.meta.eve)) {
+      throw new Error(`registry item ${name} has no eve metadata`);
+    }
+    item.meta.eve.requires = `>=${eveVersion}`;
+  }
+  return registry;
+}
+
+export async function materializeRegistryReleaseRequirements(paths = {}) {
+  const resolvedRegistryPath = paths.registryPath ?? registryPath;
+  const resolvedRequirementsPath = paths.requirementsPath ?? requirementsPath;
+  const resolvedEvePackagePath = paths.packagePath ?? evePackagePath;
+
+  // An absent sidecar means this release has no registry requirements to stage.
+  try {
+    await stat(resolvedRequirementsPath);
+  } catch (error) {
+    if (error?.code === "ENOENT") return;
+    throw error;
+  }
+
+  const [registryText, requirementsText, packageText] = await Promise.all([
+    readFile(resolvedRegistryPath, "utf8"),
+    readFile(resolvedRequirementsPath, "utf8"),
+    readFile(resolvedEvePackagePath, "utf8"),
+  ]);
+  const registry = materializeRegistryRequirements(
+    JSON.parse(registryText),
+    JSON.parse(requirementsText),
+    JSON.parse(packageText).version,
+  );
+  await writeFile(resolvedRegistryPath, `${JSON.stringify(registry, null, 2)}\n`);
+  // This sidecar is one-release intent, not a standing policy. Deleting it
+  // makes the generated release PR consume the intent exactly once.
+  await rm(resolvedRequirementsPath);
+}
+
+if (import.meta.main) await materializeRegistryReleaseRequirements();

--- a/scripts/materialize-registry-release-requirements.test.mjs
+++ b/scripts/materialize-registry-release-requirements.test.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  materializeRegistryReleaseRequirements,
+  materializeRegistryRequirements,
+} from "./materialize-registry-release-requirements.mjs";
+
+function registry() {
+  return { items: [{ name: "channel/github", meta: { eve: { requires: ">=0.30.7" } } }] };
+}
+
+test("updates only staged requirements at the selected release version", () => {
+  const result = materializeRegistryRequirements(
+    registry(),
+    { items: ["channel/github"] },
+    "0.32.0",
+  );
+  assert.equal(result.items[0].meta.eve.requires, ">=0.32.0");
+});
+
+test("consumes staged requirements after materializing the release registry", async () => {
+  const root = await mkdtemp(join(tmpdir(), "eve-registry-release-"));
+  const registryPath = join(root, "registry.json");
+  const requirementsPath = join(root, "requirements.json");
+  const packagePath = join(root, "package.json");
+  try {
+    await Promise.all([
+      writeFile(registryPath, JSON.stringify(registry())),
+      writeFile(requirementsPath, JSON.stringify({ items: ["channel/github"] })),
+      writeFile(packagePath, JSON.stringify({ version: "0.32.0" })),
+    ]);
+    await materializeRegistryReleaseRequirements({ packagePath, registryPath, requirementsPath });
+    assert.equal(
+      JSON.parse(await readFile(registryPath, "utf8")).items[0].meta.eve.requires,
+      ">=0.32.0",
+    );
+    await assert.rejects(readFile(requirementsPath, "utf8"), { code: "ENOENT" });
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+test("does nothing when no staged requirements exist", async () => {
+  const root = await mkdtemp(join(tmpdir(), "eve-registry-release-"));
+  const registryPath = join(root, "registry.json");
+  const requirementsPath = join(root, "missing.json");
+  const packagePath = join(root, "package.json");
+  try {
+    await writeFile(registryPath, JSON.stringify(registry()));
+    await materializeRegistryReleaseRequirements({ packagePath, registryPath, requirementsPath });
+    assert.deepEqual(JSON.parse(await readFile(registryPath, "utf8")), registry());
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+test("rejects an unknown staged registry item", () => {
+  assert.throws(
+    () => materializeRegistryRequirements(registry(), { items: ["channel/missing"] }, "0.32.0"),
+    /unknown item/u,
+  );
+});

--- a/scripts/validate-public-registry-requirements.mjs
+++ b/scripts/validate-public-registry-requirements.mjs
@@ -1,0 +1,68 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const registryPath = join("apps", "docs", "registry.json");
+const evePackagePath = join("packages", "eve", "package.json");
+const minimumVersionPattern = /^>=(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/u;
+const versionPattern = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/u;
+
+function parseVersion(version, pattern) {
+  const match = pattern.exec(version);
+  if (match === null) return undefined;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4],
+  };
+}
+
+function compareVersions(left, right) {
+  for (const key of ["major", "minor", "patch"]) {
+    if (left[key] !== right[key]) return left[key] < right[key] ? -1 : 1;
+  }
+  if (left.prerelease === right.prerelease) return 0;
+  if (left.prerelease === undefined) return 1;
+  if (right.prerelease === undefined) return -1;
+  return left.prerelease.localeCompare(right.prerelease, "en");
+}
+
+export function validatePublicRegistryRequirements(registry, eveVersion) {
+  const published = parseVersion(eveVersion, versionPattern);
+  if (published === undefined)
+    throw new Error(`invalid Eve package version: ${String(eveVersion)}`);
+  if (!Array.isArray(registry?.items)) throw new Error("registry must contain an items array");
+
+  const errors = [];
+  for (const item of registry.items) {
+    const requirement = item?.meta?.eve?.requires;
+    if (requirement === undefined) continue;
+    const minimum = parseVersion(requirement, minimumVersionPattern);
+    if (minimum === undefined) {
+      errors.push(`${item.name}: unsupported Eve requirement ${JSON.stringify(requirement)}`);
+    } else if (compareVersions(minimum, published) > 0) {
+      errors.push(`${item.name}: requires ${requirement}, but packages/eve is ${eveVersion}`);
+    }
+  }
+  if (errors.length > 0) {
+    throw new Error(
+      [
+        "apps/docs/registry.json must not require an unpublished Eve version.",
+        ...errors,
+        "Add affected items to apps/docs/registry.staged-requirements.json; the Changesets release process will materialize them after selecting the Eve version.",
+      ].join("\n"),
+    );
+  }
+}
+
+export async function validatePublicRegistryRequirementsFromFiles(paths = {}) {
+  const resolvedRegistryPath = paths.registryPath ?? registryPath;
+  const resolvedEvePackagePath = paths.packagePath ?? evePackagePath;
+  const [registryText, packageText] = await Promise.all([
+    readFile(resolvedRegistryPath, "utf8"),
+    readFile(resolvedEvePackagePath, "utf8"),
+  ]);
+  validatePublicRegistryRequirements(JSON.parse(registryText), JSON.parse(packageText).version);
+}
+
+if (import.meta.main) await validatePublicRegistryRequirementsFromFiles();

--- a/scripts/validate-public-registry-requirements.test.mjs
+++ b/scripts/validate-public-registry-requirements.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { validatePublicRegistryRequirements } from "./validate-public-registry-requirements.mjs";
+
+function registry(requirement) {
+  return { items: [{ name: "channel/github", meta: { eve: { requires: requirement } } }] };
+}
+
+test("accepts public requirements satisfied by the published Eve version", () => {
+  assert.doesNotThrow(() => validatePublicRegistryRequirements(registry(">=0.31.3"), "0.31.3"));
+});
+
+test("rejects public requirements for an unpublished Eve version with staging guidance", () => {
+  assert.throws(
+    () => validatePublicRegistryRequirements(registry(">=0.31.4"), "0.31.3"),
+    /registry\.staged-requirements\.json/u,
+  );
+});


### PR DESCRIPTION
## Summary

Right now, the registry updates with merges to `main`, but `npm` releases happen as part of the Changesets PR process. This PR keeps the public registry compatible with the currently published Eve package, while staging next-release registry requirements alongside the feature work that needs them.

- `apps/docs/registry.json` powers the docs site and remains compatible with the current `packages/eve` version.
- `apps/docs/registry.staged-requirements.json` is a small, editable list of registry items that require the next Eve release.
- `pnpm version-packages` runs Changesets first, then materializes those items’ `meta.eve.requires` values using the selected `packages/eve/package.json` version.

CI validates that we don't erroneously bump registry versions outside of this process.

## Validation

- `node --test scripts/materialize-registry-release-requirements.test.mjs scripts/validate-public-registry-requirements.test.mjs`
- `node scripts/validate-public-registry-requirements.mjs`
- `pnpm --dir apps/docs registry:build`
