### PR TITLE
fix(eve): redact direct-conversation run titles

### DIFF
--- a/.changeset/calm-runs-hide.md
+++ b/.changeset/calm-runs-hide.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Built-in inbound hooks can now return `title` to set the workflow run title without changing the message sent to the model.

--- a/.changeset/direct-runs-hide.md
+++ b/.changeset/direct-runs-hide.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Automatically derived workflow run titles now use `Run` instead of message content when a built-in channel identifies a DM or equivalent direct conversation.

--- a/docs/channels/discord.mdx
+++ b/docs/channels/discord.mdx
@@ -56,7 +56,7 @@ Then configure the public `https://…/eve/v1/discord` route as the application'
 
 ### Dispatch
 
-`onCommand(ctx, interaction)` decides whether to dispatch and under what `auth`. Return `{ auth }` to proceed or `null` to drop the interaction. By default, auth comes from the invoking user. Event handlers receive `(eventData, channel, ctx)`, with Discord platform handles on `channel.discord`:
+`onCommand(ctx, interaction)` decides whether to dispatch and under what `auth`. Return `{ auth }` to proceed, `null` to drop the interaction, or `title` alongside `auth` to set the title when the dispatch starts a run. By default, auth comes from the invoking user. Event handlers receive `(eventData, channel, ctx)`, with Discord platform handles on `channel.discord`:
 
 ```ts
 import { discordChannel } from "eve/channels/discord";

--- a/docs/channels/eve.mdx
+++ b/docs/channels/eve.mdx
@@ -160,8 +160,7 @@ export default eveChannel({
 });
 ```
 
-`onMessage` must return an auth result. A successful canonical eve HTTP message
-always dispatches and therefore always produces or continues a session.
+`onMessage` must return an auth result. Return `title` alongside `auth` to set the title when the dispatch starts a run. A successful canonical eve HTTP message always dispatches and therefore always produces or continues a session.
 
 ## Clients
 

--- a/docs/channels/github.mdx
+++ b/docs/channels/github.mdx
@@ -66,7 +66,7 @@ Point the GitHub App webhook URL at `https://<deployment>/eve/v1/github`. For co
 
 ### Dispatch
 
-Inbound hooks return `{ auth }` to dispatch, or `null` to ignore. Use `defaultGitHubAuth(ctx)` to derive auth from the actor.
+Inbound hooks return `{ auth }` to dispatch, or `null` to ignore. Return `title` alongside `auth` to set the title when the dispatch starts a run. Use `defaultGitHubAuth(ctx)` to derive auth from the actor.
 
 ```ts
 import { defaultGitHubAuth, githubChannel } from "eve/channels/github";

--- a/docs/channels/linear.mdx
+++ b/docs/channels/linear.mdx
@@ -99,7 +99,7 @@ Event handlers receive `channel.linear`, which exposes `createActivity`, `listAc
 
 ## Custom hooks
 
-Return `{ auth }` to dispatch, or `null` to acknowledge without waking the agent.
+Return `{ auth }` to dispatch, or `null` to acknowledge without waking the agent. Return `title` alongside `auth` to set the title when the dispatch starts a run.
 
 ```ts
 import { defaultLinearAuth, linearChannel } from "eve/channels/linear";

--- a/docs/channels/photon.mdx
+++ b/docs/channels/photon.mdx
@@ -29,7 +29,7 @@ steers its replacement turn.
 
 Set `turnPolicy: "queue"` when every response should finish before Photon starts the next message.
 
-Customize inbound dispatch with `onMessage`. Return `null` to ignore a message:
+Customize inbound dispatch with `onMessage`. Return `null` to ignore a message, or return `title` alongside `auth` to set the title when the dispatch starts a run:
 
 ```ts
 export default photonIMessageChannel({

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -125,7 +125,7 @@ Check the delivery path in order so you can identify where a Slack event stops:
 
 ### Message hooks
 
-Message hooks return `{ auth }` to dispatch, `null` to drop, or `{ auth, context }` to inject background into history.
+Message hooks return `{ auth }` to dispatch, `null` to drop, or `{ auth, context }` to inject background into history. Return `title` alongside `auth` to set the title when the dispatch starts a run. When omitted, the title continues to use the triggering message text.
 
 - `onMessage(ctx, message)` handles Slack `message` events. eve drops messages authored by the installed app before this hook runs, preventing self-reply loops. Messages from other bots remain visible; check `message.author?.isBot` when those should also be ignored. `ctx.isBotMentioned()` and `ctx.isSubscribed()` support mention and active-thread policies.
 - `onAppMention(ctx, message)` handles only `app_mention` and takes precedence over `onMessage`. Its default derives workspace-scoped auth and posts `Thinking…`.

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -125,7 +125,7 @@ Check the delivery path in order so you can identify where a Slack event stops:
 
 ### Message hooks
 
-Message hooks return `{ auth }` to dispatch, `null` to drop, or `{ auth, context }` to inject background into history. Return `title` alongside `auth` to set the title when the dispatch starts a run. When omitted, the title continues to use the triggering message text.
+Message hooks return `{ auth }` to dispatch, `null` to drop, or `{ auth, context }` to inject background into history. Return `title` alongside `auth` to set the title when the dispatch starts a run. When omitted, channel messages use the triggering message text and direct conversations use `Run`.
 
 - `onMessage(ctx, message)` handles Slack `message` events. eve drops messages authored by the installed app before this hook runs, preventing self-reply loops. Messages from other bots remain visible; check `message.author?.isBot` when those should also be ignored. `ctx.isBotMentioned()` and `ctx.isSubscribed()` support mention and active-thread policies.
 - `onAppMention(ctx, message)` handles only `app_mention` and takes precedence over `onMessage`. Its default derives workspace-scoped auth and posts `Thinking…`.

--- a/docs/channels/teams.mdx
+++ b/docs/channels/teams.mdx
@@ -26,7 +26,7 @@ By default the channel mounts at `POST /eve/v1/teams`. Point your Azure Bot or T
 
 ### Dispatch
 
-The default `onMessage` handles two cases: personal-chat messages, and channel or group-chat messages that mention the bot directly. Ambient resource-specific-consent messages are dropped unless you override it. Before dispatch, eve strips the mention, adds a `<teams_context>` block, and scopes channel and group threads by root activity id (`replyToId ?? id`).
+The default `onMessage` handles two cases: personal-chat messages, and channel or group-chat messages that mention the bot directly. Ambient resource-specific-consent messages are dropped unless you override it. Return `title` alongside `auth` to set the title when the dispatch starts a run. Before dispatch, eve strips the mention, adds a `<teams_context>` block, and scopes channel and group threads by root activity id (`replyToId ?? id`).
 
 For example, use the contextual `isSubscribed()` helper to continue active threads without requiring another mention:
 

--- a/docs/channels/telegram.mdx
+++ b/docs/channels/telegram.mdx
@@ -39,7 +39,7 @@ In a private chat, text, captions, photos, and documents all go through. Groups 
 
 Forum topics carry `message_thread_id` in the continuation token, so each topic stays on its own thread.
 
-To customize auth or filtering, override `onMessage`. Group privacy mode itself lives in BotFather, not here.
+To customize auth or filtering, override `onMessage`. Return `title` alongside `auth` to set the title when the dispatch starts a run. Group privacy mode itself lives in BotFather, not here.
 
 ### Delivery
 

--- a/docs/channels/twilio.mdx
+++ b/docs/channels/twilio.mdx
@@ -40,7 +40,7 @@ Point your Twilio number's Messaging webhook at `/messages` and Voice webhook at
 export default twilioChannel({ allowFrom: ["+15551234567", "+15557654321"] });
 ```
 
-`onText` and `onVoiceTranscription` decide dispatch and `auth`. Return `{ auth }` to proceed, or `null` to drop the message. `onVoice` fires the moment a call comes in. Return `null` to reject it, or return an object to override the spoken prompt, language, `<Say voice>`, and speech-recognition options.
+`onText` and `onVoiceTranscription` decide dispatch and `auth`. Return `{ auth }` to proceed, `null` to drop the message, or `title` alongside `auth` to set the title when the dispatch starts a run. `onVoice` fires the moment a call comes in. Return `null` to reject it, or return an object to override the spoken prompt, language, `<Say voice>`, and speech-recognition options.
 
 ```ts
 export default twilioChannel({

--- a/docs/guides/instrumentation.md
+++ b/docs/guides/instrumentation.md
@@ -118,7 +118,7 @@ The callback receives:
 
 A channel exposes its identity through `kind`. For authored channels it is `channel:<name>`, where `<name>` is the channel's filename under `agent/channels/`, so `agent/channels/support.ts` is `channel:support`. Framework channels use `http`, `schedule`, or `subagent`, and an unrecognized or absent kind normalizes to `unknown`. The kind is also emitted as the `eve.channel.kind` span attribute. To access an authored channel's metadata with its precise type, import the channel definition and narrow with `isChannel(input.channel, supportChannel)`.
 
-Channel metadata is channel-owned. Built-in channels expose only the fields they choose to make observable; Slack, for example, projects `channelId`, `teamId`, `threadTs`, and `triggeringUserId` from its durable channel state. User-authored channels expose their own projection by returning `metadata(state)` from `defineChannel`. Runtime instrumentation never falls back to raw channel state.
+Channel metadata is channel-owned. Built-in channels expose only the fields they choose to make observable; Slack, for example, projects `channelId`, `isDM`, `teamId`, `threadTs`, and `triggeringUserId` from its durable channel state. User-authored channels expose their own projection by returning `metadata(state)` from `defineChannel`. Runtime instrumentation never falls back to raw channel state.
 
 ## Authored trace hierarchy
 
@@ -161,7 +161,7 @@ Structural tags describe each run's place in the tree:
 - `$eve.root`: session id of the root session in the chain (group a whole tree with `$eve.root=<id>`)
 - `$eve.subagent`: compiled graph node id (subagent runs only)
 - `$eve.trigger`: the channel kind that started the run
-- `$eve.title`: truncated title derived from the first user message
+- `$eve.title`: explicit run title or a truncated title derived from the first user message; derived titles use `Run` for DMs and equivalent direct conversations identified by a built-in channel
 
 Per-turn usage tags are written on each step of a turn, accumulating cumulative totals (last write wins):
 

--- a/packages/eve/src/execution/eve-workflow-attributes.test.ts
+++ b/packages/eve/src/execution/eve-workflow-attributes.test.ts
@@ -5,14 +5,16 @@ import {
   buildSubagentRootAttributes,
   buildTurnAttributes,
   deriveSessionTitle,
+  EVE_REDACTED_SESSION_TITLE,
   EVE_SESSION_TITLE_MAX_CHARS,
+  isDirectConversationSession,
   readChannelKind,
   readChannelRequestId,
   readParentLineage,
   readParentSessionId,
   readRootSessionId,
 } from "#execution/eve-workflow-attributes.js";
-import { ChannelRequestIdKey } from "#context/keys.js";
+import { ChannelInstrumentationKey, ChannelRequestIdKey } from "#context/keys.js";
 
 const slackChannelCtx = {
   "eve.channel": { kind: "slack", state: { team: "T1" } },
@@ -137,6 +139,39 @@ describe("deriveSessionTitle", () => {
   });
 });
 
+describe("isDirectConversationSession", () => {
+  it.each([
+    ["Slack DM", "slack", { isDM: true }],
+    ["Chat SDK DM", "chat-sdk", { isDM: true }],
+    ["Telegram private chat", "telegram", { isDM: true }],
+    ["Teams personal chat", "teams", { isDM: true }],
+    ["Teams group chat", "teams", { isDM: true }],
+    ["Discord DM", "discord", { isDM: true }],
+    ["Twilio conversation", "twilio", { isDM: true }],
+  ])("recognizes a %s", (_label, kind, metadata) => {
+    expect(
+      isDirectConversationSession({
+        "eve.channel": { kind, state: {} },
+        [ChannelInstrumentationKey.name]: { kind, metadata },
+      }),
+    ).toBe(true);
+  });
+
+  it.each([
+    ["Slack channel", "slack", { isDM: false }],
+    ["Telegram group", "telegram", { isDM: false }],
+    ["Teams channel", "teams", { isDM: false }],
+    ["Discord guild channel", "discord", { isDM: false }],
+  ])("does not classify a %s as direct", (_label, kind, metadata) => {
+    expect(
+      isDirectConversationSession({
+        "eve.channel": { kind, state: {} },
+        [ChannelInstrumentationKey.name]: { kind, metadata },
+      }),
+    ).toBe(false);
+  });
+});
+
 describe("buildSessionAttributes", () => {
   it("emits type=session with trigger and derived title", () => {
     const attrs = buildSessionAttributes({
@@ -172,6 +207,37 @@ describe("buildSessionAttributes", () => {
     });
 
     expect(attrs["$eve.channel_request_id"]).toBe("req_session");
+  });
+
+  it("redacts the derived title for direct conversation sessions", () => {
+    const attrs = buildSessionAttributes({
+      inputMessage: "confidential account details",
+      serializedContext: {
+        "eve.channel": { kind: "slack", state: {} },
+        [ChannelInstrumentationKey.name]: {
+          kind: "slack",
+          metadata: { isDM: true },
+        },
+      },
+    });
+
+    expect(attrs["$eve.title"]).toBe(EVE_REDACTED_SESSION_TITLE);
+  });
+
+  it("preserves an explicit title for a private channel session", () => {
+    const attrs = buildSessionAttributes({
+      inputMessage: "confidential account details",
+      serializedContext: {
+        "eve.channel": { kind: "slack", state: {} },
+        [ChannelInstrumentationKey.name]: {
+          kind: "slack",
+          metadata: { isDM: true },
+        },
+      },
+      title: "Support case 123",
+    });
+
+    expect(attrs["$eve.title"]).toBe("Support case 123");
   });
 });
 

--- a/packages/eve/src/execution/eve-workflow-attributes.ts
+++ b/packages/eve/src/execution/eve-workflow-attributes.ts
@@ -21,13 +21,13 @@
  * - `$eve.parent_turn`  — parent turn id that dispatched the subagent (subagent rows only)
  * - `$eve.subagent`     — active compiled graph node id (subagent rows only)
  * - `$eve.trigger`      — channel adapter kind (session/subagent rows)
- * - `$eve.title`        — truncated session title from the first user message
+ * - `$eve.title`        — truncated session title, or `"Run"` for direct conversations
  * - `$eve.channel_request_id` — inbound channel request id
  * - `$eve.invocation_token` — channel-local continuation token for an external invocation
  * - `$eve.invocation_owner` — SHA-256 fingerprint of the invocation's initiating principal
  */
 
-import { ChannelRequestIdKey } from "#context/keys.js";
+import { ChannelInstrumentationKey, ChannelRequestIdKey } from "#context/keys.js";
 import type { EveAttributeValue } from "#runtime/attributes/normalize.js";
 import { isNonEmptyString } from "#shared/guards.js";
 
@@ -46,6 +46,13 @@ export interface SessionIdentitySummary {
 /** Untyped channel adapter snapshot as it survives serialization. */
 interface SerializedChannelAdapter {
   readonly kind?: unknown;
+}
+
+/** Channel metadata used only to decide whether a run title may contain message text. */
+interface SerializedChannelInstrumentation {
+  readonly metadata?: {
+    readonly isDM?: unknown;
+  };
 }
 
 /** Untyped session parent snapshot as it survives serialization. */
@@ -146,6 +153,23 @@ export function readChannelRequestId(
  */
 export const EVE_SESSION_TITLE_MAX_CHARS = 125;
 
+/** Stable title used when exposing the first message would disclose a direct conversation. */
+export const EVE_REDACTED_SESSION_TITLE = "Run";
+
+/**
+ * Returns whether the built-in channel metadata identifies a DM-like conversation.
+ *
+ * Channel privacy is deliberately out of scope because providers do not expose
+ * ACL visibility consistently on inbound events.
+ */
+export function isDirectConversationSession(serializedContext: Record<string, unknown>): boolean {
+  const channel = serializedContext[ChannelInstrumentationKey.name] as
+    | SerializedChannelInstrumentation
+    | undefined;
+  const metadata = channel?.metadata;
+  return metadata?.isDM === true;
+}
+
 /**
  * Derives the `$eve.title` value from the first user message of a
  * top-level session.
@@ -208,12 +232,19 @@ function collectMessageText(message: unknown): string | undefined {
 export function buildSessionAttributes(input: {
   readonly inputMessage: unknown;
   readonly serializedContext: Record<string, unknown>;
+  readonly title?: string;
 }): Record<string, EveAttributeValue> {
+  const title = deriveSessionTitle(
+    input.title ??
+      (isDirectConversationSession(input.serializedContext)
+        ? EVE_REDACTED_SESSION_TITLE
+        : input.inputMessage),
+  );
   return {
     "$eve.channel_request_id": readChannelRequestId(input.serializedContext),
     "$eve.type": "session",
     "$eve.trigger": readChannelKind(input.serializedContext),
-    "$eve.title": deriveSessionTitle(input.inputMessage),
+    "$eve.title": title,
   };
 }
 

--- a/packages/eve/src/execution/workflow-runtime.test.ts
+++ b/packages/eve/src/execution/workflow-runtime.test.ts
@@ -369,6 +369,30 @@ describe("createWorkflowRuntime#createSession", () => {
     expect(startOptions.attributes["$eve.title"]).toBe("ship it");
   });
 
+  it("redacts a derived title when channel metadata identifies a direct conversation", async () => {
+    const compiledArtifactsSource = {} as RuntimeCompiledArtifactsSource;
+    mockBundleAndRun(compiledArtifactsSource);
+    startMock.mockResolvedValue({ runId: "driver-run" });
+    const privateAdapter: ChannelAdapter = {
+      instrumentation: {
+        metadata: () => ({ isDM: true }),
+      },
+      kind: "channel:support",
+      state: {},
+    };
+
+    await buildRuntime(compiledArtifactsSource).createSession({
+      adapter: privateAdapter,
+      auth: null,
+      input: { message: "confidential account details" },
+      mode: "conversation",
+    });
+
+    const [, workflowInput, startOptions] = startMock.mock.calls[0]!;
+    expect(workflowInput[0].input.message).toBe("confidential account details");
+    expect(startOptions.attributes["$eve.title"]).toBe("Run");
+  });
+
   it("passes the configured session timeout to the durable workflow", async () => {
     const compiledArtifactsSource = {} as RuntimeCompiledArtifactsSource;
     mockBundleAndRun(compiledArtifactsSource, 86_400_000);

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -156,8 +156,9 @@ export function createWorkflowRuntime(config: {
       const sessionAttributes =
         parentLineage.sessionId === undefined
           ? buildSessionAttributes({
-              inputMessage: input.title ?? input.input.message,
+              inputMessage: input.input.message,
               serializedContext,
+              title: input.title,
             })
           : buildSubagentRootAttributes({
               identity: { nodeId: bundle.nodeId ?? ROOT_RUNTIME_AGENT_NODE_ID },

--- a/packages/eve/src/public/channels/discord/discordChannel.test.ts
+++ b/packages/eve/src/public/channels/discord/discordChannel.test.ts
@@ -192,7 +192,13 @@ describe("discordChannel() inbound route", () => {
 
   it("dispatches verified application commands with Discord auth and state", async () => {
     const { privateKey, publicKeyHex } = testKeys();
-    const channel = discordChannel({ credentials: { publicKey: publicKeyHex } });
+    const channel = discordChannel({
+      credentials: { publicKey: publicKeyHex },
+      onCommand: (_ctx, interaction) => ({
+        auth: defaultDiscordAuth(interaction),
+        title: "Discord run",
+      }),
+    });
 
     const { response, send } = await firePost(
       channel,
@@ -220,6 +226,7 @@ describe("discordChannel() inbound route", () => {
         initialResponseSent: false,
         interactionToken: "tok",
       },
+      title: "Discord run",
     });
   });
 

--- a/packages/eve/src/public/channels/discord/discordChannel.test.ts
+++ b/packages/eve/src/public/channels/discord/discordChannel.test.ts
@@ -550,6 +550,7 @@ describe("discordChannel() default event handlers", () => {
         hasMessageAnchor: false,
         initialResponseSent: true,
         interactionToken: null,
+        isDM: null,
       },
     });
   });

--- a/packages/eve/src/public/channels/discord/discordChannel.ts
+++ b/packages/eve/src/public/channels/discord/discordChannel.ts
@@ -105,11 +105,13 @@ export interface DiscordReceiveTarget {
  * - `auth`: session auth context for the dispatched turn, or `null` for anonymous.
  * - `ephemeral`: when `true`, the deferred reply is visible only to the invoking user.
  * - `context`: model-visible context lines appended after the Discord context block.
+ * - `title`: workflow run title override that does not change model input.
  */
 export type DiscordCommandResult = {
   readonly auth: SessionAuthContext | null;
   readonly ephemeral?: boolean;
   readonly context?: readonly string[];
+  readonly title?: string;
 } | null;
 
 /** Sync or async {@link DiscordCommandResult}. */
@@ -604,6 +606,7 @@ async function dispatchCommand(input: {
         auth: input.result.auth,
         context: [contextBlock, ...channelContext],
         state: input.state,
+        title: input.result.title,
       });
   } catch (error) {
     log.error("command delivery failed", { error });

--- a/packages/eve/src/public/channels/discord/discordChannel.ts
+++ b/packages/eve/src/public/channels/discord/discordChannel.ts
@@ -76,6 +76,8 @@ export interface DiscordChannelState {
   conversationId: string | null;
   /** Discord guild id, when the interaction was invoked in a guild. */
   guildId: string | null;
+  /** Whether Discord identified the conversation as outside a guild. */
+  isDM?: boolean | null;
   /** Discord application id from the inbound interaction. */
   applicationId: string | null;
   /** Latest interaction token available to the channel. */
@@ -225,7 +227,11 @@ export function discordChannel(config: DiscordChannelConfig = {}): DiscordChanne
     kindHint: "discord",
     turnPolicy: config.turnPolicy,
     state: initialDiscordState(),
-    metadata: (state) => ({ channelId: state.channelId, guildId: state.guildId }),
+    metadata: (state) => ({
+      channelId: state.channelId,
+      guildId: state.guildId,
+      isDM: state.isDM ?? null,
+    }),
 
     context(state, session) {
       return rebuildDiscordContext(state, session, config);
@@ -304,6 +310,7 @@ export function discordChannel(config: DiscordChannelConfig = {}): DiscordChanne
           guildId: null,
           hasMessageAnchor,
           initialResponseSent: true,
+          isDM: null,
           interactionToken: null,
         },
       });
@@ -645,6 +652,7 @@ function stateFromInteraction(
     guildId: interaction.guildId ?? null,
     hasMessageAnchor: options.hasMessageAnchor,
     initialResponseSent: options.initialResponseSent,
+    isDM: interaction.guildId === undefined,
     interactionToken: interaction.token,
   };
 }
@@ -657,6 +665,7 @@ function initialDiscordState(): DiscordChannelState {
     guildId: null,
     hasMessageAnchor: false,
     initialResponseSent: false,
+    isDM: null,
     interactionToken: null,
   };
 }

--- a/packages/eve/src/public/channels/discord/index.ts
+++ b/packages/eve/src/public/channels/discord/index.ts
@@ -15,6 +15,8 @@ export interface DiscordInstrumentationMetadata extends Record<string, unknown> 
   readonly channelId: string | null;
   /** Originating Discord guild id, or `null` when the interaction was not in a guild. */
   readonly guildId: string | null;
+  /** Whether Discord identified the conversation as outside a guild. */
+  readonly isDM: boolean | null;
 }
 
 export {

--- a/packages/eve/src/public/channels/eve.test.ts
+++ b/packages/eve/src/public/channels/eve.test.ts
@@ -588,7 +588,11 @@ describe("eveChannel — onMessage", () => {
       expect(ctx.eve.sessionId).toBeUndefined();
       expect(ctx.eve.request.url).toBe("https://example.com/eve/v1/session");
       expect(message).toBe("What word is selected?");
-      return { auth: defaultEveAuth(ctx), context: ["Authenticated caller profile: enterprise"] };
+      return {
+        auth: defaultEveAuth(ctx),
+        context: ["Authenticated caller profile: enterprise"],
+        title: "HTTP run",
+      };
     });
     const handler = createEveCreateHandler({
       auth: () => ACCEPTED_AUTH,
@@ -612,6 +616,7 @@ describe("eveChannel — onMessage", () => {
     });
     const options = handler.send.mock.calls[0]?.[1] as MockSendOptions;
     expect(options.auth).toEqual(ACCEPTED_AUTH);
+    expect(options.title).toBe("HTTP run");
   });
 
   it("uses auth returned from onMessage for create requests", async () => {

--- a/packages/eve/src/public/channels/eve.ts
+++ b/packages/eve/src/public/channels/eve.ts
@@ -127,6 +127,8 @@ export interface EveMessageContext {
 export type EveMessageResult = {
   readonly auth: SessionAuthContext | null;
   readonly context?: readonly string[];
+  /** Overrides the workflow run title without changing the message sent to the model. */
+  readonly title?: string;
 };
 
 /** Synchronous or asynchronous `onMessage` result. */
@@ -319,6 +321,7 @@ export function eveChannel(input: EveChannelInput): EveChannel {
             },
             mode: body.mode ?? "conversation",
             parentTraceContext,
+            title: messageResult.title,
           });
         } catch (error) {
           // A concurrent create-once request won the token: adopt its session
@@ -765,6 +768,7 @@ function normalizeEveCorsOrigin(
 interface OnMessageOutcome {
   readonly auth: SessionAuthContext | null;
   readonly context?: readonly string[];
+  readonly title?: string;
 }
 
 async function resolveOnMessage(input: {
@@ -797,10 +801,7 @@ async function resolveOnMessage(input: {
     );
   }
 
-  if (result.context === undefined) {
-    return { auth: result.auth };
-  }
-  return { auth: result.auth, context: result.context };
+  return { auth: result.auth, context: result.context, title: result.title };
 }
 
 function defaultOnMessage(ctx: EveMessageContext): EveMessageResult {

--- a/packages/eve/src/public/channels/github/dispatch.ts
+++ b/packages/eve/src/public/channels/github/dispatch.ts
@@ -239,6 +239,7 @@ async function dispatchWebhookEventTurn(input: {
     }),
     from: input.from,
     state: input.state,
+    title: result.title,
   });
 }
 
@@ -275,6 +276,7 @@ async function dispatchCommentTurn(input: {
     }),
     from: input.from,
     state: input.state,
+    title: result.title,
   });
 }
 
@@ -301,6 +303,7 @@ async function sendGitHubTurn(input: {
   readonly context: readonly string[] | undefined;
   readonly from: ChannelFrom<GitHubChannelState>;
   readonly state: GitHubChannelState;
+  readonly title: string | undefined;
 }): Promise<void> {
   const contextBlock = formatGitHubContextBlock({
     deliveryId: input.event.delivery.id,
@@ -317,6 +320,7 @@ async function sendGitHubTurn(input: {
       auth: input.auth,
       context: [contextBlock, ...(input.context ?? [])],
       state: input.state,
+      title: input.title,
     });
   } catch (error) {
     logError(log, input.logMessage ?? "GitHub delivery failed", error, {

--- a/packages/eve/src/public/channels/github/githubChannel.test.ts
+++ b/packages/eve/src/public/channels/github/githubChannel.test.ts
@@ -211,6 +211,7 @@ describe("githubChannel", () => {
     const channel = githubChannel({
       botName: "testbot",
       credentials: { webhookSecret: SECRET },
+      onComment: (ctx) => ({ auth: defaultGitHubAuth(ctx), title: "GitHub run" }),
     });
     const { send } = await firePost(
       channel,
@@ -254,6 +255,7 @@ describe("githubChannel", () => {
         repo: "eve",
         triggeringCommentId: 10,
       },
+      title: "GitHub run",
     });
   });
 

--- a/packages/eve/src/public/channels/github/githubChannel.ts
+++ b/packages/eve/src/public/channels/github/githubChannel.ts
@@ -109,6 +109,8 @@ export interface GitHubEventContext extends GitHubChannelContext, ChannelContinu
 export type GitHubInboundResult = {
   readonly auth: SessionAuthContext | null;
   readonly context?: readonly string[];
+  /** Overrides the workflow run title without changing the message sent to the model. */
+  readonly title?: string;
 } | null;
 
 /**

--- a/packages/eve/src/public/channels/linear/linearChannel.test.ts
+++ b/packages/eve/src/public/channels/linear/linearChannel.test.ts
@@ -8,6 +8,7 @@ import { ContextContainer, contextStorage } from "#context/container.js";
 import { SessionKey } from "#context/keys.js";
 import { mockChannelContext } from "#internal/testing/mocks/mock-channel-operations.js";
 import type { UnstampedMessageStreamEvent } from "#protocol/message.js";
+import { defaultLinearAuth } from "#public/channels/linear/defaults.js";
 import { linearChannel, type LinearChannelState } from "#public/channels/linear/linearChannel.js";
 import { signLinearWebhookBody } from "#public/channels/linear/verify.js";
 import type { InputRequest } from "#runtime/input/types.js";
@@ -157,7 +158,13 @@ function makeRequest(overrides: Partial<InputRequest> = {}): InputRequest {
 
 describe("linearChannel inbound Agent Session events", () => {
   it("dispatches created events with auth, context, token, and state", async () => {
-    const channel = linearChannel({ credentials: { webhookSecret: SECRET } });
+    const channel = linearChannel({
+      credentials: { webhookSecret: SECRET },
+      onAgentSession: (_ctx, event) => ({
+        auth: defaultLinearAuth(event),
+        title: "Linear run",
+      }),
+    });
     const { response, send } = await firePost(channel, signedRequest(sessionPayload()));
 
     expect(response.status).toBe(200);
@@ -178,6 +185,7 @@ describe("linearChannel inbound Agent Session events", () => {
         issueIdentifier: "EVE-123",
         organizationId: "org_1",
       },
+      title: "Linear run",
     });
   });
 

--- a/packages/eve/src/public/channels/linear/linearChannel.ts
+++ b/packages/eve/src/public/channels/linear/linearChannel.ts
@@ -162,6 +162,8 @@ export interface LinearChannelEvents {
 export type LinearInboundResult = {
   readonly auth: SessionAuthContext | null;
   readonly context?: readonly string[];
+  /** Overrides the workflow run title without changing the message sent to the model. */
+  readonly title?: string;
 } | null;
 
 /** Sync or async {@link LinearInboundResult}. */
@@ -362,6 +364,7 @@ async function dispatchAgentSession(input: {
       ...(result.context ?? []),
     ],
     state: stateFromAgentSession(event.agentSession),
+    title: result.title,
   });
 }
 

--- a/packages/eve/src/public/channels/photon/photonIMessageChannel.test.ts
+++ b/packages/eve/src/public/channels/photon/photonIMessageChannel.test.ts
@@ -37,6 +37,7 @@ describe("photonIMessageChannel", () => {
   it("inherits the shared steering default for a direct message", async () => {
     photonIMessageChannel({
       credentials: async () => ({ projectId: "project-id", projectSecret: "project-secret" }),
+      onMessage: () => ({ auth: null, title: "Photon run" }),
     });
     const handler = directMessage.mock.calls[0]?.[0];
     if (handler === undefined) throw new Error("Expected an inbound direct-message handler.");
@@ -53,7 +54,7 @@ describe("photonIMessageChannel", () => {
 
     expect(send).toHaveBeenCalledWith(
       { context: [], message: "Steer this response" },
-      { auth: null, thread },
+      { auth: null, thread, title: "Photon run" },
     );
   });
 
@@ -99,7 +100,7 @@ describe("photonIMessageChannel", () => {
 
     expect(send).toHaveBeenCalledWith(
       { context: [], message: "Hello group" },
-      { auth: null, thread },
+      { auth: null, thread, title: undefined },
     );
   });
 });

--- a/packages/eve/src/public/channels/photon/photonIMessageChannel.ts
+++ b/packages/eve/src/public/channels/photon/photonIMessageChannel.ts
@@ -29,6 +29,8 @@ export interface PhotonInboundMessageContext {
 export type PhotonInboundResult = {
   readonly auth: SessionAuthContext | null;
   readonly context?: readonly string[];
+  /** Overrides the workflow run title without changing the message sent to the model. */
+  readonly title?: string;
 } | null;
 
 /** Sync or async {@link PhotonInboundResult}. */
@@ -125,7 +127,7 @@ async function dispatchMessage(
       context: [...(result.context ?? [])],
       message: content,
     },
-    { auth: result.auth, thread },
+    { auth: result.auth, thread, title: result.title },
   );
 }
 

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -1457,6 +1457,21 @@ describe("slackChannel() inbound mention pipeline", () => {
     expect(input.title).toBe("hello");
   });
 
+  it("uses the run title returned by onAppMention without changing the message", async () => {
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-test" },
+      onAppMention: () => ({ auth: null, title: "Run" }),
+    });
+
+    const { body } = buildMentionBody({ text: "private message text" });
+    const { send } = await firePost(channel, buildSignedRequest({ body }));
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const [, input] = send.mock.calls[0]!;
+    expect(input.title).toBe("Run");
+    expect(input.message).toContain("<content>\nprivate message text\n</content>");
+  });
+
   it("uses only this app's reply as the incremental thread context boundary", async () => {
     const threadTs = "1700000000.000001";
     const currentTs = "1700000000.000006";
@@ -2171,6 +2186,22 @@ describe("slackChannel() inbound direct message pipeline", () => {
     const opts = options as { auth: unknown; state: { channelId: string } };
     expect(opts.auth).toMatchObject({ principalId: "U01", authenticator: "test" });
     expect(opts.state.channelId).toBe(channelId);
+    expect(options.title).toBe("hello");
+  });
+
+  it("uses the run title returned by onDirectMessage", async () => {
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-test" },
+      onDirectMessage: () => ({ auth: null, title: "Private support case" }),
+    });
+
+    const { body } = buildDirectMessageBody({ text: "sensitive message" });
+    const { send } = await firePost(channel, buildSignedRequest({ body }));
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const [, options] = send.mock.calls[0]!;
+    expect(options.title).toBe("Private support case");
+    expect(options.message).toContain("<content>\nsensitive message\n</content>");
   });
 
   it("does not dispatch when onDirectMessage resolves to null", async () => {

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -1276,6 +1276,7 @@ describe("slackChannel() inbound mention pipeline", () => {
       message: "Imperative follow-up",
       state: {
         channelId: "C_BOUND",
+        isDM: false,
         teamId: "T01",
         threadTs: "1700000000.000300",
         triggeringUserId: "U01",
@@ -1907,6 +1908,37 @@ describe("slackChannel() generic Events API pipeline", () => {
     expect(compact).toHaveBeenCalledWith("C01:1700000000.000001");
   });
 
+  it("does not mark a private channel as a DM", async () => {
+    const send = vi.fn().mockResolvedValue({ id: "s1" });
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-test" },
+      async onEvent(ctx) {
+        await ctx.send("follow up", {
+          auth: null,
+          target: { channelId: "C01", threadTs: "1700000000.000001" },
+        });
+      },
+    });
+
+    const body = buildEventBody(
+      { channel_type: "group", type: "reaction_added", user: "U01" },
+      { teamId: "T_WORKSPACE" },
+    );
+    await firePost(channel, buildSignedRequest({ body }), { send });
+
+    expect(send).toHaveBeenCalledWith("C01:1700000000.000001", {
+      auth: null,
+      message: "follow up",
+      state: {
+        channelId: "C01",
+        isDM: false,
+        teamId: "T_WORKSPACE",
+        threadTs: "1700000000.000001",
+        triggeringUserId: "U01",
+      },
+    });
+  });
+
   it("binds Slack session state when a generic event send creates", async () => {
     const send = vi.fn().mockResolvedValue({ id: "s1" });
     const channel = slackChannel({
@@ -1927,6 +1959,7 @@ describe("slackChannel() generic Events API pipeline", () => {
       message: "follow up",
       state: {
         channelId: "C01",
+        isDM: false,
         teamId: "T_WORKSPACE",
         threadTs: "1700000000.000001",
         triggeringUserId: "U01",
@@ -2183,10 +2216,11 @@ describe("slackChannel() inbound direct message pipeline", () => {
     expect(onDirectMessage).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenCalledTimes(1);
     const [, options] = send.mock.calls[0]!;
-    const opts = options as { auth: unknown; state: { channelId: string } };
+    const opts = options as { auth: unknown; state: { channelId: string; isDM: boolean } };
     expect(opts.auth).toMatchObject({ principalId: "U01", authenticator: "test" });
     expect(opts.state.channelId).toBe(channelId);
-    expect(options.title).toBe("hello");
+    expect(opts.state.isDM).toBe(true);
+    expect(options.title).toBeUndefined();
   });
 
   it("uses the run title returned by onDirectMessage", async () => {
@@ -2906,6 +2940,7 @@ describe("slackChannel().receive", () => {
     expect(input.message).toBe("do the thing");
     expect(input.state).toEqual({
       channelId: "C123",
+      isDM: null,
       threadTs: "1700000000.000001",
       teamId: null,
       triggeringUserId: null,

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -420,11 +420,13 @@ export interface SlackInteractionUser {
  * Result of an `onAppMention` or `onDirectMessage` callback. Return an
  * object (auth may be `null`) to dispatch a turn, or `null` to drop the
  * inbound message. `context` strings are appended as user messages to
- * session history before the delivery message.
+ * session history before the delivery message. `title` overrides the
+ * workflow run title without changing the message sent to the model.
  */
 export type SlackMentionResult = {
   readonly auth: SessionAuthContext | null;
   readonly context?: readonly string[];
+  readonly title?: string;
 } | null;
 
 export type SlackMentionResultOrPromise = SlackMentionResult | Promise<SlackMentionResult>;
@@ -1225,14 +1227,11 @@ async function deliverSlackMessage(input: {
     );
 
     const channelContext = input.result.context ?? [];
+    const title = input.result.title ?? message.markdown;
     const sendOptions: SlackSendOptions =
       channelContext.length === 0
-        ? { auth: input.result.auth, title: message.markdown }
-        : {
-            auth: input.result.auth,
-            context: channelContext,
-            title: message.markdown,
-          };
+        ? { auth: input.result.auth, title }
+        : { auth: input.result.auth, context: channelContext, title };
 
     await input.sessionOperations.send(turnMessage, sendOptions);
   } catch (error) {

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -58,7 +58,6 @@ import { SLACK_CHANNEL_DEFAULT_ROUTE } from "#public/channels/slack/constants.js
 import { handleInteractionPost } from "#public/channels/slack/interactions.js";
 import {
   bindSlackSessionOperations,
-  type SlackSendOptions,
   type SlackSessionOperations,
 } from "#public/channels/slack/session-operations.js";
 import {
@@ -185,6 +184,8 @@ export interface SlackPendingApprovalCard {
 export interface SlackChannelState {
   /** Slack channel id seeded by the inbound mention. */
   channelId: string | null;
+  /** Whether Slack identified the conversation as a direct or group direct message. */
+  isDM?: boolean | null;
   /** Slack thread root ts. */
   threadTs: string | null;
   /** Slack team id, when the inbound event carried one. */
@@ -233,6 +234,7 @@ export interface SlackChannelState {
  */
 export interface SlackInstrumentationMetadata extends Record<string, unknown> {
   readonly channelId: string | null;
+  readonly isDM: boolean | null;
   readonly teamId: string | null;
   readonly threadTs: string | null;
   readonly triggeringUserId: string | null;
@@ -700,6 +702,7 @@ export function slackChannel(config: SlackChannelConfig = {}): SlackChannel {
     kindHint: "slack",
     state: {
       channelId: null as string | null,
+      isDM: null as boolean | null,
       threadTs: null as string | null,
       teamId: null as string | null,
       triggeringUserId: null,
@@ -715,6 +718,7 @@ export function slackChannel(config: SlackChannelConfig = {}): SlackChannel {
     metadata(state): SlackInstrumentationMetadata {
       return {
         channelId: state.channelId,
+        isDM: state.isDM ?? null,
         teamId: state.teamId,
         threadTs: state.threadTs,
         triggeringUserId: state.triggeringUserId ?? null,
@@ -793,6 +797,8 @@ async function receiveOnSlack(
     readonly teamId?: string;
     /** Slack user id seeded into session state, when the trigger carried one. */
     readonly triggeringUserId?: string;
+    /** Whether Slack identified the trigger as a direct or group direct message. */
+    readonly isDM?: boolean;
   },
 ): Promise<Session> {
   const receiveTarget = input.target as Partial<SlackReceiveTarget>;
@@ -835,6 +841,7 @@ async function receiveOnSlack(
     auth: input.auth,
     state: {
       channelId,
+      isDM: deps.isDM ?? null,
       threadTs: threadTs || null,
       teamId: deps.teamId ?? null,
       triggeringUserId: deps.triggeringUserId ?? null,
@@ -1067,6 +1074,7 @@ async function dispatchSlackMessage(input: {
     resolveSession: input.resolveSession,
     state: {
       channelId: input.message.channelId,
+      isDM: input.kind === "direct_message" || isSlackDmChannelType(input.message.raw.channel_type),
       teamId: input.message.teamId ?? null,
       threadTs: input.message.threadTs,
       triggeringUserId: author?.userId ?? null,
@@ -1140,6 +1148,7 @@ async function dispatchSlackEvent(input: {
           from: input.from,
           credentials: input.credentials,
           teamId,
+          isDM: isSlackDmChannelType(input.envelope.event.channel_type),
           ...(typeof input.envelope.event.user === "string"
             ? { triggeringUserId: input.envelope.event.user }
             : {}),
@@ -1164,6 +1173,10 @@ async function dispatchSlackEvent(input: {
   }
 
   await Promise.allSettled(waitUntilTasks);
+}
+
+function isSlackDmChannelType(value: unknown): boolean {
+  return value === "im" || value === "mpim";
 }
 
 /**
@@ -1227,11 +1240,15 @@ async function deliverSlackMessage(input: {
     );
 
     const channelContext = input.result.context ?? [];
-    const title = input.result.title ?? message.markdown;
-    const sendOptions: SlackSendOptions =
-      channelContext.length === 0
-        ? { auth: input.result.auth, title }
-        : { auth: input.result.auth, context: channelContext, title };
+    const title =
+      input.result.title ?? (input.kind === "direct_message" ? undefined : message.markdown);
+    const sendOptions: {
+      auth: SessionAuthContext | null;
+      context?: readonly string[];
+      title?: string;
+    } = { auth: input.result.auth };
+    if (channelContext.length > 0) sendOptions.context = channelContext;
+    if (title !== undefined) sendOptions.title = title;
 
     await input.sessionOperations.send(turnMessage, sendOptions);
   } catch (error) {

--- a/packages/eve/src/public/channels/teams/index.ts
+++ b/packages/eve/src/public/channels/teams/index.ts
@@ -3,12 +3,13 @@ export type { ModelMessage } from "ai";
 /**
  * Instrumentation metadata for Teams sessions, read from the channel state: the
  * Teams team/channel id (`channelId`), the conversation type (`personal`,
- * `groupChat`, `channel`, or platform value), and the team id. Each field is
- * null when the inbound activity did not include it.
+ * `groupChat`, `channel`, or platform value), whether that type is direct, and
+ * the team id. Values are null when the inbound activity did not identify them.
  */
 export interface TeamsInstrumentationMetadata extends Record<string, unknown> {
   readonly channelId: string | null;
   readonly conversationType: string | null;
+  readonly isDM: boolean | null;
   readonly teamId: string | null;
 }
 

--- a/packages/eve/src/public/channels/teams/teamsChannel.test.ts
+++ b/packages/eve/src/public/channels/teams/teamsChannel.test.ts
@@ -90,6 +90,7 @@ describe("teamsChannel", () => {
             principalId: "USER",
             principalType: "user",
           },
+          title: "Teams run",
         };
       },
     });
@@ -108,6 +109,7 @@ describe("teamsChannel", () => {
         replyToActivityId: null,
         serviceUrl: "https://smba.example.test/teams",
       },
+      title: "Teams run",
     });
     expect(send.mock.calls[0]![1].context[0]).toContain("<teams_context>");
   });

--- a/packages/eve/src/public/channels/teams/teamsChannel.ts
+++ b/packages/eve/src/public/channels/teams/teamsChannel.ts
@@ -137,6 +137,8 @@ export interface TeamsReceiveTarget {
 export type TeamsInboundResult = {
   readonly auth: SessionAuthContext | null;
   readonly context?: readonly string[];
+  /** Overrides the workflow run title without changing the message sent to the model. */
+  readonly title?: string;
 } | null;
 
 /** Sync or async {@link TeamsInboundResult}. */
@@ -612,6 +614,7 @@ async function dispatchMessage(input: {
       auth: result.auth,
       context: [formatTeamsContextBlock(inboundContext), ...channelContext],
       state,
+      title: result.title,
     });
   } catch (error) {
     log.error("Teams message delivery failed", { error });

--- a/packages/eve/src/public/channels/teams/teamsChannel.ts
+++ b/packages/eve/src/public/channels/teams/teamsChannel.ts
@@ -293,6 +293,10 @@ export function teamsChannel(config: TeamsChannelConfig = {}): TeamsChannel {
     metadata: (state) => ({
       channelId: state.channelId,
       conversationType: state.conversationType,
+      isDM:
+        state.conversationType === null
+          ? null
+          : state.conversationType === "personal" || state.conversationType === "groupChat",
       teamId: state.teamId,
     }),
 

--- a/packages/eve/src/public/channels/telegram/index.ts
+++ b/packages/eve/src/public/channels/telegram/index.ts
@@ -2,13 +2,14 @@ export type { ModelMessage } from "ai";
 
 /**
  * Per-session instrumentation metadata for the Telegram channel, exposed to
- * observability tooling. The channel derives `chatId`, `chatType`, and
- * `triggeringUserId` from the current channel state; each stays `null` until an
- * inbound update populates it.
+ * observability tooling. The channel derives `chatId`, `chatType`, `isDM`,
+ * and `triggeringUserId` from the current channel state; each stays `null` until
+ * an inbound update populates it.
  */
 export interface TelegramInstrumentationMetadata extends Record<string, unknown> {
   readonly chatId: string | null;
   readonly chatType: import("#public/channels/telegram/inbound.js").TelegramChatType | null;
+  readonly isDM: boolean | null;
   readonly triggeringUserId: string | null;
 }
 

--- a/packages/eve/src/public/channels/telegram/telegramChannel.test.ts
+++ b/packages/eve/src/public/channels/telegram/telegramChannel.test.ts
@@ -8,7 +8,11 @@ import { ContextContainer, contextStorage } from "#context/container.js";
 import { SessionKey } from "#context/keys.js";
 import { mockChannelContext } from "#internal/testing/mocks/mock-channel-operations.js";
 import type { UnstampedMessageStreamEvent } from "#protocol/message.js";
-import { telegramChannel, type TelegramChannelState } from "#public/channels/telegram/index.js";
+import {
+  defaultTelegramAuth,
+  telegramChannel,
+  type TelegramChannelState,
+} from "#public/channels/telegram/index.js";
 
 const SECRET = "telegram-secret";
 
@@ -142,6 +146,10 @@ describe("telegramChannel() inbound route", () => {
     const channel = telegramChannel({
       api: { fetch: fakeTelegramFetch() },
       credentials: { botToken: "bot-token", webhookSecretToken: SECRET },
+      onMessage: (_ctx, message) => ({
+        auth: defaultTelegramAuth(message),
+        title: "Telegram run",
+      }),
     });
 
     const { response, send } = await firePost(channel, {
@@ -170,6 +178,7 @@ describe("telegramChannel() inbound route", () => {
         chatType: "private",
         conversationId: null,
       },
+      title: "Telegram run",
     });
   });
 

--- a/packages/eve/src/public/channels/telegram/telegramChannel.ts
+++ b/packages/eve/src/public/channels/telegram/telegramChannel.ts
@@ -109,6 +109,8 @@ export interface TelegramReceiveTarget {
 export type TelegramInboundResult = {
   readonly auth: SessionAuthContext | null;
   readonly context?: readonly string[];
+  /** Overrides the workflow run title without changing the message sent to the model. */
+  readonly title?: string;
 } | null;
 
 /** Sync or async {@link TelegramInboundResult}. */
@@ -529,6 +531,7 @@ async function dispatchMessage(input: {
         auth: result.auth,
         context: [contextBlock, ...channelContext],
         state,
+        title: result.title,
       });
     } else {
       await source.respond(replyInputResponses, {

--- a/packages/eve/src/public/channels/telegram/telegramChannel.ts
+++ b/packages/eve/src/public/channels/telegram/telegramChannel.ts
@@ -222,6 +222,7 @@ export function telegramChannel(config: TelegramChannelConfig = {}): TelegramCha
     metadata: (state) => ({
       chatId: state.chatId,
       chatType: state.chatType,
+      isDM: state.chatType === null ? null : state.chatType === "private",
       triggeringUserId: state.triggeringUserId ?? null,
     }),
     fetchFile: createTelegramFetchFile({

--- a/packages/eve/src/public/channels/twilio/twilioChannel.test.ts
+++ b/packages/eve/src/public/channels/twilio/twilioChannel.test.ts
@@ -260,7 +260,10 @@ describe("twilioChannel() inbound text pipeline", () => {
   });
 
   it("passes inbound media metadata from Twilio message webhooks", async () => {
-    const onText = vi.fn((_ctx: TwilioContext, _message: TwilioTextMessage) => ({ auth: null }));
+    const onText = vi.fn((_ctx: TwilioContext, _message: TwilioTextMessage) => ({
+      auth: null,
+      title: "Twilio text run",
+    }));
     const channel = twilioChannel({ allowFrom: "*", onText });
     const params = new URLSearchParams({
       Body: "see attached",
@@ -271,7 +274,7 @@ describe("twilioChannel() inbound text pipeline", () => {
       To: "+15557654321",
     });
 
-    await firePost(channel, "/eve/v1/twilio/messages", params);
+    const { send } = await firePost(channel, "/eve/v1/twilio/messages", params);
 
     expect(onText).toHaveBeenCalledTimes(1);
     expect(onText.mock.calls[0]![1]).toMatchObject({
@@ -283,6 +286,7 @@ describe("twilioChannel() inbound text pipeline", () => {
         },
       ],
     });
+    expect(send.mock.calls[0]![1]).toMatchObject({ title: "Twilio text run" });
   });
 
   it("drops inbound text when the sender is not in allowFrom", async () => {
@@ -509,7 +513,10 @@ describe("twilioChannel() voice pipeline", () => {
   });
 
   it("dispatches a Gather SpeechResult as voice transcription", async () => {
-    const channel = twilioChannel({ allowFrom: "*" });
+    const channel = twilioChannel({
+      allowFrom: "*",
+      onVoiceTranscription: () => ({ auth: null, title: "Twilio voice run" }),
+    });
     const params = new URLSearchParams({
       CallSid: "CA123",
       From: "+15551234567",
@@ -541,6 +548,7 @@ describe("twilioChannel() voice pipeline", () => {
         lastMessageSid: null,
         to: "+15557654321",
       },
+      title: "Twilio voice run",
     });
   });
 

--- a/packages/eve/src/public/channels/twilio/twilioChannel.ts
+++ b/packages/eve/src/public/channels/twilio/twilioChannel.ts
@@ -99,6 +99,8 @@ export interface TwilioReceiveTarget {
 /** Result of an inbound Twilio text or transcription hook. Return `null` (or `undefined`) to drop the webhook without dispatching; otherwise supply the session `auth` context. */
 export type TwilioInboundResult = {
   auth: SessionAuthContext | null;
+  /** Overrides the workflow run title without changing the message sent to the model. */
+  title?: string;
 } | null;
 
 /** Sync or async {@link TwilioInboundResult}. */
@@ -569,6 +571,7 @@ async function dispatchText(input: {
         lastMessageSid: message.messageSid ?? null,
         to: message.to ?? null,
       },
+      title: result.title,
     });
   } catch (error) {
     log.error("text delivery failed", { error });
@@ -642,6 +645,7 @@ async function dispatchVoiceTranscription(input: {
           lastMessageSid: null,
           to: transcription.to ?? null,
         },
+        title: result.title,
       });
   } catch (error) {
     log.error("voice transcription delivery failed", { error });

--- a/packages/eve/src/public/channels/twilio/twilioChannel.ts
+++ b/packages/eve/src/public/channels/twilio/twilioChannel.ts
@@ -79,6 +79,7 @@ export interface TwilioChannelState {
 /** Per-session instrumentation snapshot for Twilio runtime telemetry. Reports the active phone-number pair and the most recent message and call SIDs. */
 export interface TwilioInstrumentationMetadata extends Record<string, unknown> {
   readonly from: string | null;
+  readonly isDM: true;
   readonly lastCallSid: string | null;
   readonly lastMessageSid: string | null;
   readonly to: string | null;
@@ -310,6 +311,7 @@ export function twilioChannel(config: TwilioChannelConfig): TwilioChannel {
     metadata(state): TwilioInstrumentationMetadata {
       return {
         from: state.from,
+        isDM: true,
         lastCallSid: state.lastCallSid ?? null,
         lastMessageSid: state.lastMessageSid ?? null,
         to: state.to,


### PR DESCRIPTION
### Summary

Closes #2102. This PR is stacked on #2103, which adds the shared inbound-hook title option. Automatically derived Agent Runs titles now use `Run` when channel metadata identifies a DM or equivalent direct conversation, while explicit titles still win. Non-DM conversations—including private Slack channels—retain message-derived titles, and model input is unchanged.

### Validation

The rebased focused suite passes all 220 tests, covering direct-channel classification, explicit-title precedence, unchanged model input, Slack DM/group-DM detection, and the private-channel boundary. Documentation validation and invariant checks also pass.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 3 files · `+8 / -3`

Documents the direct-conversation title rule and records the published behavior change.

**Implementation** — 10 files · `+85 / -16`

Centralizes derived-title redaction and projects direct-conversation metadata from the built-in channels that can identify it.

**Tests** — 4 files · `+129 / -3`

Covers title precedence and input preservation alongside provider-specific direct-conversation boundaries.
