### PR TITLE
test: cover optional session callback task id

### DIFF
--- a/packages/eve/src/channel/session-callback.test.ts
+++ b/packages/eve/src/channel/session-callback.test.ts
@@ -45,6 +45,18 @@ describe("parseSessionCallback callback-URL token extraction", () => {
     ).toMatchObject({ ok: true });
   });
 
+  it("accepts callback metadata with an optional task id", () => {
+    expect(
+      parseSessionCallback({
+        ...createCallback("https://agent.example.com/eve/v1/callback/tok123"),
+        taskId: "task-1",
+      }),
+    ).toMatchObject({
+      callback: { taskId: "task-1" },
+      ok: true,
+    });
+  });
+
   it("rejects a URL without the callback route", () => {
     expect(
       parseSessionCallback(


### PR DESCRIPTION
## Summary

- add unit coverage for the optional `taskId` field in session callback metadata

## Why

This makes the existing schema behavior explicit and protects the optional field during callback parsing.

## Impact

Test-only change. No production code, routing, networking, or security behavior is modified.

## Verification

- `pnpm exec vitest run --config vitest.unit.config.ts src/channel/session-callback.test.ts` — 10 passed
- The broader unit command was also attempted in the Windows environment and currently has unrelated pre-existing path/platform failures; this change does not affect those failures.