### PR TITLE
docs: cross-link orphaned pages from hub pages

### DIFF
--- a/.agents/skills/technical-writing/SKILL.md
+++ b/.agents/skills/technical-writing/SKILL.md
@@ -42,6 +42,7 @@ Use support evidence to identify the reader's problem, not to establish product 
 - Prefer TypeScript examples. Include imports and language labels, and verify examples against current exports.
 - Show only supported commands and flags. Check CLI help or the command implementation before documenting them.
 - Link to related pages with descriptive text. Include the critical fact locally because retrieved sections may be read without their links.
+- Leave no page orphaned. Every page needs at least one descriptive inbound body link from a related hub or overview page; a `meta.json` sidebar entry or a routing-table cell alone is not enough. When adding a page, add the inbound link from the page that owns the topic in the same change, and keep every page reachable by following body links from `getting-started`.
 - Do not document proposed behavior as shipped. Describe unsupported boundaries directly when they affect a user task.
 
 ## Write for the task
@@ -71,6 +72,7 @@ Use support evidence to identify the reader's problem, not to establish product 
 1. Re-read every changed page in full.
 2. Verify each new technical claim against its source.
 3. Search for contradictory statements and affected cross-links.
-4. Run the review workflow.
-5. Check changed prose against the prose-quality reference when wording changed materially.
-6. Run `pnpm docs:check` when preparing to push, unless the user requests earlier validation.
+4. Confirm added or moved pages have an inbound body link from a related page, so no page is orphaned.
+5. Run the review workflow.
+6. Check changed prose against the prose-quality reference when wording changed materially.
+7. Run `pnpm docs:check` when preparing to push, unless the user requests earlier validation.

--- a/docs/channels/custom.mdx
+++ b/docs/channels/custom.mdx
@@ -395,3 +395,4 @@ The framework handles staging bytes to the sandbox, enforcing upload policy, hyd
 - [Channels overview](./overview)
 - [Dynamic capabilities](../guides/dynamic-capabilities)
 - [Auth & route protection](../guides/auth-and-route-protection)
+- [Universal Commerce Protocol (UCP)](../protocols/ucp): serve a UCP profile from a custom channel

--- a/docs/channels/overview.mdx
+++ b/docs/channels/overview.mdx
@@ -85,12 +85,15 @@ eve's first-class channels use eve-owned runtimes for webhook handling, verifica
 
 As the deployer, it is your responsibility to ensure your agent complies with applicable laws.
 
-Where an eve agent communicates with people, you may be required to disclose that they are interacting with an automated AI system where law requires it. eve does not add this disclosure automatically; configure it in your instructions and/or channel responses.
+Where an eve agent communicates with people, you may be required to disclose that they are interacting with an automated AI system where law requires it. eve does not add this disclosure automatically; configure it in your instructions and/or channel responses. See [Responsible use](../responsible-use) for the full deployer responsibilities.
 
 ## What to read next
 
+- [eve HTTP channel](./eve): the default session API behind the TUI, SDK clients, and browser UIs
 - [Slack](./slack): the most common platform channel, end to end
 - [MCP](./mcp): expose the agent as a durable invocation service
+- [Photon](./photon), [Discord](./discord), [Teams](./teams), [Telegram](./telegram), [Twilio](./twilio), [GitHub](./github), and [Linear](./linear): the other first-class platform channels
+- [Chat SDK adapters](./chat-sdk): reach services eve has no first-class channel for
 - [Custom channels](./custom): build a channel for any surface with `defineChannel`
 - [Frontend](../guides/frontend/overview): browser chat on the eve channel with `useEveAgent`
 - [Integrations](/integrations): browse every built-in channel in one gallery using the Channels filter

--- a/docs/guides/auth-and-route-protection.md
+++ b/docs/guides/auth-and-route-protection.md
@@ -392,4 +392,5 @@ Inline providers derive a stable tool-qualified auth key from Vercel Connect met
 
 - [Security model](../concepts/security-model): trust boundaries and the pre-production checklist
 - [Connections](../connections): connection auth shapes (`connect()` vs static token)
+- [Multi-tenant outbound auth](../patterns/multi-tenant-auth): select tenant-scoped outbound credentials from the verified inbound identity
 - [Deployment](./deployment/overview): where route-auth secrets live in production

--- a/docs/guides/dev-tui.md
+++ b/docs/guides/dev-tui.md
@@ -86,3 +86,4 @@ For a Vercel deployment that needs authentication, run `/vc:login` and follow th
 
 - [Instrumentation](./instrumentation): traces, OpenTelemetry, and diagnostics.
 - [CLI](../reference/cli): commands and flags.
+- [Agent Client Protocol (ACP)](../protocols/acp): drive the same agent from ACP clients such as Zed instead of the TUI.

--- a/docs/instructions.mdx
+++ b/docs/instructions.mdx
@@ -97,3 +97,4 @@ Where an eve agent communicates with people, you may be required to disclose tha
 - [Tools](./tools): typed actions, the next capability to add
 - [Context control](./concepts/context-control): all the levers for what the model sees
 - [Skills](./skills): on-demand procedures, the counterpart to always-on instructions
+- [Multi-tenant memory](./patterns/multi-tenant-memory): dynamic instructions that load per-tenant memories each turn


### PR DESCRIPTION
### Summary

An audit of the published docs flagged a set of pages as orphaned (weakly cross-linked). Most flagged pages turned out to already have inbound links from hub pages, but a few were genuinely thin: `protocols/ucp` had no inbound links at all, `protocols/acp` and the two multi-tenant patterns were linked only from other flagged pages, the non-Slack platform channels were linked only from a routing table, and `responsible-use` had a single inbound link.

This PR adds descriptive cross-links from the owning hub pages and codifies the rule in the technical-writing skill so new pages ship with an inbound link: the channels overview now lists every first-class channel in "What to read next" and links responsible use from its disclaimer, custom channels link UCP, the dev TUI page links ACP, the auth guide links the multi-tenant outbound auth pattern, and the instructions page links the multi-tenant memory pattern. After this change every published docs page has at least one inbound link and all pages are reachable by following body links from `getting-started`.

No issue exists for this change; it came from an ad-hoc docs audit.

### Validation

Built the internal link graph for `docs/` with a script to confirm zero pages remain without inbound links and full reachability from `getting-started`, and verified each new link's claim against the target page. `pnpm docs:check` passes.

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package (docs-only; not applicable)
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 6 files · `+13 / -4`

One-line "What to read next" additions on five hub pages, the expanded channel list on the channels overview, and a technical-writing skill addendum requiring an inbound body link for every page.

**Implementation** — 0 files · `+0 / -0`

Not applicable.

**Tests** — 0 files · `+0 / -0`

Not applicable.

