### PR TITLE
chore(agent-workflow-stress): diagnostics - log workflow run ids

### DIFF
--- a/e2e/fixtures/agent-workflow-stress/evals/concurrent-workflow-turns.eval.ts
+++ b/e2e/fixtures/agent-workflow-stress/evals/concurrent-workflow-turns.eval.ts
@@ -14,6 +14,9 @@ export default defineEval({
     const firstTurns = await Promise.all(
       sessions.map((session, index) => session.send(markerFor(index, 1))),
     );
+    firstTurns.forEach((turn, index) => {
+      t.log(`workflow run id (${index + 1}/${SESSION_COUNT}): ${turn.sessionId}`);
+    });
     const secondTurns = await Promise.all(
       sessions.map((session, index) => session.send(markerFor(index, 2))),
     );

--- a/e2e/fixtures/agent-workflow-stress/evals/sequential-workflow-turns.eval.ts
+++ b/e2e/fixtures/agent-workflow-stress/evals/sequential-workflow-turns.eval.ts
@@ -20,9 +20,13 @@ export default defineEval({
         `turn ${String(turnNumber).padStart(3, "0")}/${TURN_COUNT} completed in ${elapsedSeconds.toFixed(3)}s`,
       );
 
+      if (sessionId === undefined) {
+        sessionId = result.sessionId;
+        t.log(`workflow run id: ${sessionId}`);
+      }
+
       const turn = result.expectOk();
 
-      sessionId ??= turn.sessionId;
       await t.require(turn.sessionId, equals(sessionId));
       await t.require(turn.message, equals(`stress-ack:${turnNumber}:${marker}`));
     }


### PR DESCRIPTION
### Summary

Closes #2037. Workflow stress failures did not expose their Workflow run IDs in CI output, which made the corresponding runs and traces harder to locate. The sequential eval now logs its ID once, while the concurrent eval logs a labeled ID for each of its 50 sessions as soon as their first turns return.

### Validation

The workflow stress fixture builds successfully. Full Workflow execution remains CI-only and will be covered by the Postgres E2E job.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 0 files · `+0 / -0`

Not applicable.

**Tests** — 2 files · `+8 / -1`

Keeps the diagnostic output local to the sequential and concurrent stress evals.
