### PR TITLE
chore(eve): memory - cover file-provider recall

### DIFF
--- a/e2e/fixtures/agent-memory/.gitignore
+++ b/e2e/fixtures/agent-memory/.gitignore
@@ -1,0 +1,10 @@
+node_modules
+.env*
+.eve
+.vercel
+.next
+.output
+.nitro
+dist
+.DS_Store
+*.tsbuildinfo

--- a/e2e/fixtures/agent-memory/.vercelignore
+++ b/e2e/fixtures/agent-memory/.vercelignore
@@ -1,0 +1,6 @@
+node_modules
+.eve
+.next
+.output
+.nitro
+dist

--- a/e2e/fixtures/agent-memory/agent/agent.ts
+++ b/e2e/fixtures/agent-memory/agent/agent.ts
@@ -15,9 +15,12 @@ function respond(request: MockModelRequest): MockModelResponse | string {
   }
 
   if (/verification phrase/iu.test(prompt)) {
-    return request.userMessages.some((message) => message.includes(MEMORY_FACT))
+    const recalls = request.userMessages.filter((message) => message.includes(MEMORY_FACT));
+    return recalls.length === 1
       ? MEMORY_PHRASE
-      : "MEMORY-NOT-FOUND";
+      : recalls.length === 0
+        ? "MEMORY-NOT-FOUND"
+        : "MEMORY-DUPLICATED";
   }
 
   return `Mock reply: ${prompt}`;

--- a/e2e/fixtures/agent-memory/agent/agent.ts
+++ b/e2e/fixtures/agent-memory/agent/agent.ts
@@ -1,0 +1,29 @@
+import { e2eAgentConfig } from "@eve-e2e/config";
+import { defineAgent } from "eve";
+import type { MockModelRequest, MockModelResponse } from "eve/evals";
+
+import { MEMORY_FACT, MEMORY_PHRASE, SAVE_CONFIRMATION } from "./constants.js";
+
+function respond(request: MockModelRequest): MockModelResponse | string {
+  const prompt = request.lastUserMessage ?? "";
+
+  if (prompt.includes("user__save_memory") && prompt.includes(MEMORY_FACT)) {
+    const saved = request.toolResults.some((result) => result.name === "user__save_memory");
+    return saved
+      ? SAVE_CONFIRMATION
+      : { toolCalls: [{ input: { text: MEMORY_FACT }, name: "user__save_memory" }] };
+  }
+
+  if (/verification phrase/iu.test(prompt)) {
+    return request.userMessages.some((message) => message.includes(MEMORY_FACT))
+      ? MEMORY_PHRASE
+      : "MEMORY-NOT-FOUND";
+  }
+
+  return `Mock reply: ${prompt}`;
+}
+
+export default defineAgent({
+  ...e2eAgentConfig({ mock: respond }),
+  reasoning: "high",
+});

--- a/e2e/fixtures/agent-memory/agent/constants.ts
+++ b/e2e/fixtures/agent-memory/agent/constants.ts
@@ -1,0 +1,3 @@
+export const MEMORY_FACT = "The verification phrase is MEMORY-E2E-MARIGOLD-7F2Q.";
+export const MEMORY_PHRASE = "MEMORY-E2E-MARIGOLD-7F2Q";
+export const SAVE_CONFIRMATION = "MEMORY-SAVED";

--- a/e2e/fixtures/agent-memory/agent/instructions.md
+++ b/e2e/fixtures/agent-memory/agent/instructions.md
@@ -1,0 +1,5 @@
+# Identity
+
+You are a test agent verifying persistent user memory. Follow requests to use
+memory tools exactly. When asked for a verification phrase, answer from the
+recalled memory context and return only the phrase.

--- a/e2e/fixtures/agent-memory/agent/memory/user.ts
+++ b/e2e/fixtures/agent-memory/agent/memory/user.ts
@@ -1,0 +1,14 @@
+import { defineMemory } from "eve/memory";
+import { fileMemory, inMemory } from "eve/memory/file";
+
+const provider = process.env.VERCEL
+  ? fileMemory()
+  : fileMemory({
+      backend: inMemory(),
+    });
+
+export default defineMemory({
+  provider,
+  scope: () =>
+    process.env.VERCEL_DEPLOYMENT_ID?.trim() || process.env.VERCEL_URL?.trim() || "local-e2e",
+});

--- a/e2e/fixtures/agent-memory/agent/memory/user.ts
+++ b/e2e/fixtures/agent-memory/agent/memory/user.ts
@@ -8,6 +8,7 @@ const provider = process.env.VERCEL
     });
 
 export default defineMemory({
+  description: "Personal facts and preferences for future conversations.",
   provider,
   scope: () =>
     process.env.VERCEL_DEPLOYMENT_ID?.trim() || process.env.VERCEL_URL?.trim() || "local-e2e",

--- a/e2e/fixtures/agent-memory/evals/evals.config.ts
+++ b/e2e/fixtures/agent-memory/evals/evals.config.ts
@@ -1,0 +1,6 @@
+import { e2eJudgeModel } from "@eve-e2e/config";
+import { defineEvalConfig } from "eve/evals";
+
+export default defineEvalConfig({
+  judge: { model: e2eJudgeModel() },
+});

--- a/e2e/fixtures/agent-memory/evals/file-memory.eval.ts
+++ b/e2e/fixtures/agent-memory/evals/file-memory.eval.ts
@@ -4,7 +4,7 @@ import { equals } from "eve/evals/expect";
 import { MEMORY_FACT, MEMORY_PHRASE, SAVE_CONFIRMATION } from "../agent/constants.js";
 
 export default defineEval({
-  description: "File memory persists a saved fact and recalls it in a new session.",
+  description: "File memory persists, recalls, and does not duplicate an unchanged document.",
 
   async test(t) {
     const saved = await t.send(
@@ -28,5 +28,13 @@ export default defineEval({
     recalled.usedNoTools();
     recalled.messageIncludes(MEMORY_PHRASE);
     await t.require(recalled.sessionId === saved.sessionId, equals(false));
+
+    const recalledAgain = await nextSession.send(
+      "What is the verification phrase in persistent memory? Reply with the phrase only. " +
+        "Do not call any tools.",
+    );
+    recalledAgain.expectOk();
+    recalledAgain.usedNoTools();
+    recalledAgain.messageIncludes(MEMORY_PHRASE);
   },
 });

--- a/e2e/fixtures/agent-memory/evals/file-memory.eval.ts
+++ b/e2e/fixtures/agent-memory/evals/file-memory.eval.ts
@@ -1,0 +1,32 @@
+import { defineEval } from "eve/evals";
+import { equals } from "eve/evals/expect";
+
+import { MEMORY_FACT, MEMORY_PHRASE, SAVE_CONFIRMATION } from "../agent/constants.js";
+
+export default defineEval({
+  description: "File memory persists a saved fact and recalls it in a new session.",
+
+  async test(t) {
+    const saved = await t.send(
+      `Call \`user__save_memory\` exactly once with this exact \`text\` argument: ` +
+        `"${MEMORY_FACT}" After the tool succeeds, reply with exactly ${SAVE_CONFIRMATION}.`,
+    );
+    saved.expectOk();
+    saved.calledTool("user__save_memory", {
+      count: 1,
+      input: { text: MEMORY_FACT },
+      status: "completed",
+    });
+    saved.messageIncludes(SAVE_CONFIRMATION);
+
+    const nextSession = t.newSession();
+    const recalled = await nextSession.send(
+      "What is the verification phrase in persistent memory? Reply with the phrase only. " +
+        "Do not call any tools.",
+    );
+    recalled.expectOk();
+    recalled.usedNoTools();
+    recalled.messageIncludes(MEMORY_PHRASE);
+    await t.require(recalled.sessionId === saved.sessionId, equals(false));
+  },
+});

--- a/e2e/fixtures/agent-memory/package.json
+++ b/e2e/fixtures/agent-memory/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "agent-memory",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "eve build",
+    "dev": "eve dev",
+    "start": "eve start",
+    "typecheck": "eve build && tsc",
+    "test:e2e": "eve eval --strict"
+  },
+  "dependencies": {
+    "@eve-e2e/config": "workspace:*",
+    "@workflow/world-postgres": "catalog:",
+    "eve": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  },
+  "e2e": {
+    "modelMatrix": "full"
+  }
+}

--- a/e2e/fixtures/agent-memory/tsconfig.json
+++ b/e2e/fixtures/agent-memory/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["agent/**/*.ts", "evals/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -682,6 +682,25 @@ importers:
         specifier: 'catalog:'
         version: 7.0.2
 
+  e2e/fixtures/agent-memory:
+    dependencies:
+      '@eve-e2e/config':
+        specifier: workspace:*
+        version: link:../e2e-config
+      '@workflow/world-postgres':
+        specifier: 'catalog:'
+        version: 5.0.0-beta.34(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(sql.js@1.14.1)(supports-color@10.2.2)(typescript@7.0.2)
+      eve:
+        specifier: workspace:*
+        version: link:../../../packages/eve
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+
   e2e/fixtures/agent-model:
     dependencies:
       '@eve-e2e/config':


### PR DESCRIPTION
### Summary

Related to #1510 and stacked on #2144. This adds fixture-owned end-to-end coverage for `fileMemory()`: a described personal-memory slot saves one exact fact through `user__save_memory`, and a distinct session receives it at turn start as user-role recalled context without a retrieval tool. A second turn in that session must still contain exactly one copy of the document, catching append-only implementations that duplicate unchanged recall. The same eval is registered for the live-model matrix and deterministic Postgres and Vercel worlds; the authored scope includes deployment identity so concurrent Preview deployments cannot share a memory document.

### Validation

The fixture's production build and TypeScript check pass locally. On the final pushed head, the eval passes with OpenAI, Anthropic, and ZAI models and in the deterministic Postgres and Vercel worlds, covering both cross-session persistence and unchanged-recall deduplication.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 1 file · `+19 / -0`

The workspace lockfile registers the new fixture package.

**Tests** — 10 files · `+159 / -0`

The self-contained fixture defines the agent, described scoped memory slot, deterministic behavior, persistence eval, duplicate-recall assertion, and deployment metadata needed for the E2E matrix.
