### PR TITLE
feat(eve): publish authored channel routes in Next.js

### DIFF
--- a/.changeset/clean-next-channel-routes.md
+++ b/.changeset/clean-next-channel-routes.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Publish authored channel routes through the Next.js integration in local development and Vercel deployments.

--- a/.changeset/tidy-mcp-routes.md
+++ b/.changeset/tidy-mcp-routes.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Configure MCP channel endpoints with `route`, default them to `/eve/v1/mcp`, and derive OAuth protected-resource metadata paths from the MCP resource identifier.

--- a/docs/guides/frontend/nextjs.mdx
+++ b/docs/guides/frontend/nextjs.mdx
@@ -54,6 +54,8 @@ const billing = useEveAgent({ agent: "billing" });
 
 Use either `eveRoot` or `agents`, not both. `eveRoot` remains the shorthand for a single unnamed agent mounted at `/eve/v1/*`.
 
+`withEve()` also publishes authored channel routes at their configured paths, including path-specific OAuth protected-resource metadata. Named-agent channel routes receive the same `/eve/agents/<name>` public prefix while the eve service continues to receive the authored path.
+
 Generated agent services build with `EVE_PUBLIC_ROUTE_PREFIX` set to the agent's public mount (for example `/eve/agents/support`) so framework-minted callback URLs — OAuth connection callbacks and remote-subagent session callbacks — resolve to the public per-agent path. If you configure eve services manually in `vercel.json` instead, export that variable in each named agent's build command.
 
 ### `withEve` options
@@ -93,7 +95,7 @@ The browser still needs a production authentication policy. See [Authenticate br
 ## Dev vs deploy topology
 
 - **Local dev.** `npm run dev` boots the eve dev server next to `next dev` and rewrites the eve routes over to it. The browser only ever talks to the Next.js origin.
-- **Vercel.** The web app and the eve runtime deploy as a single project. `withEve()` writes Build Output `services` for eve and `routes` that send `/eve/v1/**` to that service before filesystem routing; the Next.js app itself remains the default app. Vercel assembles authored [schedules](../../schedules) into the project config as Vercel Cron Jobs, including correctly prefixed jobs for named agents, while cron entries owned by the Next.js app are preserved. By default, generated services run the installed eve binary from the agent root, so the agent directory does not need its own `package.json`. When the agent needs its own build step, set `eveBuildCommand`:
+- **Vercel.** The web app and the eve runtime deploy as a single project. `withEve()` writes Build Output `services` for eve and `routes` that send `/eve/v1/**` and authored channel paths to that service before filesystem routing; the Next.js app itself remains the default app. Vercel assembles authored [schedules](../../schedules) into the project config as Vercel Cron Jobs, including correctly prefixed jobs for named agents, while cron entries owned by the Next.js app are preserved. By default, generated services run the installed eve binary from the agent root, so the agent directory does not need its own `package.json`. When the agent needs its own build step, set `eveBuildCommand`:
 
   ```ts
   export default withEve(nextConfig, {

--- a/packages/eve/src/execution/multi-agent-callback-routing.scenario.test.ts
+++ b/packages/eve/src/execution/multi-agent-callback-routing.scenario.test.ts
@@ -173,6 +173,7 @@ describe("multi-agent callback routing", () => {
         agents: DEPLOYMENT_AGENTS.map((agent) => ({
           appRoot: join(nextRoot, "agents", agent.name),
           buildCommand: "eve build",
+          channelRouteMounts: [],
           name: agent.name,
           publicRoutePrefix: agent.publicRoutePrefix,
           servicePrefix: `/_eve_internal/eve/${agent.name}`,

--- a/packages/eve/src/internal/invocation/mcp-agent-channel.scenario.test.ts
+++ b/packages/eve/src/internal/invocation/mcp-agent-channel.scenario.test.ts
@@ -205,7 +205,7 @@ async function mcpRequest(
     headers["mcp-protocol-version"] = MCP_PROTOCOL_VERSION;
     if (typeof params.name === "string") headers["mcp-name"] = params.name;
   }
-  return await fetch(new URL("/mcp", serverUrl), {
+  return await fetch(new URL("/eve/v1/mcp", serverUrl), {
     body: JSON.stringify({
       id: crypto.randomUUID(),
       jsonrpc: "2.0",

--- a/packages/eve/src/internal/mcp/http-security.test.ts
+++ b/packages/eve/src/internal/mcp/http-security.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { validateMcpHttpRequest, validateMcpMetadataRequest } from "#internal/mcp/http-security.js";
+import {
+  resolveMcpPublicRequestUrl,
+  validateMcpHttpRequest,
+  validateMcpMetadataRequest,
+} from "#internal/mcp/http-security.js";
 
 describe("MCP HTTP security", () => {
   it("accepts secure non-browser requests and exact same-origin browser requests", () => {
@@ -50,6 +54,53 @@ describe("MCP HTTP security", () => {
         request("https://agent.example/mcp", { origin: "https://agent.example:444" }),
       )?.status,
     ).toBe(403);
+  });
+
+  it("validates proxied browser requests against their public origin", () => {
+    const proxied = request("http://127.0.0.1:55335/mcp", {
+      origin: "https://agent.example",
+      "x-forwarded-host": "agent.example",
+      "x-forwarded-proto": "https",
+    });
+
+    expect(validateMcpHttpRequest(proxied)).toBeUndefined();
+    expect(resolveMcpPublicRequestUrl(proxied).toString()).toBe("https://agent.example/mcp");
+    expect(
+      validateMcpHttpRequest(
+        request("http://127.0.0.1:55335/mcp", {
+          origin: "https://attacker.example",
+          "x-forwarded-host": "agent.example",
+          "x-forwarded-proto": "https",
+        }),
+      )?.status,
+    ).toBe(403);
+    expect(
+      validateMcpHttpRequest(
+        request("http://agent.example/mcp", {
+          "x-forwarded-host": "agent.example",
+          "x-forwarded-proto": "https",
+        }),
+      )?.status,
+    ).toBe(403);
+  });
+
+  it("rejects insecure or malformed forwarded origins", () => {
+    expect(
+      validateMcpHttpRequest(
+        request("http://127.0.0.1:55335/mcp", {
+          "x-forwarded-host": "agent.example",
+          "x-forwarded-proto": "http",
+        }),
+      )?.status,
+    ).toBe(403);
+    expect(
+      validateMcpHttpRequest(
+        request("http://127.0.0.1:55335/mcp", {
+          "x-forwarded-host": "agent.example/path",
+          "x-forwarded-proto": "https",
+        }),
+      )?.status,
+    ).toBe(400);
   });
 
   it("allows cross-origin OAuth metadata discovery while retaining base guards", () => {

--- a/packages/eve/src/internal/mcp/http-security.ts
+++ b/packages/eve/src/internal/mcp/http-security.ts
@@ -10,7 +10,7 @@ export function validateMcpHttpRequest(request: Request): Response | undefined {
   const baseFailure = validateMcpHttpRequestBase(request);
   if (baseFailure !== undefined) return baseFailure;
 
-  const target = new URL(request.url);
+  const target = resolveMcpPublicRequestUrl(request);
   const originHeader = request.headers.get("origin");
   if (originHeader === null || originHeader.length === 0) return undefined;
 
@@ -37,22 +37,57 @@ export function validateMcpMetadataRequest(request: Request): Response | undefin
 
 function validateMcpHttpRequestBase(request: Request): Response | undefined {
   let target: URL;
+  let publicTarget: URL;
   try {
     target = new URL(request.url);
+    publicTarget = resolveMcpPublicRequestUrl(request);
   } catch {
-    return securityError("Invalid MCP request URL.", 400);
+    return securityError("Invalid MCP request URL or forwarded host.", 400);
   }
 
-  if (
-    target.protocol !== "https:" &&
-    !(target.protocol === "http:" && isLoopbackHostname(target.hostname))
-  ) {
+  if (!isSecureMcpTarget(target) || !isSecureMcpTarget(publicTarget)) {
     return securityError("MCP endpoints require HTTPS except on loopback.");
   }
 
   const hostFailure = validateHostHeader(request, target);
   if (hostFailure !== undefined) return hostFailure;
   return undefined;
+}
+
+function isSecureMcpTarget(target: URL): boolean {
+  return (
+    target.protocol === "https:" ||
+    (target.protocol === "http:" && isLoopbackHostname(target.hostname))
+  );
+}
+
+function pickFirstForwardedValue(value: string | null): string | undefined {
+  const first = value?.split(",")[0]?.trim();
+  return first === undefined || first.length === 0 ? undefined : first;
+}
+
+/** Resolves the public URL in front of an eve host integration or reverse proxy. */
+export function resolveMcpPublicRequestUrl(request: Request): URL {
+  const requestUrl = new URL(request.url);
+  const forwardedHost = pickFirstForwardedValue(request.headers.get("x-forwarded-host"));
+  const forwardedProto = pickFirstForwardedValue(request.headers.get("x-forwarded-proto"));
+  if (forwardedHost === undefined && forwardedProto === undefined) return requestUrl;
+
+  const protocol = forwardedProto ?? requestUrl.protocol.slice(0, -1);
+  if (protocol !== "http" && protocol !== "https") {
+    throw new TypeError("Unsupported forwarded protocol.");
+  }
+  const authority = new URL(`${protocol}://${forwardedHost ?? requestUrl.host}`);
+  if (
+    authority.username !== "" ||
+    authority.password !== "" ||
+    authority.pathname !== "/" ||
+    authority.search !== "" ||
+    authority.hash !== ""
+  ) {
+    throw new TypeError("Invalid forwarded host.");
+  }
+  return new URL(`${requestUrl.pathname}${requestUrl.search}`, authority);
 }
 
 function validateHostHeader(request: Request, target: URL): Response | undefined {

--- a/packages/eve/src/public/channels/mcp.test.ts
+++ b/packages/eve/src/public/channels/mcp.test.ts
@@ -28,9 +28,9 @@ describe("mcpChannel", () => {
   it("publishes task-mode durable invocation compatibility tools", async () => {
     const channel = mcpChannel({ auth: none() });
     expect(channel.routes.map((route) => `${route.method} ${route.path}`)).toEqual([
-      "GET /mcp",
-      "POST /mcp",
-      "DELETE /mcp",
+      "GET /eve/v1/mcp",
+      "POST /eve/v1/mcp",
+      "DELETE /eve/v1/mcp",
     ]);
     const postRoute = channel.routes[1]!;
     if (postRoute.transport === "websocket") throw new Error("expected HTTP route");
@@ -225,12 +225,12 @@ describe("mcpChannel", () => {
           scopes: ["agent:invoke"],
         },
       ),
-      path: "/delegate",
+      route: "/delegate",
     });
     expect(channel.routes.map((route) => `${route.method} ${route.path}`)).toEqual([
-      "GET /.well-known/oauth-protected-resource",
-      "HEAD /.well-known/oauth-protected-resource",
-      "OPTIONS /.well-known/oauth-protected-resource",
+      "GET /.well-known/oauth-protected-resource/delegate",
+      "HEAD /.well-known/oauth-protected-resource/delegate",
+      "OPTIONS /.well-known/oauth-protected-resource/delegate",
       "GET /delegate",
       "POST /delegate",
       "DELETE /delegate",
@@ -239,7 +239,7 @@ describe("mcpChannel", () => {
     const metadataRoute = channel.routes[0]!;
     if (metadataRoute.transport === "websocket") throw new Error("expected HTTP route");
     const metadata = await metadataRoute.handler(
-      requestWithHost("https://private.example/.well-known/oauth-protected-resource"),
+      requestWithHost("https://private.example/.well-known/oauth-protected-resource/delegate"),
       {} as never,
     );
     await expect(metadata.json()).resolves.toEqual({
@@ -258,7 +258,7 @@ describe("mcpChannel", () => {
     expect(response.status).toBe(401);
     const challenge = response.headers.get("www-authenticate");
     expect(challenge).toContain(
-      'resource_metadata="https://agent.example/.well-known/oauth-protected-resource"',
+      'resource_metadata="https://agent.example/.well-known/oauth-protected-resource/delegate"',
     );
     expect(challenge).toContain('Basic realm="eve"');
     expect(challenge).toContain('scope="agent:invoke"');
@@ -277,7 +277,7 @@ describe("mcpChannel", () => {
     const genericRoute = genericChannel.routes[4]!;
     if (genericRoute.transport === "websocket") throw new Error("expected HTTP route");
     const generic = await genericRoute.handler(
-      requestWithHost("https://agent.example/mcp", { method: "POST" }),
+      requestWithHost("https://agent.example/eve/v1/mcp", { method: "POST" }),
       {} as never,
     );
     expect(generic.status).toBe(403);
@@ -301,7 +301,7 @@ describe("mcpChannel", () => {
     const scopedRoute = scopedChannel.routes[4]!;
     if (scopedRoute.transport === "websocket") throw new Error("expected HTTP route");
     const scoped = await scopedRoute.handler(
-      requestWithHost("https://agent.example/mcp", { method: "POST" }),
+      requestWithHost("https://agent.example/eve/v1/mcp", { method: "POST" }),
       {} as never,
     );
     const scopedChallenge = scoped.headers.get("www-authenticate");
@@ -310,7 +310,7 @@ describe("mcpChannel", () => {
     expect(scopedChallenge).toContain('scope="agent:admin"');
     expect(scopedChallenge).not.toContain('scope="agent:invoke"');
     expect(scopedChallenge).toContain(
-      'resource_metadata="https://agent.example/.well-known/oauth-protected-resource"',
+      'resource_metadata="https://agent.example/.well-known/oauth-protected-resource/eve/v1/mcp"',
     );
     expect(scopedChallenge?.match(/\bBearer\b/g)).toHaveLength(1);
   });
@@ -328,7 +328,7 @@ describe("mcpChannel", () => {
     const route = channel.routes[4]!;
     if (route.transport === "websocket") throw new Error("expected HTTP route");
     const response = await route.handler(
-      requestWithHost("https://agent.example/mcp", {
+      requestWithHost("https://agent.example/eve/v1/mcp", {
         headers: { authorization: "Bearer expired-token" },
         method: "POST",
       }),
@@ -340,7 +340,7 @@ describe("mcpChannel", () => {
     expect(challenge).toContain('error="invalid_token"');
     expect(challenge).toContain('scope="agent:invoke"');
     expect(challenge).toContain(
-      'resource_metadata="https://agent.example/.well-known/oauth-protected-resource"',
+      'resource_metadata="https://agent.example/.well-known/oauth-protected-resource/eve/v1/mcp"',
     );
     expect(challenge?.match(/\bBearer\b/g)).toHaveLength(1);
   });
@@ -348,18 +348,32 @@ describe("mcpChannel", () => {
   it("derives the protected resource from the public request origin", async () => {
     const channel = mcpChannel({
       auth: oauthResource(() => null, { issuer: "https://issuer.example" }),
-      path: "/delegate",
+      route: "/delegate",
     });
     const route = channel.routes[0]!;
     if (route.transport === "websocket") throw new Error("expected HTTP route");
     const response = await route.handler(
-      requestWithHost("https://agent.example/.well-known/oauth-protected-resource"),
+      requestWithHost("https://agent.example/.well-known/oauth-protected-resource/delegate"),
       {} as never,
     );
     await expect(response.json()).resolves.toEqual({
       authorization_servers: ["https://issuer.example"],
       resource: "https://agent.example/delegate",
     });
+  });
+
+  it("allows overriding the protected-resource metadata path", () => {
+    const channel = mcpChannel({
+      auth: oauthResource(() => null, {
+        issuer: "https://issuer.example",
+        metadataPath: "/.well-known/custom-resource",
+      }),
+    });
+    expect(channel.routes.slice(0, 3).map((route) => `${route.method} ${route.path}`)).toEqual([
+      "GET /.well-known/custom-resource",
+      "HEAD /.well-known/custom-resource",
+      "OPTIONS /.well-known/custom-resource",
+    ]);
   });
 
   it("serves protected-resource metadata to cross-origin browser clients", async () => {
@@ -380,7 +394,7 @@ describe("mcpChannel", () => {
 
     const origin = "https://client.example";
     const get = await getRoute.handler(
-      requestWithHost("https://agent.example/.well-known/oauth-protected-resource", {
+      requestWithHost("https://agent.example/.well-known/oauth-protected-resource/eve/v1/mcp", {
         headers: { origin },
       }),
       {} as never,
@@ -389,7 +403,7 @@ describe("mcpChannel", () => {
     expect(get.headers.get("access-control-allow-origin")).toBe("*");
 
     const head = await headRoute.handler(
-      requestWithHost("https://agent.example/.well-known/oauth-protected-resource", {
+      requestWithHost("https://agent.example/.well-known/oauth-protected-resource/eve/v1/mcp", {
         headers: { origin },
         method: "HEAD",
       }),
@@ -401,7 +415,7 @@ describe("mcpChannel", () => {
     expect(await head.text()).toBe("");
 
     const options = await optionsRoute.handler(
-      requestWithHost("https://agent.example/.well-known/oauth-protected-resource", {
+      requestWithHost("https://agent.example/.well-known/oauth-protected-resource/eve/v1/mcp", {
         headers: {
           "access-control-request-headers": "authorization, mcp-protocol-version",
           "access-control-request-method": "GET",

--- a/packages/eve/src/public/channels/mcp.test.ts
+++ b/packages/eve/src/public/channels/mcp.test.ts
@@ -362,6 +362,43 @@ describe("mcpChannel", () => {
     });
   });
 
+  it("derives OAuth URLs from a reverse proxy's public origin", async () => {
+    const channel = mcpChannel({
+      auth: oauthResource(() => null, { issuer: "https://issuer.example" }),
+      route: "/mcp",
+    });
+    const metadataRoute = channel.routes[0]!;
+    const mcpRoute = channel.routes[4]!;
+    if (metadataRoute.transport === "websocket" || mcpRoute.transport === "websocket") {
+      throw new Error("expected HTTP routes");
+    }
+    const forwardedHeaders = {
+      "x-forwarded-host": "agent.example",
+      "x-forwarded-proto": "https",
+    };
+
+    const metadata = await metadataRoute.handler(
+      requestWithHost("http://127.0.0.1:55335/.well-known/oauth-protected-resource/mcp", {
+        headers: forwardedHeaders,
+      }),
+      {} as never,
+    );
+    await expect(metadata.json()).resolves.toMatchObject({
+      resource: "https://agent.example/mcp",
+    });
+
+    const unauthorized = await mcpRoute.handler(
+      requestWithHost("http://127.0.0.1:55335/mcp", {
+        headers: forwardedHeaders,
+        method: "POST",
+      }),
+      {} as never,
+    );
+    expect(unauthorized.headers.get("www-authenticate")).toContain(
+      'resource_metadata="https://agent.example/.well-known/oauth-protected-resource/mcp"',
+    );
+  });
+
   it("allows overriding the protected-resource metadata path", () => {
     const channel = mcpChannel({
       auth: oauthResource(() => null, {

--- a/packages/eve/src/public/channels/mcp.ts
+++ b/packages/eve/src/public/channels/mcp.ts
@@ -16,7 +16,11 @@ import type {
 } from "#internal/invocation/agent-invocation.js";
 import { WorkflowAgentInvocationExecution } from "#internal/invocation/workflow-execution.js";
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
-import { validateMcpHttpRequest, validateMcpMetadataRequest } from "#internal/mcp/http-security.js";
+import {
+  resolveMcpPublicRequestUrl,
+  validateMcpHttpRequest,
+  validateMcpMetadataRequest,
+} from "#internal/mcp/http-security.js";
 import {
   createMcpStreamableHttpServer,
   defineMcpTool,
@@ -117,7 +121,7 @@ function protectedResourceMetadataResponse(
   const securityFailure = validateMcpMetadataRequest(request);
   if (securityFailure !== undefined) return securityFailure;
   const resource =
-    options.resource ?? new URL(resourcePath, new URL(request.url).origin).toString();
+    options.resource ?? new URL(resourcePath, resolveMcpPublicRequestUrl(request)).toString();
   const authorizationServers =
     options.issuer !== undefined ? [options.issuer] : options.authorizationServers;
   const response = Response.json(
@@ -161,7 +165,7 @@ function addResourceChallenge(
 ): Response {
   if (response.status !== 401 && response.status !== 403) return response;
   const metadataPath = protectedResourceMetadataPath(options, new URL(request.url).pathname);
-  const publicBase = options.resource ?? new URL(request.url).origin;
+  const publicBase = options.resource ?? resolveMcpPublicRequestUrl(request).origin;
   const metadataUrl = new URL(metadataPath, publicBase).toString();
   const headers = new Headers(response.headers);
   const existing = headers.get("www-authenticate");

--- a/packages/eve/src/public/channels/mcp.ts
+++ b/packages/eve/src/public/channels/mcp.ts
@@ -43,8 +43,8 @@ import {
 export interface McpChannelInput {
   /** Existing eve route-auth policy. Use `none()` for explicit public access. */
   readonly auth: AuthFn<Request> | readonly AuthFn<Request>[];
-  /** Streamable HTTP endpoint path. Defaults to `/mcp`. */
-  readonly path?: string;
+  /** Override the default MCP route path (`/eve/v1/mcp`). */
+  readonly route?: string;
 }
 
 /** Public MCP channel exposing durable agent invocation compatibility tools. */
@@ -62,7 +62,7 @@ export function mcpChannel(input: McpChannelInput): McpChannel {
   if (input?.auth === undefined) {
     throw new Error("mcpChannel requires auth. Use none() for explicit public access.");
   }
-  const path = input.path ?? "/mcp";
+  const path = input.route ?? "/eve/v1/mcp";
   const oauth = readOAuthResourceOptions(input.auth);
   const routes = [
     GET(
@@ -85,7 +85,7 @@ export function mcpChannel(input: McpChannelInput): McpChannel {
 }
 
 function protectedResourceMetadataRoutes(options: OAuthResourceOptions, resourcePath: string) {
-  const metadataPath = options.metadataPath ?? "/.well-known/oauth-protected-resource";
+  const metadataPath = protectedResourceMetadataPath(options, resourcePath);
   return [
     GET(metadataPath, async (request) =>
       protectedResourceMetadataResponse(request, options, resourcePath, false),
@@ -95,6 +95,17 @@ function protectedResourceMetadataRoutes(options: OAuthResourceOptions, resource
     ),
     OPTIONS(metadataPath, async (request) => protectedResourceMetadataOptionsResponse(request)),
   ] as const;
+}
+
+function protectedResourceMetadataPath(
+  options: OAuthResourceOptions,
+  resourcePath: string,
+): string {
+  if (options.metadataPath !== undefined) return options.metadataPath;
+  const path = options.resource === undefined ? resourcePath : new URL(options.resource).pathname;
+  return path === "/"
+    ? "/.well-known/oauth-protected-resource"
+    : `/.well-known/oauth-protected-resource${path}`;
 }
 
 function protectedResourceMetadataResponse(
@@ -149,7 +160,7 @@ function addResourceChallenge(
   options: OAuthResourceOptions,
 ): Response {
   if (response.status !== 401 && response.status !== 403) return response;
-  const metadataPath = options.metadataPath ?? "/.well-known/oauth-protected-resource";
+  const metadataPath = protectedResourceMetadataPath(options, new URL(request.url).pathname);
   const publicBase = options.resource ?? new URL(request.url).origin;
   const metadataUrl = new URL(metadataPath, publicBase).toString();
   const headers = new Headers(response.headers);

--- a/packages/eve/src/public/next/channel-route-mounts.test.ts
+++ b/packages/eve/src/public/next/channel-route-mounts.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import type { CompiledChannelEntry } from "#compiler/manifest.js";
+import {
+  createEveChannelRouteMounts,
+  createVercelRequestPath,
+  createVercelRouteSource,
+} from "./channel-route-mounts.js";
+
+function channel(urlPath: string, method: "GET" | "POST" = "POST"): CompiledChannelEntry {
+  return {
+    kind: "channel",
+    logicalPath: "channels/test.ts",
+    method,
+    name: "test",
+    sourceId: `test:${method}:${urlPath}`,
+    sourceKind: "module",
+    urlPath,
+  };
+}
+
+describe("eve Next.js channel route mounts", () => {
+  it("publishes each non-protocol channel path once", () => {
+    expect(
+      createEveChannelRouteMounts({
+        channels: [
+          channel("/mcp", "GET"),
+          channel("/mcp"),
+          channel("/.well-known/oauth-protected-resource/mcp", "GET"),
+          channel("/eve/v1/session"),
+        ],
+        publicRoutePrefix: "",
+      }),
+    ).toEqual([
+      {
+        publicPath: "/.well-known/oauth-protected-resource/mcp",
+        routePath: "/.well-known/oauth-protected-resource/mcp",
+      },
+      { publicPath: "/mcp", routePath: "/mcp" },
+    ]);
+  });
+
+  it("prefixes named-agent routes while preserving the service request path", () => {
+    expect(
+      createEveChannelRouteMounts({
+        channels: [channel("/mcp")],
+        publicRoutePrefix: "/eve/agents/support",
+      }),
+    ).toEqual([
+      {
+        publicPath: "/eve/agents/support/mcp",
+        routePath: "/mcp",
+      },
+    ]);
+  });
+
+  it("converts channel parameters to Vercel named captures", () => {
+    expect(createVercelRouteSource("/api/stream/:sessionId")).toBe(
+      "^/api/stream/(?<sessionId>[^/]+)$",
+    );
+    expect(createVercelRequestPath("/api/stream/:sessionId")).toBe("/api/stream/$sessionId");
+  });
+});

--- a/packages/eve/src/public/next/channel-route-mounts.ts
+++ b/packages/eve/src/public/next/channel-route-mounts.ts
@@ -1,0 +1,74 @@
+import type { CompiledChannelEntry } from "#compiler/manifest.js";
+
+export interface EveChannelRouteMount {
+  readonly publicPath: string;
+  readonly routePath: string;
+}
+
+function joinRoutePrefix(prefix: string, path: string): string {
+  return `${prefix.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
+}
+
+function isEveProtocolRoute(path: string): boolean {
+  return path === "/eve/v1" || path.startsWith("/eve/v1/");
+}
+
+export function createEveChannelRouteMounts(input: {
+  readonly channels: readonly CompiledChannelEntry[];
+  readonly publicRoutePrefix: string;
+}): readonly EveChannelRouteMount[] {
+  const routePaths = new Set(
+    input.channels
+      .filter((channel) => channel.kind === "channel")
+      .map((channel) => channel.urlPath)
+      .filter((path) => !isEveProtocolRoute(path)),
+  );
+
+  return [...routePaths].sort().map((routePath) => ({
+    publicPath:
+      input.publicRoutePrefix.length === 0
+        ? routePath
+        : joinRoutePrefix(input.publicRoutePrefix, routePath),
+    routePath,
+  }));
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function parseRoutePath(
+  path: string,
+): readonly { readonly name?: string; readonly value: string }[] {
+  if (!path.startsWith("/")) {
+    throw new Error(`eve channel route ${JSON.stringify(path)} must start with "/".`);
+  }
+
+  return path
+    .split("/")
+    .slice(1)
+    .map((segment) => {
+      if (!segment.startsWith(":")) return { value: segment };
+      const name = segment.slice(1);
+      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+        throw new Error(
+          `eve channel route ${JSON.stringify(path)} has unsupported parameter ${JSON.stringify(segment)}.`,
+        );
+      }
+      return { name, value: segment };
+    });
+}
+
+export function createVercelRouteSource(path: string): string {
+  const segments = parseRoutePath(path).map((segment) =>
+    segment.name === undefined ? escapeRegExp(segment.value) : `(?<${segment.name}>[^/]+)`,
+  );
+  return `^/${segments.join("/")}$`;
+}
+
+export function createVercelRequestPath(path: string): string {
+  const segments = parseRoutePath(path).map((segment) =>
+    segment.name === undefined ? segment.value : `$${segment.name}`,
+  );
+  return `/${segments.join("/")}`;
+}

--- a/packages/eve/src/public/next/index.test.ts
+++ b/packages/eve/src/public/next/index.test.ts
@@ -27,7 +27,12 @@ vi.mock("./vercel-output-config.js", () => ({
   ),
 }));
 
+vi.mock("./resolve-channel-route-mounts.js", () => ({
+  resolveEveChannelRouteMounts: vi.fn(async () => []),
+}));
+
 const { ensureEveVercelOutputConfig } = await import("./vercel-output-config.js");
+const { resolveEveChannelRouteMounts } = await import("./resolve-channel-route-mounts.js");
 
 vi.mock("./server.js", async (importOriginal) => {
   const original = await importOriginal<typeof import("./server.js")>();
@@ -60,6 +65,7 @@ describe("withEve", () => {
   afterEach(() => {
     vi.mocked(resolveEveDestinationPrefix).mockClear();
     vi.mocked(ensureEveVercelOutputConfig).mockClear();
+    vi.mocked(resolveEveChannelRouteMounts).mockReset().mockResolvedValue([]);
     vi.unstubAllEnvs();
   });
 
@@ -119,17 +125,54 @@ describe("withEve", () => {
     expect(beforeFiles.every((rewrite) => rewrite.source.startsWith("/eve/v1/"))).toBe(true);
   });
 
-  it("rewrites authored channel routes under the eve protocol prefix", async () => {
+  it("rewrites authored channel routes at their configured public paths", async () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("EVE_NEXT_PRODUCTION_ORIGIN", "https://agent.example.com");
+    vi.mocked(resolveEveChannelRouteMounts).mockResolvedValue([
+      { publicPath: "/mcp", routePath: "/mcp" },
+      {
+        publicPath: "/.well-known/oauth-protected-resource/mcp",
+        routePath: "/.well-known/oauth-protected-resource/mcp",
+      },
+    ]);
 
     const config = await resolveConfig(withEve<TestConfig>({}));
     const rewrites = await config.rewrites?.();
 
-    expect(getBeforeFiles(rewrites)).toContainEqual({
-      destination: `https://agent.example.com${EVE_NEXT_SERVICE_PREFIX}/eve/v1/:path+`,
-      source: "/eve/v1/:path+",
-    });
+    expect(getBeforeFiles(rewrites)).toEqual([
+      {
+        destination: `https://agent.example.com${EVE_NEXT_SERVICE_PREFIX}/eve/v1/:path+`,
+        source: "/eve/v1/:path+",
+      },
+      {
+        destination: `https://agent.example.com${EVE_NEXT_SERVICE_PREFIX}/mcp`,
+        source: "/mcp",
+      },
+      {
+        destination: `https://agent.example.com${EVE_NEXT_SERVICE_PREFIX}/.well-known/oauth-protected-resource/mcp`,
+        source: "/.well-known/oauth-protected-resource/mcp",
+      },
+    ]);
+  });
+
+  it("fails when an authored channel path conflicts with an existing rewrite", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("EVE_NEXT_PRODUCTION_ORIGIN", "https://agent.example.com");
+    vi.mocked(resolveEveChannelRouteMounts).mockResolvedValue([
+      { publicPath: "/mcp", routePath: "/mcp" },
+    ]);
+
+    const config = await resolveConfig(
+      withEve<TestConfig>({
+        async rewrites() {
+          return [{ destination: "/api/other", source: "/mcp" }];
+        },
+      }),
+    );
+
+    await expect(config.rewrites?.()).rejects.toThrow(
+      'eve channel route "/mcp" conflicts with an existing Next.js rewrite',
+    );
   });
 
   it("uses EVE_BASE_URL in development instead of starting a server", async () => {
@@ -349,6 +392,7 @@ describe("withEve", () => {
         {
           appRoot: expect.stringContaining("/agents/billing"),
           buildCommand: "pnpm build:billing-agent",
+          channelRouteMounts: [],
           name: "billing",
           publicRoutePrefix: "/eve/agents/billing",
           servicePrefix: "/_eve_internal/billing",
@@ -356,6 +400,7 @@ describe("withEve", () => {
         {
           appRoot: expect.stringContaining("/agents/support"),
           buildCommand: "node '../../node_modules/eve/bin/eve.js' build",
+          channelRouteMounts: [],
           name: "support",
           publicRoutePrefix: "/eve/agents/support",
           servicePrefix: `${EVE_NEXT_SERVICE_PREFIX}/support`,

--- a/packages/eve/src/public/next/index.ts
+++ b/packages/eve/src/public/next/index.ts
@@ -4,6 +4,8 @@ import type { NextConfig } from "next";
 
 import { EVE_ROUTE_PREFIX } from "#protocol/routes.js";
 import { resolveEveBinaryPath } from "#shared/resolve-eve-binary.js";
+import type { EveChannelRouteMount } from "./channel-route-mounts.js";
+import { resolveEveChannelRouteMounts } from "./resolve-channel-route-mounts.js";
 import { resolveEveDestinationPrefix } from "./server.js";
 import { ensureEveVercelOutputConfig } from "./vercel-output-config.js";
 
@@ -263,6 +265,16 @@ function createEveRewriteRule(input: {
   };
 }
 
+function createChannelRewriteRule(input: {
+  readonly destinationPrefix: string;
+  readonly mount: EveChannelRouteMount;
+}): EveNextRewriteRule {
+  return {
+    destination: joinRoutePrefix(input.destinationPrefix, input.mount.routePath),
+    source: input.mount.publicPath,
+  };
+}
+
 async function resolveExistingRewrites(
   rewrites: EveNextConfig["rewrites"],
 ): Promise<EveNextRewrites | undefined> {
@@ -290,6 +302,32 @@ function mergeRewriteRules(
     ...existing,
     beforeFiles: [...eveRules, ...(existing.beforeFiles ?? [])],
   };
+}
+
+function collectRewriteSources(rewrites: EveNextRewrites | undefined): ReadonlySet<string> {
+  if (rewrites === undefined) return new Set();
+  if (!isRewriteSections(rewrites)) return new Set(rewrites.map((rewrite) => rewrite.source));
+  return new Set(
+    [
+      ...(rewrites.beforeFiles ?? []),
+      ...(rewrites.afterFiles ?? []),
+      ...(rewrites.fallback ?? []),
+    ].map((rewrite) => rewrite.source),
+  );
+}
+
+function assertNoRewriteCollisions(
+  existing: EveNextRewrites | undefined,
+  eveRules: readonly EveNextRewriteRule[],
+): void {
+  const existingSources = collectRewriteSources(existing);
+  for (const rule of eveRules) {
+    if (existingSources.has(rule.source)) {
+      throw new Error(
+        `eve channel route ${JSON.stringify(rule.source)} conflicts with an existing Next.js rewrite. Change the channel route or remove the rewrite.`,
+      );
+    }
+  }
 }
 
 function isRewriteSections(rewrites: EveNextRewrites): rewrites is EveNextRewriteSections {
@@ -408,10 +446,20 @@ export function withEve<TConfig extends EveNextConfig>(
   return async function eveNextConfig(phase, context) {
     const nextConfig = await resolveNextConfig(configOrFunction, phase, context);
     const existingRewrites = nextConfig.rewrites;
+    const agentsWithChannelRoutes = await Promise.all(
+      agents.map(async (agent) => ({
+        ...agent,
+        channelRouteMounts: await resolveEveChannelRouteMounts({
+          appRoot: agent.appRoot,
+          publicRoutePrefix: agent.publicRoutePrefix,
+        }),
+      })),
+    );
     const configuredVercel = await ensureEveVercelOutputConfig({
-      agents: agents.map((agent) => ({
+      agents: agentsWithChannelRoutes.map((agent) => ({
         appRoot: agent.appRoot,
         buildCommand: agent.buildCommand,
+        channelRouteMounts: agent.channelRouteMounts,
         name: agent.name,
         publicRoutePrefix: agent.publicRoutePrefix,
         servicePrefix: agent.servicePrefix,
@@ -426,7 +474,7 @@ export function withEve<TConfig extends EveNextConfig>(
     const configuredAgentByName = new Map(
       configuredVercel.agents.map((agent) => [agent.name, agent] as const),
     );
-    const agentsWithDestinations = agents.map((agent) => {
+    const agentsWithDestinations = agentsWithChannelRoutes.map((agent) => {
       const configuredAgent = configuredAgentByName.get(agent.name);
       const productionDestination = resolveProductionDestination({
         localProductionPortOffset: agent.localProductionPortOffset,
@@ -455,15 +503,22 @@ export function withEve<TConfig extends EveNextConfig>(
                 productionServerOrigin: agent.productionDestination.localServerOrigin,
               });
 
-              return createEveRewriteRule({
-                destinationPrefix,
-                publicRoutePrefix: agent.publicRoutePrefix,
-              });
+              return [
+                createEveRewriteRule({
+                  destinationPrefix,
+                  publicRoutePrefix: agent.publicRoutePrefix,
+                }),
+                ...agent.channelRouteMounts.map((mount) =>
+                  createChannelRewriteRule({ destinationPrefix, mount }),
+                ),
+              ];
             }),
           ),
         ]);
 
-        return mergeRewriteRules(existing, eveRules);
+        const flattenedEveRules = eveRules.flat();
+        assertNoRewriteCollisions(existing, flattenedEveRules);
+        return mergeRewriteRules(existing, flattenedEveRules);
       },
     };
   };

--- a/packages/eve/src/public/next/resolve-channel-route-mounts.ts
+++ b/packages/eve/src/public/next/resolve-channel-route-mounts.ts
@@ -1,0 +1,22 @@
+import { compileAgent } from "#compiler/compile-agent.js";
+import { DiscoveryProjectResolutionError } from "#discover/project.js";
+import { createEveChannelRouteMounts, type EveChannelRouteMount } from "./channel-route-mounts.js";
+
+export async function resolveEveChannelRouteMounts(input: {
+  readonly appRoot: string;
+  readonly publicRoutePrefix: string;
+}): Promise<readonly EveChannelRouteMount[]> {
+  try {
+    const result = await compileAgent({ startPath: input.appRoot });
+    return createEveChannelRouteMounts({
+      channels: result.manifest.channels,
+      publicRoutePrefix: input.publicRoutePrefix,
+    });
+  } catch (error) {
+    // Preserve withEve's existing config-time behavior for projects whose
+    // agent files are created later in the build. The eve build still reports
+    // a missing agent with its normal discovery diagnostic.
+    if (error instanceof DiscoveryProjectResolutionError) return [];
+    throw error;
+  }
+}

--- a/packages/eve/src/public/next/vercel-output-config.integration.test.ts
+++ b/packages/eve/src/public/next/vercel-output-config.integration.test.ts
@@ -1,0 +1,76 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ensureEveVercelOutputConfig } from "./vercel-output-config.js";
+
+describe("eve Next.js Vercel output config", () => {
+  const temporaryRoots: string[] = [];
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await Promise.all(
+      temporaryRoots.splice(0).map((root) => rm(root, { force: true, recursive: true })),
+    );
+  });
+
+  it("publishes prefixed channel routes to the owning eve service", async () => {
+    const nextRoot = await mkdtemp(join(tmpdir(), "eve-next-channel-routes-"));
+    temporaryRoots.push(nextRoot);
+    vi.stubEnv("VERCEL", "1");
+
+    await ensureEveVercelOutputConfig({
+      agents: [
+        {
+          appRoot: join(nextRoot, "agents", "support"),
+          buildCommand: "eve build",
+          channelRouteMounts: [
+            {
+              publicPath: "/eve/agents/support/mcp",
+              routePath: "/mcp",
+            },
+            {
+              publicPath: "/eve/agents/support/.well-known/oauth-protected-resource/mcp",
+              routePath: "/.well-known/oauth-protected-resource/mcp",
+            },
+          ],
+          name: "support",
+          publicRoutePrefix: "/eve/agents/support",
+          servicePrefix: "/_eve_internal/eve/support",
+        },
+      ],
+      nextRoot,
+    });
+
+    const config = JSON.parse(
+      await readFile(join(nextRoot, ".vercel", "output", "config.json"), "utf8"),
+    ) as {
+      routes: unknown[];
+    };
+
+    expect(config.routes).toEqual(
+      expect.arrayContaining([
+        {
+          src: "^/eve/agents/support/mcp$",
+          transforms: [{ args: "/mcp", op: "set", type: "request.path" }],
+        },
+        {
+          destination: { service: "eve-support", type: "service" },
+          src: "^/eve/agents/support/mcp$",
+        },
+        {
+          src: "^/eve/agents/support/\\.well-known/oauth-protected-resource/mcp$",
+          transforms: [
+            {
+              args: "/.well-known/oauth-protected-resource/mcp",
+              op: "set",
+              type: "request.path",
+            },
+          ],
+        },
+      ]),
+    );
+  });
+});

--- a/packages/eve/src/public/next/vercel-output-config.ts
+++ b/packages/eve/src/public/next/vercel-output-config.ts
@@ -13,6 +13,11 @@ import {
   findClosestLinkedVercelDirectory,
   findClosestVercelOutputDirectory,
 } from "#shared/vercel-output-directory.js";
+import {
+  createVercelRequestPath,
+  createVercelRouteSource,
+  type EveChannelRouteMount,
+} from "./channel-route-mounts.js";
 
 const VERCEL_JSON_FILE_NAME = "vercel.json";
 const VERCEL_OUTPUT_CONFIG_FILE_NAME = ".vercel/output/config.json";
@@ -90,6 +95,7 @@ export interface EnsureVercelOutputConfigResult {
 export interface EnsureVercelOutputConfigAgentInput {
   readonly appRoot: string;
   readonly buildCommand: string;
+  readonly channelRouteMounts: readonly EveChannelRouteMount[];
   readonly name?: string;
   readonly publicRoutePrefix: string;
   readonly servicePrefix: string;
@@ -398,21 +404,25 @@ function createEveServiceRoute(serviceName: string, routeSrc: string): VercelRou
   };
 }
 
-function isEveServiceRequestPathRoute(route: VercelRouteConfig, routeSrc: string): boolean {
-  return route.src === routeSrc;
-}
-
-function createEveServiceRequestPathRoute(routeSrc: string): VercelRouteConfig {
+function createRequestPathRoute(routeSrc: string, requestPath: string): VercelRouteConfig {
   return {
     src: routeSrc,
     transforms: [
       {
-        args: EVE_SERVICE_ROUTE_PATH,
+        args: requestPath,
         op: "set",
         type: "request.path",
       },
     ],
   };
+}
+
+function isEveServiceRequestPathRoute(route: VercelRouteConfig, routeSrc: string): boolean {
+  return route.src === routeSrc;
+}
+
+function createEveServiceRequestPathRoute(routeSrc: string): VercelRouteConfig {
+  return createRequestPathRoute(routeSrc, EVE_SERVICE_ROUTE_PATH);
 }
 
 function insertEveServiceRequestPathRoute(
@@ -430,22 +440,28 @@ function insertEveServiceRequestPathRoute(
 function insertEveServiceRoutes(
   routes: readonly VercelRouteConfig[],
   eveRoutes: readonly {
+    readonly requestPath?: string;
     readonly routeSrc: string;
     readonly serviceName: string;
   }[],
 ): readonly VercelRouteConfig[] {
   const routesWithoutEveRoutes = routes.filter(
     (route) =>
-      !eveRoutes.some((eveRoute) =>
-        isEveServiceRoute(route, eveRoute.serviceName, eveRoute.routeSrc),
+      !eveRoutes.some(
+        (eveRoute) =>
+          isEveServiceRoute(route, eveRoute.serviceName, eveRoute.routeSrc) ||
+          (route.src === eveRoute.routeSrc && route.transforms !== undefined),
       ),
   );
   const filesystemRouteIndex = routesWithoutEveRoutes.findIndex(
     (route) => route.handle === "filesystem",
   );
-  const nextEveRoutes = eveRoutes.map((eveRoute) =>
+  const nextEveRoutes = eveRoutes.flatMap((eveRoute) => [
+    ...(eveRoute.requestPath === undefined
+      ? []
+      : [createRequestPathRoute(eveRoute.routeSrc, eveRoute.requestPath)]),
     createEveServiceRoute(eveRoute.serviceName, eveRoute.routeSrc),
-  );
+  ]);
 
   if (filesystemRouteIndex === -1) {
     return [...nextEveRoutes, ...routesWithoutEveRoutes];
@@ -502,9 +518,11 @@ export async function ensureEveVercelOutputConfig(input: {
     ...existingServices,
   };
   const eveRoutes: {
+    requestPath?: string;
     routeSrc: string;
     serviceName: string;
   }[] = [];
+  const mountedChannelRouteSources = new Map<string, string>();
 
   for (const agent of input.agents) {
     const configuredEveServiceEntry = findConfiguredEveServiceEntry(existingServices, agent);
@@ -545,6 +563,24 @@ export async function ensureEveVercelOutputConfig(input: {
       routeSrc,
       serviceName,
     });
+    for (const mount of agent.channelRouteMounts) {
+      const channelRouteSrc = createVercelRouteSource(mount.publicPath);
+      const existingServiceName = mountedChannelRouteSources.get(channelRouteSrc);
+      if (existingServiceName !== undefined && existingServiceName !== serviceName) {
+        throw new Error(
+          `eve channel route ${JSON.stringify(mount.publicPath)} is claimed by both ${JSON.stringify(existingServiceName)} and ${JSON.stringify(serviceName)}. Configure distinct channel paths or named-agent prefixes.`,
+        );
+      }
+      mountedChannelRouteSources.set(channelRouteSrc, serviceName);
+      eveRoutes.push({
+        requestPath:
+          mount.publicPath === mount.routePath
+            ? undefined
+            : createVercelRequestPath(mount.routePath),
+        routeSrc: channelRouteSrc,
+        serviceName,
+      });
+    }
   }
 
   const { services: _services, ...configWithoutLegacyServices } = existingConfig;


### PR DESCRIPTION
### Summary

Stacked on #2114. The public MCP channel guide follows #2114 directly in #2120.

`withEve()` now publishes authored channel routes through both local Next.js rewrites and Vercel Build Output service routes. This makes routes outside `/eve/v1/**`—including custom MCP endpoints and OAuth protected-resource metadata—reachable from the application's public origin.

```ts
import { oauthResource, vercelOidc } from "eve/channels/auth";
import { mcpChannel } from "eve/channels/mcp";

export default mcpChannel({
  auth: oauthResource(vercelOidc(), {
    issuer: "https://auth.example.com",
    scopes: ["agent:invoke"],
  }),
  route: "/mcp",
});
```

For this configuration, `withEve()` publishes both `/mcp` and `/.well-known/oauth-protected-resource/mcp`. Named agents receive their configured public agent prefix, while requests sent to the eve service retain the authored channel path.

The integration deduplicates route methods, preserves route parameters in Next.js and Vercel representations, and reports explicit errors when an authored channel route collides with an application rewrite. MCP metadata, origin validation, and authorization challenges resolve the validated forwarded public origin instead of exposing the private eve service address.

### Validation

- Focused MCP security and Next.js unit tests: 41 passed
- Vercel-output route integration test: passed
- eve TypeScript check: passed
- Documentation validation: passed
- Lint: passed, with three pre-existing unused-variable warnings in OAuth HITL fixtures

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+8 / -1`

Documents authored-channel publication in the Next.js integration and records the package behavior change.

**Implementation** — 6 files · `+252 / -26`

Adds shared route-mount derivation for local rewrites and Vercel services, collision diagnostics, parameter transforms, and validated forwarded-origin resolution for MCP OAuth responses.

**Tests** — 6 files · `+279 / -6`

Covers route deduplication and parameters, custom and path-specific MCP routes, rewrite conflicts, named-agent mounts, Vercel service transforms, and forwarded-origin security cases.
