### PR TITLE
fix(docs): upgrade geistdocs to 1.20.2

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -24,7 +24,7 @@
     "@icons-pack/react-simple-icons": "13.13.0",
     "@streamdown/code": "1.1.1",
     "@vercel/analytics": "2.0.1",
-    "@vercel/geistdocs": "1.19.6",
+    "@vercel/geistdocs": "1.20.2",
     "@vercel/speed-insights": "2.0.0",
     "@vgpu/core": "0.0.7",
     "@vgpu/render": "0.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,8 +153,8 @@ importers:
         specifier: 2.0.1
         version: 2.0.1(@sveltejs/kit@2.63.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(next@16.3.0-preview.6(@babel/core@7.29.0(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nuxt@4.4.6(d63bb97f4e3da4922a64b57be4708ff3))(react@19.2.6)(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vue@3.5.35(typescript@6.0.3))
       '@vercel/geistdocs':
-        specifier: 1.19.6
-        version: 1.19.6(bfac3c4f3ad5892c9ab3875b1f065b4e)
+        specifier: 1.20.2
+        version: 1.20.2(bfac3c4f3ad5892c9ab3875b1f065b4e)
       '@vercel/speed-insights':
         specifier: 2.0.0
         version: 2.0.0(@sveltejs/kit@2.63.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(next@16.3.0-preview.6(@babel/core@7.29.0(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nuxt@4.4.6(d63bb97f4e3da4922a64b57be4708ff3))(react@19.2.6)(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vue@3.5.35(typescript@6.0.3))
@@ -7676,8 +7676,8 @@ packages:
   '@vercel/gatsby-plugin-vercel-builder@2.2.35':
     resolution: {integrity: sha512-H1qNhnvyRIhek/esVnVK+RoFsxrSOLl4qiM4iyV2IcjDoqY4H0Ped65tc5ZgZEP/P2KGNYfEDSBEukdBZa+kCg==}
 
-  '@vercel/geistdocs@1.19.6':
-    resolution: {integrity: sha512-R5e5OTnXWTZzYUhuqc0PiLNKmN1FGPeFnin+zzbB83Ca3iGLv9AeZoYKTaf34buwkjpQP/qvKslB3byBy2ct3g==}
+  '@vercel/geistdocs@1.20.2':
+    resolution: {integrity: sha512-GiQBdl/bS1jI7/qZS8cNmiebP/bC1Saca8Fvq9pzSfT6IcOTlhvAExtgeRbdb3WqDygs9+qH9OaZi0NGBoKEaQ==}
     hasBin: true
     peerDependencies:
       next: ^16.2.11
@@ -22001,7 +22001,7 @@ snapshots:
       etag: 1.8.1
       fs-extra: 11.1.0
 
-  '@vercel/geistdocs@1.19.6(bfac3c4f3ad5892c9ab3875b1f065b4e)':
+  '@vercel/geistdocs@1.20.2(bfac3c4f3ad5892c9ab3875b1f065b4e)':
     dependencies:
       '@ai-sdk/react': 3.0.193(react@19.2.6)(zod@4.4.3)
       '@clack/prompts': 0.11.0


### PR DESCRIPTION
### Summary

Related to vercel/geistdocs#235. Ask AI follow-up queries fail because the docs site sends the continuation-token request shape removed in eve 0.31. This upgrades Geistdocs to 1.20.2, which follows sessions by their fixed session ID and recovers inactive sessions with a bounded transcript.

The draft is intended to produce a Vercel preview where the protected help-eve integration and a second Ask AI query can be tested; local Next.js development cannot authenticate to that production agent.

### Validation

- `pnpm --filter eve-docs test:unit` (139 tests passed)
- `pnpm --filter eve-docs exec tsc --noEmit --project tsconfig.json`
- `pnpm exec oxfmt --check apps/docs/package.json pnpm-lock.yaml`
- `pnpm exec oxlint apps/docs/app/api/chat/route.ts`
- `git diff --check`

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package (not applicable; docs app only)
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
