### PR TITLE
fix(eve): read repository-style Vercel links

### DIFF
--- a/.changeset/fix-repository-style-vercel-links.md
+++ b/.changeset/fix-repository-style-vercel-links.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Recognize repository-style Vercel link metadata during guided setup, so Vercel Connect integrations can continue after Vercel CLI links a repository-backed project.

--- a/packages/eve/src/internal/vercel/project-link.test.ts
+++ b/packages/eve/src/internal/vercel/project-link.test.ts
@@ -13,17 +13,50 @@ afterEach(() => {
 });
 
 describe("readVercelProjectLink", () => {
-  it("reads repository-style link metadata", async () => {
+  it("reads the matching repository-style link metadata", async () => {
     mockedReadFile
       .mockRejectedValueOnce(new Error("ENOENT"))
-      .mockResolvedValueOnce(JSON.stringify({ orgId: "team_example", projectId: "prj_example" }));
+      .mockRejectedValueOnce(new Error("ENOENT"))
+      .mockRejectedValueOnce(new Error("ENOENT"))
+      .mockResolvedValueOnce(
+        JSON.stringify({
+          projects: [
+            { directory: "apps/other", id: "prj_other", name: "other", orgId: "team_other" },
+            { directory: "apps/agent", id: "prj_agent", name: "agent", orgId: "team_agent" },
+          ],
+          remoteName: "origin",
+        }),
+      );
+
+    await expect(readVercelProjectLink("/repo/apps/agent")).resolves.toEqual({
+      orgId: "team_agent",
+      projectId: "prj_agent",
+      projectName: "agent",
+    });
+    expect(mockedReadFile).toHaveBeenNthCalledWith(
+      1,
+      "/repo/apps/agent/.vercel/project.json",
+      "utf8",
+    );
+    expect(mockedReadFile).toHaveBeenNthCalledWith(2, "/repo/apps/agent/.vercel/repo.json", "utf8");
+    expect(mockedReadFile).toHaveBeenNthCalledWith(3, "/repo/apps/.vercel/repo.json", "utf8");
+    expect(mockedReadFile).toHaveBeenNthCalledWith(4, "/repo/.vercel/repo.json", "utf8");
+  });
+
+  it("uses a repo-level owner when the matching project has none", async () => {
+    mockedReadFile.mockRejectedValueOnce(new Error("ENOENT")).mockResolvedValueOnce(
+      JSON.stringify({
+        orgId: "team_repo",
+        projects: [{ directory: ".", id: "prj_agent", name: "agent" }],
+        remoteName: "origin",
+      }),
+    );
 
     await expect(readVercelProjectLink("/agent")).resolves.toEqual({
-      orgId: "team_example",
-      projectId: "prj_example",
+      orgId: "team_repo",
+      projectId: "prj_agent",
+      projectName: "agent",
     });
-    expect(mockedReadFile).toHaveBeenNthCalledWith(1, "/agent/.vercel/project.json", "utf8");
-    expect(mockedReadFile).toHaveBeenNthCalledWith(2, "/agent/.vercel/repo.json", "utf8");
   });
 
   it("keeps project metadata authoritative when both link formats exist", async () => {

--- a/packages/eve/src/internal/vercel/project-link.test.ts
+++ b/packages/eve/src/internal/vercel/project-link.test.ts
@@ -1,0 +1,40 @@
+import { readFile } from "node:fs/promises";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { readVercelProjectLink } from "./project-link.js";
+
+vi.mock("node:fs/promises", () => ({ readFile: vi.fn() }));
+
+const mockedReadFile = vi.mocked(readFile);
+
+afterEach(() => {
+  mockedReadFile.mockReset();
+});
+
+describe("readVercelProjectLink", () => {
+  it("reads repository-style link metadata", async () => {
+    mockedReadFile
+      .mockRejectedValueOnce(new Error("ENOENT"))
+      .mockResolvedValueOnce(JSON.stringify({ orgId: "team_example", projectId: "prj_example" }));
+
+    await expect(readVercelProjectLink("/agent")).resolves.toEqual({
+      orgId: "team_example",
+      projectId: "prj_example",
+    });
+    expect(mockedReadFile).toHaveBeenNthCalledWith(1, "/agent/.vercel/project.json", "utf8");
+    expect(mockedReadFile).toHaveBeenNthCalledWith(2, "/agent/.vercel/repo.json", "utf8");
+  });
+
+  it("keeps project metadata authoritative when both link formats exist", async () => {
+    mockedReadFile.mockResolvedValueOnce(
+      JSON.stringify({ orgId: "team_project", projectId: "prj_project" }),
+    );
+
+    await expect(readVercelProjectLink("/agent")).resolves.toEqual({
+      orgId: "team_project",
+      projectId: "prj_project",
+    });
+    expect(mockedReadFile).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/eve/src/internal/vercel/project-link.ts
+++ b/packages/eve/src/internal/vercel/project-link.ts
@@ -9,18 +9,19 @@ export const VercelProjectLinkSchema = z.object({
   projectName: z.string().min(1).optional(),
 });
 
-/** Validated Vercel owner and project identifiers from `.vercel/project.json`. */
+/** Validated Vercel owner and project identifiers from Vercel link metadata. */
 export type VercelProjectLink = z.infer<typeof VercelProjectLinkSchema>;
 
 /** Reads a validated Vercel project link without mutating local project state. */
 export async function readVercelProjectLink(
   projectPath: string,
 ): Promise<VercelProjectLink | undefined> {
-  try {
-    const raw = await readFile(join(projectPath, ".vercel", "project.json"), "utf8");
-    const parsed = VercelProjectLinkSchema.safeParse(JSON.parse(raw));
-    return parsed.success ? parsed.data : undefined;
-  } catch {
-    return undefined;
+  for (const fileName of ["project.json", "repo.json"]) {
+    try {
+      const raw = await readFile(join(projectPath, ".vercel", fileName), "utf8");
+      const parsed = VercelProjectLinkSchema.safeParse(JSON.parse(raw));
+      if (parsed.success) return parsed.data;
+    } catch {}
   }
+  return undefined;
 }

--- a/packages/eve/src/internal/vercel/project-link.ts
+++ b/packages/eve/src/internal/vercel/project-link.ts
@@ -1,5 +1,5 @@
 import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join, relative } from "node:path";
 
 import { z } from "#compiled/zod/index.js";
 
@@ -12,16 +12,68 @@ export const VercelProjectLinkSchema = z.object({
 /** Validated Vercel owner and project identifiers from Vercel link metadata. */
 export type VercelProjectLink = z.infer<typeof VercelProjectLinkSchema>;
 
+const VercelRepoLinkSchema = z.object({
+  orgId: z.string().min(1).optional(),
+  projects: z.array(
+    z.object({
+      directory: z.string().min(1),
+      id: z.string().min(1),
+      name: z.string().min(1),
+      orgId: z.string().min(1).optional(),
+    }),
+  ),
+});
+
+function normalizeDirectory(directory: string): string {
+  return directory === "." ? directory : directory.replaceAll("\\", "/").replace(/\/+$/, "");
+}
+
+function resolveRepoProjectLink(
+  repo: z.infer<typeof VercelRepoLinkSchema>,
+  repoRoot: string,
+  projectPath: string,
+): VercelProjectLink | undefined {
+  const path = normalizeDirectory(relative(repoRoot, projectPath));
+  const matches = repo.projects
+    .filter((project) => {
+      const directory = normalizeDirectory(project.directory);
+      return directory === "." || path === directory || path.startsWith(`${directory}/`);
+    })
+    .sort((left, right) => right.directory.length - left.directory.length);
+  const project = matches[0];
+  if (project === undefined) return undefined;
+  if (matches.filter((candidate) => candidate.directory === project.directory).length !== 1) {
+    return undefined;
+  }
+  const orgId = project.orgId ?? repo.orgId;
+  return orgId === undefined
+    ? undefined
+    : { orgId, projectId: project.id, projectName: project.name };
+}
+
+async function readVercelRepoLink(projectPath: string): Promise<VercelProjectLink | undefined> {
+  let directory = projectPath;
+  while (true) {
+    try {
+      const raw = await readFile(join(directory, ".vercel", "repo.json"), "utf8");
+      const parsed = VercelRepoLinkSchema.safeParse(JSON.parse(raw));
+      if (parsed.success) return resolveRepoProjectLink(parsed.data, directory, projectPath);
+    } catch {}
+
+    const parent = dirname(directory);
+    if (parent === directory) return undefined;
+    directory = parent;
+  }
+}
+
 /** Reads a validated Vercel project link without mutating local project state. */
 export async function readVercelProjectLink(
   projectPath: string,
 ): Promise<VercelProjectLink | undefined> {
-  for (const fileName of ["project.json", "repo.json"]) {
-    try {
-      const raw = await readFile(join(projectPath, ".vercel", fileName), "utf8");
-      const parsed = VercelProjectLinkSchema.safeParse(JSON.parse(raw));
-      if (parsed.success) return parsed.data;
-    } catch {}
-  }
-  return undefined;
+  try {
+    const raw = await readFile(join(projectPath, ".vercel", "project.json"), "utf8");
+    const parsed = VercelProjectLinkSchema.safeParse(JSON.parse(raw));
+    if (parsed.success) return parsed.data;
+  } catch {}
+  return await readVercelRepoLink(projectPath);
 }

--- a/packages/eve/src/internal/vercel/project-link.ts
+++ b/packages/eve/src/internal/vercel/project-link.ts
@@ -12,57 +12,79 @@ export const VercelProjectLinkSchema = z.object({
 /** Validated Vercel owner and project identifiers from Vercel link metadata. */
 export type VercelProjectLink = z.infer<typeof VercelProjectLinkSchema>;
 
+const VercelRepoProjectSchema = z.object({
+  directory: z.string().min(1),
+  id: z.string().min(1),
+  name: z.string().min(1),
+  orgId: z.string().min(1).optional(),
+});
+
 const VercelRepoLinkSchema = z.object({
   orgId: z.string().min(1).optional(),
-  projects: z.array(
-    z.object({
-      directory: z.string().min(1),
-      id: z.string().min(1),
-      name: z.string().min(1),
-      orgId: z.string().min(1).optional(),
-    }),
-  ),
+  projects: z.array(VercelRepoProjectSchema),
 });
+
+type VercelRepoLink = z.infer<typeof VercelRepoLinkSchema>;
 
 function normalizeDirectory(directory: string): string {
   return directory === "." ? directory : directory.replaceAll("\\", "/").replace(/\/+$/, "");
 }
 
-function resolveRepoProjectLink(
-  repo: z.infer<typeof VercelRepoLinkSchema>,
+function containsDirectory(directory: string, path: string): boolean {
+  return directory === "." || path === directory || path.startsWith(`${directory}/`);
+}
+
+function resolveRepoProject(
+  repo: VercelRepoLink,
   repoRoot: string,
   projectPath: string,
 ): VercelProjectLink | undefined {
   const path = normalizeDirectory(relative(repoRoot, projectPath));
-  const matches = repo.projects
-    .filter((project) => {
-      const directory = normalizeDirectory(project.directory);
-      return directory === "." || path === directory || path.startsWith(`${directory}/`);
-    })
-    .sort((left, right) => right.directory.length - left.directory.length);
-  const project = matches[0];
+  const matches = repo.projects.filter((project) =>
+    containsDirectory(normalizeDirectory(project.directory), path),
+  );
+  const deepestDirectoryLength = Math.max(...matches.map((project) => project.directory.length));
+  const deepestMatches = matches.filter(
+    (project) => project.directory.length === deepestDirectoryLength,
+  );
+  const project = deepestMatches.length === 1 ? deepestMatches[0] : undefined;
   if (project === undefined) return undefined;
-  if (matches.filter((candidate) => candidate.directory === project.directory).length !== 1) {
-    return undefined;
-  }
+
   const orgId = project.orgId ?? repo.orgId;
   return orgId === undefined
     ? undefined
     : { orgId, projectId: project.id, projectName: project.name };
 }
 
-async function readVercelRepoLink(projectPath: string): Promise<VercelProjectLink | undefined> {
-  let directory = projectPath;
-  while (true) {
-    try {
-      const raw = await readFile(join(directory, ".vercel", "repo.json"), "utf8");
-      const parsed = VercelRepoLinkSchema.safeParse(JSON.parse(raw));
-      if (parsed.success) return resolveRepoProjectLink(parsed.data, directory, projectPath);
-    } catch {}
+async function readProjectFile(projectPath: string): Promise<VercelProjectLink | undefined> {
+  try {
+    const raw = await readFile(join(projectPath, ".vercel", "project.json"), "utf8");
+    const parsed = VercelProjectLinkSchema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : undefined;
+  } catch {
+    return undefined;
+  }
+}
 
-    const parent = dirname(directory);
-    if (parent === directory) return undefined;
-    directory = parent;
+async function readRepoFile(repoRoot: string): Promise<VercelRepoLink | undefined> {
+  try {
+    const raw = await readFile(join(repoRoot, ".vercel", "repo.json"), "utf8");
+    const parsed = VercelRepoLinkSchema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function readRepoProjectLink(projectPath: string): Promise<VercelProjectLink | undefined> {
+  let repoRoot = projectPath;
+  while (true) {
+    const repo = await readRepoFile(repoRoot);
+    if (repo !== undefined) return resolveRepoProject(repo, repoRoot, projectPath);
+
+    const parent = dirname(repoRoot);
+    if (parent === repoRoot) return undefined;
+    repoRoot = parent;
   }
 }
 
@@ -70,10 +92,5 @@ async function readVercelRepoLink(projectPath: string): Promise<VercelProjectLin
 export async function readVercelProjectLink(
   projectPath: string,
 ): Promise<VercelProjectLink | undefined> {
-  try {
-    const raw = await readFile(join(projectPath, ".vercel", "project.json"), "utf8");
-    const parsed = VercelProjectLinkSchema.safeParse(JSON.parse(raw));
-    if (parsed.success) return parsed.data;
-  } catch {}
-  return await readVercelRepoLink(projectPath);
+  return (await readProjectFile(projectPath)) ?? (await readRepoProjectLink(projectPath));
 }

--- a/packages/eve/src/setup/project-resolution.ts
+++ b/packages/eve/src/setup/project-resolution.ts
@@ -166,7 +166,7 @@ async function fetchVercelName(
 
 /**
  * Resolves a linked project's human-readable name and team for the dashboard
- * status bar, from local `.vercel/project.json` plus the Vercel API. A
+ * status bar, from local Vercel link metadata plus the Vercel API. A
  * personal-account project (a non-`team_` org) carries no team, so `teamName`
  * is absent; the project name falls back to its id if the API call fails.
  *
@@ -220,8 +220,8 @@ export function projectResolutionFromDeployment(deployment: DeploymentInfo): Pro
 }
 
 /**
- * Side-effect-free fact gathering after a link: reads `.vercel/project.json`
- * to resolve the project. The on-disk link is the single source of truth.
+ * Side-effect-free fact gathering after a link: reads local Vercel link
+ * metadata to resolve the project. The on-disk link is the single source of truth.
  */
 export async function detectProjectResolution(
   projectRoot: string,

--- a/packages/eve/src/setup/slack-connect-lifecycle.ts
+++ b/packages/eve/src/setup/slack-connect-lifecycle.ts
@@ -1,6 +1,4 @@
-import { readFile } from "node:fs/promises";
-import { join } from "node:path";
-
+import { readVercelProjectLink } from "#internal/vercel/project-link.js";
 import { SLACK_CHANNEL_DEFAULT_ROUTE } from "#setup/scaffold/index.js";
 import {
   CONNECT_MUTATION_TIMEOUT_MS,
@@ -9,8 +7,6 @@ import {
 } from "#setup/connect-provisioning.js";
 import { createPromptCommandOutput, type ChannelSetupLog } from "#setup/cli/index.js";
 import { captureVercel, runVercel } from "#setup/primitives/run-vercel.js";
-import { z } from "zod";
-
 import {
   parseSlackConnectorDetails,
   parseSlackConnectors,
@@ -22,11 +18,6 @@ import {
 } from "./slack-connect.js";
 
 export const CONNECT_LOOKUP_TIMEOUT_MS = 60_000;
-
-const VercelProjectLinkSchema = z.object({
-  projectId: z.string().min(1),
-  orgId: z.string().min(1),
-});
 
 /** Connect subprocess operations needed to inventory and remove Slack connectors. */
 export interface SlackConnectLifecycleDeps {
@@ -82,19 +73,8 @@ export async function listSlackConnectors(
   }
 }
 
-/** Project and team identifiers from a valid on-disk Vercel link. */
-export type VercelProjectLink = z.infer<typeof VercelProjectLinkSchema>;
-
-/** Reads the linked Vercel project and team ids from `.vercel/project.json`. */
-export async function readProjectLink(projectRoot: string): Promise<VercelProjectLink | undefined> {
-  try {
-    const raw = await readFile(join(projectRoot, ".vercel", "project.json"), "utf8");
-    const parsed = VercelProjectLinkSchema.safeParse(JSON.parse(raw));
-    return parsed.success ? parsed.data : undefined;
-  } catch {
-    return undefined;
-  }
-}
+/** Reads the linked Vercel project and team ids from local link metadata. */
+export const readProjectLink = readVercelProjectLink;
 
 export type SlackConnectorLookup =
   | {

--- a/packages/eve/src/setup/slack-connect-lifecycle.ts
+++ b/packages/eve/src/setup/slack-connect-lifecycle.ts
@@ -1,4 +1,3 @@
-import { readVercelProjectLink } from "#internal/vercel/project-link.js";
 import { SLACK_CHANNEL_DEFAULT_ROUTE } from "#setup/scaffold/index.js";
 import {
   CONNECT_MUTATION_TIMEOUT_MS,
@@ -72,9 +71,6 @@ export async function listSlackConnectors(
     return { state: "failed", message: "Vercel returned invalid JSON for the connector list." };
   }
 }
-
-/** Reads the linked Vercel project and team ids from local link metadata. */
-export const readProjectLink = readVercelProjectLink;
 
 export type SlackConnectorLookup =
   | {

--- a/packages/eve/src/setup/slackbot.ts
+++ b/packages/eve/src/setup/slackbot.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { performance } from "node:perf_hooks";
 import { setTimeout as sleep } from "node:timers/promises";
 
+import { readProjectLink } from "#setup/project-resolution.js";
 import { SLACK_CHANNEL_DEFAULT_ROUTE } from "#setup/scaffold/index.js";
 import {
   createPromptCommandOutput,
@@ -21,7 +22,6 @@ import {
   CONNECT_LOOKUP_TIMEOUT_MS,
   fetchSlackWorkspace,
   findSlackConnector,
-  readProjectLink,
   listSlackConnectors,
   type SlackConnectLifecycleDeps,
   type SlackConnectorCleanupResult,


### PR DESCRIPTION
### Summary

Repository-style Vercel links store project mappings in `.vercel/repo.json`, but eve only read per-directory `project.json` metadata and treated successful Git-backed links as unresolved. The shared reader now walks to the repo mapping, resolves the single project whose configured directory contains the current app, and retains `project.json` precedence when both formats apply. Slack uses the same setup-level reader rather than exporting a duplicate one.

This also fixes non-Connect consumers of the shared reader, including local Vercel OIDC targeting and development channel dispatch.

### Validation

- `pnpm --filter eve build:compiled`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/internal/vercel/project-link.test.ts src/setup/slackbot.test.ts`
- `pnpm --filter eve exec tsc --noEmit --pretty false --project tsconfig.json`
- `pnpm exec oxlint packages/eve/src/internal/vercel/project-link.ts packages/eve/src/internal/vercel/project-link.test.ts packages/eve/src/setup/project-resolution.ts packages/eve/src/setup/slack-connect-lifecycle.ts`
- `pnpm exec oxfmt --check packages/eve/src/internal/vercel/project-link.ts packages/eve/src/internal/vercel/project-link.test.ts .changeset/fix-repository-style-vercel-links.md`

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
