### PR TITLE
feat(docs): add the Software Factory template to the gallery

### DIFF
--- a/apps/docs/lib/templates/manifest.ts
+++ b/apps/docs/lib/templates/manifest.ts
@@ -181,6 +181,35 @@ export const templateManifest: TemplateManifestEntry[] = [
     ],
   },
   {
+    slug: "eve-software-factory-template",
+    title: "Software factory",
+    setupPrompt:
+      "I want to build a software factory with the eve framework, using the Foreman template. Read the setup instructions at https://ask-foreman.dev/docs/getting-started and follow them. They cover deploying the template, connecting GitHub and Linear, running it locally, and how the pipeline works overall.",
+    description:
+      "Foreman, a software factory that takes tasks from GitHub and Linear, runs each through classifier, analyst, implementer, and reviewer stations, and delivers a reviewed draft pull request on your repository.",
+    demoHref: "https://ask-foreman.dev",
+    sourceHref: "https://github.com/vercel-labs/eve-software-factory-template/tree/main",
+    category: "Collaboration",
+    model: "openai/gpt-5.6-terra-fast",
+    integrations: ["GitHub", "Linear"],
+    source: "Vercel Templates",
+    github: { owner: "vercel-labs", repo: "eve-software-factory-template", ref: "main" },
+    files: [
+      "agent/agent.ts",
+      "agent/channels/github.ts",
+      "agent/channels/linear.ts",
+      "agent/extensions/github.ts",
+      "agent/instructions.ts",
+      "agent/lib/github/approval.ts",
+      "agent/lib/trust.ts",
+      "agent/subagents/analyst/agent.ts",
+      "agent/subagents/classifier/agent.ts",
+      "agent/subagents/implementer/agent.ts",
+      "agent/subagents/implementer/tools/push_branch.ts",
+      "agent/subagents/reviewer/agent.ts",
+    ],
+  },
+  {
     slug: "marketing-team-eve-template",
     title: "Marketing team",
     setupPrompt:


### PR DESCRIPTION
Adds [Foreman, the eve Software Factory template](https://github.com/vercel-labs/eve-software-factory-template), to the gallery at eve.dev/templates.

## The entry

```ts
{
  slug: "eve-software-factory-template",
  title: "Software factory",
  category: "Collaboration",
  model: "openai/gpt-5.6-terra-fast",
  integrations: ["GitHub", "Linear"],
  ...
}
```

Foreman takes tasks from GitHub (issue labels, @mentions) and Linear, moves each through four subagent stations (classifier, analyst, implementer, reviewer), and delivers a reviewed draft pull request. The file list surfaces what makes the template distinctive: the two channel intakes, the extension-based GitHub tool surface, the trust/approval policy layer, the four station contracts, and the implementer's structurally-inert `push_branch` tool.

The setup prompt points at the template's own docs site, [ask-foreman.dev/docs/getting-started](https://ask-foreman.dev/docs/getting-started), which carries both the deploy-button flow and the manual CLI setup. The demo link goes to the docs landing page. `model` shows the orchestrator's model; the implementer deliberately runs `anthropic/claude-fable-5` on a different provider than the reviewer, which the template docs explain.

## Validation

`templates:sync` resolves the entry (`main → 9a7ca86`, all 12 files fetched), the `lib/templates` tests pass (20/20), and typecheck, lint, and fmt are clean. No changeset: `eve-docs` is a private app.