### PR TITLE
docs: update instrumentation integrations for the provider layout

### DIFF
--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -1901,43 +1901,33 @@ const instrumentationPresentations: Record<string, InstrumentationPresentation> 
 eve add instrumentation/braintrust
 \`\`\``,
 
-    quickStart: `eve installs a hook that traces agent activity and an instrumentation file that initializes the Braintrust logger:
+    quickStart: `Enable the instrumentation providers layout and install the Braintrust provider:
 
 \`\`\`ts
-// agent/hooks/braintrust.ts
-import { braintrustEveHook } from "braintrust";
-import { defineState } from "eve/context";
-import { defineHook } from "eve/hooks";
+// agent/agent.ts
+import { defineAgent } from "eve";
 
-export default defineHook(
-  braintrustEveHook({
-    defineState,
-    metadata: {
-      app: "my-eve-agent", // Replace with your app name
-    },
-  }) as Parameters<typeof defineHook>[0],
-);
+export default defineAgent({
+  experimental: { instrumentationProviders: true },
+  // ...model, tools, etc.
+});
 \`\`\`
 
 \`\`\`ts
-// agent/instrumentation.ts
-import { braintrustEveInstrumentation, initLogger } from "braintrust";
-import { defineState } from "eve/context";
+// agent/instrumentation/braintrust.ts
+import { braintrustEveInstrumentation } from "braintrust";
 import { defineInstrumentation } from "eve/instrumentation";
 
 export default defineInstrumentation(
   braintrustEveInstrumentation({
-    defineState,
-    setup: ({ agentName }) => {
-      initLogger({
-        projectName: agentName,
-        apiKey: process.env.BRAINTRUST_API_KEY,
-      });
-    },
-  }) as Parameters<typeof defineInstrumentation>[0],
+    recordInputs: true,
+    recordOutputs: true,
+  }),
 );
-\`\`\``,
-    configure: `Create an API key in the Braintrust dashboard and expose it as \`BRAINTRUST_API_KEY\`. Replace the hook's \`app\` metadata with your app name. Spans land in the Braintrust project named after your agent. See the [instrumentation guide](/docs/guides/instrumentation) for the trace hierarchy and the \`recordInputs\`/\`recordOutputs\` controls.`,
+\`\`\`
+
+The provider initializes the Braintrust logger from \`BRAINTRUST_API_KEY\` by default. Pass a \`setup\` callback to customize initialization.`,
+    configure: `Create an API key in the Braintrust dashboard and expose it as \`BRAINTRUST_API_KEY\`. Spans land in the Braintrust project named after your agent. Set \`recordInputs\` and \`recordOutputs\` to \`true\` to capture prompts, responses, and tool payloads. See the [instrumentation guide](/docs/guides/instrumentation) for the trace hierarchy.`,
   },
   "posthog-instrumentation": {
     logo: "posthog",
@@ -1949,44 +1939,21 @@ export default defineInstrumentation(
 eve add instrumentation/posthog
 \`\`\``,
 
-    quickStart: `eve installs \`agent/instrumentation.ts\` with PostHog's trace exporter. It also links spans to the user who initiated the session when an authenticated principal is available:
+    quickStart: `eve installs \`agent/instrumentation/posthog.ts\` with PostHog's trace exporter:
 
 \`\`\`ts
-// agent/instrumentation.ts
-import { trace } from "@opentelemetry/api";
-import { SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
+// agent/instrumentation/posthog.ts
 import { PostHogTraceExporter } from "@posthog/ai/otel";
-import { registerOTel } from "@vercel/otel";
-import { defineInstrumentation } from "eve/instrumentation";
+import { otelIntegration } from "eve/instrumentation/otel";
 
-export default defineInstrumentation({
-  setup: ({ agentName }) =>
-    registerOTel({
-      serviceName: agentName,
-      spanProcessors: [
-        new SimpleSpanProcessor(
-          new PostHogTraceExporter({
-            projectToken: process.env.POSTHOG_PROJECT_TOKEN!,
-            host: process.env.POSTHOG_HOST,
-          }),
-        ),
-      ],
-    }),
-  events: {
-    "step.started"(input) {
-      const distinctId =
-        input.session.auth.initiator?.principalId ??
-        input.session.auth.current?.principalId;
-
-      if (!distinctId) return undefined;
-
-      trace.getActiveSpan()?.setAttribute("posthog.distinct_id", distinctId);
-      return { runtimeContext: { posthog_distinct_id: distinctId } };
-    },
-  },
+export default otelIntegration({
+  traceExporter: new PostHogTraceExporter({
+    projectToken: process.env.POSTHOG_PROJECT_TOKEN!,
+    host: process.env.POSTHOG_HOST,
+  }),
 });
 \`\`\``,
-    configure: `Copy your project token and client API host from PostHog's project settings and expose them as \`POSTHOG_PROJECT_TOKEN\` and \`POSTHOG_HOST\`. Remove the \`events\` handler to capture generations anonymously. PostHog groups turns using \`eve.session.id\` and preserves eve's trace hierarchy. See [PostHog's eve installation guide](https://posthog.com/docs/ai-observability/installation/eve) for verification steps and the [instrumentation guide](/docs/guides/instrumentation) for input and output capture controls.`,
+    configure: `Copy your project token and client API host from PostHog's project settings and expose them as \`POSTHOG_PROJECT_TOKEN\` and \`POSTHOG_HOST\`. PostHog groups turns using \`eve.session.id\` and preserves eve's trace hierarchy. See [PostHog's eve installation guide](https://posthog.com/docs/ai-observability/installation/eve) for verification steps and the [instrumentation guide](/docs/guides/instrumentation) for input and output capture controls.`,
   },
   "sentry-instrumentation": {
     logo: "sentry",
@@ -1998,24 +1965,20 @@ export default defineInstrumentation({
 eve add instrumentation/sentry
 \`\`\``,
 
-    quickStart: `Create \`agent/instrumentation.ts\` and point the OTLP exporter at your project's Sentry traces endpoint:
+    quickStart: `eve installs \`agent/instrumentation/sentry.ts\` with an OTLP exporter pointed at your Sentry traces endpoint:
 
 \`\`\`ts
-// agent/instrumentation.ts
-import { defineInstrumentation } from "eve/instrumentation";
-import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
+// agent/instrumentation/sentry.ts
+import { OTLPHttpProtoTraceExporter } from "@vercel/otel";
+import { otelIntegration } from "eve/instrumentation/otel";
 
-export default defineInstrumentation({
-  setup: ({ agentName }) =>
-    registerOTel({
-      serviceName: agentName,
-      traceExporter: new OTLPHttpProtoTraceExporter({
-        url: process.env.SENTRY_OTLP_TRACES_ENDPOINT!,
-        headers: {
-          "x-sentry-auth": \`sentry sentry_key=\${process.env.SENTRY_PUBLIC_KEY}\`,
-        },
-      }),
-    }),
+export default otelIntegration({
+  traceExporter: new OTLPHttpProtoTraceExporter({
+    url: process.env.SENTRY_OTLP_TRACES_ENDPOINT!,
+    headers: {
+      "x-sentry-auth": \`sentry sentry_key=\${process.env.SENTRY_PUBLIC_KEY}\`,
+    },
+  }),
 });
 \`\`\``,
     configure: `Copy the OTLP traces endpoint and public key from your Sentry project under **Settings → Client Keys (DSN)** and expose them as environment variables. Sentry's OTLP intake accepts traces only, and span events are dropped at ingestion. See the [instrumentation guide](/docs/guides/instrumentation) for the trace hierarchy and the \`recordInputs\`/\`recordOutputs\` controls.`,
@@ -2029,22 +1992,18 @@ export default defineInstrumentation({
 \`\`\`bash
 eve add instrumentation/datadog
 \`\`\``,
-    quickStart: `Create \`agent/instrumentation.ts\` and point the OTLP exporter at Datadog's intake for your site, authenticated with your API key:
+    quickStart: `eve installs \`agent/instrumentation/datadog.ts\` with an OTLP exporter pointed at Datadog's intake for your site:
 
 \`\`\`ts
-// agent/instrumentation.ts
-import { defineInstrumentation } from "eve/instrumentation";
-import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
+// agent/instrumentation/datadog.ts
+import { OTLPHttpProtoTraceExporter } from "@vercel/otel";
+import { otelIntegration } from "eve/instrumentation/otel";
 
-export default defineInstrumentation({
-  setup: ({ agentName }) =>
-    registerOTel({
-      serviceName: agentName,
-      traceExporter: new OTLPHttpProtoTraceExporter({
-        url: process.env.DATADOG_OTLP_TRACES_ENDPOINT!,
-        headers: { "dd-api-key": process.env.DD_API_KEY! },
-      }),
-    }),
+export default otelIntegration({
+  traceExporter: new OTLPHttpProtoTraceExporter({
+    url: process.env.DATADOG_OTLP_TRACES_ENDPOINT!,
+    headers: { "dd-api-key": process.env.DD_API_KEY! },
+  }),
 });
 \`\`\``,
     configure: `Datadog's direct OTLP trace intake is site-specific (for example \`datadoghq.com\` vs \`datadoghq.eu\`) and currently in Preview; look up the endpoint for your site in Datadog's OTLP intake docs. For production, Datadog recommends routing through an OpenTelemetry Collector with the Datadog exporter instead. See the [instrumentation guide](/docs/guides/instrumentation) for the trace hierarchy and the \`recordInputs\`/\`recordOutputs\` controls.`,
@@ -2059,22 +2018,18 @@ export default defineInstrumentation({
 eve add instrumentation/honeycomb
 \`\`\``,
 
-    quickStart: `Create \`agent/instrumentation.ts\` and send traces to Honeycomb's OTLP endpoint with your ingest key:
+    quickStart: `eve installs \`agent/instrumentation/honeycomb.ts\` with an OTLP exporter pointed at Honeycomb's OTLP endpoint:
 
 \`\`\`ts
-// agent/instrumentation.ts
-import { defineInstrumentation } from "eve/instrumentation";
-import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
+// agent/instrumentation/honeycomb.ts
+import { OTLPHttpProtoTraceExporter } from "@vercel/otel";
+import { otelIntegration } from "eve/instrumentation/otel";
 
-export default defineInstrumentation({
-  setup: ({ agentName }) =>
-    registerOTel({
-      serviceName: agentName,
-      traceExporter: new OTLPHttpProtoTraceExporter({
-        url: "https://api.honeycomb.io/v1/traces",
-        headers: { "x-honeycomb-team": process.env.HONEYCOMB_API_KEY! },
-      }),
-    }),
+export default otelIntegration({
+  traceExporter: new OTLPHttpProtoTraceExporter({
+    url: "https://api.honeycomb.io/v1/traces",
+    headers: { "x-honeycomb-team": process.env.HONEYCOMB_API_KEY! },
+  }),
 });
 \`\`\``,
     configure: `Create an ingest key under your Honeycomb environment settings and expose it as \`HONEYCOMB_API_KEY\`. Spans arrive in a dataset named after your agent (the OTel service name). EU teams use \`https://api.eu1.honeycomb.io/v1/traces\`. See the [instrumentation guide](/docs/guides/instrumentation) for the trace hierarchy and the \`recordInputs\`/\`recordOutputs\` controls.`,
@@ -2089,29 +2044,24 @@ export default defineInstrumentation({
 eve add instrumentation/arize
 \`\`\``,
 
-    quickStart: `Create \`agent/instrumentation.ts\` and send traces to Arize's OTLP endpoint with your space ID and API key:
+    quickStart: `eve installs \`agent/instrumentation/arize.ts\` with an OTLP exporter pointed at Arize's OTLP endpoint:
 
 \`\`\`ts
-// agent/instrumentation.ts
-import { defineInstrumentation } from "eve/instrumentation";
-import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
+// agent/instrumentation/arize.ts
+import { OTLPHttpProtoTraceExporter } from "@vercel/otel";
+import { otelIntegration } from "eve/instrumentation/otel";
 
-export default defineInstrumentation({
-  setup: ({ agentName }) =>
-    registerOTel({
-      serviceName: agentName,
-      attributes: { "openinference.project.name": agentName },
-      traceExporter: new OTLPHttpProtoTraceExporter({
-        url: "https://otlp.arize.com/v1/traces",
-        headers: {
-          space_id: process.env.ARIZE_SPACE_ID!,
-          api_key: process.env.ARIZE_API_KEY!,
-        },
-      }),
-    }),
+export default otelIntegration({
+  traceExporter: new OTLPHttpProtoTraceExporter({
+    url: "https://otlp.arize.com/v1/traces",
+    headers: {
+      space_id: process.env.ARIZE_SPACE_ID!,
+      api_key: process.env.ARIZE_API_KEY!,
+    },
+  }),
 });
 \`\`\``,
-    configure: `Copy the space ID and API key from your Arize AX space settings and expose them as \`ARIZE_SPACE_ID\` and \`ARIZE_API_KEY\`. The \`openinference.project.name\` resource attribute routes spans to a project named after your agent. See the [instrumentation guide](/docs/guides/instrumentation) for the trace hierarchy and the \`recordInputs\`/\`recordOutputs\` controls.`,
+    configure: `Copy the space ID and API key from your Arize AX space settings and expose them as \`ARIZE_SPACE_ID\` and \`ARIZE_API_KEY\`. See the [instrumentation guide](/docs/guides/instrumentation) for the trace hierarchy and the \`recordInputs\`/\`recordOutputs\` controls.`,
   },
   raindrop: {
     logo: "raindrop",
@@ -2123,24 +2073,20 @@ export default defineInstrumentation({
 eve add instrumentation/raindrop
 \`\`\``,
 
-    quickStart: `Create \`agent/instrumentation.ts\` and send traces to Raindrop's OTLP endpoint with your write key:
+    quickStart: `eve installs \`agent/instrumentation/raindrop.ts\` with an OTLP exporter pointed at Raindrop's OTLP endpoint:
 
 \`\`\`ts
-// agent/instrumentation.ts
-import { defineInstrumentation } from "eve/instrumentation";
-import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
+// agent/instrumentation/raindrop.ts
+import { OTLPHttpProtoTraceExporter } from "@vercel/otel";
+import { otelIntegration } from "eve/instrumentation/otel";
 
-export default defineInstrumentation({
-  setup: ({ agentName }) =>
-    registerOTel({
-      serviceName: agentName,
-      traceExporter: new OTLPHttpProtoTraceExporter({
-        url: "https://api.raindrop.ai/v1/traces",
-        headers: {
-          Authorization: \`Bearer \${process.env.RAINDROP_WRITE_KEY}\`,
-        },
-      }),
-    }),
+export default otelIntegration({
+  traceExporter: new OTLPHttpProtoTraceExporter({
+    url: "https://api.raindrop.ai/v1/traces",
+    headers: {
+      Authorization: \`Bearer \${process.env.RAINDROP_WRITE_KEY}\`,
+    },
+  }),
 });
 \`\`\``,
     configure: `Create a write key in the Raindrop dashboard and expose it as \`RAINDROP_WRITE_KEY\`. Raindrop's Vercel AI SDK integration picks up the AI SDK spans eve emits on every turn. See the [instrumentation guide](/docs/guides/instrumentation) for the trace hierarchy and the \`recordInputs\`/\`recordOutputs\` controls.`,
@@ -2154,21 +2100,17 @@ export default defineInstrumentation({
 \`\`\`bash
 eve add instrumentation/jaeger
 \`\`\``,
-    quickStart: `Create \`agent/instrumentation.ts\` and point the OTLP exporter at your Jaeger collector:
+    quickStart: `eve installs \`agent/instrumentation/jaeger.ts\` with an OTLP exporter pointed at your Jaeger collector:
 
 \`\`\`ts
-// agent/instrumentation.ts
-import { defineInstrumentation } from "eve/instrumentation";
-import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
+// agent/instrumentation/jaeger.ts
+import { OTLPHttpProtoTraceExporter } from "@vercel/otel";
+import { otelIntegration } from "eve/instrumentation/otel";
 
-export default defineInstrumentation({
-  setup: ({ agentName }) =>
-    registerOTel({
-      serviceName: agentName,
-      traceExporter: new OTLPHttpProtoTraceExporter({
-        url: "http://localhost:4318/v1/traces",
-      }),
-    }),
+export default otelIntegration({
+  traceExporter: new OTLPHttpProtoTraceExporter({
+    url: "http://localhost:4318/v1/traces",
+  }),
 });
 \`\`\``,
     configure: `Run Jaeger locally with Docker and open the UI at \`http://localhost:16686\`:

--- a/apps/docs/lib/integrations/discovery.test.ts
+++ b/apps/docs/lib/integrations/discovery.test.ts
@@ -151,7 +151,7 @@ describe("integration discovery", () => {
 
     const markdown = integrationMarkdown(braintrust!);
     expect(markdown).toContain("eve add instrumentation/braintrust");
-    expect(markdown).toContain("agent/instrumentation.ts");
+    expect(markdown).toContain("agent/instrumentation/braintrust.ts");
     expect(markdown).toContain("BRAINTRUST_API_KEY");
 
     const posthog = getIntegration("posthog-instrumentation");

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -1994,7 +1994,7 @@
         {
           "path": "registry/instrumentation/braintrust.ts",
           "type": "registry:file",
-          "target": "agent/instrumentation.ts"
+          "target": "agent/instrumentation/braintrust.ts"
         },
         {
           "path": "registry/instrumentation/braintrust-hook.ts",
@@ -2008,13 +2008,7 @@
       "type": "registry:item",
       "title": "PostHog",
       "description": "Send agent traces and generations to PostHog AI Observability.",
-      "dependencies": [
-        "@posthog/ai@^7.19.6",
-        "@opentelemetry/api",
-        "@opentelemetry/exporter-trace-otlp-http",
-        "@opentelemetry/sdk-trace-base",
-        "@vercel/otel"
-      ],
+      "dependencies": ["@posthog/ai@^7.19.6"],
       "envVars": {
         "POSTHOG_PROJECT_TOKEN": "",
         "POSTHOG_HOST": ""
@@ -2023,7 +2017,7 @@
         {
           "path": "registry/instrumentation/posthog.ts",
           "type": "registry:file",
-          "target": "agent/instrumentation.ts"
+          "target": "agent/instrumentation/posthog.ts"
         }
       ]
     },
@@ -2041,7 +2035,7 @@
         {
           "path": "registry/instrumentation/sentry.ts",
           "type": "registry:file",
-          "target": "agent/instrumentation.ts"
+          "target": "agent/instrumentation/sentry.ts"
         }
       ]
     },
@@ -2059,7 +2053,7 @@
         {
           "path": "registry/instrumentation/datadog.ts",
           "type": "registry:file",
-          "target": "agent/instrumentation.ts"
+          "target": "agent/instrumentation/datadog.ts"
         }
       ]
     },
@@ -2076,7 +2070,7 @@
         {
           "path": "registry/instrumentation/honeycomb.ts",
           "type": "registry:file",
-          "target": "agent/instrumentation.ts"
+          "target": "agent/instrumentation/honeycomb.ts"
         }
       ]
     },
@@ -2094,7 +2088,7 @@
         {
           "path": "registry/instrumentation/arize.ts",
           "type": "registry:file",
-          "target": "agent/instrumentation.ts"
+          "target": "agent/instrumentation/arize.ts"
         }
       ]
     },
@@ -2111,7 +2105,7 @@
         {
           "path": "registry/instrumentation/raindrop.ts",
           "type": "registry:file",
-          "target": "agent/instrumentation.ts"
+          "target": "agent/instrumentation/raindrop.ts"
         }
       ]
     },
@@ -2125,7 +2119,7 @@
         {
           "path": "registry/instrumentation/jaeger.ts",
           "type": "registry:file",
-          "target": "agent/instrumentation.ts"
+          "target": "agent/instrumentation/jaeger.ts"
         }
       ]
     }

--- a/apps/docs/registry/instrumentation/arize.ts
+++ b/apps/docs/registry/instrumentation/arize.ts
@@ -1,17 +1,12 @@
-import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
-import { defineInstrumentation } from "eve/instrumentation";
+import { OTLPHttpProtoTraceExporter } from "@vercel/otel";
+import { otelIntegration } from "eve/instrumentation/otel";
 
-export default defineInstrumentation({
-  setup: ({ agentName }) =>
-    registerOTel({
-      serviceName: agentName,
-      attributes: { "openinference.project.name": agentName },
-      traceExporter: new OTLPHttpProtoTraceExporter({
-        url: "https://otlp.arize.com/v1/traces",
-        headers: {
-          space_id: process.env.ARIZE_SPACE_ID!,
-          api_key: process.env.ARIZE_API_KEY!,
-        },
-      }),
-    }),
+export default otelIntegration({
+  traceExporter: new OTLPHttpProtoTraceExporter({
+    url: "https://otlp.arize.com/v1/traces",
+    headers: {
+      space_id: process.env.ARIZE_SPACE_ID!,
+      api_key: process.env.ARIZE_API_KEY!,
+    },
+  }),
 });

--- a/apps/docs/registry/instrumentation/braintrust.ts
+++ b/apps/docs/registry/instrumentation/braintrust.ts
@@ -1,15 +1,9 @@
-import { braintrustEveInstrumentation, initLogger } from "braintrust";
-import { defineState } from "eve/context";
+import { braintrustEveInstrumentation } from "braintrust";
 import { defineInstrumentation } from "eve/instrumentation";
 
 export default defineInstrumentation(
   braintrustEveInstrumentation({
-    defineState,
-    setup: ({ agentName }) => {
-      initLogger({
-        projectName: agentName,
-        apiKey: process.env.BRAINTRUST_API_KEY,
-      });
-    },
-  }) as Parameters<typeof defineInstrumentation>[0],
+    recordInputs: true,
+    recordOutputs: true,
+  }),
 );

--- a/apps/docs/registry/instrumentation/datadog.ts
+++ b/apps/docs/registry/instrumentation/datadog.ts
@@ -1,13 +1,9 @@
-import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
-import { defineInstrumentation } from "eve/instrumentation";
+import { OTLPHttpProtoTraceExporter } from "@vercel/otel";
+import { otelIntegration } from "eve/instrumentation/otel";
 
-export default defineInstrumentation({
-  setup: ({ agentName }) =>
-    registerOTel({
-      serviceName: agentName,
-      traceExporter: new OTLPHttpProtoTraceExporter({
-        url: process.env.DATADOG_OTLP_TRACES_ENDPOINT!,
-        headers: { "dd-api-key": process.env.DD_API_KEY! },
-      }),
-    }),
+export default otelIntegration({
+  traceExporter: new OTLPHttpProtoTraceExporter({
+    url: process.env.DATADOG_OTLP_TRACES_ENDPOINT!,
+    headers: { "dd-api-key": process.env.DD_API_KEY! },
+  }),
 });

--- a/apps/docs/registry/instrumentation/honeycomb.ts
+++ b/apps/docs/registry/instrumentation/honeycomb.ts
@@ -1,13 +1,9 @@
-import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
-import { defineInstrumentation } from "eve/instrumentation";
+import { OTLPHttpProtoTraceExporter } from "@vercel/otel";
+import { otelIntegration } from "eve/instrumentation/otel";
 
-export default defineInstrumentation({
-  setup: ({ agentName }) =>
-    registerOTel({
-      serviceName: agentName,
-      traceExporter: new OTLPHttpProtoTraceExporter({
-        url: "https://api.honeycomb.io/v1/traces",
-        headers: { "x-honeycomb-team": process.env.HONEYCOMB_API_KEY! },
-      }),
-    }),
+export default otelIntegration({
+  traceExporter: new OTLPHttpProtoTraceExporter({
+    url: "https://api.honeycomb.io/v1/traces",
+    headers: { "x-honeycomb-team": process.env.HONEYCOMB_API_KEY! },
+  }),
 });

--- a/apps/docs/registry/instrumentation/jaeger.ts
+++ b/apps/docs/registry/instrumentation/jaeger.ts
@@ -1,12 +1,8 @@
-import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
-import { defineInstrumentation } from "eve/instrumentation";
+import { OTLPHttpProtoTraceExporter } from "@vercel/otel";
+import { otelIntegration } from "eve/instrumentation/otel";
 
-export default defineInstrumentation({
-  setup: ({ agentName }) =>
-    registerOTel({
-      serviceName: agentName,
-      traceExporter: new OTLPHttpProtoTraceExporter({
-        url: "http://localhost:4318/v1/traces",
-      }),
-    }),
+export default otelIntegration({
+  traceExporter: new OTLPHttpProtoTraceExporter({
+    url: "http://localhost:4318/v1/traces",
+  }),
 });

--- a/apps/docs/registry/instrumentation/posthog.ts
+++ b/apps/docs/registry/instrumentation/posthog.ts
@@ -1,31 +1,9 @@
-import { trace } from "@opentelemetry/api";
-import { SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { PostHogTraceExporter } from "@posthog/ai/otel";
-import { registerOTel } from "@vercel/otel";
-import { defineInstrumentation } from "eve/instrumentation";
+import { otelIntegration } from "eve/instrumentation/otel";
 
-export default defineInstrumentation({
-  setup: ({ agentName }) =>
-    registerOTel({
-      serviceName: agentName,
-      spanProcessors: [
-        new SimpleSpanProcessor(
-          new PostHogTraceExporter({
-            projectToken: process.env.POSTHOG_PROJECT_TOKEN!,
-            host: process.env.POSTHOG_HOST,
-          }),
-        ),
-      ],
-    }),
-  events: {
-    "step.started"(input) {
-      const distinctId =
-        input.session.auth.initiator?.principalId ?? input.session.auth.current?.principalId;
-
-      if (!distinctId) return undefined;
-
-      trace.getActiveSpan()?.setAttribute("posthog.distinct_id", distinctId);
-      return { runtimeContext: { posthog_distinct_id: distinctId } };
-    },
-  },
+export default otelIntegration({
+  traceExporter: new PostHogTraceExporter({
+    projectToken: process.env.POSTHOG_PROJECT_TOKEN!,
+    host: process.env.POSTHOG_HOST,
+  }),
 });

--- a/apps/docs/registry/instrumentation/raindrop.ts
+++ b/apps/docs/registry/instrumentation/raindrop.ts
@@ -1,15 +1,11 @@
-import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
-import { defineInstrumentation } from "eve/instrumentation";
+import { OTLPHttpProtoTraceExporter } from "@vercel/otel";
+import { otelIntegration } from "eve/instrumentation/otel";
 
-export default defineInstrumentation({
-  setup: ({ agentName }) =>
-    registerOTel({
-      serviceName: agentName,
-      traceExporter: new OTLPHttpProtoTraceExporter({
-        url: "https://api.raindrop.ai/v1/traces",
-        headers: {
-          Authorization: `Bearer ${process.env.RAINDROP_WRITE_KEY}`,
-        },
-      }),
-    }),
+export default otelIntegration({
+  traceExporter: new OTLPHttpProtoTraceExporter({
+    url: "https://api.raindrop.ai/v1/traces",
+    headers: {
+      Authorization: `Bearer ${process.env.RAINDROP_WRITE_KEY}`,
+    },
+  }),
 });

--- a/apps/docs/registry/instrumentation/sentry.ts
+++ b/apps/docs/registry/instrumentation/sentry.ts
@@ -1,15 +1,11 @@
-import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
-import { defineInstrumentation } from "eve/instrumentation";
+import { OTLPHttpProtoTraceExporter } from "@vercel/otel";
+import { otelIntegration } from "eve/instrumentation/otel";
 
-export default defineInstrumentation({
-  setup: ({ agentName }) =>
-    registerOTel({
-      serviceName: agentName,
-      traceExporter: new OTLPHttpProtoTraceExporter({
-        url: process.env.SENTRY_OTLP_TRACES_ENDPOINT!,
-        headers: {
-          "x-sentry-auth": `sentry sentry_key=${process.env.SENTRY_PUBLIC_KEY}`,
-        },
-      }),
-    }),
+export default otelIntegration({
+  traceExporter: new OTLPHttpProtoTraceExporter({
+    url: process.env.SENTRY_OTLP_TRACES_ENDPOINT!,
+    headers: {
+      "x-sentry-auth": `sentry sentry_key=${process.env.SENTRY_PUBLIC_KEY}`,
+    },
+  }),
 });

--- a/apps/docs/scripts/validate-instrumentation-registry.ts
+++ b/apps/docs/scripts/validate-instrumentation-registry.ts
@@ -51,7 +51,7 @@ for (const item of items) {
   const expectedFiles: RegistryFile[] = [
     {
       path: expectedPath,
-      target: "agent/instrumentation.ts",
+      target: `agent/instrumentation/${slug}.ts`,
     },
     ...(slug === "braintrust"
       ? [

--- a/docs/install-integrations.mdx
+++ b/docs/install-integrations.mdx
@@ -16,7 +16,7 @@ eve add linear
 eve add instrumentation/braintrust
 ```
 
-Extensions may create a mount under `agent/extensions/`. Connections write their initial definition under `agent/connections/` and install `@vercel/connect` when required. Instrumentation providers write `agent/instrumentation.ts`; because an agent has one instrumentation file, compose multiple exporters there by hand. Configure generated files and required environment variables before running your agent.
+Extensions may create a mount under `agent/extensions/`. Connections write their initial definition under `agent/connections/` and install `@vercel/connect` when required. Instrumentation providers write one file per backend under `agent/instrumentation/`, so add multiple backends as separate files rather than composing exporters by hand. Configure generated files and required environment variables before running your agent.
 
 Some integrations package several independently installable components. For example, `eve add linear` lets you choose the Linear Channel, Linear MCP, or both; both are selected by default. The specific `eve add channel/linear-agent` and `eve add connection/linear` commands remain available.
 


### PR DESCRIPTION
### Summary

Updates the instrumentation integration docs and registry scaffolding on [eve.dev/integrations](https://eve.dev/integrations?filter=instrumentation) for the provider-directory layout (`agent/instrumentation/<slug>.ts`), replacing the legacy single-file `defineInstrumentation({ setup: () => registerOTel(...) })` form.

The seven OTLP/OTel backends (PostHog, Sentry, Datadog, Honeycomb, Arize, Raindrop, Jaeger) now export an `otelIntegration({ traceExporter })` destination from `eve/instrumentation/otel`. The framework folds all declared destinations into one pipeline at startup, so per-backend `registerOTel`/`setup` is no longer needed. PostHog's `step.started` distinct_id attribution and Arize's `openinference.project.name` resource attribute are dropped — the former is not expressible as a destination, and the latter belongs on `otel()`, not per-destination.

Braintrust is not OTel and stays on its own SDK helper (`braintrustEveInstrumentation`), simplified to the self-initializing form without `initLogger`/`defineState`/`setup` (pending [braintrust-sdk PR #2363](https://github.com/braintrustdata/braintrust-sdk-javascript/pull/2363)).

Registry install targets, the instrumentation registry validator, the integration-page docs presentations, and the `install-integrations.mdx` layout sentence are updated to the directory layout.

**Note:** The registry `tsc` check will fail until the Braintrust SDK PR ships and the `braintrust` dependency is bumped. This draft is not intended to merge before then.

### Validation

- `pnpm --filter eve-docs run registry:validate:instrumentation` — passes
- `pnpm --filter eve-docs run test:unit` — 154 passed
- `pnpm docs:check` — 82 files, 262 snippets, 82 mdx ok
- `node scripts/validate-public-registry-requirements.mjs` — passes
- `pnpm lint`, `pnpm fmt` — clean
- `tsc --project registry/tsconfig.json` — **fails** on `braintrust.ts` only (expected, pending SDK #2363)

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
