### PR TITLE
feat(eve): build - move Nitro to project-local engine

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,11 +2,14 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [["@eve/build", "eve"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  },
   "privatePackages": {
     "version": false,
     "tag": false

--- a/.changeset/lean-build-engine.md
+++ b/.changeset/lean-build-engine.md
@@ -1,0 +1,9 @@
+---
+"@eve/build": patch
+"eve": patch
+---
+
+Move Nitro and Rolldown into the project-local `@eve/build` development package so lightweight
+`npx eve` commands no longer resolve Nitro's dependency graph. New and updated projects install
+the matching engine automatically; existing projects must add `@eve/build` before running source
+compilation commands.

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ playwright-report/
 test-results/
 
 # Package lifecycle artifacts (copied from the repo root at prepack)
+packages/eve-build/LICENSE
+packages/eve-build/NOTICE
 packages/eve/docs/
 packages/eve/LICENSE
 packages/eve/NOTICE

--- a/apps/fixtures/agent-tui-client/package.json
+++ b/apps/fixtures/agent-tui-client/package.json
@@ -14,6 +14,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@eve/build": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:"
   }

--- a/apps/fixtures/weather-agent/package.json
+++ b/apps/fixtures/weather-agent/package.json
@@ -12,5 +12,8 @@
   "dependencies": {
     "eve": "workspace:*",
     "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@eve/build": "workspace:*"
   }
 }

--- a/apps/frameworks/next-multi-agent/package.json
+++ b/apps/frameworks/next-multi-agent/package.json
@@ -18,6 +18,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@eve/build": "workspace:*",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",

--- a/apps/frameworks/next/package.json
+++ b/apps/frameworks/next/package.json
@@ -22,6 +22,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@eve/build": "workspace:*",
     "@tailwindcss/postcss": "4.3.0",
     "@types/node": "catalog:",
     "@types/react": "catalog:",

--- a/apps/frameworks/nuxt/package.json
+++ b/apps/frameworks/nuxt/package.json
@@ -18,6 +18,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@eve/build": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "6.0.3",
     "vue-tsc": "3.3.6"

--- a/apps/frameworks/sveltekit/package.json
+++ b/apps/frameworks/sveltekit/package.json
@@ -18,6 +18,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@eve/build": "workspace:*",
     "@types/node": "catalog:"
   }
 }

--- a/apps/package-artifacts/README.md
+++ b/apps/package-artifacts/README.md
@@ -1,11 +1,15 @@
 # eve package artifacts
 
-Git-linked Vercel project that builds an eve tarball from each `vercel/eve` `main` commit and uploads immutable SHA-addressed package and manifest artifacts to private Vercel Blob using deployment OIDC.
+Git-linked Vercel project that builds coordinated `eve` and `@eve/build` tarballs from each
+`vercel/eve` `main` commit and uploads immutable SHA-addressed package and manifest artifacts to
+private Vercel Blob using deployment OIDC.
 
 ```text
 /main/eve.tgz
+/main/eve-build.tgz
 /main/latest.json
 /<full-sha>/eve.tgz
+/<full-sha>/eve-build.tgz
 ```
 
 The publisher uses Vercel's `VERCEL_PROJECT_PRODUCTION_URL` system environment variable as the public package domain. For example, if the production domain is `packages.example.com`, initialize an agent from the current `main` build with:

--- a/apps/package-artifacts/api/package.js
+++ b/apps/package-artifacts/api/package.js
@@ -10,6 +10,10 @@ export default async function handler(request, response) {
   if (typeof ref !== "string" || (ref !== "main" && !SHA_PATTERN.test(ref))) {
     return packageNotFound(response);
   }
+  const packageSlug = request.query.package ?? "eve";
+  if (packageSlug !== "eve" && packageSlug !== "eve-build") {
+    return packageNotFound(response);
+  }
 
   // Resolve `main` to the commit represented by the current production deployment.
   const sourceSha = ref === "main" ? process.env.VERCEL_GIT_COMMIT_SHA : ref;
@@ -27,10 +31,13 @@ export default async function handler(request, response) {
   }
   if (ref === "main") {
     response.setHeader("Cache-Control", "public, max-age=60");
-    return response.redirect(302, manifest.tarball);
+    return response.redirect(
+      302,
+      packageSlug === "eve-build" ? manifest.buildTarball : manifest.tarball,
+    );
   }
 
-  const artifact = await get(packageArtifactPath(sourceSha), { access: "private" });
+  const artifact = await get(packageArtifactPath(sourceSha, packageSlug), { access: "private" });
   if (artifact === null) return packageNotFound(response);
 
   response.setHeader("Cache-Control", "public, max-age=31536000, immutable");
@@ -52,7 +59,9 @@ async function resolveManifest(sourceSha) {
     manifest.sourceSha !== sourceSha ||
     typeof manifest.version !== "string" ||
     typeof manifest.tarball !== "string" ||
-    typeof manifest.sha256 !== "string"
+    typeof manifest.sha256 !== "string" ||
+    typeof manifest.buildTarball !== "string" ||
+    typeof manifest.buildSha256 !== "string"
   ) {
     return undefined;
   }

--- a/apps/package-artifacts/api/package.test.mjs
+++ b/apps/package-artifacts/api/package.test.mjs
@@ -12,6 +12,8 @@ const manifest = {
   version: `0.33.0+main.${sha}`,
   tarball: `https://packages.example.com/${sha}/eve.tgz`,
   sha256: "b".repeat(64),
+  buildTarball: `https://packages.example.com/${sha}/eve-build.tgz`,
+  buildSha256: "c".repeat(64),
 };
 
 function response() {
@@ -67,9 +69,23 @@ describe("package route", () => {
     expect(artifact.setHeader).toHaveBeenCalledWith("Content-Type", "application/gzip");
     expect(artifact.read()).toEqual(Buffer.from("package bytes"));
 
+    const buildArtifact = response();
+    await handler({ query: { ref: sha, package: "eve-build" } }, buildArtifact);
+    expect(get).toHaveBeenLastCalledWith(`packages/${sha}/eve-build.tgz`, {
+      access: "private",
+    });
+    expect(buildArtifact.read()).toEqual(Buffer.from("package bytes"));
+
     const latest = response();
     await handler({ query: { ref: sha, manifest: "1" } }, latest);
     expect(latest.status).toHaveBeenCalledWith(404);
+  });
+
+  test("resolves the main build engine through the deployment commit", async () => {
+    const res = response();
+    await handler({ query: { ref: "main", package: "eve-build" } }, res);
+
+    expect(res.redirect).toHaveBeenCalledWith(302, manifest.buildTarball);
   });
 
   test("rejects unsupported refs and missing artifacts", async () => {

--- a/apps/package-artifacts/lib/package.mjs
+++ b/apps/package-artifacts/lib/package.mjs
@@ -1,17 +1,17 @@
 export const SHA_PATTERN = /^[0-9a-f]{40}$/i;
 
-export function packageArtifactPath(sourceSha) {
-  return `packages/${sourceSha}/eve.tgz`;
+export function packageArtifactPath(sourceSha, packageSlug = "eve") {
+  return `packages/${sourceSha}/${packageSlug}.tgz`;
 }
 
 export function packageManifestPath(sourceSha) {
   return `packages/${sourceSha}/manifest.json`;
 }
 
-export function packageDependencyUrl(baseUrl, sourceSha) {
+export function packageDependencyUrl(baseUrl, sourceSha, packageSlug = "eve") {
   const url = new URL(baseUrl);
   if (url.protocol !== "https:") throw new Error("Package base URL must use HTTPS.");
-  url.pathname = `${url.pathname.replace(/\/$/, "")}/${sourceSha}/eve.tgz`;
+  url.pathname = `${url.pathname.replace(/\/$/, "")}/${sourceSha}/${packageSlug}.tgz`;
   return url.toString();
 }
 

--- a/apps/package-artifacts/lib/package.test.mjs
+++ b/apps/package-artifacts/lib/package.test.mjs
@@ -21,6 +21,10 @@ describe("package artifacts", () => {
     expect(packageDependencyUrl("https://packages.example.com", sha)).toBe(
       `https://packages.example.com/${sha}/eve.tgz`,
     );
+    expect(packageArtifactPath(sha, "eve-build")).toBe(`packages/${sha}/eve-build.tgz`);
+    expect(packageDependencyUrl("https://packages.example.com", sha, "eve-build")).toBe(
+      `https://packages.example.com/${sha}/eve-build.tgz`,
+    );
   });
 
   test("requires an HTTPS package base URL", () => {

--- a/apps/package-artifacts/scripts/build.mjs
+++ b/apps/package-artifacts/scripts/build.mjs
@@ -15,8 +15,10 @@ import {
 import { packPackage } from "../lib/pack.mjs";
 const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const repoRoot = resolve(appRoot, "../..");
-const packageRoot = join(repoRoot, "packages/eve");
-const packageJsonPath = join(packageRoot, "package.json");
+const evePackageRoot = join(repoRoot, "packages/eve");
+const evePackageJsonPath = join(evePackageRoot, "package.json");
+const buildPackageRoot = join(repoRoot, "packages/eve-build");
+const buildPackageJsonPath = join(buildPackageRoot, "package.json");
 const artifactDirectory = join(appRoot, ".artifacts");
 const sourceSha = process.env.VERCEL_GIT_COMMIT_SHA;
 const branch = process.env.VERCEL_GIT_COMMIT_REF;
@@ -38,23 +40,28 @@ if (typeof productionDomain !== "string" || productionDomain.length === 0) {
   throw new Error("VERCEL_PROJECT_PRODUCTION_URL is required for package publishing.");
 }
 
-const originalPackageJson = await readFile(packageJsonPath, "utf8");
-const preparedPackageJson = preparePackageJson(JSON.parse(originalPackageJson), sourceSha);
-const version = preparedPackageJson.version;
+const originalEvePackageJson = await readFile(evePackageJsonPath, "utf8");
+const originalBuildPackageJson = await readFile(buildPackageJsonPath, "utf8");
+const preparedEvePackageJson = preparePackageJson(JSON.parse(originalEvePackageJson), sourceSha);
+const preparedBuildPackageJson = preparePackageJson(
+  JSON.parse(originalBuildPackageJson),
+  sourceSha,
+);
+const version = preparedEvePackageJson.version;
 // Generated projects pin this deployment's immutable SHA route, never the moving main route.
 const dependencyUrl = packageDependencyUrl(`https://${productionDomain}`, sourceSha);
+const buildDependencyUrl = packageDependencyUrl(
+  `https://${productionDomain}`,
+  sourceSha,
+  "eve-build",
+);
 const artifactPath = packageArtifactPath(sourceSha);
+const buildArtifactPath = packageArtifactPath(sourceSha, "eve-build");
 
-try {
-  await rm(artifactDirectory, { force: true, recursive: true });
-  await writeFile(packageJsonPath, `${JSON.stringify(preparedPackageJson, null, 2)}\n`);
-  const tarball = await packPackage(packageRoot, version, {
-    ...process.env,
-    EVE_MAIN_DEPENDENCY_URL: dependencyUrl,
-  });
+async function publishArtifact(path, tarball) {
   const sha256 = createHash("sha256").update(tarball).digest("hex");
   try {
-    await put(artifactPath, tarball, {
+    await put(path, tarball, {
       access: "private",
       addRandomSuffix: false,
       allowOverwrite: false,
@@ -62,9 +69,8 @@ try {
       contentType: "application/gzip",
     });
   } catch (error) {
-    // Redeploys are valid only when this commit still produces identical package bytes.
     if (!(error instanceof Error) || !error.message.includes("already exists")) throw error;
-    const publishedArtifact = await get(artifactPath, { access: "private", useCache: false });
+    const publishedArtifact = await get(path, { access: "private", useCache: false });
     if (publishedArtifact === null) {
       throw new Error("Published package artifact could not be read.");
     }
@@ -75,8 +81,32 @@ try {
       throw new Error(`Commit ${sourceSha} was already published with different package contents.`);
     }
   }
+  return sha256;
+}
 
-  const manifest = { sourceSha, version, tarball: dependencyUrl, sha256 };
+try {
+  await rm(artifactDirectory, { force: true, recursive: true });
+  await writeFile(evePackageJsonPath, `${JSON.stringify(preparedEvePackageJson, null, 2)}\n`);
+  await writeFile(buildPackageJsonPath, `${JSON.stringify(preparedBuildPackageJson, null, 2)}\n`);
+  const buildTarball = await packPackage(buildPackageRoot, preparedBuildPackageJson.version);
+  const tarball = await packPackage(evePackageRoot, version, {
+    ...process.env,
+    EVE_BUILD_DEPENDENCY_URL: buildDependencyUrl,
+    EVE_MAIN_DEPENDENCY_URL: dependencyUrl,
+  });
+  const [buildSha256, sha256] = await Promise.all([
+    publishArtifact(buildArtifactPath, buildTarball),
+    publishArtifact(artifactPath, tarball),
+  ]);
+
+  const manifest = {
+    sourceSha,
+    version,
+    tarball: dependencyUrl,
+    sha256,
+    buildTarball: buildDependencyUrl,
+    buildSha256,
+  };
   const manifestPath = packageManifestPath(sourceSha);
   const existingManifest = await get(manifestPath, { access: "private", useCache: false });
   if (existingManifest === null) {
@@ -89,7 +119,7 @@ try {
     });
   } else {
     const published = JSON.parse(await new Response(existingManifest.stream).text());
-    if (published.sha256 !== sha256) {
+    if (published.sha256 !== sha256 || published.buildSha256 !== buildSha256) {
       throw new Error(`Commit ${sourceSha} was already published with different package contents.`);
     }
   }
@@ -101,6 +131,7 @@ try {
   );
   process.stdout.write(`${JSON.stringify(manifest)}\n`);
 } finally {
-  await writeFile(packageJsonPath, originalPackageJson);
+  await writeFile(evePackageJsonPath, originalEvePackageJson);
+  await writeFile(buildPackageJsonPath, originalBuildPackageJson);
   await rm(artifactDirectory, { force: true, recursive: true });
 }

--- a/apps/package-artifacts/scripts/check-smoke.mjs
+++ b/apps/package-artifacts/scripts/check-smoke.mjs
@@ -1,24 +1,30 @@
 const origin = process.env.DEPLOYMENT_URL;
 if (!origin) throw new Error("DEPLOYMENT_URL is required.");
 
-const artifact = await fetch(`${origin.replace(/\/$/, "")}/main/eve.tgz`, { redirect: "manual" });
-const location = artifact.headers.get("location") ?? "";
-if (
-  location.includes("vercel.com/login") ||
-  location.includes("vercel.com/sso-api") ||
-  location.includes("/_vercel/login")
-) {
-  throw new Error("Package deployment is protected; disable Deployment Protection.");
-}
-if (artifact.status !== 302) throw new Error(`/main/eve.tgz returned ${artifact.status}.`);
+for (const packageSlug of ["eve", "eve-build"]) {
+  const artifact = await fetch(`${origin.replace(/\/$/, "")}/main/${packageSlug}.tgz`, {
+    redirect: "manual",
+  });
+  const location = artifact.headers.get("location") ?? "";
+  if (
+    location.includes("vercel.com/login") ||
+    location.includes("vercel.com/sso-api") ||
+    location.includes("/_vercel/login")
+  ) {
+    throw new Error("Package deployment is protected; disable Deployment Protection.");
+  }
+  if (artifact.status !== 302) {
+    throw new Error(`/main/${packageSlug}.tgz returned ${artifact.status}.`);
+  }
 
-if (!location.startsWith(`${origin.replace(/\/$/, "")}/`)) {
-  throw new Error("Package route redirected outside the package deployment.");
-}
+  if (!location.startsWith(`${origin.replace(/\/$/, "")}/`)) {
+    throw new Error("Package route redirected outside the package deployment.");
+  }
 
-const tarball = await fetch(location);
-if (!tarball.ok) throw new Error(`Package artifact returned ${tarball.status}.`);
-const signature = new Uint8Array(await tarball.arrayBuffer()).subarray(0, 2);
-if (signature[0] !== 0x1f || signature[1] !== 0x8b) {
-  throw new Error("Package artifact is not a gzip tarball.");
+  const tarball = await fetch(location);
+  if (!tarball.ok) throw new Error(`Package artifact returned ${tarball.status}.`);
+  const signature = new Uint8Array(await tarball.arrayBuffer()).subarray(0, 2);
+  if (signature[0] !== 0x1f || signature[1] !== 0x8b) {
+    throw new Error("Package artifact is not a gzip tarball.");
+  }
 }

--- a/apps/package-artifacts/vercel.json
+++ b/apps/package-artifacts/vercel.json
@@ -4,6 +4,10 @@
   "installCommand": "pnpm install --frozen-lockfile",
   "outputDirectory": "public",
   "rewrites": [
+    {
+      "source": "/:ref*/eve-build.tgz",
+      "destination": "/api/package?ref=:ref&package=eve-build"
+    },
     { "source": "/:ref*/eve.tgz", "destination": "/api/package?ref=:ref" },
     {
       "source": "/main/latest.json",

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -115,6 +115,7 @@ The scaffold's `package.json` declares separate source and distribution roots:
     "zod": "^x",
   },
   "devDependencies": {
+    "@eve/build": "x.y.z",
     "@types/node": "^x",
     "eve": "x.y.z",
     "typescript": "^x",
@@ -138,7 +139,10 @@ eve extension build
 
 `eve extension build` writes an agent-shaped `dist/extension` tree, copies skill assets, emits declarations, and records compatibility metadata. It also manages the package exports for the mount factory (`@acme/crm`) and tool definitions (`@acme/crm/tools`). Publish `dist/`; consumers do not need the author's TypeScript source.
 
-The exact `eve` development pin controls the extension authoring API and build tooling. The wildcard peer lets the consumer provide the runtime copy of eve. At consumption time, eve checks generated metadata, not the npm peer range. Do not add eve to regular `dependencies`.
+The exact, matching `eve` and `@eve/build` development pins control the extension authoring API
+and build tooling. The wildcard peer lets the consumer provide the runtime copy of eve. At
+consumption time, eve checks generated metadata, not the npm peer range. Do not add either
+development package to regular `dependencies`.
 
 Put runtime packages such as `zod` or an SDK in `dependencies`. If a dependency cannot be bundled, such as a native addon, tell consumers to add it to `build.externalDependencies` in `agent.ts`.
 

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -38,7 +38,8 @@ To add eve to a project that already has a `package.json`, run this command from
 npx eve@latest init .
 ```
 
-eve adds the missing `eve`, `ai`, and `zod` dependencies without changing files the project already owns.
+eve adds the missing `eve`, `ai`, and `zod` runtime dependencies plus the project-local
+`@eve/build` development dependency without changing files the project already owns.
 
 ## Run the agent
 
@@ -159,11 +160,16 @@ Run `eve info` when eve does not discover a file. It lists the discovered surfac
 
 ## Install manually
 
-If you do not want to use the scaffold, install the runtime dependencies:
+If you do not want to use the scaffold, install the runtime dependencies and matching build engine:
 
 ```bash
 npm install eve@latest ai zod
+npm install --save-dev @eve/build@latest
 ```
+
+Keep `eve` and `@eve/build` on the same version. The build package supplies Nitro and Rolldown to
+source-compilation commands such as `eve dev`, `eve build`, and `eve extension build`. It is not
+needed to run the compiled `.output/` with `eve start`.
 
 Declare Node.js 24 in `package.json`, then create `agent/instructions.md` and, when you need runtime configuration, `agent/agent.ts`.
 

--- a/docs/guides/frontend/nextjs.mdx
+++ b/docs/guides/frontend/nextjs.mdx
@@ -7,7 +7,7 @@ description: "Run an eve agent and a Next.js app as one project with withEve."
 
 ## Prerequisites
 
-- The `eve` package installed in your project (`npm install eve@latest`).
+- Matching `eve` and `@eve/build` packages installed in your project (`npm install eve@latest && npm install --save-dev @eve/build@latest`).
 - An existing eve agent directory. If you don't have one, start from [Getting started](../../getting-started).
 - A Next.js app to mount the agent in.
 

--- a/docs/guides/frontend/nuxt.mdx
+++ b/docs/guides/frontend/nuxt.mdx
@@ -7,7 +7,7 @@ The `eve/nuxt` module runs a Nuxt frontend and an eve agent as a single project 
 
 ## Prerequisites
 
-- The `eve` package installed in your project (`npm install eve@latest`).
+- Matching `eve` and `@eve/build` packages installed in your project (`npm install eve@latest && npm install --save-dev @eve/build@latest`).
 - An existing eve agent directory. If you don't have one, start from [Getting started](../../getting-started).
 - A Nuxt app to mount the agent in.
 

--- a/docs/guides/frontend/sveltekit.mdx
+++ b/docs/guides/frontend/sveltekit.mdx
@@ -7,7 +7,7 @@ description: "Run an eve agent and a SvelteKit app as one project with the eveSv
 
 ## Prerequisites
 
-- The `eve` package installed in your project (`npm install eve@latest`).
+- Matching `eve` and `@eve/build` packages installed in your project (`npm install eve@latest && npm install --save-dev @eve/build@latest`).
 - An existing eve agent directory. If you don't have one, start from [Getting started](../../getting-started).
 - A SvelteKit app to mount the agent in.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -43,7 +43,7 @@ Creates a new agent app or adds an agent to an existing app. Always installs dep
 | Target                                    | What happens                                                                                                                                             |
 | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `eve init my-agent`                       | New agent project in `my-agent/`                                                                                                                         |
-| `eve init .` (or an existing project dir) | Adds `agent/` plus missing `eve`, `ai`, and `zod` deps. Needs a `package.json` and no `agent/` files yet                                                 |
+| `eve init .` (or an existing project dir) | Adds `agent/`, missing runtime deps, and the `@eve/build` dev dependency. Needs a `package.json` and no `agent/` files yet                               |
 | `eve init` with no target                 | Same as `eve init .`, except coding agents (Claude Code, Cursor, and similar) get a setup guide instead of scaffolding — they have not chosen a name yet |
 
 After scaffolding, a human terminal usually continues into `eve dev`. If a coding-agent REPL is on `PATH`, the handoff menu can open it instead or exit without starting either process. Coding-agent launches print the next steps instead of opening the TUI, so the session does not get stuck. Fresh projects use the parent workspace's package manager when there is one; otherwise they use the manager that launched `eve init`.
@@ -150,6 +150,10 @@ eve build [--profile <path>] [--skip-sandbox-prewarm]
 ```
 
 Compiles and bundles in an invocation-owned directory under `.eve/builds/`, then publishes the completed host output and prints its path. Scratch workspaces are removed after success or failure.
+
+Source-compilation commands load Nitro and Rolldown from the project's `@eve/build` development
+dependency. Keep it on the same version as `eve`. The completed `.output/` contains the Nitro
+server router and runs through `eve start` without `@eve/build` installed in production.
 
 | Flag                     | Type   | Default | Description                                                                                   |
 | ------------------------ | ------ | ------- | --------------------------------------------------------------------------------------------- |

--- a/e2e/fixtures/agent-basic-runtime/package.json
+++ b/e2e/fixtures/agent-basic-runtime/package.json
@@ -17,6 +17,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@eve/build": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:"
   }

--- a/e2e/fixtures/agent-cancellation/package.json
+++ b/e2e/fixtures/agent-cancellation/package.json
@@ -17,6 +17,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@eve/build": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:"
   }

--- a/e2e/fixtures/agent-channels/package.json
+++ b/e2e/fixtures/agent-channels/package.json
@@ -16,6 +16,7 @@
     "eve": "workspace:*"
   },
   "devDependencies": {
+    "@eve/build": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:"
   }

--- a/e2e/fixtures/agent-compaction-regressions/package.json
+++ b/e2e/fixtures/agent-compaction-regressions/package.json
@@ -17,6 +17,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@eve/build": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:"
   },

--- a/e2e/fixtures/agent-model/package.json
+++ b/e2e/fixtures/agent-model/package.json
@@ -16,6 +16,7 @@
     "eve": "workspace:*"
   },
   "devDependencies": {
+    "@eve/build": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:"
   },

--- a/e2e/fixtures/agent-openapi-swagger/package.json
+++ b/e2e/fixtures/agent-openapi-swagger/package.json
@@ -16,6 +16,7 @@
     "eve": "workspace:*"
   },
   "devDependencies": {
+    "@eve/build": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:"
   }

--- a/e2e/fixtures/agent-prompt-cache/package.json
+++ b/e2e/fixtures/agent-prompt-cache/package.json
@@ -18,6 +18,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@eve/build": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:"
   },

--- a/e2e/fixtures/agent-schedules/package.json
+++ b/e2e/fixtures/agent-schedules/package.json
@@ -17,6 +17,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@eve/build": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:"
   }

--- a/e2e/fixtures/agent-session-limits/package.json
+++ b/e2e/fixtures/agent-session-limits/package.json
@@ -17,6 +17,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@eve/build": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:"
   }

--- a/e2e/fixtures/agent-session-timeout/package.json
+++ b/e2e/fixtures/agent-session-timeout/package.json
@@ -16,6 +16,7 @@
     "eve": "workspace:*"
   },
   "devDependencies": {
+    "@eve/build": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:"
   }

--- a/e2e/fixtures/agent-skills/package.json
+++ b/e2e/fixtures/agent-skills/package.json
@@ -16,6 +16,7 @@
     "eve": "workspace:*"
   },
   "devDependencies": {
+    "@eve/build": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:"
   }

--- a/e2e/fixtures/agent-subagents-hitl/package.json
+++ b/e2e/fixtures/agent-subagents-hitl/package.json
@@ -17,6 +17,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@eve/build": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:"
   }

--- a/e2e/fixtures/agent-subagents/package.json
+++ b/e2e/fixtures/agent-subagents/package.json
@@ -17,6 +17,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@eve/build": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:"
   },

--- a/e2e/fixtures/agent-tools-hitl-openai/package.json
+++ b/e2e/fixtures/agent-tools-hitl-openai/package.json
@@ -17,6 +17,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@eve/build": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:"
   }

--- a/e2e/fixtures/agent-tools-hitl/package.json
+++ b/e2e/fixtures/agent-tools-hitl/package.json
@@ -17,6 +17,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@eve/build": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:"
   }

--- a/e2e/fixtures/agent-tools-sandbox/package.json
+++ b/e2e/fixtures/agent-tools-sandbox/package.json
@@ -17,6 +17,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@eve/build": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:"
   }

--- a/e2e/fixtures/agent-tools/package.json
+++ b/e2e/fixtures/agent-tools/package.json
@@ -18,6 +18,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@eve/build": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:"
   },

--- a/e2e/fixtures/agent-workflow-stress/package.json
+++ b/e2e/fixtures/agent-workflow-stress/package.json
@@ -16,6 +16,7 @@
     "eve": "workspace:*"
   },
   "devDependencies": {
+    "@eve/build": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:"
   }

--- a/e2e/fixtures/dist-extensions/package.json
+++ b/e2e/fixtures/dist-extensions/package.json
@@ -17,6 +17,7 @@
     "gizmo-extension": "file:../gizmo-extension"
   },
   "devDependencies": {
+    "@eve/build": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:"
   }

--- a/e2e/fixtures/extensions/package.json
+++ b/e2e/fixtures/extensions/package.json
@@ -20,6 +20,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@eve/build": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:"
   }

--- a/e2e/fixtures/gadget-extension/package.json
+++ b/e2e/fixtures/gadget-extension/package.json
@@ -24,6 +24,7 @@
     "zod": "4.4.3"
   },
   "devDependencies": {
+    "@eve/build": "workspace:*",
     "@types/node": "catalog:",
     "eve": "workspace:*",
     "typescript": "catalog:"

--- a/e2e/fixtures/gizmo-extension/package.json
+++ b/e2e/fixtures/gizmo-extension/package.json
@@ -23,6 +23,7 @@
     "zod": "4.4.3"
   },
   "devDependencies": {
+    "@eve/build": "workspace:*",
     "@types/node": "catalog:",
     "eve": "workspace:*",
     "typescript": "catalog:"

--- a/e2e/fixtures/js-only-extension/package.json
+++ b/e2e/fixtures/js-only-extension/package.json
@@ -23,6 +23,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@eve/build": "workspace:*",
     "@types/node": "catalog:",
     "eve": "workspace:*",
     "typescript": "catalog:"

--- a/e2e/fixtures/toolkit-extension/package.json
+++ b/e2e/fixtures/toolkit-extension/package.json
@@ -23,6 +23,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@eve/build": "workspace:*",
     "@types/node": "catalog:",
     "eve": "workspace:*",
     "typescript": "catalog:"

--- a/packages/eve-build/README.md
+++ b/packages/eve-build/README.md
@@ -1,0 +1,15 @@
+# @eve/build
+
+Project-local build engine for [`eve`](https://eve.dev) applications. It supplies Nitro and
+Rolldown to `eve dev` and `eve build` without adding that dependency graph to lightweight
+`npx eve` commands.
+
+Install this package as a development dependency alongside the matching `eve` version:
+
+```sh
+pnpm add eve
+pnpm add --save-dev @eve/build
+```
+
+This package is an internal implementation boundary. Applications should invoke `eve` commands
+instead of importing `@eve/build`.

--- a/packages/eve-build/index.d.ts
+++ b/packages/eve-build/index.d.ts
@@ -1,0 +1,33 @@
+export { build, copyPublicAssets, createNitro, prepare, prerender } from "nitro/builder";
+export type { H3Event } from "nitro";
+export type { Nitro } from "nitro/types";
+
+export declare const EVE_BUILD_ENGINE_PROTOCOL: 1;
+
+export interface RolldownOutputChunk {
+  readonly type: "chunk";
+  readonly code: string;
+  readonly fileName: string;
+}
+
+export interface RolldownOutputAsset {
+  readonly type: "asset";
+  readonly fileName: string;
+  readonly source: string | Uint8Array;
+}
+
+export interface RolldownOutput {
+  readonly output: readonly [RolldownOutputChunk, ...(RolldownOutputChunk | RolldownOutputAsset)[]];
+}
+
+export declare function buildWithRolldown(
+  options: Record<string, unknown>,
+): Promise<RolldownOutput>;
+
+export declare function parseWithRolldown(
+  sourceText: string,
+  options?: Record<string, unknown> | null,
+  filename?: string,
+): Promise<unknown>;
+
+export declare function resolveNitroDependency(specifier: string): string;

--- a/packages/eve-build/index.mjs
+++ b/packages/eve-build/index.mjs
@@ -1,0 +1,36 @@
+import { createRequire } from "node:module";
+import { pathToFileURL } from "node:url";
+
+export { build, copyPublicAssets, createNitro, prepare, prerender } from "nitro/builder";
+
+export const EVE_BUILD_ENGINE_PROTOCOL = 1;
+
+const require = createRequire(import.meta.url);
+const nitroRequire = createRequire(require.resolve("nitro/package.json"));
+
+let rolldownPromise;
+let rolldownParseAstPromise;
+
+function loadRolldown() {
+  rolldownPromise ??= import(pathToFileURL(nitroRequire.resolve("rolldown")).href);
+  return rolldownPromise;
+}
+
+function loadRolldownParseAst() {
+  rolldownParseAstPromise ??= import(pathToFileURL(nitroRequire.resolve("rolldown/parseAst")).href);
+  return rolldownParseAstPromise;
+}
+
+export async function buildWithRolldown(options) {
+  const { build } = await loadRolldown();
+  return await build(options);
+}
+
+export async function parseWithRolldown(sourceText, options, filename) {
+  const { parseAst } = await loadRolldownParseAst();
+  return parseAst(sourceText, options, filename);
+}
+
+export function resolveNitroDependency(specifier) {
+  return nitroRequire.resolve(specifier);
+}

--- a/packages/eve-build/package.json
+++ b/packages/eve-build/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@eve/build",
+  "version": "0.34.0",
+  "description": "Project-local build engine for eve applications.",
+  "keywords": [
+    "agents",
+    "ai",
+    "build",
+    "eve",
+    "nitro"
+  ],
+  "homepage": "https://github.com/vercel/eve#readme",
+  "bugs": {
+    "url": "https://github.com/vercel/eve/issues"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vercel/eve.git",
+    "directory": "packages/eve-build"
+  },
+  "files": [
+    "index.d.ts",
+    "index.mjs",
+    "NOTICE",
+    "README.md"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.mjs",
+      "default": "./index.mjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "node --check index.mjs",
+    "prepack": "pnpm run build && node ../../scripts/copy-package-license.mjs .",
+    "typecheck": "tsc --ignoreConfig --noEmit --allowJs --checkJs --skipLibCheck --noImplicitAny false --module NodeNext --moduleResolution NodeNext --target ES2024 index.mjs"
+  },
+  "dependencies": {
+    "nitro": "3.0.260610-beta"
+  },
+  "engines": {
+    "node": ">=24"
+  }
+}

--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -314,7 +314,6 @@
     "test:vercel": "vitest run --config vitest.vercel.config.ts"
   },
   "dependencies": {
-    "nitro": "3.0.260610-beta",
     "undici": "8.9.0"
   },
   "devDependencies": {
@@ -330,6 +329,7 @@
     "@chat-adapter/state-memory": "4.34.0",
     "@chat-adapter/twilio": "4.34.0",
     "@clack/core": "1.3.1",
+    "@eve/build": "workspace:*",
     "@eve/catalog": "workspace:*",
     "@nuxt/kit": "^4.0.0",
     "@opentelemetry/context-async-hooks": "catalog:",
@@ -384,6 +384,7 @@
     "zod-validation-error": "5.0.0"
   },
   "peerDependencies": {
+    "@eve/build": "workspace:>=0.34.0 <1",
     "@opentelemetry/api": "^1.0.0",
     "ai": "catalog:",
     "braintrust": "^3.0.0",
@@ -391,6 +392,9 @@
     "microsandbox": "^0.5.0"
   },
   "peerDependenciesMeta": {
+    "@eve/build": {
+      "optional": true
+    },
     "@opentelemetry/api": {
       "optional": true
     },

--- a/packages/eve/scripts/build-rolldown.mjs
+++ b/packages/eve/scripts/build-rolldown.mjs
@@ -127,17 +127,16 @@ const EXCLUDED_DIRECTORIES = new Set([join("internal", "testing")]);
  *
  *   - Peer dependencies (`ai`, `next`, `react`, `@opentelemetry/api`,
  *     `braintrust`) — consumers provide the install.
- *   - Runtime dependencies (`nitro`, `undici`) — resolved at
- *     runtime against the eve installation.
- *   - Optional peer dependency (`just-bash`) — the opt-in local sandbox
- *     engine; resolved lazily against the consumer's install and never
- *     bundled with eve.
+ *   - Runtime dependency (`undici`) — resolved at runtime against the eve installation.
+ *   - Optional peer dependencies (`@eve/build`, `just-bash`) — project-local
+ *     engines resolved lazily against the consumer's install and never bundled with eve.
  *
  * `#compiled/*` is also external (handled separately) so the vendored
  * dependency tree under `dist/src/compiled/**` resolves at runtime via
  * the package `imports` map.
  */
 const EXTERNAL_PACKAGES = new Set([
+  "@eve/build",
   "@nuxt/kit",
   "@opentelemetry/api",
   "@sveltejs/kit",
@@ -146,7 +145,6 @@ const EXTERNAL_PACKAGES = new Set([
   "just-bash",
   "microsandbox",
   "next",
-  "nitro",
   "react",
   "svelte",
   "undici",

--- a/packages/eve/scripts/check-bin-runtime-dependencies.mjs
+++ b/packages/eve/scripts/check-bin-runtime-dependencies.mjs
@@ -1,16 +1,13 @@
 import { readFile, readdir } from "node:fs/promises";
-import { createRequire, isBuiltin } from "node:module";
+import { isBuiltin } from "node:module";
 import { join, relative } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 
 const packageRoot = fileURLToPath(new URL("..", import.meta.url));
 const packageJson = JSON.parse(await readFile(join(packageRoot, "package.json"), "utf8"));
 const runtimeDependencies = new Set(Object.keys(packageJson.dependencies ?? {}));
 const binRoot = join(packageRoot, "bin");
-const require = createRequire(import.meta.url);
-const nitroRequire = createRequire(require.resolve("nitro/package.json"));
-const parseAstPath = nitroRequire.resolve("rolldown/parseAst");
-const { parseAst } = await import(pathToFileURL(parseAstPath).href);
+const { parseWithRolldown } = await import("@eve/build");
 
 function packageName(specifier) {
   if (specifier.startsWith("@")) {
@@ -44,7 +41,7 @@ const violations = [];
 
 for await (const path of walkJavaScriptFiles(binRoot)) {
   const source = await readFile(path, "utf8");
-  const ast = parseAst(
+  const ast = await parseWithRolldown(
     source,
     { astType: "ts", lang: "js", range: true, sourceType: "module" },
     relative(packageRoot, path),

--- a/packages/eve/scripts/nitro-rolldown.mjs
+++ b/packages/eve/scripts/nitro-rolldown.mjs
@@ -1,19 +1,5 @@
-import { createRequire } from "node:module";
-import { pathToFileURL } from "node:url";
-
-let rolldownPromise;
-
-export async function loadNitroRolldown() {
-  rolldownPromise ??= (async () => {
-    const require = createRequire(import.meta.url);
-    const nitroRequire = createRequire(require.resolve("nitro/package.json"));
-    return await import(pathToFileURL(nitroRequire.resolve("rolldown")).href);
-  })();
-
-  return await rolldownPromise;
-}
+import { buildWithRolldown } from "@eve/build";
 
 export async function buildWithNitroRolldown(options) {
-  const { build } = await loadNitroRolldown();
-  return await build(options);
+  return await buildWithRolldown(options);
 }

--- a/packages/eve/scripts/stamp-version-tokens.mjs
+++ b/packages/eve/scripts/stamp-version-tokens.mjs
@@ -40,10 +40,13 @@ if (typeof nodeEngine !== "string") {
 }
 
 const evePackageDependencyVersion = process.env.EVE_MAIN_DEPENDENCY_URL ?? packageJson.version;
+const eveBuildPackageDependencyVersion =
+  process.env.EVE_BUILD_DEPENDENCY_URL ?? packageJson.version;
 
 const replacements = {
   __EVE_PACKAGE_VERSION__: packageJson.version,
   __EVE_PACKAGE_DEPENDENCY_VERSION__: evePackageDependencyVersion,
+  __EVE_BUILD_PACKAGE_DEPENDENCY_VERSION__: eveBuildPackageDependencyVersion,
   __NODE_ENGINE__: nodeEngine,
   __AI_SDK_VERSION__: await resolveCatalogVersion("ai"),
   __BETTER_AUTH_VERSION__: await resolveCatalogVersion("better-auth"),

--- a/packages/eve/src/cli/commands/extension-init.integration.test.ts
+++ b/packages/eve/src/cli/commands/extension-init.integration.test.ts
@@ -13,6 +13,7 @@ import { pathExists } from "#setup/path-exists.js";
 
 import type { GitInitResult } from "./init-git.js";
 import {
+  EVE_INIT_BUILD_PACKAGE_SPEC_ENV,
   EVE_INIT_PACKAGE_SPEC_ENV,
   runExtensionInitCommand,
   type ExtensionInitCliLogger,
@@ -105,7 +106,7 @@ describe("runExtensionInitCommand", () => {
       files?: string[];
       peerDependencies?: { eve?: string };
       peerDependenciesMeta?: Record<string, unknown>;
-      devDependencies?: { eve?: string; typescript?: string };
+      devDependencies?: { "@eve/build"?: string; eve?: string; typescript?: string };
       dependencies?: { zod?: string; ai?: string };
       scripts?: Record<string, string>;
     };
@@ -117,6 +118,7 @@ describe("runExtensionInitCommand", () => {
     expect(packageJson.peerDependencies?.eve).toBe("*");
     expect(packageJson.peerDependenciesMeta).toBeUndefined();
     expect(packageJson.devDependencies?.eve).toBe("0.6.0");
+    expect(packageJson.devDependencies?.["@eve/build"]).toBe("0.6.0");
     expect(packageJson.dependencies?.zod).toBe("4.0.0");
     expect(packageJson.dependencies?.ai).toBeUndefined();
     expect(packageJson.scripts?.build).toBe("eve extension build");
@@ -199,6 +201,7 @@ describe("runExtensionInitCommand", () => {
     const parentDirectory = await mkdtemp(join(tmpdir(), "eve-extension-init-spec-"));
     const output = logger();
     const deps = dependencies();
+    vi.stubEnv(EVE_INIT_BUILD_PACKAGE_SPEC_ENV, "file:/tmp/eve-build-local.tgz");
     vi.stubEnv(EVE_INIT_PACKAGE_SPEC_ENV, "file:/tmp/eve-local.tgz");
 
     await runExtensionInitCommand(output, parentDirectory, "my-crm", deps);
@@ -207,9 +210,10 @@ describe("runExtensionInitCommand", () => {
       await readFile(join(parentDirectory, "my-crm", "package.json"), "utf8"),
     ) as {
       peerDependencies?: { eve?: string };
-      devDependencies?: { eve?: string };
+      devDependencies?: { "@eve/build"?: string; eve?: string };
     };
     expect(packageJson.peerDependencies?.eve).toBe("*");
     expect(packageJson.devDependencies?.eve).toBe("file:/tmp/eve-local.tgz");
+    expect(packageJson.devDependencies?.["@eve/build"]).toBe("file:/tmp/eve-build-local.tgz");
   });
 });

--- a/packages/eve/src/cli/commands/extension-init.ts
+++ b/packages/eve/src/cli/commands/extension-init.ts
@@ -58,6 +58,7 @@ const defaultDependencies: ExtensionInitCommandDependencies = {
 const CURRENT_DIRECTORY_PROJECT_NAME = ".";
 /** Same override env as agent `eve init` so CI can pin the eve package specifier. */
 export const EVE_INIT_PACKAGE_SPEC_ENV = "EVE_INIT_PACKAGE_SPEC";
+export const EVE_INIT_BUILD_PACKAGE_SPEC_ENV = "EVE_INIT_BUILD_PACKAGE_SPEC";
 
 const initLog = createLogger("extension-init");
 
@@ -203,6 +204,9 @@ function resolveInitEvePackageOverride(): EvePackageContract | undefined {
   }
 
   return {
+    buildVersion:
+      process.env[EVE_INIT_BUILD_PACKAGE_SPEC_ENV]?.trim() ||
+      DEFAULT_EVE_PACKAGE_CONTRACT.buildVersion,
     nodeEngine: DEFAULT_EVE_PACKAGE_CONTRACT.nodeEngine,
     version: spec,
   };

--- a/packages/eve/src/cli/commands/init.integration.test.ts
+++ b/packages/eve/src/cli/commands/init.integration.test.ts
@@ -23,6 +23,7 @@ import { WizardCancelledError } from "#setup/step.js";
 import type { GitInitResult } from "./init-git.js";
 import { initAgentReplPrompt } from "./agent-instructions.js";
 import {
+  EVE_INIT_BUILD_PACKAGE_SPEC_ENV,
   EVE_INIT_PACKAGE_SPEC_ENV,
   runInitCommand,
   type InitCliLogger,
@@ -38,7 +39,7 @@ const BASE_VERSIONS = {
 } as const;
 
 const RELEASE_AGE_POLICY =
-  'minimumReleaseAgeExclude:\n  - "@ai-sdk/*"\n  - "@rolldown/*"\n  - "@vercel/*"\n  - "@workflow/*"\n  - ai\n  - experimental-ai-sdk-code-mode\n  - eve\n  - nitro\n  - rolldown\n  - workflow\n';
+  'minimumReleaseAgeExclude:\n  - "@eve/*"\n  - "@vercel/*"\n  - "@workflow/*"\n  - eve\n  - nitro\n  - workflow\n';
 
 const WEB_VERSIONS = {
   ...BASE_VERSIONS,
@@ -311,14 +312,19 @@ describe("runInitCommand", () => {
     const parentDirectory = await mkdtemp(join(tmpdir(), "eve-init-package-spec-"));
     const output = logger();
     const deps = dependencies();
+    vi.stubEnv(EVE_INIT_BUILD_PACKAGE_SPEC_ENV, "file:/tmp/eve-build-0.11.5.tgz");
     vi.stubEnv(EVE_INIT_PACKAGE_SPEC_ENV, "file:/tmp/eve-0.11.5.tgz");
 
     await runInitCommand(output, parentDirectory, "my-agent", {}, deps);
 
     const packageJson = JSON.parse(
       await readFile(join(parentDirectory, "my-agent", "package.json"), "utf8"),
-    ) as { dependencies: Record<string, string> };
+    ) as {
+      dependencies: Record<string, string>;
+      devDependencies: Record<string, string>;
+    };
     expect(packageJson.dependencies.eve).toBe("file:/tmp/eve-0.11.5.tgz");
+    expect(packageJson.devDependencies["@eve/build"]).toBe("file:/tmp/eve-build-0.11.5.tgz");
   });
 
   it("uses an explicit init package spec when adding to an existing project", async () => {
@@ -326,14 +332,17 @@ describe("runInitCommand", () => {
     const projectRoot = await createHostProject(parentDirectory);
     const output = logger();
     const deps = dependencies();
+    vi.stubEnv(EVE_INIT_BUILD_PACKAGE_SPEC_ENV, "file:/tmp/eve-build-0.11.5.tgz");
     vi.stubEnv(EVE_INIT_PACKAGE_SPEC_ENV, "file:/tmp/eve-0.11.5.tgz");
 
     await runInitCommand(output, parentDirectory, "host-app", {}, deps);
 
     const packageJson = JSON.parse(await readFile(join(projectRoot, "package.json"), "utf8")) as {
       dependencies: Record<string, string>;
+      devDependencies: Record<string, string>;
     };
     expect(packageJson.dependencies.eve).toBe("file:/tmp/eve-0.11.5.tgz");
+    expect(packageJson.devDependencies["@eve/build"]).toBe("file:/tmp/eve-build-0.11.5.tgz");
   });
 
   it.each([undefined, ".", "./"] as const)(

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -92,6 +92,7 @@ const defaultDependencies: InitCommandDependencies = {
 
 const CURRENT_DIRECTORY_PROJECT_NAME = ".";
 export const EVE_INIT_PACKAGE_SPEC_ENV = "EVE_INIT_PACKAGE_SPEC";
+export const EVE_INIT_BUILD_PACKAGE_SPEC_ENV = "EVE_INIT_BUILD_PACKAGE_SPEC";
 
 const initLog = createLogger("init");
 
@@ -579,6 +580,9 @@ function resolveInitEvePackageOverride(): EvePackageContract | undefined {
   }
 
   return {
+    buildVersion:
+      process.env[EVE_INIT_BUILD_PACKAGE_SPEC_ENV]?.trim() ||
+      DEFAULT_EVE_PACKAGE_CONTRACT.buildVersion,
     nodeEngine: DEFAULT_EVE_PACKAGE_CONTRACT.nodeEngine,
     version: spec,
   };

--- a/packages/eve/src/execution/sandbox/prewarm.ts
+++ b/packages/eve/src/execution/sandbox/prewarm.ts
@@ -1,9 +1,8 @@
 import { join } from "node:path";
 
 import type { CompiledWorkspaceResourceRoot } from "#compiler/manifest.js";
-import { loadCompiledModuleMapFromAuthoredSource } from "#internal/authored-module-map-loader.js";
-import { resolvePackageSourceFilePath } from "#internal/application/package.js";
 import { createAuthoredSourceRuntimeCompiledArtifactsSource } from "#internal/application/runtime-compiled-artifacts-source.js";
+import { loadCompiledModuleMapFromAuthoredSource } from "#internal/authored-module-map-loader.js";
 import type {
   SandboxBackend,
   SandboxBackendPrewarmInput,
@@ -21,6 +20,7 @@ import { type ResolvedAgentGraphBundle, ROOT_RUNTIME_AGENT_NODE_ID } from "#runt
 import { loadCompileMetadata } from "#runtime/loaders/compile-metadata.js";
 import { withBundledCompiledArtifacts } from "#runtime/loaders/bundled-artifacts.js";
 import { loadCompiledManifest } from "#runtime/loaders/manifest.js";
+import { loadCompiledModuleMap } from "#runtime/loaders/module-map.js";
 import { resolveRuntimeCompilerArtifactPaths } from "#runtime/loaders/artifact-paths.js";
 import { resolveRuntimeAgentGraph } from "#runtime/resolve-agent-graph.js";
 import { createRuntimeSandboxTemplateKey } from "#runtime/sandbox/keys.js";
@@ -195,7 +195,6 @@ export async function prewarmBuiltAppSandboxes(input: {
 }): Promise<void> {
   const builtArtifactsRoot = join(input.appRoot, ".output");
   const builtArtifactsSource = createDiskRuntimeCompiledArtifactsSource(builtArtifactsRoot, {
-    moduleMapLoaderPath: resolvePackageSourceFilePath("src/internal/authored-module-map-loader.ts"),
     sandboxAppRoot: input.appRoot,
   });
   const [metadata, manifest, moduleMap] = await Promise.all([
@@ -205,7 +204,7 @@ export async function prewarmBuiltAppSandboxes(input: {
     loadCompiledManifest({
       compiledArtifactsSource: builtArtifactsSource,
     }),
-    loadCompiledModuleMapFromAuthoredSource({
+    loadCompiledModuleMap({
       compiledArtifactsSource: builtArtifactsSource,
     }),
   ]);

--- a/packages/eve/src/internal/application/package.ts
+++ b/packages/eve/src/internal/application/package.ts
@@ -265,10 +265,6 @@ export function resolvePackageSourceDirectoryPath(relativeSourcePath: string): s
   return join(resolvePackageRoot(), relativeSourcePath);
 }
 
-export function resolvePackageDependencyPath(specifier: string): string {
-  return require.resolve(specifier);
-}
-
 /**
  * Resolves one vendored compiled asset from the current eve installation.
  */

--- a/packages/eve/src/internal/application/production-compiler-artifacts.ts
+++ b/packages/eve/src/internal/application/production-compiler-artifacts.ts
@@ -1,12 +1,22 @@
-import { cp, mkdir } from "node:fs/promises";
+import { copyFile, cp, mkdir } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
+import { materializeAuthoredModules } from "#internal/materialized-authored-modules.js";
+
 export async function stageProductionCompilerArtifacts(input: {
-  readonly compilerArtifactsRoot: string;
+  readonly compilerRoot: string;
   readonly outputDir: string;
 }): Promise<void> {
+  const materialized = await materializeAuthoredModules({
+    runtimeAppRoot: input.compilerRoot,
+  });
+  const compilerArtifactsRoot = join(input.compilerRoot, ".eve");
   const destinationDirectory = join(input.outputDir, ".eve");
 
   await mkdir(dirname(destinationDirectory), { recursive: true });
-  await cp(input.compilerArtifactsRoot, destinationDirectory, { recursive: true });
+  await cp(compilerArtifactsRoot, destinationDirectory, { recursive: true });
+  await copyFile(
+    join(destinationDirectory, "compile", materialized.moduleMap),
+    join(destinationDirectory, "compile", "module-map.mjs"),
+  );
 }

--- a/packages/eve/src/internal/build-engine.test.ts
+++ b/packages/eve/src/internal/build-engine.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const importState = vi.hoisted(() => ({
+  protocol: 1,
+}));
+
+vi.mock("@eve/build", () => ({
+  get EVE_BUILD_ENGINE_PROTOCOL() {
+    return importState.protocol;
+  },
+}));
+
+describe("loadBuildEngine", () => {
+  beforeEach(() => {
+    importState.protocol = 1;
+    vi.resetModules();
+  });
+
+  it("loads a compatible project-local engine", async () => {
+    const { loadBuildEngine } = await import("./build-engine.js");
+
+    await expect(loadBuildEngine()).resolves.toMatchObject({ EVE_BUILD_ENGINE_PROTOCOL: 1 });
+  });
+
+  it("rejects an incompatible engine protocol", async () => {
+    importState.protocol = 2;
+    const { loadBuildEngine } = await import("./build-engine.js");
+
+    await expect(loadBuildEngine()).rejects.toThrow(
+      "Incompatible @eve/build protocol 2; eve requires protocol 1",
+    );
+  });
+});

--- a/packages/eve/src/internal/build-engine.ts
+++ b/packages/eve/src/internal/build-engine.ts
@@ -1,0 +1,51 @@
+import type * as EveBuildEngine from "@eve/build";
+
+import { resolveInstalledPackageInfo } from "#internal/application/package.js";
+
+const BUILD_ENGINE_PACKAGE_NAME = "@eve/build";
+const SUPPORTED_BUILD_ENGINE_PROTOCOL = 1;
+
+let buildEnginePromise: Promise<typeof EveBuildEngine> | undefined;
+
+function missingBuildEngineError(): Error {
+  const eveVersion = resolveInstalledPackageInfo().version;
+  return new Error(
+    `This eve command requires the project-local ${BUILD_ENGINE_PACKAGE_NAME} package. ` +
+      `Install the matching engine with \`pnpm add --save-dev ${BUILD_ENGINE_PACKAGE_NAME}@${eveVersion}\`.`,
+  );
+}
+
+function isMissingBuildEngineError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    error.code === "ERR_MODULE_NOT_FOUND" &&
+    error.message.includes(BUILD_ENGINE_PACKAGE_NAME)
+  );
+}
+
+async function importBuildEngine(): Promise<typeof EveBuildEngine> {
+  try {
+    return await import("@eve/build");
+  } catch (error) {
+    if (isMissingBuildEngineError(error)) {
+      throw missingBuildEngineError();
+    }
+    throw error;
+  }
+}
+
+/** Loads and validates the project-local build engine used by heavy commands. */
+export async function loadBuildEngine(): Promise<typeof EveBuildEngine> {
+  buildEnginePromise ??= importBuildEngine();
+  const buildEngine = await buildEnginePromise;
+
+  if (buildEngine.EVE_BUILD_ENGINE_PROTOCOL !== SUPPORTED_BUILD_ENGINE_PROTOCOL) {
+    throw new Error(
+      `Incompatible ${BUILD_ENGINE_PACKAGE_NAME} protocol ${String(buildEngine.EVE_BUILD_ENGINE_PROTOCOL)}; ` +
+        `eve requires protocol ${SUPPORTED_BUILD_ENGINE_PROTOCOL}. Install matching eve and ${BUILD_ENGINE_PACKAGE_NAME} versions.`,
+    );
+  }
+
+  return buildEngine;
+}

--- a/packages/eve/src/internal/bundler/nitro-rolldown.ts
+++ b/packages/eve/src/internal/bundler/nitro-rolldown.ts
@@ -1,70 +1,8 @@
-import { createRequire } from "node:module";
-import { pathToFileURL } from "node:url";
+import type { RolldownOutput, RolldownOutputChunk } from "@eve/build";
 
-type RolldownOutputChunk = {
-  readonly type: "chunk";
-  readonly code: string;
-  readonly fileName: string;
-};
+import { loadBuildEngine } from "#internal/build-engine.js";
 
-type RolldownOutputAsset = {
-  readonly type: "asset";
-  readonly fileName: string;
-  readonly source: string | Uint8Array;
-};
-
-type RolldownOutput = {
-  readonly output: readonly [RolldownOutputChunk, ...(RolldownOutputChunk | RolldownOutputAsset)[]];
-};
-
-type RolldownBuild = (options: Record<string, unknown>) => Promise<RolldownOutput>;
-type RolldownParseAst = (
-  sourceText: string,
-  options?: Record<string, unknown> | null,
-  filename?: string,
-) => unknown;
 export type RolldownParserLanguage = "js" | "jsx" | "ts" | "tsx";
-
-type RolldownModule = {
-  readonly build: RolldownBuild;
-};
-
-type RolldownParseAstModule = {
-  readonly parseAst: RolldownParseAst;
-};
-
-let rolldownPromise: Promise<RolldownModule> | undefined;
-let rolldownParseAstPromise: Promise<RolldownParseAstModule> | undefined;
-
-/**
- * Loads Rolldown from Nitro's dependency tree so eve does not carry a second
- * native bundler package in its own install footprint.
- */
-function loadNitroRolldown(): Promise<RolldownModule> {
-  rolldownPromise ??= (async () => {
-    const require = createRequire(import.meta.url);
-    const nitroRequire = createRequire(require.resolve("nitro/package.json"));
-    const rolldownPath = nitroRequire.resolve("rolldown");
-    return (await import(pathToFileURL(rolldownPath).href)) as RolldownModule;
-  })();
-
-  return rolldownPromise;
-}
-
-/**
- * Loads Rolldown's parser from Nitro's dependency tree so workflow directive
- * transforms can use the same bundler dependency without exposing it publicly.
- */
-export function loadNitroRolldownParseAst(): Promise<RolldownParseAstModule> {
-  rolldownParseAstPromise ??= (async () => {
-    const require = createRequire(import.meta.url);
-    const nitroRequire = createRequire(require.resolve("nitro/package.json"));
-    const parseAstPath = nitroRequire.resolve("rolldown/parseAst");
-    return (await import(pathToFileURL(parseAstPath).href)) as RolldownParseAstModule;
-  })();
-
-  return rolldownParseAstPromise;
-}
 
 export function inferRolldownParserLanguage(filename: string): RolldownParserLanguage {
   if (filename.endsWith(".tsx")) return "tsx";
@@ -77,8 +15,8 @@ export async function parseWithNitroRolldownAst(
   filename: string,
   sourceText: string,
 ): Promise<unknown> {
-  const { parseAst } = await loadNitroRolldownParseAst();
-  return parseAst(
+  const { parseWithRolldown } = await loadBuildEngine();
+  return await parseWithRolldown(
     sourceText,
     {
       astType: "ts",
@@ -98,8 +36,8 @@ export async function parseWithNitroRolldownAst(
 export async function buildWithNitroRolldown(
   options: Record<string, unknown>,
 ): Promise<RolldownOutput> {
-  const { build } = await loadNitroRolldown();
-  return await build(options);
+  const { buildWithRolldown } = await loadBuildEngine();
+  return await buildWithRolldown(options);
 }
 
 /**

--- a/packages/eve/src/internal/nitro/host/build-application.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/host/build-application.scenario.test.ts
@@ -1,7 +1,7 @@
 import { lstat, mkdir, readFile, realpath, symlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
-import type { Nitro } from "nitro/types";
+import type { Nitro } from "@eve/build";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createCompiledAgentManifest } from "#compiler/manifest.js";
@@ -87,6 +87,22 @@ const createProductionApplicationNitroMock = vi.fn();
 const prepareProductionApplicationHostMock = vi.fn();
 const prepareMock = vi.fn(async () => undefined);
 const prerenderMock = vi.fn(async () => undefined);
+const materializeAuthoredModulesMock = vi.fn(async (input: { runtimeAppRoot: string }) => {
+  const compileDirectory = join(input.runtimeAppRoot, ".eve", "compile");
+  const materializedModulePath = join("authored-modules", "production-module-map.mjs");
+
+  await mkdir(join(compileDirectory, "authored-modules"), { recursive: true });
+  await writeFile(
+    join(compileDirectory, materializedModulePath),
+    "export const moduleMap = { nodes: {} }; export default moduleMap;\n",
+  );
+
+  return {
+    fingerprint: "production-module-map",
+    moduleMap: materializedModulePath,
+    version: 3 as const,
+  };
+});
 const resolveDiscoveryProjectMock = vi.fn(async (appRoot: string) => ({
   agentRoot: join(appRoot, "agent"),
   appRoot,
@@ -94,7 +110,8 @@ const resolveDiscoveryProjectMock = vi.fn(async (appRoot: string) => ({
 }));
 const runVercelBuildPrewarmMock = vi.fn(async () => undefined);
 
-vi.mock("nitro/builder", () => ({
+vi.mock("@eve/build", () => ({
+  EVE_BUILD_ENGINE_PROTOCOL: 1,
   build: buildNitroMock,
   copyPublicAssets: copyPublicAssetsMock,
   prepare: prepareMock,
@@ -107,6 +124,10 @@ vi.mock("./create-application-nitro.js", () => ({
 
 vi.mock("./prepare-application-host.js", () => ({
   prepareProductionApplicationHost: prepareProductionApplicationHostMock,
+}));
+
+vi.mock("#internal/materialized-authored-modules.js", () => ({
+  materializeAuthoredModules: materializeAuthoredModulesMock,
 }));
 
 vi.mock("#discover/project.js", () => ({
@@ -237,6 +258,12 @@ describe("buildApplication", () => {
     await expect(
       readFile(join(appRoot, ".eve", "compile", "compiled-agent-manifest.json"), "utf8"),
     ).rejects.toThrow();
+    await expect(
+      readFile(join(outputDir, ".eve", "compile", "module-map.mjs"), "utf8"),
+    ).resolves.toBe("export const moduleMap = { nodes: {} }; export default moduleMap;\n");
+    expect(materializeAuthoredModulesMock).toHaveBeenCalledWith({
+      runtimeAppRoot: expect.stringContaining(join(appRoot, ".eve", "builds")),
+    });
 
     const summary = JSON.parse(
       await readFile(join(appRoot, VERCEL_EVE_AGENT_SUMMARY_OUTPUT_PATH), "utf8"),

--- a/packages/eve/src/internal/nitro/host/build-application.ts
+++ b/packages/eve/src/internal/nitro/host/build-application.ts
@@ -1,10 +1,10 @@
 import { readFile } from "node:fs/promises";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 
-import { build as buildNitro, copyPublicAssets, prepare, prerender } from "nitro/builder";
-import type { Nitro } from "nitro/types";
+import type { Nitro } from "@eve/build";
 
 import { resolvePackageSourceFilePath } from "#internal/application/package.js";
+import { loadBuildEngine } from "#internal/build-engine.js";
 import {
   prepareEveVersionedCacheDirectory,
   writeEveVersionedCacheMetadata,
@@ -299,6 +299,7 @@ async function buildNitroOutput(
   phasePrefix: string,
 ): Promise<string> {
   const outputDirectory = trimTrailingSlash(nitro.options.output.dir);
+  const { build: buildNitro, copyPublicAssets, prepare, prerender } = await loadBuildEngine();
 
   await measureBuildPhase(profiler, `${phasePrefix}.cache.prepare`, () =>
     prepareEveVersionedCacheDirectory(outputDirectory),
@@ -460,7 +461,7 @@ async function buildApplicationInWorkspace(
     if (!isVercelBuild) {
       await measureBuildPhase(profiler, "compiler-artifacts.stage", () =>
         stageProductionCompilerArtifacts({
-          compilerArtifactsRoot: workspace.compiler.artifactsDir,
+          compilerRoot: workspace.compiler.rootDir,
           outputDir: workspace.publication.output.stagedDir,
         }),
       );

--- a/packages/eve/src/internal/nitro/host/channel-routes.test.ts
+++ b/packages/eve/src/internal/nitro/host/channel-routes.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, it } from "vitest";
 import { createDevelopmentNitroArtifactsConfig } from "#internal/nitro/host/artifacts-config.js";
 import { registerChannelVirtualHandlers } from "#internal/nitro/host/channel-routes.js";
 
+const NITRO_MODULE_PATH = "/app/node_modules/nitro/dist/index.mjs";
+const NITRO_H3_MODULE_PATH = "/app/node_modules/nitro/dist/runtime/internal/h3.mjs";
+
 describe("registerChannelVirtualHandlers", () => {
   it("wraps CORS-enabled HTTP routes and registers preflight handlers", () => {
     const nitro = {
@@ -16,6 +19,8 @@ describe("registerChannelVirtualHandlers", () => {
       artifactsConfig: createDevelopmentNitroArtifactsConfig({
         appRoot: "/app",
       }),
+      nitroH3ModulePath: NITRO_H3_MODULE_PATH,
+      nitroModulePath: NITRO_MODULE_PATH,
       registrations: [{ cors: {}, method: "POST", route: "/eve/v1/session" }],
     });
 
@@ -54,6 +59,8 @@ describe("registerChannelVirtualHandlers", () => {
       artifactsConfig: createDevelopmentNitroArtifactsConfig({
         appRoot: "/app",
       }),
+      nitroH3ModulePath: NITRO_H3_MODULE_PATH,
+      nitroModulePath: NITRO_MODULE_PATH,
       registrations: [
         { cors: {}, method: "GET", route: "/eve/v1/session/:sessionId/events" },
         { cors: {}, method: "POST", route: "/eve/v1/session/:sessionId/events" },
@@ -80,6 +87,8 @@ describe("registerChannelVirtualHandlers", () => {
       artifactsConfig: createDevelopmentNitroArtifactsConfig({
         appRoot: "/app",
       }),
+      nitroH3ModulePath: NITRO_H3_MODULE_PATH,
+      nitroModulePath: NITRO_MODULE_PATH,
       registrations: [{ method: "WEBSOCKET", route: "/voice" }],
     });
 

--- a/packages/eve/src/internal/nitro/host/channel-routes.ts
+++ b/packages/eve/src/internal/nitro/host/channel-routes.ts
@@ -1,4 +1,4 @@
-import type { Nitro } from "nitro/types";
+import type { Nitro } from "@eve/build";
 
 import type { NormalizedChannelCorsOptions } from "#channel/cors.js";
 import type { ChannelRouteMethod } from "#public/definitions/channel.js";
@@ -7,10 +7,7 @@ import {
   getFrameworkChannelDefinitions,
 } from "#runtime/framework-channels/index.js";
 import { stringifyEsmImportSpecifier } from "#internal/application/import-specifier.js";
-import {
-  resolvePackageDependencyPath,
-  resolvePackageSourceFilePath,
-} from "#internal/application/package.js";
+import { resolvePackageSourceFilePath } from "#internal/application/package.js";
 import type { NitroArtifactsConfig } from "#internal/nitro/routes/runtime-artifacts.js";
 import type { PreparedApplicationHost } from "#internal/nitro/host/types.js";
 
@@ -89,6 +86,8 @@ export function registerChannelVirtualHandlers(
   nitro: Pick<ChannelRouteNitro, "options">,
   input: {
     readonly artifactsConfig: NitroArtifactsConfig;
+    readonly nitroH3ModulePath: string;
+    readonly nitroModulePath: string;
     readonly registrations: readonly NitroChannelRouteRegistration[];
   },
 ): void {
@@ -98,6 +97,8 @@ export function registerChannelVirtualHandlers(
       artifactsConfig: input.artifactsConfig,
       cors: registration.cors,
       method: registration.method,
+      nitroH3ModulePath: input.nitroH3ModulePath,
+      nitroModulePath: input.nitroModulePath,
       preflightRoutes,
       route: registration.route,
     });
@@ -114,6 +115,8 @@ function addChannelVirtualHandler(
     artifactsConfig: NitroArtifactsConfig;
     cors?: NormalizedChannelCorsOptions;
     method: ChannelRouteMethod;
+    nitroH3ModulePath: string;
+    nitroModulePath: string;
     preflightRoutes: Set<string>;
     route: string;
   },
@@ -123,8 +126,8 @@ function addChannelVirtualHandler(
   const dispatchModulePath = stringifyEsmImportSpecifier(
     resolvePackageSourceFilePath("src/internal/nitro/routes/channel-dispatch.ts"),
   );
-  const nitroModulePath = stringifyEsmImportSpecifier(resolvePackageDependencyPath("nitro"));
-  const nitroH3ModulePath = stringifyEsmImportSpecifier(resolvePackageDependencyPath("nitro/h3"));
+  const nitroModulePath = stringifyEsmImportSpecifier(input.nitroModulePath);
+  const nitroH3ModulePath = stringifyEsmImportSpecifier(input.nitroH3ModulePath);
 
   if (input.method === "WEBSOCKET") {
     nitro.options.handlers.push({

--- a/packages/eve/src/internal/nitro/host/configure-nitro-routes.test.ts
+++ b/packages/eve/src/internal/nitro/host/configure-nitro-routes.test.ts
@@ -1,4 +1,4 @@
-import type { Nitro } from "nitro/types";
+import type { Nitro } from "@eve/build";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { PreparedApplicationHost } from "./types.js";
@@ -56,9 +56,14 @@ const fsMocks = vi.hoisted(() => ({
 
 vi.mock("node:fs/promises", () => fsMocks);
 
+vi.mock("../../build-engine.js", () => ({
+  loadBuildEngine: async () => ({
+    resolveNitroDependency: (specifier: string) =>
+      `G:\\projects\\test-eve\\node_modules\\.pnpm\\nitro@1.0.0\\node_modules\\${specifier}\\dist\\index.js`,
+  }),
+}));
+
 vi.mock("../../application/package.js", () => ({
-  resolvePackageDependencyPath: (specifier: string) =>
-    `G:\\projects\\test-eve\\node_modules\\.pnpm\\${specifier}@1.0.0\\node_modules\\${specifier}\\dist\\index.js`,
   resolvePackageRoot: () =>
     "G:\\projects\\test-eve\\node_modules\\.pnpm\\eve@0.3.0\\node_modules\\eve",
   resolvePackageSourceFilePath: (relativeSourcePath: string) =>

--- a/packages/eve/src/internal/nitro/host/configure-nitro-routes.ts
+++ b/packages/eve/src/internal/nitro/host/configure-nitro-routes.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join, relative } from "node:path";
 
-import type { Nitro } from "nitro/types";
+import type { Nitro } from "@eve/build";
 import {
   EVE_DEV_DISPATCH_SCHEDULE_ROUTE_PATTERN,
   EVE_DEV_RUNTIME_ARTIFACTS_ROUTE_PATH,
@@ -12,6 +12,7 @@ import {
   stringifyEsmImportSpecifier,
 } from "#internal/application/import-specifier.js";
 import { isVercelBuildEnvironment } from "#internal/application/paths.js";
+import { loadBuildEngine } from "#internal/build-engine.js";
 import {
   resolvePackageRoot,
   resolvePackageSourceFilePath,
@@ -275,11 +276,11 @@ async function registerWorkflowArtifactBuildHook(
   });
 }
 
-function registerApplicationRoutes(
+async function registerApplicationRoutes(
   nitro: Nitro,
   preparedHost: PreparedApplicationHost,
   artifactsConfig: NitroArtifactsConfig,
-): void {
+): Promise<void> {
   addFrameworkVirtualHandler(nitro, {
     args: JSON.stringify({
       agentName: preparedHost.compileResult.manifest.config.name,
@@ -296,8 +297,11 @@ function registerApplicationRoutes(
       route: EVE_HEALTH_ROUTE_PATH,
     });
   }
+  const { resolveNitroDependency } = await loadBuildEngine();
   registerChannelVirtualHandlers(nitro, {
     artifactsConfig,
+    nitroH3ModulePath: resolveNitroDependency("nitro/h3"),
+    nitroModulePath: resolveNitroDependency("nitro"),
     registrations: computeChannelRouteRegistrations(preparedHost),
   });
 }
@@ -387,7 +391,7 @@ export async function configureDevelopmentNitroRoutes(
     appRoot: preparedHost.appRoot,
     configuredWorld: preparedHost.compileResult.manifest.config.experimental?.workflow?.world,
   });
-  registerApplicationRoutes(nitro, preparedHost, artifactsConfig);
+  await registerApplicationRoutes(nitro, preparedHost, artifactsConfig);
   registerDevelopmentControlRoutes(nitro, artifactsConfig);
 
   const workflowBundlePath = join(workflowBuildDirectory, "workflows.mjs");
@@ -426,7 +430,7 @@ export async function configureProductionNitroRoutes(
   };
   await registerWorkflowArtifactBuildHook(nitro, syncWorkflowArtifacts);
 
-  registerApplicationRoutes(nitro, preparedHost, createProductionNitroArtifactsConfig());
+  await registerApplicationRoutes(nitro, preparedHost, createProductionNitroArtifactsConfig());
 
   const workflowBundlePath = join(preparedHost.workflowBuildDir, "workflows.mjs");
   const hasConfiguredWorkflowWorld =

--- a/packages/eve/src/internal/nitro/host/create-application-nitro.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/host/create-application-nitro.scenario.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import type { Nitro } from "nitro/types";
+import type { Nitro } from "@eve/build";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -38,7 +38,8 @@ const configureProductionNitroRoutes = vi.fn(async () => undefined);
 const createNitroMock = vi.fn();
 const registerScheduleTaskHandlers = vi.fn();
 
-vi.mock("nitro/builder", () => ({
+vi.mock("@eve/build", () => ({
+  EVE_BUILD_ENGINE_PROTOCOL: 1,
   createNitro: createNitroMock,
 }));
 

--- a/packages/eve/src/internal/nitro/host/create-application-nitro.ts
+++ b/packages/eve/src/internal/nitro/host/create-application-nitro.ts
@@ -2,8 +2,7 @@ import { readFile } from "node:fs/promises";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { createNitro } from "nitro/builder";
-import type { Nitro } from "nitro/types";
+import type { Nitro } from "@eve/build";
 import { EVE_PACKAGE_NAME } from "#internal/package-name.js";
 import {
   resolvePackageRoot,
@@ -16,6 +15,7 @@ import {
   writeEveVersionedCacheMetadata,
 } from "#internal/application/cache-metadata.js";
 import { createProductionNitroArtifactsConfig } from "#internal/nitro/host/artifacts-config.js";
+import { loadBuildEngine } from "#internal/build-engine.js";
 import { createCompiledSandboxBackendPrunePlugin } from "#internal/nitro/host/compiled-sandbox-backend-prune-plugin.js";
 import { createExtensionScopePlugin } from "#internal/bundler/extension-scope-plugin.js";
 import {
@@ -614,7 +614,10 @@ function createApplicationNitroBundlerConfiguration(
     ? createCompiledSandboxBackendPrunePlugin()
     : null;
   const configuredOptionalEnginePackages: string[] = [];
-  const unconfiguredOptionalEnginePackages: string[] = [];
+  // The project-local build engine is available to this build process but is
+  // never part of the generated server. Keep its lazy import external and
+  // untraced just like an unconfigured optional runtime engine.
+  const unconfiguredOptionalEnginePackages: string[] = ["@eve/build"];
   for (const [backendName, packageName] of Object.entries(
     OPTIONAL_ENGINE_PACKAGES_BY_BACKEND_NAME,
   )) {
@@ -730,6 +733,7 @@ function externalizeDevelopmentWorkflowBundle(
 export async function createDevelopmentApplicationNitro(
   preparedHost: PreparedDevelopmentApplicationHost,
 ): Promise<Nitro> {
+  const { createNitro } = await loadBuildEngine();
   const nitroBuildDir = preparedHost.workspace.nitroBuildDir;
   const bundler = createApplicationNitroBundlerConfiguration(preparedHost, undefined);
   const plugins = createApplicationNitroPlugins(preparedHost);
@@ -802,6 +806,7 @@ export async function createProductionApplicationNitro(
   preparedHost: PreparedApplicationHost,
   options: ProductionApplicationNitroOptions,
 ): Promise<Nitro> {
+  const { createNitro } = await loadBuildEngine();
   const preset = resolveProductionNitroPreset();
   const bundler = createApplicationNitroBundlerConfiguration(preparedHost, preset);
   const nitroPlugins = createApplicationNitroPlugins(preparedHost);

--- a/packages/eve/src/internal/nitro/host/cron-handler-route.test.ts
+++ b/packages/eve/src/internal/nitro/host/cron-handler-route.test.ts
@@ -1,4 +1,4 @@
-import type { Nitro } from "nitro/types";
+import type { Nitro } from "@eve/build";
 import { describe, expect, it } from "vitest";
 
 import { EVE_ROUTE_PREFIX } from "#protocol/routes.js";

--- a/packages/eve/src/internal/nitro/host/cron-handler-route.ts
+++ b/packages/eve/src/internal/nitro/host/cron-handler-route.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "node:crypto";
 
-import type { Nitro } from "nitro/types";
+import type { Nitro } from "@eve/build";
 
 import { EVE_ROUTE_PREFIX } from "#protocol/routes.js";
 

--- a/packages/eve/src/internal/nitro/host/dev-host-candidate.ts
+++ b/packages/eve/src/internal/nitro/host/dev-host-candidate.ts
@@ -1,8 +1,8 @@
 import { resolve } from "node:path";
 
-import { build as buildNitro, prepare } from "nitro/builder";
-import type { Nitro } from "nitro/types";
+import type { Nitro } from "@eve/build";
 
+import { loadBuildEngine } from "#internal/build-engine.js";
 import type { PreparedDevelopmentApplicationHost } from "#internal/nitro/host/types.js";
 
 const CANDIDATE_BUILD_TIMEOUT_MS = 120_000;
@@ -23,6 +23,7 @@ export async function buildDevelopmentHostCandidate(input: {
   readonly nitro: Nitro;
 }): Promise<DevelopmentWorkerPayload> {
   const nitro = input.nitro;
+  const { build: buildNitro, prepare } = await loadBuildEngine();
   let settled = false;
   let payload: DevelopmentWorkerPayload | undefined;
   let buildError: unknown;

--- a/packages/eve/src/internal/nitro/host/nitro-routing-import-specifier-plugin.ts
+++ b/packages/eve/src/internal/nitro/host/nitro-routing-import-specifier-plugin.ts
@@ -1,4 +1,4 @@
-import type { Nitro } from "nitro/types";
+import type { Nitro } from "@eve/build";
 
 import { normalizeGeneratedEsmImportSpecifiers } from "#internal/application/import-specifier.js";
 

--- a/packages/eve/src/internal/nitro/host/optional-engine-dependency-plugin.ts
+++ b/packages/eve/src/internal/nitro/host/optional-engine-dependency-plugin.ts
@@ -1,11 +1,7 @@
 /**
- * Optional sandbox engine packages eve's runtime references through
- * lazy dynamic imports. Bundlers follow literal dynamic imports like
- * static imports — so without intervention mere *resolvability* (for
- * example eve's own workspace devDependencies) would pull them into
- * every hosted build. The source of truth for whether an application
- * opted in is its compiled sandbox config: the backend names captured
- * into the manifest at compile time.
+ * Optional sandbox engine packages eve's runtime references through lazy
+ * dynamic imports. The same bundler policy also handles the project-local
+ * build engine supplied by the caller.
  */
 export const OPTIONAL_ENGINE_PACKAGES_BY_BACKEND_NAME: Readonly<Record<string, string>> = {
   "just-bash": "just-bash",

--- a/packages/eve/src/internal/nitro/host/schedule-task-routes.test.ts
+++ b/packages/eve/src/internal/nitro/host/schedule-task-routes.test.ts
@@ -1,4 +1,4 @@
-import type { Nitro } from "nitro/types";
+import type { Nitro } from "@eve/build";
 import { describe, expect, it } from "vitest";
 
 import {

--- a/packages/eve/src/internal/nitro/host/schedule-task-routes.ts
+++ b/packages/eve/src/internal/nitro/host/schedule-task-routes.ts
@@ -1,4 +1,4 @@
-import type { Nitro } from "nitro/types";
+import type { Nitro } from "@eve/build";
 
 import {
   EVE_SCHEDULE_TASK_NAME_PREFIX,

--- a/packages/eve/src/internal/nitro/host/start-development-server.test.ts
+++ b/packages/eve/src/internal/nitro/host/start-development-server.test.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { Nitro } from "nitro/types";
+import type { Nitro } from "@eve/build";
 
 import type {
   DevelopmentServerHandle,

--- a/packages/eve/src/internal/nitro/host/start-development-server.ts
+++ b/packages/eve/src/internal/nitro/host/start-development-server.ts
@@ -1,6 +1,6 @@
 import { EVE_DEV_ENV_FLAG } from "#internal/application/optional-package-install.js";
 
-import type { Nitro } from "nitro/types";
+import type { Nitro } from "@eve/build";
 
 import { createDevelopmentApplicationNitro } from "#internal/nitro/host/create-application-nitro.js";
 import { DrainedNitroDevServer } from "#internal/nitro/host/drained-nitro-dev-server.js";

--- a/packages/eve/src/internal/nitro/routes/channel-dispatch.test.ts
+++ b/packages/eve/src/internal/nitro/routes/channel-dispatch.test.ts
@@ -1,4 +1,4 @@
-import type { H3Event } from "nitro";
+import type { H3Event } from "@eve/build";
 import {
   context as apiContext,
   propagation as apiPropagation,

--- a/packages/eve/src/internal/nitro/routes/channel-dispatch.ts
+++ b/packages/eve/src/internal/nitro/routes/channel-dispatch.ts
@@ -1,4 +1,4 @@
-import type { H3Event } from "nitro";
+import type { H3Event } from "@eve/build";
 import type { Span } from "#compiled/@opentelemetry/api/index.js";
 import type { RouteContext } from "#public/definitions/channel.js";
 import { getChannelInstrumentationKind } from "#channel/compiled-channel.js";

--- a/packages/eve/src/internal/nitro/routes/health.ts
+++ b/packages/eve/src/internal/nitro/routes/health.ts
@@ -1,4 +1,4 @@
-import type { H3Event } from "nitro";
+import type { H3Event } from "@eve/build";
 import { workflowEntryReference } from "#execution/workflow-runtime.js";
 
 /**

--- a/packages/eve/src/internal/nitro/routes/index.ts
+++ b/packages/eve/src/internal/nitro/routes/index.ts
@@ -1,4 +1,4 @@
-import type { H3Event } from "nitro";
+import type { H3Event } from "@eve/build";
 
 /**
  * Public docs URL surfaced from the barebones home page. Kept in source

--- a/packages/eve/src/internal/workflow-bundle/vercel-workflow-output.ts
+++ b/packages/eve/src/internal/workflow-bundle/vercel-workflow-output.ts
@@ -19,13 +19,13 @@ import {
   normalizeEveVercelRoutes,
 } from "#internal/workflow-bundle/eve-service-route-output.js";
 
-// just-bash and microsandbox are optional peer dependencies (the
-// opt-in local sandbox engines) loaded lazily from the application's
-// install; just-bash additionally exposes native optional codecs for
-// xz/zstd support. All of these must stay external so workflow step
-// bundles neither fail resolving an absent optional install nor try to
-// inline platform-specific `.node` artifacts.
+// @eve/build, just-bash, and microsandbox are optional peer dependencies
+// loaded lazily from the application's install. The build engine owns Nitro's
+// native-capable toolchain, while just-bash exposes optional codecs for xz/zstd.
+// All must stay external so workflow step bundles neither fail resolving an
+// absent optional install nor inline platform-specific `.node` artifacts.
 export const WORKFLOW_STEP_EXTERNAL_PACKAGES = [
+  "@eve/build",
   "@mongodb-js/zstd",
   "just-bash",
   "microsandbox",

--- a/packages/eve/src/setup/primitives/pm/pnpm.ts
+++ b/packages/eve/src/setup/primitives/pm/pnpm.ts
@@ -13,15 +13,11 @@ import type { PackageManagerStrategy } from "./types.js";
 export const PNPM_WORKSPACE_PATH = "pnpm-workspace.yaml";
 export const PNPM_WORKSPACE_MEMBERSHIP_ARGUMENTS = ["list", "--depth", "-1", "--json"] as const;
 const RELEASE_AGE_EXCLUSIONS = [
-  "@ai-sdk/*",
-  "@rolldown/*",
+  "@eve/*",
   "@vercel/*",
   "@workflow/*",
-  "ai",
-  "experimental-ai-sdk-code-mode",
   "eve",
   "nitro",
-  "rolldown",
   "workflow",
 ] as const;
 

--- a/packages/eve/src/setup/scaffold/create/add-to-project.ts
+++ b/packages/eve/src/setup/scaffold/create/add-to-project.ts
@@ -145,6 +145,12 @@ export async function addAgentToProject(
   if (Object.keys(additions).length > 0) {
     patch.dependencies = additions;
   }
+  const buildAddition: Record<string, string> = hasDeclaredDependency(packageJson, "@eve/build")
+    ? {}
+    : { "@eve/build": formatEveDependencySpecifier(evePackage.buildVersion) };
+  if (Object.keys(buildAddition).length > 0) {
+    patch.devDependencies = buildAddition;
+  }
   const workspaceMember = isPackageManagerWorkspaceMember(packageManager, options.projectRoot);
   if (!workspaceMember) {
     patch.nodeEngineRequirement = evePackage.nodeEngine;
@@ -169,7 +175,7 @@ export async function addAgentToProject(
 
   return {
     filesWritten,
-    dependenciesAdded: Object.keys(additions).sort(),
+    dependenciesAdded: [...Object.keys(additions), ...Object.keys(buildAddition)].sort(),
     nodeEngineOverride,
   };
 }

--- a/packages/eve/src/setup/scaffold/create/extension.ts
+++ b/packages/eve/src/setup/scaffold/create/extension.ts
@@ -25,6 +25,7 @@ const DEFAULT_TYPESCRIPT_PACKAGE_VERSION = "__TYPESCRIPT_VERSION__";
 
 interface ExtensionTemplateContext {
   appName: string;
+  eveBuildVersion: string;
   eveVersion: string;
   zodPackageVersion: string;
   typescriptPackageVersion: string;
@@ -35,6 +36,7 @@ interface ExtensionTemplateContext {
 function renderTemplate(content: string, ctx: ExtensionTemplateContext): string {
   return content
     .replaceAll("__EVE_INIT_APP_NAME__", ctx.appName)
+    .replaceAll("__EVE_INIT_BUILD_PACKAGE_VERSION__", ctx.eveBuildVersion)
     .replaceAll("__EVE_INIT_PACKAGE_VERSION__", ctx.eveVersion)
     .replaceAll("__EVE_INIT_ZOD_VERSION__", ctx.zodPackageVersion)
     .replaceAll("__EVE_INIT_TYPESCRIPT_VERSION__", ctx.typescriptPackageVersion)
@@ -77,6 +79,7 @@ function packageJsonTemplate(includeRootOnlyFields: boolean): string {
       zod: "__EVE_INIT_ZOD_VERSION__",
     },
     devDependencies: {
+      "@eve/build": "__EVE_INIT_BUILD_PACKAGE_VERSION__",
       "@types/node": "__EVE_INIT_TYPES_NODE_VERSION__",
       eve: "__EVE_INIT_PACKAGE_VERSION__",
       typescript: "__EVE_INIT_TYPESCRIPT_VERSION__",
@@ -244,6 +247,7 @@ export async function scaffoldExtensionProject(
 
   const ctx: ExtensionTemplateContext = {
     appName: basename(targetRoot),
+    eveBuildVersion: evePackage.buildVersion,
     eveVersion: evePackage.version,
     zodPackageVersion: resolveVersionToken(
       "zodPackageVersion",

--- a/packages/eve/src/setup/scaffold/create/project.ts
+++ b/packages/eve/src/setup/scaffold/create/project.ts
@@ -32,21 +32,32 @@ const DEFAULT_TYPESCRIPT_PACKAGE_VERSION = "__TYPESCRIPT_VERSION__";
 export interface EvePackageContract {
   /** eve dependency version or npm specifier written to the generated package. */
   version: string;
+  /** Matching @eve/build version or npm specifier. Defaults to {@link version}. */
+  buildVersion?: string;
   /** The matching eve release's authored `package.json` `engines.node` value. */
   nodeEngine: string;
 }
 
 export const DEFAULT_EVE_PACKAGE_CONTRACT: EvePackageContract = {
   version: "__EVE_PACKAGE_DEPENDENCY_VERSION__",
+  buildVersion: "__EVE_BUILD_PACKAGE_DEPENDENCY_VERSION__",
   nodeEngine: "__NODE_ENGINE__",
 };
+
+interface ResolvedEvePackageContract extends EvePackageContract {
+  buildVersion: string;
+}
 
 /** Resolves a stamped or explicitly supplied eve package contract. */
 export function resolveEvePackageContract(
   contract: EvePackageContract = DEFAULT_EVE_PACKAGE_CONTRACT,
-): EvePackageContract {
+): ResolvedEvePackageContract {
   return {
     version: resolveVersionToken("evePackage.version", contract.version),
+    buildVersion: resolveVersionToken(
+      "evePackage.buildVersion",
+      contract.buildVersion ?? contract.version,
+    ),
     nodeEngine: resolveVersionToken("evePackage.nodeEngine", contract.nodeEngine),
   };
 }
@@ -56,6 +67,7 @@ interface TemplateContext {
   model: string;
   reasoning?: AgentReasoningDefinition;
   eveVersion: string;
+  eveBuildVersion: string;
   aiPackageVersion: string;
   connectPackageVersion: string;
   zodPackageVersion: string;
@@ -123,6 +135,10 @@ function renderTemplate(content: string, ctx: TemplateContext): string {
     .replaceAll("__EVE_INIT_BYOK_PROVIDER__", modelProviderSlug(ctx.model))
     .replaceAll("__EVE_INIT_BYOK_ENV_VAR__", byokProviderEnvVar(ctx.model))
     .replaceAll("__EVE_INIT_PACKAGE_VERSION__", formatEveDependencySpecifier(ctx.eveVersion))
+    .replaceAll(
+      "__EVE_INIT_BUILD_PACKAGE_VERSION__",
+      formatEveDependencySpecifier(ctx.eveBuildVersion),
+    )
     .replaceAll("__EVE_INIT_AI_SDK_VERSION__", ctx.aiPackageVersion)
     .replaceAll("__EVE_INIT_CONNECT_VERSION__", ctx.connectPackageVersion)
     .replaceAll("__EVE_INIT_ZOD_VERSION__", ctx.zodPackageVersion)
@@ -219,6 +235,7 @@ function packageJsonTemplate(input: {
     "zod": "__EVE_INIT_ZOD_VERSION__"
   },
   "devDependencies": {
+    "@eve/build": "__EVE_INIT_BUILD_PACKAGE_VERSION__",
     "@types/node": "__EVE_INIT_TYPES_NODE_VERSION__",
     "typescript": "__EVE_INIT_TYPESCRIPT_VERSION__"
   }${rootOnlyFields}
@@ -421,6 +438,7 @@ export async function scaffoldBaseProject(options: ScaffoldBaseProjectOptions): 
     appName: basename(targetRoot),
     model: options.model,
     reasoning: options.reasoning,
+    eveBuildVersion: evePackage.buildVersion,
     eveVersion: evePackage.version,
     aiPackageVersion: resolveVersionToken(
       "aiPackageVersion",

--- a/packages/eve/src/setup/scaffold/index.integration.test.ts
+++ b/packages/eve/src/setup/scaffold/index.integration.test.ts
@@ -26,7 +26,7 @@ async function createTempDir(): Promise<string> {
 const TEST_EVE_PACKAGE = { version: "0.25.0", nodeEngine: ">=24" } as const;
 const LATEST_EVE_PACKAGE = { version: "latest", nodeEngine: ">=24" } as const;
 const RELEASE_AGE_POLICY =
-  'minimumReleaseAgeExclude:\n  - "@ai-sdk/*"\n  - "@rolldown/*"\n  - "@vercel/*"\n  - "@workflow/*"\n  - ai\n  - experimental-ai-sdk-code-mode\n  - eve\n  - nitro\n  - rolldown\n  - workflow\n';
+  'minimumReleaseAgeExclude:\n  - "@eve/*"\n  - "@vercel/*"\n  - "@workflow/*"\n  - eve\n  - nitro\n  - workflow\n';
 
 const TEST_WEB_PACKAGE_VERSIONS = {
   evePackage: TEST_EVE_PACKAGE,
@@ -227,6 +227,7 @@ describe("ensureChannel", () => {
     const patchedPackageJson = JSON.parse(
       await readFile(join(projectRoot, "package.json"), "utf8"),
     ) as { devDependencies: Record<string, string> };
+    expect(patchedPackageJson.devDependencies["@eve/build"]).toBe("^0.25.0");
     expect(patchedPackageJson.devDependencies.typescript).toBe("6.0.3");
     await expect(readFile(join(projectRoot, "app/page.tsx"), "utf8")).resolves.toContain(
       "AgentChat",
@@ -625,7 +626,7 @@ describe("ensureChannel", () => {
     });
 
     await expect(readFile(pnpmWorkspacePath, "utf8")).resolves.toBe(
-      'minimumReleaseAgeExclude:\n  - react\n  - "@ai-sdk/*"\n  - "@rolldown/*"\n  - "@vercel/*"\n  - "@workflow/*"\n  - ai\n  - experimental-ai-sdk-code-mode\n  - eve\n  - nitro\n  - rolldown\n  - workflow\nallowBuilds:\n  sharp: false\n',
+      'minimumReleaseAgeExclude:\n  - react\n  - "@eve/*"\n  - "@vercel/*"\n  - "@workflow/*"\n  - eve\n  - nitro\n  - workflow\nallowBuilds:\n  sharp: false\n',
     );
     expect(result.filesWritten).toContain(pnpmWorkspacePath);
   });
@@ -907,6 +908,7 @@ describe("scaffoldExtensionProject", () => {
       engines: { node: "24.x" },
     });
     expect(packageJson.devDependencies?.eve).toBe("0.25.0");
+    expect(packageJson.devDependencies?.["@eve/build"]).toBe("0.25.0");
     expect(packageJson.peerDependenciesMeta).toBeUndefined();
     expect(packageJson.devDependencies?.typescript).toBe("7.0.2");
     expect(packageJson.dependencies?.ai).toBeUndefined();
@@ -953,6 +955,7 @@ describe("scaffoldBaseProject", () => {
     expect(agentSource).not.toContain("modelOptions");
     const packageJson = await readFile(join(projectRoot, "package.json"), "utf8");
     expect(packageJson).toContain('"eve": "^0.25.0"');
+    expect(packageJson).toContain('"@eve/build": "^0.25.0"');
     // Channels added later (`eve add channel/slack`, possibly next to a
     // running `eve dev`) import @vercel/connect; init ships it so a later
     // channel add never introduces a missing dependency.

--- a/packages/eve/src/setup/scaffold/update/channels.ts
+++ b/packages/eve/src/setup/scaffold/update/channels.ts
@@ -286,6 +286,7 @@ async function patchWebPackageJson(
   } satisfies Record<string, string>;
   const devDependencies = {
     ...WEB_APP_TEMPLATE_PACKAGE_JSON.devDependencies,
+    "@eve/build": formatEveDependencySpecifier(evePackage.buildVersion),
     "@types/node": nodeEngine,
     "@types/react": resolveVersionToken(
       "typesReactPackageVersion",

--- a/packages/eve/src/setup/scaffold/version-tokens.ts
+++ b/packages/eve/src/setup/scaffold/version-tokens.ts
@@ -31,6 +31,7 @@ const NODE_ENGINE_TOKEN = bareToken("NODE_ENGINE");
 const TOKEN_SOURCES: Readonly<Record<string, TokenSource>> = {
   [versionToken("EVE_PACKAGE")]: { kind: "eve-version" },
   [versionToken("EVE_PACKAGE_DEPENDENCY")]: { kind: "eve-version" },
+  [versionToken("EVE_BUILD_PACKAGE_DEPENDENCY")]: { kind: "eve-version" },
   [NODE_ENGINE_TOKEN]: { kind: "eve-node-engine" },
   [versionToken("AI_SDK")]: { kind: "catalog", packageName: "ai" },
   [versionToken("VERCEL_CONNECT")]: { kind: "catalog", packageName: "@vercel/connect" },

--- a/packages/eve/test/scenarios/agent-info-route.scenario.test.ts
+++ b/packages/eve/test/scenarios/agent-info-route.scenario.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
-import type { H3Event } from "nitro";
+import type { H3Event } from "@eve/build";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { compileAgent } from "../../src/compiler/compile-agent.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,6 +358,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -373,6 +376,10 @@ importers:
       zod:
         specifier: 'catalog:'
         version: 4.4.3
+    devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
 
   apps/frameworks/next:
     dependencies:
@@ -401,6 +408,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
       '@tailwindcss/postcss':
         specifier: 4.3.0
         version: 4.3.0
@@ -447,6 +457,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -478,6 +491,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -512,6 +528,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -541,6 +560,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -563,6 +585,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -582,6 +607,9 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/eve
     devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -604,6 +632,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -623,6 +654,9 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/eve
     devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -642,6 +676,9 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/eve
     devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -667,6 +704,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -689,6 +729,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -711,6 +754,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -730,6 +776,9 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/eve
     devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -749,6 +798,9 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/eve
     devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -771,6 +823,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -793,6 +848,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -818,6 +876,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -840,6 +901,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -862,6 +926,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -884,6 +951,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -903,6 +973,9 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/eve
     devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -928,6 +1001,9 @@ importers:
         specifier: file:../gizmo-extension
         version: file:e2e/fixtures/gizmo-extension(eve@packages+eve)
     devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -978,6 +1054,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -994,6 +1073,9 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
     devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -1010,6 +1092,9 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
     devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -1026,6 +1111,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -1042,6 +1130,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../../../packages/eve-build
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.1
@@ -1060,9 +1151,6 @@ importers:
       braintrust:
         specifier: ^3.0.0
         version: 3.24.0(@aws-sdk/credential-provider-web-identity@3.972.49)(supports-color@10.2.2)(zod@4.4.3)
-      nitro:
-        specifier: 3.0.260610-beta
-        version: 3.0.260610-beta(@upstash/redis@1.38.0)(@vercel/blob@2.4.0)(@vercel/functions@3.9.3(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.3(bufferutil@4.1.0)))(aws4fetch@1.0.20)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(pg@8.20.0)(sql.js@1.14.1))(giget@3.3.0)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(lru-cache@11.5.2)(rollup@4.62.2)(vite@8.1.5(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
       undici:
         specifier: 8.9.0
         version: 8.9.0
@@ -1103,6 +1191,9 @@ importers:
       '@clack/core':
         specifier: 1.3.1
         version: 1.3.1
+      '@eve/build':
+        specifier: workspace:*
+        version: link:../eve-build
       '@eve/catalog':
         specifier: workspace:*
         version: link:../eve-catalog
@@ -1195,7 +1286,7 @@ importers:
         version: 0.6.0
       env-runner:
         specifier: 0.1.16
-        version: 0.1.16
+        version: 0.1.16(@vercel/queue@0.4.0(@opentelemetry/api@1.9.1))
       eventsource-parser:
         specifier: 3.1.0
         version: 3.1.0
@@ -1259,6 +1350,12 @@ importers:
       zod-validation-error:
         specifier: 5.0.0
         version: 5.0.0(zod@4.4.3)
+
+  packages/eve-build:
+    dependencies:
+      nitro:
+        specifier: 3.0.260610-beta
+        version: 3.0.260610-beta(@upstash/redis@1.38.0)(@vercel/blob@2.4.0)(@vercel/functions@3.9.3(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.3(bufferutil@4.1.0)))(aws4fetch@1.0.20)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(pg@8.20.0)(sql.js@1.14.1))(giget@3.3.0)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(lru-cache@11.5.2)(rollup@4.62.2)(vite@8.1.5(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/eve-buzz-acp-adapter:
     dependencies:
@@ -13317,6 +13414,7 @@ packages:
   rolldown@1.1.5:
     resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
 
   rollup-plugin-visualizer@7.0.1:
     resolution: {integrity: sha512-UJUT4+1Ho4OcWmPYU3sYXgUqI8B8Ayfe06MX7y0qCJ1K8aGoKtR/NDd/2nZqM7ADkrzny+I99Ul7GgyoiVNAgg==}
@@ -13673,6 +13771,7 @@ packages:
   srvx@0.11.22:
     resolution: {integrity: sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ==}
     engines: {node: '>=20.16.0'}
+    hasBin: true
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
@@ -23899,12 +23998,14 @@ snapshots:
 
   env-paths@3.0.0: {}
 
-  env-runner@0.1.16:
+  env-runner@0.1.16(@vercel/queue@0.4.0(@opentelemetry/api@1.9.1)):
     dependencies:
       crossws: 0.4.10(srvx@0.11.22)
       exsolve: 1.1.0
       httpxy: 0.5.5
       srvx: 0.11.22
+    optionalDependencies:
+      '@vercel/queue': 0.4.0(@opentelemetry/api@1.9.1)
 
   error-ex@1.3.4:
     dependencies:
@@ -27420,7 +27521,7 @@ snapshots:
       consola: 3.4.2
       crossws: 0.4.10(srvx@0.11.22)
       db0: 0.3.4(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(pg@8.20.0)(sql.js@1.14.1))
-      env-runner: 0.1.16
+      env-runner: 0.1.16(@vercel/queue@0.4.0(@opentelemetry/api@1.9.1))
       h3: 2.0.1-rc.22(crossws@0.4.10(srvx@0.11.22))
       hookable: 6.1.1
       nf3: 0.3.17

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -56,6 +56,7 @@ catalog:
 minimumReleaseAge: 2880 # 2 days
 
 minimumReleaseAgeExclude:
+  - "@eve/*"
   - "@vercel/*"
   - "@workflow/*"
   - nitro

--- a/scripts/assert-changeset-publish-packages.mjs
+++ b/scripts/assert-changeset-publish-packages.mjs
@@ -1,7 +1,7 @@
 import { access, readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 
-const allowedPublicPackages = new Set(["@eve/buzz-acp-adapter", "eve"]);
+const allowedPublicPackages = new Set(["@eve/build", "@eve/buzz-acp-adapter", "eve"]);
 const workspaceRoots = ["apps", "packages"];
 
 async function readJson(path) {

--- a/scripts/init-install-report.mjs
+++ b/scripts/init-install-report.mjs
@@ -177,6 +177,7 @@ async function runInitCommand(input) {
     env: {
       ...process.env,
       CODEX_CI: "1",
+      EVE_INIT_BUILD_PACKAGE_SPEC: input.eveBuildPackageSpec,
       EVE_INIT_PACKAGE_SPEC: input.evePackageSpec,
       npm_config_user_agent: `npm/? node/${process.versions.node} ${process.platform} ${process.arch}`,
     },
@@ -193,6 +194,7 @@ export async function collectInitInstallReportFromTarball(options) {
 
   try {
     const initialized = await runInitCommand({
+      eveBuildPackageSpec: `file:${options.buildTarballPath}`,
       evePackageSpec: `file:${options.tarballPath}`,
       packageRoot,
       parentDirectory: initDirectory,
@@ -210,6 +212,7 @@ export async function collectInitInstallReportFromTarball(options) {
     const installedSizeBytes = installedFiles.reduce((total, file) => total + file.size, 0);
     const packageSizes = new Map();
     const packageSpec = `file:${basename(options.tarballPath)}`;
+    const buildPackageSpec = `file:${basename(options.buildTarballPath)}`;
 
     for (const file of installedFiles) {
       const packageName = readInstalledPackageName(file.relativePath);
@@ -229,10 +232,16 @@ export async function collectInitInstallReportFromTarball(options) {
       },
     );
     const devDependencies = normalizeDependencyRanges(
-      attachInstalledBytes(readDependencyBlock(packageJson, "devDependencies"), packageSizes),
+      normalizeDependencyRanges(
+        attachInstalledBytes(readDependencyBlock(packageJson, "devDependencies"), packageSizes),
+        {
+          packageName: "eve",
+          packageSpec,
+        },
+      ),
       {
-        packageName: "eve",
-        packageSpec,
+        packageName: "@eve/build",
+        packageSpec: buildPackageSpec,
       },
     );
     const directDependencyNames = new Set(dependencies.map((dependency) => dependency.name));
@@ -285,13 +294,21 @@ export async function collectInitInstallReport(options) {
 
   try {
     const packResult = await runPack(packageRoot, packDirectory);
+    const buildPackageRoot = resolve(packageRoot, "../eve-build");
+    const buildPackResult = await runPack(buildPackageRoot, packDirectory);
     const tarballFilename = typeof packResult.filename === "string" ? packResult.filename : null;
+    const buildTarballFilename =
+      typeof buildPackResult.filename === "string" ? buildPackResult.filename : null;
 
     if (!tarballFilename) {
       throw new Error(`npm pack did not report a tarball filename for "${packageRoot}".`);
     }
+    if (!buildTarballFilename) {
+      throw new Error(`npm pack did not report a tarball filename for "${buildPackageRoot}".`);
+    }
 
     return collectInitInstallReportFromTarball({
+      buildTarballPath: join(packDirectory, buildTarballFilename),
       packageLabel: options.packageLabel,
       packageRoot,
       tarballPath: join(packDirectory, tarballFilename),

--- a/scripts/nitro-bundle-report.mjs
+++ b/scripts/nitro-bundle-report.mjs
@@ -1512,10 +1512,17 @@ async function collectPackageReports(options) {
 
   try {
     const packResult = await runPack(packageRoot, packDirectory);
+    const buildPackageRoot = resolve(packageRoot, "../eve-build");
+    const buildPackResult = await runPack(buildPackageRoot, packDirectory);
     const tarballFilename = typeof packResult.filename === "string" ? packResult.filename : null;
+    const buildTarballFilename =
+      typeof buildPackResult.filename === "string" ? buildPackResult.filename : null;
 
     if (!tarballFilename) {
       throw new Error(`npm pack did not report a tarball filename for "${packageRoot}".`);
+    }
+    if (!buildTarballFilename) {
+      throw new Error(`npm pack did not report a tarball filename for "${buildPackageRoot}".`);
     }
 
     const tarballPath = join(packDirectory, tarballFilename);
@@ -1527,6 +1534,7 @@ async function collectPackageReports(options) {
       tarballPath,
     });
     const initInstall = await collectInitInstallReportFromTarball({
+      buildTarballPath: join(packDirectory, buildTarballFilename),
       packageLabel: options.packageLabel,
       packageRoot,
       tarballPath,


### PR DESCRIPTION
Closes #2041.

### Summary

Nitro and its Rolldown/native dependency graph were installed with every `eve` runtime even though they are needed only while developing or building an application. This introduces `@eve/build`, an eve-owned project-local build engine, and makes it a development dependency of generated projects, extensions, framework fixtures, and the repository's build consumers. `eve dev`, `eve build`, and extension builds load that engine through a small versioned protocol; the published `eve` package keeps it as an optional peer and no longer installs Nitro.

Production output remains a Nitro-generated server. The build now materializes the compiled module map inside that output, so the server router and sandbox prewarm path run from the finished artifact without project source or `@eve/build`. `eve start` has no build fallback: it starts the existing `.output` bundle or fails immediately with explicit `eve build` guidance when the bundle is missing.

The package-artifact service now publishes and smoke-tests both tarballs, scaffolding injects compatible package specs, release policy keeps `eve` and `@eve/build` versioned together, and the CLI/framework documentation describes the build-time boundary.

### Validation

The full unit suite passed with 6,483 tests and one existing skip, the full integration suite passed, and 33 focused Nitro build/start scenarios plus 11 package-artifact tests passed. Packed-install validation confirmed that an `eve`-only install contains neither `@eve/build` nor Nitro, still runs `eve --version`, and makes `eve start` fail with explicit build guidance when output is absent. A separately packed application built successfully, then started and returned a 200 health response after `@eve/build` was physically removed.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 10 files · +54 / -9

Adds the paired-package changeset and documents installation, extensions, framework setup, CLI behavior, and the package-artifact contract.

**Implementation** — 45 files · +511 / -191

Adds `@eve/build`, moves Nitro and Rolldown access behind the build-engine protocol, makes production artifacts source-free, and updates scaffolding, release, lockfile, and artifact publication paths.

**Tests** — 46 files · +185 / -36

Adds build-engine and source-free startup regressions, extends package-artifact coverage, and updates workspace, framework, and end-to-end fixtures to exercise the project-local engine.
