### PR TITLE
feat(eve): poll local subagent work snapshots

### DIFF
--- a/packages/eve/src/execution/refresh-local-subagent-work-step.ts
+++ b/packages/eve/src/execution/refresh-local-subagent-work-step.ts
@@ -1,0 +1,36 @@
+import { deserializeContext, serializeContext } from "#context/serialize.js";
+import { WorkGraphKey } from "#context/keys.js";
+import type { DurableSessionState } from "#execution/durable-session-store.js";
+import { readLocalSubagentWork } from "#execution/local-subagent-work-query.js";
+import { findRunningLocalAgentHandles } from "#harness/handles/query.js";
+import { adoptChildWorkSnapshot } from "#harness/work-graph.js";
+
+/** Pulls newer direct local-subagent work snapshots into a parent work graph. */
+export async function refreshLocalSubagentWorkStep(input: {
+  readonly serializedContext: Record<string, unknown>;
+  readonly sessionState: DurableSessionState;
+}): Promise<{ readonly serializedContext: Record<string, unknown> }> {
+  "use step";
+
+  const ctx = await deserializeContext(input.serializedContext);
+  let work = ctx.get(WorkGraphKey);
+  if (work === undefined) return { serializedContext: input.serializedContext };
+
+  const handles = findRunningLocalAgentHandles(input.sessionState.snapshot?.session.state);
+  for (const handle of handles) {
+    const child = await readLocalSubagentWork({
+      callId: handle.operation.callId,
+      parentState: input.sessionState.snapshot?.session.state,
+    });
+    if (child.kind !== "available") continue;
+    work = adoptChildWorkSnapshot(work, {
+      callId: handle.operation.callId,
+      sessionId: handle.address.sessionId,
+      snapshot: child.work,
+    });
+  }
+
+  if (work === ctx.get(WorkGraphKey)) return { serializedContext: input.serializedContext };
+  ctx.set(WorkGraphKey, work);
+  return { serializedContext: serializeContext(ctx) };
+}

--- a/packages/eve/src/execution/turn-workflow.ts
+++ b/packages/eve/src/execution/turn-workflow.ts
@@ -22,6 +22,7 @@ import { claimHookOwnership, disposeHook, isHookConflictError } from "#execution
 import type { NextDriverAction } from "#execution/next-driver-action.js";
 import { routeDeliverToChildren } from "#execution/route-child-delivery.js";
 import { runProxySubagentEventStep } from "#execution/subagent-event-proxy-step.js";
+import { refreshLocalSubagentWorkStep } from "#execution/refresh-local-subagent-work-step.js";
 import {
   createTurnCancellationControl,
   type TurnCancellationControl,
@@ -307,6 +308,8 @@ interface AcceptedRuntimeActionBatch {
   readonly results: readonly RuntimeActionResult[];
 }
 
+const LOCAL_SUBAGENT_WORK_REFRESH_MS = 15_000;
+
 async function waitForRuntimeActionResults(input: {
   readonly bufferedDeliveries: DeliverHookPayload[];
   readonly cancellation: TurnCancellationControl | undefined;
@@ -326,6 +329,9 @@ async function waitForRuntimeActionResults(input: {
       acceptedAtMsByKey.set(getRuntimeActionResultKey(result), input.initialAcceptedAtMs);
     }
   }
+  let nextWorkRefresh = workflowSleep(LOCAL_SUBAGENT_WORK_REFRESH_MS).then(
+    () => "work-refresh" as const,
+  );
 
   while (true) {
     const ready = resolveRuntimeActionResultsForKeys({
@@ -368,8 +374,8 @@ async function waitForRuntimeActionResults(input: {
     // never surfaces as unhandled.
     nextPromise.catch(() => {});
     const next = await (input.cancellation === undefined
-      ? nextPromise
-      : Promise.race([nextPromise, input.cancellation.requested]));
+      ? Promise.race([nextPromise, nextWorkRefresh])
+      : Promise.race([nextPromise, nextWorkRefresh, input.cancellation.requested]));
     if (next === "cancel") {
       if (pendingDeliveryRequest !== undefined) {
         // Release the raced public input back to the driver so it stays
@@ -380,6 +386,17 @@ async function waitForRuntimeActionResults(input: {
         });
       }
       return "cancelled";
+    }
+    if (next === "work-refresh") {
+      const refreshed = await refreshLocalSubagentWorkStep({
+        serializedContext: input.cursor.serializedContext,
+        sessionState: input.cursor.sessionState,
+      });
+      await input.cursor.adopt({ ...refreshed, sessionState: input.cursor.sessionState });
+      nextWorkRefresh = workflowSleep(LOCAL_SUBAGENT_WORK_REFRESH_MS).then(
+        () => "work-refresh" as const,
+      );
+      continue;
     }
     if (next.done) throw new Error("Turn inbox closed before runtime actions completed.");
 

--- a/packages/eve/src/harness/handles/query.ts
+++ b/packages/eve/src/harness/handles/query.ts
@@ -47,6 +47,16 @@ export function findRunningAgentHandle(
   );
 }
 
+/** Returns direct running local subagents owned by this session. */
+export function findRunningLocalAgentHandles(
+  state: SessionStateMap | undefined,
+): readonly RunningAgentHandle[] {
+  return readAgentHandles(state).filter(
+    (handle): handle is RunningAgentHandle =>
+      handle.phase === "running" && handle.address.kind === "agent/local",
+  );
+}
+
 /**
  * A subagent result may settle a call only when a running handle records
  * its callId: a late or duplicate result for an already-settled call finds

--- a/packages/eve/src/harness/work-graph.ts
+++ b/packages/eve/src/harness/work-graph.ts
@@ -25,6 +25,7 @@ export interface WorkAction {
   readonly phase: WorkPhase;
   readonly child?: {
     readonly sessionId: string;
+    readonly work?: WorkGraph;
   };
 }
 
@@ -53,6 +54,12 @@ export interface WorkGraph {
   readonly turn?: WorkTurn;
 }
 
+export interface ChildWorkSnapshot {
+  readonly callId: string;
+  readonly sessionId: string;
+  readonly snapshot: WorkGraph;
+}
+
 const EMPTY_WORK_GRAPH: WorkGraph = { revision: 0 };
 
 /** Reduces authoritative stream lifecycle facts into the live work graph. */
@@ -62,6 +69,29 @@ export function reduceWorkGraph(
 ): WorkGraph {
   const next = reduce(graph, event);
   return next === graph ? graph : { ...next, revision: graph.revision + 1 };
+}
+
+/** Adopts a newer snapshot from one direct running local subagent. */
+export function adoptChildWorkSnapshot(graph: WorkGraph, child: ChildWorkSnapshot): WorkGraph {
+  const turn = graph.turn;
+  if (turn === undefined || isTerminal(turn.phase)) return graph;
+  const stepIndex = turn.steps.findIndex((step) =>
+    step.actions.some((action) => action.callId === child.callId),
+  );
+  if (stepIndex === -1) return graph;
+  const step = turn.steps[stepIndex]!;
+  let changed = false;
+  const actions = step.actions.map((action) => {
+    if (action.callId !== child.callId || isTerminal(action.phase)) return action;
+    if (action.child?.sessionId !== child.sessionId) return action;
+    if ((action.child.work?.revision ?? -1) >= child.snapshot.revision) return action;
+    changed = true;
+    return { ...action, child: { ...action.child, work: child.snapshot } };
+  });
+  if (!changed) return graph;
+  const steps = [...turn.steps];
+  steps[stepIndex] = { ...step, actions };
+  return { ...graph, revision: graph.revision + 1, turn: { ...turn, steps } };
 }
 
 function reduce(graph: WorkGraph, event: UnstampedMessageStreamEvent): WorkGraph {


### PR DESCRIPTION
### Summary

Related to #1673. Build on #2040 by periodically pulling the latest committed work snapshot for each direct running local subagent while a parent waits for runtime-action results. The parent adopts only newer snapshots and continues using its existing inbox for terminal and other control-relevant child updates.

This keeps observational child work off the parent wake path: child steps write their own `eve.work` projection stream, and the parent performs bounded tail reads on its timer. Remote agents and public rendering APIs remain out of scope.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/execution/turn-workflow.test.ts src/harness/work-graph.test.ts src/execution/local-subagent-work-query.test.ts`
- `pnpm --filter eve exec tsc --noEmit -p tsconfig.json`

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
