### PR TITLE
feat: route channel messages directly to remote agents

### DIFF
--- a/.changeset/smart-channel-routing.md
+++ b/.changeset/smart-channel-routing.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Allow channel message handlers to route an explicit message directly to a remote eve agent through the canonical session lifecycle without invoking the local model.

--- a/packages/eve/extension-contracts/compatibility/dynamicInstructions/v11.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicInstructions/v11.ts
@@ -1,0 +1,10 @@
+import { defineDynamic, defineInstructions } from "#public/instructions/index.js";
+
+export default defineDynamic({
+  events: {
+    "session.started": (_event, ctx) =>
+      defineInstructions({
+        markdown: `Use session ${ctx.session.id} when correlating evidence.`,
+      }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/dynamicSkill/v10.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicSkill/v10.ts
@@ -1,0 +1,11 @@
+import { defineDynamic, defineSkill } from "#public/skills/index.js";
+
+export default defineDynamic({
+  events: {
+    "turn.started": (_event, ctx) =>
+      defineSkill({
+        description: `Review evidence for session ${ctx.session.id}.`,
+        markdown: "# Evidence review\n\nCheck every claim against its source.",
+      }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/dynamicTool/v16.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicTool/v16.ts
@@ -1,0 +1,14 @@
+import { z as z3 } from "zod/v3";
+
+import { defineDynamic, defineTool } from "#public/tools/index.js";
+
+export default defineDynamic({
+  events: {
+    "session.started": (_event, ctx) =>
+      defineTool({
+        description: "Return the active session identifier.",
+        inputSchema: z3.object({ prefix: z3.string() }),
+        execute: ({ prefix }) => ({ sessionId: `${prefix}:${ctx.session.id}` }),
+      }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/hook/v12.ts
+++ b/packages/eve/extension-contracts/compatibility/hook/v12.ts
@@ -1,0 +1,13 @@
+import { defineHook } from "#public/hooks/index.js";
+
+export default defineHook({
+  events: {
+    "subagent.completed"(event, ctx) {
+      console.info("subagent completed", {
+        output: event.data.output,
+        sessionId: ctx.session.id,
+        subagentName: event.data.subagentName,
+      });
+    },
+  },
+});

--- a/packages/eve/extension-contracts/reports/dynamicInstructions/v12.json
+++ b/packages/eve/extension-contracts/reports/dynamicInstructions/v12.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicInstructions",
+  "epoch": 12,
+  "sha256": "d3a3f0e0a7e0a72f89c5de74c722df7fb176837ac13eced33c326a6c379e421b",
+  "exports": ["defineDynamic"]
+}

--- a/packages/eve/extension-contracts/reports/dynamicSkill/v11.json
+++ b/packages/eve/extension-contracts/reports/dynamicSkill/v11.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicSkill",
+  "epoch": 11,
+  "sha256": "af0f788e5b333bfd32dc7d7738994ad4aef20d34cc808d082527dc0af17221eb",
+  "exports": ["defineDynamic"]
+}

--- a/packages/eve/extension-contracts/reports/dynamicTool/v17.json
+++ b/packages/eve/extension-contracts/reports/dynamicTool/v17.json
@@ -1,0 +1,13 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicTool",
+  "epoch": 17,
+  "sha256": "78641661fda04bd8d03b545928d023968ada304009fad575b336e2b051ae571d",
+  "exports": [
+    "DynamicToolEntry",
+    "DynamicToolEvents",
+    "DynamicToolResult",
+    "DynamicToolSet",
+    "defineDynamic"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/hook/v13.json
+++ b/packages/eve/extension-contracts/reports/hook/v13.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "hook",
+  "epoch": 13,
+  "sha256": "5d34feb4ae35633b274ea9e4c5a1fb2145ccb18a2115d04b7fc95c8b6440c263",
+  "exports": ["defineHook"]
+}

--- a/packages/eve/src/channel/channel-address.test.ts
+++ b/packages/eve/src/channel/channel-address.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { createChannelAddress } from "#channel/channel-address.js";
+import { createChannelAddress, dispatchOrCreateChannelRoute } from "#channel/channel-address.js";
+import { RuntimeSessionOwnershipConflictError } from "#execution/runtime-errors.js";
 import type { Runtime } from "#channel/types.js";
 
 function createRuntime(): Runtime {
@@ -15,6 +16,42 @@ function createRuntime(): Runtime {
 }
 
 describe("createChannelAddress", () => {
+  it("retries a routed command against the winner of a creation race", async () => {
+    const runtime = createRuntime();
+    vi.mocked(runtime.dispatchContinuation)
+      .mockResolvedValueOnce({ status: "session_not_active" })
+      .mockResolvedValueOnce({ sessionId: "winner", status: "accepted" });
+    vi.mocked(runtime.createSession).mockRejectedValueOnce(
+      new RuntimeSessionOwnershipConflictError({
+        continuationToken: "slack:C1:T1",
+        ownerSessionId: "winner",
+        sessionId: "loser",
+      }),
+    );
+    const address = createChannelAddress({
+      adapter: { kind: "slack" },
+      channelName: "slack",
+      continuationToken: "C1:T1",
+      runtime,
+    });
+    const command = {
+      auth: null,
+      kind: "route-remote" as const,
+      message: "hello",
+      remote: { description: "Remote", path: "/eve/v1/session", url: "https://example.com" },
+      routeId: "remote",
+    };
+
+    const session = await dispatchOrCreateChannelRoute({
+      address,
+      command,
+      options: { auth: null },
+    });
+
+    expect(session.id).toBe("winner");
+    expect(runtime.dispatchContinuation).toHaveBeenCalledTimes(2);
+  });
+
   it("rejects channel addresses in the framework-reserved session namespace", () => {
     expect(() =>
       createChannelAddress({

--- a/packages/eve/src/channel/channel-address.ts
+++ b/packages/eve/src/channel/channel-address.ts
@@ -61,10 +61,28 @@ export interface ChannelAddress<TState = undefined> {
   resolveSession(): Promise<Session | undefined>;
 }
 
+export async function dispatchOrCreateChannelRoute<TState>(input: {
+  readonly address: ChannelAddress<TState>;
+  readonly command: Extract<SessionCommand, { readonly kind: "route-remote" }>;
+  readonly options: ChannelAddressDeliveryOptions<TState>;
+}): Promise<Session> {
+  return await (input.address as InternalChannelAddress<TState>).dispatchRoute(
+    input.command,
+    input.options,
+  );
+}
+
+interface InternalChannelAddress<TState = undefined> extends ChannelAddress<TState> {
+  dispatchRoute(
+    command: Extract<SessionCommand, { readonly kind: "route-remote" }>,
+    options: ChannelAddressDeliveryOptions<TState>,
+  ): Promise<Session>;
+}
+
 /** Factory for binding a route-local continuation token to a {@link ChannelAddress}. */
 export type ChannelAddressFn<TState = undefined> = (
   continuationToken: string,
-) => ChannelAddress<TState>;
+) => InternalChannelAddress<TState>;
 
 /** Creates one channel address backed by the runtime's continuation dispatch primitive. */
 export function createChannelAddress<TState = undefined>(input: {
@@ -74,12 +92,51 @@ export function createChannelAddress<TState = undefined>(input: {
   readonly metadata?: ChannelDeliverySource;
   readonly runtime: Runtime;
   readonly turnPolicy?: TurnPolicy;
-}): ChannelAddress<TState> {
+}): InternalChannelAddress<TState> {
   const metadata: Partial<ChannelDeliverySource> = input.metadata ?? {};
   const namespacedToken = `${input.channelName}:${input.continuationToken}`;
   if (isReservedSessionCommandToken(namespacedToken)) {
     throw new Error(`Channel address "${namespacedToken}" uses eve's reserved session namespace.`);
   }
+
+  const fixedSession = (sessionId: string): Session =>
+    createSession(sessionId, input.runtime, {
+      ...metadata,
+      turnPolicy: input.turnPolicy,
+    });
+  const mergeAdapterState = (state: TState | undefined): ChannelAdapter<any> =>
+    state === undefined
+      ? input.adapter
+      : {
+          ...input.adapter,
+          state: { ...input.adapter.state, ...(state as Record<string, unknown>) },
+        };
+  const dispatchOrCreateSession = async (args: {
+    readonly command: Extract<SessionCommand, { readonly kind: "send" | "route-remote" }>;
+    readonly createRunInput: (adapter: ChannelAdapter<any>) => RunInput;
+    readonly state?: TState;
+  }): Promise<Session> => {
+    const dispatch = async (): Promise<Session | undefined> => {
+      const result = await input.runtime.dispatchContinuation({
+        command: args.command,
+        continuationToken: namespacedToken,
+      });
+      return result.status === "accepted" ? fixedSession(result.sessionId) : undefined;
+    };
+    const existing = await dispatch();
+    if (existing !== undefined) return existing;
+    try {
+      const handle = await input.runtime.createSession(
+        args.createRunInput(mergeAdapterState(args.state)),
+      );
+      return fixedSession(handle.sessionId);
+    } catch (error) {
+      if (!isRuntimeSessionOwnershipConflictError(error)) throw error;
+      const winner = await dispatch();
+      if (winner !== undefined) return winner;
+      throw error;
+    }
+  };
 
   return {
     continuationToken: input.continuationToken,
@@ -106,65 +163,50 @@ export function createChannelAddress<TState = undefined>(input: {
       };
       const command: Extract<SessionCommand, { readonly kind: "send" }> =
         caller === undefined ? commandWithoutCaller : { ...commandWithoutCaller, caller };
-      const dispatch = async (): Promise<Session | undefined> => {
-        const result = await input.runtime.dispatchContinuation({
-          command,
-          continuationToken: namespacedToken,
-        });
-        return result.status === "accepted"
-          ? createSession(result.sessionId, input.runtime, {
-              ...metadata,
-              turnPolicy: input.turnPolicy,
-            })
-          : undefined;
-      };
-
-      const existing = await dispatch();
-      if (existing !== undefined) return existing;
-      if (payload.inputResponses && payload.inputResponses.length > 0) {
-        throw new Error(
-          "Cannot deliver inputResponses — the target session was not found via continuation token.",
-        );
-      }
-
       const state = (options as { readonly state?: TState }).state;
-      const adapter =
-        state === undefined
-          ? input.adapter
-          : {
-              ...input.adapter,
-              state: { ...input.adapter.state, ...(state as Record<string, unknown>) },
-            };
-      const runInput: RunInput = {
+      const createRunInput = (adapter: ChannelAdapter<any>): RunInput => {
+        if (payload.inputResponses && payload.inputResponses.length > 0) {
+          throw new Error(
+            "Cannot deliver inputResponses — the target session was not found via continuation token.",
+          );
+        }
+        return {
+          adapter,
+          auth: options.auth,
+          capabilities: options.mode === "task" ? undefined : { requestInput: true },
+          callback: options.callback,
+          channelName: input.channelName,
+          continuationToken: namespacedToken,
+          delivery,
+          initiatorAuth: options.initiatorAuth,
+          input: {
+            context: payload.context,
+            message: serializeUrlFilePartsInMessage(payload.message) ?? "",
+            outputSchema: payload.outputSchema,
+          },
+          mode: options.mode ?? "conversation",
+          requestId: metadata.requestId,
+          title: options.title,
+        };
+      };
+      return await dispatchOrCreateSession({ command, createRunInput, state });
+    },
+    async dispatchRoute(command, options) {
+      const state = (options as { readonly state?: TState }).state;
+      const createRunInput = (adapter: ChannelAdapter<any>): RunInput => ({
         adapter,
         auth: options.auth,
-        capabilities: options.mode === "task" ? undefined : { requestInput: true },
-        callback: options.callback,
+        capabilities: { requestInput: true },
         channelName: input.channelName,
         continuationToken: namespacedToken,
-        delivery,
+        initialRouteRemote: command,
         initiatorAuth: options.initiatorAuth,
-        input: {
-          context: payload.context,
-          message: serializeUrlFilePartsInMessage(payload.message) ?? "",
-          outputSchema: payload.outputSchema,
-        },
-        mode: options.mode ?? "conversation",
+        input: { message: command.message },
+        mode: "conversation",
         requestId: metadata.requestId,
         title: options.title,
-      };
-      try {
-        const handle = await input.runtime.createSession(runInput);
-        return createSession(handle.sessionId, input.runtime, {
-          ...metadata,
-          turnPolicy: input.turnPolicy,
-        });
-      } catch (error) {
-        if (!isRuntimeSessionOwnershipConflictError(error)) throw error;
-        const winner = await dispatch();
-        if (winner !== undefined) return winner;
-        throw error;
-      }
+      });
+      return await dispatchOrCreateSession({ command, createRunInput, state });
     },
     async send(message, options) {
       return await this.deliver({ message }, options);

--- a/packages/eve/src/channel/channel-operations.ts
+++ b/packages/eve/src/channel/channel-operations.ts
@@ -1,9 +1,15 @@
 import type { UserContent } from "ai";
+import type { RemoteAgentDefinition } from "#public/definitions/remote-agent.js";
+import {
+  channelDirectedRemoteIdentity,
+  normalizeChannelDirectedRemote,
+} from "#execution/channel-directed-remote.js";
 
 import type { ChannelAdapter } from "#channel/adapter.js";
 import type { ChannelDeliverySource } from "#channel/delivery-metadata.js";
 import {
   createChannelAddressFn,
+  dispatchOrCreateChannelRoute,
   type ChannelAddressDeliveryOptions,
 } from "#channel/channel-address.js";
 import type { SendPayload } from "#channel/routes.js";
@@ -47,10 +53,27 @@ interface BaseChannelRespondOptions {
 /** Options for answering pending input requests at an existing continuation address. */
 export type ChannelRespondOptions = BaseChannelRespondOptions;
 
+interface BaseChannelRouteOptions {
+  readonly auth: SessionAuthContext | null;
+  readonly initiatorAuth?: SessionAuthContext | null;
+  readonly title?: string;
+}
+
+/** Supported options for a channel-directed remote turn. */
+export type ChannelRouteOptions<TState = undefined> = [TState] extends [undefined]
+  ? BaseChannelRouteOptions
+  : BaseChannelRouteOptions & { readonly state: TState };
+
 /** Dynamic handle for whichever session currently owns one channel-local address. */
 export interface ChannelSource<TState = undefined> {
   /** Starts or resumes a turn with a user message. May create a session. */
   send(message: string | UserContent, options: ChannelSendOptions<TState>): Promise<Session>;
+  /** Routes an explicit message to a remote through the canonical session driver. */
+  route(
+    remote: RemoteAgentDefinition,
+    message: string,
+    options: ChannelRouteOptions<TState>,
+  ): Promise<Session>;
   /** Answers pending input requests. Never creates a session. */
   respond(
     inputResponses: readonly InputResponse[],
@@ -111,6 +134,17 @@ export function createChannelOperations<TState = undefined>(input: {
             },
             options,
           );
+        },
+        async route(remote, message, options) {
+          const normalized = await normalizeChannelDirectedRemote(remote);
+          const command = {
+            auth: options.auth,
+            kind: "route-remote" as const,
+            message,
+            remote: normalized,
+            routeId: channelDirectedRemoteIdentity(normalized),
+          };
+          return await dispatchOrCreateChannelRoute({ address: bound, command, options });
         },
         async respond(inputResponses, options) {
           if (inputResponses.length === 0) {

--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -6,6 +6,7 @@ import type { RunMode } from "#shared/run-mode.js";
 import type { RuntimeSubagentChildResult } from "#runtime/actions/types.js";
 import type { InputRequest, InputResponse } from "#runtime/input/types.js";
 import type { ChannelAdapter } from "#channel/adapter.js";
+import type { SerializableRemoteAgentConfig } from "#runtime/subagents/dynamic-remote-agent-config.js";
 import type { AgentLimitsDefinition } from "#shared/agent-definition.js";
 import type { JsonObject } from "#shared/json.js";
 
@@ -177,6 +178,13 @@ export type SessionCommand =
       readonly requestId?: string;
       readonly turnPolicy?: TurnPolicy;
     }
+  | {
+      readonly auth: SessionAuthContext | null;
+      readonly kind: "route-remote";
+      readonly message: string;
+      readonly remote: SerializableRemoteAgentConfig;
+      readonly routeId: string;
+    }
   | { readonly kind: "cancel"; readonly turnId?: string }
   | { readonly kind: "compact" }
   | { readonly kind: "clear" }
@@ -192,7 +200,7 @@ export type ResetSessionResult =
   | { readonly status: "no_active_session" };
 
 export type SessionCommandResult<TCommand extends SessionCommand = SessionCommand> =
-  TCommand extends { readonly kind: "send" }
+  TCommand extends { readonly kind: "send" | "route-remote" }
     ? SessionSendCommandResult
     : TCommand extends { readonly kind: "cancel" }
       ? CancelTurnResult
@@ -385,6 +393,8 @@ export interface SessionCapabilities {
  * subagent tool wrapper).
  */
 export interface RunInput {
+  /** Internal first command for a model-free channel-directed remote session. */
+  readonly initialRouteRemote?: Extract<SessionCommand, { readonly kind: "route-remote" }>;
   readonly adapter: ChannelAdapter<any>;
   /**
    * Registered channel name for root sessions started from an authored

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -23,14 +23,14 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
   extension: { current: 1, supported: [1], dropped: {} },
   tool: { current: 12, supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], dropped: {} },
   dynamicTool: {
-    current: 16,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+    current: 17,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17],
     dropped: {},
   },
   connection: { current: 5, supported: [1, 2, 3, 4, 5], dropped: {} },
   hook: {
-    current: 12,
-    supported: [10, 11, 12],
+    current: 13,
+    supported: [10, 11, 12, 13],
     dropped: {
       1: "Model identity moved from session.started runtime metadata to step.started call attribution.",
       2: "Model identity moved from session.started runtime metadata to step.started call attribution.",
@@ -44,11 +44,15 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     },
   },
   skill: { current: 1, supported: [1], dropped: {} },
-  dynamicSkill: { current: 10, supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dropped: {} },
-  instructions: { current: 2, supported: [1, 2], dropped: {} },
-  dynamicInstructions: {
+  dynamicSkill: {
     current: 11,
     supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+    dropped: {},
+  },
+  instructions: { current: 2, supported: [1, 2], dropped: {} },
+  dynamicInstructions: {
+    current: 12,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
     dropped: {},
   },
   config: { current: 1, supported: [1], dropped: {} },

--- a/packages/eve/src/execution/agent-continuation-bundle.ts
+++ b/packages/eve/src/execution/agent-continuation-bundle.ts
@@ -14,10 +14,14 @@ type DynamicRemoteAgentConfig = NonNullable<
 export function createAgentContinuationBundle(input: {
   readonly action: RuntimeAgentHandleAction;
   readonly bundle: CompiledBundle;
-  readonly dynamicRemoteAgent?: DynamicRemoteAgentConfig;
+  readonly remoteConfig?: DynamicRemoteAgentConfig;
 }): CompiledBundle {
-  const { action, dynamicRemoteAgent } = input;
-  if (action.kind !== "remote-agent-call" || dynamicRemoteAgent === undefined) {
+  const { action, remoteConfig } = input;
+  if (
+    action.kind !== "remote-agent-call" ||
+    action.remoteTarget?.kind === "inline" ||
+    remoteConfig === undefined
+  ) {
     return input.bundle;
   }
 
@@ -27,7 +31,7 @@ export function createAgentContinuationBundle(input: {
       nodeId === action.nodeId
         ? {
             definition: resolveRemoteAgentForAction({
-              dynamicRemoteAgent,
+              dynamicRemoteAgent: remoteConfig,
               nodeId,
               registry,
               remoteAgentName: action.remoteAgentName,

--- a/packages/eve/src/execution/agent-handle-dispatch.ts
+++ b/packages/eve/src/execution/agent-handle-dispatch.ts
@@ -22,7 +22,7 @@ import type { CompiledBundle } from "#runtime/sessions/runtime-context-keys.js";
 import {
   continueRemoteAgentSession,
   isRetryableRemoteAgentContinueError,
-  resolveRemoteAgentForAction,
+  resolveRemoteAgentTarget,
 } from "#execution/remote-agent-dispatch.js";
 import { isRuntimeNoActiveSessionError } from "#execution/runtime-errors.js";
 import type { hydrateDurableSession } from "#execution/session.js";
@@ -230,10 +230,12 @@ async function deliverToAgentHandle(input: {
   if (address.kind === "agent/remote") {
     let resolvedRemote;
     try {
-      resolvedRemote = resolveRemoteAgentForAction({
+      resolvedRemote = resolveRemoteAgentTarget({
         nodeId: identity.nodeId,
         remoteAgentName: identity.name,
         registry: bundle.subagentRegistry.subagentsByNodeId,
+        dynamicRemoteAgent: undefined,
+        target: action.kind === "remote-agent-call" ? action.remoteTarget : undefined,
       });
     } catch (error) {
       // The agent's node is gone from the compiled bundle; no retry can

--- a/packages/eve/src/execution/cancel-descendant-turns-step.test.ts
+++ b/packages/eve/src/execution/cancel-descendant-turns-step.test.ts
@@ -7,6 +7,7 @@ import {
   cancelRemoteAgentTurn,
   isRetryableRemoteAgentCancelError,
   resolveRemoteAgentForAction,
+  resolveRemoteAgentTransport,
 } from "#execution/remote-agent-dispatch.js";
 import { requestWorkflowTurnCancellation } from "#execution/workflow-runtime.js";
 import { AGENT_HANDLES_STATE_KEY, type AgentHandle } from "#harness/handles/store.js";
@@ -24,6 +25,7 @@ vi.mock("./remote-agent-dispatch.js", () => ({
   cancelRemoteAgentTurn: vi.fn(),
   isRetryableRemoteAgentCancelError: vi.fn(),
   resolveRemoteAgentForAction: vi.fn(),
+  resolveRemoteAgentTransport: vi.fn(),
 }));
 
 const LOCAL_RUNNING_HANDLE: AgentHandle = {
@@ -129,6 +131,42 @@ describe("cancelDescendantTurnsStep", () => {
       sessionId: "local-child",
     });
     expect(deserializeContext).not.toHaveBeenCalled();
+  });
+
+  it("uses a handle's inline remote config when cancelling", async () => {
+    const inlineConfig = {
+      credentialsStepId: "inline-credentials",
+      description: "Channel-directed remote.",
+      path: "/eve/v1/session",
+      url: "https://remote.example.com",
+    };
+    if (REMOTE_RUNNING_HANDLE.address.kind !== "agent/remote") throw new Error("expected remote");
+    const inlineHandle: AgentHandle = {
+      ...REMOTE_RUNNING_HANDLE,
+      address: {
+        ...REMOTE_RUNNING_HANDLE.address,
+        inline: true,
+        inlineCredentialsStepId: inlineConfig.credentialsStepId,
+      },
+    };
+    installRemoteRegistry();
+    vi.mocked(resolveRemoteAgentTransport).mockReturnValue(remote as never);
+    vi.mocked(cancelRemoteAgentTurn).mockResolvedValue({
+      sessionId: "remote-child",
+      status: "accepted",
+    });
+
+    await cancelDescendantTurnsStep({
+      serializedContext: {},
+      sessionState: createRunningState({ remoteHandle: inlineHandle }),
+    });
+
+    expect(resolveRemoteAgentTransport).toHaveBeenCalledWith({
+      credentialsStepId: inlineConfig.credentialsStepId,
+      name: REMOTE_RUNNING_HANDLE.identity.name,
+      nodeId: REMOTE_RUNNING_HANDLE.identity.nodeId,
+      url: REMOTE_RUNNING_HANDLE.address.url,
+    });
   });
 
   it("uses the selected dynamic remote config when cancelling", async () => {
@@ -302,10 +340,12 @@ function installRemoteRegistry(selection?: unknown): void {
   } as never);
 }
 
-function createRunningState(input: { readonly includeRemote?: boolean } = {}) {
+function createRunningState(
+  input: { readonly includeRemote?: boolean; readonly remoteHandle?: AgentHandle } = {},
+) {
   const includeRemote = input.includeRemote ?? true;
   const handles = includeRemote
-    ? [LOCAL_RUNNING_HANDLE, REMOTE_RUNNING_HANDLE]
+    ? [LOCAL_RUNNING_HANDLE, input.remoteHandle ?? REMOTE_RUNNING_HANDLE]
     : [LOCAL_RUNNING_HANDLE];
   return createDurableSessionState({
     session: createSession({ [AGENT_HANDLES_STATE_KEY]: { handles } }),

--- a/packages/eve/src/execution/cancel-descendant-turns-step.ts
+++ b/packages/eve/src/execution/cancel-descendant-turns-step.ts
@@ -6,6 +6,7 @@ import {
   cancelRemoteAgentTurn,
   isRetryableRemoteAgentCancelError,
   resolveRemoteAgentForAction,
+  resolveRemoteAgentTransport,
 } from "#execution/remote-agent-dispatch.js";
 import { requestWorkflowTurnCancellation } from "#execution/workflow-runtime.js";
 import { getAgentHandleStore, type AgentHandle } from "#harness/handles/store.js";
@@ -113,12 +114,20 @@ async function cancelRemoteDescendant(input: {
   try {
     const { ctx, registry } = await input.remoteContext;
     const selection = getDynamicSubagentSelection(ctx, handle.identity.nodeId);
-    const resolved = await resolveRemoteAgentForAction({
-      dynamicRemoteAgent: selection?.kind === "remote" ? selection.remoteAgent : undefined,
-      nodeId: handle.identity.nodeId,
-      remoteAgentName: handle.identity.name,
-      registry,
-    });
+    const resolved =
+      handle.address.inline === true
+        ? resolveRemoteAgentTransport({
+            credentialsStepId: handle.address.inlineCredentialsStepId,
+            name: handle.identity.name,
+            nodeId: handle.identity.nodeId,
+            url: handle.address.url,
+          })
+        : await resolveRemoteAgentForAction({
+            dynamicRemoteAgent: selection?.kind === "remote" ? selection.remoteAgent : undefined,
+            nodeId: handle.identity.nodeId,
+            remoteAgentName: handle.identity.name,
+            registry,
+          });
     // Cancel where the child actually runs: the registry URL may point at a
     // newer deployment than the one that adopted this child, so the
     // dispatch-recorded URL wins — mirroring continuation delivery.

--- a/packages/eve/src/execution/channel-directed-remote.test.ts
+++ b/packages/eve/src/execution/channel-directed-remote.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  channelDirectedRemoteIdentity,
+  normalizeChannelDirectedRemote,
+} from "#execution/channel-directed-remote.js";
+
+describe("normalizeChannelDirectedRemote", () => {
+  it("stores a credential resolver id rather than resolved credentials", async () => {
+    const resolver = Object.assign(() => ({}), { stepId: "credential-step" });
+    const definition = {
+      auth: async () => ({ headers: { authorization: "secret" } }),
+      description: "Remote.",
+      kind: "remote" as const,
+      path: "/eve/v1/session/",
+      url: "https://remote.example.com/",
+    };
+    Object.defineProperty(definition, "__eveResolveRemoteAgentCredentials", {
+      value: resolver,
+    });
+    const remote = await normalizeChannelDirectedRemote(definition);
+
+    expect(remote).toEqual({
+      credentialsStepId: "credential-step",
+      description: "Remote.",
+      path: "/eve/v1/session",
+      url: "https://remote.example.com",
+    });
+    expect(JSON.stringify(remote)).not.toContain("secret");
+    expect(channelDirectedRemoteIdentity(remote)).toBe(
+      "https://remote.example.com\n/eve/v1/session",
+    );
+  });
+
+  it("rejects unregistered credentials", async () => {
+    await expect(
+      normalizeChannelDirectedRemote({
+        auth: async () => ({ headers: { authorization: "secret" } }),
+        description: "Remote.",
+        kind: "remote",
+        path: "/eve/v1/session",
+        url: "https://remote.example.com",
+      }),
+    ).rejects.toThrow("credentials stay out of durable workflow state");
+  });
+});

--- a/packages/eve/src/execution/channel-directed-remote.ts
+++ b/packages/eve/src/execution/channel-directed-remote.ts
@@ -1,0 +1,23 @@
+import type { RemoteAgentDefinition } from "#public/definitions/remote-agent.js";
+import {
+  normalizeSerializableRemoteAgentConfig,
+  type SerializableRemoteAgentConfig,
+} from "#runtime/subagents/dynamic-remote-agent-config.js";
+
+export async function normalizeChannelDirectedRemote(
+  remote: RemoteAgentDefinition,
+): Promise<SerializableRemoteAgentConfig> {
+  const config = await normalizeSerializableRemoteAgentConfig({
+    message: "Channel routing requires a valid defineRemoteAgent(...) value.",
+    value: remote,
+  });
+  return {
+    ...config,
+    path: `/${config.path.replace(/^\/+|\/+$/gu, "")}`,
+    url: config.url.replace(/\/$/u, ""),
+  };
+}
+
+export function channelDirectedRemoteIdentity(remote: SerializableRemoteAgentConfig): string {
+  return `${remote.url}\n${remote.path}`;
+}

--- a/packages/eve/src/execution/channel-directed-turn.test.ts
+++ b/packages/eve/src/execution/channel-directed-turn.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  channelDirectedCallId,
+  prepareChannelDirectedTurn,
+} from "#execution/channel-directed-turn.js";
+import {
+  getPendingRuntimeActionBatch,
+  setPendingRuntimeActionBatch,
+} from "#harness/runtime-actions.js";
+import { settlePassThroughRuntimeActionTurn } from "#execution/pass-through-runtime-action-turn.js";
+
+function session(sequence = 0) {
+  return {
+    agent: { modelReference: { id: "mock/test" }, system: "", tools: [] },
+    compaction: { recentWindowSize: 10, threshold: 1000 },
+    continuationToken: "slack:C1:T1",
+    history: [],
+    sessionId: "session-1",
+    state: {
+      "eve.harness.emission": { sessionStarted: true, sequence, stepIndex: 0, turnId: "" },
+    },
+  };
+}
+
+const command = {
+  auth: null,
+  kind: "route-remote" as const,
+  message: "hello",
+  remote: { description: "Remote", path: "/eve/v1/session", url: "https://example.com" },
+  routeId: "https://example.com\n/eve/v1/session",
+};
+
+describe("prepareChannelDirectedTurn", () => {
+  it("uses sequence-specific call identity and does not change model history", () => {
+    const original = session(3);
+    const prepared = prepareChannelDirectedTurn({ command, session: original });
+    const batch = getPendingRuntimeActionBatch(prepared.state);
+
+    expect(prepared.history).toEqual([]);
+    expect(batch?.event).toEqual({ sequence: 3, stepIndex: 0, turnId: "turn_3" });
+    expect(batch?.actions[0]).toMatchObject({
+      callId: channelDirectedCallId(command.routeId, 3),
+      input: { message: "hello" },
+      kind: "remote-agent-call",
+    });
+  });
+
+  it("applies the configured output schema to every routed action", () => {
+    const withSchema = {
+      ...command,
+      remote: {
+        ...command.remote,
+        outputSchema: { properties: { answer: { type: "string" } }, type: "object" },
+      },
+    };
+    const prepared = prepareChannelDirectedTurn({ command: withSchema, session: session(0) });
+    expect(getPendingRuntimeActionBatch(prepared.state)?.actions[0]?.input).toMatchObject({
+      outputSchema: withSchema.remote.outputSchema,
+    });
+  });
+
+  it("rejects pass-through batches containing multiple actions", async () => {
+    const original = session(0);
+    const action = prepareChannelDirectedTurn({ command, session: original });
+    const batch = getPendingRuntimeActionBatch(action.state)!;
+    const invalid = setPendingRuntimeActionBatch({
+      actions: [batch.actions[0]!, batch.actions[0]!],
+      event: batch.event,
+      responseMessages: [],
+      session: action,
+      settlement: "pass-through",
+    });
+
+    await expect(
+      settlePassThroughRuntimeActionTurn({ emit: async () => {}, results: [], session: invalid }),
+    ).rejects.toThrow("exactly one action");
+  });
+
+  it("settles an immediate dispatch failure without changing model history", async () => {
+    const prepared = prepareChannelDirectedTurn({ command, session: session(1) });
+    const callId = channelDirectedCallId(command.routeId, 1);
+    const events: string[] = [];
+    const settled = await settlePassThroughRuntimeActionTurn({
+      emit: async (event) => {
+        events.push(event.type);
+      },
+      results: [
+        {
+          callId,
+          isError: true,
+          kind: "subagent-result",
+          origin: "dispatch",
+          output: { code: "REMOTE_AGENT_START_FAILED", message: "unavailable" },
+          subagentName: command.routeId,
+        },
+      ],
+      session: prepared,
+    });
+
+    expect(settled?.history).toEqual([]);
+    expect(getPendingRuntimeActionBatch(settled?.state)).toBeUndefined();
+    expect(events).toEqual(["action.result", "step.failed", "turn.failed", "session.waiting"]);
+  });
+});

--- a/packages/eve/src/execution/channel-directed-turn.ts
+++ b/packages/eve/src/execution/channel-directed-turn.ts
@@ -1,0 +1,63 @@
+import type { SessionCommand } from "#channel/types.js";
+import { getHarnessEmissionState, setHarnessEmissionState } from "#harness/emission.js";
+import { setPendingRuntimeActionBatch } from "#harness/runtime-actions.js";
+import type { HarnessSession } from "#harness/types.js";
+import { getAgentHandleStore } from "#harness/handles/store.js";
+import type { RuntimeRemoteAgentCallActionRequest } from "#runtime/actions/types.js";
+
+export type RouteRemoteCommand = Extract<SessionCommand, { readonly kind: "route-remote" }>;
+
+/** Seeds a model-free canonical turn with one remote runtime action. */
+export function prepareChannelDirectedTurn(input: {
+  readonly command: RouteRemoteCommand;
+  readonly session: HarnessSession;
+}): HarnessSession {
+  const emission = getHarnessEmissionState(input.session.state);
+  const turnId = `turn_${String(emission.sequence)}`;
+  const agentId = findRemoteAgentId(input.session, input.command.routeId);
+  const actionInput: {
+    agentId?: string;
+    message: string;
+    outputSchema?: typeof input.command.remote.outputSchema;
+  } = {
+    message: input.command.message,
+  };
+  if (agentId !== undefined) actionInput.agentId = agentId;
+  if (input.command.remote.outputSchema !== undefined) {
+    actionInput.outputSchema = input.command.remote.outputSchema;
+  }
+  const action: RuntimeRemoteAgentCallActionRequest = {
+    callId: channelDirectedCallId(input.command.routeId, emission.sequence),
+    remoteTarget: { config: input.command.remote, kind: "inline" },
+    sessionMode: "conversation",
+    description: input.command.remote.description,
+    input: actionInput,
+    kind: "remote-agent-call",
+    messageFormat: "verbatim",
+    name: input.command.routeId,
+    nodeId: `$channel:${input.command.routeId}`,
+    remoteAgentName: input.command.routeId,
+  };
+  return setPendingRuntimeActionBatch({
+    actions: [action],
+    event: { sequence: emission.sequence, stepIndex: 0, turnId },
+    responseMessages: [],
+    settlement: "pass-through",
+    session: setHarnessEmissionState(input.session, {
+      sessionStarted: emission.sessionStarted,
+      sequence: emission.sequence,
+      stepIndex: 0,
+      turnId,
+    }),
+  });
+}
+
+export function channelDirectedCallId(routeId: string, sequence: number): string {
+  return `route:${routeId}:${String(sequence)}`;
+}
+
+function findRemoteAgentId(session: HarnessSession, routeId: string): string | undefined {
+  return getAgentHandleStore(session.state)?.handles.find(
+    (handle) => handle.identity.name === routeId && handle.phase === "parked",
+  )?.identity.id;
+}

--- a/packages/eve/src/execution/dispatch-runtime-actions-step.integration.test.ts
+++ b/packages/eve/src/execution/dispatch-runtime-actions-step.integration.test.ts
@@ -147,6 +147,106 @@ describe("dispatchRuntimeActionsStep child starts", () => {
     parentTurnId: "turn-1",
   });
 
+  it("starts and continues an inline remote without a registry definition", async () => {
+    const inline = {
+      description: "Inline preview.",
+      outputSchema: { properties: { answer: { type: "string" } }, type: "object" },
+      path: "/eve/v1/session",
+      url: "https://inline.example.com",
+    } as const;
+    const first = setPendingRuntimeActionBatch({
+      actions: [
+        {
+          callId: "route:one",
+          description: inline.description,
+          input: { message: "first", outputSchema: inline.outputSchema },
+          kind: "remote-agent-call" as const,
+          messageFormat: "verbatim" as const,
+          name: "inline-route",
+          nodeId: "$channel:inline-route",
+          remoteAgentName: "inline-route",
+          remoteTarget: { config: inline, kind: "inline" as const },
+          sessionMode: "conversation" as const,
+        },
+      ],
+      event: { sequence: 1, stepIndex: 0, turnId: "turn_1" },
+      responseMessages: [],
+      settlement: "pass-through",
+      session: createBaseSession(),
+    });
+    installContext(first);
+
+    const started = await dispatchRuntimeActionsStep({
+      callbackBaseUrl: "https://caller.example.com",
+      parentContinuationToken: "turn-inbox",
+      parentWritable: createWritable(),
+      serializedContext: {},
+      sessionState: BASE_STATE,
+    });
+
+    expect(mocks.startRemoteAgentSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: expect.objectContaining({
+          input: { message: "first", outputSchema: inline.outputSchema },
+          messageFormat: "verbatim",
+        }),
+        persistentSessions: true,
+        remote: expect.objectContaining({ url: inline.url }),
+      }),
+    );
+    const handle = getAgentHandleStore(readResultSessionState(started, first))?.handles[0];
+    if (handle?.phase !== "running" || handle.address.kind !== "agent/remote") {
+      throw new Error("expected running remote handle");
+    }
+    const parked: AgentHandle = {
+      address: handle.address,
+      identity: handle.identity,
+      lastStatus: "first result",
+      phase: "parked",
+    };
+    const followUp = setPendingRuntimeActionBatch({
+      actions: [
+        {
+          callId: "route:two",
+          description: inline.description,
+          input: {
+            agentId: parked.identity.id,
+            message: "second",
+            outputSchema: inline.outputSchema,
+          },
+          kind: "remote-agent-call" as const,
+          messageFormat: "verbatim" as const,
+          name: "inline-route",
+          nodeId: "$channel:inline-route",
+          remoteAgentName: "inline-route",
+          remoteTarget: { config: inline, kind: "inline" as const },
+          sessionMode: "conversation" as const,
+        },
+      ],
+      event: { sequence: 2, stepIndex: 0, turnId: "turn_2" },
+      responseMessages: [],
+      settlement: "pass-through",
+      session: createBaseSession(parked),
+    });
+    installContext(followUp);
+
+    await dispatchRuntimeActionsStep({
+      parentContinuationToken: "turn-inbox-2",
+      parentWritable: createWritable(),
+      serializedContext: {},
+      sessionState: BASE_STATE,
+    });
+
+    expect(mocks.continueRemoteAgentSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "second",
+        outputSchema: inline.outputSchema,
+        remote: expect.objectContaining({ url: handle.address.url }),
+        sessionId: handle.address.sessionId,
+      }),
+    );
+  });
+
   it("owns a local child before the start effect and confirms its running address", async () => {
     const session = createStartSession({ kind: "local" });
     installContext(session, {

--- a/packages/eve/src/execution/dispatch-runtime-actions-step.ts
+++ b/packages/eve/src/execution/dispatch-runtime-actions-step.ts
@@ -51,7 +51,7 @@ import {
   readDurableSession,
 } from "#execution/durable-session-store.js";
 import {
-  resolveRemoteAgentForAction,
+  resolveRemoteAgentTarget,
   startRemoteAgentSession,
 } from "#execution/remote-agent-dispatch.js";
 import {
@@ -93,7 +93,7 @@ type DispatchPlanEntry =
       readonly kind: "resume";
       readonly action: RuntimeAgentHandleAction;
       readonly agentId: string;
-      readonly dynamicRemoteAgent?: DynamicRemoteAgentConfig;
+      readonly remoteConfig?: DynamicRemoteAgentConfig;
     }
   | { readonly kind: "reject"; readonly result: RuntimeSubagentDispatchFailure }
   | { readonly kind: "start"; readonly target: DispatchStartTarget };
@@ -108,7 +108,7 @@ type DispatchStartTarget =
   | {
       readonly kind: "remote";
       readonly action: RuntimeRemoteAgentCallActionRequest;
-      readonly dynamicRemoteAgent?: DynamicRemoteAgentConfig;
+      readonly remoteConfig?: DynamicRemoteAgentConfig;
     };
 
 export async function dispatchRuntimeActionsStep(input: {
@@ -189,7 +189,7 @@ export async function dispatchRuntimeActionsStep(input: {
             bundle: createAgentContinuationBundle({
               action: entry.action,
               bundle,
-              dynamicRemoteAgent: entry.dynamicRemoteAgent,
+              remoteConfig: entry.remoteConfig,
             }),
             currentSession: nextSession,
             parentToken: input.parentContinuationToken ?? session.continuationToken,
@@ -311,9 +311,13 @@ function planDispatch(input: {
         return {
           action,
           agentId,
-          dynamicRemoteAgent:
-            action.kind === "remote-agent-call" && dynamicSubagentSelection?.kind === "remote"
-              ? dynamicSubagentSelection.remoteAgent
+          remoteConfig:
+            action.kind === "remote-agent-call"
+              ? action.remoteTarget?.kind === "inline"
+                ? action.remoteTarget.config
+                : dynamicSubagentSelection?.kind === "remote"
+                  ? dynamicSubagentSelection.remoteAgent
+                  : undefined
               : undefined,
           kind: "resume",
         };
@@ -409,10 +413,12 @@ function classifyFreshStart(input: {
         kind: "start",
         target: {
           action,
-          dynamicRemoteAgent:
-            dynamicSubagentSelection?.kind === "remote"
-              ? dynamicSubagentSelection.remoteAgent
-              : undefined,
+          remoteConfig:
+            action.remoteTarget?.kind === "inline"
+              ? action.remoteTarget.config
+              : dynamicSubagentSelection?.kind === "remote"
+                ? dynamicSubagentSelection.remoteAgent
+                : undefined,
           kind: "remote",
         },
       };
@@ -464,11 +470,12 @@ async function startSubagent(input: {
         bundle: input.bundle,
         callbackBaseUrl: input.callbackBaseUrl,
         currentSession: input.currentSession,
-        dynamicRemoteAgent: input.target.dynamicRemoteAgent,
+        remoteConfig: input.target.remoteConfig,
         initiatorAuth: input.initiatorAuth,
         parentContinuationToken: input.parentContinuationToken,
         parentTraceContext: input.parentTraceContext,
-        persistentSessions: input.persistentSessions,
+        persistentSessions:
+          input.target.action.sessionMode === "conversation" || input.persistentSessions,
         session: input.session,
       });
     default: {
@@ -590,7 +597,7 @@ async function startRemoteSubagent(input: {
   readonly bundle: CompiledBundle;
   readonly callbackBaseUrl: string | undefined;
   readonly currentSession: RuntimeSession;
-  readonly dynamicRemoteAgent?: DynamicRemoteAgentConfig;
+  readonly remoteConfig?: DynamicRemoteAgentConfig;
   readonly initiatorAuth: Parameters<typeof startRemoteAgentSession>[0]["initiatorAuth"];
   readonly parentContinuationToken: string | undefined;
   readonly parentTraceContext: Parameters<typeof startRemoteAgentSession>[0]["parentTraceContext"];
@@ -602,17 +609,18 @@ async function startRemoteSubagent(input: {
   // Preflight resolution failures happen before ownership exists, so they
   // reject without touching the handle store.
   let callbackBaseUrl: string;
-  let resolvedRemote: ReturnType<typeof resolveRemoteAgentForAction>;
+  let resolvedRemote: ReturnType<typeof resolveRemoteAgentTarget>;
   try {
     if (input.callbackBaseUrl === undefined) {
       throw new Error("Cannot dispatch remote agent without a callback base URL.");
     }
     callbackBaseUrl = input.callbackBaseUrl;
-    resolvedRemote = resolveRemoteAgentForAction({
-      dynamicRemoteAgent: input.dynamicRemoteAgent,
+    resolvedRemote = resolveRemoteAgentTarget({
+      dynamicRemoteAgent: input.remoteConfig,
       nodeId: action.nodeId,
       remoteAgentName: action.remoteAgentName,
       registry: input.bundle.subagentRegistry.subagentsByNodeId,
+      target: action.remoteTarget,
     });
   } catch (error) {
     logError(log, "remote agent start failed", error, {
@@ -637,7 +645,11 @@ async function startRemoteSubagent(input: {
   const preparedSession = prepareAgentStart(input.currentSession, {
     identity,
     operation,
-    target: { callbackBaseUrl, kind: "agent/remote", url: resolvedRemote.url },
+    target: {
+      callbackBaseUrl,
+      kind: "agent/remote",
+      url: resolvedRemote.url,
+    },
   });
 
   try {
@@ -654,6 +666,11 @@ async function startRemoteSubagent(input: {
     });
     const address = {
       callbackBaseUrl,
+      inline: action.remoteTarget?.kind === "inline" ? true : undefined,
+      inlineCredentialsStepId:
+        action.remoteTarget?.kind === "inline"
+          ? action.remoteTarget.config.credentialsStepId
+          : undefined,
       kind: "agent/remote",
       sessionId: child.sessionId,
       url: resolvedRemote.url,

--- a/packages/eve/src/execution/durable-session-migrations/turn-workflow.ts
+++ b/packages/eve/src/execution/durable-session-migrations/turn-workflow.ts
@@ -33,6 +33,7 @@ interface RuntimeActionResultStepInput {
 
 export type TurnStepPayload =
   | Exclude<HookPayload, RuntimeActionResultHookPayload>
+  | Extract<import("#channel/types.js").SessionCommand, { readonly kind: "route-remote" }>
   | RuntimeActionResultStepInput;
 
 export interface TurnStepInput {
@@ -63,7 +64,7 @@ export interface TurnWorkflowInput {
 export interface TurnWorkflowDispatchInput {
   readonly capabilities: SessionCapabilities | undefined;
   readonly completionToken: string;
-  readonly delivery: HookPayload;
+  readonly delivery: TurnStepPayload;
   readonly mode: RunMode;
   readonly parentWritable: WritableStream<Uint8Array>;
   readonly serializedContext: Record<string, unknown>;

--- a/packages/eve/src/execution/parked-delivery-wait.test.ts
+++ b/packages/eve/src/execution/parked-delivery-wait.test.ts
@@ -104,7 +104,7 @@ const sessionState = { sessionId: "ses-parked-wait" } as DurableSessionState;
 function waitInput(inbox: SessionCommandInbox): Parameters<typeof nextTurnDelivery>[0] {
   return {
     awaitAuthorizationCallbacks: true,
-    bufferedDeliveries: [],
+    bufferedTurnWork: [],
     bufferedSessionControls: [],
     commandInbox: inbox,
     driverWritable: new WritableStream<Uint8Array>(),
@@ -171,26 +171,57 @@ describe("nextTurnDelivery", () => {
 
     const next = await nextTurnDelivery({
       ...waitInput(inbox),
-      bufferedDeliveries,
+      bufferedTurnWork: bufferedDeliveries.map((delivery) => ({
+        delivery,
+        kind: "delivery" as const,
+      })),
     });
 
     expect(next.kind).toBe("authorization");
     expect(bufferedDeliveries).toHaveLength(1);
   });
 
-  it("buffers task deliveries until the authorization callback arrives", async () => {
-    const inbox = createMockInbox([messageRead("deferred"), authorizationRead()]);
-    const bufferedDeliveries: DeliverHookPayload[] = [];
+  it("preserves delivery then route ordering while authorization defers turn work", async () => {
+    const route = {
+      auth: null,
+      kind: "route-remote" as const,
+      message: "second",
+      remote: { description: "Remote", path: "/eve/v1/session", url: "https://example.com" },
+      routeId: "remote",
+    };
+    const inbox = createMockInbox([
+      messageRead("first"),
+      { result: { done: false, value: route }, source: "session" },
+      authorizationRead(),
+    ]);
+    const bufferedTurnWork: import("#execution/turn-control-receiver.js").BufferedTurnWork[] = [];
 
     const next = await nextTurnDelivery({
       ...waitInput(inbox),
-      bufferedDeliveries,
-      deferDeliveries: true,
+      bufferedTurnWork,
+      deferTurnWork: true,
     });
 
     expect(next.kind).toBe("authorization");
-    expect(bufferedDeliveries).toMatchObject([
-      { kind: "deliver", payloads: [{ message: "deferred" }] },
+    expect(bufferedTurnWork).toEqual([
+      { kind: "delivery", delivery: expect.objectContaining({ payloads: [{ message: "first" }] }) },
+      route,
+    ]);
+  });
+
+  it("buffers task deliveries until the authorization callback arrives", async () => {
+    const inbox = createMockInbox([messageRead("deferred"), authorizationRead()]);
+    const bufferedTurnWork: import("#execution/turn-control-receiver.js").BufferedTurnWork[] = [];
+
+    const next = await nextTurnDelivery({
+      ...waitInput(inbox),
+      bufferedTurnWork,
+      deferTurnWork: true,
+    });
+
+    expect(next.kind).toBe("authorization");
+    expect(bufferedTurnWork).toMatchObject([
+      { kind: "delivery", delivery: { kind: "deliver", payloads: [{ message: "deferred" }] } },
     ]);
   });
 

--- a/packages/eve/src/execution/parked-delivery-wait.ts
+++ b/packages/eve/src/execution/parked-delivery-wait.ts
@@ -1,11 +1,15 @@
-import type { DeliverHookPayload, DeliverPayload } from "#channel/types.js";
+import type { DeliverHookPayload, DeliverPayload, SessionCommand } from "#channel/types.js";
+import type { BufferedTurnWork } from "#execution/turn-control-receiver.js";
 import type { DurableSessionState } from "#execution/durable-session-store.js";
 import { routeDeliverToChildren } from "#execution/route-child-delivery.js";
 import type { SessionCommandInbox } from "#execution/session-command-inbox.js";
 import { sendCommandToDelivery } from "#execution/session-command-wire.js";
-import { coalesceDeliveries } from "#harness/messages.js";
 
 type NextSessionAction =
+  | {
+      readonly command: Extract<SessionCommand, { readonly kind: "route-remote" }>;
+      readonly kind: "route-remote";
+    }
   | { readonly kind: "clear" }
   | { readonly kind: "compact" }
   | { readonly kind: "expired" }
@@ -27,6 +31,11 @@ export interface AuthorizationCallbackInstruction {
 
 /** What the parked driver should do with the next session activity. */
 export type NextTurnInstruction =
+  | {
+      readonly command: Extract<SessionCommand, { readonly kind: "route-remote" }>;
+      readonly kind: "route-remote";
+      readonly sessionState: DurableSessionState;
+    }
   | { readonly kind: "clear"; readonly sessionState: DurableSessionState }
   | { readonly kind: "compact"; readonly sessionState: DurableSessionState }
   | { readonly kind: "expired"; readonly sessionState: DurableSessionState }
@@ -56,10 +65,10 @@ export type NextTurnInstruction =
  */
 export async function nextTurnDelivery(input: {
   readonly awaitAuthorizationCallbacks?: boolean;
-  readonly bufferedDeliveries: DeliverHookPayload[];
+  readonly bufferedTurnWork: BufferedTurnWork[];
   readonly bufferedSessionControls: Array<"clear" | "compact" | "expired" | "reset">;
   readonly commandInbox: SessionCommandInbox;
-  readonly deferDeliveries?: boolean;
+  readonly deferTurnWork?: boolean;
   readonly driverWritable: WritableStream<Uint8Array>;
   readonly sessionState: DurableSessionState;
 }): Promise<NextTurnInstruction> {
@@ -76,10 +85,10 @@ export async function nextTurnDelivery(input: {
 }
 
 async function awaitNextTurnDelivery(input: {
-  readonly bufferedDeliveries: DeliverHookPayload[];
+  readonly bufferedTurnWork: BufferedTurnWork[];
   readonly bufferedSessionControls: Array<"clear" | "compact" | "expired" | "reset">;
   readonly commandInbox: SessionCommandInbox;
-  readonly deferDeliveries?: boolean;
+  readonly deferTurnWork?: boolean;
   readonly driverWritable: WritableStream<Uint8Array>;
   readonly sessionState: DurableSessionState;
 }): Promise<NextTurnInstruction> {
@@ -87,14 +96,18 @@ async function awaitNextTurnDelivery(input: {
 
   while (true) {
     const nextAction = await waitForNextSessionAction({
-      bufferedDeliveries: input.bufferedDeliveries,
+      bufferedTurnWork: input.bufferedTurnWork,
       bufferedSessionControls: input.bufferedSessionControls,
       commandInbox: input.commandInbox,
-      deferDeliveries: input.deferDeliveries,
+      deferTurnWork: input.deferTurnWork,
     });
 
     if (nextAction.kind === "authorization") {
       return { ...nextAction, sessionState };
+    }
+
+    if (nextAction.kind === "route-remote") {
+      return { command: nextAction.command, kind: "route-remote", sessionState };
     }
 
     if (nextAction.kind !== "delivery") {
@@ -127,25 +140,27 @@ async function awaitNextTurnDelivery(input: {
 }
 
 async function waitForNextSessionAction(input: {
-  readonly bufferedDeliveries: DeliverHookPayload[];
+  readonly bufferedTurnWork: BufferedTurnWork[];
   readonly bufferedSessionControls: Array<"clear" | "compact" | "expired" | "reset">;
   readonly commandInbox: SessionCommandInbox;
-  readonly deferDeliveries?: boolean;
+  readonly deferTurnWork?: boolean;
 }): Promise<NextSessionAction> {
   const pendingSessionControl = input.bufferedSessionControls.shift();
   if (pendingSessionControl !== undefined) {
     return { kind: pendingSessionControl };
   }
-
   if (
-    input.deferDeliveries !== true &&
+    input.deferTurnWork !== true &&
     !input.commandInbox.hasReadyAuthorization() &&
-    input.bufferedDeliveries.length > 0
+    input.bufferedTurnWork.length > 0
   ) {
-    return {
-      delivery: takeBufferedTurnDelivery(input.bufferedDeliveries),
-      kind: "delivery",
-    };
+    const work = input.bufferedTurnWork.shift();
+    if (work?.kind === "route-remote") {
+      return { command: work, kind: "route-remote" };
+    }
+    if (work?.kind === "delivery") {
+      return { delivery: work.delivery, kind: "delivery" };
+    }
   }
 
   while (true) {
@@ -171,6 +186,14 @@ async function waitForNextSessionAction(input: {
       return { kind: "expired" };
     }
 
+    if (first.value.kind === "route-remote") {
+      if (input.deferTurnWork === true) {
+        input.bufferedTurnWork.push(first.value);
+        continue;
+      }
+      return { command: first.value, kind: "route-remote" };
+    }
+
     if (
       first.value.kind === "clear" ||
       first.value.kind === "compact" ||
@@ -190,43 +213,18 @@ async function waitForNextSessionAction(input: {
     }
 
     if (first.value.kind === "deliver") {
-      if (input.deferDeliveries === true) {
-        input.bufferedDeliveries.push(first.value);
+      if (input.deferTurnWork === true) {
+        input.bufferedTurnWork.push({ delivery: first.value, kind: "delivery" });
         continue;
       }
       return { delivery: first.value, kind: "delivery" };
     }
 
     const delivery = sendCommandToDelivery(first.value);
-    if (input.deferDeliveries === true) {
-      input.bufferedDeliveries.push(delivery);
+    if (input.deferTurnWork === true) {
+      input.bufferedTurnWork.push({ delivery, kind: "delivery" });
       continue;
     }
     return { delivery, kind: "delivery" };
   }
-}
-
-function takeBufferedTurnDelivery(bufferedDeliveries: DeliverHookPayload[]): DeliverHookPayload {
-  const first = bufferedDeliveries.shift();
-  if (first === undefined) {
-    throw new Error("Cannot take a turn delivery from an empty buffer.");
-  }
-
-  const turnDeliveries = [first];
-  let caller = first.caller;
-  while (bufferedDeliveries.length > 0) {
-    const next = bufferedDeliveries[0];
-    if (next === undefined || (caller !== undefined && next.caller !== undefined)) {
-      break;
-    }
-
-    const delivery = bufferedDeliveries.shift();
-    if (delivery === undefined) {
-      throw new Error("Buffered turn delivery disappeared while partitioning.");
-    }
-    turnDeliveries.push(delivery);
-    caller ??= delivery.caller;
-  }
-
-  return coalesceDeliveries(turnDeliveries);
 }

--- a/packages/eve/src/execution/pass-through-runtime-action-turn.ts
+++ b/packages/eve/src/execution/pass-through-runtime-action-turn.ts
@@ -1,0 +1,58 @@
+import {
+  getPendingRuntimeActionBatch,
+  settleReadyRuntimeActions,
+} from "#harness/runtime-actions.js";
+import {
+  emitRecoverableFailedTurn,
+  emitTurnEpilogue,
+  getHarnessEmissionState,
+  setHarnessEmissionState,
+} from "#harness/emission.js";
+import type { HarnessEmitFn, HarnessSession } from "#harness/types.js";
+import { createMessageCompletedEvent } from "#protocol/message.js";
+import type { RuntimeActionResult } from "#runtime/actions/types.js";
+
+export async function settlePassThroughRuntimeActionTurn(input: {
+  readonly emit: HarnessEmitFn;
+  readonly results: readonly RuntimeActionResult[];
+  readonly session: HarnessSession;
+}): Promise<HarnessSession | undefined> {
+  const batch = getPendingRuntimeActionBatch(input.session.state);
+  if (batch?.settlement !== "pass-through") return undefined;
+  if (batch.actions.length !== 1) {
+    throw new Error("Pass-through runtime-action turns require exactly one action.");
+  }
+  const settled = await settleReadyRuntimeActions(input);
+  if (settled === undefined || settled.results.length !== 1) {
+    throw new Error("Pass-through runtime action returned no bound result.");
+  }
+  const result = settled.results[0]!;
+  const session = settled.session;
+  const emission = getHarnessEmissionState(session.state);
+  if (result.isError === true) {
+    return setHarnessEmissionState(
+      session,
+      await emitRecoverableFailedTurn(input.emit, emission, {
+        code: "REMOTE_AGENT_FAILED",
+        continuationToken: session.continuationToken,
+        message: stringify(result.output),
+      }),
+    );
+  }
+  await input.emit(
+    createMessageCompletedEvent({
+      message: stringify(result.output),
+      sequence: emission.sequence,
+      stepIndex: emission.stepIndex,
+      turnId: emission.turnId,
+    }),
+  );
+  return setHarnessEmissionState(
+    session,
+    await emitTurnEpilogue(input.emit, emission, "conversation"),
+  );
+}
+
+function stringify(value: unknown): string {
+  return typeof value === "string" ? value : (JSON.stringify(value) ?? "");
+}

--- a/packages/eve/src/execution/remote-agent-dispatch.test.ts
+++ b/packages/eve/src/execution/remote-agent-dispatch.test.ts
@@ -150,6 +150,37 @@ describe("startRemoteAgentSession", () => {
     });
   });
 
+  it("sends channel-directed first messages verbatim", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        Response.json(
+          { ok: true, sessionId: "remote-session", status: "accepted" },
+          { status: 202 },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const action = createAction();
+
+    await startRemoteAgentSession({
+      action: { ...action, messageFormat: "verbatim" },
+      callbackBaseUrl: "https://caller.example.com",
+      persistentSessions: true,
+      remote: createRemoteAgent(),
+      session: {
+        agent: { modelReference: { id: "mock/test" }, system: "", tools: [] },
+        compaction: { recentWindowSize: 10, threshold: 100000 },
+        continuationToken: "eve:parent-token",
+        history: [],
+        sessionId: "parent-session",
+      },
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string);
+    expect(body.message).toBe("find the marker");
+    expect(body.mode).toBe("conversation");
+  });
+
   it("rejects the former create-session response shape", async () => {
     const fetchMock = vi
       .fn()

--- a/packages/eve/src/execution/remote-agent-dispatch.ts
+++ b/packages/eve/src/execution/remote-agent-dispatch.ts
@@ -1,6 +1,7 @@
 import { z } from "#compiled/zod/index.js";
 import { CancelTurnResponseSchema } from "#protocol/cancel-turn.js";
 import { AgentHandleError } from "#protocol/agent-handle-error.js";
+import { EVE_SESSION_ROUTE_PATH } from "#protocol/routes.js";
 import {
   createEveCallbackRoutePath,
   createEveSessionCancelRoutePath,
@@ -29,9 +30,9 @@ const CreateSessionResponseSchema = z.object({
   status: z.literal("accepted"),
 });
 
-type RemoteAgentSessionCoordinates = {
+interface RemoteAgentSessionCoordinates {
   readonly sessionId: string;
-};
+}
 
 class RemoteAgentCancelRequestError extends Error {
   readonly retryable: boolean;
@@ -93,11 +94,14 @@ export async function startRemoteAgentSession(input: {
         createEveCallbackRoutePath(callbackToken),
       ),
     },
-    message: formatRemoteAgentCallInputMessage({
-      action: input.action,
-      persistentSession: input.persistentSessions,
-      remote: input.remote,
-    }),
+    message:
+      input.action.messageFormat === "verbatim"
+        ? readRemoteAgentMessage(input.action)
+        : formatRemoteAgentCallInputMessage({
+            action: input.action,
+            persistentSession: input.persistentSessions,
+            remote: input.remote,
+          }),
     mode: input.persistentSessions === true ? "conversation" : "task",
     outputSchema:
       normalizeRequestedOutputSchema(input.action.input.outputSchema) ?? input.remote.outputSchema,
@@ -298,6 +302,59 @@ export function isRetryableRemoteAgentCancelError(error: unknown): boolean {
   return !(error instanceof RemoteAgentCancelRequestError) || error.retryable;
 }
 
+export function resolveRemoteAgentTarget(input: {
+  readonly dynamicRemoteAgent?: DynamicRemoteAgentConfig;
+  readonly nodeId: string;
+  readonly registry: RuntimeSubagentRegistry["subagentsByNodeId"];
+  readonly remoteAgentName: string;
+  readonly target: RuntimeRemoteAgentCallActionRequest["remoteTarget"];
+}): ResolvedRuntimeRemoteAgentNode {
+  if (input.target?.kind === "inline") {
+    return resolveInlineRemoteAgent({
+      config: input.target.config,
+      name: input.remoteAgentName,
+      nodeId: input.nodeId,
+    });
+  }
+  return resolveRemoteAgentForAction(input);
+}
+
+export function resolveRemoteAgentTransport(input: {
+  readonly credentialsStepId?: string;
+  readonly name: string;
+  readonly nodeId: string;
+  readonly url: string;
+}): ResolvedRuntimeRemoteAgentNode {
+  return resolveInlineRemoteAgent({
+    config: {
+      credentialsStepId: input.credentialsStepId,
+      description: "Remote agent transport.",
+      path: EVE_SESSION_ROUTE_PATH,
+      url: input.url,
+    },
+    name: input.name,
+    nodeId: input.nodeId,
+  });
+}
+
+function resolveInlineRemoteAgent(input: {
+  readonly config: DynamicRemoteAgentConfig;
+  readonly name: string;
+  readonly nodeId: string;
+}): ResolvedRuntimeRemoteAgentNode {
+  const credentials = resolveDynamicRemoteAgentCredentials(input.config);
+  return {
+    ...input.config,
+    ...credentials,
+    kind: "remote",
+    logicalPath: "framework://inline-remote-agent",
+    name: input.name,
+    nodeId: input.nodeId,
+    sourceId: "eve:inline-remote-agent",
+    sourceKind: "module",
+  };
+}
+
 export function resolveRemoteAgentForAction(input: {
   readonly dynamicRemoteAgent?: DynamicRemoteAgentConfig;
   readonly nodeId: string;
@@ -448,12 +505,16 @@ async function resolveRemoteAgentRequestHeaders(
   return headers;
 }
 
+function readRemoteAgentMessage(action: RuntimeRemoteAgentCallActionRequest): string {
+  return typeof action.input.message === "string" ? action.input.message : "";
+}
+
 function formatRemoteAgentCallInputMessage(input: {
   readonly action: RuntimeRemoteAgentCallActionRequest;
   readonly persistentSession?: boolean;
   readonly remote: ResolvedRuntimeRemoteAgentNode;
 }): string {
-  const message = typeof input.action.input.message === "string" ? input.action.input.message : "";
+  const message = readRemoteAgentMessage(input.action);
   return formatSubagentInput({
     description: input.remote.description,
     message,

--- a/packages/eve/src/execution/remote-agent-target.test.ts
+++ b/packages/eve/src/execution/remote-agent-target.test.ts
@@ -1,0 +1,26 @@
+import { expect, it } from "vitest";
+
+import { resolveRemoteAgentTarget } from "#execution/remote-agent-dispatch.js";
+
+it("resolves an inline remote without a registry node", () => {
+  const resolved = resolveRemoteAgentTarget({
+    nodeId: "$channel:preview",
+    registry: new Map(),
+    remoteAgentName: "preview",
+    target: {
+      config: {
+        description: "Preview",
+        path: "/eve/v1/session",
+        url: "https://preview.example.com",
+      },
+      kind: "inline",
+    },
+  });
+
+  expect(resolved).toMatchObject({
+    kind: "remote",
+    name: "preview",
+    nodeId: "$channel:preview",
+    url: "https://preview.example.com",
+  });
+});

--- a/packages/eve/src/execution/turn-control-receiver.test.ts
+++ b/packages/eve/src/execution/turn-control-receiver.test.ts
@@ -146,20 +146,50 @@ describe("TurnControlReceiver", () => {
     expect(bufferedSessionControls).toEqual(["clear", "compact", "expired"]);
   });
 
+  it("preserves FIFO ordering between sends and routed work during a turn", async () => {
+    installControlHook([parkResult()], true);
+    const bufferedTurnWork: import("#execution/turn-control-receiver.js").BufferedTurnWork[] = [];
+    const route = {
+      auth: null,
+      kind: "route-remote" as const,
+      message: "second",
+      remote: { description: "Remote", path: "/eve/v1/session", url: "https://example.com" },
+      routeId: "remote",
+    };
+
+    await runReceiver([], {
+      bufferedTurnWork,
+      commandInbox: createCommandInbox([{ kind: "send", payload: { message: "first" } }, route]),
+    });
+
+    expect(bufferedTurnWork).toEqual([
+      expect.objectContaining({
+        kind: "delivery",
+        delivery: expect.objectContaining({ payloads: [{ message: "first" }] }),
+      }),
+      route,
+    ]);
+  });
+
   it("buffers a steering message before cancelling the active turn", async () => {
     installControlHook([parkResult()], true);
     const bufferedDeliveries: DeliverHookPayload[] = [];
+    const bufferedTurnWork: import("#execution/turn-control-receiver.js").BufferedTurnWork[] = [];
     vi.mocked(forwardTurnCancellationStep).mockImplementation(async () => {
-      expect(bufferedDeliveries).toEqual([
-        expect.objectContaining({
-          payloads: [{ message: "replace this turn" }],
-          turnPolicy: "steer",
-        }),
+      expect(bufferedTurnWork).toEqual([
+        {
+          kind: "delivery",
+          delivery: expect.objectContaining({
+            payloads: [{ message: "replace this turn" }],
+            turnPolicy: "steer",
+          }),
+        },
       ]);
       return true;
     });
 
     await runReceiver(bufferedDeliveries, {
+      bufferedTurnWork,
       commandInbox: createCommandInbox([
         {
           kind: "send",
@@ -220,17 +250,28 @@ describe("TurnControlReceiver", () => {
 function runReceiver(
   bufferedDeliveries: DeliverHookPayload[],
   options: {
+    readonly bufferedTurnWork?: import("#execution/turn-control-receiver.js").BufferedTurnWork[];
     readonly bufferedSessionControls?: Array<"clear" | "compact" | "expired" | "reset">;
     readonly commandInbox?: SessionCommandInbox;
   } = {},
 ): ReturnType<TurnControlReceiver["waitForAction"]> {
+  const bufferedTurnWork =
+    options.bufferedTurnWork ??
+    bufferedDeliveries.map((delivery) => ({ delivery, kind: "delivery" as const }));
   const receiver = new TurnControlReceiver({
-    bufferedDeliveries,
+    bufferedTurnWork,
     bufferedSessionControls: options.bufferedSessionControls ?? [],
     commandInbox: options.commandInbox ?? createCommandInbox(),
     token: "turn-control",
   });
-  return receiver.waitForAction().finally(() => receiver.dispose());
+  return receiver.waitForAction().finally(async () => {
+    bufferedDeliveries.splice(
+      0,
+      bufferedDeliveries.length,
+      ...bufferedTurnWork.flatMap((work) => (work.kind === "delivery" ? [work.delivery] : [])),
+    );
+    await receiver.dispose();
+  });
 }
 
 function deliveryRequest(requestId: string): TurnControlPayload {

--- a/packages/eve/src/execution/turn-control-receiver.ts
+++ b/packages/eve/src/execution/turn-control-receiver.ts
@@ -1,6 +1,10 @@
 import { createHook, type Hook } from "#compiled/@workflow/core/index.js";
 
-import type { DeliverHookPayload } from "#channel/types.js";
+import type { DeliverHookPayload, SessionCommand } from "#channel/types.js";
+
+export type BufferedTurnWork =
+  | { readonly delivery: DeliverHookPayload; readonly kind: "delivery" }
+  | Extract<SessionCommand, { readonly kind: "route-remote" }>;
 import { forwardTurnCancellationStep } from "#execution/forward-turn-cancellation-step.js";
 import type { TurnControlPayload } from "#execution/turn-control-protocol.js";
 import { forwardTurnDeliveryStep } from "#execution/forward-turn-delivery-step.js";
@@ -17,22 +21,22 @@ export type TurnDriverAction = NextDriverAction;
 
 /** Owns one turn's driver-side control hook and public-delivery relay state. */
 export class TurnControlReceiver {
-  private readonly bufferedDeliveries: DeliverHookPayload[];
   private readonly bufferedSessionControls: Array<"clear" | "compact" | "expired" | "reset">;
+  private readonly bufferedTurnWork: BufferedTurnWork[];
   private readonly commandInbox: SessionCommandInbox;
   private readonly control: Hook<TurnControlPayload>;
   private readonly controlIterator: AsyncIterator<TurnControlPayload>;
   private pendingControl: Promise<IteratorResult<TurnControlPayload>> | null = null;
 
   constructor(input: {
-    readonly bufferedDeliveries: DeliverHookPayload[];
+    readonly bufferedTurnWork: BufferedTurnWork[];
     readonly bufferedSessionControls: Array<"clear" | "compact" | "expired" | "reset">;
     readonly commandInbox: SessionCommandInbox;
     readonly token: string;
   }) {
-    this.bufferedDeliveries = input.bufferedDeliveries;
     this.bufferedSessionControls = input.bufferedSessionControls;
     this.commandInbox = input.commandInbox;
+    this.bufferedTurnWork = input.bufferedTurnWork;
     this.control = createHook<TurnControlPayload>({ token: input.token });
     this.controlIterator = this.control[Symbol.asyncIterator]();
   }
@@ -88,6 +92,10 @@ export class TurnControlReceiver {
       this.bufferedSessionControls.push("expired");
       return undefined;
     }
+    if (command.kind === "route-remote") {
+      this.bufferedTurnWork.push(command);
+      return undefined;
+    }
     if (command.kind === "runtime-action-result") {
       return undefined;
     }
@@ -110,7 +118,7 @@ export class TurnControlReceiver {
   }
 
   private async bufferDelivery(delivery: DeliverHookPayload): Promise<void> {
-    this.bufferedDeliveries.push(delivery);
+    this.bufferedTurnWork.push({ delivery, kind: "delivery" });
     if (delivery.turnPolicy !== "steer" || !deliveryHasMessage(delivery)) return;
 
     await forwardTurnCancellationStep({
@@ -123,7 +131,9 @@ export class TurnControlReceiver {
     payload: Extract<TurnControlPayload, { readonly kind: "turn-result" }>,
   ): void {
     if (payload.bufferedDeliveries !== undefined) {
-      this.bufferedDeliveries.unshift(...payload.bufferedDeliveries);
+      this.bufferedTurnWork.unshift(
+        ...payload.bufferedDeliveries.map((delivery) => ({ delivery, kind: "delivery" as const })),
+      );
     }
   }
 
@@ -246,9 +256,13 @@ export class TurnControlReceiver {
   }
 
   private takeInputResponseDelivery(): DeliverHookPayload | undefined {
-    const index = this.bufferedDeliveries.findIndex((delivery) => !deliveryHasMessage(delivery));
+    const index = this.bufferedTurnWork.findIndex(
+      (work) => work.kind === "delivery" && !deliveryHasMessage(work.delivery),
+    );
     if (index === -1) return undefined;
-    return this.bufferedDeliveries.splice(index, 1)[0];
+    const work = this.bufferedTurnWork.splice(index, 1)[0];
+    if (work?.kind !== "delivery") return undefined;
+    return work.delivery;
   }
 
   /**
@@ -266,7 +280,7 @@ export class TurnControlReceiver {
       if (winner.kind === "command") {
         const terminal = await this.handleSessionCommand(winner.command);
         if (terminal !== undefined) {
-          this.bufferedDeliveries.unshift(outstanding);
+          this.rebufferDelivery(outstanding);
           return terminal;
         }
         continue;
@@ -279,17 +293,20 @@ export class TurnControlReceiver {
       }
 
       if (payload.kind === "turn-delivery-cancelled" && payload.requestId === requestId) {
-        this.bufferedDeliveries.unshift(outstanding);
+        this.rebufferDelivery(outstanding);
         return undefined;
       }
 
       if (payload.kind === "turn-result") {
-        this.bufferedDeliveries.unshift(outstanding);
+        this.rebufferDelivery(outstanding);
       }
 
       const terminal = this.readTerminalControl(payload);
       if (terminal !== undefined) return terminal;
     }
+  }
+  private rebufferDelivery(delivery: DeliverHookPayload): void {
+    this.bufferedTurnWork.unshift({ delivery, kind: "delivery" });
   }
 }
 

--- a/packages/eve/src/execution/turn-dispatch.test.ts
+++ b/packages/eve/src/execution/turn-dispatch.test.ts
@@ -40,7 +40,7 @@ describe("dispatchAndAwaitTurn", () => {
     const commandInbox = createCommandInbox({ rekeyContinuation: rekeyHook });
 
     await dispatchAndAwaitTurn({
-      bufferedDeliveries: [],
+      bufferedTurnWork: [],
       bufferedSessionControls: [],
       commandInbox,
       controlToken: "turn-control",
@@ -74,7 +74,7 @@ describe("dispatchAndAwaitTurn", () => {
     const commandInbox = createCommandInbox({ rekeyContinuation: rekeyHook });
 
     await dispatchAndAwaitTurn({
-      bufferedDeliveries: [],
+      bufferedTurnWork: [],
       bufferedSessionControls: [],
       commandInbox,
       controlToken: "turn-control",
@@ -129,9 +129,9 @@ describe("dispatchAndAwaitTurn", () => {
       }),
     );
 
-    const bufferedDeliveries: DeliverHookPayload[] = [];
+    const bufferedTurnWork: import("#execution/turn-control-receiver.js").BufferedTurnWork[] = [];
     await dispatchAndAwaitTurn({
-      bufferedDeliveries,
+      bufferedTurnWork,
       bufferedSessionControls: [],
       commandInbox: createCommandInbox({
         next: async () => ({
@@ -150,11 +150,17 @@ describe("dispatchAndAwaitTurn", () => {
       sessionState: state,
     });
 
-    expect(bufferedDeliveries).toEqual([
-      { kind: "deliver", payloads: [{ message: "earlier remainder" }] },
-      expect.objectContaining({
-        payloads: [{ inputResponses: [{ optionId: "yes", requestId: "input-1" }] }],
-      }),
+    expect(bufferedTurnWork).toEqual([
+      {
+        delivery: { kind: "deliver", payloads: [{ message: "earlier remainder" }] },
+        kind: "delivery",
+      },
+      {
+        delivery: expect.objectContaining({
+          payloads: [{ inputResponses: [{ optionId: "yes", requestId: "input-1" }] }],
+        }),
+        kind: "delivery",
+      },
     ]);
   });
 
@@ -180,9 +186,11 @@ describe("dispatchAndAwaitTurn", () => {
       },
     ]);
 
-    const bufferedDeliveries: DeliverHookPayload[] = [delivery];
+    const bufferedTurnWork: import("#execution/turn-control-receiver.js").BufferedTurnWork[] = [
+      { delivery, kind: "delivery" },
+    ];
     const turn = await dispatchAndAwaitTurn({
-      bufferedDeliveries,
+      bufferedTurnWork,
       bufferedSessionControls: [],
       commandInbox: createCommandInbox(),
       controlToken: "turn-control",
@@ -195,7 +203,7 @@ describe("dispatchAndAwaitTurn", () => {
 
     expect(forwardTurnDeliveryStep).toHaveBeenCalledOnce();
     expect(turn.action.kind).toBe("park");
-    expect(bufferedDeliveries).toEqual([delivery]);
+    expect(bufferedTurnWork).toEqual([{ delivery, kind: "delivery" }]);
   });
 
   it("defers control-hook disposal until the caller invokes dispose()", async () => {
@@ -208,7 +216,7 @@ describe("dispatchAndAwaitTurn", () => {
     ]);
 
     const turn = await dispatchAndAwaitTurn({
-      bufferedDeliveries: [],
+      bufferedTurnWork: [],
       bufferedSessionControls: [],
       commandInbox: createCommandInbox(),
       controlToken: "turn-control",

--- a/packages/eve/src/execution/turn-dispatch.ts
+++ b/packages/eve/src/execution/turn-dispatch.ts
@@ -1,4 +1,6 @@
-import type { DeliverHookPayload, HookPayload, SessionCapabilities } from "#channel/types.js";
+import type { SessionCapabilities } from "#channel/types.js";
+import type { TurnStepPayload } from "#execution/durable-session-migrations/turn-workflow.js";
+import type { BufferedTurnWork } from "#execution/turn-control-receiver.js";
 import { dispatchTurnStep } from "#execution/dispatch-turn-step.js";
 import { TurnControlReceiver } from "#execution/turn-control-receiver.js";
 import type { DurableSessionState } from "#execution/durable-session-store.js";
@@ -22,11 +24,11 @@ export interface DispatchedTurn {
 
 /** Dispatches one turn and services its private-inbox control protocol until it terminates. */
 export async function dispatchAndAwaitTurn(input: {
-  readonly bufferedDeliveries: DeliverHookPayload[];
+  readonly bufferedTurnWork: BufferedTurnWork[];
   readonly bufferedSessionControls: Array<"clear" | "compact" | "expired" | "reset">;
   readonly capabilities?: SessionCapabilities;
   readonly controlToken: string;
-  readonly delivery: HookPayload;
+  readonly delivery: TurnStepPayload;
   readonly commandInbox: SessionCommandInbox;
   readonly mode: RunMode;
   readonly parentWritable: WritableStream<Uint8Array>;
@@ -34,7 +36,7 @@ export async function dispatchAndAwaitTurn(input: {
   readonly sessionState: DurableSessionState;
 }): Promise<DispatchedTurn> {
   const control = new TurnControlReceiver({
-    bufferedDeliveries: input.bufferedDeliveries,
+    bufferedTurnWork: input.bufferedTurnWork,
     bufferedSessionControls: input.bufferedSessionControls,
     commandInbox: input.commandInbox,
     token: input.controlToken,

--- a/packages/eve/src/execution/workflow-entry.test.ts
+++ b/packages/eve/src/execution/workflow-entry.test.ts
@@ -145,6 +145,32 @@ describe("workflowEntry", () => {
     vi.unstubAllEnvs();
   });
 
+  it("runs an initial route-remote command without dispatching a model turn", async () => {
+    const sessionState = createBaseSessionState();
+    vi.mocked(createSessionStep).mockResolvedValue(createSessionStepResultForMock(sessionState));
+    installHookMocks({
+      deliveryHooks: [{ getConflict: vi.fn(async () => null), token: "http:test" }],
+      turnControls: [],
+    });
+    const command = {
+      auth: null,
+      kind: "route-remote" as const,
+      message: "direct",
+      remote: { description: "Remote", path: "/eve/v1/session", url: "https://example.com" },
+      routeId: "remote",
+    };
+
+    const pending = workflowEntry({
+      initialRouteRemote: command,
+      input: { message: "" },
+      serializedContext: createSerializedContext(),
+    }).catch(() => undefined);
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    expect(dispatchTurnStep).toHaveBeenCalledWith(expect.objectContaining({ delivery: command }));
+    await pending;
+  });
+
   it("injects the workflow run id as the canonical session id before the first turn", async () => {
     const sessionState = createBaseSessionState();
     const getConflict = vi.fn(async () => null);

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -1,7 +1,6 @@
 import { getWorkflowMetadata, getWritable } from "#compiled/@workflow/core/index.js";
 
 import type {
-  DeliverHookPayload,
   DeliverPayload,
   HookPayload,
   RunInput,
@@ -11,6 +10,7 @@ import type {
 import { readChannelRequestId, readRootSessionId } from "#execution/eve-workflow-attributes.js";
 import type { RunMode } from "#shared/run-mode.js";
 import type { DurableCompiledArtifactsSource } from "#runtime/durable-compiled-artifacts-source.js";
+import type { TurnStepPayload } from "#execution/durable-session-migrations/turn-workflow.js";
 import {
   notifyDelegatedParentStep,
   notifyTurnCallerStep,
@@ -37,6 +37,7 @@ import { DEFAULT_SESSION_TIMEOUT_MS } from "#execution/session-timeout.js";
 import { emitTerminalSessionCompletionStep } from "#execution/terminal-session-completion-step.js";
 import { createSessionTimeoutControl } from "#execution/session-timeout-control.js";
 import { terminateChildSessionsStep } from "#execution/terminate-child-sessions-step.js";
+import type { BufferedTurnWork } from "#execution/turn-control-receiver.js";
 import { readSerializedSubagentDepth } from "#harness/subagent-depth.js";
 import type { DynamicSubagentAgentConfig } from "#runtime/subagents/dynamic-agent-config.js";
 import type { TokenUsage } from "#shared/token-usage.js";
@@ -55,6 +56,7 @@ const SAFE_OUTER_WORKFLOW_FAILURE_MESSAGE =
  */
 export interface WorkflowEntryInput {
   readonly input: RunInput["input"];
+  readonly initialRouteRemote?: RunInput["initialRouteRemote"];
   readonly limits?: RunInput["limits"];
   readonly sessionTimeoutMs?: number | false;
   readonly serializedContext: Record<string, unknown>;
@@ -181,28 +183,30 @@ export async function workflowEntry(input: WorkflowEntryInput): Promise<Workflow
     const outcome = await runDriverLoop({
       capabilities,
       driverWritable,
-      initialInput: {
-        deliveryMetadata:
-          input.serializedContext["eve.channelDelivery"] === undefined
-            ? undefined
-            : [
-                {
-                  ...(input.serializedContext["eve.channelDelivery"] as NonNullable<
-                    RunInput["delivery"]
-                  >),
-                  payloadIndex: 0,
-                },
-              ],
-        kind: "deliver",
-        payloads: [
-          {
-            message: input.input.message,
-            context: input.input.context,
-            outputSchema: input.input.outputSchema,
-          },
-        ],
-        requestId: readChannelRequestId(input.serializedContext),
-      },
+      initialInput:
+        input.initialRouteRemote ??
+        ({
+          deliveryMetadata:
+            input.serializedContext["eve.channelDelivery"] === undefined
+              ? undefined
+              : [
+                  {
+                    ...(input.serializedContext["eve.channelDelivery"] as NonNullable<
+                      RunInput["delivery"]
+                    >),
+                    payloadIndex: 0,
+                  },
+                ],
+          kind: "deliver",
+          payloads: [
+            {
+              message: input.input.message,
+              context: input.input.context,
+              outputSchema: input.input.outputSchema,
+            },
+          ],
+          requestId: readChannelRequestId(input.serializedContext),
+        } satisfies HookPayload),
       crashCleanupState,
       mode,
       serializedContext: input.serializedContext,
@@ -294,7 +298,7 @@ function createSafeOuterWorkflowError(): Error {
 async function runDriverLoop(input: {
   readonly capabilities?: SessionCapabilities;
   readonly driverWritable: WritableStream<Uint8Array>;
-  readonly initialInput: HookPayload;
+  readonly initialInput: TurnStepPayload;
   readonly crashCleanupState: CrashCleanupState;
   readonly mode: RunMode;
   readonly serializedContext: Record<string, unknown>;
@@ -345,10 +349,10 @@ async function runDriverLoop(input: {
 
       const next = await nextTurnDelivery({
         awaitAuthorizationCallbacks: expectedAttemptIds.size > 0,
-        bufferedDeliveries,
+        bufferedTurnWork,
         bufferedSessionControls,
         commandInbox,
-        deferDeliveries: input.mode === "task" && expectedAttemptIds.size > 0,
+        deferTurnWork: input.mode === "task" && expectedAttemptIds.size > 0,
         driverWritable: input.driverWritable,
         sessionState,
       });
@@ -381,7 +385,7 @@ async function runDriverLoop(input: {
   const nextTurnControlToken = (): string =>
     `${input.sessionState.sessionId}:turn-control:${String(turnDispatchIndex++)}`;
 
-  const bufferedDeliveries: DeliverHookPayload[] = [];
+  const bufferedTurnWork: BufferedTurnWork[] = [];
   const bufferedSessionControls: Array<"clear" | "compact" | "expired" | "reset"> = [];
   const commandInbox = createSessionCommandInbox();
   const stableCommandToken = sessionCommandHookToken(input.sessionState.sessionId);
@@ -403,12 +407,12 @@ async function runDriverLoop(input: {
   // Control-hook disposal is deferred one turn — see DispatchedTurn.
   let disposeSettledTurnControl: (() => Promise<void>) | undefined;
   const runTurn = async (args: {
-    readonly delivery: HookPayload;
+    readonly delivery: TurnStepPayload;
     readonly serializedContext: Record<string, unknown>;
     readonly sessionState: DurableSessionState;
   }): Promise<TurnDriverAction> => {
     const turn = await dispatchAndAwaitTurn({
-      bufferedDeliveries,
+      bufferedTurnWork,
       bufferedSessionControls,
       capabilities: input.capabilities,
       commandInbox,
@@ -525,6 +529,16 @@ async function runDriverLoop(input: {
       if (next.kind === "reset") {
         await terminateChildSessionsStep({ sessionState: action.sessionState });
         return { kind: "result", result: { output: "" } };
+      }
+
+      if (next.kind === "route-remote") {
+        action = await runTurn({
+          delivery: next.command,
+          serializedContext: action.serializedContext,
+          sessionState: next.sessionState,
+        });
+        input.crashCleanupState.lastSessionState = action.sessionState;
+        continue;
       }
 
       if (next.kind === "clear" || next.kind === "compact") {

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -139,6 +139,7 @@ export function createWorkflowRuntime(config: {
         -readonly [K in keyof WorkflowEntryInput]: WorkflowEntryInput[K];
       } = {
         input: input.input,
+        initialRouteRemote: input.initialRouteRemote,
         limits: input.limits,
         serializedContext,
       };

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -26,7 +26,7 @@ import {
   SessionDynamicToolRuntimeRevisionKey,
 } from "#context/keys.js";
 import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
-import { runStep } from "#context/run-step.js";
+import { runStep, withContextScope } from "#context/run-step.js";
 import { deserializeContext, serializeContext } from "#context/serialize.js";
 import {
   emitTurnPreamble,
@@ -55,6 +55,8 @@ import {
 } from "#harness/workflow-runtime-action-state.js";
 import { getPendingWorkflowInterrupt } from "#harness/workflow-interrupt-state.js";
 import { getPendingRuntimeActionBatch } from "#harness/runtime-actions.js";
+import { settlePassThroughRuntimeActionTurn } from "#execution/pass-through-runtime-action-turn.js";
+import { prepareChannelDirectedTurn } from "#execution/channel-directed-turn.js";
 import type { HarnessSession, SettledTurn, StepInput, StepResult } from "#harness/types.js";
 import { getTurnUsageState, takeSessionUsageDelta, toUsage } from "#harness/turn-tag-state.js";
 import type { TokenUsage } from "#shared/token-usage.js";
@@ -210,21 +212,84 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
     }
   }
 
-  // Apply deliver-time auth ferried via `resumeHook` (initial-turn
-  // input has no auth; it was seeded by buildRunContext).
+  if (input.input?.kind === "route-remote") {
+    ctx.set(AuthKey, input.input.auth);
+  }
+  // Apply deliver-time auth ferried via `resumeHook` (initial-turn input has no
+  // auth; it was seeded by buildRunContext).
   if (input.input?.kind === "deliver" && input.input.auth !== undefined) {
     ctx.set(AuthKey, input.input.auth ?? null);
   }
 
-  const initialSession = hydrateDurableSession({
-    compactionOverrides: {
-      thresholdPercent: effectiveAgent.thresholdPercent,
-    },
+  let initialSession = hydrateDurableSession({
+    compactionOverrides: { thresholdPercent: effectiveAgent.thresholdPercent },
     durable: durableSession,
     turnAgent: effectiveAgent.turnAgent,
   });
   const instrumentation = getInstrumentationRuntime();
   const initialEmissionState = getHarnessEmissionState(initialSession.state);
+
+  const routeEmit = async (event: UnstampedMessageStreamEvent) => {
+    await contextStorage.run(ctx, async () => {
+      const adapterCtx = buildAdapterContext(adapter, ctx);
+      const handled = await callAdapterEventHandler(adapter, event, adapterCtx);
+      const writer = input.parentWritable.getWriter();
+      try {
+        await writer.write(encodeMessageStreamEvent(stampMessageStreamEvent(handled)));
+      } finally {
+        writer.releaseLock();
+      }
+    });
+  };
+
+  const routeCommand = input.input?.kind === "route-remote" ? input.input : undefined;
+  if (routeCommand !== undefined) {
+    const scoped = await withContextScope(ctx, initialSession, async (session) => {
+      const emission = await emitTurnPreamble(
+        routeEmit,
+        { message: routeCommand.message },
+        getHarnessEmissionState(session.state),
+      );
+      const prepared = prepareChannelDirectedTurn({
+        command: routeCommand,
+        session: setHarnessEmissionState(session, emission),
+      });
+      return { result: undefined, session: prepared };
+    });
+    initialSession = scoped.session;
+    return {
+      action: "park",
+      ...derivePendingState(initialSession),
+      serializedContext: serializeContext(ctx),
+      sessionState: createDurableSessionState({ session: initialSession }),
+    };
+  }
+
+  const runtimeActionResult =
+    input.input?.kind === "runtime-action-result" ? input.input : undefined;
+  if (runtimeActionResult !== undefined) {
+    recordSubagentUsageSpans(runtimeActionResult.results);
+    if (runtimeActionResult.acceptedAtMsByCallId !== undefined) {
+      ctx.set(RuntimeActionSettlementTimesKey, runtimeActionResult.acceptedAtMsByCallId);
+    }
+    const scoped = await withContextScope(ctx, initialSession, async (session) => {
+      const settled = await settlePassThroughRuntimeActionTurn({
+        emit: routeEmit,
+        results: runtimeActionResult.results,
+        session,
+      });
+      return { result: settled, session: settled ?? session };
+    });
+    if (scoped.result !== undefined) {
+      initialSession = scoped.session;
+      return {
+        action: "park",
+        ...derivePendingState(initialSession),
+        serializedContext: serializeContext(ctx),
+        sessionState: createDurableSessionState({ session: initialSession }),
+      };
+    }
+  }
 
   if (rawInput.input?.kind === "deliver") {
     await contextStorage.run(ctx, () =>
@@ -277,10 +342,6 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
     }
     resolved = results.length === 0 ? undefined : results.reduce(coalesceTurnInputs);
   } else if (input.input?.kind === "runtime-action-result") {
-    recordSubagentUsageSpans(input.input.results);
-    if (input.input.acceptedAtMsByCallId !== undefined) {
-      ctx.set(RuntimeActionSettlementTimesKey, input.input.acceptedAtMsByCallId);
-    }
     resolved = { runtimeActionResults: input.input.results };
   }
 

--- a/packages/eve/src/harness/handles/store.ts
+++ b/packages/eve/src/harness/handles/store.ts
@@ -87,6 +87,8 @@ export type AgentAddress =
       readonly sessionId: string;
       readonly url: string;
       readonly callbackBaseUrl: string;
+      readonly inline?: true;
+      readonly inlineCredentialsStepId?: string;
     };
 
 /**
@@ -176,6 +178,8 @@ const addressSchema: z.ZodType<AgentAddress> = z.discriminatedUnion("kind", [
   }),
   z.strictObject({
     callbackBaseUrl: z.url(),
+    inline: z.literal(true).optional(),
+    inlineCredentialsStepId: nonEmptyString.optional(),
     kind: z.literal("agent/remote"),
     sessionId: nonEmptyString,
     url: z.url(),

--- a/packages/eve/src/harness/runtime-actions.ts
+++ b/packages/eve/src/harness/runtime-actions.ts
@@ -58,6 +58,7 @@ interface PendingRuntimeActionEventMetadata {
  */
 export interface PendingRuntimeActionBatch {
   readonly actions: readonly RuntimeActionRequest[];
+  readonly settlement?: "pass-through";
   readonly event: PendingRuntimeActionEventMetadata;
   readonly responseMessages: readonly ModelMessage[];
 }
@@ -119,13 +120,21 @@ export function setPendingRuntimeActionBatch(input: {
   readonly event: PendingRuntimeActionEventMetadata;
   readonly responseMessages: readonly ModelMessage[];
   readonly session: HarnessSession;
+  readonly settlement?: "pass-through";
 }): HarnessSession {
   const state = { ...input.session.state };
-  state[PENDING_RUNTIME_ACTION_BATCH_KEY] = {
+  const batch: {
+    actions: RuntimeActionRequest[];
+    event: PendingRuntimeActionEventMetadata;
+    responseMessages: ModelMessage[];
+    settlement?: "pass-through";
+  } = {
     actions: [...input.actions],
     event: input.event,
     responseMessages: [...input.responseMessages],
-  } satisfies PendingRuntimeActionBatch;
+  };
+  if (input.settlement !== undefined) batch.settlement = input.settlement;
+  state[PENDING_RUNTIME_ACTION_BATCH_KEY] = batch;
 
   return { ...input.session, state };
 }
@@ -135,7 +144,7 @@ export function setPendingRuntimeActionBatch(input: {
  * batch when every action has a matching result. Unknown and duplicate results
  * are ignored.
  */
-function resolveReadyRuntimeActionResults(input: {
+export function resolveReadyRuntimeActionResults(input: {
   readonly results: readonly RuntimeActionResult[];
   readonly session: HarnessSession;
 }): RuntimeActionResult[] | undefined {
@@ -163,6 +172,85 @@ function resolveRuntimeActionResultsForBatch(input: {
   });
 }
 
+/** Settles the non-model lifecycle shared by every runtime-action batch. */
+export async function settleReadyRuntimeActions(input: {
+  readonly emit?: HarnessEmitFn;
+  readonly results: readonly RuntimeActionResult[];
+  readonly session: HarnessSession;
+}): Promise<
+  | {
+      readonly batch: PendingRuntimeActionBatch;
+      readonly results: readonly RuntimeActionResult[];
+      readonly session: HarnessSession;
+    }
+  | undefined
+> {
+  const batch = getPendingRuntimeActionBatch(input.session.state);
+  if (batch === undefined) return undefined;
+  const readyResults = resolveRuntimeActionResultsForBatch({
+    batch,
+    results: input.results,
+    state: input.session.state,
+  });
+  if (readyResults === undefined) return undefined;
+
+  if (input.emit !== undefined) {
+    for (const result of readyResults) {
+      if (result.kind === "subagent-result" && result.isError !== true) {
+        await input.emit({
+          data: {
+            callId: result.callId,
+            output:
+              typeof result.output === "string" ? result.output : JSON.stringify(result.output),
+            subagentName: result.subagentName,
+          },
+          type: "subagent.completed",
+        } satisfies Extract<UnstampedMessageStreamEvent, { type: "subagent.completed" }>);
+      }
+      await input.emit(
+        createActionResultEvent({
+          result,
+          sequence: batch.event.sequence,
+          stepIndex: batch.event.stepIndex,
+          turnId: batch.event.turnId,
+        }),
+      );
+    }
+  }
+
+  let session = input.session;
+  for (const result of readyResults) {
+    if (result.kind !== "subagent-result" || result.origin !== "child") continue;
+    const handle = findRunningAgentHandle(session.state, { callId: result.callId });
+    if (handle === undefined) continue;
+    const outcome = readSubagentResultOutcome(result);
+    if (outcome === undefined) continue;
+    if (outcome.kind === "terminal" && "continuationToken" in handle.address) {
+      session = clearProxyInputRequestsForChild(session, handle.address.continuationToken);
+    }
+    const settled = settleAgentTurn(session, {
+      operationId: handle.operation.id,
+      outcome,
+    });
+    if (settled.kind === "settled") session = settled.session;
+  }
+
+  session = clearPendingRuntimeActionBatch(session);
+  for (const result of readyResults) {
+    if (result.kind !== "subagent-result") continue;
+    const outcome = readSubagentResultOutcome(result);
+    if (outcome === undefined) continue;
+    session = setTurnUsageState(
+      session,
+      accumulateSessionUsage({
+        previous: getTurnUsageState(session.state),
+        usage: outcome.usageDelta,
+      }),
+    );
+  }
+  return { batch, results: readyResults, session };
+}
+
 /**
  * Resolves one pending runtime-action batch back into model history.
  *
@@ -186,109 +274,17 @@ export async function resolvePendingRuntimeActions(input: {
     };
   }
 
-  const readyResults = resolveReadyRuntimeActionResults({
+  const settled = await settleReadyRuntimeActions({
+    emit: input.emit,
     results: input.stepInput?.runtimeActionResults ?? [],
     session: input.session,
   });
-
-  if (readyResults === undefined) {
-    return {
-      messages: [...input.session.history],
-      outcome: "unresolved",
-      session: input.session,
-    };
+  if (settled === undefined) {
+    return { messages: [...input.session.history], outcome: "unresolved", session: input.session };
   }
+  const nextSession = settled.session;
 
-  if (input.emit !== undefined) {
-    for (const result of readyResults) {
-      if (result.kind === "subagent-result" && result.isError !== true) {
-        await input.emit({
-          data: {
-            callId: result.callId,
-            output:
-              typeof result.output === "string" ? result.output : JSON.stringify(result.output),
-            subagentName: result.subagentName,
-          },
-          type: "subagent.completed",
-        } satisfies Extract<UnstampedMessageStreamEvent, { type: "subagent.completed" }>);
-      }
-
-      await input.emit(
-        createActionResultEvent({
-          result,
-          sequence: batch.event.sequence,
-          stepIndex: batch.event.stepIndex,
-          turnId: batch.event.turnId,
-        }),
-      );
-    }
-  }
-
-  // Settle each bound child result against its running handle from the
-  // outcome the child engine reported: `parked` keeps the handle (the child
-  // is idle and resumable), `terminal` deletes it. Before a terminal
-  // deletion the proxy-input entry keyed by the child's continuation token
-  // is cleared (the handle is the only record of that token) so future
-  // deliveries don't route responses to a dead child.
-  let nextSession: HarnessSession = input.session;
-  for (const result of readyResults) {
-    // Dispatch failures never settle handles: the dispatch step already
-    // rejected (deleted) the handle when it synthesized the failure.
-    if (result.kind !== "subagent-result" || result.origin !== "child") {
-      continue;
-    }
-    const handle = findRunningAgentHandle(nextSession.state, { callId: result.callId });
-    if (handle === undefined) {
-      continue;
-    }
-    const outcome = readSubagentResultOutcome(result);
-    if (outcome === undefined) {
-      continue;
-    }
-    if (outcome.kind === "terminal" && "continuationToken" in handle.address) {
-      nextSession = clearProxyInputRequestsForChild(nextSession, handle.address.continuationToken);
-    }
-    const settled = settleAgentTurn(nextSession, {
-      operationId: handle.operation.id,
-      outcome,
-    });
-    if (settled.kind === "settled") {
-      nextSession = settled.session;
-    }
-  }
-
-  const state = { ...nextSession.state };
-  delete state[PENDING_RUNTIME_ACTION_BATCH_KEY];
-  nextSession = {
-    ...nextSession,
-    state: Object.keys(state).length > 0 ? state : undefined,
-  };
-
-  // Draw settled child spend down against the parent's session totals so
-  // the session token limits and the remaining-quota budget granted to later
-  // delegations account for what the tree has already spent. Every outcome
-  // carries the child turn's `usageDelta`, folded exactly once per settled
-  // result (each batch resolves once), so repeated turns of a persistent
-  // child never double-count earlier turns. Only child-produced results
-  // carry an outcome; parent-side dispatch failures never do.
-  for (const result of readyResults) {
-    if (result.kind !== "subagent-result") {
-      continue;
-    }
-    const outcome = readSubagentResultOutcome(result);
-    if (outcome === undefined) {
-      continue;
-    }
-    nextSession = setTurnUsageState(
-      nextSession,
-      accumulateSessionUsage({
-        previous: getTurnUsageState(nextSession.state),
-        usage: outcome.usageDelta,
-      }),
-    );
-  }
-
-  const toolResults = readyResults.map((result) => {
+  const toolResults = settled.results.map((result) => {
     switch (result.kind) {
       case "load-skill-result":
         return {
@@ -375,9 +371,12 @@ export function createRuntimeActionRequestFromToolCall(input: {
         toolName: input.toolCall.toolName,
       }),
       kind: "remote-agent-call",
+      messageFormat: "delegated",
       name: definition.name,
       nodeId: definition.runtimeAction.nodeId,
       remoteAgentName: definition.runtimeAction.remoteAgentName ?? definition.name,
+      remoteTarget: { kind: "registered" },
+      sessionMode: "task",
     };
   }
 

--- a/packages/eve/src/internal/testing/mocks/mock-channel-operations.ts
+++ b/packages/eve/src/internal/testing/mocks/mock-channel-operations.ts
@@ -25,6 +25,9 @@ export function mockChannelContext<TState = undefined>(
   return {
     from(continuationToken) {
       const source: InternalChannelSource<TState> = {
+        async route() {
+          throw new Error("route() is not implemented by mockChannelOperations.");
+        },
         async send(message, options) {
           return (await observeDelivery(continuationToken, { ...options, message })) as never;
         },

--- a/packages/eve/src/internal/workflow-bundle/dynamic-capability-transform-plugin.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-capability-transform-plugin.ts
@@ -13,7 +13,8 @@ export function createDynamicCapabilityTransformPlugin(
       const transformDynamicTools =
         options.dynamicTools !== false && normalizedId.includes("/tools/");
       const transformDynamicRemoteAgents =
-        options.dynamicRemoteAgents !== false && normalizedId.includes("/subagents/");
+        options.dynamicRemoteAgents !== false &&
+        (normalizedId.includes("/subagents/") || normalizedId.includes("/channels/"));
       if (!transformDynamicTools && !transformDynamicRemoteAgents) {
         return null;
       }

--- a/packages/eve/src/internal/workflow-bundle/dynamic-remote-agent-transform.test.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-remote-agent-transform.test.ts
@@ -131,6 +131,14 @@ export default defineDynamic({
     expect(credentials.headers!()).toEqual({ "x-runtime": "fresh" });
   });
 
+  it("transforms channel-authored remote definitions without defineDynamic", async () => {
+    const result = await transformDynamicRemoteAgentCredentials(
+      "channels/slack.ts",
+      `const preview = defineRemoteAgent({ auth: createAuth(), description: "Preview", url: "https://example.com" });`,
+    );
+    expect(result?.code).toContain("__eveResolveRemoteAgentCredentials");
+  });
+
   it("does not transform public remote definitions without credentials", async () => {
     await expect(
       transformDynamicRemoteAgentCredentials(

--- a/packages/eve/src/internal/workflow-bundle/dynamic-remote-agent-transform.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-remote-agent-transform.ts
@@ -25,7 +25,6 @@ export async function transformDynamicRemoteAgentCredentials(
   source: string,
 ): Promise<{ code: string } | null> {
   if (
-    !source.includes("defineDynamic") ||
     !source.includes("defineRemoteAgent") ||
     (!source.includes("auth") && !source.includes("headers"))
   ) {

--- a/packages/eve/src/public/channels/slack/index.ts
+++ b/packages/eve/src/public/channels/slack/index.ts
@@ -37,6 +37,7 @@ export {
   type SlackReceiveTarget,
   type SlackSessionTarget,
   type SlackRespondOptions,
+  type SlackRouteOptions,
   type SlackSendOptions,
   type SlackSessionOperations,
   type SlackThread,

--- a/packages/eve/src/public/channels/slack/session-operations.ts
+++ b/packages/eve/src/public/channels/slack/session-operations.ts
@@ -2,12 +2,14 @@ import type {
   ChannelFrom,
   ChannelResolveSession,
   ChannelRespondOptions,
+  ChannelRouteOptions,
   ChannelSendOptions,
   ChannelSource,
 } from "#channel/channel-operations.js";
 import type { SessionAuthContext } from "#channel/types.js";
 import type { InputResponse } from "#runtime/input/types.js";
 import type { UserContent } from "ai";
+import type { RemoteAgentDefinition } from "#public/definitions/remote-agent.js";
 import type { SlackChannelState } from "#public/channels/slack/slackChannel.js";
 
 type SlackSource = ChannelSource<SlackChannelState>;
@@ -18,6 +20,10 @@ export type SlackSendOptions = Omit<ChannelSendOptions<SlackChannelState>, "auth
 };
 
 /** Options for an input response already bound to one Slack thread. */
+export type SlackRouteOptions = Omit<ChannelRouteOptions<SlackChannelState>, "auth" | "state"> & {
+  readonly auth?: SessionAuthContext | null;
+};
+
 export type SlackRespondOptions = Omit<ChannelRespondOptions, "auth"> & {
   readonly auth?: SessionAuthContext | null;
 };
@@ -25,6 +31,11 @@ export type SlackRespondOptions = Omit<ChannelRespondOptions, "auth"> & {
 /** Current-owner operations already bound to one Slack thread. */
 export interface SlackSessionOperations {
   send(message: string | UserContent, options?: SlackSendOptions): ReturnType<SlackSource["send"]>;
+  route(
+    remote: RemoteAgentDefinition,
+    message: string,
+    options?: SlackRouteOptions,
+  ): ReturnType<SlackSource["route"]>;
   respond(
     inputResponses: readonly InputResponse[],
     options?: SlackRespondOptions,
@@ -51,6 +62,13 @@ export function bindSlackSessionOperations(input: {
   return {
     async send(message, options = {}) {
       return await source.send(message, {
+        ...options,
+        auth: auth(options.auth),
+        state: input.state,
+      });
+    },
+    async route(remote, message, options = {}) {
+      return await source.route(remote, message, {
         ...options,
         auth: auth(options.auth),
         state: input.state,

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -72,6 +72,7 @@ import { markEventHandled } from "./utils.js";
 
 export type {
   SlackRespondOptions,
+  SlackRouteOptions,
   SlackSendOptions,
   SlackSessionOperations,
 } from "#public/channels/slack/session-operations.js";

--- a/packages/eve/src/runtime/actions/types.ts
+++ b/packages/eve/src/runtime/actions/types.ts
@@ -58,15 +58,34 @@ export type RuntimeRemoteAgentCallActionRequest = z.infer<
 /**
  * Zod schema for one runtime-owned remote-agent-call action request.
  */
+export const serializableRemoteAgentConfigSchema = z
+  .object({
+    credentialsStepId: z.string().optional(),
+    description: z.string(),
+    forwardPrincipal: z.boolean().optional(),
+    outputSchema: jsonObjectSchema.optional(),
+    path: z.string(),
+    url: z.string(),
+  })
+  .strict();
+
+const remoteAgentTargetSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("registered") }).strict(),
+  z.object({ config: serializableRemoteAgentConfigSchema, kind: z.literal("inline") }).strict(),
+]);
+
 export const runtimeRemoteAgentCallActionRequestSchema = z
   .object({
     callId: z.string(),
     description: z.string(),
     input: jsonObjectSchema,
     kind: z.literal("remote-agent-call"),
+    messageFormat: z.enum(["delegated", "verbatim"]).optional(),
     name: z.string(),
     nodeId: z.string(),
     remoteAgentName: z.string(),
+    remoteTarget: remoteAgentTargetSchema.optional(),
+    sessionMode: z.enum(["conversation", "task"]).optional(),
   })
   .strict();
 

--- a/packages/eve/src/runtime/subagents/dynamic-remote-agent-config.ts
+++ b/packages/eve/src/runtime/subagents/dynamic-remote-agent-config.ts
@@ -11,7 +11,7 @@ import { EVE_SESSION_ROUTE_PATH } from "#protocol/routes.js";
 import type { JsonObject } from "#shared/json.js";
 import { serializeOutputSchema, type ToolSchemaSource } from "#shared/tool-schema.js";
 
-export interface DynamicRemoteAgentConfig {
+export interface SerializableRemoteAgentConfig {
   readonly credentialsStepId?: string;
   readonly description: string;
   readonly forwardPrincipal?: boolean;
@@ -20,22 +20,18 @@ export interface DynamicRemoteAgentConfig {
   readonly url: string;
 }
 
-export async function normalizeDynamicRemoteAgentConfig(input: {
-  readonly name: string;
+export async function normalizeSerializableRemoteAgentConfig(input: {
+  readonly message: string;
   readonly value: unknown;
-}): Promise<DynamicRemoteAgentConfig> {
-  const message = `Dynamic subagent "${input.name}" must return defineAgent(...), defineRemoteAgent(...), or null.`;
+}): Promise<SerializableRemoteAgentConfig> {
+  const { message } = input;
   const record = expectObjectRecord(input.value, message);
   expectOnlyKnownKeys(
     record,
     ["auth", "description", "forwardPrincipal", "headers", "kind", "outputSchema", "path", "url"],
     message,
   );
-
-  if (record.kind !== "remote") {
-    throw new Error(message);
-  }
-
+  if (record.kind !== "remote") throw new Error(message);
   const url = await resolveUrl(record.url, message);
   const credentialsStepId = readCredentialsStepId(record);
   validateCredentials(record, message);
@@ -44,7 +40,7 @@ export async function normalizeDynamicRemoteAgentConfig(input: {
     credentialsStepId === undefined
   ) {
     throw new Error(
-      `${message} Dynamic remote auth and headers must be compiled by eve so credentials stay out of durable workflow state.`,
+      `${message} Remote auth and headers must be compiled by eve so credentials stay out of durable workflow state.`,
     );
   }
   const config: {
@@ -59,18 +55,22 @@ export async function normalizeDynamicRemoteAgentConfig(input: {
     path: record.path === undefined ? EVE_SESSION_ROUTE_PATH : expectString(record.path, message),
     url,
   };
-
-  if (credentialsStepId !== undefined) {
-    config.credentialsStepId = credentialsStepId;
-  }
+  if (credentialsStepId !== undefined) config.credentialsStepId = credentialsStepId;
   if (record.forwardPrincipal !== undefined) {
     config.forwardPrincipal = expectBoolean(record.forwardPrincipal, message);
   }
   if (record.outputSchema !== undefined) {
     config.outputSchema = serializeOutputSchema(record.outputSchema as ToolSchemaSource);
   }
-
   return config;
+}
+
+export async function normalizeDynamicRemoteAgentConfig(input: {
+  readonly name: string;
+  readonly value: unknown;
+}): Promise<SerializableRemoteAgentConfig> {
+  const message = `Dynamic subagent "${input.name}" must return defineAgent(...), defineRemoteAgent(...), or null.`;
+  return await normalizeSerializableRemoteAgentConfig({ message, value: input.value });
 }
 
 async function resolveUrl(value: unknown, message: string): Promise<string> {
@@ -101,3 +101,6 @@ function readCredentialsStepId(record: Record<string, unknown>): string | undefi
   const stepId = (resolver as { readonly stepId?: unknown }).stepId;
   return typeof stepId === "string" ? stepId : undefined;
 }
+
+/** @deprecated Internal compatibility alias. */
+export type DynamicRemoteAgentConfig = SerializableRemoteAgentConfig;


### PR DESCRIPTION
### Summary

Related to #1955. Adds deterministic channel routing to a remote agent without invoking the local model.

`from(address).route(remote, message, options)` shares normal channel-address ownership and race recovery. Routed work uses canonical turns, remote handles, callbacks, cancellation, FIFO ordering, and Slack adapter event context; repeated routes continue the remote conversation while local model history remains unchanged. Durable state stores remote configuration and credential-resolver identity only, resolving request credentials at dispatch time.

### Validation

- `pnpm guard:invariants`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/channel/channel-address.test.ts src/channel/channel-operations.test.ts src/execution/channel-directed-turn.test.ts src/execution/remote-agent-dispatch.test.ts src/execution/workflow-steps.test.ts` (72 tests)
- Production Slack to protected Vercel Preview routing smoke-tested with native callbacks

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
