### PR TITLE
fix(eve): polish authorization completion page

### DIFF
--- a/.changeset/polite-plums-connect.md
+++ b/.changeset/polite-plums-connect.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Polish the connection authorization completion page with a Vercel-styled success state.

--- a/packages/eve/src/runtime/connections/authorization-complete-page.ts
+++ b/packages/eve/src/runtime/connections/authorization-complete-page.ts
@@ -18,47 +18,89 @@ export function buildAuthorizationCompletePage(): Response {
     <style>
       :root {
         color-scheme: light dark;
-        --bg: #fafafa;
-        --fg: #111111;
-        --muted: #525252;
-        --card-bg: #ffffff;
-        --card-border: #e5e5e5;
+        --background: oklch(0.984 0 0);
+        --foreground: oklch(0.205 0 0);
+        --secondary: oklch(0.42 0 0);
       }
       @media (prefers-color-scheme: dark) {
         :root {
-          --bg: #0a0a0a;
-          --fg: #fafafa;
-          --muted: #a3a3a3;
-          --card-bg: #171717;
-          --card-border: #262626;
+          --background: oklch(0.027 0 0);
+          --foreground: oklch(0.946 0 0);
+          --secondary: oklch(0.706 0 0);
         }
       }
+      * { box-sizing: border-box; }
       body {
         margin: 0;
-        min-height: 100vh;
-        display: grid;
-        place-items: center;
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
-        background: var(--bg);
-        color: var(--fg);
+        font-family: "Geist Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+        -webkit-font-smoothing: antialiased;
+        background: var(--background);
+        color: var(--foreground);
       }
-      .card {
-        max-width: 28rem;
-        padding: 2rem 2.25rem;
-        border: 1px solid var(--card-border);
-        border-radius: 12px;
-        background: var(--card-bg);
-        color: var(--fg);
+      .screen {
+        min-height: 100vh;
+        min-height: 100dvh;
+        padding: 2rem 1rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: var(--background);
+        color: var(--foreground);
+      }
+      .content {
+        width: 100%;
+        max-width: 27.5rem;
+      }
+      .header {
+        padding: 1.5rem 1.5rem 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
         text-align: center;
       }
-      h1 { font-size: 1.25rem; margin: 0 0 0.5rem; color: var(--fg); }
-      p { margin: 0; color: var(--muted); line-height: 1.5; }
+      .icon {
+        width: 2rem;
+        height: 2rem;
+        margin-top: 1.5rem;
+        color: var(--foreground);
+      }
+      .icon svg {
+        display: block;
+        width: 100%;
+        height: 100%;
+      }
+      h1 {
+        margin: 1.5rem 0 0;
+        color: var(--foreground);
+        font-size: 1.5rem;
+        font-weight: 600;
+        line-height: 2rem;
+        letter-spacing: -0.06rem;
+      }
+      p {
+        margin: 0;
+        padding: 1rem 1.5rem;
+        color: var(--secondary);
+        font-size: 0.8125rem;
+        line-height: 1.125rem;
+        text-align: center;
+      }
     </style>
   </head>
   <body>
-    <main class="card">
-      <h1>Authorization complete</h1>
-      <p>You can close this tab and return to your app.</p>
+    <main class="screen" aria-labelledby="authorization-title">
+      <div class="content">
+        <div class="header">
+          <h1 id="authorization-title">Authorization complete</h1>
+          <div class="icon" aria-hidden="true">
+            <svg viewBox="0 0 16 16" fill="none">
+              <path fill="currentColor" fill-rule="evenodd" d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0m-4.47-1.47.53-.53L11 4.94l-.53.53L6.5 9.44l-.97-.97L5 7.94 3.94 9l.53.53 1.5 1.5c.3.3.77.3 1.06 0z" clip-rule="evenodd" />
+            </svg>
+          </div>
+        </div>
+        <div style="height: 0.5rem" aria-hidden="true"></div>
+        <p>You can close this tab and return to your app.</p>
+      </div>
     </main>
   </body>
 </html>`;

--- a/packages/eve/src/runtime/connections/callback-route.test.ts
+++ b/packages/eve/src/runtime/connections/callback-route.test.ts
@@ -112,6 +112,9 @@ describe("handleConnectionCallbackRequest", () => {
     expect(response.headers.get("content-type")).toContain("text/html");
     const body = await response.text();
     expect(body).toContain("Authorization complete");
+    expect(body).toContain("You can close this tab and return to your app.");
+    expect(body).toContain('aria-labelledby="authorization-title"');
+    expect(body).toContain('class="icon" aria-hidden="true"');
 
     expect(resumeHookMock).toHaveBeenCalledTimes(1);
     const [token, payload] = resumeHookMock.mock.calls[0] ?? [];


### PR DESCRIPTION
### Summary

Closes #2079.

The static page shown after a connection OAuth callback was visually sparse and disconnected from our UI language. This keeps the callback's eve-specific title and instructions while adopting the cleaner, cardless treatment used across Vercel: a soft background, 24px heading, filled success icon, 440px content width, responsive padding, and light/dark color tokens.

The callback contract is unchanged: the page remains self-contained with no scripts or external assets, preserves the existing completion copy, and continues returning a non-cacheable HTML response.

### Before and After

| Before | After |
| :--: | :--: |
| ![Authorization completion page before](https://raw.githubusercontent.com/vercel/eve/allenzhou/pr-2080-screenshots/before.png) | ![Authorization completion page after](https://raw.githubusercontent.com/vercel/eve/allenzhou/pr-2080-screenshots/after.png) |

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/runtime/connections/callback-route.test.ts` — 10 tests passed
- `pnpm --filter eve typecheck` — passed
- `pnpm lint` — passed with three pre-existing unused-variable warnings in `e2e/fixtures/agent-tools-hitl`
- `pnpm guard:invariants` — passed
- Used `apps/vercel-connect/app/callback/CallbackContent.tsx`, `CompletionScreen.tsx`, and the shared `AuthScreen` composition as visual references
- Manually rendered before and after at the same 1446×910 viewport

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
