### PR TITLE
chore(e2e): memory - add file memory fixture

### DIFF
--- a/.changeset/dynamic-lifecycle-context.md
+++ b/.changeset/dynamic-lifecycle-context.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Expose message snapshots and cancellation signals in hook contexts. Dynamic resolvers receive the latest durable message snapshot across lifecycle events, and durable tools fail closed when replay functions are unavailable.
+Expose message snapshots and cancellation signals in hook contexts. Dynamic resolvers receive the latest durable message snapshot across lifecycle events, dynamic tools can opt into fail-closed resolution with `onError: "throw"`, and durable tools fail closed when replay functions are unavailable.

--- a/.changeset/file-memory-vercel-blob.md
+++ b/.changeset/file-memory-vercel-blob.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Add a scope-neutral `fileMemory()` provider with indexed save and remove tools, a configurable 100-memory default limit, and a portable versioned-document backend. Development defaults to process-local storage; Vercel deployments with an attached Blob store select private Blob storage automatically, while other production configurations must provide a backend.
+Add a scope-neutral `fileMemory()` provider with indexed save and remove tools, a configurable 100-entry `maxEntries` limit, and a portable versioned-document backend. Development defaults to process-local storage; Vercel deployments with an attached Blob store select private Blob storage automatically, while other production configurations must provide a backend.

--- a/docs/guides/dynamic-capabilities.md
+++ b/docs/guides/dynamic-capabilities.md
@@ -187,6 +187,25 @@ export default defineDynamic({
 
 Resolvers across files run concurrently.
 
+By default, eve logs and skips a dynamic tool resolver that throws, then continues with tools
+from the remaining resolvers. Set `onError: "throw"` when the model must not run without that
+resolver's tools:
+
+```ts title="agent/tools/required.ts"
+import { defineDynamic } from "eve/tools";
+import { loadRequiredTools } from "../lib/tools";
+
+export default defineDynamic({
+  events: {
+    "step.started": async () => loadRequiredTools(),
+  },
+  onError: "throw",
+});
+```
+
+The `onError` option applies to dynamic tools. `"continue"` is the default and preserves the
+other resolved tools; `"throw"` fails the active lifecycle boundary.
+
 ## Dynamic skills
 
 A dynamic skills file resolves which [skill](../skills) a caller can load, keyed on the principal. It resolves on `session.started` and `turn.started` only (`step.started` is reserved for dynamic tools). Read `ctx.session.auth` or channel metadata and return a `defineSkill(...)` (named after the file slug) or `null`:

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -30,7 +30,7 @@ export default defineMemory({
 });
 ```
 
-`byPrincipal()` partitions the slot by the authenticated caller and disables it for unauthenticated turns. For another trusted partition, supply a scope resolver that returns or asynchronously resolves an ordered tuple of non-empty strings or `null`:
+`byPrincipal()` partitions the slot by the authenticated caller, including its issuer when present, and disables it for unauthenticated turns. For another trusted partition, supply a scope resolver that returns or asynchronously resolves an ordered tuple of non-empty strings or `null`:
 
 ```ts
 async scope(ctx) {
@@ -59,7 +59,7 @@ The stored file contains one memory per line, so the recalled context gives the 
 
 eve allocates each new memory one index above the current highest index and never rewrites the indexes of surviving memories. It also normalizes saved text to one line, preserves unrelated memories, and retries conditional writes when another invocation changes the document concurrently. Saving identical text returns its existing index instead of adding a duplicate. Removing an index that no longer exists is a no-op.
 
-The provider stores at most 100 memories by default. Configure `memoryLimit` to change that count. At the limit, a failed save tells the model to remove an outdated memory by index and retry. The provider tells the model to keep stable context and omit secrets, instructions, and current-task details. It does not run a hidden capture model or persist complete transcripts.
+The provider stores at most 100 memories by default. Configure `maxEntries` to change that count. At the limit, a failed save tells the model to remove an outdated memory by index and retry. The provider tells the model to keep stable context and omit secrets, instructions, and current-task details. It does not run a hidden capture model or persist complete transcripts.
 
 On Vercel, the default backend stores private `MEMORY.md` objects in Vercel Blob when `BLOB_STORE_ID` or the legacy `BLOB_READ_WRITE_TOKEN` is available. The store-ID path authenticates with Vercel OIDC at request time. If the deployment does not have an attached Blob store, `fileMemory()` fails on its first storage operation instead of silently using process-local memory. Attach a Blob store to the project or pass an explicit backend. Outside Vercel, development and test environments default to process-local memory. A production deployment outside Vercel must pass an explicit backend so it cannot silently run with memory that disappears on restart.
 
@@ -76,7 +76,7 @@ export default defineMemory({
       prefix: "my-agent/memory/files",
       token: process.env.BLOB_READ_WRITE_TOKEN,
     }),
-    memoryLimit: 200,
+    maxEntries: 200,
   }),
   scope: byPrincipal(),
 });

--- a/e2e/fixtures/agent-memory/.gitignore
+++ b/e2e/fixtures/agent-memory/.gitignore
@@ -1,0 +1,10 @@
+node_modules
+.env*
+.eve
+.vercel
+.next
+.output
+.nitro
+dist
+.DS_Store
+*.tsbuildinfo

--- a/e2e/fixtures/agent-memory/.vercelignore
+++ b/e2e/fixtures/agent-memory/.vercelignore
@@ -1,0 +1,6 @@
+node_modules
+.eve
+.next
+.output
+.nitro
+dist

--- a/e2e/fixtures/agent-memory/agent/agent.ts
+++ b/e2e/fixtures/agent-memory/agent/agent.ts
@@ -1,0 +1,29 @@
+import { e2eAgentConfig } from "@eve-e2e/config";
+import { defineAgent } from "eve";
+import type { MockModelRequest, MockModelResponse } from "eve/evals";
+
+import { MEMORY_FACT, MEMORY_PHRASE, SAVE_CONFIRMATION } from "./constants.js";
+
+function respond(request: MockModelRequest): MockModelResponse | string {
+  const prompt = request.lastUserMessage ?? "";
+
+  if (prompt.includes("user__save_memory") && prompt.includes(MEMORY_FACT)) {
+    const saved = request.toolResults.some((result) => result.name === "user__save_memory");
+    return saved
+      ? SAVE_CONFIRMATION
+      : { toolCalls: [{ input: { text: MEMORY_FACT }, name: "user__save_memory" }] };
+  }
+
+  if (/verification phrase/iu.test(prompt)) {
+    return request.userMessages.some((message) => message.includes(MEMORY_FACT))
+      ? MEMORY_PHRASE
+      : "MEMORY-NOT-FOUND";
+  }
+
+  return `Mock reply: ${prompt}`;
+}
+
+export default defineAgent({
+  ...e2eAgentConfig({ mock: respond }),
+  reasoning: "high",
+});

--- a/e2e/fixtures/agent-memory/agent/constants.ts
+++ b/e2e/fixtures/agent-memory/agent/constants.ts
@@ -1,0 +1,3 @@
+export const MEMORY_FACT = "The verification phrase is MEMORY-E2E-MARIGOLD-7F2Q.";
+export const MEMORY_PHRASE = "MEMORY-E2E-MARIGOLD-7F2Q";
+export const SAVE_CONFIRMATION = "MEMORY-SAVED";

--- a/e2e/fixtures/agent-memory/agent/instructions.md
+++ b/e2e/fixtures/agent-memory/agent/instructions.md
@@ -1,0 +1,5 @@
+# Identity
+
+You are a test agent verifying persistent user memory. Follow requests to use
+memory tools exactly. When asked for a verification phrase, answer from the
+persistent memories supplied in user messages and return only the phrase.

--- a/e2e/fixtures/agent-memory/agent/memory/user.ts
+++ b/e2e/fixtures/agent-memory/agent/memory/user.ts
@@ -1,0 +1,15 @@
+import { defineMemory } from "eve/memory";
+import { fileMemory, inMemory } from "eve/memory/file";
+
+const provider = process.env.VERCEL
+  ? fileMemory()
+  : fileMemory({
+      backend: inMemory(),
+    });
+
+export default defineMemory({
+  provider,
+  scope: () => [
+    process.env.VERCEL_DEPLOYMENT_ID?.trim() || process.env.VERCEL_URL?.trim() || "local-e2e",
+  ],
+});

--- a/e2e/fixtures/agent-memory/evals/evals.config.ts
+++ b/e2e/fixtures/agent-memory/evals/evals.config.ts
@@ -1,0 +1,6 @@
+import { e2eJudgeModel } from "@eve-e2e/config";
+import { defineEvalConfig } from "eve/evals";
+
+export default defineEvalConfig({
+  judge: { model: e2eJudgeModel() },
+});

--- a/e2e/fixtures/agent-memory/evals/file-memory.eval.ts
+++ b/e2e/fixtures/agent-memory/evals/file-memory.eval.ts
@@ -1,0 +1,31 @@
+import { defineEval } from "eve/evals";
+import { equals } from "eve/evals/expect";
+
+import { MEMORY_FACT, MEMORY_PHRASE, SAVE_CONFIRMATION } from "../agent/constants.js";
+
+export default defineEval({
+  description: "File memory persists a saved fact and recalls it in a new session.",
+
+  async test(t) {
+    const saved = await t.send(
+      `Call \`user__save_memory\` exactly once with this exact \`text\` argument: ` +
+        `"${MEMORY_FACT}" After the tool succeeds, reply with exactly ${SAVE_CONFIRMATION}.`,
+    );
+    saved.expectOk();
+    saved.calledTool("user__save_memory", {
+      input: { text: MEMORY_FACT },
+      status: "completed",
+    });
+    saved.messageIncludes(SAVE_CONFIRMATION);
+
+    const nextSession = t.newSession();
+    const recalled = await nextSession.send(
+      "What is the verification phrase in persistent memory? Reply with the phrase only. " +
+        "Do not call any tools.",
+    );
+    recalled.expectOk();
+    recalled.usedNoTools();
+    recalled.messageIncludes(MEMORY_PHRASE);
+    await t.require(recalled.sessionId === saved.sessionId, equals(false));
+  },
+});

--- a/e2e/fixtures/agent-memory/package.json
+++ b/e2e/fixtures/agent-memory/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "agent-memory",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "eve build",
+    "dev": "eve dev",
+    "start": "eve start",
+    "typecheck": "eve build && tsc",
+    "test:e2e": "eve eval --strict"
+  },
+  "dependencies": {
+    "@eve-e2e/config": "workspace:*",
+    "@workflow/world-postgres": "catalog:",
+    "eve": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  },
+  "e2e": {
+    "modelMatrix": "full"
+  }
+}

--- a/e2e/fixtures/agent-memory/tsconfig.json
+++ b/e2e/fixtures/agent-memory/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["agent/**/*.ts", "evals/**/*.ts"]
+}

--- a/packages/eve/extension-contracts/compatibility/dynamicTool/v15.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicTool/v15.ts
@@ -1,0 +1,14 @@
+import { z as z3 } from "zod/v3";
+
+import { defineDynamic, defineTool } from "#public/tools/index.js";
+
+export default defineDynamic({
+  events: {
+    "session.started": (_event, ctx) =>
+      defineTool({
+        description: "Return the active session identifier.",
+        inputSchema: z3.object({ prefix: z3.string() }),
+        execute: ({ prefix }) => ({ sessionId: `${prefix}:${ctx.session.id}` }),
+      }),
+  },
+});

--- a/packages/eve/extension-contracts/reports/dynamicTool/v16.json
+++ b/packages/eve/extension-contracts/reports/dynamicTool/v16.json
@@ -1,0 +1,13 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicTool",
+  "epoch": 16,
+  "sha256": "66fcbea31b0b43f4fe090d4e925b6788f50c49deb9349cf3676be48e62cac30a",
+  "exports": [
+    "DynamicToolEntry",
+    "DynamicToolEvents",
+    "DynamicToolResult",
+    "DynamicToolSet",
+    "defineDynamic"
+  ]
+}

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -23,8 +23,8 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
   extension: { current: 1, supported: [1], dropped: {} },
   tool: { current: 12, supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], dropped: {} },
   dynamicTool: {
-    current: 15,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    current: 16,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
     dropped: {},
   },
   connection: { current: 5, supported: [1, 2, 3, 4, 5], dropped: {} },

--- a/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
@@ -451,6 +451,7 @@ function createResolver(
   slug: string,
   eventNames: readonly string[],
   handler: (event: unknown, ctx: unknown) => unknown | Promise<unknown>,
+  onError?: ResolvedDynamicToolResolver["onError"],
 ): ResolvedDynamicToolResolver {
   const events: Record<string, (event: unknown, ctx: unknown) => unknown | Promise<unknown>> = {};
   for (const name of eventNames) {
@@ -460,6 +461,7 @@ function createResolver(
     slug,
     eventNames,
     events,
+    onError,
     sourceId: `test:${slug}`,
     sourceKind: "module",
     logicalPath: `agent/tools/${slug}.ts`,
@@ -1073,6 +1075,27 @@ describe("dispatchDynamicToolEvent", () => {
     const tools = buildDynamicTools(ctx);
     expect(tools).toHaveLength(1);
     expect(tools[0]!.name).toBe("working");
+  });
+
+  it("throws when a resolver opts into fail-closed errors", async () => {
+    const ctx = createCtx();
+    const resolver = createResolver(
+      "required",
+      ["step.started"],
+      () => {
+        throw new Error("resolver exploded");
+      },
+      "throw",
+    );
+
+    await expect(
+      dispatchDynamicToolEvent({
+        ctx,
+        resolvers: [resolver],
+        messages: [],
+        event: makeEvent("step.started"),
+      }),
+    ).rejects.toThrow("resolver exploded");
   });
 
   it("uses file slug when handler returns a single entry", async () => {

--- a/packages/eve/src/context/dynamic-tool-lifecycle.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.ts
@@ -222,8 +222,11 @@ async function resolveToolsFromEvent(
   // allowed and handled at merge time).
   const dynamicToolOwners = new Map<string, string>();
 
-  for (const outcome of outcomes) {
+  for (const [index, outcome] of outcomes.entries()) {
     if (outcome.status === "rejected") {
+      if (resolvers[index]!.onError === "throw") {
+        throw outcome.reason;
+      }
       log.error(`Dynamic tool resolver (${event.type}) threw — skipping.`, {
         error: toErrorMessage(outcome.reason),
       });

--- a/packages/eve/src/context/memory-lifecycle.test.ts
+++ b/packages/eve/src/context/memory-lifecycle.test.ts
@@ -250,10 +250,79 @@ describe("memory lifecycle", () => {
       });
 
       await prepare(requested);
-      setSession(ctx, "user-2", 4);
+      setSession(ctx, "user-1", 4, "other-issuer");
       await expect(prepare(turnStarted(4))).rejects.toThrow(
         /must be resumed by the principal that initiated it/u,
       );
+
+      setSession(ctx, "user-2", 5);
+      await expect(prepare(turnStarted(5))).rejects.toThrow(
+        /must be resumed by the principal that initiated it/u,
+      );
+    });
+  });
+
+  it("resolves a fresh scope for standalone compaction", async () => {
+    let scopeResolutions = 0;
+    const memory: ResolvedMemoryDefinition = {
+      logicalPath: "memory/user.ts",
+      provider: defineMemoryProvider({}),
+      scope: (context) => {
+        scopeResolutions += 1;
+        return [context.session.auth.current!.principalId];
+      },
+      slot: "user",
+      sourceId: "memory/user.ts",
+      sourceKind: "module",
+    };
+    const ctx = createContext();
+    const prepare = (event: Parameters<typeof prepareMemoryLifecycleEvent>[0]["event"]) =>
+      prepareMemoryLifecycleEvent({
+        abortSignal: new AbortController().signal,
+        ctx,
+        event,
+        identity: { agentId: "agent-1", nodeId: "__root__" },
+        memories: [memory],
+      });
+    const compactionRequested = (sequence: number) =>
+      stampMessageStreamEvent(
+        createCompactionRequestedEvent({
+          modelId: "mock/model",
+          sequence,
+          sessionId: "session-1",
+          turnId: `turn-${sequence}`,
+          usageInputTokens: 10,
+        }),
+      );
+    const compactionCompleted = (sequence: number) =>
+      stampMessageStreamEvent(
+        createCompactionCompletedEvent({
+          modelId: "mock/model",
+          sequence,
+          sessionId: "session-1",
+          turnId: `turn-${sequence}`,
+        }),
+      );
+
+    await contextStorage.run(ctx, async () => {
+      await prepare(
+        stampMessageStreamEvent(createTurnStartedEvent({ sequence: 2, turnId: "turn-2" })),
+      );
+      const activeTurnScope = ctx.require(TurnMemoryStateKey).slots[0]!.scope.key;
+
+      await prepare(compactionRequested(2));
+      expect(ctx.require(TurnMemoryStateKey).slots[0]!.scope.key).toBe(activeTurnScope);
+      expect(scopeResolutions).toBe(1);
+
+      setSession(ctx, "user-2", 3);
+      await prepare(compactionRequested(3));
+      const manualCompactionScope = ctx.require(TurnMemoryStateKey).slots[0]!.scope.key;
+      expect(manualCompactionScope).not.toBe(activeTurnScope);
+      expect(scopeResolutions).toBe(2);
+
+      await prepare(compactionCompleted(3));
+      expect(ctx.require(TurnMemoryStateKey).slots[0]!.scope.key).toBe(manualCompactionScope);
+      expect(scopeResolutions).toBe(2);
     });
   });
 
@@ -295,12 +364,18 @@ function createContext(): ContextContainer {
   return ctx;
 }
 
-function setSession(ctx: ContextContainer, principalId: string, sequence: number): void {
+function setSession(
+  ctx: ContextContainer,
+  principalId: string,
+  sequence: number,
+  issuer?: string,
+): void {
   ctx.set(SessionKey, {
     auth: {
       current: {
         attributes: {},
         authenticator: "test",
+        issuer,
         principalId,
         principalType: "user",
       },

--- a/packages/eve/src/context/memory-lifecycle.ts
+++ b/packages/eve/src/context/memory-lifecycle.ts
@@ -129,7 +129,12 @@ function principalIdentity(principal: SessionAuthContext | null): string {
   return JSON.stringify(
     principal === null
       ? null
-      : [principal.principalType, principal.authenticator, principal.principalId],
+      : [
+          principal.principalType,
+          principal.authenticator,
+          principal.issuer ?? null,
+          principal.principalId,
+        ],
   );
 }
 
@@ -271,7 +276,7 @@ async function ensureTurnState(
   turnId: string,
 ): Promise<DurableTurnMemoryState> {
   const existing = input.ctx.get(TurnMemoryStateKey);
-  if (existing !== undefined) return existing;
+  if (existing?.sequence === sequence && existing.turnId === turnId) return existing;
   const state = await resolveTurnState({ ...input, sequence, turnId });
   input.ctx.set(TurnMemoryStateKey, state);
   return state;

--- a/packages/eve/src/internal/authored-definition/schema-backed.test.ts
+++ b/packages/eve/src/internal/authored-definition/schema-backed.test.ts
@@ -4,7 +4,7 @@ import { z } from "#compiled/zod/index.js";
 
 import {
   defineTool,
-  defineDynamic,
+  defineDynamicTool as defineDynamic,
   disableTool,
   experimental_workflow,
 } from "#public/definitions/tool.js";
@@ -249,12 +249,14 @@ describe("normalizeToolDefinition", () => {
           }),
         }),
       },
+      onError: "throw",
     });
 
     const entry = normalizeToolDefinition(dynamicTools, FAILURE_MESSAGE);
     expect(entry.kind).toBe("dynamic-tool");
     if (entry.kind !== "dynamic-tool") throw new Error("expected dynamic-tool");
     expect(entry.eventNames).toEqual(["session.started"]);
+    expect(dynamicTools.onError).toBe("throw");
   });
 
   it("returns a dynamic-tool entry for a defineDynamic({ events }) export with a single entry", () => {

--- a/packages/eve/src/internal/authored-definition/schema-backed.ts
+++ b/packages/eve/src/internal/authored-definition/schema-backed.ts
@@ -18,7 +18,7 @@ import {
 } from "#shared/tool-schema.js";
 import { normalizeApproval } from "#internal/authored-definition/approval.js";
 import {
-  assertResolverOnlyDynamicSentinel,
+  assertDynamicToolSentinel,
   isDynamicSentinel,
   type DynamicToolEventName,
 } from "#shared/dynamic-tool-definition.js";
@@ -60,7 +60,7 @@ type NormalizedToolEntry =
  */
 export function normalizeToolDefinition(value: unknown, message: string): NormalizedToolEntry {
   if (isDynamicSentinel(value)) {
-    assertResolverOnlyDynamicSentinel(value, message);
+    assertDynamicToolSentinel(value, message);
     return {
       kind: "dynamic-tool",
       eventNames: Object.keys(value.events) as DynamicToolEventName[],

--- a/packages/eve/src/public/definitions/tool.ts
+++ b/packages/eve/src/public/definitions/tool.ts
@@ -19,6 +19,8 @@ import {
   TOOL_BRAND,
   type DynamicEvents,
   type DynamicSentinel,
+  type DynamicToolErrorBehavior,
+  type DynamicToolSentinel,
 } from "#shared/dynamic-tool-definition.js";
 
 type ApprovalContextInput<TInput> = unknown extends TInput ? Record<string, unknown> : TInput;
@@ -306,11 +308,31 @@ export function defineDynamic<const TEvents extends DynamicEvents>(definition: {
 export function defineDynamic<TResult = unknown>(definition: {
   readonly events: DynamicEvents<TResult>;
 }): DynamicSentinel<TResult> {
-  const sentinel = {
+  return createDynamicSentinel(definition.events);
+}
+
+export function defineDynamicTool<const TEvents extends DynamicEvents>(definition: {
+  readonly events: TEvents;
+  /** Resolver error behavior. Defaults to `"continue"`. */
+  readonly onError?: DynamicToolErrorBehavior;
+}): DynamicToolSentinel<DynamicEventMapResult<TEvents>>;
+export function defineDynamicTool<TResult = unknown>(definition: {
+  readonly events: DynamicEvents<TResult>;
+  readonly onError?: DynamicToolErrorBehavior;
+}): DynamicToolSentinel<TResult> {
+  return createDynamicSentinel(definition.events, definition.onError);
+}
+
+function createDynamicSentinel<TResult>(
+  events: DynamicEvents<TResult>,
+  onError?: DynamicToolErrorBehavior,
+): DynamicToolSentinel<TResult> {
+  const sentinel: DynamicToolSentinel<TResult> = {
     kind: DYNAMIC_SENTINEL_KIND,
-    events: definition.events,
-  } as DynamicSentinel<TResult>;
-  stampDefinitionKey(sentinel, `dynamic:${Object.keys(definition.events).join(",")}`);
+    events,
+  };
+  if (onError !== undefined) Object.assign(sentinel, { onError });
+  stampDefinitionKey(sentinel, `dynamic:${Object.keys(events).join(",")}`);
   return sentinel;
 }
 

--- a/packages/eve/src/public/memory/file/provider.test.ts
+++ b/packages/eve/src/public/memory/file/provider.test.ts
@@ -11,6 +11,7 @@ import {
 } from "#protocol/message.js";
 
 const signal = new AbortController().signal;
+const toolContext = { abortSignal: signal } as never;
 const sessionStartedEvent = stampMessageStreamEvent(
   createSessionStartedEvent(),
 ) as HookEventMap["session.started"];
@@ -26,7 +27,7 @@ const compactionCompletedEvent = stampMessageStreamEvent(
 describe("fileMemory", () => {
   it("returns a provider and recalls indexed durable context", async () => {
     const backend = inMemory();
-    const created = fileMemory({ backend, memoryLimit: 100 });
+    const created = fileMemory({ backend, maxEntries: 100 });
     expect(
       await created.events?.["session.started"]?.(sessionStartedEvent, providerContext()),
     ).toBeNull();
@@ -69,7 +70,7 @@ describe("fileMemory", () => {
     const firstTools = await resolveTools(provider);
 
     await expect(
-      firstTools.save_memory.execute({ text: "  Prefers\n dark mode.  " }, {} as never),
+      firstTools.save_memory.execute({ text: "  Prefers\n dark mode.  " }, toolContext),
     ).resolves.toEqual({ index: 0 });
     await expect(backend.read({ key: "mem_scope", signal })).resolves.toMatchObject({
       content: "0: Prefers dark mode.\n",
@@ -77,7 +78,7 @@ describe("fileMemory", () => {
 
     const secondTools = await resolveTools(provider);
     await expect(
-      secondTools.save_memory.execute({ text: "Likes concise answers." }, {} as never),
+      secondTools.save_memory.execute({ text: "Likes concise answers." }, toolContext),
     ).resolves.toEqual({ index: 1 });
     await expect(backend.read({ key: "mem_scope", signal })).resolves.toMatchObject({
       content: "0: Prefers dark mode.\n1: Likes concise answers.\n",
@@ -85,7 +86,7 @@ describe("fileMemory", () => {
 
     const duplicateTools = await resolveTools(provider);
     await expect(
-      duplicateTools.save_memory.execute({ text: "Likes concise answers." }, {} as never),
+      duplicateTools.save_memory.execute({ text: "Likes concise answers." }, toolContext),
     ).resolves.toEqual({ index: 1 });
   });
 
@@ -100,7 +101,7 @@ describe("fileMemory", () => {
     const provider = fileMemory({ backend });
     const tools = await resolveTools(provider);
 
-    await expect(tools.remove_memory.execute({ index: 1 }, {} as never)).resolves.toBeUndefined();
+    await expect(tools.remove_memory.execute({ index: 1 }, toolContext)).resolves.toBeUndefined();
     const removed = await backend.read({ key: "mem_scope", signal });
     expect(removed?.content).toBe("0: First.\n2: Third.\n");
     expect(removed?.version).not.toBe(first.version);
@@ -108,20 +109,20 @@ describe("fileMemory", () => {
     const unchanged = await backend.read({ key: "mem_scope", signal });
     const nextTools = await resolveTools(provider);
     await expect(
-      nextTools.remove_memory.execute({ index: 9 }, {} as never),
+      nextTools.remove_memory.execute({ index: 9 }, toolContext),
     ).resolves.toBeUndefined();
     await expect(backend.read({ key: "mem_scope", signal })).resolves.toEqual(unchanged);
 
     const saveTools = await resolveTools(provider);
     await expect(
-      saveTools.save_memory.execute({ text: "Replacement." }, {} as never),
+      saveTools.save_memory.execute({ text: "Replacement." }, toolContext),
     ).resolves.toEqual({ index: 3 });
     await expect(backend.read({ key: "mem_scope", signal })).resolves.toMatchObject({
       content: "0: First.\n2: Third.\n3: Replacement.\n",
     });
   });
 
-  it("merges concurrent saves and removals with conditional retries", async () => {
+  it("applies saves and removals to the latest document", async () => {
     const backend = inMemory();
     const original = await backend.write({
       content: "0: Original.\n",
@@ -130,7 +131,7 @@ describe("fileMemory", () => {
       signal,
     });
     const provider = fileMemory({ backend });
-    const staleTools = await resolveTools(provider);
+    const tools = await resolveTools(provider);
     await backend.write({
       content: "0: Original.\n1: Concurrent.\n",
       expectedVersion: original.version,
@@ -138,11 +139,10 @@ describe("fileMemory", () => {
       signal,
     });
 
-    await expect(staleTools.save_memory.execute({ text: "Mine." }, {} as never)).resolves.toEqual({
+    await expect(tools.save_memory.execute({ text: "Mine." }, toolContext)).resolves.toEqual({
       index: 2,
     });
 
-    const staleRemoveTools = await resolveTools(provider);
     const beforeRemove = await backend.read({ key: "mem_scope", signal });
     if (beforeRemove === null) throw new Error("expected memory document");
     await backend.write({
@@ -151,9 +151,7 @@ describe("fileMemory", () => {
       key: "mem_scope",
       signal,
     });
-    await expect(
-      staleRemoveTools.remove_memory.execute({ index: 0 }, {} as never),
-    ).resolves.toBeUndefined();
+    await expect(tools.remove_memory.execute({ index: 0 }, toolContext)).resolves.toBeUndefined();
     await expect(backend.read({ key: "mem_scope", signal })).resolves.toMatchObject({
       content: "1: Concurrent.\n2: Mine.\n3: Also concurrent.\n",
     });
@@ -167,19 +165,19 @@ describe("fileMemory", () => {
       key: "mem_scope",
       signal,
     });
-    const provider = fileMemory({ backend, memoryLimit: 2 });
+    const provider = fileMemory({ backend, maxEntries: 2 });
     const tools = await resolveTools(provider);
 
-    await expect(tools.save_memory.execute({ text: "Third." }, {} as never)).rejects.toThrow(
+    await expect(tools.save_memory.execute({ text: "Third." }, toolContext)).rejects.toThrow(
       "configured limit of 2 memories. Remove an outdated memory by index, then retry this save.",
     );
-    await expect(tools.save_memory.execute({ text: "Second." }, {} as never)).resolves.toEqual({
+    await expect(tools.save_memory.execute({ text: "Second." }, toolContext)).resolves.toEqual({
       index: 1,
     });
 
-    await expect(tools.remove_memory.execute({ index: 0 }, {} as never)).resolves.toBeUndefined();
+    await expect(tools.remove_memory.execute({ index: 0 }, toolContext)).resolves.toBeUndefined();
     const nextTools = await resolveTools(provider);
-    await expect(nextTools.save_memory.execute({ text: "Third." }, {} as never)).resolves.toEqual({
+    await expect(nextTools.save_memory.execute({ text: "Third." }, toolContext)).resolves.toEqual({
       index: 2,
     });
     await expect(backend.read({ key: "mem_scope", signal })).resolves.toMatchObject({
@@ -198,19 +196,19 @@ describe("fileMemory", () => {
     });
     const tools = await resolveTools(fileMemory({ backend }));
 
-    await expect(tools.save_memory.execute({ text: "One too many." }, {} as never)).rejects.toThrow(
+    await expect(tools.save_memory.execute({ text: "One too many." }, toolContext)).rejects.toThrow(
       "configured limit of 100 memories. Remove an outdated memory by index, then retry this save.",
     );
   });
 
   it("rejects invalid limits, empty text, and malformed stored documents", async () => {
-    expect(() => fileMemory({ memoryLimit: 0 })).toThrow("positive safe integer");
-    expect(() => fileMemory({ memoryLimit: 1.5 })).toThrow("positive safe integer");
+    expect(() => fileMemory({ maxEntries: 0 })).toThrow("positive safe integer");
+    expect(() => fileMemory({ maxEntries: 1.5 })).toThrow("positive safe integer");
 
     const backend = inMemory();
     const provider = fileMemory({ backend });
     const tools = await resolveTools(provider);
-    await expect(tools.save_memory.execute({ text: " \n " }, {} as never)).rejects.toThrow(
+    await expect(tools.save_memory.execute({ text: " \n " }, toolContext)).rejects.toThrow(
       "cannot be empty",
     );
     await backend.write({
@@ -242,9 +240,29 @@ describe("fileMemory", () => {
     });
     const tools = await resolveTools(provider);
 
-    await expect(tools.save_memory.execute({ text: "Mine." }, {} as never)).resolves.toEqual({
+    await expect(tools.save_memory.execute({ text: "Mine." }, toolContext)).resolves.toEqual({
       index: 1,
     });
+  });
+
+  it("registers tools without reading the backend", async () => {
+    let reads = 0;
+    const backend = {
+      async read() {
+        reads += 1;
+        return null;
+      },
+      async write({ content }: { readonly content: string }) {
+        return { content, version: "v1" };
+      },
+    };
+    const tools = await resolveTools(fileMemory({ backend }));
+
+    expect(reads).toBe(0);
+    await expect(tools.save_memory.execute({ text: "Remembered." }, toolContext)).resolves.toEqual({
+      index: 0,
+    });
+    expect(reads).toBe(1);
   });
 });
 

--- a/packages/eve/src/public/memory/file/provider.ts
+++ b/packages/eve/src/public/memory/file/provider.ts
@@ -15,7 +15,7 @@ import {
   type MemoryProviderContext,
 } from "#public/memory/index.js";
 
-const DEFAULT_MEMORY_LIMIT = 100;
+const DEFAULT_MAX_ENTRIES = 100;
 const MAX_CONFLICT_RETRIES = 8;
 
 /** Configuration for the bounded, model-maintained memory file provider. */
@@ -23,7 +23,7 @@ export interface FileMemoryOptions {
   /** Storage implementation. Defaults by runtime environment. */
   readonly backend?: MemoryDocumentBackend;
   /** Maximum number of stored memories. Defaults to 100. */
-  readonly memoryLimit?: number;
+  readonly maxEntries?: number;
 }
 
 /** Result returned after saving one memory. */
@@ -43,7 +43,7 @@ interface FileMemoryEntry {
  */
 export function fileMemory(options: FileMemoryOptions = {}): MemoryProvider {
   const backend = options.backend ?? defaultFileMemoryBackend();
-  const memoryLimit = normalizeMemoryLimit(options.memoryLimit);
+  const maxEntries = normalizeMaxEntries(options.maxEntries);
 
   return defineMemoryProvider({
     events: {
@@ -52,37 +52,21 @@ export function fileMemory(options: FileMemoryOptions = {}): MemoryProvider {
     },
     tools: defineDynamic({
       events: {
-        async "step.started"(_event, context) {
+        "step.started"(_event, context) {
           const key = context.memory.scope.key;
-          const document = await readDocument({
-            backend,
-            key,
-            signal: context.abortSignal,
-          });
-          const save = async (input: { readonly text: string }) =>
-            await saveMemory({
-              backend,
-              document,
-              key,
-              memoryLimit,
-              signal: context.abortSignal,
-              text: input.text,
-            });
-          const remove = async (input: { readonly index: number }) => {
-            await removeMemory({
-              backend,
-              document,
-              index: input.index,
-              key,
-              signal: context.abortSignal,
-            });
-          };
 
           return {
             remove_memory: defineTool({
               description:
                 "Remove one persistent memory by the index shown in recalled memory. Use when it is wrong, outdated, or no longer needed.",
-              execute: remove,
+              async execute(input, toolContext) {
+                await removeMemory({
+                  backend,
+                  index: input.index,
+                  key,
+                  signal: toolContext.abortSignal,
+                });
+              },
               inputSchema: z.object({
                 index: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
               }),
@@ -90,7 +74,15 @@ export function fileMemory(options: FileMemoryOptions = {}): MemoryProvider {
             save_memory: defineTool({
               description:
                 "Save one concise, stable fact or preference for future conversations. Omit secrets, instructions, and current-task details.",
-              execute: save,
+              async execute(input, toolContext) {
+                return await saveMemory({
+                  backend,
+                  key,
+                  maxEntries,
+                  signal: toolContext.abortSignal,
+                  text: input.text,
+                });
+              },
               inputSchema: z.object({
                 text: z.string().min(1),
               }),
@@ -120,23 +112,22 @@ async function recallMemory(
 
 async function saveMemory(input: {
   readonly backend: MemoryDocumentBackend;
-  readonly document: MemoryDocument | null;
   readonly key: string;
-  readonly memoryLimit: number;
+  readonly maxEntries: number;
   readonly signal: AbortSignal;
   readonly text: string;
 }): Promise<FileMemorySaveResult> {
   const text = normalizeMemoryText(input.text);
-  let document = input.document;
+  let document = await readDocument(input);
   let conflicts = 0;
 
   for (;;) {
     const entries = parseMemoryDocument(document?.content ?? "");
     const existing = entries.find((entry) => entry.text === text);
     if (existing !== undefined) return { index: existing.index };
-    if (entries.length >= input.memoryLimit) {
+    if (entries.length >= input.maxEntries) {
       throw new RangeError(
-        `Memory has reached the configured limit of ${input.memoryLimit} memories. Remove an outdated memory by index, then retry this save.`,
+        `Memory has reached the configured limit of ${input.maxEntries} memories. Remove an outdated memory by index, then retry this save.`,
       );
     }
 
@@ -162,12 +153,11 @@ async function saveMemory(input: {
 
 async function removeMemory(input: {
   readonly backend: MemoryDocumentBackend;
-  readonly document: MemoryDocument | null;
   readonly index: number;
   readonly key: string;
   readonly signal: AbortSignal;
 }): Promise<void> {
-  let document = input.document;
+  let document = await readDocument(input);
   let conflicts = 0;
 
   for (;;) {
@@ -250,12 +240,12 @@ function normalizeMemoryText(value: string): string {
   return text;
 }
 
-function normalizeMemoryLimit(value: number | undefined): number {
-  const memoryLimit = value ?? DEFAULT_MEMORY_LIMIT;
-  if (!Number.isSafeInteger(memoryLimit) || memoryLimit < 1) {
-    throw new TypeError("fileMemory() memoryLimit must be a positive safe integer.");
+function normalizeMaxEntries(value: number | undefined): number {
+  const maxEntries = value ?? DEFAULT_MAX_ENTRIES;
+  if (!Number.isSafeInteger(maxEntries) || maxEntries < 1) {
+    throw new TypeError("fileMemory() maxEntries must be a positive safe integer.");
   }
-  return memoryLimit;
+  return maxEntries;
 }
 
 function formatRecallContext(entries: readonly FileMemoryEntry[]): string {

--- a/packages/eve/src/public/memory/index.test.ts
+++ b/packages/eve/src/public/memory/index.test.ts
@@ -10,7 +10,7 @@ import {
   defineMemoryProvider,
 } from "#public/memory/index.js";
 
-function scopeContext(principalId?: string): MemoryScopeContext {
+function scopeContext(principalId?: string, issuer?: string): MemoryScopeContext {
   return {
     abortSignal: new AbortController().signal,
     session: {
@@ -21,6 +21,7 @@ function scopeContext(principalId?: string): MemoryScopeContext {
             : {
                 attributes: {},
                 authenticator: "slack",
+                issuer,
                 principalId,
                 principalType: "user",
               },
@@ -84,6 +85,7 @@ describe("memory authoring", () => {
     expect(tools).toMatchObject({
       kind: "eve:dynamic",
       events: { "step.started": expect.any(Function) },
+      onError: "throw",
     });
     expect(provider.tools).toBe(tools);
   });
@@ -101,6 +103,12 @@ describe("memory authoring", () => {
     const scope = byPrincipal();
 
     expect(scope(scopeContext("U123"))).toEqual(["user", "slack", "U123"]);
+    expect(scope(scopeContext("U123", "slack:T123"))).toEqual([
+      "user",
+      "slack",
+      "slack:T123",
+      "U123",
+    ]);
     expect(scope(scopeContext())).toBeNull();
   });
 });

--- a/packages/eve/src/public/memory/index.ts
+++ b/packages/eve/src/public/memory/index.ts
@@ -4,11 +4,11 @@ import type { SessionContext } from "#public/definitions/callback-context.js";
 import type { ExactDefinition } from "#public/definitions/exact.js";
 import type { HookEventMap } from "#public/definitions/hook.js";
 import {
-  defineDynamic as defineDynamicBase,
+  defineDynamicTool as defineDynamicBase,
   type ToolContext,
   type ToolDefinition,
 } from "#public/definitions/tool.js";
-import type { DynamicSentinel } from "#shared/dynamic-tool-definition.js";
+import type { DynamicToolSentinel } from "#shared/dynamic-tool-definition.js";
 
 /** One opaque identifier in an authored memory partition tuple. */
 export type MemoryScopePart = string;
@@ -86,7 +86,7 @@ type MemoryDynamicResult<TEvents extends MemoryDynamicEvents> = Awaited<
 >;
 
 /** The standard dynamic sentinel with memory-specific events and callback context. */
-type MemoryDynamicSentinel<TResult = unknown> = Omit<DynamicSentinel<TResult>, "events"> & {
+type MemoryDynamicSentinel<TResult = unknown> = Omit<DynamicToolSentinel<TResult>, "events"> & {
   readonly events: MemoryDynamicEvents<TResult>;
 };
 
@@ -138,9 +138,10 @@ export function defineMemory<const T extends MemoryDefinition>(
 export function defineDynamic<const TEvents extends MemoryDynamicEvents>(definition: {
   readonly events: TEvents;
 }): MemoryDynamicSentinel<MemoryDynamicResult<TEvents>> {
-  return defineDynamicBase({ events: definition.events as never }) as MemoryDynamicSentinel<
-    MemoryDynamicResult<TEvents>
-  >;
+  return defineDynamicBase({
+    events: definition.events as never,
+    onError: "throw",
+  }) as MemoryDynamicSentinel<MemoryDynamicResult<TEvents>>;
 }
 
 /** Scopes memory to the authenticated caller; unauthenticated turns disable the slot. */
@@ -148,6 +149,11 @@ export function byPrincipal(): MemoryScopeDefinition {
   return (context) => {
     const principal = context.session.auth.current;
     if (principal === null) return null;
-    return [principal.principalType, principal.authenticator, principal.principalId];
+    return [
+      principal.principalType,
+      principal.authenticator,
+      ...(principal.issuer === undefined ? [] : [principal.issuer]),
+      principal.principalId,
+    ];
   };
 }

--- a/packages/eve/src/public/tools/index.ts
+++ b/packages/eve/src/public/tools/index.ts
@@ -6,7 +6,7 @@ export {
   type DisabledToolSentinel,
   type ExperimentalWorkflowToolDefinition,
   type ExperimentalWorkflowToolInput,
-  defineDynamic,
+  defineDynamicTool as defineDynamic,
   defineTool,
   disableTool,
   experimental_workflow,
@@ -39,7 +39,7 @@ export type {
   DynamicEvents,
   DynamicToolEvents,
   DynamicResolveContext,
-  DynamicSentinel,
+  DynamicToolSentinel as DynamicSentinel,
   DynamicToolSet,
   DynamicToolResult,
 } from "#shared/dynamic-tool-definition.js";

--- a/packages/eve/src/runtime/resolve-dynamic-tool.ts
+++ b/packages/eve/src/runtime/resolve-dynamic-tool.ts
@@ -2,7 +2,11 @@ import type { CompiledDynamicToolDefinition } from "#compiler/manifest.js";
 import type { CompiledModuleMap } from "#compiler/module-map.js";
 import { expectFunction, expectObjectRecord } from "#internal/authored-module.js";
 import { registerDefinitionSource, stampDefinitionKey } from "#public/tool-result-narrowing.js";
-import { isDynamicSentinel, type DynamicSentinel } from "#shared/dynamic-tool-definition.js";
+import {
+  assertDynamicToolSentinel,
+  isDynamicSentinel,
+  type DynamicToolSentinel,
+} from "#shared/dynamic-tool-definition.js";
 import { toErrorMessage } from "#shared/errors.js";
 import type { ModuleSourceRef } from "#shared/source-ref.js";
 import { loadResolvedModuleExport, ResolveAgentError } from "#runtime/resolve-helpers.js";
@@ -76,7 +80,7 @@ export function resolveLoadedDynamicToolDefinition(
 }
 
 function createResolvedDynamicToolResolver(
-  value: DynamicSentinel,
+  value: DynamicToolSentinel,
   source: DynamicToolResolverSource,
   eventNames: readonly string[],
 ): ResolvedDynamicToolResolver {
@@ -102,6 +106,7 @@ function createResolvedDynamicToolResolver(
     exportName: source.exportName,
     extensionNamespace: source.extensionNamespace,
     logicalPath: source.logicalPath,
+    onError: value.onError,
     slug: source.slug,
     sourceId: source.sourceId,
     sourceKind: "module",
@@ -111,11 +116,12 @@ function createResolvedDynamicToolResolver(
 function expectDynamicToolValue(
   value: unknown,
   definition: DynamicToolResolverSource,
-): DynamicSentinel {
+): DynamicToolSentinel {
   const record = expectObjectRecord(value, describe(definition, "to return an object"));
   if (!isDynamicSentinel(record)) {
     throw new Error(describe(definition, "to be created by defineDynamic()"));
   }
+  assertDynamicToolSentinel(record, describe(definition, "to match the dynamic tool shape"));
   expectObjectRecord(record.events, describe(definition, "to provide an events object"));
   return record;
 }

--- a/packages/eve/src/runtime/resolve-memory.test.ts
+++ b/packages/eve/src/runtime/resolve-memory.test.ts
@@ -34,6 +34,7 @@ describe("resolveMemoryDefinition", () => {
       dynamicToolResolver: {
         eventNames: ["step.started"],
         extensionNamespace: "user",
+        onError: "throw",
       },
       provider,
       slot: "user",

--- a/packages/eve/src/runtime/types.ts
+++ b/packages/eve/src/runtime/types.ts
@@ -37,6 +37,7 @@ import type { NamedSkillDefinition } from "#shared/skill-definition.js";
 import type { InternalAgentDefinition } from "#shared/agent-definition.js";
 import type { RuntimeDynamicModelReference } from "#runtime/agent/bootstrap.js";
 import type { InternalToolDefinitionWithExecuteFn } from "#shared/tool-definition.js";
+import type { DynamicToolErrorBehavior } from "#shared/dynamic-tool-definition.js";
 import type { WebSearchProvider } from "#shared/web-search.js";
 import type { SandboxBackend } from "#shared/sandbox-backend.js";
 import type { SandboxBootstrapContext, SandboxSessionContext } from "#shared/sandbox-definition.js";
@@ -365,6 +366,7 @@ interface ResolvedAgentMetadata {
 export interface ResolvedDynamicToolResolver extends Readonly<ModuleSourceRef> {
   readonly slug: string;
   readonly eventNames: readonly string[];
+  readonly onError?: DynamicToolErrorBehavior;
   readonly events: Readonly<
     Record<string, (event: unknown, ctx: unknown) => unknown | Promise<unknown>>
   >;

--- a/packages/eve/src/shared/dynamic-tool-definition.ts
+++ b/packages/eve/src/shared/dynamic-tool-definition.ts
@@ -137,6 +137,9 @@ export type DynamicEvents<TResult = unknown> = {
   ) => TResult | Promise<TResult>;
 };
 
+/** Behavior when a dynamic tool resolver throws. */
+export type DynamicToolErrorBehavior = "continue" | "throw";
+
 /**
  * Marker discriminator for a `defineDynamic({ events })` export.
  */
@@ -151,6 +154,12 @@ export type DynamicSentinel<TResult = unknown> = {
   readonly events: DynamicEvents<TResult>;
 };
 
+/** Dynamic tool sentinel with tool-specific resolver error behavior. */
+export type DynamicToolSentinel<TResult = unknown> = DynamicSentinel<TResult> & {
+  /** Dynamic-tool error behavior. Defaults to `"continue"`. */
+  readonly onError?: DynamicToolErrorBehavior;
+};
+
 export function assertResolverOnlyDynamicSentinel(
   sentinel: DynamicSentinel,
   message: string,
@@ -158,6 +167,22 @@ export function assertResolverOnlyDynamicSentinel(
   const unknownKeys = Object.keys(sentinel).filter((key) => key !== "events" && key !== "kind");
   if (unknownKeys.length > 0) {
     throw new Error(`${message} Unknown key(s): ${unknownKeys.join(", ")}.`);
+  }
+}
+
+export function assertDynamicToolSentinel(
+  sentinel: DynamicSentinel,
+  message: string,
+): asserts sentinel is DynamicToolSentinel {
+  const unknownKeys = Object.keys(sentinel).filter(
+    (key) => key !== "events" && key !== "kind" && key !== "onError",
+  );
+  if (unknownKeys.length > 0) {
+    throw new Error(`${message} Unknown key(s): ${unknownKeys.join(", ")}.`);
+  }
+  const onError = (sentinel as Partial<DynamicToolSentinel>).onError;
+  if (onError !== undefined && onError !== "continue" && onError !== "throw") {
+    throw new Error(`${message} Expected "onError" to be one of: continue, throw.`);
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -680,6 +680,25 @@ importers:
         specifier: 'catalog:'
         version: 7.0.2
 
+  e2e/fixtures/agent-memory:
+    dependencies:
+      '@eve-e2e/config':
+        specifier: workspace:*
+        version: link:../e2e-config
+      '@workflow/world-postgres':
+        specifier: 'catalog:'
+        version: 5.0.0-beta.32(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(sql.js@1.14.1)(supports-color@10.2.2)(typescript@7.0.2)
+      eve:
+        specifier: workspace:*
+        version: link:../../../packages/eve
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+
   e2e/fixtures/agent-model:
     dependencies:
       '@eve-e2e/config':

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -100,7 +100,7 @@ type MemoryScopeDefinition = (
 ) => readonly MemoryScopePart[] | null | Promise<readonly MemoryScopePart[] | null>;
 ```
 
-Scope parts come from trusted auth, application, or channel context. They cannot come from model input or unattested message fields. Parts have no built-in entity types, and no position has special meaning. `[userId, channelId]` means only that both values participate in the provider partition. `byPrincipal()` disables the slot for unauthenticated callers and otherwise returns `[principalType, authenticator, principalId]`.
+Scope parts come from trusted auth, application, or channel context. They cannot come from model input or unattested message fields. Parts have no built-in entity types, and no position has special meaning. `[userId, channelId]` means only that both values participate in the provider partition. `byPrincipal()` disables the slot for unauthenticated callers. It returns `[principalType, authenticator, principalId]` when the principal has no issuer and `[principalType, authenticator, issuer, principalId]` when it does.
 
 For each resolved slot, eve creates this scope value:
 
@@ -231,7 +231,7 @@ Returning `{ content }` materializes one message. Returning an array materialize
 interface FileMemoryOptions {
   readonly backend?: MemoryDocumentBackend;
   /** Defaults to 100. */
-  readonly memoryLimit?: number;
+  readonly maxEntries?: number;
 }
 
 function fileMemory(options?: FileMemoryOptions): MemoryProvider;
@@ -239,7 +239,7 @@ function fileMemory(options?: FileMemoryOptions): MemoryProvider;
 
 It stores one indexed `MEMORY.md`-style document per scope. `session.started` recalls the document once when the session opens, and `compaction.completed` recalls the latest document after every successful automatic or manual compaction. The recalled context is returned as a `MemoryMessage`, so eve persists it as ordinary user history. It is not repeated on every turn.
 
-The provider exposes `save_memory({ text })`, which returns `{ index }`, and `remove_memory({ index })`. The slot name qualifies both tools. The document preserves indexes for surviving entries, normalizes saved text to one line, treats identical saves and missing removals as idempotent, and conditionally replaces the document so concurrent operations preserve unrelated memories. The provider retries write conflicts and enforces `memoryLimit`; it does not run a hidden capture model or save complete transcripts.
+The provider exposes `save_memory({ text })`, which returns `{ index }`, and `remove_memory({ index })`. The slot name qualifies both tools. The document preserves indexes for surviving entries, normalizes saved text to one line, treats identical saves and missing removals as idempotent, and conditionally replaces the document so concurrent operations preserve unrelated memories. The provider retries write conflicts and enforces `maxEntries`; it does not run a hidden capture model or save complete transcripts.
 
 Calling `fileMemory()` without a backend uses this lazy, process-cached selection:
 
@@ -261,7 +261,7 @@ import { fileMemory, inMemory } from "eve/memory/file";
 const backend = inMemory();
 
 export default defineMemory({
-  provider: fileMemory({ backend, memoryLimit: 200 }),
+  provider: fileMemory({ backend, maxEntries: 200 }),
   scope: byPrincipal(),
 });
 ```


### PR DESCRIPTION
### Summary

Related to #1510.

Stacked on #1703. Review this fixture commit after the file-memory implementation in its base branch.

This adds full-suite coverage for the portable file-memory provider:

- Vercel deployments use `fileMemory()`'s default private Blob backend and isolate each preview with a deployment-specific scope.
- Local-model and Postgres world runs explicitly share one process-local `inMemory()` backend.
- One untagged eval saves an exact fact in one session and verifies that a new session receives and recalls it. A scripted mock keeps world-suite coverage deterministic, while `e2e.modelMatrix: "full"` schedules both registered real models.

This is fixture-only follow-up work: it does not change the published API, documentation, or package release surface.

### Validation

- `pnpm --filter agent-memory typecheck`
- `EVE_E2E_MODEL=mock ./node_modules/.bin/eve eval --strict` from `e2e/fixtures/agent-memory` — 1 eval passed, 5/5 gates
- `VERCEL=1 VERCEL_ENV=preview VERCEL_TARGET_ENV=preview pnpm --filter agent-memory build`
- `pnpm exec oxfmt --check e2e/fixtures/agent-memory pnpm-lock.yaml`
- `pnpm exec oxlint e2e/fixtures/agent-memory`
- `pnpm guard:invariants`
- `.github/scripts/discover-e2e-fixtures.mjs` schedules `agent-memory` for OpenAI, Anthropic, Vercel, and Postgres

The local environment has no AI Gateway credential, so the two live-model executions are left to the configured CI matrix.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
