### PR TITLE
fix(eve): unify project discovery behavior across CLI

### DIFF
--- a/.changeset/warm-roots-discover.md
+++ b/.changeset/warm-roots-discover.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Use canonical project discovery for project-scoped CLI commands, including instructions-only agents and commands invoked from descendant directories.

--- a/packages/eve/src/cli/application-command.ts
+++ b/packages/eve/src/cli/application-command.ts
@@ -1,7 +1,9 @@
 import type { Command } from "#compiled/commander/index.js";
+import type { ResolvedDiscoveryProject } from "#discover/project.js";
 
 export interface CliApplicationContext {
   root: string;
+  project?: ResolvedDiscoveryProject;
   resolve(): Promise<void>;
 }
 

--- a/packages/eve/src/cli/application-root.test.ts
+++ b/packages/eve/src/cli/application-root.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   findCliApplicationRoot,
+  resolveCliApplicationProject,
   resolveCliApplicationRoot,
   type ResolveCliApplicationRootDependencies,
 } from "#cli/application-root.js";
@@ -30,6 +31,17 @@ function dependencies(
 }
 
 describe("resolveCliApplicationRoot", () => {
+  it("returns the complete project resolved by discovery", async () => {
+    const project = {
+      agentRoot: "/repo/agent",
+      appRoot: "/repo",
+      layout: "nested" as const,
+    };
+    const deps = dependencies(async () => project);
+
+    await expect(resolveCliApplicationProject("/repo/agent/tools", deps)).resolves.toEqual(project);
+  });
+
   it("uses the application root resolved by project discovery", async () => {
     const deps = dependencies(async () => ({
       agentRoot: "/repo/agent",

--- a/packages/eve/src/cli/application-root.ts
+++ b/packages/eve/src/cli/application-root.ts
@@ -1,6 +1,10 @@
 import { resolve } from "node:path";
 
-import { DiscoveryProjectResolutionError, resolveDiscoveryProject } from "#discover/project.js";
+import {
+  DiscoveryProjectResolutionError,
+  resolveDiscoveryProject,
+  type ResolvedDiscoveryProject,
+} from "#discover/project.js";
 
 export interface ResolveCliApplicationRootDependencies {
   readonly resolveDiscoveryProject: typeof resolveDiscoveryProject;
@@ -9,6 +13,14 @@ export interface ResolveCliApplicationRootDependencies {
 const defaultDependencies: ResolveCliApplicationRootDependencies = {
   resolveDiscoveryProject,
 };
+
+/** Resolves the nearest enclosing eve application and agent roots. */
+export async function resolveCliApplicationProject(
+  cwd: string = process.cwd(),
+  dependencies: ResolveCliApplicationRootDependencies = defaultDependencies,
+): Promise<ResolvedDiscoveryProject> {
+  return dependencies.resolveDiscoveryProject(cwd);
+}
 
 /** Finds the nearest enclosing eve application. */
 export async function findCliApplicationRoot(

--- a/packages/eve/src/cli/commands/channels.ts
+++ b/packages/eve/src/cli/commands/channels.ts
@@ -1,6 +1,5 @@
-import { isEveProject, listAuthoredChannels } from "#setup/scaffold/index.js";
-
-import { NOT_AN_AGENT_MESSAGE } from "./preconditions.js";
+import type { ResolvedDiscoveryProject } from "#discover/project.js";
+import { listAuthoredChannels } from "#setup/scaffold/index.js";
 
 export interface CliLogger {
   error(message: string): void;
@@ -13,16 +12,10 @@ export interface ListChannelsCommandOptions {
 
 export async function runChannelsListCommand(
   logger: CliLogger,
-  appRoot: string,
+  project: ResolvedDiscoveryProject,
   options: ListChannelsCommandOptions,
 ): Promise<void> {
-  if (!(await isEveProject(appRoot))) {
-    logger.error(NOT_AN_AGENT_MESSAGE);
-    process.exitCode = 1;
-    return;
-  }
-
-  const channels = await listAuthoredChannels(appRoot);
+  const channels = await listAuthoredChannels(project.agentRoot);
 
   if (options.json) {
     logger.log(JSON.stringify({ channels }, null, 2));

--- a/packages/eve/src/cli/commands/deploy.integration.test.ts
+++ b/packages/eve/src/cli/commands/deploy.integration.test.ts
@@ -7,7 +7,6 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { createFakePrompter } from "#internal/testing/fake-prompter.js";
 import type { DeployProjectDeps } from "#setup/boxes/deploy-project.js";
 import type { DeploymentInfo } from "#setup/project-resolution.js";
-import { isEveProject } from "#setup/scaffold/index.js";
 
 import { runDeployCommand, type DeployCliLogger } from "./deploy.js";
 
@@ -63,21 +62,6 @@ afterEach(() => {
 });
 
 describe("runDeployCommand", () => {
-  test("refuses a directory without an eve agent", async () => {
-    const projectRoot = await mkdtemp(join(tmpdir(), "eve-deploy-empty-"));
-    const logger = new TestLogger();
-
-    await runDeployCommand(logger, projectRoot, {
-      isEveProject,
-      hasInteractiveTerminal: () => true,
-    });
-
-    expect(logger.errors).toEqual([
-      "No eve agent in this directory. Run `eve init <name>`, then run this command from inside the new project.",
-    ]);
-    expect(process.exitCode).toBe(1);
-  });
-
   test("points an unlinked non-interactive run at eve link", async () => {
     const projectRoot = await createAgentProject();
     const logger = new TestLogger();
@@ -86,7 +70,6 @@ describe("runDeployCommand", () => {
 
     await runDeployCommand(logger, projectRoot, {
       createPrompter: () => fake.prompter,
-      isEveProject,
       hasInteractiveTerminal: () => false,
       flowDeps: {
         detectDeployment: vi.fn(async () => ({ state: "unlinked" }) as DeploymentInfo),
@@ -107,7 +90,6 @@ describe("runDeployCommand", () => {
 
     await runDeployCommand(logger, projectRoot, {
       createPrompter: () => fake.prompter,
-      isEveProject,
       hasInteractiveTerminal: () => false,
       flowDeps: {
         detectDeployment: vi.fn(async () => LINKED),

--- a/packages/eve/src/cli/commands/deploy.ts
+++ b/packages/eve/src/cli/commands/deploy.ts
@@ -1,9 +1,7 @@
-import { isEveProject } from "#setup/scaffold/index.js";
-
 import { runDeployFlow, type DeployFlowDeps } from "#setup/flows/deploy.js";
 import { createPrompter, type Prompter } from "#setup/prompter.js";
 
-import { hasInteractiveTerminal, NOT_AN_AGENT_MESSAGE } from "./preconditions.js";
+import { hasInteractiveTerminal } from "./preconditions.js";
 
 export interface DeployCliLogger {
   error(message: string): void;
@@ -12,14 +10,12 @@ export interface DeployCliLogger {
 
 export interface DeployCommandDependencies {
   createPrompter?: () => Prompter;
-  isEveProject(projectPath: string): Promise<boolean>;
   hasInteractiveTerminal(): boolean;
   /** Test seam into the flow's detection and box effects. */
   flowDeps?: Partial<DeployFlowDeps>;
 }
 
 const defaultDependencies: DeployCommandDependencies = {
-  isEveProject,
   hasInteractiveTerminal,
 };
 
@@ -35,12 +31,6 @@ export async function runDeployCommand(
   appRoot: string,
   dependencies: DeployCommandDependencies = defaultDependencies,
 ): Promise<void> {
-  if (!(await dependencies.isEveProject(appRoot))) {
-    logger.error(NOT_AN_AGENT_MESSAGE);
-    process.exitCode = 1;
-    return;
-  }
-
   const prompter = dependencies.createPrompter?.() ?? createPrompter();
   prompter.intro("Deploy your eve agent to Vercel");
   try {

--- a/packages/eve/src/cli/commands/integration-connect.ts
+++ b/packages/eve/src/cli/commands/integration-connect.ts
@@ -15,11 +15,9 @@ import { resolveIntegrationVercelProject } from "#setup/integrations/shared/verc
 import { readProjectLink } from "#setup/project-resolution.js";
 import { createPrompter, type Prompter } from "#setup/prompter.js";
 import { createRegistrySetupClient } from "#setup/registry-setup-client.js";
-import { isEveProject } from "#setup/scaffold/index.js";
 import { updateConnectionConnectorUid } from "#setup/scaffold/update/update-connection-connector.js";
 import { WizardCancelledError } from "#setup/step.js";
 
-import { NOT_AN_AGENT_MESSAGE } from "./preconditions.js";
 import type { RegistryCommandLogger } from "./registry.js";
 import { serializeHeadlessSetupEvent } from "./setup-headless.js";
 
@@ -126,11 +124,6 @@ export async function runIntegrationConnectCommand(
   options: IntegrationConnectOptions = {},
   dependencies: IntegrationConnectDependencies = defaultDependencies,
 ): Promise<void> {
-  if (!(await isEveProject(appRoot))) {
-    logger.error(NOT_AN_AGENT_MESSAGE);
-    process.exitCode = 1;
-    return;
-  }
   const client = createRegistrySetupClient({ signal: options.signal });
   try {
     await runIntegrationConnect({

--- a/packages/eve/src/cli/commands/integration-setup.ts
+++ b/packages/eve/src/cli/commands/integration-setup.ts
@@ -15,10 +15,8 @@ import {
   runIntegrationSetup,
   type IntegrationSetupRunnerDeps,
 } from "#setup/integrations/runner.js";
-import { isEveProject } from "#setup/scaffold/index.js";
 import { setupQuestionToWire } from "#setup/setup-question-wire.js";
 
-import { NOT_AN_AGENT_MESSAGE } from "./preconditions.js";
 import type { RegistryCommandLogger } from "./registry.js";
 import { serializeHeadlessSetupEvent } from "./setup-headless.js";
 
@@ -45,12 +43,6 @@ export async function runIntegrationSetupCommand(
   options: IntegrationSetupOptions = {},
   dependencies: IntegrationSetupDependencies = defaultIntegrationSetupDependencies,
 ): Promise<void> {
-  if (!(await isEveProject(appRoot))) {
-    logger.error(NOT_AN_AGENT_MESSAGE);
-    process.exitCode = 1;
-    return;
-  }
-
   const client = createRegistrySetupClient({
     process: dependencies.setupProcess,
     signal: options.signal,

--- a/packages/eve/src/cli/commands/link.integration.test.ts
+++ b/packages/eve/src/cli/commands/link.integration.test.ts
@@ -9,7 +9,6 @@ import type { ApplyAiGatewayCredentialDeps } from "#setup/boxes/apply-ai-gateway
 import type { LinkProjectDeps } from "#setup/boxes/link-project.js";
 import type { ResolveProvisioningDeps } from "#setup/boxes/resolve-provisioning.js";
 import type { LinkFlowDeps } from "#setup/flows/link.js";
-import { isEveProject } from "#setup/scaffold/index.js";
 
 import { runLinkCommand, type LinkCliLogger } from "./link.js";
 
@@ -108,27 +107,11 @@ afterEach(() => {
 });
 
 describe("runLinkCommand", () => {
-  test("refuses a directory without an eve agent", async () => {
-    const projectRoot = await mkdtemp(join(tmpdir(), "eve-link-empty-"));
-    const logger = new TestLogger();
-
-    await runLinkCommand(logger, projectRoot, {
-      isEveProject,
-      hasInteractiveTerminal: () => true,
-    });
-
-    expect(logger.errors).toEqual([
-      "No eve agent in this directory. Run `eve init <name>`, then run this command from inside the new project.",
-    ]);
-    expect(process.exitCode).toBe(1);
-  });
-
   test("refuses without an interactive terminal", async () => {
     const projectRoot = await createAgentProject();
     const logger = new TestLogger();
 
     await runLinkCommand(logger, projectRoot, {
-      isEveProject,
       hasInteractiveTerminal: () => false,
     });
 
@@ -149,7 +132,6 @@ describe("runLinkCommand", () => {
 
     await runLinkCommand(logger, projectRoot, {
       createPrompter: () => fake.prompter,
-      isEveProject,
       hasInteractiveTerminal: () => true,
       flowDeps,
     });

--- a/packages/eve/src/cli/commands/link.ts
+++ b/packages/eve/src/cli/commands/link.ts
@@ -1,9 +1,7 @@
-import { isEveProject } from "#setup/scaffold/index.js";
-
 import { runLinkFlow, type LinkFlowDeps } from "#setup/flows/link.js";
 import { createPrompter, type Prompter } from "#setup/prompter.js";
 
-import { hasInteractiveTerminal, NOT_AN_AGENT_MESSAGE } from "./preconditions.js";
+import { hasInteractiveTerminal } from "./preconditions.js";
 
 export interface LinkCliLogger {
   error(message: string): void;
@@ -12,14 +10,12 @@ export interface LinkCliLogger {
 
 export interface LinkCommandDependencies {
   createPrompter?: () => Prompter;
-  isEveProject(projectPath: string): Promise<boolean>;
   hasInteractiveTerminal(): boolean;
   /** Test seam into the flow's detection and box effects. */
   flowDeps?: Partial<LinkFlowDeps>;
 }
 
 const defaultDependencies: LinkCommandDependencies = {
-  isEveProject,
   hasInteractiveTerminal,
 };
 
@@ -36,11 +32,6 @@ export async function runLinkCommand(
   appRoot: string,
   dependencies: LinkCommandDependencies = defaultDependencies,
 ): Promise<void> {
-  if (!(await dependencies.isEveProject(appRoot))) {
-    logger.error(NOT_AN_AGENT_MESSAGE);
-    process.exitCode = 1;
-    return;
-  }
   if (!dependencies.hasInteractiveTerminal()) {
     logger.error(
       "`eve link` needs an interactive terminal to pick the team and project. In CI, run `vercel link --project <name> --yes --non-interactive` instead.",

--- a/packages/eve/src/cli/commands/registry-recovery.ts
+++ b/packages/eve/src/cli/commands/registry-recovery.ts
@@ -1,7 +1,4 @@
-import { isEveProject } from "#setup/scaffold/index.js";
 import { WizardCancelledError } from "#setup/step.js";
-
-import { NOT_AN_AGENT_MESSAGE } from "./preconditions.js";
 
 export interface RegistryCommandLogger {
   error(message: string): void;
@@ -22,15 +19,9 @@ function isRegistryNotFoundError(error: unknown): boolean {
 
 export async function runRegistryAction<T>(
   logger: RegistryCommandLogger,
-  appRoot: string,
+  _appRoot: string,
   action: () => Promise<T>,
 ): Promise<T | undefined> {
-  if (!(await isEveProject(appRoot))) {
-    logger.error(NOT_AN_AGENT_MESSAGE);
-    process.exitCode = 1;
-    return undefined;
-  }
-
   try {
     return await action();
   } catch (error) {

--- a/packages/eve/src/cli/commands/set.test.ts
+++ b/packages/eve/src/cli/commands/set.test.ts
@@ -25,7 +25,6 @@ function dependencies(overrides: Partial<SetCommandDependencies> = {}): SetComma
         reasoning: "high",
       }),
     ),
-    isEveProject: vi.fn(async () => true),
     ...overrides,
   };
 }

--- a/packages/eve/src/cli/commands/set.ts
+++ b/packages/eve/src/cli/commands/set.ts
@@ -1,4 +1,3 @@
-import { isEveProject } from "#setup/scaffold/index.js";
 import {
   changeAgentModelSettings,
   formatApplyModelSettingsOutcome,
@@ -6,8 +5,6 @@ import {
 } from "#setup/flows/model-source-change.js";
 import type { AgentReasoningDefinition } from "#shared/agent-definition.js";
 import type { AgentModelSettingsPatch } from "#source-change/apply-agent-model-settings.js";
-
-import { NOT_AN_AGENT_MESSAGE } from "./preconditions.js";
 
 export interface SetCommandLogger {
   error(message: string): void;
@@ -24,12 +21,10 @@ export interface SetCommandDependencies {
     appRoot: string;
     patch: AgentModelSettingsPatch;
   }) => Promise<ApplyModelSettingsOutcome>;
-  isEveProject: typeof isEveProject;
 }
 
 const defaultDependencies: SetCommandDependencies = {
   changeAgentModelSettings,
-  isEveProject,
 };
 
 function fail(logger: SetCommandLogger, message: string): void {
@@ -45,11 +40,6 @@ export async function runSetCommand(
 ): Promise<void> {
   if (options.model === undefined && options.reasoning === undefined) {
     fail(logger, "Pass --model, --reasoning, or both.");
-    return;
-  }
-
-  if (!(await dependencies.isEveProject(appRoot))) {
-    fail(logger, NOT_AN_AGENT_MESSAGE);
     return;
   }
 

--- a/packages/eve/src/cli/run.test.ts
+++ b/packages/eve/src/cli/run.test.ts
@@ -7,13 +7,18 @@ import { MockScreen } from "#cli/dev/tui/test/mock-terminal.js";
 import type { RunDevelopmentTuiInput } from "#cli/dev/tui/tui.js";
 import type { DevelopmentServerOptions } from "#internal/nitro/host/types.js";
 
+function resolvedProject(appRoot: string) {
+  return { agentRoot: `${appRoot}/agent`, appRoot, layout: "nested" as const };
+}
+
 const { runInitCommand, runSetCommand } = vi.hoisted(() => ({
   runInitCommand: vi.fn(async () => {}),
   runSetCommand: vi.fn(async () => {}),
 }));
 
 vi.mock("#cli/application-root.js", () => ({
-  resolveCliApplicationRoot: vi.fn(async (cwd: string) => cwd),
+  findCliApplicationRoot: vi.fn(async () => undefined),
+  resolveCliApplicationProject: vi.fn(async (cwd: string) => resolvedProject(cwd)),
 }));
 vi.mock("#cli/commands/init.js", () => ({ runInitCommand }));
 vi.mock("#cli/commands/set.js", () => ({ runSetCommand }));
@@ -82,14 +87,14 @@ describe("CLI command registration", () => {
 
   it("runs project commands with the resolved application root", async () => {
     const logger = { error: vi.fn(), log: vi.fn() };
-    const resolveRoot = vi.fn(async () => "/workspace/weather");
+    const resolveProject = vi.fn(async () => resolvedProject("/workspace/weather"));
     runSetCommand.mockClear();
 
     await runCli(["set", "--model", "openai/gpt-5.6-sol"], logger, {
-      resolveApplicationRoot: resolveRoot,
+      resolveApplicationProject: resolveProject,
     });
 
-    expect(resolveRoot).toHaveBeenCalledWith(resolve(process.cwd()));
+    expect(resolveProject).toHaveBeenCalledWith(resolve(process.cwd()));
     expect(runSetCommand).toHaveBeenCalledWith(logger, "/workspace/weather", {
       model: "openai/gpt-5.6-sol",
       reasoning: undefined,
@@ -97,17 +102,17 @@ describe("CLI command registration", () => {
   });
 
   it("does not resolve an application root for command help", async () => {
-    const resolveRoot = vi.fn(async () => "/workspace/weather");
+    const resolveProject = vi.fn(async () => resolvedProject("/workspace/weather"));
 
     await runCli(
       ["set", "--help"],
       { error: vi.fn(), log: vi.fn() },
       {
-        resolveApplicationRoot: resolveRoot,
+        resolveApplicationProject: resolveProject,
       },
     );
 
-    expect(resolveRoot).not.toHaveBeenCalled();
+    expect(resolveProject).not.toHaveBeenCalled();
   });
 
   it("lists model and reasoning options for the set command", async () => {
@@ -493,16 +498,16 @@ describe("eve invoke", () => {
 
   it("prints the JSON schema without resolving or invoking an agent", async () => {
     const runInvoke = vi.fn();
-    const resolveRoot = vi.fn(async () => "/workspace/weather");
+    const resolveProject = vi.fn(async () => resolvedProject("/workspace/weather"));
     const output: string[] = [];
 
     await runCli(
       ["invoke", "--json-schema"],
       { error: () => {}, log: (message) => output.push(message) },
-      { resolveApplicationRoot: resolveRoot, runInvoke },
+      { resolveApplicationProject: resolveProject, runInvoke },
     );
 
-    expect(resolveRoot).not.toHaveBeenCalled();
+    expect(resolveProject).not.toHaveBeenCalled();
     expect(runInvoke).not.toHaveBeenCalled();
     expect(JSON.parse(output[0]!)).toMatchObject({ title: "eve invoke result" });
   });
@@ -519,13 +524,13 @@ describe("eve invoke", () => {
 
 describe("eve dev --url protocol", () => {
   it("does not resolve a local application for a remote URL", async () => {
-    const resolveRoot = vi.fn(async () => "/workspace/weather");
+    const resolveProject = vi.fn(async () => resolvedProject("/workspace/weather"));
 
     await runInteractiveDev(["dev", "https://example.com"], {
-      resolveApplicationRoot: resolveRoot,
+      resolveApplicationProject: resolveProject,
     });
 
-    expect(resolveRoot).not.toHaveBeenCalled();
+    expect(resolveProject).not.toHaveBeenCalled();
   });
 
   it("preserves query parameters on the remote target URL", async () => {

--- a/packages/eve/src/cli/run.ts
+++ b/packages/eve/src/cli/run.ts
@@ -640,9 +640,7 @@ function createCliProgram(
   return program;
 }
 
-/**
- * Runs the eve CLI entrypoint.
- */
+/** Runs the eve CLI entrypoint. */
 export async function runCli(
   argv: string[] = process.argv.slice(2),
   logger: CliLogger = console,

--- a/packages/eve/src/cli/run.ts
+++ b/packages/eve/src/cli/run.ts
@@ -5,7 +5,7 @@ import { resolveApplicationRoot } from "#internal/application/paths.js";
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
 import { isCodingAgentLaunch } from "#cli/agent-detection.js";
 import { applicationCommand, type CliApplicationContext } from "#cli/application-command.js";
-import { findCliApplicationRoot, resolveCliApplicationRoot } from "#cli/application-root.js";
+import { findCliApplicationRoot, resolveCliApplicationProject } from "#cli/application-root.js";
 import { eveCliBanner } from "#cli/banner.js";
 import { registerIntegrationCommands } from "#cli/commands/register-integration-commands.js";
 import { registerProjectCommands } from "#cli/commands/register-project-commands.js";
@@ -86,7 +86,7 @@ interface CliRuntimeDependencies {
     appRoot: string,
   ): Promise<void>;
   startHost(appRoot: string, options?: DevelopmentServerOptions): DevelopmentServer;
-  resolveApplicationRoot(cwd: string): Promise<string>;
+  resolveApplicationProject: typeof resolveCliApplicationProject;
   startProductionHost(
     appRoot: string,
     options?: {
@@ -190,7 +190,7 @@ function createCliProgram(
     .option("--json", "Output as JSON")
     .action(async (options: { json?: boolean }) => {
       const { runChannelsListCommand } = await import("#cli/commands/channels.js");
-      await runChannelsListCommand(logger, applicationContext.root, options);
+      await runChannelsListCommand(logger, applicationContext.project!, options);
     });
 
   registerIntegrationCommands({ program, logger, applicationContext });
@@ -651,9 +651,11 @@ export async function runCli(
   const applicationContext: CliApplicationContext = {
     root: resolveApplicationRoot(),
     async resolve() {
-      applicationContext.root = await (runtime.resolveApplicationRoot ?? resolveCliApplicationRoot)(
+      const project = await (runtime.resolveApplicationProject ?? resolveCliApplicationProject)(
         applicationContext.root,
       );
+      applicationContext.project = project;
+      applicationContext.root = project.appRoot;
     },
   };
   const program = createCliProgram(logger, runtime, applicationContext);

--- a/packages/eve/src/setup/scaffold/index.integration.test.ts
+++ b/packages/eve/src/setup/scaffold/index.integration.test.ts
@@ -871,7 +871,10 @@ describe("listAuthoredChannels", () => {
     await writeFile(join(projectRoot, "agent/channels/slack/connection.ts"), "", "utf8");
     await writeFile(join(projectRoot, "agent/channels/email.mts"), "", "utf8");
 
-    await expect(listAuthoredChannels(projectRoot)).resolves.toEqual(["email", "slack"]);
+    await expect(listAuthoredChannels(join(projectRoot, "agent"))).resolves.toEqual([
+      "email",
+      "slack",
+    ]);
   });
 });
 

--- a/packages/eve/src/setup/scaffold/update/channels.ts
+++ b/packages/eve/src/setup/scaffold/update/channels.ts
@@ -37,7 +37,6 @@ const NEXT_TYPESCRIPT_PACKAGE_VERSION = "6.0.3";
 const CONNECT_PACKAGE_NAME = "@vercel/connect";
 const NEXT_PACKAGE_NAME = "next";
 const PACKAGE_DEPENDENCY_FIELDS = ["dependencies", "devDependencies"] as const;
-const USER_AUTHORED_CHANNEL_DIR = "agent/channels";
 const WEB_CHANNEL_PATH = "agent/channels/eve.ts";
 const WEB_NEXT_CONFIG_PATH = "next.config.ts";
 const WEB_VERCEL_JSON_PATH = "vercel.json";
@@ -655,8 +654,8 @@ async function ensureSlackChannel(
   return result;
 }
 
-export async function listAuthoredChannels(projectRoot: string): Promise<string[]> {
-  const channelsDir = join(projectRoot, USER_AUTHORED_CHANNEL_DIR);
+export async function listAuthoredChannels(agentRoot: string): Promise<string[]> {
+  const channelsDir = join(agentRoot, "channels");
   let entries;
   try {
     entries = await readdir(channelsDir, { withFileTypes: true });

--- a/packages/eve/test/scenarios/cli.scenario.test.ts
+++ b/packages/eve/test/scenarios/cli.scenario.test.ts
@@ -346,7 +346,7 @@ describe("runCli", () => {
   });
 
   it("passes host and port to the production start host", async () => {
-    const workspaceRoot = await createScratchDirectory("eve-cli-start-options-");
+    const workspaceRoot = await createMinimalAppRoot("eve-cli-start-options-");
     const resolvedWorkspaceRoot = await realpath(workspaceRoot);
     const previousCwd = process.cwd();
     const logger = {
@@ -376,7 +376,7 @@ describe("runCli", () => {
   });
 
   it("fails clearly when start runs before build output exists", async () => {
-    const workspaceRoot = await createScratchDirectory("eve-cli-start-missing-output-");
+    const workspaceRoot = await createMinimalAppRoot("eve-cli-start-missing-output-");
     const resolvedWorkspaceRoot = await realpath(workspaceRoot);
     const previousCwd = process.cwd();
     const logger = {
@@ -480,7 +480,7 @@ describe("runCli", () => {
   });
 
   it("loads development env files before running build", async () => {
-    const workspaceRoot = await createScratchDirectory("eve-cli-build-env-");
+    const workspaceRoot = await createMinimalAppRoot("eve-cli-build-env-");
     const resolvedWorkspaceRoot = await realpath(workspaceRoot);
     const previousCwd = process.cwd();
     const logger = {
@@ -542,7 +542,7 @@ describe("runCli", () => {
   });
 
   it("forwards the sandbox prewarm opt-out to the build host", async () => {
-    const workspaceRoot = await createScratchDirectory("eve-cli-build-skip-prewarm-");
+    const workspaceRoot = await createMinimalAppRoot("eve-cli-build-skip-prewarm-");
     const resolvedWorkspaceRoot = await realpath(workspaceRoot);
     const previousCwd = process.cwd();
     const logger = {

--- a/packages/eve/test/scenarios/eval-command-environment.scenario.test.ts
+++ b/packages/eve/test/scenarios/eval-command-environment.scenario.test.ts
@@ -1,4 +1,4 @@
-import { readFile, realpath, writeFile } from "node:fs/promises";
+import { mkdir, readFile, realpath, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -50,6 +50,17 @@ const DEVELOPMENT_ENV_KEYS = [
 
 async function createEnvironmentFixture(): Promise<string> {
   const fixtureRoot = await createScratchDirectory("eve-eval-env-");
+
+  await mkdir(join(fixtureRoot, "agent"), { recursive: true });
+  await writeFile(
+    join(fixtureRoot, "package.json"),
+    `${JSON.stringify({ name: "eve-eval-env-test", private: true, type: "module" })}\n`,
+  );
+  await writeFile(
+    join(fixtureRoot, "agent", "agent.mjs"),
+    'export default { model: "openai/gpt-5.4" };\n',
+  );
+  await writeFile(join(fixtureRoot, "agent", "instructions.md"), "You are a precise assistant.\n");
 
   await writeFile(
     join(fixtureRoot, ".env"),


### PR DESCRIPTION
### Summary

Project-scoped commands still rechecked the resolved application with the scaffold-specific `isEveProject()`, so instructions-only agents could be discovered successfully and then rejected. This change makes canonical discovery the sole command precondition, retains the complete app/agent root result, and passes the appropriate resolved root downstream. It is the first PR in the onboarding reliability stack.

### User experience

Before, an instructions-only agent could be discovered by `eve dev` but rejected by setup commands:

```console
$ cd weather/agent/tools
$ eve deploy
No eve agent in this directory. Run `eve init <name>`...
```

After, project-scoped commands use the same enclosing app and agent roots:

```console
$ cd weather/agent/tools
$ eve deploy
Deploy your eve agent to Vercel
```

### Validation

Focused CLI unit coverage passes (76 tests), including complete discovery results and command root propagation. Package typechecking, formatting, linting, and invariant checks pass. The focused link/deploy integration run is currently blocked before test collection by an unrelated missing `#internal/workflow-bundle/workflow-builders.js` import on `main`.

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

The changeset records the user-visible discovery correction.

**Implementation** — 11 files · `+30 / -75`

The command context now retains canonical discovery output, while redundant scaffold checks are removed from project-scoped commands.

**Tests** — 6 files · `+34 / -51`

Coverage verifies complete project resolution and root propagation; obsolete command-local rejection tests are removed because discovery owns that precondition.


