### PR TITLE
feat(slack): render active work in thread

### DIFF
--- a/packages/eve/src/channel/adapter.ts
+++ b/packages/eve/src/channel/adapter.ts
@@ -170,6 +170,11 @@ export type ChannelAdapter<TCtx extends ChannelAdapterContext<any> = ChannelAdap
   readonly instrumentation?: {
     readonly metadata?: ChannelInstrumentationMetadataProjector;
   };
+
+  /** Internal channel-owned rendering of a changed active work graph. */
+  readonly work?: {
+    readonly render: (ctx: TCtx) => void | Promise<void>;
+  };
 } & ChannelEventHandlers<TCtx>;
 
 // ---------------------------------------------------------------------------

--- a/packages/eve/src/channel/adapter.ts
+++ b/packages/eve/src/channel/adapter.ts
@@ -173,7 +173,10 @@ export type ChannelAdapter<TCtx extends ChannelAdapterContext<any> = ChannelAdap
 
   /** Internal channel-owned rendering of a changed active work graph. */
   readonly work?: {
-    readonly render: (ctx: TCtx) => void | Promise<void>;
+    readonly render: (
+      ctx: TCtx,
+      options?: { readonly allowPost?: boolean },
+    ) => void | Promise<void>;
   };
 } & ChannelEventHandlers<TCtx>;
 

--- a/packages/eve/src/execution/local-subagent-work-monitor-steps.ts
+++ b/packages/eve/src/execution/local-subagent-work-monitor-steps.ts
@@ -7,8 +7,13 @@ import type { LocalSubagentWorkMonitorInput } from "#execution/local-subagent-wo
 /** Starts the sibling workflow that polls local child work for channel rendering. */
 export async function startLocalSubagentWorkMonitorStep(
   input: LocalSubagentWorkMonitorInput,
-): Promise<void> {
+): Promise<{ readonly runId: string }> {
   "use step";
 
-  await startWorkflowPreferLatest(localSubagentWorkMonitorWorkflowReference, [input]);
+  const run = await startWorkflowPreferLatest(localSubagentWorkMonitorWorkflowReference, [input]);
+  console.error("[eve.work] started local subagent work monitor", {
+    monitorRunId: run.runId,
+    parentSessionId: input.sessionState.sessionId,
+  });
+  return { runId: run.runId };
 }

--- a/packages/eve/src/execution/local-subagent-work-monitor-steps.ts
+++ b/packages/eve/src/execution/local-subagent-work-monitor-steps.ts
@@ -1,0 +1,14 @@
+import {
+  localSubagentWorkMonitorWorkflowReference,
+  startWorkflowPreferLatest,
+} from "#execution/workflow-runtime.js";
+import type { LocalSubagentWorkMonitorInput } from "#execution/local-subagent-work-monitor-workflow.js";
+
+/** Starts the sibling workflow that polls local child work for channel rendering. */
+export async function startLocalSubagentWorkMonitorStep(
+  input: LocalSubagentWorkMonitorInput,
+): Promise<void> {
+  "use step";
+
+  await startWorkflowPreferLatest(localSubagentWorkMonitorWorkflowReference, [input]);
+}

--- a/packages/eve/src/execution/local-subagent-work-monitor-workflow.ts
+++ b/packages/eve/src/execution/local-subagent-work-monitor-workflow.ts
@@ -3,7 +3,7 @@ import { sleep } from "#compiled/@workflow/core/index.js";
 import { refreshLocalSubagentWorkStep } from "#execution/refresh-local-subagent-work-step.js";
 import type { DurableSessionState } from "#execution/durable-session-store.js";
 
-export const LOCAL_SUBAGENT_WORK_REFRESH_MS = 15_000;
+export const LOCAL_SUBAGENT_WORK_REFRESH_MS = 10_000;
 
 export interface LocalSubagentWorkMonitorInput {
   readonly serializedContext: Record<string, unknown>;

--- a/packages/eve/src/execution/local-subagent-work-monitor-workflow.ts
+++ b/packages/eve/src/execution/local-subagent-work-monitor-workflow.ts
@@ -1,0 +1,29 @@
+import { sleep } from "#compiled/@workflow/core/index.js";
+
+import { refreshLocalSubagentWorkStep } from "#execution/refresh-local-subagent-work-step.js";
+import type { DurableSessionState } from "#execution/durable-session-store.js";
+
+export const LOCAL_SUBAGENT_WORK_REFRESH_MS = 15_000;
+
+export interface LocalSubagentWorkMonitorInput {
+  readonly serializedContext: Record<string, unknown>;
+  readonly sessionState: DurableSessionState;
+}
+
+/** Polls direct local subagent work without participating in parent turn control flow. */
+export async function localSubagentWorkMonitorWorkflow(
+  input: LocalSubagentWorkMonitorInput,
+): Promise<void> {
+  "use workflow";
+
+  let serializedContext = input.serializedContext;
+  while (true) {
+    const refreshed = await refreshLocalSubagentWorkStep({
+      serializedContext,
+      sessionState: input.sessionState,
+    });
+    serializedContext = refreshed.serializedContext;
+    if (!refreshed.hasRunningLocalSubagents) return;
+    await sleep(LOCAL_SUBAGENT_WORK_REFRESH_MS);
+  }
+}

--- a/packages/eve/src/execution/local-subagent-work-monitor-workflow.ts
+++ b/packages/eve/src/execution/local-subagent-work-monitor-workflow.ts
@@ -17,13 +17,39 @@ export async function localSubagentWorkMonitorWorkflow(
   "use workflow";
 
   let serializedContext = input.serializedContext;
+  let poll = 0;
+  console.error("[eve.work] local subagent work monitor started", {
+    parentSessionId: input.sessionState.sessionId,
+  });
   while (true) {
+    poll += 1;
+    console.error("[eve.work] local subagent work monitor poll", {
+      parentSessionId: input.sessionState.sessionId,
+      poll,
+    });
     const refreshed = await refreshLocalSubagentWorkStep({
       serializedContext,
       sessionState: input.sessionState,
     });
     serializedContext = refreshed.serializedContext;
-    if (!refreshed.hasRunningLocalSubagents) return;
+    console.error("[eve.work] local subagent work monitor refresh complete", {
+      ...refreshed.poll,
+      hasRunningLocalSubagents: refreshed.hasRunningLocalSubagents,
+      parentSessionId: input.sessionState.sessionId,
+      poll,
+    });
+    if (!refreshed.hasRunningLocalSubagents) {
+      console.error("[eve.work] local subagent work monitor settled", {
+        parentSessionId: input.sessionState.sessionId,
+        poll,
+      });
+      return;
+    }
+    console.error("[eve.work] local subagent work monitor sleeping", {
+      durationMs: LOCAL_SUBAGENT_WORK_REFRESH_MS,
+      parentSessionId: input.sessionState.sessionId,
+      poll,
+    });
     await sleep(LOCAL_SUBAGENT_WORK_REFRESH_MS);
   }
 }

--- a/packages/eve/src/execution/refresh-local-subagent-work-step.ts
+++ b/packages/eve/src/execution/refresh-local-subagent-work-step.ts
@@ -1,5 +1,7 @@
+import { buildAdapterContext } from "#channel/adapter-context.js";
 import { deserializeContext, serializeContext } from "#context/serialize.js";
 import { WorkGraphKey } from "#context/keys.js";
+import { ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
 import type { DurableSessionState } from "#execution/durable-session-store.js";
 import { readLocalSubagentWork } from "#execution/local-subagent-work-query.js";
 import { findRunningLocalAgentHandles } from "#harness/handles/query.js";
@@ -32,5 +34,11 @@ export async function refreshLocalSubagentWorkStep(input: {
 
   if (work === ctx.get(WorkGraphKey)) return { serializedContext: input.serializedContext };
   ctx.set(WorkGraphKey, work);
+  const adapter = ctx.require(ChannelKey);
+  const render = adapter.work?.render;
+  if (render !== undefined) {
+    await render(buildAdapterContext(adapter, ctx));
+    ctx.set(ChannelKey, { ...adapter, state: { ...ctx.require(ChannelKey).state } });
+  }
   return { serializedContext: serializeContext(ctx) };
 }

--- a/packages/eve/src/execution/refresh-local-subagent-work-step.ts
+++ b/packages/eve/src/execution/refresh-local-subagent-work-step.ts
@@ -11,18 +11,24 @@ import { adoptChildWorkSnapshot } from "#harness/work-graph.js";
 export async function refreshLocalSubagentWorkStep(input: {
   readonly serializedContext: Record<string, unknown>;
   readonly sessionState: DurableSessionState;
-}): Promise<{ readonly serializedContext: Record<string, unknown> }> {
+}): Promise<{
+  readonly hasRunningLocalSubagents: boolean;
+  readonly serializedContext: Record<string, unknown>;
+}> {
   "use step";
 
   const ctx = await deserializeContext(input.serializedContext);
   let work = ctx.get(WorkGraphKey);
-  if (work === undefined) return { serializedContext: input.serializedContext };
+  if (work === undefined) {
+    return { hasRunningLocalSubagents: false, serializedContext: input.serializedContext };
+  }
 
   const handles = findRunningLocalAgentHandles(input.sessionState.snapshot?.session.state);
   console.error("[eve.work] querying direct local subagents", {
     callIds: handles.map((handle) => handle.operation.callId),
     parentSessionId: input.sessionState.sessionId,
   });
+  let allChildrenTerminal = handles.length > 0;
   for (const handle of handles) {
     const child = await readLocalSubagentWork({
       callId: handle.operation.callId,
@@ -34,7 +40,16 @@ export async function refreshLocalSubagentWorkStep(input: {
       outcome: child.kind === "available" ? `available:${child.revision}` : child.reason,
       parentSessionId: input.sessionState.sessionId,
     });
-    if (child.kind !== "available") continue;
+    if (child.kind !== "available") {
+      allChildrenTerminal = false;
+      continue;
+    }
+    if (
+      child.work.turn === undefined ||
+      !["completed", "failed", "cancelled"].includes(child.work.turn.phase)
+    ) {
+      allChildrenTerminal = false;
+    }
     const priorRevision = work.revision;
     work = adoptChildWorkSnapshot(work, {
       callId: handle.operation.callId,
@@ -53,7 +68,10 @@ export async function refreshLocalSubagentWorkStep(input: {
     console.error("[eve.work] parent refresh unchanged", {
       parentSessionId: input.sessionState.sessionId,
     });
-    return { serializedContext: input.serializedContext };
+    return {
+      hasRunningLocalSubagents: !allChildrenTerminal,
+      serializedContext: input.serializedContext,
+    };
   }
   ctx.set(WorkGraphKey, work);
   const adapter = ctx.require(ChannelKey);
@@ -72,5 +90,5 @@ export async function refreshLocalSubagentWorkStep(input: {
     parentSessionId: input.sessionState.sessionId,
     revision: work.revision,
   });
-  return { serializedContext };
+  return { hasRunningLocalSubagents: !allChildrenTerminal, serializedContext };
 }

--- a/packages/eve/src/execution/refresh-local-subagent-work-step.ts
+++ b/packages/eve/src/execution/refresh-local-subagent-work-step.ts
@@ -13,6 +13,16 @@ export async function refreshLocalSubagentWorkStep(input: {
   readonly sessionState: DurableSessionState;
 }): Promise<{
   readonly hasRunningLocalSubagents: boolean;
+  readonly poll: {
+    readonly adoptedCallIds: readonly string[];
+    readonly childWork: readonly {
+      readonly callId: string;
+      readonly outcome: "available" | "not-local" | "not-running" | "not-yet-committed";
+      readonly revision?: number;
+    }[];
+    readonly rendered: boolean;
+    readonly workRevision: number;
+  };
   readonly serializedContext: Record<string, unknown>;
 }> {
   "use step";
@@ -20,10 +30,20 @@ export async function refreshLocalSubagentWorkStep(input: {
   const ctx = await deserializeContext(input.serializedContext);
   let work = ctx.get(WorkGraphKey);
   if (work === undefined) {
-    return { hasRunningLocalSubagents: false, serializedContext: input.serializedContext };
+    return {
+      hasRunningLocalSubagents: false,
+      poll: { adoptedCallIds: [], childWork: [], rendered: false, workRevision: 0 },
+      serializedContext: input.serializedContext,
+    };
   }
 
   const handles = findRunningLocalAgentHandles(input.sessionState.snapshot?.session.state);
+  const childWork: {
+    callId: string;
+    outcome: "available" | "not-local" | "not-running" | "not-yet-committed";
+    revision?: number;
+  }[] = [];
+  const adoptedCallIds: string[] = [];
   console.error("[eve.work] querying direct local subagents", {
     callIds: handles.map((handle) => handle.operation.callId),
     parentSessionId: input.sessionState.sessionId,
@@ -41,9 +61,15 @@ export async function refreshLocalSubagentWorkStep(input: {
       parentSessionId: input.sessionState.sessionId,
     });
     if (child.kind !== "available") {
+      childWork.push({ callId: handle.operation.callId, outcome: child.reason });
       allChildrenTerminal = false;
       continue;
     }
+    childWork.push({
+      callId: handle.operation.callId,
+      outcome: "available",
+      revision: child.revision,
+    });
     if (
       child.work.turn === undefined ||
       !["completed", "failed", "cancelled"].includes(child.work.turn.phase)
@@ -56,6 +82,7 @@ export async function refreshLocalSubagentWorkStep(input: {
       sessionId: handle.address.sessionId,
       snapshot: child.work,
     });
+    if (work.revision !== priorRevision) adoptedCallIds.push(handle.operation.callId);
     console.error("[eve.work] local subagent work adoption", {
       callId: handle.operation.callId,
       childRevision: child.revision,
@@ -70,6 +97,12 @@ export async function refreshLocalSubagentWorkStep(input: {
     });
     return {
       hasRunningLocalSubagents: !allChildrenTerminal,
+      poll: {
+        adoptedCallIds,
+        childWork,
+        rendered: false,
+        workRevision: work.revision,
+      },
       serializedContext: input.serializedContext,
     };
   }
@@ -90,5 +123,14 @@ export async function refreshLocalSubagentWorkStep(input: {
     parentSessionId: input.sessionState.sessionId,
     revision: work.revision,
   });
-  return { hasRunningLocalSubagents: !allChildrenTerminal, serializedContext };
+  return {
+    hasRunningLocalSubagents: !allChildrenTerminal,
+    poll: {
+      adoptedCallIds,
+      childWork,
+      rendered: render !== undefined,
+      workRevision: work.revision,
+    },
+    serializedContext,
+  };
 }

--- a/packages/eve/src/execution/refresh-local-subagent-work-step.ts
+++ b/packages/eve/src/execution/refresh-local-subagent-work-step.ts
@@ -115,7 +115,7 @@ export async function refreshLocalSubagentWorkStep(input: {
     revision: work.revision,
   });
   if (render !== undefined) {
-    await render(buildAdapterContext(adapter, ctx));
+    await render(buildAdapterContext(adapter, ctx), { allowPost: false });
     ctx.set(ChannelKey, { ...adapter, state: { ...ctx.require(ChannelKey).state } });
   }
   const serializedContext = serializeContext(ctx);

--- a/packages/eve/src/execution/refresh-local-subagent-work-step.ts
+++ b/packages/eve/src/execution/refresh-local-subagent-work-step.ts
@@ -19,7 +19,7 @@ export async function refreshLocalSubagentWorkStep(input: {
   if (work === undefined) return { serializedContext: input.serializedContext };
 
   const handles = findRunningLocalAgentHandles(input.sessionState.snapshot?.session.state);
-  console.info("[eve.work] querying direct local subagents", {
+  console.error("[eve.work] querying direct local subagents", {
     callIds: handles.map((handle) => handle.operation.callId),
     parentSessionId: input.sessionState.sessionId,
   });
@@ -28,7 +28,7 @@ export async function refreshLocalSubagentWorkStep(input: {
       callId: handle.operation.callId,
       parentState: input.sessionState.snapshot?.session.state,
     });
-    console.info("[eve.work] local subagent work query", {
+    console.error("[eve.work] local subagent work query", {
       callId: handle.operation.callId,
       childSessionId: handle.address.sessionId,
       outcome: child.kind === "available" ? `available:${child.revision}` : child.reason,
@@ -41,7 +41,7 @@ export async function refreshLocalSubagentWorkStep(input: {
       sessionId: handle.address.sessionId,
       snapshot: child.work,
     });
-    console.info("[eve.work] local subagent work adoption", {
+    console.error("[eve.work] local subagent work adoption", {
       callId: handle.operation.callId,
       childRevision: child.revision,
       parentRevision: work.revision,
@@ -50,7 +50,7 @@ export async function refreshLocalSubagentWorkStep(input: {
   }
 
   if (work === ctx.get(WorkGraphKey)) {
-    console.info("[eve.work] parent refresh unchanged", {
+    console.error("[eve.work] parent refresh unchanged", {
       parentSessionId: input.sessionState.sessionId,
     });
     return { serializedContext: input.serializedContext };

--- a/packages/eve/src/execution/refresh-local-subagent-work-step.ts
+++ b/packages/eve/src/execution/refresh-local-subagent-work-step.ts
@@ -19,20 +19,42 @@ export async function refreshLocalSubagentWorkStep(input: {
   if (work === undefined) return { serializedContext: input.serializedContext };
 
   const handles = findRunningLocalAgentHandles(input.sessionState.snapshot?.session.state);
+  console.info("[eve.work] querying direct local subagents", {
+    callIds: handles.map((handle) => handle.operation.callId),
+    parentSessionId: input.sessionState.sessionId,
+  });
   for (const handle of handles) {
     const child = await readLocalSubagentWork({
       callId: handle.operation.callId,
       parentState: input.sessionState.snapshot?.session.state,
     });
+    console.info("[eve.work] local subagent work query", {
+      callId: handle.operation.callId,
+      childSessionId: handle.address.sessionId,
+      outcome: child.kind === "available" ? `available:${child.revision}` : child.reason,
+      parentSessionId: input.sessionState.sessionId,
+    });
     if (child.kind !== "available") continue;
+    const priorRevision = work.revision;
     work = adoptChildWorkSnapshot(work, {
       callId: handle.operation.callId,
       sessionId: handle.address.sessionId,
       snapshot: child.work,
     });
+    console.info("[eve.work] local subagent work adoption", {
+      callId: handle.operation.callId,
+      childRevision: child.revision,
+      parentRevision: work.revision,
+      parentRevisionBefore: priorRevision,
+    });
   }
 
-  if (work === ctx.get(WorkGraphKey)) return { serializedContext: input.serializedContext };
+  if (work === ctx.get(WorkGraphKey)) {
+    console.info("[eve.work] parent refresh unchanged", {
+      parentSessionId: input.sessionState.sessionId,
+    });
+    return { serializedContext: input.serializedContext };
+  }
   ctx.set(WorkGraphKey, work);
   const adapter = ctx.require(ChannelKey);
   const render = adapter.work?.render;

--- a/packages/eve/src/execution/refresh-local-subagent-work-step.ts
+++ b/packages/eve/src/execution/refresh-local-subagent-work-step.ts
@@ -58,9 +58,19 @@ export async function refreshLocalSubagentWorkStep(input: {
   ctx.set(WorkGraphKey, work);
   const adapter = ctx.require(ChannelKey);
   const render = adapter.work?.render;
+  console.error("[eve.work] parent refresh rendering", {
+    parentSessionId: input.sessionState.sessionId,
+    renderAvailable: render !== undefined,
+    revision: work.revision,
+  });
   if (render !== undefined) {
     await render(buildAdapterContext(adapter, ctx));
     ctx.set(ChannelKey, { ...adapter, state: { ...ctx.require(ChannelKey).state } });
   }
-  return { serializedContext: serializeContext(ctx) };
+  const serializedContext = serializeContext(ctx);
+  console.error("[eve.work] parent refresh committed", {
+    parentSessionId: input.sessionState.sessionId,
+    revision: work.revision,
+  });
+  return { serializedContext };
 }

--- a/packages/eve/src/execution/turn-workflow.test.ts
+++ b/packages/eve/src/execution/turn-workflow.test.ts
@@ -70,7 +70,7 @@ describe("turnWorkflow", () => {
     createHookMock.mockReset();
     sleepMock.mockClear();
     vi.mocked(startLocalSubagentWorkMonitorStep).mockReset();
-    vi.mocked(startLocalSubagentWorkMonitorStep).mockResolvedValue();
+    vi.mocked(startLocalSubagentWorkMonitorStep).mockResolvedValue({ runId: "monitor-run" });
   });
 
   it("notifies the driver when a turn completes", async () => {

--- a/packages/eve/src/execution/turn-workflow.test.ts
+++ b/packages/eve/src/execution/turn-workflow.test.ts
@@ -6,6 +6,7 @@ import { cancelDescendantTurnsStep } from "#execution/cancel-descendant-turns-st
 import { dispatchRuntimeActionsStep } from "#execution/dispatch-runtime-actions-step.js";
 import { dispatchWorkflowRuntimeActionsStep } from "#execution/dispatch-workflow-runtime-actions-step.js";
 import type { DurableSessionState } from "#execution/durable-session-store.js";
+import { startLocalSubagentWorkMonitorStep } from "#execution/local-subagent-work-monitor-steps.js";
 import { runProxySubagentEventStep } from "#execution/subagent-event-proxy-step.js";
 import { turnWorkflow } from "#execution/turn-workflow.js";
 import {
@@ -54,6 +55,10 @@ vi.mock("./cancel-descendant-turns-step.js", () => ({
   cancelDescendantTurnsStep: vi.fn(),
 }));
 
+vi.mock("./local-subagent-work-monitor-steps.js", () => ({
+  startLocalSubagentWorkMonitorStep: vi.fn(),
+}));
+
 vi.mock("./workflow-callback-url.js", () => ({
   resolveWorkflowCallbackBaseUrl: vi.fn((metadataUrl: string) => metadataUrl),
 }));
@@ -64,6 +69,8 @@ describe("turnWorkflow", () => {
     resumeHookMock.mockReset();
     createHookMock.mockReset();
     sleepMock.mockClear();
+    vi.mocked(startLocalSubagentWorkMonitorStep).mockReset();
+    vi.mocked(startLocalSubagentWorkMonitorStep).mockResolvedValue();
   });
 
   it("notifies the driver when a turn completes", async () => {

--- a/packages/eve/src/execution/turn-workflow.ts
+++ b/packages/eve/src/execution/turn-workflow.ts
@@ -23,6 +23,7 @@ import type { NextDriverAction } from "#execution/next-driver-action.js";
 import { routeDeliverToChildren } from "#execution/route-child-delivery.js";
 import { runProxySubagentEventStep } from "#execution/subagent-event-proxy-step.js";
 import { refreshLocalSubagentWorkStep } from "#execution/refresh-local-subagent-work-step.js";
+import { writeLocalSubagentWorkStep } from "#execution/write-local-subagent-work-step.js";
 import {
   createTurnCancellationControl,
   type TurnCancellationControl,
@@ -32,8 +33,6 @@ import { resolveWorkflowCallbackBaseUrl } from "#execution/workflow-callback-url
 import { normalizeSerializableError } from "#execution/workflow-errors.js";
 import { turnStep } from "#execution/workflow-steps.js";
 import { activeTurnId } from "#harness/active-turn-id.js";
-import { deserializeContext } from "#context/serialize.js";
-import { WorkGraphKey } from "#context/keys.js";
 import { getRuntimeActionResultKey } from "#runtime/actions/keys.js";
 import { resolveRuntimeActionResultsForKeys } from "#runtime/actions/results.js";
 import type { RuntimeActionResult } from "#runtime/actions/types.js";
@@ -263,15 +262,10 @@ async function writeCommittedWorkSnapshot(
   workWritable: WritableStream<unknown> | undefined,
 ): Promise<void> {
   if (workWritable === undefined) return;
-  const ctx = await deserializeContext(result.serializedContext);
-  const work = ctx.get(WorkGraphKey);
-  if (work === undefined || work.revision === 0) return;
-  const writer = workWritable.getWriter();
-  try {
-    await writer.write(work);
-  } finally {
-    writer.releaseLock();
-  }
+  await writeLocalSubagentWorkStep({
+    serializedContext: result.serializedContext,
+    workWritable,
+  });
 }
 
 async function finishCancelledTurn(input: {

--- a/packages/eve/src/execution/turn-workflow.ts
+++ b/packages/eve/src/execution/turn-workflow.ts
@@ -22,6 +22,7 @@ import { claimHookOwnership, disposeHook, isHookConflictError } from "#execution
 import type { NextDriverAction } from "#execution/next-driver-action.js";
 import { routeDeliverToChildren } from "#execution/route-child-delivery.js";
 import { runProxySubagentEventStep } from "#execution/subagent-event-proxy-step.js";
+import { startLocalSubagentWorkMonitorStep } from "#execution/local-subagent-work-monitor-steps.js";
 import { writeLocalSubagentWorkStep } from "#execution/write-local-subagent-work-step.js";
 import {
   createTurnCancellationControl,
@@ -191,6 +192,10 @@ async function runTurnOwnedWorkflow(input: TurnWorkflowInput): Promise<void> {
         const initialAcceptedAtMs = dispatchResult.results.length === 0 ? undefined : Date.now();
         await cursor.adopt(dispatchResult);
         await acknowledgeDelegatedTasksStep({ tasks: dispatchResult.pendingTasks });
+        await startLocalSubagentWorkMonitorStep({
+          serializedContext: cursor.serializedContext,
+          sessionState: cursor.sessionState,
+        });
 
         const results = await waitForRuntimeActionResults({
           bufferedDeliveries,
@@ -301,8 +306,6 @@ interface AcceptedRuntimeActionBatch {
   readonly results: readonly RuntimeActionResult[];
 }
 
-const LOCAL_SUBAGENT_WORK_REFRESH_MS = 15_000;
-
 async function waitForRuntimeActionResults(input: {
   readonly bufferedDeliveries: DeliverHookPayload[];
   readonly cancellation: TurnCancellationControl | undefined;
@@ -322,12 +325,7 @@ async function waitForRuntimeActionResults(input: {
       acceptedAtMsByKey.set(getRuntimeActionResultKey(result), input.initialAcceptedAtMs);
     }
   }
-  let nextWorkRefresh = workflowSleep(LOCAL_SUBAGENT_WORK_REFRESH_MS).then(
-    () => "work-refresh" as const,
-  );
   let nextPromise = input.iterator.next();
-  // A timer can win while this read remains pending. Keep one read alive
-  // across refreshes so a child result cannot be consumed and discarded.
   nextPromise.catch(() => {});
 
   while (true) {
@@ -372,10 +370,9 @@ async function waitForRuntimeActionResults(input: {
     }
 
     const inbox = nextPromise.then((next) => ({ kind: "inbox" as const, next }));
-    const refresh = nextWorkRefresh.then(() => ({ kind: "work-refresh" as const }));
     const next = await (input.cancellation === undefined
-      ? Promise.race([inbox, refresh])
-      : Promise.race([inbox, refresh, input.cancellation.requested]));
+      ? inbox
+      : Promise.race([inbox, input.cancellation.requested]));
     if (next === "cancel") {
       if (pendingDeliveryRequest !== undefined) {
         // Release the raced public input back to the driver so it stays
@@ -386,28 +383,6 @@ async function waitForRuntimeActionResults(input: {
         });
       }
       return "cancelled";
-    }
-    if (next.kind === "work-refresh") {
-      console.error("[eve.work] parent refresh tick", {
-        pendingActionKeys: input.pendingActionKeys,
-        sessionId: input.cursor.sessionState.sessionId,
-      });
-      const { refreshLocalSubagentWorkStep } =
-        await import("#execution/refresh-local-subagent-work-step.js");
-      const refreshed = await refreshLocalSubagentWorkStep({
-        serializedContext: input.cursor.serializedContext,
-        sessionState: input.cursor.sessionState,
-      });
-      const contextChanged = refreshed.serializedContext !== input.cursor.serializedContext;
-      await input.cursor.adopt({ ...refreshed, sessionState: input.cursor.sessionState });
-      console.error("[eve.work] parent refresh adopted", {
-        serializedContextChanged: contextChanged,
-        sessionId: input.cursor.sessionState.sessionId,
-      });
-      nextWorkRefresh = workflowSleep(LOCAL_SUBAGENT_WORK_REFRESH_MS).then(
-        () => "work-refresh" as const,
-      );
-      continue;
     }
     if (next.next.done) throw new Error("Turn inbox closed before runtime actions completed.");
 

--- a/packages/eve/src/execution/turn-workflow.ts
+++ b/packages/eve/src/execution/turn-workflow.ts
@@ -382,6 +382,10 @@ async function waitForRuntimeActionResults(input: {
       return "cancelled";
     }
     if (next.kind === "work-refresh") {
+      console.info("[eve.work] parent refresh tick", {
+        pendingActionKeys: input.pendingActionKeys,
+        sessionId: input.cursor.sessionState.sessionId,
+      });
       const { refreshLocalSubagentWorkStep } =
         await import("#execution/refresh-local-subagent-work-step.js");
       const refreshed = await refreshLocalSubagentWorkStep({
@@ -400,6 +404,10 @@ async function waitForRuntimeActionResults(input: {
     nextPromise = input.iterator.next();
     nextPromise.catch(() => {});
     if (value.kind === "runtime-action-result") {
+      console.info("[eve.work] parent received child result", {
+        callIds: value.results.map((result) => result.callId),
+        sessionId: input.cursor.sessionState.sessionId,
+      });
       // The inbox token is shared by every callee in the batch, so an inbox
       // subagent result must bind to a running agent handle in the adopted
       // session snapshot: its callId on the handle's operation and, when it
@@ -412,6 +420,11 @@ async function waitForRuntimeActionResults(input: {
       const accepted = value.results.filter((result) =>
         isInboxSubagentResultFromRunningHandle(sessionSnapshotState, result),
       );
+      console.info("[eve.work] parent child result binding", {
+        acceptedCallIds: accepted.map((result) => result.callId),
+        receivedCallIds: value.results.map((result) => result.callId),
+        sessionId: input.cursor.sessionState.sessionId,
+      });
       if (accepted.length > 0) {
         const acceptedAtMs = Date.now();
         results.push(...accepted);

--- a/packages/eve/src/execution/turn-workflow.ts
+++ b/packages/eve/src/execution/turn-workflow.ts
@@ -382,7 +382,7 @@ async function waitForRuntimeActionResults(input: {
       return "cancelled";
     }
     if (next.kind === "work-refresh") {
-      console.info("[eve.work] parent refresh tick", {
+      console.error("[eve.work] parent refresh tick", {
         pendingActionKeys: input.pendingActionKeys,
         sessionId: input.cursor.sessionState.sessionId,
       });
@@ -404,7 +404,7 @@ async function waitForRuntimeActionResults(input: {
     nextPromise = input.iterator.next();
     nextPromise.catch(() => {});
     if (value.kind === "runtime-action-result") {
-      console.info("[eve.work] parent received child result", {
+      console.error("[eve.work] parent received child result", {
         callIds: value.results.map((result) => result.callId),
         sessionId: input.cursor.sessionState.sessionId,
       });
@@ -420,7 +420,7 @@ async function waitForRuntimeActionResults(input: {
       const accepted = value.results.filter((result) =>
         isInboxSubagentResultFromRunningHandle(sessionSnapshotState, result),
       );
-      console.info("[eve.work] parent child result binding", {
+      console.error("[eve.work] parent child result binding", {
         acceptedCallIds: accepted.map((result) => result.callId),
         receivedCallIds: value.results.map((result) => result.callId),
         sessionId: input.cursor.sessionState.sessionId,

--- a/packages/eve/src/execution/turn-workflow.ts
+++ b/packages/eve/src/execution/turn-workflow.ts
@@ -335,6 +335,12 @@ async function waitForRuntimeActionResults(input: {
       pendingKeys: input.pendingActionKeys,
       results,
     });
+    console.error("[eve.work] parent action-result wait state", {
+      pendingActionKeys: input.pendingActionKeys,
+      ready: ready !== undefined,
+      resultCallIds: results.map((result) => result.callId),
+      sessionId: input.cursor.sessionState.sessionId,
+    });
     if (ready !== undefined) {
       if (pendingDeliveryRequest !== undefined) {
         // The entry may already be racing public input against this wait.
@@ -392,7 +398,12 @@ async function waitForRuntimeActionResults(input: {
         serializedContext: input.cursor.serializedContext,
         sessionState: input.cursor.sessionState,
       });
+      const contextChanged = refreshed.serializedContext !== input.cursor.serializedContext;
       await input.cursor.adopt({ ...refreshed, sessionState: input.cursor.sessionState });
+      console.error("[eve.work] parent refresh adopted", {
+        serializedContextChanged: contextChanged,
+        sessionId: input.cursor.sessionState.sessionId,
+      });
       nextWorkRefresh = workflowSleep(LOCAL_SUBAGENT_WORK_REFRESH_MS).then(
         () => "work-refresh" as const,
       );
@@ -432,6 +443,10 @@ async function waitForRuntimeActionResults(input: {
           acceptedAtMsByKey.set(getRuntimeActionResultKey(result), acceptedAtMs);
         }
       }
+      console.error("[eve.work] parent child results accumulated", {
+        resultCallIds: results.map((result) => result.callId),
+        sessionId: input.cursor.sessionState.sessionId,
+      });
       continue;
     }
 

--- a/packages/eve/src/execution/turn-workflow.ts
+++ b/packages/eve/src/execution/turn-workflow.ts
@@ -194,7 +194,7 @@ async function runTurnOwnedWorkflow(input: TurnWorkflowInput): Promise<void> {
         await acknowledgeDelegatedTasksStep({ tasks: dispatchResult.pendingTasks });
         await startLocalSubagentWorkMonitorStep({
           serializedContext: cursor.serializedContext,
-          sessionState: cursor.sessionState,
+          sessionState: dispatchResult.sessionState,
         });
 
         const results = await waitForRuntimeActionResults({

--- a/packages/eve/src/execution/turn-workflow.ts
+++ b/packages/eve/src/execution/turn-workflow.ts
@@ -22,7 +22,6 @@ import { claimHookOwnership, disposeHook, isHookConflictError } from "#execution
 import type { NextDriverAction } from "#execution/next-driver-action.js";
 import { routeDeliverToChildren } from "#execution/route-child-delivery.js";
 import { runProxySubagentEventStep } from "#execution/subagent-event-proxy-step.js";
-import { refreshLocalSubagentWorkStep } from "#execution/refresh-local-subagent-work-step.js";
 import { writeLocalSubagentWorkStep } from "#execution/write-local-subagent-work-step.js";
 import {
   createTurnCancellationControl,
@@ -382,6 +381,8 @@ async function waitForRuntimeActionResults(input: {
       return "cancelled";
     }
     if (next === "work-refresh") {
+      const { refreshLocalSubagentWorkStep } =
+        await import("#execution/refresh-local-subagent-work-step.js");
       const refreshed = await refreshLocalSubagentWorkStep({
         serializedContext: input.cursor.serializedContext,
         sessionState: input.cursor.sessionState,

--- a/packages/eve/src/execution/turn-workflow.ts
+++ b/packages/eve/src/execution/turn-workflow.ts
@@ -325,6 +325,10 @@ async function waitForRuntimeActionResults(input: {
   let nextWorkRefresh = workflowSleep(LOCAL_SUBAGENT_WORK_REFRESH_MS).then(
     () => "work-refresh" as const,
   );
+  let nextPromise = input.iterator.next();
+  // A timer can win while this read remains pending. Keep one read alive
+  // across refreshes so a child result cannot be consumed and discarded.
+  nextPromise.catch(() => {});
 
   while (true) {
     const ready = resolveRuntimeActionResultsForKeys({
@@ -361,14 +365,11 @@ async function waitForRuntimeActionResults(input: {
       });
     }
 
-    const nextPromise = input.iterator.next();
-    // When a cancel wins the race, the dangling inbox `next()` is dropped
-    // by disposal in teardown; pre-attach a handler so a late rejection
-    // never surfaces as unhandled.
-    nextPromise.catch(() => {});
+    const inbox = nextPromise.then((next) => ({ kind: "inbox" as const, next }));
+    const refresh = nextWorkRefresh.then(() => ({ kind: "work-refresh" as const }));
     const next = await (input.cancellation === undefined
-      ? Promise.race([nextPromise, nextWorkRefresh])
-      : Promise.race([nextPromise, nextWorkRefresh, input.cancellation.requested]));
+      ? Promise.race([inbox, refresh])
+      : Promise.race([inbox, refresh, input.cancellation.requested]));
     if (next === "cancel") {
       if (pendingDeliveryRequest !== undefined) {
         // Release the raced public input back to the driver so it stays
@@ -380,7 +381,7 @@ async function waitForRuntimeActionResults(input: {
       }
       return "cancelled";
     }
-    if (next === "work-refresh") {
+    if (next.kind === "work-refresh") {
       const { refreshLocalSubagentWorkStep } =
         await import("#execution/refresh-local-subagent-work-step.js");
       const refreshed = await refreshLocalSubagentWorkStep({
@@ -393,9 +394,11 @@ async function waitForRuntimeActionResults(input: {
       );
       continue;
     }
-    if (next.done) throw new Error("Turn inbox closed before runtime actions completed.");
+    if (next.next.done) throw new Error("Turn inbox closed before runtime actions completed.");
 
-    const value = next.value;
+    const value = next.next.value;
+    nextPromise = input.iterator.next();
+    nextPromise.catch(() => {});
     if (value.kind === "runtime-action-result") {
       // The inbox token is shared by every callee in the batch, so an inbox
       // subagent result must bind to a running agent handle in the adopted

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -58,6 +58,7 @@ const WORKFLOW_ENTRY_NAME = "workflowEntry";
 const TURN_WORKFLOW_NAME = "turnWorkflow";
 const SESSION_TIMEOUT_WORKFLOW_NAME = "sessionTimeoutWorkflow";
 const TASK_RUN_WORKFLOW_NAME = "taskRunWorkflow";
+const LOCAL_SUBAGENT_WORK_MONITOR_WORKFLOW_NAME = "localSubagentWorkMonitorWorkflow";
 const EVE_PACKAGE_INFO = resolveInstalledPackageInfo();
 const COMMAND_HOOK_READY_TIMEOUT_MS = 30_000;
 
@@ -79,6 +80,7 @@ export const STABLE_WORKFLOW_NAMES: ReadonlySet<string> = new Set([
   TURN_WORKFLOW_NAME,
   SESSION_TIMEOUT_WORKFLOW_NAME,
   TASK_RUN_WORKFLOW_NAME,
+  LOCAL_SUBAGENT_WORK_MONITOR_WORKFLOW_NAME,
 ]);
 
 const STABLE_ID_BASE = EVE_PACKAGE_INFO.name;
@@ -119,6 +121,11 @@ export const sessionTimeoutWorkflowReference = {
 /** Stable workflow reference for durable task runs (`experimental.tasks`). */
 export const taskRunWorkflowReference = {
   workflowId: `workflow//${STABLE_ID_BASE}//${TASK_RUN_WORKFLOW_NAME}`,
+};
+
+/** Stable workflow reference for local subagent work monitoring. */
+export const localSubagentWorkMonitorWorkflowReference = {
+  workflowId: `workflow//${STABLE_ID_BASE}//${LOCAL_SUBAGENT_WORK_MONITOR_WORKFLOW_NAME}`,
 };
 
 /**

--- a/packages/eve/src/execution/write-local-subagent-work-step.ts
+++ b/packages/eve/src/execution/write-local-subagent-work-step.ts
@@ -11,10 +11,10 @@ export async function writeLocalSubagentWorkStep(input: {
   const ctx = await deserializeContext(input.serializedContext);
   const work = ctx.get(WorkGraphKey);
   if (work === undefined || work.revision === 0) {
-    console.info("[eve.work] child projection skipped", { reason: "no-work" });
+    console.error("[eve.work] child projection skipped", { reason: "no-work" });
     return;
   }
-  console.info("[eve.work] child projection write", { revision: work.revision });
+  console.error("[eve.work] child projection write", { revision: work.revision });
   const writer = input.workWritable.getWriter();
   try {
     await writer.write(work);

--- a/packages/eve/src/execution/write-local-subagent-work-step.ts
+++ b/packages/eve/src/execution/write-local-subagent-work-step.ts
@@ -1,0 +1,20 @@
+import { deserializeContext } from "#context/serialize.js";
+import { WorkGraphKey } from "#context/keys.js";
+
+/** Writes the latest committed work graph to a session-owned projection stream. */
+export async function writeLocalSubagentWorkStep(input: {
+  readonly serializedContext: Record<string, unknown>;
+  readonly workWritable: WritableStream<unknown>;
+}): Promise<void> {
+  "use step";
+
+  const ctx = await deserializeContext(input.serializedContext);
+  const work = ctx.get(WorkGraphKey);
+  if (work === undefined || work.revision === 0) return;
+  const writer = input.workWritable.getWriter();
+  try {
+    await writer.write(work);
+  } finally {
+    writer.releaseLock();
+  }
+}

--- a/packages/eve/src/execution/write-local-subagent-work-step.ts
+++ b/packages/eve/src/execution/write-local-subagent-work-step.ts
@@ -10,7 +10,11 @@ export async function writeLocalSubagentWorkStep(input: {
 
   const ctx = await deserializeContext(input.serializedContext);
   const work = ctx.get(WorkGraphKey);
-  if (work === undefined || work.revision === 0) return;
+  if (work === undefined || work.revision === 0) {
+    console.info("[eve.work] child projection skipped", { reason: "no-work" });
+    return;
+  }
+  console.info("[eve.work] child projection write", { revision: work.revision });
   const writer = input.workWritable.getWriter();
   try {
     await writer.write(work);

--- a/packages/eve/src/harness/work-graph.ts
+++ b/packages/eve/src/harness/work-graph.ts
@@ -23,6 +23,7 @@ export interface WorkAction {
   readonly kind: RuntimeActionRequest["kind"];
   readonly name: string;
   readonly phase: WorkPhase;
+  readonly detail?: string;
   readonly child?: {
     readonly sessionId: string;
     readonly work?: WorkGraph;
@@ -298,7 +299,13 @@ function toWorkAction(action: RuntimeActionRequest): WorkAction {
         phase: "running",
       };
     case "tool-call":
-      return { callId: action.callId, kind: action.kind, name: action.toolName, phase: "running" };
+      return {
+        callId: action.callId,
+        detail: typeof action.input.stage === "string" ? action.input.stage : undefined,
+        kind: action.kind,
+        name: action.toolName,
+        phase: "running",
+      };
   }
 }
 

--- a/packages/eve/src/public/channels/slack/defaults.ts
+++ b/packages/eve/src/public/channels/slack/defaults.ts
@@ -31,6 +31,10 @@ import type {
   SlackContext,
   SlackMentionResult,
 } from "#public/channels/slack/slackChannel.js";
+import {
+  renderSlackWorkActivity,
+  settleSlackWorkActivity,
+} from "#public/channels/slack/work-activity.js";
 import type { InputRequest } from "#runtime/input/types.js";
 
 const log = createLogger("slack.defaults");
@@ -275,6 +279,10 @@ export const defaultEvents: SlackChannelInternalEvents = {
   },
 
   async "actions.requested"(event, channel, _ctx) {
+    await renderSlackWorkActivity({
+      channel,
+      work: workGraphFromChannelContext(channel),
+    });
     const buffered = channel.state.pendingToolCallMessage;
     channel.state.pendingToolCallMessage = null;
     if (buffered) {
@@ -302,7 +310,16 @@ export const defaultEvents: SlackChannelInternalEvents = {
     await channel.thread.post(event.message);
   },
 
+  async "turn.completed"(_event, channel, _ctx) {
+    await settleSlackWorkActivity(channel);
+  },
+
+  async "turn.cancelled"(_event, channel, _ctx) {
+    await settleSlackWorkActivity(channel);
+  },
+
   async "turn.failed"(event, channel, _ctx) {
+    await settleSlackWorkActivity(channel);
     const hint = formatErrorHint(event);
     const errorId = extractErrorId(event.details);
     await channel.thread.post(

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -224,6 +224,9 @@ export interface SlackChannelState {
   pendingApprovalCards?: Record<string, SlackPendingApprovalCard>;
   pendingApprovalCandidateUsers?: Record<string, string>;
   approvalResponderUsers?: Record<string, string>;
+  /** Replaceable internal activity message for the active work graph. */
+  workActivityMessageTs?: string | null;
+  workActivityTurnId?: string | null;
 }
 
 /**
@@ -759,6 +762,8 @@ export function slackChannel(config: SlackChannelConfig = {}): SlackChannel {
       pendingApprovalCards: {},
       pendingApprovalCandidateUsers: {},
       approvalResponderUsers: {},
+      workActivityMessageTs: null,
+      workActivityTurnId: null,
     },
     fetchFile: slackFetchFile,
     metadata(state): SlackInstrumentationMetadata {

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -768,8 +768,9 @@ export function slackChannel(config: SlackChannelConfig = {}): SlackChannel {
       workActivityTurnId: null,
     },
     fetchFile: slackFetchFile,
-    work: (state, _session, ctx) =>
+    work: (state, _session, ctx, options) =>
       renderSlackWorkActivity({
+        allowPost: options?.allowPost,
         channel: rebuildSlackContext(state, _session, config.credentials),
         work: ctx.get(WorkGraphKey),
       }),

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -56,6 +56,8 @@ import {
   type LoadThreadContextMessagesOptions,
 } from "#public/channels/slack/thread.js";
 import { buildSlackAuthContext, slackUserIdFromAuthContext } from "#public/channels/slack/auth.js";
+import { renderSlackWorkActivity } from "#public/channels/slack/work-activity.js";
+import { WorkGraphKey } from "#context/keys.js";
 import { SLACK_CHANNEL_DEFAULT_ROUTE } from "#public/channels/slack/constants.js";
 import { handleInteractionPost } from "#public/channels/slack/interactions.js";
 import {
@@ -766,6 +768,11 @@ export function slackChannel(config: SlackChannelConfig = {}): SlackChannel {
       workActivityTurnId: null,
     },
     fetchFile: slackFetchFile,
+    work: (state, _session, ctx) =>
+      renderSlackWorkActivity({
+        channel: rebuildSlackContext(state, _session, config.credentials),
+        work: ctx.get(WorkGraphKey),
+      }),
     metadata(state): SlackInstrumentationMetadata {
       return {
         channelId: state.channelId,

--- a/packages/eve/src/public/channels/slack/work-activity.test.ts
+++ b/packages/eve/src/public/channels/slack/work-activity.test.ts
@@ -63,6 +63,68 @@ describe("renderSlackWorkActivity", () => {
     });
   });
 
+  it("shows the most recent child action while the child turn is still running", async () => {
+    const post = vi.fn(async () => ({ id: "activity-1" }));
+    const channel = {
+      slack: { channelId: "C1", request: vi.fn(async () => ({ ok: true })) },
+      state: {},
+      thread: { post },
+    };
+
+    await renderSlackWorkActivity({
+      channel,
+      work: {
+        revision: 1,
+        turn: {
+          blockers: [],
+          id: "turn-1",
+          phase: "running",
+          steps: [
+            {
+              actions: [
+                {
+                  callId: "child-1",
+                  child: {
+                    sessionId: "child-session",
+                    work: {
+                      revision: 5,
+                      turn: {
+                        blockers: [],
+                        id: "turn-0",
+                        phase: "running",
+                        steps: [
+                          {
+                            actions: [
+                              {
+                                callId: "stage-1",
+                                kind: "tool-call",
+                                name: "research_stage",
+                                phase: "completed",
+                              },
+                            ],
+                            phase: "completed",
+                            stepIndex: 0,
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  kind: "subagent-call",
+                  name: "researcher",
+                  phase: "running",
+                },
+              ],
+              phase: "running",
+              stepIndex: 0,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(post).toHaveBeenCalledWith("*Working*\n\n◐ researcher — research_stage");
+  });
+
   it("reposts when its tracked message is gone", async () => {
     const post = vi.fn(async () => ({ id: "activity-2" }));
     const request = vi.fn(async () => ({ error: "message_not_found", ok: false }));

--- a/packages/eve/src/public/channels/slack/work-activity.test.ts
+++ b/packages/eve/src/public/channels/slack/work-activity.test.ts
@@ -76,7 +76,6 @@ describe("renderSlackWorkActivity", () => {
     expect(post).toHaveBeenCalledOnce();
     expect(request).toHaveBeenCalledWith("chat.update", {
       blocks: [
-        { elements: [{ text: "*Working*", type: "mrkdwn" }], type: "context" },
         {
           status: "complete",
           task_id: "work-0",
@@ -152,7 +151,6 @@ describe("renderSlackWorkActivity", () => {
 
     expect(post).toHaveBeenCalledWith({
       blocks: [
-        { elements: [{ text: "*Working*", type: "mrkdwn" }], type: "context" },
         {
           details: {
             elements: [

--- a/packages/eve/src/public/channels/slack/work-activity.test.ts
+++ b/packages/eve/src/public/channels/slack/work-activity.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { renderSlackWorkActivity } from "#public/channels/slack/work-activity.js";
+
+describe("renderSlackWorkActivity", () => {
+  it("posts once then updates the same turn activity message", async () => {
+    const post = vi.fn(async () => ({ id: "activity-1" }));
+    const request = vi.fn(async () => ({ ok: true }));
+    const channel = {
+      slack: { channelId: "C1", request },
+      state: {},
+      thread: { post },
+    };
+    const running = {
+      revision: 1,
+      turn: {
+        blockers: [],
+        id: "turn-1",
+        phase: "running" as const,
+        steps: [
+          {
+            actions: [
+              {
+                callId: "call-1",
+                kind: "tool-call" as const,
+                name: "search_docs",
+                phase: "running" as const,
+              },
+            ],
+            phase: "running" as const,
+            stepIndex: 0,
+          },
+        ],
+      },
+    };
+
+    await renderSlackWorkActivity({ channel, work: running });
+    await renderSlackWorkActivity({
+      channel,
+      work: {
+        ...running,
+        revision: 2,
+        turn: {
+          ...running.turn,
+          steps: [
+            {
+              actions: [
+                { callId: "call-1", kind: "tool-call", name: "search_docs", phase: "completed" },
+              ],
+              phase: "completed",
+              stepIndex: 0,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(post).toHaveBeenCalledOnce();
+    expect(request).toHaveBeenCalledWith("chat.update", {
+      channel: "C1",
+      text: "*Working*\n\n✓ search_docs",
+      ts: "activity-1",
+    });
+  });
+
+  it("reposts when its tracked message is gone", async () => {
+    const post = vi.fn(async () => ({ id: "activity-2" }));
+    const request = vi.fn(async () => ({ error: "message_not_found", ok: false }));
+    const channel = {
+      slack: { channelId: "C1", request },
+      state: { workActivityMessageTs: "missing", workActivityTurnId: "turn-1" },
+      thread: { post },
+    };
+
+    await renderSlackWorkActivity({
+      channel,
+      work: {
+        revision: 1,
+        turn: {
+          blockers: [],
+          id: "turn-1",
+          phase: "running",
+          steps: [
+            {
+              actions: [
+                { callId: "call-1", kind: "tool-call", name: "search_docs", phase: "running" },
+              ],
+              phase: "running",
+              stepIndex: 0,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(post).toHaveBeenCalledOnce();
+    expect(channel.state.workActivityMessageTs).toBe("activity-2");
+  });
+});

--- a/packages/eve/src/public/channels/slack/work-activity.test.ts
+++ b/packages/eve/src/public/channels/slack/work-activity.test.ts
@@ -76,17 +76,12 @@ describe("renderSlackWorkActivity", () => {
     expect(post).toHaveBeenCalledOnce();
     expect(request).toHaveBeenCalledWith("chat.update", {
       blocks: [
+        { elements: [{ text: "*Working*", type: "mrkdwn" }], type: "context" },
         {
-          tasks: [
-            {
-              status: "complete",
-              task_id: "work-0",
-              title: "search_docs",
-              type: "task_card",
-            },
-          ],
-          title: "Working",
-          type: "plan",
+          status: "complete",
+          task_id: "work-0",
+          title: "search_docs",
+          type: "task_card",
         },
       ],
       channel: "C1",
@@ -157,26 +152,21 @@ describe("renderSlackWorkActivity", () => {
 
     expect(post).toHaveBeenCalledWith({
       blocks: [
+        { elements: [{ text: "*Working*", type: "mrkdwn" }], type: "context" },
         {
-          tasks: [
-            {
-              details: {
-                elements: [
-                  {
-                    elements: [{ text: "✓ discover", type: "text" }],
-                    type: "rich_text_section",
-                  },
-                ],
-                type: "rich_text",
+          details: {
+            elements: [
+              {
+                elements: [{ text: "✓ discover", type: "text" }],
+                type: "rich_text_section",
               },
-              status: "in_progress",
-              task_id: "work-0",
-              title: "researcher",
-              type: "task_card",
-            },
-          ],
-          title: "Working",
-          type: "plan",
+            ],
+            type: "rich_text",
+          },
+          status: "in_progress",
+          task_id: "work-0",
+          title: "researcher",
+          type: "task_card",
         },
       ],
       text: "Working\n◐ researcher\n  ✓ discover",

--- a/packages/eve/src/public/channels/slack/work-activity.test.ts
+++ b/packages/eve/src/public/channels/slack/work-activity.test.ts
@@ -98,6 +98,7 @@ describe("renderSlackWorkActivity", () => {
                               {
                                 callId: "stage-1",
                                 kind: "tool-call",
+                                detail: "discover",
                                 name: "research_stage",
                                 phase: "completed",
                               },
@@ -122,7 +123,41 @@ describe("renderSlackWorkActivity", () => {
       },
     });
 
-    expect(post).toHaveBeenCalledWith("*Working*\n\n◐ researcher — research_stage");
+    expect(post).toHaveBeenCalledWith("*Working*\n\n◐ researcher — research_stage — discover");
+  });
+
+  it("does not post when a monitor cannot find the parent-owned activity message", async () => {
+    const post = vi.fn(async () => ({ id: "activity-2" }));
+    const request = vi.fn(async () => ({ error: "message_not_found", ok: false }));
+    const channel = {
+      slack: { channelId: "C1", request },
+      state: { workActivityMessageTs: "missing", workActivityTurnId: "turn-1" },
+      thread: { post },
+    };
+
+    await renderSlackWorkActivity({
+      allowPost: false,
+      channel,
+      work: {
+        revision: 1,
+        turn: {
+          blockers: [],
+          id: "turn-1",
+          phase: "running",
+          steps: [
+            {
+              actions: [
+                { callId: "call-1", kind: "tool-call", name: "search_docs", phase: "running" },
+              ],
+              phase: "running",
+              stepIndex: 0,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(post).not.toHaveBeenCalled();
   });
 
   it("reposts when its tracked message is gone", async () => {

--- a/packages/eve/src/public/channels/slack/work-activity.test.ts
+++ b/packages/eve/src/public/channels/slack/work-activity.test.ts
@@ -76,8 +76,18 @@ describe("renderSlackWorkActivity", () => {
     expect(post).toHaveBeenCalledOnce();
     expect(request).toHaveBeenCalledWith("chat.update", {
       blocks: [
-        { text: { emoji: true, text: "Working", type: "plain_text" }, type: "header" },
-        { text: { text: "✓ search_docs", type: "mrkdwn" }, type: "section" },
+        {
+          tasks: [
+            {
+              status: "complete",
+              task_id: "work-0",
+              title: "search_docs",
+              type: "task_card",
+            },
+          ],
+          title: "Working",
+          type: "plan",
+        },
       ],
       channel: "C1",
       text: "Working\n✓ search_docs",
@@ -147,8 +157,27 @@ describe("renderSlackWorkActivity", () => {
 
     expect(post).toHaveBeenCalledWith({
       blocks: [
-        { text: { emoji: true, text: "Working", type: "plain_text" }, type: "header" },
-        { text: { text: "◐ *researcher*\n   ✓ discover", type: "mrkdwn" }, type: "section" },
+        {
+          tasks: [
+            {
+              details: {
+                elements: [
+                  {
+                    elements: [{ text: "✓ discover", type: "text" }],
+                    type: "rich_text_section",
+                  },
+                ],
+                type: "rich_text",
+              },
+              status: "in_progress",
+              task_id: "work-0",
+              title: "researcher",
+              type: "task_card",
+            },
+          ],
+          title: "Working",
+          type: "plan",
+        },
       ],
       text: "Working\n◐ researcher\n  ✓ discover",
     });

--- a/packages/eve/src/public/channels/slack/work-activity.test.ts
+++ b/packages/eve/src/public/channels/slack/work-activity.test.ts
@@ -1,8 +1,26 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { renderSlackWorkActivity } from "#public/channels/slack/work-activity.js";
+import {
+  renderSlackWorkActivity,
+  settleSlackWorkActivity,
+} from "#public/channels/slack/work-activity.js";
 
 describe("renderSlackWorkActivity", () => {
+  it("removes the transient activity message when the parent turn settles", async () => {
+    const request = vi.fn(async () => ({ ok: true }));
+    const channel = {
+      slack: { channelId: "C1", request },
+      state: { workActivityMessageTs: "activity-1", workActivityTurnId: "turn-1" },
+      thread: { post: vi.fn() },
+    };
+
+    await settleSlackWorkActivity(channel);
+
+    expect(request).toHaveBeenCalledWith("chat.delete", { channel: "C1", ts: "activity-1" });
+    expect(channel.state.workActivityMessageTs).toBeNull();
+    expect(channel.state.workActivityTurnId).toBeNull();
+  });
+
   it("posts once then updates the same turn activity message", async () => {
     const post = vi.fn(async () => ({ id: "activity-1" }));
     const request = vi.fn(async () => ({ ok: true }));
@@ -57,8 +75,12 @@ describe("renderSlackWorkActivity", () => {
 
     expect(post).toHaveBeenCalledOnce();
     expect(request).toHaveBeenCalledWith("chat.update", {
+      blocks: [
+        { text: { emoji: true, text: "Working", type: "plain_text" }, type: "header" },
+        { text: { text: "✓ search_docs", type: "mrkdwn" }, type: "section" },
+      ],
       channel: "C1",
-      text: "*Working*\n\n✓ search_docs",
+      text: "Working\n✓ search_docs",
       ts: "activity-1",
     });
   });
@@ -123,7 +145,13 @@ describe("renderSlackWorkActivity", () => {
       },
     });
 
-    expect(post).toHaveBeenCalledWith("*Working*\n\n◐ researcher — research_stage — discover");
+    expect(post).toHaveBeenCalledWith({
+      blocks: [
+        { text: { emoji: true, text: "Working", type: "plain_text" }, type: "header" },
+        { text: { text: "◐ *researcher*\n   ✓ discover", type: "mrkdwn" }, type: "section" },
+      ],
+      text: "Working\n◐ researcher\n  ✓ discover",
+    });
   });
 
   it("does not post when a monitor cannot find the parent-owned activity message", async () => {

--- a/packages/eve/src/public/channels/slack/work-activity.test.ts
+++ b/packages/eve/src/public/channels/slack/work-activity.test.ts
@@ -157,7 +157,10 @@ describe("renderSlackWorkActivity", () => {
           details: {
             elements: [
               {
-                elements: [{ text: "✓ discover", type: "text" }],
+                elements: [
+                  { style: { bold: true }, text: "✓", type: "text" },
+                  { text: " discover", type: "text" },
+                ],
                 type: "rich_text_section",
               },
             ],

--- a/packages/eve/src/public/channels/slack/work-activity.ts
+++ b/packages/eve/src/public/channels/slack/work-activity.ts
@@ -115,13 +115,7 @@ function renderWorkActivity(input: {
   if (rows.length === 0) return undefined;
   const text = ["Working", ...rows.map((row) => row.text)].join("\n");
   return {
-    blocks: [
-      {
-        elements: [{ text: "*Working*", type: "mrkdwn" }],
-        type: "context",
-      },
-      ...actions.map(workTaskCard),
-    ],
+    blocks: actions.map(workTaskCard),
     text,
   };
 }

--- a/packages/eve/src/public/channels/slack/work-activity.ts
+++ b/packages/eve/src/public/channels/slack/work-activity.ts
@@ -117,10 +117,10 @@ function renderWorkActivity(input: {
   return {
     blocks: [
       {
-        tasks: actions.map(workTaskCard),
-        title: "Working",
-        type: "plan",
+        elements: [{ text: "*Working*", type: "mrkdwn" }],
+        type: "context",
       },
+      ...actions.map(workTaskCard),
     ],
     text,
   };

--- a/packages/eve/src/public/channels/slack/work-activity.ts
+++ b/packages/eve/src/public/channels/slack/work-activity.ts
@@ -162,13 +162,16 @@ function workTaskCard(action: WorkAction, index: number): SlackBlock {
 }
 
 function richText(text: string): SlackBlock {
+  const lines = text.split("\n");
+  const elements = lines.flatMap((line, index) => {
+    const [glyph, ...rest] = line.split(" ");
+    return [
+      { style: { bold: true }, text: glyph, type: "text" },
+      { text: ` ${rest.join(" ")}${index === lines.length - 1 ? "" : "\n"}`, type: "text" },
+    ];
+  });
   return {
-    elements: [
-      {
-        elements: [{ text, type: "text" }],
-        type: "rich_text_section",
-      },
-    ],
+    elements: [{ elements, type: "rich_text_section" }],
     type: "rich_text",
   };
 }
@@ -193,7 +196,7 @@ function phaseGlyph(phase: WorkPhase): string {
     case "blocked":
       return "!";
     case "cancelled":
-      return "–";
+      return "⊘";
     case "completed":
       return "✓";
     case "failed":

--- a/packages/eve/src/public/channels/slack/work-activity.ts
+++ b/packages/eve/src/public/channels/slack/work-activity.ts
@@ -1,0 +1,122 @@
+import type { WorkAction, WorkGraph, WorkPhase } from "#harness/work-graph.js";
+
+const ACTIVITY_MESSAGE_MAX_ITEMS = 8;
+
+export interface SlackWorkActivityState {
+  workActivityMessageTs?: string | null;
+  workActivityTurnId?: string | null;
+}
+
+export interface SlackWorkActivityChannel {
+  readonly slack: {
+    readonly channelId: string;
+    request(
+      operation: "chat.update",
+      body: { readonly channel: string; readonly text: string; readonly ts: string },
+    ): Promise<{ readonly error?: string; readonly ok: boolean }>;
+  };
+  readonly state: SlackWorkActivityState;
+  readonly thread: {
+    post(message: string): Promise<{ readonly id: string }>;
+  };
+}
+
+/** Best-effort Slack activity message for the current work graph. */
+export async function settleSlackWorkActivity(channel: SlackWorkActivityChannel): Promise<void> {
+  const ts = channel.state.workActivityMessageTs;
+  if (!ts) return;
+  try {
+    await channel.slack.request("chat.update", {
+      channel: channel.slack.channelId,
+      text: "*Work complete*",
+      ts,
+    });
+  } catch {
+    // Activity rendering is cosmetic.
+  }
+}
+
+export async function renderSlackWorkActivity(input: {
+  readonly channel: SlackWorkActivityChannel;
+  readonly work: WorkGraph | undefined;
+}): Promise<void> {
+  const turn = input.work?.turn;
+  if (turn === undefined) return;
+  const text = renderWorkActivity({
+    actions: turn.steps.flatMap((step) => step.actions),
+    blockers: turn.blockers,
+  });
+  if (text === undefined) return;
+
+  const currentTs =
+    input.channel.state.workActivityTurnId === turn.id
+      ? input.channel.state.workActivityMessageTs
+      : undefined;
+  if (currentTs) {
+    try {
+      const response = await input.channel.slack.request("chat.update", {
+        channel: input.channel.slack.channelId,
+        text,
+        ts: currentTs,
+      });
+      if (response.ok === true) return;
+      if (response.error !== "message_not_found") return;
+    } catch {
+      return;
+    }
+  }
+
+  try {
+    const posted = await input.channel.thread.post(text);
+    if (posted.id) {
+      input.channel.state.workActivityMessageTs = posted.id;
+      input.channel.state.workActivityTurnId = turn.id;
+    }
+  } catch {
+    // Activity rendering is cosmetic.
+  }
+}
+
+function renderWorkActivity(input: {
+  readonly actions: readonly WorkAction[];
+  readonly blockers: readonly { kind: string; label?: string; phase: string }[];
+}): string | undefined {
+  const blockers = input.blockers
+    .filter((blocker) => blocker.phase === "blocked")
+    .map((blocker) => `! ${blocker.label ?? `Waiting for ${blocker.kind}`}`);
+  const actions = input.actions
+    .filter((action) => action.phase !== "queued")
+    .slice(-ACTIVITY_MESSAGE_MAX_ITEMS - blockers.length)
+    .map(renderAction);
+  const items = [...blockers, ...actions];
+  return items.length === 0 ? undefined : ["*Working*", "", ...items].join("\n");
+}
+
+function renderAction(action: WorkAction): string {
+  const child = action.child?.work?.turn;
+  const detail =
+    child === undefined ? undefined : summarizeChild(child.steps.flatMap((step) => step.actions));
+  return `${phaseGlyph(action.phase)} ${action.name}${detail ? ` — ${detail}` : ""}`;
+}
+
+function summarizeChild(actions: readonly WorkAction[]): string | undefined {
+  const active = actions.find((action) => action.phase === "running");
+  return active?.name;
+}
+
+function phaseGlyph(phase: WorkPhase): string {
+  switch (phase) {
+    case "blocked":
+      return "!";
+    case "cancelled":
+      return "–";
+    case "completed":
+      return "✓";
+    case "failed":
+      return "✕";
+    case "queued":
+      return "○";
+    case "running":
+      return "◐";
+  }
+}

--- a/packages/eve/src/public/channels/slack/work-activity.ts
+++ b/packages/eve/src/public/channels/slack/work-activity.ts
@@ -100,8 +100,7 @@ function renderAction(action: WorkAction): string {
 }
 
 function summarizeChild(actions: readonly WorkAction[]): string | undefined {
-  const active = actions.find((action) => action.phase === "running");
-  return active?.name;
+  return actions.find((action) => action.phase === "running")?.name ?? actions.at(-1)?.name;
 }
 
 function phaseGlyph(phase: WorkPhase): string {

--- a/packages/eve/src/public/channels/slack/work-activity.ts
+++ b/packages/eve/src/public/channels/slack/work-activity.ts
@@ -2,6 +2,8 @@ import type { WorkAction, WorkGraph, WorkPhase } from "#harness/work-graph.js";
 
 const ACTIVITY_MESSAGE_MAX_ITEMS = 8;
 
+type SlackBlock = Record<string, unknown>;
+
 export interface SlackWorkActivityState {
   workActivityMessageTs?: string | null;
   workActivityTurnId?: string | null;
@@ -11,26 +13,38 @@ export interface SlackWorkActivityChannel {
   readonly slack: {
     readonly channelId: string;
     request(
+      operation: "chat.delete",
+      body: { readonly channel: string; readonly ts: string },
+    ): Promise<{ readonly error?: string; readonly ok: boolean }>;
+    request(
       operation: "chat.update",
-      body: { readonly channel: string; readonly text: string; readonly ts: string },
+      body: {
+        readonly blocks: readonly SlackBlock[];
+        readonly channel: string;
+        readonly text: string;
+        readonly ts: string;
+      },
     ): Promise<{ readonly error?: string; readonly ok: boolean }>;
   };
   readonly state: SlackWorkActivityState;
   readonly thread: {
-    post(message: string): Promise<{ readonly id: string }>;
+    post(message: { readonly blocks: readonly SlackBlock[]; readonly text: string }): Promise<{
+      readonly id: string;
+    }>;
   };
 }
 
-/** Best-effort Slack activity message for the current work graph. */
+/** Removes the transient activity card once the parent turn reaches a terminal event. */
 export async function settleSlackWorkActivity(channel: SlackWorkActivityChannel): Promise<void> {
   const ts = channel.state.workActivityMessageTs;
   if (!ts) return;
   try {
-    await channel.slack.request("chat.update", {
+    await channel.slack.request("chat.delete", {
       channel: channel.slack.channelId,
-      text: "*Work complete*",
       ts,
     });
+    channel.state.workActivityMessageTs = null;
+    channel.state.workActivityTurnId = null;
   } catch {
     // Activity rendering is cosmetic.
   }
@@ -43,11 +57,11 @@ export async function renderSlackWorkActivity(input: {
 }): Promise<void> {
   const turn = input.work?.turn;
   if (turn === undefined) return;
-  const text = renderWorkActivity({
+  const activity = renderWorkActivity({
     actions: turn.steps.flatMap((step) => step.actions),
     blockers: turn.blockers,
   });
-  if (text === undefined) return;
+  if (activity === undefined) return;
 
   const currentTs =
     input.channel.state.workActivityTurnId === turn.id
@@ -57,7 +71,8 @@ export async function renderSlackWorkActivity(input: {
     try {
       const response = await input.channel.slack.request("chat.update", {
         channel: input.channel.slack.channelId,
-        text,
+        blocks: activity.blocks,
+        text: activity.text,
         ts: currentTs,
       });
       if (response.ok === true) return;
@@ -70,7 +85,10 @@ export async function renderSlackWorkActivity(input: {
   if (input.allowPost === false) return;
 
   try {
-    const posted = await input.channel.thread.post(text);
+    const posted = await input.channel.thread.post({
+      blocks: activity.blocks,
+      text: activity.text,
+    });
     if (posted.id) {
       input.channel.state.workActivityMessageTs = posted.id;
       input.channel.state.workActivityTurnId = turn.id;
@@ -83,30 +101,50 @@ export async function renderSlackWorkActivity(input: {
 function renderWorkActivity(input: {
   readonly actions: readonly WorkAction[];
   readonly blockers: readonly { kind: string; label?: string; phase: string }[];
-}): string | undefined {
+}): { readonly blocks: readonly SlackBlock[]; readonly text: string } | undefined {
   const blockers = input.blockers
     .filter((blocker) => blocker.phase === "blocked")
-    .map((blocker) => `! ${blocker.label ?? `Waiting for ${blocker.kind}`}`);
+    .map((blocker) => {
+      const text = `! ${blocker.label ?? `Waiting for ${blocker.kind}`}`;
+      return { markdown: text, text };
+    });
   const actions = input.actions
     .filter((action) => action.phase !== "queued")
-    .slice(-ACTIVITY_MESSAGE_MAX_ITEMS - blockers.length)
-    .map(renderAction);
-  const items = [...blockers, ...actions];
-  return items.length === 0 ? undefined : ["*Working*", "", ...items].join("\n");
+    .slice(-ACTIVITY_MESSAGE_MAX_ITEMS - blockers.length);
+  const rows = [...blockers, ...actions.map(renderAction)];
+  if (rows.length === 0) return undefined;
+  const text = ["Working", ...rows.map((row) => row.text)].join("\n");
+  return {
+    blocks: [
+      { text: { emoji: true, text: "Working", type: "plain_text" }, type: "header" },
+      {
+        text: { text: rows.map((row) => row.markdown).join("\n\n"), type: "mrkdwn" },
+        type: "section",
+      },
+    ],
+    text,
+  };
 }
 
-function renderAction(action: WorkAction): string {
+function renderAction(action: WorkAction): { readonly markdown: string; readonly text: string } {
   const child = action.child?.work?.turn;
-  const detail =
-    child === undefined ? undefined : summarizeChild(child.steps.flatMap((step) => step.actions));
-  return `${phaseGlyph(action.phase)} ${action.name}${detail ? ` — ${detail}` : ""}`;
-}
-
-function summarizeChild(actions: readonly WorkAction[]): string | undefined {
-  const action = actions.find((action) => action.phase === "running") ?? actions.at(-1);
-  return action === undefined
-    ? undefined
-    : [action.name, action.detail].filter(Boolean).join(" — ");
+  if (child === undefined) {
+    const text = `${phaseGlyph(action.phase)} ${action.name}`;
+    return { markdown: text, text };
+  }
+  const childActions = child.steps.flatMap((step) => step.actions);
+  const childRows = childActions.map((childAction) => {
+    const text = `${phaseGlyph(childAction.phase)} ${childAction.detail ?? childAction.name}`;
+    return { markdown: `   ${text}`, text };
+  });
+  const text = `${phaseGlyph(action.phase)} ${action.name}`;
+  return {
+    markdown: [
+      `${phaseGlyph(action.phase)} *${action.name}*`,
+      ...childRows.map((row) => row.markdown),
+    ].join("\n"),
+    text: [text, ...childRows.map((row) => `  ${row.text}`)].join("\n"),
+  };
 }
 
 function phaseGlyph(phase: WorkPhase): string {

--- a/packages/eve/src/public/channels/slack/work-activity.ts
+++ b/packages/eve/src/public/channels/slack/work-activity.ts
@@ -116,10 +116,10 @@ function renderWorkActivity(input: {
   const text = ["Working", ...rows.map((row) => row.text)].join("\n");
   return {
     blocks: [
-      { text: { emoji: true, text: "Working", type: "plain_text" }, type: "header" },
       {
-        text: { text: rows.map((row) => row.markdown).join("\n\n"), type: "mrkdwn" },
-        type: "section",
+        tasks: actions.map(workTaskCard),
+        title: "Working",
+        type: "plan",
       },
     ],
     text,
@@ -145,6 +145,47 @@ function renderAction(action: WorkAction): { readonly markdown: string; readonly
     ].join("\n"),
     text: [text, ...childRows.map((row) => `  ${row.text}`)].join("\n"),
   };
+}
+
+function workTaskCard(action: WorkAction, index: number): SlackBlock {
+  const childActions = action.child?.work?.turn?.steps.flatMap((step) => step.actions) ?? [];
+  const details = childActions
+    .map((child) => `${phaseGlyph(child.phase)} ${child.detail ?? child.name}`)
+    .join("\n");
+  return {
+    status: planTaskStatus(action.phase),
+    task_id: `work-${index}`,
+    title: action.name,
+    type: "task_card",
+    ...(details === "" ? {} : { details: richText(details) }),
+  };
+}
+
+function richText(text: string): SlackBlock {
+  return {
+    elements: [
+      {
+        elements: [{ text, type: "text" }],
+        type: "rich_text_section",
+      },
+    ],
+    type: "rich_text",
+  };
+}
+
+function planTaskStatus(phase: WorkPhase): "complete" | "error" | "in_progress" | "pending" {
+  switch (phase) {
+    case "completed":
+      return "complete";
+    case "cancelled":
+    case "failed":
+      return "error";
+    case "blocked":
+    case "queued":
+      return "pending";
+    case "running":
+      return "in_progress";
+  }
 }
 
 function phaseGlyph(phase: WorkPhase): string {

--- a/packages/eve/src/public/channels/slack/work-activity.ts
+++ b/packages/eve/src/public/channels/slack/work-activity.ts
@@ -37,6 +37,7 @@ export async function settleSlackWorkActivity(channel: SlackWorkActivityChannel)
 }
 
 export async function renderSlackWorkActivity(input: {
+  readonly allowPost?: boolean;
   readonly channel: SlackWorkActivityChannel;
   readonly work: WorkGraph | undefined;
 }): Promise<void> {
@@ -65,6 +66,8 @@ export async function renderSlackWorkActivity(input: {
       return;
     }
   }
+
+  if (input.allowPost === false) return;
 
   try {
     const posted = await input.channel.thread.post(text);
@@ -100,7 +103,10 @@ function renderAction(action: WorkAction): string {
 }
 
 function summarizeChild(actions: readonly WorkAction[]): string | undefined {
-  return actions.find((action) => action.phase === "running")?.name ?? actions.at(-1)?.name;
+  const action = actions.find((action) => action.phase === "running") ?? actions.at(-1);
+  return action === undefined
+    ? undefined
+    : [action.name, action.detail].filter(Boolean).join(" — ");
 }
 
 function phaseGlyph(phase: WorkPhase): string {

--- a/packages/eve/src/public/definitions/channel.ts
+++ b/packages/eve/src/public/definitions/channel.ts
@@ -324,7 +324,8 @@ function buildAdapter<TState, TCtx, TReceiveTarget, TMetadata extends Record<str
   const hasFetchFile = definition.fetchFile !== undefined;
   const metadata = definition.metadata;
   const hasMetadata = metadata !== undefined;
-  const hasBehavior = hasState || hasContext || hasMetadata;
+  const work = definition.work;
+  const hasBehavior = hasState || hasContext || hasMetadata || work !== undefined;
 
   const eventHandlers: Record<string, unknown> = {};
   let hasEventHandlers = false;
@@ -396,6 +397,13 @@ function buildAdapter<TState, TCtx, TReceiveTarget, TMetadata extends Record<str
       if (definition.deliver === undefined) return defaultDeliverResult(payload);
       return definition.deliver(payload, adapterCtx as TCtx);
     },
+
+    work:
+      work === undefined
+        ? undefined
+        : {
+            render: (adapterCtx: any) => work(adapterCtx.state, adapterCtx.session, adapterCtx.ctx),
+          },
 
     ...eventHandlers,
   } as ChannelAdapter<any>;

--- a/packages/eve/src/public/definitions/channel.ts
+++ b/packages/eve/src/public/definitions/channel.ts
@@ -402,7 +402,8 @@ function buildAdapter<TState, TCtx, TReceiveTarget, TMetadata extends Record<str
       work === undefined
         ? undefined
         : {
-            render: (adapterCtx: any) => work(adapterCtx.state, adapterCtx.session, adapterCtx.ctx),
+            render: (adapterCtx: any, options) =>
+              work(adapterCtx.state, adapterCtx.session, adapterCtx.ctx, options),
           },
 
     ...eventHandlers,

--- a/packages/eve/src/runtime/channels/registry.ts
+++ b/packages/eve/src/runtime/channels/registry.ts
@@ -41,6 +41,7 @@ const ADAPTER_NON_EVENT_FIELDS: ReadonlySet<string> = new Set([
   "createAdapterContext",
   "fetchFile",
   "instrumentation",
+  "work",
 ]);
 
 /**

--- a/packages/eve/src/shared/channel-definition.ts
+++ b/packages/eve/src/shared/channel-definition.ts
@@ -106,6 +106,7 @@ export interface GenericChannelDefinition<
     state: NonNullable<TState>,
     session: SessionHandle,
     ctx: ContextAccessor,
+    options?: { readonly allowPost?: boolean },
   ) => void | Promise<void>;
 
   /**

--- a/packages/eve/src/shared/channel-definition.ts
+++ b/packages/eve/src/shared/channel-definition.ts
@@ -1,6 +1,7 @@
 import { type ChannelCors } from "#channel/cors.js";
 import type { UserContent } from "ai";
 import type { ChannelReceiveContext } from "#channel/channel-operations.js";
+import type { ContextAccessor } from "#context/key.js";
 import type { RouteDefinition } from "#channel/routes.js";
 import type { Session, SessionHandle } from "#channel/session.js";
 import type { DeliverPayload, SessionAuthContext, TurnPolicy } from "#channel/types.js";
@@ -99,6 +100,13 @@ export interface GenericChannelDefinition<
    * values such as `Date` or `Map`.
    */
   readonly metadata?: (state: NonNullable<TState>) => TMetadata;
+
+  /** @internal Renders framework-owned active work after a bounded refresh. */
+  readonly work?: (
+    state: NonNullable<TState>,
+    session: SessionHandle,
+    ctx: ContextAccessor,
+  ) => void | Promise<void>;
 
   /**
    * Identifier of the adapter family this channel belongs to. Set by


### PR DESCRIPTION
### Summary

Related to #1673. Build on #1992 with an internal replaceable Slack activity message driven by the same work graph as the status renderer. It posts the active work once per turn, updates stable rows as actions settle, includes current local-subagent activity, renders blockers distinctly, recovers from a deleted message, and settles the activity message at terminal turn events.

This is an internal Slack consumer, not a public channel progress API. The renderer deliberately uses plain message text while the graph shape is still being validated; richer Block Kit structure can follow without changing work ownership.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/channels/slack/work-activity.test.ts src/public/channels/slack/action-status.test.ts`
- `pnpm --filter eve exec tsc --noEmit -p tsconfig.json`

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
