### PR TITLE
fix(release): mark eve as the latest release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,7 @@ jobs:
         run: rm -f .git/objects/pack/.tmp-* .git/objects/pack/tmp_*
 
       - name: Create release pull request or publish
+        id: changesets
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: pnpm version-packages
@@ -59,3 +60,14 @@ jobs:
           commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Mark eve as the latest GitHub release
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+        run: |
+          version="$(jq -r '.[] | select(.name == "eve") | .version' <<< "$PUBLISHED_PACKAGES")"
+          if [[ -n "$version" ]]; then
+            gh release edit "eve@$version" --latest
+          fi


### PR DESCRIPTION
### Summary

Changesets creates a GitHub release for every published workspace package, and each new release implicitly claims the repository's `Latest` label. After publishing completes, explicitly mark the new `eve` release as latest so secondary packages cannot occupy the repository release card. Publications that do not include `eve` leave the existing latest release unchanged.

This works around https://github.com/changesets/action/issues/340 until Changesets supports controlling `make_latest` per release.

### Validation

- `pnpm guard:invariants`
- `pnpm exec oxfmt --check .github/workflows/release.yml`
- Exercised the `publishedPackages` selection with mixed-package and adapter-only payloads

Runtime tests and a changeset are not applicable to this release-workflow-only change.

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
