### PR TITLE
fix(eve): preserve canary package metadata

### DIFF
--- a/apps/package-artifacts/lib/pack.mjs
+++ b/apps/package-artifacts/lib/pack.mjs
@@ -1,0 +1,45 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCallback);
+
+export async function packPackage(packageRoot, version, env = process.env) {
+  const workDirectory = await mkdtemp(join(tmpdir(), "eve-package-artifacts-"));
+  const pnpmTarballPath = join(workDirectory, "pnpm.tgz");
+  const extractedDirectory = join(workDirectory, "extracted");
+  const finalDirectory = join(workDirectory, "final");
+
+  try {
+    await execFile("pnpm", ["--dir", packageRoot, "pack", "--out", pnpmTarballPath], { env });
+    await mkdir(extractedDirectory);
+    await execFile("tar", ["-xzf", pnpmTarballPath, "-C", extractedDirectory]);
+
+    const packedPackageRoot = join(extractedDirectory, "package");
+    const packedPackageJsonPath = join(packedPackageRoot, "package.json");
+    const packedPackageJson = JSON.parse(await readFile(packedPackageJsonPath, "utf8"));
+    packedPackageJson.version = version;
+    await writeFile(packedPackageJsonPath, `${JSON.stringify(packedPackageJson, null, 2)}\n`);
+
+    await mkdir(finalDirectory);
+    const { stdout } = await execFile(
+      "npm",
+      ["pack", "--ignore-scripts", "--json", "--pack-destination", finalDirectory],
+      { cwd: packedPackageRoot, env },
+    );
+    const [packResult] = JSON.parse(stdout);
+    if (typeof packResult?.filename !== "string") {
+      throw new Error("npm pack did not report a tarball filename.");
+    }
+    if (packResult.version !== version) {
+      throw new Error(
+        `Expected packed version ${version}, received ${String(packResult.version)}.`,
+      );
+    }
+    return readFile(join(finalDirectory, packResult.filename));
+  } finally {
+    await rm(workDirectory, { force: true, recursive: true });
+  }
+}

--- a/apps/package-artifacts/lib/pack.mjs
+++ b/apps/package-artifacts/lib/pack.mjs
@@ -13,6 +13,7 @@ export async function packPackage(packageRoot, version, env = process.env) {
   const finalDirectory = join(workDirectory, "final");
 
   try {
+    // Let pnpm resolve workspace and catalog specifiers in the published manifest.
     await execFile("pnpm", ["--dir", packageRoot, "pack", "--out", pnpmTarballPath], { env });
     await mkdir(extractedDirectory);
     await execFile("tar", ["-xzf", pnpmTarballPath, "-C", extractedDirectory]);
@@ -23,6 +24,7 @@ export async function packPackage(packageRoot, version, env = process.env) {
     packedPackageJson.version = version;
     await writeFile(packedPackageJsonPath, `${JSON.stringify(packedPackageJson, null, 2)}\n`);
 
+    // Repack outside the workspace so pnpm's cached stable version cannot replace the canary version.
     await mkdir(finalDirectory);
     const { stdout } = await execFile(
       "npm",

--- a/apps/package-artifacts/lib/pack.test.mjs
+++ b/apps/package-artifacts/lib/pack.test.mjs
@@ -1,0 +1,46 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+import { afterEach, describe, expect, test } from "vitest";
+
+import { packPackage } from "./pack.mjs";
+
+const execFile = promisify(execFileCallback);
+let testRoot;
+
+afterEach(async () => {
+  if (testRoot !== undefined) await rm(testRoot, { force: true, recursive: true });
+});
+
+describe("packPackage", () => {
+  test("preserves pnpm manifest transformations and stamps build metadata", async () => {
+    testRoot = await mkdtemp(join(tmpdir(), "eve-package-artifacts-test-"));
+    const packageRoot = join(testRoot, "packages", "test-package");
+    await mkdir(packageRoot, { recursive: true });
+    await writeFile(
+      join(testRoot, "pnpm-workspace.yaml"),
+      'packages:\n  - "packages/*"\ncatalog:\n  example: "1.2.3"\n',
+    );
+    await writeFile(
+      join(packageRoot, "package.json"),
+      JSON.stringify({
+        name: "eve-pack-test",
+        version: "0.33.3",
+        peerDependencies: { example: "catalog:" },
+      }),
+    );
+
+    const version = "0.33.3+main.abc";
+    const tarball = await packPackage(packageRoot, version);
+    const tarballPath = join(testRoot, "package.tgz");
+    await writeFile(tarballPath, tarball);
+
+    const { stdout } = await execFile("tar", ["-xOf", tarballPath, "package/package.json"]);
+    const packageJson = JSON.parse(stdout);
+    expect(packageJson.version).toBe(version);
+    expect(packageJson.peerDependencies.example).toBe("1.2.3");
+  });
+});

--- a/apps/package-artifacts/scripts/build.mjs
+++ b/apps/package-artifacts/scripts/build.mjs
@@ -1,9 +1,7 @@
-import { execFile as execFileCallback } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { promisify } from "node:util";
 
 import { get, head, put } from "@vercel/blob";
 
@@ -14,8 +12,7 @@ import {
   packageManifestPath,
   preparePackageJson,
 } from "../lib/package.mjs";
-
-const execFile = promisify(execFileCallback);
+import { packPackage } from "../lib/pack.mjs";
 const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const repoRoot = resolve(appRoot, "../..");
 const packageRoot = join(repoRoot, "packages/eve");
@@ -51,12 +48,10 @@ const artifactPath = packageArtifactPath(sourceSha);
 try {
   await rm(artifactDirectory, { force: true, recursive: true });
   await writeFile(packageJsonPath, `${JSON.stringify(preparedPackageJson, null, 2)}\n`);
-  await execFile("pnpm", ["--dir", packageRoot, "pack", "--pack-destination", artifactDirectory], {
-    cwd: repoRoot,
-    env: { ...process.env, EVE_MAIN_DEPENDENCY_URL: dependencyUrl },
+  const tarball = await packPackage(packageRoot, version, {
+    ...process.env,
+    EVE_MAIN_DEPENDENCY_URL: dependencyUrl,
   });
-
-  const tarball = await readFile(join(artifactDirectory, `eve-${version}.tgz`));
   const sha256 = createHash("sha256").update(tarball).digest("hex");
   let artifact;
   try {


### PR DESCRIPTION
### Summary

Canary publishing rewrites `packages/eve/package.json` after workspace installation, but `pnpm pack` reads the original version from pnpm's cached workspace state. It therefore emits a stable-version tarball while the publisher expects the new `+main.<sha>` filename and fails with `ENOENT`.

This PR fixes this by packing in two stages: pnpm first produces the manifest with `catalog:` ranges resolved, then the artifact builder stamps that packed manifest with the canary version and repacks it with npm. The final archive keeps pnpm's dependency transformations while reliably carrying the SHA build metadata.

Follow-up to #1991.

### Validation

- `pnpm --filter eve-package-artifacts test` (10 tests passed)
- New focused test invokes both real packers, extracts the final archive, and verifies its build-metadata version and resolved catalog peer dependency
- Packed the real `packages/eve` package through the two-stage helper and inspected the resulting 7.6 MB archive: version `0.33.3+main.<sha>`, `ai` peer resolved to `^7.0.58`, no `catalog:`/`workspace:` specs, and the `eve` binary present
- `pnpm exec oxfmt --check apps/package-artifacts/scripts/build.mjs apps/package-artifacts/lib/pack.mjs apps/package-artifacts/lib/pack.test.mjs`
- `pnpm exec oxlint apps/package-artifacts/scripts/build.mjs apps/package-artifacts/lib/pack.mjs apps/package-artifacts/lib/pack.test.mjs`
- `git diff --check`

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant *(added real archive coverage; no documentation change needed)*
- [x] I added a changeset if this touches the published `eve` package *(not applicable; internal deployment app only)*
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
