### PR TITLE
fix(eve): slack - preserve default HITL authorization

### DIFF
--- a/.changeset/brave-slack-input-gate.md
+++ b/.changeset/brave-slack-input-gate.md
@@ -1,5 +1,5 @@
 ---
-"eve": minor
+"eve": patch
 ---
 
-Authorize Slack HITL answers with `onInputResponse` before they resume a parked session. Slack channels with authored inbound hooks now reject built-in HITL responses unless they define a matching input-response policy.
+Authorize Slack HITL answers with `onInputResponse` before they resume a parked session. Omitting the hook preserves the existing submitting-user authorization behavior regardless of other Slack handlers.

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -187,7 +187,7 @@ Keep authorization checks inside sensitive tools too. The inbound allowlist cont
 
 `onInputResponse` runs after eve decodes a built-in HITL answer but before the parked session resumes. Return `{ auth }` to accept the answer. Returning `null` or throwing rejects it, leaves the request pending, and keeps the Slack controls active. `ctx.defaultAuth` identifies the Slack user who submitted the signed interaction; it does not authorize that user by itself.
 
-Without authored inbound hooks, Slack accepts HITL answers with the submitting user's auth. If you author `onAppMention`, `onDirectMessage`, `onMessage`, or `onEvent` but omit `onInputResponse`, eve rejects built-in HITL answers instead of bypassing the authored ingress policy. Put sensitive prompts in conversations limited to the intended approvers, and re-check `ctx.session.auth.current` inside a sensitive tool before performing its side effect.
+If you omit `onInputResponse`, Slack accepts HITL answers with the submitting user's auth, regardless of which message or event handlers you define. Define `onInputResponse` when those handlers enforce an invocation policy that must also apply to HITL answers. Put sensitive prompts in conversations limited to the intended approvers, and re-check `ctx.session.auth.current` inside a sensitive tool before performing its side effect.
 
 #### Continue conversations without repeated mentions
 

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -2540,7 +2540,7 @@ describe("slackChannel() HITL interaction pipeline", () => {
     }
   });
 
-  it("rejects HITL by default when an inbound hook is authored", async () => {
+  it("uses default HITL auth when onAppMention is authored", async () => {
     const channel = slackChannel({
       credentials: { botToken: "xoxb-test" },
       onAppMention: () => ({ auth: null }),
@@ -2548,11 +2548,8 @@ describe("slackChannel() HITL interaction pipeline", () => {
 
     const { send } = await firePost(channel, buildHitlButtonRequest());
 
-    expect(send).not.toHaveBeenCalled();
-    expect(fetchMock).not.toHaveBeenCalledWith(
-      "https://slack.com/api/chat.update",
-      expect.anything(),
-    );
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0]?.[1].auth?.principalId).toBe("slack:T01:U_APPROVER");
   });
 
   it("does not mark a HITL card answered when response delivery fails", async () => {

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -635,10 +635,9 @@ export interface SlackChannelConfig {
    * Return `{ auth }` to accept the response, or `null` to reject it and keep
    * the request pending. Thrown errors are logged and treated as rejection.
    *
-   * When this hook is omitted, Slack keeps its built-in submitting-user auth
-   * only if no inbound message or Events API hook is authored. Authoring
-   * `onAppMention`, `onDirectMessage`, `onMessage`, or `onEvent` without a
-   * matching `onInputResponse` rejects HITL responses by default.
+   * When this hook is omitted, Slack preserves its built-in behavior and
+   * accepts the response with the submitting user's auth, regardless of other
+   * authored handlers.
    */
   onInputResponse?(
     ctx: SlackInputResponseContext,
@@ -692,9 +691,7 @@ export interface SlackChannel extends Channel<
 export function slackChannel(config: SlackChannelConfig = {}): SlackChannel {
   const uploadPolicy = mergeUploadPolicy(config.uploadPolicy);
   const slackFetchFile = createSlackFetchFile({ botToken: config.credentials?.botToken });
-  const onInputResponse =
-    config.onInputResponse ??
-    (hasAuthoredInboundHook(config) ? rejectInputResponse : defaultOnInputResponse);
+  const onInputResponse = config.onInputResponse ?? defaultOnInputResponse;
   const authorizationRequiredOverride = config.events?.["authorization.required"];
   const candidateHandler =
     config.events?.["approval.candidate"] ?? defaultEvents["approval.candidate"]!;
@@ -824,21 +821,8 @@ export function slackChannel(config: SlackChannelConfig = {}): SlackChannel {
   });
 }
 
-function hasAuthoredInboundHook(config: SlackChannelConfig): boolean {
-  return (
-    config.onAppMention !== undefined ||
-    config.onDirectMessage !== undefined ||
-    config.onMessage !== undefined ||
-    config.onEvent !== undefined
-  );
-}
-
 function defaultOnInputResponse(ctx: SlackInputResponseContext): SlackInputResponseResult {
   return { auth: ctx.defaultAuth };
-}
-
-function rejectInputResponse(): null {
-  return null;
 }
 
 /**


### PR DESCRIPTION
### Summary

Related to #2156. Follow-up to #2157.

The merged Slack HITL hook incorrectly treated the presence of a custom message or event handler as evidence of an authorization policy. Omitting `onInputResponse` now always preserves the existing behavior and resumes HITL with the submitting user's Slack auth, while defining the hook still enables explicit admission policy. This also restores the feature to a non-breaking patch changeset.

### Validation

Focused Slack coverage confirms that default HITL authorization still works when `onAppMention` is authored, alongside the existing explicit acceptance and rejection paths; all 94 focused assertions pass.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+3 / -3`

Corrects the public fallback contract and the pending release note.

**Implementation** — 1 file · `+4 / -20`

Removes the handler-presence heuristic and its rejection fallback.

**Tests** — 1 file · `+3 / -6`

Inverts the focused regression to require unchanged default authorization with an authored handler.
