### PR TITLE
WIP: register Slack Preview Deployment agents

### DIFF
--- a/packages/eve/src/public/agents/vercel.test.ts
+++ b/packages/eve/src/public/agents/vercel.test.ts
@@ -7,6 +7,7 @@ vi.mock("#compiled/@vercel/oidc/index.js", () => ({
 import { getVercelOidcToken } from "#compiled/@vercel/oidc/index.js";
 import { VERCEL_TRUSTED_OIDC_IDP_TOKEN_HEADER } from "#client/types.js";
 
+import { normalizeChannelDirectedRemote } from "#execution/channel-directed-remote.js";
 import { defineVercelBranchAgent } from "#public/agents/vercel.js";
 
 describe("defineVercelBranchAgent", () => {
@@ -33,6 +34,9 @@ describe("defineVercelBranchAgent", () => {
         authorization: "Bearer oidc-token",
         [VERCEL_TRUSTED_OIDC_IDP_TOKEN_HEADER]: "oidc-token",
       },
+    });
+    await expect(normalizeChannelDirectedRemote(agent)).resolves.toMatchObject({
+      credentialsStepId: "eve:vercel-branch-agent//credentials",
     });
   });
 

--- a/packages/eve/src/public/agents/vercel.ts
+++ b/packages/eve/src/public/agents/vercel.ts
@@ -32,14 +32,17 @@ export function defineVercelBranchAgent(input: VercelBranchAgentInput): RemoteAg
   const branch = rawBranch.trim();
   if (!branch) throw new Error("defineVercelBranchAgent requires a non-empty branch.");
 
-  return defineRemoteAgent({
-    ...remote,
-    auth: vercelDeploymentOidc(),
+  const agent = Object.assign(defineRemoteAgent(remote), { auth: vercelDeploymentOidc });
+  Object.defineProperty(agent, "__eveResolveRemoteAgentCredentials", {
+    value: vercelDeploymentOidc,
   });
+  return agent;
 }
 
-function vercelDeploymentOidc(): OutboundAuthFn {
-  return async () => {
+const VERCEL_BRANCH_AGENT_CREDENTIALS_STEP_ID = "eve:vercel-branch-agent//credentials";
+
+const vercelDeploymentOidc = Object.assign(
+  async () => {
     const token = await getVercelOidcToken();
     return {
       headers: {
@@ -47,5 +50,12 @@ function vercelDeploymentOidc(): OutboundAuthFn {
         [VERCEL_TRUSTED_OIDC_IDP_TOKEN_HEADER]: token,
       },
     };
-  };
-}
+  },
+  { stepId: VERCEL_BRANCH_AGENT_CREDENTIALS_STEP_ID },
+) satisfies OutboundAuthFn & { readonly stepId: string };
+
+const stepRegistryKey = Symbol.for("@workflow/core//registeredSteps");
+const globalRegistry = globalThis as Record<symbol, Map<string, Function> | undefined>;
+const stepRegistry = globalRegistry[stepRegistryKey] ?? new Map<string, Function>();
+globalRegistry[stepRegistryKey] = stepRegistry;
+stepRegistry.set(VERCEL_BRANCH_AGENT_CREDENTIALS_STEP_ID, vercelDeploymentOidc);

--- a/packages/eve/src/public/channels/slack/index.ts
+++ b/packages/eve/src/public/channels/slack/index.ts
@@ -68,6 +68,12 @@ export {
 export { defaultSlackAuth } from "#public/channels/slack/defaults.js";
 
 export {
+  slackUserGroupMentions,
+  withoutSlackUserGroupMention,
+  type SlackUserGroupMention,
+} from "#public/channels/slack/user-groups.js";
+
+export {
   describeActionRequest,
   describeActionRequests,
 } from "#public/channels/slack/action-status.js";

--- a/packages/eve/src/public/channels/slack/user-groups.test.ts
+++ b/packages/eve/src/public/channels/slack/user-groups.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  slackUserGroupMentions,
+  withoutSlackUserGroupMention,
+} from "#public/channels/slack/user-groups.js";
+
+describe("slackUserGroupMentions", () => {
+  it("returns unique opaque group ids in mention order", () => {
+    expect(
+      slackUserGroupMentions("Ask <!subteam^S123|preview> then <!subteam^S456>. <!subteam^S123>"),
+    ).toEqual([{ id: "S123" }, { id: "S456" }]);
+  });
+});
+
+describe("withoutSlackUserGroupMention", () => {
+  it("removes only the selected group mention", () => {
+    expect(
+      withoutSlackUserGroupMention("<!subteam^S123|preview> check <!subteam^S456>", "S123"),
+    ).toBe("check <!subteam^S456>");
+  });
+});

--- a/packages/eve/src/public/channels/slack/user-groups.ts
+++ b/packages/eve/src/public/channels/slack/user-groups.ts
@@ -1,0 +1,34 @@
+const USER_GROUP_MENTION = /<!subteam\^([A-Z0-9]+)(?:\|[^>]+)?>/gu;
+
+/** One Slack user-group mention found in message text. */
+export interface SlackUserGroupMention {
+  readonly id: string;
+}
+
+/**
+ * Returns unique Slack user-group ids mentioned in text in first-mention
+ * order. The parser deliberately retains Slack's opaque id rather than a
+ * mutable display handle so channel-owned registries can verify ownership.
+ */
+export function slackUserGroupMentions(text: string): readonly SlackUserGroupMention[] {
+  const seen = new Set<string>();
+  const mentions: SlackUserGroupMention[] = [];
+  for (const match of text.matchAll(USER_GROUP_MENTION)) {
+    const id = match[1];
+    if (id === undefined || seen.has(id)) continue;
+    seen.add(id);
+    mentions.push({ id });
+  }
+  return mentions;
+}
+
+/**
+ * Removes one recognized user-group mention using the same whitespace
+ * normalization callers use for an empty Slack app mention.
+ */
+export function withoutSlackUserGroupMention(text: string, userGroupId: string): string {
+  return text
+    .replace(USER_GROUP_MENTION, (mention, id: string) => (id === userGroupId ? "" : mention))
+    .replace(/\s+/gu, " ")
+    .trim();
+}


### PR DESCRIPTION
### Summary

Related to #1955. Adds Slack user-group mention helpers as the first channel-owned registration/routing layer, stacked on #1959 and the channel-directed remote primitive in #2007.

The helpers parse immutable Slack user-group IDs and remove only a selected recognized mention. Follow-up work in this PR will add the approval-gated branch management tool and bot-owned group registry; aliases remain Slack metadata rather than framework-global state.

### Validation

- `pnpm --filter eve run build:compiled`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/channels/slack/user-groups.test.ts`
- Top-of-stack package vendored into a real Slack agent and typechecked

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
