### PR TITLE
fix(docs): render masked integration social images

### DIFF
--- a/apps/docs/lib/integrations/logos.tsx
+++ b/apps/docs/lib/integrations/logos.tsx
@@ -38,7 +38,7 @@ import {
   SiZapier,
   SiZomato,
 } from "@icons-pack/react-simple-icons";
-import { type ComponentProps, useId } from "react";
+import type { ComponentProps } from "react";
 
 type LogoProps = ComponentProps<"svg">;
 
@@ -60,26 +60,22 @@ export const webLogo = (props: LogoProps) => (
   </svg>
 );
 
-export const BuzzLogo = (props: LogoProps) => {
-  const maskId = useId();
-
-  return (
-    <svg fill="none" viewBox="0 0 466 309" xmlns="http://www.w3.org/2000/svg" {...props}>
-      <defs>
-        <mask id={maskId}>
-          <circle cx="91.7" cy="154.5" fill="white" r="91.7" />
-          <circle cx="374.3" cy="154.5" fill="white" r="91.7" />
-          <rect fill="white" height="309" rx="34" width="210" x="128" />
-          <ellipse cx="193.3" cy="84.4" fill="black" rx="27" ry="27" />
-          <ellipse cx="276" cy="84.4" fill="black" rx="27" ry="27" />
-          <rect fill="black" height="38.3" rx="5" width="136.9" x="166.3" y="157.2" />
-          <rect fill="black" height="37.6" rx="5" width="136.2" x="166.9" y="235.1" />
-        </mask>
-      </defs>
-      <rect fill="currentColor" height="309" mask={`url(#${maskId})`} width="466" />
-    </svg>
-  );
-};
+export const BuzzLogo = (props: LogoProps) => (
+  <svg fill="none" viewBox="0 0 466 309" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <defs>
+      <mask id="buzz-logo-mask">
+        <circle cx="91.7" cy="154.5" fill="white" r="91.7" />
+        <circle cx="374.3" cy="154.5" fill="white" r="91.7" />
+        <rect fill="white" height="309" rx="34" width="210" x="128" />
+        <ellipse cx="193.3" cy="84.4" fill="black" rx="27" ry="27" />
+        <ellipse cx="276" cy="84.4" fill="black" rx="27" ry="27" />
+        <rect fill="black" height="38.3" rx="5" width="136.9" x="166.3" y="157.2" />
+        <rect fill="black" height="37.6" rx="5" width="136.2" x="166.9" y="235.1" />
+      </mask>
+    </defs>
+    <rect fill="currentColor" height="309" mask="url(#buzz-logo-mask)" width="466" />
+  </svg>
+);
 
 export const browserUseLogo = (props: LogoProps) => (
   <svg fill="none" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg" {...props}>

--- a/apps/docs/lib/integrations/og-image.tsx
+++ b/apps/docs/lib/integrations/og-image.tsx
@@ -145,7 +145,10 @@ const rasterizeLogo = async (logo: ReactNode): Promise<RasterizedLogo> => {
 const collectLogoColors = (node: ReactNode, colors = new Set<string>()): Set<string> => {
   if (!isValidElement(node)) return colors;
 
-  const { children, fill, stroke } = (node as ReactElement<LogoElementProps>).props;
+  const element = node as ReactElement<LogoElementProps>;
+  if (element.type === "mask") return colors;
+
+  const { children, fill, stroke } = element.props;
   for (const color of [fill, stroke]) {
     if (color && color !== "none" && color !== "currentColor") colors.add(color.toLowerCase());
   }
@@ -174,6 +177,8 @@ const recolorLogo = (node: ReactNode, preserveTones: boolean): ReactNode => {
   if (!isValidElement(node)) return node;
 
   const element = node as ReactElement<LogoElementProps>;
+  if (element.type === "mask") return element;
+
   const props = element.props;
   const recolor = (color: string | undefined): string | undefined => {
     if (!color || color === "none") return color;


### PR DESCRIPTION
### Summary

The Buzz integration's social image endpoint returned HTTP 500 because its logo called `useId()` while the OG pipeline resolves logo components outside React's render lifecycle. Use a stable, logo-specific SVG mask ID and preserve mask colors during logo recoloring so Open Graph and X images include the complete Buzz mark.

### Validation

Requested the Buzz Open Graph image from the local docs server, confirmed a `200 image/png` response containing a 1200×628 PNG, and visually verified that the rendered logo includes the bee body, wings, eyes, and stripes.

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 2 files · `+23 / -22`

Keeps the stable ID local to the Buzz SVG and prevents the shared OG recoloring pass from inverting the luminance semantics of SVG masks.

**Tests** — 0 files · `+0 / -0`

The generated image was verified directly and visually against the local endpoint.
