### PR TITLE
feat(eve): query committed local subagent work

### DIFF
--- a/packages/eve/src/execution/durable-session-migrations/turn-workflow.ts
+++ b/packages/eve/src/execution/durable-session-migrations/turn-workflow.ts
@@ -40,6 +40,8 @@ export interface TurnStepInput {
   readonly abortSignal?: AbortSignal;
   readonly input: TurnStepPayload | undefined;
   readonly parentWritable: WritableStream<Uint8Array>;
+  /** Session-owned latest work projection stream. */
+  readonly workWritable?: WritableStream<unknown>;
   readonly serializedContext: Record<string, unknown>;
   readonly sessionState: DurableSessionState;
 }
@@ -66,6 +68,8 @@ export interface TurnWorkflowDispatchInput {
   readonly delivery: HookPayload;
   readonly mode: RunMode;
   readonly parentWritable: WritableStream<Uint8Array>;
+  /** Session-owned latest work projection stream. */
+  readonly workWritable?: WritableStream<unknown>;
   readonly serializedContext: Record<string, unknown>;
   readonly sessionState: DurableSessionState;
 }
@@ -82,6 +86,7 @@ export function createTurnWorkflowInput(input: TurnWorkflowDispatchInput): TurnW
       input: input.delivery,
       parentWritable: input.parentWritable,
       serializedContext: input.serializedContext,
+      workWritable: input.workWritable,
       sessionState: input.sessionState,
     },
     version: TURN_WORKFLOW_INPUT_VERSION,

--- a/packages/eve/src/execution/local-subagent-work-query.test.ts
+++ b/packages/eve/src/execution/local-subagent-work-query.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { readLocalSubagentWork } from "#execution/local-subagent-work-query.js";
+import { AGENT_HANDLES_STATE_KEY } from "#harness/handles/store.js";
+
+const getRunMock = vi.fn();
+
+vi.mock("#internal/workflow/runtime.js", () => ({
+  getRun: (...args: unknown[]) => getRunMock(...args),
+}));
+
+describe("readLocalSubagentWork", () => {
+  it("reads the latest dedicated work snapshot for a direct local child", async () => {
+    const cancel = vi.fn(async () => {});
+    const releaseLock = vi.fn();
+    const getReadable = vi.fn(() => ({
+      getReader: () => ({
+        cancel,
+        read: async () => ({ done: false, value: { revision: 3 } }),
+        releaseLock,
+      }),
+    }));
+    getRunMock.mockReturnValue({ getReadable });
+
+    await expect(
+      readLocalSubagentWork({
+        callId: "call-1",
+        parentState: {
+          [AGENT_HANDLES_STATE_KEY]: {
+            handles: [
+              {
+                address: {
+                  continuationToken: "subagent:child",
+                  kind: "agent/local",
+                  sessionId: "child-session",
+                },
+                identity: { id: "ag_research", name: "researcher", nodeId: "subagents/researcher" },
+                operation: { callId: "call-1", id: "op-1", kind: "start", parentTurnId: "turn-1" },
+                phase: "running",
+              },
+            ],
+          },
+        },
+      }),
+    ).resolves.toEqual({ kind: "available", revision: 3, work: { revision: 3 } });
+
+    expect(getReadable).toHaveBeenCalledWith({ namespace: "eve.work", startIndex: -1 });
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(releaseLock).toHaveBeenCalledOnce();
+  });
+
+  it("does not query remote or missing children", async () => {
+    getRunMock.mockClear();
+    await expect(readLocalSubagentWork({ callId: "missing", parentState: {} })).resolves.toEqual({
+      kind: "unavailable",
+      reason: "not-running",
+    });
+    expect(getRunMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/eve/src/execution/local-subagent-work-query.ts
+++ b/packages/eve/src/execution/local-subagent-work-query.ts
@@ -1,0 +1,45 @@
+import { getRun } from "#internal/workflow/runtime.js";
+import { findRunningAgentHandle } from "#harness/handles/query.js";
+import type { WorkGraph } from "#harness/work-graph.js";
+import type { SessionStateMap } from "#harness/types.js";
+
+export const LOCAL_SUBAGENT_WORK_NAMESPACE = "eve.work";
+
+export type LocalSubagentWorkQueryResult =
+  | { readonly kind: "available"; readonly revision: number; readonly work: WorkGraph }
+  | {
+      readonly kind: "unavailable";
+      readonly reason: "not-local" | "not-running" | "not-yet-committed";
+    };
+
+/** Reads the latest committed work graph for one direct running local subagent. */
+export async function readLocalSubagentWork(input: {
+  readonly callId: string;
+  readonly parentState: SessionStateMap | undefined;
+}): Promise<LocalSubagentWorkQueryResult> {
+  const handle = findRunningAgentHandle(input.parentState, { callId: input.callId });
+  if (handle === undefined) return { kind: "unavailable", reason: "not-running" };
+  if (handle.address.kind !== "agent/local") return { kind: "unavailable", reason: "not-local" };
+
+  const reader = getRun(handle.address.sessionId)
+    .getReadable<unknown>({ namespace: LOCAL_SUBAGENT_WORK_NAMESPACE, startIndex: -1 })
+    .getReader();
+  try {
+    const next = await reader.read();
+    const work = parseWorkGraph(next.value);
+    return work === undefined
+      ? { kind: "unavailable", reason: "not-yet-committed" }
+      : { kind: "available", revision: work.revision, work };
+  } finally {
+    await reader.cancel().catch(() => {});
+    reader.releaseLock();
+  }
+}
+
+function parseWorkGraph(value: unknown): WorkGraph | undefined {
+  if (value === null || typeof value !== "object") return undefined;
+  const work = value as Partial<WorkGraph>;
+  return typeof work.revision === "number" && Number.isSafeInteger(work.revision)
+    ? (work as WorkGraph)
+    : undefined;
+}

--- a/packages/eve/src/execution/turn-dispatch.ts
+++ b/packages/eve/src/execution/turn-dispatch.ts
@@ -32,6 +32,7 @@ export async function dispatchAndAwaitTurn(input: {
   readonly commandInbox: SessionCommandInbox;
   readonly mode: RunMode;
   readonly parentWritable: WritableStream<Uint8Array>;
+  readonly workWritable?: WritableStream<unknown>;
   readonly serializedContext: Record<string, unknown>;
   readonly seenTaskDeliveries?: Set<string>;
   readonly sessionState: DurableSessionState;
@@ -54,6 +55,7 @@ export async function dispatchAndAwaitTurn(input: {
       mode: input.mode,
       parentWritable: input.parentWritable,
       serializedContext: input.serializedContext,
+      workWritable: input.workWritable,
       sessionState: input.sessionState,
     });
     const action = await control.waitForAction();

--- a/packages/eve/src/execution/turn-workflow.ts
+++ b/packages/eve/src/execution/turn-workflow.ts
@@ -31,6 +31,8 @@ import { resolveWorkflowCallbackBaseUrl } from "#execution/workflow-callback-url
 import { normalizeSerializableError } from "#execution/workflow-errors.js";
 import { turnStep } from "#execution/workflow-steps.js";
 import { activeTurnId } from "#harness/active-turn-id.js";
+import { deserializeContext } from "#context/serialize.js";
+import { WorkGraphKey } from "#context/keys.js";
 import { getRuntimeActionResultKey } from "#runtime/actions/keys.js";
 import { resolveRuntimeActionResultsForKeys } from "#runtime/actions/results.js";
 import type { RuntimeActionResult } from "#runtime/actions/types.js";
@@ -137,6 +139,8 @@ async function runTurnOwnedWorkflow(input: TurnWorkflowInput): Promise<void> {
         await finishCancelledTurn({ bufferedDeliveries, cancellation, cursor });
         return;
       }
+
+      await writeCommittedWorkSnapshot(result, input.stepInput.workWritable);
 
       if (result.sleepDurationMs !== undefined) {
         const outcome = await waitForTurnSleep(result.sleepDurationMs, cancellation);
@@ -250,6 +254,22 @@ async function runTurnOwnedWorkflow(input: TurnWorkflowInput): Promise<void> {
     // run's teardown; this backstop covers the error path.
     if (cancellation !== undefined) await cancellation.dispose();
     if (ownsInbox) await disposeHook(inbox);
+  }
+}
+
+async function writeCommittedWorkSnapshot(
+  result: { readonly serializedContext: Record<string, unknown> },
+  workWritable: WritableStream<unknown> | undefined,
+): Promise<void> {
+  if (workWritable === undefined) return;
+  const ctx = await deserializeContext(result.serializedContext);
+  const work = ctx.get(WorkGraphKey);
+  if (work === undefined || work.revision === 0) return;
+  const writer = workWritable.getWriter();
+  try {
+    await writer.write(work);
+  } finally {
+    writer.releaseLock();
   }
 }
 

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -150,6 +150,7 @@ export async function workflowEntry(input: WorkflowEntryInput): Promise<Workflow
   input.serializedContext["eve.sessionId"] = sessionId;
 
   const driverWritable = getWritable<Uint8Array>();
+  const workWritable = getWritable<unknown>({ namespace: "eve.work" });
   const crashCleanupState: CrashCleanupState = {
     caller: undefined,
     callerResolved: false,
@@ -214,6 +215,7 @@ export async function workflowEntry(input: WorkflowEntryInput): Promise<Workflow
       crashCleanupState,
       mode,
       serializedContext: input.serializedContext,
+      workWritable,
       sessionState,
       sessionTimeoutDeadline:
         input.sessionTimeoutMs === false
@@ -309,6 +311,7 @@ async function runDriverLoop(input: {
   readonly serializedContext: Record<string, unknown>;
   readonly sessionState: DurableSessionState;
   readonly sessionTimeoutDeadline?: Date;
+  readonly workWritable: WritableStream<unknown>;
 }): Promise<DriverLoopOutcome> {
   // One payload per exact authorization attempt accumulates across
   // intervening turns. Replaced attempts are pruned at each park.
@@ -443,6 +446,7 @@ async function runDriverLoop(input: {
       serializedContext,
       seenTaskDeliveries,
       sessionState: stateCursor.sessionState,
+      workWritable: input.workWritable,
     });
     await disposeSettledTurnControl?.();
     disposeSettledTurnControl = turn.dispose;


### PR DESCRIPTION
### Summary

Related to #1673. Spike a narrow query primitive for the latest committed work graph of a direct running local subagent. The child session now writes its committed graph to an internal `eve.work` stream; callers validate direct local-handle ownership by `callId` before reading that stream's tail.

This avoids consuming the child’s full event stream or waking the parent once per child step. It does not yet schedule parent polling or render queried child detail; those remain separate decisions.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/execution/local-subagent-work-query.test.ts`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/execution/workflow-steps.test.ts src/execution/turn-dispatch.test.ts src/execution/durable-session-migrations/turn-workflow.test.ts`
- `pnpm --filter eve exec tsc --noEmit -p tsconfig.json`

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
