### PR TITLE
fix(buzz): accept compatible eve patch releases

### DIFF
--- a/.changeset/quiet-buzz-releases.md
+++ b/.changeset/quiet-buzz-releases.md
@@ -1,0 +1,5 @@
+---
+"@eve/buzz-acp-adapter": patch
+---
+
+Accept compatible eve patch releases without requiring a new adapter release for each eve update.

--- a/.syncpackrc.json
+++ b/.syncpackrc.json
@@ -18,6 +18,13 @@
       "isIgnored": true
     },
     {
+      "label": "The Buzz adapter accepts compatible eve patch releases",
+      "dependencies": ["eve"],
+      "packages": ["@eve/buzz-acp-adapter"],
+      "dependencyTypes": ["prod"],
+      "pinVersion": "workspace:^"
+    },
+    {
       "label": "Workspace packages must use the workspace: protocol",
       "dependencies": ["eve-*", "eve"],
       "dependencyTypes": ["dev", "prod", "peer"],

--- a/packages/eve-buzz-acp-adapter/package.json
+++ b/packages/eve-buzz-acp-adapter/package.json
@@ -40,7 +40,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "eve": "workspace:*"
+    "eve": "workspace:^"
   },
   "devDependencies": {
     "vitest": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1341,7 +1341,7 @@ importers:
   packages/eve-buzz-acp-adapter:
     dependencies:
       eve:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../eve
     devDependencies:
       vitest:


### PR DESCRIPTION
### Summary

The Buzz adapter's exact `workspace:*` dependency caused Changesets to publish a dependency-only adapter release for every eve patch. Use `workspace:^` so published adapters accept compatible eve patches without repeated releases; eve minor versions remain outside the range and will still trigger an adapter update.

### Validation

- `pnpm check:deps`
- `pnpm guard:invariants`
- `pnpm exec oxfmt --check .github/workflows/release.yml .syncpackrc.json packages/eve-buzz-acp-adapter/package.json .changeset/quiet-buzz-releases.md pnpm-lock.yaml`
- Simulated an eve-only patch release with `pnpm changeset status`; the adapter was excluded from the release plan
- Packed the adapter and confirmed its published eve dependency is `^0.38.2`

Runtime tests and documentation are not applicable; this only changes package release compatibility metadata.

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
