### PR TITLE
feat(eve): publish unverified preview package artifacts

### DIFF
--- a/.changeset/unverified-package-artifacts.md
+++ b/.changeset/unverified-package-artifacts.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Preview package-artifact builds can publish isolated, SHA-pinned unverified tarballs for testing changes before they reach main.

--- a/.changeset/unverified-package-artifacts.md
+++ b/.changeset/unverified-package-artifacts.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Preview package-artifact builds can package an isolated, deployment-pinned tarball for testing changes before they reach main.
+Pull requests now publish SHA-pinned package artifacts through a credential-isolated GitHub workflow for testing changes before they reach main.

--- a/.changeset/unverified-package-artifacts.md
+++ b/.changeset/unverified-package-artifacts.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Preview package-artifact builds can publish isolated, SHA-pinned unverified tarballs for testing changes before they reach main.
+Preview package-artifact builds can package an isolated, deployment-pinned tarball for testing changes before they reach main.

--- a/.github/workflows/package-artifact-build.yml
+++ b/.github/workflows/package-artifact-build.yml
@@ -1,0 +1,64 @@
+name: Package artifact build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Select source
+        id: source
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MAIN_SHA: ${{ github.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [ "$EVENT_NAME" = "push" ]; then
+            echo "sha=$MAIN_SHA" >> "$GITHUB_OUTPUT"
+            echo "ref=main" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=$PR_SHA" >> "$GITHUB_OUTPUT"
+            echo "ref=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ steps.source.outputs.sha }}
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build package artifact
+        env:
+          EVE_PACKAGE_OUTPUT_DIRECTORY: package-artifact
+          EVE_PACKAGE_PUBLIC_ORIGIN: https://pkg.eve.dev
+          EVE_PACKAGE_REF: ${{ steps.source.outputs.ref }}
+          EVE_PACKAGE_SOURCE_SHA: ${{ steps.source.outputs.sha }}
+        run: pnpm --filter eve-package-artifacts package:prepare
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: eve-package
+          path: package-artifact
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/package-artifact-build.yml
+++ b/.github/workflows/package-artifact-build.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Build package artifact
         env:
-          EVE_PACKAGE_OUTPUT_DIRECTORY: package-artifact
+          EVE_PACKAGE_OUTPUT_DIRECTORY: ${{ github.workspace }}/package-artifact
           EVE_PACKAGE_PUBLIC_ORIGIN: https://pkg.eve.dev
           EVE_PACKAGE_REF: ${{ steps.source.outputs.ref }}
           EVE_PACKAGE_SOURCE_SHA: ${{ steps.source.outputs.sha }}

--- a/.github/workflows/package-artifact-build.yml
+++ b/.github/workflows/package-artifact-build.yml
@@ -19,12 +19,15 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           MAIN_SHA: ${{ github.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
           PR_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           if [ "$EVENT_NAME" = "push" ]; then
+            echo "repository=${{ github.repository }}" >> "$GITHUB_OUTPUT"
             echo "sha=$MAIN_SHA" >> "$GITHUB_OUTPUT"
             echo "ref=main" >> "$GITHUB_OUTPUT"
           else
+            echo "repository=$PR_REPOSITORY" >> "$GITHUB_OUTPUT"
             echo "sha=$PR_SHA" >> "$GITHUB_OUTPUT"
             echo "ref=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           fi
@@ -32,6 +35,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          repository: ${{ steps.source.outputs.repository }}
           ref: ${{ steps.source.outputs.sha }}
           persist-credentials: false
 

--- a/.github/workflows/package-artifact-publish.yml
+++ b/.github/workflows/package-artifact-publish.yml
@@ -4,6 +4,12 @@ on:
   workflow_run:
     workflows: [Package artifact build]
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        description: Pull request number to publish
+        required: true
+        type: string
 
 permissions:
   actions: read
@@ -12,35 +18,71 @@ permissions:
 
 jobs:
   publish:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push')
     runs-on: ubuntu-latest
     steps:
       - name: Resolve trusted publication target
         id: target
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+        env:
+          PULL_REQUEST: ${{ inputs.pull_request }}
         with:
           script: |
-            const run = context.payload.workflow_run;
-            if (run.event === "push") {
-              if (run.head_branch !== "main") throw new Error("Only main pushes may publish a main package.");
+            if (context.eventName === "workflow_run") {
+              const run = context.payload.workflow_run;
+              if (run.head_branch !== "main") throw new Error("Only main pushes publish automatically.");
+              const { data: branch } = await github.rest.repos.getBranch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                branch: "main",
+              });
+              if (branch.commit.sha !== run.head_sha) {
+                throw new Error(`Refusing to publish stale main build ${run.head_sha}; main is ${branch.commit.sha}.`);
+              }
+              core.setOutput("run-id", String(run.id));
               core.setOutput("sha", run.head_sha);
               core.setOutput("ref", "main");
               return;
             }
-            if (run.event !== "pull_request" || run.pull_requests.length !== 1) {
-              throw new Error("Expected one pull request for the package build.");
+
+            if (!/^[1-9]\d*$/.test(process.env.PULL_REQUEST ?? "")) {
+              throw new Error("pull_request must be a positive integer.");
             }
-            const linked = run.pull_requests[0];
+            const pullNumber = Number(process.env.PULL_REQUEST);
             const { data: pull } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: linked.number,
+              pull_number: pullNumber,
             });
-            if (pull.head.sha !== run.head_sha) {
-              throw new Error("The workflow run is not for the pull request's current head SHA.");
+            if (pull.state !== "open") throw new Error(`Pull request #${pullNumber} is not open.`);
+
+            const { data: workflow } = await github.rest.actions.getWorkflow({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: "package-artifact-build.yml",
+            });
+            const runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event: "pull_request",
+              head_sha: pull.head.sha,
+              status: "success",
+              per_page: 100,
+            });
+            const run = runs.find(
+              (candidate) =>
+                candidate.workflow_id === workflow.id &&
+                candidate.pull_requests.some((linked) => linked.number === pullNumber),
+            );
+            if (!run) {
+              throw new Error(`No successful package build found for PR #${pullNumber} at ${pull.head.sha}.`);
             }
-            core.setOutput("sha", run.head_sha);
-            core.setOutput("ref", String(linked.number));
+
+            core.setOutput("run-id", String(run.id));
+            core.setOutput("sha", pull.head.sha);
+            core.setOutput("ref", String(pullNumber));
 
       - name: Download package artifact
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
@@ -48,7 +90,7 @@ jobs:
           name: eve-package
           path: package-artifact
           github-token: ${{ github.token }}
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ steps.target.outputs.run-id }}
 
       - name: Checkout trusted publisher
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -78,4 +120,4 @@ jobs:
           EVE_PACKAGE_INPUT_DIRECTORY: ${{ github.workspace }}/package-artifact
           EVE_PACKAGE_REF: ${{ steps.target.outputs.ref }}
           EVE_PACKAGE_SOURCE_SHA: ${{ steps.target.outputs.sha }}
-        run: pnpm --filter eve-package-artifacts publish
+        run: pnpm --filter eve-package-artifacts package:publish

--- a/.github/workflows/package-artifact-publish.yml
+++ b/.github/workflows/package-artifact-publish.yml
@@ -1,0 +1,82 @@
+name: Package artifact publish
+
+on:
+  workflow_run:
+    workflows: [Package artifact build]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+
+jobs:
+  publish:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    environment: package-artifacts
+    steps:
+      - name: Resolve trusted publication target
+        id: target
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            if (run.event === "push") {
+              if (run.head_branch !== "main") throw new Error("Only main pushes may publish a main package.");
+              core.setOutput("sha", run.head_sha);
+              core.setOutput("ref", "main");
+              return;
+            }
+            if (run.event !== "pull_request" || run.pull_requests.length !== 1) {
+              throw new Error("Expected one pull request for the package build.");
+            }
+            const linked = run.pull_requests[0];
+            const { data: pull } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: linked.number,
+            });
+            if (pull.head.sha !== run.head_sha) {
+              throw new Error("The workflow run is not for the pull request's current head SHA.");
+            }
+            core.setOutput("sha", run.head_sha);
+            core.setOutput("ref", String(linked.number));
+
+      - name: Download package artifact
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          name: eve-package
+          path: package-artifact
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Checkout trusted publisher
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          path: trusted
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: trusted/.nvmrc
+          cache: pnpm
+          cache-dependency-path: trusted/pnpm-lock.yaml
+
+      - name: Install trusted publisher dependencies
+        working-directory: trusted
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Publish package artifact
+        working-directory: trusted
+        env:
+          EVE_PACKAGE_BLOB_READ_WRITE_TOKEN: ${{ secrets.EVE_PACKAGE_BLOB_READ_WRITE_TOKEN }}
+          EVE_PACKAGE_INPUT_DIRECTORY: ${{ github.workspace }}/package-artifact
+          EVE_PACKAGE_REF: ${{ steps.target.outputs.ref }}
+          EVE_PACKAGE_SOURCE_SHA: ${{ steps.target.outputs.sha }}
+        run: pnpm --filter eve-package-artifacts publish

--- a/.github/workflows/package-artifact-publish.yml
+++ b/.github/workflows/package-artifact-publish.yml
@@ -4,8 +4,12 @@ on:
   workflow_run:
     workflows: [Package artifact build]
     types: [completed]
-  issue_comment:
-    types: [created]
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        description: Pull request number to publish
+        required: true
+        type: string
 
 permissions:
   actions: read
@@ -15,16 +19,18 @@ permissions:
 jobs:
   publish:
     if: >-
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request && github.event.comment.body == '/publish-package') ||
+      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push')
     runs-on: ubuntu-latest
     concurrency:
-      group: package-artifact-publish-${{ github.event_name == 'issue_comment' && format('pr-{0}', github.event.issue.number) || 'main' }}
+      group: package-artifact-publish-${{ github.event_name == 'workflow_dispatch' && format('pr-{0}', inputs.pull_request) || 'main' }}
       cancel-in-progress: false
     steps:
-      - name: Resolve trusted publication target
+      - name: Resolve publication target
         id: target
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+        env:
+          PULL_REQUEST: ${{ inputs.pull_request }}
         with:
           script: |
             if (context.eventName === "workflow_run") {
@@ -44,16 +50,10 @@ jobs:
               return;
             }
 
-            const pullNumber = context.payload.issue.number;
-            const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              username: context.actor,
-            });
-            if (!["admin", "maintain", "write"].includes(permission.permission)) {
-              throw new Error(`${context.actor} is not authorized to publish package artifacts.`);
+            if (!/^[1-9]\d*$/.test(process.env.PULL_REQUEST ?? "")) {
+              throw new Error("pull_request must be a positive integer.");
             }
-
+            const pullNumber = Number(process.env.PULL_REQUEST);
             const { data: pull } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -95,10 +95,10 @@ jobs:
           github-token: ${{ github.token }}
           run-id: ${{ steps.target.outputs.run-id }}
 
-      - name: Checkout trusted publisher
+      - name: Checkout publisher
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: main
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || 'main' }}
           path: trusted
           persist-credentials: false
 
@@ -112,7 +112,7 @@ jobs:
           cache: pnpm
           cache-dependency-path: trusted/pnpm-lock.yaml
 
-      - name: Install trusted publisher dependencies
+      - name: Install publisher dependencies
         working-directory: trusted
         run: pnpm install --frozen-lockfile --ignore-scripts
 

--- a/.github/workflows/package-artifact-publish.yml
+++ b/.github/workflows/package-artifact-publish.yml
@@ -14,7 +14,6 @@ jobs:
   publish:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
-    environment: package-artifacts
     steps:
       - name: Resolve trusted publication target
         id: target

--- a/.github/workflows/package-artifact-publish.yml
+++ b/.github/workflows/package-artifact-publish.yml
@@ -77,7 +77,9 @@ jobs:
             const run = runs.find(
               (candidate) =>
                 candidate.workflow_id === workflow.id &&
-                candidate.pull_requests.some((linked) => linked.number === pullNumber),
+                candidate.head_sha === pull.head.sha &&
+                candidate.head_branch === pull.head.ref &&
+                candidate.head_repository?.full_name === pull.head.repo.full_name,
             );
             if (!run) {
               throw new Error(`No successful package build found for PR #${pullNumber} at ${pull.head.sha}.`);

--- a/.github/workflows/package-artifact-publish.yml
+++ b/.github/workflows/package-artifact-publish.yml
@@ -4,12 +4,8 @@ on:
   workflow_run:
     workflows: [Package artifact build]
     types: [completed]
-  workflow_dispatch:
-    inputs:
-      pull_request:
-        description: Pull request number to publish
-        required: true
-        type: string
+  issue_comment:
+    types: [created]
 
 permissions:
   actions: read
@@ -19,15 +15,16 @@ permissions:
 jobs:
   publish:
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push')
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && github.event.comment.body == '/publish-package') ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push')
     runs-on: ubuntu-latest
+    concurrency:
+      group: package-artifact-publish-${{ github.event_name == 'issue_comment' && format('pr-{0}', github.event.issue.number) || 'main' }}
+      cancel-in-progress: false
     steps:
       - name: Resolve trusted publication target
         id: target
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
-        env:
-          PULL_REQUEST: ${{ inputs.pull_request }}
         with:
           script: |
             if (context.eventName === "workflow_run") {
@@ -47,10 +44,16 @@ jobs:
               return;
             }
 
-            if (!/^[1-9]\d*$/.test(process.env.PULL_REQUEST ?? "")) {
-              throw new Error("pull_request must be a positive integer.");
+            const pullNumber = context.payload.issue.number;
+            const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.actor,
+            });
+            if (!["admin", "maintain", "write"].includes(permission.permission)) {
+              throw new Error(`${context.actor} is not authorized to publish package artifacts.`);
             }
-            const pullNumber = Number(process.env.PULL_REQUEST);
+
             const { data: pull } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/apps/package-artifacts/README.md
+++ b/apps/package-artifacts/README.md
@@ -22,7 +22,7 @@ A pull-request build is available at `/pr/<number>/eve.tgz` after its package wo
 
 [Package artifact build](../../.github/workflows/package-artifact-build.yml) runs for `main` pushes and pull requests without credentials. It checks out the exact source SHA, packages eve, and uploads the tarball and metadata as a short-lived GitHub Actions artifact.
 
-[Package artifact publish](../../.github/workflows/package-artifact-publish.yml) publishes `main` automatically through `workflow_run`, while pull requests require a manual `workflow_dispatch` with the PR number. GitHub loads the publisher from trusted `main`; it resolves the PR's current head through the API, finds that SHA's successful package build, downloads its artifact, checks out the trusted publisher from `main`, and uploads the bytes without executing or extracting them. Pull-request code controls package contents but never receives the Blob token or controls the destination paths.
+[Package artifact publish](../../.github/workflows/package-artifact-publish.yml) publishes `main` automatically through `workflow_run`. A repository collaborator with write access can publish a pull request by commenting `/publish-package` on it. Both triggers load the publisher from trusted `main`; it resolves the PR's current head through the API, finds that SHA's successful package build, downloads its artifact, checks out the trusted publisher from `main`, and uploads the bytes without executing or extracting them. Pull-request code controls package contents but never receives the Blob token or controls the destination paths.
 
 The publisher writes:
 
@@ -45,6 +45,6 @@ The Vercel package project must:
 - set its Ignored Build Step to `test "$VERCEL_GIT_COMMIT_REF" != "main"`; and
 - disable Deployment Protection so package managers can reach the public proxy.
 
-Set the repository Actions secret `EVE_PACKAGE_BLOB_READ_WRITE_TOKEN` to the package store's write token. The build workflow never references this secret; only the publisher loaded from trusted `main` can access it. Pull-request builds inherit the repository's existing contributor approval policy, and publishing a PR requires a separate manual run of **Package artifact publish** from `main`.
+Set the repository Actions secret `EVE_PACKAGE_BLOB_READ_WRITE_TOKEN` to the package store's write token. The build workflow never references this secret; only the publisher loaded from trusted `main` can access it. Pull-request builds inherit the repository's existing contributor approval policy, and publishing a PR requires a separate `/publish-package` command from an authorized collaborator.
 
 The smoke check verifies public access and the downloaded main artifact's gzip signature.

--- a/apps/package-artifacts/README.md
+++ b/apps/package-artifacts/README.md
@@ -1,28 +1,43 @@
 # eve package artifacts
 
-Git-linked Vercel project that builds an eve tarball from each `vercel/eve` `main` commit and uploads immutable SHA-addressed package and manifest artifacts to private Vercel Blob using deployment OIDC.
+The trusted package project builds an eve tarball from each `vercel/eve` `main` commit and uploads immutable SHA-addressed artifacts to private Vercel Blob using deployment OIDC. A separate unverified builder project publishes pull-request artifacts from its own Preview deployment domain and Blob store.
 
 ```text
 /main/eve.tgz
 /main/latest.json
 /<full-sha>/eve.tgz
+/unverified/sha/<full-sha>/eve.tgz
+/unverified/pr/<number>/eve.tgz
+/unverified/pr/<number>/latest.json
 ```
 
-The publisher uses Vercel's `VERCEL_PROJECT_PRODUCTION_URL` system environment variable as the public package domain. For example, if the production domain is `packages.example.com`, initialize an agent from the current `main` build with:
+The publisher uses Vercel's `VERCEL_PROJECT_PRODUCTION_URL` system environment variable as the public package domain. For example, if the production domain is `pkg.eve.dev`, initialize an agent from the current `main` build with:
 
 ```bash
-npm exec --yes --package=https://packages.example.com/main/eve.tgz -- eve init my-agent
+npm exec --yes --package=https://pkg.eve.dev/main/eve.tgz -- eve init my-agent
 ```
 
-The production deployment resolves `main` to its checked-out commit. Its `latest.json` exposes metadata for that package, including the source SHA, immutable package URL, and checksum. The packaged CLI stamps its immutable commit URL into generated projects, so a project created through the moving `main` URL remains pinned to the package used to create it. The package route reads private Blob objects with deployment OIDC and streams them through the public project domain.
+Trusted `main` builds stamp immutable `/<sha>/eve.tgz` dependencies into generated projects. An unverified package stamps its immutable `/unverified/sha/<sha>/eve.tgz` dependency instead. The pull-request URL is a short-lived convenience redirect and must not be used as a pinned dependency.
 
-The Vercel project must:
+## Trust boundaries
+
+The trusted publisher project must:
 
 - use this directory as its project root;
 - enable access to Vercel system environment variables;
 - deploy `main` to Production;
-- connect a private Blob store to Production;
+- connect only the trusted private Blob store;
 - omit `BLOB_READ_WRITE_TOKEN` so Blob writes use Vercel OIDC; and
 - disable Deployment Protection so npm can reach the production origin anonymously.
 
-Only production builds of `main` publish artifacts. Other builds produce a placeholder deployment; configure the project's Ignored Build Step as `test "$VERCEL_GIT_COMMIT_REF" != "main"` to skip non-`main` deployments before install and build. The smoke check verifies public access and the downloaded artifact's gzip signature.
+An unverified builder must be a **separate** Vercel project connected only to a separate private Blob store. Give it `EVE_PACKAGE_ARTIFACT_SCOPE=unverified` for Preview deployments. It must never receive the trusted Blob connection, a production secret, or any credential that can access trusted artifacts. Configure it with the same root and build command; Preview builds write immutable SHA artifacts and an optional mutable PR pointer when `EVE_PULL_REQUEST_NUMBER` is set.
+
+The unverified builder serves its own artifacts from its Preview deployment domain and needs write access only to the unverified store. The trusted publisher never receives access to that store.
+
+Only `main` Production builds publish trusted artifacts. For the trusted project, set the Ignored Build Step to:
+
+```sh
+test "$VERCEL_ENV" = "production" && test "$VERCEL_GIT_COMMIT_REF" != "main"
+```
+
+That permits Preview deployments while preventing a non-main Production deployment from publishing. The smoke check verifies public access and the downloaded artifact's gzip signature.

--- a/apps/package-artifacts/README.md
+++ b/apps/package-artifacts/README.md
@@ -1,44 +1,50 @@
 # eve package artifacts
 
-The trusted package project builds an eve tarball from each `vercel/eve` `main` commit and uploads immutable SHA-addressed artifacts to private Vercel Blob using deployment OIDC. Preview deployments package their own checkout into static output; they do not use Blob.
+A stable, read-only Vercel app at `pkg.eve.dev` proxies private Blob artifacts published by GitHub Actions. The app itself never packages source or writes Blob objects.
 
 ```text
 /main/eve.tgz
 /main/latest.json
+/pr/<number>/eve.tgz
+/pr/<number>/latest.json
 /<full-sha>/eve.tgz
 ```
 
-The publisher uses Vercel's `VERCEL_PROJECT_PRODUCTION_URL` system environment variable as the public package domain. For example, if the production domain is `pkg.eve.dev`, initialize an agent from the current `main` build with:
+Initialize an agent from the current `main` build with:
 
 ```bash
 npm exec --yes --package=https://pkg.eve.dev/main/eve.tgz -- eve init my-agent
 ```
 
-Trusted `main` builds stamp immutable `/<sha>/eve.tgz` dependencies into generated projects. A Preview build writes `eve.tgz` to its own deployment output and stamps that deployment's immutable `https://<deployment>/eve.tgz` URL instead. Preview URLs are explicitly for testing unreviewed code and are never published through the trusted package host.
+A pull-request build is available at `/pr/<number>/eve.tgz` after its package workflow succeeds. Both moving routes redirect to an immutable `/<sha>/eve.tgz` artifact, and the packaged CLI stamps that immutable URL into generated projects.
 
-## Trust boundary
+## Publishing
 
-The trusted package project must:
+[Package artifact build](../../.github/workflows/package-artifact-build.yml) runs for `main` pushes and pull requests without credentials. It checks out the exact source SHA, packages eve, and uploads the tarball and metadata as a short-lived GitHub Actions artifact.
+
+[Package artifact publish](../../.github/workflows/package-artifact-publish.yml) runs through `workflow_run`, so GitHub loads its workflow definition from trusted `main`. On a fresh runner it verifies the target from GitHub event/API metadata, downloads the build artifact, checks out the trusted publisher from `main`, and uploads the bytes without executing or extracting them. Pull-request code controls package contents but never receives the Blob token or controls the destination paths.
+
+The publisher writes:
+
+```text
+packages/<sha>/eve.tgz
+packages/<sha>/manifest.json
+packages/refs/main.json
+packages/refs/pr/<number>.json
+```
+
+SHA objects are immutable. Main and PR pointer objects are mutable and short-cached.
+
+## Project setup
+
+The Vercel package project must:
 
 - use this directory as its project root;
-- enable access to Vercel system environment variables;
+- connect the private package Blob store for reads;
 - deploy `main` to Production;
-- connect the trusted private Blob store to Production only;
-- omit `BLOB_READ_WRITE_TOKEN` so Blob writes use Vercel OIDC; and
-- disable Deployment Protection so npm can reach the production origin anonymously.
+- set its Ignored Build Step to `test "$VERCEL_GIT_COMMIT_REF" != "main"`; and
+- disable Deployment Protection so package managers can reach the public proxy.
 
-Only `main` builds may run in the trusted project. Set its Ignored Build Step to:
+Create a protected GitHub environment named `package-artifacts` and set `EVE_PACKAGE_BLOB_READ_WRITE_TOKEN` to the package store's write token there. Restrict environment deployment access to the trusted team that may publish package artifacts. The build workflow never references this environment or secret.
 
-```sh
-test "$VERCEL_GIT_COMMIT_REF" != "main"
-```
-
-This skips every non-main revision before dependency installation and prevents untrusted branch code from running with the trusted project's Blob access. The smoke check verifies public access and the downloaded artifact's gzip signature.
-
-To build Preview package artifacts, use a separate Vercel project with the same root and build command, no Blob connection, no package-host credentials, and no production secrets. It must permit Preview deployments and skip Production deployments:
-
-```sh
-test "$VERCEL_ENV" = "production"
-```
-
-The Preview project's deployment URL is the artifact host. The generated package is self-contained: a project initialized from it continues to pin the same Preview deployment's `/eve.tgz` URL.
+The smoke check verifies public access and the downloaded main artifact's gzip signature.

--- a/apps/package-artifacts/README.md
+++ b/apps/package-artifacts/README.md
@@ -1,14 +1,11 @@
 # eve package artifacts
 
-The trusted package project builds an eve tarball from each `vercel/eve` `main` commit and uploads immutable SHA-addressed artifacts to private Vercel Blob using deployment OIDC. A separate unverified builder project publishes pull-request artifacts to an isolated Blob store; the trusted package host proxies both artifact classes from its permanent domain.
+The trusted package project builds an eve tarball from each `vercel/eve` `main` commit and uploads immutable SHA-addressed artifacts to private Vercel Blob using deployment OIDC. Preview deployments package their own checkout into static output; they do not use Blob.
 
 ```text
 /main/eve.tgz
 /main/latest.json
 /<full-sha>/eve.tgz
-/unverified/sha/<full-sha>/eve.tgz
-/unverified/pr/<number>/eve.tgz
-/unverified/pr/<number>/latest.json
 ```
 
 The publisher uses Vercel's `VERCEL_PROJECT_PRODUCTION_URL` system environment variable as the public package domain. For example, if the production domain is `pkg.eve.dev`, initialize an agent from the current `main` build with:
@@ -17,22 +14,18 @@ The publisher uses Vercel's `VERCEL_PROJECT_PRODUCTION_URL` system environment v
 npm exec --yes --package=https://pkg.eve.dev/main/eve.tgz -- eve init my-agent
 ```
 
-Trusted `main` builds stamp immutable `/<sha>/eve.tgz` dependencies into generated projects. An unverified package stamps its immutable `/unverified/sha/<sha>/eve.tgz` dependency instead. The pull-request URL is a short-lived convenience redirect and must not be used as a pinned dependency.
+Trusted `main` builds stamp immutable `/<sha>/eve.tgz` dependencies into generated projects. A Preview build writes `eve.tgz` to its own deployment output and stamps that deployment's immutable `https://<deployment>/eve.tgz` URL instead. Preview URLs are explicitly for testing unreviewed code and are never published through the trusted package host.
 
-## Trust boundaries
+## Trust boundary
 
-The trusted publisher project must:
+The trusted package project must:
 
 - use this directory as its project root;
 - enable access to Vercel system environment variables;
 - deploy `main` to Production;
-- connect only the trusted private Blob store;
+- connect the trusted private Blob store to Production only;
 - omit `BLOB_READ_WRITE_TOKEN` so Blob writes use Vercel OIDC; and
 - disable Deployment Protection so npm can reach the production origin anonymously.
-
-An unverified builder must be a **separate** Vercel project connected only to a separate private Blob store. Give it `EVE_PACKAGE_ARTIFACT_SCOPE=unverified` and `EVE_PACKAGE_PUBLIC_ORIGIN=https://pkg.eve.dev` for Preview deployments. It must never receive the trusted Blob connection, a production secret, or any credential that can access trusted artifacts. Configure it with the same root and build command; Preview builds write immutable SHA artifacts and an optional mutable PR pointer when `EVE_PULL_REQUEST_NUMBER` is set.
-
-The unverified builder needs write access only to the unverified store. The trusted package host reads that store with `EVE_UNVERIFIED_BLOB_READ_WRITE_TOKEN` in its Production environment and proxies it through `pkg.eve.dev`; never configure that token in the unverified builder.
 
 Only `main` builds may run in the trusted project. Set its Ignored Build Step to:
 
@@ -40,4 +33,12 @@ Only `main` builds may run in the trusted project. Set its Ignored Build Step to
 test "$VERCEL_GIT_COMMIT_REF" != "main"
 ```
 
-This skips every non-main revision before dependency installation and prevents untrusted branch code from running with the trusted project’s Blob access. The separate unverified builder is the only project that builds Preview branches. The smoke check verifies public access and the downloaded artifact's gzip signature.
+This skips every non-main revision before dependency installation and prevents untrusted branch code from running with the trusted project's Blob access. The smoke check verifies public access and the downloaded artifact's gzip signature.
+
+To build Preview package artifacts, use a separate Vercel project with the same root and build command, no Blob connection, no package-host credentials, and no production secrets. It must permit Preview deployments and skip Production deployments:
+
+```sh
+test "$VERCEL_ENV" = "production"
+```
+
+The Preview project's deployment URL is the artifact host. The generated package is self-contained: a project initialized from it continues to pin the same Preview deployment's `/eve.tgz` URL.

--- a/apps/package-artifacts/README.md
+++ b/apps/package-artifacts/README.md
@@ -45,6 +45,6 @@ The Vercel package project must:
 - set its Ignored Build Step to `test "$VERCEL_GIT_COMMIT_REF" != "main"`; and
 - disable Deployment Protection so package managers can reach the public proxy.
 
-Create a protected GitHub environment named `package-artifacts` and set `EVE_PACKAGE_BLOB_READ_WRITE_TOKEN` to the package store's write token there. Restrict environment deployment access to the trusted team that may publish package artifacts. The build workflow never references this environment or secret.
+Set the repository Actions secret `EVE_PACKAGE_BLOB_READ_WRITE_TOKEN` to the package store's write token. The build workflow never references this secret; only the `workflow_run` publisher loaded from trusted `main` can access it. Pull-request builds inherit the repository's existing contributor approval policy, so internal changes run automatically while outside contributors require the same approval as the test workflows.
 
 The smoke check verifies public access and the downloaded main artifact's gzip signature.

--- a/apps/package-artifacts/README.md
+++ b/apps/package-artifacts/README.md
@@ -1,6 +1,6 @@
 # eve package artifacts
 
-The trusted package project builds an eve tarball from each `vercel/eve` `main` commit and uploads immutable SHA-addressed artifacts to private Vercel Blob using deployment OIDC. A separate unverified builder project publishes pull-request artifacts from its own Preview deployment domain and Blob store.
+The trusted package project builds an eve tarball from each `vercel/eve` `main` commit and uploads immutable SHA-addressed artifacts to private Vercel Blob using deployment OIDC. A separate unverified builder project publishes pull-request artifacts to an isolated Blob store; the trusted package host proxies both artifact classes from its permanent domain.
 
 ```text
 /main/eve.tgz
@@ -30,9 +30,9 @@ The trusted publisher project must:
 - omit `BLOB_READ_WRITE_TOKEN` so Blob writes use Vercel OIDC; and
 - disable Deployment Protection so npm can reach the production origin anonymously.
 
-An unverified builder must be a **separate** Vercel project connected only to a separate private Blob store. Give it `EVE_PACKAGE_ARTIFACT_SCOPE=unverified` for Preview deployments. It must never receive the trusted Blob connection, a production secret, or any credential that can access trusted artifacts. Configure it with the same root and build command; Preview builds write immutable SHA artifacts and an optional mutable PR pointer when `EVE_PULL_REQUEST_NUMBER` is set.
+An unverified builder must be a **separate** Vercel project connected only to a separate private Blob store. Give it `EVE_PACKAGE_ARTIFACT_SCOPE=unverified` and `EVE_PACKAGE_PUBLIC_ORIGIN=https://pkg.eve.dev` for Preview deployments. It must never receive the trusted Blob connection, a production secret, or any credential that can access trusted artifacts. Configure it with the same root and build command; Preview builds write immutable SHA artifacts and an optional mutable PR pointer when `EVE_PULL_REQUEST_NUMBER` is set.
 
-The unverified builder serves its own artifacts from its Preview deployment domain and needs write access only to the unverified store. The trusted publisher never receives access to that store.
+The unverified builder needs write access only to the unverified store. The trusted package host reads that store with `EVE_UNVERIFIED_BLOB_READ_WRITE_TOKEN` in its Production environment and proxies it through `pkg.eve.dev`; never configure that token in the unverified builder.
 
 Only `main` Production builds publish trusted artifacts. For the trusted project, set the Ignored Build Step to:
 

--- a/apps/package-artifacts/README.md
+++ b/apps/package-artifacts/README.md
@@ -22,7 +22,7 @@ A pull-request build is available at `/pr/<number>/eve.tgz` after its package wo
 
 [Package artifact build](../../.github/workflows/package-artifact-build.yml) runs for `main` pushes and pull requests without credentials. It checks out the exact source SHA, packages eve, and uploads the tarball and metadata as a short-lived GitHub Actions artifact.
 
-[Package artifact publish](../../.github/workflows/package-artifact-publish.yml) publishes `main` automatically through `workflow_run`. A repository collaborator with write access can publish a pull request by commenting `/publish-package` on it. Both triggers load the publisher from trusted `main`; it resolves the PR's current head through the API, finds that SHA's successful package build, downloads its artifact, checks out the trusted publisher from `main`, and uploads the bytes without executing or extracting them. Pull-request code controls package contents but never receives the Blob token or controls the destination paths.
+[Package artifact publish](../../.github/workflows/package-artifact-publish.yml) publishes `main` automatically through `workflow_run`. Pull requests require a manual `workflow_dispatch` with the PR number. The default branch selection runs the publisher from trusted `main`; intentionally selecting another branch runs that branch's publisher with the Blob credential for testing. The publisher resolves the PR's current head through the API, finds that SHA's successful package build, downloads its artifact, and uploads the bytes without executing or extracting them.
 
 The publisher writes:
 
@@ -45,6 +45,6 @@ The Vercel package project must:
 - set its Ignored Build Step to `test "$VERCEL_GIT_COMMIT_REF" != "main"`; and
 - disable Deployment Protection so package managers can reach the public proxy.
 
-Set the repository Actions secret `EVE_PACKAGE_BLOB_READ_WRITE_TOKEN` to the package store's write token. The build workflow never references this secret; only the publisher loaded from trusted `main` can access it. Pull-request builds inherit the repository's existing contributor approval policy, and publishing a PR requires a separate `/publish-package` command from an authorized collaborator.
+Set the repository Actions secret `EVE_PACKAGE_BLOB_READ_WRITE_TOKEN` to the package store's write token. The build workflow never references this secret. Pull-request builds inherit the repository's existing contributor approval policy, and publishing a PR requires a separate manual run of **Package artifact publish**. Leave **Use workflow from** set to `main` for the normal trusted publisher; selecting another branch explicitly grants that branch's publisher access to the Blob credential.
 
 The smoke check verifies public access and the downloaded main artifact's gzip signature.

--- a/apps/package-artifacts/README.md
+++ b/apps/package-artifacts/README.md
@@ -22,7 +22,7 @@ A pull-request build is available at `/pr/<number>/eve.tgz` after its package wo
 
 [Package artifact build](../../.github/workflows/package-artifact-build.yml) runs for `main` pushes and pull requests without credentials. It checks out the exact source SHA, packages eve, and uploads the tarball and metadata as a short-lived GitHub Actions artifact.
 
-[Package artifact publish](../../.github/workflows/package-artifact-publish.yml) runs through `workflow_run`, so GitHub loads its workflow definition from trusted `main`. On a fresh runner it verifies the target from GitHub event/API metadata, downloads the build artifact, checks out the trusted publisher from `main`, and uploads the bytes without executing or extracting them. Pull-request code controls package contents but never receives the Blob token or controls the destination paths.
+[Package artifact publish](../../.github/workflows/package-artifact-publish.yml) publishes `main` automatically through `workflow_run`, while pull requests require a manual `workflow_dispatch` with the PR number. GitHub loads the publisher from trusted `main`; it resolves the PR's current head through the API, finds that SHA's successful package build, downloads its artifact, checks out the trusted publisher from `main`, and uploads the bytes without executing or extracting them. Pull-request code controls package contents but never receives the Blob token or controls the destination paths.
 
 The publisher writes:
 
@@ -45,6 +45,6 @@ The Vercel package project must:
 - set its Ignored Build Step to `test "$VERCEL_GIT_COMMIT_REF" != "main"`; and
 - disable Deployment Protection so package managers can reach the public proxy.
 
-Set the repository Actions secret `EVE_PACKAGE_BLOB_READ_WRITE_TOKEN` to the package store's write token. The build workflow never references this secret; only the `workflow_run` publisher loaded from trusted `main` can access it. Pull-request builds inherit the repository's existing contributor approval policy, so internal changes run automatically while outside contributors require the same approval as the test workflows.
+Set the repository Actions secret `EVE_PACKAGE_BLOB_READ_WRITE_TOKEN` to the package store's write token. The build workflow never references this secret; only the publisher loaded from trusted `main` can access it. Pull-request builds inherit the repository's existing contributor approval policy, and publishing a PR requires a separate manual run of **Package artifact publish** from `main`.
 
 The smoke check verifies public access and the downloaded main artifact's gzip signature.

--- a/apps/package-artifacts/README.md
+++ b/apps/package-artifacts/README.md
@@ -34,10 +34,10 @@ An unverified builder must be a **separate** Vercel project connected only to a 
 
 The unverified builder needs write access only to the unverified store. The trusted package host reads that store with `EVE_UNVERIFIED_BLOB_READ_WRITE_TOKEN` in its Production environment and proxies it through `pkg.eve.dev`; never configure that token in the unverified builder.
 
-Only `main` Production builds publish trusted artifacts. For the trusted project, set the Ignored Build Step to:
+Only `main` builds may run in the trusted project. Set its Ignored Build Step to:
 
 ```sh
-test "$VERCEL_ENV" = "production" && test "$VERCEL_GIT_COMMIT_REF" != "main"
+test "$VERCEL_GIT_COMMIT_REF" != "main"
 ```
 
-That permits Preview deployments while preventing a non-main Production deployment from publishing. The smoke check verifies public access and the downloaded artifact's gzip signature.
+This skips every non-main revision before dependency installation and prevents untrusted branch code from running with the trusted project’s Blob access. The separate unverified builder is the only project that builds Preview branches. The smoke check verifies public access and the downloaded artifact's gzip signature.

--- a/apps/package-artifacts/api/package.js
+++ b/apps/package-artifacts/api/package.js
@@ -62,8 +62,8 @@ function parseManifest(source, expectedSha) {
     !SHA_PATTERN.test(manifest.sourceSha ?? "") ||
     (expectedSha !== undefined && manifest.sourceSha !== expectedSha) ||
     typeof manifest.version !== "string" ||
-    typeof manifest.tarball !== "string" ||
-    typeof manifest.sha256 !== "string"
+    manifest.tarball !== `https://pkg.eve.dev/${manifest.sourceSha}/eve.tgz` ||
+    !/^[0-9a-f]{64}$/i.test(manifest.sha256 ?? "")
   ) {
     return undefined;
   }

--- a/apps/package-artifacts/api/package.js
+++ b/apps/package-artifacts/api/package.js
@@ -3,37 +3,20 @@ import { pipeline } from "node:stream/promises";
 
 import { get } from "@vercel/blob";
 
-import {
-  PULL_REQUEST_PATTERN,
-  SHA_PATTERN,
-  packageArtifactPath,
-  packageManifestPath,
-  unverifiedPackageArtifactPath,
-  unverifiedPackageManifestPath,
-  unverifiedPullRequestManifestPath,
-} from "../lib/package.mjs";
+import { SHA_PATTERN, packageArtifactPath, packageManifestPath } from "../lib/package.mjs";
 
 export default async function handler(request, response) {
-  const scope = request.query.scope === "unverified" ? "unverified" : "trusted";
-  const blobOptions = scope === "unverified" ? unverifiedBlobOptions() : undefined;
   const ref = request.query.ref;
-  const pullRequest = request.query.pr;
-
-  if (scope === "unverified" && typeof pullRequest === "string") {
-    return servePullRequest(pullRequest, request, response, blobOptions);
-  }
-  if (
-    typeof ref !== "string" ||
-    (scope === "trusted" && ref !== "main" && !SHA_PATTERN.test(ref))
-  ) {
+  if (typeof ref !== "string" || (ref !== "main" && !SHA_PATTERN.test(ref))) {
     return packageNotFound(response);
   }
-  if (scope === "unverified" && !SHA_PATTERN.test(ref)) return packageNotFound(response);
 
   const sourceSha = ref === "main" ? process.env.VERCEL_GIT_COMMIT_SHA : ref;
-  if (!SHA_PATTERN.test(sourceSha ?? "")) return packageNotFound(response);
+  if (!SHA_PATTERN.test(sourceSha ?? "")) {
+    return packageNotFound(response);
+  }
 
-  const manifest = await resolveManifest(sourceSha, scope, blobOptions);
+  const manifest = await resolveManifest(sourceSha);
   if (manifest === undefined) return packageNotFound(response);
 
   if (request.query.manifest === "1") {
@@ -46,35 +29,7 @@ export default async function handler(request, response) {
     return response.redirect(302, manifest.tarball);
   }
 
-  return streamArtifact(sourceSha, scope, response, blobOptions);
-}
-
-async function servePullRequest(pullRequest, request, response, blobOptions) {
-  if (!PULL_REQUEST_PATTERN.test(pullRequest)) return packageNotFound(response);
-  const pointer = await get(unverifiedPullRequestManifestPath(pullRequest), {
-    access: "private",
-    ...blobOptions,
-  });
-  if (pointer === null) return packageNotFound(response);
-
-  const manifest = parseManifest(await new Response(pointer.stream).text(), "unverified");
-  if (manifest === undefined || manifest.pullRequest !== Number(pullRequest)) {
-    return packageNotFound(response);
-  }
-  if (request.query.manifest === "1") {
-    response.setHeader("Cache-Control", "public, max-age=60");
-    return response.status(200).json(manifest);
-  }
-  response.setHeader("Cache-Control", "public, max-age=60");
-  return response.redirect(302, manifest.tarball);
-}
-
-async function streamArtifact(sourceSha, scope, response, blobOptions) {
-  const path =
-    scope === "unverified"
-      ? unverifiedPackageArtifactPath(sourceSha)
-      : packageArtifactPath(sourceSha);
-  const artifact = await get(path, { access: "private", ...blobOptions });
+  const artifact = await get(packageArtifactPath(sourceSha), { access: "private" });
   if (artifact === null) return packageNotFound(response);
 
   response.setHeader("Cache-Control", "public, max-age=31536000, immutable");
@@ -87,32 +42,16 @@ function packageNotFound(response) {
   return response.status(404).send("Package not found.\n");
 }
 
-async function resolveManifest(sourceSha, scope, blobOptions) {
-  const path =
-    scope === "unverified"
-      ? unverifiedPackageManifestPath(sourceSha)
-      : packageManifestPath(sourceSha);
-  const result = await get(path, { access: "private", ...blobOptions });
+async function resolveManifest(sourceSha) {
+  const result = await get(packageManifestPath(sourceSha), { access: "private" });
   if (result === null) return undefined;
-  return parseManifest(await new Response(result.stream).text(), scope);
-}
 
-function unverifiedBlobOptions() {
-  const token = process.env.EVE_UNVERIFIED_BLOB_READ_WRITE_TOKEN;
-  if (typeof token !== "string" || token.length === 0) {
-    throw new Error("EVE_UNVERIFIED_BLOB_READ_WRITE_TOKEN is required for unverified artifacts.");
-  }
-  return { token };
-}
-
-function parseManifest(source, scope) {
-  const manifest = JSON.parse(source);
+  const manifest = JSON.parse(await new Response(result.stream).text());
   if (
-    !SHA_PATTERN.test(manifest.sourceSha ?? "") ||
+    manifest.sourceSha !== sourceSha ||
     typeof manifest.version !== "string" ||
     typeof manifest.tarball !== "string" ||
-    typeof manifest.sha256 !== "string" ||
-    manifest.trust !== scope
+    typeof manifest.sha256 !== "string"
   ) {
     return undefined;
   }

--- a/apps/package-artifacts/api/package.js
+++ b/apps/package-artifacts/api/package.js
@@ -3,39 +3,42 @@ import { pipeline } from "node:stream/promises";
 
 import { get } from "@vercel/blob";
 
-import { SHA_PATTERN, packageArtifactPath, packageManifestPath } from "../lib/package.mjs";
+import {
+  PULL_REQUEST_PATTERN,
+  SHA_PATTERN,
+  packageArtifactPath,
+  packageManifestPath,
+  packagePointerPath,
+} from "../lib/package.mjs";
 
 export default async function handler(request, response) {
   const ref = request.query.ref;
-  if (typeof ref !== "string" || (ref !== "main" && !SHA_PATTERN.test(ref))) {
-    return packageNotFound(response);
+  if (ref === "main" || (typeof ref === "string" && PULL_REQUEST_PATTERN.test(ref))) {
+    return servePointer(ref, request, response);
   }
+  if (typeof ref !== "string" || !SHA_PATTERN.test(ref)) return packageNotFound(response);
 
-  const sourceSha = ref === "main" ? process.env.VERCEL_GIT_COMMIT_SHA : ref;
-  if (!SHA_PATTERN.test(sourceSha ?? "")) {
-    return packageNotFound(response);
-  }
-
-  const manifest = await resolveManifest(sourceSha);
+  const manifest = await resolveManifest(ref);
   if (manifest === undefined) return packageNotFound(response);
+  if (request.query.manifest === "1") return packageNotFound(response);
 
-  if (request.query.manifest === "1") {
-    if (ref !== "main") return packageNotFound(response);
-    response.setHeader("Cache-Control", "public, max-age=60");
-    return response.status(200).json(manifest);
-  }
-  if (ref === "main") {
-    response.setHeader("Cache-Control", "public, max-age=60");
-    return response.redirect(302, manifest.tarball);
-  }
-
-  const artifact = await get(packageArtifactPath(sourceSha), { access: "private" });
+  const artifact = await get(packageArtifactPath(ref), { access: "private" });
   if (artifact === null) return packageNotFound(response);
-
   response.setHeader("Cache-Control", "public, max-age=31536000, immutable");
   response.setHeader("Content-Type", "application/gzip");
   await pipeline(Readable.fromWeb(artifact.stream), response);
   return undefined;
+}
+
+async function servePointer(ref, request, response) {
+  const result = await get(packagePointerPath(ref), { access: "private" });
+  if (result === null) return packageNotFound(response);
+  const manifest = parseManifest(await new Response(result.stream).text());
+  if (manifest === undefined) return packageNotFound(response);
+
+  response.setHeader("Cache-Control", "public, max-age=60");
+  if (request.query.manifest === "1") return response.status(200).json(manifest);
+  return response.redirect(302, manifest.tarball);
 }
 
 function packageNotFound(response) {
@@ -45,10 +48,19 @@ function packageNotFound(response) {
 async function resolveManifest(sourceSha) {
   const result = await get(packageManifestPath(sourceSha), { access: "private" });
   if (result === null) return undefined;
+  return parseManifest(await new Response(result.stream).text(), sourceSha);
+}
 
-  const manifest = JSON.parse(await new Response(result.stream).text());
+function parseManifest(source, expectedSha) {
+  let manifest;
+  try {
+    manifest = JSON.parse(source);
+  } catch {
+    return undefined;
+  }
   if (
-    manifest.sourceSha !== sourceSha ||
+    !SHA_PATTERN.test(manifest.sourceSha ?? "") ||
+    (expectedSha !== undefined && manifest.sourceSha !== expectedSha) ||
     typeof manifest.version !== "string" ||
     typeof manifest.tarball !== "string" ||
     typeof manifest.sha256 !== "string"

--- a/apps/package-artifacts/api/package.js
+++ b/apps/package-artifacts/api/package.js
@@ -3,21 +3,36 @@ import { pipeline } from "node:stream/promises";
 
 import { get } from "@vercel/blob";
 
-import { SHA_PATTERN, packageArtifactPath, packageManifestPath } from "../lib/package.mjs";
+import {
+  PULL_REQUEST_PATTERN,
+  SHA_PATTERN,
+  packageArtifactPath,
+  packageManifestPath,
+  unverifiedPackageArtifactPath,
+  unverifiedPackageManifestPath,
+  unverifiedPullRequestManifestPath,
+} from "../lib/package.mjs";
 
 export default async function handler(request, response) {
+  const scope = request.query.scope === "unverified" ? "unverified" : "trusted";
   const ref = request.query.ref;
-  if (typeof ref !== "string" || (ref !== "main" && !SHA_PATTERN.test(ref))) {
+  const pullRequest = request.query.pr;
+
+  if (scope === "unverified" && typeof pullRequest === "string") {
+    return servePullRequest(pullRequest, request, response);
+  }
+  if (
+    typeof ref !== "string" ||
+    (scope === "trusted" && ref !== "main" && !SHA_PATTERN.test(ref))
+  ) {
     return packageNotFound(response);
   }
+  if (scope === "unverified" && !SHA_PATTERN.test(ref)) return packageNotFound(response);
 
-  // Resolve `main` to the commit represented by the current production deployment.
   const sourceSha = ref === "main" ? process.env.VERCEL_GIT_COMMIT_SHA : ref;
-  if (!SHA_PATTERN.test(sourceSha ?? "")) {
-    return packageNotFound(response);
-  }
+  if (!SHA_PATTERN.test(sourceSha ?? "")) return packageNotFound(response);
 
-  const manifest = await resolveManifest(sourceSha);
+  const manifest = await resolveManifest(sourceSha, scope);
   if (manifest === undefined) return packageNotFound(response);
 
   if (request.query.manifest === "1") {
@@ -30,7 +45,32 @@ export default async function handler(request, response) {
     return response.redirect(302, manifest.tarball);
   }
 
-  const artifact = await get(packageArtifactPath(sourceSha), { access: "private" });
+  return streamArtifact(sourceSha, scope, response);
+}
+
+async function servePullRequest(pullRequest, request, response) {
+  if (!PULL_REQUEST_PATTERN.test(pullRequest)) return packageNotFound(response);
+  const pointer = await get(unverifiedPullRequestManifestPath(pullRequest), { access: "private" });
+  if (pointer === null) return packageNotFound(response);
+
+  const manifest = parseManifest(await new Response(pointer.stream).text(), "unverified");
+  if (manifest === undefined || manifest.pullRequest !== Number(pullRequest)) {
+    return packageNotFound(response);
+  }
+  if (request.query.manifest === "1") {
+    response.setHeader("Cache-Control", "public, max-age=60");
+    return response.status(200).json(manifest);
+  }
+  response.setHeader("Cache-Control", "public, max-age=60");
+  return response.redirect(302, manifest.tarball);
+}
+
+async function streamArtifact(sourceSha, scope, response) {
+  const path =
+    scope === "unverified"
+      ? unverifiedPackageArtifactPath(sourceSha)
+      : packageArtifactPath(sourceSha);
+  const artifact = await get(path, { access: "private" });
   if (artifact === null) return packageNotFound(response);
 
   response.setHeader("Cache-Control", "public, max-age=31536000, immutable");
@@ -43,16 +83,24 @@ function packageNotFound(response) {
   return response.status(404).send("Package not found.\n");
 }
 
-async function resolveManifest(sourceSha) {
-  const result = await get(packageManifestPath(sourceSha), { access: "private" });
+async function resolveManifest(sourceSha, scope) {
+  const path =
+    scope === "unverified"
+      ? unverifiedPackageManifestPath(sourceSha)
+      : packageManifestPath(sourceSha);
+  const result = await get(path, { access: "private" });
   if (result === null) return undefined;
+  return parseManifest(await new Response(result.stream).text(), scope);
+}
 
-  const manifest = JSON.parse(await new Response(result.stream).text());
+function parseManifest(source, scope) {
+  const manifest = JSON.parse(source);
   if (
-    manifest.sourceSha !== sourceSha ||
+    !SHA_PATTERN.test(manifest.sourceSha ?? "") ||
     typeof manifest.version !== "string" ||
     typeof manifest.tarball !== "string" ||
-    typeof manifest.sha256 !== "string"
+    typeof manifest.sha256 !== "string" ||
+    manifest.trust !== scope
   ) {
     return undefined;
   }

--- a/apps/package-artifacts/api/package.js
+++ b/apps/package-artifacts/api/package.js
@@ -15,11 +15,12 @@ import {
 
 export default async function handler(request, response) {
   const scope = request.query.scope === "unverified" ? "unverified" : "trusted";
+  const blobOptions = scope === "unverified" ? unverifiedBlobOptions() : undefined;
   const ref = request.query.ref;
   const pullRequest = request.query.pr;
 
   if (scope === "unverified" && typeof pullRequest === "string") {
-    return servePullRequest(pullRequest, request, response);
+    return servePullRequest(pullRequest, request, response, blobOptions);
   }
   if (
     typeof ref !== "string" ||
@@ -32,7 +33,7 @@ export default async function handler(request, response) {
   const sourceSha = ref === "main" ? process.env.VERCEL_GIT_COMMIT_SHA : ref;
   if (!SHA_PATTERN.test(sourceSha ?? "")) return packageNotFound(response);
 
-  const manifest = await resolveManifest(sourceSha, scope);
+  const manifest = await resolveManifest(sourceSha, scope, blobOptions);
   if (manifest === undefined) return packageNotFound(response);
 
   if (request.query.manifest === "1") {
@@ -45,12 +46,15 @@ export default async function handler(request, response) {
     return response.redirect(302, manifest.tarball);
   }
 
-  return streamArtifact(sourceSha, scope, response);
+  return streamArtifact(sourceSha, scope, response, blobOptions);
 }
 
-async function servePullRequest(pullRequest, request, response) {
+async function servePullRequest(pullRequest, request, response, blobOptions) {
   if (!PULL_REQUEST_PATTERN.test(pullRequest)) return packageNotFound(response);
-  const pointer = await get(unverifiedPullRequestManifestPath(pullRequest), { access: "private" });
+  const pointer = await get(unverifiedPullRequestManifestPath(pullRequest), {
+    access: "private",
+    ...blobOptions,
+  });
   if (pointer === null) return packageNotFound(response);
 
   const manifest = parseManifest(await new Response(pointer.stream).text(), "unverified");
@@ -65,12 +69,12 @@ async function servePullRequest(pullRequest, request, response) {
   return response.redirect(302, manifest.tarball);
 }
 
-async function streamArtifact(sourceSha, scope, response) {
+async function streamArtifact(sourceSha, scope, response, blobOptions) {
   const path =
     scope === "unverified"
       ? unverifiedPackageArtifactPath(sourceSha)
       : packageArtifactPath(sourceSha);
-  const artifact = await get(path, { access: "private" });
+  const artifact = await get(path, { access: "private", ...blobOptions });
   if (artifact === null) return packageNotFound(response);
 
   response.setHeader("Cache-Control", "public, max-age=31536000, immutable");
@@ -83,14 +87,22 @@ function packageNotFound(response) {
   return response.status(404).send("Package not found.\n");
 }
 
-async function resolveManifest(sourceSha, scope) {
+async function resolveManifest(sourceSha, scope, blobOptions) {
   const path =
     scope === "unverified"
       ? unverifiedPackageManifestPath(sourceSha)
       : packageManifestPath(sourceSha);
-  const result = await get(path, { access: "private" });
+  const result = await get(path, { access: "private", ...blobOptions });
   if (result === null) return undefined;
   return parseManifest(await new Response(result.stream).text(), scope);
+}
+
+function unverifiedBlobOptions() {
+  const token = process.env.EVE_UNVERIFIED_BLOB_READ_WRITE_TOKEN;
+  if (typeof token !== "string" || token.length === 0) {
+    throw new Error("EVE_UNVERIFIED_BLOB_READ_WRITE_TOKEN is required for unverified artifacts.");
+  }
+  return { token };
 }
 
 function parseManifest(source, scope) {

--- a/apps/package-artifacts/api/package.test.mjs
+++ b/apps/package-artifacts/api/package.test.mjs
@@ -26,40 +26,43 @@ function response() {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  process.env.VERCEL_GIT_COMMIT_SHA = sha;
   get.mockImplementation(async (pathname) => ({
     stream: new Blob([
-      pathname.endsWith("manifest.json") ? JSON.stringify(manifest) : "package bytes",
+      pathname.endsWith("eve.tgz") ? "package bytes" : JSON.stringify(manifest),
     ]).stream(),
   }));
 });
 
 describe("package route", () => {
-  test("resolves main through the deployment commit", async () => {
+  test("resolves main through its published pointer", async () => {
     const res = response();
     await handler({ query: { ref: "main" } }, res);
 
-    expect(get).toHaveBeenCalledWith(`packages/${sha}/manifest.json`, {
-      access: "private",
-    });
+    expect(get).toHaveBeenCalledWith("packages/refs/main.json", { access: "private" });
     expect(res.setHeader).toHaveBeenCalledWith("Cache-Control", "public, max-age=60");
     expect(res.redirect).toHaveBeenCalledWith(302, manifest.tarball);
   });
 
-  test("serves the current main manifest", async () => {
+  test("resolves a pull request through its published pointer", async () => {
     const res = response();
-    await handler({ query: { ref: "main", manifest: "1" } }, res);
+    await handler({ query: { ref: "123" } }, res);
+
+    expect(get).toHaveBeenCalledWith("packages/refs/pr/123.json", { access: "private" });
+    expect(res.redirect).toHaveBeenCalledWith(302, manifest.tarball);
+  });
+
+  test("serves mutable pointer manifests", async () => {
+    const res = response();
+    await handler({ query: { ref: "123", manifest: "1" } }, res);
 
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith(manifest);
   });
 
-  test("serves SHA tarballs but not SHA latest manifests", async () => {
+  test("serves SHA tarballs but not SHA manifests", async () => {
     const artifact = response();
     await handler({ query: { ref: sha } }, artifact);
-    expect(get).toHaveBeenLastCalledWith(`packages/${sha}/eve.tgz`, {
-      access: "private",
-    });
+    expect(get).toHaveBeenLastCalledWith(`packages/${sha}/eve.tgz`, { access: "private" });
     expect(artifact.setHeader).toHaveBeenCalledWith(
       "Cache-Control",
       "public, max-age=31536000, immutable",

--- a/apps/package-artifacts/api/package.test.mjs
+++ b/apps/package-artifacts/api/package.test.mjs
@@ -12,6 +12,13 @@ const manifest = {
   version: `0.33.0+main.${sha}`,
   tarball: `https://packages.example.com/${sha}/eve.tgz`,
   sha256: "b".repeat(64),
+  trust: "trusted",
+};
+const unverifiedManifest = {
+  ...manifest,
+  version: `0.33.0+unverified.${sha}`,
+  tarball: `https://packages.example.com/unverified/sha/${sha}/eve.tgz`,
+  trust: "unverified",
 };
 
 function response() {
@@ -39,9 +46,7 @@ describe("package route", () => {
     const res = response();
     await handler({ query: { ref: "main" } }, res);
 
-    expect(get).toHaveBeenCalledWith(`packages/${sha}/manifest.json`, {
-      access: "private",
-    });
+    expect(get).toHaveBeenCalledWith(`packages/${sha}/manifest.json`, { access: "private" });
     expect(res.setHeader).toHaveBeenCalledWith("Cache-Control", "public, max-age=60");
     expect(res.redirect).toHaveBeenCalledWith(302, manifest.tarball);
   });
@@ -57,9 +62,7 @@ describe("package route", () => {
   test("serves SHA tarballs but not SHA latest manifests", async () => {
     const artifact = response();
     await handler({ query: { ref: sha } }, artifact);
-    expect(get).toHaveBeenLastCalledWith(`packages/${sha}/eve.tgz`, {
-      access: "private",
-    });
+    expect(get).toHaveBeenLastCalledWith(`packages/${sha}/eve.tgz`, { access: "private" });
     expect(artifact.setHeader).toHaveBeenCalledWith(
       "Cache-Control",
       "public, max-age=31536000, immutable",
@@ -70,6 +73,35 @@ describe("package route", () => {
     const latest = response();
     await handler({ query: { ref: sha, manifest: "1" } }, latest);
     expect(latest.status).toHaveBeenCalledWith(404);
+  });
+
+  test("serves immutable unverified SHA tarballs", async () => {
+    get.mockImplementation(async (pathname) => ({
+      stream: new Blob([
+        pathname.endsWith("manifest.json") ? JSON.stringify(unverifiedManifest) : "package bytes",
+      ]).stream(),
+    }));
+    const artifact = response();
+    await handler({ query: { scope: "unverified", ref: sha } }, artifact);
+
+    expect(get).toHaveBeenCalledWith(`unverified/sha/${sha}/manifest.json`, { access: "private" });
+    expect(get).toHaveBeenLastCalledWith(`unverified/sha/${sha}/eve.tgz`, { access: "private" });
+    expect(artifact.setHeader).toHaveBeenCalledWith(
+      "Cache-Control",
+      "public, max-age=31536000, immutable",
+    );
+  });
+
+  test("redirects a pull request to its immutable unverified artifact", async () => {
+    get.mockResolvedValue({
+      stream: new Blob([JSON.stringify({ ...unverifiedManifest, pullRequest: 123 })]).stream(),
+    });
+    const res = response();
+    await handler({ query: { scope: "unverified", pr: "123" } }, res);
+
+    expect(get).toHaveBeenCalledWith("unverified/pr/123/latest.json", { access: "private" });
+    expect(res.setHeader).toHaveBeenCalledWith("Cache-Control", "public, max-age=60");
+    expect(res.redirect).toHaveBeenCalledWith(302, unverifiedManifest.tarball);
   });
 
   test("rejects unsupported refs and missing artifacts", async () => {

--- a/apps/package-artifacts/api/package.test.mjs
+++ b/apps/package-artifacts/api/package.test.mjs
@@ -34,6 +34,7 @@ function response() {
 beforeEach(() => {
   vi.clearAllMocks();
   process.env.VERCEL_GIT_COMMIT_SHA = sha;
+  process.env.EVE_UNVERIFIED_BLOB_READ_WRITE_TOKEN = "unverified-token";
   get.mockImplementation(async (pathname) => ({
     stream: new Blob([
       pathname.endsWith("manifest.json") ? JSON.stringify(manifest) : "package bytes",
@@ -84,8 +85,14 @@ describe("package route", () => {
     const artifact = response();
     await handler({ query: { scope: "unverified", ref: sha } }, artifact);
 
-    expect(get).toHaveBeenCalledWith(`unverified/sha/${sha}/manifest.json`, { access: "private" });
-    expect(get).toHaveBeenLastCalledWith(`unverified/sha/${sha}/eve.tgz`, { access: "private" });
+    expect(get).toHaveBeenCalledWith(`unverified/sha/${sha}/manifest.json`, {
+      access: "private",
+      token: "unverified-token",
+    });
+    expect(get).toHaveBeenLastCalledWith(`unverified/sha/${sha}/eve.tgz`, {
+      access: "private",
+      token: "unverified-token",
+    });
     expect(artifact.setHeader).toHaveBeenCalledWith(
       "Cache-Control",
       "public, max-age=31536000, immutable",
@@ -99,7 +106,10 @@ describe("package route", () => {
     const res = response();
     await handler({ query: { scope: "unverified", pr: "123" } }, res);
 
-    expect(get).toHaveBeenCalledWith("unverified/pr/123/latest.json", { access: "private" });
+    expect(get).toHaveBeenCalledWith("unverified/pr/123/latest.json", {
+      access: "private",
+      token: "unverified-token",
+    });
     expect(res.setHeader).toHaveBeenCalledWith("Cache-Control", "public, max-age=60");
     expect(res.redirect).toHaveBeenCalledWith(302, unverifiedManifest.tarball);
   });

--- a/apps/package-artifacts/api/package.test.mjs
+++ b/apps/package-artifacts/api/package.test.mjs
@@ -12,13 +12,6 @@ const manifest = {
   version: `0.33.0+main.${sha}`,
   tarball: `https://packages.example.com/${sha}/eve.tgz`,
   sha256: "b".repeat(64),
-  trust: "trusted",
-};
-const unverifiedManifest = {
-  ...manifest,
-  version: `0.33.0+unverified.${sha}`,
-  tarball: `https://packages.example.com/unverified/sha/${sha}/eve.tgz`,
-  trust: "unverified",
 };
 
 function response() {
@@ -34,7 +27,6 @@ function response() {
 beforeEach(() => {
   vi.clearAllMocks();
   process.env.VERCEL_GIT_COMMIT_SHA = sha;
-  process.env.EVE_UNVERIFIED_BLOB_READ_WRITE_TOKEN = "unverified-token";
   get.mockImplementation(async (pathname) => ({
     stream: new Blob([
       pathname.endsWith("manifest.json") ? JSON.stringify(manifest) : "package bytes",
@@ -47,7 +39,9 @@ describe("package route", () => {
     const res = response();
     await handler({ query: { ref: "main" } }, res);
 
-    expect(get).toHaveBeenCalledWith(`packages/${sha}/manifest.json`, { access: "private" });
+    expect(get).toHaveBeenCalledWith(`packages/${sha}/manifest.json`, {
+      access: "private",
+    });
     expect(res.setHeader).toHaveBeenCalledWith("Cache-Control", "public, max-age=60");
     expect(res.redirect).toHaveBeenCalledWith(302, manifest.tarball);
   });
@@ -63,7 +57,9 @@ describe("package route", () => {
   test("serves SHA tarballs but not SHA latest manifests", async () => {
     const artifact = response();
     await handler({ query: { ref: sha } }, artifact);
-    expect(get).toHaveBeenLastCalledWith(`packages/${sha}/eve.tgz`, { access: "private" });
+    expect(get).toHaveBeenLastCalledWith(`packages/${sha}/eve.tgz`, {
+      access: "private",
+    });
     expect(artifact.setHeader).toHaveBeenCalledWith(
       "Cache-Control",
       "public, max-age=31536000, immutable",
@@ -74,44 +70,6 @@ describe("package route", () => {
     const latest = response();
     await handler({ query: { ref: sha, manifest: "1" } }, latest);
     expect(latest.status).toHaveBeenCalledWith(404);
-  });
-
-  test("serves immutable unverified SHA tarballs", async () => {
-    get.mockImplementation(async (pathname) => ({
-      stream: new Blob([
-        pathname.endsWith("manifest.json") ? JSON.stringify(unverifiedManifest) : "package bytes",
-      ]).stream(),
-    }));
-    const artifact = response();
-    await handler({ query: { scope: "unverified", ref: sha } }, artifact);
-
-    expect(get).toHaveBeenCalledWith(`unverified/sha/${sha}/manifest.json`, {
-      access: "private",
-      token: "unverified-token",
-    });
-    expect(get).toHaveBeenLastCalledWith(`unverified/sha/${sha}/eve.tgz`, {
-      access: "private",
-      token: "unverified-token",
-    });
-    expect(artifact.setHeader).toHaveBeenCalledWith(
-      "Cache-Control",
-      "public, max-age=31536000, immutable",
-    );
-  });
-
-  test("redirects a pull request to its immutable unverified artifact", async () => {
-    get.mockResolvedValue({
-      stream: new Blob([JSON.stringify({ ...unverifiedManifest, pullRequest: 123 })]).stream(),
-    });
-    const res = response();
-    await handler({ query: { scope: "unverified", pr: "123" } }, res);
-
-    expect(get).toHaveBeenCalledWith("unverified/pr/123/latest.json", {
-      access: "private",
-      token: "unverified-token",
-    });
-    expect(res.setHeader).toHaveBeenCalledWith("Cache-Control", "public, max-age=60");
-    expect(res.redirect).toHaveBeenCalledWith(302, unverifiedManifest.tarball);
   });
 
   test("rejects unsupported refs and missing artifacts", async () => {

--- a/apps/package-artifacts/api/package.test.mjs
+++ b/apps/package-artifacts/api/package.test.mjs
@@ -10,7 +10,7 @@ const sha = "a".repeat(40);
 const manifest = {
   sourceSha: sha,
   version: `0.33.0+main.${sha}`,
-  tarball: `https://packages.example.com/${sha}/eve.tgz`,
+  tarball: `https://pkg.eve.dev/${sha}/eve.tgz`,
   sha256: "b".repeat(64),
 };
 
@@ -73,6 +73,19 @@ describe("package route", () => {
     const latest = response();
     await handler({ query: { ref: sha, manifest: "1" } }, latest);
     expect(latest.status).toHaveBeenCalledWith(404);
+  });
+
+  test("rejects pointers that redirect outside the package host", async () => {
+    get.mockResolvedValueOnce({
+      stream: new Blob([
+        JSON.stringify({ ...manifest, tarball: "https://example.com/eve.tgz" }),
+      ]).stream(),
+    });
+    const res = response();
+    await handler({ query: { ref: "main" } }, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.redirect).not.toHaveBeenCalled();
   });
 
   test("rejects unsupported refs and missing artifacts", async () => {

--- a/apps/package-artifacts/lib/package.mjs
+++ b/apps/package-artifacts/lib/package.mjs
@@ -1,4 +1,5 @@
 export const SHA_PATTERN = /^[0-9a-f]{40}$/i;
+export const PULL_REQUEST_PATTERN = /^[1-9]\d*$/;
 
 export function packageArtifactPath(sourceSha) {
   return `packages/${sourceSha}/eve.tgz`;
@@ -8,17 +9,16 @@ export function packageManifestPath(sourceSha) {
   return `packages/${sourceSha}/manifest.json`;
 }
 
+export function packagePointerPath(ref) {
+  if (ref === "main") return "packages/refs/main.json";
+  if (PULL_REQUEST_PATTERN.test(ref)) return `packages/refs/pr/${ref}.json`;
+  throw new Error("Package ref must be main or a positive pull request number.");
+}
+
 export function packageDependencyUrl(baseUrl, sourceSha) {
   const url = new URL(baseUrl);
   if (url.protocol !== "https:") throw new Error("Package base URL must use HTTPS.");
   url.pathname = `${url.pathname.replace(/\/$/, "")}/${sourceSha}/eve.tgz`;
-  return url.toString();
-}
-
-export function previewPackageDependencyUrl(baseUrl) {
-  const url = new URL(baseUrl);
-  if (url.protocol !== "https:") throw new Error("Package base URL must use HTTPS.");
-  url.pathname = `${url.pathname.replace(/\/$/, "")}/eve.tgz`;
   return url.toString();
 }
 

--- a/apps/package-artifacts/lib/package.mjs
+++ b/apps/package-artifacts/lib/package.mjs
@@ -1,4 +1,5 @@
 export const SHA_PATTERN = /^[0-9a-f]{40}$/i;
+export const PULL_REQUEST_PATTERN = /^[1-9]\d*$/;
 
 export function packageArtifactPath(sourceSha) {
   return `packages/${sourceSha}/eve.tgz`;
@@ -8,19 +9,38 @@ export function packageManifestPath(sourceSha) {
   return `packages/${sourceSha}/manifest.json`;
 }
 
-export function packageDependencyUrl(baseUrl, sourceSha) {
+export function unverifiedPackageArtifactPath(sourceSha) {
+  return `unverified/sha/${sourceSha}/eve.tgz`;
+}
+
+export function unverifiedPackageManifestPath(sourceSha) {
+  return `unverified/sha/${sourceSha}/manifest.json`;
+}
+
+export function unverifiedPullRequestManifestPath(pullRequest) {
+  if (!PULL_REQUEST_PATTERN.test(pullRequest)) {
+    throw new Error("Pull request number must be a positive integer.");
+  }
+  return `unverified/pr/${pullRequest}/latest.json`;
+}
+
+export function packageDependencyUrl(baseUrl, sourceSha, scope = "trusted") {
   const url = new URL(baseUrl);
   if (url.protocol !== "https:") throw new Error("Package base URL must use HTTPS.");
-  url.pathname = `${url.pathname.replace(/\/$/, "")}/${sourceSha}/eve.tgz`;
+  url.pathname =
+    scope === "unverified"
+      ? `${url.pathname.replace(/\/$/, "")}/unverified/sha/${sourceSha}/eve.tgz`
+      : `${url.pathname.replace(/\/$/, "")}/${sourceSha}/eve.tgz`;
   return url.toString();
 }
 
-export function packageVersion(stableVersion, sourceSha) {
+export function packageVersion(stableVersion, sourceSha, scope = "trusted") {
   const match = stableVersion.match(/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/);
   if (match === null) throw new Error(`Expected a stable eve version, received ${stableVersion}.`);
-  return `${stableVersion}+main.${sourceSha}`;
+  const channel = scope === "unverified" ? "unverified" : "main";
+  return `${stableVersion}+${channel}.${sourceSha}`;
 }
 
-export function preparePackageJson(packageJson, sourceSha) {
-  return { ...packageJson, version: packageVersion(packageJson.version, sourceSha) };
+export function preparePackageJson(packageJson, sourceSha, scope) {
+  return { ...packageJson, version: packageVersion(packageJson.version, sourceSha, scope) };
 }

--- a/apps/package-artifacts/lib/package.mjs
+++ b/apps/package-artifacts/lib/package.mjs
@@ -1,5 +1,4 @@
 export const SHA_PATTERN = /^[0-9a-f]{40}$/i;
-export const PULL_REQUEST_PATTERN = /^[1-9]\d*$/;
 
 export function packageArtifactPath(sourceSha) {
   return `packages/${sourceSha}/eve.tgz`;
@@ -9,38 +8,26 @@ export function packageManifestPath(sourceSha) {
   return `packages/${sourceSha}/manifest.json`;
 }
 
-export function unverifiedPackageArtifactPath(sourceSha) {
-  return `unverified/sha/${sourceSha}/eve.tgz`;
-}
-
-export function unverifiedPackageManifestPath(sourceSha) {
-  return `unverified/sha/${sourceSha}/manifest.json`;
-}
-
-export function unverifiedPullRequestManifestPath(pullRequest) {
-  if (!PULL_REQUEST_PATTERN.test(pullRequest)) {
-    throw new Error("Pull request number must be a positive integer.");
-  }
-  return `unverified/pr/${pullRequest}/latest.json`;
-}
-
-export function packageDependencyUrl(baseUrl, sourceSha, scope = "trusted") {
+export function packageDependencyUrl(baseUrl, sourceSha) {
   const url = new URL(baseUrl);
   if (url.protocol !== "https:") throw new Error("Package base URL must use HTTPS.");
-  url.pathname =
-    scope === "unverified"
-      ? `${url.pathname.replace(/\/$/, "")}/unverified/sha/${sourceSha}/eve.tgz`
-      : `${url.pathname.replace(/\/$/, "")}/${sourceSha}/eve.tgz`;
+  url.pathname = `${url.pathname.replace(/\/$/, "")}/${sourceSha}/eve.tgz`;
   return url.toString();
 }
 
-export function packageVersion(stableVersion, sourceSha, scope = "trusted") {
+export function previewPackageDependencyUrl(baseUrl) {
+  const url = new URL(baseUrl);
+  if (url.protocol !== "https:") throw new Error("Package base URL must use HTTPS.");
+  url.pathname = `${url.pathname.replace(/\/$/, "")}/eve.tgz`;
+  return url.toString();
+}
+
+export function packageVersion(stableVersion, sourceSha, channel = "main") {
   const match = stableVersion.match(/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/);
   if (match === null) throw new Error(`Expected a stable eve version, received ${stableVersion}.`);
-  const channel = scope === "unverified" ? "unverified" : "main";
   return `${stableVersion}+${channel}.${sourceSha}`;
 }
 
-export function preparePackageJson(packageJson, sourceSha, scope) {
-  return { ...packageJson, version: packageVersion(packageJson.version, sourceSha, scope) };
+export function preparePackageJson(packageJson, sourceSha, channel) {
+  return { ...packageJson, version: packageVersion(packageJson.version, sourceSha, channel) };
 }

--- a/apps/package-artifacts/lib/package.test.mjs
+++ b/apps/package-artifacts/lib/package.test.mjs
@@ -4,46 +4,42 @@ import {
   packageArtifactPath,
   packageDependencyUrl,
   packageManifestPath,
+  packagePointerPath,
   packageVersion,
   preparePackageJson,
-  previewPackageDependencyUrl,
 } from "./package.mjs";
 
 const sha = "a".repeat(40);
 
 describe("package artifacts", () => {
-  test("derives main and preview build versions", () => {
+  test("derives channel-specific build versions", () => {
     expect(packageVersion("0.33.0", sha)).toBe(`0.33.0+main.${sha}`);
-    expect(packageVersion("0.33.0", sha, "preview")).toBe(`0.33.0+preview.${sha}`);
+    expect(packageVersion("0.33.0", sha, "git")).toBe(`0.33.0+git.${sha}`);
   });
 
-  test("derives immutable trusted and deployment-local preview URLs", () => {
+  test("derives immutable artifacts and mutable pointers", () => {
     expect(packageArtifactPath(sha)).toBe(`packages/${sha}/eve.tgz`);
     expect(packageManifestPath(sha)).toBe(`packages/${sha}/manifest.json`);
+    expect(packagePointerPath("main")).toBe("packages/refs/main.json");
+    expect(packagePointerPath("123")).toBe("packages/refs/pr/123.json");
     expect(packageDependencyUrl("https://packages.example.com", sha)).toBe(
       `https://packages.example.com/${sha}/eve.tgz`,
     );
-    expect(previewPackageDependencyUrl("https://preview.example.com")).toBe(
-      "https://preview.example.com/eve.tgz",
-    );
   });
 
-  test("requires an HTTPS package base URL", () => {
+  test("requires HTTPS and valid pointer refs", () => {
     expect(() => packageDependencyUrl("http://packages.example.com", sha)).toThrow(
       "must use HTTPS",
     );
+    expect(() => packagePointerPath("0")).toThrow("positive pull request");
   });
 
   test("prepares package metadata without mutating the source", () => {
     const source = { name: "eve", version: "0.33.0" };
-    expect(preparePackageJson(source, sha, "preview")).toEqual({
+    expect(preparePackageJson(source, sha, "git")).toEqual({
       name: "eve",
-      version: `0.33.0+preview.${sha}`,
+      version: `0.33.0+git.${sha}`,
     });
     expect(source.version).toBe("0.33.0");
-  });
-
-  test("rejects non-stable source versions", () => {
-    expect(() => packageVersion("0.33.1-main.1", sha)).toThrow("Expected a stable eve version");
   });
 });

--- a/apps/package-artifacts/lib/package.test.mjs
+++ b/apps/package-artifacts/lib/package.test.mjs
@@ -6,45 +6,39 @@ import {
   packageManifestPath,
   packageVersion,
   preparePackageJson,
-  unverifiedPackageArtifactPath,
-  unverifiedPackageManifestPath,
-  unverifiedPullRequestManifestPath,
+  previewPackageDependencyUrl,
 } from "./package.mjs";
 
 const sha = "a".repeat(40);
 
 describe("package artifacts", () => {
-  test("derives trusted and unverified build versions", () => {
+  test("derives main and preview build versions", () => {
     expect(packageVersion("0.33.0", sha)).toBe(`0.33.0+main.${sha}`);
-    expect(packageVersion("0.33.0", sha, "unverified")).toBe(`0.33.0+unverified.${sha}`);
+    expect(packageVersion("0.33.0", sha, "preview")).toBe(`0.33.0+preview.${sha}`);
   });
 
-  test("derives immutable trusted and unverified artifact URLs", () => {
+  test("derives immutable trusted and deployment-local preview URLs", () => {
     expect(packageArtifactPath(sha)).toBe(`packages/${sha}/eve.tgz`);
     expect(packageManifestPath(sha)).toBe(`packages/${sha}/manifest.json`);
     expect(packageDependencyUrl("https://packages.example.com", sha)).toBe(
       `https://packages.example.com/${sha}/eve.tgz`,
     );
-    expect(unverifiedPackageArtifactPath(sha)).toBe(`unverified/sha/${sha}/eve.tgz`);
-    expect(unverifiedPackageManifestPath(sha)).toBe(`unverified/sha/${sha}/manifest.json`);
-    expect(unverifiedPullRequestManifestPath("123")).toBe("unverified/pr/123/latest.json");
-    expect(packageDependencyUrl("https://packages.example.com", sha, "unverified")).toBe(
-      `https://packages.example.com/unverified/sha/${sha}/eve.tgz`,
+    expect(previewPackageDependencyUrl("https://preview.example.com")).toBe(
+      "https://preview.example.com/eve.tgz",
     );
   });
 
-  test("requires an HTTPS package base URL and a positive pull request number", () => {
+  test("requires an HTTPS package base URL", () => {
     expect(() => packageDependencyUrl("http://packages.example.com", sha)).toThrow(
       "must use HTTPS",
     );
-    expect(() => unverifiedPullRequestManifestPath("0")).toThrow("positive integer");
   });
 
   test("prepares package metadata without mutating the source", () => {
     const source = { name: "eve", version: "0.33.0" };
-    expect(preparePackageJson(source, sha, "unverified")).toEqual({
+    expect(preparePackageJson(source, sha, "preview")).toEqual({
       name: "eve",
-      version: `0.33.0+unverified.${sha}`,
+      version: `0.33.0+preview.${sha}`,
     });
     expect(source.version).toBe("0.33.0");
   });

--- a/apps/package-artifacts/lib/package.test.mjs
+++ b/apps/package-artifacts/lib/package.test.mjs
@@ -6,34 +6,45 @@ import {
   packageManifestPath,
   packageVersion,
   preparePackageJson,
+  unverifiedPackageArtifactPath,
+  unverifiedPackageManifestPath,
+  unverifiedPullRequestManifestPath,
 } from "./package.mjs";
 
 const sha = "a".repeat(40);
 
 describe("package artifacts", () => {
-  test("derives a main build version", () => {
+  test("derives trusted and unverified build versions", () => {
     expect(packageVersion("0.33.0", sha)).toBe(`0.33.0+main.${sha}`);
+    expect(packageVersion("0.33.0", sha, "unverified")).toBe(`0.33.0+unverified.${sha}`);
   });
 
-  test("derives immutable artifact and dependency URLs", () => {
+  test("derives immutable trusted and unverified artifact URLs", () => {
     expect(packageArtifactPath(sha)).toBe(`packages/${sha}/eve.tgz`);
     expect(packageManifestPath(sha)).toBe(`packages/${sha}/manifest.json`);
     expect(packageDependencyUrl("https://packages.example.com", sha)).toBe(
       `https://packages.example.com/${sha}/eve.tgz`,
     );
+    expect(unverifiedPackageArtifactPath(sha)).toBe(`unverified/sha/${sha}/eve.tgz`);
+    expect(unverifiedPackageManifestPath(sha)).toBe(`unverified/sha/${sha}/manifest.json`);
+    expect(unverifiedPullRequestManifestPath("123")).toBe("unverified/pr/123/latest.json");
+    expect(packageDependencyUrl("https://packages.example.com", sha, "unverified")).toBe(
+      `https://packages.example.com/unverified/sha/${sha}/eve.tgz`,
+    );
   });
 
-  test("requires an HTTPS package base URL", () => {
+  test("requires an HTTPS package base URL and a positive pull request number", () => {
     expect(() => packageDependencyUrl("http://packages.example.com", sha)).toThrow(
       "must use HTTPS",
     );
+    expect(() => unverifiedPullRequestManifestPath("0")).toThrow("positive integer");
   });
 
   test("prepares package metadata without mutating the source", () => {
     const source = { name: "eve", version: "0.33.0" };
-    expect(preparePackageJson(source, sha)).toEqual({
+    expect(preparePackageJson(source, sha, "unverified")).toEqual({
       name: "eve",
-      version: `0.33.0+main.${sha}`,
+      version: `0.33.0+unverified.${sha}`,
     });
     expect(source.version).toBe("0.33.0");
   });

--- a/apps/package-artifacts/package.json
+++ b/apps/package-artifacts/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "scripts": {
     "build": "node scripts/build.mjs",
+    "package:prepare": "node scripts/prepare.mjs",
+    "publish": "node scripts/publish.mjs",
     "test": "vitest run --config vitest.config.ts",
     "test:smoke": "node scripts/check-smoke.mjs"
   },

--- a/apps/package-artifacts/package.json
+++ b/apps/package-artifacts/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "node scripts/build.mjs",
     "package:prepare": "node scripts/prepare.mjs",
-    "publish": "node scripts/publish.mjs",
+    "package:publish": "node scripts/publish.mjs",
     "test": "vitest run --config vitest.config.ts",
     "test:smoke": "node scripts/check-smoke.mjs"
   },

--- a/apps/package-artifacts/scripts/build.mjs
+++ b/apps/package-artifacts/scripts/build.mjs
@@ -1,127 +1,13 @@
-import { createHash } from "node:crypto";
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { get, put } from "@vercel/blob";
-
-import {
-  SHA_PATTERN,
-  packageArtifactPath,
-  packageDependencyUrl,
-  packageManifestPath,
-  preparePackageJson,
-  previewPackageDependencyUrl,
-} from "../lib/package.mjs";
-import { packPackage } from "../lib/pack.mjs";
-
 const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const repoRoot = resolve(appRoot, "../..");
-const packageRoot = join(repoRoot, "packages/eve");
-const packageJsonPath = join(packageRoot, "package.json");
-const artifactDirectory = join(appRoot, ".artifacts");
-const sourceSha = process.env.VERCEL_GIT_COMMIT_SHA;
-const branch = process.env.VERCEL_GIT_COMMIT_REF;
-const productionDomain = process.env.VERCEL_PROJECT_PRODUCTION_URL;
-const previewDomain = process.env.VERCEL_URL;
-const isTrustedPublisher = branch === "main" && process.env.VERCEL_ENV === "production";
-const isPreviewPackage = process.env.VERCEL_ENV === "preview";
 
-if (!SHA_PATTERN.test(sourceSha ?? "")) {
-  throw new Error("VERCEL_GIT_COMMIT_SHA must be a 40-character Git commit SHA.");
-}
-if (!isTrustedPublisher && !isPreviewPackage) {
-  await writeLandingPage();
-  process.exit(0);
-}
-
-const packageDomain = isTrustedPublisher ? productionDomain : previewDomain;
-if (typeof packageDomain !== "string" || packageDomain.length === 0) {
-  throw new Error(
-    isTrustedPublisher
-      ? "VERCEL_PROJECT_PRODUCTION_URL is required for trusted package publishing."
-      : "VERCEL_URL is required for preview package publishing.",
-  );
-}
-
-const channel = isTrustedPublisher ? "main" : "preview";
-const originalPackageJson = await readFile(packageJsonPath, "utf8");
-const preparedPackageJson = preparePackageJson(JSON.parse(originalPackageJson), sourceSha, channel);
-const version = preparedPackageJson.version;
-const dependencyUrl = isTrustedPublisher
-  ? packageDependencyUrl(`https://${packageDomain}`, sourceSha)
-  : previewPackageDependencyUrl(`https://${packageDomain}`);
-
-try {
-  await rm(artifactDirectory, { force: true, recursive: true });
-  await writeFile(packageJsonPath, `${JSON.stringify(preparedPackageJson, null, 2)}\n`);
-  const tarball = await packPackage(packageRoot, version, {
-    ...process.env,
-    EVE_PACKAGE_DEPENDENCY_URL: dependencyUrl,
-  });
-
-  if (isPreviewPackage) {
-    await mkdir(join(appRoot, "public"), { recursive: true });
-    await writeFile(join(appRoot, "public", "eve.tgz"), tarball);
-    await writeLandingPage();
-    process.stdout.write(`${JSON.stringify({ sourceSha, version, tarball: dependencyUrl })}\n`);
-    process.exit(0);
-  }
-
-  const sha256 = createHash("sha256").update(tarball).digest("hex");
-  const artifactPath = packageArtifactPath(sourceSha);
-  try {
-    await put(artifactPath, tarball, {
-      access: "private",
-      addRandomSuffix: false,
-      allowOverwrite: false,
-      cacheControlMaxAge: 31_536_000,
-      contentType: "application/gzip",
-    });
-  } catch (error) {
-    if (!(error instanceof Error) || !error.message.includes("already exists")) throw error;
-    const publishedArtifact = await get(artifactPath, { access: "private", useCache: false });
-    if (publishedArtifact === null) {
-      throw new Error("Published package artifact could not be read.");
-    }
-    const publishedSha256 = createHash("sha256")
-      .update(Buffer.from(await new Response(publishedArtifact.stream).arrayBuffer()))
-      .digest("hex");
-    if (publishedSha256 !== sha256) {
-      throw new Error(`Commit ${sourceSha} was already published with different package contents.`);
-    }
-  }
-
-  const manifest = { sourceSha, version, tarball: dependencyUrl, sha256 };
-  const manifestPath = packageManifestPath(sourceSha);
-  const existingManifest = await get(manifestPath, { access: "private", useCache: false });
-  if (existingManifest === null) {
-    await put(manifestPath, JSON.stringify(manifest), {
-      access: "private",
-      addRandomSuffix: false,
-      allowOverwrite: false,
-      cacheControlMaxAge: 31_536_000,
-      contentType: "application/json",
-    });
-  } else {
-    const published = JSON.parse(await new Response(existingManifest.stream).text());
-    if (published.sha256 !== sha256) {
-      throw new Error(`Commit ${sourceSha} was already published with different package contents.`);
-    }
-  }
-
-  await writeLandingPage();
-  process.stdout.write(`${JSON.stringify(manifest)}\n`);
-} finally {
-  await writeFile(packageJsonPath, originalPackageJson);
-  await rm(artifactDirectory, { force: true, recursive: true });
-}
-
-async function writeLandingPage() {
-  await mkdir(join(appRoot, "public"), { recursive: true });
-  await writeFile(
-    join(appRoot, "public", "index.html"),
-    `<!doctype html>
+await mkdir(join(appRoot, "public"), { recursive: true });
+await writeFile(
+  join(appRoot, "public", "index.html"),
+  `<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8">
@@ -141,5 +27,4 @@ async function writeLandingPage() {
   <body><main><div class="mark" aria-hidden="true"></div><h1>eve packages</h1><p>Package artifacts for eve development.</p></main></body>
 </html>
 `,
-  );
-}
+);

--- a/apps/package-artifacts/scripts/build.mjs
+++ b/apps/package-artifacts/scripts/build.mjs
@@ -6,13 +6,18 @@ import { fileURLToPath } from "node:url";
 import { get, put } from "@vercel/blob";
 
 import {
+  PULL_REQUEST_PATTERN,
   SHA_PATTERN,
   packageArtifactPath,
   packageDependencyUrl,
   packageManifestPath,
   preparePackageJson,
+  unverifiedPackageArtifactPath,
+  unverifiedPackageManifestPath,
+  unverifiedPullRequestManifestPath,
 } from "../lib/package.mjs";
 import { packPackage } from "../lib/pack.mjs";
+
 const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const repoRoot = resolve(appRoot, "../..");
 const packageRoot = join(repoRoot, "packages/eve");
@@ -21,86 +26,144 @@ const artifactDirectory = join(appRoot, ".artifacts");
 const sourceSha = process.env.VERCEL_GIT_COMMIT_SHA;
 const branch = process.env.VERCEL_GIT_COMMIT_REF;
 const productionDomain = process.env.VERCEL_PROJECT_PRODUCTION_URL;
+const deploymentDomain = process.env.VERCEL_URL;
+const pullRequest = process.env.EVE_PULL_REQUEST_NUMBER;
+const isTrustedPublisher =
+  branch === "main" &&
+  process.env.VERCEL_ENV === "production" &&
+  process.env.EVE_PACKAGE_ARTIFACT_SCOPE !== "unverified";
+// Configure this only in the separate Preview project connected to the unverified Blob store.
+const isUnverifiedPublisher =
+  process.env.VERCEL_ENV === "preview" && process.env.EVE_PACKAGE_ARTIFACT_SCOPE === "unverified";
 
 if (!SHA_PATTERN.test(sourceSha ?? "")) {
   throw new Error("VERCEL_GIT_COMMIT_SHA must be a 40-character Git commit SHA.");
 }
-if (branch !== "main" || process.env.VERCEL_ENV !== "production") {
-  await mkdir(join(appRoot, "public"), { recursive: true });
-  await writeFile(
-    join(appRoot, "public/index.html"),
-    "<!doctype html><title>eve packages</title><p>Artifacts are only published from main.</p>\n",
-  );
+if (pullRequest !== undefined && !PULL_REQUEST_PATTERN.test(pullRequest)) {
+  throw new Error("EVE_PULL_REQUEST_NUMBER must be a positive integer.");
+}
+
+if (!isTrustedPublisher && !isUnverifiedPublisher) {
+  await writeLandingPage();
   process.exit(0);
 }
 
-if (typeof productionDomain !== "string" || productionDomain.length === 0) {
-  throw new Error("VERCEL_PROJECT_PRODUCTION_URL is required for package publishing.");
+const scope = isTrustedPublisher ? "trusted" : "unverified";
+const packageDomain = isTrustedPublisher ? productionDomain : deploymentDomain;
+if (typeof packageDomain !== "string" || packageDomain.length === 0) {
+  throw new Error(
+    isTrustedPublisher
+      ? "VERCEL_PROJECT_PRODUCTION_URL is required for trusted package publishing."
+      : "VERCEL_URL is required for unverified package publishing.",
+  );
 }
 
 const originalPackageJson = await readFile(packageJsonPath, "utf8");
-const preparedPackageJson = preparePackageJson(JSON.parse(originalPackageJson), sourceSha);
+const preparedPackageJson = preparePackageJson(JSON.parse(originalPackageJson), sourceSha, scope);
 const version = preparedPackageJson.version;
-// Generated projects pin this deployment's immutable SHA route, never the moving main route.
-const dependencyUrl = packageDependencyUrl(`https://${productionDomain}`, sourceSha);
-const artifactPath = packageArtifactPath(sourceSha);
+const baseUrl = `https://${packageDomain}`;
+const dependencyUrl = packageDependencyUrl(baseUrl, sourceSha, scope);
+const artifactPath = isTrustedPublisher
+  ? packageArtifactPath(sourceSha)
+  : unverifiedPackageArtifactPath(sourceSha);
+const manifestPath = isTrustedPublisher
+  ? packageManifestPath(sourceSha)
+  : unverifiedPackageManifestPath(sourceSha);
 
 try {
   await rm(artifactDirectory, { force: true, recursive: true });
   await writeFile(packageJsonPath, `${JSON.stringify(preparedPackageJson, null, 2)}\n`);
   const tarball = await packPackage(packageRoot, version, {
     ...process.env,
-    EVE_MAIN_DEPENDENCY_URL: dependencyUrl,
+    EVE_PACKAGE_DEPENDENCY_URL: dependencyUrl,
   });
   const sha256 = createHash("sha256").update(tarball).digest("hex");
-  try {
-    await put(artifactPath, tarball, {
+  const manifest = { sourceSha, version, tarball: dependencyUrl, sha256, trust: scope };
+
+  await putImmutableArtifact(artifactPath, tarball, sha256);
+  await putImmutableManifest(manifestPath, manifest);
+
+  if (isUnverifiedPublisher && typeof pullRequest === "string") {
+    const pullRequestManifest = { ...manifest, pullRequest: Number(pullRequest) };
+    await put(unverifiedPullRequestManifestPath(pullRequest), JSON.stringify(pullRequestManifest), {
       access: "private",
       addRandomSuffix: false,
-      allowOverwrite: false,
-      cacheControlMaxAge: 31_536_000,
-      contentType: "application/gzip",
+      allowOverwrite: true,
+      cacheControlMaxAge: 60,
+      contentType: "application/json",
     });
+  }
+
+  await writeLandingPage();
+  process.stdout.write(`${JSON.stringify(manifest)}\n`);
+} finally {
+  await writeFile(packageJsonPath, originalPackageJson);
+  await rm(artifactDirectory, { force: true, recursive: true });
+}
+
+async function putImmutableArtifact(pathname, tarball, sha256) {
+  try {
+    await put(pathname, tarball, immutablePutOptions("application/gzip"));
   } catch (error) {
-    // Redeploys are valid only when this commit still produces identical package bytes.
     if (!(error instanceof Error) || !error.message.includes("already exists")) throw error;
-    const publishedArtifact = await get(artifactPath, { access: "private", useCache: false });
-    if (publishedArtifact === null) {
-      throw new Error("Published package artifact could not be read.");
-    }
+    const published = await get(pathname, { access: "private", useCache: false });
+    if (published === null) throw new Error("Published package artifact could not be read.");
     const publishedSha256 = createHash("sha256")
-      .update(Buffer.from(await new Response(publishedArtifact.stream).arrayBuffer()))
+      .update(Buffer.from(await new Response(published.stream).arrayBuffer()))
       .digest("hex");
     if (publishedSha256 !== sha256) {
       throw new Error(`Commit ${sourceSha} was already published with different package contents.`);
     }
   }
+}
 
-  const manifest = { sourceSha, version, tarball: dependencyUrl, sha256 };
-  const manifestPath = packageManifestPath(sourceSha);
-  const existingManifest = await get(manifestPath, { access: "private", useCache: false });
-  if (existingManifest === null) {
-    await put(manifestPath, JSON.stringify(manifest), {
-      access: "private",
-      addRandomSuffix: false,
-      allowOverwrite: false,
-      cacheControlMaxAge: 31_536_000,
-      contentType: "application/json",
-    });
-  } else {
-    const published = JSON.parse(await new Response(existingManifest.stream).text());
-    if (published.sha256 !== sha256) {
+async function putImmutableManifest(pathname, manifest) {
+  try {
+    await put(pathname, JSON.stringify(manifest), immutablePutOptions("application/json"));
+  } catch (error) {
+    if (!(error instanceof Error) || !error.message.includes("already exists")) throw error;
+    const published = await get(pathname, { access: "private", useCache: false });
+    if (published === null) throw new Error("Published package manifest could not be read.");
+    const existing = JSON.parse(await new Response(published.stream).text());
+    if (existing.sha256 !== manifest.sha256) {
       throw new Error(`Commit ${sourceSha} was already published with different package contents.`);
     }
   }
+}
 
+function immutablePutOptions(contentType) {
+  return {
+    access: "private",
+    addRandomSuffix: false,
+    allowOverwrite: false,
+    cacheControlMaxAge: 31_536_000,
+    contentType,
+  };
+}
+
+async function writeLandingPage() {
   await mkdir(join(appRoot, "public"), { recursive: true });
   await writeFile(
-    join(appRoot, "public/index.html"),
-    `<!doctype html><title>eve packages</title><pre>${JSON.stringify(manifest, null, 2)}</pre>\n`,
+    join(appRoot, "public", "index.html"),
+    `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>eve packages</title>
+    <style>
+      :root { color-scheme: light dark; }
+      * { box-sizing: border-box; }
+      body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #fff; color: #111; font-family: Geist, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      main { width: min(100% - 48px, 480px); text-align: center; }
+      .mark { width: 32px; height: 32px; margin: 0 auto 24px; border-radius: 50%; background: #111; }
+      h1 { margin: 0; font-size: 20px; font-weight: 500; letter-spacing: -0.03em; }
+      p { margin: 8px 0 0; color: #666; font-size: 14px; }
+      @media (prefers-color-scheme: dark) { body { background: #000; color: #ededed; } .mark { background: #ededed; } p { color: #888; } }
+    </style>
+  </head>
+  <body><main><div class="mark" aria-hidden="true"></div><h1>eve packages</h1><p>Package artifacts for eve development.</p></main></body>
+</html>
+`,
   );
-  process.stdout.write(`${JSON.stringify(manifest)}\n`);
-} finally {
-  await writeFile(packageJsonPath, originalPackageJson);
-  await rm(artifactDirectory, { force: true, recursive: true });
 }

--- a/apps/package-artifacts/scripts/build.mjs
+++ b/apps/package-artifacts/scripts/build.mjs
@@ -26,7 +26,7 @@ const artifactDirectory = join(appRoot, ".artifacts");
 const sourceSha = process.env.VERCEL_GIT_COMMIT_SHA;
 const branch = process.env.VERCEL_GIT_COMMIT_REF;
 const productionDomain = process.env.VERCEL_PROJECT_PRODUCTION_URL;
-const deploymentDomain = process.env.VERCEL_URL;
+const unverifiedPackageOrigin = process.env.EVE_PACKAGE_PUBLIC_ORIGIN;
 const pullRequest = process.env.EVE_PULL_REQUEST_NUMBER;
 const isTrustedPublisher =
   branch === "main" &&
@@ -49,20 +49,23 @@ if (!isTrustedPublisher && !isUnverifiedPublisher) {
 }
 
 const scope = isTrustedPublisher ? "trusted" : "unverified";
-const packageDomain = isTrustedPublisher ? productionDomain : deploymentDomain;
-if (typeof packageDomain !== "string" || packageDomain.length === 0) {
+const packageOrigin = isTrustedPublisher
+  ? typeof productionDomain === "string" && productionDomain.length > 0
+    ? `https://${productionDomain}`
+    : undefined
+  : unverifiedPackageOrigin;
+if (typeof packageOrigin !== "string" || packageOrigin.length === 0) {
   throw new Error(
     isTrustedPublisher
       ? "VERCEL_PROJECT_PRODUCTION_URL is required for trusted package publishing."
-      : "VERCEL_URL is required for unverified package publishing.",
+      : "EVE_PACKAGE_PUBLIC_ORIGIN is required for unverified package publishing.",
   );
 }
 
 const originalPackageJson = await readFile(packageJsonPath, "utf8");
 const preparedPackageJson = preparePackageJson(JSON.parse(originalPackageJson), sourceSha, scope);
 const version = preparedPackageJson.version;
-const baseUrl = `https://${packageDomain}`;
-const dependencyUrl = packageDependencyUrl(baseUrl, sourceSha, scope);
+const dependencyUrl = packageDependencyUrl(packageOrigin, sourceSha, scope);
 const artifactPath = isTrustedPublisher
   ? packageArtifactPath(sourceSha)
   : unverifiedPackageArtifactPath(sourceSha);

--- a/apps/package-artifacts/scripts/build.mjs
+++ b/apps/package-artifacts/scripts/build.mjs
@@ -6,15 +6,12 @@ import { fileURLToPath } from "node:url";
 import { get, put } from "@vercel/blob";
 
 import {
-  PULL_REQUEST_PATTERN,
   SHA_PATTERN,
   packageArtifactPath,
   packageDependencyUrl,
   packageManifestPath,
   preparePackageJson,
-  unverifiedPackageArtifactPath,
-  unverifiedPackageManifestPath,
-  unverifiedPullRequestManifestPath,
+  previewPackageDependencyUrl,
 } from "../lib/package.mjs";
 import { packPackage } from "../lib/pack.mjs";
 
@@ -26,52 +23,34 @@ const artifactDirectory = join(appRoot, ".artifacts");
 const sourceSha = process.env.VERCEL_GIT_COMMIT_SHA;
 const branch = process.env.VERCEL_GIT_COMMIT_REF;
 const productionDomain = process.env.VERCEL_PROJECT_PRODUCTION_URL;
-const unverifiedPackageOrigin = process.env.EVE_PACKAGE_PUBLIC_ORIGIN;
-const pullRequest = process.env.EVE_PULL_REQUEST_NUMBER;
-const isTrustedPublisher =
-  branch === "main" &&
-  process.env.VERCEL_ENV === "production" &&
-  process.env.EVE_PACKAGE_ARTIFACT_SCOPE !== "unverified";
-// Configure this only in the separate Preview project connected to the unverified Blob store.
-const isUnverifiedPublisher =
-  process.env.VERCEL_ENV === "preview" && process.env.EVE_PACKAGE_ARTIFACT_SCOPE === "unverified";
+const previewDomain = process.env.VERCEL_URL;
+const isTrustedPublisher = branch === "main" && process.env.VERCEL_ENV === "production";
+const isPreviewPackage = process.env.VERCEL_ENV === "preview";
 
 if (!SHA_PATTERN.test(sourceSha ?? "")) {
   throw new Error("VERCEL_GIT_COMMIT_SHA must be a 40-character Git commit SHA.");
 }
-if (pullRequest !== undefined && !PULL_REQUEST_PATTERN.test(pullRequest)) {
-  throw new Error("EVE_PULL_REQUEST_NUMBER must be a positive integer.");
-}
-
-if (!isTrustedPublisher && !isUnverifiedPublisher) {
+if (!isTrustedPublisher && !isPreviewPackage) {
   await writeLandingPage();
   process.exit(0);
 }
 
-const scope = isTrustedPublisher ? "trusted" : "unverified";
-const packageOrigin = isTrustedPublisher
-  ? typeof productionDomain === "string" && productionDomain.length > 0
-    ? `https://${productionDomain}`
-    : undefined
-  : unverifiedPackageOrigin;
-if (typeof packageOrigin !== "string" || packageOrigin.length === 0) {
+const packageDomain = isTrustedPublisher ? productionDomain : previewDomain;
+if (typeof packageDomain !== "string" || packageDomain.length === 0) {
   throw new Error(
     isTrustedPublisher
       ? "VERCEL_PROJECT_PRODUCTION_URL is required for trusted package publishing."
-      : "EVE_PACKAGE_PUBLIC_ORIGIN is required for unverified package publishing.",
+      : "VERCEL_URL is required for preview package publishing.",
   );
 }
 
+const channel = isTrustedPublisher ? "main" : "preview";
 const originalPackageJson = await readFile(packageJsonPath, "utf8");
-const preparedPackageJson = preparePackageJson(JSON.parse(originalPackageJson), sourceSha, scope);
+const preparedPackageJson = preparePackageJson(JSON.parse(originalPackageJson), sourceSha, channel);
 const version = preparedPackageJson.version;
-const dependencyUrl = packageDependencyUrl(packageOrigin, sourceSha, scope);
-const artifactPath = isTrustedPublisher
-  ? packageArtifactPath(sourceSha)
-  : unverifiedPackageArtifactPath(sourceSha);
-const manifestPath = isTrustedPublisher
-  ? packageManifestPath(sourceSha)
-  : unverifiedPackageManifestPath(sourceSha);
+const dependencyUrl = isTrustedPublisher
+  ? packageDependencyUrl(`https://${packageDomain}`, sourceSha)
+  : previewPackageDependencyUrl(`https://${packageDomain}`);
 
 try {
   await rm(artifactDirectory, { force: true, recursive: true });
@@ -80,21 +59,55 @@ try {
     ...process.env,
     EVE_PACKAGE_DEPENDENCY_URL: dependencyUrl,
   });
+
+  if (isPreviewPackage) {
+    await mkdir(join(appRoot, "public"), { recursive: true });
+    await writeFile(join(appRoot, "public", "eve.tgz"), tarball);
+    await writeLandingPage();
+    process.stdout.write(`${JSON.stringify({ sourceSha, version, tarball: dependencyUrl })}\n`);
+    process.exit(0);
+  }
+
   const sha256 = createHash("sha256").update(tarball).digest("hex");
-  const manifest = { sourceSha, version, tarball: dependencyUrl, sha256, trust: scope };
-
-  await putImmutableArtifact(artifactPath, tarball, sha256);
-  await putImmutableManifest(manifestPath, manifest);
-
-  if (isUnverifiedPublisher && typeof pullRequest === "string") {
-    const pullRequestManifest = { ...manifest, pullRequest: Number(pullRequest) };
-    await put(unverifiedPullRequestManifestPath(pullRequest), JSON.stringify(pullRequestManifest), {
+  const artifactPath = packageArtifactPath(sourceSha);
+  try {
+    await put(artifactPath, tarball, {
       access: "private",
       addRandomSuffix: false,
-      allowOverwrite: true,
-      cacheControlMaxAge: 60,
+      allowOverwrite: false,
+      cacheControlMaxAge: 31_536_000,
+      contentType: "application/gzip",
+    });
+  } catch (error) {
+    if (!(error instanceof Error) || !error.message.includes("already exists")) throw error;
+    const publishedArtifact = await get(artifactPath, { access: "private", useCache: false });
+    if (publishedArtifact === null) {
+      throw new Error("Published package artifact could not be read.");
+    }
+    const publishedSha256 = createHash("sha256")
+      .update(Buffer.from(await new Response(publishedArtifact.stream).arrayBuffer()))
+      .digest("hex");
+    if (publishedSha256 !== sha256) {
+      throw new Error(`Commit ${sourceSha} was already published with different package contents.`);
+    }
+  }
+
+  const manifest = { sourceSha, version, tarball: dependencyUrl, sha256 };
+  const manifestPath = packageManifestPath(sourceSha);
+  const existingManifest = await get(manifestPath, { access: "private", useCache: false });
+  if (existingManifest === null) {
+    await put(manifestPath, JSON.stringify(manifest), {
+      access: "private",
+      addRandomSuffix: false,
+      allowOverwrite: false,
+      cacheControlMaxAge: 31_536_000,
       contentType: "application/json",
     });
+  } else {
+    const published = JSON.parse(await new Response(existingManifest.stream).text());
+    if (published.sha256 !== sha256) {
+      throw new Error(`Commit ${sourceSha} was already published with different package contents.`);
+    }
   }
 
   await writeLandingPage();
@@ -102,46 +115,6 @@ try {
 } finally {
   await writeFile(packageJsonPath, originalPackageJson);
   await rm(artifactDirectory, { force: true, recursive: true });
-}
-
-async function putImmutableArtifact(pathname, tarball, sha256) {
-  try {
-    await put(pathname, tarball, immutablePutOptions("application/gzip"));
-  } catch (error) {
-    if (!(error instanceof Error) || !error.message.includes("already exists")) throw error;
-    const published = await get(pathname, { access: "private", useCache: false });
-    if (published === null) throw new Error("Published package artifact could not be read.");
-    const publishedSha256 = createHash("sha256")
-      .update(Buffer.from(await new Response(published.stream).arrayBuffer()))
-      .digest("hex");
-    if (publishedSha256 !== sha256) {
-      throw new Error(`Commit ${sourceSha} was already published with different package contents.`);
-    }
-  }
-}
-
-async function putImmutableManifest(pathname, manifest) {
-  try {
-    await put(pathname, JSON.stringify(manifest), immutablePutOptions("application/json"));
-  } catch (error) {
-    if (!(error instanceof Error) || !error.message.includes("already exists")) throw error;
-    const published = await get(pathname, { access: "private", useCache: false });
-    if (published === null) throw new Error("Published package manifest could not be read.");
-    const existing = JSON.parse(await new Response(published.stream).text());
-    if (existing.sha256 !== manifest.sha256) {
-      throw new Error(`Commit ${sourceSha} was already published with different package contents.`);
-    }
-  }
-}
-
-function immutablePutOptions(contentType) {
-  return {
-    access: "private",
-    addRandomSuffix: false,
-    allowOverwrite: false,
-    cacheControlMaxAge: 31_536_000,
-    contentType,
-  };
 }
 
 async function writeLandingPage() {

--- a/apps/package-artifacts/scripts/prepare.mjs
+++ b/apps/package-artifacts/scripts/prepare.mjs
@@ -1,0 +1,58 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  PULL_REQUEST_PATTERN,
+  SHA_PATTERN,
+  packageDependencyUrl,
+  preparePackageJson,
+} from "../lib/package.mjs";
+import { packPackage } from "../lib/pack.mjs";
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = resolve(appRoot, "../..");
+const packageRoot = join(repoRoot, "packages/eve");
+const packageJsonPath = join(packageRoot, "package.json");
+const sourceSha = process.env.EVE_PACKAGE_SOURCE_SHA;
+const ref = process.env.EVE_PACKAGE_REF;
+const packageOrigin = process.env.EVE_PACKAGE_PUBLIC_ORIGIN;
+const outputDirectory = resolve(process.env.EVE_PACKAGE_OUTPUT_DIRECTORY ?? "package-artifact");
+
+if (!SHA_PATTERN.test(sourceSha ?? "")) {
+  throw new Error("EVE_PACKAGE_SOURCE_SHA must be a 40-character Git commit SHA.");
+}
+if (ref !== "main" && !PULL_REQUEST_PATTERN.test(ref ?? "")) {
+  throw new Error("EVE_PACKAGE_REF must be main or a positive pull request number.");
+}
+if (typeof packageOrigin !== "string" || packageOrigin.length === 0) {
+  throw new Error("EVE_PACKAGE_PUBLIC_ORIGIN is required.");
+}
+
+const originalPackageJson = await readFile(packageJsonPath, "utf8");
+const preparedPackageJson = preparePackageJson(JSON.parse(originalPackageJson), sourceSha, "git");
+const dependencyUrl = packageDependencyUrl(packageOrigin, sourceSha);
+
+try {
+  await writeFile(packageJsonPath, `${JSON.stringify(preparedPackageJson, null, 2)}\n`);
+  const tarball = await packPackage(packageRoot, preparedPackageJson.version, {
+    ...process.env,
+    EVE_PACKAGE_DEPENDENCY_URL: dependencyUrl,
+  });
+  const metadata = {
+    sourceSha,
+    ref,
+    version: preparedPackageJson.version,
+    tarball: dependencyUrl,
+    sha256: createHash("sha256").update(tarball).digest("hex"),
+  };
+
+  await rm(outputDirectory, { force: true, recursive: true });
+  await mkdir(outputDirectory, { recursive: true });
+  await writeFile(join(outputDirectory, "eve.tgz"), tarball);
+  await writeFile(join(outputDirectory, "metadata.json"), `${JSON.stringify(metadata)}\n`);
+  process.stdout.write(`${JSON.stringify(metadata)}\n`);
+} finally {
+  await writeFile(packageJsonPath, originalPackageJson);
+}

--- a/apps/package-artifacts/scripts/publish.mjs
+++ b/apps/package-artifacts/scripts/publish.mjs
@@ -1,0 +1,107 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+import { get, put } from "@vercel/blob";
+
+import {
+  PULL_REQUEST_PATTERN,
+  SHA_PATTERN,
+  packageArtifactPath,
+  packageManifestPath,
+  packagePointerPath,
+} from "../lib/package.mjs";
+
+const inputDirectory = resolve(process.env.EVE_PACKAGE_INPUT_DIRECTORY ?? "package-artifact");
+const expectedSha = process.env.EVE_PACKAGE_SOURCE_SHA;
+const expectedRef = process.env.EVE_PACKAGE_REF;
+const token = process.env.EVE_PACKAGE_BLOB_READ_WRITE_TOKEN;
+
+if (!SHA_PATTERN.test(expectedSha ?? "")) {
+  throw new Error("EVE_PACKAGE_SOURCE_SHA must be a 40-character Git commit SHA.");
+}
+if (expectedRef !== "main" && !PULL_REQUEST_PATTERN.test(expectedRef ?? "")) {
+  throw new Error("EVE_PACKAGE_REF must be main or a positive pull request number.");
+}
+if (typeof token !== "string" || token.length === 0) {
+  throw new Error("EVE_PACKAGE_BLOB_READ_WRITE_TOKEN is required.");
+}
+
+const tarball = await readFile(join(inputDirectory, "eve.tgz"));
+const metadata = JSON.parse(await readFile(join(inputDirectory, "metadata.json"), "utf8"));
+const sha256 = createHash("sha256").update(tarball).digest("hex");
+if (
+  metadata.sourceSha !== expectedSha ||
+  metadata.ref !== expectedRef ||
+  metadata.sha256 !== sha256 ||
+  typeof metadata.version !== "string" ||
+  typeof metadata.tarball !== "string"
+) {
+  throw new Error("Package artifact metadata does not match the trusted publication target.");
+}
+const expectedUrl = `https://pkg.eve.dev/${expectedSha}/eve.tgz`;
+if (metadata.tarball !== expectedUrl) {
+  throw new Error(`Package artifact URL must be ${expectedUrl}.`);
+}
+
+const manifest = {
+  sourceSha: expectedSha,
+  version: metadata.version,
+  tarball: expectedUrl,
+  sha256,
+};
+await putImmutableArtifact(packageArtifactPath(expectedSha), tarball, sha256);
+await putImmutableManifest(packageManifestPath(expectedSha), manifest);
+await put(packagePointerPath(expectedRef), JSON.stringify(manifest), {
+  access: "private",
+  addRandomSuffix: false,
+  allowOverwrite: true,
+  cacheControlMaxAge: 60,
+  contentType: "application/json",
+  token,
+});
+process.stdout.write(`${JSON.stringify(manifest)}\n`);
+
+async function putImmutableArtifact(pathname, bytes, expectedHash) {
+  try {
+    await put(pathname, bytes, immutableOptions("application/gzip"));
+  } catch (error) {
+    if (!(error instanceof Error) || !error.message.includes("already exists")) throw error;
+    const published = await get(pathname, { access: "private", useCache: false, token });
+    if (published === null) throw new Error("Published package artifact could not be read.");
+    const publishedHash = createHash("sha256")
+      .update(Buffer.from(await new Response(published.stream).arrayBuffer()))
+      .digest("hex");
+    if (publishedHash !== expectedHash) {
+      throw new Error(
+        `Commit ${expectedSha} was already published with different package contents.`,
+      );
+    }
+  }
+}
+
+async function putImmutableManifest(pathname, value) {
+  try {
+    await put(pathname, JSON.stringify(value), immutableOptions("application/json"));
+  } catch (error) {
+    if (!(error instanceof Error) || !error.message.includes("already exists")) throw error;
+    const published = await get(pathname, { access: "private", useCache: false, token });
+    if (published === null) throw new Error("Published package manifest could not be read.");
+    if (JSON.parse(await new Response(published.stream).text()).sha256 !== value.sha256) {
+      throw new Error(
+        `Commit ${expectedSha} was already published with different package contents.`,
+      );
+    }
+  }
+}
+
+function immutableOptions(contentType) {
+  return {
+    access: "private",
+    addRandomSuffix: false,
+    allowOverwrite: false,
+    cacheControlMaxAge: 31_536_000,
+    contentType,
+    token,
+  };
+}

--- a/apps/package-artifacts/scripts/publish.mjs
+++ b/apps/package-artifacts/scripts/publish.mjs
@@ -34,7 +34,8 @@ if (
   metadata.sourceSha !== expectedSha ||
   metadata.ref !== expectedRef ||
   metadata.sha256 !== sha256 ||
-  typeof metadata.version !== "string" ||
+  !/^\d+\.\d+\.\d+\+git\.[0-9a-f]{40}$/i.test(metadata.version ?? "") ||
+  !metadata.version.endsWith(`+git.${expectedSha}`) ||
   typeof metadata.tarball !== "string"
 ) {
   throw new Error("Package artifact metadata does not match the trusted publication target.");

--- a/apps/package-artifacts/vercel.json
+++ b/apps/package-artifacts/vercel.json
@@ -4,6 +4,8 @@
   "installCommand": "pnpm install --frozen-lockfile",
   "outputDirectory": "public",
   "rewrites": [
+    { "source": "/pr/:ref/eve.tgz", "destination": "/api/package?ref=:ref" },
+    { "source": "/pr/:ref/latest.json", "destination": "/api/package?ref=:ref&manifest=1" },
     { "source": "/:ref/eve.tgz", "destination": "/api/package?ref=:ref" },
     { "source": "/main/latest.json", "destination": "/api/package?ref=main&manifest=1" }
   ]

--- a/apps/package-artifacts/vercel.json
+++ b/apps/package-artifacts/vercel.json
@@ -4,10 +4,19 @@
   "installCommand": "pnpm install --frozen-lockfile",
   "outputDirectory": "public",
   "rewrites": [
-    { "source": "/:ref*/eve.tgz", "destination": "/api/package?ref=:ref" },
     {
-      "source": "/main/latest.json",
-      "destination": "/api/package?ref=main&manifest=1"
-    }
+      "source": "/unverified/sha/:sha/eve.tgz",
+      "destination": "/api/package?scope=unverified&ref=:sha"
+    },
+    {
+      "source": "/unverified/pr/:pr/eve.tgz",
+      "destination": "/api/package?scope=unverified&pr=:pr"
+    },
+    {
+      "source": "/unverified/pr/:pr/latest.json",
+      "destination": "/api/package?scope=unverified&pr=:pr&manifest=1"
+    },
+    { "source": "/:ref/eve.tgz", "destination": "/api/package?ref=:ref" },
+    { "source": "/main/latest.json", "destination": "/api/package?ref=main&manifest=1" }
   ]
 }

--- a/apps/package-artifacts/vercel.json
+++ b/apps/package-artifacts/vercel.json
@@ -4,18 +4,6 @@
   "installCommand": "pnpm install --frozen-lockfile",
   "outputDirectory": "public",
   "rewrites": [
-    {
-      "source": "/unverified/sha/:sha/eve.tgz",
-      "destination": "/api/package?scope=unverified&ref=:sha"
-    },
-    {
-      "source": "/unverified/pr/:pr/eve.tgz",
-      "destination": "/api/package?scope=unverified&pr=:pr"
-    },
-    {
-      "source": "/unverified/pr/:pr/latest.json",
-      "destination": "/api/package?scope=unverified&pr=:pr&manifest=1"
-    },
     { "source": "/:ref/eve.tgz", "destination": "/api/package?ref=:ref" },
     { "source": "/main/latest.json", "destination": "/api/package?ref=main&manifest=1" }
   ]

--- a/packages/eve/scripts/stamp-version-tokens.mjs
+++ b/packages/eve/scripts/stamp-version-tokens.mjs
@@ -39,7 +39,7 @@ if (typeof nodeEngine !== "string") {
   throw new Error("eve package.json is missing a string engines.node");
 }
 
-const evePackageDependencyVersion = process.env.EVE_MAIN_DEPENDENCY_URL ?? packageJson.version;
+const evePackageDependencyVersion = process.env.EVE_PACKAGE_DEPENDENCY_URL ?? packageJson.version;
 
 const replacements = {
   __EVE_PACKAGE_VERSION__: packageJson.version,


### PR DESCRIPTION
### Summary

Closes #2053. Contributors need a safe way to install an eve build from a pull request before it reaches `main`, without giving pull-request code access to the trusted package store. This adds a secretless build workflow and a separately trusted publisher workflow: `main` publishes automatically, while pull requests are published manually after the publisher verifies the current PR head and matching successful build. `pkg.eve.dev` serves mutable `/main` and `/pr/<number>` routes that redirect to immutable SHA-addressed tarballs, and generated projects pin the immutable URL.

The package host remains read-only: untrusted build code never receives the Blob token or controls publication paths. This branch also merges current `main` and preserves its shortened 16-character package version suffix for both main and PR artifacts.

### Validation

- `pnpm --filter eve-package-artifacts test` — 3 test files and 11 tests passed.
- `pnpm exec oxfmt --check .github/workflows/package-artifact-build.yml .github/workflows/package-artifact-publish.yml apps/package-artifacts packages/eve/scripts/stamp-version-tokens.mjs` — passed.
- `pnpm exec oxlint apps/package-artifacts packages/eve/scripts/stamp-version-tokens.mjs` — passed with 0 warnings and 0 errors.
- `EVE_PACKAGE_OUTPUT_DIRECTORY=<temporary directory> EVE_PACKAGE_PUBLIC_ORIGIN=https://pkg.eve.dev EVE_PACKAGE_REF=123 EVE_PACKAGE_SOURCE_SHA=<current SHA> pnpm --filter eve-package-artifacts package:prepare` — produced a gzip tarball and metadata with the expected PR ref, immutable URL, SHA-256, and `0.54.5+git.<16-char-sha>` version.
- GitHub commit verification and DCO checks pass for the pushed update.
- Local `actionlint` was unavailable; GitHub Actions validation is running on the PR.

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
