### PR TITLE
fix(eve): stabilize workflow-entry integration tests on Windows CI

### DIFF
--- a/packages/eve/src/execution/workflow-entry.integration.test.ts
+++ b/packages/eve/src/execution/workflow-entry.integration.test.ts
@@ -815,7 +815,10 @@ describe("workflowEntry integration", () => {
           await reader.cancel();
         }
 
-        expect(replayedIds).toEqual(ids);
+        // Order is not contractual across separate steps (see comment above):
+        // compare membership and count, not append order.
+        expect(replayedIds).toHaveLength(ids.length);
+        expect(new Set(replayedIds)).toEqual(new Set(ids));
       } finally {
         await run.cancel();
       }
@@ -1331,7 +1334,7 @@ async function withTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
       new Promise<never>((_resolve, reject) => {
         timeout = setTimeout(() => {
           reject(new Error(`Timed out waiting for ${label}.`));
-        }, 10_000);
+        }, 30_000);
       }),
     ]);
   } finally {


### PR DESCRIPTION
### Summary

Stabilizes two `workflow-entry.integration.test.ts` cases that flaked repeatedly on `test-integration (windows-latest)` over the last 48 hours, on PRs that don't touch this code (docs #1916, refactor #2013). Ubuntu, unit, scenario, lint, and typecheck all passed on the same runs; only the Windows integration job failed, twice, with two different failure modes.

1. **`stamps every stream event with an id that survives a rewind`** — asserted order-sensitive `expect(replayedIds).toEqual(ids)` between live emission order and durable replay order. The test's own comment (lines 795–798) documents that order is *not* contractual across separate steps, since events append from steps whose writes interleave behind minting. The assertion contradicted the documented contract and flaked whenever interleaving swapped two adjacent ids. Now compares membership and count via `Set`, matching the idiom already used at line 178. Uniqueness is still proven at line 793.

2. **`resumes normal follow-ups after an interactive authorization callback`** — timed out at the fixed 10s `withTimeout` deadline with `Timed out waiting for initial auth-required event.` The auth flow is deterministic (the integration mock model auto-activates under `NODE_ENV=test`), so the timeout fired as a false negative under Windows CI runner load (setup took 143s on the failing run vs 100s on a passing run). Raised the deadline to 30s to absorb CI variance while still catching a genuinely missing event.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/execution/workflow-entry.integration.test.ts` — 16/16 passed
- `pnpm lint`, `pnpm typecheck` — clean
- E2E not applicable: test-only stabilization, no published-package behavior change

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [ ] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

No changeset: test-only stabilization with no published-package behavior change.
