### PR TITLE
research: durable hierarchical progress

### DIFF
--- a/research/durable-hierarchical-progress.md
+++ b/research/durable-hierarchical-progress.md
@@ -8,246 +8,352 @@ last_updated: "2026-08-05"
 
 ## Summary
 
-eve should represent progress independently from any channel presentation. Agent
-lifecycle facts reduce into a durable progress projection; delegated agents
-publish their projection to their parent, which incorporates it into its own
-projection. Only the root channel renders the resulting projection into an
-external presentation.
+eve should maintain a durable, framework-owned work graph for the active turn
+and its delegated work. The graph is derived from authoritative runtime
+lifecycle state, composes through child sessions, and remains independent of
+channel effects. A root channel may render a safe, selected view of that graph.
 
 ```text
-child lifecycle facts ──reduce──▶ child projection
-                                      │ durable child update
-                                      ▼
-parent facts + child projections ──reduce──▶ parent projection
-                                              │
-                                              ▼
-                                       channel renderer
-                                  indicator | message | blocks
+runtime lifecycle + direct child state
+                │
+                ▼
+       durable work graph
+                │
+                ▼
+    channel-specific presentation
 ```
 
-A Slack thread status is one possible rendering. A replaceable thread message,
-a Block Kit tree of parallel work, a terminal spinner, or no visible rendering
-are equally valid. Progress is desired state, not a command to call a specific
-channel API.
+The first implementation should prove this boundary using existing lifecycle
+facts and local subagents. It should not initially define a general progress
+platform around plans, arbitrary annotations, public client events, remote
+capability negotiation, or custom channel APIs.
 
-## Current Slack behavior
+A later PR should add action-local `reportProgress()` and automatic MCP progress
+adaptation after action ownership, child propagation, and rendering semantics
+are stable.
 
-Slack status text currently comes directly from channel event handlers in
-`public/channels/slack/defaults.ts`:
+## Problem
 
-| Source                                         | Current projection                                                                                                    |
-| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| inbound mention or DM                          | `Thinking...` before runtime dispatch                                                                                 |
-| `turn.started`                                 | `Working...`                                                                                                          |
-| `reasoning.appended`                           | first non-empty reasoning line, locally throttled                                                                     |
-| `actions.requested`                            | preceding assistant narration when available, otherwise a label derived from the first requested action and `+N more` |
-| `message.completed`                            | preserve narration before tool calls; otherwise post the answer or clear an empty status                              |
-| `authorization.completed`                      | `Connected to <name>. Resuming...`                                                                                    |
-| terminal session/turn events and visible posts | stop or supersede the active status                                                                                   |
+Channels currently infer progress independently from low-level stream events.
+Slack, for example, derives status text from turn start, reasoning, assistant
+narration, action requests, authorization completion, visible output, and
+terminal events. The resulting state is implicit and channel-local.
 
-This is an implicit last-write-wins reducer spread across event handlers and
-`SlackChannelState` fields. `pendingToolCallMessage` carries narration across
-`message.completed` and `actions.requested`; `lastReasoningTyping*` implements
-presentation throttling. The status text is therefore derived from useful
-channel-neutral facts, but its reduction and Slack effect are interleaved.
+Delegated sessions make this boundary more visible. A parent knows that it
+started a child and eventually receives its terminal result, but the child's
+ordinary step and action lifecycle does not bubble through the parent. A channel
+that wants to show parallel delegated work must attach to child streams and
+rebuild ownership, ordering, and terminal state itself.
 
-## Existing event and delegation boundaries
+The missing primitive is not presentation text. It is durable work ownership:
 
-Normal root-agent stream events pass through the active channel adapter in
-`execution/workflow-steps.ts`. This gives Slack the facts above, but does not
-persist an explicit progress projection.
+> What work is currently active, waiting, or terminal, and what direct child
+> work does it own?
 
-Delegated agents run with the framework-owned subagent adapter. Today it only
-forwards child authorization and input-request events through the parent's
-durable turn inbox. The parent separately observes:
+## Design principles
 
-- `actions.requested`, which identifies the requested subagent call;
-- `subagent.called`, emitted after a durable child starts;
-- the terminal runtime-action result returned through the inbox.
+1. **Observed work is the core.** The graph records runtime truth: active turn,
+   model steps, actions, blockers, and delegated children.
+2. **Plans are separate intent.** A todo list may later attach to a turn, but it
+   does not define execution truth and does not imply action-to-plan-item edges.
+3. **The graph is desired state, not history.** The durable event stream remains
+   the complete audit trail.
+4. **Reduction is framework-owned.** Agents do not customize graph invariants,
+   retention, child revisions, or terminal precedence.
+5. **Children publish snapshots.** Parents receive versioned child state rather
+   than every raw child event.
+6. **Presentation belongs to channels.** The graph contains no Slack blocks,
+   message ids, API operations, or presentation-maintenance timers.
+7. **Blockers are first-class.** Waiting for input, authorization, or approval is
+   authoritative work state, not an absence of progress.
+8. **Terminal state wins.** Late or replayed updates cannot resurrect settled
+   actions or children.
 
-The child agent's ordinary turn, reasoning, action, and nested-subagent events
-do not bubble to the parent. The protocol contains inline `subagent.started`,
-`subagent.event`, and `subagent.completed` shapes, but delegated workflow
-subagents do not use those as a general child event stream. A hierarchical
-progress design therefore needs a new durable child-progress lane rather than
-assuming the parent can reduce its child's existing public stream.
+## Proposed v1 semantics
 
-PR [#1665](https://github.com/vercel/eve/pull/1665) adds another useful source:
-streaming tools may yield complete intermediate output snapshots, exposed as
-`action.partial`. This is an incremental tool-output data plane rather than a
-progress model. The snapshots are arbitrary tool output, can be much richer
-and more frequent than useful status changes, and are independently valuable
-to clients. Progress reduction may consume them without making every partial a
-progress revision or forwarding raw partials through the subagent tree.
+### Work graph
 
-## Design boundary
-
-The proposal separates four responsibilities:
-
-1. operations publish structured reports or partial-output projections;
-2. eve materializes deterministic canonical progress from existing turn, step,
-   action, blocker, plan, and child-session state;
-3. delegated sessions publish versioned canonical snapshots to their parent;
-4. the root channel selects, summarizes, and renders a presentation.
-
-Canonical progress is desired state, not an audit log and not presentation
-commands. The durable event stream remains the complete history. Channel state
-owns external message ids, capability fallbacks, and cached summaries.
-Platform-specific presentation maintenance, such as renewing an expiring Slack
-status, stays inside that channel implementation and is not part of the
-canonical progress or generic channel contract.
-
-## Public API design space
-
-The public API needs boundaries at four levels: producers contribute meaning,
-the agent materializes canonical state, delegated sessions publish canonical
-snapshots, and the root channel renders a presentation. These
-levels should not share one generic `reduce(event)` callback.
-
-### Canonical types
-
-Three shapes are plausible.
-
-#### Recursive activity tree
+The first graph is deliberately small and internal:
 
 ```ts
-interface ProgressSnapshot {
+type WorkPhase = "queued" | "running" | "blocked" | "completed" | "failed" | "cancelled";
+
+interface WorkSnapshot {
   readonly revision: number;
-  readonly root: ProgressScope;
+  readonly root: WorkScope;
 }
 
-interface ProgressScope {
-  readonly id: string;
-  readonly kind: "agent";
-  readonly name: string;
-  readonly phase: ProgressPhase;
-  readonly summary?: string;
-  readonly startedAt: string;
-  readonly updatedAt: string;
-  readonly turn?: ProgressTurn;
-}
-
-interface ProgressTurn {
-  readonly id: string;
-  readonly phase: ProgressPhase;
-  readonly plan?: ProgressPlan;
-  readonly steps: readonly ProgressStep[];
-  readonly blockers: readonly ProgressBlocker[];
-}
-
-interface ProgressStep {
-  readonly stepIndex: number;
-  readonly phase: ProgressPhase;
-  readonly label?: string;
-  readonly actions: readonly (ProgressAction | ProgressChild)[];
-}
-
-type ProgressActivity = ProgressAction | ProgressChild | ProgressPlan | ProgressBlocker;
-
-interface ProgressChild extends ProgressActivityBase {
-  readonly kind: "agent";
-  readonly callId: string;
+interface WorkScope {
   readonly sessionId: string;
-  readonly progress: ProgressScope;
+  readonly agentName: string;
+  readonly phase: WorkPhase;
+  readonly turn?: WorkTurn;
+}
+
+interface WorkTurn {
+  readonly turnId: string;
+  readonly phase: WorkPhase;
+  readonly steps: readonly WorkStep[];
+  readonly blockers: readonly WorkBlocker[];
+}
+
+interface WorkStep {
+  readonly stepIndex: number;
+  readonly phase: WorkPhase;
+  readonly actions: readonly WorkAction[];
+}
+
+interface WorkAction {
+  readonly callId: string;
+  readonly kind: "tool" | "skill" | "subagent" | "remote-agent";
+  readonly name: string;
+  readonly phase: WorkPhase;
+  readonly child?: WorkScope;
+}
+
+interface WorkBlocker {
+  readonly id: string;
+  readonly kind: "input" | "authorization" | "approval";
+  readonly phase: "blocked" | "completed" | "cancelled";
+  readonly ownerCallId?: string;
 }
 ```
 
-This is easiest for renderers and naturally represents nested agents. A session
-has at most one live turn projection; completed turn history stays in the event
-stream rather than accumulating in `ProgressScope`. Updating a deep child
-replaces a path and can duplicate large subtrees on the wire unless snapshots
-are bounded or structurally shared internally.
+The public names and exact serialization are not committed by v1. The initial
+shape should remain internal until two renderers consume it successfully.
 
-#### Normalized graph
+### Planless turns
+
+Every turn already has model-step and action boundaries. A planless graph uses
+those boundaries directly:
+
+```text
+turn [running]
+├── step 0 [completed]
+│   ├── search docs [completed]
+│   └── read source [completed]
+└── step 1 [running]
+    ├── run reproduction [running]
+    └── researcher [running]
+        └── child turn
+            └── inspect traces [running]
+```
+
+Actions observed under the same `stepIndex` are siblings. Because
+`actions.requested` may arrive incrementally, the reducer uses runtime action
+state—not one event batch—to determine which actions are concurrently active.
+A delegated action owns its child scope.
+
+The graph does not infer a plan, user intent, or a relationship between an
+action and a hypothetical task.
+
+### Blocked work
+
+A blocker belongs to the turn and may identify its owning action:
+
+```text
+turn [blocked]
+├── step 1 [completed]
+│   └── update feature flag [blocked]
+└── approval [blocked]
+    └── owner: update feature flag
+```
+
+When the blocker resolves, the same blocker settles and the turn resumes. It is
+not replaced with a new unrelated status.
+
+### Scope compaction
+
+The live graph is not an audit log:
+
+- retain all active and blocked actions;
+- retain completed actions while their step remains active;
+- collapse completed step internals to a step outcome when the turn advances;
+- retain failure/cancellation detail needed to explain the outcome;
+- retain active child scopes until their owning action settles;
+- remove the completed turn from the live session scope after settlement;
+- preserve the full sequence in the existing durable event stream.
+
+These rules are deterministic framework invariants, not authored retention
+settings.
+
+## Local child propagation
+
+A delegated local session reduces its own graph and publishes a versioned
+snapshot through the existing parent turn inbox topology:
 
 ```ts
-interface ProgressSnapshot {
+interface ChildWorkUpdate {
+  readonly kind: "subagent-work";
+  readonly callId: string;
+  readonly childSessionId: string;
   readonly revision: number;
-  readonly rootId: string;
-  readonly nodes: Readonly<Record<string, ProgressNode>>;
-}
-
-interface ProgressNode {
-  readonly id: string;
-  readonly parentId?: string;
-  readonly kind: "agent" | "action" | "plan" | "blocker";
-  readonly phase: ProgressPhase;
-  readonly children: readonly string[];
-  readonly report?: ProgressReport;
+  readonly snapshot: WorkSnapshot;
+  readonly subagentName: string;
 }
 ```
 
-This is compact, stable under replacement, and convenient for stale-revision
-checks. It is less pleasant for ordinary channel authors and exposes graph
-integrity concerns they should not need to maintain.
+The parent:
 
-#### Snapshot plus opaque extension contributions
+1. binds the update to a running child handle by `callId` and session id;
+2. rejects stale revisions;
+3. replaces the child snapshot on the owning action;
+4. increments its own revision only when desired state changes;
+5. republishes its snapshot upward when it is itself delegated;
+6. rejects every child update after the action becomes terminal.
 
-```ts
-interface ProgressActivity {
-  readonly id: string;
-  readonly kind: string;
-  readonly phase: ProgressPhase;
-  readonly label?: string;
-  readonly data?: JsonValue;
-}
+Terminal result delivery and work updates may race. Both orders must converge
+to the same terminal parent graph. Child progress delivery is best-effort and
+must not delay model execution or terminal settlement indefinitely.
+
+The v1 payload is runtime-internal. Its shape should avoid assumptions that
+would prevent later remote delivery, but v1 does not define public remote
+capability negotiation.
+
+## Initial Slack consumers
+
+Slack is the proving ground, not part of the graph contract.
+
+### Deterministic status renderer
+
+The first consumer selects one compact line from the graph while preserving
+current visible behavior where practical:
+
+```text
+Running the checkout reproduction…
 ```
 
-This is extensible but gives channels little portable structure. Every renderer
-would eventually switch on tool-specific `kind` values.
+For parallel work:
 
-The recommended public read shape is a recursive tree with a bounded canonical
-schema. The runtime may store or propagate it as a normalized graph. Domain data
-can ride in namespaced optional annotations, but core identity, phase, nesting,
-counts, timestamps, and errors remain portable.
+```text
+Researching three approaches…
+```
+
+The renderer owns:
+
+- human labels for known action kinds;
+- truncation and safe argument selection;
+- prioritizing blockers over active work;
+- summarizing parallel children;
+- clearing or superseding status after visible output;
+- all Slack API behavior and presentation maintenance.
+
+Reasoning-derived or model-narrated status can remain a separate Slack policy
+while the graph is evaluated; raw reasoning does not need to enter the v1 work
+graph.
+
+### Hierarchical activity-message spike
+
+The second consumer updates one Slack message from the same graph:
+
+```text
+Cold-start investigation
+
+✓ Dependency analysis
+  Found eager initialization
+
+◐ Bundle analysis
+  Running measurements
+
+! Runtime analysis
+  Waiting for access
+```
+
+This renderer validates that the graph contains enough information for the
+motivating nested-work use case. It should support:
+
+- parallel and nested local children;
+- active, blocked, completed, failed, and cancelled states;
+- stable in-place updates;
+- completed-scope collapse;
+- missing-message recovery;
+- terminal settlement.
+
+It may remain internal or experimental. The generic channel API should be
+extracted only after the status and activity renderers demonstrate a stable
+common input.
+
+## PR stack
+
+### PR 1 — Pure internal work graph
+
+Add a pure reducer over existing authoritative lifecycle facts:
+
+- turn and step lifecycle;
+- runtime action requests and results;
+- child dispatch and settlement;
+- input, authorization, and approval waits;
+- cancellation and failure.
+
+Establish stable action identity, planless step grouping, replay determinism,
+terminal precedence, and scope compaction. Add no visible behavior or public
+API.
+
+Acceptance criteria:
+
+- planless turns reduce identically across replay;
+- incremental action request events converge on runtime action state;
+- parallel actions retain independent `callId` identity;
+- blockers attach and settle without losing their owner;
+- late events cannot rewrite terminal actions;
+- completed step detail collapses deterministically.
+
+### PR 2 — Durable local-child composition
+
+Publish versioned local-child snapshots and compose them into the parent graph.
+
+Acceptance criteria:
+
+- two parallel children remain independent;
+- a nested child update bubbles one parent at a time;
+- stale revisions are ignored;
+- terminal result/update races converge;
+- cancellation settles descendant work;
+- propagation failure does not fail an active turn;
+- no public remote wire contract is introduced.
+
+### PR 3 — Internal Slack status consumer
+
+Render the work graph through Slack's existing compact status surface. Preserve
+visible defaults where practical and keep every Slack-specific concern inside
+the Slack package.
+
+Acceptance criteria:
+
+- simple tool calls show useful deterministic status;
+- parallel children collapse to compact copy;
+- blockers outrank generic running status;
+- terminal and visible-output behavior remains correct;
+- the work graph contains no Slack fields.
+
+### PR 4 — Internal Slack activity-message renderer
+
+Add an internal or experimental replaceable message that renders hierarchical
+work.
+
+Acceptance criteria:
+
+- simple planless turns are not blank;
+- parallel and nested children update stable rows in place;
+- completed scopes collapse while failures remain legible;
+- blockers render distinctly from running work;
+- terminal state settles the message;
+- the renderer requires no child stream attachment outside framework snapshot
+  propagation.
+
+### PR 5 — `reportProgress()` and automatic MCP adaptation
+
+After the graph and propagation path are proven, add action-local authored
+reports:
 
 ```ts
-type ProgressPhase = "queued" | "running" | "blocked" | "completed" | "failed" | "cancelled";
-
 interface ProgressReport {
   readonly message?: string;
   readonly progress?: number;
   readonly total?: number;
   readonly unit?: string;
 }
-```
 
-`message` is semantic authored copy, not channel markup. `progress` is the
-amount completed, not necessarily a percentage; `total` uses the same scale.
-Numeric fields align with MCP progress notifications, while eve adds optional
-`unit` and permits message-only reports. Correlation is not public payload:
-authored tools inherit their active `callId`, and the MCP adapter privately maps
-`progressToken` to that call.
-
-Plans deserve a core canonical variant rather than a namespaced annotation:
-
-```ts
-interface ProgressPlan extends ProgressActivityBase {
-  readonly kind: "plan";
-  readonly title?: string;
-  readonly items: readonly ProgressPlanItem[];
-}
-
-interface ProgressPlanItem {
-  readonly id: string;
-  readonly label: string;
-  readonly description?: string;
-  readonly phase: "pending" | "running" | "completed" | "cancelled" | "failed";
-}
-```
-
-This supports plan cards, web checklists, and pinned TUI plans. The current
-framework todo schema has no plan title, description, or item id. A first-class
-plan contribution therefore requires a deliberate todo API change if stable
-item identity is part of the contract.
-
-### Producer APIs
-
-There are three useful producer shapes, and eve likely needs two of them.
-
-#### Explicit operation-local reporting
-
-```ts
 export default defineTool({
   async execute(input, ctx) {
     await ctx.reportProgress({
@@ -260,459 +366,120 @@ export default defineTool({
 });
 ```
 
-This is initially a `ToolContext` API: the active `callId` supplies ownership.
-It is natural for long operations that know when a meaningful milestone occurs.
-`reportProgress` must be asynchronous and revisioned. Its durability semantics must be explicit: it sends an out-of-band
-checkpoint rather than pretending an atomic tool step committed early. Rapid
-reports may coalesce latest-per-call while preserving the latest accepted
-checkpoint.
+`ToolContext.callId` supplies ownership. MCP `notifications/progress` enters the
+same internal action-report path by privately correlating `progressToken` to the
+active eve call.
 
-MCP tools get this path without authored configuration when their server emits
-`notifications/progress`. The MCP client supplies a private `progressToken`,
-correlates the notification back to the active eve `callId`, and submits the
-same internal report. MCP supplies no hierarchy; ordinary eve child snapshots
-carry the resulting action progress upward.
+This PR owns the hard durability semantics:
 
-#### Projection from tool lifecycle and partial output
+- define exactly what awaiting `reportProgress()` guarantees;
+- identify updates by call, execution attempt, and revision;
+- reject reports from stale attempts and terminal actions;
+- define whether numeric progress must be monotonic within one attempt;
+- coalesce rapid reports without losing the latest accepted snapshot;
+- prevent terminal settlement from being followed by a late resurrection;
+- bound propagation volume through nested parents;
+- remove MCP correlation state on settlement.
 
-```ts
-export default defineTool({
-  async *execute(input) {
-    yield { indexed: 250, total: 1_000 };
-    yield { indexed: 1_000, total: 1_000 };
-  },
-  progress: {
-    started(input) {
-      return { message: `Indexing ${input.collection}` };
-    },
-    updated(output) {
-      return {
-        progress: output.indexed,
-        total: output.total,
-        unit: "documents",
-      };
-    },
-    completed(output) {
-      return { message: `Indexed ${output.total} documents` };
-    },
-  },
-});
-```
+Acceptance criteria:
 
-This keeps a typed relation to tool input/output and lets `action.partial`
-remain a richer client stream. It cannot describe milestones that are not
-represented in yielded output.
+- report, crash, and retry do not regress or duplicate action state incorrectly;
+- a late report after terminal settlement is rejected;
+- rapid reports coalesce to the latest accepted report;
+- parallel tools report independently;
+- a nested child's report reaches the root renderer;
+- MCP progress reaches the same renderer without authored eve-specific code;
+- MCP servers that emit no progress retain useful lifecycle fallback.
 
-#### Generic progress tool
+This is the first PR likely to expose a new authored API and therefore needs
+public documentation, focused integration coverage, extension compatibility
+updates, and a changeset.
 
-A model-facing `report_progress` tool is useful for semantic work between tools,
-but should be additive. Requiring the model to narrate every operation is noisy
-and unreliable. Structured `todo` remains the better source for multi-step
-plans.
+## Follow-on hypotheses
 
-Recommended producer API: support explicit `ctx.reportProgress()` and an
-optional typed `progress` projector on `defineTool`. Both normalize to the same
-`ProgressReport`; the last accepted explicit report wins over an inferred
-partial contribution until another lifecycle boundary. The projector is a
-convenience for `action.partial`; explicit reporting remains the primary API.
+The following are deliberately outside the first five PRs.
 
-### Agent-level authoring
+### Structured plans
 
-The initial agent API should be zero-config:
+The framework todo is model-authored intent, not execution truth. A future
+change may add stable item ids, plan title, description, and merge-by-id, then
+attach an optional plan beside the observed step ladder:
 
 ```ts
-export default defineAgent({
-  model: "openai/gpt-5.4",
-});
-```
-
-A raw `(state, event) => state` replacement API is too easy to make lossy or
-break child and terminal invariants. Fixed retention counts are also the wrong
-abstraction: canonical progress is scoped around meaningful work, not a sliding
-window of recent events.
-
-Plans are optional. Today a turn has model-step and action-batch boundaries;
-it has a plan only when the model calls the framework `todo` tool. Without a
-plan, eve builds a faithful ladder from those existing boundaries:
-
-```text
-turn
-├── step 0 [completed]
-│   ├── search logs [completed]
-│   └── read source [completed]
-└── step 1 [running]
-    ├── researcher [running]
-    │   └── child progress…
-    └── run reproduction [running]
-```
-
-Actions observed under the same `stepIndex` are siblings; the runtime's action
-state determines which are concurrently active, since `actions.requested` may
-arrive incrementally. A subagent action owns its child scope. Optional pre-tool
-narration may label the step; otherwise channels derive mechanical copy from
-action names. When `todo` exists, the canonical turn also carries its structured
-plan:
-
-```text
-turn
-├── plan
-│   ├── Reproduce [completed]
-│   ├── Implement fix [running]
-│   └── Open PR [pending]
-└── steps
-    └── current step
-        ├── edit file [completed]
-        └── run tests [running]
-```
-
-The framework applies deterministic scope-based compaction:
-
-- retain every active or blocked action;
-- group planless actions by native step and action-batch boundaries rather than
-  inferring a plan;
-- keep the optional plan and native step ladder as orthogonal views: the current
-  protocol does not identify which action implements which todo item;
-- while a step is active, retain its completed actions;
-- when a step completes, retain its outcome and collapse internal action detail
-  from the live projection;
-- retain failed/cancelled detail sufficient to explain the outcome;
-- retain the current plan and active child scopes until their owning turn
-  settles;
-- leave the complete audit trail in the durable event stream.
-
-Whether completed scopes are expanded or hidden is channel presentation policy.
-`preferPlans` therefore does not belong on the agent definition either.
-Agent-authored semantic state enters through optional structured plans and
-`reportProgress()`, not a custom canonical reducer. Defer agent annotations and
-reducer middleware until adoption demonstrates information that cannot be
-expressed as a contribution.
-
-The canonical projection should be observable without being mutable:
-
-```ts
-export default defineHook({
-  events: {
-    "progress.updated"(event, ctx) {
-      console.info(event.data.progress.revision);
-    },
-  },
-});
-```
-
-This event fires only when canonical state changes, not for presentation-only
-channel maintenance.
-
-### Delegated-agent boundary
-
-The child-to-parent contract should remain framework-owned. Public authors read
-the same `ProgressSnapshot` whether a scope is root or nested; they do not send
-`subagent-progress` hook payloads themselves. A child may attach an authored
-semantic annotation or summary, but cannot choose what the parent discards.
-
-For remote agents, capability negotiation can accept either:
-
-```ts
-{
-  kind: ("progress.snapshot", revision, progress);
+interface ProgressPlan {
+  readonly id: string;
+  readonly title?: string;
+  readonly items: readonly ProgressPlanItem[];
 }
 ```
 
-or a coarse remote task status that eve adapts into one child node. Lack of
-progress capability leaves the child as a running node until its terminal
-result.
+No action-to-plan-item relationship should be inferred without an explicit
+protocol field.
 
-### Channel API
+### Generic channel API
 
-The initial channel surface is one effectful callback. It receives an extensible
-input object and owns presentation state in the channel's existing durable
-state:
+After two Slack consumers prove a stable input, extract the smallest generic
+channel hook from their common needs. Do not commit to a public
+`defineChannel({ progress() {} })` shape before that evidence exists.
 
-```ts
-interface ChannelProgressInput {
-  readonly progress: ProgressSnapshot;
-  readonly reason: "changed" | "terminal";
-}
-```
+### Public observation
 
-```ts
-export default defineChannel({
-  state: { progressMessageId: null },
-  async progress({ progress, reason }, channel, ctx) {
-    channel.state.progressMessageId = await upsertProgressMessage({
-      messageId: channel.state.progressMessageId,
-      progress,
-      reason,
-    });
-  },
-});
-```
+A future `progress.updated` hook or client event may expose snapshots to authored
+observers and web clients. Publishing the graph creates a durable protocol
+commitment and should follow stabilization.
 
-This fits existing channel event handlers and lets a channel post, update,
-delete, summarize, or intentionally ignore progress. Model-summary caching,
-create-versus-update state, and testability remain the author's responsibility.
-Built-in channel presets may internally split pure projection from effects and
-cache model-generated summaries by canonical fingerprint.
+### Remote child capability
 
-The callback runs only when canonical progress changes or terminates. A channel
-that needs presentation-only maintenance owns its timer and reuses its last
-rendered state without manufacturing a progress update.
+Remote agents eventually need capability negotiation or a coarse compatibility
+adapter. The local-child protocol should remain transportable, but v1 does not
+publish a remote wire format.
 
-For Slack, the built-in offers presets and an escape hatch:
+### Partial-output projection
 
-```ts
-slackChannel({
-  progress: slackProgress.status(),
-});
+Streaming tool output may later project into `ProgressReport`. The full
+`action.partial` stream remains independently valuable and should not be
+replaced by progress.
 
-slackChannel({
-  progress: slackProgress.message({
-    blocks(progress) {
-      return renderParallelAgentBlocks(progress);
-    },
-  }),
-});
+### Model summaries
 
-slackChannel({
-  progress: slackProgress.plan({
-    fallback: slackProgress.status(),
-  }),
-});
+A channel may eventually use a cheap model to summarize a bounded graph for its
+audience. Summarization is presentation-only, cached by graph fingerprint, and
+must fall back to deterministic copy. It never replaces canonical child state.
 
-slackChannel({
-  async progress({ progress, reason }, channel) {
-    await renderCustomSlackProgress({ channel, progress, reason });
-  },
-});
-```
+### Liveness
 
-`slackProgress.plan()` selects the optional canonical plan and falls back when
-a turn has none. `slackProgress.message()` updates a thread message.
-`slackProgress.status()` owns any Slack-specific status renewal internally.
-`progress: false` suppresses the built-in renderer without suppressing canonical
-progress or `progress.updated` observation.
+Remote liveness, elapsed-time decoration, and stall policy are operational
+concerns distinct from semantic work phase. Lack of recent activity must not be
+interpreted automatically as failure.
 
-### API recommendation
+## Verification strategy
 
-The smallest coherent first public surface is:
+Choose the narrowest test tier for each invariant:
 
-1. `ProgressReport`, `ProgressSnapshot`, and recursive read-only node types;
-2. `ctx.reportProgress()` for operation-local milestones and automatic MCP
-   progress adaptation;
-3. optional typed tool `progress` projectors;
-4. deterministic framework-owned scope reduction, with no initial agent config;
-5. `progress.updated` as an observe-only hook event;
-6. one effectful channel `progress({ progress, reason }, channel, ctx)` callback;
-7. Slack status, plan, and message presets built on the same canonical input.
+- pure reducer and compaction tests at the unit tier;
+- in-memory child composition and race tests at the integration tier;
+- workflow retry, cancellation, and durable inbox behavior at the scenario
+  tier where necessary;
+- deterministic fixture coverage for final Slack integration behavior.
 
-The runtime child propagation protocol remains internal until remote capability
-negotiation requires a public wire contract.
+The implementation stack is successful when:
 
-## Proposed semantic split
+- planless root work reduces deterministically;
+- nested local work composes without channel-side child stream readers;
+- stale or late updates cannot overwrite terminal state;
+- status and activity renderers consume the same graph;
+- the graph remains free of Slack state;
+- ordinary tools remain useful without authored progress reports;
+- PR 5 can add precise reports without changing graph ownership or child
+  propagation semantics.
 
-### Progress facts
+## Out of scope
 
-A progress fact records a meaningful lifecycle transition, not presentation
-instructions. Initial facts should cover:
-
-- turn and model-step started, completed, failed, or cancelled, preserving
-  `stepIndex`;
-- reasoning summary changed;
-- action batches requested and actions settled, keyed by call id;
-- authorization or human input required and resumed;
-- delegated child started, updated, and settled, keyed by call id and child
-  session id;
-- a streaming tool published a new intermediate output snapshot, keyed by call
-  id.
-
-Facts need stable identities and ordering coordinates. They must not contain
-Slack text, blocks, message timestamps, refresh intervals, or API operations.
-High-frequency stream deltas and tool partials may be ignored or coalesced
-before reduction, but the latest desired projection must cross the next durable
-boundary. A default reducer should not guess status text from arbitrary partial
-output. An authored tool projector can interpret its domain-specific snapshot
-and map
-`TOutput` to a small progress report without changing what clients or the model
-see.
-
-### Canonical agent projection
-
-The framework canonical reducer folds facts into durable agent state. It must be
-deterministic, side-effect free, and deliberately low-loss so workflow retries
-produce the same result and every parent receives enough structure to choose a
-different presentation. It may compact transport detail, such as replacing ten
-partials for one call with the latest typed contribution, but should retain
-active action identities, child projections, plan items, phases, timestamps,
-errors, and terminal outcomes.
-
-The public read shape is the recursive `ProgressSnapshot` above: agent scope,
-the live turn, its native step ladder, optional plan, actions, blockers, and
-nested child snapshots. The runtime may normalize this graph internally.
-
-Canonical reduction is framework-owned and zero-config. Do not expose an
-agent-level reducer initially: custom reduction could discard child progress,
-break terminal precedence, or make different agents publish incompatible
-snapshots. Opinionated selection and summarization belong in the channel
-callback.
-
-Do not require an agent author to reconstruct the action map, child revision
-checks, terminal precedence, or retention. Those are framework invariants.
-Agent-level authoring should add typed domain contributions, not collapse the
-graph to one display string. Tool-level projectors answer what one operation's
-output means; the canonical reducer combines and scope-compacts those
-contributions around native turns and steps, and optional plans when present,
-without deciding what a particular audience should see.
-
-A child may publish an explicit semantic summary because it understands its own
-domain, but that summary is one field alongside its canonical child projection,
-not a replacement for it. Automatically invoking a summarization model at each
-subagent boundary would add latency, cost, nondeterminism, and cumulative
-information loss. If a very wide tree eventually requires hierarchical model
-summaries, store them as optional derived annotations keyed by the source
-projection fingerprint and always propagate the source projection too.
-
-Do not expose a public agent reducer until the tree survives nested delegation
-without channel-specific fields and a concrete adoption cannot be expressed as
-a progress report or channel projection.
-
-### Channel renderer
-
-The root channel receives a complete desired projection and renders external
-state. It owns effectful and presentation-specific concerns:
-
-- select which canonical nodes matter for this channel and audience;
-- optionally summarize them with authored code or a cheap model;
-- choose an indicator, one updated message, multiple posts, or blocks;
-- create and remember external resource ids;
-- update or clear prior presentation;
-- truncate, throttle, and debounce according to platform limits;
-- decide how completed children remain visible.
-
-A model summarizer is an optional, best-effort presentation stage. Its input is
-the bounded canonical graph; its output may be cached by projection fingerprint
-in channel state. Failure falls back to deterministic copy.
-
-The renderer's durable channel state contains external ids, the last
-successfully rendered projection fingerprint, and any cached presentation.
-Canonical reducer state must not contain those values. Rendering is best-effort
-and must not fail the agent turn.
-
-## Hierarchical propagation
-
-Each session reduces its own facts. A delegated session sends a versioned
-snapshot when its desired projection changes:
-
-```ts
-interface ChildProgressUpdate {
-  readonly kind: "subagent-progress";
-  readonly callId: string;
-  readonly childSessionId: string;
-  readonly revision: number;
-  readonly projection: ProgressSnapshot;
-  readonly subagentName: string;
-}
-```
-
-The parent admits this through the same durable turn inbox ownership model used
-for child HITL and terminal results, but handles it as a separate payload. It
-rejects stale revisions, associates the child with the pending call, reduces
-the child snapshot into its own state, and publishes its new snapshot upward
-if it is itself delegated.
-
-Snapshots, rather than every raw child event, provide three properties:
-
-1. a parent never needs to replay the child's complete event history;
-2. nested trees compose one level at a time;
-3. update volume can be coalesced without losing current desired state.
-
-The snapshot must retain stable child and action identities so a channel can
-display parallel work rather than collapsing everything to the latest string.
-Parent canonical reduction embeds the child without lossy summarization; the
-root channel decides what to summarize, hide, reorder, or expand.
-
-Terminal delivery and progress delivery can race. Revisions and the terminal
-fact must make both orders converge to the same parent projection. A late child
-snapshot cannot resurrect a settled call.
-
-## Durability and ownership
-
-Reducer state belongs to the session's durable runtime state, not process-local
-maps or channel adapter state. Reduction occurs in the same durable step that
-observes the source lifecycle event. A changed delegated projection is then
-forwarded through a workflow hook step to its parent.
-
-The root channel renderer observes projections after they have been adopted
-into serialized context. Its effect checkpoint includes updated channel state.
-External APIs without idempotency still have an unavoidable response/checkpoint
-crash window; initial implementations should prefer naturally idempotent
-replace operations and explicitly document create-operation semantics rather
-than claiming exactly-once posts.
-
-Progress propagation must never block model execution or terminal settlement
-indefinitely. Failed parent notification or channel rendering is diagnostic;
-the latest durable projection can be retried or superseded by a newer revision.
-
-## Open decisions
-
-1. Is `progress.updated` part of the public client stream, only an authored
-   hook event, or both? Publishing snapshots helps non-channel clients but
-   creates a long-lived protocol contract.
-2. Which reasoning representation is safe and useful as progress? Raw reasoning
-   may be unsupported by some providers and inappropriate to expose verbatim.
-3. Should a custom channel that uses model summarization receive a framework
-   cache helper, or own caching in durable channel state?
-4. How are reducer versions pinned and migrated for sessions spanning
-   deployments?
-5. What coalescing boundary prevents reasoning deltas from producing excessive
-   workflow steps while preserving prompt updates?
-6. Besides `reportProgress()` and structured plans, is another typed
-   domain-specific contribution needed?
-7. Should typed tool projectors for `action.partial` ship initially, or follow
-   the explicit `reportProgress()` API?
-8. At what boundary are rapid tool partials coalesced so clients retain the
-   full incremental stream while parent progress receives only meaningful
-   snapshots?
-9. At which turn/step settlement boundary should completed child internals
-   collapse, especially when persistent subagent sessions are continued by a
-   later call?
-10. Is elapsed time a renderer projection over durable `startedAt`, or semantic
-    progress? It should not require a new child revision every minute.
-11. How should remote liveness observations enter progress without confusing
-    "no recent event" with failure?
-12. Should the framework todo gain stable item ids, title, and description, or
-    should richer plans remain a separate contribution? How should parent and
-    child plans settle for channel renderers?
-13. What size bound on the canonical graph permits low-loss propagation without
-    unbounded session growth? Retention should be explicit and deterministic,
-    not delegated to a summarization model.
-14. Does the channel summarizer receive auth/audience metadata so it can avoid
-    exposing child details inappropriate for a shared thread, or must the
-    canonical projection be visibility-labeled before it reaches the channel?
-
-## Implementation sequence
-
-1. Add pure internal progress facts, native turn/step/action scopes, optional
-   plan projection, durable reducer state, and tests for planless and planned
-   root sessions. Do not change channel output.
-2. Add `reportProgress()`, automatic MCP adaptation, and optional partial-output
-   projection behind the same action-local report path.
-3. Add a versioned child-progress hook payload and prove nested, parallel,
-   stale-update, terminal-race, retry, and cancellation semantics.
-4. Feed root projections to the channel progress callback and adapt Slack's
-   existing status behavior as the first renderer without changing visible
-   defaults.
-5. Spike Slack plan and message presets, including a parallel-child block
-   renderer. Use them to validate the projection shape.
-6. Only then expose public APIs, documentation, and a changeset.
-
-## Verification
-
-- planless native step/action ladders and optional plans reduce deterministically
-  across replay;
-- two parallel child calls retain independent identities and ordering;
-- nested child updates bubble one parent at a time to the root;
-- stale or late child revisions cannot overwrite terminal state;
-- reducer and propagation failures do not fail an active turn;
-- a renderer retry does not alter reducer state or emit a new child revision;
-- indicator and message/block renderers consume the same projection;
-- existing Slack-visible behavior remains unchanged until a renderer is
-  explicitly selected.
+- a custom agent reducer;
+- authored retention counts;
+- inferred action-to-plan-item ownership;
+- raw reasoning in the work graph;
+- exactly-once external message creation;
+- public remote-agent progress negotiation in v1;
+- automatic model summarization in canonical reduction;
+- replacing the durable event stream with the live work graph.

--- a/research/durable-hierarchical-progress.md
+++ b/research/durable-hierarchical-progress.md
@@ -87,191 +87,21 @@ and more frequent than useful status changes, and are independently valuable
 to clients. Progress reduction may consume them without making every partial a
 progress revision or forwarding raw partials through the subagent tree.
 
-## Existing agent workarounds
+## Design boundary
 
-Internal agents already implement two ends of the desired design outside eve.
-They are useful requirements, not APIs to preserve.
+The proposal separates four responsibilities:
 
-`v` maintains a small delegation reducer in its Slack channel state:
+1. operations publish structured reports or partial-output projections;
+2. eve materializes deterministic canonical progress from existing turn, step,
+   action, blocker, plan, and child-session state;
+3. delegated sessions publish versioned canonical snapshots to their parent;
+4. the root channel selects, summarizes, and reconciles a presentation,
+   including timer-driven refresh when the presentation expires.
 
-- `actions.requested` extracts remote and local calls by `callId`, records
-  `pendingDelegations`, and reduces names to `calling d0 + content...`;
-- `action.result` removes the matching call and records failures and elapsed
-  time;
-- a detached 75-second loop re-renders that same status, adds elapsed minutes,
-  posts a five-minute still-working notice, and eventually probes remote child
-  sessions before deciding whether work is alive, stalled, or unknown;
-- `subagent.called` is attached by reaching into the channel adapter because
-  the public Slack event map cannot expose the child session id. The id is
-  copied to Postgres because the detached refresh invocation cannot read the
-  parent's durable channel state.
-
-This is an operation-set reducer plus a channel reconciler, but lifecycle,
-liveness, rendering, timer ownership, and external persistence are interleaved.
-It demonstrates that a useful aggregate needs stable call identity, child
-session identity, parallel labels, elapsed time, stale/unknown semantics, and
-an explicit distinction between refreshing presentation and changing progress.
-
-`e0` demonstrates structured, model-authored progress. Its current `todo`
-override extends eve's durable todo state with a sticky plan `title` and required
-per-step `description`. Each successful todo result is a complete snapshot. The
-Slack channel projects it to Slack's native `plan` block with one `task_card`
-per item:
-
-```ts
-{
-  type: "plan",
-  title: plan.title ?? "Plan",
-  tasks: plan.todos.map((todo, index) => ({
-    type: "task_card",
-    task_id: `todo-${index}`,
-    title: todo.content,
-    details: richText(todo.description),
-    status: mapTodoStatus(todo.status),
-  })),
-}
-```
-
-The renderer keeps `{ messageTs, title, todos, turnId }` in durable Slack channel
-state. Later snapshots in the same turn update that message; a new turn posts a
-new card; a missing message posts a replacement. Terminal completion marks
-unfinished tasks complete, while failure or cancellation marks them errored.
-The plan block is treated as a capability: after `invalid_blocks` or
-`invalid_block_type`, the renderer persists that rejection and uses a Markdown
-list plus `N of M steps` fallback for the rest of the session.
-
-This is stronger prior art than a generic block renderer. The producer schema
-was shaped by a concrete presentation need (`title` and `description`), yet its
-output remains semantic and independently useful. The renderer owns Slack's
-status mapping, rich-text conversion, message identity, update/recovery,
-terminal settlement, clipping, and capability fallback. It argues for a
-first-class canonical `plan` contribution in eve rather than representing every
-plan as generic action nodes or arbitrary annotations.
-
-An earlier e0 implementation attached to local child session streams and
-rendered each child's todo plan separately. The current implementation removed
-child-plan fan-in and follows child streams only to refresh the flat typing
-status from child reasoning/action events. That retreat is informative: raw
-child event mirroring made ownership and Slack-message reconciliation complex.
-Framework-owned child progress snapshots should make nested plan rendering
-possible without channel-side stream attachment.
-
-Together these implementations favor a layered authoring model:
-
-1. tools publish structured snapshots or tool-owned progress contributions;
-2. eve owns the default action/child tree and lifecycle invariants;
-3. the agent level materializes a deterministic canonical progress graph;
-4. the root channel selects and summarizes that graph, then reconciles the
-   presentation, including timer-driven refresh.
-
-Other internal agents reinforce this boundary. Revoa executes approved plans
-with deterministic per-step callbacks carrying step index, total, description,
-and result, then maps those facts to one updated Slack message. CSE maintains a
-durable investigation budget from `actions.requested`: deadline, maximum
-subagent calls, and calls used. Devbox maps known tools to authored activity
-labels and deliberately suppresses noisy polling while retaining task state.
-None of the inspected channel implementations invokes an LLM to derive status
-from lifecycle events. They use typed state, stable identities, and explicit
-policy, then apply opinion only while rendering.
-
-## External prior art
-
-No inspected framework provides the complete combination of durable canonical
-progress, hierarchical child rollup, and channel-specific summarization. The
-closest systems support distinct pieces and generally preserve structured facts
-before rendering them.
-
-### AG-UI activities
-
-[AG-UI](https://github.com/ag-ui-protocol/ag-ui) is the closest presentation
-protocol. `ACTIVITY_SNAPSHOT` carries a stable `messageId`, open
-`activityType`, and arbitrary structured `content`; `ACTIVITY_DELTA` applies
-RFC 6902 patches to that content. Its Mastra background-agent example maps a
-long-running tool to an activity whose content includes task id, tool name,
-status, arguments, outputs, and result, while a custom renderer displays a
-Background Task card. Normal tool rendering can be suppressed without losing
-the structured activity.
-
-This supports snapshot identity, replace-in-place semantics, open activity
-types, and renderer-owned presentation. It does not define how nested agents
-reduce their activity into a parent, durability/replay semantics, or a canonical
-cross-agent schema. eve can potentially project its root canonical graph into
-AG-UI activity snapshots without adopting AG-UI as internal durable state.
-
-### A2A tasks
-
-The [Agent2Agent protocol](https://github.com/a2aproject/A2A) separates a
-retrievable `Task` snapshot from streamed updates. A task has lifecycle state,
-status message, artifacts, history, and metadata. `TaskStatusUpdateEvent`
-replaces status using stable task and context ids; `TaskArtifactUpdateEvent`
-updates an artifact independently and supports append/final-chunk semantics.
-Disconnected clients receive significant notifications and then fetch the
-complete current task.
-
-A2A validates the snapshot-plus-notification model and the separation between
-status and incremental output. Its lifecycle is intentionally coarse
-(`working`, `input-required`, `auth-required`, terminal states), its status
-message is agent-authored prose, and it does not standardize nested child trees
-or presentation reduction.
-
-### LangGraph state and stream projections
-
-[LangGraph](https://github.com/langchain-ai/langgraph) combines deterministic
-state-channel reducers with separate stream modes. Nodes can emit arbitrary
-`custom` stream data through a runtime writer. Stream events carry namespaces,
-and subgraph streaming preserves nested namespaces. Its newer stream
-transformers observe the event mux and build typed derived projections without
-changing graph state; async derived work can land on an independent projection.
-
-This is strong precedent for keeping durable execution state separate from
-consumer projections and for preserving hierarchy through namespaces. The
-custom writer remains an untyped data plane, however, and LangGraph does not
-supply an opinionated agent-progress graph or channel refresh contract.
-
-### Agent SDK lifecycle streams
-
-OpenAI Agents SDK and AutoGen expose normalized higher-level events for tool
-calls/results, handoffs or agent changes, messages, and reasoning. AutoGen
-explicitly describes agent events as observable by users and applications, not
-agent-to-agent communication. These are useful fact sources but leave state
-materialization and presentation to consumers. They resemble eve's existing
-stream more than the proposed canonical progress layer.
-
-Google ADK preserves hierarchy more explicitly: events carry workflow node
-paths, parent run identity, branch/isolation scope, output ownership, and state
-deltas. This is relevant to canonical child identity and visibility, but it is
-still a session event model rather than a reduced progress projection.
-
-### Operation-local progress
-
-MCP progress notifications correlate `progress`, optional `total`, and optional
-message to one request token. Temporal activity heartbeats persist arbitrary
-latest details, support retry resumption, and double as liveness/cancellation
-checkpoints. Both reinforce operation-local typed progress with stable identity.
-Neither performs agent-level rollup. Temporal heartbeats are control-plane
-state, not a user-facing event stream, which is a useful warning not to equate
-liveness with presentation.
-
-### Design consequence
-
-The recurring external shape is:
-
-```text
-operation events or snapshots
-        │ stable id + structured state
-        ▼
-durable task/graph state
-        │ notification or projection stream
-        ▼
-consumer-owned renderer
-```
-
-AG-UI is the strongest precedent for the outer activity/rendering boundary;
-A2A for durable task snapshots and reconnect; LangGraph and Google ADK for
-hierarchical identity and derived projections; MCP and Temporal for
-operation-local progress. None is evidence for lossy or model-based reduction
-inside every child. An optional channel summarizer remains a novel but natural
-consumer-owned stage, and should cache by canonical projection fingerprint.
+Canonical progress is desired state, not an audit log and not presentation
+commands. The durable event stream remains the complete history. Channel state
+owns external message ids, capability fallbacks, cached summaries, and refresh
+policy.
 
 ## Public API design space
 
@@ -300,7 +130,22 @@ interface ProgressScope {
   readonly summary?: string;
   readonly startedAt: string;
   readonly updatedAt: string;
-  readonly activities: readonly ProgressActivity[];
+  readonly turn?: ProgressTurn;
+}
+
+interface ProgressTurn {
+  readonly id: string;
+  readonly phase: ProgressPhase;
+  readonly plan?: ProgressPlan;
+  readonly steps: readonly ProgressStep[];
+  readonly blockers: readonly ProgressBlocker[];
+}
+
+interface ProgressStep {
+  readonly stepIndex: number;
+  readonly phase: ProgressPhase;
+  readonly label?: string;
+  readonly actions: readonly (ProgressAction | ProgressChild)[];
 }
 
 type ProgressActivity = ProgressAction | ProgressChild | ProgressPlan | ProgressBlocker;
@@ -313,9 +158,11 @@ interface ProgressChild extends ProgressActivityBase {
 }
 ```
 
-This is easiest for renderers and naturally represents nested agents. Updating a
-deep child replaces a path and can duplicate large subtrees on the wire unless
-snapshots are bounded or structurally shared internally.
+This is easiest for renderers and naturally represents nested agents. A session
+has at most one live turn projection; completed turn history stays in the event
+stream rather than accumulating in `ProgressScope`. Updating a deep child
+replaces a path and can duplicate large subtrees on the wire unless snapshots
+are bounded or structurally shared internally.
 
 #### Normalized graph
 
@@ -332,7 +179,7 @@ interface ProgressNode {
   readonly kind: "agent" | "action" | "plan" | "blocker";
   readonly phase: ProgressPhase;
   readonly children: readonly string[];
-  readonly contribution?: ProgressContribution;
+  readonly report?: ProgressReport;
 }
 ```
 
@@ -363,18 +210,20 @@ counts, timestamps, and errors remain portable.
 ```ts
 type ProgressPhase = "queued" | "running" | "blocked" | "completed" | "failed" | "cancelled";
 
-interface ProgressContribution {
-  readonly label?: string;
-  readonly detail?: string;
-  readonly completed?: number;
+interface ProgressReport {
+  readonly message?: string;
+  readonly progress?: number;
   readonly total?: number;
   readonly unit?: string;
 }
 ```
 
-`label` and `detail` are semantic authored copy, not channel markup. They are
-optional because an action's tool or agent name is already a deterministic
-fallback.
+`message` is semantic authored copy, not channel markup. `progress` is the
+amount completed, not necessarily a percentage; `total` uses the same scale.
+Numeric fields align with MCP progress notifications, while eve adds optional
+`unit` and permits message-only reports. Correlation is not public payload:
+authored tools inherit their active `callId`, and the MCP adapter privately maps
+`progressToken` to that call.
 
 Plans deserve a core canonical variant rather than a namespaced annotation:
 
@@ -393,9 +242,10 @@ interface ProgressPlanItem {
 }
 ```
 
-This directly covers e0's Slack plan card while remaining useful to web, TUI,
-and other channels. Stable item ids should come from the producer rather than
-e0's current array index, so reordering or insertion does not change identity.
+This supports plan cards, web checklists, and pinned TUI plans. The current
+framework todo schema has no plan title, description, or item id. A first-class
+plan contribution therefore requires a deliberate todo API change if stable
+item identity is part of the contract.
 
 ### Producer APIs
 
@@ -406,9 +256,9 @@ There are three useful producer shapes, and eve likely needs two of them.
 ```ts
 export default defineTool({
   async execute(input, ctx) {
-    await ctx.progress.report({
-      label: "Indexing documents",
-      completed: 250,
+    await ctx.reportProgress({
+      message: "Indexing documents",
+      progress: 250,
       total: 1_000,
       unit: "documents",
     });
@@ -416,11 +266,18 @@ export default defineTool({
 });
 ```
 
-This is natural for callbacks, MCP progress, and long operations that know when
-a meaningful milestone occurs. `report` must be asynchronous and revisioned.
-Its durability semantics must be explicit: it sends an out-of-band checkpoint
-rather than pretending an atomic tool step committed early. Rapid reports may
-coalesce latest-per-call while preserving the latest accepted checkpoint.
+This is initially a `ToolContext` API: the active `callId` supplies ownership.
+It is natural for long operations that know when a meaningful milestone occurs.
+`reportProgress` must be asynchronous and revisioned. Its durability semantics must be explicit: it sends an out-of-band
+checkpoint rather than pretending an atomic tool step committed early. Rapid
+reports may coalesce latest-per-call while preserving the latest accepted
+checkpoint.
+
+MCP tools get this path without authored configuration when their server emits
+`notifications/progress`. The MCP client supplies a private `progressToken`,
+correlates the notification back to the active eve `callId`, and submits the
+same internal report. MCP supplies no hierarchy; ordinary eve child snapshots
+carry the resulting action progress upward.
 
 #### Projection from tool lifecycle and partial output
 
@@ -432,17 +289,17 @@ export default defineTool({
   },
   progress: {
     started(input) {
-      return { label: `Indexing ${input.collection}` };
+      return { message: `Indexing ${input.collection}` };
     },
     updated(output) {
       return {
-        completed: output.indexed,
+        progress: output.indexed,
         total: output.total,
         unit: "documents",
       };
     },
     completed(output) {
-      return { label: `Indexed ${output.total} documents` };
+      return { message: `Indexed ${output.total} documents` };
     },
   },
 });
@@ -459,10 +316,11 @@ but should be additive. Requiring the model to narrate every operation is noisy
 and unreliable. Structured `todo` remains the better source for multi-step
 plans.
 
-Recommended producer API: support explicit `ctx.progress.report()` and an
+Recommended producer API: support explicit `ctx.reportProgress()` and an
 optional typed `progress` projector on `defineTool`. Both normalize to the same
-`ProgressContribution`; the last accepted explicit report wins over an inferred
-partial contribution until another lifecycle boundary.
+`ProgressReport`; the last accepted explicit report wins over an inferred
+partial contribution until another lifecycle boundary. The projector is a
+convenience for `action.partial`; explicit reporting remains the primary API.
 
 ### Agent-level authoring
 
@@ -479,26 +337,50 @@ break child and terminal invariants. Fixed retention counts are also the wrong
 abstraction: canonical progress is scoped around meaningful work, not a sliding
 window of recent events.
 
+Plans are optional. Today a turn has model-step and action-batch boundaries;
+it has a plan only when the model calls the framework `todo` tool. Without a
+plan, eve builds a faithful ladder from those existing boundaries:
+
 ```text
 turn
-└── plan
-    ├── item: Reproduce
-    │   ├── search logs       [completed]
-    │   └── run test          [completed]
-    ├── item: Implement fix   [running]
-    │   ├── edit file         [completed]
-    │   └── run tests         [running]
-    └── item: Open PR         [pending]
+├── step 0 [completed]
+│   ├── search logs [completed]
+│   └── read source [completed]
+└── step 1 [running]
+    ├── researcher [running]
+    │   └── child progress…
+    └── run reproduction [running]
+```
+
+Actions observed under the same `stepIndex` are siblings; the runtime's action
+state determines which are concurrently active, since `actions.requested` may
+arrive incrementally. A subagent action owns its child scope. Optional pre-tool
+narration may label the step; otherwise channels derive mechanical copy from
+action names. When `todo` exists, the canonical turn also carries its structured
+plan:
+
+```text
+turn
+├── plan
+│   ├── Reproduce [completed]
+│   ├── Implement fix [running]
+│   └── Open PR [pending]
+└── steps
+    └── current step
+        ├── edit file [completed]
+        └── run tests [running]
 ```
 
 The framework applies deterministic scope-based compaction:
 
 - retain every active or blocked action;
-- attach actions to the most specific active plan item, child, or implicit turn
-  phase;
-- while a scope is active, retain its completed actions;
-- when a plan item completes, retain its outcome and collapse internal action
-  detail from the live projection;
+- group planless actions by native step and action-batch boundaries rather than
+  inferring a plan;
+- keep the optional plan and native step ladder as orthogonal views: the current
+  protocol does not identify which action implements which todo item;
+- while a step is active, retain its completed actions;
+- when a step completes, retain its outcome and collapse internal action detail
+  from the live projection;
 - retain failed/cancelled detail sufficient to explain the outcome;
 - retain the current plan and active child scopes until their owning turn
   settles;
@@ -506,7 +388,7 @@ The framework applies deterministic scope-based compaction:
 
 Whether completed scopes are expanded or hidden is channel presentation policy.
 `preferPlans` therefore does not belong on the agent definition either.
-Agent-authored semantic state enters through structured plans and
+Agent-authored semantic state enters through optional structured plans and
 `reportProgress()`, not a custom canonical reducer. Defer agent annotations and
 reducer middleware until adoption demonstrates information that cannot be
 expressed as a contribution.
@@ -540,7 +422,7 @@ For remote agents, capability negotiation can accept either:
 }
 ```
 
-or a coarse A2A-style task status that eve adapts into one child node. Lack of
+or a coarse remote task status that eve adapts into one child node. Lack of
 progress capability leaves the child as a running node until its terminal
 result.
 
@@ -592,45 +474,40 @@ progress: {
 This resembles UI reducers but mixes pure state and effects unless another
 command layer is introduced.
 
-Recommended channel API: project then reconcile.
+The recommended initial channel API is the one effectful callback. It receives
+an extensible input object and owns presentation state in the channel's existing
+durable state:
 
 ```ts
-interface ChannelProgressProjectContext {
-  readonly reason: "changed" | "terminal";
-  readonly previous?: ChannelProgressPresentation;
-  readonly session: SessionContext["session"];
-}
-
-interface ChannelProgressReconcileContext<TPresentation> {
-  readonly presentation: TPresentation;
-  readonly previous?: TPresentation;
+interface ChannelProgressInput {
+  readonly progress: ProgressSnapshot;
   readonly reason: "changed" | "refresh" | "terminal";
 }
 
-interface ChannelProgressReconcileResult {
+interface ChannelProgressResult {
   readonly refreshAfterMs?: number;
 }
 ```
 
-For a custom channel:
-
 ```ts
 export default defineChannel({
   state: { progressMessageId: null },
-  progress: defineChannelProgress({
-    project(progress) {
-      return mechanicalSummary(progress);
-    },
-    async reconcile(input, channel) {
-      channel.state.progressMessageId = await upsertProgressMessage(
-        channel.state.progressMessageId,
-        input.presentation,
-      );
-      return {};
-    },
-  }),
+  async progress({ progress, reason }, channel, ctx) {
+    channel.state.progressMessageId = await upsertProgressMessage({
+      messageId: channel.state.progressMessageId,
+      progress,
+      reason,
+    });
+    return {};
+  },
 });
 ```
+
+Built-in channel presets may internally split pure projection from effects and
+cache model-generated summaries by canonical fingerprint. A custom callback
+that invokes a model owns equivalent caching. Keep `defineChannelProgress({
+project, reconcile })` as a possible later convenience rather than part of the
+initial surface.
 
 For Slack, the built-in offers presets and an escape hatch:
 
@@ -649,37 +526,36 @@ slackChannel({
 
 slackChannel({
   progress: slackProgress.plan({
-    select(progress) {
-      return progress.root.activities.find(
-        (activity): activity is ProgressPlan => activity.kind === "plan",
-      );
-    },
+    fallback: slackProgress.status(),
   }),
 });
 
 slackChannel({
-  progress: defineSlackProgress({ project, reconcile }),
+  async progress({ progress, reason }, channel) {
+    return renderCustomSlackProgress({ channel, progress, reason });
+  },
 });
 ```
 
 `slackProgress.status()` refreshes the cached status presentation before Slack
-expires it. `slackProgress.message()` updates a thread message and normally
-requests no refresh. `progress: false` suppresses the built-in renderer without
-suppressing canonical progress or `progress.updated` observation.
+expires it. `slackProgress.plan()` selects the optional canonical plan and falls
+back when a turn has none. `slackProgress.message()` updates a thread message
+and normally requests no refresh. `progress: false` suppresses the built-in
+renderer without suppressing canonical progress or `progress.updated`
+observation.
 
 ### API recommendation
 
 The smallest coherent first public surface is:
 
-1. `ProgressContribution`, `ProgressSnapshot`, and recursive read-only node
-   types;
-2. `ctx.progress.report()` for operation-local milestones;
+1. `ProgressReport`, `ProgressSnapshot`, and recursive read-only node types;
+2. `ctx.reportProgress()` for operation-local milestones and automatic MCP
+   progress adaptation;
 3. optional typed tool `progress` projectors;
 4. deterministic framework-owned scope reduction, with no initial agent config;
 5. `progress.updated` as an observe-only hook event;
-6. `defineChannelProgress({ project, reconcile })` with cached project output
-   and refresh reasons;
-7. Slack status and message presets built on the same channel contract.
+6. one effectful channel `progress({ progress, reason }, channel, ctx)` callback;
+7. Slack status, plan, and message presets built on the same channel contract.
 
 The runtime child propagation protocol remains internal until remote capability
 negotiation requires a public wire contract.
@@ -691,9 +567,10 @@ negotiation requires a public wire contract.
 A progress fact records a meaningful lifecycle transition, not presentation
 instructions. Initial facts should cover:
 
-- turn started, waiting, completed, failed, or cancelled;
+- turn and model-step started, completed, failed, or cancelled, preserving
+  `stepIndex`;
 - reasoning summary changed;
-- actions requested and actions settled, keyed by call id;
+- action batches requested and actions settled, keyed by call id;
 - authorization or human input required and resumed;
 - delegated child started, updated, and settled, keyed by call id and child
   session id;
@@ -703,15 +580,16 @@ instructions. Initial facts should cover:
 Facts need stable identities and ordering coordinates. They must not contain
 Slack text, blocks, message timestamps, refresh intervals, or API operations.
 High-frequency stream deltas and tool partials may be ignored or coalesced
-before reduction, but the latest desired projection must cross the next
-durable boundary. A default reducer should not guess status text from arbitrary
-partial output. An authored reducer can interpret a tool's domain-specific
-snapshot; a future tool-level projector could explicitly map `TOutput` to a
-small progress contribution without changing what clients or the model see.
+before reduction, but the latest desired projection must cross the next durable
+boundary. A default reducer should not guess status text from arbitrary partial
+output. An authored tool projector can interpret its domain-specific snapshot
+and map
+`TOutput` to a small progress report without changing what clients or the model
+see.
 
 ### Canonical agent projection
 
-The agent-level reducer folds facts into durable canonical state. It must be
+The framework canonical reducer folds facts into durable agent state. It must be
 deterministic, side-effect free, and deliberately low-loss so workflow retries
 produce the same result and every parent receives enough structure to choose a
 different presentation. It may compact transport detail, such as replacing ten
@@ -719,39 +597,23 @@ partials for one call with the latest typed contribution, but should retain
 active action identities, child projections, plan items, phases, timestamps,
 errors, and terminal outcomes.
 
-A default reducer can preserve today's broad behavior while producing a
-channel-neutral tree:
+The public read shape is the recursive `ProgressSnapshot` above: agent scope,
+the live turn, its native step ladder, optional plan, actions, blockers, and
+nested child snapshots. The runtime may normalize this graph internally.
 
-```ts
-interface ProgressNode {
-  readonly id: string;
-  readonly phase: "active" | "blocked" | "completed" | "failed" | "cancelled";
-  readonly summary?: string;
-  readonly children?: readonly ProgressNode[];
-}
-```
-
-This shape is illustrative rather than final. In particular, completed child
-retention, ordering, error detail, and whether `summary` is authored text or a
-structured activity need API design.
-
-Custom reduction should be configured independently from channel rendering.
-Two viable authoring shapes need a spike:
-
-1. **Constrained projection:** users customize `(projection, fact) =>
-ProgressNode`. Every channel can understand the result, but the shared shape
-   may become either too weak or presentation-shaped.
-2. **Generic projection:** users own serializable reducer state and output;
-   their channel reconciler consumes the matching type. This is expressive but
-   requires a clean way to connect agent and channel types across filesystem
-   definitions and delegated-agent boundaries.
+Canonical reduction is framework-owned and zero-config. Do not expose an
+agent-level reducer initially: custom reduction could discard child progress,
+break terminal precedence, or make different agents publish incompatible
+snapshots. Opinionated selection and summarization belong in the channel
+callback.
 
 Do not require an agent author to reconstruct the action map, child revision
 checks, terminal precedence, or retention. Those are framework invariants.
 Agent-level authoring should add typed domain contributions, not collapse the
 graph to one display string. Tool-level projectors answer what one operation's
 output means; the canonical reducer combines and scope-compacts those
-contributions without deciding what a particular audience should see.
+contributions around native turns and steps, and optional plans when present,
+without deciding what a particular audience should see.
 
 A child may publish an explicit semantic summary because it understands its own
 domain, but that summary is one field alongside its canonical child projection,
@@ -761,9 +623,9 @@ information loss. If a very wide tree eventually requires hierarchical model
 summaries, store them as optional derived annotations keyed by the source
 projection fingerprint and always propagate the source projection too.
 
-Start with the constrained internal projection to establish semantics. Do not
-expose a public reducer until the tree survives nested delegation without
-channel-specific fields.
+Do not expose a public agent reducer until the tree survives nested delegation
+without channel-specific fields and a concrete adoption cannot be expressed as
+a progress report or channel projection.
 
 ### Channel reconciler
 
@@ -802,7 +664,7 @@ interface ChildProgressUpdate {
   readonly callId: string;
   readonly childSessionId: string;
   readonly revision: number;
-  readonly projection: ProgressNode;
+  readonly projection: ProgressSnapshot;
   readonly subagentName: string;
 }
 ```
@@ -819,10 +681,10 @@ Snapshots, rather than every raw child event, provide three properties:
 2. nested trees compose one level at a time;
 3. update volume can be coalesced without losing current desired state.
 
-The snapshot must retain stable child and action identities so a custom reducer
-can display parallel work rather than collapsing everything to the latest
-string. Parent reduction remains authoritative: it can summarize, hide, reorder,
-or retain child nodes instead of blindly embedding them.
+The snapshot must retain stable child and action identities so a channel can
+display parallel work rather than collapsing everything to the latest string.
+Parent canonical reduction embeds the child without lossy summarization; the
+root channel decides what to summarize, hide, reorder, or expand.
 
 Terminal delivery and progress delivery can race. Revisions and the terminal
 fact must make both orders converge to the same parent projection. A late child
@@ -865,34 +727,35 @@ and child propagation are unchanged in either case.
 
 ## Open decisions
 
-1. Is a progress projection part of the public event stream, or only an
-   internal channel/subagent projection? Publishing it helps non-channel
-   clients but creates a long-lived protocol contract.
+1. Is `progress.updated` part of the public client stream, only an authored
+   hook event, or both? Publishing snapshots helps non-channel clients but
+   creates a long-lived protocol contract.
 2. Which reasoning representation is safe and useful as progress? Raw reasoning
    may be unsupported by some providers and inappropriate to expose verbatim.
-3. Should custom reducers be agent-level, channel-level, or composed from an
-   agent reducer and a channel projection policy?
+3. Should a custom channel that uses model summarization receive a framework
+   cache helper, or own caching in durable channel state?
 4. How are reducer versions pinned and migrated for sessions spanning
    deployments?
 5. What coalescing boundary prevents reasoning deltas from producing excessive
    workflow steps while preserving prompt updates?
-6. Should a parent receive only the child's default projection, or can a child
-   publish structured domain-specific progress explicitly?
-7. Should tools declare a `toProgress`-style projector for `action.partial`
-   snapshots, rely on the agent reducer to recognize their output, or gain a
-   separate explicit progress-reporting API?
+6. Besides `reportProgress()` and structured plans, is another typed
+   domain-specific contribution needed?
+7. Should typed tool projectors for `action.partial` ship initially, or follow
+   the explicit `reportProgress()` API?
 8. At what boundary are rapid tool partials coalesced so clients retain the
    full incremental stream while parent progress receives only meaningful
    snapshots?
-9. How long do completed child nodes remain in the projection, especially when
-   persistent subagent sessions are continued by a later call?
+9. At which turn/step settlement boundary should completed child internals
+   collapse, especially when persistent subagent sessions are continued by a
+   later call?
 10. Is elapsed time a renderer concern, a refresh-time projection over durable
-    `startedAt`, or semantic progress? v needs it without creating a new child
+    `startedAt`, or semantic progress? It should not require a new child
     revision every minute.
-11. How should liveness observations such as v's remote session probes enter
-    progress without confusing "no recent event" with failure?
-12. Can root and child structured plans use one projection while retaining e0's
-    policy that completed root plans remain visible and child plans disappear?
+11. How should remote liveness observations enter progress without confusing
+    "no recent event" with failure?
+12. Should the framework todo gain stable item ids, title, and description, or
+    should richer plans remain a separate contribution? How should parent and
+    child plans settle for channel renderers?
 13. What size bound on the canonical graph permits low-loss propagation without
     unbounded session growth? Retention should be explicit and deterministic,
     not delegated to a summarization model.
@@ -902,21 +765,24 @@ and child propagation are unchanged in either case.
 
 ## Implementation sequence
 
-1. Add pure internal progress facts, a default reducer, durable reducer state,
-   and tests for one root session. Do not change channel output.
-2. Add a versioned child-progress hook payload and prove nested, parallel,
+1. Add pure internal progress facts, native turn/step/action scopes, optional
+   plan projection, durable reducer state, and tests for planless and planned
+   root sessions. Do not change channel output.
+2. Add `reportProgress()`, automatic MCP adaptation, and optional partial-output
+   projection behind the same action-local report path.
+3. Add a versioned child-progress hook payload and prove nested, parallel,
    stale-update, terminal-race, retry, and cancellation semantics.
-3. Feed root projections to an internal channel reconciler and adapt Slack's
+4. Feed root projections to the channel progress callback and adapt Slack's
    existing status behavior as the first renderer without changing visible
    defaults.
-4. Spike an alternate Slack reconciler that maintains a thread message with
-   parallel child blocks. Use the spike to validate the projection shape.
-5. Only then expose reducer/reconciler authoring APIs, documentation, and a
-   changeset.
+5. Spike Slack plan and message presets, including a parallel-child block
+   renderer. Use them to validate the projection shape.
+6. Only then expose public APIs, documentation, and a changeset.
 
 ## Verification
 
-- root lifecycle facts reduce deterministically across replay;
+- planless native step/action ladders and optional plans reduce deterministically
+  across replay;
 - two parallel child calls retain independent identities and ordering;
 - nested child updates bubble one parent at a time to the root;
 - stale or late child revisions cannot overwrite terminal state;

--- a/research/durable-hierarchical-progress.md
+++ b/research/durable-hierarchical-progress.md
@@ -15,25 +15,24 @@ channel effects. A root channel can render a selected view without rebuilding
 execution ownership from raw streams.
 
 ```text
-runtime lifecycle + child observations
-                 │
-                 ▼
-        durable work graph
-                 │
-                 ▼
-     channel-specific presentation
+runtime lifecycle + task updates
+                │
+                ▼
+       durable work graph
+                │
+                ▼
+    channel-specific presentation
 ```
 
-The implementation experiment has validated the main boundary:
+The implementation experiment validated the main boundary:
 
-- ordinary turn, step, action, blocker, and local-child state can reduce into a
+- ordinary turn, step, action, blocker, and child-task state can reduce into a
   useful graph without authored progress calls;
-- local child snapshots can be read without forwarding every child event;
 - Slack can render compact status and hierarchical activity from the same graph;
-- observation polling must remain separate from the parent's terminal-result
-  control loop;
-- channel presentation state needs explicit ownership across parent and monitor
-  workflows.
+- channel presentation state needs explicit ownership across parent and
+  rendering workflows;
+- polling child streams adds orchestration and does not scale to background or
+  remote work, so it should not be part of the proposed architecture.
 
 Since the original proposal, eve also gained child-authored `task_update`
 notifications for background tasks in [PR #2113](https://github.com/vercel/eve/pull/2113).
@@ -81,25 +80,25 @@ and presentation.
    the complete audit trail.
 5. **Reduction is framework-owned.** Agents do not customize graph invariants,
    child revisions, retention, or terminal precedence.
-6. **Children own their projections.** Parents read versioned child state rather
-   than ingesting every raw child event.
-7. **Control and observation stay separate.** Terminal results, input, and
-   authorization use immediate control paths. Routine child observations must
-   not destabilize or wake the parent turn for every step.
+6. **Task runs own child delivery.** Parents consume durable task views and
+   deduplicated task notifications rather than raw child events.
+7. **Reuse task delivery.** Terminal results, input, authorization, and explicit
+   task updates use the existing task inbox or callback transport. Progress
+   must not introduce child-stream readers or polling workflows.
 8. **Presentation belongs to channels.** The graph contains no Slack blocks,
    message IDs, API operations, or presentation timers.
 9. **Blockers are first-class.** Waiting for input, authorization, or approval is
    authoritative state, not an absence of progress.
-10. **Terminal state wins.** Late, replayed, or polled updates cannot resurrect
-    settled actions or channel activity.
+10. **Terminal state wins.** Late or replayed updates cannot resurrect settled
+    actions or channel activity.
 
 ## Proposed core semantics
 
 ### Session-relative work graph
 
 The initial graph should remain small and internal. A session-relative shape is
-sufficient; recursive child snapshots provide hierarchy without requiring a
-public root wrapper:
+sufficient. Delegated task nodes provide hierarchy without importing a child's
+raw event stream:
 
 ```ts
 type WorkPhase = "queued" | "running" | "blocked" | "completed" | "failed" | "cancelled";
@@ -129,15 +128,16 @@ interface WorkAction {
   readonly phase: WorkPhase;
   readonly detail?: string;
   readonly update?: WorkUpdate;
-  readonly child?: {
-    readonly sessionId: string;
-    readonly work?: WorkGraph;
+  readonly task?: {
+    readonly taskId: string;
+    readonly sessionId?: string;
+    readonly phase: WorkPhase;
   };
 }
 
 interface WorkUpdate {
+  readonly id: string;
   readonly message: string;
-  readonly revision: number;
   readonly source: "task-update";
 }
 
@@ -166,15 +166,14 @@ turn [running]
 └── step 1 [running]
     ├── run reproduction [running]
     └── researcher [running]
-        └── child turn
-            ├── discover [completed]
-            └── inspect [running]
+        └── Inspecting the deployment trace
 ```
 
 Actions observed under the same `stepIndex` are siblings. A delegated action
-owns its child graph. Tool inputs may contribute bounded deterministic detail
-when a renderer-safe field is known, but the graph must not expose arbitrary
-arguments or infer future work.
+owns a task node whose lifecycle comes from the durable task view and whose
+current semantic detail may come from `task_update`. Tool inputs may contribute
+bounded deterministic detail when a renderer-safe field is known, but the graph
+must not expose arbitrary arguments or infer future work.
 
 The graph does not infer a plan, user intent, or a relationship between an
 action and a hypothetical task.
@@ -202,96 +201,136 @@ The live graph is not an audit log:
   active presentation;
 - collapse completed step internals as the turn advances;
 - retain failure or cancellation detail needed to explain the outcome;
-- retain active child graphs until their owning action settles;
+- retain active task nodes until their owning action settles;
 - remove the completed turn from live session state after settlement;
 - preserve the full sequence in the existing durable event stream.
 
-The implementation experiment retained more completed child actions than this
-minimal policy so Slack could show observed stage history. The final compaction
-rule should be based on bounded size and renderer needs, not on the fixture's
-three-stage shape.
+The implementation experiment retained completed child actions so Slack could
+show observed stage history. Without child event propagation, free-form task
+updates contribute one current semantic detail rather than recreating that
+history. Any future history must be explicitly bounded.
 
-## Child observation and control
+## Child updates and work composition
 
-### Local child work projections
-
-A local child writes its latest committed `WorkGraph` to a child-owned,
-namespaced workflow stream. A reader resolves the child session through the
-parent's running handle and reads the latest committed snapshot.
-
-```text
-child turn workflow
-  └── commit work graph → child eve.work projection
-
-parent control path
-  └── wait for terminal/input/auth inbox messages
-
-sibling work monitor
-  ├── read direct child eve.work tails
-  ├── compose newer snapshots
-  ├── render changed desired state
-  └── sleep for a bounded interval
-```
-
-This structure follows from a failed experiment. Racing a durable timer against
-the parent turn's inbox iterator introduced competing replay paths and prevented
-the turn from reliably advancing after both child results were ready. Polling in
-a sibling workflow leaves the existing result-wait protocol unchanged.
-
-The monitor is observational:
-
-- it does not own terminal child results;
-- it does not mutate the parent's turn cursor;
-- it adopts only newer child revisions;
-- it stops when observed children are terminal;
-- polling failure must not fail the parent turn.
-
-The prototype uses a ten-second interval. That value is an operational default,
-not part of the graph contract.
-
-### Background task updates
-
-Merged background-task support gives task-owned children an immediate semantic
-path:
+Merged background-task support gives task-owned children one immediate update
+path for local and remote execution:
 
 ```text
 task-owned child
   └── task_update({ message })
         └── local task inbox or remote callback
-              └── deduplicated parent notification
+              └── deduplicated parent delivery
+                    └── work graph reduction
+                          └── channel rendering
 ```
 
-A task update should annotate the matching child action or task node. It should
-not change the action's phase, append unbounded history, or replace framework-
-observed lifecycle facts.
+This path resolves the main orchestration question from the original proposal.
+eve should not consume child event streams or poll child-owned projections.
+Those approaches add serverless invocations, scale with the number of children,
+and do not naturally cover tasks that outlive a parent turn. The durable task
+run already owns child routing, deduplication, lifecycle transitions, and parent
+wake policy.
 
-The two sources have different guarantees:
+### Keep `task_update` free-form
 
-| Source        | Meaning                            | Delivery                 | Coverage                             |
-| ------------- | ---------------------------------- | ------------------------ | ------------------------------------ |
-| Work snapshot | Framework-observed lifecycle state | Bounded local polling    | Local delegated sessions             |
-| `task_update` | Child-authored semantic milestone  | Immediate task transport | Task-owned local and remote children |
+`task_update({ message })` should remain a separate child-only tool with one
+terse, activity-focused message. It should not accept work-graph structure or
+let the child claim lifecycle status.
 
-A practical next integration should use immediate task updates when available
-and retain snapshot polling as reconciliation and as a fallback for ordinary
-local subagents. The framework should coalesce repeated authored updates and
-bind them to stable task or call identity.
+```ts
+task_update({
+  message: "Inspecting the deployment trace",
+});
+```
+
+Keeping the tool free-form preserves a useful division of authority:
+
+- the child describes its current semantic activity;
+- the task run owns durable task identity and delivery;
+- the runtime owns `working`, `input_required`, and terminal lifecycle state;
+- the work reducer binds the update to the owning task or action;
+- the parent channel decides what to expose.
+
+A structured progress tool would let a model duplicate or contradict facts the
+runtime already knows. Numeric progress, nested item creation, and phase changes
+should therefore stay out of `task_update` until a concrete use case cannot be
+represented by task lifecycle plus one current message.
+
+### Add structure at the transport boundary
+
+The model-facing tool can stay free-form while the framework notification gains
+the identity needed for deterministic reduction. The current delivery ID already
+uses task, child turn, child step, and tool call identity. The work reducer
+should receive equivalent internal metadata:
+
+```ts
+interface TaskWorkUpdate {
+  readonly kind: "task-update";
+  readonly taskId: string;
+  readonly childTurnId: string;
+  readonly childStepIndex: number;
+  readonly callId: string;
+  readonly message: string;
+}
+```
+
+The task update does not need a child-authored revision. Its existing identity
+forms an idempotency key, and each accepted update replaces the current message
+on the owning task node. The graph stores bounded desired state, not an update
+history.
+
+The task view should remain the lifecycle source of truth. Whether the current
+message also belongs in `TaskView` requires a separate decision: persisting it
+there makes `task_peek` and late renderers consistent, but changes a model-
+visible task contract. The narrow first integration can project the update into
+the active parent work graph without expanding `TaskView`.
+
+### Parent wake policy
+
+`task_update` currently sends a deduplicated parent delivery. A parked parent may
+start a turn, and an active parent observes it at a safe boundary. That behavior
+is appropriate for agent-to-agent communication, but presentation should not
+require a new model turn for every update.
+
+The integration should split one accepted update into two consumers:
+
+```text
+accepted task update
+  ├── parent notification for model awareness
+  └── framework work update for channel presentation
+```
+
+Both consumers use the same task identity and deduplication key. The channel
+consumer must not append the message to model history or independently change
+task lifecycle state. If immediate channel rendering cannot reuse the parent
+notification without waking model execution, the task run should emit a
+framework-owned presentation callback rather than reintroducing polling.
+
+### Non-task subagents
+
+A synchronous declared subagent that is not task-owned has no explicit
+intermediate-update transport. Without polling or child stream attachment, its
+parent graph can show dispatch, running, blockers already proxied to the parent,
+and terminal settlement, but not the child's internal tool ladder.
+
+That is an acceptable boundary for the first integration. Fine-grained child
+activity should require task ownership and `task_update` rather than adding a
+second transport for ordinary subagents. If synchronous subagents later need the
+same capability, eve should generalize the task notification transport instead
+of reviving child stream polling.
 
 ### Terminal precedence
 
-Control and presentation can still race. The following sequence is valid:
+Task lifecycle remains authoritative when updates race settlement:
 
-```text
-parent terminal renderer deletes or settles activity
-late monitor poll attempts an update
-channel rejects or ignores the stale update
-```
+- buffer a fast update until task dispatch is acknowledged;
+- deliver buffered updates before the terminal wake when they win the race;
+- reject or ignore updates after the task is terminal;
+- prevent a late presentation effect from recreating terminal channel activity.
 
-The channel must fence terminal presentation. In the Slack experiment, the
-parent owns creation and terminal deletion of the transient activity message;
-the monitor may update an existing message but cannot recreate a missing one.
-A general channel contract needs equivalent ownership without exposing Slack
-message semantics in the graph.
+A channel-specific renderer still owns external message identity and terminal
+cleanup. The work graph expresses terminal desired state; it does not encode
+Slack message operations.
 
 ## Slack as the proving ground
 
@@ -307,17 +346,15 @@ reasoning does not belong in the work graph.
 ### Hierarchical activity
 
 The activity renderer maintains one transient Slack message with one native
-`task_card` block per direct action or subagent. Child actions appear as
-rich-text details:
+`task_card` block per direct action or task. A task update supplies the current
+rich-text detail without changing the card's framework-owned status:
 
 ```text
 Researcher [in progress]
-  ✓ discover
-  ◐ inspect
+  Inspecting the deployment trace
 
 Verifier [in progress]
-  ✓ prepare
-  ◐ validate
+  Validating the reproduction
 ```
 
 The experiment established several presentation constraints:
@@ -330,8 +367,8 @@ The experiment established several presentation constraints:
   updates are a better candidate for native live agent progress than repeated
   full-message replacement, but adopting them changes response ownership and
   needs separate design;
-- the parent must own terminal cleanup so a stale monitor cannot leave a live
-  card after the final response.
+- the parent must own terminal cleanup so a late task update cannot leave live
+  activity after the final response.
 
 The current activity renderer should remain internal while those tradeoffs are
 evaluated. A generic public channel progress hook is premature.
@@ -344,16 +381,17 @@ Reduce existing turn, step, action, blocker, delegation, cancellation, and
 failure facts. Prove deterministic identity and terminal precedence with unit
 tests.
 
-### 2. Child-owned local projections
+### 2. Task-update composition
 
-Write committed local child snapshots to a namespaced stream and support direct
-latest-snapshot reads. Keep this layer independent of channels.
+Project merged `task_update` notifications onto the owning task or child action.
+Preserve the free-form child tool while carrying stable task, turn, step, and
+call identity through the internal notification.
 
-### 3. Isolated observation monitor
+### 3. Presentation delivery
 
-Run bounded polling in a sibling workflow. Do not race observation timers
-against the parent control inbox. Prove replay, result delivery, cancellation,
-and monitor settlement independently.
+Deliver changed work to channels without polling child streams or requiring a
+new model turn for each presentation update. Reuse task-run deduplication and
+terminal precedence. Keep this internal until the effect ownership is proven.
 
 ### 4. Slack consumers
 
@@ -361,11 +399,10 @@ Consume the same graph for compact status and hierarchical activity. Keep
 message identity, Block Kit, API calls, fallback behavior, and terminal cleanup
 inside Slack.
 
-### 5. Task-update composition
+### 5. Remote and background validation
 
-Project merged `task_update` notifications onto the owning task or child action.
-Use them for immediate semantic milestones while preserving observed graph phase
-and bounded snapshot reconciliation.
+Validate the same task-update reduction for local tasks, remote tasks, concurrent
+children, and tasks that outlive the dispatching turn.
 
 Acceptance criteria:
 
@@ -373,9 +410,10 @@ Acceptance criteria:
 - an update cannot revive a terminal task or action;
 - a fast update that races terminal settlement converges on terminal state;
 - local and remote task updates use the same annotation semantics;
-- ordinary local subagents remain useful without authored updates;
-- renderers can prefer a fresh semantic message without losing structured child
-  lifecycle state.
+- tasks remain useful without authored updates through their observed lifecycle;
+- renderers can prefer a fresh semantic message without losing authoritative
+  task lifecycle state;
+- no child stream polling or monitor workflow is required.
 
 ### 6. Reassess authored tool progress
 
@@ -410,8 +448,8 @@ internal stabilization.
 ### Remote child observations
 
 `task_update` covers semantic milestones for task-owned remote children, not a
-complete remote work graph. Full remote observation still requires capability
-negotiation or a coarse compatibility projection.
+complete remote internal action graph. A future remote protocol may expose more
+observed structure, but it should not be a prerequisite for useful task status.
 
 ### Streaming Slack tasks
 
@@ -429,22 +467,21 @@ of recent activity must not automatically imply failure.
 
 Use the narrowest tier for each invariant:
 
-- unit tests for pure reduction, compaction, child adoption, and Slack rendering;
-- integration tests for in-memory child composition and task-update projection;
-- scenario tests for workflow replay, monitor isolation, cancellation, and
+- unit tests for pure reduction, compaction, task updates, and Slack rendering;
+- integration tests for task-view composition and task-update projection;
+- scenario tests for workflow replay, task-update delivery, cancellation, and
   terminal races;
 - deterministic fixture evals for final Slack behavior.
 
 The design is successful when:
 
 - planless root work reduces deterministically;
-- nested local work composes without channel-side child stream attachment;
-- the parent control path remains unchanged by observation polling;
+- task work composes without child stream attachment or polling;
 - authored task updates annotate rather than replace observed state;
-- stale child or monitor updates cannot overwrite terminal state;
+- stale task updates cannot overwrite terminal state;
 - compact and hierarchical renderers consume the same graph;
 - the graph remains free of Slack state;
-- ordinary tools and subagents remain useful without authored progress calls.
+- ordinary tools and tasks remain useful without authored progress calls.
 
 ## Out of scope
 

--- a/research/durable-hierarchical-progress.md
+++ b/research/durable-hierarchical-progress.md
@@ -126,8 +126,19 @@ Together these implementations favor a layered authoring model:
 
 1. tools publish structured snapshots or tool-owned progress contributions;
 2. eve owns the default action/child tree and lifecycle invariants;
-3. an agent-level policy selects, combines, and summarizes contributions;
-4. the root channel reconciles the projection, including timer-driven refresh.
+3. the agent level materializes a deterministic canonical progress graph;
+4. the root channel selects and summarizes that graph, then reconciles the
+   presentation, including timer-driven refresh.
+
+Other internal agents reinforce this boundary. Revoa executes approved plans
+with deterministic per-step callbacks carrying step index, total, description,
+and result, then maps those facts to one updated Slack message. CSE maintains a
+durable investigation budget from `actions.requested`: deadline, maximum
+subagent calls, and calls used. Devbox maps known tools to authored activity
+labels and deliberately suppresses noisy polling while retaining task state.
+None of the inspected channel implementations invokes an LLM to derive status
+from lifecycle events. They use typed state, stable identities, and explicit
+policy, then apply opinion only while rendering.
 
 ## Proposed semantic split
 
@@ -154,10 +165,15 @@ partial output. An authored reducer can interpret a tool's domain-specific
 snapshot; a future tool-level projector could explicitly map `TOutput` to a
 small progress contribution without changing what clients or the model see.
 
-### Progress reducer
+### Canonical agent projection
 
-A reducer folds facts into durable desired state. It must be deterministic and
-side-effect free so workflow retries produce the same result.
+The agent-level reducer folds facts into durable canonical state. It must be
+deterministic, side-effect free, and deliberately low-loss so workflow retries
+produce the same result and every parent receives enough structure to choose a
+different presentation. It may compact transport detail, such as replacing ten
+partials for one call with the latest typed contribution, but should retain
+active action identities, child projections, plan items, phases, timestamps,
+errors, and terminal outcomes.
 
 A default reducer can preserve today's broad behavior while producing a
 channel-neutral tree:
@@ -188,11 +204,18 @@ ProgressNode`. Every channel can understand the result, but the shared shape
 
 Do not require an agent author to reconstruct the action map, child revision
 checks, or terminal precedence. Those are framework invariants. Agent-level
-authoring should wrap a default structural reducer or configure policies such
-as which completed nodes to retain, how to summarize parallel children, and
-whether a structured plan supersedes low-level actions. Tool-level projectors
-answer what one operation's output means; the agent policy answers what matters
-across the whole tree.
+authoring should primarily add typed domain contributions and configure bounded
+retention, not collapse the graph to one display string. Tool-level projectors
+answer what one operation's output means; the canonical reducer combines those
+contributions without deciding what a particular audience should see.
+
+A child may publish an explicit semantic summary because it understands its own
+domain, but that summary is one field alongside its canonical child projection,
+not a replacement for it. Automatically invoking a summarization model at each
+subagent boundary would add latency, cost, nondeterminism, and cumulative
+information loss. If a very wide tree eventually requires hierarchical model
+summaries, store them as optional derived annotations keyed by the source
+projection fingerprint and always propagate the source projection too.
 
 Start with the constrained internal projection to establish semantics. Do not
 expose a public reducer until the tree survives nested delegation without
@@ -200,18 +223,29 @@ channel-specific fields.
 
 ### Channel reconciler
 
-The root channel receives a complete desired projection and reconciles it with
-external state. It owns effectful and presentation-specific concerns:
+The root channel receives a complete desired projection and reduces it into a
+presentation before reconciling external state. It owns effectful and
+presentation-specific concerns:
 
+- select which canonical nodes matter for this channel and audience;
+- optionally summarize them with authored code or a cheap model;
 - choose an indicator, one updated message, multiple posts, or blocks;
 - create and remember external resource ids;
 - update or clear prior presentation;
 - truncate, throttle, debounce, and refresh according to platform limits;
 - decide how completed children remain visible.
 
-The reconciler's durable channel state contains external ids and the last
-successfully rendered projection fingerprint. Reducer state must not contain
-those values. Reconciliation is best-effort and must not fail the agent turn.
+A model summarizer is an optional, best-effort presentation stage. Its input is
+the bounded canonical graph; its output is cached by projection fingerprint in
+channel state. Failure falls back to deterministic copy. A timer refresh with
+an unchanged fingerprint reuses the cached summary and repeats only the channel
+effect, so a 75-second Slack refresh neither calls the model again nor creates a
+progress revision.
+
+The reconciler's durable channel state contains external ids, the last
+successfully rendered projection fingerprint, and any cached presentation.
+Canonical reducer state must not contain those values. Reconciliation is
+best-effort and must not fail the agent turn.
 
 ## Hierarchical propagation
 
@@ -315,6 +349,12 @@ and child propagation are unchanged in either case.
     progress without confusing "no recent event" with failure?
 12. Can root and child structured plans use one projection while retaining e0's
     policy that completed root plans remain visible and child plans disappear?
+13. What size bound on the canonical graph permits low-loss propagation without
+    unbounded session growth? Retention should be explicit and deterministic,
+    not delegated to a summarization model.
+14. Does the channel summarizer receive auth/audience metadata so it can avoid
+    exposing child details inappropriate for a shared thread, or must the
+    canonical projection be visibility-labeled before it reaches the channel?
 
 ## Implementation sequence
 

--- a/research/durable-hierarchical-progress.md
+++ b/research/durable-hierarchical-progress.md
@@ -1,0 +1,266 @@
+---
+issue: https://github.com/vercel/eve/issues/1673
+status: proposed
+last_updated: "2026-08-05"
+---
+
+# Durable hierarchical progress
+
+## Summary
+
+eve should represent progress independently from any channel presentation. Agent
+lifecycle facts reduce into a durable progress projection; delegated agents
+publish their projection to their parent, which incorporates it into its own
+projection. Only the root channel reconciles the resulting projection into an
+external presentation.
+
+```text
+child lifecycle facts ──reduce──▶ child projection
+                                      │ durable child update
+                                      ▼
+parent facts + child projections ──reduce──▶ parent projection
+                                              │
+                                              ▼
+                                      channel reconciler
+                                  indicator | message | blocks
+```
+
+A Slack thread status is one possible reconciler. A replaceable thread message,
+a Block Kit tree of parallel work, a terminal spinner, or no visible rendering
+are equally valid. Progress is desired state, not a command to call a specific
+channel API.
+
+## Current Slack behavior
+
+Slack status text currently comes directly from channel event handlers in
+`public/channels/slack/defaults.ts`:
+
+| Source                                         | Current projection                                                                                                    |
+| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| inbound mention or DM                          | `Thinking...` before runtime dispatch                                                                                 |
+| `turn.started`                                 | `Working...`                                                                                                          |
+| `reasoning.appended`                           | first non-empty reasoning line, locally throttled                                                                     |
+| `actions.requested`                            | preceding assistant narration when available, otherwise a label derived from the first requested action and `+N more` |
+| `message.completed`                            | preserve narration before tool calls; otherwise post the answer or clear an empty status                              |
+| `authorization.completed`                      | `Connected to <name>. Resuming...`                                                                                    |
+| terminal session/turn events and visible posts | stop or supersede the active status                                                                                   |
+
+This is an implicit last-write-wins reducer spread across event handlers and
+`SlackChannelState` fields:
+
+- `pendingToolCallMessage` carries narration across `message.completed` and
+  `actions.requested`;
+- `lastReasoningTyping*` implements presentation throttling;
+- `statusKeepaliveStatus` remembers the latest non-empty desired status;
+- the thread-status controller turns that desired string into
+  `assistant.threads.setStatus` calls and refreshes it while work is parked.
+
+The status text is therefore derived from useful channel-neutral facts, but its
+reduction, scheduling, and Slack effect are currently interleaved.
+
+## Existing event and delegation boundaries
+
+Normal root-agent stream events pass through the active channel adapter in
+`execution/workflow-steps.ts`. This gives Slack the facts above, but does not
+persist an explicit progress projection.
+
+Delegated agents run with the framework-owned subagent adapter. Today it only
+forwards child authorization and input-request events through the parent's
+durable turn inbox. The parent separately observes:
+
+- `actions.requested`, which identifies the requested subagent call;
+- `subagent.called`, emitted after a durable child starts;
+- the terminal runtime-action result returned through the inbox.
+
+The child agent's ordinary turn, reasoning, action, and nested-subagent events
+do not bubble to the parent. The protocol contains inline `subagent.started`,
+`subagent.event`, and `subagent.completed` shapes, but delegated workflow
+subagents do not use those as a general child event stream. A hierarchical
+progress design therefore needs a new durable child-progress lane rather than
+assuming the parent can reduce its child's existing public stream.
+
+## Proposed semantic split
+
+### Progress facts
+
+A progress fact records a meaningful lifecycle transition, not presentation
+instructions. Initial facts should cover:
+
+- turn started, waiting, completed, failed, or cancelled;
+- reasoning summary changed;
+- actions requested and actions settled, keyed by call id;
+- authorization or human input required and resumed;
+- delegated child started, updated, and settled, keyed by call id and child
+  session id.
+
+Facts need stable identities and ordering coordinates. They must not contain
+Slack text, blocks, message timestamps, refresh intervals, or API operations.
+High-frequency stream deltas may be coalesced before reduction, but the latest
+desired projection must cross the next durable boundary.
+
+### Progress reducer
+
+A reducer folds facts into durable desired state. It must be deterministic and
+side-effect free so workflow retries produce the same result.
+
+A default reducer can preserve today's broad behavior while producing a
+channel-neutral tree:
+
+```ts
+interface ProgressNode {
+  readonly id: string;
+  readonly phase: "active" | "blocked" | "completed" | "failed" | "cancelled";
+  readonly summary?: string;
+  readonly children?: readonly ProgressNode[];
+}
+```
+
+This shape is illustrative rather than final. In particular, completed child
+retention, ordering, error detail, and whether `summary` is authored text or a
+structured activity need API design.
+
+Custom reduction should be configured independently from channel rendering.
+Two viable authoring shapes need a spike:
+
+1. **Constrained projection:** users customize `(projection, fact) =>
+ProgressNode`. Every channel can understand the result, but the shared shape
+   may become either too weak or presentation-shaped.
+2. **Generic projection:** users own serializable reducer state and output;
+   their channel reconciler consumes the matching type. This is expressive but
+   requires a clean way to connect agent and channel types across filesystem
+   definitions and delegated-agent boundaries.
+
+Start with the constrained internal projection to establish semantics. Do not
+expose a public reducer until the tree survives nested delegation without
+channel-specific fields.
+
+### Channel reconciler
+
+The root channel receives a complete desired projection and reconciles it with
+external state. It owns effectful and presentation-specific concerns:
+
+- choose an indicator, one updated message, multiple posts, or blocks;
+- create and remember external resource ids;
+- update or clear prior presentation;
+- truncate, throttle, debounce, and refresh according to platform limits;
+- decide how completed children remain visible.
+
+The reconciler's durable channel state contains external ids and the last
+successfully rendered projection fingerprint. Reducer state must not contain
+those values. Reconciliation is best-effort and must not fail the agent turn.
+
+## Hierarchical propagation
+
+Each session reduces its own facts. A delegated session sends a versioned
+snapshot when its desired projection changes:
+
+```ts
+interface ChildProgressUpdate {
+  readonly kind: "subagent-progress";
+  readonly callId: string;
+  readonly childSessionId: string;
+  readonly revision: number;
+  readonly projection: ProgressNode;
+  readonly subagentName: string;
+}
+```
+
+The parent admits this through the same durable turn inbox ownership model used
+for child HITL and terminal results, but handles it as a separate payload. It
+rejects stale revisions, associates the child with the pending call, reduces
+the child snapshot into its own state, and publishes its new snapshot upward
+if it is itself delegated.
+
+Snapshots, rather than every raw child event, provide three properties:
+
+1. a parent never needs to replay the child's complete event history;
+2. nested trees compose one level at a time;
+3. update volume can be coalesced without losing current desired state.
+
+The snapshot must retain stable child and action identities so a custom reducer
+can display parallel work rather than collapsing everything to the latest
+string. Parent reduction remains authoritative: it can summarize, hide, reorder,
+or retain child nodes instead of blindly embedding them.
+
+Terminal delivery and progress delivery can race. Revisions and the terminal
+fact must make both orders converge to the same parent projection. A late child
+snapshot cannot resurrect a settled call.
+
+## Durability and ownership
+
+Reducer state belongs to the session's durable runtime state, not process-local
+maps or channel adapter state. Reduction occurs in the same durable step that
+observes the source lifecycle event. A changed delegated projection is then
+forwarded through a workflow hook step to its parent.
+
+The root channel reconciler observes projections after they have been adopted
+into serialized context. Its effect checkpoint includes updated channel state.
+External APIs without idempotency still have an unavoidable response/checkpoint
+crash window; initial implementations should prefer naturally idempotent
+replace operations and explicitly document create-operation semantics rather
+than claiming exactly-once posts.
+
+Progress propagation must never block model execution or terminal settlement
+indefinitely. Failed parent notification or channel rendering is diagnostic;
+the latest durable projection can be retried or superseded by a newer revision.
+
+## Relationship to status keepalive
+
+The status-keepalive work supplies useful scheduling for a root channel whose
+current presentation expires while the parent waits on delegated results. It
+is not the progress model.
+
+Under this design:
+
+- reducer output establishes desired progress;
+- the channel reconciler renders that desired progress;
+- optional status refresh reasserts an expiring presentation without producing
+  a new progress fact or reducer revision.
+
+A Block Kit reconciler may return no refresh deadline at all. A status
+indicator reconciler may request periodic refreshes. The durable progress tree
+and child propagation are unchanged in either case.
+
+## Open decisions
+
+1. Is a progress projection part of the public event stream, or only an
+   internal channel/subagent projection? Publishing it helps non-channel
+   clients but creates a long-lived protocol contract.
+2. Which reasoning representation is safe and useful as progress? Raw reasoning
+   may be unsupported by some providers and inappropriate to expose verbatim.
+3. Should custom reducers be agent-level, channel-level, or composed from an
+   agent reducer and a channel projection policy?
+4. How are reducer versions pinned and migrated for sessions spanning
+   deployments?
+5. What coalescing boundary prevents reasoning deltas from producing excessive
+   workflow steps while preserving prompt updates?
+6. Should a parent receive only the child's default projection, or can a child
+   publish structured domain-specific progress explicitly?
+7. How long do completed child nodes remain in the projection, especially when
+   persistent subagent sessions are continued by a later call?
+
+## Implementation sequence
+
+1. Add pure internal progress facts, a default reducer, durable reducer state,
+   and tests for one root session. Do not change channel output.
+2. Add a versioned child-progress hook payload and prove nested, parallel,
+   stale-update, terminal-race, retry, and cancellation semantics.
+3. Feed root projections to an internal channel reconciler and adapt Slack's
+   existing status behavior as the first renderer without changing visible
+   defaults.
+4. Spike an alternate Slack reconciler that maintains a thread message with
+   parallel child blocks. Use the spike to validate the projection shape.
+5. Only then expose reducer/reconciler authoring APIs, documentation, and a
+   changeset.
+
+## Verification
+
+- root lifecycle facts reduce deterministically across replay;
+- two parallel child calls retain independent identities and ordering;
+- nested child updates bubble one parent at a time to the root;
+- stale or late child revisions cannot overwrite terminal state;
+- reducer and propagation failures do not fail an active turn;
+- a renderer retry does not alter reducer state or emit a new child revision;
+- indicator and message/block renderers consume the same projection;
+- existing Slack-visible behavior remains unchanged until a renderer is
+  explicitly selected.

--- a/research/durable-hierarchical-progress.md
+++ b/research/durable-hierarchical-progress.md
@@ -140,6 +140,105 @@ None of the inspected channel implementations invokes an LLM to derive status
 from lifecycle events. They use typed state, stable identities, and explicit
 policy, then apply opinion only while rendering.
 
+## External prior art
+
+No inspected framework provides the complete combination of durable canonical
+progress, hierarchical child rollup, and channel-specific summarization. The
+closest systems support distinct pieces and generally preserve structured facts
+before rendering them.
+
+### AG-UI activities
+
+[AG-UI](https://github.com/ag-ui-protocol/ag-ui) is the closest presentation
+protocol. `ACTIVITY_SNAPSHOT` carries a stable `messageId`, open
+`activityType`, and arbitrary structured `content`; `ACTIVITY_DELTA` applies
+RFC 6902 patches to that content. Its Mastra background-agent example maps a
+long-running tool to an activity whose content includes task id, tool name,
+status, arguments, outputs, and result, while a custom renderer displays a
+Background Task card. Normal tool rendering can be suppressed without losing
+the structured activity.
+
+This supports snapshot identity, replace-in-place semantics, open activity
+types, and renderer-owned presentation. It does not define how nested agents
+reduce their activity into a parent, durability/replay semantics, or a canonical
+cross-agent schema. eve can potentially project its root canonical graph into
+AG-UI activity snapshots without adopting AG-UI as internal durable state.
+
+### A2A tasks
+
+The [Agent2Agent protocol](https://github.com/a2aproject/A2A) separates a
+retrievable `Task` snapshot from streamed updates. A task has lifecycle state,
+status message, artifacts, history, and metadata. `TaskStatusUpdateEvent`
+replaces status using stable task and context ids; `TaskArtifactUpdateEvent`
+updates an artifact independently and supports append/final-chunk semantics.
+Disconnected clients receive significant notifications and then fetch the
+complete current task.
+
+A2A validates the snapshot-plus-notification model and the separation between
+status and incremental output. Its lifecycle is intentionally coarse
+(`working`, `input-required`, `auth-required`, terminal states), its status
+message is agent-authored prose, and it does not standardize nested child trees
+or presentation reduction.
+
+### LangGraph state and stream projections
+
+[LangGraph](https://github.com/langchain-ai/langgraph) combines deterministic
+state-channel reducers with separate stream modes. Nodes can emit arbitrary
+`custom` stream data through a runtime writer. Stream events carry namespaces,
+and subgraph streaming preserves nested namespaces. Its newer stream
+transformers observe the event mux and build typed derived projections without
+changing graph state; async derived work can land on an independent projection.
+
+This is strong precedent for keeping durable execution state separate from
+consumer projections and for preserving hierarchy through namespaces. The
+custom writer remains an untyped data plane, however, and LangGraph does not
+supply an opinionated agent-progress graph or channel refresh contract.
+
+### Agent SDK lifecycle streams
+
+OpenAI Agents SDK and AutoGen expose normalized higher-level events for tool
+calls/results, handoffs or agent changes, messages, and reasoning. AutoGen
+explicitly describes agent events as observable by users and applications, not
+agent-to-agent communication. These are useful fact sources but leave state
+materialization and presentation to consumers. They resemble eve's existing
+stream more than the proposed canonical progress layer.
+
+Google ADK preserves hierarchy more explicitly: events carry workflow node
+paths, parent run identity, branch/isolation scope, output ownership, and state
+deltas. This is relevant to canonical child identity and visibility, but it is
+still a session event model rather than a reduced progress projection.
+
+### Operation-local progress
+
+MCP progress notifications correlate `progress`, optional `total`, and optional
+message to one request token. Temporal activity heartbeats persist arbitrary
+latest details, support retry resumption, and double as liveness/cancellation
+checkpoints. Both reinforce operation-local typed progress with stable identity.
+Neither performs agent-level rollup. Temporal heartbeats are control-plane
+state, not a user-facing event stream, which is a useful warning not to equate
+liveness with presentation.
+
+### Design consequence
+
+The recurring external shape is:
+
+```text
+operation events or snapshots
+        │ stable id + structured state
+        ▼
+durable task/graph state
+        │ notification or projection stream
+        ▼
+consumer-owned renderer
+```
+
+AG-UI is the strongest precedent for the outer activity/rendering boundary;
+A2A for durable task snapshots and reconnect; LangGraph and Google ADK for
+hierarchical identity and derived projections; MCP and Temporal for
+operation-local progress. None is evidence for lossy or model-based reduction
+inside every child. An optional channel summarizer remains a novel but natural
+consumer-owned stage, and should cache by canonical projection fingerprint.
+
 ## Proposed semantic split
 
 ### Progress facts

--- a/research/durable-hierarchical-progress.md
+++ b/research/durable-hierarchical-progress.md
@@ -11,7 +11,7 @@ last_updated: "2026-08-05"
 eve should represent progress independently from any channel presentation. Agent
 lifecycle facts reduce into a durable progress projection; delegated agents
 publish their projection to their parent, which incorporates it into its own
-projection. Only the root channel reconciles the resulting projection into an
+projection. Only the root channel renders the resulting projection into an
 external presentation.
 
 ```text
@@ -21,11 +21,11 @@ child lifecycle facts ──reduce──▶ child projection
 parent facts + child projections ──reduce──▶ parent projection
                                               │
                                               ▼
-                                      channel reconciler
+                                       channel renderer
                                   indicator | message | blocks
 ```
 
-A Slack thread status is one possible reconciler. A replaceable thread message,
+A Slack thread status is one possible rendering. A replaceable thread message,
 a Block Kit tree of parallel work, a terminal spinner, or no visible rendering
 are equally valid. Progress is desired state, not a command to call a specific
 channel API.
@@ -46,17 +46,10 @@ Slack status text currently comes directly from channel event handlers in
 | terminal session/turn events and visible posts | stop or supersede the active status                                                                                   |
 
 This is an implicit last-write-wins reducer spread across event handlers and
-`SlackChannelState` fields:
-
-- `pendingToolCallMessage` carries narration across `message.completed` and
-  `actions.requested`;
-- `lastReasoningTyping*` implements presentation throttling;
-- `statusKeepaliveStatus` remembers the latest non-empty desired status;
-- the thread-status controller turns that desired string into
-  `assistant.threads.setStatus` calls and refreshes it while work is parked.
-
-The status text is therefore derived from useful channel-neutral facts, but its
-reduction, scheduling, and Slack effect are currently interleaved.
+`SlackChannelState` fields. `pendingToolCallMessage` carries narration across
+`message.completed` and `actions.requested`; `lastReasoningTyping*` implements
+presentation throttling. The status text is therefore derived from useful
+channel-neutral facts, but its reduction and Slack effect are interleaved.
 
 ## Existing event and delegation boundaries
 
@@ -95,19 +88,20 @@ The proposal separates four responsibilities:
 2. eve materializes deterministic canonical progress from existing turn, step,
    action, blocker, plan, and child-session state;
 3. delegated sessions publish versioned canonical snapshots to their parent;
-4. the root channel selects, summarizes, and reconciles a presentation,
-   including timer-driven refresh when the presentation expires.
+4. the root channel selects, summarizes, and renders a presentation.
 
 Canonical progress is desired state, not an audit log and not presentation
 commands. The durable event stream remains the complete history. Channel state
-owns external message ids, capability fallbacks, cached summaries, and refresh
-policy.
+owns external message ids, capability fallbacks, and cached summaries.
+Platform-specific presentation maintenance, such as renewing an expiring Slack
+status, stays inside that channel implementation and is not part of the
+canonical progress or generic channel contract.
 
 ## Public API design space
 
 The public API needs boundaries at four levels: producers contribute meaning,
 the agent materializes canonical state, delegated sessions publish canonical
-snapshots, and the root channel projects and reconciles a presentation. These
+snapshots, and the root channel renders a presentation. These
 levels should not share one generic `reduce(event)` callback.
 
 ### Canonical types
@@ -405,7 +399,8 @@ export default defineHook({
 });
 ```
 
-This event fires only when canonical state changes, not on channel refresh.
+This event fires only when canonical state changes, not for presentation-only
+channel maintenance.
 
 ### Delegated-agent boundary
 
@@ -426,66 +421,16 @@ or a coarse remote task status that eve adapts into one child node. Lack of
 progress capability leaves the child as a running node until its terminal
 result.
 
-### Channel APIs
+### Channel API
 
-The channel boundary needs to distinguish pure/derived presentation from
-external effects and refresh. Three shapes are plausible.
-
-#### One effectful callback
-
-```ts
-progress: async ({ progress, reason }, channel, ctx) => {
-  await channel.thread.startTyping(selectStatus(progress));
-  return { refreshAfterMs: 75_000 };
-};
-```
-
-This is simple and fits existing channel event handlers. It makes model-summary
-caching, create-versus-update state, and testability the author's problem.
-
-#### Project then reconcile
-
-```ts
-progress: defineChannelProgress({
-  async project(progress, ctx) {
-    return summarizeForSlack(progress, ctx);
-  },
-  async reconcile(view, channel, ctx) {
-    await channel.thread.startTyping(view.status);
-    return { refreshAfterMs: 75_000 };
-  },
-});
-```
-
-`project` runs only for a changed canonical fingerprint. It may call a cheap
-model and must return serializable presentation state. `reconcile` runs for
-`changed`, `refresh`, and `terminal` reasons and owns effects. On refresh it
-receives the cached view.
-
-#### Event reducer over canonical changes
-
-```ts
-progress: {
-  initial: () => ({ messageTs: null, view: null }),
-  reduce(state, event) { /* changed | refresh | terminal */ },
-}
-```
-
-This resembles UI reducers but mixes pure state and effects unless another
-command layer is introduced.
-
-The recommended initial channel API is the one effectful callback. It receives
-an extensible input object and owns presentation state in the channel's existing
-durable state:
+The initial channel surface is one effectful callback. It receives an extensible
+input object and owns presentation state in the channel's existing durable
+state:
 
 ```ts
 interface ChannelProgressInput {
   readonly progress: ProgressSnapshot;
-  readonly reason: "changed" | "refresh" | "terminal";
-}
-
-interface ChannelProgressResult {
-  readonly refreshAfterMs?: number;
+  readonly reason: "changed" | "terminal";
 }
 ```
 
@@ -498,16 +443,19 @@ export default defineChannel({
       progress,
       reason,
     });
-    return {};
   },
 });
 ```
 
+This fits existing channel event handlers and lets a channel post, update,
+delete, summarize, or intentionally ignore progress. Model-summary caching,
+create-versus-update state, and testability remain the author's responsibility.
 Built-in channel presets may internally split pure projection from effects and
-cache model-generated summaries by canonical fingerprint. A custom callback
-that invokes a model owns equivalent caching. Keep `defineChannelProgress({
-project, reconcile })` as a possible later convenience rather than part of the
-initial surface.
+cache model-generated summaries by canonical fingerprint.
+
+The callback runs only when canonical progress changes or terminates. A channel
+that needs presentation-only maintenance owns its timer and reuses its last
+rendered state without manufacturing a progress update.
 
 For Slack, the built-in offers presets and an escape hatch:
 
@@ -532,17 +480,16 @@ slackChannel({
 
 slackChannel({
   async progress({ progress, reason }, channel) {
-    return renderCustomSlackProgress({ channel, progress, reason });
+    await renderCustomSlackProgress({ channel, progress, reason });
   },
 });
 ```
 
-`slackProgress.status()` refreshes the cached status presentation before Slack
-expires it. `slackProgress.plan()` selects the optional canonical plan and falls
-back when a turn has none. `slackProgress.message()` updates a thread message
-and normally requests no refresh. `progress: false` suppresses the built-in
-renderer without suppressing canonical progress or `progress.updated`
-observation.
+`slackProgress.plan()` selects the optional canonical plan and falls back when
+a turn has none. `slackProgress.message()` updates a thread message.
+`slackProgress.status()` owns any Slack-specific status renewal internally.
+`progress: false` suppresses the built-in renderer without suppressing canonical
+progress or `progress.updated` observation.
 
 ### API recommendation
 
@@ -555,7 +502,7 @@ The smallest coherent first public surface is:
 4. deterministic framework-owned scope reduction, with no initial agent config;
 5. `progress.updated` as an observe-only hook event;
 6. one effectful channel `progress({ progress, reason }, channel, ctx)` callback;
-7. Slack status, plan, and message presets built on the same channel contract.
+7. Slack status, plan, and message presets built on the same canonical input.
 
 The runtime child propagation protocol remains internal until remote capability
 negotiation requires a public wire contract.
@@ -627,31 +574,27 @@ Do not expose a public agent reducer until the tree survives nested delegation
 without channel-specific fields and a concrete adoption cannot be expressed as
 a progress report or channel projection.
 
-### Channel reconciler
+### Channel renderer
 
-The root channel receives a complete desired projection and reduces it into a
-presentation before reconciling external state. It owns effectful and
-presentation-specific concerns:
+The root channel receives a complete desired projection and renders external
+state. It owns effectful and presentation-specific concerns:
 
 - select which canonical nodes matter for this channel and audience;
 - optionally summarize them with authored code or a cheap model;
 - choose an indicator, one updated message, multiple posts, or blocks;
 - create and remember external resource ids;
 - update or clear prior presentation;
-- truncate, throttle, debounce, and refresh according to platform limits;
+- truncate, throttle, and debounce according to platform limits;
 - decide how completed children remain visible.
 
 A model summarizer is an optional, best-effort presentation stage. Its input is
-the bounded canonical graph; its output is cached by projection fingerprint in
-channel state. Failure falls back to deterministic copy. A timer refresh with
-an unchanged fingerprint reuses the cached summary and repeats only the channel
-effect, so a 75-second Slack refresh neither calls the model again nor creates a
-progress revision.
+the bounded canonical graph; its output may be cached by projection fingerprint
+in channel state. Failure falls back to deterministic copy.
 
-The reconciler's durable channel state contains external ids, the last
+The renderer's durable channel state contains external ids, the last
 successfully rendered projection fingerprint, and any cached presentation.
-Canonical reducer state must not contain those values. Reconciliation is
-best-effort and must not fail the agent turn.
+Canonical reducer state must not contain those values. Rendering is best-effort
+and must not fail the agent turn.
 
 ## Hierarchical propagation
 
@@ -697,7 +640,7 @@ maps or channel adapter state. Reduction occurs in the same durable step that
 observes the source lifecycle event. A changed delegated projection is then
 forwarded through a workflow hook step to its parent.
 
-The root channel reconciler observes projections after they have been adopted
+The root channel renderer observes projections after they have been adopted
 into serialized context. Its effect checkpoint includes updated channel state.
 External APIs without idempotency still have an unavoidable response/checkpoint
 crash window; initial implementations should prefer naturally idempotent
@@ -707,23 +650,6 @@ than claiming exactly-once posts.
 Progress propagation must never block model execution or terminal settlement
 indefinitely. Failed parent notification or channel rendering is diagnostic;
 the latest durable projection can be retried or superseded by a newer revision.
-
-## Relationship to status keepalive
-
-The status-keepalive work supplies useful scheduling for a root channel whose
-current presentation expires while the parent waits on delegated results. It
-is not the progress model.
-
-Under this design:
-
-- reducer output establishes desired progress;
-- the channel reconciler renders that desired progress;
-- optional status refresh reasserts an expiring presentation without producing
-  a new progress fact or reducer revision.
-
-A Block Kit reconciler may return no refresh deadline at all. A status
-indicator reconciler may request periodic refreshes. The durable progress tree
-and child propagation are unchanged in either case.
 
 ## Open decisions
 
@@ -748,9 +674,8 @@ and child propagation are unchanged in either case.
 9. At which turn/step settlement boundary should completed child internals
    collapse, especially when persistent subagent sessions are continued by a
    later call?
-10. Is elapsed time a renderer concern, a refresh-time projection over durable
-    `startedAt`, or semantic progress? It should not require a new child
-    revision every minute.
+10. Is elapsed time a renderer projection over durable `startedAt`, or semantic
+    progress? It should not require a new child revision every minute.
 11. How should remote liveness observations enter progress without confusing
     "no recent event" with failure?
 12. Should the framework todo gain stable item ids, title, and description, or

--- a/research/durable-hierarchical-progress.md
+++ b/research/durable-hierarchical-progress.md
@@ -79,6 +79,14 @@ subagents do not use those as a general child event stream. A hierarchical
 progress design therefore needs a new durable child-progress lane rather than
 assuming the parent can reduce its child's existing public stream.
 
+PR [#1665](https://github.com/vercel/eve/pull/1665) adds another useful source:
+streaming tools may yield complete intermediate output snapshots, exposed as
+`action.partial`. This is an incremental tool-output data plane rather than a
+progress model. The snapshots are arbitrary tool output, can be much richer
+and more frequent than useful status changes, and are independently valuable
+to clients. Progress reduction may consume them without making every partial a
+progress revision or forwarding raw partials through the subagent tree.
+
 ## Proposed semantic split
 
 ### Progress facts
@@ -91,12 +99,18 @@ instructions. Initial facts should cover:
 - actions requested and actions settled, keyed by call id;
 - authorization or human input required and resumed;
 - delegated child started, updated, and settled, keyed by call id and child
-  session id.
+  session id;
+- a streaming tool published a new intermediate output snapshot, keyed by call
+  id.
 
 Facts need stable identities and ordering coordinates. They must not contain
 Slack text, blocks, message timestamps, refresh intervals, or API operations.
-High-frequency stream deltas may be coalesced before reduction, but the latest
-desired projection must cross the next durable boundary.
+High-frequency stream deltas and tool partials may be ignored or coalesced
+before reduction, but the latest desired projection must cross the next
+durable boundary. A default reducer should not guess status text from arbitrary
+partial output. An authored reducer can interpret a tool's domain-specific
+snapshot; a future tool-level projector could explicitly map `TOutput` to a
+small progress contribution without changing what clients or the model see.
 
 ### Progress reducer
 
@@ -236,7 +250,13 @@ and child propagation are unchanged in either case.
    workflow steps while preserving prompt updates?
 6. Should a parent receive only the child's default projection, or can a child
    publish structured domain-specific progress explicitly?
-7. How long do completed child nodes remain in the projection, especially when
+7. Should tools declare a `toProgress`-style projector for `action.partial`
+   snapshots, rely on the agent reducer to recognize their output, or gain a
+   separate explicit progress-reporting API?
+8. At what boundary are rapid tool partials coalesced so clients retain the
+   full incremental stream while parent progress receives only meaningful
+   snapshots?
+9. How long do completed child nodes remain in the projection, especially when
    persistent subagent sessions are continued by a later call?
 
 ## Implementation sequence

--- a/research/durable-hierarchical-progress.md
+++ b/research/durable-hierarchical-progress.md
@@ -466,65 +466,52 @@ partial contribution until another lifecycle boundary.
 
 ### Agent-level authoring
 
+The initial agent API should be zero-config:
+
+```ts
+export default defineAgent({
+  model: "openai/gpt-5.4",
+});
+```
+
 A raw `(state, event) => state` replacement API is too easy to make lossy or
-break child and terminal invariants. Consider three levels of power.
+break child and terminal invariants. Fixed retention counts are also the wrong
+abstraction: canonical progress is scoped around meaningful work, not a sliding
+window of recent events.
 
-#### Declarative policy
-
-```ts
-export default defineAgent({
-  model: "openai/gpt-5.4",
-  progress: {
-    retainCompletedActions: 5,
-    retainCompletedChildren: "turn",
-    plans: "prefer-over-actions",
-  },
-});
+```text
+turn
+└── plan
+    ├── item: Reproduce
+    │   ├── search logs       [completed]
+    │   └── run test          [completed]
+    ├── item: Implement fix   [running]
+    │   ├── edit file         [completed]
+    │   └── run tests         [running]
+    └── item: Open PR         [pending]
 ```
 
-This handles common retention choices but cannot add domain-specific aggregate
-state.
+The framework applies deterministic scope-based compaction:
 
-#### Canonical annotations
+- retain every active or blocked action;
+- attach actions to the most specific active plan item, child, or implicit turn
+  phase;
+- while a scope is active, retain its completed actions;
+- when a plan item completes, retain its outcome and collapse internal action
+  detail from the live projection;
+- retain failed/cancelled detail sufficient to explain the outcome;
+- retain the current plan and active child scopes until their owning turn
+  settles;
+- leave the complete audit trail in the durable event stream.
 
-```ts
-export default defineAgent({
-  model: "openai/gpt-5.4",
-  progress: defineProgress({
-    annotate(snapshot, update) {
-      if (update.kind === "plan.updated") {
-        return { focus: update.plan.items.find((item) => item.phase === "running")?.label };
-      }
-    },
-  }),
-});
-```
+Whether completed scopes are expanded or hidden is channel presentation policy.
+`preferPlans` therefore does not belong on the agent definition either.
+Agent-authored semantic state enters through structured plans and
+`reportProgress()`, not a custom canonical reducer. Defer agent annotations and
+reducer middleware until adoption demonstrates information that cannot be
+expressed as a contribution.
 
-Annotations add bounded, serializable information while the framework still
-owns the canonical graph. They do not remove or rewrite nodes.
-
-#### Reducer middleware
-
-```ts
-progress: defineProgress({
-  reduce(base, update) {
-    const next = base(update);
-    return { ...next, annotations: updateAnnotations(next, update) };
-  },
-});
-```
-
-This is flexible but exposes ordering and replay semantics. If offered, `base`
-must always establish structural invariants first, and the callback should only
-be able to change an owned extension state or derived annotations, not core
-nodes.
-
-Recommended initial API: an optional `progress` field on `defineAgent` with
-declarative retention plus typed `annotate`. Every subagent definition gets the
-same surface. Do not add a separate filesystem slot until multiple independent
-progress modules need composition.
-
-The canonical projection should also be observable without being mutable:
+The canonical projection should be observable without being mutable:
 
 ```ts
 export default defineHook({
@@ -688,7 +675,7 @@ The smallest coherent first public surface is:
    types;
 2. `ctx.progress.report()` for operation-local milestones;
 3. optional typed tool `progress` projectors;
-4. agent `progress` retention/annotation policy, not arbitrary core reduction;
+4. deterministic framework-owned scope reduction, with no initial agent config;
 5. `progress.updated` as an observe-only hook event;
 6. `defineChannelProgress({ project, reconcile })` with cached project output
    and refresh reasons;
@@ -760,10 +747,10 @@ ProgressNode`. Every channel can understand the result, but the shared shape
    definitions and delegated-agent boundaries.
 
 Do not require an agent author to reconstruct the action map, child revision
-checks, or terminal precedence. Those are framework invariants. Agent-level
-authoring should primarily add typed domain contributions and configure bounded
-retention, not collapse the graph to one display string. Tool-level projectors
-answer what one operation's output means; the canonical reducer combines those
+checks, terminal precedence, or retention. Those are framework invariants.
+Agent-level authoring should add typed domain contributions, not collapse the
+graph to one display string. Tool-level projectors answer what one operation's
+output means; the canonical reducer combines and scope-compacts those
 contributions without deciding what a particular audience should see.
 
 A child may publish an explicit semantic summary because it understands its own

--- a/research/durable-hierarchical-progress.md
+++ b/research/durable-hierarchical-progress.md
@@ -112,15 +112,49 @@ It demonstrates that a useful aggregate needs stable call identity, child
 session identity, parallel labels, elapsed time, stale/unknown semantics, and
 an explicit distinction between refreshing presentation and changing progress.
 
-`e0` demonstrates structured, model-authored progress. Its `todo` results are
-validated as full snapshots, keyed by root or child session and turn, and
-reconciled into one Slack message that is updated in place. Root plans remain
-visible as completed; child plans are removed at child completion. e0 also
-attaches to each local child session stream to observe nested todo results,
-reasoning summaries, and action requests, then writes all of them directly to
-the parent Slack thread. This is effectively a hand-built hierarchical progress
-projection, but it depends on channel-side child stream attachment and embeds
-Slack message metadata in the persistence strategy.
+`e0` demonstrates structured, model-authored progress. Its current `todo`
+override extends eve's durable todo state with a sticky plan `title` and required
+per-step `description`. Each successful todo result is a complete snapshot. The
+Slack channel projects it to Slack's native `plan` block with one `task_card`
+per item:
+
+```ts
+{
+  type: "plan",
+  title: plan.title ?? "Plan",
+  tasks: plan.todos.map((todo, index) => ({
+    type: "task_card",
+    task_id: `todo-${index}`,
+    title: todo.content,
+    details: richText(todo.description),
+    status: mapTodoStatus(todo.status),
+  })),
+}
+```
+
+The renderer keeps `{ messageTs, title, todos, turnId }` in durable Slack channel
+state. Later snapshots in the same turn update that message; a new turn posts a
+new card; a missing message posts a replacement. Terminal completion marks
+unfinished tasks complete, while failure or cancellation marks them errored.
+The plan block is treated as a capability: after `invalid_blocks` or
+`invalid_block_type`, the renderer persists that rejection and uses a Markdown
+list plus `N of M steps` fallback for the rest of the session.
+
+This is stronger prior art than a generic block renderer. The producer schema
+was shaped by a concrete presentation need (`title` and `description`), yet its
+output remains semantic and independently useful. The renderer owns Slack's
+status mapping, rich-text conversion, message identity, update/recovery,
+terminal settlement, clipping, and capability fallback. It argues for a
+first-class canonical `plan` contribution in eve rather than representing every
+plan as generic action nodes or arbitrary annotations.
+
+An earlier e0 implementation attached to local child session streams and
+rendered each child's todo plan separately. The current implementation removed
+child-plan fan-in and follows child streams only to refresh the flat typing
+status from child reasoning/action events. That retreat is informative: raw
+child event mirroring made ownership and Slack-message reconciliation complex.
+Framework-owned child progress snapshots should make nested plan rendering
+possible without channel-side stream attachment.
 
 Together these implementations favor a layered authoring model:
 
@@ -341,6 +375,27 @@ interface ProgressContribution {
 `label` and `detail` are semantic authored copy, not channel markup. They are
 optional because an action's tool or agent name is already a deterministic
 fallback.
+
+Plans deserve a core canonical variant rather than a namespaced annotation:
+
+```ts
+interface ProgressPlan extends ProgressActivityBase {
+  readonly kind: "plan";
+  readonly title?: string;
+  readonly items: readonly ProgressPlanItem[];
+}
+
+interface ProgressPlanItem {
+  readonly id: string;
+  readonly label: string;
+  readonly description?: string;
+  readonly phase: "pending" | "running" | "completed" | "cancelled" | "failed";
+}
+```
+
+This directly covers e0's Slack plan card while remaining useful to web, TUI,
+and other channels. Stable item ids should come from the producer rather than
+e0's current array index, so reordering or insertion does not change identity.
 
 ### Producer APIs
 
@@ -601,6 +656,16 @@ slackChannel({
   progress: slackProgress.message({
     blocks(progress) {
       return renderParallelAgentBlocks(progress);
+    },
+  }),
+});
+
+slackChannel({
+  progress: slackProgress.plan({
+    select(progress) {
+      return progress.root.activities.find(
+        (activity): activity is ProgressPlan => activity.kind === "plan",
+      );
     },
   }),
 });

--- a/research/durable-hierarchical-progress.md
+++ b/research/durable-hierarchical-progress.md
@@ -87,6 +87,48 @@ and more frequent than useful status changes, and are independently valuable
 to clients. Progress reduction may consume them without making every partial a
 progress revision or forwarding raw partials through the subagent tree.
 
+## Existing agent workarounds
+
+Internal agents already implement two ends of the desired design outside eve.
+They are useful requirements, not APIs to preserve.
+
+`v` maintains a small delegation reducer in its Slack channel state:
+
+- `actions.requested` extracts remote and local calls by `callId`, records
+  `pendingDelegations`, and reduces names to `calling d0 + content...`;
+- `action.result` removes the matching call and records failures and elapsed
+  time;
+- a detached 75-second loop re-renders that same status, adds elapsed minutes,
+  posts a five-minute still-working notice, and eventually probes remote child
+  sessions before deciding whether work is alive, stalled, or unknown;
+- `subagent.called` is attached by reaching into the channel adapter because
+  the public Slack event map cannot expose the child session id. The id is
+  copied to Postgres because the detached refresh invocation cannot read the
+  parent's durable channel state.
+
+This is an operation-set reducer plus a channel reconciler, but lifecycle,
+liveness, rendering, timer ownership, and external persistence are interleaved.
+It demonstrates that a useful aggregate needs stable call identity, child
+session identity, parallel labels, elapsed time, stale/unknown semantics, and
+an explicit distinction between refreshing presentation and changing progress.
+
+`e0` demonstrates structured, model-authored progress. Its `todo` results are
+validated as full snapshots, keyed by root or child session and turn, and
+reconciled into one Slack message that is updated in place. Root plans remain
+visible as completed; child plans are removed at child completion. e0 also
+attaches to each local child session stream to observe nested todo results,
+reasoning summaries, and action requests, then writes all of them directly to
+the parent Slack thread. This is effectively a hand-built hierarchical progress
+projection, but it depends on channel-side child stream attachment and embeds
+Slack message metadata in the persistence strategy.
+
+Together these implementations favor a layered authoring model:
+
+1. tools publish structured snapshots or tool-owned progress contributions;
+2. eve owns the default action/child tree and lifecycle invariants;
+3. an agent-level policy selects, combines, and summarizes contributions;
+4. the root channel reconciles the projection, including timer-driven refresh.
+
 ## Proposed semantic split
 
 ### Progress facts
@@ -143,6 +185,14 @@ ProgressNode`. Every channel can understand the result, but the shared shape
    their channel reconciler consumes the matching type. This is expressive but
    requires a clean way to connect agent and channel types across filesystem
    definitions and delegated-agent boundaries.
+
+Do not require an agent author to reconstruct the action map, child revision
+checks, or terminal precedence. Those are framework invariants. Agent-level
+authoring should wrap a default structural reducer or configure policies such
+as which completed nodes to retain, how to summarize parallel children, and
+whether a structured plan supersedes low-level actions. Tool-level projectors
+answer what one operation's output means; the agent policy answers what matters
+across the whole tree.
 
 Start with the constrained internal projection to establish semantics. Do not
 expose a public reducer until the tree survives nested delegation without
@@ -258,6 +308,13 @@ and child propagation are unchanged in either case.
    snapshots?
 9. How long do completed child nodes remain in the projection, especially when
    persistent subagent sessions are continued by a later call?
+10. Is elapsed time a renderer concern, a refresh-time projection over durable
+    `startedAt`, or semantic progress? v needs it without creating a new child
+    revision every minute.
+11. How should liveness observations such as v's remote session probes enter
+    progress without confusing "no recent event" with failure?
+12. Can root and child structured plans use one projection while retaining e0's
+    policy that completed root plans remain visible and child plans disappear?
 
 ## Implementation sequence
 

--- a/research/durable-hierarchical-progress.md
+++ b/research/durable-hierarchical-progress.md
@@ -1,7 +1,7 @@
 ---
 issue: https://github.com/vercel/eve/issues/1673
 status: proposed
-last_updated: "2026-08-05"
+last_updated: "2026-08-14"
 ---
 
 # Durable hierarchical progress
@@ -9,89 +9,108 @@ last_updated: "2026-08-05"
 ## Summary
 
 eve should maintain a durable, framework-owned work graph for the active turn
-and its delegated work. The graph is derived from authoritative runtime
-lifecycle state, composes through child sessions, and remains independent of
-channel effects. A root channel may render a safe, selected view of that graph.
+and its delegated work. The graph should derive from authoritative runtime
+lifecycle state, compose through child sessions, and remain independent of
+channel effects. A root channel can render a selected view without rebuilding
+execution ownership from raw streams.
 
 ```text
-runtime lifecycle + direct child state
-                │
-                ▼
-       durable work graph
-                │
-                ▼
-    channel-specific presentation
+runtime lifecycle + child observations
+                 │
+                 ▼
+        durable work graph
+                 │
+                 ▼
+     channel-specific presentation
 ```
 
-The first implementation should prove this boundary using existing lifecycle
-facts and local subagents. It should not initially define a general progress
-platform around plans, arbitrary annotations, public client events, remote
-capability negotiation, or custom channel APIs.
+The implementation experiment has validated the main boundary:
 
-A later PR should add action-local `reportProgress()` and automatic MCP progress
-adaptation after action ownership, child propagation, and rendering semantics
-are stable.
+- ordinary turn, step, action, blocker, and local-child state can reduce into a
+  useful graph without authored progress calls;
+- local child snapshots can be read without forwarding every child event;
+- Slack can render compact status and hierarchical activity from the same graph;
+- observation polling must remain separate from the parent's terminal-result
+  control loop;
+- channel presentation state needs explicit ownership across parent and monitor
+  workflows.
+
+Since the original proposal, eve also gained child-authored `task_update`
+notifications for background tasks in [PR #2113](https://github.com/vercel/eve/pull/2113).
+Those updates provide immediate semantic milestones over the existing task
+transport. They complement rather than replace the observed work graph: a task
+update says what the child chooses to report, while the graph records what the
+runtime can verify.
+
+The next design step should combine those sources before adding a broad public
+progress API. In particular, this proposal no longer recommends introducing
+`ctx.reportProgress()` as the immediate next layer.
 
 ## Problem
 
 Channels currently infer progress independently from low-level stream events.
-Slack, for example, derives status text from turn start, reasoning, assistant
-narration, action requests, authorization completion, visible output, and
-terminal events. The resulting state is implicit and channel-local.
+Slack, for example, can derive status text from turn start, reasoning, assistant
+narration, action requests, visible output, and terminal events. That state is
+implicit and channel-local.
 
-Delegated sessions make this boundary more visible. A parent knows that it
-started a child and eventually receives its terminal result, but the child's
-ordinary step and action lifecycle does not bubble through the parent. A channel
-that wants to show parallel delegated work must attach to child streams and
-rebuild ownership, ordering, and terminal state itself.
+Delegated sessions make the gap clearer. A parent owns a child action and
+receives its terminal result, but the child's ordinary step and action lifecycle
+does not appear in the parent session stream. A channel that wants to show
+parallel delegated work must otherwise attach to child streams and reconstruct
+ownership, ordering, and terminal state itself.
 
-The missing primitive is not presentation text. It is durable work ownership:
+The missing primitive is durable work ownership:
 
-> What work is currently active, waiting, or terminal, and what direct child
+> What work is currently active, blocked, or terminal, and what direct child
 > work does it own?
+
+A free-form status message alone cannot answer that question. Conversely, an
+observed graph cannot always explain the child's semantic goal. eve needs a
+clear boundary between observed execution facts, child-authored milestones,
+and presentation.
 
 ## Design principles
 
-1. **Observed work is the core.** The graph records runtime truth: active turn,
-   model steps, actions, blockers, and delegated children.
-2. **Plans are separate intent.** A todo list may later attach to a turn, but it
-   does not define execution truth and does not imply action-to-plan-item edges.
-3. **The graph is desired state, not history.** The durable event stream remains
+1. **Observed work is the core.** The graph records runtime truth: the active
+   turn, model steps, actions, blockers, and delegated children.
+2. **Authored updates annotate observed work.** A child milestone may add useful
+   text to its owning action, but it does not redefine lifecycle phase.
+3. **Plans are separate intent.** A todo list may attach to a turn, but it does
+   not define execution truth or imply action-to-plan-item edges.
+4. **The graph is desired state, not history.** The durable event stream remains
    the complete audit trail.
-4. **Reduction is framework-owned.** Agents do not customize graph invariants,
-   retention, child revisions, or terminal precedence.
-5. **Children publish snapshots.** Parents receive versioned child state rather
-   than every raw child event.
-6. **Presentation belongs to channels.** The graph contains no Slack blocks,
-   message ids, API operations, or presentation-maintenance timers.
-7. **Blockers are first-class.** Waiting for input, authorization, or approval is
-   authoritative work state, not an absence of progress.
-8. **Terminal state wins.** Late or replayed updates cannot resurrect settled
-   actions or children.
+5. **Reduction is framework-owned.** Agents do not customize graph invariants,
+   child revisions, retention, or terminal precedence.
+6. **Children own their projections.** Parents read versioned child state rather
+   than ingesting every raw child event.
+7. **Control and observation stay separate.** Terminal results, input, and
+   authorization use immediate control paths. Routine child observations must
+   not destabilize or wake the parent turn for every step.
+8. **Presentation belongs to channels.** The graph contains no Slack blocks,
+   message IDs, API operations, or presentation timers.
+9. **Blockers are first-class.** Waiting for input, authorization, or approval is
+   authoritative state, not an absence of progress.
+10. **Terminal state wins.** Late, replayed, or polled updates cannot resurrect
+    settled actions or channel activity.
 
-## Proposed v1 semantics
+## Proposed core semantics
 
-### Work graph
+### Session-relative work graph
 
-The first graph is deliberately small and internal:
+The initial graph should remain small and internal. A session-relative shape is
+sufficient; recursive child snapshots provide hierarchy without requiring a
+public root wrapper:
 
 ```ts
 type WorkPhase = "queued" | "running" | "blocked" | "completed" | "failed" | "cancelled";
 
-interface WorkSnapshot {
+interface WorkGraph {
   readonly revision: number;
-  readonly root: WorkScope;
-}
-
-interface WorkScope {
-  readonly sessionId: string;
-  readonly agentName: string;
-  readonly phase: WorkPhase;
   readonly turn?: WorkTurn;
 }
 
 interface WorkTurn {
-  readonly turnId: string;
+  readonly id: string;
   readonly phase: WorkPhase;
   readonly steps: readonly WorkStep[];
   readonly blockers: readonly WorkBlocker[];
@@ -105,10 +124,21 @@ interface WorkStep {
 
 interface WorkAction {
   readonly callId: string;
-  readonly kind: "tool" | "skill" | "subagent" | "remote-agent";
+  readonly kind: "tool-call" | "load-skill" | "subagent-call" | "remote-agent-call";
   readonly name: string;
   readonly phase: WorkPhase;
-  readonly child?: WorkScope;
+  readonly detail?: string;
+  readonly update?: WorkUpdate;
+  readonly child?: {
+    readonly sessionId: string;
+    readonly work?: WorkGraph;
+  };
+}
+
+interface WorkUpdate {
+  readonly message: string;
+  readonly revision: number;
+  readonly source: "task-update";
 }
 
 interface WorkBlocker {
@@ -119,8 +149,9 @@ interface WorkBlocker {
 }
 ```
 
-The public names and exact serialization are not committed by v1. The initial
-shape should remain internal until two renderers consume it successfully.
+The exact serialization and public names are not committed here. The graph
+should remain internal until its lifecycle and presentation consumers
+stabilize.
 
 ### Planless turns
 
@@ -136,13 +167,14 @@ turn [running]
     ├── run reproduction [running]
     └── researcher [running]
         └── child turn
-            └── inspect traces [running]
+            ├── discover [completed]
+            └── inspect [running]
 ```
 
-Actions observed under the same `stepIndex` are siblings. Because
-`actions.requested` may arrive incrementally, the reducer uses runtime action
-state—not one event batch—to determine which actions are concurrently active.
-A delegated action owns its child scope.
+Actions observed under the same `stepIndex` are siblings. A delegated action
+owns its child graph. Tool inputs may contribute bounded deterministic detail
+when a renderer-safe field is known, but the graph must not expose arbitrary
+arguments or infer future work.
 
 The graph does not infer a plan, user intent, or a relationship between an
 action and a hypothetical task.
@@ -153,325 +185,266 @@ A blocker belongs to the turn and may identify its owning action:
 
 ```text
 turn [blocked]
-├── step 1 [completed]
-│   └── update feature flag [blocked]
+├── update feature flag [blocked]
 └── approval [blocked]
     └── owner: update feature flag
 ```
 
 When the blocker resolves, the same blocker settles and the turn resumes. It is
-not replaced with a new unrelated status.
+not replaced with an unrelated status.
 
 ### Scope compaction
 
 The live graph is not an audit log:
 
-- retain all active and blocked actions;
-- retain completed actions while their step remains active;
-- collapse completed step internals to a step outcome when the turn advances;
-- retain failure/cancellation detail needed to explain the outcome;
-- retain active child scopes until their owning action settles;
-- remove the completed turn from the live session scope after settlement;
+- retain active and blocked actions;
+- retain completed actions while their surrounding work remains useful to the
+  active presentation;
+- collapse completed step internals as the turn advances;
+- retain failure or cancellation detail needed to explain the outcome;
+- retain active child graphs until their owning action settles;
+- remove the completed turn from live session state after settlement;
 - preserve the full sequence in the existing durable event stream.
 
-These rules are deterministic framework invariants, not authored retention
-settings.
+The implementation experiment retained more completed child actions than this
+minimal policy so Slack could show observed stage history. The final compaction
+rule should be based on bounded size and renderer needs, not on the fixture's
+three-stage shape.
 
-## Local child propagation
+## Child observation and control
 
-A delegated local session reduces its own graph and publishes a versioned
-snapshot through the existing parent turn inbox topology:
+### Local child work projections
 
-```ts
-interface ChildWorkUpdate {
-  readonly kind: "subagent-work";
-  readonly callId: string;
-  readonly childSessionId: string;
-  readonly revision: number;
-  readonly snapshot: WorkSnapshot;
-  readonly subagentName: string;
-}
-```
-
-The parent:
-
-1. binds the update to a running child handle by `callId` and session id;
-2. rejects stale revisions;
-3. replaces the child snapshot on the owning action;
-4. increments its own revision only when desired state changes;
-5. republishes its snapshot upward when it is itself delegated;
-6. rejects every child update after the action becomes terminal.
-
-Terminal result delivery and work updates may race. Both orders must converge
-to the same terminal parent graph. Child progress delivery is best-effort and
-must not delay model execution or terminal settlement indefinitely.
-
-The v1 payload is runtime-internal. Its shape should avoid assumptions that
-would prevent later remote delivery, but v1 does not define public remote
-capability negotiation.
-
-## Initial Slack consumers
-
-Slack is the proving ground, not part of the graph contract.
-
-### Deterministic status renderer
-
-The first consumer selects one compact line from the graph while preserving
-current visible behavior where practical:
+A local child writes its latest committed `WorkGraph` to a child-owned,
+namespaced workflow stream. A reader resolves the child session through the
+parent's running handle and reads the latest committed snapshot.
 
 ```text
-Running the checkout reproduction…
+child turn workflow
+  └── commit work graph → child eve.work projection
+
+parent control path
+  └── wait for terminal/input/auth inbox messages
+
+sibling work monitor
+  ├── read direct child eve.work tails
+  ├── compose newer snapshots
+  ├── render changed desired state
+  └── sleep for a bounded interval
 ```
 
-For parallel work:
+This structure follows from a failed experiment. Racing a durable timer against
+the parent turn's inbox iterator introduced competing replay paths and prevented
+the turn from reliably advancing after both child results were ready. Polling in
+a sibling workflow leaves the existing result-wait protocol unchanged.
+
+The monitor is observational:
+
+- it does not own terminal child results;
+- it does not mutate the parent's turn cursor;
+- it adopts only newer child revisions;
+- it stops when observed children are terminal;
+- polling failure must not fail the parent turn.
+
+The prototype uses a ten-second interval. That value is an operational default,
+not part of the graph contract.
+
+### Background task updates
+
+Merged background-task support gives task-owned children an immediate semantic
+path:
 
 ```text
-Researching three approaches…
+task-owned child
+  └── task_update({ message })
+        └── local task inbox or remote callback
+              └── deduplicated parent notification
 ```
 
-The renderer owns:
+A task update should annotate the matching child action or task node. It should
+not change the action's phase, append unbounded history, or replace framework-
+observed lifecycle facts.
 
-- human labels for known action kinds;
-- truncation and safe argument selection;
-- prioritizing blockers over active work;
-- summarizing parallel children;
-- clearing or superseding status after visible output;
-- all Slack API behavior and presentation maintenance.
+The two sources have different guarantees:
 
-Reasoning-derived or model-narrated status can remain a separate Slack policy
-while the graph is evaluated; raw reasoning does not need to enter the v1 work
-graph.
+| Source        | Meaning                            | Delivery                 | Coverage                             |
+| ------------- | ---------------------------------- | ------------------------ | ------------------------------------ |
+| Work snapshot | Framework-observed lifecycle state | Bounded local polling    | Local delegated sessions             |
+| `task_update` | Child-authored semantic milestone  | Immediate task transport | Task-owned local and remote children |
 
-### Hierarchical activity-message spike
+A practical next integration should use immediate task updates when available
+and retain snapshot polling as reconciliation and as a fallback for ordinary
+local subagents. The framework should coalesce repeated authored updates and
+bind them to stable task or call identity.
 
-The second consumer updates one Slack message from the same graph:
+### Terminal precedence
+
+Control and presentation can still race. The following sequence is valid:
 
 ```text
-Cold-start investigation
-
-✓ Dependency analysis
-  Found eager initialization
-
-◐ Bundle analysis
-  Running measurements
-
-! Runtime analysis
-  Waiting for access
+parent terminal renderer deletes or settles activity
+late monitor poll attempts an update
+channel rejects or ignores the stale update
 ```
 
-This renderer validates that the graph contains enough information for the
-motivating nested-work use case. It should support:
+The channel must fence terminal presentation. In the Slack experiment, the
+parent owns creation and terminal deletion of the transient activity message;
+the monitor may update an existing message but cannot recreate a missing one.
+A general channel contract needs equivalent ownership without exposing Slack
+message semantics in the graph.
 
-- parallel and nested local children;
-- active, blocked, completed, failed, and cancelled states;
-- stable in-place updates;
-- completed-scope collapse;
-- missing-message recovery;
-- terminal settlement.
+## Slack as the proving ground
 
-It may remain internal or experimental. The generic channel API should be
-extracted only after the status and activity renderers demonstrate a stable
-common input.
+Slack is a consumer of the graph, not part of its contract.
 
-## PR stack
+### Compact status
 
-### PR 1 — Pure internal work graph
+The compact renderer selects one deterministic line from active work. It owns
+human labels, truncation, blocker priority, parallel-child summarization, and
+status clearing. Reasoning-derived status may remain a separate policy; raw
+reasoning does not belong in the work graph.
 
-Add a pure reducer over existing authoritative lifecycle facts:
+### Hierarchical activity
 
-- turn and step lifecycle;
-- runtime action requests and results;
-- child dispatch and settlement;
-- input, authorization, and approval waits;
-- cancellation and failure.
+The activity renderer maintains one transient Slack message with one native
+`task_card` block per direct action or subagent. Child actions appear as
+rich-text details:
 
-Establish stable action identity, planless step grouping, replay determinism,
-terminal precedence, and scope compaction. Add no visible behavior or public
-API.
+```text
+Researcher [in progress]
+  ✓ discover
+  ◐ inspect
 
-Acceptance criteria:
-
-- planless turns reduce identically across replay;
-- incremental action request events converge on runtime action state;
-- parallel actions retain independent `callId` identity;
-- blockers attach and settle without losing their owner;
-- late events cannot rewrite terminal actions;
-- completed step detail collapses deterministically.
-
-### PR 2 — Durable local-child composition
-
-Publish versioned local-child snapshots and compose them into the parent graph.
-
-Acceptance criteria:
-
-- two parallel children remain independent;
-- a nested child update bubbles one parent at a time;
-- stale revisions are ignored;
-- terminal result/update races converge;
-- cancellation settles descendant work;
-- propagation failure does not fail an active turn;
-- no public remote wire contract is introduced.
-
-### PR 3 — Internal Slack status consumer
-
-Render the work graph through Slack's existing compact status surface. Preserve
-visible defaults where practical and keep every Slack-specific concern inside
-the Slack package.
-
-Acceptance criteria:
-
-- simple tool calls show useful deterministic status;
-- parallel children collapse to compact copy;
-- blockers outrank generic running status;
-- terminal and visible-output behavior remains correct;
-- the work graph contains no Slack fields.
-
-### PR 4 — Internal Slack activity-message renderer
-
-Add an internal or experimental replaceable message that renders hierarchical
-work.
-
-Acceptance criteria:
-
-- simple planless turns are not blank;
-- parallel and nested children update stable rows in place;
-- completed scopes collapse while failures remain legible;
-- blockers render distinctly from running work;
-- terminal state settles the message;
-- the renderer requires no child stream attachment outside framework snapshot
-  propagation.
-
-### PR 5 — `reportProgress()` and automatic MCP adaptation
-
-After the graph and propagation path are proven, add action-local authored
-reports:
-
-```ts
-interface ProgressReport {
-  readonly message?: string;
-  readonly progress?: number;
-  readonly total?: number;
-  readonly unit?: string;
-}
-
-export default defineTool({
-  async execute(input, ctx) {
-    await ctx.reportProgress({
-      message: "Indexing documents",
-      progress: 250,
-      total: 1_000,
-      unit: "documents",
-    });
-  },
-});
+Verifier [in progress]
+  ✓ prepare
+  ◐ validate
 ```
 
-`ToolContext.callId` supplies ownership. MCP `notifications/progress` enters the
-same internal action-report path by privately correlating `progressToken` to the
-active eve call.
+The experiment established several presentation constraints:
 
-This PR owns the hard durability semantics:
+- native `plan` blocks and standalone `task_card` details may collapse when a
+  whole message is replaced with `chat.update`;
+- Slack does not expose client expansion state through Block Kit;
+- standard section blocks remain the predictable always-expanded fallback;
+- Slack's `chat.startStream`, `chat.appendStream`, and `chat.stopStream` task
+  updates are a better candidate for native live agent progress than repeated
+  full-message replacement, but adopting them changes response ownership and
+  needs separate design;
+- the parent must own terminal cleanup so a stale monitor cannot leave a live
+  card after the final response.
 
-- define exactly what awaiting `reportProgress()` guarantees;
-- identify updates by call, execution attempt, and revision;
-- reject reports from stale attempts and terminal actions;
-- define whether numeric progress must be monotonic within one attempt;
-- coalesce rapid reports without losing the latest accepted snapshot;
-- prevent terminal settlement from being followed by a late resurrection;
-- bound propagation volume through nested parents;
-- remove MCP correlation state on settlement.
+The current activity renderer should remain internal while those tradeoffs are
+evaluated. A generic public channel progress hook is premature.
+
+## Revised rollout
+
+### 1. Internal work graph
+
+Reduce existing turn, step, action, blocker, delegation, cancellation, and
+failure facts. Prove deterministic identity and terminal precedence with unit
+tests.
+
+### 2. Child-owned local projections
+
+Write committed local child snapshots to a namespaced stream and support direct
+latest-snapshot reads. Keep this layer independent of channels.
+
+### 3. Isolated observation monitor
+
+Run bounded polling in a sibling workflow. Do not race observation timers
+against the parent control inbox. Prove replay, result delivery, cancellation,
+and monitor settlement independently.
+
+### 4. Slack consumers
+
+Consume the same graph for compact status and hierarchical activity. Keep
+message identity, Block Kit, API calls, fallback behavior, and terminal cleanup
+inside Slack.
+
+### 5. Task-update composition
+
+Project merged `task_update` notifications onto the owning task or child action.
+Use them for immediate semantic milestones while preserving observed graph phase
+and bounded snapshot reconciliation.
 
 Acceptance criteria:
 
-- report, crash, and retry do not regress or duplicate action state incorrectly;
-- a late report after terminal settlement is rejected;
-- rapid reports coalesce to the latest accepted report;
-- parallel tools report independently;
-- a nested child's report reaches the root renderer;
-- MCP progress reaches the same renderer without authored eve-specific code;
-- MCP servers that emit no progress retain useful lifecycle fallback.
+- duplicate task updates do not append duplicate graph state;
+- an update cannot revive a terminal task or action;
+- a fast update that races terminal settlement converges on terminal state;
+- local and remote task updates use the same annotation semantics;
+- ordinary local subagents remain useful without authored updates;
+- renderers can prefer a fresh semantic message without losing structured child
+  lifecycle state.
 
-This is the first PR likely to expose a new authored API and therefore needs
-public documentation, focused integration coverage, extension compatibility
-updates, and a changeset.
+### 6. Reassess authored tool progress
+
+Do not add `ctx.reportProgress()` until task updates and streaming tool partials
+have shown a missing authoring case. Preliminary tool results may already
+provide a natural action-owned source for authored tools. MCP
+`notifications/progress` still needs private `progressToken`-to-`callId`
+correlation, attempt identity, coalescing, and terminal rejection.
+
+If a common report shape remains necessary, design it from those proven sources
+rather than adding a parallel side channel first.
 
 ## Follow-on hypotheses
-
-The following are deliberately outside the first five PRs.
 
 ### Structured plans
 
 The framework todo is model-authored intent, not execution truth. A future
-change may add stable item ids, plan title, description, and merge-by-id, then
-attach an optional plan beside the observed step ladder:
-
-```ts
-interface ProgressPlan {
-  readonly id: string;
-  readonly title?: string;
-  readonly items: readonly ProgressPlanItem[];
-}
-```
-
-No action-to-plan-item relationship should be inferred without an explicit
-protocol field.
+change may attach a structured plan beside the observed step ladder. No
+action-to-plan-item edge should be inferred without an explicit protocol field.
 
 ### Generic channel API
 
-After two Slack consumers prove a stable input, extract the smallest generic
-channel hook from their common needs. Do not commit to a public
-`defineChannel({ progress() {} })` shape before that evidence exists.
+Extract the smallest channel-neutral hook only after multiple channel consumers
+or Slack presentation strategies prove a stable input and ownership model.
 
 ### Public observation
 
-A future `progress.updated` hook or client event may expose snapshots to authored
-observers and web clients. Publishing the graph creates a durable protocol
-commitment and should follow stabilization.
+A future client event or hook may expose snapshots to authored observers.
+Publishing the graph creates a durable protocol commitment and should follow
+internal stabilization.
 
-### Remote child capability
+### Remote child observations
 
-Remote agents eventually need capability negotiation or a coarse compatibility
-adapter. The local-child protocol should remain transportable, but v1 does not
-publish a remote wire format.
+`task_update` covers semantic milestones for task-owned remote children, not a
+complete remote work graph. Full remote observation still requires capability
+negotiation or a coarse compatibility projection.
 
-### Partial-output projection
+### Streaming Slack tasks
 
-Streaming tool output may later project into `ProgressReport`. The full
-`action.partial` stream remains independently valuable and should not be
-replaced by progress.
-
-### Model summaries
-
-A channel may eventually use a cheap model to summarize a bounded graph for its
-audience. Summarization is presentation-only, cached by graph fingerprint, and
-must fall back to deterministic copy. It never replaces canonical child state.
+Slack's streaming task updates may avoid the collapse behavior caused by
+`chat.update`. They also couple activity progress to a streaming response
+message, so the design must define who starts and stops the stream, how replayed
+updates deduplicate, and how the final response is delivered.
 
 ### Liveness
 
-Remote liveness, elapsed-time decoration, and stall policy are operational
-concerns distinct from semantic work phase. Lack of recent activity must not be
-interpreted automatically as failure.
+Elapsed time, remote liveness, and stall policy are operational concerns. Lack
+of recent activity must not automatically imply failure.
 
 ## Verification strategy
 
-Choose the narrowest test tier for each invariant:
+Use the narrowest tier for each invariant:
 
-- pure reducer and compaction tests at the unit tier;
-- in-memory child composition and race tests at the integration tier;
-- workflow retry, cancellation, and durable inbox behavior at the scenario
-  tier where necessary;
-- deterministic fixture coverage for final Slack integration behavior.
+- unit tests for pure reduction, compaction, child adoption, and Slack rendering;
+- integration tests for in-memory child composition and task-update projection;
+- scenario tests for workflow replay, monitor isolation, cancellation, and
+  terminal races;
+- deterministic fixture evals for final Slack behavior.
 
-The implementation stack is successful when:
+The design is successful when:
 
 - planless root work reduces deterministically;
-- nested local work composes without channel-side child stream readers;
-- stale or late updates cannot overwrite terminal state;
-- status and activity renderers consume the same graph;
+- nested local work composes without channel-side child stream attachment;
+- the parent control path remains unchanged by observation polling;
+- authored task updates annotate rather than replace observed state;
+- stale child or monitor updates cannot overwrite terminal state;
+- compact and hierarchical renderers consume the same graph;
 - the graph remains free of Slack state;
-- ordinary tools remain useful without authored progress reports;
-- PR 5 can add precise reports without changing graph ownership or child
-  propagation semantics.
+- ordinary tools and subagents remain useful without authored progress calls.
 
 ## Out of scope
 
@@ -480,6 +453,6 @@ The implementation stack is successful when:
 - inferred action-to-plan-item ownership;
 - raw reasoning in the work graph;
 - exactly-once external message creation;
-- public remote-agent progress negotiation in v1;
+- a public remote work-graph protocol;
 - automatic model summarization in canonical reduction;
 - replacing the durable event stream with the live work graph.

--- a/research/durable-hierarchical-progress.md
+++ b/research/durable-hierarchical-progress.md
@@ -239,6 +239,399 @@ operation-local progress. None is evidence for lossy or model-based reduction
 inside every child. An optional channel summarizer remains a novel but natural
 consumer-owned stage, and should cache by canonical projection fingerprint.
 
+## Public API design space
+
+The public API needs boundaries at four levels: producers contribute meaning,
+the agent materializes canonical state, delegated sessions publish canonical
+snapshots, and the root channel projects and reconciles a presentation. These
+levels should not share one generic `reduce(event)` callback.
+
+### Canonical types
+
+Three shapes are plausible.
+
+#### Recursive activity tree
+
+```ts
+interface ProgressSnapshot {
+  readonly revision: number;
+  readonly root: ProgressScope;
+}
+
+interface ProgressScope {
+  readonly id: string;
+  readonly kind: "agent";
+  readonly name: string;
+  readonly phase: ProgressPhase;
+  readonly summary?: string;
+  readonly startedAt: string;
+  readonly updatedAt: string;
+  readonly activities: readonly ProgressActivity[];
+}
+
+type ProgressActivity = ProgressAction | ProgressChild | ProgressPlan | ProgressBlocker;
+
+interface ProgressChild extends ProgressActivityBase {
+  readonly kind: "agent";
+  readonly callId: string;
+  readonly sessionId: string;
+  readonly progress: ProgressScope;
+}
+```
+
+This is easiest for renderers and naturally represents nested agents. Updating a
+deep child replaces a path and can duplicate large subtrees on the wire unless
+snapshots are bounded or structurally shared internally.
+
+#### Normalized graph
+
+```ts
+interface ProgressSnapshot {
+  readonly revision: number;
+  readonly rootId: string;
+  readonly nodes: Readonly<Record<string, ProgressNode>>;
+}
+
+interface ProgressNode {
+  readonly id: string;
+  readonly parentId?: string;
+  readonly kind: "agent" | "action" | "plan" | "blocker";
+  readonly phase: ProgressPhase;
+  readonly children: readonly string[];
+  readonly contribution?: ProgressContribution;
+}
+```
+
+This is compact, stable under replacement, and convenient for stale-revision
+checks. It is less pleasant for ordinary channel authors and exposes graph
+integrity concerns they should not need to maintain.
+
+#### Snapshot plus opaque extension contributions
+
+```ts
+interface ProgressActivity {
+  readonly id: string;
+  readonly kind: string;
+  readonly phase: ProgressPhase;
+  readonly label?: string;
+  readonly data?: JsonValue;
+}
+```
+
+This is extensible but gives channels little portable structure. Every renderer
+would eventually switch on tool-specific `kind` values.
+
+The recommended public read shape is a recursive tree with a bounded canonical
+schema. The runtime may store or propagate it as a normalized graph. Domain data
+can ride in namespaced optional annotations, but core identity, phase, nesting,
+counts, timestamps, and errors remain portable.
+
+```ts
+type ProgressPhase = "queued" | "running" | "blocked" | "completed" | "failed" | "cancelled";
+
+interface ProgressContribution {
+  readonly label?: string;
+  readonly detail?: string;
+  readonly completed?: number;
+  readonly total?: number;
+  readonly unit?: string;
+}
+```
+
+`label` and `detail` are semantic authored copy, not channel markup. They are
+optional because an action's tool or agent name is already a deterministic
+fallback.
+
+### Producer APIs
+
+There are three useful producer shapes, and eve likely needs two of them.
+
+#### Explicit operation-local reporting
+
+```ts
+export default defineTool({
+  async execute(input, ctx) {
+    await ctx.progress.report({
+      label: "Indexing documents",
+      completed: 250,
+      total: 1_000,
+      unit: "documents",
+    });
+  },
+});
+```
+
+This is natural for callbacks, MCP progress, and long operations that know when
+a meaningful milestone occurs. `report` must be asynchronous and revisioned.
+Its durability semantics must be explicit: it sends an out-of-band checkpoint
+rather than pretending an atomic tool step committed early. Rapid reports may
+coalesce latest-per-call while preserving the latest accepted checkpoint.
+
+#### Projection from tool lifecycle and partial output
+
+```ts
+export default defineTool({
+  async *execute(input) {
+    yield { indexed: 250, total: 1_000 };
+    yield { indexed: 1_000, total: 1_000 };
+  },
+  progress: {
+    started(input) {
+      return { label: `Indexing ${input.collection}` };
+    },
+    updated(output) {
+      return {
+        completed: output.indexed,
+        total: output.total,
+        unit: "documents",
+      };
+    },
+    completed(output) {
+      return { label: `Indexed ${output.total} documents` };
+    },
+  },
+});
+```
+
+This keeps a typed relation to tool input/output and lets `action.partial`
+remain a richer client stream. It cannot describe milestones that are not
+represented in yielded output.
+
+#### Generic progress tool
+
+A model-facing `report_progress` tool is useful for semantic work between tools,
+but should be additive. Requiring the model to narrate every operation is noisy
+and unreliable. Structured `todo` remains the better source for multi-step
+plans.
+
+Recommended producer API: support explicit `ctx.progress.report()` and an
+optional typed `progress` projector on `defineTool`. Both normalize to the same
+`ProgressContribution`; the last accepted explicit report wins over an inferred
+partial contribution until another lifecycle boundary.
+
+### Agent-level authoring
+
+A raw `(state, event) => state` replacement API is too easy to make lossy or
+break child and terminal invariants. Consider three levels of power.
+
+#### Declarative policy
+
+```ts
+export default defineAgent({
+  model: "openai/gpt-5.4",
+  progress: {
+    retainCompletedActions: 5,
+    retainCompletedChildren: "turn",
+    plans: "prefer-over-actions",
+  },
+});
+```
+
+This handles common retention choices but cannot add domain-specific aggregate
+state.
+
+#### Canonical annotations
+
+```ts
+export default defineAgent({
+  model: "openai/gpt-5.4",
+  progress: defineProgress({
+    annotate(snapshot, update) {
+      if (update.kind === "plan.updated") {
+        return { focus: update.plan.items.find((item) => item.phase === "running")?.label };
+      }
+    },
+  }),
+});
+```
+
+Annotations add bounded, serializable information while the framework still
+owns the canonical graph. They do not remove or rewrite nodes.
+
+#### Reducer middleware
+
+```ts
+progress: defineProgress({
+  reduce(base, update) {
+    const next = base(update);
+    return { ...next, annotations: updateAnnotations(next, update) };
+  },
+});
+```
+
+This is flexible but exposes ordering and replay semantics. If offered, `base`
+must always establish structural invariants first, and the callback should only
+be able to change an owned extension state or derived annotations, not core
+nodes.
+
+Recommended initial API: an optional `progress` field on `defineAgent` with
+declarative retention plus typed `annotate`. Every subagent definition gets the
+same surface. Do not add a separate filesystem slot until multiple independent
+progress modules need composition.
+
+The canonical projection should also be observable without being mutable:
+
+```ts
+export default defineHook({
+  events: {
+    "progress.updated"(event, ctx) {
+      console.info(event.data.progress.revision);
+    },
+  },
+});
+```
+
+This event fires only when canonical state changes, not on channel refresh.
+
+### Delegated-agent boundary
+
+The child-to-parent contract should remain framework-owned. Public authors read
+the same `ProgressSnapshot` whether a scope is root or nested; they do not send
+`subagent-progress` hook payloads themselves. A child may attach an authored
+semantic annotation or summary, but cannot choose what the parent discards.
+
+For remote agents, capability negotiation can accept either:
+
+```ts
+{
+  kind: ("progress.snapshot", revision, progress);
+}
+```
+
+or a coarse A2A-style task status that eve adapts into one child node. Lack of
+progress capability leaves the child as a running node until its terminal
+result.
+
+### Channel APIs
+
+The channel boundary needs to distinguish pure/derived presentation from
+external effects and refresh. Three shapes are plausible.
+
+#### One effectful callback
+
+```ts
+progress: async ({ progress, reason }, channel, ctx) => {
+  await channel.thread.startTyping(selectStatus(progress));
+  return { refreshAfterMs: 75_000 };
+};
+```
+
+This is simple and fits existing channel event handlers. It makes model-summary
+caching, create-versus-update state, and testability the author's problem.
+
+#### Project then reconcile
+
+```ts
+progress: defineChannelProgress({
+  async project(progress, ctx) {
+    return summarizeForSlack(progress, ctx);
+  },
+  async reconcile(view, channel, ctx) {
+    await channel.thread.startTyping(view.status);
+    return { refreshAfterMs: 75_000 };
+  },
+});
+```
+
+`project` runs only for a changed canonical fingerprint. It may call a cheap
+model and must return serializable presentation state. `reconcile` runs for
+`changed`, `refresh`, and `terminal` reasons and owns effects. On refresh it
+receives the cached view.
+
+#### Event reducer over canonical changes
+
+```ts
+progress: {
+  initial: () => ({ messageTs: null, view: null }),
+  reduce(state, event) { /* changed | refresh | terminal */ },
+}
+```
+
+This resembles UI reducers but mixes pure state and effects unless another
+command layer is introduced.
+
+Recommended channel API: project then reconcile.
+
+```ts
+interface ChannelProgressProjectContext {
+  readonly reason: "changed" | "terminal";
+  readonly previous?: ChannelProgressPresentation;
+  readonly session: SessionContext["session"];
+}
+
+interface ChannelProgressReconcileContext<TPresentation> {
+  readonly presentation: TPresentation;
+  readonly previous?: TPresentation;
+  readonly reason: "changed" | "refresh" | "terminal";
+}
+
+interface ChannelProgressReconcileResult {
+  readonly refreshAfterMs?: number;
+}
+```
+
+For a custom channel:
+
+```ts
+export default defineChannel({
+  state: { progressMessageId: null },
+  progress: defineChannelProgress({
+    project(progress) {
+      return mechanicalSummary(progress);
+    },
+    async reconcile(input, channel) {
+      channel.state.progressMessageId = await upsertProgressMessage(
+        channel.state.progressMessageId,
+        input.presentation,
+      );
+      return {};
+    },
+  }),
+});
+```
+
+For Slack, the built-in offers presets and an escape hatch:
+
+```ts
+slackChannel({
+  progress: slackProgress.status(),
+});
+
+slackChannel({
+  progress: slackProgress.message({
+    blocks(progress) {
+      return renderParallelAgentBlocks(progress);
+    },
+  }),
+});
+
+slackChannel({
+  progress: defineSlackProgress({ project, reconcile }),
+});
+```
+
+`slackProgress.status()` refreshes the cached status presentation before Slack
+expires it. `slackProgress.message()` updates a thread message and normally
+requests no refresh. `progress: false` suppresses the built-in renderer without
+suppressing canonical progress or `progress.updated` observation.
+
+### API recommendation
+
+The smallest coherent first public surface is:
+
+1. `ProgressContribution`, `ProgressSnapshot`, and recursive read-only node
+   types;
+2. `ctx.progress.report()` for operation-local milestones;
+3. optional typed tool `progress` projectors;
+4. agent `progress` retention/annotation policy, not arbitrary core reduction;
+5. `progress.updated` as an observe-only hook event;
+6. `defineChannelProgress({ project, reconcile })` with cached project output
+   and refresh reasons;
+7. Slack status and message presets built on the same channel contract.
+
+The runtime child propagation protocol remains internal until remote capability
+negotiation requires a public wire contract.
+
 ## Proposed semantic split
 
 ### Progress facts


### PR DESCRIPTION
### Summary

Related to #1673. This research revises the durable hierarchical progress proposal with evidence from the implementation spike and merged background-task updates in #2113.

The proposal keeps a framework-owned work graph as the canonical projection of observed turn, action, blocker, and task lifecycle state. It drops child-stream polling from the proposed architecture and instead composes the existing child-only `task_update({ message })` transport into the graph. The tool remains a free-form semantic update; stable task, turn, step, and call identity is added internally so the runtime can reduce updates deterministically without letting a child claim lifecycle state.

Slack remains the proving ground. Its status, task-card rendering, message ownership, terminal cleanup, and possible streaming-task integration stay channel-specific and internal. The proposal defers `ctx.reportProgress()` and a generic channel API until task updates and tool partials show a concrete missing contract. This PR remains a design artifact and changes no runtime behavior.

### Review focus

- Observed task lifecycle versus child-authored `task_update` annotations
- Reusing task inbox/callback delivery instead of polling child streams
- Keeping `task_update` free-form while structuring its internal identity
- Separating parent model awareness from immediate channel presentation
- Whether the current task message should eventually persist in `TaskView`

### Validation

- `pnpm exec oxfmt research/durable-hierarchical-progress.md`
- `git diff --check`
- No runtime tests were run; this PR changes only a research proposal

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)