### PR TITLE
fix(eve): surface model catalog request errors

### DIFF
--- a/.changeset/surface-model-catalog-errors.md
+++ b/.changeset/surface-model-catalog-errors.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Surface AI Gateway model catalog request failures during compilation instead of reporting affected models as missing context-window metadata.

--- a/packages/eve/src/compiler/model-catalog.test.ts
+++ b/packages/eve/src/compiler/model-catalog.test.ts
@@ -245,16 +245,31 @@ describe("createCompiledRuntimeModelCatalogLoader", () => {
 
   it("falls back to built-in limits when fetch fails", async () => {
     vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"));
-    const loader = createCompiledRuntimeModelCatalogLoader("/tmp/test-app");
+    const loader = createCompiledRuntimeModelCatalogLoader(
+      `/tmp/test-app-built-in-fetch-failure-${Date.now()}`,
+    );
     const limits = await loader.getModelLimits("openai/gpt-5.4");
     expect(limits).toEqual({ contextWindowTokens: 400_000, maxOutputTokens: 128_000 });
   });
 
-  it("returns null for unknown model when fetch fails", async () => {
-    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"));
-    const loader = createCompiledRuntimeModelCatalogLoader("/tmp/test-app");
-    const limits = await loader.getModelLimits("unknown/model");
-    expect(limits).toBeNull();
+  it("throws for an unknown model when the catalog fetch fails", async () => {
+    const error = new Error("offline");
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(error);
+    const loader = createCompiledRuntimeModelCatalogLoader(
+      `/tmp/test-app-fetch-failure-${Date.now()}`,
+    );
+
+    await expect(loader.getModelLimits("unknown/model")).rejects.toBe(error);
+  });
+
+  it("throws for an unknown provider model when the catalog fetch fails", async () => {
+    const error = new Error("offline");
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(error);
+    const loader = createCompiledRuntimeModelCatalogLoader(
+      `/tmp/test-app-provider-fetch-failure-${Date.now()}`,
+    );
+
+    await expect(loader.getByProviderModelId("unknown", "model")).rejects.toBe(error);
   });
 
   it("returns cache path under .eve/cache", () => {

--- a/packages/eve/src/compiler/model-catalog.ts
+++ b/packages/eve/src/compiler/model-catalog.ts
@@ -129,48 +129,46 @@ export function createCompiledRuntimeModelCatalogLoader(
   const resolveModelsFromCacheOrFetch = async (): Promise<{
     models: readonly CatalogModel[];
     providerAliases: Readonly<Record<string, string>>;
-  } | null> => {
+  }> => {
     const cachedCatalog = await getCachedCatalog();
 
     if (cachedCatalog !== null && isCacheFresh(cachedCatalog)) {
       return cachedCatalog;
     }
 
-    try {
-      return await getFetchedCatalog();
-    } catch {
-      if (cachedCatalog !== null) {
-        return cachedCatalog;
-      }
-      return null;
-    }
+    return await getFetchedCatalog();
   };
 
   return {
     async getModelLimits(modelId) {
       const normalizedId = normalizeCatalogModelId(modelId);
-      const resolved = await resolveModelsFromCacheOrFetch();
+      const builtInLimits = builtInCompiledRuntimeModelLimitsById.get(normalizedId);
+      let resolved: Awaited<ReturnType<typeof resolveModelsFromCacheOrFetch>>;
 
-      if (resolved !== null) {
-        const model = findCatalogModelBySlug(resolved.models, normalizedId);
-        if (model) {
-          for (const p of model.providers) {
-            const limits = modelCatalogLimitsFromProvider(p);
-            if (limits !== null) {
-              return limits;
-            }
+      try {
+        resolved = await resolveModelsFromCacheOrFetch();
+      } catch (error) {
+        if (builtInLimits !== undefined) {
+          return builtInLimits;
+        }
+        throw error;
+      }
+
+      const model = findCatalogModelBySlug(resolved.models, normalizedId);
+      if (model) {
+        for (const p of model.providers) {
+          const limits = modelCatalogLimitsFromProvider(p);
+          if (limits !== null) {
+            return limits;
           }
         }
       }
 
-      return builtInCompiledRuntimeModelLimitsById.get(normalizedId) ?? null;
+      return builtInLimits ?? null;
     },
 
     async getByProviderModelId(provider, providerModelId) {
       const resolved = await resolveModelsFromCacheOrFetch();
-      if (resolved === null) {
-        return null;
-      }
 
       const match = findCatalogModelByProviderModelId({
         models: resolved.models,

--- a/packages/eve/src/compiler/normalize-agent-config.test.ts
+++ b/packages/eve/src/compiler/normalize-agent-config.test.ts
@@ -77,6 +77,33 @@ describe("compileAgentConfig", () => {
     expect(compiled.description).toBeUndefined();
     expect(compiled.source?.sourceId).toBe("agent-config");
   });
+
+  it("surfaces model catalog fetch failures with their cause", async () => {
+    const manifest = createAgentSourceManifest({
+      agentId: "app",
+      agentRoot: "/app/agent",
+      appRoot: "/app",
+      configModule: createModuleSourceRef({
+        logicalPath: "agent.ts",
+        sourceId: "agent-config",
+      }),
+    });
+    const cause = new Error("offline");
+    const modelCatalog = createModelCatalog();
+    vi.mocked(modelCatalog.getModelLimits).mockRejectedValue(cause);
+
+    const error = await compileAgentConfig(
+      manifest,
+      { modelCatalog },
+      { definition: { model: "anthropic/claude-opus-4.8" } },
+    ).catch((error: unknown) => error);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(
+      'Failed to load AI Gateway model metadata for the primary compaction trigger model "anthropic/claude-opus-4.8". offline',
+    );
+    expect((error as Error).cause).toBe(cause);
+  });
 });
 
 function createModelCatalog(): ManifestCompileContext["modelCatalog"] {

--- a/packages/eve/src/compiler/normalize-agent-config.ts
+++ b/packages/eve/src/compiler/normalize-agent-config.ts
@@ -339,6 +339,7 @@ async function withCompiledRuntimeModelLimits(
   } catch (error) {
     throw new Error(
       `Failed to load AI Gateway model metadata for ${input.purpose} "${model.id}". ${toErrorMessage(error)}`,
+      { cause: error },
     );
   }
 


### PR DESCRIPTION
### Summary

Closes #2153. A failed `/v1/models/catalog` request was collapsed into `null`, so compilation blamed the configured model for missing context-window metadata.

- Before: catalog request failure → missing-model diagnostic.
- After: catalog request failure → catalog-load diagnostic with the upstream error preserved as `cause`.

Fresh caches and eve-owned built-in limits still work. A successfully loaded catalog that lacks the model still produces the existing missing-metadata diagnostic; an expired cache no longer hides a failed refresh.

### Validation

The focused compiler suite passes all 27 tests, including catalog request failures through both lookup methods, offline built-in fallback, and preservation of the compiler error cause.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the required patch changeset for the compiler error behavior.

**Implementation** — 2 files · `+21 / -22`

Keeps the distinction between catalog transport failure and missing model at the catalog/compiler boundary while preserving built-in limits.

**Tests** — 2 files · `+48 / -6`

Replaces the masking expectation and covers both catalog lookup methods, offline built-ins, and the compiler-level error cause.
