### PR TITLE
Add local project doctor

### DIFF
--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -351,7 +351,7 @@ function reportExistingProjectChanges(
 ): void {
   logger.log("Updated existing project:");
   for (const path of project.filesWritten) {
-    logger.log(`  Created ${relative(project.projectPath, path)}`);
+    logger.log(`  Created ${relative(project.projectPath, path).replaceAll("\\", "/")}`);
   }
   if (project.dependenciesAdded.length > 0) {
     logger.log(`  Added dependencies: ${project.dependenciesAdded.join(", ")}`);


### PR DESCRIPTION
### Summary

This final PR in the onboarding stack adds `eve doctor [path]`, a local, read-only diagnostic command for an eve project. It runs applicable checks without network access or mutations, reports failures without stopping at the first one, and supports human or JSON output. Human output groups environment, package, and Git checks under blue section headings; the Node check derives its semver range from eve’s canonical package contract.

### Before / after

Before, diagnosing a local setup required manually running and interpreting separate commands:

```console
$ node --version
$ pnpm install
$ git status
$ git remote -v
$ eve build
```

After, one command reports local runtime, project discovery, package-manager, dependency, and Git state:

```console
$ eve doctor
Environment
✓ Node.js 24.x is available at /path/to/node.
✓ Found eve project at /path/to/project.

Packages
✗ Project dependencies are not installed; commands that load project code may fail.
    Run: pnpm install

Git
! No Git remote is configured. Local development works, but you cannot push or share this repository.
```

Automation can consume the same results without terminal formatting:

```console
$ eve doctor --json
{
  "summary": { "pass": 2, "warn": 1, "fail": 1, "unknown": 0 },
  "diagnostics": []
}
```

### Validation

Unit coverage verifies diagnostic policy and rendering, while integration coverage verifies independent local checks continue when Git is absent and discovery fails. No broader validation was run for this PR separately.

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [ ] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+27 / -8`

The CLI reference documents command scope, exit behavior, JSON output, and the deliberate no-compilation boundary; the changeset records the release behavior.

**Implementation** — 16 files · `+539 / -43`

The new doctor module separates fact collection, policy, and rendering so local checks remain composable and every applicable diagnostic can run independently. A small shared package-contract module keeps doctor and scaffolding on the same Node.js engine requirement.

**Tests** — 4 files · `+220 / -0`

Unit and integration coverage exercise policies, terminal and JSON rendering, command exit status, independent-check behavior, unavailable Git tooling, sectioned human output, and Node-engine boundaries.
