### PR TITLE
refactor(eve): simplify local trace viewers

### DIFF
--- a/.changeset/simplify-trace-viewers.md
+++ b/.changeset/simplify-trace-viewers.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+The local trace viewer now reads user messages and runtime actions from durable channel delivery and action spans, avoiding duplicate SDK tool details in `eve traces` output.

--- a/packages/eve/src/cli/commands/trace-detail.test.ts
+++ b/packages/eve/src/cli/commands/trace-detail.test.ts
@@ -25,7 +25,7 @@ function span(overrides: Partial<LocalTraceSpan> = {}): LocalTraceSpan {
 }
 
 describe("spanMetricChips", () => {
-  it("emits token, cost, and tool chips only when present", () => {
+  it("emits token and cost chips only when present", () => {
     expect(
       spanMetricChips(
         span({
@@ -39,11 +39,7 @@ describe("spanMetricChips", () => {
     ).toEqual(["↑1.4K", "↓213", "$0.0031"]);
 
     expect(spanMetricChips(span())).toEqual([]);
-    expect(
-      spanMetricChips(
-        span({ name: "ai.toolCall", attributes: { "gen_ai.tool.name": "get_weather" } }),
-      ),
-    ).toEqual(["get_weather"]);
+    expect(spanMetricChips(span({ name: "ai.toolCall" }))).toEqual([]);
   });
 
   it("prefers gateway cost over provider cost and parses string ints", () => {

--- a/packages/eve/src/cli/commands/trace-detail.ts
+++ b/packages/eve/src/cli/commands/trace-detail.ts
@@ -27,8 +27,9 @@ export interface LocalTraceSummary {
 
 /**
  * Compact metrics for one tree row: token chips (`↑1.4K`/`↓213`), cost
- * (`$0.0031`), and the tool name for `ai.toolCall` spans. Only chips whose
- * attributes the span actually carries — rows without usage stay clean.
+ * (`$0.0031`). Only chips whose attributes the span actually carries — rows
+ * without usage stay clean. Tool names belong to eve's durable `agent.action`
+ * label instead of the AI SDK's child span.
  * Raw values: callers sanitize for their output surface.
  */
 export function spanMetricChips(span: LocalTraceSpan): string[] {
@@ -39,10 +40,6 @@ export function spanMetricChips(span: LocalTraceSpan): string[] {
   if (output !== undefined) chips.push(`↓${formatCompactTokenCount(output)}`);
   const cost = spanCostUsd(span);
   if (cost !== undefined) chips.push(formatCostUsd(cost));
-  if (span.name === "ai.toolCall") {
-    const tool = span.attributes["gen_ai.tool.name"];
-    if (typeof tool === "string" && tool.length > 0) chips.push(tool);
-  }
   return chips;
 }
 

--- a/packages/eve/src/cli/commands/trace.integration.test.ts
+++ b/packages/eve/src/cli/commands/trace.integration.test.ts
@@ -256,7 +256,7 @@ describe("eve traces", () => {
     expect(output.out[0]).toContain("Cost");
     expect(output.out[0]).toContain("$0.0031");
     expect(output.out[0]).toContain("agent.step [step 0, attempt 0]  70ms  ↑1.4K ↓213 $0.0031");
-    expect(output.out[0]).toContain("ai.toolCall  10ms  get_weather");
+    expect(output.out[0]).toContain("ai.toolCall  10ms");
     // Attributes and events stay behind --verbose.
     expect(output.out[0]).not.toContain("events:");
     expect(output.out[0]).not.toContain("agent.model.id:");
@@ -296,7 +296,7 @@ describe("eve traces", () => {
     expect(output.out[0]).toContain("├─ step.started  +0ms");
     expect(output.out[0]).toContain("└─ step.completed  +70ms");
     expect(output.out[0]).toContain("step.index: 0");
-    expect(output.out[0]).toContain("└─ ai.toolCall  10ms  get_weather ERROR");
+    expect(output.out[0]).toContain("└─ ai.toolCall  10ms ERROR");
     expect(output.out[0]).toContain("├─ status: ERROR — tool exploded");
     expect(output.out[0]).toContain("└─ gen_ai.tool.name: get_weather");
     expect(output.out[0]).toContain("Errors");

--- a/packages/eve/src/cli/dev/tui/traces/trace-conversation.test.ts
+++ b/packages/eve/src/cli/dev/tui/traces/trace-conversation.test.ts
@@ -42,8 +42,21 @@ function trace(spans: readonly LocalTraceSpan[]): LocalTrace {
   };
 }
 
+function delivery(
+  spanId: string,
+  startMs: number,
+  turnId: string,
+  message: string,
+): LocalTraceSpan {
+  return span(spanId, "agent.channel.delivery", startMs, startMs, undefined, {
+    "agent.channel.delivery.input": JSON.stringify({ message }),
+    "agent.turn.id": turnId,
+  });
+}
+
 function weatherTurn(): LocalTraceSpan[] {
   const turn = span("a".repeat(16), "agent.turn", 0, 0, undefined, { "agent.turn.id": "turn_0" });
+  const inbound = delivery("0".repeat(16), 0, "turn_0", "weather in sf?");
   const step = span("b".repeat(16), "agent.step", 10, 5000, turn.spanId, {});
   const messages = JSON.stringify([
     { role: "user", content: "weather in nyc?" },
@@ -57,21 +70,32 @@ function weatherTurn(): LocalTraceSpan[] {
     "agent.usage.input_tokens": 6200,
     "agent.usage.output_tokens": 50,
   });
-  const action = span("d".repeat(16), "agent.action", 2100, 2400, step.spanId, {});
-  const toolCall = span("e".repeat(16), "ai.toolCall", 2100, 2400, action.spanId, {
-    "gen_ai.tool.name": "get_weather",
+  const action = span("d".repeat(16), "agent.action", 2100, 2400, turn.spanId, {
+    "agent.action.name": "get_weather",
     "gen_ai.tool.call.arguments": '{"city":"sf"}',
     "gen_ai.tool.call.result": '{"temperatureF":72}',
   });
-  return [turn, step, model, action, toolCall];
+  return [turn, inbound, step, model, action];
 }
 
 describe("buildConversationItems", () => {
-  it("extracts the user message from the turn's first model prompt", () => {
+  it("reads the user message from the channel delivery", () => {
     const items = buildConversationItems(trace(weatherTurn()));
     expect(items[0]?.kind).toBe("user");
     expect(items[0]?.text).toBe("weather in sf?");
-    expect(items[0]?.span.name).toBe("agent.turn");
+    expect(items[0]?.span.name).toBe("agent.channel.delivery");
+  });
+
+  it("skips metadata-only channel deliveries", () => {
+    const items = buildConversationItems(
+      trace([
+        span("a".repeat(16), "agent.channel.delivery", 0, 0, undefined, {
+          "agent.channel.delivery.input": JSON.stringify({ context: ["sidebar"] }),
+        }),
+      ]),
+    );
+
+    expect(items).toEqual([]);
   });
 
   it("builds assistant and tool items in time order", () => {
@@ -140,7 +164,9 @@ describe("buildConversationItems", () => {
       "agent.parent.session.id": "session-root",
       "agent.parent.turn.id": "turn_0",
       "agent.subagent.name": "echo-marker",
+      "agent.turn.id": "turn_child",
     });
+    const childDelivery = delivery("3".repeat(16), 6000, "turn_child", "delegated task");
     const childStep = span("1".repeat(16), "agent.step", 6010, 8000, childTurn.spanId, {});
     const childModel = span(
       "2".repeat(16),
@@ -153,7 +179,9 @@ describe("buildConversationItems", () => {
         "ai.response.text": "delegated reply",
       },
     );
-    const items = buildConversationItems(trace([...parent, childTurn, childStep, childModel]));
+    const items = buildConversationItems(
+      trace([...parent, childTurn, childDelivery, childStep, childModel]),
+    );
     const parentItems = items.filter((item) => item.subagent === undefined);
     const childItems = items.filter((item) => item.subagent !== undefined);
     expect(parentItems.length).toBeGreaterThan(0);
@@ -169,7 +197,10 @@ describe("buildConversationItems", () => {
     // The parent parks while the child runs: step 1 dispatches, the child
     // works, step 2 replies with the result. Cards must read in that order,
     // not with the child appended after the parent's whole turn.
-    const turn = span("a".repeat(16), "agent.turn", 0, 0, undefined, {});
+    const turn = span("a".repeat(16), "agent.turn", 0, 0, undefined, {
+      "agent.turn.id": "turn_0",
+    });
+    const parentDelivery = delivery("0".repeat(16), 0, "turn_0", "run the subagent");
     const step1 = span("b".repeat(16), "agent.step", 10, 20, turn.spanId, {});
     const dispatch = span("c".repeat(16), "ai.streamText.doStream", 12, 18, step1.spanId, {
       "ai.prompt.messages": JSON.stringify([{ role: "user", content: "run the subagent" }]),
@@ -180,7 +211,9 @@ describe("buildConversationItems", () => {
       "agent.parent.session.id": "session-root",
       "agent.parent.turn.id": "turn_0",
       "agent.subagent.name": "echo-marker",
+      "agent.turn.id": "turn_child",
     });
+    const childDelivery = delivery("5".repeat(16), 30, "turn_child", "delegated task");
     const childStep = span("1".repeat(16), "agent.step", 32, 40, childTurn.spanId, {});
     const childModel = span("2".repeat(16), "ai.streamText.doStream", 34, 38, childStep.spanId, {
       "ai.prompt.messages": JSON.stringify([{ role: "user", content: "delegated task" }]),
@@ -191,7 +224,18 @@ describe("buildConversationItems", () => {
       "ai.response.text": "The subagent said: delegated reply",
     });
     const items = buildConversationItems(
-      trace([turn, step1, dispatch, childTurn, childStep, childModel, step2, reply]),
+      trace([
+        turn,
+        parentDelivery,
+        step1,
+        dispatch,
+        childTurn,
+        childDelivery,
+        childStep,
+        childModel,
+        step2,
+        reply,
+      ]),
     );
     expect(items.map((item) => [item.kind, item.subagent !== undefined])).toEqual([
       ["user", false],
@@ -202,14 +246,14 @@ describe("buildConversationItems", () => {
     ]);
   });
 
-  it("skips model spans with no response text", () => {
+  it("does not infer a user card from a model prompt", () => {
     const turn = span("a".repeat(16), "agent.turn", 0, 0, undefined, {});
     const step = span("b".repeat(16), "agent.step", 10, 5000, turn.spanId, {});
     const model = span("c".repeat(16), "ai.streamText.doStream", 20, 2000, step.spanId, {
       "ai.prompt.messages": JSON.stringify([{ role: "user", content: "hi" }]),
     });
     const items = buildConversationItems(trace([turn, step, model]));
-    expect(items.map((item) => item.kind)).toEqual(["user"]);
+    expect(items).toEqual([]);
   });
 
   it("keeps model spans that failed with an error", () => {
@@ -225,8 +269,8 @@ describe("buildConversationItems", () => {
       2,
     );
     const items = buildConversationItems(trace([turn, step, model]));
-    expect(items.map((item) => item.kind)).toEqual(["user", "assistant"]);
-    expect(items[1]?.error).toBe(true);
+    expect(items.map((item) => item.kind)).toEqual(["assistant"]);
+    expect(items[0]?.error).toBe(true);
   });
 
   it("keeps model spans that carry only token usage", () => {
@@ -238,8 +282,8 @@ describe("buildConversationItems", () => {
       "agent.usage.output_tokens": 10,
     });
     const items = buildConversationItems(trace([turn, step, model]));
-    expect(items.map((item) => item.kind)).toEqual(["user", "assistant"]);
-    expect(items[1]?.inputTokens).toBe(100);
+    expect(items.map((item) => item.kind)).toEqual(["assistant"]);
+    expect(items[0]?.inputTokens).toBe(100);
   });
 
   it("flags error tool calls", () => {
@@ -249,19 +293,18 @@ describe("buildConversationItems", () => {
       "ai.prompt.messages": JSON.stringify([{ role: "user", content: "hi" }]),
       "agent.usage.input_tokens": 10,
     });
-    const action = span("d".repeat(16), "agent.action", 60, 200, step.spanId, {});
-    const toolCall = span(
-      "e".repeat(16),
-      "ai.toolCall",
+    const action = span(
+      "d".repeat(16),
+      "agent.action",
       60,
       200,
-      action.spanId,
-      { "gen_ai.tool.name": "explode" },
+      step.spanId,
+      { "agent.action.name": "explode" },
       2,
     );
-    const items = buildConversationItems(trace([turn, step, model, action, toolCall]));
-    expect(items.map((item) => item.kind)).toEqual(["user", "assistant", "tool"]);
-    expect(items[2]?.error).toBe(true);
+    const items = buildConversationItems(trace([turn, step, model, action]));
+    expect(items.map((item) => item.kind)).toEqual(["assistant", "tool"]);
+    expect(items[1]?.error).toBe(true);
   });
 });
 

--- a/packages/eve/src/cli/dev/tui/traces/trace-conversation.ts
+++ b/packages/eve/src/cli/dev/tui/traces/trace-conversation.ts
@@ -1,10 +1,8 @@
 /**
  * Conversation view for the `/traces` viewer: the same trace, re-told as a
  * flow of user messages, assistant replies, and tool calls instead of a
- * latency waterfall. Items are built from the span tree (turns in order,
- * subtrees in time order) with text pulled from the content attributes —
- * the user's message from the turn's first model prompt, replies and tool
- * calls from response/tool spans.
+ * latency waterfall. Durable delivery and action spans provide the user and
+ * tool cards directly; model response spans provide assistant cards.
  */
 
 import { formatElapsed } from "#cli/format-elapsed.js";
@@ -20,7 +18,7 @@ import { SURFACE_CLOSE } from "./trace-surfaces.js";
 
 export interface ConversationItem {
   readonly kind: "system" | "user" | "assistant" | "tool";
-  /** Detail-drawer source for this item (the turn span for users). */
+  /** Detail-drawer source for this item. */
   readonly span: LocalTraceSpan;
   /** Tool name for tool items. */
   readonly name?: string;
@@ -58,149 +56,140 @@ export interface ConversationSubagent {
 /** Max rendered lines for one collapsed card payload (args, result, or text). */
 const CARD_PAYLOAD_LINES = 3;
 
-/** Builds the conversation flow for a trace, one item per message/action. */
+/** Builds the conversation flow from eve's durable delivery, model, and action spans. */
 export function buildConversationItems(trace: LocalTrace): ConversationItem[] {
   const byId = new Map(trace.spans.map((span) => [span.spanId, span]));
-  const children = new Map<string, LocalTraceSpan[]>();
+  const subagents = new Map<string, ConversationSubagent>();
   for (const span of trace.spans) {
-    if (span.parentSpanId === undefined) continue;
-    const siblings = children.get(span.parentSpanId) ?? [];
-    siblings.push(span);
-    children.set(span.parentSpanId, siblings);
+    if (span.name !== "agent.turn") continue;
+    const turnId = stringAttribute(span, "agent.turn.id");
+    const subagent = turnSubagent(span);
+    if (turnId !== undefined && subagent !== undefined) subagents.set(turnId, subagent);
   }
-  for (const siblings of children.values()) siblings.sort(compareLocalTraceSpans);
-
-  // Turns are matched by name, not by root position: they parent to the
-  // `agent.session` window span when one exists (and to nothing on older
-  // spools), and a subagent child's turns sit beside the parent's in the
-  // same trace.
-  const turns = trace.spans.filter((span) => span.name === "agent.turn");
-  turns.sort(compareLocalTraceSpans);
-
-  // Cards order by when their span started, not turn by turn: a parent
-  // parks while its subagent runs and resumes afterwards, so the child's
-  // cards belong between the parent's dispatch step and its final reply.
-  // The system card pins to the front regardless.
   const entries: { readonly item: ConversationItem; readonly order: bigint }[] = [];
-  for (const root of turns) {
-    const subagent = turnSubagent(root);
-    const subtree: LocalTraceSpan[] = [];
-    const walk = (span: LocalTraceSpan): void => {
-      subtree.push(span);
-      for (const child of children.get(span.spanId) ?? []) walk(child);
-    };
-    walk(root);
-    subtree.sort(compareLocalTraceSpans);
+  const firstSystemSpan = [...trace.spans]
+    .sort(compareLocalTraceSpans)
+    .find((span) => isModelSpan(span) && typeof span.attributes["ai.prompt.system"] === "string");
+  const systemText = firstSystemSpan?.attributes["ai.prompt.system"];
+  if (firstSystemSpan !== undefined && typeof systemText === "string" && systemText.length > 0) {
+    entries.push({
+      item: {
+        kind: "system",
+        durationMs: 0,
+        error: false,
+        span: firstSystemSpan,
+        subagent: subagentFor(firstSystemSpan, subagents, byId),
+        text: systemText,
+      },
+      order: 0n,
+    });
+  }
 
-    if (entries.length === 0) {
-      const systemSpan = subtree.find(
-        (span) => isModelSpan(span) && typeof span.attributes["ai.prompt.system"] === "string",
-      );
-      const systemText = systemSpan?.attributes["ai.prompt.system"];
-      if (systemSpan !== undefined && typeof systemText === "string" && systemText.length > 0) {
-        entries.push({
-          item: {
-            kind: "system",
-            durationMs: 0,
-            error: false,
-            span: systemSpan,
-            subagent,
-            text: systemText,
-          },
-          order: 0n,
-        });
-      }
-    }
-    const userText = extractUserText(subtree.find(isModelSpan));
-    if (userText !== undefined) {
+  for (const span of trace.spans) {
+    const subagent = subagentFor(span, subagents, byId);
+    if (span.name === "agent.channel.delivery") {
+      const text = deliveryText(stringAttribute(span, "agent.channel.delivery.input"));
+      if (text === undefined) continue;
       entries.push({
         item: {
           kind: "user",
-          durationMs: 0,
-          error: false,
-          span: root,
+          durationMs: spanDurationMs(span),
+          error: span.statusCode === 2,
+          span,
           subagent,
-          text: userText,
+          text,
         },
-        order: root.startTimeNs,
+        order: span.startTimeNs,
       });
+      continue;
     }
-    for (const span of subtree) {
-      if (isModelSpan(span)) {
-        const text = stringAttribute(span, "ai.response.text");
-        const reasoning = stringAttribute(span, "ai.response.reasoning");
-        const hasUsage =
-          numberAttribute(span, "agent.usage.input_tokens") !== undefined ||
-          numberAttribute(span, "agent.usage.output_tokens") !== undefined;
-        const hasToolCalls = span.attributes["ai.response.tool_calls"] !== undefined;
-        const isEmpty =
-          (text === undefined || text.trim().length === 0) &&
-          (reasoning === undefined || reasoning.trim().length === 0) &&
-          !hasUsage &&
-          !hasToolCalls &&
-          span.statusCode !== 2;
-        if (isEmpty) continue;
-        entries.push({
-          item: {
-            kind: "assistant",
-            costUsd: stepCostUsd(span, byId),
-            durationMs: spanDurationMs(span),
-            error: span.statusCode === 2,
-            inputTokens: numberAttribute(span, "agent.usage.input_tokens"),
-            model: stringAttribute(span, "gen_ai.request.model"),
-            outputTokens: numberAttribute(span, "agent.usage.output_tokens"),
-            reasoning,
-            span,
-            subagent,
-            text,
-            toolCallNames: hasToolCalls
-              ? parseToolCallNames(stringAttribute(span, "ai.response.tool_calls"))
-              : undefined,
-          },
-          order: span.startTimeNs,
-        });
-        // Provider-executed tools (e.g. web_search) run inside the model
-        // call and never get an ai.toolCall span; their results only exist
-        // on the model span. Emit a card per result right after the
-        // assistant card (same order, stable sort keeps emission order).
-        for (const result of parseProviderToolResults(
-          stringAttribute(span, "ai.response.tool_results"),
-        )) {
-          entries.push({
-            item: {
-              kind: "tool",
-              args: result.args,
-              durationMs: 0,
-              error: result.error,
-              name: stripTerminalControls(result.name),
-              result: result.result,
-              span,
-              subagent,
-            },
-            order: span.startTimeNs,
-          });
-        }
-      } else if (span.name === "ai.toolCall") {
+    if (isModelSpan(span)) {
+      const text = stringAttribute(span, "ai.response.text");
+      const reasoning = stringAttribute(span, "ai.response.reasoning");
+      const hasUsage =
+        numberAttribute(span, "agent.usage.input_tokens") !== undefined ||
+        numberAttribute(span, "agent.usage.output_tokens") !== undefined;
+      const hasToolCalls = span.attributes["ai.response.tool_calls"] !== undefined;
+      const isEmpty =
+        (text === undefined || text.trim().length === 0) &&
+        (reasoning === undefined || reasoning.trim().length === 0) &&
+        !hasUsage &&
+        !hasToolCalls &&
+        span.statusCode !== 2;
+      if (isEmpty) continue;
+      entries.push({
+        item: {
+          kind: "assistant",
+          costUsd: stepCostUsd(span, byId),
+          durationMs: spanDurationMs(span),
+          error: span.statusCode === 2,
+          inputTokens: numberAttribute(span, "agent.usage.input_tokens"),
+          model: stringAttribute(span, "gen_ai.request.model"),
+          outputTokens: numberAttribute(span, "agent.usage.output_tokens"),
+          reasoning,
+          span,
+          subagent,
+          text,
+          toolCallNames: hasToolCalls
+            ? parseToolCallNames(stringAttribute(span, "ai.response.tool_calls"))
+            : undefined,
+        },
+        order: span.startTimeNs,
+      });
+      // Provider-executed tools (e.g. web_search) run inside the model
+      // call, so their results only exist on this response span.
+      for (const result of parseProviderToolResults(
+        stringAttribute(span, "ai.response.tool_results"),
+      )) {
         entries.push({
           item: {
             kind: "tool",
-            args: stringAttribute(span, "gen_ai.tool.call.arguments"),
-            durationMs: spanDurationMs(span),
-            error: span.statusCode === 2,
-            name: stripTerminalControls(stringAttribute(span, "gen_ai.tool.name") ?? "tool"),
-            result: unwrapJsonString(stringAttribute(span, "gen_ai.tool.call.result")),
+            args: result.args,
+            durationMs: 0,
+            error: result.error,
+            name: stripTerminalControls(result.name),
+            result: result.result,
             span,
             subagent,
           },
           order: span.startTimeNs,
         });
       }
+      continue;
+    }
+    if (span.name === "agent.action") {
+      entries.push({
+        item: {
+          kind: "tool",
+          args: stringAttribute(span, "gen_ai.tool.call.arguments"),
+          durationMs: spanDurationMs(span),
+          error: span.statusCode === 2,
+          name: stripTerminalControls(stringAttribute(span, "agent.action.name") ?? "action"),
+          result: unwrapJsonString(stringAttribute(span, "gen_ai.tool.call.result")),
+          span,
+          subagent,
+        },
+        order: span.startTimeNs,
+      });
     }
   }
-  // Stable, so equal timestamps keep their per-turn emission order.
   return entries
     .sort((left, right) => (left.order === right.order ? 0 : left.order < right.order ? -1 : 1))
     .map((entry) => entry.item);
+}
+
+function subagentFor(
+  span: LocalTraceSpan,
+  subagents: ReadonlyMap<string, ConversationSubagent>,
+  byId: ReadonlyMap<string, LocalTraceSpan>,
+): ConversationSubagent | undefined {
+  let current: LocalTraceSpan | undefined = span;
+  while (current !== undefined) {
+    const turnId = stringAttribute(current, "agent.turn.id");
+    if (turnId !== undefined) return subagents.get(turnId);
+    current = current.parentSpanId === undefined ? undefined : byId.get(current.parentSpanId);
+  }
+  return undefined;
 }
 
 /** Reads the dispatch lineage a subagent turn carries on its turn span. */
@@ -518,37 +507,18 @@ function estimateTokens(text: string): number {
   return Math.ceil(text.length / 4);
 }
 
-/** The user's message for a turn = the last user message in its first prompt. */
-function extractUserText(firstModelSpan: LocalTraceSpan | undefined): string | undefined {
-  if (firstModelSpan === undefined) return undefined;
-  const raw = firstModelSpan.attributes["ai.prompt.messages"];
-  if (typeof raw !== "string") return undefined;
-  let messages: unknown;
+/** The channel delivery projection holds the original message without prompt history. */
+function deliveryText(raw: string | undefined): string | undefined {
+  if (raw === undefined) return undefined;
   try {
-    messages = JSON.parse(raw);
-  } catch {
+    const input: unknown = JSON.parse(raw);
+    if (isRecord(input) && typeof input.message === "string") return input.message;
+    // Interaction-only deliveries have no user-facing text to render.
     return undefined;
+  } catch {
+    // Content capture uses JSON, but keep an unexpected scalar readable.
+    return raw;
   }
-  if (!Array.isArray(messages)) return undefined;
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const message = messages[index];
-    if (!isRecord(message) || message.role !== "user") continue;
-    const text = contentText(message.content).trim();
-    if (text.length > 0) return text;
-  }
-  return undefined;
-}
-
-function contentText(content: unknown): string {
-  if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-  return content
-    .filter(
-      (part): part is { text: string } =>
-        isRecord(part) && part.type === "text" && typeof part.text === "string",
-    )
-    .map((part) => part.text)
-    .join("\n");
 }
 
 /** Text tool results are stored JSON-encoded; unwrap them to plain text. */

--- a/packages/eve/src/cli/dev/tui/traces/trace-view.test.ts
+++ b/packages/eve/src/cli/dev/tui/traces/trace-view.test.ts
@@ -43,6 +43,10 @@ function span(
 /** A turn with a user message, an assistant reply, and a tool call. */
 function conversationSpans(): LocalTraceSpan[] {
   const turn = span("a".repeat(16), "agent.turn", 0, 0, undefined, { "agent.turn.id": "turn_0" });
+  const delivery = span("0".repeat(16), "agent.channel.delivery", 0, 0, undefined, {
+    "agent.channel.delivery.input": JSON.stringify({ message: "hi" }),
+    "agent.turn.id": "turn_0",
+  });
   const step = span("b".repeat(16), "agent.step", 10, 5000, turn.spanId, {});
   const model = span("c".repeat(16), "ai.streamText.doStream", 20, 2000, step.spanId, {
     "gen_ai.request.model": "gpt-5",
@@ -51,12 +55,11 @@ function conversationSpans(): LocalTraceSpan[] {
     "ai.prompt.system": "You are a test assistant.",
     "ai.response.text": "reply",
   });
-  const action = span("d".repeat(16), "agent.action", 2100, 2400, step.spanId, {});
-  const toolCall = span("e".repeat(16), "ai.toolCall", 2100, 2400, action.spanId, {
-    "gen_ai.tool.name": "get_weather",
+  const action = span("d".repeat(16), "agent.action", 2100, 2400, turn.spanId, {
+    "agent.action.name": "get_weather",
     "gen_ai.tool.call.arguments": '{"city":"sf"}',
   });
-  return [turn, step, model, action, toolCall];
+  return [turn, delivery, step, model, action];
 }
 
 function viewerState(
@@ -208,15 +211,22 @@ describe("renderTraceViewer", () => {
       "ai.response.text": "reply",
       "agent.usage.input_tokens": 10,
     });
-    const action = span("d".repeat(16), "agent.action", 110, 200, step.spanId, {});
-    const failingToolCall = {
-      ...span("f".repeat(16), "ai.toolCall", 110, 200, action.spanId, {
-        "gen_ai.tool.name": "explode",
-      }),
-      statusCode: 2,
-    };
+    const delivery = span("0".repeat(16), "agent.channel.delivery", 0, 0, undefined, {
+      "agent.channel.delivery.input": JSON.stringify({ message: "hi" }),
+    });
+    const action = span(
+      "d".repeat(16),
+      "agent.action",
+      110,
+      200,
+      turn.spanId,
+      {
+        "agent.action.name": "explode",
+      },
+      2,
+    );
     const frame = render(
-      viewerState([turn, step, model, action, failingToolCall], {
+      viewerState([turn, delivery, step, model, action], {
         panelOpen: true,
         selectedRow: 2,
       }),
@@ -250,9 +260,8 @@ describe("renderTraceViewer", () => {
       Array.from({ length: 30 }, (_, index) => [`key.${index}`, `value-${index}`]),
     );
     const turn = span("a".repeat(16), "agent.turn", 0, 0);
-    const action = span("d".repeat(16), "agent.action", 100, 200, turn.spanId, {});
-    const toolCall = span("f".repeat(16), "ai.toolCall", 100, 200, action.spanId, attributes);
-    const state = viewerState([turn, action, toolCall], {
+    const action = span("d".repeat(16), "agent.action", 100, 200, turn.spanId, attributes);
+    const state = viewerState([turn, action], {
       panelOpen: true,
       selectedRow: 0,
       panelScroll: 15,
@@ -298,9 +307,9 @@ describe("renderTraceViewer", () => {
     // A tool result ending in a real newline used to split its composed row
     // and inject a phantom blank line into the frame.
     const turn = span("a".repeat(16), "agent.turn", 0, 0);
-    const selected = span("f".repeat(16), "ai.toolCall", 100, 200, turn.spanId, {
+    const selected = span("f".repeat(16), "agent.action", 100, 200, turn.spanId, {
+      "agent.action.name": "load_skill",
       "gen_ai.tool.call.result": "When the user asks about weather, call the tool.\n",
-      "gen_ai.tool.name": "load_skill",
     });
     const frame = render(viewerState([turn, selected], { panelOpen: true }), 100, 24);
     for (const row of frame.rows) {

--- a/packages/eve/src/cli/dev/tui/traces/trace-viewer-session.test.ts
+++ b/packages/eve/src/cli/dev/tui/traces/trace-viewer-session.test.ts
@@ -88,12 +88,20 @@ describe("TraceViewerSession drag copy", () => {
         "ai.response.text": "reply",
       },
     };
+    const delivery: LocalTraceSpan = {
+      ...span("c".repeat(16), "session-mine"),
+      name: "agent.channel.delivery",
+      attributes: {
+        "agent.channel.delivery.input": JSON.stringify({ message: "copy me please" }),
+        "agent.turn.id": "turn_0",
+      },
+    };
     const store = stubStore([
       {
         endTimeNs: 1_000_000n,
         sessionId: "session-mine",
         sessionIds: ["session-mine"],
-        spans: [turn, model],
+        spans: [turn, delivery, model],
         startTimeNs: 1_000_000n,
         traceId: "c".repeat(32),
       },
@@ -130,7 +138,7 @@ describe("TraceViewerSession drag copy", () => {
     session.handleKey({ type: "mouse", action: "press", button: 32, x: 75, y: 5 });
     session.handleKey({ type: "mouse", action: "release", button: 0, x: 75, y: 5 });
     expect(copied).toHaveLength(2);
-    expect(copied[1]).toContain("agent.turn");
+    expect(copied[1]).toContain("agent.channel.delivery");
     session.dispose();
   });
 });

--- a/packages/eve/src/cli/dev/tui/traces/trace-viewer-state.test.ts
+++ b/packages/eve/src/cli/dev/tui/traces/trace-viewer-state.test.ts
@@ -43,7 +43,19 @@ function trace(spans: readonly LocalTraceSpan[], traceId = "t".repeat(32)): Loca
 
 /** A turn with a user message, an assistant reply, and a tool call. */
 function conversationTrace(options: { readonly longReply?: boolean } = {}): LocalTrace {
-  const turn = span({ name: "agent.turn", spanId: "a".repeat(16) });
+  const turn = span({
+    name: "agent.turn",
+    spanId: "a".repeat(16),
+    attributes: { "agent.turn.id": "turn_0" },
+  });
+  const delivery = span({
+    name: "agent.channel.delivery",
+    spanId: "0".repeat(16),
+    attributes: {
+      "agent.channel.delivery.input": JSON.stringify({ message: "hi" }),
+      "agent.turn.id": "turn_0",
+    },
+  });
   const step = span({ name: "agent.step", spanId: "b".repeat(16), parentSpanId: turn.spanId });
   const model = span({
     name: "ai.streamText.doStream",
@@ -54,14 +66,13 @@ function conversationTrace(options: { readonly longReply?: boolean } = {}): Loca
       "ai.response.text": options.longReply === true ? "a long reply. ".repeat(60) : "reply",
     },
   });
-  const action = span({ name: "agent.action", spanId: "d".repeat(16), parentSpanId: step.spanId });
-  const toolCall = span({
-    name: "ai.toolCall",
-    spanId: "e".repeat(16),
-    parentSpanId: action.spanId,
-    attributes: { "gen_ai.tool.name": "get_weather" },
+  const action = span({
+    name: "agent.action",
+    spanId: "d".repeat(16),
+    parentSpanId: turn.spanId,
+    attributes: { "agent.action.name": "get_weather" },
   });
-  return trace([turn, step, model, action, toolCall]);
+  return trace([turn, delivery, step, model, action]);
 }
 
 function entry(traceId: string, lastActivityMs = 0): TraceStoreEntry {
@@ -488,7 +499,19 @@ describe("applyLoadedTrace", () => {
     let state = applyLoadedTrace(
       createTraceViewerState(),
       trace([
-        span({ name: "agent.turn", spanId: "a".repeat(16) }),
+        span({
+          name: "agent.turn",
+          spanId: "a".repeat(16),
+          attributes: { "agent.turn.id": "turn_0" },
+        }),
+        span({
+          name: "agent.channel.delivery",
+          spanId: "0".repeat(16),
+          attributes: {
+            "agent.channel.delivery.input": JSON.stringify({ message: "hi" }),
+            "agent.turn.id": "turn_0",
+          },
+        }),
         span({ name: "agent.step", spanId: "b".repeat(16), parentSpanId: "a".repeat(16) }),
         span({
           name: "ai.streamText.doStream",

--- a/packages/eve/test/tui-client/tui-traces.ts
+++ b/packages/eve/test/tui-client/tui-traces.ts
@@ -60,10 +60,10 @@ void (async () => {
   try {
     const sessionWindow = "9".repeat(16);
     const turn = "a".repeat(16);
+    const delivery = "0".repeat(16);
     const step = "b".repeat(16);
     const model = "c".repeat(16);
     const action = "e".repeat(16);
-    const toolCall = "f".repeat(16);
     // A real capture roots turns under the session's window span, so the
     // fixture does too — turn discovery must not depend on root position.
     await writeSegment(appRoot, TRACE_ONE, {
@@ -83,7 +83,22 @@ void (async () => {
       start: 1_000,
       end: 1_000,
       parentSpanId: sessionWindow,
-      attributes: { "agent.session.id": "session-smoke", "agent.name": "smoke-agent" },
+      attributes: {
+        "agent.session.id": "session-smoke",
+        "agent.name": "smoke-agent",
+        "agent.turn.id": "turn_0",
+      },
+    });
+    await writeSegment(appRoot, TRACE_ONE, {
+      spanId: delivery,
+      name: "agent.channel.delivery",
+      start: 1_000,
+      end: 1_000,
+      parentSpanId: sessionWindow,
+      attributes: {
+        "agent.channel.delivery.input": JSON.stringify({ message: "smoke prompt" }),
+        "agent.turn.id": "turn_0",
+      },
     });
     await writeSegment(appRoot, TRACE_ONE, {
       spanId: step,
@@ -102,7 +117,6 @@ void (async () => {
       attributes: {
         "gen_ai.request.model": "smoke-model-v1",
         "ai.prompt.system": SYSTEM_PROMPT,
-        "ai.prompt.messages": JSON.stringify([{ role: "user", content: "smoke prompt" }]),
         "ai.response.text": "smoke reply",
       },
     });
@@ -111,19 +125,12 @@ void (async () => {
       name: "agent.action",
       start: 6_000,
       end: 6_300,
-      parentSpanId: step,
-      attributes: { "agent.action.kind": "tool", "agent.action.name": "get_weather" },
-    });
-    await writeSegment(appRoot, TRACE_ONE, {
-      spanId: toolCall,
-      name: "ai.toolCall",
-      start: 6_000,
-      end: 6_300,
-      parentSpanId: action,
+      parentSpanId: turn,
       attributes: {
+        "agent.action.kind": "tool",
+        "agent.action.name": "get_weather",
         "gen_ai.tool.call.arguments": '{"city":"San Francisco"}',
         "gen_ai.tool.call.result": '{"temperature":72}',
-        "gen_ai.tool.name": "get_weather",
       },
     });
     // A subagent child turn recorded into the same trace, carrying its
@@ -140,6 +147,18 @@ void (async () => {
         "agent.parent.turn.id": "turn_0",
         "agent.parent.call_id": "call-1",
         "agent.subagent.name": "echo",
+        "agent.turn.id": "turn_child",
+      },
+    });
+    await writeSegment(appRoot, TRACE_ONE, {
+      spanId: "5".repeat(16),
+      name: "agent.channel.delivery",
+      start: 7_000,
+      end: 7_000,
+      parentSpanId: sessionWindow,
+      attributes: {
+        "agent.channel.delivery.input": JSON.stringify({ message: "delegated task" }),
+        "agent.turn.id": "turn_child",
       },
     });
     await writeSegment(appRoot, TRACE_ONE, {
@@ -158,7 +177,6 @@ void (async () => {
       parentSpanId: "7".repeat(16),
       attributes: {
         "gen_ai.request.model": "smoke-model-v1",
-        "ai.prompt.messages": JSON.stringify([{ role: "user", content: "delegated task" }]),
         "ai.response.text": "delegated reply",
       },
     });
@@ -235,7 +253,7 @@ void (async () => {
     input.enter();
     await screen.waitForText("status", 5_000);
     await screen.waitForText("duration", 5_000);
-    await screen.waitForText("gen_ai.tool.name", 5_000);
+    await screen.waitForText("agent.action.name", 5_000);
     if (!screen.snapshot().includes('"city"')) {
       throw new Error(`The tool card lost its inline payload:\n${screen.snapshot()}`);
     }
@@ -250,7 +268,7 @@ void (async () => {
     // key merges into an unfinished CSI in the input tokenizer and wedges
     // every key after it (the lone-ESC flush never fires).
     input.send("\x1b");
-    await waitForAbsence(screen, "gen_ai.tool.name", 5_000);
+    await waitForAbsence(screen, "agent.action.name", 5_000);
 
     // The subagent child turn renders below the fold; End jumps to its cards,
     // which carry the dispatch lineage badge.


### PR DESCRIPTION
### Summary

The `/traces` viewer reads user messages from durable channel-delivery spans and tool cards from durable action spans instead of rebuilding both from model prompts and AI SDK child spans. Metadata-only deliveries no longer render as raw JSON user messages. Assistant cards and provider-native tool results still use model response spans; subagent labels retain the minimal parent lookup they require.

`eve traces` no longer repeats tool names on SDK child spans because the owning `agent.action` span already carries that label.

### Validation

- `../../node_modules/.bin/vitest run --config vitest.unit.config.ts src/cli/dev/tui/traces/trace-conversation.test.ts`
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/cli/commands/trace.integration.test.ts`
- `pnpm --filter eve typecheck`

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)