### PR TITLE
Fixed sample-db.ts failed to find the WASM path

### DIFF
--- a/docs/tutorial/query-sample-data.mdx
+++ b/docs/tutorial/query-sample-data.mdx
@@ -11,8 +11,12 @@ To make the first query work without setup, bundle a small in-memory dataset und
 
 ```ts title="agent/lib/sample-db.ts"
 // A toy SQLite-in-memory stand-in. Swap for your real warehouse in Step 4.
-import initSqlJs from "sql.js";
+import { readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import initSqlJs from "sql.js"; // npm install this package first, this is not included in "npx eve@latest init"
 
+// define the WASM path, there are case sql.js failed to find the WASM
+const wasmPath = createRequire(import.meta.url).resolve("sql.js/dist/sql-wasm.wasm");
 const SEED = `
   CREATE TABLE orders (id INTEGER, customer_id INTEGER, amount_cents INTEGER, created_at TEXT);
   INSERT INTO orders VALUES
@@ -26,7 +30,8 @@ const SEED = `
 let dbPromise: Promise<import("sql.js").Database> | null = null;
 
 async function db() {
-  dbPromise ??= initSqlJs().then((SQL) => {
+  // init the in-memory database with the WASM path defined.
+  dbPromise ??= initSqlJs({ wasmBinary: await readFile(wasmPath) }).then((SQL) => {
     const database = new SQL.Database();
     database.run(SEED);
     return database;


### PR DESCRIPTION
Updated the sample database initialization to include WASM path handling and added necessary imports.

### Summary

There are issue when tested locally in OSX, npm run dev failed to run due to this script 

### Validation

After copy pasted this code, run command below to make sure we can run eve now.

```shell
npm run dev
```

### Checklist

I did not run these checklist below due this PR just improving documentation.
Please let me know if still needed.

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [ ] I ran the relevant checks from `CONTRIBUTING.md`
- [ ] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [ ] DCO sign-off passes for every commit (`git commit --signoff`)
