### PR TITLE
fix(eve): default init to current directory

### DIFF
--- a/.changeset/quiet-cougars-buy.md
+++ b/.changeset/quiet-cougars-buy.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+`eve init` now scaffolds the current directory when no target is provided, including when launched by a coding agent.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -40,11 +40,11 @@ eve init [target] [--model <provider/model-id>] [--reasoning <effort>] [--channe
 
 Creates a new agent app or adds an agent to an existing app. Always installs dependencies. New directories also initialize Git.
 
-| Target                                    | What happens                                                                                                                                             |
-| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `eve init my-agent`                       | New agent project in `my-agent/`                                                                                                                         |
-| `eve init .` (or an existing project dir) | Adds `agent/` plus missing `eve`, `ai`, and `zod` deps. Needs a `package.json` and no `agent/` files yet                                                 |
-| `eve init` with no target                 | Same as `eve init .`, except coding agents (Claude Code, Cursor, and similar) get a setup guide instead of scaffolding — they have not chosen a name yet |
+| Target                                    | What happens                                                                                             |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `eve init my-agent`                       | New agent project in `my-agent/`                                                                         |
+| `eve init .` (or an existing project dir) | Adds `agent/` plus missing `eve`, `ai`, and `zod` deps. Needs a `package.json` and no `agent/` files yet |
+| `eve init` with no target                 | Same as `eve init .`                                                                                     |
 
 After scaffolding, a human terminal usually continues into `eve dev`. If a coding-agent REPL is on `PATH`, the handoff menu can open it instead or exit without starting either process. Coding-agent launches print the next steps instead of opening the TUI, so the session does not get stuck. Fresh projects use the parent workspace's package manager when there is one; otherwise they use the manager that launched `eve init`.
 

--- a/packages/eve/src/cli/commands/agent-instructions.ts
+++ b/packages/eve/src/cli/commands/agent-instructions.ts
@@ -2,10 +2,11 @@ import { readFileSync } from "node:fs";
 
 // The two coding-agent prompts are one onboarding flow in two phases, composed
 // from the section files in `agent-prompt/`. The setup guide runs before
-// anything is scaffolded (a bare `eve init`); the handoff runs once a project
-// exists (after `eve init <name>`, or when seeding a REPL). They share the
-// `collect-intent`, `vercel-connect`, and `build-and-verify` sections verbatim,
-// so guidance authored once reaches both. `{{devCommand}}` is rendered per
+// anything is scaffolded when malformed init input prevents the command from
+// running; the handoff runs once a project exists (after `eve init`, or when
+// seeding a REPL). Both reuse the `collect-intent`, `vercel-connect`, and
+// `build-and-verify` sections verbatim, so guidance authored once reaches both.
+// `{{devCommand}}` is rendered per
 // caller; `{{workingDirectory}}` is post-scaffold only and lives in the handoff
 // intro. The shared sections use paths relative to the project directory so the
 // setup guide, which has no working directory yet, can reuse them unchanged.
@@ -46,15 +47,15 @@ function compose(
 }
 
 /**
- * The pre-scaffold setup guide, shown when a coding agent runs a bare
- * `eve init`. It scaffolds from scratch, so it renders with the universal
- * `npx eve dev` rather than a launcher-specific command.
+ * The pre-scaffold setup guide shown after malformed coding-agent input. It
+ * scaffolds from scratch, so it renders with the universal `npx eve dev` rather
+ * than a launcher-specific command.
  */
 export function initAgentInstructions(): string {
   return compose(SETUP_SECTIONS, { devCommand: "npx eve dev" });
 }
 
-/** The post-scaffold handoff printed after a coding agent runs `eve init <name>`. */
+/** The post-scaffold handoff printed after a coding agent runs `eve init`. */
 export function initAgentDevHandoff(options: { projectPath: string; devCommand: string }): string {
   return compose(HANDOFF_SECTIONS, {
     devCommand: options.devCommand,

--- a/packages/eve/src/cli/commands/init.integration.test.ts
+++ b/packages/eve/src/cli/commands/init.integration.test.ts
@@ -1047,7 +1047,7 @@ describe("runInitCommand", () => {
     expect(deps.runPackageManagerInstall).not.toHaveBeenCalled();
   });
 
-  it("hands a coding agent the setup guide when it omits the target", async () => {
+  it("scaffolds the current directory for a coding agent that omits the target", async () => {
     const parentDirectory = await mkdtemp(join(tmpdir(), "eve-init-agent-bare-"));
     const output = logger();
     const deps = dependencies();
@@ -1055,15 +1055,19 @@ describe("runInitCommand", () => {
 
     await runInitCommand(output, parentDirectory, undefined, {}, deps);
 
-    // A bare `eve init` from an agent means it has not chosen what to build, so
-    // we print the guide and touch nothing — no scaffold, install, Git, or dev.
-    await expect(pathExists(join(parentDirectory, "agent"))).resolves.toBe(false);
-    expect(deps.runPackageManagerInstall).not.toHaveBeenCalled();
-    expect(deps.tryInitializeGit).not.toHaveBeenCalled();
+    expect(await readFile(join(parentDirectory, "agent/agent.ts"), "utf8")).toContain(
+      DEFAULT_AGENT_MODEL_ID,
+    );
+    expect(deps.runPackageManagerInstall).toHaveBeenCalledWith(
+      "pnpm",
+      parentDirectory,
+      expect.anything(),
+    );
+    expect(deps.tryInitializeGit).toHaveBeenCalledWith(parentDirectory);
+    expect(deps.selectInitHandoff).not.toHaveBeenCalled();
+    expect(deps.spawnCodingAgentRepl).not.toHaveBeenCalled();
     expect(deps.spawnPackageManager).not.toHaveBeenCalled();
-    const printed = output.messages.join("\n");
-    expect(printed).toContain("Set up an eve agent");
-    expect(printed).toContain("npx eve@latest init <name>");
+    expect(output.messages.join("\n")).toContain("Created an eve agent in");
   });
 
   it("scaffolds and initializes Git for a coding agent but does not spawn the dev server", async () => {

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -36,11 +36,7 @@ import {
   type EvePackageContract,
 } from "#setup/scaffold/create/project.js";
 
-import {
-  initAgentDevHandoff,
-  initAgentInstructions,
-  initAgentReplPrompt,
-} from "./agent-instructions.js";
+import { initAgentDevHandoff, initAgentReplPrompt } from "./agent-instructions.js";
 import { tryInitializeGit, type GitInitResult } from "./init-git.js";
 import { selectInitHandoff, spawnCodingAgentRepl, type InitHandoff } from "./init-repl.js";
 
@@ -463,9 +459,6 @@ async function runInitSteps(input: {
  *
  * Runs launched by a coding agent get the dev command printed instead of
  * spawned after scaffolding, since the dev TUI would wedge the launching agent.
- * A coding agent that omits the target entirely gets the setup guide printed and
- * nothing scaffolded, since a bare `eve init` means it has not yet chosen what to
- * build.
  *
  * For extension packages, use `eve extension init` instead.
  */
@@ -476,15 +469,6 @@ export async function runInitCommand(
   options: InitCommandOptions,
   dependencies: InitCommandDependencies = defaultDependencies,
 ): Promise<void> {
-  // A coding agent that runs `eve init` with no target has not decided what to
-  // build yet. Hand it the setup guide (collect intent, then re-run with an
-  // explicit target) rather than silently scaffolding the current directory. A
-  // human, or an explicit `.`/`<name>`, still scaffolds.
-  if (target === undefined && (await dependencies.isCodingAgentLaunch())) {
-    logger.log(initAgentInstructions());
-    return;
-  }
-
   const result = await runInitSteps({ dependencies, logger, options, parentDirectory, target });
 
   if (result.kind === "created") {

--- a/packages/eve/test/scenarios/eve-init.scenario.test.ts
+++ b/packages/eve/test/scenarios/eve-init.scenario.test.ts
@@ -301,7 +301,7 @@ describe("eve init smoke", () => {
     ]);
   });
 
-  it("hands a coding agent the setup guide when it omits the target", async () => {
+  it("scaffolds the current directory for a coding agent that omits the target", async () => {
     const scratch = await createScratchDirectory("eve-init-agent-bare-");
     const fakePnpmRoot = await createScratchDirectory("eve-init-agent-bare-pnpm-");
     const fakePnpm = await createFakePnpmEnvironment(fakePnpmRoot);
@@ -309,12 +309,25 @@ describe("eve init smoke", () => {
     const result = await runEveBin(scratch, ["init"], { ...fakePnpm.env, AI_AGENT: "claude" });
 
     expect(result.exitCode, result.stderr).toBe(0);
-    // A bare `eve init` from an agent prints the setup guide and scaffolds
-    // nothing — no agent files written. (No install runs, so the fake pnpm is
-    // never invoked and writes no call log.)
-    expect(result.stdout).toContain("Set up an eve agent");
-    expect(result.stdout).toContain("npx eve@latest init <name>");
-    await expect(pathExists(join(scratch, "agent/agent.ts"))).resolves.toBe(false);
+    const canonicalProjectDir = await realpath(scratch);
+    expect(await readFile(join(scratch, "agent/agent.ts"), "utf8")).toContain(
+      DEFAULT_AGENT_MODEL_ID,
+    );
+    await expect(pathExists(join(scratch, ".git"))).resolves.toBe(true);
+    expect(await fakePnpm.readCalls()).toEqual([
+      {
+        args: [
+          "--dir",
+          canonicalProjectDir,
+          "install",
+          "--no-frozen-lockfile",
+          "--config.minimum-release-age=0",
+        ],
+        cwd: canonicalProjectDir,
+      },
+    ]);
+    expect(result.stdout).toContain("Created an eve agent in ");
+    expect(result.stdout).toContain("eve dev --no-ui");
   });
 
   it("warns and continues when a coding agent passes the compatibility yes flag", async () => {


### PR DESCRIPTION
### Summary

Closes #2060. `eve init` without a target now consistently scaffolds the current directory, including when a coding agent launches it. Coding-agent launches still avoid spawning the development TUI and print the post-scaffold handoff; malformed `eve init` commands still receive the setup guide.

### Validation

The full init integration suite passes (54 tests), including regression coverage for a coding-agent launch with no target. The built CLI scenario suite for `eve init` passes (9 tests), and related CLI and prompt unit coverage passes 61 tests. Docs validation and mechanical invariant checks also pass.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+10 / -5`

Updates the CLI reference and records the user-visible behavior in a patch changeset.

**Implementation** — 2 files · `+10 / -25`

Removes the coding-agent-only early return and keeps the remaining prompt comments aligned with their malformed-input use.

**Tests** — 2 files · `+33 / -16`

Replaces the previous setup-guide expectations with integration and built-CLI scenario coverage for in-place scaffolding and the non-blocking coding-agent handoff.
