### PR TITLE
feat(eve): preserve dispatched local subagent work

### DIFF
--- a/packages/eve/src/execution/dispatch-runtime-actions-shared.ts
+++ b/packages/eve/src/execution/dispatch-runtime-actions-shared.ts
@@ -8,6 +8,7 @@
  */
 
 import { buildAdapterContext } from "#channel/adapter-context.js";
+import type { ContextContainer } from "#context/container.js";
 import {
   callAdapterEventHandler,
   type ChannelAdapter,
@@ -19,6 +20,7 @@ import {
   ChannelInstrumentationKey,
   InitiatorAuthKey,
   SandboxKey,
+  WorkGraphKey,
 } from "#context/keys.js";
 import { withContextScope } from "#context/run-step.js";
 import {
@@ -26,7 +28,7 @@ import {
   ChannelKey,
   type CompiledBundle,
 } from "#runtime/sessions/runtime-context-keys.js";
-import { deserializeContext } from "#context/serialize.js";
+import { deserializeContext, serializeContext } from "#context/serialize.js";
 import {
   type DispatchOutcome,
   isAgentHandleAction,
@@ -66,6 +68,7 @@ import { workflowEntryReference } from "#execution/workflow-runtime.js";
 import { createLogger, logError } from "#internal/logging.js";
 import { readSessionTraceContext } from "#tracing/agent-trace-context-store.js";
 import { resolveSubagentDepth } from "#harness/subagent-depth.js";
+import { reduceWorkGraph } from "#harness/work-graph.js";
 import { getDynamicSubagentSelection } from "#context/dynamic-subagent-lifecycle.js";
 import { resolveEffectiveAgentRuntime } from "#execution/effective-agent-config.js";
 import { isTaskControlAction } from "#execution/tasks/parent/dispatch.js";
@@ -127,6 +130,7 @@ export interface RuntimeActionDispatchInput {
  */
 export interface RuntimeActionDispatchResult {
   readonly results: readonly RuntimeActionResult[];
+  readonly serializedContext?: Record<string, unknown>;
   readonly sessionState: DurableSessionState;
   readonly pendingTasks: readonly {
     readonly taskInboxToken: string;
@@ -138,6 +142,7 @@ export interface RuntimeActionDispatchResult {
 /** Everything preflight produces before either step's dispatch loop runs. */
 export interface PreparedRuntimeActionDispatch {
   readonly adapter: ChannelAdapter;
+  readonly context: ContextContainer;
   readonly adapterCtx: ChannelAdapterContext;
   readonly auth: Parameters<typeof buildSubagentRunInput>[0]["auth"];
   readonly batch: NonNullable<ReturnType<typeof getPendingRuntimeActionBatch>>;
@@ -226,6 +231,7 @@ export async function prepareRuntimeActionDispatch(input: {
     batch,
     bundle,
     capabilities: ctx.get(CapabilitiesKey),
+    context: ctx,
     channelMetadata: ctx.get(ChannelInstrumentationKey),
     fanoutSize: plan.filter((entry) => entry.kind === "start" && entry.target.kind === "local")
       .length,
@@ -287,36 +293,37 @@ export async function emitSubagentCalled(input: {
         : entry.target.kind === "remote"
           ? entry.target.dynamicRemoteAgent
           : undefined;
-    const parentEvent = await callAdapterEventHandler(
-      input.adapter,
-      createSubagentCalledEvent({
-        callId: outcome.callId,
-        childSessionId: outcome.address.sessionId,
-        name: outcome.name,
-        remote:
-          outcome.address.kind === "agent/remote"
-            ? {
-                // The proxy route re-resolves outbound auth from this key via
-                // resolveRemoteAgentStreamHeaders: a node id lands in
-                // subagentRegistry.subagentsByNodeId (static definition), a
-                // credentialsStepId lands in the step registry (dynamic
-                // definition). Both sides of this ternary must stay in sync
-                // with that lookup order.
-                resolverId:
-                  dynamicRemoteAgent === undefined
-                    ? action.nodeId
-                    : dynamicRemoteAgent.credentialsStepId,
-                url: outcome.address.url,
-              }
-            : undefined,
-        sequence: input.batchEvent.sequence,
-        sessionId: input.sessionId,
-        toolName: outcome.toolName,
-        turnId: input.batchEvent.turnId,
-        workflowId: workflowEntryReference.workflowId,
-      }),
-      input.adapterCtx,
+    const childCalled = createSubagentCalledEvent({
+      callId: outcome.callId,
+      childSessionId: outcome.address.sessionId,
+      name: outcome.name,
+      remote:
+        outcome.address.kind === "agent/remote"
+          ? {
+              // The proxy route re-resolves outbound auth from this key via
+              // resolveRemoteAgentStreamHeaders: a node id lands in
+              // subagentRegistry.subagentsByNodeId (static definition), a
+              // credentialsStepId lands in the step registry (dynamic
+              // definition). Both sides of this ternary must stay in sync
+              // with that lookup order.
+              resolverId:
+                dynamicRemoteAgent === undefined
+                  ? action.nodeId
+                  : dynamicRemoteAgent.credentialsStepId,
+              url: outcome.address.url,
+            }
+          : undefined,
+      sequence: input.batchEvent.sequence,
+      sessionId: input.sessionId,
+      toolName: outcome.toolName,
+      turnId: input.batchEvent.turnId,
+      workflowId: workflowEntryReference.workflowId,
+    });
+    input.adapterCtx.ctx.set(
+      WorkGraphKey,
+      reduceWorkGraph(input.adapterCtx.ctx.get(WorkGraphKey), childCalled),
     );
+    const parentEvent = await callAdapterEventHandler(input.adapter, childCalled, input.adapterCtx);
     await input.writer.write(encodeMessageStreamEvent(stampMessageStreamEvent(parentEvent)));
   } catch (error) {
     logError(log, "subagent.called emission failed", error, {
@@ -325,6 +332,14 @@ export async function emitSubagentCalled(input: {
       toolName: outcome.toolName,
     });
   }
+}
+
+/** Serializes dispatch-time context only when a work graph is present. */
+export function serializeRuntimeActionDispatchContext(
+  prepared: PreparedRuntimeActionDispatch,
+): Record<string, unknown> | undefined {
+  const work = prepared.context.get(WorkGraphKey);
+  return work !== undefined && work.revision > 0 ? serializeContext(prepared.context) : undefined;
 }
 
 /**

--- a/packages/eve/src/execution/dispatch-runtime-actions-step.ts
+++ b/packages/eve/src/execution/dispatch-runtime-actions-step.ts
@@ -20,6 +20,7 @@ import { createAgentContinuationBundle } from "#execution/agent-continuation-bun
 import {
   emitSubagentCalled,
   prepareRuntimeActionDispatch,
+  serializeRuntimeActionDispatchContext,
   type RuntimeActionDispatchInput,
   type RuntimeActionDispatchResult,
   startSubagent,
@@ -123,6 +124,7 @@ export async function dispatchRuntimeActionsStep(
 
   return {
     results,
+    serializedContext: serializeRuntimeActionDispatchContext(prepared),
     sessionState:
       nextSession === session
         ? input.sessionState

--- a/packages/eve/src/execution/dispatch-workflow-runtime-actions-step.ts
+++ b/packages/eve/src/execution/dispatch-workflow-runtime-actions-step.ts
@@ -35,6 +35,7 @@ export async function dispatchWorkflowRuntimeActionsStep(input: {
   readonly sessionState: DurableSessionState;
 }): Promise<{
   readonly results: readonly RuntimeActionResult[];
+  readonly serializedContext?: Record<string, unknown>;
   readonly sessionState: DurableSessionState;
   readonly pendingTasks: readonly {
     readonly taskInboxToken: string;
@@ -116,6 +117,7 @@ export async function dispatchWorkflowRuntimeActionsStep(input: {
 
   return {
     results: [...dispatched.results, ...blockedResults],
+    serializedContext: dispatched.serializedContext,
     sessionState: dispatched.sessionState,
     pendingTasks: dispatched.pendingTasks,
   };

--- a/packages/eve/src/execution/tasks/parent/dispatch-task-step.ts
+++ b/packages/eve/src/execution/tasks/parent/dispatch-task-step.ts
@@ -24,6 +24,7 @@ import { createAgentContinuationBundle } from "#execution/agent-continuation-bun
 import {
   emitSubagentCalled,
   prepareRuntimeActionDispatch,
+  serializeRuntimeActionDispatchContext,
   type RuntimeActionDispatchInput,
   type RuntimeActionDispatchResult,
   startSubagent,
@@ -213,6 +214,7 @@ export async function dispatchTaskStep(
 
   return {
     results,
+    serializedContext: serializeRuntimeActionDispatchContext(prepared),
     sessionState:
       nextSession === session
         ? input.sessionState


### PR DESCRIPTION
### Summary

Related to #1673. Build on #1985 by preserving work-graph changes made when the runtime dispatches a local subagent outside the ordinary harness event emitter. A local subagent is an authored `subagent-call` that runs through this eve deployment; remote-agent progress remains out of scope for this layer.

The dispatch step adopts updated serialized context only when local-subagent work state changed, so the parent’s durable cursor retains direct local-subagent ownership during its wait. This intentionally does not publish live child snapshots: parent-owned live rendering needs a separate cross-session snapshot-query design rather than waking the parent once for every committed child step.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/execution/turn-workflow.test.ts src/execution/workflow-steps.test.ts`
- `pnpm --filter eve exec tsc --noEmit -p tsconfig.json`

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
