### PR TITLE
chore(release): bootstrap Buzz adapter npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -59,3 +60,5 @@ jobs:
           commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Bootstrap @eve/buzz-acp-adapter before npm trusted publishing can be configured.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_RELEASE_BOT }}

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -318,7 +318,7 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     kind: "extension",
     tagline:
       "Give your agent workspace-scoped long-term memory with recall, storage, and brain notes.",
-    surfaces: { scaffoldable: false, gallery: true },
+    surfaces: { scaffoldable: false, registry: false, gallery: true },
   },
   {
     slug: "hindsight",
@@ -725,7 +725,7 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     name: "Tinybird",
     kind: "connection",
     tagline: "Query pipes and data sources in your Tinybird Workspace.",
-    surfaces: { scaffoldable: false, gallery: true },
+    surfaces: { scaffoldable: false, registry: false, gallery: true },
     connection: {
       description:
         "Tinybird: query pipes and data sources, and run SQL. A token grants one Workspace, so add a connection per Workspace.",


### PR DESCRIPTION
### Summary

Temporarily authenticate npm publishes with `NPM_RELEASE_BOT` so Changesets can perform the initial `@eve/buzz-acp-adapter` release. Once the package exists and `release.yml` is registered as its npm trusted publisher, this token wiring should be reverted so releases return to OIDC authentication.

This also marks Arcana and Tinybird as unavailable from the registry, fixing the missing catalog fields that caused the current `main` typecheck and downstream test jobs to fail.

### Validation

- `git diff --check`
- `pnpm exec oxfmt --check .github/workflows/release.yml`
- `pnpm exec oxfmt --check packages/eve-catalog/src/index.ts`
- `pnpm --filter @eve/catalog typecheck`
- `pnpm --filter @eve/catalog test:unit` (21 tests passed)

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
