### PR TITLE
perf(eve): share authored module build graphs

### DIFF
--- a/.changeset/tidy-authored-builds.md
+++ b/.changeset/tidy-authored-builds.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Compile compatible authored definitions through one shared Rolldown graph per agent node and package instead of rebuilding each TypeScript definition independently.

--- a/packages/eve/src/compiler/normalize-agent-config.test.ts
+++ b/packages/eve/src/compiler/normalize-agent-config.test.ts
@@ -4,6 +4,7 @@ import { createAgentSourceManifest, createModuleSourceRef } from "#discover/mani
 import { defineDynamic } from "#public/definitions/tool.js";
 import { compileAgentConfig } from "#compiler/normalize-agent-config.js";
 import type { ManifestCompileContext } from "#compiler/normalize-helpers.js";
+import { authoredModuleNamespaceResolver } from "#internal/authored-module-loader.js";
 
 const mocks = vi.hoisted(() => ({
   loadModuleBackedDefinition: vi.fn(),
@@ -40,7 +41,10 @@ describe("compileAgentConfig", () => {
     });
 
     const modelCatalog = createModelCatalog();
-    const compiled = await compileAgentConfig(manifest, { modelCatalog });
+    const compiled = await compileAgentConfig(manifest, {
+      modelCatalog,
+      moduleResolver: authoredModuleNamespaceResolver,
+    });
 
     expect(compiled.model).toBeUndefined();
     expect(compiled.dynamicModel).toEqual({
@@ -65,7 +69,10 @@ describe("compileAgentConfig", () => {
 
     const compiled = await compileAgentConfig(
       manifest,
-      { modelCatalog: createModelCatalog() },
+      {
+        modelCatalog: createModelCatalog(),
+        moduleResolver: authoredModuleNamespaceResolver,
+      },
       {
         definition: {
           model: "openai/gpt-5.5",

--- a/packages/eve/src/compiler/normalize-agent-config.ts
+++ b/packages/eve/src/compiler/normalize-agent-config.ts
@@ -48,6 +48,7 @@ export async function compileAgentConfig(
             agentRoot: manifest.agentRoot,
             displayPath: configModulePath!,
             kind: "agent config",
+            moduleResolver: context.moduleResolver,
             source: configModule,
           }),
     configModule === undefined

--- a/packages/eve/src/compiler/normalize-channel.ts
+++ b/packages/eve/src/compiler/normalize-channel.ts
@@ -30,6 +30,7 @@ export async function compileChannelDefinition(
     agentRoot,
     externalDependencies: options.externalDependencies,
     kind: "channel",
+    moduleResolver: options.moduleResolver,
     source,
   });
 

--- a/packages/eve/src/compiler/normalize-connection.ts
+++ b/packages/eve/src/compiler/normalize-connection.ts
@@ -37,6 +37,7 @@ export async function compileConnectionDefinition(
     agentRoot,
     externalDependencies: options.externalDependencies,
     kind: "connection",
+    moduleResolver: options.moduleResolver,
     source,
   });
   const protocol = readConnectionProtocol(loaded);

--- a/packages/eve/src/compiler/normalize-extension.ts
+++ b/packages/eve/src/compiler/normalize-extension.ts
@@ -11,7 +11,10 @@ import type {
   CompiledToolDefinition,
 } from "#compiler/manifest.js";
 import { compileConnectionDefinition } from "#compiler/normalize-connection.js";
-import type { ManifestCompileContext } from "#compiler/normalize-helpers.js";
+import type {
+  ManifestCompileContext,
+  ModuleBackedDefinitionLoadOptions,
+} from "#compiler/normalize-helpers.js";
 import { compileHookEntry } from "#compiler/normalize-hook.js";
 import { compileInstructionsEntry } from "#compiler/normalize-instructions.js";
 import { compileSkillSource } from "#compiler/normalize-skill.js";
@@ -51,7 +54,10 @@ export async function compileExtensionContributions(input: {
   readonly externalDependencies: readonly string[];
 }): Promise<CompiledExtensionContributions> {
   const { mount, consumerAgentRoot } = input;
-  const options = { externalDependencies: input.externalDependencies };
+  const options = {
+    externalDependencies: input.externalDependencies,
+    moduleResolver: input.context.moduleResolver,
+  };
 
   const base = await composeManifestContributions({
     manifest: mount.manifest,
@@ -147,9 +153,7 @@ export function applyOverrideDisables(input: {
   };
 }
 
-interface ComposeOptions {
-  readonly externalDependencies: readonly string[];
-}
+type ComposeOptions = ModuleBackedDefinitionLoadOptions;
 
 /**
  * Compiles one agent-shaped manifest into namespaced extension contributions

--- a/packages/eve/src/compiler/normalize-helpers.ts
+++ b/packages/eve/src/compiler/normalize-helpers.ts
@@ -6,7 +6,8 @@ import {
 } from "#internal/authored-module.js";
 import {
   type AuthoredModuleLoadOptions,
-  loadAuthoredModuleNamespace,
+  type AuthoredModuleNamespaceResolver,
+  authoredModuleNamespaceResolver,
 } from "#internal/authored-module-loader.js";
 import { toErrorMessage } from "#shared/errors.js";
 import type { ModuleSourceRef } from "#shared/source-ref.js";
@@ -22,10 +23,12 @@ import type { CompiledRuntimeModelCatalogLoader } from "#compiler/model-catalog.
  */
 export interface ManifestCompileContext {
   readonly modelCatalog: CompiledRuntimeModelCatalogLoader;
+  readonly moduleResolver: AuthoredModuleNamespaceResolver;
 }
 
 export interface ModuleBackedDefinitionLoadOptions {
   readonly externalDependencies?: AuthoredModuleLoadOptions["externalDependencies"];
+  readonly moduleResolver?: AuthoredModuleNamespaceResolver;
 }
 
 /**
@@ -42,9 +45,10 @@ export async function loadModuleBackedDefinition(input: {
   readonly displayPath?: string;
   readonly externalDependencies?: ModuleBackedDefinitionLoadOptions["externalDependencies"];
   readonly kind: string;
+  readonly moduleResolver?: AuthoredModuleNamespaceResolver;
   readonly source: ModuleSourceRef;
 }): Promise<unknown> {
-  const moduleNamespace = await loadAuthoredModuleNamespace(
+  const moduleNamespace = await (input.moduleResolver ?? authoredModuleNamespaceResolver).load(
     join(input.agentRoot, input.source.logicalPath),
     { externalDependencies: input.externalDependencies },
   );

--- a/packages/eve/src/compiler/normalize-instructions.ts
+++ b/packages/eve/src/compiler/normalize-instructions.ts
@@ -68,6 +68,7 @@ export async function compileInstructionsEntry(
     agentRoot,
     externalDependencies: options.externalDependencies,
     kind: "instructions",
+    moduleResolver: options.moduleResolver,
     source,
   });
 

--- a/packages/eve/src/compiler/normalize-manifest.ts
+++ b/packages/eve/src/compiler/normalize-manifest.ts
@@ -1,3 +1,5 @@
+import { join } from "node:path";
+
 import type { AgentSourceManifest } from "#discover/manifest.js";
 import { mountRefNamespace, packageStateNamespace } from "#discover/extensions.js";
 import {
@@ -31,6 +33,11 @@ import { compileScheduleDefinition } from "#compiler/normalize-schedule.js";
 import { compileSkillSource } from "#compiler/normalize-skill.js";
 import { compileSubagentGraph } from "#compiler/normalize-subagent.js";
 import { compileToolEntry } from "#compiler/normalize-tool.js";
+import {
+  authoredModuleNamespaceResolver,
+  createAuthoredModuleGraphResolver,
+  type AuthoredModuleGraphEntry,
+} from "#internal/authored-module-loader.js";
 
 /**
  * Compiles one discovery manifest into the normalized manifest loaded by the runtime.
@@ -40,6 +47,7 @@ export async function compileAgentManifest(
 ): Promise<CompiledAgentManifest> {
   const context: ManifestCompileContext = {
     modelCatalog: createCompiledRuntimeModelCatalogLoader(manifest.appRoot),
+    moduleResolver: authoredModuleNamespaceResolver,
   };
   const compiledNode = await compileAgentNodeManifest(manifest, context);
   const subagentGraph = await compileSubagentGraph({
@@ -104,9 +112,14 @@ async function compileAgentResources(
   options: { readonly externalDependencies?: readonly string[] } = {},
 ): Promise<CompiledAgentResources> {
   const externalDependencies = [...(options.externalDependencies ?? [])];
+  const moduleResolver = createAuthoredModuleGraphResolver(
+    collectAuthoredDefinitionGraphEntries(manifest, externalDependencies),
+  );
+  const resourceContext: ManifestCompileContext = { ...context, moduleResolver };
+  const loadOptions = { externalDependencies, moduleResolver };
   const compiledToolEntries = await Promise.all(
     manifest.tools.map((toolSource) =>
-      compileToolEntry(manifest.agentRoot, toolSource, { externalDependencies }),
+      compileToolEntry(manifest.agentRoot, toolSource, loadOptions),
     ),
   );
   const tools: CompiledToolDefinition[] = [];
@@ -131,7 +144,7 @@ async function compileAgentResources(
 
   const compiledChannelResults = await Promise.all(
     manifest.channels.map((channelSource) =>
-      compileChannelDefinition(manifest.agentRoot, channelSource, { externalDependencies }),
+      compileChannelDefinition(manifest.agentRoot, channelSource, loadOptions),
     ),
   );
 
@@ -142,7 +155,7 @@ async function compileAgentResources(
 
   const compiledSkillEntries = await Promise.all(
     manifest.skills.map((skillSource) =>
-      compileSkillSource(manifest.agentRoot, skillSource, { externalDependencies }),
+      compileSkillSource(manifest.agentRoot, skillSource, loadOptions),
     ),
   );
   const skills: CompiledSkillDefinition[] = [];
@@ -158,7 +171,7 @@ async function compileAgentResources(
 
   const compiledInstructionsEntries = await Promise.all(
     manifest.instructions.map((source) =>
-      compileInstructionsEntry(manifest.agentRoot, source, { externalDependencies }),
+      compileInstructionsEntry(manifest.agentRoot, source, loadOptions),
     ),
   );
   const staticInstructions: CompiledInstructionsDefinition[] = [];
@@ -174,13 +187,13 @@ async function compileAgentResources(
 
   const connections = await Promise.all(
     manifest.connections.map((connectionSource) =>
-      compileConnectionDefinition(manifest.agentRoot, connectionSource, { externalDependencies }),
+      compileConnectionDefinition(manifest.agentRoot, connectionSource, loadOptions),
     ),
   );
   const hooks = manifest.hooks.map((hookSource) => compileHookEntry(hookSource));
   const schedules = await Promise.all(
     manifest.schedules.map((scheduleSource) =>
-      compileScheduleDefinition(manifest.agentRoot, scheduleSource, { externalDependencies }),
+      compileScheduleDefinition(manifest.agentRoot, scheduleSource, loadOptions),
     ),
   );
 
@@ -196,7 +209,7 @@ async function compileAgentResources(
   )) {
     const contributions = await compileExtensionContributions({
       mount,
-      context,
+      context: resourceContext,
       consumerAgentRoot: manifest.agentRoot,
       externalDependencies,
     });
@@ -263,9 +276,7 @@ async function compileAgentResources(
     sandbox:
       manifest.sandbox === null
         ? null
-        : await compileSandboxDefinition(manifest.agentRoot, manifest.sandbox, {
-            externalDependencies,
-          }),
+        : await compileSandboxDefinition(manifest.agentRoot, manifest.sandbox, loadOptions),
     sandboxWorkspaces: manifest.sandboxWorkspaces.map((workspace) => ({
       logicalPath: workspace.logicalPath,
       rootEntries: [...workspace.rootEntries],
@@ -278,6 +289,39 @@ async function compileAgentResources(
     instructions: composedInstructions,
     tools,
   });
+}
+
+function collectAuthoredDefinitionGraphEntries(
+  manifest: AgentSourceManifest,
+  externalDependencies: readonly string[],
+): AuthoredModuleGraphEntry[] {
+  const entries: AuthoredModuleGraphEntry[] = [];
+  const addManifest = (sourceManifest: AgentSourceManifest, packageRoot: string): void => {
+    const sources = [
+      ...sourceManifest.tools,
+      ...sourceManifest.channels,
+      ...sourceManifest.connections,
+      ...sourceManifest.instructions,
+      ...sourceManifest.schedules,
+      ...sourceManifest.skills,
+      ...(sourceManifest.sandbox === null ? [] : [sourceManifest.sandbox]),
+    ];
+    for (const source of sources) {
+      if (source.sourceKind !== "module") continue;
+      entries.push({
+        modulePath: join(sourceManifest.agentRoot, source.logicalPath),
+        options: { externalDependencies },
+        packageRoot,
+      });
+    }
+  };
+
+  addManifest(manifest, manifest.appRoot);
+  for (const mount of manifest.resolvedExtensions) {
+    addManifest(mount.manifest, mount.packageRoot);
+    if (mount.overrides !== undefined) addManifest(mount.overrides, manifest.appRoot);
+  }
+  return entries;
 }
 
 function compileExtensionMounts(manifest: AgentSourceManifest): CompiledExtensionMount[] {

--- a/packages/eve/src/compiler/normalize-sandbox.ts
+++ b/packages/eve/src/compiler/normalize-sandbox.ts
@@ -26,6 +26,7 @@ export async function compileSandboxDefinition(
       agentRoot,
       externalDependencies: options.externalDependencies,
       kind: "sandbox",
+      moduleResolver: options.moduleResolver,
       source,
     }),
     message,

--- a/packages/eve/src/compiler/normalize-schedule.ts
+++ b/packages/eve/src/compiler/normalize-schedule.ts
@@ -35,6 +35,7 @@ export async function compileScheduleDefinition(
             agentRoot,
             externalDependencies: options.externalDependencies,
             kind: "schedule",
+            moduleResolver: options.moduleResolver,
             source,
           }),
           `Expected the schedule export "${source.exportName ?? "default"}" from "${source.logicalPath}" to match the public eve shape.`,

--- a/packages/eve/src/compiler/normalize-skill.ts
+++ b/packages/eve/src/compiler/normalize-skill.ts
@@ -72,6 +72,7 @@ export async function compileSkillSource(
     agentRoot,
     externalDependencies: options.externalDependencies,
     kind: "skill",
+    moduleResolver: options.moduleResolver,
     source,
   });
 

--- a/packages/eve/src/compiler/normalize-subagent.ts
+++ b/packages/eve/src/compiler/normalize-subagent.ts
@@ -148,6 +148,7 @@ async function compileSubagentDefinition(input: {
     displayPath: configModuleSource.logicalPath,
     externalDependencies: input.externalDependencies,
     kind: "subagent config",
+    moduleResolver: input.context.moduleResolver,
     source: configModule,
   });
   const dynamic = normalizeDynamicSubagentDefinition(

--- a/packages/eve/src/compiler/normalize-tool.ts
+++ b/packages/eve/src/compiler/normalize-tool.ts
@@ -43,6 +43,7 @@ export async function compileToolEntry(
       agentRoot,
       externalDependencies: options.externalDependencies,
       kind: "tool",
+      moduleResolver: options.moduleResolver,
       source,
     }),
     `Expected the tool export "${source.exportName ?? "default"}" from "${source.logicalPath}" to match the public eve shape.`,

--- a/packages/eve/src/internal/authored-module-loader.scenario.test.ts
+++ b/packages/eve/src/internal/authored-module-loader.scenario.test.ts
@@ -8,12 +8,64 @@ import { compileAgentManifest } from "#compiler/normalize-manifest.js";
 import { discoverAgent } from "#discover/discover-agent.js";
 import {
   bundleAuthoredModuleForGeneration,
+  createAuthoredModuleGraphResolver,
   loadAuthoredModuleNamespace,
 } from "#internal/authored-module-loader.js";
+import {
+  EveRolldownBuildProfiler,
+  runWithEveRolldownBuildProfiler,
+} from "#internal/bundler/build-profile.js";
 import { useScenarioApp } from "#internal/testing/scenario-app.js";
 
 describe("loadAuthoredModuleNamespace", () => {
   const scenarioApp = useScenarioApp();
+
+  it("loads compatible definitions through one shared module graph", async () => {
+    const app = await scenarioApp({
+      files: {
+        "agent/lib/shared.ts": [
+          'const key = "__eveSharedAuthoredGraphEvaluations";',
+          "const globals = globalThis as Record<string, number>;",
+          "globals[key] = (globals[key] ?? 0) + 1;",
+          "export const evaluation = globals[key];",
+          "",
+        ].join("\n"),
+        "agent/tools/first.ts": [
+          'import { evaluation } from "../lib/shared";',
+          'export default { name: "first", evaluation };',
+          "",
+        ].join("\n"),
+        "agent/tools/second.ts": [
+          'import { evaluation } from "../lib/shared";',
+          'export default { name: "second", evaluation };',
+          "",
+        ].join("\n"),
+      },
+      name: "shared-authored-module-graph",
+    });
+    const firstPath = join(app.appRoot, "agent", "tools", "first.ts");
+    const secondPath = join(app.appRoot, "agent", "tools", "second.ts");
+    const resolver = createAuthoredModuleGraphResolver([
+      { modulePath: firstPath },
+      { modulePath: secondPath },
+    ]);
+    const profiler = new EveRolldownBuildProfiler();
+    const globals = globalThis as Record<string, unknown>;
+    delete globals.__eveSharedAuthoredGraphEvaluations;
+
+    const [first, second] = await runWithEveRolldownBuildProfiler(
+      profiler,
+      async () => await Promise.all([resolver.load(firstPath), resolver.load(secondPath)]),
+    );
+
+    expect(first.default).toEqual({ evaluation: 1, name: "first" });
+    expect(second.default).toEqual({ evaluation: 1, name: "second" });
+    expect(globals.__eveSharedAuthoredGraphEvaluations).toBe(1);
+    expect(profiler.finish()).toMatchObject({
+      categories: [{ category: "authored-module", invocations: 1 }],
+      invocations: 1,
+    });
+  });
 
   it("preserves cached channel identity for relative channel imports", async () => {
     const app = await scenarioApp({

--- a/packages/eve/src/internal/authored-module-loader.ts
+++ b/packages/eve/src/internal/authored-module-loader.ts
@@ -51,6 +51,23 @@ export interface AuthoredModuleLoadOptions {
   readonly extensionScopeNamespace?: string;
 }
 
+/** Resolves authored module namespaces for compiler normalization. */
+export interface AuthoredModuleNamespaceResolver {
+  load(modulePath: string, options?: AuthoredModuleLoadOptions): Promise<Record<string, unknown>>;
+}
+
+/** One module included in a shared compile-time authored graph. */
+export interface AuthoredModuleGraphEntry {
+  readonly modulePath: string;
+  readonly options?: AuthoredModuleLoadOptions;
+  readonly packageRoot?: string;
+}
+
+/** Default resolver used for config modules and standalone compiler calls. */
+export const authoredModuleNamespaceResolver: AuthoredModuleNamespaceResolver = {
+  load: loadAuthoredModuleNamespace,
+};
+
 function getChannelModuleCache(): Map<string, unknown> | undefined {
   return (globalThis as Record<string, unknown>)[CHANNEL_MODULE_CACHE_KEY] as
     | Map<string, unknown>
@@ -138,6 +155,65 @@ function createFileImportSpecifier(modulePath: string): string {
   return normalizedPath;
 }
 
+interface AuthoredModuleGraphGroup {
+  readonly modulePaths: string[];
+  readonly options: AuthoredModuleLoadOptions;
+  readonly packageRoot: string;
+  promise?: Promise<ReadonlyMap<string, Record<string, unknown>>>;
+}
+
+/**
+ * Creates a node-scoped resolver that bundles compatible authored definitions
+ * as one graph. Entries outside the declared scope retain standalone loading.
+ */
+export function createAuthoredModuleGraphResolver(
+  entries: readonly AuthoredModuleGraphEntry[],
+): AuthoredModuleNamespaceResolver {
+  const groups = new Map<string, AuthoredModuleGraphGroup>();
+  const entryGroups = new Map<string, AuthoredModuleGraphGroup>();
+
+  for (const entry of entries) {
+    const modulePath = resolve(entry.modulePath);
+    const options = entry.options ?? {};
+    const packageRoot = entry.packageRoot ?? resolveAuthoredPackageRoot(modulePath);
+    const groupKey = createAuthoredModuleGraphGroupKey(packageRoot, options);
+    let group = groups.get(groupKey);
+    if (group === undefined) {
+      group = { modulePaths: [], options, packageRoot };
+      groups.set(groupKey, group);
+    }
+    group.modulePaths.push(modulePath);
+    entryGroups.set(createInFlightModuleLoadKey(modulePath, options), group);
+  }
+
+  return {
+    async load(modulePath, options = {}) {
+      const resolvedPath = resolve(modulePath);
+      const group = entryGroups.get(createInFlightModuleLoadKey(resolvedPath, options));
+      if (group === undefined) return await loadAuthoredModuleNamespace(resolvedPath, options);
+
+      group.promise ??= loadAuthoredModuleGraph(
+        group.modulePaths,
+        group.options,
+        group.packageRoot,
+      );
+      const modules = await group.promise;
+      const moduleNamespace = modules.get(resolvedPath);
+      if (moduleNamespace === undefined) {
+        throw new Error(`Shared authored module graph omitted "${resolvedPath}".`);
+      }
+      return moduleNamespace;
+    },
+  };
+}
+
+function createAuthoredModuleGraphGroupKey(
+  packageRoot: string,
+  options: AuthoredModuleLoadOptions,
+): string {
+  return `${resolve(packageRoot)}\0${normalizeExternalDependencies(options.externalDependencies).join("\0")}\0${options.extensionScopeNamespace ?? ""}`;
+}
+
 /**
  * Bundles one authored entry for immediate dev/eval loading. Package dependencies
  * remain external while relative authored source is inlined.
@@ -155,6 +231,90 @@ export async function bundleAuthoredModuleCode(
     plugins: [],
     sourcemap: "inline",
   });
+}
+
+async function loadAuthoredModuleGraph(
+  modulePaths: readonly string[],
+  options: AuthoredModuleLoadOptions,
+  packageRoot: string,
+): Promise<ReadonlyMap<string, Record<string, unknown>>> {
+  const uniqueModulePaths = [
+    ...new Set(modulePaths.map((modulePath) => resolve(modulePath))),
+  ].sort();
+  const firstModulePath = uniqueModulePaths[0];
+  if (firstModulePath === undefined) return new Map();
+
+  const resolvedPackageRoot = resolve(packageRoot);
+  const virtualEntryId = `\0eve-authored-module-graph:${createHash("sha1")
+    .update(uniqueModulePaths.join("\0"))
+    .digest("hex")}`;
+  const virtualEntrySource = [
+    ...uniqueModulePaths.map(
+      (modulePath, index) =>
+        `import * as module_${index} from ${JSON.stringify(modulePath.replaceAll("\\", "/"))};`,
+    ),
+    `export default {${uniqueModulePaths
+      .map((modulePath, index) => `${JSON.stringify(modulePath)}:module_${index}`)
+      .join(",")}};`,
+  ].join("\n");
+  const code = await buildAuthoredModuleBundle(firstModulePath, options, {
+    channelIdentity: true,
+    input: virtualEntryId,
+    packageRoot: resolvedPackageRoot,
+    packageBoundaryPlugin: createRuntimeLoaderPackageBoundaryPlugin({
+      externalDependencies: normalizeExternalDependencies(options.externalDependencies),
+      packageRoot: resolvedPackageRoot,
+    }),
+    plugins: [
+      createVirtualGenerationModuleMapPlugin({ id: virtualEntryId, source: virtualEntrySource }),
+    ],
+    sourcemap: "inline",
+  });
+  const graphHash = createHash("sha1")
+    .update(resolvedPackageRoot)
+    .update("\0")
+    .update(uniqueModulePaths.join("\0"))
+    .update("\0")
+    .update(normalizeExternalDependencies(options.externalDependencies).join("\0"))
+    .update("\0")
+    .update(options.extensionScopeNamespace ?? "")
+    .update("\0")
+    .update(code)
+    .digest("hex");
+  const bundleDirectoryPath = join(resolvedPackageRoot, AUTHORED_MODULE_BUNDLE_DIRECTORY_PATH);
+  const bundlePath = join(bundleDirectoryPath, `graph-${graphHash}.mjs`);
+
+  if (!existsSync(bundlePath)) {
+    mkdirSync(bundleDirectoryPath, { recursive: true });
+    writeFileSync(bundlePath, code);
+  }
+
+  let loaded: unknown;
+  try {
+    loaded = await import(`${createFileImportSpecifier(bundlePath)}?v=${graphHash}`);
+  } catch (error) {
+    throw createAuthoredModuleEvaluationError(firstModulePath, error);
+  }
+
+  const graphNamespace = expectObjectRecord(
+    loaded,
+    `Expected shared authored module graph for "${resolvedPackageRoot}" to export a module namespace object.`,
+  );
+  const graph = expectObjectRecord(
+    graphNamespace.default,
+    `Expected shared authored module graph for "${resolvedPackageRoot}" to export its module map as default.`,
+  );
+  const modules = new Map<string, Record<string, unknown>>();
+  for (const modulePath of uniqueModulePaths) {
+    modules.set(
+      modulePath,
+      expectObjectRecord(
+        graph[modulePath],
+        `Expected shared authored module graph for "${resolvedPackageRoot}" to include "${modulePath}".`,
+      ),
+    );
+  }
+  return modules;
 }
 
 /**
@@ -344,13 +504,15 @@ async function buildAuthoredModuleBundle(
   options: AuthoredModuleLoadOptions,
   configuration: {
     readonly channelIdentity: boolean;
+    readonly input?: string;
+    readonly packageRoot?: string;
     readonly packageBoundaryPlugin: Record<string, unknown>;
     readonly plugins: readonly Record<string, unknown>[];
     readonly sourcemap: false | "inline";
   },
 ): Promise<string> {
   const channelCache = configuration.channelIdentity ? getChannelModuleCache() : undefined;
-  const packageRoot = resolveAuthoredPackageRoot(modulePath);
+  const packageRoot = configuration.packageRoot ?? resolveAuthoredPackageRoot(modulePath);
   const tsconfigPath = resolveAuthoredTsConfigPath(packageRoot);
   const channelIdentityPlugin =
     channelCache && channelCache.size > 0
@@ -420,7 +582,7 @@ async function buildAuthoredModuleBundle(
       `authored module for "${modulePath}"`,
       {
         cwd: packageRoot,
-        input: modulePath,
+        input: configuration.input ?? modulePath,
         platform: "node",
         plugins,
         resolve: {


### PR DESCRIPTION
### Summary

Stacked on #1990. Compiler normalization now evaluates each agent config first, then resolves compatible TypeScript-backed definitions through one shared Rolldown graph per agent node, package root, and external-dependency configuration. This replaces independent builds for each tool, channel, connection, skill, instruction source, schedule, and sandbox while preserving standalone loading for configs and callers outside a declared graph; shared imports now follow normal module-graph semantics and evaluate once within that scope.

Three sequential local `e2e/fixtures/agent-tools` builds with `--skip-sandbox-prewarm`, compared with the base PR:

| Measurement | Base median | Shared graph median | Change |
| --- | ---: | ---: | ---: |
| Internal profiled build | 482.0 ms | 461.0 ms | -4.4% |
| `host.prepare` | 51.2 ms | 39.9 ms | -22.1% |
| `nitro.bundle` | 340.7 ms | 330.0 ms | -3.1% |
| eve-owned Rolldown invocation time | 411.7 ms | 46.5 ms | -88.7% |
| Authored-module Rolldown time | 385.4 ms | 20.2 ms | -94.8% |
| Authored-module invocations | 26 | 2 | -92.3% |

The two remaining authored-module invocations are the root config and the shared resource graph. Invocation duration is cumulative and previously overlapped heavily because per-definition builds ran concurrently, so the structural reduction is much larger than the end-to-end improvement.

### Validation

- `pnpm --filter eve test:unit` (592 files, 6,212 passed)
- `pnpm --filter eve test:integration` (86 files, 623 passed)
- `pnpm --filter eve exec vitest run --config vitest.scenario.config.ts src/internal/authored-module-loader.scenario.test.ts` (23 tests)
- `pnpm --filter eve typecheck`
- `pnpm guard:invariants`
- Built `e2e/fixtures/agent-tools` three times and confirmed the profile comparison above
- Built `e2e/fixtures/extensions` and `e2e/fixtures/agent-subagents` to exercise separate package-root and agent-node scopes

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
