### PR TITLE
chore(agents): PR descriptions - require diff size justification

### DIFF
--- a/.agents/skills/gh-pr-description/SKILL.md
+++ b/.agents/skills/gh-pr-description/SKILL.md
@@ -31,35 +31,64 @@ exactly one of these categories:
   and generated runtime artifacts
 - **Tests** — tests, evals, test-only fixtures, and snapshots
 
-Use a table with one row for each category, including categories with no
-changes:
+Use three full-width category blocks in the order above, including categories
+with no changes. Do not use a table: file paths and justification need the full
+description width to remain readable on GitHub.
 
 ```markdown
 ### Diff size
 
-| Category       | Files changed                          | Diff size | Justification                                     |
-| -------------- | -------------------------------------- | --------: | ------------------------------------------------- |
-| Docs           | 0                                      |   +0 / -0 | Not applicable                                    |
-| Implementation | 1 — `packages/eve/src/example.ts`      |  +12 / -4 | Focused implementation of the behavior above      |
-| Tests          | 1 — `packages/eve/src/example.test.ts` |  +28 / -0 | Regression coverage for success and failure paths |
+**Docs** — 0 files · `+0 / -0`
+
+Not applicable.
+
+**Implementation** — 1 file · `+12 / -4`
+
+- `packages/eve/src/example.ts`
+
+Focused implementation of the behavior above.
+
+**Tests** — 1 file · `+28 / -0`
+
+- `packages/eve/src/example.test.ts`
+
+Regression coverage for success and failure paths.
 ```
 
-Report both the file count and the paths in **Files changed**. Compact path
-groups are acceptable only when every changed path remains accounted for.
-Report additions and deletions from the full branch diff against the PR base in
-**Diff size**, and verify that the three rows reconcile with the complete diff.
-Note binary files separately instead of treating them as zero-line changes.
-Classify a mixed-purpose file by its primary purpose and say that it is
-mixed-purpose in the justification.
+Keep each category's file count, additions, and deletions visible on its bold
+heading line. List its paths as bullets; compact path groups are acceptable only
+when every changed path remains accounted for. For an unwieldy path list, put
+only the paths in a `<details>` block with a `Files (N)` summary. Do not collapse
+the category totals or the entire Diff size section.
+
+Report additions and deletions from the full branch diff against the PR base,
+and verify that the three categories reconcile with the complete diff. Note
+binary files separately instead of treating them as zero-line changes. Classify
+a mixed-purpose file by its primary purpose and say that it is mixed-purpose in
+the justification.
 
 The justification must explain why each category needs that amount of change,
 not merely restate its line count. Explicitly call out unusually large files or
 categories, especially generated files, snapshots, fixtures, mechanical
 changes, or a file that disproportionately dominates the diff, and explain why
-that outlier is necessary and could not reasonably be smaller. If the size is
+that outlier is necessary and could not reasonably be smaller. Keep a concise
+outlier warning visible, then put a long explanation in a category-local
+`<details>` block titled `Why this category is unusually large`. If the size is
 surprising for the stated behavior, flag it for reviewer attention rather than
 normalizing it. The rest of the description should still discuss behavior
 rather than enumerate files; this section is the required exception.
+
+```markdown
+This category is unusually large because generated output dominates the diff.
+
+<details>
+<summary>Why this category is unusually large</summary>
+
+Explain the outlier, why it is necessary, and why it could not reasonably be
+smaller.
+
+</details>
+```
 
 Default to the shortest body that answers the five questions below. Keep the
 Summary under 5 sentences for most PRs; exceed 10 lines only for breaking or
@@ -87,11 +116,21 @@ the compiler now treats missing optional directories as empty.
 
 ### Diff size
 
-| Category       | Files changed                                   | Diff size | Justification                                              |
-| -------------- | ----------------------------------------------- | --------: | ---------------------------------------------------------- |
-| Docs           | 0                                               |   +0 / -0 | Not applicable                                             |
-| Implementation | 1 — `packages/eve/src/compiler/example.ts`      |   +6 / -2 | Keeps the missing-directory handling local to the compiler |
-| Tests          | 1 — `packages/eve/src/compiler/example.test.ts` |  +14 / -0 | Covers the regression without broad fixture changes        |
+**Docs** — 0 files · `+0 / -0`
+
+Not applicable.
+
+**Implementation** — 1 file · `+6 / -2`
+
+- `packages/eve/src/compiler/example.ts`
+
+Keeps the missing-directory handling local to the compiler.
+
+**Tests** — 1 file · `+14 / -0`
+
+- `packages/eve/src/compiler/example.test.ts`
+
+Covers the regression without broad fixture changes.
 ```
 
 Under validation, list exact checks actually run and useful manual coverage. State

--- a/.agents/skills/gh-pr-description/SKILL.md
+++ b/.agents/skills/gh-pr-description/SKILL.md
@@ -21,7 +21,47 @@ Fill in the repository template. Write for a reviewer:
 - link the prior issue with `Closes #N`, `Related to #N`, or equivalent
 - scale length with risk, not diff size
 
-Default to the shortest body that answers the four questions below. Keep the
+Append a `### Diff size` section after the template checklist. This must be the
+last section of every PR description and must account for every changed file in
+exactly one of these categories:
+
+- **Docs** — documentation, research, changesets, and other prose or release
+  metadata
+- **Implementation** — product code, configuration, dependencies, build files,
+  and generated runtime artifacts
+- **Tests** — tests, evals, test-only fixtures, and snapshots
+
+Use a table with one row for each category, including categories with no
+changes:
+
+```markdown
+### Diff size
+
+| Category       | Files changed                          | Diff size | Justification                                     |
+| -------------- | -------------------------------------- | --------: | ------------------------------------------------- |
+| Docs           | 0                                      |   +0 / -0 | Not applicable                                    |
+| Implementation | 1 — `packages/eve/src/example.ts`      |  +12 / -4 | Focused implementation of the behavior above      |
+| Tests          | 1 — `packages/eve/src/example.test.ts` |  +28 / -0 | Regression coverage for success and failure paths |
+```
+
+Report both the file count and the paths in **Files changed**. Compact path
+groups are acceptable only when every changed path remains accounted for.
+Report additions and deletions from the full branch diff against the PR base in
+**Diff size**, and verify that the three rows reconcile with the complete diff.
+Note binary files separately instead of treating them as zero-line changes.
+Classify a mixed-purpose file by its primary purpose and say that it is
+mixed-purpose in the justification.
+
+The justification must explain why each category needs that amount of change,
+not merely restate its line count. Explicitly call out unusually large files or
+categories, especially generated files, snapshots, fixtures, mechanical
+changes, or a file that disproportionately dominates the diff, and explain why
+that outlier is necessary and could not reasonably be smaller. If the size is
+surprising for the stated behavior, flag it for reviewer attention rather than
+normalizing it. The rest of the description should still discuss behavior
+rather than enumerate files; this section is the required exception.
+
+Default to the shortest body that answers the five questions below. Keep the
 Summary under 5 sentences for most PRs; exceed 10 lines only for breaking or
 cross-cutting changes. Prefer plain language. Include implementation detail or
 jargon only when the reviewer cannot assess behavior or risk without it. Do not
@@ -44,6 +84,14 @@ the compiler now treats missing optional directories as empty.
 ### Checklist
 
 (preserved from the template; only verified items checked)
+
+### Diff size
+
+| Category       | Files changed                                   | Diff size | Justification                                              |
+| -------------- | ----------------------------------------------- | --------: | ---------------------------------------------------------- |
+| Docs           | 0                                               |   +0 / -0 | Not applicable                                             |
+| Implementation | 1 — `packages/eve/src/compiler/example.ts`      |   +6 / -2 | Keeps the missing-directory handling local to the compiler |
+| Tests          | 1 — `packages/eve/src/compiler/example.test.ts` |  +14 / -0 | Covers the regression without broad fixture changes        |
 ```
 
 Under validation, list exact checks actually run and useful manual coverage. State
@@ -59,10 +107,12 @@ Before returning or publishing the description, confirm that it answers:
 2. What meaningfully changes?
 3. How was it validated?
 4. What should the reviewer pay special attention to?
+5. How is the complete diff divided among docs, implementation, and tests, and
+   why is each category that size?
 
-Then prune: delete any sentence that restates the diff, the issue, or the
-template, and any detail the reviewer does not need. If the answer to question
-4 is "nothing," leave it out.
+Then prune: outside the required Diff size section, delete any sentence that
+restates the diff, the issue, or the template, and any detail the reviewer does
+not need. If the answer to question 4 is "nothing," leave it out.
 
 When asked only to draft, return the body for review. When asked to create or
 update the PR, pass a body file to `gh pr create` or `gh pr edit`.

--- a/.agents/skills/gh-pr-description/SKILL.md
+++ b/.agents/skills/gh-pr-description/SKILL.md
@@ -32,8 +32,8 @@ exactly one of these categories:
 - **Tests** — tests, evals, test-only fixtures, and snapshots
 
 Use three full-width category blocks in the order above, including categories
-with no changes. Do not use a table: file paths and justification need the full
-description width to remain readable on GitHub.
+with no changes. Do not use a table: the overview and any reviewer-relevant
+context need the full description width to remain readable on GitHub.
 
 ```markdown
 ### Diff size
@@ -44,47 +44,51 @@ Not applicable.
 
 **Implementation** — 1 file · `+12 / -4`
 
-- `packages/eve/src/example.ts`
-
 Focused implementation of the behavior above.
 
 **Tests** — 1 file · `+28 / -0`
-
-- `packages/eve/src/example.test.ts`
 
 Regression coverage for success and failure paths.
 ```
 
 Keep each category's file count, additions, and deletions visible on its bold
-heading line. List its paths as bullets; compact path groups are acceptable only
-when every changed path remains accounted for. For an unwieldy path list, put
-only the paths in a `<details>` block with a `Files (N)` summary. Do not collapse
-the category totals or the entire Diff size section.
+heading line. Treat the section as an overview, not a file inventory: do not
+list every changed path. Mention individual files only when they are critical
+to understanding or reviewing the change, under a short `Key files` list. Omit
+paths entirely when no file needs special attention. The category counts must
+still include every changed file. Do not collapse the category totals or the
+entire Diff size section.
 
 Report additions and deletions from the full branch diff against the PR base,
 and verify that the three categories reconcile with the complete diff. Note
 binary files separately instead of treating them as zero-line changes. Classify
-a mixed-purpose file by its primary purpose and say that it is mixed-purpose in
-the justification.
+a mixed-purpose file by its primary purpose; mention that ambiguity only when it
+is useful to the reviewer.
 
 The justification must explain why each category needs that amount of change,
-not merely restate its line count. Explicitly call out unusually large files or
-categories, especially generated files, snapshots, fixtures, mechanical
-changes, or a file that disproportionately dominates the diff, and explain why
-that outlier is necessary and could not reasonably be smaller. Keep a concise
-outlier warning visible, then put a long explanation in a category-local
-`<details>` block titled `Why this category is unusually large`. If the size is
+not merely restate its line count. Call out a file or category only when its
+size is genuinely surprising or materially disproportionate to the behavior
+and review scope, especially for generated files, snapshots, fixtures, or
+mechanical changes. Being the only changed file, the largest category, or a
+modest one-file diff does not make something an outlier.
+
+Keep a concise explanation visible. If supporting detail would be lengthy, use
+a category-local `<details>` block with a specific, natural summary such as
+`Generated output`, `Fixture expansion`, or `Mechanical migration`; do not use
+a prescribed heading or force words such as `unusually`. Explain why the large
+portion is necessary and could not reasonably be smaller. If the size is
 surprising for the stated behavior, flag it for reviewer attention rather than
-normalizing it. The rest of the description should still discuss behavior
-rather than enumerate files; this section is the required exception.
+normalizing it. Do not manufacture an outlier explanation for an ordinary diff.
+The rest of the description should still discuss behavior rather than enumerate
+files; this section is the required exception.
 
 ```markdown
-This category is unusually large because generated output dominates the diff.
+Generated output accounts for most of the implementation diff.
 
 <details>
-<summary>Why this category is unusually large</summary>
+<summary>Generated output</summary>
 
-Explain the outlier, why it is necessary, and why it could not reasonably be
+Explain why the generated changes are necessary and could not reasonably be
 smaller.
 
 </details>
@@ -122,13 +126,9 @@ Not applicable.
 
 **Implementation** — 1 file · `+6 / -2`
 
-- `packages/eve/src/compiler/example.ts`
-
 Keeps the missing-directory handling local to the compiler.
 
 **Tests** — 1 file · `+14 / -0`
-
-- `packages/eve/src/compiler/example.test.ts`
 
 Covers the regression without broad fixture changes.
 ```


### PR DESCRIPTION
### Summary

PR descriptions did not explain how review volume was divided among documentation, implementation, and tests, which made disproportionate generated or mechanical changes easy to overlook. The `gh-pr-description` skill now requires a final `### Diff size` overview that reports file counts and line totals for those three categories and reconciles them with the full branch diff. Individual paths are optional and reserved for files that deserve reviewer attention; genuinely surprising portions require justification, with context-specific disclosure headings when details are lengthy. This changes agent-facing review guidance only; framework behavior is unchanged.

### Validation

- `git diff --check origin/main...HEAD`
- `pnpm exec oxfmt --check .agents/skills/gh-pr-description/SKILL.md`
- Reviewed the rendered Markdown and verified all category totals against `git diff --numstat origin/main...HEAD`
- Tests and changeset are not applicable because this only updates an internal skill

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [ ] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+93 / -4`

Adds the category-level accounting rules, GitHub-friendly format, examples, and guidance for reviewer-relevant file callouts and genuinely disproportionate diffs.

**Implementation** — 0 files · `+0 / -0`

Not applicable; no product code, configuration, dependencies, or generated runtime artifacts changed.

**Tests** — 0 files · `+0 / -0`

Not applicable; the change is agent guidance with no executable behavior to cover.
