### PR TITLE
fix(eve): reattach durable settlements on direct approval delivery

### DIFF
--- a/.changeset/warm-batches-resume.md
+++ b/.changeset/warm-batches-resume.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Reattach durable approval settlements to every delivery result, so a multi-request approval batch answered one response per respond() call resumes the parked turn once its last request settles instead of stranding the session with settled-but-never-executed tool calls.

--- a/packages/eve/src/harness/approval-delivery-coordinator.test.ts
+++ b/packages/eve/src/harness/approval-delivery-coordinator.test.ts
@@ -119,7 +119,7 @@ describe("coordinateApprovalDelivery", () => {
     const respondedIds = (stepInput?: { inputResponses?: readonly { requestId: string }[] }) =>
       (stepInput?.inputResponses ?? []).map((response) => response.requestId).sort();
 
-    let result;
+    let result: Awaited<ReturnType<typeof coordinateApprovalDelivery>> | undefined;
     for (const [index, request] of requests.entries()) {
       result = await coordinateApprovalDelivery({
         now: 100 + index,

--- a/packages/eve/src/harness/approval-delivery-coordinator.test.ts
+++ b/packages/eve/src/harness/approval-delivery-coordinator.test.ts
@@ -82,4 +82,68 @@ describe("coordinateApprovalDelivery", () => {
       { optionId: "cancel", requestId: request.requestId },
     ]);
   });
+
+  // #2182: each delivery's result carried only its newest response, so a
+  // batch answered one response per delivery never resolved.
+  it("reattaches earlier settlements when a later delivery settles another batch request", async () => {
+    const batchRequest = (index: number): InputRequest => ({
+      action: {
+        callId: `call-${index}`,
+        input: { marker: `note-${index}` },
+        kind: "tool-call",
+        toolName: "gate",
+      },
+      allowFreeform: false,
+      display: "confirmation",
+      kind: "tool-approval",
+      options: [
+        { id: "approve", label: "Approve" },
+        { id: "cancel", label: "Cancel" },
+      ],
+      prompt: `Approve tool call: gate (${index})`,
+      requestId: `approval-${index}`,
+    });
+    const requests = [batchRequest(1), batchRequest(2), batchRequest(3)];
+    let session: HarnessSession = appendPendingInputBatch({
+      requests,
+      responseMessages: [],
+      session: {
+        agent: { modelReference: { id: "test" }, system: "", tools: [] },
+        compaction: { recentWindowSize: 10, threshold: 0.8 },
+        continuationToken: "test",
+        history: [],
+        sessionId: "session-1",
+      },
+    });
+
+    const respondedIds = (stepInput?: { inputResponses?: readonly { requestId: string }[] }) =>
+      (stepInput?.inputResponses ?? []).map((response) => response.requestId).sort();
+
+    let result;
+    for (const [index, request] of requests.entries()) {
+      result = await coordinateApprovalDelivery({
+        now: 100 + index,
+        session,
+        stepInput: {
+          attributedInputResponses: [
+            {
+              auth: responder,
+              response: { optionId: "approve", requestId: request.requestId },
+            },
+          ],
+        },
+        tools: new Map(),
+      });
+      session = result.session;
+      expect(result.kind).toBe("continue");
+      // Every delivery result must carry this response plus every earlier
+      // settlement, so the batch resolves the moment its last answer lands.
+      expect(respondedIds(result.stepInput)).toEqual(
+        requests.slice(0, index + 1).map((entry) => entry.requestId),
+      );
+    }
+    expect(
+      result?.stepInput?.inputResponses?.every((response) => response.optionId === "approve"),
+    ).toBe(true);
+  });
 });

--- a/packages/eve/src/harness/approval-delivery-coordinator.ts
+++ b/packages/eve/src/harness/approval-delivery-coordinator.ts
@@ -240,17 +240,29 @@ export async function coordinateApprovalDelivery(input: {
   }
 
   const remainingStepInput = removeConsumedResponses(stepInput, consumed);
-  if (consumed.size > 0) {
+  if (consumed.size > 0 || didCommit) {
+    // Reattach settlements for still-pending requests so downstream input
+    // resolution sees the whole batch: a batch answered one response per
+    // delivery otherwise carries only its newest response and the parked
+    // turn never resumes (#2182).
+    const respondedRequestIds = new Set([
+      ...(remainingStepInput?.inputResponses ?? []).map((response) => response.requestId),
+      ...(remainingStepInput?.attributedInputResponses ?? []).map(
+        ({ response }) => response.requestId,
+      ),
+    ]);
+    const settledPending = getApprovalAuditState(session.state).settlements.filter(
+      (settlement) =>
+        pendingRequestIds.has(settlement.requestId) &&
+        !respondedRequestIds.has(settlement.requestId),
+    );
     return deliveryResult(
       session,
-      remainingStepInput,
-      didCommit ? "continue-coordination" : "continue",
+      appendSettledResponses(remainingStepInput, settledPending),
+      consumed.size > 0 && didCommit ? "continue-coordination" : "continue",
       [],
       feedback,
     );
-  }
-  if (didCommit) {
-    return deliveryResult(session, remainingStepInput, "continue", [], feedback);
   }
 
   // Candidates are persisted in an earlier pass. Run pending candidates and


### PR DESCRIPTION
### Summary

Closes #2182.

A multi-request approval batch answered one `respond()` call at a time settles
every request durably (`approval.settled` ×N) but never resumes the parked
turn — the approved tools never execute and the session waits forever.

The coordinator already reattaches pending settlements on the empty-input
recovery pass and the candidate/authorizer pass (`appendSettledResponses`),
but the direct-settlement path returns early, before that reattachment. Each
delivery result therefore carries only its newest response, so
`resolveApprovalInputBatches` never observes a fully-answered batch — as
triage put it on #2182: "the coordinator returns before reattaching earlier
durable settlements, so each turn retains only its newest response."

The fix reattaches settlements for still-pending requests (that have no
response in the current step input) on those early returns, using the existing
`appendSettledResponses` helper. Result kinds are unchanged:
`continue-coordination` when authorization-required responses were consumed
alongside a commit, `continue` otherwise. Single-respond batches and the
recovery/candidate paths behave exactly as before.

### Validation

- `pnpm test:unit approval-delivery-coordinator` (in `packages/eve`) — 3 passed,
  including a new regression test: a 3-request batch answered across three
  deliveries must carry every earlier settlement on each delivery result. Red
  on main (`expected ['approval-2'] to deeply equal ['approval-1',
  'approval-2']`), green with the fix.
- `pnpm test:unit` (in `packages/eve`) — 6759 passed, 1 skipped.
- Manual end-to-end against the #2182 reproduction
  (https://github.com/Hazem-khriji/eve-batch-approval-repro): with this build,
  the previously-stuck shape now emits `approval.settled ×3 → turn.started →
  action.result ×3 → turn.completed`; the `--batch` control is unchanged.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
