### PR TITLE
chore: add cmpadden as package code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-/packages/*/package.json @andrewbarba @ctgowrie @ruiconti @ijjk
+/packages/*/package.json @andrewbarba @ctgowrie @ruiconti @ijjk @cmpadden


### PR DESCRIPTION
### Summary

Add `@cmpadden` as an owner to perform releases.

### Validation

- `git diff --check HEAD^ HEAD`
- Tests and documentation are not applicable to this ownership-only change

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [ ] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
