### PR TITLE
fix(eve): forward Slack event send titles

### DIFF
--- a/.changeset/tidy-slack-events-title.md
+++ b/.changeset/tidy-slack-events-title.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Slack `onEvent` handlers can now pass `title` to `ctx.send()` to set the run title without changing the message sent to the model.

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -297,7 +297,7 @@ Reset returns `{ status: "reset", previousSessionId }` when the thread had a ses
 
 ### Other Events API callbacks
 
-Use `onEvent` for subscribed events such as `reaction_added`, `team_join`, or `channel_created`. It receives the raw, open-ended Slack event and owns control flow. Call `ctx.send(message, { target, auth })` zero, one, or many times to start turns. Each call returns the resulting session.
+Use `onEvent` for subscribed events such as `reaction_added`, `team_join`, or `channel_created`. It receives the raw, open-ended Slack event and owns control flow. Call `ctx.send(message, { target, auth, title })` zero, one, or many times to start turns. `title` sets the run title without changing the message sent to the model. Each call returns the resulting session.
 
 ```ts title="agent/channels/slack.ts"
 import { connectSlackCredentials } from "@vercel/connect/eve";

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -1909,7 +1909,7 @@ describe("slackChannel() generic Events API pipeline", () => {
     expect(compact).toHaveBeenCalledWith("C01:1700000000.000001");
   });
 
-  it("binds Slack session state when a generic event send creates", async () => {
+  it("binds Slack session state and title when a generic event send creates", async () => {
     const send = vi.fn().mockResolvedValue({ id: "s1" });
     const channel = slackChannel({
       credentials: { botToken: "xoxb-test" },
@@ -1917,6 +1917,7 @@ describe("slackChannel() generic Events API pipeline", () => {
         await ctx.send("follow up", {
           auth: null,
           target: { channelId: "C01", threadTs: "1700000000.000001" },
+          title: "Reaction follow-up",
         });
       },
     });
@@ -1933,6 +1934,7 @@ describe("slackChannel() generic Events API pipeline", () => {
         threadTs: "1700000000.000001",
         triggeringUserId: "U01",
       },
+      title: "Reaction follow-up",
     });
   });
 

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -293,6 +293,8 @@ export interface SlackInitialMessage {
 export interface SlackEventSendOptions {
   readonly auth: SessionAuthContext | null;
   readonly target: SlackReceiveTarget;
+  /** Overrides the workflow run title without changing the message sent to the model. */
+  readonly title?: string;
 }
 
 /** Options for answering pending input requests from a generic Slack event handler. */
@@ -850,6 +852,7 @@ async function receiveOnSlack(
     readonly auth: SessionAuthContext | null;
     readonly message: string | UserContent;
     readonly target: SlackReceiveTarget;
+    readonly title?: string;
   },
   deps: {
     readonly from: ChannelFrom<SlackChannelState>;
@@ -904,6 +907,7 @@ async function receiveOnSlack(
       teamId: deps.teamId ?? null,
       triggeringUserId: deps.triggeringUserId ?? null,
     },
+    title: input.title,
   });
 }
 
@@ -1198,9 +1202,9 @@ async function dispatchSlackEvent(input: {
       input.resolveSession(slackContinuationToken(target.channelId, target.threadTs)),
     respond: (inputResponses, { auth, target }) =>
       sourceFor(target).respond(inputResponses, { auth }),
-    send: (message, { auth, target }) =>
+    send: (message, { auth, target, title }) =>
       receiveOnSlack(
-        { auth, message, target },
+        { auth, message, target, title },
         {
           from: input.from,
           credentials: input.credentials,


### PR DESCRIPTION
### Summary

Closes #2102. Raw Slack `onEvent` handlers can now pass `title` to `ctx.send(...)`, matching Slack's message hooks. Previously, ambient-message and reaction handlers using the raw event API could not prevent a new private-channel run from deriving its title from the message sent to the model. The title now flows through the Slack receive path into session delivery; omitting it preserves existing behavior, and model input is unchanged.

This replaces draft #2108 now that its direct-message redaction has landed separately.

### Validation

The focused Slack unit suite passes all 93 tests, including regression coverage that asserts a raw event's custom title reaches channel delivery together with Slack session state.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+6 / -1`

Documents the new `onEvent` send option and records the published behavior change.

**Implementation** — 1 file · `+6 / -2`

Extends the existing Slack event-send path without changing other channel behavior.

**Tests** — 1 file · `+3 / -1`

Adds focused regression coverage to the existing generic Events API pipeline.
