### PR TITLE
WIP: route channel messages to remote agents

### DIFF
--- a/packages/eve/src/execution/remote-agent-dispatch.test.ts
+++ b/packages/eve/src/execution/remote-agent-dispatch.test.ts
@@ -4,6 +4,7 @@ import type { SessionAuthContext } from "#channel/types.js";
 import {
   cancelRemoteAgentTurn,
   continueRemoteAgentSession,
+  createRemoteAgentSession,
   isRetryableRemoteAgentCancelError,
   isRetryableRemoteAgentContinueError,
   resolveRemoteAgentForAction,
@@ -66,6 +67,58 @@ describe("resolveRemoteAgentForAction", () => {
     });
     await expect(resolved.auth?.()).resolves.toEqual({
       headers: { authorization: "Bearer selected" },
+    });
+  });
+});
+
+describe("createRemoteAgentSession", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uses the standard remote create-session transport for a caller-owned callback", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, sessionId: "remote-session", status: "accepted" }), {
+        status: 202,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      createRemoteAgentSession({
+        remote: createRemoteAgent(),
+        request: {
+          callback: {
+            callId: "route-call",
+            subagentName: "preview",
+            token: "route-inbox",
+            url: "https://caller.example.com/eve/v1/callback/route-inbox",
+          },
+          capabilities: {},
+          message: "Investigate the failure.",
+          mode: "conversation",
+        },
+      }),
+    ).resolves.toEqual({ sessionId: "remote-session" });
+
+    expect(fetchMock).toHaveBeenCalledWith("https://remote.example.com/eve/v1/session", {
+      body: JSON.stringify({
+        callback: {
+          callId: "route-call",
+          subagentName: "preview",
+          token: "route-inbox",
+          url: "https://caller.example.com/eve/v1/callback/route-inbox",
+        },
+        capabilities: {},
+        message: "Investigate the failure.",
+        mode: "conversation",
+      }),
+      headers: {
+        authorization: "Bearer remote-token",
+        "content-type": "application/json",
+        "x-static": "yes",
+      },
+      method: "POST",
     });
   });
 });

--- a/packages/eve/src/execution/remote-agent-dispatch.ts
+++ b/packages/eve/src/execution/remote-agent-dispatch.ts
@@ -28,9 +28,28 @@ const CreateSessionResponseSchema = z.object({
   status: z.literal("accepted"),
 });
 
-type RemoteAgentSessionCoordinates = {
+export interface RemoteAgentSessionCoordinates {
   readonly sessionId: string;
-};
+}
+
+/**
+ * Framework-owned create-session request for a remote eve agent. Kept separate
+ * from model subagent actions so other durable callers can use the same remote
+ * protocol without reimplementing request validation or credentials.
+ */
+export interface RemoteAgentSessionRequest {
+  readonly callback: {
+    readonly callId: string;
+    readonly subagentName: string;
+    readonly token: string;
+    readonly url: string;
+  };
+  readonly capabilities: {};
+  readonly forwardedPrincipal?: ForwardedPrincipal;
+  readonly message: string;
+  readonly mode: "conversation" | "task";
+  readonly outputSchema?: object;
+}
 
 class RemoteAgentCancelRequestError extends Error {
   readonly retryable: boolean;
@@ -104,9 +123,26 @@ export async function startRemoteAgentSession(input: {
     requestBody.forwardedPrincipal = forwardedPrincipal;
   }
 
+  return await createRemoteAgentSession({
+    remote: input.remote,
+    request: requestBody,
+  });
+}
+
+/**
+ * Starts a remote eve session using the standard remote-agent transport.
+ *
+ * Model subagent dispatch builds its request through
+ * {@link startRemoteAgentSession}; durable channel routing can use this lower
+ * layer after it has constructed its own callback ownership.
+ */
+export async function createRemoteAgentSession(input: {
+  readonly remote: ResolvedRuntimeRemoteAgentNode;
+  readonly request: RemoteAgentSessionRequest;
+}): Promise<RemoteAgentSessionCoordinates> {
   const headers = await resolveRemoteAgentRequestHeaders(input.remote);
   const response = await fetch(createRemoteAgentSessionUrl(input.remote), {
-    body: JSON.stringify(requestBody),
+    body: JSON.stringify(input.request),
     headers: {
       "content-type": "application/json",
       ...headers,
@@ -116,7 +152,7 @@ export async function startRemoteAgentSession(input: {
 
   if (!response.ok) {
     throw new Error(
-      `Remote agent "${input.action.remoteAgentName}" create-session request failed with HTTP ${response.status}.`,
+      `Remote agent "${input.remote.name}" create-session request failed with HTTP ${response.status}.`,
     );
   }
 
@@ -125,15 +161,13 @@ export async function startRemoteAgentSession(input: {
     body = await response.json();
   } catch {
     throw new Error(
-      `Remote agent "${input.action.remoteAgentName}" create-session response was not valid JSON.`,
+      `Remote agent "${input.remote.name}" create-session response was not valid JSON.`,
     );
   }
 
   const parsed = CreateSessionResponseSchema.safeParse(body);
   if (!parsed.success) {
-    throw new Error(
-      `Remote agent "${input.action.remoteAgentName}" create-session response was invalid.`,
-    );
+    throw new Error(`Remote agent "${input.remote.name}" create-session response was invalid.`);
   }
 
   return { sessionId: parsed.data.sessionId };


### PR DESCRIPTION
### Summary

Related to #1955. Begins the provider-neutral remote channel-routing work by extracting the standard remote create-session transport from model subagent dispatch.

This draft will add the coordinating parent turn and channel message-context route operation. The extracted transport lets that coordinator use the same credentials, callback validation, and forwarding behavior as existing remote agents rather than a client-side relay.

### Validation

- `pnpm --filter eve run build:compiled`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/execution/remote-agent-dispatch.test.ts`

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
