### PR TITLE
fix(eve): ignore quoted lines in GitHub replies

### DIFF
--- a/.changeset/github-quoted-approval.md
+++ b/.changeset/github-quoted-approval.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix GitHub channel approval replies when users quote the approval prompt.

--- a/packages/eve/src/public/channels/github/inbound.test.ts
+++ b/packages/eve/src/public/channels/github/inbound.test.ts
@@ -289,6 +289,51 @@ describe("GitHub inbound parsing", () => {
     ).toBeNull();
   });
 
+  it("extracts an approval reply outside the quoted prompt", () => {
+    expect(
+      extractGitHubCommentTrigger({
+        body: [
+          "> Approve tool call: approval_test",
+          "> ",
+          "> 1. Approve",
+          "> 2. Cancel",
+          "> ",
+          "> Answer by mentioning me in a reply, e.g. `@eve-gh-approval-repro Approve`.",
+          "",
+          "@eve-gh-approval-repro Approve",
+        ].join("\n"),
+        botName: "eve-gh-approval-repro",
+      }),
+    ).toEqual({
+      kind: "mention",
+      message: "Approve",
+      token: "@eve-gh-approval-repro",
+    });
+  });
+
+  it("does not dispatch when the bot mention is only quoted", () => {
+    const input = {
+      body: "  > @testbot Approve\n\nThanks for the prompt.",
+      botName: "testbot",
+    };
+
+    expect(extractGitHubCommentTrigger(input)).toBeNull();
+    expect(shouldDispatchGitHubComment(input)).toBe(false);
+  });
+
+  it("preserves quoted content after the bot mention", () => {
+    expect(
+      extractGitHubCommentTrigger({
+        body: "@testbot explain this:\n> error details",
+        botName: "testbot",
+      }),
+    ).toEqual({
+      kind: "mention",
+      message: "explain this:\n> error details",
+      token: "@testbot",
+    });
+  });
+
   it("ignores bot and hidden-marker comments in default dispatch", () => {
     expect(
       shouldDispatchGitHubComment({

--- a/packages/eve/src/public/channels/github/inbound.ts
+++ b/packages/eve/src/public/channels/github/inbound.ts
@@ -94,13 +94,20 @@ export function extractGitHubCommentTrigger(input: {
 }): GitHubCommentTrigger | null {
   const botName = input.botName?.trim();
   if (!botName) return null;
-  const mention = new RegExp(`@${escapeRegExp(botName)}(?=$|[^A-Za-z0-9_-])`, "iu").exec(
-    input.body,
+  const mentionPattern = new RegExp(`@${escapeRegExp(botName)}(?=$|[^A-Za-z0-9_-])`, "iu");
+  const lines = input.body.split("\n");
+  const mentionLineIndex = lines.findIndex(
+    (line) => !line.trimStart().startsWith(">") && mentionPattern.test(line),
   );
+  if (mentionLineIndex === -1) return null;
+  const body = lines
+    .filter((line, index) => index >= mentionLineIndex || !line.trimStart().startsWith(">"))
+    .join("\n");
+  const mention = mentionPattern.exec(body);
   if (mention === null) return null;
   const start = mention.index;
   const end = start + mention[0].length;
-  const message = `${input.body.slice(0, start)}${input.body.slice(end)}`.trim();
+  const message = `${body.slice(0, start)}${body.slice(end)}`.trim();
   return { kind: "mention", message, token: mention[0] };
 }
 


### PR DESCRIPTION
## What

GitHub quote replies now resolve a pending tool approval from the unquoted reply command.

Previously, the mention parser matched the bot mention inside the quoted approval prompt first. The resulting message included the full prompt instead of only `Approve`, so Eve treated it as a new user message and requested approval again.

This fixes replies sent with GitHub's **Quote reply** action while keeping the normal unquoted reply behavior unchanged.

Closes #2137.

## How

`extractGitHubCommentTrigger()` now finds the bot mention on an unquoted line before building the trigger message. Markdown blockquote lines before that mention are removed, so the approval handler receives `Approve` instead of the quoted prompt.

A comment that only quotes a bot mention does not wake the agent. Quoted lines after the real mention remain part of the user's message.

## Tests / changeset

- Added a unit regression using the full quoted approval reply from #2137, asserting that the trigger message is exactly `Approve`.
- Added coverage that a quote-only bot mention does not dispatch.
- Added coverage that quoted content after the real mention is preserved.
- Kept the existing unquoted mention behavior covered.
- Added a `patch` changeset for `eve`.

## Verification

- `fnm exec --using v24.15.0 -- pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/channels/github/inbound.test.ts`
- `fnm exec --using v24.15.0 -- pnpm test:unit`
- `fnm exec --using v24.15.0 -- pnpm test:integration`
- `fnm exec --using v24.15.0 -- pnpm test:scenario`
- `fnm exec --using v24.15.0 -- pnpm typecheck`
- `fnm exec --using v24.15.0 -- pnpm lint`
- `fnm exec --using v24.15.0 -- pnpm fmt`
- `fnm exec --using v24.15.0 -- pnpm guard:invariants`
- `fnm exec --using v24.15.0 -- pnpm check:deps`
- `fnm exec --using v24.15.0 -- pnpm docs:check`
- `fnm exec --using v24.15.0 -- pnpm build`
- `git diff --check`
