### PR TITLE
fix(eve): make canary versions peer-compatible

### DIFF
--- a/apps/package-artifacts/api/package.test.mjs
+++ b/apps/package-artifacts/api/package.test.mjs
@@ -7,7 +7,7 @@ const { default: handler } = await import("./package.js");
 const sha = "a".repeat(40);
 const manifest = {
   sourceSha: sha,
-  version: `0.33.1-main.${sha}`,
+  version: `0.33.0+main.${sha}`,
   tarball: "https://example.public.blob.vercel-storage.com/eve.tgz",
   sha256: "b".repeat(64),
 };

--- a/apps/package-artifacts/lib/package.mjs
+++ b/apps/package-artifacts/lib/package.mjs
@@ -18,8 +18,7 @@ export function packageDependencyUrl(baseUrl, sourceSha) {
 export function packageVersion(stableVersion, sourceSha) {
   const match = stableVersion.match(/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/);
   if (match === null) throw new Error(`Expected a stable eve version, received ${stableVersion}.`);
-  const [, major, minor, patch] = match;
-  return `${major}.${minor}.${Number(patch) + 1}-main.${sourceSha}`;
+  return `${stableVersion}+main.${sourceSha}`;
 }
 
 export function preparePackageJson(packageJson, sourceSha) {

--- a/apps/package-artifacts/lib/package.test.mjs
+++ b/apps/package-artifacts/lib/package.test.mjs
@@ -11,8 +11,8 @@ import {
 const sha = "a".repeat(40);
 
 describe("package artifacts", () => {
-  test("derives the next patch main version", () => {
-    expect(packageVersion("0.33.0", sha)).toBe(`0.33.1-main.${sha}`);
+  test("derives a main build version", () => {
+    expect(packageVersion("0.33.0", sha)).toBe(`0.33.0+main.${sha}`);
   });
 
   test("derives immutable artifact and dependency URLs", () => {
@@ -31,7 +31,7 @@ describe("package artifacts", () => {
     const source = { name: "eve", version: "0.33.0" };
     expect(preparePackageJson(source, sha)).toEqual({
       name: "eve",
-      version: `0.33.1-main.${sha}`,
+      version: `0.33.0+main.${sha}`,
     });
     expect(source.version).toBe("0.33.0");
   });


### PR DESCRIPTION
### Summary

Canary tarballs currently use a prerelease version such as `0.33.4-main.<sha>`, which npm correctly excludes from ordinary peer ranges like `eve >=0.13.7`; this makes `eve init` fail when the scaffold installs `@vercel/connect`. Stamp canaries as build metadata on the checked-out stable version (`0.33.3+main.<sha>`) instead. The immutable SHA-addressed tarball URL remains the package identity, while the version now satisfies stable eve peer ranges and still reports its source commit.

Follow-up to #1950.

### Validation

- `pnpm --filter eve-package-artifacts test` (9 tests passed)
- `pnpm exec oxfmt --check apps/package-artifacts/lib/package.mjs apps/package-artifacts/lib/package.test.mjs apps/package-artifacts/api/package.test.mjs`
- `pnpm exec oxlint apps/package-artifacts/lib/package.mjs apps/package-artifacts/lib/package.test.mjs apps/package-artifacts/api/package.test.mjs`
- Reproduced the peer graph with local tarballs: npm 10 and npm 12 reject `0.33.4-main.<sha>` against `eve >=0.13.7`, and both install `0.33.3+main.<sha>` successfully
- Confirmed the build-metadata tarball installs with pnpm 10 strict peers and Yarn 1; Bun 1.2 installed the prerelease case, but the build-metadata run was blocked by an unrelated download failure
- `git diff --check`

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant *(updated focused tests; no documentation change needed)*
- [x] I added a changeset if this touches the published `eve` package *(not applicable; internal deployment app only)*
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
