### PR TITLE
Optimize Nights cold loading

### DIFF
--- a/apps/docs/app/(nights)/layout.tsx
+++ b/apps/docs/app/(nights)/layout.tsx
@@ -1,0 +1,23 @@
+import "../global.css";
+import { Analytics } from "@vercel/analytics/next";
+import { SpeedInsights } from "@vercel/speed-insights/next";
+import type { Metadata } from "next";
+import { mono, sans } from "@/lib/geistdocs/fonts";
+import { getSiteOrigin } from "@/lib/geistdocs/url";
+import { cn } from "@/lib/utils";
+
+export const metadata: Metadata = {
+  metadataBase: new URL(getSiteOrigin()),
+};
+
+const NightsLayout = ({ children }: { children: React.ReactNode }) => (
+  <html className={cn(sans.variable, mono.variable, "antialiased")} lang="en">
+    <body>
+      {children}
+      <Analytics />
+      <SpeedInsights />
+    </body>
+  </html>
+);
+
+export default NightsLayout;

--- a/apps/docs/app/(nights)/nights/nights-galaxy.tsx
+++ b/apps/docs/app/(nights)/nights/nights-galaxy.tsx
@@ -279,6 +279,11 @@ const BLOOM_REVEAL_DELAY_MS = 1000;
 // this, the reveal would silently "tick" through the compile time and
 // users would see the animation skip its opening.
 const REVEAL_WARMUP_FRAMES = 2;
+// Never leave the event content hidden if WebGPU initialization stalls.
+const SHADER_READY_TIMEOUT_MS = 3000;
+// The logo tops out near 1080 device pixels, so 1024 preserves its detail
+// while avoiding the larger main-thread pixel copy of the former 1600 texture.
+const LOGO_TEXTURE_SIZE = 1024;
 const revealTargets = {
   logoMinMul: 0.025,
   // The eve mark has broad horizontal strokes; a lower multiplier keeps
@@ -338,6 +343,25 @@ export function NightsGalaxy(): JSX.Element {
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
+
+    const route = container.closest<HTMLElement>("[data-nights-route]");
+    let shaderStateSignaled = false;
+    let shaderReadyTimeout: number | null = null;
+    const signalShaderState = (state: "ready" | "error"): void => {
+      if (shaderStateSignaled) return;
+      shaderStateSignaled = true;
+      container.dataset.shaderState = state;
+      route?.setAttribute("data-shader-state", state);
+      if (shaderReadyTimeout !== null) {
+        window.clearTimeout(shaderReadyTimeout);
+        shaderReadyTimeout = null;
+      }
+    };
+    route?.setAttribute("data-shader-state", "loading");
+    shaderReadyTimeout = window.setTimeout(
+      () => signalShaderState("ready"),
+      SHADER_READY_TIMEOUT_MS,
+    );
 
     const scene = new THREE.Scene();
     scene.background = new THREE.Color(0x000000);
@@ -1003,6 +1027,8 @@ export function NightsGalaxy(): JSX.Element {
         debugQuads[hoverDebug.mode].render(renderer);
       }
 
+      if (revealStart !== null) signalShaderState("ready");
+
       animationFrameId = requestAnimationFrame(animate);
     };
 
@@ -1022,7 +1048,7 @@ export function NightsGalaxy(): JSX.Element {
     };
     document.addEventListener("visibilitychange", handleVisibilityChange);
 
-    void Promise.all([initPromise, rasterizeSvgToTexture(rgbLogoSvgString, 1600)])
+    void Promise.all([initPromise, rasterizeSvgToTexture(rgbLogoSvgString, LOGO_TEXTURE_SIZE)])
       .then(([, { texture }]) => {
         if (!running) {
           texture.dispose();
@@ -1117,7 +1143,7 @@ export function NightsGalaxy(): JSX.Element {
       })
       .catch((error: unknown) => {
         if (!running) return;
-        container.dataset.shaderState = "error";
+        signalShaderState("error");
         console.error("Failed to initialize the nights shader", error);
       });
 
@@ -1149,6 +1175,7 @@ export function NightsGalaxy(): JSX.Element {
 
     return () => {
       running = false;
+      if (shaderReadyTimeout !== null) window.clearTimeout(shaderReadyTimeout);
       if (animationFrameId !== null) cancelAnimationFrame(animationFrameId);
       sceneRef.current = null;
       window.removeEventListener("resize", handleResize);
@@ -1316,6 +1343,7 @@ export function NightsGalaxy(): JSX.Element {
     };
   }, []);
 
+  // Mobile stays bounded to the logo row; desktop intentionally expands to the viewport.
   return (
     <div
       ref={containerRef}

--- a/apps/docs/app/(nights)/nights/page.tsx
+++ b/apps/docs/app/(nights)/nights/page.tsx
@@ -61,11 +61,15 @@ const LogoPlaceholder = ({ target = false }: { target?: boolean }) => (
 );
 
 const NightsPage = () => (
-  <div data-nights-route className="relative h-lvh overflow-hidden bg-black text-white">
+  <div
+    data-nights-route
+    data-shader-state="loading"
+    className="relative h-lvh overflow-hidden bg-black text-white"
+  >
     <div className="pointer-events-none fixed inset-0" aria-hidden="true">
-      <NightsGalaxy />
       <div className="mx-auto grid h-full w-full max-w-6xl grid-cols-1 grid-rows-[40svh_1fr] min-[740px]:grid-cols-2 min-[740px]:grid-rows-1">
-        <div className="flex h-full items-center justify-center p-4">
+        <div className="relative flex h-full items-center justify-center p-4">
+          <NightsGalaxy />
           <LogoPlaceholder target />
         </div>
       </div>

--- a/apps/docs/app/(nights)/nights/rasterize-svg-to-texture.ts
+++ b/apps/docs/app/(nights)/nights/rasterize-svg-to-texture.ts
@@ -37,7 +37,7 @@ export async function rasterizeSvgToTexture(
 
     const imageData = ctx.getImageData(0, 0, size, size);
 
-    // Flip Y so y=0 in the DataTexture sits at the bottom (Three.js UV convention).
+    // Flip Y here so layout coordinates can remain top-origin in the shader.
     const pixels = new Uint8Array(size * size * 4);
     const rowBytes = size * 4;
     for (let y = 0; y < size; y++) {

--- a/apps/docs/app/(nights)/nights/rgb-logo.ts
+++ b/apps/docs/app/(nights)/nights/rgb-logo.ts
@@ -1,3 +1,4 @@
+// The black inset prevents clamp-to-edge sampling from exposing the texture boundary.
 export const rgbLogoSvgString = `<svg width="169" height="53" viewBox="0 0 169 53" preserveAspectRatio="none" fill="none" xmlns="http://www.w3.org/2000/svg">
   <rect width="169" height="53" fill="black"/>
   <g fill="url(#eve-fill)" stroke="url(#eve-outline)" stroke-width="0.8" stroke-linejoin="round" transform="translate(2 2) scale(0.976331 0.924528)">

--- a/apps/docs/app/styles/geistdocs.css
+++ b/apps/docs/app/styles/geistdocs.css
@@ -31,11 +31,6 @@ body:has([data-nights-route]) {
   color-scheme: dark;
 }
 
-body:has([data-nights-route]) > div > header,
-body:has([data-nights-route]) > div > footer {
-  display: none;
-}
-
 @keyframes eve-nights-rise {
   from {
     opacity: 0;
@@ -46,6 +41,10 @@ body:has([data-nights-route]) > div > footer {
     opacity: 1;
     transform: translateY(0);
   }
+}
+
+[data-nights-route][data-shader-state="loading"] [data-nights-animated] {
+  animation-play-state: paused;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/apps/docs/proxy.ts
+++ b/apps/docs/proxy.ts
@@ -1,5 +1,5 @@
 import { createProxy } from "@vercel/geistdocs/proxy";
-import type { NextFetchEvent, NextRequest } from "next/server";
+import { NextResponse, type NextFetchEvent, type NextRequest } from "next/server";
 import { config as geistdocsConfig } from "@/lib/geistdocs/config";
 import { removeProxyMarkdownCanonical } from "@/lib/geistdocs/markdown-canonical";
 import { markdownRoutes } from "@/lib/geistdocs/markdown-routes";
@@ -9,7 +9,7 @@ const geistdocsProxy = createProxy({
   config: geistdocsConfig,
   markdownRoutes,
   trackMarkdownRequest: trackMdRequest,
-  before: () => null,
+  before: ({ request }) => (request.nextUrl.pathname === "/nights" ? NextResponse.next() : null),
 });
 
 const proxy = async (request: NextRequest, context: NextFetchEvent) =>


### PR DESCRIPTION
### Summary
Optimize /nights page load

Speeds up /nights by removing unnecessary docs-shell hydration and reducing mobile shader work, while preserving the existing visuals and interactions.