### PR TITLE
docs: streamline PR validation guidance

### DIFF
--- a/.agents/skills/gh-pr-description/SKILL.md
+++ b/.agents/skills/gh-pr-description/SKILL.md
@@ -112,7 +112,7 @@ the compiler now treats missing optional directories as empty.
 ### Validation
 
 Reproduced the crash with the weather fixture and confirmed the fix with
-regression coverage, unit tests, and type checking.
+focused regression coverage.
 
 ### Checklist
 
@@ -135,8 +135,10 @@ Covers the regression without broad fixture changes.
 
 Under validation, write one short prose description, not a bullet list of
 commands. For a bug fix, say what was reproduced and how the fix was
-confirmed. For a feature, say how coverage demonstrates the new behavior. Note
-limitations honestly and do not claim checks that only CI will run.
+confirmed. For a feature, say how coverage demonstrates the new behavior. Do
+not mention routine formatting, linting, type checking, or other baseline
+checks; CI coverage is assumed. Note limitations honestly and do not claim
+checks that only CI will run.
 
 Preserve the checklist and check only verified items. If tests, docs, or a
 changeset are not applicable, say so in one short line at most.

--- a/.agents/skills/gh-pr-description/SKILL.md
+++ b/.agents/skills/gh-pr-description/SKILL.md
@@ -111,8 +111,8 @@ the compiler now treats missing optional directories as empty.
 
 ### Validation
 
-- Reproduced the crash with the weather fixture, then confirmed a clean boot
-- `pnpm test:unit`, `pnpm typecheck`
+Reproduced the crash with the weather fixture and confirmed the fix with
+regression coverage, unit tests, and type checking.
 
 ### Checklist
 
@@ -133,9 +133,10 @@ Keeps the missing-directory handling local to the compiler.
 Covers the regression without broad fixture changes.
 ```
 
-Under validation, list exact checks actually run and useful manual coverage. State
-limitations honestly. Do not infer results or claim checks that only CI will
-run.
+Under validation, write one short prose description, not a bullet list of
+commands. For a bug fix, say what was reproduced and how the fix was
+confirmed. For a feature, say how coverage demonstrates the new behavior. Note
+limitations honestly and do not claim checks that only CI will run.
 
 Preserve the checklist and check only verified items. If tests, docs, or a
 changeset are not applicable, say so in one short line at most.


### PR DESCRIPTION
### Summary

Updates the PR-description skill so Validation explains the evidence for a fix or feature instead of listing every command that ran. The shorter guidance and example focus reviewers on reproduction, confirmation, and coverage.

### Validation

Reviewed the revised example and guidance. No runtime behavior changes or tests apply.

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+8 / -5`

Updates internal PR-writing guidance and its example, keeping routine checks out of validation summaries.

**Implementation** — 0 files · `+0 / -0`

Not applicable.

**Tests** — 0 files · `+0 / -0`

Not applicable.
