### PR TITLE
docs: add LLM council template

### DIFF
--- a/apps/docs/lib/templates/manifest.ts
+++ b/apps/docs/lib/templates/manifest.ts
@@ -75,7 +75,7 @@ export const templateManifest: TemplateManifestEntry[] = [
     slug: "eve-llm-council-template",
     title: "LLM council",
     setupPrompt:
-      "Set up the eve LLM council template in my current workspace using https://github.com/vercel/eve-examples/tree/main/eve-llm-council-template as the source. Copy the project files, install its dependencies, and follow the repository README to configure it. Preserve the existing project if the workspace is not empty, and tell me about any required environment variables or manual setup steps.",
+      "Set up the LLM council template in my current workspace using https://github.com/vercel/eve-examples/tree/main/eve-llm-council-template as the source. Copy the project files, install its dependencies, and follow the repository README to configure it. Preserve the existing project if the workspace is not empty, and tell me about any required environment variables or manual setup steps.",
     description:
       "A Next.js LLM council that sends one prompt to four models in parallel, streams their answers, and asks a judge model for a concise answer with per-model agreement scores.",
     sourceHref: "https://github.com/vercel/eve-examples/tree/main/eve-llm-council-template",

--- a/apps/docs/lib/templates/manifest.ts
+++ b/apps/docs/lib/templates/manifest.ts
@@ -72,6 +72,35 @@ export const templateManifest: TemplateManifestEntry[] = [
     ],
   },
   {
+    slug: "eve-llm-council-template",
+    title: "LLM council",
+    setupPrompt:
+      "Set up the eve LLM council template in my current workspace using https://github.com/vercel/eve-examples/tree/main/eve-llm-council-template as the source. Copy the project files, install its dependencies, and follow the repository README to configure it. Preserve the existing project if the workspace is not empty, and tell me about any required environment variables or manual setup steps.",
+    description:
+      "A Next.js LLM council that sends one prompt to four models in parallel, streams their answers, and asks a judge model for a concise answer with per-model agreement scores.",
+    sourceHref: "https://github.com/vercel/eve-examples/tree/main/eve-llm-council-template",
+    category: "Example",
+    model: "anthropic/claude-opus-5",
+    integrations: ["Web chat"],
+    source: "Vercel Templates",
+    github: {
+      owner: "vercel",
+      repo: "eve-examples",
+      ref: "main",
+      pathPrefix: "eve-llm-council-template",
+    },
+    files: [
+      "agent/agent.ts",
+      "agent/channels/eve.ts",
+      "agent/instructions.md",
+      "agent/lib/schemas.ts",
+      "agent/subagents/claude/agent.ts",
+      "agent/subagents/grok/agent.ts",
+      "agent/subagents/kimi/agent.ts",
+      "agent/subagents/openai/agent.ts",
+    ],
+  },
+  {
     slug: "eve-design-template",
     title: "Design",
     setupPrompt:


### PR DESCRIPTION
### Summary

Adds the LLM council to the templates gallery while keeping its source in `vercel/eve-examples`. The docs build fetches the README and curated agent files from the `eve-llm-council-template` directory, matching the existing chat and Slack template flow.

### Validation

- `pnpm --filter eve-docs build`
- `pnpm --filter eve-docs test:unit` (139 tests passed)
- `pnpm docs:check`
- `pnpm exec oxfmt --check apps/docs/lib/templates/manifest.ts`

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
