### PR TITLE
fix(eve): scope auth probes to linked projects

### DIFF
--- a/.changeset/scoped-whoami.md
+++ b/.changeset/scoped-whoami.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Scope Vercel CLI authentication checks to an existing linked team project, preventing an unrelated default CLI scope from blocking integration setup.

--- a/packages/eve/src/setup/vercel-project.test.ts
+++ b/packages/eve/src/setup/vercel-project.test.ts
@@ -92,8 +92,24 @@ describe("vercelAuthBlockerReason", () => {
 
 describe("getVercelAuthStatus", () => {
   it("reports authenticated when whoami succeeds", async () => {
+    mockedReadProjectLink.mockResolvedValueOnce(undefined);
     mockedCaptureVercel.mockResolvedValueOnce(captured("acme\n"));
     await expect(getVercelAuthStatus("/tmp/eve-agent")).resolves.toBe("authenticated");
+    expect(mockedCaptureVercel).toHaveBeenCalledWith(
+      ["whoami"],
+      expect.objectContaining({ cwd: "/tmp/eve-agent" }),
+    );
+  });
+
+  it("scopes whoami to an existing linked team project", async () => {
+    mockedReadProjectLink.mockResolvedValueOnce({ orgId: "team_demo", projectId: "prj_demo" });
+    mockedCaptureVercel.mockResolvedValueOnce(captured("demo\n"));
+
+    await expect(getVercelAuthStatus("/tmp/eve-agent")).resolves.toBe("authenticated");
+    expect(mockedCaptureVercel).toHaveBeenCalledWith(
+      ["whoami", "--scope", "team_demo"],
+      expect.objectContaining({ cwd: "/tmp/eve-agent" }),
+    );
   });
 
   it("reports logged-out when whoami ran but exited non-zero", async () => {

--- a/packages/eve/src/setup/vercel-project.ts
+++ b/packages/eve/src/setup/vercel-project.ts
@@ -171,9 +171,15 @@ export function requireVercelLogin(failure?: VercelCaptureFailure): never {
  */
 const WHOAMI_TIMEOUT_MS = 10_000;
 
-/** Runs the bounded, read-only `vercel whoami` probe shared by the auth checks. */
-function probeWhoami(projectRoot: string, options: VercelProjectOperationOptions) {
-  return captureVercel(["whoami"], {
+/**
+ * Runs the bounded, read-only `vercel whoami` probe shared by the auth checks.
+ * A linked team project is the user's explicit scope choice, so authenticate
+ * against that owner instead of whichever account scope the CLI last selected.
+ */
+async function probeWhoami(projectRoot: string, options: VercelProjectOperationOptions) {
+  const link = await readProjectLink(projectRoot);
+  const args = ["whoami", ...(link?.orgId.startsWith("team_") ? ["--scope", link.orgId] : [])];
+  return captureVercel(args, {
     cwd: projectRoot,
     signal: options.signal,
     timeoutMs: WHOAMI_TIMEOUT_MS,


### PR DESCRIPTION
## Summary

`vercel whoami` fails if the local credential doesn't have permissions for the user's default team. This PR applies an explicit `--scope` to the whoami call if the local project is linked to a team, ensuring that narrow team-scoped credentials succeed.

Unlinked and personal-account projects retain the existing unscoped probe.

## Validation

- `pnpm --filter eve build:compiled`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/setup/vercel-project.test.ts`