### PR TITLE
feat(eve): reduce active turn work graph

### DIFF
--- a/packages/eve/src/context/keys.ts
+++ b/packages/eve/src/context/keys.ts
@@ -20,6 +20,7 @@ import type {
 import { ContextKey } from "#context/key.js";
 import type { InstrumentationChannelDeliveryRef } from "#harness/instrumentation/lifecycle.js";
 import type { HarnessToolDefinition } from "#harness/execute-tool.js";
+import type { WorkGraph } from "#harness/work-graph.js";
 import type { DynamicSubagentAgentConfig } from "#runtime/subagents/dynamic-agent-config.js";
 import type { DynamicRemoteAgentConfig } from "#runtime/subagents/dynamic-remote-agent-config.js";
 import type { SandboxAccess } from "#sandbox/state.js";
@@ -91,6 +92,8 @@ export const ParentSessionKey = new ContextKey<SessionParent>("eve.parentSession
 /** Separate from {@link ParentSessionKey} so it stays out of what extensions read. */
 export const ParentTraceContextKey = new ContextKey<SessionTraceContext>("eve.parentTraceContext");
 export const SubagentDepthKey = new ContextKey<number>("eve.subagentDepth");
+/** Framework-owned live work graph for the active turn. */
+export const WorkGraphKey = new ContextKey<WorkGraph>("eve.workGraph");
 
 /**
  * Session-level capability flags (see {@link SessionCapabilities}). Set

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -27,6 +27,7 @@ import {
   SessionDynamicSubagentRuntimeRevisionKey,
   SessionDynamicToolRuntimeRevisionKey,
   TurnTaskDeliveryKey,
+  WorkGraphKey,
 } from "#context/keys.js";
 import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
 import { runStep } from "#context/run-step.js";
@@ -60,6 +61,7 @@ import { getPendingWorkflowInterrupt } from "#harness/workflow-interrupt-state.j
 import { getPendingRuntimeActionBatch } from "#harness/runtime-actions.js";
 import type { HarnessSession, SettledTurn, StepInput, StepResult } from "#harness/types.js";
 import { getTurnUsageState, takeSessionUsageDelta, toUsage } from "#harness/turn-tag-state.js";
+import { reduceWorkGraph } from "#harness/work-graph.js";
 import type { TokenUsage } from "#shared/token-usage.js";
 import { getRuntimeActionRequestKey } from "#runtime/actions/keys.js";
 import {
@@ -392,6 +394,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
 
   // Stamp once: the persisted chunk and the hooks below must agree on the id.
   const emit = async (event: UnstampedMessageStreamEvent): Promise<MessageStreamEvent> => {
+    ctx.set(WorkGraphKey, reduceWorkGraph(ctx.get(WorkGraphKey), event));
     const toEmit = await callAdapterEventHandler(adapter, event, adapterCtx);
     setChannelContext(ctx, { ...adapter, state: { ...adapterCtx.state } });
     const stamped = stampMessageStreamEvent(toEmit);

--- a/packages/eve/src/harness/work-graph.test.ts
+++ b/packages/eve/src/harness/work-graph.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+
+import { reduceWorkGraph } from "#harness/work-graph.js";
+import type { UnstampedMessageStreamEvent } from "#protocol/message.js";
+
+function reduce(...events: readonly UnstampedMessageStreamEvent[]) {
+  return events.reduce(reduceWorkGraph, undefined);
+}
+
+describe("work graph", () => {
+  it("groups incrementally requested actions under their model step", () => {
+    const graph = reduce(
+      { data: { sequence: 0, turnId: "turn-1" }, type: "turn.started" },
+      {
+        data: { modelId: "test", sequence: 0, stepIndex: 0, turnId: "turn-1" },
+        type: "step.started",
+      },
+      {
+        data: {
+          actions: [
+            {
+              callId: "call-search",
+              input: { query: "eve" },
+              kind: "tool-call",
+              toolName: "search_docs",
+            },
+          ],
+          sequence: 0,
+          stepIndex: 0,
+          turnId: "turn-1",
+        },
+        type: "actions.requested",
+      },
+      {
+        data: {
+          actions: [
+            {
+              callId: "call-read",
+              input: { path: "docs/slack.md" },
+              kind: "tool-call",
+              toolName: "read_file",
+            },
+          ],
+          sequence: 0,
+          stepIndex: 0,
+          turnId: "turn-1",
+        },
+        type: "actions.requested",
+      },
+    );
+
+    expect(graph).toEqual({
+      revision: 4,
+      turn: {
+        blockers: [],
+        id: "turn-1",
+        phase: "running",
+        steps: [
+          {
+            actions: [
+              { callId: "call-search", kind: "tool-call", name: "search_docs", phase: "running" },
+              { callId: "call-read", kind: "tool-call", name: "read_file", phase: "running" },
+            ],
+            phase: "running",
+            stepIndex: 0,
+          },
+        ],
+      },
+    });
+  });
+
+  it("attaches a child session and does not let its terminal action resurrect", () => {
+    const graph = reduce(
+      { data: { sequence: 0, turnId: "turn-1" }, type: "turn.started" },
+      {
+        data: {
+          actions: [
+            {
+              callId: "call-child",
+              description: "Research the issue.",
+              input: {},
+              kind: "subagent-call",
+              name: "researcher",
+              nodeId: "subagents/researcher",
+              subagentName: "researcher",
+            },
+          ],
+          sequence: 0,
+          stepIndex: 0,
+          turnId: "turn-1",
+        },
+        type: "actions.requested",
+      },
+      {
+        data: {
+          callId: "call-child",
+          childSessionId: "child-1",
+          childStreamPath: "/eve/v1/session/parent-1/subagents/call-child/child-1/stream",
+          name: "researcher",
+          sequence: 0,
+          sessionId: "parent-1",
+          toolName: "researcher",
+          turnId: "turn-1",
+          workflowId: "workflow-1",
+        },
+        type: "subagent.called",
+      },
+      {
+        data: {
+          result: {
+            callId: "call-child",
+            isError: false,
+            kind: "subagent-result",
+            origin: "child",
+            outcome: {
+              kind: "terminal",
+              result: { kind: "succeeded", output: "done" },
+              usageDelta: {
+                cacheReadTokens: 0,
+                cacheWriteTokens: 0,
+                inputTokens: 0,
+                outputTokens: 0,
+              },
+            },
+            output: "done",
+            subagentName: "researcher",
+          },
+          sequence: 0,
+          status: "completed",
+          stepIndex: 0,
+          turnId: "turn-1",
+        },
+        type: "action.result",
+      },
+      {
+        data: {
+          callId: "call-child",
+          childSessionId: "late-child",
+          childStreamPath: "/eve/v1/session/parent-1/subagents/call-child/late-child/stream",
+          name: "researcher",
+          sequence: 0,
+          sessionId: "parent-1",
+          toolName: "researcher",
+          turnId: "turn-1",
+          workflowId: "workflow-1",
+        },
+        type: "subagent.called",
+      },
+    );
+
+    expect(graph?.turn?.steps[0]?.actions[0]).toEqual({
+      callId: "call-child",
+      child: { sessionId: "child-1" },
+      kind: "subagent-call",
+      name: "researcher",
+      phase: "completed",
+    });
+  });
+
+  it("represents authorization as a settled blocker", () => {
+    const graph = reduce(
+      { data: { sequence: 0, turnId: "turn-1" }, type: "turn.started" },
+      {
+        data: {
+          description: "Sign in to Notion.",
+          name: "notion",
+          sequence: 0,
+          stepIndex: 0,
+          turnId: "turn-1",
+        },
+        type: "authorization.required",
+      },
+      {
+        data: {
+          name: "notion",
+          outcome: "authorized",
+          sequence: 0,
+          stepIndex: 0,
+          turnId: "turn-1",
+        },
+        type: "authorization.completed",
+      },
+    );
+
+    expect(graph?.turn).toMatchObject({
+      blockers: [{ id: "authorization:notion", kind: "authorization", phase: "completed" }],
+      phase: "running",
+    });
+  });
+});

--- a/packages/eve/src/harness/work-graph.ts
+++ b/packages/eve/src/harness/work-graph.ts
@@ -1,0 +1,299 @@
+import type {
+  ActionResultStreamEvent,
+  ActionsRequestedStreamEvent,
+  AuthorizationCompletedStreamEvent,
+  AuthorizationRequiredStreamEvent,
+  InputRequestedStreamEvent,
+  StepCompletedStreamEvent,
+  StepFailedStreamEvent,
+  StepStartedStreamEvent,
+  SubagentCalledStreamEvent,
+  TurnCancelledStreamEvent,
+  TurnCompletedStreamEvent,
+  TurnFailedStreamEvent,
+  TurnStartedStreamEvent,
+  UnstampedMessageStreamEvent,
+} from "#protocol/message.js";
+import type { RuntimeActionRequest } from "#runtime/actions/types.js";
+
+export type WorkPhase = "queued" | "running" | "blocked" | "completed" | "failed" | "cancelled";
+
+export interface WorkAction {
+  readonly callId: string;
+  readonly kind: RuntimeActionRequest["kind"];
+  readonly name: string;
+  readonly phase: WorkPhase;
+  readonly child?: {
+    readonly sessionId: string;
+  };
+}
+
+export interface WorkStep {
+  readonly phase: WorkPhase;
+  readonly stepIndex: number;
+  readonly actions: readonly WorkAction[];
+}
+
+export interface WorkBlocker {
+  readonly id: string;
+  readonly kind: "approval" | "authorization" | "input";
+  readonly ownerCallId?: string;
+  readonly phase: "blocked" | "cancelled" | "completed";
+}
+
+export interface WorkTurn {
+  readonly id: string;
+  readonly phase: WorkPhase;
+  readonly steps: readonly WorkStep[];
+  readonly blockers: readonly WorkBlocker[];
+}
+
+export interface WorkGraph {
+  readonly revision: number;
+  readonly turn?: WorkTurn;
+}
+
+const EMPTY_WORK_GRAPH: WorkGraph = { revision: 0 };
+
+/** Reduces authoritative stream lifecycle facts into the live work graph. */
+export function reduceWorkGraph(
+  graph: WorkGraph = EMPTY_WORK_GRAPH,
+  event: UnstampedMessageStreamEvent,
+): WorkGraph {
+  const next = reduce(graph, event);
+  return next === graph ? graph : { ...next, revision: graph.revision + 1 };
+}
+
+function reduce(graph: WorkGraph, event: UnstampedMessageStreamEvent): WorkGraph {
+  switch (event.type) {
+    case "turn.started":
+      return startTurn(graph, event);
+    case "step.started":
+      return updateStep(graph, event, (step) => ({ ...step, phase: "running" }));
+    case "step.completed":
+      return updateStep(graph, event, (step) => ({ ...step, phase: "completed" }));
+    case "step.failed":
+      return updateStep(graph, event, (step) => ({ ...step, phase: "failed" }));
+    case "actions.requested":
+      return addActions(graph, event);
+    case "action.result":
+      return settleAction(graph, event);
+    case "subagent.called":
+      return attachChild(graph, event);
+    case "input.requested":
+      return addInputBlocker(graph, event);
+    case "authorization.required":
+      return addAuthorizationBlocker(graph, event);
+    case "authorization.completed":
+      return settleAuthorizationBlocker(graph, event);
+    case "turn.completed":
+      return settleTurn(graph, event, "completed");
+    case "turn.failed":
+      return settleTurn(graph, event, "failed");
+    case "turn.cancelled":
+      return settleTurn(graph, event, "cancelled");
+    default:
+      return graph;
+  }
+}
+
+function startTurn(graph: WorkGraph, event: TurnStartedStreamEvent): WorkGraph {
+  if (graph.turn?.id === event.data.turnId) return graph;
+  return {
+    ...graph,
+    turn: {
+      blockers: [],
+      id: event.data.turnId,
+      phase: "running",
+      steps: [],
+    },
+  };
+}
+
+function updateStep(
+  graph: WorkGraph,
+  event:
+    | ActionsRequestedStreamEvent
+    | StepStartedStreamEvent
+    | StepCompletedStreamEvent
+    | StepFailedStreamEvent,
+  update: (step: WorkStep) => WorkStep,
+): WorkGraph {
+  const turn = activeTurn(graph, event.data.turnId);
+  if (turn === undefined) return graph;
+  const index = turn.steps.findIndex((step) => step.stepIndex === event.data.stepIndex);
+  const current: WorkStep =
+    index === -1
+      ? { actions: [], phase: "queued", stepIndex: event.data.stepIndex }
+      : turn.steps[index]!;
+  const next = update(current);
+  if (next === current) return graph;
+  const steps = [...turn.steps];
+  if (index === -1) steps.push(next);
+  else steps[index] = next;
+  return replaceTurn(graph, {
+    ...turn,
+    steps: steps.sort((left, right) => left.stepIndex - right.stepIndex),
+  });
+}
+
+function addActions(graph: WorkGraph, event: ActionsRequestedStreamEvent): WorkGraph {
+  return updateStep(graph, event, (step) => {
+    const existing = new Set(step.actions.map((action) => action.callId));
+    const added = event.data.actions
+      .filter((action) => !existing.has(action.callId))
+      .map(toWorkAction);
+    return added.length === 0
+      ? step
+      : { ...step, actions: [...step.actions, ...added], phase: "running" };
+  });
+}
+
+function settleAction(graph: WorkGraph, event: ActionResultStreamEvent): WorkGraph {
+  const turn = activeTurn(graph, event.data.turnId);
+  if (turn === undefined) return graph;
+  const phase: WorkPhase = event.data.status === "completed" ? "completed" : "failed";
+  const stepIndex = turn.steps.findIndex((step) =>
+    step.actions.some((action) => action.callId === event.data.result.callId),
+  );
+  if (stepIndex === -1) return graph;
+  const step = turn.steps[stepIndex]!;
+  let changed = false;
+  const actions = step.actions.map((action) => {
+    if (action.callId !== event.data.result.callId || isTerminal(action.phase)) return action;
+    changed = true;
+    return { ...action, phase };
+  });
+  if (!changed) return graph;
+  const steps = [...turn.steps];
+  steps[stepIndex] = { ...step, actions };
+  return replaceTurn(graph, { ...turn, steps });
+}
+
+function attachChild(graph: WorkGraph, event: SubagentCalledStreamEvent): WorkGraph {
+  const turn = activeTurn(graph, event.data.turnId);
+  if (turn === undefined) return graph;
+  const stepIndex = turn.steps.findIndex((step) =>
+    step.actions.some((action) => action.callId === event.data.callId),
+  );
+  if (stepIndex === -1) return graph;
+  const step = turn.steps[stepIndex]!;
+  let changed = false;
+  const actions = step.actions.map((action) => {
+    if (action.callId !== event.data.callId || action.child !== undefined) return action;
+    changed = true;
+    return { ...action, child: { sessionId: event.data.childSessionId } };
+  });
+  if (!changed) return graph;
+  const steps = [...turn.steps];
+  steps[stepIndex] = { ...step, actions };
+  return replaceTurn(graph, { ...turn, steps });
+}
+
+function addInputBlocker(graph: WorkGraph, event: InputRequestedStreamEvent): WorkGraph {
+  const turn = activeTurn(graph, event.data.turnId);
+  if (turn === undefined || event.data.requests.length === 0) return graph;
+  const blockers = event.data.requests.map((request) => ({
+    id: request.requestId,
+    kind: "input" as const,
+    phase: "blocked" as const,
+  }));
+  return replaceTurn(graph, {
+    ...turn,
+    blockers: mergeBlockers(turn.blockers, blockers),
+    phase: "blocked",
+  });
+}
+
+function addAuthorizationBlocker(
+  graph: WorkGraph,
+  event: AuthorizationRequiredStreamEvent,
+): WorkGraph {
+  const turn = activeTurn(graph, event.data.turnId);
+  if (turn === undefined) return graph;
+  const blocker: WorkBlocker = {
+    id: `authorization:${event.data.name}`,
+    kind: "authorization",
+    phase: "blocked",
+  };
+  return replaceTurn(graph, {
+    ...turn,
+    blockers: mergeBlockers(turn.blockers, [blocker]),
+    phase: "blocked",
+  });
+}
+
+function settleAuthorizationBlocker(
+  graph: WorkGraph,
+  event: AuthorizationCompletedStreamEvent,
+): WorkGraph {
+  const turn = activeTurn(graph, event.data.turnId);
+  if (turn === undefined) return graph;
+  const id = `authorization:${event.data.name}`;
+  const phase: WorkBlocker["phase"] =
+    event.data.outcome === "authorized" ? "completed" : "cancelled";
+  const blockers = turn.blockers.map((blocker) =>
+    blocker.id === id && blocker.phase === "blocked" ? { ...blocker, phase } : blocker,
+  );
+  if (blockers === turn.blockers) return graph;
+  return replaceTurn(graph, { ...turn, blockers, phase: "running" });
+}
+
+function settleTurn(
+  graph: WorkGraph,
+  event: TurnCompletedStreamEvent | TurnFailedStreamEvent | TurnCancelledStreamEvent,
+  phase: "completed" | "failed" | "cancelled",
+): WorkGraph {
+  const turn = activeTurn(graph, event.data.turnId);
+  if (turn === undefined || isTerminal(turn.phase)) return graph;
+  return replaceTurn(graph, { ...turn, phase });
+}
+
+function toWorkAction(action: RuntimeActionRequest): WorkAction {
+  switch (action.kind) {
+    case "load-skill":
+      return { callId: action.callId, kind: action.kind, name: "load_skill", phase: "running" };
+    case "remote-agent-call":
+      return {
+        callId: action.callId,
+        kind: action.kind,
+        name: action.remoteAgentName,
+        phase: "running",
+      };
+    case "subagent-call":
+      return {
+        callId: action.callId,
+        kind: action.kind,
+        name: action.subagentName,
+        phase: "running",
+      };
+    case "tool-call":
+      return { callId: action.callId, kind: action.kind, name: action.toolName, phase: "running" };
+  }
+}
+
+function activeTurn(graph: WorkGraph, id: string): WorkTurn | undefined {
+  return graph.turn?.id === id && !isTerminal(graph.turn.phase) ? graph.turn : undefined;
+}
+
+function replaceTurn(graph: WorkGraph, turn: WorkTurn): WorkGraph {
+  return graph.turn === turn ? graph : { ...graph, turn };
+}
+
+function mergeBlockers(
+  existing: readonly WorkBlocker[],
+  added: readonly WorkBlocker[],
+): readonly WorkBlocker[] {
+  const byId = new Map(existing.map((blocker) => [blocker.id, blocker]));
+  for (const blocker of added) byId.set(blocker.id, blocker);
+  const next = [...byId.values()];
+  return sameBlockers(existing, next) ? existing : next;
+}
+
+function sameBlockers(left: readonly WorkBlocker[], right: readonly WorkBlocker[]): boolean {
+  return left.length === right.length && left.every((blocker, index) => blocker === right[index]);
+}
+
+function isTerminal(phase: WorkPhase): boolean {
+  return phase === "completed" || phase === "failed" || phase === "cancelled";
+}


### PR DESCRIPTION
### Summary

Related to #1673. Add an internal, durable work-graph reducer for the active turn so eve has one framework-owned view of running, blocked, and settled actions rather than requiring channels to reconstruct it from stream events. The graph is derived from existing lifecycle facts and persisted in serialized context; it is not public and does not change channel rendering yet.

The graph preserves native turn and `stepIndex` boundaries, stable action `callId`s, authorization blockers, and local child-session ownership. Completed and terminal state is monotonic, so late child-dispatch events cannot reopen a settled action.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/harness/work-graph.test.ts`
- `pnpm --filter eve exec tsc --noEmit -p tsconfig.json`

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
