### PR TITLE
feat(eve): allow inbound hooks to set run titles

### DIFF
--- a/.changeset/calm-runs-hide.md
+++ b/.changeset/calm-runs-hide.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Built-in inbound hooks can now return `title` to set the workflow run title without changing the message sent to the model.

--- a/docs/channels/discord.mdx
+++ b/docs/channels/discord.mdx
@@ -56,7 +56,7 @@ Then configure the public `https://…/eve/v1/discord` route as the application'
 
 ### Dispatch
 
-`onCommand(ctx, interaction)` decides whether to dispatch and under what `auth`. Return `{ auth }` to proceed or `null` to drop the interaction. By default, auth comes from the invoking user. Event handlers receive `(eventData, channel, ctx)`, with Discord platform handles on `channel.discord`:
+`onCommand(ctx, interaction)` decides whether to dispatch and under what `auth`. Return `{ auth }` to proceed, `null` to drop the interaction, or `title` alongside `auth` to set the title when the dispatch starts a run. By default, auth comes from the invoking user. Event handlers receive `(eventData, channel, ctx)`, with Discord platform handles on `channel.discord`:
 
 ```ts
 import { discordChannel } from "eve/channels/discord";

--- a/docs/channels/eve.mdx
+++ b/docs/channels/eve.mdx
@@ -160,8 +160,7 @@ export default eveChannel({
 });
 ```
 
-`onMessage` must return an auth result. A successful canonical eve HTTP message
-always dispatches and therefore always produces or continues a session.
+`onMessage` must return an auth result. Return `title` alongside `auth` to set the title when the dispatch starts a run. A successful canonical eve HTTP message always dispatches and therefore always produces or continues a session.
 
 ## Clients
 

--- a/docs/channels/github.mdx
+++ b/docs/channels/github.mdx
@@ -66,7 +66,7 @@ Point the GitHub App webhook URL at `https://<deployment>/eve/v1/github`. For co
 
 ### Dispatch
 
-Inbound hooks return `{ auth }` to dispatch, or `null` to ignore. Use `defaultGitHubAuth(ctx)` to derive auth from the actor.
+Inbound hooks return `{ auth }` to dispatch, or `null` to ignore. Return `title` alongside `auth` to set the title when the dispatch starts a run. Use `defaultGitHubAuth(ctx)` to derive auth from the actor.
 
 ```ts
 import { defaultGitHubAuth, githubChannel } from "eve/channels/github";

--- a/docs/channels/linear.mdx
+++ b/docs/channels/linear.mdx
@@ -99,7 +99,7 @@ Event handlers receive `channel.linear`, which exposes `createActivity`, `listAc
 
 ## Custom hooks
 
-Return `{ auth }` to dispatch, or `null` to acknowledge without waking the agent.
+Return `{ auth }` to dispatch, or `null` to acknowledge without waking the agent. Return `title` alongside `auth` to set the title when the dispatch starts a run.
 
 ```ts
 import { defaultLinearAuth, linearChannel } from "eve/channels/linear";

--- a/docs/channels/photon.mdx
+++ b/docs/channels/photon.mdx
@@ -29,7 +29,7 @@ steers its replacement turn.
 
 Set `turnPolicy: "queue"` when every response should finish before Photon starts the next message.
 
-Customize inbound dispatch with `onMessage`. Return `null` to ignore a message:
+Customize inbound dispatch with `onMessage`. Return `null` to ignore a message, or return `title` alongside `auth` to set the title when the dispatch starts a run:
 
 ```ts
 export default photonIMessageChannel({

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -125,7 +125,7 @@ Check the delivery path in order so you can identify where a Slack event stops:
 
 ### Message hooks
 
-Message hooks return `{ auth }` to dispatch, `null` to drop, or `{ auth, context }` to inject background into history.
+Message hooks return `{ auth }` to dispatch, `null` to drop, or `{ auth, context }` to inject background into history. Return `title` alongside `auth` to set the title when the dispatch starts a run. When omitted, the title continues to use the triggering message text.
 
 - `onMessage(ctx, message)` handles Slack `message` events. eve drops messages authored by the installed app before this hook runs, preventing self-reply loops. Messages from other bots remain visible; check `message.author?.isBot` when those should also be ignored. `ctx.isBotMentioned()` and `ctx.isSubscribed()` support mention and active-thread policies.
 - `onAppMention(ctx, message)` handles only `app_mention` and takes precedence over `onMessage`. Its default derives workspace-scoped auth and posts `Thinking…`.

--- a/docs/channels/teams.mdx
+++ b/docs/channels/teams.mdx
@@ -26,7 +26,7 @@ By default the channel mounts at `POST /eve/v1/teams`. Point your Azure Bot or T
 
 ### Dispatch
 
-The default `onMessage` handles two cases: personal-chat messages, and channel or group-chat messages that mention the bot directly. Ambient resource-specific-consent messages are dropped unless you override it. Before dispatch, eve strips the mention, adds a `<teams_context>` block, and scopes channel and group threads by root activity id (`replyToId ?? id`).
+The default `onMessage` handles two cases: personal-chat messages, and channel or group-chat messages that mention the bot directly. Ambient resource-specific-consent messages are dropped unless you override it. Return `title` alongside `auth` to set the title when the dispatch starts a run. Before dispatch, eve strips the mention, adds a `<teams_context>` block, and scopes channel and group threads by root activity id (`replyToId ?? id`).
 
 For example, use the contextual `isSubscribed()` helper to continue active threads without requiring another mention:
 

--- a/docs/channels/telegram.mdx
+++ b/docs/channels/telegram.mdx
@@ -39,7 +39,7 @@ In a private chat, text, captions, photos, and documents all go through. Groups 
 
 Forum topics carry `message_thread_id` in the continuation token, so each topic stays on its own thread.
 
-To customize auth or filtering, override `onMessage`. Group privacy mode itself lives in BotFather, not here.
+To customize auth or filtering, override `onMessage`. Return `title` alongside `auth` to set the title when the dispatch starts a run. Group privacy mode itself lives in BotFather, not here.
 
 ### Delivery
 

--- a/docs/channels/twilio.mdx
+++ b/docs/channels/twilio.mdx
@@ -40,7 +40,7 @@ Point your Twilio number's Messaging webhook at `/messages` and Voice webhook at
 export default twilioChannel({ allowFrom: ["+15551234567", "+15557654321"] });
 ```
 
-`onText` and `onVoiceTranscription` decide dispatch and `auth`. Return `{ auth }` to proceed, or `null` to drop the message. `onVoice` fires the moment a call comes in. Return `null` to reject it, or return an object to override the spoken prompt, language, `<Say voice>`, and speech-recognition options.
+`onText` and `onVoiceTranscription` decide dispatch and `auth`. Return `{ auth }` to proceed, `null` to drop the message, or `title` alongside `auth` to set the title when the dispatch starts a run. `onVoice` fires the moment a call comes in. Return `null` to reject it, or return an object to override the spoken prompt, language, `<Say voice>`, and speech-recognition options.
 
 ```ts
 export default twilioChannel({

--- a/packages/eve/src/public/channels/discord/discordChannel.test.ts
+++ b/packages/eve/src/public/channels/discord/discordChannel.test.ts
@@ -192,7 +192,13 @@ describe("discordChannel() inbound route", () => {
 
   it("dispatches verified application commands with Discord auth and state", async () => {
     const { privateKey, publicKeyHex } = testKeys();
-    const channel = discordChannel({ credentials: { publicKey: publicKeyHex } });
+    const channel = discordChannel({
+      credentials: { publicKey: publicKeyHex },
+      onCommand: (_ctx, interaction) => ({
+        auth: defaultDiscordAuth(interaction),
+        title: "Discord run",
+      }),
+    });
 
     const { response, send } = await firePost(
       channel,
@@ -220,6 +226,7 @@ describe("discordChannel() inbound route", () => {
         initialResponseSent: false,
         interactionToken: "tok",
       },
+      title: "Discord run",
     });
   });
 

--- a/packages/eve/src/public/channels/discord/discordChannel.ts
+++ b/packages/eve/src/public/channels/discord/discordChannel.ts
@@ -105,11 +105,13 @@ export interface DiscordReceiveTarget {
  * - `auth`: session auth context for the dispatched turn, or `null` for anonymous.
  * - `ephemeral`: when `true`, the deferred reply is visible only to the invoking user.
  * - `context`: model-visible context lines appended after the Discord context block.
+ * - `title`: workflow run title override that does not change model input.
  */
 export type DiscordCommandResult = {
   readonly auth: SessionAuthContext | null;
   readonly ephemeral?: boolean;
   readonly context?: readonly string[];
+  readonly title?: string;
 } | null;
 
 /** Sync or async {@link DiscordCommandResult}. */
@@ -604,6 +606,7 @@ async function dispatchCommand(input: {
         auth: input.result.auth,
         context: [contextBlock, ...channelContext],
         state: input.state,
+        title: input.result.title,
       });
   } catch (error) {
     log.error("command delivery failed", { error });

--- a/packages/eve/src/public/channels/eve.test.ts
+++ b/packages/eve/src/public/channels/eve.test.ts
@@ -588,7 +588,11 @@ describe("eveChannel — onMessage", () => {
       expect(ctx.eve.sessionId).toBeUndefined();
       expect(ctx.eve.request.url).toBe("https://example.com/eve/v1/session");
       expect(message).toBe("What word is selected?");
-      return { auth: defaultEveAuth(ctx), context: ["Authenticated caller profile: enterprise"] };
+      return {
+        auth: defaultEveAuth(ctx),
+        context: ["Authenticated caller profile: enterprise"],
+        title: "HTTP run",
+      };
     });
     const handler = createEveCreateHandler({
       auth: () => ACCEPTED_AUTH,
@@ -612,6 +616,7 @@ describe("eveChannel — onMessage", () => {
     });
     const options = handler.send.mock.calls[0]?.[1] as MockSendOptions;
     expect(options.auth).toEqual(ACCEPTED_AUTH);
+    expect(options.title).toBe("HTTP run");
   });
 
   it("uses auth returned from onMessage for create requests", async () => {

--- a/packages/eve/src/public/channels/eve.ts
+++ b/packages/eve/src/public/channels/eve.ts
@@ -127,6 +127,8 @@ export interface EveMessageContext {
 export type EveMessageResult = {
   readonly auth: SessionAuthContext | null;
   readonly context?: readonly string[];
+  /** Overrides the workflow run title without changing the message sent to the model. */
+  readonly title?: string;
 };
 
 /** Synchronous or asynchronous `onMessage` result. */
@@ -319,6 +321,7 @@ export function eveChannel(input: EveChannelInput): EveChannel {
             },
             mode: body.mode ?? "conversation",
             parentTraceContext,
+            title: messageResult.title,
           });
         } catch (error) {
           // A concurrent create-once request won the token: adopt its session
@@ -765,6 +768,7 @@ function normalizeEveCorsOrigin(
 interface OnMessageOutcome {
   readonly auth: SessionAuthContext | null;
   readonly context?: readonly string[];
+  readonly title?: string;
 }
 
 async function resolveOnMessage(input: {
@@ -797,10 +801,7 @@ async function resolveOnMessage(input: {
     );
   }
 
-  if (result.context === undefined) {
-    return { auth: result.auth };
-  }
-  return { auth: result.auth, context: result.context };
+  return { auth: result.auth, context: result.context, title: result.title };
 }
 
 function defaultOnMessage(ctx: EveMessageContext): EveMessageResult {

--- a/packages/eve/src/public/channels/github/dispatch.ts
+++ b/packages/eve/src/public/channels/github/dispatch.ts
@@ -239,6 +239,7 @@ async function dispatchWebhookEventTurn(input: {
     }),
     from: input.from,
     state: input.state,
+    title: result.title,
   });
 }
 
@@ -275,6 +276,7 @@ async function dispatchCommentTurn(input: {
     }),
     from: input.from,
     state: input.state,
+    title: result.title,
   });
 }
 
@@ -301,6 +303,7 @@ async function sendGitHubTurn(input: {
   readonly context: readonly string[] | undefined;
   readonly from: ChannelFrom<GitHubChannelState>;
   readonly state: GitHubChannelState;
+  readonly title: string | undefined;
 }): Promise<void> {
   const contextBlock = formatGitHubContextBlock({
     deliveryId: input.event.delivery.id,
@@ -317,6 +320,7 @@ async function sendGitHubTurn(input: {
       auth: input.auth,
       context: [contextBlock, ...(input.context ?? [])],
       state: input.state,
+      title: input.title,
     });
   } catch (error) {
     logError(log, input.logMessage ?? "GitHub delivery failed", error, {

--- a/packages/eve/src/public/channels/github/githubChannel.test.ts
+++ b/packages/eve/src/public/channels/github/githubChannel.test.ts
@@ -211,6 +211,7 @@ describe("githubChannel", () => {
     const channel = githubChannel({
       botName: "testbot",
       credentials: { webhookSecret: SECRET },
+      onComment: (ctx) => ({ auth: defaultGitHubAuth(ctx), title: "GitHub run" }),
     });
     const { send } = await firePost(
       channel,
@@ -254,6 +255,7 @@ describe("githubChannel", () => {
         repo: "eve",
         triggeringCommentId: 10,
       },
+      title: "GitHub run",
     });
   });
 

--- a/packages/eve/src/public/channels/github/githubChannel.ts
+++ b/packages/eve/src/public/channels/github/githubChannel.ts
@@ -109,6 +109,8 @@ export interface GitHubEventContext extends GitHubChannelContext, ChannelContinu
 export type GitHubInboundResult = {
   readonly auth: SessionAuthContext | null;
   readonly context?: readonly string[];
+  /** Overrides the workflow run title without changing the message sent to the model. */
+  readonly title?: string;
 } | null;
 
 /**

--- a/packages/eve/src/public/channels/linear/linearChannel.test.ts
+++ b/packages/eve/src/public/channels/linear/linearChannel.test.ts
@@ -8,6 +8,7 @@ import { ContextContainer, contextStorage } from "#context/container.js";
 import { SessionKey } from "#context/keys.js";
 import { mockChannelContext } from "#internal/testing/mocks/mock-channel-operations.js";
 import type { UnstampedMessageStreamEvent } from "#protocol/message.js";
+import { defaultLinearAuth } from "#public/channels/linear/defaults.js";
 import { linearChannel, type LinearChannelState } from "#public/channels/linear/linearChannel.js";
 import { signLinearWebhookBody } from "#public/channels/linear/verify.js";
 import type { InputRequest } from "#runtime/input/types.js";
@@ -157,7 +158,13 @@ function makeRequest(overrides: Partial<InputRequest> = {}): InputRequest {
 
 describe("linearChannel inbound Agent Session events", () => {
   it("dispatches created events with auth, context, token, and state", async () => {
-    const channel = linearChannel({ credentials: { webhookSecret: SECRET } });
+    const channel = linearChannel({
+      credentials: { webhookSecret: SECRET },
+      onAgentSession: (_ctx, event) => ({
+        auth: defaultLinearAuth(event),
+        title: "Linear run",
+      }),
+    });
     const { response, send } = await firePost(channel, signedRequest(sessionPayload()));
 
     expect(response.status).toBe(200);
@@ -178,6 +185,7 @@ describe("linearChannel inbound Agent Session events", () => {
         issueIdentifier: "EVE-123",
         organizationId: "org_1",
       },
+      title: "Linear run",
     });
   });
 

--- a/packages/eve/src/public/channels/linear/linearChannel.ts
+++ b/packages/eve/src/public/channels/linear/linearChannel.ts
@@ -162,6 +162,8 @@ export interface LinearChannelEvents {
 export type LinearInboundResult = {
   readonly auth: SessionAuthContext | null;
   readonly context?: readonly string[];
+  /** Overrides the workflow run title without changing the message sent to the model. */
+  readonly title?: string;
 } | null;
 
 /** Sync or async {@link LinearInboundResult}. */
@@ -362,6 +364,7 @@ async function dispatchAgentSession(input: {
       ...(result.context ?? []),
     ],
     state: stateFromAgentSession(event.agentSession),
+    title: result.title,
   });
 }
 

--- a/packages/eve/src/public/channels/photon/photonIMessageChannel.test.ts
+++ b/packages/eve/src/public/channels/photon/photonIMessageChannel.test.ts
@@ -37,6 +37,7 @@ describe("photonIMessageChannel", () => {
   it("inherits the shared steering default for a direct message", async () => {
     photonIMessageChannel({
       credentials: async () => ({ projectId: "project-id", projectSecret: "project-secret" }),
+      onMessage: () => ({ auth: null, title: "Photon run" }),
     });
     const handler = directMessage.mock.calls[0]?.[0];
     if (handler === undefined) throw new Error("Expected an inbound direct-message handler.");
@@ -53,7 +54,7 @@ describe("photonIMessageChannel", () => {
 
     expect(send).toHaveBeenCalledWith(
       { context: [], message: "Steer this response" },
-      { auth: null, thread },
+      { auth: null, thread, title: "Photon run" },
     );
   });
 
@@ -99,7 +100,7 @@ describe("photonIMessageChannel", () => {
 
     expect(send).toHaveBeenCalledWith(
       { context: [], message: "Hello group" },
-      { auth: null, thread },
+      { auth: null, thread, title: undefined },
     );
   });
 });

--- a/packages/eve/src/public/channels/photon/photonIMessageChannel.ts
+++ b/packages/eve/src/public/channels/photon/photonIMessageChannel.ts
@@ -29,6 +29,8 @@ export interface PhotonInboundMessageContext {
 export type PhotonInboundResult = {
   readonly auth: SessionAuthContext | null;
   readonly context?: readonly string[];
+  /** Overrides the workflow run title without changing the message sent to the model. */
+  readonly title?: string;
 } | null;
 
 /** Sync or async {@link PhotonInboundResult}. */
@@ -125,7 +127,7 @@ async function dispatchMessage(
       context: [...(result.context ?? [])],
       message: content,
     },
-    { auth: result.auth, thread },
+    { auth: result.auth, thread, title: result.title },
   );
 }
 

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -1457,6 +1457,21 @@ describe("slackChannel() inbound mention pipeline", () => {
     expect(input.title).toBe("hello");
   });
 
+  it("uses the run title returned by onAppMention without changing the message", async () => {
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-test" },
+      onAppMention: () => ({ auth: null, title: "Run" }),
+    });
+
+    const { body } = buildMentionBody({ text: "private message text" });
+    const { send } = await firePost(channel, buildSignedRequest({ body }));
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const [, input] = send.mock.calls[0]!;
+    expect(input.title).toBe("Run");
+    expect(input.message).toContain("<content>\nprivate message text\n</content>");
+  });
+
   it("uses only this app's reply as the incremental thread context boundary", async () => {
     const threadTs = "1700000000.000001";
     const currentTs = "1700000000.000006";
@@ -2171,6 +2186,22 @@ describe("slackChannel() inbound direct message pipeline", () => {
     const opts = options as { auth: unknown; state: { channelId: string } };
     expect(opts.auth).toMatchObject({ principalId: "U01", authenticator: "test" });
     expect(opts.state.channelId).toBe(channelId);
+    expect(options.title).toBe("hello");
+  });
+
+  it("uses the run title returned by onDirectMessage", async () => {
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-test" },
+      onDirectMessage: () => ({ auth: null, title: "Private support case" }),
+    });
+
+    const { body } = buildDirectMessageBody({ text: "sensitive message" });
+    const { send } = await firePost(channel, buildSignedRequest({ body }));
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const [, options] = send.mock.calls[0]!;
+    expect(options.title).toBe("Private support case");
+    expect(options.message).toContain("<content>\nsensitive message\n</content>");
   });
 
   it("does not dispatch when onDirectMessage resolves to null", async () => {

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -420,11 +420,13 @@ export interface SlackInteractionUser {
  * Result of an `onAppMention` or `onDirectMessage` callback. Return an
  * object (auth may be `null`) to dispatch a turn, or `null` to drop the
  * inbound message. `context` strings are appended as user messages to
- * session history before the delivery message.
+ * session history before the delivery message. `title` overrides the
+ * workflow run title without changing the message sent to the model.
  */
 export type SlackMentionResult = {
   readonly auth: SessionAuthContext | null;
   readonly context?: readonly string[];
+  readonly title?: string;
 } | null;
 
 export type SlackMentionResultOrPromise = SlackMentionResult | Promise<SlackMentionResult>;
@@ -1225,14 +1227,11 @@ async function deliverSlackMessage(input: {
     );
 
     const channelContext = input.result.context ?? [];
+    const title = input.result.title ?? message.markdown;
     const sendOptions: SlackSendOptions =
       channelContext.length === 0
-        ? { auth: input.result.auth, title: message.markdown }
-        : {
-            auth: input.result.auth,
-            context: channelContext,
-            title: message.markdown,
-          };
+        ? { auth: input.result.auth, title }
+        : { auth: input.result.auth, context: channelContext, title };
 
     await input.sessionOperations.send(turnMessage, sendOptions);
   } catch (error) {

--- a/packages/eve/src/public/channels/teams/teamsChannel.test.ts
+++ b/packages/eve/src/public/channels/teams/teamsChannel.test.ts
@@ -90,6 +90,7 @@ describe("teamsChannel", () => {
             principalId: "USER",
             principalType: "user",
           },
+          title: "Teams run",
         };
       },
     });
@@ -108,6 +109,7 @@ describe("teamsChannel", () => {
         replyToActivityId: null,
         serviceUrl: "https://smba.example.test/teams",
       },
+      title: "Teams run",
     });
     expect(send.mock.calls[0]![1].context[0]).toContain("<teams_context>");
   });

--- a/packages/eve/src/public/channels/teams/teamsChannel.ts
+++ b/packages/eve/src/public/channels/teams/teamsChannel.ts
@@ -137,6 +137,8 @@ export interface TeamsReceiveTarget {
 export type TeamsInboundResult = {
   readonly auth: SessionAuthContext | null;
   readonly context?: readonly string[];
+  /** Overrides the workflow run title without changing the message sent to the model. */
+  readonly title?: string;
 } | null;
 
 /** Sync or async {@link TeamsInboundResult}. */
@@ -612,6 +614,7 @@ async function dispatchMessage(input: {
       auth: result.auth,
       context: [formatTeamsContextBlock(inboundContext), ...channelContext],
       state,
+      title: result.title,
     });
   } catch (error) {
     log.error("Teams message delivery failed", { error });

--- a/packages/eve/src/public/channels/telegram/telegramChannel.test.ts
+++ b/packages/eve/src/public/channels/telegram/telegramChannel.test.ts
@@ -8,7 +8,11 @@ import { ContextContainer, contextStorage } from "#context/container.js";
 import { SessionKey } from "#context/keys.js";
 import { mockChannelContext } from "#internal/testing/mocks/mock-channel-operations.js";
 import type { UnstampedMessageStreamEvent } from "#protocol/message.js";
-import { telegramChannel, type TelegramChannelState } from "#public/channels/telegram/index.js";
+import {
+  defaultTelegramAuth,
+  telegramChannel,
+  type TelegramChannelState,
+} from "#public/channels/telegram/index.js";
 
 const SECRET = "telegram-secret";
 
@@ -142,6 +146,10 @@ describe("telegramChannel() inbound route", () => {
     const channel = telegramChannel({
       api: { fetch: fakeTelegramFetch() },
       credentials: { botToken: "bot-token", webhookSecretToken: SECRET },
+      onMessage: (_ctx, message) => ({
+        auth: defaultTelegramAuth(message),
+        title: "Telegram run",
+      }),
     });
 
     const { response, send } = await firePost(channel, {
@@ -170,6 +178,7 @@ describe("telegramChannel() inbound route", () => {
         chatType: "private",
         conversationId: null,
       },
+      title: "Telegram run",
     });
   });
 

--- a/packages/eve/src/public/channels/telegram/telegramChannel.ts
+++ b/packages/eve/src/public/channels/telegram/telegramChannel.ts
@@ -109,6 +109,8 @@ export interface TelegramReceiveTarget {
 export type TelegramInboundResult = {
   readonly auth: SessionAuthContext | null;
   readonly context?: readonly string[];
+  /** Overrides the workflow run title without changing the message sent to the model. */
+  readonly title?: string;
 } | null;
 
 /** Sync or async {@link TelegramInboundResult}. */
@@ -529,6 +531,7 @@ async function dispatchMessage(input: {
         auth: result.auth,
         context: [contextBlock, ...channelContext],
         state,
+        title: result.title,
       });
     } else {
       await source.respond(replyInputResponses, {

--- a/packages/eve/src/public/channels/twilio/twilioChannel.test.ts
+++ b/packages/eve/src/public/channels/twilio/twilioChannel.test.ts
@@ -260,7 +260,10 @@ describe("twilioChannel() inbound text pipeline", () => {
   });
 
   it("passes inbound media metadata from Twilio message webhooks", async () => {
-    const onText = vi.fn((_ctx: TwilioContext, _message: TwilioTextMessage) => ({ auth: null }));
+    const onText = vi.fn((_ctx: TwilioContext, _message: TwilioTextMessage) => ({
+      auth: null,
+      title: "Twilio text run",
+    }));
     const channel = twilioChannel({ allowFrom: "*", onText });
     const params = new URLSearchParams({
       Body: "see attached",
@@ -271,7 +274,7 @@ describe("twilioChannel() inbound text pipeline", () => {
       To: "+15557654321",
     });
 
-    await firePost(channel, "/eve/v1/twilio/messages", params);
+    const { send } = await firePost(channel, "/eve/v1/twilio/messages", params);
 
     expect(onText).toHaveBeenCalledTimes(1);
     expect(onText.mock.calls[0]![1]).toMatchObject({
@@ -283,6 +286,7 @@ describe("twilioChannel() inbound text pipeline", () => {
         },
       ],
     });
+    expect(send.mock.calls[0]![1]).toMatchObject({ title: "Twilio text run" });
   });
 
   it("drops inbound text when the sender is not in allowFrom", async () => {
@@ -509,7 +513,10 @@ describe("twilioChannel() voice pipeline", () => {
   });
 
   it("dispatches a Gather SpeechResult as voice transcription", async () => {
-    const channel = twilioChannel({ allowFrom: "*" });
+    const channel = twilioChannel({
+      allowFrom: "*",
+      onVoiceTranscription: () => ({ auth: null, title: "Twilio voice run" }),
+    });
     const params = new URLSearchParams({
       CallSid: "CA123",
       From: "+15551234567",
@@ -541,6 +548,7 @@ describe("twilioChannel() voice pipeline", () => {
         lastMessageSid: null,
         to: "+15557654321",
       },
+      title: "Twilio voice run",
     });
   });
 

--- a/packages/eve/src/public/channels/twilio/twilioChannel.ts
+++ b/packages/eve/src/public/channels/twilio/twilioChannel.ts
@@ -99,6 +99,8 @@ export interface TwilioReceiveTarget {
 /** Result of an inbound Twilio text or transcription hook. Return `null` (or `undefined`) to drop the webhook without dispatching; otherwise supply the session `auth` context. */
 export type TwilioInboundResult = {
   auth: SessionAuthContext | null;
+  /** Overrides the workflow run title without changing the message sent to the model. */
+  title?: string;
 } | null;
 
 /** Sync or async {@link TwilioInboundResult}. */
@@ -569,6 +571,7 @@ async function dispatchText(input: {
         lastMessageSid: message.messageSid ?? null,
         to: message.to ?? null,
       },
+      title: result.title,
     });
   } catch (error) {
     log.error("text delivery failed", { error });
@@ -642,6 +645,7 @@ async function dispatchVoiceTranscription(input: {
           lastMessageSid: null,
           to: transcription.to ?? null,
         },
+        title: result.title,
       });
   } catch (error) {
     log.error("voice transcription delivery failed", { error });


### PR DESCRIPTION
### Summary

Closes #2104. Built-in inbound hooks that dispatch agent turns can now return an optional `title`, covering Discord, the eve HTTP channel, GitHub, Linear, Photon, Slack, Teams, Telegram, and Twilio. The title reaches the existing channel-delivery option without changing model input; omitting it preserves existing behavior, including Slack's message-derived fallback. Direct-conversation redaction remains isolated in stacked follow-up #2107.

### Validation

The full unit suite passes 6,711 tests with one skipped, including focused title-forwarding coverage for every affected channel. Documentation validation and invariant checks also pass.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 10 files · `+14 / -10`

Documents the shared return option in each affected channel and records the release note.

**Implementation** — 10 files · `+36 / -12`

Adds `title` to each inbound result and forwards it through the existing delivery boundary.

**Tests** — 9 files · `+82 / -9`

Covers title forwarding across all affected channels and Slack's unchanged fallback behavior.
