### PR TITLE
feat(eve): show add help without an item

### DIFF
--- a/.changeset/helpful-add-search.md
+++ b/.changeset/helpful-add-search.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Show `eve add` help and registry search guidance when no item is provided.

--- a/docs/install-integrations.mdx
+++ b/docs/install-integrations.mdx
@@ -18,6 +18,8 @@ eve add instrumentation/braintrust
 
 If an item is not found, `eve add` searches the available catalogs and prints close matches without installing anything.
 
+If you do not know an item name yet, run `eve add` without an argument. Its help output shows how to search the registry with `eve registry search <query>`.
+
 Extensions may create a mount under `agent/extensions/`. Connections write their initial definition under `agent/connections/` and install `@vercel/connect` when required. Instrumentation providers write `agent/instrumentation.ts`; because an agent has one instrumentation file, compose multiple exporters there by hand. Configure generated files and required environment variables before running your agent.
 
 Some integrations package several independently installable components. For example, `eve add linear` lets you choose the Linear Channel, Linear MCP, or both; both are selected by default. The specific `eve add channel/linear-agent` and `eve add connection/linear` commands remain available.

--- a/packages/eve/src/cli/commands/register-registry-commands.ts
+++ b/packages/eve/src/cli/commands/register-registry-commands.ts
@@ -33,7 +33,7 @@ export function registerRegistryCommands(input: {
 }): void {
   const { applicationContext, logger, program } = input;
 
-  applicationCommand(program.command("add <item>"), applicationContext)
+  const add = applicationCommand(program.command("add [item]"), applicationContext)
     .description("Install a registry item; relative paths use the official eve registry.")
     .option("-o, --overwrite", "Overwrite existing files.")
     .option("--skip-install", "Run the item's setup flow without installing it.")
@@ -48,9 +48,10 @@ export function registerRegistryCommands(input: {
       parseSetupAnswer,
     )
     .option("-y, --yes", "Run setup and accept its recommended defaults.")
+    .addHelpText("after", "\nSearch the registry:\n  $ eve registry search <query>\n")
     .action(
       async (
-        item: string,
+        item: string | undefined,
         options: {
           skipInstall?: boolean;
           overwrite?: boolean;
@@ -60,6 +61,10 @@ export function registerRegistryCommands(input: {
           yes?: boolean;
         },
       ) => {
+        if (item === undefined) {
+          add.outputHelp();
+          return;
+        }
         if (options.answer !== undefined && !options.nonInteractive) {
           throw new InvalidArgumentError("--answer requires --non-interactive.");
         }

--- a/packages/eve/src/cli/run.test.ts
+++ b/packages/eve/src/cli/run.test.ts
@@ -151,6 +151,21 @@ describe("CLI command registration", () => {
     expect(help).not.toContain("--path");
   });
 
+  it("shows add help and registry search guidance when no item is provided", async () => {
+    const errors: string[] = [];
+    const output: string[] = [];
+
+    await runCli(["add"], {
+      error: (message) => errors.push(message),
+      log: (message) => output.push(message),
+    });
+
+    const help = output.join("\n");
+    expect(errors).toEqual([]);
+    expect(help).toContain("Usage: eve add [options] [item]");
+    expect(help).toContain("eve registry search <query>");
+  });
+
   it("registers JSON output and a search result limit for registry discovery commands", async () => {
     const output: string[] = [];
     const logger = {


### PR DESCRIPTION
### Summary

Closes #2109. Running `eve add` without an item currently fails before users can discover how to find one. This change treats the omitted item as a help request: the command exits successfully, prints the `eve add` help, and includes an `eve registry search <query>` example. Normal `eve add <item>` installation behavior is unchanged.

### Validation

Focused CLI regression coverage invokes the no-item path and verifies that it emits no error, shows the optional-item usage, and includes registry search guidance. A built CLI invocation exits successfully with the expected help and search example.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+7 / -0`

Documents the no-argument discovery path and records the user-visible patch release.

**Implementation** — 1 file · `+7 / -2`

Keeps the behavior local to `eve add` command registration while preserving normal installation handling.

**Tests** — 1 file · `+15 / -0`

Covers successful help output, optional-item usage, registry search guidance, and the absence of error output.
