### PR TITLE
fix(eve): fix issue with blob fetch in package artifact deployment

### DIFF
--- a/apps/package-artifacts/api/package.js
+++ b/apps/package-artifacts/api/package.js
@@ -33,7 +33,7 @@ function packageNotFound(response) {
 }
 
 async function resolveManifest(sourceSha) {
-  const result = await get(packageManifestPath(sourceSha), { access: "public", useCache: false });
+  const result = await get(packageManifestPath(sourceSha), { access: "public" });
   if (result === null) return undefined;
 
   const manifest = JSON.parse(await new Response(result.stream).text());

--- a/apps/package-artifacts/api/package.test.mjs
+++ b/apps/package-artifacts/api/package.test.mjs
@@ -37,7 +37,6 @@ describe("package route", () => {
 
     expect(get).toHaveBeenCalledWith(`packages/${sha}/manifest.json`, {
       access: "public",
-      useCache: false,
     });
     expect(res.setHeader).toHaveBeenCalledWith("Cache-Control", "public, max-age=60");
     expect(res.redirect).toHaveBeenCalledWith(302, manifest.tarball);

--- a/apps/package-artifacts/scripts/build.mjs
+++ b/apps/package-artifacts/scripts/build.mjs
@@ -85,7 +85,7 @@ try {
 
   const manifest = { sourceSha, version, tarball: artifact.url, sha256 };
   const manifestPath = packageManifestPath(sourceSha);
-  const existingManifest = await get(manifestPath, { access: "public", useCache: false });
+  const existingManifest = await get(manifestPath, { access: "public" });
   if (existingManifest === null) {
     await put(manifestPath, JSON.stringify(manifest), {
       access: "public",


### PR DESCRIPTION
### Summary

Public package artifact deployments fail after uploading the tarball because `@vercel/blob` returns a 400 when `useCache: false` is used to fetch a public manifest (it's intended only for use in private blob stores). This removes the unused / invalid option. 

Follow-up to #1950.

### Validation

- `pnpm --filter eve-package-artifacts test` (9 tests passed)
- `pnpm exec oxfmt --check apps/package-artifacts/api/package.js apps/package-artifacts/api/package.test.mjs apps/package-artifacts/scripts/build.mjs`
- `pnpm exec oxlint apps/package-artifacts/api/package.js apps/package-artifacts/api/package.test.mjs apps/package-artifacts/scripts/build.mjs`
- `git diff --check`

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant *(updated the focused assertion; no documentation change needed)*
- [x] I added a changeset if this touches the published `eve` package *(not applicable; internal deployment app only)*
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
