### PR TITLE
fix(eve): follow pending authorization callbacks

### DIFF
--- a/.changeset/authorization-callback-mitigation.md
+++ b/.changeset/authorization-callback-mitigation.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Keep mounted frontend bindings attached through pending authorization callbacks so the completed grant and resumed agent output appear without a refresh.

--- a/docs/guides/client/streaming.mdx
+++ b/docs/guides/client/streaming.mdx
@@ -121,13 +121,15 @@ client-resolvable `http(s)` and `data:` URLs.
 
 ## Authorization pauses
 
-`authorization.required` is different from the normal `session.waiting` boundary. It means a connection needs OAuth or another authorization challenge before the parked turn can continue. Chat UIs should render the authorization prompt, disable ordinary text input for that session, and persist the event with the rest of the chat history.
+`authorization.required` is different from the normal `session.waiting` boundary. It means a connection needs OAuth or another authorization challenge before the parked operation can continue. Chat UIs should render the authorization prompt, disable ordinary text input for that session, and persist the event with the rest of the chat history.
 
-If you support refresh while an authorization prompt is pending, keep the session cursor from the started session and rehydrate the saved events on load. Do not treat a missing `session.waiting` after `authorization.required` as a finished conversation; the callback or a structured decline should resume the same eve session.
+While the page remains mounted, the frontend bindings keep the submitted `send()` attached after `session.waiting`. The callback starts another turn on the same session; its `authorization.completed` event and resumed output reach the binding before `send()` settles. The binding remains `streaming` and rejects another `send()` until that happens.
+
+This is a serialized mitigation, not general session reattachment. A page loaded from a saved cursor does not automatically follow later events; applications that support refresh while authorization is pending must own that recovery until the frontend bindings expose a session-level subscription.
 
 ## Reconnection
 
-HTTP connections can end before a run does. The client reconnects from the number of events already consumed, so long turns continue without replaying events. By default, a turn response keeps reconnecting until it reaches a turn boundary or is aborted, including while the turn is paused for authorization. A manually opened `session.stream()` eventually stops after repeated empty streams when it can no longer make progress.
+HTTP connections can end before a run does. The client reconnects from the number of events already consumed, so long turns continue without replaying events. By default, a turn response keeps reconnecting until it reaches a turn boundary or is aborted. When a frontend binding reaches that boundary with authorization still pending, its serialized follow uses the same bounded session-stream reconnection policy. General reattachment after that policy is exhausted remains application-owned. A manually opened `session.stream()` has the same bounded behavior.
 
 If your consumer persists events, key on `event.meta.id`. It is stable across reconnects and rewinds, so an overlapping replay is safe to ingest twice. See [the event envelope](../../concepts/sessions-runs-and-streaming#the-event-envelope).
 

--- a/packages/eve/src/client/eve-agent-store.test.ts
+++ b/packages/eve/src/client/eve-agent-store.test.ts
@@ -4,10 +4,13 @@ import { detachEveAgentStore, EveAgentStore } from "#client/eve-agent-store.js";
 import { defaultMessageReducer } from "#client/message-reducer.js";
 import { stampTestEvents } from "#internal/testing/events.js";
 import {
+  createAuthorizationCompletedEvent,
+  createAuthorizationRequiredEvent,
   createMessageCompletedEvent,
   createMessageReceivedEvent,
   createSessionWaitingEvent,
   createTurnCancelledEvent,
+  createTurnCompletedEvent,
   createTurnStartedEvent,
   EVE_SESSION_ID_HEADER,
   type UnstampedMessageStreamEvent,
@@ -96,6 +99,66 @@ afterEach(() => {
 });
 
 describe("EveAgentStore stream overlap", () => {
+  it("keeps a send attached through a pending authorization callback", async () => {
+    const events = stampTestEvents([
+      createMessageReceivedEvent({ message: "Use Linear", sequence: 0, turnId: "turn_1" }),
+      createAuthorizationRequiredEvent({
+        description: "Sign in to Linear",
+        name: "linear",
+        sequence: 1,
+        stepIndex: 0,
+        turnId: "turn_1",
+      }),
+      createTurnCompletedEvent({ sequence: 2, turnId: "turn_1" }),
+      createSessionWaitingEvent(),
+      createTurnStartedEvent({ sequence: 0, turnId: "turn_2" }),
+      createAuthorizationCompletedEvent({
+        name: "linear",
+        outcome: "authorized",
+        sequence: 1,
+        stepIndex: 0,
+        turnId: "turn_2",
+      }),
+      createMessageCompletedEvent({
+        finishReason: "stop",
+        message: "Linear is connected.",
+        sequence: 2,
+        stepIndex: 0,
+        turnId: "turn_2",
+      }),
+      createTurnCompletedEvent({ sequence: 3, turnId: "turn_2" }),
+      createSessionWaitingEvent(),
+    ]);
+    const callbackResponse = Promise.withResolvers<Response>();
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(startedResponse())
+      .mockResolvedValueOnce(streamResponse(events.slice(0, 4)))
+      .mockReturnValueOnce(callbackResponse.promise);
+    const store = new EveAgentStore({ reducer: defaultMessageReducer() });
+
+    let settled = false;
+    const sending = store.send({ message: "Use Linear" }).finally(() => {
+      settled = true;
+    });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+
+    expect(settled).toBe(false);
+    expect(store.snapshot.status).toBe("streaming");
+    await expect(store.send({ message: "While we wait" })).rejects.toThrow(
+      "eve session is already processing a turn.",
+    );
+
+    callbackResponse.resolve(streamResponse(events.slice(4)));
+    await sending;
+
+    expect(store.snapshot.events.map((event) => event.type)).toEqual(
+      events.map((event) => event.type),
+    );
+    expect(store.snapshot.status).toBe("ready");
+    expect(store.snapshot.session).toEqual({ sessionId: "session_1", streamIndex: events.length });
+  });
+
   it("rejects a prepared turn containing both a message and input responses", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch");
     const store = new EveAgentStore({ reducer: defaultMessageReducer() });

--- a/packages/eve/src/client/eve-agent-store.ts
+++ b/packages/eve/src/client/eve-agent-store.ts
@@ -3,7 +3,7 @@ import type { MessageResponse } from "#client/message-response.js";
 import type { EveAgentReducer, EveAgentReducerEvent } from "#client/reducer.js";
 import type { ClientSession } from "#client/session.js";
 import { createEventDeduper } from "#protocol/event-dedupe.js";
-import type { MessageStreamEvent } from "#protocol/message.js";
+import { isCurrentTurnBoundaryEvent, type MessageStreamEvent } from "#protocol/message.js";
 import { toError } from "#shared/errors.js";
 import type {
   CancelSessionResult,
@@ -216,6 +216,7 @@ export class EveAgentStore<TData> {
       turn.resolveResponse(response);
 
       let sawEvent = false;
+      let pendingAuthorizationCount = 0;
       for await (const event of response) {
         if (!this.#isActiveTurn(turn)) {
           return;
@@ -226,15 +227,36 @@ export class EveAgentStore<TData> {
           this.#status = "streaming";
         }
 
-        if (!this.#seenEvents.admit(event)) {
-          continue;
+        if (this.#acceptServerEvent(event)) {
+          pendingAuthorizationCount = updatePendingAuthorizationCount(
+            pendingAuthorizationCount,
+            event,
+          );
         }
+      }
 
-        this.#events = [...this.#events, event];
-        this.#applyServerEvent(event);
-        this.#callbacks.onEvent?.(event);
-        this.#applyTerminalStreamFailure(event);
-        this.#publish();
+      const session = this.#session;
+      if (pendingAuthorizationCount > 0 && session !== undefined) {
+        for await (const event of session.stream({
+          signal: turnInput.signal,
+          streamReconnectPolicy: preparedInput.streamReconnectPolicy,
+        })) {
+          if (!this.#isActiveTurn(turn)) return;
+
+          if (this.#acceptServerEvent(event)) {
+            pendingAuthorizationCount = updatePendingAuthorizationCount(
+              pendingAuthorizationCount,
+              event,
+            );
+          }
+
+          if (
+            isCurrentTurnBoundaryEvent(event) &&
+            (event.type !== "session.waiting" || pendingAuthorizationCount === 0)
+          ) {
+            break;
+          }
+        }
       }
 
       if (!this.#isActiveTurn(turn)) {
@@ -386,6 +408,17 @@ export class EveAgentStore<TData> {
     this.#appendProjectionEvent(event);
   }
 
+  #acceptServerEvent(event: MessageStreamEvent): boolean {
+    if (!this.#seenEvents.admit(event)) return false;
+
+    this.#events = [...this.#events, event];
+    this.#applyServerEvent(event);
+    this.#callbacks.onEvent?.(event);
+    this.#applyTerminalStreamFailure(event);
+    this.#publish();
+    return true;
+  }
+
   #applyTerminalStreamFailure(event: MessageStreamEvent): void {
     const error = toTerminalStreamFailureError(event);
     if (error === undefined) {
@@ -527,6 +560,12 @@ function summarizeUserContent(message: string | UserContent): string {
 
 function isAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === "AbortError";
+}
+
+function updatePendingAuthorizationCount(count: number, event: MessageStreamEvent): number {
+  if (event.type === "authorization.required") return count + 1;
+  if (event.type === "authorization.completed") return Math.max(0, count - 1);
+  return count;
 }
 
 function toTerminalStreamFailureError(event: MessageStreamEvent): Error | undefined {


### PR DESCRIPTION
### Summary

Related to #737. Follow-up to #1830, which fixed #1525.

#1525 reported that an authorization park never emitted a turn boundary, leaving `useEveAgent` stuck in `streaming`. #1830 fixed that session wedge and kept the session receptive while authorization remained open. The resulting lifecycle is intentionally multi-turn: the requesting turn now ends at `session.waiting`, and the OAuth callback later starts another turn that emits `authorization.completed` and resumes the blocked operation.

That exposed the frontend gap addressed here. `EveAgentStore` consumes the requesting turn's `MessageResponse`, so it stopped at the new boundary and never observed the callback turn. A mounted chat therefore kept showing a pending authorization until refresh or another dispatch.

This PR is a serialized mitigation. When a submitted turn reaches `session.waiting` with authorization still pending, the store keeps that `send()` active and follows the same session from its advanced cursor. While that bounded follow remains attached, it consumes the later callback turn through the boundary where the observed authorizations settle. The binding remains `streaming`, so another `send()` is still rejected. `MessageResponse` remains one-turn scoped, and the patch adds no background observer or stream-ownership handoff.

The long-term fix remains #737: one store-owned, cursor-based session subscription that crosses turn boundaries and reattaches after transport loss while feeding events through the normal reducer and `onEvent` path. #2116 introduces that single-follower ownership model for queueing and steering, but bounded reconnect exhaustion and refresh recovery still need the general subscription contract. Once that exists, this authorization-specific follow should be removed.

Scope boundaries: this mitigation does not automatically reattach a page loaded from a saved cursor, does not enable concurrent frontend sends while authorization is pending, and inherits the caller's bounded `session.stream()` reconnect policy.

### Validation

The full `eve` package unit suite passes with 640 test files and 6,750 passing tests (1 skipped). The regression test covers the requesting boundary, a later callback turn, delivery of `authorization.completed` and resumed output, the pending store `send()` promise, and rejection of a concurrent send. Workspace typecheck passes all 37 tasks; docs checks and invariant guards pass. Lint exits successfully with three pre-existing unused-variable warnings in OAuth HITL eval fixtures.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+10 / -3`

Explains why authorization callbacks now occupy a later turn, documents the serialized mitigation and its recovery boundary, and adds patch release notes.

**Implementation** — 1 file · `+47 / -8`

Counts pending authorizations while consuming the submitted turn, then follows the same session until they settle at a later boundary. It reuses the existing store lifecycle and session cursor instead of adding a background observer or handoff state machine.

**Tests** — 1 file · `+63 / -0`

Covers the two-turn callback sequence, store-send lifetime, cursor advancement, resumed output, and the intentional concurrent-send restriction.

**Total** — 4 files · `+120 / -11`
