### PR TITLE
feat(slack): derive status from active work graph

### DIFF
--- a/packages/eve/src/public/channels/slack/action-status.test.ts
+++ b/packages/eve/src/public/channels/slack/action-status.test.ts
@@ -1,94 +1,57 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  describeActionRequest,
-  describeActionRequests,
-} from "#public/channels/slack/action-status.js";
-import type { RuntimeActionRequest } from "#runtime/actions/types.js";
-import type { JsonObject } from "#shared/json.js";
+import { describeWorkGraph } from "#public/channels/slack/action-status.js";
 
-function toolCall(toolName: string, input: JsonObject = {}): RuntimeActionRequest {
-  return { callId: "c1", input, kind: "tool-call", toolName };
-}
-
-describe("describeActionRequest", () => {
-  it("labels tool calls with the tool name plus the salient argument", () => {
+describe("describeWorkGraph", () => {
+  it("prioritizes a blocker over active actions", () => {
     expect(
-      describeActionRequest(toolCall("grep", { path: "packages", pattern: "useEveAgent" })),
-    ).toBe("grep useEveAgent");
-    expect(describeActionRequest(toolCall("read_file", { filePath: "agent/agent.ts" }))).toBe(
-      "read_file agent/agent.ts",
-    );
-    expect(describeActionRequest(toolCall("bash", { command: "pnpm test\npnpm lint" }))).toBe(
-      "bash pnpm test",
-    );
-  });
-
-  it("keeps the tail of long paths and clips long commands", () => {
-    expect(
-      describeActionRequest(
-        toolCall("read_file", {
-          filePath: "/workspace/eve/packages/eve/src/runtime/actions/executor-registry.ts",
-        }),
-      ),
-    ).toBe("read_file actions/executor-registry.ts");
-
-    const clipped = describeActionRequest(toolCall("bash", { command: "x".repeat(120) }));
-    expect(clipped.length).toBeLessThanOrEqual("bash ".length + 40);
-    expect(clipped.endsWith("...")).toBe(true);
-  });
-
-  it("probes generic keys for tools without a salient-key entry", () => {
-    expect(describeActionRequest(toolCall("close_issue", { issueNumber: 42 }))).toBe(
-      "close_issue 42",
-    );
-  });
-
-  it("falls back to the bare tool name without a telling argument", () => {
-    expect(describeActionRequest(toolCall("list_new_issues"))).toBe("list_new_issues");
-  });
-
-  it("labels dispatched calls with the target name and skill loads with the skill", () => {
-    expect(
-      describeActionRequest({
-        callId: "c1",
-        description: "Reason about the issue",
-        input: {},
-        kind: "subagent-call",
-        name: "reasoner",
-        nodeId: "n1",
-        subagentName: "reasoner",
+      describeWorkGraph({
+        revision: 1,
+        turn: {
+          blockers: [{ id: "auth", kind: "authorization", phase: "blocked" }],
+          id: "turn-1",
+          phase: "blocked",
+          steps: [
+            {
+              actions: [
+                { callId: "call-1", kind: "tool-call", name: "read_file", phase: "running" },
+              ],
+              phase: "running",
+              stepIndex: 0,
+            },
+          ],
+        },
       }),
-    ).toBe("reasoner");
+    ).toBe("Waiting for sign-in...");
+  });
+
+  it("summarizes the newest active step", () => {
     expect(
-      describeActionRequest({
-        callId: "c1",
-        description: "Triage remotely",
-        input: {},
-        kind: "remote-agent-call",
-        name: "triage",
-        nodeId: "n1",
-        remoteAgentName: "triage",
+      describeWorkGraph({
+        revision: 1,
+        turn: {
+          blockers: [],
+          id: "turn-1",
+          phase: "running",
+          steps: [
+            {
+              actions: [
+                { callId: "call-1", kind: "tool-call", name: "search_docs", phase: "completed" },
+              ],
+              phase: "completed",
+              stepIndex: 0,
+            },
+            {
+              actions: [
+                { callId: "call-2", kind: "subagent-call", name: "researcher", phase: "running" },
+                { callId: "call-3", kind: "tool-call", name: "read_file", phase: "running" },
+              ],
+              phase: "running",
+              stepIndex: 1,
+            },
+          ],
+        },
       }),
-    ).toBe("triage");
-    expect(
-      describeActionRequest({ callId: "c1", input: { skill: "arena" }, kind: "load-skill" }),
-    ).toBe("load_skill arena");
-  });
-});
-
-describe("describeActionRequests", () => {
-  it("shows the first label and a count for the rest of the batch", () => {
-    expect(
-      describeActionRequests([
-        toolCall("grep", { pattern: "digest" }),
-        toolCall("read_file", { filePath: "a.ts" }),
-        toolCall("read_file", { filePath: "b.ts" }),
-      ]),
-    ).toBe("grep digest +2 more");
-  });
-
-  it("returns a generic label for an empty batch", () => {
-    expect(describeActionRequests([])).toBe("Working...");
+    ).toBe("researcher +1 more");
   });
 });

--- a/packages/eve/src/public/channels/slack/action-status.ts
+++ b/packages/eve/src/public/channels/slack/action-status.ts
@@ -4,6 +4,9 @@
  * label is the action's name plus its most telling argument — `grep useEve`
  * or `read_file agent/agent.ts` instead of `Running grep...`.
  */
+import type { ContextAccessor } from "#context/key.js";
+import { WorkGraphKey } from "#context/keys.js";
+import type { WorkGraph } from "#harness/work-graph.js";
 import type { RuntimeActionRequest } from "#runtime/actions/types.js";
 
 /** Argument keys worth surfacing, most telling first, per tool. */
@@ -88,4 +91,29 @@ export function describeActionRequests(actions: readonly RuntimeActionRequest[])
   if (first === undefined) return "Working...";
   const label = describeActionRequest(first);
   return actions.length === 1 ? label : `${label} +${actions.length - 1} more`;
+}
+
+/** Selects one deterministic Slack status from framework-owned active work. */
+export function describeWorkGraph(work: WorkGraph | undefined): string | undefined {
+  const turn = work?.turn;
+  if (turn === undefined) return undefined;
+  const blocker = turn.blockers.find((entry) => entry.phase === "blocked");
+  if (blocker !== undefined)
+    return blocker.kind === "authorization" ? "Waiting for sign-in..." : "Waiting for input...";
+
+  for (const step of [...turn.steps].reverse()) {
+    const running = step.actions.filter((action) => action.phase === "running");
+    if (running.length === 0) continue;
+    const [first] = running;
+    if (first === undefined) continue;
+    const label = first.name;
+    return running.length === 1 ? label : `${label} +${running.length - 1} more`;
+  }
+  return undefined;
+}
+
+/** Reads the internal work graph when this handler runs through an adapter context. */
+export function workGraphFromChannelContext(channel: unknown): WorkGraph | undefined {
+  const ctx = (channel as { readonly ctx?: ContextAccessor }).ctx;
+  return ctx?.get(WorkGraphKey);
 }

--- a/packages/eve/src/public/channels/slack/defaults.ts
+++ b/packages/eve/src/public/channels/slack/defaults.ts
@@ -1,7 +1,11 @@
 import type { SessionAuthContext } from "#channel/types.js";
 
 import { createLogger, extractErrorId, formatErrorHint } from "#internal/logging.js";
-import { describeActionRequests } from "#public/channels/slack/action-status.js";
+import {
+  describeActionRequests,
+  describeWorkGraph,
+  workGraphFromChannelContext,
+} from "#public/channels/slack/action-status.js";
 import { buildSlackAuthContext, slackUserIdFromAuthContext } from "#public/channels/slack/auth.js";
 import {
   buildAuthCompletedText,
@@ -242,7 +246,9 @@ export const defaultEvents: SlackChannelInternalEvents = {
     channel.state.pendingToolCallMessage = null;
     channel.state.lastReasoningTypingAtMs = null;
     channel.state.lastReasoningTypingStatus = null;
-    await channel.thread.startTyping("Working...");
+    await channel.thread.startTyping(
+      describeWorkGraph(workGraphFromChannelContext(channel)) ?? "Working...",
+    );
   },
 
   async "reasoning.appended"(event, channel, _ctx) {
@@ -275,7 +281,10 @@ export const defaultEvents: SlackChannelInternalEvents = {
       await channel.thread.startTyping(truncateTypingStatus(buffered));
       return;
     }
-    await channel.thread.startTyping(truncateTypingStatus(describeActionRequests(event.actions)));
+    const status = describeWorkGraph(workGraphFromChannelContext(channel));
+    await channel.thread.startTyping(
+      truncateTypingStatus(status ?? describeActionRequests(event.actions)),
+    );
   },
 
   async "message.completed"(event, channel, _ctx) {


### PR DESCRIPTION
### Summary

Related to #1673. Build on #1986 by making Slack’s default typing status select the active framework work graph before falling back to the existing action-request label. Blockers take priority over running work; otherwise Slack renders the newest active step and summarizes parallel actions.

This is the first internal consumer of the work graph. It preserves Slack’s existing narration and reasoning paths, introduces no public channel API, and keeps Slack-specific presentation behavior inside the Slack package.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/channels/slack/action-status.test.ts`

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
