### PR TITLE
docs: add native shared-sandbox example

### DIFF
--- a/docs/patterns/meta.json
+++ b/docs/patterns/meta.json
@@ -5,6 +5,7 @@
     "multi-tenant-memory",
     "dynamic-scheduling",
     "multi-tenant-auth",
-    "multi-tenant-approvals"
+    "multi-tenant-approvals",
+    "shared-sandbox"
   ]
 }

--- a/docs/sandbox.mdx
+++ b/docs/sandbox.mdx
@@ -250,7 +250,7 @@ The `"*": []` catch-all keeps general egress open while the `transform` applies 
 
 ## What to read next
 
-- [Subagents](./subagents): each subagent gets its own sandbox, independent of its parent.
+- [Subagents](./subagents): each subagent gets its own sandbox, independent of its parent. To deliberately share one, see [Share a sandbox with a subagent](./patterns/shared-sandbox).
 - [Tools](./tools): authored tools run in the app runtime (full `process.env`); only sandbox tools run in the sandbox.
 - [Security model](./concepts/security-model): the app-runtime/sandbox trust boundary in full.
 - [Vercel Sandbox](https://vercel.com/docs/sandbox): platform docs, including credential brokering and persistence limits.

--- a/examples/shared-sandbox/.gitignore
+++ b/examples/shared-sandbox/.gitignore
@@ -1,0 +1,2 @@
+.vercel
+.env*

--- a/examples/shared-sandbox/agent/agent.ts
+++ b/examples/shared-sandbox/agent/agent.ts
@@ -1,0 +1,5 @@
+import { defineAgent } from "eve";
+
+export default defineAgent({
+  model: "anthropic/claude-sonnet-5",
+});

--- a/examples/shared-sandbox/agent/instructions.md
+++ b/examples/shared-sandbox/agent/instructions.md
@@ -1,0 +1,10 @@
+You are the parent coding agent.
+
+For file-based delegation:
+
+1. Write the task brief to `/workspace/brief.md`.
+2. Call the declared `worker` subagent.
+3. After the worker returns, read `/workspace/child-result.md`.
+4. Summarize the result for the user.
+
+The worker shares this session's sandbox, so its filesystem writes are immediately visible to you.

--- a/examples/shared-sandbox/agent/subagents/worker/agent.ts
+++ b/examples/shared-sandbox/agent/subagents/worker/agent.ts
@@ -1,0 +1,7 @@
+import { defineAgent } from "eve";
+
+export default defineAgent({
+  description:
+    "Implement the task in /workspace/brief.md and write a summary to /workspace/child-result.md.",
+  model: "anthropic/claude-sonnet-5",
+});

--- a/examples/shared-sandbox/agent/subagents/worker/instructions.md
+++ b/examples/shared-sandbox/agent/subagents/worker/instructions.md
@@ -1,0 +1,1 @@
+Read `/workspace/brief.md`, complete the requested work, and write a concise summary to `/workspace/child-result.md` before replying to the parent.

--- a/examples/shared-sandbox/evals/evals.config.ts
+++ b/examples/shared-sandbox/evals/evals.config.ts
@@ -1,0 +1,6 @@
+import { defineEvalConfig } from "eve/evals";
+
+export default defineEvalConfig({
+  maxConcurrency: 1,
+  timeoutMs: 120_000,
+});

--- a/examples/shared-sandbox/evals/shared-filesystem.eval.ts
+++ b/examples/shared-sandbox/evals/shared-filesystem.eval.ts
@@ -1,0 +1,31 @@
+import { randomUUID } from "node:crypto";
+import { defineEval } from "eve/evals";
+
+export default defineEval({
+  tags: ["real-model"],
+  description: "The worker reads a parent-created file and the parent reads a worker-created file.",
+  async test(t) {
+    const nonce = `SHARED_SANDBOX_${randomUUID()}`;
+    const proof = `WORKER_SAW_${nonce}`;
+
+    await t.send(
+      [
+        `Run exactly: printf '%s\\n' '${nonce}' > /workspace/parent-nonce.txt`,
+        "Call worker and tell it to read /workspace/parent-nonce.txt, verify the exact nonce,",
+        `write exactly ${proof} to /workspace/worker-proof.txt, and return exactly ${proof}.`,
+        "After worker returns, run exactly: cat /workspace/worker-proof.txt",
+        `Reply with exactly ${proof}.`,
+      ].join("\n"),
+    );
+
+    t.succeeded();
+    t.noFailedActions();
+    t.calledSubagent("worker", { output: new RegExp(proof), count: 1 });
+    t.calledTool("bash", {
+      input: { command: "cat /workspace/worker-proof.txt" },
+      output: new RegExp(proof),
+      count: 1,
+    });
+    t.messageIncludes(proof);
+  },
+});

--- a/examples/shared-sandbox/package.json
+++ b/examples/shared-sandbox/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "eve-example-shared-sandbox",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "eve build",
+    "dev": "eve dev",
+    "eval": "eve eval shared-filesystem",
+    "typecheck": "eve build && tsc"
+  },
+  "dependencies": {
+    "ai": "catalog:",
+    "eve": "workspace:*",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  },
+  "engines": {
+    "node": ">=24"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "changeset": "changeset",
     "check:deps": "syncpack lint",
     "dev": "node ./scripts/dev.mjs",
-    "docs:check": "node ./scripts/check-docs.mjs && node ./scripts/check-doc-snippets.mjs && node ./scripts/check-doc-mdx.mjs",
+    "docs:check": "node ./scripts/check-docs.mjs && node ./scripts/check-doc-snippets.mjs && node ./scripts/check-doc-examples.mjs && node ./scripts/check-doc-mdx.mjs",
     "fix:deps": "syncpack fix-mismatches && syncpack format",
     "fmt": "oxfmt",
     "guard:fixtures": "node ./scripts/guard-test-fixtures.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1226,6 +1226,25 @@ importers:
         specifier: 'catalog:'
         version: 7.0.2
 
+  examples/shared-sandbox:
+    dependencies:
+      ai:
+        specifier: 'catalog:'
+        version: 7.0.58(zod@4.4.3)
+      eve:
+        specifier: workspace:*
+        version: link:../../packages/eve
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+
   packages/eve:
     dependencies:
       '@opentelemetry/api':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - apps/*
   - apps/*/*
   - e2e/fixtures/*
+  - examples/*
   - packages/*
 
 allowBuilds:

--- a/scripts/check-doc-examples.mjs
+++ b/scripts/check-doc-examples.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * CI lint that keeps documentation snippets in sync with `/examples` source.
+ *
+ * A pattern doc that claims to show real example code rots silently when the
+ * example changes. Any fenced code block under /docs whose `title` is an
+ * `examples/...` path must match that file's exact contents, so a drifted
+ * snippet fails the build instead of shipping stale documentation.
+ */
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const docsDir = `${repoRoot}/docs`;
+
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = `${dir}/${entry}`;
+    if (statSync(full).isDirectory()) out.push(...walk(full));
+    else if (entry.endsWith(".md") || entry.endsWith(".mdx")) out.push(full);
+  }
+  return out;
+}
+
+const fenceRe = /```[^\n]*\btitle="(examples\/[^"]+)"[^\n]*\n([\s\S]*?)```/g;
+
+const failures = [];
+let snippetCount = 0;
+
+for (const abs of walk(docsDir)) {
+  const rel = relative(repoRoot, abs);
+  const source = readFileSync(abs, "utf8");
+  let block;
+  while ((block = fenceRe.exec(source)) !== null) {
+    snippetCount += 1;
+    const [, examplePath, snippet] = block;
+    const exampleAbs = `${repoRoot}/${examplePath}`;
+    if (!existsSync(exampleAbs)) {
+      failures.push(`${rel}: titled snippet points at missing file ${examplePath}`);
+      continue;
+    }
+    if (readFileSync(exampleAbs, "utf8").trim() !== snippet.trim()) {
+      failures.push(`${rel}: snippet is out of sync with ${examplePath}`);
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error("[docs:examples] failed:");
+  for (const failure of failures) console.error(`  - ${failure}`);
+  process.exit(1);
+}
+
+console.log(`[docs:examples] ok — ${snippetCount} example-titled snippets match their source.`);


### PR DESCRIPTION
## What

- add a runnable app where a parent agent and declared worker share the parent's live sandbox through `parent.sandbox`
- add an eval that proves files written by either agent are visible to the other
- add the example to the workspace typecheck
- make `docs:check` fail when a code block titled with an `examples/...` path drifts from its source file

## Sandbox flow

PR #1889 adds the runtime path: a child sandbox definition returns `parent.sandbox`, and eve restores the parent's persisted sandbox identity for the child session.

This PR adds the runnable consumer of that API. The parent creates a file, dispatches the worker, and the worker reads that file and writes a proof file back into the same `/workspace`. Agent conversations and durable state remain separate; only the sandbox is shared.

## Docs/source flow

Before: example snippets in docs could drift from runnable source without CI noticing.

After: `scripts/check-doc-examples.mjs` resolves code blocks titled with an `examples/...` path and compares them byte-for-byte with the referenced file as part of `docs:check`.

## Stack

- base: #1889
- this PR contains only the example, eval, docs navigation, and docs/source consistency check
- the native `parent.sandbox` API and runtime implementation are reviewed in #1889
