### PR TITLE
docs(eve): add Sign in with Vercel MCP authentication

### DIFF
--- a/docs/channels/mcp.mdx
+++ b/docs/channels/mcp.mdx
@@ -102,6 +102,78 @@ export default mcpChannel({
 
 You can wrap any strategy in `oauthResource()`, including `vercelOidc()`, but the advertised authorization server must issue tokens that strategy accepts. `vercelOidc()` by itself is preconfigured Vercel workload identity and does not advertise an interactive login.
 
+### Sign in with Vercel
+
+Use [Sign in with Vercel](https://vercel.com/docs/sign-in-with-vercel) when MCP users should authenticate with their Vercel account. Vercel publishes OAuth and OpenID Connect discovery at `https://vercel.com/.well-known/openid-configuration`, including client registration, authorization, token, and introspection endpoints.
+
+Sign in with Vercel access tokens are opaque rather than JWTs. Validate them with Vercel's token introspection endpoint instead of `verifyOidc()`:
+
+```ts title="agent/channels/mcp.ts"
+import {
+  extractBearerToken,
+  oauthResource,
+  type AuthFn,
+  withAuthChallenges,
+} from "eve/channels/auth";
+import { mcpChannel } from "eve/channels/mcp";
+
+const issuer = "https://vercel.com";
+const introspectionEndpoint = "https://api.vercel.com/login/oauth/token/introspect";
+
+interface VercelTokenIntrospection {
+  active?: unknown;
+  iss?: unknown;
+  sub?: unknown;
+  token_type?: unknown;
+}
+
+const verifySignInWithVercel: AuthFn<Request> = async (request) => {
+  const token = extractBearerToken(request.headers.get("authorization"));
+  if (token === null) return null;
+
+  const response = await fetch(introspectionEndpoint, {
+    method: "POST",
+    body: new URLSearchParams({ token }),
+    signal: AbortSignal.timeout(5_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Vercel token introspection failed with status ${response.status}.`);
+  }
+
+  const result = (await response.json()) as VercelTokenIntrospection;
+  if (
+    result.active !== true ||
+    result.iss !== issuer ||
+    result.token_type !== "bearer" ||
+    typeof result.sub !== "string" ||
+    result.sub.length === 0
+  ) {
+    return null;
+  }
+
+  return {
+    attributes: {},
+    authenticator: "sign-in-with-vercel",
+    principalId: result.sub,
+    principalType: "user",
+  };
+};
+
+const signInWithVercel = withAuthChallenges(verifySignInWithVercel, [{ scheme: "Bearer" }]);
+
+export default mcpChannel({
+  auth: oauthResource(signInWithVercel, {
+    issuer,
+    scopes: ["openid"],
+  }),
+});
+```
+
+The MCP client discovers Vercel from eve's protected-resource metadata, registers or uses an OAuth client, and opens Vercel's authorization flow. The introspection response's `sub` becomes the eve principal, so each Vercel user owns only their invocations.
+
+This example authenticates any active Sign in with Vercel user. Add application authorization inside `verifySignInWithVercel` when access should be limited to particular users, teams, or OAuth client IDs. `vercelOidc()` serves a different purpose: it verifies Vercel workload identity for deployments and does not produce this user sign-in experience.
+
 ### Protected-resource metadata
 
 By default, eve derives the metadata path from the complete MCP resource identifier according to RFC 9728:


### PR DESCRIPTION
### Summary

Documents how to use Sign in with Vercel as the interactive identity provider for an eve MCP channel. The guide shows how to advertise Vercel through OAuth protected-resource metadata, introspect Vercel's opaque access tokens, and map the verified Vercel subject to an eve user principal.

It also distinguishes user-facing Sign in with Vercel from workload-oriented `vercelOidc()` and calls out where applications should add user, team, or OAuth-client authorization policy.

### Validation

`pnpm docs:check` validates all 80 documentation pages, including eve import paths across 344 code blocks and MDX compilation. `oxfmt --check docs/channels/mcp.mdx` also passes. Tests and a changeset are not applicable to this documentation-only change.

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+72 / -0`

Adds a focused Sign in with Vercel section to the MCP channel guide, including a complete token-introspection verifier and security guidance.

**Implementation** — 0 files · `+0 / -0`

Not applicable.

**Tests** — 0 files · `+0 / -0`

Not applicable; documentation validation covers the example's imports, links, and MDX compilation.
