### PR TITLE
fix(eve): keep active turn streams connected

### DIFF
--- a/.changeset/tidy-streams-resume.md
+++ b/.changeset/tidy-streams-resume.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Keep active client turns connected while they are paused for authorization so responses resume automatically after the callback completes.

--- a/docs/guides/client/streaming.mdx
+++ b/docs/guides/client/streaming.mdx
@@ -126,7 +126,7 @@ If you support refresh while an authorization prompt is pending, keep the sessio
 
 ## Reconnection
 
-HTTP connections can end before a run does. The client reconnects from the number of events already consumed, so long turns continue without replaying events. It stops at a turn boundary, when aborted, or when the stream can no longer make progress.
+HTTP connections can end before a run does. The client reconnects from the number of events already consumed, so long turns continue without replaying events. By default, a turn response keeps reconnecting until it reaches a turn boundary or is aborted, including while the turn is paused for authorization. A manually opened `session.stream()` eventually stops after repeated empty streams when it can no longer make progress.
 
 If your consumer persists events, key on `event.meta.id`. It is stable across reconnects and rewinds, so an overlapping replay is safe to ingest twice. See [the event envelope](../../concepts/sessions-runs-and-streaming#the-event-envelope).
 

--- a/packages/eve/src/client/open-stream.ts
+++ b/packages/eve/src/client/open-stream.ts
@@ -76,6 +76,8 @@ function resolveStreamReconnectPolicy(
  */
 interface FollowStreamInput {
   readonly host: string;
+  /** Keep reconnecting after empty streams until the consumer aborts or stops iteration. */
+  readonly keepAlive?: boolean;
   readonly streamReconnectPolicy?: StreamReconnectPolicy;
   readonly resolveHeaders: () => Promise<Headers>;
   readonly redirect?: ClientRedirectPolicy;
@@ -177,6 +179,7 @@ export async function* followStreamIterable(
     }
 
     if (
+      input.keepAlive !== true &&
       !deliveredEvent &&
       !initialConnection &&
       (idleReconnects += 1) >= idleRetryPolicy.maxAttempts

--- a/packages/eve/src/client/session.test.ts
+++ b/packages/eve/src/client/session.test.ts
@@ -840,6 +840,31 @@ describe("ClientSession", () => {
     expect(session.state.streamIndex).toBe(3);
   });
 
+  it("honors an explicit idle reconnect limit for an active turn", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (_request, init) => {
+      return (init?.method ?? "GET") === "POST"
+        ? createAcceptedResponse()
+        : createStreamResponse([]);
+    });
+    const session = createSession();
+
+    vi.useFakeTimers();
+    try {
+      const eventTypes = await collectEventTypes(
+        await session.send("first", {
+          streamReconnectPolicy: {
+            streamIdleReconnectPolicy: { baseDelayMs: 10, maxAttempts: 2 },
+          },
+        }),
+      );
+      expect(eventTypes).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
   it("preserves the session cursor when a turn stream is aborted mid-flight", async () => {
     const encoder = new TextEncoder();
     const abortController = new AbortController();

--- a/packages/eve/src/client/session.test.ts
+++ b/packages/eve/src/client/session.test.ts
@@ -800,6 +800,46 @@ describe("ClientSession", () => {
     ]);
   });
 
+  it("keeps following an active turn while authorization is pending", async () => {
+    let streamRequest = 0;
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (_request, init) => {
+      if ((init?.method ?? "GET") === "POST") {
+        return createAcceptedResponse();
+      }
+
+      streamRequest += 1;
+      if (streamRequest === 1) {
+        return createStreamResponse([{ type: "authorization.required", data: {} }]);
+      }
+      if (streamRequest <= 7) {
+        return createStreamResponse([]);
+      }
+      return createStreamResponse([
+        { type: "authorization.completed", data: {} },
+        {
+          type: "session.waiting",
+          data: { continuationToken: "session-id", wait: "next-user-message" },
+        },
+      ]);
+    });
+    const session = createSession();
+
+    vi.useFakeTimers();
+    try {
+      const eventTypes = await collectEventTypes(await session.send("first"));
+      expect(eventTypes).toEqual([
+        "authorization.required",
+        "authorization.completed",
+        "session.waiting",
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(9);
+    expect(session.state.streamIndex).toBe(3);
+  });
+
   it("preserves the session cursor when a turn stream is aborted mid-flight", async () => {
     const encoder = new TextEncoder();
     const abortController = new AbortController();

--- a/packages/eve/src/client/session.ts
+++ b/packages/eve/src/client/session.ts
@@ -183,9 +183,10 @@ export class ClientSession {
     try {
       for await (const event of this.#readStream({
         headers: input.headers,
+        keepAlive: shouldKeepActiveTurnAlive(input.streamReconnectPolicy),
         signal: input.signal,
         startIndex: initialStreamIndex,
-        streamReconnectPolicy: activeTurnReconnectPolicy(input.streamReconnectPolicy),
+        streamReconnectPolicy: input.streamReconnectPolicy,
       })) {
         eventCount += 1;
         yield event;
@@ -225,6 +226,7 @@ export class ClientSession {
   #readStream(input: {
     readonly follow?: boolean;
     readonly headers?: Readonly<Record<string, string>>;
+    readonly keepAlive?: boolean;
     readonly signal?: AbortSignal;
     readonly startIndex: number;
     readonly streamReconnectPolicy?: StreamOptions["streamReconnectPolicy"];
@@ -232,6 +234,7 @@ export class ClientSession {
     return followStreamIterable({
       follow: input.follow,
       host: this.#context.host,
+      keepAlive: input.keepAlive,
       resolveHeaders: () => this.#context.resolveHeaders(input.headers),
       redirect: this.#context.redirect,
       sessionId: this.#state.sessionId,
@@ -242,20 +245,12 @@ export class ClientSession {
   }
 }
 
-function activeTurnReconnectPolicy(
-  policy: StreamOptions["streamReconnectPolicy"],
-): StreamOptions["streamReconnectPolicy"] {
+function shouldKeepActiveTurnAlive(policy: StreamOptions["streamReconnectPolicy"]): boolean {
   if (policy && "reconnect" in policy) {
-    return policy;
+    return false;
   }
 
-  return {
-    ...policy,
-    streamIdleReconnectPolicy: {
-      ...policy?.streamIdleReconnectPolicy,
-      maxAttempts: policy?.streamIdleReconnectPolicy?.maxAttempts ?? Number.POSITIVE_INFINITY,
-    },
-  };
+  return policy?.streamIdleReconnectPolicy?.maxAttempts === undefined;
 }
 
 async function postTurn(

--- a/packages/eve/src/client/session.ts
+++ b/packages/eve/src/client/session.ts
@@ -185,7 +185,7 @@ export class ClientSession {
         headers: input.headers,
         signal: input.signal,
         startIndex: initialStreamIndex,
-        streamReconnectPolicy: input.streamReconnectPolicy,
+        streamReconnectPolicy: activeTurnReconnectPolicy(input.streamReconnectPolicy),
       })) {
         eventCount += 1;
         yield event;
@@ -240,6 +240,22 @@ export class ClientSession {
       streamReconnectPolicy: input.streamReconnectPolicy,
     });
   }
+}
+
+function activeTurnReconnectPolicy(
+  policy: StreamOptions["streamReconnectPolicy"],
+): StreamOptions["streamReconnectPolicy"] {
+  if (policy && "reconnect" in policy) {
+    return policy;
+  }
+
+  return {
+    ...policy,
+    streamIdleReconnectPolicy: {
+      ...policy?.streamIdleReconnectPolicy,
+      maxAttempts: policy?.streamIdleReconnectPolicy?.maxAttempts ?? Number.POSITIVE_INFINITY,
+    },
+  };
 }
 
 async function postTurn(

--- a/packages/eve/src/react/use-eve-agent.test.ts
+++ b/packages/eve/src/react/use-eve-agent.test.ts
@@ -142,6 +142,54 @@ describe("useEveAgent", () => {
     expect(seenHelpers.at(-1)).toBe(firstHelpers);
   });
 
+  it("stops an active turn stream when the component unmounts", async () => {
+    let streamSignal: AbortSignal | null | undefined;
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (_request, init) => {
+      if ((init?.method ?? "GET") === "POST") {
+        return createStartedMessageResponse("session_1", "http:session_1");
+      }
+
+      streamSignal = init?.signal;
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            streamSignal?.addEventListener("abort", () => controller.error(createAbortError()));
+          },
+        }),
+      );
+    });
+
+    let helpers: UseEveAgentHelpers<EveMessageData> | undefined;
+    let root: ReturnType<typeof create> | undefined;
+
+    function TestComponent() {
+      helpers = useEveAgent();
+      return null;
+    }
+
+    await act(async () => {
+      root = create(createElement(TestComponent));
+    });
+
+    let sendPromise: Promise<void> | undefined;
+    await act(async () => {
+      sendPromise = helpers?.send("Hello");
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    });
+
+    expect(streamSignal?.aborted).toBe(false);
+
+    await act(async () => {
+      root?.unmount();
+    });
+
+    expect(streamSignal?.aborted).toBe(true);
+
+    await act(async () => {
+      await sendPromise;
+    });
+  });
+
   it("sends a message and projects streamed events with the default reducer", async () => {
     const events = [
       createMessageReceivedEvent({

--- a/packages/eve/src/react/use-eve-agent.ts
+++ b/packages/eve/src/react/use-eve-agent.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from "react";
 
 import {
   EveAgentStore,
@@ -167,6 +167,8 @@ export function useEveAgent<TData>(
     () => store.snapshot,
     () => store.snapshot,
   );
+
+  useEffect(() => () => store.stop(), [store]);
 
   const reset = useCallback(() => store.reset(), [store]);
   const send = useCallback(


### PR DESCRIPTION
### Summary

Related to #737. Active `send()` and `respond()` streams currently inherit the five-attempt idle reconnect budget, so a turn parked for OAuth can stop reaching the client before its callback resumes the workflow. Turn responses now explicitly keep the internal stream alive until Eve emits a turn boundary or the caller aborts, while manual `session.stream()` attachments retain their bounded idle behavior and explicit reconnect policies remain authoritative. React bindings also abort an active stream when their component unmounts, matching the existing Vue and Svelte cleanup behavior.

### Validation

Reproduced the failure with a turn that emits `authorization.required`, exceeds the old idle reconnect budget, and later emits `authorization.completed` plus a session boundary; focused session and React tests also verify cursor advancement, explicit finite retry limits, and unmount cancellation. Existing stream-follow integration coverage, Eve package typecheck, file-scoped lint, and docs checks pass. The full unit suite reached 6,482 passing tests; one unrelated production-server test could not bind `127.0.0.1` in the local sandbox.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+6 / -1`

Updates the reconnect contract and adds patch release notes for the user-visible fix.

**Implementation** — 3 files · `+17 / -1`

Uses an internal stream-lifetime flag, rather than a numeric infinity sentinel, to keep the behavior local to active turn responses and frontend lifecycle cleanup while preserving manual-stream and caller-configured policies.

**Tests** — 2 files · `+113 / -0`

Covers an authorization pause that exceeds the previous idle reconnect budget, verifies completion events and cursor advancement, preserves explicit finite retry limits, and confirms React unmount aborts the active stream.
