### PR TITLE
feat(eve): extensions - support schedules

### DIFF
--- a/.changeset/tidy-schedules-compose.md
+++ b/.changeset/tidy-schedules-compose.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Extensions can contribute schedules. Mounted schedule IDs use the extension namespace while cron expressions and handler behavior remain unchanged.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -3,7 +3,7 @@ title: "Extensions"
 description: "Package reusable eve capabilities and mount them from npm or a monorepo workspace."
 ---
 
-Extensions package eve tools, channels, connections, skills, instruction fragments, and hooks. An author builds an extension package; each agent that uses it declares the package as a dependency and mounts it. The package can be published to a package registry or kept private inside a monorepo workspace.
+Extensions package eve tools, channels, connections, skills, schedules, instruction fragments, and hooks. An author builds an extension package; each agent that uses it declares the package as a dependency and mounts it. The package can be published to a package registry or kept private inside a monorepo workspace.
 
 Ready-made extensions can also be distributed through an eve integration registry. See [Add Integrations](./install-integrations) to discover and add one with `eve add`; this page explains how extension packages are authored, mounted, configured, and overridden.
 
@@ -32,6 +32,7 @@ An extension uses the same file conventions as an agent for its contributions:
     channels/webhook.ts
     connections/api.ts
     skills/triage/SKILL.md
+    schedules/sync.ts
     instructions.md
     hooks/audit.ts
     lib/http.ts
@@ -39,9 +40,9 @@ An extension uses the same file conventions as an agent for its contributions:
 
 Each listed slot accepts the same authored forms as its agent counterpart. Static and dynamic tools, skills, and instructions all work in an extension: `extension/instructions.ts` is as valid as `extension/instructions.md`, and `extension/tools/` can contain `defineDynamic(...)`.
 
-Names come from paths, so call the tool `search`, not `crm_search`; the consumer's mount adds the `crm__` prefix. The same prefix applies to channel IDs, while channel route paths stay unchanged. Keep shared code in `extension/lib/`.
+Names come from paths, so call the tool `search`, not `crm_search`; the consumer's mount adds the `crm__` prefix. The same prefix applies to channel and schedule IDs, while channel route paths and schedule cron expressions stay unchanged. Keep shared code in `extension/lib/`.
 
-Keep agent configuration, sandboxes, schedules, and nested extensions in the consumer's agent.
+Keep agent configuration, sandboxes, and nested extensions in the consumer's agent.
 
 ### Add configuration and contributions
 
@@ -59,7 +60,7 @@ export default defineExtension({
 });
 ```
 
-Contributions import that handle to read the validated configuration. Defaults have already been applied:
+Contributions, including schedule handlers, can import that handle to read the validated configuration. Defaults have already been applied:
 
 ```ts title="extension/tools/search.ts"
 import { defineTool } from "eve/tools";
@@ -169,7 +170,7 @@ export default crm({ apiKey: process.env.CRM_API_KEY! });
 
 Set `CRM_API_KEY` in the consumer's environment, such as `.env.local` for local development.
 
-The mount adds `crm__` to named contributions: `tools/search.ts` becomes `crm__search`, `channels/webhook.ts` becomes `crm__webhook`, and `connections/api.ts` becomes `crm__api`. A channel keeps the route paths declared in its `defineChannel(...)` definition.
+The mount adds `crm__` to named contributions: `tools/search.ts` becomes `crm__search`, `channels/webhook.ts` becomes `crm__webhook`, `schedules/sync.ts` becomes `crm__sync`, and `connections/api.ts` becomes `crm__api`. Channels keep their declared route paths, and schedules keep their cron expressions.
 
 For an extension with no configuration, mount its default export directly:
 
@@ -275,7 +276,7 @@ import crm from "@acme/crm";
 export default crm({ apiKey: process.env.CRM_API_KEY! });
 ```
 
-A same-named consumer channel, tool, connection, or skill wins. To adjust an extension tool, import it from the package's `./tools` export and define it again:
+A same-named consumer channel, tool, connection, skill, or schedule wins. To adjust an extension tool, import it from the package's `./tools` export and define it again:
 
 ```ts title="agent/extensions/crm/tools/search.ts"
 import { search } from "@acme/crm/tools";
@@ -331,4 +332,5 @@ At build time, eve checks the extension's generated capability metadata. If the 
 - [Skills](/docs/skills): package procedures and supporting files
 - [Connections](/docs/connections): integrate external services
 - [Channels](/docs/channels/overview): receive messages and expose routes
+- [Schedules](/docs/schedules): run the agent on a cron cadence
 - [Hooks](/docs/guides/hooks): observe agent events

--- a/docs/schedules.mdx
+++ b/docs/schedules.mdx
@@ -3,9 +3,9 @@ title: "Schedules"
 description: "Run an agent on a cron cadence, either a fire-and-forget prompt or a handler that hands work off to a channel."
 ---
 
-A schedule starts the agent on its own clock instead of waiting for an inbound message. Use one for daily digests, data syncs, cleanup sweeps, heartbeats, or anything that should fire on a cadence. Each one is a single file under `agent/schedules/` carrying a cron expression. Schedules are root-only, so declared subagents cannot have a `schedules/` directory.
+A schedule starts the agent on its own clock instead of waiting for an inbound message. Use one for daily digests, data syncs, cleanup sweeps, heartbeats, or anything that should fire on a cadence. Root-authored schedules are single files under `agent/schedules/`, and mounted extensions can contribute them from `extension/schedules/`. Declared subagents cannot have a `schedules/` directory.
 
-The name comes from the path under `schedules/` (`agent/schedules/billing/sweep.ts` → `"billing/sweep"`), and nested directories are fine.
+The name comes from the path under `schedules/` (`agent/schedules/billing/sweep.ts` → `"billing/sweep"`), and nested directories are fine. An extension mount prefixes that name (`extension/schedules/sweep.ts` mounted as `crm` → `"crm__sweep"`) without changing its cron expression.
 
 ## `defineSchedule`
 

--- a/packages/eve/extension-contracts/entrypoints/schedule.ts
+++ b/packages/eve/extension-contracts/entrypoints/schedule.ts
@@ -1,0 +1,8 @@
+export {
+  defineSchedule,
+  type ScheduleDefinition,
+  type ScheduleHandlerArgs,
+  type ScheduleRunHandler,
+  type ScheduleToFn,
+  type TypedReceiveTarget,
+} from "../../src/public/schedules/index.ts";

--- a/packages/eve/extension-contracts/reports/schedule/v1.json
+++ b/packages/eve/extension-contracts/reports/schedule/v1.json
@@ -1,0 +1,14 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "schedule",
+  "epoch": 1,
+  "sha256": "33daead219299aa9b5af3183849d187ae239685f8887947a85cfc0c84fb53b50",
+  "exports": [
+    "ScheduleDefinition",
+    "ScheduleHandlerArgs",
+    "ScheduleRunHandler",
+    "ScheduleToFn",
+    "TypedReceiveTarget",
+    "defineSchedule"
+  ]
+}

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -28,6 +28,7 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     dropped: {},
   },
   channel: { current: 1, supported: [1], dropped: {} },
+  schedule: { current: 1, supported: [1], dropped: {} },
   connection: { current: 5, supported: [1, 2, 3, 4, 5], dropped: {} },
   hook: {
     current: 13,

--- a/packages/eve/src/compiler/normalize-extension.test.ts
+++ b/packages/eve/src/compiler/normalize-extension.test.ts
@@ -21,6 +21,7 @@ function contributions(
     dynamicInstructions: [],
     connections: [],
     instructions: [],
+    schedules: [],
     ...overrides,
   };
 }
@@ -36,6 +37,7 @@ describe("mergeContributions", () => {
       connections: [{ connectionName: "crm__api", logicalPath: "override" }] as never,
       skills: [{ name: "crm__lookup", logicalPath: "override" }] as never,
       dynamicTools: [{ slug: "crm__dynamic", logicalPath: "override" }] as never,
+      schedules: [{ name: "crm__sweep", logicalPath: "override" }] as never,
     });
     const secondary = contributions({
       channels: [
@@ -49,6 +51,10 @@ describe("mergeContributions", () => {
       connections: [{ connectionName: "crm__api", logicalPath: "extension" }] as never,
       skills: [{ name: "crm__lookup", logicalPath: "extension" }] as never,
       dynamicTools: [{ slug: "crm__dynamic", logicalPath: "extension" }] as never,
+      schedules: [
+        { name: "crm__sweep", logicalPath: "extension" },
+        { name: "crm__digest", logicalPath: "extension" },
+      ] as never,
     });
 
     const merged = mergeContributions(primary, secondary);
@@ -65,6 +71,10 @@ describe("mergeContributions", () => {
     expect(merged.connections).toEqual([{ connectionName: "crm__api", logicalPath: "override" }]);
     expect(merged.skills).toEqual([{ name: "crm__lookup", logicalPath: "override" }]);
     expect(merged.dynamicTools).toEqual([{ slug: "crm__dynamic", logicalPath: "override" }]);
+    expect(merged.schedules).toEqual([
+      { name: "crm__sweep", logicalPath: "override" },
+      { name: "crm__digest", logicalPath: "extension" },
+    ]);
   });
 
   it("concatenates unnamed contributions from both sets", () => {

--- a/packages/eve/src/compiler/normalize-extension.ts
+++ b/packages/eve/src/compiler/normalize-extension.ts
@@ -9,6 +9,7 @@ import type {
   CompiledDynamicToolDefinition,
   CompiledHookDefinition,
   CompiledInstructionsDefinition,
+  CompiledScheduleDefinition,
   CompiledSkillDefinition,
   CompiledToolDefinition,
 } from "#compiler/manifest.js";
@@ -17,6 +18,7 @@ import { compileConnectionDefinition } from "#compiler/normalize-connection.js";
 import type { ManifestCompileContext } from "#compiler/normalize-helpers.js";
 import { compileHookEntry } from "#compiler/normalize-hook.js";
 import { compileInstructionsEntry } from "#compiler/normalize-instructions.js";
+import { compileScheduleDefinition } from "#compiler/normalize-schedule.js";
 import { compileSkillSource } from "#compiler/normalize-skill.js";
 import { compileToolEntry } from "#compiler/normalize-tool.js";
 
@@ -34,6 +36,7 @@ export interface CompiledExtensionContributions {
   readonly dynamicInstructions: CompiledDynamicInstructionsDefinition[];
   readonly connections: CompiledConnectionDefinition[];
   readonly instructions: CompiledInstructionsDefinition[];
+  readonly schedules: CompiledScheduleDefinition[];
 }
 
 /**
@@ -301,6 +304,18 @@ async function composeManifestContributions(input: {
     }
   }
 
+  const schedules = await Promise.all(
+    manifest.schedules.map(async (source) => {
+      const schedule = await compileScheduleDefinition(sourceRoot, source, options);
+      return {
+        ...schedule,
+        name: `${prefix}${schedule.name}`,
+        sourceId: scopeSourceId(schedule.sourceId),
+        logicalPath: rebase(schedule.logicalPath),
+      };
+    }),
+  );
+
   return {
     contributions: {
       channels,
@@ -312,6 +327,7 @@ async function composeManifestContributions(input: {
       dynamicInstructions,
       connections,
       instructions,
+      schedules,
     },
     disabledToolTargets,
   };
@@ -329,7 +345,7 @@ function describeExtensionSource(
 
 /**
  * Merges two composed contribution sets with earlier-set-wins precedence per
- * composed name. Named contributions dedup by their model-facing identifier so
+ * composed name. Named contributions dedup by their composed identifier so
  * an override shadows the extension's same-named entry. Channel entries dedup
  * as a group so every route from the winning channel is preserved. Unnamed
  * contributions (hooks, dynamic skills, dynamic instructions, static
@@ -359,6 +375,10 @@ export function mergeContributions(
       (connection) => connection.connectionName,
     ),
     skills: dedupeBy([...primary.skills, ...secondary.skills], (skill) => skill.name),
+    schedules: dedupeBy(
+      [...primary.schedules, ...secondary.schedules],
+      (schedule) => schedule.name,
+    ),
     hooks: [...primary.hooks, ...secondary.hooks],
     dynamicSkills: [...primary.dynamicSkills, ...secondary.dynamicSkills],
     dynamicInstructions: [...primary.dynamicInstructions, ...secondary.dynamicInstructions],

--- a/packages/eve/src/compiler/normalize-manifest.ts
+++ b/packages/eve/src/compiler/normalize-manifest.ts
@@ -230,6 +230,7 @@ async function compileAgentResources(
         skills.push(skill);
       }
     }
+    schedules.push(...contributions.schedules);
     hooks.push(...contributions.hooks);
     dynamicSkills.push(...contributions.dynamicSkills);
     dynamicInstructions.push(...contributions.dynamicInstructions);

--- a/packages/eve/src/discover/agent.integration.test.ts
+++ b/packages/eve/src/discover/agent.integration.test.ts
@@ -15,7 +15,6 @@ import {
   DISCOVER_EXTENSION_MOUNT_MISSING_DECLARATION,
   DISCOVER_EXTENSION_NESTED_MOUNT_UNSUPPORTED,
   DISCOVER_EXTENSION_OVERRIDE_OUTSIDE_MOUNT,
-  DISCOVER_EXTENSION_SCHEDULE_UNSUPPORTED,
 } from "#discover/extensions.js";
 import {
   DISCOVER_DEPRECATED_SYSTEM_SLOT,
@@ -1084,7 +1083,7 @@ describe("discoverAgent (memory)", () => {
     expect(result.manifest.resolvedExtensions).toHaveLength(1);
   });
 
-  it("rejects an extension that declares schedules", async () => {
+  it("discovers schedules declared by an extension", async () => {
     const project = buildMemoryAgentProject({
       appFiles: {
         "node_modules/@acme/crm/package.json": JSON.stringify({
@@ -1093,7 +1092,6 @@ describe("discoverAgent (memory)", () => {
         }),
         "node_modules/@acme/crm/extension/_manifest.json": EXTENSION_COMPATIBILITY_MANIFEST,
         "node_modules/@acme/crm/extension/extension.ts": "export default {};\n",
-        // Background scheduling is the consuming agent's to own, not an extension's.
         "node_modules/@acme/crm/extension/schedules/sweep.md":
           '---\ncron: "0 9 * * *"\n---\nSweep.',
       },
@@ -1109,9 +1107,14 @@ describe("discoverAgent (memory)", () => {
       source: project.source,
     });
 
-    expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toContain(
-      DISCOVER_EXTENSION_SCHEDULE_UNSUPPORTED,
-    );
+    expect(result.diagnostics).toEqual([]);
+    expect(result.manifest.resolvedExtensions[0]?.manifest.schedules).toMatchObject([
+      {
+        logicalPath: "schedules/sweep.md",
+        sourceId: "schedules/sweep.md",
+        sourceKind: "markdown",
+      },
+    ]);
   });
 
   it("rejects an extension that mounts another extension", async () => {

--- a/packages/eve/src/discover/discover-agent.ts
+++ b/packages/eve/src/discover/discover-agent.ts
@@ -10,7 +10,6 @@ import {
   DISCOVER_EXTENSION_NESTED_MOUNT_UNSUPPORTED,
   DISCOVER_EXTENSION_OVERRIDE_OUTSIDE_MOUNT,
   DISCOVER_EXTENSION_SANDBOX_UNSUPPORTED,
-  DISCOVER_EXTENSION_SCHEDULE_UNSUPPORTED,
   locateExtensionMount,
   mountNamespace,
 } from "#discover/extensions.js";
@@ -179,17 +178,6 @@ export async function discoverAgent(input: DiscoverAgentInput): Promise<Discover
           code: DISCOVER_EXTENSION_SANDBOX_UNSUPPORTED,
           message: "An extension may not declare a sandbox — it is the consuming agent's to own.",
           sourcePath: join(agentRoot, sandboxResult.sandbox.logicalPath),
-        }),
-      );
-    }
-    const [firstSchedule] = schedulesResult.schedules;
-    if (firstSchedule !== undefined) {
-      diagnostics.push(
-        createDiscoverErrorDiagnostic({
-          code: DISCOVER_EXTENSION_SCHEDULE_UNSUPPORTED,
-          message:
-            "An extension may not declare schedules — background scheduling runs on the consuming agent's deployment under its limits, so it is the consuming agent's to own.",
-          sourcePath: join(agentRoot, firstSchedule.logicalPath),
         }),
       );
     }

--- a/packages/eve/src/discover/extensions.ts
+++ b/packages/eve/src/discover/extensions.ts
@@ -78,13 +78,6 @@ export const DISCOVER_EXTENSION_AGENT_CONFIG_UNSUPPORTED =
 export const DISCOVER_EXTENSION_SANDBOX_UNSUPPORTED = "discover/extension-sandbox-unsupported";
 
 /**
- * Emitted when an extension source tree declares `schedules`. Background
- * scheduling runs sessions on the consuming agent's deployment under its limits,
- * so it is the consuming agent's to own, not an extension's.
- */
-export const DISCOVER_EXTENSION_SCHEDULE_UNSUPPORTED = "discover/extension-schedule-unsupported";
-
-/**
  * Resolved on-disk location of one mounted extension package.
  */
 export interface ExtensionMountLocation {

--- a/packages/eve/src/internal/nitro/host/extension-capability-requirements.ts
+++ b/packages/eve/src/internal/nitro/host/extension-capability-requirements.ts
@@ -47,6 +47,7 @@ export async function deriveExtensionCapabilityRequirements(input: {
   if (input.manifest.channels.length > 0) required.add("channel");
   if (input.manifest.connections.length > 0) required.add("connection");
   if (input.manifest.hooks.length > 0) required.add("hook");
+  if (input.manifest.schedules.length > 0) required.add("schedule");
   if (skills.length > 0) required.add("skill");
   if (skills.some((entry) => entry.kind === "dynamic-skill")) required.add("dynamicSkill");
   if (instructions.length > 0) required.add("instructions");

--- a/packages/eve/src/setup/scaffold/create/extension.ts
+++ b/packages/eve/src/setup/scaffold/create/extension.ts
@@ -132,7 +132,7 @@ dist
 const AGENTS_MD_TEMPLATE = `# eve Extension Package
 
 This package is an eve extension — a reusable package of tools, channels,
-connections, skills, hooks, and instruction fragments that a consuming agent
+connections, skills, schedules, hooks, and instruction fragments that a consuming agent
 mounts under \`agent/extensions/\`.
 
 Before writing code, read the Extensions guide from the installed eve package
@@ -145,12 +145,12 @@ unavailable, use https://eve.dev/docs/extensions as a fallback.
 
 - Declare the extension in \`extension/extension.ts\` with \`defineExtension\` from
   \`eve/extension\`. Config is optional; read bound values via the handle's
-  \`.config\` in tools, channels, and hooks.
+  \`.config\` in tools, channels, schedules, and hooks.
 - Add contributions under \`extension/\` the same way as in an agent:
-  \`tools/\`, \`channels/\`, \`connections/\`, \`skills/\`, \`hooks/\`, and optional instruction
-  fragments. Names come from file paths; the mount supplies the namespace, so
+  \`tools/\`, \`channels/\`, \`connections/\`, \`skills/\`, \`schedules/\`, \`hooks/\`, and
+  optional instruction fragments. Names come from file paths; the mount supplies the namespace, so
   name tools for what they do (\`search\`, not \`crm_search\`).
-- An extension cannot declare \`agent.ts\`, \`sandbox\`, \`schedules\`, or nested
+- An extension cannot declare \`agent.ts\`, \`sandbox\`, or nested
   \`extensions/\` — those belong to the consuming agent.
 
 ## Build and publish

--- a/packages/eve/test/scenarios/mounted-extension-installed.scenario.test.ts
+++ b/packages/eve/test/scenarios/mounted-extension-installed.scenario.test.ts
@@ -15,6 +15,7 @@ import { useScenarioApp } from "../../src/internal/testing/scenario-app.js";
 import { createDiskRuntimeCompiledArtifactsSource } from "../../src/runtime/compiled-artifacts-source.js";
 import { loadCompiledManifest } from "../../src/runtime/loaders/manifest.js";
 import { resolveRuntimeAgentGraph } from "../../src/runtime/resolve-agent-graph.js";
+import { loadResolvedModuleExport } from "../../src/runtime/resolve-helpers.js";
 
 const scenarioApp = useScenarioApp();
 const tempRoots: string[] = [];
@@ -83,6 +84,17 @@ const EXT_TREE: Readonly<Record<string, string>> = {
     "  routes: [",
     '    GET("/crm/status", async () => new Response(extension.config.apiKey)),',
     "  ],",
+    "});",
+    "",
+  ].join("\n"),
+  "extension/schedules/sync.ts": [
+    'import { defineSchedule } from "eve/schedules";',
+    'import extension from "../extension.js";',
+    "export default defineSchedule({",
+    '  cron: "0 9 * * *",',
+    "  run({ waitUntil }) {",
+    "    waitUntil(Promise.resolve(extension.config.apiKey));",
+    "  },",
     "});",
     "",
   ].join("\n"),
@@ -209,7 +221,7 @@ describe("mounted extension installed under node_modules", () => {
     );
     expect(
       JSON.parse(extensionFiles[`node_modules/${PACKAGE_NAME}/dist/extension/_manifest.json`]!),
-    ).toMatchObject({ requires: { channel: 1 } });
+    ).toMatchObject({ requires: { channel: 1, schedule: 1 } });
     const app = await scenarioApp({
       name: "mounted-extension-installed",
       installDependencies: true,
@@ -258,6 +270,29 @@ describe("mounted extension installed under node_modules", () => {
       waitUntil() {},
     });
     await expect(response.text()).resolves.toBe("sk-installed");
+
+    const sync = manifest.schedules.find((entry) => entry.name === "crm__sync");
+    expect(sync).toMatchObject({
+      cron: "0 9 * * *",
+      hasRun: true,
+      sourceId: "ext:crm:schedules/sync.mjs",
+    });
+    if (sync === undefined) throw new Error("Expected the extension schedule to compile.");
+    const syncDefinition = (await loadResolvedModuleExport({
+      definition: sync,
+      kindLabel: "schedule",
+      moduleMap,
+      nodeId: undefined,
+    })) as {
+      run(input: { waitUntil(task: Promise<unknown>): void }): Promise<void> | void;
+    };
+    let scheduledTask: Promise<unknown> | undefined;
+    await syncDefinition.run({
+      waitUntil(task) {
+        scheduledTask = task;
+      },
+    });
+    await expect(scheduledTask).resolves.toBe("sk-installed");
 
     expect(graph.root.agent.skills.map((skill) => skill.name)).toEqual(
       expect.arrayContaining(["crm__notes", "crm__research", "crm__guide"]),

--- a/scripts/extension-contracts/configuration.mjs
+++ b/scripts/extension-contracts/configuration.mjs
@@ -19,6 +19,7 @@ export const COMPATIBILITY_FIXTURE_PLACEHOLDER = "REPLACE_WITH_RETAINED_AUTHORIN
 export const PUBLIC_SURFACES = [
   { path: "src/public/extension/index.ts", capabilities: ["extension", "config"] },
   { path: "src/public/channels/index.ts", capabilities: ["channel"] },
+  { path: "src/public/schedules/index.ts", capabilities: ["schedule"] },
   { path: "src/public/tools/index.ts", capabilities: ["tool", "dynamicTool"] },
   { path: "src/public/connections/index.ts", capabilities: ["connection"] },
   { path: "src/public/hooks/index.ts", capabilities: ["hook"] },


### PR DESCRIPTION
### Summary

Closes #2100. Extensions previously rejected authored schedules, forcing each consumer to duplicate periodic work that belonged with the packaged capability. Mounted extensions now contribute the existing TypeScript and Markdown schedule forms with mount-prefixed IDs while preserving cron expressions and handler behavior. Module-backed handlers retain bound extension configuration, directory-mount overrides win by schedule ID, and the consuming agent's deployment continues to own execution and limits.

### Validation

Focused merge coverage verifies consumer override precedence, discovery coverage accepts an extension-authored Markdown schedule, and the dist-only installed-extension scenario builds a TypeScript handler, checks its capability metadata and namespaced identity, then loads it through the compiled module map and confirms bound config is available.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 3 files · `+15 / -8`

Updates the extension and schedule guides for namespaced schedules and adds the release note.

**Implementation** — 10 files · `+52 / -25`

Uses the existing schedule compiler and extension composition path, removes the discovery rejection, updates the scaffold guidance, and adds the schedule capability contract and generated epoch report.

**Tests** — 3 files · `+55 / -7`

Replaces rejection coverage with acceptance, extends the existing override test, and adds schedule behavior to the installed-extension scenario.
