### PR TITLE
feat(eve): add setup exit and Vercel linking

### DIFF
--- a/.changeset/calm-ducks-exit.md
+++ b/.changeset/calm-ducks-exit.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Interactive setup now offers an explicit exit after `eve init` and runs Vercel login and project linking in place whenever Vercel-backed integration setup needs them.
+Interactive setup now offers an explicit exit after `eve init` and runs Vercel login and project linking in place whenever Vercel-backed integration setup or deployment needs them.

--- a/.changeset/calm-ducks-exit.md
+++ b/.changeset/calm-ducks-exit.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Interactive setup now offers an explicit exit after `eve init` and runs Vercel login and project linking in place when Slack setup needs them.
+Interactive setup now offers an explicit exit after `eve init` and runs Vercel login and project linking in place whenever Vercel-backed integration setup needs them.

--- a/.changeset/calm-ducks-exit.md
+++ b/.changeset/calm-ducks-exit.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Interactive setup now offers an explicit exit after `eve init` and runs Vercel login and project linking in place when Slack setup needs them.

--- a/docs/channels/discord.mdx
+++ b/docs/channels/discord.mdx
@@ -16,6 +16,7 @@ pnpm eve add channel/discord
 
 The setup guides you through creating a Discord application and bot, then:
 
+- signs you in to Vercel and creates or links a project when needed;
 - validates the bot token;
 - creates a Vercel Connect client and attaches `/eve/v1/discord` as its trigger destination;
 - registers an application command with a required `message` option;

--- a/docs/channels/github.mdx
+++ b/docs/channels/github.mdx
@@ -14,7 +14,7 @@ Run the registry setup from the agent directory:
 eve add channel/github
 ```
 
-The flow checks that the Vercel CLI is authenticated, creates or links a Vercel project when needed, provisions an app-scoped GitHub Connect client, and registers `/eve/v1/github` as a trigger destination. It then installs `@vercel/connect` and writes `agent/channels/github.ts` with the connector UID.
+The flow signs you in to Vercel when needed, creates or links a Vercel project, provisions an app-scoped GitHub Connect client, and registers `/eve/v1/github` as a trigger destination. It then installs `@vercel/connect` and writes `agent/channels/github.ts` with the connector UID.
 
 Vercel Connect creates the GitHub App, receives and verifies its webhooks, and forwards them to the deployed agent. After deploying, open the GitHub App in the Connect dashboard and install it in the organization or account where you want to use it. Add the generated invocation token (for example, `@my-agent`) to a new issue, pull request, or review comment to start a conversation. GitHub may not autocomplete the token or render it as a linked mention.
 

--- a/docs/channels/linear.mdx
+++ b/docs/channels/linear.mdx
@@ -16,7 +16,7 @@ eve add linear
 
 Select **Linear Channel** in the component checklist. **Linear MCP** is also selected by default if you want the agent to search and update Linear through MCP. Run `eve add channel/linear-agent` instead to install only the channel directly.
 
-The flow checks that the Vercel CLI is authenticated, creates or links a Vercel project when needed, reuses a compatible existing connector when available or provisions an app-scoped Linear Connect client, and registers `/eve/v1/linear` as a trigger destination. It then installs `@vercel/connect` and writes `agent/channels/linear.ts` with the connector UID.
+The flow signs you in to Vercel when needed, creates or links a Vercel project, reuses a compatible existing connector when available or provisions an app-scoped Linear Connect client, and registers `/eve/v1/linear` as a trigger destination. It then installs `@vercel/connect` and writes `agent/channels/linear.ts` with the connector UID.
 
 Vercel Connect creates the Linear app with the `app:assignable` and `app:mentionable` scopes required for Agent Sessions, receives and verifies `AgentSessionEvent` webhooks, and forwards them to the deployed agent. After deploying, open the Linear app in the Connect dashboard and install it in the workspace where you want to delegate work. Then delegate an issue or mention the agent in a Linear Agent Session.
 

--- a/docs/channels/photon.mdx
+++ b/docs/channels/photon.mdx
@@ -7,8 +7,9 @@ Use `photonIMessageChannel` to receive and reply to iMessages through a Photon p
 
 Run `eve add channel/photon-imessage` to create or use a Photon project and register
 your phone number. It then asks whether to configure Vercel Connect or portable
-credentials. With Vercel Connect, eve creates the connector and configures
-Photon’s webhook through Connect. The channel resolves credentials lazily when
+credentials. With Vercel Connect, eve signs you in and creates or links a Vercel
+project when needed, then creates the connector and configures Photon’s webhook
+through Connect. The channel resolves credentials lazily when
 the adapter first initializes:
 
 ```ts title="agent/channels/photon.ts"

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -18,7 +18,7 @@ The command recommends Vercel Connect, then scaffolds `agent/channels/slack.ts` 
 
 ### Recommended: use Vercel Connect
 
-Vercel Connect setup requires an authenticated Vercel CLI and a linked Vercel project. The guided flow creates or reuses a Slack connector, waits for you to install it in a workspace, and registers `/eve/v1/slack` as a trigger destination before writing the channel file.
+Vercel Connect setup requires the Vercel CLI. The guided flow signs you in when needed, creates or links a Vercel project, creates or reuses a Slack connector, waits for you to install it in a workspace, and registers `/eve/v1/slack` as a trigger destination before writing the channel file.
 
 The generated channel resolves credentials at runtime:
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -22,7 +22,7 @@ Run `eve init` with a project name:
 npx eve@latest init my-agent
 ```
 
-The command creates `my-agent/`, installs dependencies, initializes Git, and starts eve's development server. If a supported coding-agent REPL is available, eve offers to open it instead.
+The command creates `my-agent/`, installs dependencies, and initializes Git. If a supported coding-agent REPL is available, eve offers to start the development server, open the REPL, or exit after scaffolding.
 
 ## Run the agent
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -45,7 +45,7 @@ Creates a new agent app or adds an agent to an existing app. Always installs dep
 | `eve init .` (or an existing project dir) | Adds `agent/` plus missing `eve`, `ai`, and `zod` deps. Needs a `package.json` and no `agent/` files yet                                                 |
 | `eve init` with no target                 | Same as `eve init .`, except coding agents (Claude Code, Cursor, and similar) get a setup guide instead of scaffolding — they have not chosen a name yet |
 
-After scaffolding, a human terminal usually continues into `eve dev` (or a coding-agent REPL if one is on `PATH` and you pick it). Coding-agent launches print the next steps instead of opening the TUI, so the session does not get stuck. Fresh projects use the parent workspace's package manager when there is one; otherwise they use the manager that launched `eve init`.
+After scaffolding, a human terminal usually continues into `eve dev`. If a coding-agent REPL is on `PATH`, the handoff menu can open it instead or exit without starting either process. Coding-agent launches print the next steps instead of opening the TUI, so the session does not get stuck. Fresh projects use the parent workspace's package manager when there is one; otherwise they use the manager that launched `eve init`.
 
 | Flag                   | Type | Default | Description                                                                                          |
 | ---------------------- | ---- | ------- | ---------------------------------------------------------------------------------------------------- |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -305,7 +305,7 @@ Links the current directory to a Vercel project. After selecting a team, you can
 eve deploy
 ```
 
-Deploys the agent to Vercel production (`vercel deploy --prod`), installing dependencies first and pulling environment variables after. An already-linked project deploys with or without a TTY (non-interactive runs pass the non-interactive `vercel` flags). An unlinked directory walks the `eve link` pickers when a terminal is present, and exits with guidance otherwise.
+Deploys the agent to Vercel production (`vercel deploy --prod`), installing dependencies first and pulling environment variables after. An already-linked project deploys with or without a TTY (non-interactive runs pass the non-interactive `vercel` flags). When a terminal is present, an unlinked deployment signs in to Vercel if needed and then walks the `eve link` pickers; otherwise, it exits with guidance.
 
 ## `eve eval`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -98,7 +98,7 @@ eve registry view @acme/my-extension
 eve add @acme/my-extension
 ```
 
-`eve add` asks before running setup declared by an official item and runs multiple declared flows in declaration order. Product-level packages can offer independently installable components: `eve add linear` lets you select the Linear Channel, Linear MCP, or both, with both selected by default. `--yes` installs a package's default components and accepts detected or recommended setup answers.
+`eve add` asks before running setup declared by an official item and runs multiple declared flows in declaration order. Product-level packages can offer independently installable components: `eve add linear` lets you select the Linear Channel, Linear MCP, or both, with both selected by default. Interactive Vercel-backed setup signs in and creates or links a project when needed instead of stopping with a prerequisite. `--yes` installs a package's default components and accepts detected or recommended setup answers.
 
 Coding agents should use `eve add <item> --non-interactive`, adding `--yes` to accept recommended setup values and reduce setup round trips. Explicit `--answer` values take precedence. This mode never opens an eve prompt. When a component or setup decision is missing, the NDJSON terminal event includes a stable question key and a safe continuation command; add the requested answer to that command. Supply answers with repeatable `--answer 'key=<JSON value>'` options. Follow a reported `eve link` prerequisite before retrying Vercel Connect setup. Do not put secrets in command-line answers; use the integration's documented environment variable or secret store.
 

--- a/packages/eve/README.md
+++ b/packages/eve/README.md
@@ -124,9 +124,10 @@ npx eve@latest init my-agent
 
 `eve init` writes a new agent with eve's default model. Pass `--channel-web-nextjs` to add the
 Web Chat application. It installs dependencies, initializes Git, and starts the
-development server. Targeting an existing project directory (`eve init .`) adds
-the agent files and missing dependencies instead. It does not create a Vercel
-project or deploy the agent.
+development server. When it finds a supported coding-agent REPL, the handoff
+menu can open that REPL instead or exit. Targeting an existing project directory
+(`eve init .`) adds the agent files and missing dependencies instead. It does
+not create a Vercel project or deploy the agent.
 
 CLI commands:
 

--- a/packages/eve/src/cli/commands/init-repl.test.ts
+++ b/packages/eve/src/cli/commands/init-repl.test.ts
@@ -92,10 +92,11 @@ describe("selectInitHandoff", () => {
       onSelect: (options) => {
         expect(options.message).toBe("How would you like to continue?");
         expect(options.initialValue).toBe("eve-dev");
-        expect(options.options.map((option) => option.value)).toEqual(["eve-dev", "codex"]);
+        expect(options.options.map((option) => option.value)).toEqual(["eve-dev", "codex", "exit"]);
         expect(options.options.map((option) => option.focusHint)).toEqual([
           "talk to 'weather-bot' in your terminal",
           "build 'weather-bot' using Codex",
+          "return to your terminal",
         ]);
         // Hints are focus-only, like the dev TUI lists, so no always-on hint is set.
         expect(options.options.every((option) => option.hint === undefined)).toBe(true);

--- a/packages/eve/src/cli/commands/init-repl.ts
+++ b/packages/eve/src/cli/commands/init-repl.ts
@@ -33,7 +33,7 @@ type CodingAgentReplDefinition = (typeof CODING_AGENT_REPLS)[number];
 export type CodingAgentRepl = CodingAgentReplDefinition["command"];
 
 /** The one post-init continuation point for a human terminal session. */
-export type InitHandoff = "eve-dev" | CodingAgentRepl;
+export type InitHandoff = "exit" | "eve-dev" | CodingAgentRepl;
 
 export interface InitReplDependencies {
   createPrompter(): Prompter;
@@ -103,6 +103,11 @@ function handoffOptions(
       label: `Open ${repl.label}`,
       focusHint: `build '${agentName}' using ${repl.label}`,
     })),
+    {
+      value: "exit",
+      label: "Exit",
+      focusHint: "return to your terminal",
+    },
   ];
 }
 

--- a/packages/eve/src/cli/commands/init.integration.test.ts
+++ b/packages/eve/src/cli/commands/init.integration.test.ts
@@ -236,6 +236,21 @@ describe("runInitCommand", () => {
     expect(output.errors).toEqual([]);
   });
 
+  it("exits after init without starting a handoff when selected", async () => {
+    const parentDirectory = await mkdtemp(join(tmpdir(), "eve-init-exit-handoff-"));
+    const output = logger();
+    const deps = dependencies();
+    deps.selectInitHandoff.mockResolvedValue("exit");
+
+    await runInitCommand(output, parentDirectory, "my-agent", {}, deps);
+
+    const projectPath = join(parentDirectory, "my-agent");
+    await expect(pathExists(join(projectPath, "agent/agent.ts"))).resolves.toBe(true);
+    expect(deps.spawnCodingAgentRepl).not.toHaveBeenCalled();
+    expect(deps.spawnPackageManager).not.toHaveBeenCalled();
+    expect(output.errors).toEqual([]);
+  });
+
   it("uses an explicit init package spec for fresh project scaffolds", async () => {
     const parentDirectory = await mkdtemp(join(tmpdir(), "eve-init-package-spec-"));
     const output = logger();

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -511,6 +511,7 @@ export async function runInitCommand(
     if (error instanceof WizardCancelledError) return;
     throw error;
   }
+  if (handoff === "exit") return;
   if (handoff !== "eve-dev") {
     logger.log(pc.dim(`$ ${handoff}`));
     if (

--- a/packages/eve/src/cli/commands/integration-connect.test.ts
+++ b/packages/eve/src/cli/commands/integration-connect.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createFakePrompter } from "#internal/testing/fake-prompter.js";
+import { WizardCancelledError } from "#setup/step.js";
 
 import { runIntegrationConnect, runIntegrationConnectCommand } from "./integration-connect.js";
 
@@ -17,8 +18,8 @@ function dependencies(overrides: Record<string, unknown> = {}) {
   const fake = createFakePrompter();
   return {
     createPrompter: () => fake.prompter,
+    ensureVercelProject: vi.fn(async () => PROJECT),
     readProjectLink: vi.fn(async () => PROJECT),
-    runLinkFlow: vi.fn(async () => ({ kind: "done" as const })),
     setupConnectionConnector: vi.fn(async () => ({
       kind: "existing" as const,
       connectorUid: "linear/real",
@@ -58,8 +59,7 @@ describe("runIntegrationConnect", () => {
   });
 
   it("links an unlinked project before connector setup", async () => {
-    const readProjectLink = vi.fn().mockResolvedValueOnce(undefined).mockResolvedValueOnce(PROJECT);
-    const deps = dependencies({ readProjectLink });
+    const deps = dependencies({ readProjectLink: vi.fn(async () => undefined) });
 
     await runIntegrationConnect({
       appRoot: "/project",
@@ -68,12 +68,12 @@ describe("runIntegrationConnect", () => {
       dependencies: deps,
     });
 
-    expect(deps.runLinkFlow).toHaveBeenCalledWith(
-      expect.objectContaining({ appRoot: "/project", projectSelection: "create-or-link" }),
+    expect(deps.ensureVercelProject).toHaveBeenCalledWith(
+      expect.objectContaining({ appRoot: "/project" }),
     );
   });
 
-  it("requires a linked project without starting the link flow non-interactively", async () => {
+  it("requires a linked project without starting interactive resolution", async () => {
     const deps = dependencies({ readProjectLink: vi.fn(async () => undefined) });
 
     await expect(
@@ -87,7 +87,26 @@ describe("runIntegrationConnect", () => {
     ).rejects.toMatchObject({
       prerequisite: expect.objectContaining({ code: "vercel-project-link", command: "eve link" }),
     });
-    expect(deps.runLinkFlow).not.toHaveBeenCalled();
+    expect(deps.ensureVercelProject).not.toHaveBeenCalled();
+    expect(deps.setupConnectionConnector).not.toHaveBeenCalled();
+  });
+
+  it("keeps a cancelled project link as a clean setup cancellation", async () => {
+    const deps = dependencies({
+      readProjectLink: vi.fn(async () => undefined),
+      ensureVercelProject: vi.fn(async () => {
+        throw new WizardCancelledError();
+      }),
+    });
+
+    await expect(
+      runIntegrationConnect({
+        appRoot: "/project",
+        slug: "linear",
+        service: "mcp.linear.app",
+        dependencies: deps,
+      }),
+    ).resolves.toBeUndefined();
     expect(deps.setupConnectionConnector).not.toHaveBeenCalled();
   });
 

--- a/packages/eve/src/cli/commands/integration-connect.ts
+++ b/packages/eve/src/cli/commands/integration-connect.ts
@@ -5,7 +5,10 @@ import {
   setupConnectionConnector,
   type SetupConnectionConnectorOptions,
 } from "#setup/connection-connector.js";
-import { runLinkFlow, type LinkFlowDeps } from "#setup/flows/link.js";
+import {
+  ensureVercelProject,
+  type EnsureVercelProjectDeps,
+} from "#setup/flows/ensure-vercel-project.js";
 import { createHeadlessPrompter } from "#setup/headless.js";
 import { SetupPrerequisiteRequired } from "#setup/integrations/shared/prerequisite.js";
 import { resolveIntegrationVercelProject } from "#setup/integrations/shared/vercel-project.js";
@@ -14,6 +17,7 @@ import { createPrompter, type Prompter } from "#setup/prompter.js";
 import { createRegistrySetupClient } from "#setup/registry-setup-client.js";
 import { isEveProject } from "#setup/scaffold/index.js";
 import { updateConnectionConnectorUid } from "#setup/scaffold/update/update-connection-connector.js";
+import { WizardCancelledError } from "#setup/step.js";
 
 import { NOT_AN_AGENT_MESSAGE } from "./preconditions.js";
 import type { RegistryCommandLogger } from "./registry.js";
@@ -26,17 +30,17 @@ export interface IntegrationConnectOptions {
 
 export interface IntegrationConnectDependencies {
   createPrompter?: () => Prompter;
+  ensureVercelProject: typeof ensureVercelProject;
+  ensureVercelProjectDeps?: Partial<EnsureVercelProjectDeps>;
   readProjectLink: typeof readProjectLink;
-  runLinkFlow: typeof runLinkFlow;
-  linkFlowDeps?: Partial<LinkFlowDeps>;
   setupConnectionConnector: typeof setupConnectionConnector;
   cleanupCreatedConnectionConnector: typeof cleanupCreatedConnectionConnector;
   updateConnectionConnectorUid: typeof updateConnectionConnectorUid;
 }
 
 const defaultDependencies: IntegrationConnectDependencies = {
+  ensureVercelProject,
   readProjectLink,
-  runLinkFlow,
   setupConnectionConnector,
   cleanupCreatedConnectionConnector,
   updateConnectionConnectorUid,
@@ -69,18 +73,19 @@ export async function runIntegrationConnect(input: {
         deps: { readProjectLink: dependencies.readProjectLink },
       });
     } else {
-      const link = await dependencies.runLinkFlow({
-        appRoot: input.appRoot,
-        prompter,
-        signal,
-        projectSelection: "create-or-link",
-        teamSelectMessage: () =>
-          `You need to link to a project to use ${input.slug} through Vercel Connect.\n\nSelect your team`,
-        deps: dependencies.linkFlowDeps,
-      });
-      if (link.kind === "cancelled") return;
-      project = await dependencies.readProjectLink(input.appRoot);
-      if (project === undefined) throw new Error("Project link was not found after linking.");
+      try {
+        project = await dependencies.ensureVercelProject({
+          appRoot: input.appRoot,
+          prompter,
+          signal,
+          teamSelectMessage: () =>
+            `You need to link to a project to use ${input.slug} through Vercel Connect.\n\nSelect your team`,
+          deps: dependencies.ensureVercelProjectDeps,
+        });
+      } catch (error) {
+        if (error instanceof WizardCancelledError) return;
+        throw error;
+      }
     }
   }
 

--- a/packages/eve/src/setup/flows/deploy.test.ts
+++ b/packages/eve/src/setup/flows/deploy.test.ts
@@ -6,7 +6,8 @@ import type { LinkProjectDeps } from "#setup/boxes/link-project.js";
 import type { ResolveProvisioningDeps } from "#setup/boxes/resolve-provisioning.js";
 import type { DeploymentInfo } from "#setup/project-resolution.js";
 
-import { runDeployFlow } from "./deploy.js";
+import { runDeployFlow, type DeployFlowDeps } from "./deploy.js";
+import type { LoginFlowResult } from "./login.js";
 
 const APP_ROOT = "/app/my-agent";
 
@@ -83,10 +84,15 @@ function createLinkProjectDeps() {
   };
 }
 
+function createLoginFlow(result: LoginFlowResult = { kind: "already" }) {
+  return vi.fn<DeployFlowDeps["runLoginFlow"]>(async () => result);
+}
+
 describe("runDeployFlow", () => {
   it("deploys an already-linked project without asking anything", async () => {
     const fake = createFakePrompter({});
     const deployDeps = createDeployProjectDeps();
+    const login = createLoginFlow();
 
     const result = await runDeployFlow({
       appRoot: APP_ROOT,
@@ -94,11 +100,13 @@ describe("runDeployFlow", () => {
       interactive: true,
       deps: {
         detectDeployment: vi.fn(async () => LINKED),
+        runLoginFlow: login,
         deployProject: deployDeps,
       },
     });
 
     expect(result).toEqual({ kind: "deployed", productionUrl: "https://my-agent.vercel.app" });
+    expect(login).not.toHaveBeenCalled();
     expect(fake.selectMessages).toEqual([]);
     expect(deployDeps.runVercel).toHaveBeenCalledWith(
       ["deploy", "--prod", "--yes"],
@@ -109,6 +117,7 @@ describe("runDeployFlow", () => {
   it("refuses an unlinked non-interactive run before any effect", async () => {
     const fake = createFakePrompter({});
     const deployDeps = createDeployProjectDeps();
+    const login = createLoginFlow();
 
     const result = await runDeployFlow({
       appRoot: APP_ROOT,
@@ -116,21 +125,60 @@ describe("runDeployFlow", () => {
       interactive: false,
       deps: {
         detectDeployment: vi.fn(async () => UNLINKED),
+        runLoginFlow: login,
         deployProject: deployDeps,
       },
     });
 
     expect(result).toEqual({ kind: "needs-link" });
+    expect(login).not.toHaveBeenCalled();
     expect(deployDeps.runVercel).not.toHaveBeenCalled();
   });
 
-  it("walks the pickers and links before deploying from an unlinked directory", async () => {
+  it("logs in, links, and deploys from an unlinked directory", async () => {
     const fake = createFakePrompter({
       single: (opts) => {
         if (opts.message === "Vercel project") return "new";
         throw new Error(`Unexpected select: ${opts.message}`);
       },
     });
+    const deployDeps = createDeployProjectDeps();
+    const linkDeps = createLinkProjectDeps();
+    const provisioningDeps = createProvisioningDeps();
+    const login = createLoginFlow({ kind: "logged-in" });
+
+    const result = await runDeployFlow({
+      appRoot: APP_ROOT,
+      prompter: fake.prompter,
+      interactive: true,
+      deps: {
+        detectDeployment: vi.fn(async () => UNLINKED),
+        runLoginFlow: login,
+        resolveProvisioning: provisioningDeps,
+        linkProject: linkDeps,
+        deployProject: deployDeps,
+      },
+    });
+
+    expect(result).toEqual({ kind: "deployed", productionUrl: "https://my-agent.vercel.app" });
+    expect(login).toHaveBeenCalledWith({
+      appRoot: APP_ROOT,
+      prompter: fake.prompter,
+      signal: undefined,
+    });
+    expect(provisioningDeps.pickTeam).toHaveBeenCalled();
+    expect(login.mock.invocationCallOrder[0]).toBeLessThan(
+      provisioningDeps.pickTeam.mock.invocationCallOrder[0]!,
+    );
+    expect(linkDeps.linkProject).toHaveBeenCalled();
+    expect(deployDeps.runVercel).toHaveBeenCalledWith(
+      ["deploy", "--prod", "--yes"],
+      expect.objectContaining({ cwd: APP_ROOT }),
+    );
+  });
+
+  it("cancels before project selection when Vercel login is cancelled", async () => {
+    const fake = createFakePrompter({});
     const deployDeps = createDeployProjectDeps();
     const linkDeps = createLinkProjectDeps();
     const provisioningDeps = createProvisioningDeps();
@@ -141,24 +189,23 @@ describe("runDeployFlow", () => {
       interactive: true,
       deps: {
         detectDeployment: vi.fn(async () => UNLINKED),
+        runLoginFlow: createLoginFlow({ kind: "cancelled" }),
         resolveProvisioning: provisioningDeps,
         linkProject: linkDeps,
         deployProject: deployDeps,
       },
     });
 
-    expect(result).toEqual({ kind: "deployed", productionUrl: "https://my-agent.vercel.app" });
-    expect(provisioningDeps.pickTeam).toHaveBeenCalled();
-    expect(linkDeps.linkProject).toHaveBeenCalled();
-    expect(deployDeps.runVercel).toHaveBeenCalledWith(
-      ["deploy", "--prod", "--yes"],
-      expect.objectContaining({ cwd: APP_ROOT }),
-    );
+    expect(result).toEqual({ kind: "cancelled" });
+    expect(provisioningDeps.pickTeam).not.toHaveBeenCalled();
+    expect(linkDeps.linkProject).not.toHaveBeenCalled();
+    expect(deployDeps.runVercel).not.toHaveBeenCalled();
   });
 
   it("deploys headlessly when linked, passing the non-interactive vercel flags", async () => {
     const fake = createFakePrompter({});
     const deployDeps = createDeployProjectDeps();
+    const login = createLoginFlow();
 
     const result = await runDeployFlow({
       appRoot: APP_ROOT,
@@ -166,11 +213,13 @@ describe("runDeployFlow", () => {
       interactive: false,
       deps: {
         detectDeployment: vi.fn(async () => LINKED),
+        runLoginFlow: login,
         deployProject: deployDeps,
       },
     });
 
     expect(result).toEqual({ kind: "deployed", productionUrl: "https://my-agent.vercel.app" });
+    expect(login).not.toHaveBeenCalled();
     expect(deployDeps.runVercel).toHaveBeenCalledWith(
       ["deploy", "--prod", "--yes", "--non-interactive"],
       expect.objectContaining({ cwd: APP_ROOT, nonInteractive: true }),

--- a/packages/eve/src/setup/flows/deploy.ts
+++ b/packages/eve/src/setup/flows/deploy.ts
@@ -17,10 +17,12 @@ import { snapshotSetupState, type SetupState } from "../state.js";
 import { withSpinner } from "../with-spinner.js";
 
 import { inProjectSetupState, prompterSink } from "./in-project.js";
+import { runLoginFlow } from "./login.js";
 
 /** Injected for tests; defaults to the real detection and box effects. */
 export interface DeployFlowDeps {
   detectDeployment: typeof detectDeployment;
+  runLoginFlow: typeof runLoginFlow;
   resolveProvisioning?: ResolveProvisioningDeps;
   linkProject?: LinkProjectDeps;
   deployProject?: DeployProjectDeps;
@@ -41,9 +43,9 @@ function productionUrlOf(project: ProjectResolution): string | undefined {
  * state is the safety-critical input for a deploy, so it is re-detected at
  * decision time, never trusted from an earlier render. An already-linked
  * project goes straight to the deploy box; an unlinked one walks the same
- * team/project pickers as onboarding (resolve-provisioning with the deploy
- * gate pre-answered — invoking deploy IS the deploy decision), then links
- * non-interactively so the deploy box never hits its bare-`vercel link`
+ * login and team/project flow as onboarding (resolve-provisioning with the
+ * deploy gate pre-answered — invoking deploy IS the deploy decision), then
+ * links non-interactively so the deploy box never hits its bare-`vercel link`
  * fallback. A non-interactive run with no link refuses with `needs-link`
  * before any side effect.
  */
@@ -56,7 +58,7 @@ export async function runDeployFlow(input: {
   deps?: Partial<DeployFlowDeps>;
 }): Promise<DeployFlowResult> {
   const { appRoot, prompter, interactive, signal } = input;
-  const deps: DeployFlowDeps = { detectDeployment, ...input.deps };
+  const deps: DeployFlowDeps = { detectDeployment, runLoginFlow, ...input.deps };
 
   const project = await withSpinner(prompter, "Checking the current Vercel link...", async () => {
     const deployment = await deps.detectDeployment(appRoot, { signal });
@@ -67,6 +69,10 @@ export async function runDeployFlow(input: {
   const linked = isProjectResolved(project);
   if (!linked && !interactive) {
     return { kind: "needs-link" };
+  }
+  if (!linked) {
+    const login = await deps.runLoginFlow({ appRoot, prompter, signal });
+    if (login.kind === "cancelled") return { kind: "cancelled" };
   }
 
   const state = inProjectSetupState(appRoot, project, { deploymentPending: true });

--- a/packages/eve/src/setup/flows/ensure-vercel-project.test.ts
+++ b/packages/eve/src/setup/flows/ensure-vercel-project.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createFakePrompter } from "#internal/testing/fake-prompter.js";
+import { WizardCancelledError } from "#setup/step.js";
+
+import { ensureVercelProject } from "./ensure-vercel-project.js";
+
+describe("ensureVercelProject", () => {
+  it("logs in before reusing an existing project link", async () => {
+    const project = { orgId: "team", projectId: "project" };
+    const runLoginFlow = vi.fn(async () => ({ kind: "logged-in" as const }));
+    const readProjectLink = vi.fn(async () => project);
+    const { prompter } = createFakePrompter();
+
+    await expect(
+      ensureVercelProject({
+        appRoot: "/project",
+        prompter,
+        deps: { readProjectLink, runLoginFlow },
+      }),
+    ).resolves.toBe(project);
+
+    expect(runLoginFlow).toHaveBeenCalledWith({
+      appRoot: "/project",
+      prompter,
+      signal: undefined,
+    });
+    expect(readProjectLink).toHaveBeenCalledOnce();
+  });
+
+  it("cancels before project selection when login is cancelled", async () => {
+    const readProjectLink = vi.fn();
+
+    await expect(
+      ensureVercelProject({
+        appRoot: "/project",
+        prompter: createFakePrompter().prompter,
+        deps: {
+          readProjectLink,
+          runLoginFlow: vi.fn(async () => ({ kind: "cancelled" as const })),
+        },
+      }),
+    ).rejects.toBeInstanceOf(WizardCancelledError);
+
+    expect(readProjectLink).not.toHaveBeenCalled();
+  });
+});

--- a/packages/eve/src/setup/flows/ensure-vercel-project.ts
+++ b/packages/eve/src/setup/flows/ensure-vercel-project.ts
@@ -9,15 +9,19 @@ import { readProjectLink, type VercelProjectReference } from "../project-resolut
 import { runInteractive, type AnySetupBox } from "../runner.js";
 import { snapshotSetupState, type SetupState } from "../state.js";
 import { WizardCancelledError } from "../step.js";
+import { requireAuth } from "../vercel-project.js";
 import { inProjectSetupState, prompterSink } from "./in-project.js";
+import { runLoginFlow } from "./login.js";
 
 export interface EnsureVercelProjectDeps {
   resolveProvisioning?: ResolveProvisioningDeps;
   linkProject?: LinkProjectDeps;
   readProjectLink: typeof readProjectLink;
+  requireAuth: typeof requireAuth;
+  runLoginFlow: typeof runLoginFlow;
 }
 
-/** Ensures a project link using eve-owned prompts and a non-interactive Vercel command. */
+/** Ensures Vercel authentication and a project link using eve-owned prompts. */
 export async function ensureVercelProject(input: {
   appRoot: string;
   prompter: Prompter;
@@ -26,6 +30,18 @@ export async function ensureVercelProject(input: {
   deps?: Partial<EnsureVercelProjectDeps>;
 }): Promise<VercelProjectReference> {
   const readLink = input.deps?.readProjectLink ?? readProjectLink;
+  const login = await (input.deps?.runLoginFlow ?? runLoginFlow)({
+    appRoot: input.appRoot,
+    prompter: input.prompter,
+    signal: input.signal,
+  });
+  if (login.kind === "cancelled") throw new WizardCancelledError();
+  if (login.kind !== "already" && login.kind !== "logged-in") {
+    await (input.deps?.requireAuth ?? requireAuth)(input.appRoot, input.prompter, {
+      signal: input.signal,
+    });
+  }
+
   const existing = await readLink(input.appRoot);
   if (existing !== undefined) return existing;
 

--- a/packages/eve/src/setup/integrations/discord/setup.test.ts
+++ b/packages/eve/src/setup/integrations/discord/setup.test.ts
@@ -23,11 +23,12 @@ function deps(): DiscordSetupDeps {
 function contexts(
   answers: Record<string, unknown>,
   resolveVercelProject = vi.fn(async () => ({ orgId: "team", projectId: "project" })),
+  auth: Parameters<typeof integrationSetupEnvironment>[0] = "authenticated",
 ) {
   return createSetupContexts({
     appRoot: "/project",
     asker: withAnswers(answers)(headlessAsker()),
-    environment: integrationSetupEnvironment("authenticated", { kind: "unresolved" }),
+    environment: integrationSetupEnvironment(auth, { kind: "unresolved" }),
     prompter: createFakePrompter().prompter,
     resolveVercelProject,
   });
@@ -63,5 +64,14 @@ describe("Discord setup", () => {
       prepareDiscordSetup(contexts(ANSWERS, resolveVercelProject).prepare, effects),
     ).rejects.toThrow("eve link");
     expect(effects.provisionConnector).not.toHaveBeenCalled();
+  });
+  it("routes logged-out setup through the project resolver", async () => {
+    const effects = deps();
+    const resolveVercelProject = vi.fn(async () => ({ orgId: "team", projectId: "project" }));
+
+    await expect(
+      prepareDiscordSetup(contexts(ANSWERS, resolveVercelProject, "logged-out").prepare, effects),
+    ).resolves.toMatchObject({ project: { orgId: "team", projectId: "project" } });
+    expect(resolveVercelProject).toHaveBeenCalledWith("Discord");
   });
 });

--- a/packages/eve/src/setup/integrations/discord/setup.ts
+++ b/packages/eve/src/setup/integrations/discord/setup.ts
@@ -66,11 +66,6 @@ export async function prepareDiscordSetup(
   context: SetupPrepareContext,
   deps: DiscordSetupDeps = defaultDeps,
 ): Promise<DiscordSetupPlan> {
-  if (context.environment.vercel.kind === "unavailable") {
-    throw new Error(
-      "Discord setup requires an authenticated Vercel CLI. Run `vercel login`, then retry.",
-    );
-  }
   context.presenter.log.info(
     "Create a Discord application or open an existing one, then go to Bot → Reset Token and copy the new bot token.\nCreate: https://discord.com/developers/applications?new_application=true\nExisting applications: https://discord.com/developers/applications",
   );

--- a/packages/eve/src/setup/integrations/github/setup.test.ts
+++ b/packages/eve/src/setup/integrations/github/setup.test.ts
@@ -15,11 +15,12 @@ function deps(): GitHubSetupDeps {
 function contexts(
   answers: Record<string, unknown>,
   resolveVercelProject = vi.fn(async () => ({ orgId: "team", projectId: "project" })),
+  auth: Parameters<typeof integrationSetupEnvironment>[0] = "authenticated",
 ) {
   return createSetupContexts({
     appRoot: "/project",
     asker: withAnswers(answers)(headlessAsker()),
-    environment: integrationSetupEnvironment("authenticated", { kind: "unresolved" }),
+    environment: integrationSetupEnvironment(auth, { kind: "unresolved" }),
     prompter: createFakePrompter().prompter,
     resolveVercelProject,
   });
@@ -55,5 +56,18 @@ describe("GitHub setup", () => {
     const ctx = contexts({ "github-events": ["issue_comment"] }, resolveVercelProject);
     await expect(prepareGitHubSetup(ctx.prepare, effects)).rejects.toThrow("eve link");
     expect(effects.provisionConnector).not.toHaveBeenCalled();
+  });
+  it("routes logged-out setup through the project resolver", async () => {
+    const effects = deps();
+    const resolveVercelProject = vi.fn(async () => ({ orgId: "team", projectId: "project" }));
+
+    await expect(
+      prepareGitHubSetup(
+        contexts({ "github-events": ["issue_comment"] }, resolveVercelProject, "logged-out")
+          .prepare,
+        effects,
+      ),
+    ).resolves.toMatchObject({ project: { orgId: "team", projectId: "project" } });
+    expect(resolveVercelProject).toHaveBeenCalledWith("GitHub");
   });
 });

--- a/packages/eve/src/setup/integrations/github/setup.ts
+++ b/packages/eve/src/setup/integrations/github/setup.ts
@@ -103,11 +103,6 @@ export async function prepareGitHubSetup(
   context: SetupPrepareContext,
   deps: GitHubSetupDeps = defaultDeps,
 ): Promise<GitHubSetupPlan> {
-  if (context.environment.vercel.kind === "unavailable") {
-    throw new Error(
-      "GitHub setup requires an authenticated Vercel CLI. Run `vercel login`, then retry.",
-    );
-  }
   const events = await context.asker.askMany(githubEventsQuestion);
   const project = await context.resolveVercelProject("GitHub");
   return { events, project, slug: await deps.deriveConnectorSlug(context.appRoot) };

--- a/packages/eve/src/setup/integrations/linear/setup.test.ts
+++ b/packages/eve/src/setup/integrations/linear/setup.test.ts
@@ -22,11 +22,12 @@ function deps(): LinearSetupDeps {
 function contexts(
   answers: Record<string, unknown> = {},
   resolveVercelProject = vi.fn(async () => ({ orgId: "team", projectId: "project" })),
+  auth: Parameters<typeof integrationSetupEnvironment>[0] = "authenticated",
 ) {
   return createSetupContexts({
     appRoot: "/project",
     asker: withAnswers(answers)(withPolicy("assume")(headlessAsker())),
-    environment: integrationSetupEnvironment("authenticated", { kind: "unresolved" }),
+    environment: integrationSetupEnvironment(auth, { kind: "unresolved" }),
     prompter: createFakePrompter().prompter,
     resolveVercelProject,
   });
@@ -65,5 +66,14 @@ describe("Linear setup", () => {
       prepareLinearSetup(contexts({}, resolveVercelProject).prepare, effects),
     ).rejects.toThrow("eve link");
     expect(effects.findConnector).not.toHaveBeenCalled();
+  });
+  it("routes logged-out setup through the project resolver", async () => {
+    const effects = deps();
+    const resolveVercelProject = vi.fn(async () => ({ orgId: "team", projectId: "project" }));
+
+    await expect(
+      prepareLinearSetup(contexts({}, resolveVercelProject, "logged-out").prepare, effects),
+    ).resolves.toMatchObject({ project: { orgId: "team", projectId: "project" } });
+    expect(resolveVercelProject).toHaveBeenCalledWith("Linear");
   });
 });

--- a/packages/eve/src/setup/integrations/linear/setup.ts
+++ b/packages/eve/src/setup/integrations/linear/setup.ts
@@ -62,11 +62,6 @@ export async function prepareLinearSetup(
   context: SetupPrepareContext,
   deps: LinearSetupDeps = defaultDeps,
 ): Promise<LinearSetupPlan> {
-  if (context.environment.vercel.kind === "unavailable") {
-    throw new Error(
-      "Linear setup requires an authenticated Vercel CLI. Run `vercel login`, then retry.",
-    );
-  }
   const project = await context.resolveVercelProject("Linear");
   const defaultSlug = linearSafeConnectorSlug(await deps.deriveConnectorSlug(context.appRoot));
   const slug = linearSafeConnectorSlug(

--- a/packages/eve/src/setup/integrations/photon/setup-flow.test.ts
+++ b/packages/eve/src/setup/integrations/photon/setup-flow.test.ts
@@ -111,4 +111,23 @@ describe("Photon setup", () => {
     ).rejects.toThrow("eve link");
     expect(effects.provisionProject).not.toHaveBeenCalled();
   });
+  it("routes unavailable Connect setup through the project resolver", async () => {
+    const effects = deps();
+    const resolveVercelProject = vi.fn(async () => ({ orgId: "team", projectId: "project" }));
+
+    await expect(
+      preparePhotonSetup(
+        contexts(
+          { ...ANSWERS, "photon-credentials": "vercel" },
+          "cli-missing",
+          resolveVercelProject,
+        ).prepare,
+        effects,
+      ),
+    ).resolves.toMatchObject({
+      credentials: "vercel-connect",
+      vercelProject: { orgId: "team", projectId: "project" },
+    });
+    expect(resolveVercelProject).toHaveBeenCalledWith("Photon");
+  });
 });

--- a/packages/eve/src/setup/integrations/photon/setup-flow.ts
+++ b/packages/eve/src/setup/integrations/photon/setup-flow.ts
@@ -103,11 +103,6 @@ export async function preparePhotonSetup(
       required: true,
     }),
   );
-  if (credentials === "vercel-connect" && context.environment.vercel.kind === "unavailable") {
-    throw new Error(
-      "Vercel Connect requires an authenticated Vercel CLI. Run `vercel login`, then retry Photon setup.",
-    );
-  }
   const defaultName = `eve · ${agentName || "agent"}`;
   const project = await context.asker.askEditable({
     key: "photon-project-source",

--- a/packages/eve/src/setup/integrations/slack/setup.test.ts
+++ b/packages/eve/src/setup/integrations/slack/setup.test.ts
@@ -32,15 +32,23 @@ function deps(): SlackSetupDeps {
     reconcileSlackUid: vi.fn(async () => true),
   };
 }
-function contexts(answers: Record<string, unknown>, assume = false) {
+function contexts(
+  answers: Record<string, unknown>,
+  assume = false,
+  auth: "authenticated" | "logged-out" = "authenticated",
+) {
   const base = headlessAsker();
-  return createSetupContexts({
-    appRoot: "/project",
-    asker: withAnswers(answers)(assume ? withPolicy("assume")(base) : base),
-    environment: integrationSetupEnvironment("authenticated", { kind: "unresolved" }),
-    prompter: createFakePrompter().prompter,
-    resolveVercelProject: vi.fn(async () => ({ orgId: "team", projectId: "project" })),
-  });
+  const resolveVercelProject = vi.fn(async () => ({ orgId: "team", projectId: "project" }));
+  return {
+    ...createSetupContexts({
+      appRoot: "/project",
+      asker: withAnswers(answers)(assume ? withPolicy("assume")(base) : base),
+      environment: integrationSetupEnvironment(auth, { kind: "unresolved" }),
+      prompter: createFakePrompter().prompter,
+      resolveVercelProject,
+    }),
+    resolveVercelProject,
+  };
 }
 
 describe("Slack setup", () => {
@@ -83,5 +91,15 @@ describe("Slack setup", () => {
     await applySlackSetup(plan, ctx.apply, effects);
     const options = vi.mocked(effects.provisionSlackbot).mock.calls[0]?.[4];
     expect(await options?.selectConnector?.([], undefined)).toBe(connector);
+  });
+  it("allows the project resolver to authenticate and link Vercel Connect", async () => {
+    const effects = deps();
+    const ctx = contexts({ "slack-credentials": "vercel" }, false, "logged-out");
+
+    await expect(prepareSlackSetup(ctx.prepare, effects)).resolves.toMatchObject({
+      credentials: "vercel-connect",
+      project: { orgId: "team", projectId: "project" },
+    });
+    expect(ctx.resolveVercelProject).toHaveBeenCalledWith("Slack");
   });
 });

--- a/packages/eve/src/setup/integrations/slack/setup.ts
+++ b/packages/eve/src/setup/integrations/slack/setup.ts
@@ -155,11 +155,6 @@ export async function prepareSlackSetup(
   );
   const slug = await deps.deriveSlackConnectorSlug(context.appRoot);
   if (credentials === "environment") return { credentials, slug };
-  if (context.environment.vercel.kind === "unavailable") {
-    throw new Error(
-      "Vercel Connect requires an authenticated Vercel CLI. Run `vercel login`, then retry Slack setup.",
-    );
-  }
   const project = await context.resolveVercelProject("Slack");
   if (project.projectId.length === 0) throw new Error(SLACK_REQUIRES_VERCEL);
   const lookup = await deps.inspectConnectors(


### PR DESCRIPTION
### Summary

Closes #1931. The post-`eve init` handoff menu now includes an explicit Exit choice that leaves the completed scaffold intact without starting another process. Interactive Vercel-backed integration setup now routes missing authentication or project links through the shared login and create-or-link flow across Slack, Discord, GitHub, Linear, Photon, and installed Vercel Connect connections. Interactive unlinked deployments now authenticate before their existing project picker in both `eve deploy` and the dev TUI’s `/deploy`; linked and non-interactive deployment behavior is unchanged.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/cli/commands/init-repl.test.ts src/cli/commands/integration-connect.test.ts src/setup/flows/deploy.test.ts src/setup/flows/ensure-vercel-project.test.ts src/setup/integrations/discord/setup.test.ts src/setup/integrations/github/setup.test.ts src/setup/integrations/linear/setup.test.ts src/setup/integrations/photon/setup-flow.test.ts src/setup/integrations/slack/setup.test.ts` (54 tests)
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/cli/commands/deploy.integration.test.ts src/cli/commands/init.integration.test.ts` (53 tests)
- `pnpm exec oxfmt packages/eve/src/setup/flows/deploy.ts packages/eve/src/setup/flows/deploy.test.ts docs/reference/cli.md .changeset/calm-ducks-exit.md`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm docs:check`
- `pnpm guard:invariants`

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
