### PR TITLE
fix(docs): resolve registry validation paths

### DIFF
--- a/scripts/validate-public-registry-requirements.mjs
+++ b/scripts/validate-public-registry-requirements.mjs
@@ -1,8 +1,7 @@
 import { readFile } from "node:fs/promises";
-import { join } from "node:path";
 
-const registryPath = join("apps", "docs", "registry.json");
-const evePackagePath = join("packages", "eve", "package.json");
+const registryPath = new URL("../apps/docs/registry.json", import.meta.url);
+const evePackagePath = new URL("../packages/eve/package.json", import.meta.url);
 const minimumVersionPattern = /^>=(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/u;
 const versionPattern = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/u;
 

--- a/scripts/validate-public-registry-requirements.test.mjs
+++ b/scripts/validate-public-registry-requirements.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
+import { tmpdir } from "node:os";
 import test from "node:test";
 
-import { validatePublicRegistryRequirements } from "./validate-public-registry-requirements.mjs";
+import {
+  validatePublicRegistryRequirements,
+  validatePublicRegistryRequirementsFromFiles,
+} from "./validate-public-registry-requirements.mjs";
 
 function registry(requirement) {
   return { items: [{ name: "channel/github", meta: { eve: { requires: requirement } } }] };
@@ -16,4 +20,14 @@ test("rejects public requirements for an unpublished Eve version with staging gu
     () => validatePublicRegistryRequirements(registry(">=0.31.4"), "0.31.3"),
     /registry\.staged-requirements\.json/u,
   );
+});
+
+test("resolves repository files independently of the current working directory", async () => {
+  const previousWorkingDirectory = process.cwd();
+  try {
+    process.chdir(tmpdir());
+    await assert.doesNotReject(validatePublicRegistryRequirementsFromFiles());
+  } finally {
+    process.chdir(previousWorkingDirectory);
+  }
 });


### PR DESCRIPTION
### Summary

Closes #1940. Docs deployments run registry validation from `apps/docs`, but the validator treated repository-root paths as relative to that working directory and failed with `ENOENT`. Default registry and package paths now resolve relative to the validator module, while explicit injected paths remain supported. A regression test changes the working directory before running file validation.

### Validation

- `fnm exec --using=24.14.1 -- pnpm exec oxfmt --check scripts/validate-public-registry-requirements.mjs scripts/validate-public-registry-requirements.test.mjs`
- `fnm exec --using=24.14.1 -- pnpm exec oxlint scripts/validate-public-registry-requirements.mjs scripts/validate-public-registry-requirements.test.mjs`
- `fnm exec --using=24.14.1 -- pnpm --dir apps/docs run registry:check`

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
