### PR TITLE
feat(eve): suggest matches for missing registry items

### DIFF
--- a/.changeset/fuzzy-items-search.md
+++ b/.changeset/fuzzy-items-search.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Suggest close registry matches when `eve add` cannot find the requested item.

--- a/docs/install-integrations.mdx
+++ b/docs/install-integrations.mdx
@@ -16,6 +16,8 @@ eve add linear
 eve add instrumentation/braintrust
 ```
 
+If an item is not found, `eve add` searches the available catalogs and prints close matches without installing anything.
+
 Extensions may create a mount under `agent/extensions/`. Connections write their initial definition under `agent/connections/` and install `@vercel/connect` when required. Instrumentation providers write `agent/instrumentation.ts`; because an agent has one instrumentation file, compose multiple exporters there by hand. Configure generated files and required environment variables before running your agent.
 
 Some integrations package several independently installable components. For example, `eve add linear` lets you choose the Linear Channel, Linear MCP, or both; both are selected by default. The specific `eve add channel/linear-agent` and `eve add connection/linear` commands remain available.

--- a/packages/eve/src/cli/commands/registry-recovery.ts
+++ b/packages/eve/src/cli/commands/registry-recovery.ts
@@ -1,0 +1,68 @@
+import { isEveProject } from "#setup/scaffold/index.js";
+import { WizardCancelledError } from "#setup/step.js";
+
+import { NOT_AN_AGENT_MESSAGE } from "./preconditions.js";
+
+export interface RegistryCommandLogger {
+  error(message: string): void;
+  log(message: string): void;
+}
+
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isRegistryNotFoundError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error as Error & { code?: unknown }).code === "NOT_FOUND"
+  );
+}
+
+export async function runRegistryAction<T>(
+  logger: RegistryCommandLogger,
+  appRoot: string,
+  action: () => Promise<T>,
+): Promise<T | undefined> {
+  if (!(await isEveProject(appRoot))) {
+    logger.error(NOT_AN_AGENT_MESSAGE);
+    process.exitCode = 1;
+    return undefined;
+  }
+
+  try {
+    return await action();
+  } catch (error) {
+    if (error instanceof WizardCancelledError) return undefined;
+    logger.error(errorMessage(error));
+    process.exitCode = 1;
+    return undefined;
+  }
+}
+
+export async function resolveRegistryItemForAdd<T>(
+  logger: RegistryCommandLogger,
+  loadItem: () => Promise<T>,
+  printSuggestions: () => Promise<void>,
+): Promise<{ found: true; item: T } | { found: false }> {
+  try {
+    return { found: true, item: await loadItem() };
+  } catch (error) {
+    if (!isRegistryNotFoundError(error)) throw error;
+    logger.error(errorMessage(error));
+    await printSuggestions();
+    process.exitCode = 1;
+    return { found: false };
+  }
+}
+
+export function setupResumeCommand(item: string): string {
+  const argument = /^[\w@./:-]+$/.test(item) ? item : `'${item.replaceAll("'", `'\\''`)}'`;
+  return `eve add ${argument} --skip-install`;
+}
+
+export function setupReminder(item: string, outcome: "cancelled" | "skipped"): string {
+  const action = outcome === "cancelled" ? "Setup cancelled." : "Setup skipped.";
+  return `${action} Run \`${setupResumeCommand(item)}\` when you're ready.`;
+}

--- a/packages/eve/src/cli/commands/registry.test.ts
+++ b/packages/eve/src/cli/commands/registry.test.ts
@@ -128,6 +128,66 @@ describe("registry commands", () => {
     expect(logger.errors).toEqual([]);
   });
 
+  it("suggests matching registry items when an item is not found", async () => {
+    const logger = createLogger();
+    getRegistryItems.mockRejectedValue(
+      Object.assign(
+        new Error(
+          "The item at https://eve.dev/r/channel/salk.json was not found. It may not exist at the registry.",
+        ),
+        { code: "NOT_FOUND" },
+      ),
+    );
+    searchRegistries.mockImplementation(async ([source]: string[]) => ({
+      items:
+        source === "https://eve.dev/r/registry.json"
+          ? [
+              {
+                registry: source,
+                name: "channel/slack",
+                addCommandArgument: "https://eve.dev/r/channel/slack.json",
+                description: "Connect an eve agent to Slack.",
+              },
+            ]
+          : [],
+      pagination: {
+        total: source === "https://eve.dev/r/registry.json" ? 1 : 0,
+        offset: 0,
+        limit: 5,
+        hasMore: false,
+      },
+    }));
+
+    await runAddCommand(logger, "/project", "channel/salk", {});
+
+    expect(logger.errors).toEqual([
+      "The item at https://eve.dev/r/channel/salk.json was not found. It may not exist at the registry.",
+    ]);
+    expect(searchRegistries).toHaveBeenCalledWith(
+      ["https://eve.dev/r/registry.json"],
+      expect.objectContaining({ limit: 5, query: "channel/salk" }),
+    );
+    expect(logger.logs).toEqual([
+      "Did you mean?",
+      ["eve (1 result)", "  slack", "    channel/slack", "    Connect an eve agent to Slack."].join(
+        "\n",
+      ),
+    ]);
+    expect(addRegistryItems).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("does not search for suggestions after other registry failures", async () => {
+    const logger = createLogger();
+    getRegistryItems.mockRejectedValue(new Error("Registry unavailable."));
+
+    await runAddCommand(logger, "/project", "channel/slack", {});
+
+    expect(logger.errors).toEqual(["Registry unavailable."]);
+    expect(searchRegistries).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
   it.each(["web", "slack"] as const)(
     "installs the official %s item before running its declared setup",
     async (kind) => {

--- a/packages/eve/src/cli/commands/registry.ts
+++ b/packages/eve/src/cli/commands/registry.ts
@@ -9,11 +9,18 @@ import semver from "#compiled/semver/index.js";
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
 import { createPrompter, type Prompter } from "#setup/prompter.js";
 import type { RegistrySetupCompletion } from "#setup/registry-setup-protocol.js";
-import { isEveProject } from "#setup/scaffold/index.js";
 import { WizardCancelledError } from "#setup/step.js";
 
-import { hasInteractiveTerminal, NOT_AN_AGENT_MESSAGE } from "./preconditions.js";
+import { hasInteractiveTerminal } from "./preconditions.js";
 import { runDeclaredSetups } from "./registry-declared-setups.js";
+import {
+  errorMessage,
+  resolveRegistryItemForAdd,
+  runRegistryAction,
+  setupReminder,
+  setupResumeCommand,
+  type RegistryCommandLogger,
+} from "./registry-recovery.js";
 import {
   eveMetadataFromRegistryItem,
   parseOfficialRegistrySearchMetadata,
@@ -30,10 +37,7 @@ import type { runRegistrySetupCommand } from "./registry-setup-command.js";
 import { serializeHeadlessSetupEvent } from "./setup-headless.js";
 import { addRegistryMappings, readRegistryConfig } from "./registry-project.js";
 
-export interface RegistryCommandLogger {
-  error(message: string): void;
-  log(message: string): void;
-}
+export type { RegistryCommandLogger } from "./registry-recovery.js";
 
 export interface AddCommandOptions {
   skipInstall?: boolean;
@@ -136,6 +140,7 @@ const SKILLS_REGISTRY = "@skills";
 const SKILLS_REGISTRY_URL = "https://www.skills.sh/r/{name}?agent=eve";
 const CATALOG_PAGE_SIZE = 100;
 const DEFAULT_SEARCH_LIMIT = 10;
+const ADD_SUGGESTION_LIMIT = 5;
 
 function isRegistryAddress(value: string): boolean {
   return value.startsWith("@") || /^https?:\/\//.test(value);
@@ -159,16 +164,6 @@ export async function installOfficialRegistryItem(
   });
 }
 
-function setupResumeCommand(item: string): string {
-  const argument = /^[\w@./:-]+$/.test(item) ? item : `'${item.replaceAll("'", `'\\''`)}'`;
-  return `eve add ${argument} --skip-install`;
-}
-
-function setupReminder(item: string, outcome: "cancelled" | "skipped"): string {
-  const action = outcome === "cancelled" ? "Setup cancelled." : "Setup skipped.";
-  return `${action} Run \`${setupResumeCommand(item)}\` when you're ready.`;
-}
-
 function assertCompatibleEveVersion(requiredVersion: string | undefined): void {
   if (requiredVersion === undefined) return;
   const installedVersion = resolveInstalledPackageInfo().version;
@@ -183,31 +178,6 @@ function assertCompatibleEveVersion(requiredVersion: string | undefined): void {
 
 function isOfficialItemAddress(address: string): boolean {
   return address.startsWith(`${OFFICIAL_REGISTRY}/`);
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
-async function runRegistryAction<T>(
-  logger: RegistryCommandLogger,
-  appRoot: string,
-  action: () => Promise<T>,
-): Promise<T | undefined> {
-  if (!(await isEveProject(appRoot))) {
-    logger.error(NOT_AN_AGENT_MESSAGE);
-    process.exitCode = 1;
-    return undefined;
-  }
-
-  try {
-    return await action();
-  } catch (error) {
-    if (error instanceof WizardCancelledError) return undefined;
-    logger.error(errorMessage(error));
-    process.exitCode = 1;
-    return undefined;
-  }
 }
 
 function withBuiltInRegistries(config: RegistryConfig): RegistryConfig {
@@ -274,6 +244,26 @@ function searchPresentationSections(
           },
         ];
   });
+}
+
+async function printAddSuggestions(
+  logger: RegistryCommandLogger,
+  appRoot: string,
+  query: string,
+): Promise<void> {
+  try {
+    const { resultsBySource, sources, metadataByAddress } = await searchRegistryCatalog(appRoot, {
+      limit: ADD_SUGGESTION_LIMIT,
+      query,
+    });
+    const sections = searchPresentationSections(sources, resultsBySource, metadataByAddress);
+    if (sections.every((section) => section.items.length === 0)) return;
+
+    logger.log("Did you mean?");
+    printRegistrySearchResults(logger, { query, sections });
+  } catch {
+    // The original not-found error remains actionable when catalog search is unavailable.
+  }
 }
 
 async function searchRegistryCatalog(
@@ -492,7 +482,13 @@ export async function runAddCommand(
         );
       }
     }
-    const [registryItem] = await getRegistryItems([address], { config });
+    const registryItemResult = await resolveRegistryItemForAdd(
+      logger,
+      async () => (await getRegistryItems([address], { config }))[0],
+      () => printAddSuggestions(logger, appRoot, item),
+    );
+    if (!registryItemResult.found) return;
+    const registryItem = registryItemResult.item;
     const eveMetadata = isOfficialItemAddress(address)
       ? eveMetadataFromRegistryItem(registryItem)
       : undefined;


### PR DESCRIPTION
### Summary

Closes #2105. When `eve add` receives a structured registry `NOT_FOUND` error, it now preserves the original diagnostic and nonzero exit status while running a bounded fuzzy search across the available catalogs and printing close matches under `Did you mean?`. Other registry failures do not trigger a search, and an unavailable catalog cannot mask the original error.

### Validation

Focused registry coverage confirms the suggestion path and the non-not-found boundary; the complete eve unit suite passes with 6,711 tests passed and 1 skipped.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+7 / -0`

Adds one install-behavior note and the patch release entry.

**Implementation** — 2 files · `+106 / -42`

Reuses the existing search and presentation path. Most of the movement extracts existing command recovery helpers so the registry command remains below the enforced 700-line cap.

**Tests** — 1 file · `+60 / -0`

Covers suggested matches and verifies that unrelated registry errors do not search.
