### PR TITLE
perf(eve): slim hosted OIDC handling

### DIFF
--- a/.changeset/lean-hosted-oidc.md
+++ b/.changeset/lean-hosted-oidc.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Use the ambient Vercel request token directly in hosted functions, removing development-only OIDC refresh machinery from the deployed server bundle.

--- a/packages/eve/src/execution/sandbox/bindings/vercel-credentials.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel-credentials.ts
@@ -1,4 +1,4 @@
-import { getVercelOidcToken } from "#compiled/@vercel/oidc/index.js";
+import { getVercelOidcToken } from "#internal/vercel-oidc.js";
 import { decodeVercelOidcTokenClaims } from "#shared/vercel-project.js";
 import { withPackageUserAgent } from "#internal/user-agent.js";
 import type { VercelCreateOptions } from "#execution/sandbox/bindings/vercel-sdk-types.js";

--- a/packages/eve/src/internal/nitro/host/create-application-nitro.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/host/create-application-nitro.scenario.test.ts
@@ -18,6 +18,7 @@ import {
 } from "#compiler/manifest.js";
 import {
   resolvePackageSourceDirectoryPath,
+  resolvePackageSourceFilePath,
   resolvePackageRoot,
   resolveInstalledPackageInfo,
   resolveWorkflowModulePath,
@@ -390,6 +391,9 @@ describe("application Nitro creation", () => {
       maxDuration: "max",
       experimentalTriggers: [expect.objectContaining({ type: "queue/v2beta" })],
     });
+    expect(nitroStub.nitro.options.alias["#internal/vercel-oidc.js"]).toBe(
+      resolvePackageSourceFilePath("src/internal/vercel-oidc-hosted.ts"),
+    );
   });
 
   it("enables websockets without overriding the Vercel entry format", async () => {

--- a/packages/eve/src/internal/nitro/host/create-application-nitro.ts
+++ b/packages/eve/src/internal/nitro/host/create-application-nitro.ts
@@ -838,6 +838,11 @@ export async function createProductionApplicationNitro(
   });
   await writeEveVersionedCacheMetadata(options.buildDir);
 
+  if (preset === "vercel") {
+    nitro.options.alias["#internal/vercel-oidc.js"] = resolvePackageSourceFilePath(
+      "src/internal/vercel-oidc-hosted.ts",
+    );
+  }
   configureSharedApplicationNitro(nitro, preparedHost);
   configureNitroStepPlugins(nitro, join(preparedHost.workflowBuildDir, "steps.mjs"));
 

--- a/packages/eve/src/internal/nitro/routes/info.ts
+++ b/packages/eve/src/internal/nitro/routes/info.ts
@@ -1,4 +1,4 @@
-import { getVercelOidcToken } from "#compiled/@vercel/oidc/index.js";
+import { getVercelOidcToken } from "#internal/vercel-oidc.js";
 import { hasEnvValue } from "#internal/resolve-model-endpoint-status.js";
 import { buildAgentInfoResponseFromManifest } from "#internal/nitro/routes/agent-info/build-agent-info-response-from-manifest.js";
 import {

--- a/packages/eve/src/internal/vercel-oidc-hosted.test.ts
+++ b/packages/eve/src/internal/vercel-oidc-hosted.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getVercelOidcToken } from "./vercel-oidc-hosted.js";
+
+const requestContextSymbol = Symbol.for("@vercel/request-context");
+
+function setRequestContext(value: unknown): void {
+  (globalThis as Record<symbol, unknown>)[requestContextSymbol] = value;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  setRequestContext(undefined);
+});
+
+describe("getVercelOidcToken", () => {
+  it("prefers the request-scoped token", async () => {
+    vi.stubEnv("VERCEL_OIDC_TOKEN", "environment-token");
+    setRequestContext({
+      get: () => ({ headers: { "x-vercel-oidc-token": "request-token" } }),
+    });
+
+    await expect(getVercelOidcToken()).resolves.toBe("request-token");
+  });
+
+  it("falls back to the function environment", async () => {
+    vi.stubEnv("VERCEL_OIDC_TOKEN", "environment-token");
+
+    await expect(getVercelOidcToken()).resolves.toBe("environment-token");
+  });
+
+  it("rejects when Vercel supplied no ambient token", async () => {
+    await expect(getVercelOidcToken()).rejects.toThrow(
+      "The 'x-vercel-oidc-token' header is missing from the request.",
+    );
+  });
+});

--- a/packages/eve/src/internal/vercel-oidc-hosted.ts
+++ b/packages/eve/src/internal/vercel-oidc-hosted.ts
@@ -1,0 +1,21 @@
+interface VercelRequestContext {
+  readonly headers?: Readonly<Record<string, string | undefined>>;
+}
+
+interface VercelRequestContextProvider {
+  get?(): VercelRequestContext;
+}
+
+const VERCEL_REQUEST_CONTEXT = Symbol.for("@vercel/request-context");
+
+/** Reads the ambient token injected into a deployed Vercel function. */
+export async function getVercelOidcToken(): Promise<string> {
+  const provider = (globalThis as Record<symbol, unknown>)[VERCEL_REQUEST_CONTEXT] as
+    | VercelRequestContextProvider
+    | undefined;
+  const token = provider?.get?.().headers?.["x-vercel-oidc-token"] ?? process.env.VERCEL_OIDC_TOKEN;
+  if (!token) {
+    throw new Error("The 'x-vercel-oidc-token' header is missing from the request.");
+  }
+  return token;
+}

--- a/packages/eve/src/internal/vercel-oidc.ts
+++ b/packages/eve/src/internal/vercel-oidc.ts
@@ -1,0 +1,1 @@
+export { getVercelOidcToken } from "#compiled/@vercel/oidc/index.js";

--- a/packages/eve/src/public/agents/auth.ts
+++ b/packages/eve/src/public/agents/auth.ts
@@ -1,4 +1,4 @@
-import { getVercelOidcToken } from "#compiled/@vercel/oidc/index.js";
+import { getVercelOidcToken } from "#internal/vercel-oidc.js";
 
 import type { TokenValue } from "#client/types.js";
 

--- a/packages/eve/src/services/dev-client/request-headers.ts
+++ b/packages/eve/src/services/dev-client/request-headers.ts
@@ -1,4 +1,4 @@
-import { getVercelOidcToken } from "#compiled/@vercel/oidc/index.js";
+import { getVercelOidcToken } from "#internal/vercel-oidc.js";
 import { readVercelProjectLink } from "#internal/vercel/project-link.js";
 import { toErrorMessage } from "#shared/errors.js";
 import { z } from "zod";


### PR DESCRIPTION
### Summary

Fourth PR in stack #1999, on #1998. Vercel production bundles now resolve eve's OIDC helper to a hosted implementation that reads the request-context or environment token directly, while local development keeps `@vercel/oidc` refresh behavior. This removes development-only refresh, CLI config, and crypto machinery from deployed functions without changing the public `vercelOidc()` API.

Across `apps/fixtures/weather-agent` Vercel profiles, aggregate Nitro rendered length fell from 16,811,470 to 15,883,310 characters (-5.5%). Published output fell from 17,079,094 to 16,119,232 raw bytes (-5.6%) and from about 4,047,787 to 3,849,201 gzip bytes (-4.9%); build timings remained too noisy to claim a speedup.

### Validation

- `pnpm --filter eve typecheck`
- Focused unit tests: 62 passed across hosted OIDC, development OIDC, and Vercel sandbox credential coverage
- Focused scenario tests: 29 passed across application creation and build coverage
- `pnpm guard:invariants`
- `pnpm --filter eve build:js`
- Built `apps/fixtures/weather-agent` five times with `VERCEL=1`, `--profile`, and `--skip-sandbox-prewarm`; all profiles reported identical graph and output-size reductions

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
