### PR TITLE
Choose init or dev for bare eve commands

### DIFF
--- a/.changeset/light-buttons-scream.md
+++ b/.changeset/light-buttons-scream.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Running eve without a command now initializes the current directory when no eve project is present, and starts development when one is detected.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -3,12 +3,13 @@ title: "CLI"
 description: "Reference for every eve CLI command: init, set, info, build, start, dev, logs, trace, link, deploy, eval, channels, and extension."
 ---
 
-The `eve` binary (`bin: eve`) runs from your app root, and every command first loads `.env`/`.env.local` from that root. Running `eve` with no command runs `eve dev`.
+The `eve` binary (`bin: eve`) runs from your app root. Every command first loads `.env`/`.env.local` from that root. Running `eve` with no command runs `eve init` when the current directory is not an eve project, or `eve dev` when it is.
 
 ## Commands
 
 | Command                       | Description                                                                                                                        |
 | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `eve`                         | Initialize the current directory, or start development when it is already an eve project                                           |
 | `eve init [target]`           | Create a new agent, or add an agent to an existing project                                                                         |
 | `eve info`                    | Print the resolved application, including static instructions and discovered capabilities, routes, artifact paths, and diagnostics |
 | `eve build`                   | Compile `.eve/` artifacts and build the host output; prints the output directory                                                   |

--- a/packages/eve/README.md
+++ b/packages/eve/README.md
@@ -133,6 +133,7 @@ project or deploy the agent.
 
 CLI commands:
 
+- `eve` (including `npx eve`) — initialize the current directory, or start development in an eve project
 - `eve init <name>` — create a new agent
 - `eve info` — discovery results and compiled artifacts
 - `eve build` — compile `.eve/` and build the host output

--- a/packages/eve/src/cli/run.test.ts
+++ b/packages/eve/src/cli/run.test.ts
@@ -182,6 +182,64 @@ describe("CLI command registration", () => {
   });
 });
 
+describe("bare eve command", () => {
+  it("runs init in the current directory when no eve project is detected", async () => {
+    const logger = { error: vi.fn(), log: vi.fn() };
+    const isEveProject = vi.fn(async () => false);
+    runInitCommand.mockClear();
+
+    await runCli([], logger, { isEveProject });
+
+    expect(isEveProject).toHaveBeenCalledWith(resolve(process.cwd()));
+    expect(runInitCommand).toHaveBeenCalledWith(logger, resolve(process.cwd()), undefined, {
+      channelWebNextjs: undefined,
+      model: undefined,
+      reasoning: undefined,
+    });
+  });
+
+  it("runs dev when an eve project is detected", async () => {
+    const logger = { error: vi.fn(), log: vi.fn() };
+    const isEveProject = vi.fn(async () => true);
+    const close = vi.fn(async () => {});
+    const startHost = vi.fn(() => ({
+      start: async () => ({
+        kind: "started" as const,
+        appRoot: "/canonical/app",
+        url: "http://127.0.0.1:4321/",
+      }),
+      close,
+    }));
+    const runDevelopmentTui = vi.fn(async () => {});
+    runInitCommand.mockClear();
+
+    await withInteractiveTerminal(() =>
+      runCli([], logger, { isEveProject, runDevelopmentTui, startHost }),
+    );
+
+    expect(isEveProject).toHaveBeenCalledWith(resolve(process.cwd()));
+    expect(startHost).toHaveBeenCalledWith(resolve(process.cwd()), {
+      existing: "attach-if-unconfigured",
+      host: undefined,
+      onBootProgress: expect.any(Function),
+      output: undefined,
+      port: undefined,
+    });
+    expect(runDevelopmentTui).toHaveBeenCalledOnce();
+    expect(runInitCommand).not.toHaveBeenCalled();
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("does not inspect the project when a command is explicit", async () => {
+    const logger = { error: vi.fn(), log: vi.fn() };
+    const isEveProject = vi.fn(async () => false);
+
+    await runCli(["init"], logger, { isEveProject });
+
+    expect(isEveProject).not.toHaveBeenCalled();
+  });
+});
+
 describe("eve init compatibility flags", () => {
   it("lists the supported init options", async () => {
     const output: string[] = [];

--- a/packages/eve/src/cli/run.ts
+++ b/packages/eve/src/cli/run.ts
@@ -62,6 +62,7 @@ interface CliLogger {
 
 interface CliRuntimeDependencies {
   isCodingAgentLaunch(): Promise<boolean>;
+  isEveProject(appRoot: string): Promise<boolean>;
   isActiveDevelopmentServerForApp(input: {
     readonly appRoot: string;
     readonly serverUrl: string;
@@ -134,6 +135,10 @@ async function loadStartHost(): Promise<CliRuntimeDependencies["startHost"]> {
   return (await import("#cli/dev/local-server-process.js")).createDevelopmentServer;
 }
 
+async function loadIsEveProject(): Promise<CliRuntimeDependencies["isEveProject"]> {
+  return (await import("#setup/scaffold/index.js")).isEveProject;
+}
+
 const loadIsActiveDevelopmentServerForApp = async () =>
   (await import("#internal/nitro/host.js")).isActiveDevelopmentServerForApp;
 
@@ -145,8 +150,11 @@ function hasInteractiveTerminal(): boolean {
   return Boolean(process.stdin.isTTY && process.stdout.isTTY);
 }
 
-function createCliProgram(logger: CliLogger, runtime: CliRuntimeOverrides): Command {
-  const appRoot = resolveApplicationRoot();
+function createCliProgram(
+  logger: CliLogger,
+  runtime: CliRuntimeOverrides,
+  appRoot: string,
+): Command {
   const packageVersion = resolveInstalledPackageInfo().version;
   const program = new Command();
   const theme = createCliTheme();
@@ -632,8 +640,13 @@ export async function runCli(
   logger: CliLogger = console,
   runtime: CliRuntimeOverrides = {},
 ): Promise<void> {
-  const program = createCliProgram(logger, runtime);
-  const input = argv.length === 0 ? ["dev"] : argv;
+  const appRoot = resolveApplicationRoot();
+  const program = createCliProgram(logger, runtime, appRoot);
+  let input = argv;
+  if (input.length === 0) {
+    const detectEveProject = runtime.isEveProject ?? (await loadIsEveProject());
+    input = [(await detectEveProject(appRoot)) ? "dev" : "init"];
+  }
 
   try {
     await program.parseAsync(input, {

--- a/packages/eve/test/scenarios/cli.scenario.test.ts
+++ b/packages/eve/test/scenarios/cli.scenario.test.ts
@@ -278,11 +278,12 @@ describe("runCli", () => {
     expect(output).toContain("0 errors, 0 warnings");
   });
 
-  it("defaults to dev when no command is provided", async () => {
+  it("defaults to dev when no command is provided in an eve project", async () => {
     const logger = {
       error: vi.fn(),
       log: vi.fn(),
     };
+    const isEveProject = vi.fn(async () => true);
     const startHost = vi.fn(() => ({
       start: async () => {
         throw new Error("dev started");
@@ -292,10 +293,12 @@ describe("runCli", () => {
 
     await expect(
       runCli([], logger, {
+        isEveProject,
         startHost,
       }),
     ).rejects.toThrow("dev started");
 
+    expect(isEveProject).toHaveBeenCalledOnce();
     expect(startHost).toHaveBeenCalledOnce();
   });
 


### PR DESCRIPTION
### Summary

Closes #2065. Running `eve` or `npx eve` without a command now detects whether the current directory is an eve project. It runs `eve dev` when one is present and otherwise enters the same targetless `eve init` flow as an explicit command, including confirmation or safe refusal in non-empty directories. Explicit commands do not perform project detection.

### Validation

The focused CLI unit suite passes 57 tests across both no-command branches, and the CLI scenario suite passes all 16 tests with project detection isolated from the interactive init path. The complete unit suite passes 6,479 tests with one skipped.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 3 files · `+8 / -1`

Documents the smart default in the package README and CLI reference, with a patch changeset for the published behavior.

**Implementation** — 1 file · `+17 / -4`

Keeps project detection and command selection at the CLI entrypoint without changing explicit command handling.

**Tests** — 2 files · `+62 / -1`

Covers both smart-default branches, verifies explicit commands skip detection, and keeps the built-CLI dev scenario independent from interactive init behavior.
