### PR TITLE
feat: register Slack Preview agent aliases

### DIFF
--- a/.changeset/slack-preview-agent-aliases.md
+++ b/.changeset/slack-preview-agent-aliases.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add Slack helpers for registering bot-owned Preview agent aliases and routing explicit user-group mentions to their registered remote agent.

--- a/packages/eve/src/public/channels/slack/index.ts
+++ b/packages/eve/src/public/channels/slack/index.ts
@@ -68,6 +68,19 @@ export {
 export { defaultSlackAuth } from "#public/channels/slack/defaults.js";
 
 export {
+  registerCurrentSlackPreviewAgent,
+  registerSlackPreviewAgent,
+  resolveSlackPreviewAgentRoute,
+  slackUserGroupMentions,
+  unregisterCurrentSlackPreviewAgent,
+  unregisterSlackPreviewAgent,
+  withoutSlackUserGroupMention,
+  type SlackPreviewAgentRegistration,
+  type SlackPreviewAgentRoute,
+  type SlackUserGroupMention,
+} from "#public/channels/slack/user-groups.js";
+
+export {
   describeActionRequest,
   describeActionRequests,
 } from "#public/channels/slack/action-status.js";

--- a/packages/eve/src/public/channels/slack/user-groups.test.ts
+++ b/packages/eve/src/public/channels/slack/user-groups.test.ts
@@ -62,9 +62,9 @@ describe("Slack Preview aliases", () => {
       {
         operation: "usergroups.create",
         body: {
-          description: `eve:preview-agent:v1:${JSON.stringify(registration)}`,
+          description: `eve:pa:1:${registration.url}`,
           handle: registration.alias,
-          name: registration.alias,
+          name: registration.branch,
           team_id: "T1",
         },
       },
@@ -92,13 +92,14 @@ describe("Slack Preview aliases", () => {
               handle: registration.alias,
               id: "S1",
               is_enabled: enabled,
+              name: registration.branch,
               updated_by: "UBOT",
             },
           ],
         };
       }
       if (operation === "usergroups.update") {
-        description = `eve:preview-agent:v1:${JSON.stringify(registration)}`;
+        description = `eve:pa:1:${registration.url}`;
         return { ok: true };
       }
       if (operation === "usergroups.enable") {
@@ -114,6 +115,7 @@ describe("Slack Preview aliases", () => {
     });
     await expect(resolveSlackPreviewAgentRoute("<!subteam^S1>", slack(request))).resolves.toEqual({
       ...registration,
+      description: "Preview Deployment for feature/preview.",
       id: "S1",
     });
     expect(calls).toEqual([
@@ -135,16 +137,18 @@ describe("Slack Preview aliases", () => {
           usergroups: [
             {
               created_by: "UBOT",
-              description: `eve:preview-agent:v1:${JSON.stringify(registration)}`,
+              description: `eve:pa:1:${registration.url}`,
               handle: registration.alias,
               id: "S1",
+              name: registration.branch,
               updated_by: "UBOT",
             },
             {
               created_by: "UBOT",
-              description: `eve:preview-agent:v1:${JSON.stringify({ ...registration, alias: "other" })}`,
+              description: `eve:pa:1:${registration.url}`,
               handle: "other",
               id: "S2",
+              name: registration.branch,
               updated_by: "UBOT",
             },
           ],
@@ -156,6 +160,7 @@ describe("Slack Preview aliases", () => {
       resolveSlackPreviewAgentRoute("<!subteam^S1> investigate", slack(request)),
     ).resolves.toEqual({
       ...registration,
+      description: "Preview Deployment for feature/preview.",
       id: "S1",
     });
     await expect(

--- a/packages/eve/src/public/channels/slack/user-groups.test.ts
+++ b/packages/eve/src/public/channels/slack/user-groups.test.ts
@@ -75,6 +75,57 @@ describe("Slack Preview aliases", () => {
     ]);
   });
 
+  it("re-enables an unregistered alias so its next mention resolves", async () => {
+    const calls: string[] = [];
+    let enabled = false;
+    let description = "";
+    const request = async (operation: string): Promise<SlackApiResponse> => {
+      calls.push(operation);
+      if (operation === "auth.test") return { ok: true, team_id: "T1", user_id: "UBOT" };
+      if (operation === "usergroups.list") {
+        return {
+          ok: true,
+          usergroups: [
+            {
+              created_by: "UBOT",
+              description,
+              handle: registration.alias,
+              id: "S1",
+              is_enabled: enabled,
+              updated_by: "UBOT",
+            },
+          ],
+        };
+      }
+      if (operation === "usergroups.update") {
+        description = `eve:preview-agent:v1:${JSON.stringify(registration)}`;
+        return { ok: true };
+      }
+      if (operation === "usergroups.enable") {
+        enabled = true;
+        return { ok: true };
+      }
+      throw new Error(`Unexpected ${operation}`);
+    };
+
+    await expect(registerSlackPreviewAgent(registration, slack(request))).resolves.toEqual({
+      ...registration,
+      id: "S1",
+    });
+    await expect(resolveSlackPreviewAgentRoute("<!subteam^S1>", slack(request))).resolves.toEqual({
+      ...registration,
+      id: "S1",
+    });
+    expect(calls).toEqual([
+      "auth.test",
+      "usergroups.list",
+      "usergroups.update",
+      "usergroups.enable",
+      "auth.test",
+      "usergroups.list",
+    ]);
+  });
+
   it("resolves exactly one owned alias and rejects ambiguity", async () => {
     const request = async (operation: string): Promise<SlackApiResponse> => {
       if (operation === "auth.test") return { ok: true, team_id: "T1", user_id: "UBOT" };

--- a/packages/eve/src/public/channels/slack/user-groups.test.ts
+++ b/packages/eve/src/public/channels/slack/user-groups.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+
+import type { SlackApiResponse } from "#public/channels/slack/api.js";
+import {
+  registerSlackPreviewAgent,
+  resolveSlackPreviewAgentRoute,
+  slackUserGroupMentions,
+  unregisterSlackPreviewAgent,
+  withoutSlackUserGroupMention,
+} from "#public/channels/slack/user-groups.js";
+
+const slack = (request: (operation: string, body: unknown) => Promise<SlackApiResponse>) => ({
+  request,
+  teamId: "T1",
+});
+
+const registration = {
+  alias: "preview-feature",
+  branch: "feature/preview",
+  description: "Feature preview.",
+  url: "https://preview.example.com",
+};
+
+describe("slackUserGroupMentions", () => {
+  it("returns unique opaque group ids in mention order", () => {
+    expect(
+      slackUserGroupMentions("Ask <!subteam^S123|preview> then <!subteam^S456>. <!subteam^S123>"),
+    ).toEqual([{ id: "S123" }, { id: "S456" }]);
+  });
+});
+
+describe("withoutSlackUserGroupMention", () => {
+  it("removes only the selected group mention", () => {
+    expect(
+      withoutSlackUserGroupMention("<!subteam^S123|preview> check <!subteam^S456>", "S123"),
+    ).toBe("check <!subteam^S456>");
+  });
+});
+
+describe("Slack Preview aliases", () => {
+  it("creates a bot-owned user group with versioned route metadata", async () => {
+    const calls: Array<{ operation: string; body: unknown }> = [];
+    const route = await registerSlackPreviewAgent(
+      registration,
+      slack(async (operation, body) => {
+        calls.push({ operation, body });
+        if (operation === "auth.test") return { ok: true, team_id: "T1", user_id: "UBOT" };
+        if (operation === "usergroups.list") return { ok: true, usergroups: [] };
+        if (operation === "usergroups.create") return { ok: true, usergroup: { id: "S1" } };
+        if (operation === "usergroups.users.update") return { ok: true };
+        throw new Error(`Unexpected ${operation}`);
+      }),
+    );
+
+    expect(route).toEqual({ ...registration, id: "S1" });
+    expect(calls).toEqual([
+      { operation: "auth.test", body: {} },
+      {
+        operation: "usergroups.list",
+        body: { include_disabled: true, include_users: true, team_id: "T1" },
+      },
+      {
+        operation: "usergroups.create",
+        body: {
+          description: `eve:preview-agent:v1:${JSON.stringify(registration)}`,
+          handle: registration.alias,
+          name: registration.alias,
+          team_id: "T1",
+        },
+      },
+      {
+        operation: "usergroups.users.update",
+        body: { team_id: "T1", usergroup: "S1", users: "UBOT" },
+      },
+    ]);
+  });
+
+  it("resolves exactly one owned alias and rejects ambiguity", async () => {
+    const request = async (operation: string): Promise<SlackApiResponse> => {
+      if (operation === "auth.test") return { ok: true, team_id: "T1", user_id: "UBOT" };
+      if (operation === "usergroups.list") {
+        return {
+          ok: true,
+          usergroups: [
+            {
+              created_by: "UBOT",
+              description: `eve:preview-agent:v1:${JSON.stringify(registration)}`,
+              handle: registration.alias,
+              id: "S1",
+              updated_by: "UBOT",
+            },
+            {
+              created_by: "UBOT",
+              description: `eve:preview-agent:v1:${JSON.stringify({ ...registration, alias: "other" })}`,
+              handle: "other",
+              id: "S2",
+              updated_by: "UBOT",
+            },
+          ],
+        };
+      }
+      throw new Error(`Unexpected ${operation}`);
+    };
+    await expect(
+      resolveSlackPreviewAgentRoute("<!subteam^S1> investigate", slack(request)),
+    ).resolves.toEqual({
+      ...registration,
+      id: "S1",
+    });
+    await expect(
+      resolveSlackPreviewAgentRoute("<!subteam^S1> <!subteam^S2>", slack(request)),
+    ).rejects.toThrow("exactly one");
+  });
+
+  it("does not resolve a group the bot does not own", async () => {
+    await expect(
+      resolveSlackPreviewAgentRoute(
+        "<!subteam^S1>",
+        slack(async (operation): Promise<SlackApiResponse> => {
+          if (operation === "auth.test") return { ok: true, team_id: "T1", user_id: "UBOT" };
+          if (operation === "usergroups.list") {
+            return {
+              ok: true,
+              usergroups: [
+                {
+                  created_by: "UHUMAN",
+                  handle: registration.alias,
+                  id: "S1",
+                  updated_by: "UHUMAN",
+                },
+              ],
+            };
+          }
+          throw new Error(`Unexpected ${operation}`);
+        }),
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("disables an owned alias", async () => {
+    const calls: string[] = [];
+    await expect(
+      unregisterSlackPreviewAgent(
+        registration.alias,
+        slack(async (operation): Promise<SlackApiResponse> => {
+          calls.push(operation);
+          if (operation === "auth.test") return { ok: true, team_id: "T1", user_id: "UBOT" };
+          if (operation === "usergroups.list") {
+            return {
+              ok: true,
+              usergroups: [
+                { created_by: "UBOT", handle: registration.alias, id: "S1", updated_by: "UBOT" },
+              ],
+            };
+          }
+          if (operation === "usergroups.disable") return { ok: true };
+          throw new Error(`Unexpected ${operation}`);
+        }),
+      ),
+    ).resolves.toBe(true);
+    expect(calls).toEqual(["auth.test", "usergroups.list", "usergroups.disable"]);
+  });
+});

--- a/packages/eve/src/public/channels/slack/user-groups.test.ts
+++ b/packages/eve/src/public/channels/slack/user-groups.test.ts
@@ -188,6 +188,22 @@ describe("Slack Preview aliases", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("includes Slack's required scope in failed API errors", async () => {
+    await expect(
+      registerSlackPreviewAgent(
+        registration,
+        slack(async (operation): Promise<SlackApiResponse> => {
+          if (operation === "auth.test") return { ok: true, team_id: "T1", user_id: "UBOT" };
+          if (operation === "usergroups.list") return { ok: true, usergroups: [] };
+          if (operation === "usergroups.create") {
+            return { error: "missing_scope", needed: "usergroups:write", ok: false };
+          }
+          throw new Error(`Unexpected ${operation}`);
+        }),
+      ),
+    ).rejects.toThrow("missing_scope (required scope: usergroups:write)");
+  });
+
   it("disables an owned alias", async () => {
     const calls: string[] = [];
     await expect(

--- a/packages/eve/src/public/channels/slack/user-groups.ts
+++ b/packages/eve/src/public/channels/slack/user-groups.ts
@@ -92,6 +92,13 @@ export async function registerSlackPreviewAgent(
       usergroup: existing.id,
     });
     requireOk("usergroups.update", updated);
+    if (!existing.enabled) {
+      const enabled = await slack.request("usergroups.enable", {
+        team_id: teamId,
+        usergroup: existing.id,
+      });
+      requireOk("usergroups.enable", enabled);
+    }
     return { ...route, id: existing.id };
   }
 
@@ -235,6 +242,7 @@ function userGroups(response: SlackApiResponse): Array<{
   id: string;
   handle: string;
   description?: string;
+  enabled: boolean;
   record: Record<string, unknown>;
 }> {
   if (!Array.isArray(response.usergroups)) return [];
@@ -245,7 +253,15 @@ function userGroups(response: SlackApiResponse): Array<{
     const handle = optionalString(record.handle);
     return id === undefined || handle === undefined
       ? []
-      : [{ id, handle, description: optionalString(record.description), record }];
+      : [
+          {
+            id,
+            handle,
+            description: optionalString(record.description),
+            enabled: record.is_enabled !== false,
+            record,
+          },
+        ];
   });
 }
 

--- a/packages/eve/src/public/channels/slack/user-groups.ts
+++ b/packages/eve/src/public/channels/slack/user-groups.ts
@@ -277,8 +277,11 @@ function isOwnedBy(group: Record<string, unknown> | undefined, userId: string): 
 
 function requireOk(operation: string, response: SlackApiResponse): void {
   if (response.ok) return;
+  const needed = optionalString(response.needed);
   throw new Error(
-    `Slack ${operation} failed: ${optionalString(response.error) ?? "unknown_error"}.`,
+    `Slack ${operation} failed: ${optionalString(response.error) ?? "unknown_error"}${
+      needed === undefined ? "" : ` (required scope: ${needed})`
+    }.`,
   );
 }
 

--- a/packages/eve/src/public/channels/slack/user-groups.ts
+++ b/packages/eve/src/public/channels/slack/user-groups.ts
@@ -4,7 +4,7 @@ import { ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
 import type { SlackApiResponse, SlackHandle } from "#public/channels/slack/api.js";
 
 const USER_GROUP_MENTION = /<!subteam\^([A-Z0-9]+)(?:\|[^>]+)?>/gu;
-const PREVIEW_AGENT_ROUTE_PREFIX = "eve:preview-agent:v1:";
+const PREVIEW_AGENT_ROUTE_PREFIX = "eve:pa:1:";
 
 /** One Slack user-group mention found in message text. */
 export interface SlackUserGroupMention {
@@ -87,7 +87,7 @@ export async function registerSlackPreviewAgent(
     const updated = await slack.request("usergroups.update", {
       description: encodePreviewAgentRoute(route),
       handle: route.alias,
-      name: route.alias,
+      name: route.branch,
       team_id: teamId,
       usergroup: existing.id,
     });
@@ -105,7 +105,7 @@ export async function registerSlackPreviewAgent(
   const created = await slack.request("usergroups.create", {
     description: encodePreviewAgentRoute(route),
     handle: route.alias,
-    name: route.alias,
+    name: route.branch,
     team_id: teamId,
   });
   requireOk("usergroups.create", created);
@@ -167,7 +167,11 @@ export async function resolveSlackPreviewAgentRoute(
   const routes = mentions.flatMap((mention) => {
     const group = userGroups(listed).find((candidate) => candidate.id === mention.id);
     if (group === undefined || !isOwnedBy(group.record, userId)) return [];
-    const route = decodePreviewAgentRoute(group.description);
+    const route = decodePreviewAgentRoute({
+      alias: group.handle,
+      branch: group.name,
+      value: group.description,
+    });
     return route === undefined ? [] : [{ ...route, id: group.id }];
   });
   if (routes.length > 1) throw new Error("Mention exactly one registered Preview agent.");
@@ -224,15 +228,25 @@ function normalizeAlias(value: string): string {
 }
 
 function encodePreviewAgentRoute(route: Omit<SlackPreviewAgentRoute, "id">): string {
-  return `${PREVIEW_AGENT_ROUTE_PREFIX}${JSON.stringify(route)}`;
+  return `${PREVIEW_AGENT_ROUTE_PREFIX}${route.url}`;
 }
 
-function decodePreviewAgentRoute(value: unknown): Omit<SlackPreviewAgentRoute, "id"> | undefined {
-  if (typeof value !== "string" || !value.startsWith(PREVIEW_AGENT_ROUTE_PREFIX)) return undefined;
+function decodePreviewAgentRoute(input: {
+  readonly alias: string;
+  readonly branch: string | undefined;
+  readonly value: unknown;
+}): Omit<SlackPreviewAgentRoute, "id"> | undefined {
+  if (typeof input.value !== "string" || !input.value.startsWith(PREVIEW_AGENT_ROUTE_PREFIX)) {
+    return undefined;
+  }
+  if (input.branch === undefined) return undefined;
   try {
-    const parsed = JSON.parse(value.slice(PREVIEW_AGENT_ROUTE_PREFIX.length));
-    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
-    return normalizePreviewAgentRegistration(parsed as SlackPreviewAgentRegistration);
+    return normalizePreviewAgentRegistration({
+      alias: input.alias,
+      branch: input.branch,
+      description: `Preview Deployment for ${input.branch}.`,
+      url: input.value.slice(PREVIEW_AGENT_ROUTE_PREFIX.length),
+    });
   } catch {
     return undefined;
   }
@@ -243,6 +257,7 @@ function userGroups(response: SlackApiResponse): Array<{
   handle: string;
   description?: string;
   enabled: boolean;
+  name?: string;
   record: Record<string, unknown>;
 }> {
   if (!Array.isArray(response.usergroups)) return [];
@@ -259,6 +274,7 @@ function userGroups(response: SlackApiResponse): Array<{
             handle,
             description: optionalString(record.description),
             enabled: record.is_enabled !== false,
+            name: optionalString(record.name),
             record,
           },
         ];

--- a/packages/eve/src/public/channels/slack/user-groups.ts
+++ b/packages/eve/src/public/channels/slack/user-groups.ts
@@ -1,0 +1,287 @@
+import { buildAdapterContext } from "#channel/adapter-context.js";
+import { loadContext } from "#context/container.js";
+import { ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
+import type { SlackApiResponse, SlackHandle } from "#public/channels/slack/api.js";
+
+const USER_GROUP_MENTION = /<!subteam\^([A-Z0-9]+)(?:\|[^>]+)?>/gu;
+const PREVIEW_AGENT_ROUTE_PREFIX = "eve:preview-agent:v1:";
+
+/** One Slack user-group mention found in message text. */
+export interface SlackUserGroupMention {
+  readonly id: string;
+}
+
+/** Durable route metadata owned by the Slack bot's user group. */
+export interface SlackPreviewAgentRoute {
+  readonly alias: string;
+  readonly branch: string;
+  readonly description: string;
+  readonly id: string;
+  readonly url: string;
+}
+
+/** Input used when registering a Preview agent's Slack alias. */
+export interface SlackPreviewAgentRegistration {
+  readonly alias: string;
+  readonly branch: string;
+  readonly description: string;
+  readonly url: string;
+}
+
+/** Returns unique Slack user-group ids mentioned in text in first-mention order. */
+export function slackUserGroupMentions(text: string): readonly SlackUserGroupMention[] {
+  const seen = new Set<string>();
+  const mentions: SlackUserGroupMention[] = [];
+  for (const match of text.matchAll(USER_GROUP_MENTION)) {
+    const id = match[1];
+    if (id === undefined || seen.has(id)) continue;
+    seen.add(id);
+    mentions.push({ id });
+  }
+  return mentions;
+}
+
+/** Removes one recognized user-group mention using normalized Slack whitespace. */
+export function withoutSlackUserGroupMention(text: string, userGroupId: string): string {
+  return text
+    .replace(USER_GROUP_MENTION, (mention, id: string) => (id === userGroupId ? "" : mention))
+    .replace(/\s+/gu, " ")
+    .trim();
+}
+
+/** Registers a Preview alias with the Slack bot bound to the active tool session. */
+export async function registerCurrentSlackPreviewAgent(
+  input: SlackPreviewAgentRegistration,
+): Promise<SlackPreviewAgentRoute> {
+  return await registerSlackPreviewAgent(input, currentSlack());
+}
+
+/** Disables a Preview alias with the Slack bot bound to the active tool session. */
+export async function unregisterCurrentSlackPreviewAgent(alias: string): Promise<boolean> {
+  return await unregisterSlackPreviewAgent(alias, currentSlack());
+}
+
+/** Creates or updates a bot-owned Slack user group used as a Preview alias. */
+export async function registerSlackPreviewAgent(
+  input: SlackPreviewAgentRegistration,
+  slack: Pick<SlackHandle, "request" | "teamId">,
+): Promise<SlackPreviewAgentRoute> {
+  const route = normalizePreviewAgentRegistration(input);
+  const teamId = required(slack.teamId, "Slack did not provide a workspace id.");
+  const self = await slack.request("auth.test", {});
+  requireOk("auth.test", self);
+  requireMatchingTeam(self, teamId);
+  const userId = requiredString(self.user_id, "Slack returned no bot user id.");
+
+  const listed = await slack.request("usergroups.list", {
+    include_disabled: true,
+    include_users: true,
+    team_id: teamId,
+  });
+  requireOk("usergroups.list", listed);
+  const existing = userGroups(listed).find((group) => group.handle === route.alias);
+  if (existing !== undefined) {
+    if (!isOwnedBy(existing.record, userId)) {
+      throw new Error(`Slack alias "${route.alias}" is already owned by another user.`);
+    }
+    const updated = await slack.request("usergroups.update", {
+      description: encodePreviewAgentRoute(route),
+      handle: route.alias,
+      name: route.alias,
+      team_id: teamId,
+      usergroup: existing.id,
+    });
+    requireOk("usergroups.update", updated);
+    return { ...route, id: existing.id };
+  }
+
+  const created = await slack.request("usergroups.create", {
+    description: encodePreviewAgentRoute(route),
+    handle: route.alias,
+    name: route.alias,
+    team_id: teamId,
+  });
+  requireOk("usergroups.create", created);
+  const group = groupRecord(created.usergroup);
+  const id = requiredString(group?.id, "Slack returned no user-group id.");
+  const members = await slack.request("usergroups.users.update", {
+    team_id: teamId,
+    usergroup: id,
+    users: userId,
+  });
+  requireOk("usergroups.users.update", members);
+  return { ...route, id };
+}
+
+/** Disables a bot-owned alias, leaving Slack's immutable mention history intact. */
+export async function unregisterSlackPreviewAgent(
+  alias: string,
+  slack: Pick<SlackHandle, "request" | "teamId">,
+): Promise<boolean> {
+  const normalizedAlias = normalizeAlias(alias);
+  const teamId = required(slack.teamId, "Slack did not provide a workspace id.");
+  const [self, listed] = await Promise.all([
+    slack.request("auth.test", {}),
+    slack.request("usergroups.list", { include_disabled: true, team_id: teamId }),
+  ]);
+  requireOk("auth.test", self);
+  requireOk("usergroups.list", listed);
+  requireMatchingTeam(self, teamId);
+  const userId = requiredString(self.user_id, "Slack returned no bot user id.");
+  const existing = userGroups(listed).find((group) => group.handle === normalizedAlias);
+  if (existing === undefined) return false;
+  if (!isOwnedBy(existing.record, userId)) {
+    throw new Error(`Slack alias "${normalizedAlias}" is already owned by another user.`);
+  }
+  const response = await slack.request("usergroups.disable", {
+    team_id: teamId,
+    usergroup: existing.id,
+  });
+  requireOk("usergroups.disable", response);
+  return true;
+}
+
+/** Resolves exactly one bot-owned Preview alias in a message, or returns no route. */
+export async function resolveSlackPreviewAgentRoute(
+  text: string,
+  slack: Pick<SlackHandle, "request" | "teamId">,
+): Promise<SlackPreviewAgentRoute | undefined> {
+  const mentions = slackUserGroupMentions(text);
+  if (mentions.length === 0) return undefined;
+  const teamId = required(slack.teamId, "Slack did not provide a workspace id.");
+  const [self, listed] = await Promise.all([
+    slack.request("auth.test", {}),
+    slack.request("usergroups.list", { include_disabled: false, team_id: teamId }),
+  ]);
+  requireOk("auth.test", self);
+  requireOk("usergroups.list", listed);
+  requireMatchingTeam(self, teamId);
+  const userId = requiredString(self.user_id, "Slack returned no bot user id.");
+  const routes = mentions.flatMap((mention) => {
+    const group = userGroups(listed).find((candidate) => candidate.id === mention.id);
+    if (group === undefined || !isOwnedBy(group.record, userId)) return [];
+    const route = decodePreviewAgentRoute(group.description);
+    return route === undefined ? [] : [{ ...route, id: group.id }];
+  });
+  if (routes.length > 1) throw new Error("Mention exactly one registered Preview agent.");
+  return routes[0];
+}
+
+function currentSlack(): Pick<SlackHandle, "request" | "teamId"> {
+  const ctx = loadContext();
+  const adapterContext = buildAdapterContext(ctx.require(ChannelKey), ctx);
+  const slack = Reflect.get(adapterContext, "slack");
+  if (slack === null || typeof slack !== "object") {
+    throw new Error("Slack Preview aliases can only be managed from a Slack channel session.");
+  }
+  const request = Reflect.get(slack, "request");
+  const teamId = Reflect.get(slack, "teamId");
+  if (typeof request !== "function" || (teamId !== undefined && typeof teamId !== "string")) {
+    throw new Error("Slack Preview aliases can only be managed from a Slack channel session.");
+  }
+  return { request: request as SlackHandle["request"], teamId };
+}
+
+function normalizePreviewAgentRegistration(
+  input: SlackPreviewAgentRegistration,
+): Omit<SlackPreviewAgentRoute, "id"> {
+  const branch = required(input.branch.trim(), "Preview branch is required.");
+  const description = required(input.description.trim(), "Preview description is required.");
+  let url: URL;
+  try {
+    url = new URL(input.url);
+  } catch {
+    throw new Error("Preview URL must be a valid HTTPS origin.");
+  }
+  if (
+    url.protocol !== "https:" ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash ||
+    url.pathname !== "/"
+  ) {
+    throw new Error("Preview URL must be a plain HTTPS origin.");
+  }
+  return { alias: normalizeAlias(input.alias), branch, description, url: url.origin };
+}
+
+function normalizeAlias(value: string): string {
+  const alias = value.trim().toLowerCase();
+  if (!/^[a-z0-9][a-z0-9._-]{0,79}$/u.test(alias)) {
+    throw new Error(
+      "Preview alias must be 1–80 lowercase letters, digits, dots, underscores, or hyphens.",
+    );
+  }
+  return alias;
+}
+
+function encodePreviewAgentRoute(route: Omit<SlackPreviewAgentRoute, "id">): string {
+  return `${PREVIEW_AGENT_ROUTE_PREFIX}${JSON.stringify(route)}`;
+}
+
+function decodePreviewAgentRoute(value: unknown): Omit<SlackPreviewAgentRoute, "id"> | undefined {
+  if (typeof value !== "string" || !value.startsWith(PREVIEW_AGENT_ROUTE_PREFIX)) return undefined;
+  try {
+    const parsed = JSON.parse(value.slice(PREVIEW_AGENT_ROUTE_PREFIX.length));
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+    return normalizePreviewAgentRegistration(parsed as SlackPreviewAgentRegistration);
+  } catch {
+    return undefined;
+  }
+}
+
+function userGroups(response: SlackApiResponse): Array<{
+  id: string;
+  handle: string;
+  description?: string;
+  record: Record<string, unknown>;
+}> {
+  if (!Array.isArray(response.usergroups)) return [];
+  return response.usergroups.flatMap((value) => {
+    const record = groupRecord(value);
+    if (record === undefined) return [];
+    const id = optionalString(record.id);
+    const handle = optionalString(record.handle);
+    return id === undefined || handle === undefined
+      ? []
+      : [{ id, handle, description: optionalString(record.description), record }];
+  });
+}
+
+function groupRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function isOwnedBy(group: Record<string, unknown> | undefined, userId: string): boolean {
+  return group?.created_by === userId && group.updated_by === userId;
+}
+
+function requireOk(operation: string, response: SlackApiResponse): void {
+  if (response.ok) return;
+  throw new Error(
+    `Slack ${operation} failed: ${optionalString(response.error) ?? "unknown_error"}.`,
+  );
+}
+
+function requireMatchingTeam(response: SlackApiResponse, teamId: string): void {
+  const authenticatedTeam = optionalString(response.team_id);
+  if (authenticatedTeam !== undefined && authenticatedTeam !== teamId) {
+    throw new Error("Slack authenticated a different workspace.");
+  }
+}
+
+function required(value: string | undefined, message: string): string {
+  if (!value) throw new Error(message);
+  return value;
+}
+
+function requiredString(value: unknown, message: string): string {
+  return required(optionalString(value) ?? "", message);
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}


### PR DESCRIPTION
### Summary

Related to #1955. Adds Slack-owned Preview agent aliases backed by bot-owned Slack user groups. The helpers register or disable an alias, verify bot ownership before reading or mutating it, preserve versioned route metadata, and resolve exactly one explicit user-group mention for `ctx.route(...)`.

The framework keeps Slack credentials in the channel adapter. Applications opt in by authoring an approval-gated management tool and authorization policy; the demo health-checks the supplied Preview URL with Vercel OIDC before registering it. Messages without a registered alias retain normal local handling.

### Validation

- `pnpm guard:invariants`
- `pnpm --filter eve exec tsc --noEmit --pretty false -p tsconfig.json`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/channels/slack/user-groups.test.ts` (6 tests)
- Demo app: `pnpm typecheck`, `pnpm build`

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
