### PR TITLE
perf(eve): collapse workflow build passes

### DIFF
--- a/.changeset/bright-workflows-build.md
+++ b/.changeset/bright-workflows-build.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Discover workflow directives during Rolldown traversal, reuse that traversal for manifest generation, and remove the redundant final workflow bundling pass.

--- a/packages/eve/src/internal/workflow-bundle/builder-support.integration.test.ts
+++ b/packages/eve/src/internal/workflow-bundle/builder-support.integration.test.ts
@@ -3,23 +3,20 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { resolvePackageRoot, resolveWorkflowModulePath } from "#internal/application/package.js";
+import { resolveWorkflowModulePath } from "#internal/application/package.js";
 
 import { bundleFinalWorkflowOutput } from "./builder-support.js";
 
 describe("bundleFinalWorkflowOutput", () => {
-  it("writes the intermediate wrapper against the namespaced eve Workflow runtime facade", async () => {
+  it("writes the wrapper against the namespaced eve Workflow runtime facade", async () => {
     const dir = await mkdtemp(join(tmpdir(), "eve-workflow-runtime-facade-"));
     const target = join(dir, "workflows.mjs");
 
     try {
       await bundleFinalWorkflowOutput({
-        bundleFinalOutput: false,
         code: "globalThis.__private_workflows = new Map();",
-        format: "esm",
         outfile: target,
         queueNamespace: "evetest",
-        workingDir: resolvePackageRoot(),
       });
 
       const source = await readFile(target, "utf8");

--- a/packages/eve/src/internal/workflow-bundle/builder-support.ts
+++ b/packages/eve/src/internal/workflow-bundle/builder-support.ts
@@ -1,6 +1,6 @@
 import { builtinModules } from "node:module";
 import { existsSync } from "node:fs";
-import { mkdir, readFile, readdir } from "node:fs/promises";
+import { mkdir, readdir } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
 
 import { atomicWriteFile } from "#shared/atomic-write-file.js";
@@ -9,6 +9,7 @@ import { buildSingleRolldownChunk } from "#internal/bundler/nitro-rolldown.js";
 import { resolveWorkflowModulePath } from "#internal/application/package.js";
 import {
   applyWorkflowTransform,
+  detectWorkflowPatterns,
   getImportPath,
   type WorkflowManifest,
 } from "#internal/workflow-bundle/workflow-builders.js";
@@ -78,19 +79,15 @@ export interface WorkflowBundleDiscoveredEntries {
 }
 
 export interface WorkflowBundleCreateWorkflowsBundleOptions {
-  readonly bundleFinalOutput?: boolean;
-  readonly discoveredEntries?: WorkflowBundleDiscoveredEntries;
-  readonly format?: "cjs" | "esm";
   readonly inputFiles: readonly string[];
-  readonly keepInterimBundleContext?: boolean;
   readonly outfile: string;
   readonly tsconfigPath?: string;
 }
 
 export interface WorkflowBundleCreateWorkflowsBundleResult {
-  readonly bundleFinal?: (interimBundleResult: string) => Promise<void>;
-  readonly interimBundleCtx?: undefined;
+  readonly discoveredEntries: WorkflowBundleDiscoveredEntries;
   readonly manifest: WorkflowManifest;
+  readonly stepManifest?: WorkflowManifest;
 }
 
 interface WorkflowGraph {
@@ -98,10 +95,16 @@ interface WorkflowGraph {
   readonly nodes: readonly unknown[];
 }
 
+interface WorkflowRolldownPluginContext {
+  readonly fs: {
+    readFile(path: string, options: { encoding: "utf8" }): Promise<string>;
+  };
+}
+
 interface WorkflowRolldownPlugin {
   readonly name: string;
   readonly resolveId?: (source: string, importer?: string) => unknown;
-  readonly load?: (id: string) => unknown;
+  readonly load?: (this: WorkflowRolldownPluginContext, id: string) => unknown;
   readonly transform?: (code: string, id: string) => unknown;
 }
 
@@ -258,25 +261,92 @@ export function createEvePackageImportsPlugin(
   };
 }
 
+export function createWorkflowDiscovery(input: {
+  readonly discoveredEntries: WorkflowBundleDiscoveredEntries;
+  readonly inputFiles: readonly string[];
+  readonly manifest: WorkflowManifest;
+  readonly projectRoot: string;
+  readonly workingDir: string;
+}): {
+  readonly entrySource: string;
+  readonly plugin: WorkflowRolldownPlugin;
+  readonly runtimeSideEffectFiles: Set<string>;
+} {
+  const discoveryIds = new Map(
+    input.inputFiles.map((filePath, index) => [`\0eve-workflow-discovery:${index}`, filePath]),
+  );
+  const sources = new Map<string, string>();
+  const runtimeSideEffectFiles = new Set<string>();
+
+  return {
+    entrySource: [...discoveryIds.keys()]
+      .map((discoveryId) => `import ${JSON.stringify(discoveryId)};`)
+      .join("\n"),
+    plugin: {
+      name: "eve-workflow-discovery",
+      resolveId(id: string) {
+        return discoveryIds.has(id) ? { id } : undefined;
+      },
+      async load(id: string) {
+        const filePath = discoveryIds.get(id);
+        if (filePath === undefined) {
+          const code = sources.get(id);
+          return code === undefined ? undefined : { code };
+        }
+
+        const code = await this.fs.readFile(filePath, { encoding: "utf8" });
+        sources.set(filePath, code);
+        const patterns = detectWorkflowPatterns(code);
+        if (patterns.hasUseStep) input.discoveredEntries.discoveredSteps.push(filePath);
+        if (patterns.hasUseWorkflow) input.discoveredEntries.discoveredWorkflows.push(filePath);
+        if (patterns.hasSerde) input.discoveredEntries.discoveredSerdeFiles.push(filePath);
+        if (!patterns.hasUseWorkflow && !patterns.hasSerde) {
+          if (patterns.hasUseStep) {
+            const relativeFilepath = createManifestRelativeFilepath(input.workingDir, filePath);
+            const transformed = await applyWorkflowTransform(
+              relativeFilepath,
+              code,
+              "workflow",
+              filePath,
+              input.projectRoot,
+            );
+            mergeWorkflowManifest(input.manifest, transformed.workflowManifest);
+          }
+          return { code: "", moduleSideEffects: false, moduleType: "js" };
+        }
+        if (patterns.hasUseWorkflow || patterns.hasSerde) {
+          runtimeSideEffectFiles.add(filePath.replaceAll("\\", "/"));
+        }
+        return {
+          code: `import ${JSON.stringify(filePath.replaceAll("\\", "/"))};`,
+          moduleSideEffects: true,
+          moduleType: "js",
+        };
+      },
+    },
+    runtimeSideEffectFiles,
+  };
+}
+
 export function createWorkflowTransformPlugin(input: {
   manifest: WorkflowManifest;
   mode?: "step" | "workflow";
   projectRoot: string;
-  sideEffectFiles?: readonly string[];
+  sideEffectFiles?: Set<string> | readonly string[];
   workingDir: string;
 }): WorkflowRolldownPlugin {
-  const sideEffectFiles = new Set(
-    input.sideEffectFiles?.map((filePath) => filePath.replaceAll("\\", "/")) ?? [],
-  );
+  const sideEffectFiles =
+    input.sideEffectFiles instanceof Set
+      ? input.sideEffectFiles
+      : new Set(input.sideEffectFiles?.map((filePath) => filePath.replaceAll("\\", "/")) ?? []);
 
   return {
     name: "eve-workflow-transform",
-    async load(id: string) {
-      if (!isJavaScriptLikePath(id)) {
-        return undefined;
-      }
+    async transform(code: string, id: string) {
+      if (!isJavaScriptLikePath(id)) return undefined;
 
-      const code = await readFile(id, "utf8");
+      const normalizedId = id.replaceAll("\\", "/");
+
       const relativeFilepath = createManifestRelativeFilepath(input.workingDir, id);
       const transformed = await applyWorkflowTransform(
         relativeFilepath,
@@ -293,7 +363,7 @@ export function createWorkflowTransformPlugin(input: {
       return {
         code: transformed.code,
         map: null,
-        moduleSideEffects: sideEffectFiles.has(id.replaceAll("\\", "/")) || undefined,
+        moduleSideEffects: sideEffectFiles.has(normalizedId) || undefined,
       };
     },
   };
@@ -389,12 +459,9 @@ export function createWorkflowNodeBuiltinGuardPlugin(): WorkflowRolldownPlugin {
 }
 
 export async function bundleFinalWorkflowOutput(input: {
-  bundleFinalOutput: boolean;
   code: string;
-  format: "cjs" | "esm";
   outfile: string;
   queueNamespace: string;
-  workingDir: string;
 }): Promise<void> {
   const workflowBundleCode = input.code.endsWith("\n") ? input.code : `${input.code}\n`;
   const workflowRuntimePath = resolveWorkflowModulePath("workflow/runtime").replaceAll("\\", "/");
@@ -406,28 +473,7 @@ const workflowCode = \`${workflowBundleCode.replace(/[\\`$]/g, "\\$&")}\`;
 
 export const POST = workflowEntrypoint(workflowCode, { namespace: ${JSON.stringify(input.queueNamespace)} });`;
 
-  if (!input.bundleFinalOutput) {
-    await writeWorkflowBundleAtomically(input.outfile, workflowFunctionCode);
-    return;
-  }
-
-  const chunk = await buildSingleRolldownChunk(
-    `final workflow bundle for "${input.outfile}"`,
-    {
-      cwd: input.workingDir,
-      input: WORKFLOW_VIRTUAL_ENTRY_ID,
-      external: (source: string) => source === "@aws-sdk/credential-provider-web-identity",
-      platform: "node",
-      plugins: [createWorkflowVirtualEntryPlugin(workflowFunctionCode)],
-      output: {
-        comments: false,
-        format: input.format,
-        sourcemap: false,
-      },
-    },
-    "workflow-final",
-  );
-  await writeWorkflowBundleAtomically(input.outfile, chunk.code);
+  await writeWorkflowBundleAtomically(input.outfile, workflowFunctionCode);
 }
 
 export function convertStepsManifest(steps: WorkflowManifest["steps"]): Record<string, unknown> {

--- a/packages/eve/src/internal/workflow-bundle/builder.scenario.test.ts
+++ b/packages/eve/src/internal/workflow-bundle/builder.scenario.test.ts
@@ -59,12 +59,22 @@ class StepEntryOnlyWorkflowBundleBuilder extends WorkflowBundleBuilder {
   }
 
   protected override async createWorkflowsBundle(): Promise<{
-    bundleFinal?: (interimBundleResult: string) => Promise<void>;
-    interimBundleCtx?: undefined;
+    discoveredEntries: {
+      discoveredSerdeFiles: string[];
+      discoveredSteps: string[];
+      discoveredWorkflows: string[];
+    };
     manifest: Record<string, never>;
   }> {
     this.workflowBundleCalls += 1;
-    return { manifest: {} };
+    return {
+      discoveredEntries: {
+        discoveredSerdeFiles: [],
+        discoveredSteps: [...this.inputFiles],
+        discoveredWorkflows: [],
+      },
+      manifest: {},
+    };
   }
 }
 
@@ -235,6 +245,11 @@ describe("WorkflowBundleBuilder", () => {
 
     class TemplateLiteralWorkflowBundleBuilder extends FixtureWorkflowBundleBuilder {
       protected override async createWorkflowsBundle({ outfile }: { outfile: string }): Promise<{
+        discoveredEntries: {
+          discoveredSerdeFiles: string[];
+          discoveredSteps: string[];
+          discoveredWorkflows: string[];
+        };
         manifest: Record<string, never>;
       }> {
         const workflowBundleCode = [
@@ -256,7 +271,14 @@ describe("WorkflowBundleBuilder", () => {
           ].join("\n"),
         );
 
-        return { manifest: {} };
+        return {
+          discoveredEntries: {
+            discoveredSerdeFiles: [],
+            discoveredSteps: [...this.inputFiles],
+            discoveredWorkflows: [],
+          },
+          manifest: {},
+        };
       }
     }
 
@@ -317,6 +339,63 @@ describe("WorkflowBundleBuilder", () => {
       const workflowsModule = await import(pathToFileURL(join(outDir, "workflows.mjs")).href);
 
       expect(typeof workflowsModule.POST).toBe("function");
+    } finally {
+      await rm(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("ignores unrelated input files while discovering workflow roots", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "eve-workflow-bundle-unrelated-input-"));
+    const outDir = join(tempRoot, "workflow-build");
+    const flowFilePath = join(tempRoot, "flow.ts");
+    const unrelatedFilePath = join(tempRoot, "unrelated.ts");
+    const compiledArtifactsBootstrapPath = join(tempRoot, "compiled-artifacts-bootstrap.mjs");
+
+    try {
+      await Promise.all([
+        writeFile(compiledArtifactsBootstrapPath, "export const installed = true;\n"),
+        writeFile(
+          flowFilePath,
+          [
+            "export async function safeFlow() {",
+            '  "use workflow";',
+            '  return "ok";',
+            "}",
+            "",
+          ].join("\n"),
+        ),
+        writeFile(
+          unrelatedFilePath,
+          [
+            'import { inspect } from "node:util";',
+            "export const value = inspect({ ok: true });",
+            "",
+          ].join("\n"),
+        ),
+      ]);
+
+      const builder = new FixtureWorkflowBundleBuilder(
+        {
+          agentName: "test-agent",
+          appRoot: tempRoot,
+          compiledArtifactsBootstrapPath,
+          outDir,
+          rootDir: tempRoot,
+          watch: false,
+        },
+        [flowFilePath, unrelatedFilePath],
+      );
+
+      await builder.build();
+
+      const workflowsSource = await readFile(join(outDir, "workflows.mjs"), "utf8");
+      const encodedChunksMatch = workflowsSource.match(
+        /Buffer\.from\((\[[\s\S]*?\])\.join\(""\), "base64"\)\.toString\("utf8"\)/,
+      );
+      const encodedChunks = JSON.parse(encodedChunksMatch?.[1] ?? "[]") as string[];
+      const workflowCode = Buffer.from(encodedChunks.join(""), "base64").toString("utf8");
+      expect(workflowCode).toContain("safeFlow");
+      expect(workflowCode).not.toContain("node:util");
     } finally {
       await rm(tempRoot, { force: true, recursive: true });
     }

--- a/packages/eve/src/internal/workflow-bundle/builder.ts
+++ b/packages/eve/src/internal/workflow-bundle/builder.ts
@@ -20,7 +20,7 @@ import {
   convertStepsManifest,
   convertWorkflowsManifest,
   createEvePackageImportsPlugin,
-  createWorkflowImport,
+  createWorkflowDiscovery,
   createWorkflowNodeBuiltinGuardPlugin,
   createWorkflowPseudoPackagePlugin,
   createWorkflowTransformPlugin,
@@ -38,10 +38,7 @@ import {
   WORKFLOW_BUILDER_DEFERRED_PACKAGES,
   WORKFLOW_STEP_EXTERNAL_PACKAGES,
 } from "#internal/workflow-bundle/vercel-workflow-output.js";
-import {
-  detectWorkflowPatterns,
-  type WorkflowManifest,
-} from "#internal/workflow-bundle/workflow-builders.js";
+import type { WorkflowManifest } from "#internal/workflow-bundle/workflow-builders.js";
 import { deriveEveWorkflowQueueNamespace } from "#internal/workflow/queue-namespace.js";
 
 export class WorkflowBundleBuilder {
@@ -49,7 +46,6 @@ export class WorkflowBundleBuilder {
   readonly #outDir: string;
   readonly #queueNamespace: string;
   protected readonly config: WorkflowBundleBuilderConfig;
-  readonly #discoveredEntries = new WeakMap<readonly string[], WorkflowBundleDiscoveredEntries>();
 
   constructor(options: WorkflowBundleBuilderOptions) {
     const dirs = [resolvePackageSourceDirectoryPath("src/execution")];
@@ -94,16 +90,14 @@ export class WorkflowBundleBuilder {
     const tsconfigPath = await this.findTsConfigPath();
 
     await mkdir(this.#outDir, { recursive: true });
-    const discoveredEntries = await this.discoverEntries(inputFiles, this.#outDir, tsconfigPath);
 
     const workflowsOutfile = join(this.#outDir, "workflows.mjs");
-    const { manifest: workflowsManifest } = await this.createWorkflowsBundle({
+    const {
       discoveredEntries,
-      // eve owns dev rebuilds through `dev-authored-source-watcher`.
-      keepInterimBundleContext: false,
+      manifest: workflowsManifest,
+      stepManifest,
+    } = await this.createWorkflowsBundle({
       outfile: workflowsOutfile,
-      bundleFinalOutput: false,
-      format: "esm",
       inputFiles,
       tsconfigPath,
     });
@@ -111,6 +105,7 @@ export class WorkflowBundleBuilder {
     const stepsManifest = await writeNitroStepEntrypoint({
       builtinsPath: resolveWorkflowModulePath("workflow/internal/builtins"),
       discoveredEntries,
+      manifest: stepManifest,
       outfile: stepsOutfile,
       preferAbsoluteFileImports: true,
       projectRoot: this.config.projectRoot ?? this.config.workingDir,
@@ -123,6 +118,7 @@ export class WorkflowBundleBuilder {
       await writeNitroStepEntrypoint({
         builtinsPath: resolveWorkflowModulePath("workflow/internal/builtins"),
         discoveredEntries,
+        manifest: stepManifest,
         outfile: nitroStepOutfile,
         preferAbsoluteFileImports: true,
         projectRoot: this.config.projectRoot ?? this.config.workingDir,
@@ -205,65 +201,24 @@ export class WorkflowBundleBuilder {
     return files.flat();
   }
 
-  protected async discoverEntries(
-    inputs: readonly string[],
-    _outdir: string,
-    _tsconfigPath?: string,
-  ): Promise<WorkflowBundleDiscoveredEntries> {
-    const cached = this.#discoveredEntries.get(inputs);
-
-    if (cached !== undefined) {
-      return cached;
-    }
-
-    const discovered: WorkflowBundleDiscoveredEntries = {
+  protected async createWorkflowsBundle({
+    inputFiles,
+    outfile,
+    tsconfigPath,
+  }: WorkflowBundleCreateWorkflowsBundleOptions): Promise<WorkflowBundleCreateWorkflowsBundleResult> {
+    const discoveredEntries: WorkflowBundleDiscoveredEntries = {
       discoveredSerdeFiles: [],
       discoveredSteps: [],
       discoveredWorkflows: [],
     };
-
-    for (const filePath of inputs) {
-      const source = await readFile(filePath, "utf8");
-      const patterns = detectWorkflowPatterns(source);
-
-      if (patterns.hasUseStep) {
-        discovered.discoveredSteps.push(filePath);
-      }
-
-      if (patterns.hasUseWorkflow) {
-        discovered.discoveredWorkflows.push(filePath);
-      }
-
-      if (patterns.hasSerde) {
-        discovered.discoveredSerdeFiles.push(filePath);
-      }
-    }
-
-    this.#discoveredEntries.set(inputs, discovered);
-    return discovered;
-  }
-
-  protected async createWorkflowsBundle({
-    bundleFinalOutput = true,
-    discoveredEntries,
-    format = "cjs",
-    inputFiles,
-    keepInterimBundleContext = this.config.watch,
-    outfile,
-    tsconfigPath,
-  }: WorkflowBundleCreateWorkflowsBundleOptions): Promise<WorkflowBundleCreateWorkflowsBundleResult> {
-    const discovered =
-      discoveredEntries ?? (await this.discoverEntries(inputFiles, dirname(outfile), tsconfigPath));
-    const workflowFiles = [...discovered.discoveredWorkflows].sort();
-    const workflowFileSet = new Set(workflowFiles);
-    const serdeOnlyFiles = [...discovered.discoveredSerdeFiles]
-      .sort()
-      .filter((filePath) => !workflowFileSet.has(filePath));
     const workflowManifest: WorkflowManifest = {};
-    const virtualEntrySource = [
-      ...workflowFiles.map((filePath) => createWorkflowImport(filePath, this.config.workingDir)),
-      ...serdeOnlyFiles.map((filePath) => createWorkflowImport(filePath, this.config.workingDir)),
-    ].join("\n");
+    const discovery = createWorkflowDiscovery({
+      discoveredEntries,
+      inputFiles,
+      manifest: workflowManifest,
+      projectRoot: this.transformProjectRoot,
+      workingDir: this.config.workingDir,
+    });
     const interimBundle = await buildSingleRolldownChunk(
       `intermediate workflow bundle for "${outfile}"`,
       {
@@ -271,13 +226,14 @@ export class WorkflowBundleBuilder {
         input: WORKFLOW_VIRTUAL_ENTRY_ID,
         platform: "neutral",
         plugins: [
-          createWorkflowVirtualEntryPlugin(virtualEntrySource),
+          discovery.plugin,
+          createWorkflowVirtualEntryPlugin(discovery.entrySource),
           createWorkflowPseudoPackagePlugin(),
           createEvePackageImportsPlugin(this.config.workingDir, { workflowCondition: true }),
           createWorkflowTransformPlugin({
             manifest: workflowManifest,
             projectRoot: this.transformProjectRoot,
-            sideEffectFiles: [...workflowFiles, ...serdeOnlyFiles],
+            sideEffectFiles: discovery.runtimeSideEffectFiles,
             workingDir: this.config.workingDir,
           }),
           // Must run after the transform so `"use step"` bodies are already
@@ -301,32 +257,17 @@ export class WorkflowBundleBuilder {
     );
 
     await bundleFinalWorkflowOutput({
-      bundleFinalOutput,
       code: interimBundle.code,
-      format,
       outfile,
       queueNamespace: this.#queueNamespace,
-      workingDir: this.config.workingDir,
     });
 
-    if (keepInterimBundleContext) {
-      return {
-        bundleFinal: async (interimBundleResult: string) => {
-          await bundleFinalWorkflowOutput({
-            bundleFinalOutput,
-            code: interimBundleResult,
-            format,
-            outfile,
-            queueNamespace: this.#queueNamespace,
-            workingDir: this.config.workingDir,
-          });
-        },
-        interimBundleCtx: undefined,
-        manifest: workflowManifest,
-      };
-    }
-
-    return { manifest: workflowManifest };
+    normalizeDiscoveredEntries(discoveredEntries);
+    return {
+      discoveredEntries,
+      manifest: workflowManifest,
+      stepManifest: workflowManifest,
+    };
   }
 
   protected async createManifest({
@@ -353,6 +294,17 @@ export class WorkflowBundleBuilder {
   async #getBuildInputFiles(): Promise<string[]> {
     return await this.getInputFiles();
   }
+}
+
+function normalizeDiscoveredEntries(entries: WorkflowBundleDiscoveredEntries): void {
+  normalizeDiscoveredPaths(entries.discoveredSerdeFiles);
+  normalizeDiscoveredPaths(entries.discoveredSteps);
+  normalizeDiscoveredPaths(entries.discoveredWorkflows);
+}
+
+function normalizeDiscoveredPaths(paths: string[]): void {
+  paths.splice(0, paths.length, ...new Set(paths));
+  paths.sort();
 }
 
 async function addStepRegistrationsImport(

--- a/packages/eve/src/internal/workflow-bundle/nitro-step-entry.ts
+++ b/packages/eve/src/internal/workflow-bundle/nitro-step-entry.ts
@@ -19,6 +19,7 @@ export interface NitroStepEntrypointDiscoveredEntries {
 export async function writeNitroStepEntrypoint(input: {
   readonly builtinsPath?: string;
   readonly discoveredEntries: NitroStepEntrypointDiscoveredEntries;
+  readonly manifest?: WorkflowManifest;
   readonly outfile: string;
   readonly preferAbsoluteFileImports?: boolean;
   readonly projectRoot: string;
@@ -30,12 +31,14 @@ export async function writeNitroStepEntrypoint(input: {
   const serdeOnlyFiles = [...input.discoveredEntries.discoveredSerdeFiles]
     .sort()
     .filter((filePath) => !stepFileSet.has(filePath));
-  const manifest = await collectNitroStepManifest({
-    projectRoot: input.projectRoot,
-    stepFiles,
-    serdeOnlyFiles,
-    workingDir: input.workingDir,
-  });
+  const manifest =
+    input.manifest ??
+    (await collectNitroStepManifest({
+      projectRoot: input.projectRoot,
+      stepFiles,
+      serdeOnlyFiles,
+      workingDir: input.workingDir,
+    }));
   const outfileDirectory = dirname(input.outfile);
   const builtinsImportSpecifier =
     input.builtinsPath === undefined


### PR DESCRIPTION
### Summary

Third PR in stack #1995, on #1994. Workflow discovery now runs inside the Rolldown graph: virtual discovery entries read each candidate through Rolldown's filesystem, classify directives, and feed workflow roots into the same transform traversal. The resulting discovery and manifest data are reused for the Nitro step entry, eliminating the separate JS discovery reads, duplicate step-manifest transforms, and the dormant alternate final-workflow rebundle path; the distinct Node step entry remains, and Nitro still owns the final hosted server bundle.

On seven sequential local `e2e/fixtures/agent-tools` builds with `--skip-sandbox-prewarm`, median `host.prepare` was 38.8 ms versus 39.9 ms on #1994. The profiled workflow Rolldown duration rises from 26.3 ms to 55.2 ms because it now includes discovery and pure-step manifest transforms that previously ran as unprofiled JS work; total build medians were too noisy to claim an end-to-end improvement in this PR.

### Validation

- `pnpm --filter eve test:unit` (592 files, 6,213 passed)
- `pnpm --filter eve test:integration` (86 files, 623 passed)
- `pnpm --filter eve exec vitest run --config vitest.scenario.config.ts src/internal/workflow-bundle/builder.scenario.test.ts src/internal/nitro/host/build-application.scenario.test.ts src/internal/nitro/host/create-application-nitro.scenario.test.ts` (37 tests)
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/internal/workflow-bundle/builder-support.integration.test.ts`
- `pnpm --filter eve typecheck`
- `pnpm guard:invariants`
- `pnpm --filter eve build`
- Built `e2e/fixtures/agent-tools` seven times with profiles and confirmed workflow discovery and bundling complete through one eve-owned workflow Rolldown invocation

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
