### PR TITLE
feat: define Vercel branch agents

### DIFF
--- a/.changeset/bright-preview-branches.md
+++ b/.changeset/bright-preview-branches.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add `defineVercelBranchAgent` for routing to an explicitly supplied Vercel branch Preview URL with standard Vercel OIDC transport authentication.

--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -131,6 +131,11 @@
       "import": "./dist/src/public/agents/auth.js",
       "default": "./dist/src/public/agents/auth.js"
     },
+    "./agents/vercel": {
+      "types": "./dist/src/public/agents/vercel.d.ts",
+      "import": "./dist/src/public/agents/vercel.js",
+      "default": "./dist/src/public/agents/vercel.js"
+    },
     "./hooks": {
       "types": "./dist/src/public/hooks/index.d.ts",
       "import": "./dist/src/public/hooks/index.js",

--- a/packages/eve/src/public/agents/vercel.test.ts
+++ b/packages/eve/src/public/agents/vercel.test.ts
@@ -22,6 +22,7 @@ describe("defineVercelBranchAgent", () => {
     });
 
     expect(agent).toMatchObject({
+      branch: "feature/preview-agent",
       description: "Preview agent.",
       forwardPrincipal: true,
       kind: "remote",

--- a/packages/eve/src/public/agents/vercel.test.ts
+++ b/packages/eve/src/public/agents/vercel.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("#compiled/@vercel/oidc/index.js", () => ({
+  getVercelOidcToken: vi.fn(),
+}));
+
+import { getVercelOidcToken } from "#compiled/@vercel/oidc/index.js";
+import { VERCEL_TRUSTED_OIDC_IDP_TOKEN_HEADER } from "#client/types.js";
+
+import { normalizeChannelDirectedRemote } from "#execution/channel-directed-remote.js";
+import { defineVercelBranchAgent } from "#public/agents/vercel.js";
+
+describe("defineVercelBranchAgent", () => {
+  afterEach(() => vi.resetAllMocks());
+
+  it("returns a standard remote agent using Vercel OIDC", async () => {
+    const agent = defineVercelBranchAgent({
+      branch: "feature/preview-agent",
+      description: "Preview agent.",
+      forwardPrincipal: true,
+      url: "https://my-agent-git-feature-preview-agent-acme.vercel.app",
+    });
+
+    expect(agent).toMatchObject({
+      description: "Preview agent.",
+      forwardPrincipal: true,
+      kind: "remote",
+      path: "/eve/v1/session",
+      url: "https://my-agent-git-feature-preview-agent-acme.vercel.app",
+    });
+    vi.mocked(getVercelOidcToken).mockResolvedValue("oidc-token");
+    await expect(agent.auth?.()).resolves.toEqual({
+      headers: {
+        authorization: "Bearer oidc-token",
+        [VERCEL_TRUSTED_OIDC_IDP_TOKEN_HEADER]: "oidc-token",
+      },
+    });
+    await expect(normalizeChannelDirectedRemote(agent)).resolves.toMatchObject({
+      credentialsStepId: "eve:vercel-branch-agent//credentials",
+    });
+    const resolver = Reflect.get(agent, "__eveResolveRemoteAgentCredentials");
+    expect(resolver).toBeTypeOf("function");
+    await expect(
+      (resolver as () => { readonly auth: () => Promise<unknown> })().auth(),
+    ).resolves.toEqual({
+      headers: {
+        authorization: "Bearer oidc-token",
+        [VERCEL_TRUSTED_OIDC_IDP_TOKEN_HEADER]: "oidc-token",
+      },
+    });
+  });
+
+  it("requires a branch", () => {
+    expect(() =>
+      defineVercelBranchAgent({
+        branch: "  ",
+        description: "Preview agent.",
+        url: "https://preview.example.com",
+      }),
+    ).toThrow("requires a non-empty branch");
+  });
+});

--- a/packages/eve/src/public/agents/vercel.ts
+++ b/packages/eve/src/public/agents/vercel.ts
@@ -22,21 +22,29 @@ export interface VercelBranchAgentInput extends Omit<RemoteAgentDefinitionInput,
   readonly url: string;
 }
 
+/** A remote agent definition carrying the Git branch it represents. */
+export interface VercelBranchAgentDefinition extends RemoteAgentDefinition {
+  readonly branch: string;
+}
+
 /**
  * Returns a normal remote-agent definition for a Vercel branch Preview
  * Deployment. Outbound Vercel OIDC authenticates this deployment to the
  * preview; forwarding the end-user principal remains an explicit opt-in.
  */
-export function defineVercelBranchAgent(input: VercelBranchAgentInput): RemoteAgentDefinition {
+export function defineVercelBranchAgent(
+  input: VercelBranchAgentInput,
+): VercelBranchAgentDefinition {
   const { branch: rawBranch, ...remote } = input;
   const branch = rawBranch.trim();
   if (!branch) throw new Error("defineVercelBranchAgent requires a non-empty branch.");
 
   const agent = Object.assign(defineRemoteAgent(remote), { auth: vercelDeploymentOidc });
-  Object.defineProperty(agent, "__eveResolveRemoteAgentCredentials", {
-    value: vercelBranchAgentCredentials,
+  Object.defineProperties(agent, {
+    __eveResolveRemoteAgentCredentials: { value: vercelBranchAgentCredentials },
+    branch: { value: branch },
   });
-  return agent;
+  return agent as typeof agent & VercelBranchAgentDefinition;
 }
 
 const VERCEL_BRANCH_AGENT_CREDENTIALS_STEP_ID = "eve:vercel-branch-agent//credentials";

--- a/packages/eve/src/public/agents/vercel.ts
+++ b/packages/eve/src/public/agents/vercel.ts
@@ -1,0 +1,65 @@
+import { getVercelOidcToken } from "#compiled/@vercel/oidc/index.js";
+import type { OutboundAuthFn } from "#public/agents/auth.js";
+import { VERCEL_TRUSTED_OIDC_IDP_TOKEN_HEADER } from "#client/types.js";
+import {
+  defineRemoteAgent,
+  type RemoteAgentDefinition,
+  type RemoteAgentDefinitionInput,
+} from "#public/definitions/remote-agent.js";
+
+/**
+ * Defines a remote eve agent at a Vercel branch Preview Deployment.
+ *
+ * `url` is the branch's stable Preview URL, not an immutable deployment URL.
+ * The branch remains user-facing registration identity while Vercel advances
+ * the URL to the latest deployment for it. eve does not derive this URL: Vercel
+ * preview suffixes and custom branch domains are deployment configuration.
+ */
+export interface VercelBranchAgentInput extends Omit<RemoteAgentDefinitionInput, "auth" | "url"> {
+  /** Git branch represented by the Preview Deployment. */
+  readonly branch: string;
+  /** Stable Vercel branch Preview URL. */
+  readonly url: string;
+}
+
+/**
+ * Returns a normal remote-agent definition for a Vercel branch Preview
+ * Deployment. Outbound Vercel OIDC authenticates this deployment to the
+ * preview; forwarding the end-user principal remains an explicit opt-in.
+ */
+export function defineVercelBranchAgent(input: VercelBranchAgentInput): RemoteAgentDefinition {
+  const { branch: rawBranch, ...remote } = input;
+  const branch = rawBranch.trim();
+  if (!branch) throw new Error("defineVercelBranchAgent requires a non-empty branch.");
+
+  const agent = Object.assign(defineRemoteAgent(remote), { auth: vercelDeploymentOidc });
+  Object.defineProperty(agent, "__eveResolveRemoteAgentCredentials", {
+    value: vercelBranchAgentCredentials,
+  });
+  return agent;
+}
+
+const VERCEL_BRANCH_AGENT_CREDENTIALS_STEP_ID = "eve:vercel-branch-agent//credentials";
+
+const vercelDeploymentOidc = Object.assign(
+  async () => {
+    const token = await getVercelOidcToken();
+    return {
+      headers: {
+        authorization: `Bearer ${token}`,
+        [VERCEL_TRUSTED_OIDC_IDP_TOKEN_HEADER]: token,
+      },
+    };
+  },
+  { stepId: VERCEL_BRANCH_AGENT_CREDENTIALS_STEP_ID },
+) satisfies OutboundAuthFn;
+
+const vercelBranchAgentCredentials = Object.assign(() => ({ auth: vercelDeploymentOidc }), {
+  stepId: VERCEL_BRANCH_AGENT_CREDENTIALS_STEP_ID,
+});
+
+const stepRegistryKey = Symbol.for("@workflow/core//registeredSteps");
+const globalRegistry = globalThis as Record<symbol, Map<string, Function> | undefined>;
+const stepRegistry = globalRegistry[stepRegistryKey] ?? new Map<string, Function>();
+globalRegistry[stepRegistryKey] = stepRegistry;
+stepRegistry.set(VERCEL_BRANCH_AGENT_CREDENTIALS_STEP_ID, vercelBranchAgentCredentials);


### PR DESCRIPTION
### Summary

Related to #1955. Adds `defineVercelBranchAgent()` for an explicit Vercel branch Preview URL.

The helper builds a normal remote-agent definition, validates the branch input, and authenticates protected Preview deployments with Vercel OIDC in both required headers. Its registered credential factory resolves fresh auth only at dispatch time, so channel-routed durable state keeps an identifier rather than a token.

### Validation

- `pnpm --filter eve run build:compiled`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/agents/vercel.test.ts` (2 tests)
- `pnpm guard:invariants`
- Production-to-protected-Preview routing exercised through the Slack demo

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
