### PR TITLE
Resolve CLI commands from the enclosing eve application

### DIFF
--- a/.changeset/tidy-roots-resolve.md
+++ b/.changeset/tidy-roots-resolve.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Resolve project-scoped CLI commands from the nearest parent eve application, or prompt to select an application found in an immediate child directory.

--- a/.changeset/tidy-roots-resolve.md
+++ b/.changeset/tidy-roots-resolve.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Resolve project-scoped CLI commands from an enclosing eve application, or prompt to select an application in an immediate child directory.
+Resolve project-scoped CLI commands from the nearest enclosing eve application when run from a nested directory.

--- a/.changeset/tidy-roots-resolve.md
+++ b/.changeset/tidy-roots-resolve.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Resolve project-scoped CLI commands from the nearest enclosing eve application when run from a nested directory.
+Resolve project-scoped CLI commands from an enclosing eve application, or prompt to select an application in an immediate child directory.

--- a/.changeset/tidy-roots-resolve.md
+++ b/.changeset/tidy-roots-resolve.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Resolve project-scoped CLI commands from the nearest parent eve application, or prompt to select an application found in an immediate child directory.
+Resolve project-scoped CLI commands from the nearest enclosing eve application when run from a nested directory.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -3,9 +3,7 @@ title: "CLI"
 description: "Reference for every eve CLI command: init, set, info, build, start, dev, logs, trace, link, deploy, eval, channels, and extension."
 ---
 
-The `eve` binary (`bin: eve`) resolves the application root before running project commands. You can run a command from the application root or any directory beneath it. If the current directory is not inside an eve application, eve checks each immediate subdirectory. When it finds one or more applications, an interactive terminal asks which one to use, even when there is only one candidate. A non-interactive terminal lists the candidates and exits so it never chooses an application implicitly.
-
-Application selection does not scan nested descendants beyond those immediate subdirectories. `eve init` and `eve extension` commands continue to use the current directory because their purpose is to create or build at an explicit location. Remote `dev`, `invoke`, and `acp` commands also do not require a local application. Project commands load `.env` and `.env.local` from the resolved application root. Running `eve` with no command runs `eve init` when the current directory is not an eve project, or `eve dev` when it is.
+Relevant `eve` commands can run from the application root or any directory beneath it. Running `eve` with no command runs `eve init` when the current directory is not an eve project, or `eve dev` when it is.
 
 ## Commands
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -3,7 +3,9 @@ title: "CLI"
 description: "Reference for every eve CLI command: init, set, info, build, start, dev, logs, trace, link, deploy, eval, channels, and extension."
 ---
 
-The `eve` binary (`bin: eve`) runs from your app root. Every command first loads `.env`/`.env.local` from that root. Running `eve` with no command runs `eve init` when the current directory is not an eve project, or `eve dev` when it is.
+The `eve` binary (`bin: eve`) resolves the application root before running project commands. You can run a command from the application root or any directory beneath it. If the current directory is not inside an eve application, eve checks each immediate subdirectory. When it finds one or more applications, an interactive terminal asks which one to use, even when there is only one candidate. A non-interactive terminal lists the candidates and exits so it never chooses an application implicitly.
+
+Application selection does not scan nested descendants beyond those immediate subdirectories. `eve init` and `eve extension` commands continue to use the current directory because their purpose is to create or build at an explicit location. Remote `dev`, `invoke`, and `acp` commands also do not require a local application. Project commands load `.env` and `.env.local` from the resolved application root. Running `eve` with no command runs `eve init` when the current directory is not an eve project, or `eve dev` when it is.
 
 ## Commands
 

--- a/packages/eve/src/cli/acp/command.ts
+++ b/packages/eve/src/cli/acp/command.ts
@@ -24,7 +24,7 @@ export type ResolveVerifiedRemoteDevelopmentClient =
   typeof import("#setup/verified-remote-client.js").resolveVerifiedRemoteDevelopmentClient;
 
 export interface RegisterAcpCommandOptions {
-  readonly application: CliApplicationContext;
+  readonly applicationContext: CliApplicationContext;
   readonly eveVersion: string;
   readonly program: Command;
   readonly resolveVerifiedRemoteDevelopmentClient?: ResolveVerifiedRemoteDevelopmentClient;
@@ -34,7 +34,7 @@ export interface RegisterAcpCommandOptions {
 
 /** Registers the ACP stdio bridge for local and deployed eve agents. */
 export function registerAcpCommand(options: RegisterAcpCommandOptions): void {
-  applicationCommand(options.program.command("acp"), (command) => {
+  applicationCommand(options.program.command("acp"), options.applicationContext, (command) => {
     const commandOptions = command.opts<AcpCliOptions>();
     return (
       resolveDevelopmentUrlTarget(
@@ -58,7 +58,7 @@ export function registerAcpCommand(options: RegisterAcpCommandOptions): void {
     )
     .action(async (positionalUrl: string | undefined, commandOptions: AcpCliOptions) => {
       const target = resolveDevelopmentUrlTarget(commandOptions, positionalUrl);
-      loadDevelopmentEnvironmentFiles(options.application.root);
+      loadDevelopmentEnvironmentFiles(options.applicationContext.root);
       const lifecycle = installShutdownSignal({ exitAfterMs: FORCED_EXIT_BACKSTOP_MS });
 
       if (target !== undefined) {
@@ -87,7 +87,7 @@ export function registerAcpCommand(options: RegisterAcpCommandOptions): void {
 
       try {
         const startHost = options.startHost ?? (await loadStartHost());
-        server = startHost(options.application.root, {
+        server = startHost(options.applicationContext.root, {
           existing: "reject",
           host: "127.0.0.1",
           output: "stderr",
@@ -141,7 +141,7 @@ async function runAcp(
     serverUrl: serverInput.serverUrl,
     signal: serverInput.signal,
     vercelScope,
-    workspaceRoot: options.application.root,
+    workspaceRoot: options.applicationContext.root,
   });
   await run({
     auth: clientOptions.auth,

--- a/packages/eve/src/cli/acp/command.ts
+++ b/packages/eve/src/cli/acp/command.ts
@@ -1,4 +1,5 @@
 import { Command } from "#compiled/commander/index.js";
+import { applicationCommand, type CliApplicationContext } from "#cli/application-command.js";
 import { loadDevelopmentEnvironmentFiles } from "#cli/dev/environment.js";
 import {
   parseDevelopmentHeaderOption,
@@ -23,7 +24,7 @@ export type ResolveVerifiedRemoteDevelopmentClient =
   typeof import("#setup/verified-remote-client.js").resolveVerifiedRemoteDevelopmentClient;
 
 export interface RegisterAcpCommandOptions {
-  readonly appRoot: string;
+  readonly application: CliApplicationContext;
   readonly eveVersion: string;
   readonly program: Command;
   readonly resolveVerifiedRemoteDevelopmentClient?: ResolveVerifiedRemoteDevelopmentClient;
@@ -33,8 +34,15 @@ export interface RegisterAcpCommandOptions {
 
 /** Registers the ACP stdio bridge for local and deployed eve agents. */
 export function registerAcpCommand(options: RegisterAcpCommandOptions): void {
-  options.program
-    .command("acp")
+  applicationCommand(options.program.command("acp"), (command) => {
+    const commandOptions = command.opts<AcpCliOptions>();
+    return (
+      resolveDevelopmentUrlTarget(
+        commandOptions,
+        command.processedArgs[0] as string | undefined,
+      ) === undefined
+    );
+  })
     .description("Serve an eve agent through stable ACP v1 over stdio.")
     .argument("[url]", "Connect to an existing server URL", parseDevelopmentServerUrl)
     .option("-u, --url <url>", "Connect to an existing server URL", parseDevelopmentServerUrl)
@@ -50,7 +58,7 @@ export function registerAcpCommand(options: RegisterAcpCommandOptions): void {
     )
     .action(async (positionalUrl: string | undefined, commandOptions: AcpCliOptions) => {
       const target = resolveDevelopmentUrlTarget(commandOptions, positionalUrl);
-      loadDevelopmentEnvironmentFiles(options.appRoot);
+      loadDevelopmentEnvironmentFiles(options.application.root);
       const lifecycle = installShutdownSignal({ exitAfterMs: FORCED_EXIT_BACKSTOP_MS });
 
       if (target !== undefined) {
@@ -79,7 +87,7 @@ export function registerAcpCommand(options: RegisterAcpCommandOptions): void {
 
       try {
         const startHost = options.startHost ?? (await loadStartHost());
-        server = startHost(options.appRoot, {
+        server = startHost(options.application.root, {
           existing: "reject",
           host: "127.0.0.1",
           output: "stderr",
@@ -133,7 +141,7 @@ async function runAcp(
     serverUrl: serverInput.serverUrl,
     signal: serverInput.signal,
     vercelScope,
-    workspaceRoot: options.appRoot,
+    workspaceRoot: options.application.root,
   });
   await run({
     auth: clientOptions.auth,

--- a/packages/eve/src/cli/application-command.test.ts
+++ b/packages/eve/src/cli/application-command.test.ts
@@ -1,0 +1,36 @@
+import { Command } from "#compiled/commander/index.js";
+import { describe, expect, it, vi } from "vitest";
+
+import { applicationCommand, type CliApplicationContext } from "#cli/application-command.js";
+
+function context(): CliApplicationContext & { resolve: ReturnType<typeof vi.fn> } {
+  return { root: "/workspace", resolve: vi.fn(async () => {}) };
+}
+
+describe("applicationCommand", () => {
+  it("resolves the application root before running the action", async () => {
+    const applicationContext = context();
+    const action = vi.fn();
+    const program = new Command().exitOverride();
+    applicationCommand(program.command("build"), applicationContext).action(action);
+
+    await program.parseAsync(["build"], { from: "user" });
+
+    expect(applicationContext.resolve).toHaveBeenCalledOnce();
+    expect(action).toHaveBeenCalledOnce();
+  });
+
+  it("supports command-local conditional resolution", async () => {
+    const applicationContext = context();
+    const program = new Command().exitOverride();
+    applicationCommand(
+      program.command("invoke").option("--url <url>"),
+      applicationContext,
+      (command) => command.opts<{ url?: string }>().url === undefined,
+    ).action(vi.fn());
+
+    await program.parseAsync(["invoke", "--url", "https://example.com"], { from: "user" });
+
+    expect(applicationContext.resolve).not.toHaveBeenCalled();
+  });
+});

--- a/packages/eve/src/cli/application-command.ts
+++ b/packages/eve/src/cli/application-command.ts
@@ -1,0 +1,22 @@
+import type { Command } from "#compiled/commander/index.js";
+
+export interface CliApplicationContext {
+  root: string;
+}
+
+export type CliApplicationRootRequirement = (command: Command) => boolean;
+
+const applicationRootRequirement = new WeakMap<Command, CliApplicationRootRequirement>();
+
+/** Marks a CLI command as requiring a resolved eve application root. */
+export function applicationCommand(
+  command: Command,
+  requirement: CliApplicationRootRequirement = () => true,
+): Command {
+  applicationRootRequirement.set(command, requirement);
+  return command;
+}
+
+export function commandRequiresApplicationRoot(command: Command): boolean {
+  return applicationRootRequirement.get(command)?.(command) ?? false;
+}

--- a/packages/eve/src/cli/application-command.ts
+++ b/packages/eve/src/cli/application-command.ts
@@ -2,21 +2,18 @@ import type { Command } from "#compiled/commander/index.js";
 
 export interface CliApplicationContext {
   root: string;
+  resolve(): Promise<void>;
 }
 
 export type CliApplicationRootRequirement = (command: Command) => boolean;
 
-const applicationRootRequirement = new WeakMap<Command, CliApplicationRootRequirement>();
-
-/** Marks a CLI command as requiring a resolved eve application root. */
+/** Adds application-root resolution to a project-scoped CLI command. */
 export function applicationCommand(
   command: Command,
+  applicationContext: CliApplicationContext,
   requirement: CliApplicationRootRequirement = () => true,
 ): Command {
-  applicationRootRequirement.set(command, requirement);
-  return command;
-}
-
-export function commandRequiresApplicationRoot(command: Command): boolean {
-  return applicationRootRequirement.get(command)?.(command) ?? false;
+  return command.hook("preAction", async (_command, actionCommand) => {
+    if (requirement(actionCommand)) await applicationContext.resolve();
+  });
 }

--- a/packages/eve/src/cli/application-root.test.ts
+++ b/packages/eve/src/cli/application-root.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  resolveCliApplicationRoot,
+  type ResolveCliApplicationRootDependencies,
+} from "#cli/application-root.js";
+import type { Prompter } from "#setup/prompter.js";
+
+function dependencies(input: {
+  readonly directories?: readonly string[];
+  readonly projects?: readonly string[];
+  readonly select?: (options: unknown) => Promise<string>;
+}): ResolveCliApplicationRootDependencies {
+  const directories = input.directories ?? [];
+  const projects = new Set(input.projects ?? []);
+  return {
+    createPrompter: () =>
+      ({
+        select: input.select ?? vi.fn(),
+      }) as Prompter,
+    isEveProject: async (path) => projects.has(path),
+    readDirectory: vi.fn(async () =>
+      directories.map((name) => ({
+        name,
+        isDirectory: () => true,
+      })),
+    ),
+  };
+}
+
+describe("resolveCliApplicationRoot", () => {
+  it("uses the current application root without prompting", async () => {
+    const select = vi.fn();
+    const deps = dependencies({ projects: ["/repo"], select });
+
+    await expect(resolveCliApplicationRoot("/repo", { interactive: true }, deps)).resolves.toBe(
+      "/repo",
+    );
+    expect(select).not.toHaveBeenCalled();
+    expect(deps.readDirectory).not.toHaveBeenCalled();
+  });
+
+  it("uses the nearest ancestor application root", async () => {
+    const deps = dependencies({ projects: ["/repo", "/repo/apps/agent"] });
+
+    await expect(
+      resolveCliApplicationRoot("/repo/apps/agent/agent/tools", { interactive: true }, deps),
+    ).resolves.toBe("/repo/apps/agent");
+    expect(deps.readDirectory).not.toHaveBeenCalled();
+  });
+
+  it("asks before using a sole immediate child application", async () => {
+    const select = vi.fn(async () => "/workspace/weather");
+    const deps = dependencies({
+      directories: ["weather", "notes"],
+      projects: ["/workspace/weather"],
+      select,
+    });
+
+    await expect(
+      resolveCliApplicationRoot("/workspace", { interactive: true }, deps),
+    ).resolves.toBe("/workspace/weather");
+    expect(select).toHaveBeenCalledWith({
+      message: "Which eve application should run this command?",
+      description: "Found eve applications in immediate subdirectories.",
+      options: [{ value: "/workspace/weather", label: "./weather" }],
+      initialValue: "/workspace/weather",
+    });
+  });
+
+  it("sorts multiple immediate child applications in the prompt", async () => {
+    const select = vi.fn(async () => "/workspace/alpha");
+    const deps = dependencies({
+      directories: ["zulu", "alpha"],
+      projects: ["/workspace/alpha", "/workspace/zulu"],
+      select,
+    });
+
+    await resolveCliApplicationRoot("/workspace", { interactive: true }, deps);
+
+    expect(select).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: [
+          { value: "/workspace/alpha", label: "./alpha" },
+          { value: "/workspace/zulu", label: "./zulu" },
+        ],
+      }),
+    );
+  });
+
+  it("lists child applications instead of choosing in a non-interactive terminal", async () => {
+    const deps = dependencies({
+      directories: ["weather"],
+      projects: ["/workspace/weather"],
+    });
+
+    await expect(
+      resolveCliApplicationRoot("/workspace", { interactive: false }, deps),
+    ).rejects.toThrow("Run the command from inside one of these applications:\n  - ./weather");
+  });
+
+  it("fails when no ancestor or immediate child is an application", async () => {
+    const deps = dependencies({ directories: ["packages"] });
+
+    await expect(
+      resolveCliApplicationRoot("/workspace", { interactive: true }, deps),
+    ).rejects.toThrow(
+      "No eve application found in this directory, its ancestors, or its immediate subdirectories.",
+    );
+  });
+});

--- a/packages/eve/src/cli/application-root.test.ts
+++ b/packages/eve/src/cli/application-root.test.ts
@@ -1,111 +1,38 @@
 import { describe, expect, it, vi } from "vitest";
 
-import {
-  resolveCliApplicationRoot,
-  type ResolveCliApplicationRootDependencies,
-} from "#cli/application-root.js";
-import type { Prompter } from "#setup/prompter.js";
+import { resolveCliApplicationRoot } from "#cli/application-root.js";
 
-function dependencies(input: {
-  readonly directories?: readonly string[];
-  readonly projects?: readonly string[];
-  readonly select?: (options: unknown) => Promise<string>;
-}): ResolveCliApplicationRootDependencies {
-  const directories = input.directories ?? [];
-  const projects = new Set(input.projects ?? []);
-  return {
-    createPrompter: () =>
-      ({
-        select: input.select ?? vi.fn(),
-      }) as Prompter,
-    isEveProject: async (path) => projects.has(path),
-    readDirectory: vi.fn(async () =>
-      directories.map((name) => ({
-        name,
-        isDirectory: () => true,
-      })),
-    ),
-  };
+function dependencies(projects: readonly string[]) {
+  const knownProjects = new Set(projects);
+  return { isEveProject: vi.fn(async (path: string) => knownProjects.has(path)) };
 }
 
 describe("resolveCliApplicationRoot", () => {
-  it("uses the current application root without prompting", async () => {
-    const select = vi.fn();
-    const deps = dependencies({ projects: ["/repo"], select });
+  it("uses the current application root", async () => {
+    const deps = dependencies(["/repo"]);
 
-    await expect(resolveCliApplicationRoot("/repo", { interactive: true }, deps)).resolves.toBe(
-      "/repo",
-    );
-    expect(select).not.toHaveBeenCalled();
-    expect(deps.readDirectory).not.toHaveBeenCalled();
+    await expect(resolveCliApplicationRoot("/repo", deps)).resolves.toBe("/repo");
+    expect(deps.isEveProject).toHaveBeenCalledTimes(1);
   });
 
   it("uses the nearest ancestor application root", async () => {
-    const deps = dependencies({ projects: ["/repo", "/repo/apps/agent"] });
+    const deps = dependencies(["/repo", "/repo/apps/agent"]);
 
-    await expect(
-      resolveCliApplicationRoot("/repo/apps/agent/agent/tools", { interactive: true }, deps),
-    ).resolves.toBe("/repo/apps/agent");
-    expect(deps.readDirectory).not.toHaveBeenCalled();
-  });
-
-  it("asks before using a sole immediate child application", async () => {
-    const select = vi.fn(async () => "/workspace/weather");
-    const deps = dependencies({
-      directories: ["weather", "notes"],
-      projects: ["/workspace/weather"],
-      select,
-    });
-
-    await expect(
-      resolveCliApplicationRoot("/workspace", { interactive: true }, deps),
-    ).resolves.toBe("/workspace/weather");
-    expect(select).toHaveBeenCalledWith({
-      message: "Which eve application should run this command?",
-      description: "Found eve applications in immediate subdirectories.",
-      options: [{ value: "/workspace/weather", label: "./weather" }],
-      initialValue: "/workspace/weather",
-    });
-  });
-
-  it("sorts multiple immediate child applications in the prompt", async () => {
-    const select = vi.fn(async () => "/workspace/alpha");
-    const deps = dependencies({
-      directories: ["zulu", "alpha"],
-      projects: ["/workspace/alpha", "/workspace/zulu"],
-      select,
-    });
-
-    await resolveCliApplicationRoot("/workspace", { interactive: true }, deps);
-
-    expect(select).toHaveBeenCalledWith(
-      expect.objectContaining({
-        options: [
-          { value: "/workspace/alpha", label: "./alpha" },
-          { value: "/workspace/zulu", label: "./zulu" },
-        ],
-      }),
+    await expect(resolveCliApplicationRoot("/repo/apps/agent/agent/tools", deps)).resolves.toBe(
+      "/repo/apps/agent",
     );
+    expect(deps.isEveProject.mock.calls.map(([path]) => path)).toEqual([
+      "/repo/apps/agent/agent/tools",
+      "/repo/apps/agent/agent",
+      "/repo/apps/agent",
+    ]);
   });
 
-  it("lists child applications instead of choosing in a non-interactive terminal", async () => {
-    const deps = dependencies({
-      directories: ["weather"],
-      projects: ["/workspace/weather"],
-    });
+  it("fails when no enclosing directory is an application", async () => {
+    const deps = dependencies([]);
 
-    await expect(
-      resolveCliApplicationRoot("/workspace", { interactive: false }, deps),
-    ).rejects.toThrow("Run the command from inside one of these applications:\n  - ./weather");
-  });
-
-  it("fails when no ancestor or immediate child is an application", async () => {
-    const deps = dependencies({ directories: ["packages"] });
-
-    await expect(
-      resolveCliApplicationRoot("/workspace", { interactive: true }, deps),
-    ).rejects.toThrow(
-      "No eve application found in this directory, its ancestors, or its immediate subdirectories.",
+    await expect(resolveCliApplicationRoot("/workspace/packages", deps)).rejects.toThrow(
+      "No eve application found in this directory or its ancestors.",
     );
   });
 });

--- a/packages/eve/src/cli/application-root.test.ts
+++ b/packages/eve/src/cli/application-root.test.ts
@@ -1,44 +1,122 @@
+import { resolve } from "node:path";
+
 import { describe, expect, it, vi } from "vitest";
 
-import { findCliApplicationRoot, resolveCliApplicationRoot } from "#cli/application-root.js";
+import {
+  findCliApplicationRoot,
+  resolveCliApplicationRoot,
+  type ResolveCliApplicationRootDependencies,
+} from "#cli/application-root.js";
+import { DiscoveryProjectResolutionError } from "#discover/project.js";
+import {
+  createDiscoverErrorDiagnostic,
+  DISCOVER_PROJECT_NOT_FOUND,
+} from "#discover/diagnostics.js";
+import type { Prompter } from "#setup/prompter.js";
 
-function dependencies(projects: readonly string[]) {
-  const knownProjects = new Set(projects);
-  return { isEveProject: vi.fn(async (path: string) => knownProjects.has(path)) };
+function projectNotFound(path: string): DiscoveryProjectResolutionError {
+  return new DiscoveryProjectResolutionError(
+    createDiscoverErrorDiagnostic({
+      code: DISCOVER_PROJECT_NOT_FOUND,
+      message: `Could not resolve an eve agent root from "${path}".`,
+      sourcePath: path,
+    }),
+  );
+}
+
+function dependencies(input: {
+  readonly directories?: readonly string[];
+  readonly projects?: Readonly<Record<string, { appRoot: string; layout?: "flat" | "nested" }>>;
+  readonly select?: (options: unknown) => Promise<string>;
+}): ResolveCliApplicationRootDependencies {
+  return {
+    createPrompter: () => ({ select: input.select ?? vi.fn() }) as Prompter,
+    readDirectory: vi.fn(async () =>
+      (input.directories ?? []).map((name) => ({ name, isDirectory: () => true })),
+    ),
+    resolveDiscoveryProject: vi.fn(async (path: string | undefined) => {
+      const resolvedPath = resolve(path ?? process.cwd());
+      const project = input.projects?.[resolvedPath];
+      if (project === undefined) throw projectNotFound(resolvedPath);
+      return {
+        agentRoot: project.layout === "flat" ? project.appRoot : `${project.appRoot}/agent`,
+        appRoot: project.appRoot,
+        layout: project.layout ?? "nested",
+      };
+    }),
+  };
 }
 
 describe("resolveCliApplicationRoot", () => {
-  it("uses the current application root", async () => {
-    const deps = dependencies(["/repo"]);
+  it("uses the application root resolved by project discovery", async () => {
+    const deps = dependencies({ projects: { "/repo/agent/tools": { appRoot: "/repo" } } });
 
-    await expect(resolveCliApplicationRoot("/repo", deps)).resolves.toBe("/repo");
-    expect(deps.isEveProject).toHaveBeenCalledTimes(1);
+    await expect(resolveCliApplicationRoot("/repo/agent/tools", {}, deps)).resolves.toBe("/repo");
+    expect(deps.readDirectory).not.toHaveBeenCalled();
   });
 
-  it("uses the nearest ancestor application root", async () => {
-    const deps = dependencies(["/repo", "/repo/apps/agent"]);
+  it("finds flat application roots", async () => {
+    const deps = dependencies({
+      projects: { "/repo/agents/billing": { appRoot: "/repo/agents/billing", layout: "flat" } },
+    });
 
-    await expect(resolveCliApplicationRoot("/repo/apps/agent/agent/tools", deps)).resolves.toBe(
-      "/repo/apps/agent",
+    await expect(findCliApplicationRoot("/repo/agents/billing", deps)).resolves.toBe(
+      "/repo/agents/billing",
     );
-    expect(deps.isEveProject.mock.calls.map(([path]) => path)).toEqual([
-      "/repo/apps/agent/agent/tools",
-      "/repo/apps/agent/agent",
-      "/repo/apps/agent",
-    ]);
   });
 
-  it("returns undefined when finding from outside an application", async () => {
-    const deps = dependencies([]);
+  it("always asks before using an immediate child application", async () => {
+    const select = vi.fn(async () => "/workspace/weather");
+    const deps = dependencies({
+      directories: ["weather", "notes"],
+      projects: { "/workspace/weather": { appRoot: "/workspace/weather" } },
+      select,
+    });
 
-    await expect(findCliApplicationRoot("/workspace/packages", deps)).resolves.toBeUndefined();
+    await expect(
+      resolveCliApplicationRoot("/workspace", { interactive: true }, deps),
+    ).resolves.toBe("/workspace/weather");
+    expect(select).toHaveBeenCalledWith({
+      message: "Which eve application should run this command?",
+      options: [{ value: "/workspace/weather", label: "./weather" }],
+      initialValue: "/workspace/weather",
+    });
   });
 
-  it("fails when resolving from outside an application", async () => {
-    const deps = dependencies([]);
+  it("does not treat a child's enclosing parent application as a child candidate", async () => {
+    const deps = dependencies({
+      directories: ["nested"],
+      projects: { "/workspace/nested": { appRoot: "/workspace" } },
+    });
 
-    await expect(resolveCliApplicationRoot("/workspace/packages", deps)).rejects.toThrow(
-      "No eve application found in this directory or its ancestors.",
+    await expect(
+      resolveCliApplicationRoot("/workspace", { interactive: true }, deps),
+    ).resolves.toBe("/workspace");
+  });
+
+  it("lists child applications instead of choosing non-interactively", async () => {
+    const deps = dependencies({
+      directories: ["weather"],
+      projects: { "/workspace/weather": { appRoot: "/workspace/weather" } },
+    });
+
+    await expect(
+      resolveCliApplicationRoot("/workspace", { interactive: false }, deps),
+    ).rejects.toThrow("Run the command from inside one of these applications:\n  - ./weather");
+  });
+
+  it("preserves cwd when no enclosing or immediate-child application exists", async () => {
+    const deps = dependencies({ directories: ["packages"] });
+
+    await expect(resolveCliApplicationRoot("./workspace", {}, deps)).resolves.toBe(
+      resolve("./workspace"),
     );
+  });
+
+  it("does not hide unexpected discovery failures", async () => {
+    const deps = dependencies({});
+    vi.mocked(deps.resolveDiscoveryProject).mockRejectedValue(new Error("read failed"));
+
+    await expect(resolveCliApplicationRoot("/workspace", {}, deps)).rejects.toThrow("read failed");
   });
 });

--- a/packages/eve/src/cli/application-root.test.ts
+++ b/packages/eve/src/cli/application-root.test.ts
@@ -26,11 +26,16 @@ function projectNotFound(path: string): DiscoveryProjectResolutionError {
 
 function dependencies(input: {
   readonly directories?: readonly string[];
+  readonly packageRoots?: readonly string[];
   readonly projects?: Readonly<Record<string, { appRoot: string; layout?: "flat" | "nested" }>>;
   readonly select?: (options: unknown) => Promise<string>;
 }): ResolveCliApplicationRootDependencies {
+  const packageRoots = new Set(input.packageRoots ?? Object.keys(input.projects ?? {}));
   return {
     createPrompter: () => ({ select: input.select ?? vi.fn() }) as Prompter,
+    pathExists: vi.fn(async (path) =>
+      [...packageRoots].some((root) => path === `${root}/package.json`),
+    ),
     readDirectory: vi.fn(async () =>
       (input.directories ?? []).map((name) => ({ name, isDirectory: () => true })),
     ),
@@ -81,6 +86,37 @@ describe("resolveCliApplicationRoot", () => {
       options: [{ value: "/workspace/weather", label: "./weather" }],
       initialValue: "/workspace/weather",
     });
+  });
+
+  it("excludes a flat-shaped child without an authored package boundary", async () => {
+    const select = vi.fn();
+    const deps = dependencies({
+      directories: ["state-usage"],
+      packageRoots: [],
+      projects: { "/workspace/state-usage": { appRoot: "/workspace/state-usage", layout: "flat" } },
+      select,
+    });
+
+    await expect(
+      resolveCliApplicationRoot("/workspace", { interactive: true }, deps),
+    ).resolves.toBe("/workspace");
+    expect(select).not.toHaveBeenCalled();
+  });
+
+  it("includes a flat child inside an authored package boundary", async () => {
+    const select = vi.fn(async () => "/workspace/billing");
+    const deps = dependencies({
+      directories: ["billing"],
+      packageRoots: ["/workspace"],
+      projects: {
+        "/workspace/billing": { appRoot: "/workspace/billing", layout: "flat" },
+      },
+      select,
+    });
+
+    await expect(
+      resolveCliApplicationRoot("/workspace", { interactive: true }, deps),
+    ).resolves.toBe("/workspace/billing");
   });
 
   it("does not treat a child's enclosing parent application as a child candidate", async () => {

--- a/packages/eve/src/cli/application-root.test.ts
+++ b/packages/eve/src/cli/application-root.test.ts
@@ -7,12 +7,11 @@ import {
   resolveCliApplicationRoot,
   type ResolveCliApplicationRootDependencies,
 } from "#cli/application-root.js";
-import { DiscoveryProjectResolutionError } from "#discover/project.js";
 import {
   createDiscoverErrorDiagnostic,
   DISCOVER_PROJECT_NOT_FOUND,
 } from "#discover/diagnostics.js";
-import type { Prompter } from "#setup/prompter.js";
+import { DiscoveryProjectResolutionError } from "#discover/project.js";
 
 function projectNotFound(path: string): DiscoveryProjectResolutionError {
   return new DiscoveryProjectResolutionError(
@@ -24,135 +23,58 @@ function projectNotFound(path: string): DiscoveryProjectResolutionError {
   );
 }
 
-function dependencies(input: {
-  readonly directories?: readonly string[];
-  readonly packageRoots?: readonly string[];
-  readonly projects?: Readonly<Record<string, { appRoot: string; layout?: "flat" | "nested" }>>;
-  readonly select?: (options: unknown) => Promise<string>;
-}): ResolveCliApplicationRootDependencies {
-  const packageRoots = new Set(input.packageRoots ?? Object.keys(input.projects ?? {}));
-  return {
-    createPrompter: () => ({ select: input.select ?? vi.fn() }) as Prompter,
-    pathExists: vi.fn(async (path) =>
-      [...packageRoots].some((root) => path === `${root}/package.json`),
-    ),
-    readDirectory: vi.fn(async () =>
-      (input.directories ?? []).map((name) => ({ name, isDirectory: () => true })),
-    ),
-    resolveDiscoveryProject: vi.fn(async (path: string | undefined) => {
-      const resolvedPath = resolve(path ?? process.cwd());
-      const project = input.projects?.[resolvedPath];
-      if (project === undefined) throw projectNotFound(resolvedPath);
-      return {
-        agentRoot: project.layout === "flat" ? project.appRoot : `${project.appRoot}/agent`,
-        appRoot: project.appRoot,
-        layout: project.layout ?? "nested",
-      };
-    }),
-  };
+function dependencies(
+  implementation: ResolveCliApplicationRootDependencies["resolveDiscoveryProject"],
+): ResolveCliApplicationRootDependencies {
+  return { resolveDiscoveryProject: vi.fn(implementation) };
 }
 
 describe("resolveCliApplicationRoot", () => {
   it("uses the application root resolved by project discovery", async () => {
-    const deps = dependencies({ projects: { "/repo/agent/tools": { appRoot: "/repo" } } });
+    const deps = dependencies(async () => ({
+      agentRoot: "/repo/agent",
+      appRoot: "/repo",
+      layout: "nested",
+    }));
 
-    await expect(resolveCliApplicationRoot("/repo/agent/tools", {}, deps)).resolves.toBe("/repo");
-    expect(deps.readDirectory).not.toHaveBeenCalled();
+    await expect(resolveCliApplicationRoot("/repo/agent/tools", deps)).resolves.toBe("/repo");
   });
 
   it("finds flat application roots", async () => {
-    const deps = dependencies({
-      projects: { "/repo/agents/billing": { appRoot: "/repo/agents/billing", layout: "flat" } },
-    });
+    const deps = dependencies(async () => ({
+      agentRoot: "/repo/agents/billing",
+      appRoot: "/repo/agents/billing",
+      layout: "flat",
+    }));
 
     await expect(findCliApplicationRoot("/repo/agents/billing", deps)).resolves.toBe(
       "/repo/agents/billing",
     );
   });
 
-  it("always asks before using an immediate child application", async () => {
-    const select = vi.fn(async () => "/workspace/weather");
-    const deps = dependencies({
-      directories: ["weather", "notes"],
-      projects: { "/workspace/weather": { appRoot: "/workspace/weather" } },
-      select,
+  it("returns undefined when finding from outside an application", async () => {
+    const deps = dependencies(async (path) => {
+      throw projectNotFound(path ?? process.cwd());
     });
 
-    await expect(
-      resolveCliApplicationRoot("/workspace", { interactive: true }, deps),
-    ).resolves.toBe("/workspace/weather");
-    expect(select).toHaveBeenCalledWith({
-      message: "Which eve application should run this command?",
-      options: [{ value: "/workspace/weather", label: "./weather" }],
-      initialValue: "/workspace/weather",
-    });
+    await expect(findCliApplicationRoot("/workspace/packages", deps)).resolves.toBeUndefined();
   });
 
-  it("excludes a flat-shaped child without an authored package boundary", async () => {
-    const select = vi.fn();
-    const deps = dependencies({
-      directories: ["state-usage"],
-      packageRoots: [],
-      projects: { "/workspace/state-usage": { appRoot: "/workspace/state-usage", layout: "flat" } },
-      select,
+  it("preserves cwd when resolving from outside an application", async () => {
+    const deps = dependencies(async (path) => {
+      throw projectNotFound(path ?? process.cwd());
     });
 
-    await expect(
-      resolveCliApplicationRoot("/workspace", { interactive: true }, deps),
-    ).resolves.toBe("/workspace");
-    expect(select).not.toHaveBeenCalled();
-  });
-
-  it("includes a flat child inside an authored package boundary", async () => {
-    const select = vi.fn(async () => "/workspace/billing");
-    const deps = dependencies({
-      directories: ["billing"],
-      packageRoots: ["/workspace"],
-      projects: {
-        "/workspace/billing": { appRoot: "/workspace/billing", layout: "flat" },
-      },
-      select,
-    });
-
-    await expect(
-      resolveCliApplicationRoot("/workspace", { interactive: true }, deps),
-    ).resolves.toBe("/workspace/billing");
-  });
-
-  it("does not treat a child's enclosing parent application as a child candidate", async () => {
-    const deps = dependencies({
-      directories: ["nested"],
-      projects: { "/workspace/nested": { appRoot: "/workspace" } },
-    });
-
-    await expect(
-      resolveCliApplicationRoot("/workspace", { interactive: true }, deps),
-    ).resolves.toBe("/workspace");
-  });
-
-  it("lists child applications instead of choosing non-interactively", async () => {
-    const deps = dependencies({
-      directories: ["weather"],
-      projects: { "/workspace/weather": { appRoot: "/workspace/weather" } },
-    });
-
-    await expect(
-      resolveCliApplicationRoot("/workspace", { interactive: false }, deps),
-    ).rejects.toThrow("Run the command from inside one of these applications:\n  - ./weather");
-  });
-
-  it("preserves cwd when no enclosing or immediate-child application exists", async () => {
-    const deps = dependencies({ directories: ["packages"] });
-
-    await expect(resolveCliApplicationRoot("./workspace", {}, deps)).resolves.toBe(
-      resolve("./workspace"),
+    await expect(resolveCliApplicationRoot("./workspace/packages", deps)).resolves.toBe(
+      resolve("./workspace/packages"),
     );
   });
 
   it("does not hide unexpected discovery failures", async () => {
-    const deps = dependencies({});
-    vi.mocked(deps.resolveDiscoveryProject).mockRejectedValue(new Error("read failed"));
+    const deps = dependencies(async () => {
+      throw new Error("read failed");
+    });
 
-    await expect(resolveCliApplicationRoot("/workspace", {}, deps)).rejects.toThrow("read failed");
+    await expect(resolveCliApplicationRoot("/workspace", deps)).rejects.toThrow("read failed");
   });
 });

--- a/packages/eve/src/cli/application-root.test.ts
+++ b/packages/eve/src/cli/application-root.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { resolveCliApplicationRoot } from "#cli/application-root.js";
+import { findCliApplicationRoot, resolveCliApplicationRoot } from "#cli/application-root.js";
 
 function dependencies(projects: readonly string[]) {
   const knownProjects = new Set(projects);
@@ -28,7 +28,13 @@ describe("resolveCliApplicationRoot", () => {
     ]);
   });
 
-  it("fails when no enclosing directory is an application", async () => {
+  it("returns undefined when finding from outside an application", async () => {
+    const deps = dependencies([]);
+
+    await expect(findCliApplicationRoot("/workspace/packages", deps)).resolves.toBeUndefined();
+  });
+
+  it("fails when resolving from outside an application", async () => {
     const deps = dependencies([]);
 
     await expect(resolveCliApplicationRoot("/workspace/packages", deps)).rejects.toThrow(

--- a/packages/eve/src/cli/application-root.ts
+++ b/packages/eve/src/cli/application-root.ts
@@ -1,95 +1,27 @@
-import { readdir } from "node:fs/promises";
-import { dirname, relative, resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 
-import { createPrompter, type Prompter } from "#setup/prompter.js";
 import { isEveProject } from "#setup/scaffold/index.js";
 
-interface ApplicationRootDirectoryEntry {
-  readonly name: string;
-  isDirectory(): boolean;
-}
-
 export interface ResolveCliApplicationRootDependencies {
-  readonly createPrompter: () => Prompter;
   readonly isEveProject: (path: string) => Promise<boolean>;
-  readonly readDirectory: (
-    path: string,
-    options: { readonly withFileTypes: true },
-  ) => Promise<readonly ApplicationRootDirectoryEntry[]>;
 }
 
 const defaultDependencies: ResolveCliApplicationRootDependencies = {
-  createPrompter,
   isEveProject,
-  readDirectory: readdir,
 };
 
-function displayChildPath(cwd: string, path: string): string {
-  return `./${relative(cwd, path).replaceAll("\\", "/")}`;
-}
-
-async function findNearestApplicationRoot(
-  cwd: string,
-  isProject: ResolveCliApplicationRootDependencies["isEveProject"],
-): Promise<string | undefined> {
-  let candidate = cwd;
-  while (true) {
-    if (await isProject(candidate)) return candidate;
-    const parent = dirname(candidate);
-    if (parent === candidate) return undefined;
-    candidate = parent;
-  }
-}
-
-async function findChildApplicationRoots(
-  cwd: string,
-  dependencies: ResolveCliApplicationRootDependencies,
-): Promise<string[]> {
-  const entries = await dependencies.readDirectory(cwd, { withFileTypes: true });
-  const directories = entries
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => resolve(cwd, entry.name))
-    .sort((left, right) => left.localeCompare(right));
-
-  const matches = await Promise.all(
-    directories.map(async (path) => ((await dependencies.isEveProject(path)) ? path : undefined)),
-  );
-  return matches.filter((path): path is string => path !== undefined);
-}
-
-/** Resolves the eve application a project-scoped CLI command should operate on. */
+/** Resolves the nearest enclosing eve application for a project-scoped command. */
 export async function resolveCliApplicationRoot(
   cwd: string = process.cwd(),
-  options: { readonly interactive?: boolean } = {},
   dependencies: ResolveCliApplicationRootDependencies = defaultDependencies,
 ): Promise<string> {
-  const resolvedCwd = resolve(cwd);
-  const ancestor = await findNearestApplicationRoot(resolvedCwd, dependencies.isEveProject);
-  if (ancestor !== undefined) return ancestor;
-
-  const children = await findChildApplicationRoots(resolvedCwd, dependencies);
-  if (children.length === 0) {
-    throw new Error(
-      "No eve application found in this directory, its ancestors, or its immediate subdirectories.",
-    );
+  let candidate = resolve(cwd);
+  while (true) {
+    if (await dependencies.isEveProject(candidate)) return candidate;
+    const parent = dirname(candidate);
+    if (parent === candidate) {
+      throw new Error("No eve application found in this directory or its ancestors.");
+    }
+    candidate = parent;
   }
-
-  if (options.interactive !== true) {
-    const candidates = children
-      .map((path) => `  - ${displayChildPath(resolvedCwd, path)}`)
-      .join("\n");
-    throw new Error(
-      `Cannot choose an eve application without an interactive terminal. Run the command from inside one of these applications:\n${candidates}`,
-    );
-  }
-
-  return await dependencies.createPrompter().select<string>({
-    message: "Which eve application should run this command?",
-    description: "Found eve applications in immediate subdirectories.",
-    options: children.map((path) => ({
-      value: path,
-      label: displayChildPath(resolvedCwd, path),
-    })),
-    initialValue: children[0],
-  });
 }

--- a/packages/eve/src/cli/application-root.ts
+++ b/packages/eve/src/cli/application-root.ts
@@ -1,5 +1,5 @@
-import { readdir } from "node:fs/promises";
-import { relative, resolve } from "node:path";
+import { access, readdir } from "node:fs/promises";
+import { dirname, join, relative, resolve } from "node:path";
 
 import { createPrompter, type Prompter } from "#setup/prompter.js";
 import { DiscoveryProjectResolutionError, resolveDiscoveryProject } from "#discover/project.js";
@@ -11,6 +11,7 @@ interface ApplicationRootDirectoryEntry {
 
 export interface ResolveCliApplicationRootDependencies {
   readonly createPrompter: () => Prompter;
+  readonly pathExists: (path: string) => Promise<boolean>;
   readonly readDirectory: (
     path: string,
     options: { readonly withFileTypes: true },
@@ -20,6 +21,14 @@ export interface ResolveCliApplicationRootDependencies {
 
 const defaultDependencies: ResolveCliApplicationRootDependencies = {
   createPrompter,
+  async pathExists(path) {
+    try {
+      await access(path);
+      return true;
+    } catch {
+      return false;
+    }
+  },
   readDirectory: readdir,
   resolveDiscoveryProject,
 };
@@ -44,6 +53,19 @@ export async function findCliApplicationRoot(
   return await tryResolveApplicationRoot(cwd, dependencies);
 }
 
+async function hasAuthoredPackageBoundary(
+  appRoot: string,
+  dependencies: ResolveCliApplicationRootDependencies,
+): Promise<boolean> {
+  let directory = appRoot;
+  while (true) {
+    if (await dependencies.pathExists(join(directory, "package.json"))) return true;
+    const parent = dirname(directory);
+    if (parent === directory) return false;
+    directory = parent;
+  }
+}
+
 async function findChildApplicationRoots(
   cwd: string,
   dependencies: ResolveCliApplicationRootDependencies,
@@ -56,7 +78,8 @@ async function findChildApplicationRoots(
   const roots = await Promise.all(
     directories.map(async (directory) => {
       const appRoot = await tryResolveApplicationRoot(directory, dependencies);
-      return appRoot === directory ? appRoot : undefined;
+      if (appRoot !== directory) return undefined;
+      return (await hasAuthoredPackageBoundary(appRoot, dependencies)) ? appRoot : undefined;
     }),
   );
   return roots.filter((root): root is string => root !== undefined);

--- a/packages/eve/src/cli/application-root.ts
+++ b/packages/eve/src/cli/application-root.ts
@@ -10,18 +10,26 @@ const defaultDependencies: ResolveCliApplicationRootDependencies = {
   isEveProject,
 };
 
+/** Finds the nearest enclosing eve application. */
+export async function findCliApplicationRoot(
+  cwd: string = process.cwd(),
+  dependencies: ResolveCliApplicationRootDependencies = defaultDependencies,
+): Promise<string | undefined> {
+  let candidate = resolve(cwd);
+  while (true) {
+    if (await dependencies.isEveProject(candidate)) return candidate;
+    const parent = dirname(candidate);
+    if (parent === candidate) return undefined;
+    candidate = parent;
+  }
+}
+
 /** Resolves the nearest enclosing eve application for a project-scoped command. */
 export async function resolveCliApplicationRoot(
   cwd: string = process.cwd(),
   dependencies: ResolveCliApplicationRootDependencies = defaultDependencies,
 ): Promise<string> {
-  let candidate = resolve(cwd);
-  while (true) {
-    if (await dependencies.isEveProject(candidate)) return candidate;
-    const parent = dirname(candidate);
-    if (parent === candidate) {
-      throw new Error("No eve application found in this directory or its ancestors.");
-    }
-    candidate = parent;
-  }
+  const appRoot = await findCliApplicationRoot(cwd, dependencies);
+  if (appRoot !== undefined) return appRoot;
+  throw new Error("No eve application found in this directory or its ancestors.");
 }

--- a/packages/eve/src/cli/application-root.ts
+++ b/packages/eve/src/cli/application-root.ts
@@ -1,35 +1,99 @@
-import { dirname, resolve } from "node:path";
+import { readdir } from "node:fs/promises";
+import { relative, resolve } from "node:path";
 
-import { isEveProject } from "#setup/scaffold/index.js";
+import { createPrompter, type Prompter } from "#setup/prompter.js";
+import { DiscoveryProjectResolutionError, resolveDiscoveryProject } from "#discover/project.js";
+
+interface ApplicationRootDirectoryEntry {
+  readonly name: string;
+  isDirectory(): boolean;
+}
 
 export interface ResolveCliApplicationRootDependencies {
-  readonly isEveProject: (path: string) => Promise<boolean>;
+  readonly createPrompter: () => Prompter;
+  readonly readDirectory: (
+    path: string,
+    options: { readonly withFileTypes: true },
+  ) => Promise<readonly ApplicationRootDirectoryEntry[]>;
+  readonly resolveDiscoveryProject: typeof resolveDiscoveryProject;
 }
 
 const defaultDependencies: ResolveCliApplicationRootDependencies = {
-  isEveProject,
+  createPrompter,
+  readDirectory: readdir,
+  resolveDiscoveryProject,
 };
+
+async function tryResolveApplicationRoot(
+  path: string,
+  dependencies: ResolveCliApplicationRootDependencies,
+): Promise<string | undefined> {
+  try {
+    return (await dependencies.resolveDiscoveryProject(path)).appRoot;
+  } catch (error) {
+    if (error instanceof DiscoveryProjectResolutionError) return undefined;
+    throw error;
+  }
+}
 
 /** Finds the nearest enclosing eve application. */
 export async function findCliApplicationRoot(
   cwd: string = process.cwd(),
   dependencies: ResolveCliApplicationRootDependencies = defaultDependencies,
 ): Promise<string | undefined> {
-  let candidate = resolve(cwd);
-  while (true) {
-    if (await dependencies.isEveProject(candidate)) return candidate;
-    const parent = dirname(candidate);
-    if (parent === candidate) return undefined;
-    candidate = parent;
-  }
+  return await tryResolveApplicationRoot(cwd, dependencies);
 }
 
-/** Resolves the nearest enclosing eve application for a project-scoped command. */
+async function findChildApplicationRoots(
+  cwd: string,
+  dependencies: ResolveCliApplicationRootDependencies,
+): Promise<string[]> {
+  const entries = await dependencies.readDirectory(cwd, { withFileTypes: true });
+  const directories = entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => resolve(cwd, entry.name))
+    .sort((left, right) => left.localeCompare(right));
+  const roots = await Promise.all(
+    directories.map(async (directory) => {
+      const appRoot = await tryResolveApplicationRoot(directory, dependencies);
+      return appRoot === directory ? appRoot : undefined;
+    }),
+  );
+  return roots.filter((root): root is string => root !== undefined);
+}
+
+function displayChildPath(cwd: string, path: string): string {
+  return `./${relative(cwd, path).replaceAll("\\", "/")}`;
+}
+
+/** Resolves an enclosing or immediate-child eve application for a project-scoped command. */
 export async function resolveCliApplicationRoot(
   cwd: string = process.cwd(),
+  options: { readonly interactive?: boolean } = {},
   dependencies: ResolveCliApplicationRootDependencies = defaultDependencies,
 ): Promise<string> {
-  const appRoot = await findCliApplicationRoot(cwd, dependencies);
-  if (appRoot !== undefined) return appRoot;
-  throw new Error("No eve application found in this directory or its ancestors.");
+  const resolvedCwd = resolve(cwd);
+  const enclosingRoot = await findCliApplicationRoot(resolvedCwd, dependencies);
+  if (enclosingRoot !== undefined) return enclosingRoot;
+
+  const childRoots = await findChildApplicationRoots(resolvedCwd, dependencies);
+  if (childRoots.length === 0) return resolvedCwd;
+
+  if (options.interactive !== true) {
+    const candidates = childRoots
+      .map((path) => `  - ${displayChildPath(resolvedCwd, path)}`)
+      .join("\n");
+    throw new Error(
+      `Cannot choose an eve application without an interactive terminal. Run the command from inside one of these applications:\n${candidates}`,
+    );
+  }
+
+  return await dependencies.createPrompter().select<string>({
+    message: "Which eve application should run this command?",
+    options: childRoots.map((path) => ({
+      value: path,
+      label: displayChildPath(resolvedCwd, path),
+    })),
+    initialValue: childRoots[0],
+  });
 }

--- a/packages/eve/src/cli/application-root.ts
+++ b/packages/eve/src/cli/application-root.ts
@@ -1,0 +1,95 @@
+import { readdir } from "node:fs/promises";
+import { dirname, relative, resolve } from "node:path";
+
+import { createPrompter, type Prompter } from "#setup/prompter.js";
+import { isEveProject } from "#setup/scaffold/index.js";
+
+interface ApplicationRootDirectoryEntry {
+  readonly name: string;
+  isDirectory(): boolean;
+}
+
+export interface ResolveCliApplicationRootDependencies {
+  readonly createPrompter: () => Prompter;
+  readonly isEveProject: (path: string) => Promise<boolean>;
+  readonly readDirectory: (
+    path: string,
+    options: { readonly withFileTypes: true },
+  ) => Promise<readonly ApplicationRootDirectoryEntry[]>;
+}
+
+const defaultDependencies: ResolveCliApplicationRootDependencies = {
+  createPrompter,
+  isEveProject,
+  readDirectory: readdir,
+};
+
+function displayChildPath(cwd: string, path: string): string {
+  return `./${relative(cwd, path).replaceAll("\\", "/")}`;
+}
+
+async function findNearestApplicationRoot(
+  cwd: string,
+  isProject: ResolveCliApplicationRootDependencies["isEveProject"],
+): Promise<string | undefined> {
+  let candidate = cwd;
+  while (true) {
+    if (await isProject(candidate)) return candidate;
+    const parent = dirname(candidate);
+    if (parent === candidate) return undefined;
+    candidate = parent;
+  }
+}
+
+async function findChildApplicationRoots(
+  cwd: string,
+  dependencies: ResolveCliApplicationRootDependencies,
+): Promise<string[]> {
+  const entries = await dependencies.readDirectory(cwd, { withFileTypes: true });
+  const directories = entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => resolve(cwd, entry.name))
+    .sort((left, right) => left.localeCompare(right));
+
+  const matches = await Promise.all(
+    directories.map(async (path) => ((await dependencies.isEveProject(path)) ? path : undefined)),
+  );
+  return matches.filter((path): path is string => path !== undefined);
+}
+
+/** Resolves the eve application a project-scoped CLI command should operate on. */
+export async function resolveCliApplicationRoot(
+  cwd: string = process.cwd(),
+  options: { readonly interactive?: boolean } = {},
+  dependencies: ResolveCliApplicationRootDependencies = defaultDependencies,
+): Promise<string> {
+  const resolvedCwd = resolve(cwd);
+  const ancestor = await findNearestApplicationRoot(resolvedCwd, dependencies.isEveProject);
+  if (ancestor !== undefined) return ancestor;
+
+  const children = await findChildApplicationRoots(resolvedCwd, dependencies);
+  if (children.length === 0) {
+    throw new Error(
+      "No eve application found in this directory, its ancestors, or its immediate subdirectories.",
+    );
+  }
+
+  if (options.interactive !== true) {
+    const candidates = children
+      .map((path) => `  - ${displayChildPath(resolvedCwd, path)}`)
+      .join("\n");
+    throw new Error(
+      `Cannot choose an eve application without an interactive terminal. Run the command from inside one of these applications:\n${candidates}`,
+    );
+  }
+
+  return await dependencies.createPrompter().select<string>({
+    message: "Which eve application should run this command?",
+    description: "Found eve applications in immediate subdirectories.",
+    options: children.map((path) => ({
+      value: path,
+      label: displayChildPath(resolvedCwd, path),
+    })),
+    initialValue: children[0],
+  });
+}

--- a/packages/eve/src/cli/application-root.ts
+++ b/packages/eve/src/cli/application-root.ts
@@ -1,122 +1,32 @@
-import { access, readdir } from "node:fs/promises";
-import { dirname, join, relative, resolve } from "node:path";
+import { resolve } from "node:path";
 
-import { createPrompter, type Prompter } from "#setup/prompter.js";
 import { DiscoveryProjectResolutionError, resolveDiscoveryProject } from "#discover/project.js";
 
-interface ApplicationRootDirectoryEntry {
-  readonly name: string;
-  isDirectory(): boolean;
-}
-
 export interface ResolveCliApplicationRootDependencies {
-  readonly createPrompter: () => Prompter;
-  readonly pathExists: (path: string) => Promise<boolean>;
-  readonly readDirectory: (
-    path: string,
-    options: { readonly withFileTypes: true },
-  ) => Promise<readonly ApplicationRootDirectoryEntry[]>;
   readonly resolveDiscoveryProject: typeof resolveDiscoveryProject;
 }
 
 const defaultDependencies: ResolveCliApplicationRootDependencies = {
-  createPrompter,
-  async pathExists(path) {
-    try {
-      await access(path);
-      return true;
-    } catch {
-      return false;
-    }
-  },
-  readDirectory: readdir,
   resolveDiscoveryProject,
 };
-
-async function tryResolveApplicationRoot(
-  path: string,
-  dependencies: ResolveCliApplicationRootDependencies,
-): Promise<string | undefined> {
-  try {
-    return (await dependencies.resolveDiscoveryProject(path)).appRoot;
-  } catch (error) {
-    if (error instanceof DiscoveryProjectResolutionError) return undefined;
-    throw error;
-  }
-}
 
 /** Finds the nearest enclosing eve application. */
 export async function findCliApplicationRoot(
   cwd: string = process.cwd(),
   dependencies: ResolveCliApplicationRootDependencies = defaultDependencies,
 ): Promise<string | undefined> {
-  return await tryResolveApplicationRoot(cwd, dependencies);
-}
-
-async function hasAuthoredPackageBoundary(
-  appRoot: string,
-  dependencies: ResolveCliApplicationRootDependencies,
-): Promise<boolean> {
-  let directory = appRoot;
-  while (true) {
-    if (await dependencies.pathExists(join(directory, "package.json"))) return true;
-    const parent = dirname(directory);
-    if (parent === directory) return false;
-    directory = parent;
+  try {
+    return (await dependencies.resolveDiscoveryProject(cwd)).appRoot;
+  } catch (error) {
+    if (error instanceof DiscoveryProjectResolutionError) return undefined;
+    throw error;
   }
 }
 
-async function findChildApplicationRoots(
-  cwd: string,
-  dependencies: ResolveCliApplicationRootDependencies,
-): Promise<string[]> {
-  const entries = await dependencies.readDirectory(cwd, { withFileTypes: true });
-  const directories = entries
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => resolve(cwd, entry.name))
-    .sort((left, right) => left.localeCompare(right));
-  const roots = await Promise.all(
-    directories.map(async (directory) => {
-      const appRoot = await tryResolveApplicationRoot(directory, dependencies);
-      if (appRoot !== directory) return undefined;
-      return (await hasAuthoredPackageBoundary(appRoot, dependencies)) ? appRoot : undefined;
-    }),
-  );
-  return roots.filter((root): root is string => root !== undefined);
-}
-
-function displayChildPath(cwd: string, path: string): string {
-  return `./${relative(cwd, path).replaceAll("\\", "/")}`;
-}
-
-/** Resolves an enclosing or immediate-child eve application for a project-scoped command. */
+/** Uses the nearest enclosing eve application, or preserves cwd when none exists. */
 export async function resolveCliApplicationRoot(
   cwd: string = process.cwd(),
-  options: { readonly interactive?: boolean } = {},
   dependencies: ResolveCliApplicationRootDependencies = defaultDependencies,
 ): Promise<string> {
-  const resolvedCwd = resolve(cwd);
-  const enclosingRoot = await findCliApplicationRoot(resolvedCwd, dependencies);
-  if (enclosingRoot !== undefined) return enclosingRoot;
-
-  const childRoots = await findChildApplicationRoots(resolvedCwd, dependencies);
-  if (childRoots.length === 0) return resolvedCwd;
-
-  if (options.interactive !== true) {
-    const candidates = childRoots
-      .map((path) => `  - ${displayChildPath(resolvedCwd, path)}`)
-      .join("\n");
-    throw new Error(
-      `Cannot choose an eve application without an interactive terminal. Run the command from inside one of these applications:\n${candidates}`,
-    );
-  }
-
-  return await dependencies.createPrompter().select<string>({
-    message: "Which eve application should run this command?",
-    options: childRoots.map((path) => ({
-      value: path,
-      label: displayChildPath(resolvedCwd, path),
-    })),
-    initialValue: childRoots[0],
-  });
+  return (await findCliApplicationRoot(cwd, dependencies)) ?? resolve(cwd);
 }

--- a/packages/eve/src/cli/commands/build.ts
+++ b/packages/eve/src/cli/commands/build.ts
@@ -1,6 +1,7 @@
 import { resolve } from "node:path";
 
 import type { Command } from "#compiled/commander/index.js";
+import { applicationCommand, type CliApplicationContext } from "#cli/application-command.js";
 import { resolveInternalVercelServiceOutput } from "#cli/vercel-service-output.js";
 import { createCliTheme, renderCliTaggedLine } from "#cli/ui/output.js";
 import type { ApplicationBuildOptions } from "#internal/nitro/host/types.js";
@@ -22,15 +23,14 @@ interface BuildCliOptions {
 
 /** Registers the production application build command. */
 export function registerBuildCommand(input: {
-  readonly appRoot: string;
+  readonly application: CliApplicationContext;
   readonly buildHost?: BuildHost;
   readonly logger: BuildCommandLogger;
   readonly program: Command;
 }): void {
   const theme = createCliTheme();
 
-  input.program
-    .command("build")
+  applicationCommand(input.program.command("build"))
     .description("Build the current eve application.")
     .option("--profile <path>", "Write best-effort timing and output-size profile JSON to a file")
     .option(
@@ -40,12 +40,14 @@ export function registerBuildCommand(input: {
     .action(async (options: BuildCliOptions) => {
       const { loadDevelopmentEnvironmentFiles } = await import("#cli/dev/environment.js");
 
-      loadDevelopmentEnvironmentFiles(input.appRoot);
+      loadDevelopmentEnvironmentFiles(input.application.root);
 
       const buildHost =
         input.buildHost ?? (await import("#internal/nitro/host.js")).buildApplication;
       const profileOutputPath =
-        options.profile === undefined ? undefined : resolve(input.appRoot, options.profile);
+        options.profile === undefined
+          ? undefined
+          : resolve(input.application.root, options.profile);
       const buildOptions: {
         profileOutputPath?: string;
         readonly publicRoutePrefix: ApplicationBuildOptions["publicRoutePrefix"];
@@ -54,12 +56,12 @@ export function registerBuildCommand(input: {
       } = {
         publicRoutePrefix: normalizePublicRoutePrefix(process.env[EVE_PUBLIC_ROUTE_PREFIX_ENV]),
         skipVercelSandboxPrewarm: options.skipSandboxPrewarm === true,
-        vercelServiceOutput: resolveInternalVercelServiceOutput(input.appRoot),
+        vercelServiceOutput: resolveInternalVercelServiceOutput(input.application.root),
       };
       if (profileOutputPath !== undefined) {
         buildOptions.profileOutputPath = profileOutputPath;
       }
-      const outputDir = await buildHost(input.appRoot, buildOptions);
+      const outputDir = await buildHost(input.application.root, buildOptions);
       input.logger.log(
         renderCliTaggedLine(theme, {
           message: `built output at ${outputDir}`,

--- a/packages/eve/src/cli/commands/build.ts
+++ b/packages/eve/src/cli/commands/build.ts
@@ -23,14 +23,14 @@ interface BuildCliOptions {
 
 /** Registers the production application build command. */
 export function registerBuildCommand(input: {
-  readonly application: CliApplicationContext;
+  readonly applicationContext: CliApplicationContext;
   readonly buildHost?: BuildHost;
   readonly logger: BuildCommandLogger;
   readonly program: Command;
 }): void {
   const theme = createCliTheme();
 
-  applicationCommand(input.program.command("build"))
+  applicationCommand(input.program.command("build"), input.applicationContext)
     .description("Build the current eve application.")
     .option("--profile <path>", "Write best-effort timing and output-size profile JSON to a file")
     .option(
@@ -40,14 +40,14 @@ export function registerBuildCommand(input: {
     .action(async (options: BuildCliOptions) => {
       const { loadDevelopmentEnvironmentFiles } = await import("#cli/dev/environment.js");
 
-      loadDevelopmentEnvironmentFiles(input.application.root);
+      loadDevelopmentEnvironmentFiles(input.applicationContext.root);
 
       const buildHost =
         input.buildHost ?? (await import("#internal/nitro/host.js")).buildApplication;
       const profileOutputPath =
         options.profile === undefined
           ? undefined
-          : resolve(input.application.root, options.profile);
+          : resolve(input.applicationContext.root, options.profile);
       const buildOptions: {
         profileOutputPath?: string;
         readonly publicRoutePrefix: ApplicationBuildOptions["publicRoutePrefix"];
@@ -56,12 +56,12 @@ export function registerBuildCommand(input: {
       } = {
         publicRoutePrefix: normalizePublicRoutePrefix(process.env[EVE_PUBLIC_ROUTE_PREFIX_ENV]),
         skipVercelSandboxPrewarm: options.skipSandboxPrewarm === true,
-        vercelServiceOutput: resolveInternalVercelServiceOutput(input.application.root),
+        vercelServiceOutput: resolveInternalVercelServiceOutput(input.applicationContext.root),
       };
       if (profileOutputPath !== undefined) {
         buildOptions.profileOutputPath = profileOutputPath;
       }
-      const outputDir = await buildHost(input.application.root, buildOptions);
+      const outputDir = await buildHost(input.applicationContext.root, buildOptions);
       input.logger.log(
         renderCliTaggedLine(theme, {
           message: `built output at ${outputDir}`,

--- a/packages/eve/src/cli/commands/register-integration-commands.ts
+++ b/packages/eve/src/cli/commands/register-integration-commands.ts
@@ -1,4 +1,5 @@
 import type { Command } from "#compiled/commander/index.js";
+import { applicationCommand, type CliApplicationContext } from "#cli/application-command.js";
 
 import { parseSetupAnswer } from "./setup-answers.js";
 
@@ -11,14 +12,13 @@ interface IntegrationCommandLogger {
 export function registerIntegrationCommands(input: {
   program: Command;
   logger: IntegrationCommandLogger;
-  appRoot: string;
+  application: CliApplicationContext;
 }): void {
-  const { appRoot, logger, program } = input;
+  const { application, logger, program } = input;
 
   const integration = program.command("integration", { hidden: true });
 
-  integration
-    .command("setup <kind>")
+  applicationCommand(integration.command("setup <kind>"))
     .option("-y, --yes")
     .option(
       "--non-interactive",
@@ -40,7 +40,7 @@ export function registerIntegrationCommands(input: {
         },
       ) => {
         const { runIntegrationSetupCommand } = await import("./integration-setup.js");
-        await runIntegrationSetupCommand(logger, appRoot, kind, {
+        await runIntegrationSetupCommand(logger, application.root, kind, {
           yes: options.yes,
           nonInteractive: options.nonInteractive,
           answers: options.answer,
@@ -48,8 +48,7 @@ export function registerIntegrationCommands(input: {
       },
     );
 
-  integration
-    .command("connect <slug> <service> [canonical-name]")
+  applicationCommand(integration.command("connect <slug> <service> [canonical-name]"))
     .option("-y, --yes")
     .option(
       "--non-interactive",
@@ -63,7 +62,14 @@ export function registerIntegrationCommands(input: {
         options: { nonInteractive?: boolean },
       ) => {
         const { runIntegrationConnectCommand } = await import("./integration-connect.js");
-        await runIntegrationConnectCommand(logger, appRoot, slug, service, canonicalName, options);
+        await runIntegrationConnectCommand(
+          logger,
+          application.root,
+          slug,
+          service,
+          canonicalName,
+          options,
+        );
       },
     );
 }

--- a/packages/eve/src/cli/commands/register-integration-commands.ts
+++ b/packages/eve/src/cli/commands/register-integration-commands.ts
@@ -12,13 +12,13 @@ interface IntegrationCommandLogger {
 export function registerIntegrationCommands(input: {
   program: Command;
   logger: IntegrationCommandLogger;
-  application: CliApplicationContext;
+  applicationContext: CliApplicationContext;
 }): void {
-  const { application, logger, program } = input;
+  const { applicationContext, logger, program } = input;
 
   const integration = program.command("integration", { hidden: true });
 
-  applicationCommand(integration.command("setup <kind>"))
+  applicationCommand(integration.command("setup <kind>"), applicationContext)
     .option("-y, --yes")
     .option(
       "--non-interactive",
@@ -40,7 +40,7 @@ export function registerIntegrationCommands(input: {
         },
       ) => {
         const { runIntegrationSetupCommand } = await import("./integration-setup.js");
-        await runIntegrationSetupCommand(logger, application.root, kind, {
+        await runIntegrationSetupCommand(logger, applicationContext.root, kind, {
           yes: options.yes,
           nonInteractive: options.nonInteractive,
           answers: options.answer,
@@ -48,7 +48,10 @@ export function registerIntegrationCommands(input: {
       },
     );
 
-  applicationCommand(integration.command("connect <slug> <service> [canonical-name]"))
+  applicationCommand(
+    integration.command("connect <slug> <service> [canonical-name]"),
+    applicationContext,
+  )
     .option("-y, --yes")
     .option(
       "--non-interactive",
@@ -64,7 +67,7 @@ export function registerIntegrationCommands(input: {
         const { runIntegrationConnectCommand } = await import("./integration-connect.js");
         await runIntegrationConnectCommand(
           logger,
-          application.root,
+          applicationContext.root,
           slug,
           service,
           canonicalName,

--- a/packages/eve/src/cli/commands/register-project-commands.ts
+++ b/packages/eve/src/cli/commands/register-project-commands.ts
@@ -10,19 +10,19 @@ interface ProjectCommandLogger {
 export function registerProjectCommands(input: {
   program: Command;
   logger: ProjectCommandLogger;
-  application: CliApplicationContext;
+  applicationContext: CliApplicationContext;
 }): void {
-  applicationCommand(input.program.command("link"))
+  applicationCommand(input.program.command("link"), input.applicationContext)
     .description("Link this directory to a Vercel project and pull AI Gateway credentials.")
     .action(async () => {
       const { runLinkCommand } = await import("./link.js");
-      await runLinkCommand(input.logger, input.application.root);
+      await runLinkCommand(input.logger, input.applicationContext.root);
     });
 
-  applicationCommand(input.program.command("deploy"))
+  applicationCommand(input.program.command("deploy"), input.applicationContext)
     .description("Deploy the agent to Vercel production (links first if needed).")
     .action(async () => {
       const { runDeployCommand } = await import("./deploy.js");
-      await runDeployCommand(input.logger, input.application.root);
+      await runDeployCommand(input.logger, input.applicationContext.root);
     });
 }

--- a/packages/eve/src/cli/commands/register-project-commands.ts
+++ b/packages/eve/src/cli/commands/register-project-commands.ts
@@ -1,4 +1,5 @@
 import type { Command } from "#compiled/commander/index.js";
+import { applicationCommand, type CliApplicationContext } from "#cli/application-command.js";
 
 interface ProjectCommandLogger {
   error(message: string): void;
@@ -9,21 +10,19 @@ interface ProjectCommandLogger {
 export function registerProjectCommands(input: {
   program: Command;
   logger: ProjectCommandLogger;
-  appRoot: string;
+  application: CliApplicationContext;
 }): void {
-  input.program
-    .command("link")
+  applicationCommand(input.program.command("link"))
     .description("Link this directory to a Vercel project and pull AI Gateway credentials.")
     .action(async () => {
       const { runLinkCommand } = await import("./link.js");
-      await runLinkCommand(input.logger, input.appRoot);
+      await runLinkCommand(input.logger, input.application.root);
     });
 
-  input.program
-    .command("deploy")
+  applicationCommand(input.program.command("deploy"))
     .description("Deploy the agent to Vercel production (links first if needed).")
     .action(async () => {
       const { runDeployCommand } = await import("./deploy.js");
-      await runDeployCommand(input.logger, input.appRoot);
+      await runDeployCommand(input.logger, input.application.root);
     });
 }

--- a/packages/eve/src/cli/commands/register-registry-commands.ts
+++ b/packages/eve/src/cli/commands/register-registry-commands.ts
@@ -1,4 +1,5 @@
 import { InvalidArgumentError, type Command } from "#compiled/commander/index.js";
+import { applicationCommand, type CliApplicationContext } from "#cli/application-command.js";
 
 import { parseSetupAnswer } from "./setup-answers.js";
 
@@ -28,12 +29,11 @@ function parseSearchLimit(value: string): number {
 export function registerRegistryCommands(input: {
   program: Command;
   logger: RegistryCommandLogger;
-  appRoot: string;
+  application: CliApplicationContext;
 }): void {
-  const { appRoot, logger, program } = input;
+  const { application, logger, program } = input;
 
-  program
-    .command("add <item>")
+  applicationCommand(program.command("add <item>"))
     .description("Install a registry item; relative paths use the official eve registry.")
     .option("-o, --overwrite", "Overwrite existing files.")
     .option("--skip-install", "Run the item's setup flow without installing it.")
@@ -64,7 +64,10 @@ export function registerRegistryCommands(input: {
           throw new InvalidArgumentError("--answer requires --non-interactive.");
         }
         const { runAddCommand } = await import("./registry.js");
-        await runAddCommand(logger, appRoot, item, { ...options, answers: options.answer });
+        await runAddCommand(logger, application.root, item, {
+          ...options,
+          answers: options.answer,
+        });
       },
     );
 
@@ -72,26 +75,23 @@ export function registerRegistryCommands(input: {
     .command("registry")
     .description("Configure and browse extension and agent registry catalogs.");
 
-  registry
-    .command("add <registries...>")
+  applicationCommand(registry.command("add <registries...>"))
     .description("Add registry namespace mappings to package.json.")
     .action(async (registries: string[]) => {
       const { runRegistryAddCommand } = await import("./registry.js");
-      await runRegistryAddCommand(logger, appRoot, registries);
+      await runRegistryAddCommand(logger, application.root, registries);
     });
 
-  registry
-    .command("list")
+  applicationCommand(registry.command("list"))
     .description("List items from all registries or one source.")
     .option("-r, --registry <source>", "List items from one registry.")
     .option("--json", "Output as JSON")
     .action(async (options: { json?: boolean; registry?: string }) => {
       const { runRegistryListCommand } = await import("./registry.js");
-      await runRegistryListCommand(logger, appRoot, options.registry, options);
+      await runRegistryListCommand(logger, application.root, options.registry, options);
     });
 
-  registry
-    .command("search <query>")
+  applicationCommand(registry.command("search <query>"))
     .description("Search all registries or one source.")
     .option("-r, --registry <source>", "Search one registry.")
     .option(
@@ -104,16 +104,15 @@ export function registerRegistryCommands(input: {
     .action(
       async (query: string, options: { json?: boolean; limit: number; registry?: string }) => {
         const { runRegistrySearchCommand } = await import("./registry.js");
-        await runRegistrySearchCommand(logger, appRoot, query, options.registry, options);
+        await runRegistrySearchCommand(logger, application.root, query, options.registry, options);
       },
     );
 
-  registry
-    .command("view <item>")
+  applicationCommand(registry.command("view <item>"))
     .description("Inspect one registry item.")
     .option("--json", "Output the raw registry item as JSON.")
     .action(async (item: string, options: { json?: boolean }) => {
       const { runRegistryViewCommand } = await import("./registry.js");
-      await runRegistryViewCommand(logger, appRoot, item, options);
+      await runRegistryViewCommand(logger, application.root, item, options);
     });
 }

--- a/packages/eve/src/cli/commands/register-registry-commands.ts
+++ b/packages/eve/src/cli/commands/register-registry-commands.ts
@@ -29,11 +29,11 @@ function parseSearchLimit(value: string): number {
 export function registerRegistryCommands(input: {
   program: Command;
   logger: RegistryCommandLogger;
-  application: CliApplicationContext;
+  applicationContext: CliApplicationContext;
 }): void {
-  const { application, logger, program } = input;
+  const { applicationContext, logger, program } = input;
 
-  applicationCommand(program.command("add <item>"))
+  applicationCommand(program.command("add <item>"), applicationContext)
     .description("Install a registry item; relative paths use the official eve registry.")
     .option("-o, --overwrite", "Overwrite existing files.")
     .option("--skip-install", "Run the item's setup flow without installing it.")
@@ -64,7 +64,7 @@ export function registerRegistryCommands(input: {
           throw new InvalidArgumentError("--answer requires --non-interactive.");
         }
         const { runAddCommand } = await import("./registry.js");
-        await runAddCommand(logger, application.root, item, {
+        await runAddCommand(logger, applicationContext.root, item, {
           ...options,
           answers: options.answer,
         });
@@ -75,23 +75,23 @@ export function registerRegistryCommands(input: {
     .command("registry")
     .description("Configure and browse extension and agent registry catalogs.");
 
-  applicationCommand(registry.command("add <registries...>"))
+  applicationCommand(registry.command("add <registries...>"), applicationContext)
     .description("Add registry namespace mappings to package.json.")
     .action(async (registries: string[]) => {
       const { runRegistryAddCommand } = await import("./registry.js");
-      await runRegistryAddCommand(logger, application.root, registries);
+      await runRegistryAddCommand(logger, applicationContext.root, registries);
     });
 
-  applicationCommand(registry.command("list"))
+  applicationCommand(registry.command("list"), applicationContext)
     .description("List items from all registries or one source.")
     .option("-r, --registry <source>", "List items from one registry.")
     .option("--json", "Output as JSON")
     .action(async (options: { json?: boolean; registry?: string }) => {
       const { runRegistryListCommand } = await import("./registry.js");
-      await runRegistryListCommand(logger, application.root, options.registry, options);
+      await runRegistryListCommand(logger, applicationContext.root, options.registry, options);
     });
 
-  applicationCommand(registry.command("search <query>"))
+  applicationCommand(registry.command("search <query>"), applicationContext)
     .description("Search all registries or one source.")
     .option("-r, --registry <source>", "Search one registry.")
     .option(
@@ -104,15 +104,21 @@ export function registerRegistryCommands(input: {
     .action(
       async (query: string, options: { json?: boolean; limit: number; registry?: string }) => {
         const { runRegistrySearchCommand } = await import("./registry.js");
-        await runRegistrySearchCommand(logger, application.root, query, options.registry, options);
+        await runRegistrySearchCommand(
+          logger,
+          applicationContext.root,
+          query,
+          options.registry,
+          options,
+        );
       },
     );
 
-  applicationCommand(registry.command("view <item>"))
+  applicationCommand(registry.command("view <item>"), applicationContext)
     .description("Inspect one registry item.")
     .option("--json", "Output the raw registry item as JSON.")
     .action(async (item: string, options: { json?: boolean }) => {
       const { runRegistryViewCommand } = await import("./registry.js");
-      await runRegistryViewCommand(logger, application.root, item, options);
+      await runRegistryViewCommand(logger, applicationContext.root, item, options);
     });
 }

--- a/packages/eve/src/cli/invoke/command.ts
+++ b/packages/eve/src/cli/invoke/command.ts
@@ -38,7 +38,7 @@ interface InvokeCommandLogger {
 
 /** Registers the invoke command with lazily loaded production dependencies. */
 export function registerRuntimeInvokeCommand(input: {
-  readonly application: CliApplicationContext;
+  readonly applicationContext: CliApplicationContext;
   readonly logger: InvokeCommandLogger;
   readonly program: Command;
   readonly runtime: Partial<InvokeCliRuntimeDependencies>;
@@ -61,12 +61,12 @@ export function registerRuntimeInvokeCommand(input: {
 
 /** Registers the non-interactive invoke command. */
 export function registerInvokeCommand(input: {
-  readonly application: CliApplicationContext;
+  readonly applicationContext: CliApplicationContext;
   readonly deps: InvokeCommandDependencies;
   readonly logger: InvokeCommandLogger;
   readonly program: Command;
 }): void {
-  applicationCommand(input.program.command("invoke"), (command) => {
+  applicationCommand(input.program.command("invoke"), input.applicationContext, (command) => {
     const options = command.opts<InvokeCliOptions>();
     return options.url === undefined && options.jsonSchema !== true;
   })
@@ -87,7 +87,7 @@ export function registerInvokeCommand(input: {
 }
 
 async function runInvokeCommand(input: {
-  readonly application: CliApplicationContext;
+  readonly applicationContext: CliApplicationContext;
   readonly deps: InvokeCommandDependencies;
   readonly logger: InvokeCommandLogger;
   readonly options: InvokeCliOptions;
@@ -127,14 +127,14 @@ async function runInvokeCommand(input: {
   }
   const operation = resolveInvokeOperation({ previous, prompt: input.prompt });
 
-  await input.deps.loadEnvironment(input.application.root);
+  await input.deps.loadEnvironment(input.applicationContext.root);
   if (remoteTarget !== undefined) {
     await executeWithSignals(
       input,
       {
         kind: "remote",
         serverUrl: remoteTarget.serverUrl,
-        workspaceRoot: input.application.root,
+        workspaceRoot: input.applicationContext.root,
       },
       remoteTarget.headers,
       operation,
@@ -143,7 +143,7 @@ async function runInvokeCommand(input: {
     return;
   }
 
-  const server = await input.deps.startHost(input.application.root);
+  const server = await input.deps.startHost(input.applicationContext.root);
   try {
     const handle = await server.start();
     await executeWithSignals(

--- a/packages/eve/src/cli/invoke/command.ts
+++ b/packages/eve/src/cli/invoke/command.ts
@@ -1,4 +1,5 @@
 import { type Command, InvalidArgumentError } from "#compiled/commander/index.js";
+import { applicationCommand, type CliApplicationContext } from "#cli/application-command.js";
 import {
   parseDevelopmentHeaderOption,
   resolveDevelopmentUrlTarget,
@@ -37,7 +38,7 @@ interface InvokeCommandLogger {
 
 /** Registers the invoke command with lazily loaded production dependencies. */
 export function registerRuntimeInvokeCommand(input: {
-  readonly appRoot: string;
+  readonly application: CliApplicationContext;
   readonly logger: InvokeCommandLogger;
   readonly program: Command;
   readonly runtime: Partial<InvokeCliRuntimeDependencies>;
@@ -60,13 +61,15 @@ export function registerRuntimeInvokeCommand(input: {
 
 /** Registers the non-interactive invoke command. */
 export function registerInvokeCommand(input: {
-  readonly appRoot: string;
+  readonly application: CliApplicationContext;
   readonly deps: InvokeCommandDependencies;
   readonly logger: InvokeCommandLogger;
   readonly program: Command;
 }): void {
-  input.program
-    .command("invoke")
+  applicationCommand(input.program.command("invoke"), (command) => {
+    const options = command.opts<InvokeCliOptions>();
+    return options.url === undefined && options.jsonSchema !== true;
+  })
     .description("Invoke an eve agent without a terminal UI.")
     .argument("[prompt]", "Prompt, follow-up message, or answer to a pending input")
     .option("-u, --url <url>", "Invoke an existing server URL", parseDevelopmentServerUrl)
@@ -84,7 +87,7 @@ export function registerInvokeCommand(input: {
 }
 
 async function runInvokeCommand(input: {
-  readonly appRoot: string;
+  readonly application: CliApplicationContext;
   readonly deps: InvokeCommandDependencies;
   readonly logger: InvokeCommandLogger;
   readonly options: InvokeCliOptions;
@@ -124,14 +127,14 @@ async function runInvokeCommand(input: {
   }
   const operation = resolveInvokeOperation({ previous, prompt: input.prompt });
 
-  await input.deps.loadEnvironment(input.appRoot);
+  await input.deps.loadEnvironment(input.application.root);
   if (remoteTarget !== undefined) {
     await executeWithSignals(
       input,
       {
         kind: "remote",
         serverUrl: remoteTarget.serverUrl,
-        workspaceRoot: input.appRoot,
+        workspaceRoot: input.application.root,
       },
       remoteTarget.headers,
       operation,
@@ -140,7 +143,7 @@ async function runInvokeCommand(input: {
     return;
   }
 
-  const server = await input.deps.startHost(input.appRoot);
+  const server = await input.deps.startHost(input.application.root);
   try {
     const handle = await server.start();
     await executeWithSignals(

--- a/packages/eve/src/cli/run.test.ts
+++ b/packages/eve/src/cli/run.test.ts
@@ -218,12 +218,12 @@ describe("CLI command registration", () => {
 describe("bare eve command", () => {
   it("runs init in the current directory when no eve project is detected", async () => {
     const logger = { error: vi.fn(), log: vi.fn() };
-    const isEveProject = vi.fn(async () => false);
+    const findApplicationRoot = vi.fn(async () => undefined);
     runInitCommand.mockClear();
 
-    await runCli([], logger, { isEveProject });
+    await runCli([], logger, { findApplicationRoot });
 
-    expect(isEveProject).toHaveBeenCalledWith(resolve(process.cwd()));
+    expect(findApplicationRoot).toHaveBeenCalledWith(resolve(process.cwd()));
     expect(runInitCommand).toHaveBeenCalledWith(logger, resolve(process.cwd()), undefined, {
       channelWebNextjs: undefined,
       model: undefined,
@@ -231,9 +231,9 @@ describe("bare eve command", () => {
     });
   });
 
-  it("runs dev when an eve project is detected", async () => {
+  it("runs dev from the enclosing eve application", async () => {
     const logger = { error: vi.fn(), log: vi.fn() };
-    const isEveProject = vi.fn(async () => true);
+    const findApplicationRoot = vi.fn(async () => "/resolved/app");
     const close = vi.fn(async () => {});
     const startHost = vi.fn(() => ({
       start: async () => ({
@@ -247,11 +247,11 @@ describe("bare eve command", () => {
     runInitCommand.mockClear();
 
     await withInteractiveTerminal(() =>
-      runCli([], logger, { isEveProject, runDevelopmentTui, startHost }),
+      runCli([], logger, { findApplicationRoot, runDevelopmentTui, startHost }),
     );
 
-    expect(isEveProject).toHaveBeenCalledWith(resolve(process.cwd()));
-    expect(startHost).toHaveBeenCalledWith(resolve(process.cwd()), {
+    expect(findApplicationRoot).toHaveBeenCalledWith(resolve(process.cwd()));
+    expect(startHost).toHaveBeenCalledWith("/resolved/app", {
       existing: "attach-if-unconfigured",
       host: undefined,
       onBootProgress: expect.any(Function),
@@ -265,11 +265,11 @@ describe("bare eve command", () => {
 
   it("does not inspect the project when a command is explicit", async () => {
     const logger = { error: vi.fn(), log: vi.fn() };
-    const isEveProject = vi.fn(async () => false);
+    const findApplicationRoot = vi.fn(async () => undefined);
 
-    await runCli(["init"], logger, { isEveProject });
+    await runCli(["init"], logger, { findApplicationRoot });
 
-    expect(isEveProject).not.toHaveBeenCalled();
+    expect(findApplicationRoot).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/eve/src/cli/run.test.ts
+++ b/packages/eve/src/cli/run.test.ts
@@ -12,6 +12,9 @@ const { runInitCommand, runSetCommand } = vi.hoisted(() => ({
   runSetCommand: vi.fn(async () => {}),
 }));
 
+vi.mock("#cli/application-root.js", () => ({
+  resolveCliApplicationRoot: vi.fn(async (cwd: string) => cwd),
+}));
 vi.mock("#cli/commands/init.js", () => ({ runInitCommand }));
 vi.mock("#cli/commands/set.js", () => ({ runSetCommand }));
 
@@ -75,6 +78,36 @@ describe("CLI command registration", () => {
       model: "openai/gpt-5.6-sol",
       reasoning: "high",
     });
+  });
+
+  it("runs project commands with the resolved application root", async () => {
+    const logger = { error: vi.fn(), log: vi.fn() };
+    const resolveRoot = vi.fn(async () => "/workspace/weather");
+    runSetCommand.mockClear();
+
+    await runCli(["set", "--model", "openai/gpt-5.6-sol"], logger, {
+      resolveApplicationRoot: resolveRoot,
+    });
+
+    expect(resolveRoot).toHaveBeenCalledWith(resolve(process.cwd()), { interactive: false });
+    expect(runSetCommand).toHaveBeenCalledWith(logger, "/workspace/weather", {
+      model: "openai/gpt-5.6-sol",
+      reasoning: undefined,
+    });
+  });
+
+  it("does not resolve an application root for command help", async () => {
+    const resolveRoot = vi.fn(async () => "/workspace/weather");
+
+    await runCli(
+      ["set", "--help"],
+      { error: vi.fn(), log: vi.fn() },
+      {
+        resolveApplicationRoot: resolveRoot,
+      },
+    );
+
+    expect(resolveRoot).not.toHaveBeenCalled();
   });
 
   it("lists model and reasoning options for the set command", async () => {
@@ -443,16 +476,18 @@ describe("eve invoke", () => {
     );
   });
 
-  it("prints the JSON schema without invoking an agent", async () => {
+  it("prints the JSON schema without resolving or invoking an agent", async () => {
     const runInvoke = vi.fn();
+    const resolveRoot = vi.fn(async () => "/workspace/weather");
     const output: string[] = [];
 
     await runCli(
       ["invoke", "--json-schema"],
       { error: () => {}, log: (message) => output.push(message) },
-      { runInvoke },
+      { resolveApplicationRoot: resolveRoot, runInvoke },
     );
 
+    expect(resolveRoot).not.toHaveBeenCalled();
     expect(runInvoke).not.toHaveBeenCalled();
     expect(JSON.parse(output[0]!)).toMatchObject({ title: "eve invoke result" });
   });
@@ -468,6 +503,16 @@ describe("eve invoke", () => {
 });
 
 describe("eve dev --url protocol", () => {
+  it("does not resolve a local application for a remote URL", async () => {
+    const resolveRoot = vi.fn(async () => "/workspace/weather");
+
+    await runInteractiveDev(["dev", "https://example.com"], {
+      resolveApplicationRoot: resolveRoot,
+    });
+
+    expect(resolveRoot).not.toHaveBeenCalled();
+  });
+
   it("preserves query parameters on the remote target URL", async () => {
     const runDevelopmentTui = await runInteractiveDev([
       "dev",

--- a/packages/eve/src/cli/run.test.ts
+++ b/packages/eve/src/cli/run.test.ts
@@ -89,7 +89,7 @@ describe("CLI command registration", () => {
       resolveApplicationRoot: resolveRoot,
     });
 
-    expect(resolveRoot).toHaveBeenCalledWith(resolve(process.cwd()));
+    expect(resolveRoot).toHaveBeenCalledWith(resolve(process.cwd()), { interactive: false });
     expect(runSetCommand).toHaveBeenCalledWith(logger, "/workspace/weather", {
       model: "openai/gpt-5.6-sol",
       reasoning: undefined,

--- a/packages/eve/src/cli/run.test.ts
+++ b/packages/eve/src/cli/run.test.ts
@@ -89,7 +89,7 @@ describe("CLI command registration", () => {
       resolveApplicationRoot: resolveRoot,
     });
 
-    expect(resolveRoot).toHaveBeenCalledWith(resolve(process.cwd()), { interactive: false });
+    expect(resolveRoot).toHaveBeenCalledWith(resolve(process.cwd()));
     expect(runSetCommand).toHaveBeenCalledWith(logger, "/workspace/weather", {
       model: "openai/gpt-5.6-sol",
       reasoning: undefined,

--- a/packages/eve/src/cli/run.ts
+++ b/packages/eve/src/cli/run.ts
@@ -86,7 +86,7 @@ interface CliRuntimeDependencies {
     appRoot: string,
   ): Promise<void>;
   startHost(appRoot: string, options?: DevelopmentServerOptions): DevelopmentServer;
-  resolveApplicationRoot(cwd: string, options: { readonly interactive: boolean }): Promise<string>;
+  resolveApplicationRoot(cwd: string): Promise<string>;
   startProductionHost(
     appRoot: string,
     options?: {
@@ -657,7 +657,6 @@ export async function runCli(
     async resolve() {
       applicationContext.root = await (runtime.resolveApplicationRoot ?? resolveCliApplicationRoot)(
         applicationContext.root,
-        { interactive: hasInteractiveTerminal() },
       );
     },
   };

--- a/packages/eve/src/cli/run.ts
+++ b/packages/eve/src/cli/run.ts
@@ -4,11 +4,7 @@ import { devBootPhase, type DevBootProgressReporter } from "#internal/dev-boot-p
 import { resolveApplicationRoot } from "#internal/application/paths.js";
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
 import { isCodingAgentLaunch } from "#cli/agent-detection.js";
-import {
-  applicationCommand,
-  commandRequiresApplicationRoot,
-  type CliApplicationContext,
-} from "#cli/application-command.js";
+import { applicationCommand, type CliApplicationContext } from "#cli/application-command.js";
 import { resolveCliApplicationRoot } from "#cli/application-root.js";
 import { eveCliBanner } from "#cli/banner.js";
 import { registerIntegrationCommands } from "#cli/commands/register-integration-commands.js";
@@ -161,7 +157,7 @@ function hasInteractiveTerminal(): boolean {
 function createCliProgram(
   logger: CliLogger,
   runtime: CliRuntimeOverrides,
-  application: CliApplicationContext,
+  applicationContext: CliApplicationContext,
 ): Command {
   const packageVersion = resolveInstalledPackageInfo().version;
   const program = new Command();
@@ -173,13 +169,7 @@ function createCliProgram(
     .version(packageVersion)
     .showHelpAfterError()
     .exitOverride()
-    .hook("preAction", async (_program, actionCommand) => {
-      if (commandRequiresApplicationRoot(actionCommand)) {
-        application.root = await (runtime.resolveApplicationRoot ?? resolveCliApplicationRoot)(
-          application.root,
-          { interactive: hasInteractiveTerminal() },
-        );
-      }
+    .hook("preAction", (_program, actionCommand) => {
       if (["info", "dev", "init"].includes(actionCommand.name())) {
         logger.log(eveCliBanner());
       }
@@ -198,15 +188,16 @@ function createCliProgram(
       .command("channels")
       .description("Manage user-authored channels in the current project.")
       .command("list"),
+    applicationContext,
   )
     .description("List user-authored channels in the current project.")
     .option("--json", "Output as JSON")
     .action(async (options: { json?: boolean }) => {
       const { runChannelsListCommand } = await import("#cli/commands/channels.js");
-      await runChannelsListCommand(logger, application.root, options);
+      await runChannelsListCommand(logger, applicationContext.root, options);
     });
 
-  registerIntegrationCommands({ program, logger, application });
+  registerIntegrationCommands({ program, logger, applicationContext });
 
   const extension = program
     .command("extension")
@@ -224,7 +215,7 @@ function createCliProgram(
       }
 
       const { runExtensionInitCommand } = await import("#cli/commands/extension-init.js");
-      await runExtensionInitCommand(logger, application.root, target);
+      await runExtensionInitCommand(logger, applicationContext.root, target);
     });
 
   extension
@@ -232,13 +223,13 @@ function createCliProgram(
     .description("Build the current package as an eve extension.")
     .action(async () => {
       const { loadDevelopmentEnvironmentFiles } = await import("#cli/dev/environment.js");
-      loadDevelopmentEnvironmentFiles(application.root);
+      loadDevelopmentEnvironmentFiles(applicationContext.root);
 
       const { runExtensionBuildCommand } = await import("#cli/commands/extension-build.js");
-      await runExtensionBuildCommand(logger, application.root);
+      await runExtensionBuildCommand(logger, applicationContext.root);
     });
 
-  registerRegistryCommands({ program, logger, application });
+  registerRegistryCommands({ program, logger, applicationContext });
 
   program
     // Optional: a missing target scaffolds or updates the current directory,
@@ -268,7 +259,7 @@ function createCliProgram(
         }
 
         const { runInitCommand } = await import("#cli/commands/init.js");
-        await runInitCommand(logger, application.root, target, {
+        await runInitCommand(logger, applicationContext.root, target, {
           channelWebNextjs: options.channelWebNextjs,
           model: options.model,
           reasoning: options.reasoning,
@@ -276,7 +267,7 @@ function createCliProgram(
       },
     );
 
-  applicationCommand(program.command("set"))
+  applicationCommand(program.command("set"), applicationContext)
     .description("Change root agent model settings.")
     .option("--model <model>", "Set the agent model (provider/model-id)")
     .option(
@@ -286,29 +277,29 @@ function createCliProgram(
     )
     .action(async (options: { model?: string; reasoning?: AgentReasoningDefinition }) => {
       const { runSetCommand } = await import("#cli/commands/set.js");
-      await runSetCommand(logger, application.root, options);
+      await runSetCommand(logger, applicationContext.root, options);
     });
 
-  registerProjectCommands({ program, logger, application });
+  registerProjectCommands({ program, logger, applicationContext });
 
   registerBuildCommand({
-    application,
+    applicationContext,
     buildHost: runtime.buildHost,
     logger,
     program,
   });
 
-  applicationCommand(program.command("start"))
+  applicationCommand(program.command("start"), applicationContext)
     .description("Start a built eve application.")
     .option("--host <host>", "Host interface to bind")
     .option("--port <port>", "Port to listen on (defaults to $PORT, then 3000)", parsePortOption)
     .action(async (options: ProductionCliOptions) => {
       const { loadDevelopmentEnvironmentFiles } = await import("#cli/dev/environment.js");
 
-      loadDevelopmentEnvironmentFiles(application.root);
+      loadDevelopmentEnvironmentFiles(applicationContext.root);
 
       const startProductionHost = runtime.startProductionHost ?? (await loadStartProductionHost());
-      const server = await startProductionHost(application.root, {
+      const server = await startProductionHost(applicationContext.root, {
         host: options.host,
         port: options.port,
       });
@@ -324,10 +315,10 @@ function createCliProgram(
       await waitForShutdownSignal({ close: () => server.close(), wait: () => server.wait() });
     });
 
-  registerRuntimeInvokeCommand({ application, logger, program, runtime });
+  registerRuntimeInvokeCommand({ applicationContext, logger, program, runtime });
 
   registerAcpCommand({
-    application,
+    applicationContext,
     eveVersion: packageVersion,
     program,
     resolveVerifiedRemoteDevelopmentClient: runtime.resolveVerifiedRemoteDevelopmentClient,
@@ -335,7 +326,7 @@ function createCliProgram(
     startHost: runtime.startHost,
   });
 
-  applicationCommand(program.command("dev"), (command) => {
+  applicationCommand(program.command("dev"), applicationContext, (command) => {
     const options = command.opts<DevelopmentCliOptions>();
     return (
       resolveDevelopmentUrlTarget(options, command.processedArgs[0] as string | undefined) ===
@@ -407,7 +398,7 @@ function createCliProgram(
         const isActive =
           runtime.isActiveDevelopmentServerForApp ?? (await loadIsActiveDevelopmentServerForApp());
         existingLocalDevelopmentServer = await isActive({
-          appRoot: application.root,
+          appRoot: applicationContext.root,
           serverUrl: remoteServerUrl,
         });
       }
@@ -430,9 +421,13 @@ function createCliProgram(
             ? {
                 kind: "local",
                 serverUrl: input.serverUrl,
-                workspaceRoot: input.appRoot ?? application.root,
+                workspaceRoot: input.appRoot ?? applicationContext.root,
               }
-            : { kind: "remote", serverUrl: input.serverUrl, workspaceRoot: application.root };
+            : {
+                kind: "remote",
+                serverUrl: input.serverUrl,
+                workspaceRoot: applicationContext.root,
+              };
         const title = resolveTuiTitle({ name: options.name, target });
         if (title !== undefined) display.name = title;
         const tuiInput: RunDevelopmentTuiInput = {
@@ -469,7 +464,7 @@ function createCliProgram(
 
       if (remoteServerUrl) {
         const { loadDevelopmentEnvironmentFiles } = await import("#cli/dev/environment.js");
-        loadDevelopmentEnvironmentFiles(application.root);
+        loadDevelopmentEnvironmentFiles(applicationContext.root);
         logger.log(
           `↗ ${existingLocalDevelopmentServer ? "local" : "remote"} mode targeting ${theme.info(new URL(remoteServerUrl).host)}`,
         );
@@ -517,7 +512,7 @@ function createCliProgram(
 
       try {
         const startHost = runtime.startHost ?? (await loadStartHost());
-        server = startHost(application.root, {
+        server = startHost(applicationContext.root, {
           existing: mode === "tui" ? "attach-if-unconfigured" : "reject",
           host: options.host,
           onBootProgress,
@@ -577,24 +572,24 @@ function createCliProgram(
     .command("logs")
     .description("Inspect local `eve dev` diagnostic logs (.eve/logs).");
 
-  applicationCommand(logs.command("show [logid]", { isDefault: true }))
+  applicationCommand(logs.command("show [logid]", { isDefault: true }), applicationContext)
     .description("Print a diagnostic log (the most recent when logid is omitted).")
     .option("--dump", "Prepend the log's environment dump (.dump sibling)")
     .option("--events", "Interleave session events from the local workflow store")
     .action(async (logId: string | undefined, options: { dump?: boolean; events?: boolean }) => {
       const { runLogsShowCommand } = await import("#cli/commands/logs.js");
-      await runLogsShowCommand(logger, application.root, logId, options);
+      await runLogsShowCommand(logger, applicationContext.root, logId, options);
     });
 
-  applicationCommand(logs.command("ls"))
+  applicationCommand(logs.command("ls"), applicationContext)
     .description("List diagnostic logs, most recent first.")
     .option("--json", "Output as JSON")
     .action(async (options: { json?: boolean }) => {
       const { runLogsListCommand } = await import("#cli/commands/logs.js");
-      await runLogsListCommand(logger, application.root, options);
+      await runLogsListCommand(logger, applicationContext.root, options);
     });
 
-  const traces = applicationCommand(program.command("traces [trace]"))
+  const traces = applicationCommand(program.command("traces [trace]"), applicationContext)
     .usage("[options] [trace]\n       eve traces ls [options]")
     .description("Show a local `eve dev` trace (the most recent when trace is omitted).")
     .option("--verbose", "Expand every span with all attributes and events")
@@ -602,28 +597,29 @@ function createCliProgram(
     .action(
       async (reference: string | undefined, options: { json?: boolean; verbose?: boolean }) => {
         const { runTraceShowCommand } = await import("#cli/commands/trace.js");
-        await runTraceShowCommand(logger, application.root, reference, options);
+        await runTraceShowCommand(logger, applicationContext.root, reference, options);
       },
     );
 
-  applicationCommand(traces.command("ls"))
+  traces
+    .command("ls")
     .description("List local traces, most recent first.")
     .option("--json", "Output as JSON")
     .action(async (options: { json?: boolean }) => {
       const { runTraceListCommand } = await import("#cli/commands/trace.js");
-      await runTraceListCommand(logger, application.root, options);
+      await runTraceListCommand(logger, applicationContext.root, options);
     });
 
-  applicationCommand(program.command("info"))
+  applicationCommand(program.command("info"), applicationContext)
     .description("Print resolved application information.")
     .option("--json", "Output as JSON")
     .action(async (options: { json?: boolean }) => {
       const printApplicationInfo =
         runtime.printApplicationInfo ?? (await loadPrintApplicationInfo());
-      await printApplicationInfo(logger, application.root, options);
+      await printApplicationInfo(logger, applicationContext.root, options);
     });
 
-  applicationCommand(program.command("eval"))
+  applicationCommand(program.command("eval"), applicationContext)
     .description("Run evals against an eve agent.")
     .argument(
       "[evalIds...]",
@@ -642,7 +638,7 @@ function createCliProgram(
     .option("--verbose", "Stream per-eval t.log lines to stdout")
     .action(async (evalIds: string[], options: EvalCliOptions) => {
       const runEvalCommand = runtime.runEvalCommand ?? (await loadRunEvalCommand());
-      await runEvalCommand(evalIds, options, logger, application.root);
+      await runEvalCommand(evalIds, options, logger, applicationContext.root);
     });
 
   return program;
@@ -656,12 +652,20 @@ export async function runCli(
   logger: CliLogger = console,
   runtime: CliRuntimeOverrides = {},
 ): Promise<void> {
-  const application = { root: resolveApplicationRoot() };
-  const program = createCliProgram(logger, runtime, application);
+  const applicationContext: CliApplicationContext = {
+    root: resolveApplicationRoot(),
+    async resolve() {
+      applicationContext.root = await (runtime.resolveApplicationRoot ?? resolveCliApplicationRoot)(
+        applicationContext.root,
+        { interactive: hasInteractiveTerminal() },
+      );
+    },
+  };
+  const program = createCliProgram(logger, runtime, applicationContext);
   let input = argv;
   if (input.length === 0) {
     const detectEveProject = runtime.isEveProject ?? (await loadIsEveProject());
-    input = [(await detectEveProject(application.root)) ? "dev" : "init"];
+    input = [(await detectEveProject(applicationContext.root)) ? "dev" : "init"];
   }
 
   try {

--- a/packages/eve/src/cli/run.ts
+++ b/packages/eve/src/cli/run.ts
@@ -5,7 +5,7 @@ import { resolveApplicationRoot } from "#internal/application/paths.js";
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
 import { isCodingAgentLaunch } from "#cli/agent-detection.js";
 import { applicationCommand, type CliApplicationContext } from "#cli/application-command.js";
-import { resolveCliApplicationRoot } from "#cli/application-root.js";
+import { findCliApplicationRoot, resolveCliApplicationRoot } from "#cli/application-root.js";
 import { eveCliBanner } from "#cli/banner.js";
 import { registerIntegrationCommands } from "#cli/commands/register-integration-commands.js";
 import { registerProjectCommands } from "#cli/commands/register-project-commands.js";
@@ -64,7 +64,7 @@ interface CliLogger {
 
 interface CliRuntimeDependencies {
   isCodingAgentLaunch(): Promise<boolean>;
-  isEveProject(appRoot: string): Promise<boolean>;
+  findApplicationRoot(cwd: string): Promise<string | undefined>;
   isActiveDevelopmentServerForApp(input: {
     readonly appRoot: string;
     readonly serverUrl: string;
@@ -137,10 +137,6 @@ async function loadRunEvalCommand(): Promise<CliRuntimeDependencies["runEvalComm
 
 async function loadStartHost(): Promise<CliRuntimeDependencies["startHost"]> {
   return (await import("#cli/dev/local-server-process.js")).createDevelopmentServer;
-}
-
-async function loadIsEveProject(): Promise<CliRuntimeDependencies["isEveProject"]> {
-  return (await import("#setup/scaffold/index.js")).isEveProject;
 }
 
 const loadIsActiveDevelopmentServerForApp = async () =>
@@ -663,8 +659,14 @@ export async function runCli(
   const program = createCliProgram(logger, runtime, applicationContext);
   let input = argv;
   if (input.length === 0) {
-    const detectEveProject = runtime.isEveProject ?? (await loadIsEveProject());
-    input = [(await detectEveProject(applicationContext.root)) ? "dev" : "init"];
+    const findApplicationRoot = runtime.findApplicationRoot ?? findCliApplicationRoot;
+    const appRoot = await findApplicationRoot(applicationContext.root);
+    if (appRoot === undefined) {
+      input = ["init"];
+    } else {
+      applicationContext.root = appRoot;
+      input = ["dev"];
+    }
   }
 
   try {

--- a/packages/eve/src/cli/run.ts
+++ b/packages/eve/src/cli/run.ts
@@ -4,6 +4,12 @@ import { devBootPhase, type DevBootProgressReporter } from "#internal/dev-boot-p
 import { resolveApplicationRoot } from "#internal/application/paths.js";
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
 import { isCodingAgentLaunch } from "#cli/agent-detection.js";
+import {
+  applicationCommand,
+  commandRequiresApplicationRoot,
+  type CliApplicationContext,
+} from "#cli/application-command.js";
+import { resolveCliApplicationRoot } from "#cli/application-root.js";
 import { eveCliBanner } from "#cli/banner.js";
 import { registerIntegrationCommands } from "#cli/commands/register-integration-commands.js";
 import { registerProjectCommands } from "#cli/commands/register-project-commands.js";
@@ -81,8 +87,10 @@ interface CliRuntimeDependencies {
     evalIds: readonly string[],
     options: EvalCliOptions,
     logger: CliLogger,
+    appRoot: string,
   ): Promise<void>;
   startHost(appRoot: string, options?: DevelopmentServerOptions): DevelopmentServer;
+  resolveApplicationRoot(cwd: string, options: { readonly interactive: boolean }): Promise<string>;
   startProductionHost(
     appRoot: string,
     options?: {
@@ -153,7 +161,7 @@ function hasInteractiveTerminal(): boolean {
 function createCliProgram(
   logger: CliLogger,
   runtime: CliRuntimeOverrides,
-  appRoot: string,
+  application: CliApplicationContext,
 ): Command {
   const packageVersion = resolveInstalledPackageInfo().version;
   const program = new Command();
@@ -165,7 +173,13 @@ function createCliProgram(
     .version(packageVersion)
     .showHelpAfterError()
     .exitOverride()
-    .hook("preAction", (_program, actionCommand) => {
+    .hook("preAction", async (_program, actionCommand) => {
+      if (commandRequiresApplicationRoot(actionCommand)) {
+        application.root = await (runtime.resolveApplicationRoot ?? resolveCliApplicationRoot)(
+          application.root,
+          { interactive: hasInteractiveTerminal() },
+        );
+      }
       if (["info", "dev", "init"].includes(actionCommand.name())) {
         logger.log(eveCliBanner());
       }
@@ -179,18 +193,20 @@ function createCliProgram(
       },
     });
 
-  program
-    .command("channels")
-    .description("Manage user-authored channels in the current project.")
-    .command("list")
+  applicationCommand(
+    program
+      .command("channels")
+      .description("Manage user-authored channels in the current project.")
+      .command("list"),
+  )
     .description("List user-authored channels in the current project.")
     .option("--json", "Output as JSON")
     .action(async (options: { json?: boolean }) => {
       const { runChannelsListCommand } = await import("#cli/commands/channels.js");
-      await runChannelsListCommand(logger, appRoot, options);
+      await runChannelsListCommand(logger, application.root, options);
     });
 
-  registerIntegrationCommands({ program, logger, appRoot });
+  registerIntegrationCommands({ program, logger, application });
 
   const extension = program
     .command("extension")
@@ -208,7 +224,7 @@ function createCliProgram(
       }
 
       const { runExtensionInitCommand } = await import("#cli/commands/extension-init.js");
-      await runExtensionInitCommand(logger, appRoot, target);
+      await runExtensionInitCommand(logger, application.root, target);
     });
 
   extension
@@ -216,13 +232,13 @@ function createCliProgram(
     .description("Build the current package as an eve extension.")
     .action(async () => {
       const { loadDevelopmentEnvironmentFiles } = await import("#cli/dev/environment.js");
-      loadDevelopmentEnvironmentFiles(appRoot);
+      loadDevelopmentEnvironmentFiles(application.root);
 
       const { runExtensionBuildCommand } = await import("#cli/commands/extension-build.js");
-      await runExtensionBuildCommand(logger, appRoot);
+      await runExtensionBuildCommand(logger, application.root);
     });
 
-  registerRegistryCommands({ program, logger, appRoot });
+  registerRegistryCommands({ program, logger, application });
 
   program
     // Optional: a missing target scaffolds or updates the current directory,
@@ -252,7 +268,7 @@ function createCliProgram(
         }
 
         const { runInitCommand } = await import("#cli/commands/init.js");
-        await runInitCommand(logger, appRoot, target, {
+        await runInitCommand(logger, application.root, target, {
           channelWebNextjs: options.channelWebNextjs,
           model: options.model,
           reasoning: options.reasoning,
@@ -260,8 +276,7 @@ function createCliProgram(
       },
     );
 
-  program
-    .command("set")
+  applicationCommand(program.command("set"))
     .description("Change root agent model settings.")
     .option("--model <model>", "Set the agent model (provider/model-id)")
     .option(
@@ -271,30 +286,29 @@ function createCliProgram(
     )
     .action(async (options: { model?: string; reasoning?: AgentReasoningDefinition }) => {
       const { runSetCommand } = await import("#cli/commands/set.js");
-      await runSetCommand(logger, appRoot, options);
+      await runSetCommand(logger, application.root, options);
     });
 
-  registerProjectCommands({ program, logger, appRoot });
+  registerProjectCommands({ program, logger, application });
 
   registerBuildCommand({
-    appRoot,
+    application,
     buildHost: runtime.buildHost,
     logger,
     program,
   });
 
-  program
-    .command("start")
+  applicationCommand(program.command("start"))
     .description("Start a built eve application.")
     .option("--host <host>", "Host interface to bind")
     .option("--port <port>", "Port to listen on (defaults to $PORT, then 3000)", parsePortOption)
     .action(async (options: ProductionCliOptions) => {
       const { loadDevelopmentEnvironmentFiles } = await import("#cli/dev/environment.js");
 
-      loadDevelopmentEnvironmentFiles(appRoot);
+      loadDevelopmentEnvironmentFiles(application.root);
 
       const startProductionHost = runtime.startProductionHost ?? (await loadStartProductionHost());
-      const server = await startProductionHost(appRoot, {
+      const server = await startProductionHost(application.root, {
         host: options.host,
         port: options.port,
       });
@@ -310,10 +324,10 @@ function createCliProgram(
       await waitForShutdownSignal({ close: () => server.close(), wait: () => server.wait() });
     });
 
-  registerRuntimeInvokeCommand({ appRoot, logger, program, runtime });
+  registerRuntimeInvokeCommand({ application, logger, program, runtime });
 
   registerAcpCommand({
-    appRoot,
+    application,
     eveVersion: packageVersion,
     program,
     resolveVerifiedRemoteDevelopmentClient: runtime.resolveVerifiedRemoteDevelopmentClient,
@@ -321,8 +335,13 @@ function createCliProgram(
     startHost: runtime.startHost,
   });
 
-  program
-    .command("dev")
+  applicationCommand(program.command("dev"), (command) => {
+    const options = command.opts<DevelopmentCliOptions>();
+    return (
+      resolveDevelopmentUrlTarget(options, command.processedArgs[0] as string | undefined) ===
+      undefined
+    );
+  })
     .description("Start the eve development server or connect to an existing URL.")
     .argument("[url]", "Connect to an existing server URL", parseDevelopmentServerUrl)
     .option("--host <host>", "Host interface to bind")
@@ -387,7 +406,10 @@ function createCliProgram(
       if (remoteServerUrl !== undefined) {
         const isActive =
           runtime.isActiveDevelopmentServerForApp ?? (await loadIsActiveDevelopmentServerForApp());
-        existingLocalDevelopmentServer = await isActive({ appRoot, serverUrl: remoteServerUrl });
+        existingLocalDevelopmentServer = await isActive({
+          appRoot: application.root,
+          serverUrl: remoteServerUrl,
+        });
       }
       const runInteractiveUi = async (
         input: {
@@ -408,9 +430,9 @@ function createCliProgram(
             ? {
                 kind: "local",
                 serverUrl: input.serverUrl,
-                workspaceRoot: input.appRoot ?? appRoot,
+                workspaceRoot: input.appRoot ?? application.root,
               }
-            : { kind: "remote", serverUrl: input.serverUrl, workspaceRoot: appRoot };
+            : { kind: "remote", serverUrl: input.serverUrl, workspaceRoot: application.root };
         const title = resolveTuiTitle({ name: options.name, target });
         if (title !== undefined) display.name = title;
         const tuiInput: RunDevelopmentTuiInput = {
@@ -447,7 +469,7 @@ function createCliProgram(
 
       if (remoteServerUrl) {
         const { loadDevelopmentEnvironmentFiles } = await import("#cli/dev/environment.js");
-        loadDevelopmentEnvironmentFiles(appRoot);
+        loadDevelopmentEnvironmentFiles(application.root);
         logger.log(
           `↗ ${existingLocalDevelopmentServer ? "local" : "remote"} mode targeting ${theme.info(new URL(remoteServerUrl).host)}`,
         );
@@ -495,7 +517,7 @@ function createCliProgram(
 
       try {
         const startHost = runtime.startHost ?? (await loadStartHost());
-        server = startHost(appRoot, {
+        server = startHost(application.root, {
           existing: mode === "tui" ? "attach-if-unconfigured" : "reject",
           host: options.host,
           onBootProgress,
@@ -555,27 +577,24 @@ function createCliProgram(
     .command("logs")
     .description("Inspect local `eve dev` diagnostic logs (.eve/logs).");
 
-  logs
-    .command("show [logid]", { isDefault: true })
+  applicationCommand(logs.command("show [logid]", { isDefault: true }))
     .description("Print a diagnostic log (the most recent when logid is omitted).")
     .option("--dump", "Prepend the log's environment dump (.dump sibling)")
     .option("--events", "Interleave session events from the local workflow store")
     .action(async (logId: string | undefined, options: { dump?: boolean; events?: boolean }) => {
       const { runLogsShowCommand } = await import("#cli/commands/logs.js");
-      await runLogsShowCommand(logger, appRoot, logId, options);
+      await runLogsShowCommand(logger, application.root, logId, options);
     });
 
-  logs
-    .command("ls")
+  applicationCommand(logs.command("ls"))
     .description("List diagnostic logs, most recent first.")
     .option("--json", "Output as JSON")
     .action(async (options: { json?: boolean }) => {
       const { runLogsListCommand } = await import("#cli/commands/logs.js");
-      await runLogsListCommand(logger, appRoot, options);
+      await runLogsListCommand(logger, application.root, options);
     });
 
-  const traces = program
-    .command("traces [trace]")
+  const traces = applicationCommand(program.command("traces [trace]"))
     .usage("[options] [trace]\n       eve traces ls [options]")
     .description("Show a local `eve dev` trace (the most recent when trace is omitted).")
     .option("--verbose", "Expand every span with all attributes and events")
@@ -583,31 +602,28 @@ function createCliProgram(
     .action(
       async (reference: string | undefined, options: { json?: boolean; verbose?: boolean }) => {
         const { runTraceShowCommand } = await import("#cli/commands/trace.js");
-        await runTraceShowCommand(logger, appRoot, reference, options);
+        await runTraceShowCommand(logger, application.root, reference, options);
       },
     );
 
-  traces
-    .command("ls")
+  applicationCommand(traces.command("ls"))
     .description("List local traces, most recent first.")
     .option("--json", "Output as JSON")
     .action(async (options: { json?: boolean }) => {
       const { runTraceListCommand } = await import("#cli/commands/trace.js");
-      await runTraceListCommand(logger, appRoot, options);
+      await runTraceListCommand(logger, application.root, options);
     });
 
-  program
-    .command("info")
+  applicationCommand(program.command("info"))
     .description("Print resolved application information.")
     .option("--json", "Output as JSON")
     .action(async (options: { json?: boolean }) => {
       const printApplicationInfo =
         runtime.printApplicationInfo ?? (await loadPrintApplicationInfo());
-      await printApplicationInfo(logger, appRoot, options);
+      await printApplicationInfo(logger, application.root, options);
     });
 
-  program
-    .command("eval")
+  applicationCommand(program.command("eval"))
     .description("Run evals against an eve agent.")
     .argument(
       "[evalIds...]",
@@ -626,7 +642,7 @@ function createCliProgram(
     .option("--verbose", "Stream per-eval t.log lines to stdout")
     .action(async (evalIds: string[], options: EvalCliOptions) => {
       const runEvalCommand = runtime.runEvalCommand ?? (await loadRunEvalCommand());
-      await runEvalCommand(evalIds, options, logger);
+      await runEvalCommand(evalIds, options, logger, application.root);
     });
 
   return program;
@@ -640,12 +656,12 @@ export async function runCli(
   logger: CliLogger = console,
   runtime: CliRuntimeOverrides = {},
 ): Promise<void> {
-  const appRoot = resolveApplicationRoot();
-  const program = createCliProgram(logger, runtime, appRoot);
+  const application = { root: resolveApplicationRoot() };
+  const program = createCliProgram(logger, runtime, application);
   let input = argv;
   if (input.length === 0) {
     const detectEveProject = runtime.isEveProject ?? (await loadIsEveProject());
-    input = [(await detectEveProject(appRoot)) ? "dev" : "init"];
+    input = [(await detectEveProject(application.root)) ? "dev" : "init"];
   }
 
   try {

--- a/packages/eve/src/cli/run.ts
+++ b/packages/eve/src/cli/run.ts
@@ -86,7 +86,7 @@ interface CliRuntimeDependencies {
     appRoot: string,
   ): Promise<void>;
   startHost(appRoot: string, options?: DevelopmentServerOptions): DevelopmentServer;
-  resolveApplicationRoot(cwd: string): Promise<string>;
+  resolveApplicationRoot(cwd: string, options: { readonly interactive: boolean }): Promise<string>;
   startProductionHost(
     appRoot: string,
     options?: {
@@ -653,6 +653,7 @@ export async function runCli(
     async resolve() {
       applicationContext.root = await (runtime.resolveApplicationRoot ?? resolveCliApplicationRoot)(
         applicationContext.root,
+        { interactive: hasInteractiveTerminal() },
       );
     },
   };

--- a/packages/eve/src/cli/run.ts
+++ b/packages/eve/src/cli/run.ts
@@ -86,7 +86,7 @@ interface CliRuntimeDependencies {
     appRoot: string,
   ): Promise<void>;
   startHost(appRoot: string, options?: DevelopmentServerOptions): DevelopmentServer;
-  resolveApplicationRoot(cwd: string, options: { readonly interactive: boolean }): Promise<string>;
+  resolveApplicationRoot(cwd: string): Promise<string>;
   startProductionHost(
     appRoot: string,
     options?: {
@@ -653,7 +653,6 @@ export async function runCli(
     async resolve() {
       applicationContext.root = await (runtime.resolveApplicationRoot ?? resolveCliApplicationRoot)(
         applicationContext.root,
-        { interactive: hasInteractiveTerminal() },
       );
     },
   };

--- a/packages/eve/src/evals/cli/eval.ts
+++ b/packages/eve/src/evals/cli/eval.ts
@@ -8,7 +8,6 @@ import {
   EVE_EVALUATION_ENV_FLAG,
   EVE_EVALUATION_RUN_ID_ENV,
 } from "#internal/application/dev-environment.js";
-import { resolveApplicationRoot } from "#internal/application/paths.js";
 import { createDevelopmentServer, type DevelopmentServer } from "#internal/nitro/host.js";
 import { createEvalClient } from "#evals/cli/eval-client.js";
 import { filterEvalsByTags } from "#evals/cli/filter.js";
@@ -54,9 +53,8 @@ export async function runEvalCommand(
   evalIds: readonly string[],
   options: EvalCliOptions,
   logger: EvalCliLogger,
+  appRoot: string = process.cwd(),
 ): Promise<void> {
-  const appRoot = resolveApplicationRoot();
-
   loadDevelopmentEnvironmentFiles(appRoot);
 
   const requestedEvalIds = evalIds.length > 0 ? evalIds : undefined;

--- a/packages/eve/test/scenarios/cli.scenario.test.ts
+++ b/packages/eve/test/scenarios/cli.scenario.test.ts
@@ -283,7 +283,7 @@ describe("runCli", () => {
       error: vi.fn(),
       log: vi.fn(),
     };
-    const isEveProject = vi.fn(async () => true);
+    const findApplicationRoot = vi.fn(async () => process.cwd());
     const startHost = vi.fn(() => ({
       start: async () => {
         throw new Error("dev started");
@@ -293,12 +293,12 @@ describe("runCli", () => {
 
     await expect(
       runCli([], logger, {
-        isEveProject,
+        findApplicationRoot,
         startHost,
       }),
     ).rejects.toThrow("dev started");
 
-    expect(isEveProject).toHaveBeenCalledOnce();
+    expect(findApplicationRoot).toHaveBeenCalledOnce();
     expect(startHost).toHaveBeenCalledOnce();
   });
 


### PR DESCRIPTION
### Summary

Closes #2083. Project-scoped commands now can be executed from a subdirectory of a valid eve application.

Adds a `applicationCommand` helper that gives a uniform policy for all commands that need to be run within an eve application, and allows for special handling of things like `eve dev`, which technically do not need to be executed w/in an eve application if `--url` is provided.

Resolution reuses eve's existing project discovery, including flat agent roots, and preserves each command's existing behavior when no application is found.

### Validation

Focused CLI coverage passes with 83 tests. Type checking, invariant guards, linting, and the affected CLI/eval scenario tests pass; two additional framework scenarios were blocked locally by missing Socket registry credentials. The unrelated cancellation E2E failure timed out after a workflow replay divergence.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+6 / -1`

Adds concise application-root guidance and the patch release note.

**Implementation** — 10 files · `+274 / -111`

Adds shared CLI resolution and command-local opt-in while reusing existing project discovery.

**Tests** — 4 files · `+219 / -16`

Covers enclosing and child resolution, flat roots, command hooks, and local-versus-remote dispatch.
