### PR TITLE
fix(eve): authenticate remote task input responses

### DIFF
--- a/.changeset/secure-task-responses.md
+++ b/.changeset/secure-task-responses.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Authenticate remote background-task input responses with the current responder and remote-agent transport policy. Tool approvals now stay pending after delivery until the child accepts the responder.

--- a/docs/guides/auth-and-route-protection.md
+++ b/docs/guides/auth-and-route-protection.md
@@ -17,6 +17,7 @@ The route-auth policy lives on the HTTP channel factory (`agent/channels/eve.ts`
 - `POST /eve/v1/session`
 - `POST /eve/v1/session/:sessionId`
 - `POST /eve/v1/session/:sessionId/{cancel,compact,clear,reset}`
+- `POST /eve/v1/task-input/:token`
 - `GET /eve/v1/session/:sessionId/stream`
 
 These routes are protected by the channel's auth policy. eve fails closed by default: production traffic is rejected unless you configure an authenticator that accepts it, and anonymous access requires an explicit `none()`.
@@ -223,7 +224,7 @@ Keep secret values (`ROUTE_AUTH_BASIC_PASSWORD`, signing keys) in environment va
 
 ## Accepting forwarded identity from another deployment
 
-A `defineRemoteAgent({ forwardPrincipal: true })` caller (see [Remote agents](./remote-agents#forwarding-the-caller-identity)) asserts its end user's principal on the create-session request as a `forwardedPrincipal` body field. By default every such assertion is rejected with `403` — accepting someone else's word for who the user is requires naming exactly which forwarders you trust. Do that with `trustedForwarders` on `eveChannel`:
+A `defineRemoteAgent({ forwardPrincipal: true })` caller (see [Remote agents](./remote-agents#forwarding-the-caller-identity)) asserts its end user's principal on the create-session request as a `forwardedPrincipal` body field. The same gate applies when a background child requests input: the scoped task-input request carries the current principal that answered on the parent. By default every such assertion is rejected with `403` — accepting someone else's word for who the user is requires naming exactly which forwarders you trust. Do that with `trustedForwarders` on `eveChannel`:
 
 ```ts title="agent/channels/eve.ts"
 import { eveChannel } from "eve/channels/eve";
@@ -239,7 +240,7 @@ export default eveChannel({
 
 The predicate authorizes the _forwarder_ (the verified route-auth principal — who is asserting), not the forwarded principal (what is asserted). Match it precisely: a permissive predicate like `() => true` lets any caller that passes route auth assert any principal, including preview deployments of your own project when `vercelOidc()` is in the walk. `trustedForwarders` exists only on your authored channel — the framework default channel never accepts a forwarded principal, so a receiving deployment must author `agent/channels/eve.ts`.
 
-When the predicate accepts, the forwarded principal replaces the session principal: `ctx.session.auth.current` and `.initiator` carry the forwarded user exactly as if they had called your deployment directly, so user-scoped connections, local subagents, and further `forwardPrincipal` hops all see that user. The forwarder is recorded on the accepted contexts as the `eve:forwarded-by` attribute (always overwritten by the receiver, so a forwarder cannot falsify it). Rejections fail loud: a forwarded body without `trustedForwarders` configured or with a forwarder the predicate refuses is a `403`, and a malformed payload is a `400`. Only principal metadata is ever accepted — tokens and credentials never cross the hop.
+When the predicate accepts a create-session request, `ctx.session.auth.current` and `.initiator` carry the forwarded user exactly as if they had called your deployment directly, so user-scoped connections, local subagents, and further `forwardPrincipal` hops all see that user. A later task-input response replaces only `current`; `initiator` remains the principal that started the durable session. The forwarder is recorded on each accepted context as the `eve:forwarded-by` attribute (always overwritten by the receiver, so a forwarder cannot falsify it). Rejections fail loud: a forwarded body without `trustedForwarders` configured or with a forwarder the predicate refuses is a `403`, and a malformed payload is a `400`. Only principal metadata is ever accepted — tokens and credentials never cross the hop.
 
 ## What reaches `ctx.session.auth`
 

--- a/docs/guides/remote-agents.md
+++ b/docs/guides/remote-agents.md
@@ -114,7 +114,9 @@ export default defineRemoteAgent({
 });
 ```
 
-The create-session request then carries the parent turn's `session.auth.current` and `session.auth.initiator` as a `forwardedPrincipal` body field (`initiator` is optional on the wire; when absent, the receiver seeds both from `current`). Only principal metadata crosses the wire — never tokens or credentials. The receiving deployment mints its own per-user credentials through its own connections.
+The create-session request then carries the parent turn's `session.auth.current` and `session.auth.initiator` as a `forwardedPrincipal` body field (`initiator` is optional on the wire; when absent, the receiver seeds both from `current`). If a background child later requests input, eve resolves the remote agent's outbound auth again and forwards the responding parent's current principal on the scoped task-input request. A dynamic remote agent resolves callback auth and headers from the definition selected for its current continuation and uses that definition's `forwardPrincipal` policy, rather than reusing its start-time definition.
+
+The approval remains available for another response if the child rejects the responder; eve clears it only after the child reports `approval.settled`. Only principal metadata crosses the wire — never tokens or credentials. The receiving deployment mints its own per-user credentials through its own connections.
 
 Forwarding is explicit on both sides. The receiver names which forwarders it trusts with `eveChannel({ trustedForwarders })` (see [Auth & route protection](./auth-and-route-protection#accepting-forwarded-identity-from-another-deployment)); a receiver that refuses the forwarder — or has no `trustedForwarders` at all — rejects with a 403 and the dispatch fails. One caveat: a receiver on an eve version that predates principal forwarding drops the unknown field and runs the session as your app's service identity (per-user connections there fail with `principal_required`), so upgrade both deployments together when enabling forwarding. When the dispatching turn has no auth at all, the field is omitted and the call proceeds on transport trust alone.
 

--- a/packages/eve/src/channel/forwarded-principal.ts
+++ b/packages/eve/src/channel/forwarded-principal.ts
@@ -15,8 +15,8 @@ const log = createLogger("channel.forwarded-principal");
 export const FORWARDED_BY_ATTRIBUTE = "eve:forwarded-by";
 
 /**
- * Wire shape of the create-session `forwardedPrincipal` body field: the
- * dispatching turn's session principals, asserted by a trusted forwarder.
+ * Wire shape of a remote request's `forwardedPrincipal` body field: session
+ * principals asserted by a trusted forwarder.
  * Only principal metadata crosses the wire — never tokens or credentials.
  */
 export interface ForwardedPrincipal {
@@ -43,10 +43,9 @@ export type ForwardedPrincipalParseResult =
     };
 
 /**
- * The create route's effective session principals after the forwarded
- * principal gate: the transport principal untouched when the body carries no
- * assertion, or the stamped forwarded contexts once a trusted forwarder's
- * assertion is accepted.
+ * Effective principals after the forwarded-principal gate: the transport
+ * principal untouched when the body carries no assertion, or the stamped
+ * forwarded contexts once a trusted forwarder's assertion is accepted.
  */
 export type ResolvedForwardedPrincipal =
   | {
@@ -85,8 +84,8 @@ const forwardedPrincipalSchema = z
   .strict();
 
 /**
- * Gates the create-session `forwardedPrincipal` body field and resolves the
- * effective session principals. Returns the failure `Response` on rejection:
+ * Gates a `forwardedPrincipal` body field and resolves the effective session
+ * principals. Returns the failure `Response` on rejection:
  * 403 when the channel accepts no forwarded principal or the predicate
  * refuses the forwarder, 400 on a malformed payload, 500 when the authored
  * predicate throws. Accepted contexts are stamped with
@@ -141,8 +140,8 @@ export async function resolveForwardedPrincipal(input: {
 }
 
 /**
- * Parses the create-session `forwardedPrincipal` body field against the
- * strict wire schema. Mirrors `parseSessionCallback` for `callback`: strict
+ * Parses a `forwardedPrincipal` body field against the strict wire schema.
+ * Mirrors `parseSessionCallback` for `callback`: strict
  * keys, formatted error strings, and no exceptions.
  */
 export function parseForwardedPrincipal(value: unknown): ForwardedPrincipalParseResult {

--- a/packages/eve/src/execution/agent-handle-dispatch.ts
+++ b/packages/eve/src/execution/agent-handle-dispatch.ts
@@ -21,6 +21,7 @@ import {
   prepareAgentContinuation,
   rejectAgentEffect,
   removeTaskAgentAddress,
+  replaceTaskAgentAddress,
 } from "#harness/handles/transitions.js";
 import type {
   RuntimeActionRequest,
@@ -230,6 +231,7 @@ export async function dispatchToTaskAgentAddress(input: {
   readonly bundle: CompiledBundle;
   readonly currentSession: RuntimeSession;
   readonly parentToken: string;
+  readonly remoteTransport?: { readonly resolverId?: string };
 }): Promise<DispatchOutcome> {
   const { action, agentId } = input;
   const invokedName =
@@ -267,6 +269,7 @@ export async function dispatchToTaskAgentAddress(input: {
     bundle: input.bundle,
     identity: record.identity,
     parentToken: input.parentToken,
+    remoteTransport: input.remoteTransport,
   });
   if (!delivery.ok) {
     const { cause, permanent } = delivery.error;
@@ -289,16 +292,22 @@ export async function dispatchToTaskAgentAddress(input: {
       }),
       session: permanent
         ? removeTaskAgentAddress(input.currentSession, agentId)
-        : input.currentSession,
+        : replaceTaskAgentAddress(input.currentSession, {
+            address: delivery.error.address,
+            agentId,
+          }),
     };
   }
 
   return {
-    address: record.address,
+    address: delivery.value,
     callId: action.callId,
     kind: "called",
     name: action.name,
-    session: input.currentSession,
+    session: replaceTaskAgentAddress(input.currentSession, {
+      address: delivery.value,
+      agentId,
+    }),
     toolName: record.identity.name,
   };
 }
@@ -319,10 +328,16 @@ async function deliverToAgentAddress(input: {
   readonly bundle: CompiledBundle;
   readonly identity: AgentIdentity;
   readonly parentToken: string;
+  readonly remoteTransport?: { readonly resolverId?: string };
 }): Promise<
   Result<
-    void,
-    { readonly cause: unknown; readonly deliveryAmbiguous: boolean; readonly permanent: boolean }
+    AgentAddress,
+    {
+      readonly address: AgentAddress;
+      readonly cause: unknown;
+      readonly deliveryAmbiguous: boolean;
+      readonly permanent: boolean;
+    }
   >
 > {
   const { action, address, bundle, identity } = input;
@@ -338,8 +353,16 @@ async function deliverToAgentAddress(input: {
     } catch (error) {
       // The agent's node is gone from the compiled bundle; no retry can
       // reach this handle again.
-      return err({ cause: error, deliveryAmbiguous: false, permanent: true });
+      return err({ address, cause: error, deliveryAmbiguous: false, permanent: true });
     }
+    const deliveryAddress: AgentAddress =
+      input.remoteTransport === undefined
+        ? address
+        : {
+            ...address,
+            forwardPrincipal: resolvedRemote.forwardPrincipal,
+            resolverId: input.remoteTransport.resolverId,
+          };
     try {
       await continueRemoteAgentSession({
         callback: {
@@ -359,12 +382,13 @@ async function deliverToAgentAddress(input: {
       });
     } catch (error) {
       return err({
+        address: deliveryAddress,
         cause: error,
         deliveryAmbiguous: isAmbiguousRemoteAgentContinueError(error),
         permanent: !isRetryableRemoteAgentContinueError(error),
       });
     }
-    return ok(undefined);
+    return ok(deliveryAddress);
   }
 
   const childRuntime = createWorkflowRuntime({
@@ -390,6 +414,7 @@ async function deliverToAgentAddress(input: {
     });
     if (result.status === "session_not_active") {
       return err({
+        address,
         cause: new Error(`Agent session "${address.sessionId}" is no longer active.`),
         deliveryAmbiguous: false,
         permanent: true,
@@ -397,9 +422,9 @@ async function deliverToAgentAddress(input: {
     }
   } catch (error) {
     const permanent = isRuntimeNoActiveSessionError(error);
-    return err({ cause: error, deliveryAmbiguous: !permanent, permanent });
+    return err({ address, cause: error, deliveryAmbiguous: !permanent, permanent });
   }
-  return ok(undefined);
+  return ok(address);
 }
 
 export function createAgentErrorResult(input: {

--- a/packages/eve/src/execution/dispatch-runtime-actions-step.integration.test.ts
+++ b/packages/eve/src/execution/dispatch-runtime-actions-step.integration.test.ts
@@ -27,6 +27,7 @@ import {
   CapabilitiesKey,
   ChannelInstrumentationKey,
   InitiatorAuthKey,
+  SessionDynamicSubagentSelectionsKey,
   SessionIdKey,
   SessionKey,
 } from "#context/keys.js";
@@ -414,6 +415,45 @@ describe("dispatchRuntimeActionsStep child starts", () => {
     ]);
   });
 
+  it("records the responder transport policy on a remote task address", async () => {
+    const session = createStartSession({ kind: "remote" });
+    installContext(
+      session,
+      {
+        definition: { ...REMOTE_REGISTRY_DEFINITION, forwardPrincipal: true },
+        nodeId: "remote/research",
+      },
+      true,
+    );
+    vi.spyOn(taskRunControl, "sendTaskCommandToOwner").mockResolvedValue({
+      runId: "task-run-1",
+    });
+
+    const result = await dispatchTaskStep({
+      callbackBaseUrl: "https://caller.example.com",
+      parentContinuationToken: "turn-inbox",
+      parentWritable: createWritable(),
+      serializedContext: {},
+      sessionState: BASE_STATE,
+    });
+
+    expect(getAgentHandleStore(readResultSessionState(result, session))).toEqual({
+      handles: [
+        expect.objectContaining({
+          address: {
+            callbackBaseUrl: "https://caller.example.com",
+            forwardPrincipal: true,
+            kind: "agent/remote",
+            resolverId: "remote/research",
+            sessionId: "remote-session-123456789012",
+            url: "https://registry.example.com",
+          },
+          phase: "addressed",
+        }),
+      ],
+    });
+  });
+
   it("silently rejects a tasks-mode start that failed before index admission", async () => {
     const session = createStartSession({ kind: "local" });
     installContext(
@@ -745,6 +785,96 @@ describe("dispatchRuntimeActionsStep agent delivery", () => {
     });
     expect(mocks.dispatchSession).not.toHaveBeenCalled();
     expect(mocks.startWorkflowPreferLatest).not.toHaveBeenCalled();
+  });
+
+  it("replaces task callback policy with the current dynamic remote selection", async () => {
+    const currentCredentialsStepId = "eve:dynamic-remote-agent//current-research";
+    const registryKey = Symbol.for("@workflow/core//registeredSteps");
+    const globalRecord = globalThis as Record<
+      symbol,
+      Map<string, () => { headers: Record<string, string> }> | undefined
+    >;
+    const stepRegistry = globalRecord[registryKey] ?? new Map();
+    globalRecord[registryKey] = stepRegistry;
+    stepRegistry.set(currentCredentialsStepId, () => ({
+      headers: { authorization: "Bearer current" },
+    }));
+    const remoteAddress = REMOTE_PARKED_HANDLE.address;
+    if (remoteAddress.kind !== "agent/remote") throw new Error("Expected a remote test handle.");
+    const addressedHandle: AgentHandle = {
+      address: {
+        ...remoteAddress,
+        forwardPrincipal: true,
+        resolverId: "eve:dynamic-remote-agent//start-research",
+      },
+      identity: REMOTE_PARKED_HANDLE.identity,
+      phase: "addressed",
+    };
+    const session = createRemotePendingSession({
+      agentId: addressedHandle.identity.id,
+      handle: addressedHandle,
+    });
+    installContext(
+      session,
+      {
+        definition: {
+          ...REMOTE_REGISTRY_DEFINITION,
+          logicalPath: "agent/subagents/research.ts",
+          sourceId: "agent/subagents/research.ts",
+          sourceKind: "module",
+        },
+        nodeId: REMOTE_PARKED_HANDLE.identity.nodeId,
+      },
+      true,
+      {
+        nodeId: REMOTE_PARKED_HANDLE.identity.nodeId,
+        selection: {
+          kind: "remote",
+          prepared: {},
+          remoteAgent: {
+            credentialsStepId: currentCredentialsStepId,
+            description: "Current remote research",
+            forwardPrincipal: false,
+            path: "/current/session",
+            url: "https://current.example.com",
+          },
+        },
+      },
+    );
+
+    const result = await dispatchTaskStep({
+      parentContinuationToken: "turn-inbox",
+      parentWritable: createWritable(),
+      serializedContext: {},
+      sessionState: BASE_STATE,
+    });
+
+    expect(mocks.continueRemoteAgentSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        remote: expect.objectContaining({
+          forwardPrincipal: false,
+          path: "/current/session",
+          url: remoteAddress.url,
+        }),
+      }),
+    );
+    expect(getAgentHandleStore(readResultSessionState(result, session))).toEqual({
+      handles: [
+        {
+          address: {
+            callbackBaseUrl: remoteAddress.callbackBaseUrl,
+            forwardPrincipal: false,
+            kind: "agent/remote",
+            resolverId: currentCredentialsStepId,
+            sessionId: remoteAddress.sessionId,
+            url: remoteAddress.url,
+          },
+          identity: addressedHandle.identity,
+          phase: "addressed",
+        },
+      ],
+    });
+    stepRegistry.delete(currentCredentialsStepId);
   });
 
   const continueOperationId = deriveAgentOperationId({
@@ -1167,10 +1297,33 @@ function createPendingSession(input: {
   });
 }
 
+function createRemotePendingSession(input: {
+  readonly handle: AgentHandle;
+  readonly agentId: string;
+}): HarnessSession {
+  return setPendingRuntimeActionBatch({
+    actions: [
+      {
+        callId: "call-1",
+        description: "Research",
+        input: { agentId: input.agentId, message: "continue with current credentials" },
+        kind: "remote-agent-call",
+        name: "research",
+        nodeId: "remote/research",
+        remoteAgentName: "research",
+      },
+    ],
+    event: { sequence: 1, stepIndex: 2, turnId: "turn-1" },
+    responseMessages: [],
+    session: createBaseSession(input.handle),
+  });
+}
+
 function installContext(
   session: HarnessSession,
   remote?: { readonly definition: unknown; readonly nodeId: string },
   tasks = false,
+  dynamic?: { readonly nodeId: string; readonly selection: unknown },
 ): void {
   const subagentsByNodeId = new Map<string, { definition: unknown }>();
   if (remote !== undefined) {
@@ -1179,7 +1332,10 @@ function installContext(
   const bundle = {
     compiledArtifactsSource: {},
     resolvedAgent: { config: tasks ? { experimental: { tasks: true } } : {} },
-    subagentRegistry: { subagentsByNodeId },
+    subagentRegistry: {
+      dynamicNodeIds: dynamic === undefined ? undefined : new Set([dynamic.nodeId]),
+      subagentsByNodeId,
+    },
     turnAgent: {
       id: "test-agent",
       instructions: [],
@@ -1197,6 +1353,11 @@ function installContext(
     [InitiatorAuthKey, null],
     [ChannelKey, ADAPTER],
   ]);
+  if (dynamic !== undefined) {
+    values.set(SessionDynamicSubagentSelectionsKey, {
+      [dynamic.nodeId]: dynamic.selection,
+    });
+  }
   mocks.deserializeContext.mockResolvedValue({
     get: (key: unknown) => values.get(key),
     require: (key: unknown) => {

--- a/packages/eve/src/execution/proxied-deliver-step.ts
+++ b/packages/eve/src/execution/proxied-deliver-step.ts
@@ -9,11 +9,15 @@ import { routeDeliverPayload } from "#execution/subagent-hitl-proxy.js";
 import { sendTaskInboundPayload } from "#execution/tasks/parent/run-parent.js";
 import { resumeHook } from "#internal/workflow/runtime.js";
 import type { InputResponse } from "#runtime/input/types.js";
+import { BundleKey } from "#runtime/sessions/runtime-context-keys.js";
 import { findSessionTaskEntry } from "#tasks/session-index.js";
 import {
   createTaskInputRequestId,
+  getProxyInputRequests,
   retireProxyInputRequests,
 } from "#harness/proxy-input-requests.js";
+import { getAgentHandleStore } from "#harness/handles/store.js";
+import { isTaskInputSettledByDelivery, type TaskInboundAnswerInput } from "#tasks/types.js";
 
 export type RoutedDeliverResult =
   | {
@@ -43,7 +47,6 @@ type LegacyRoutedDeliverResult =
 
 interface ChildBucket {
   readonly childContinuationToken: string;
-  readonly childResponseUrl?: string;
   readonly metadata: NonNullable<DeliverHookPayload["deliveryMetadata"]>[number][];
   readonly payloads: DeliverPayload[];
   readonly retireRequestIds: string[];
@@ -108,14 +111,9 @@ export async function routeProxiedDeliverStep(
       const key =
         forChild.taskId === undefined
           ? forChild.childContinuationToken
-          : [
-              forChild.childContinuationToken,
-              forChild.childResponseUrl ?? "",
-              forChild.taskId,
-            ].join("\0");
+          : [forChild.childContinuationToken, forChild.taskId].join("\0");
       const child = children.get(key) ?? {
         childContinuationToken: forChild.childContinuationToken,
-        childResponseUrl: forChild.childResponseUrl,
         metadata: [],
         payloads: [],
         retireRequestIds: [],
@@ -150,14 +148,23 @@ export async function routeProxiedDeliverStep(
         mergeStrandedResponses(parentPayloads, child, taskId);
         continue;
       }
+      const target = createTaskInputDeliveryTarget({
+        childContinuationToken: child.childContinuationToken,
+        entry,
+        serializedBundle: input.serializedContext?.[BundleKey.name],
+        state: durableSession.state,
+      });
+      if (target === undefined) {
+        mergeStrandedResponses(parentPayloads, child, taskId);
+        continue;
+      }
       const delivery = await sendTaskInboundPayload({
         taskInboxToken: entry.taskInboxToken,
         payload: {
-          auth: sourceDelivery.auth,
-          childContinuationToken: child.childContinuationToken,
-          childResponseUrl: child.childResponseUrl,
+          auth: sourceDelivery.auth ?? null,
           inputResponses: coalesceDeliverPayloads(child.payloads).inputResponses ?? [],
           kind: "input-response",
+          target,
           taskId,
         },
       });
@@ -165,11 +172,14 @@ export async function routeProxiedDeliverStep(
         mergeStrandedResponses(parentPayloads, child, taskId);
         continue;
       }
-      // Hand-off to the task run succeeded. Retire the parent-visible
-      // routes so a later click cannot re-enter the same batch after the
-      // run has already accepted (or no-op'd) this answer.
-      durableSession = retireProxyInputRequests(durableSession, child.retireRequestIds);
-      retired = true;
+      const routes = getProxyInputRequests(durableSession.state);
+      const settledRequestIds = child.retireRequestIds.filter((requestId) =>
+        isTaskInputSettledByDelivery(routes.get(requestId)),
+      );
+      if (settledRequestIds.length > 0) {
+        durableSession = retireProxyInputRequests(durableSession, settledRequestIds);
+        retired = true;
+      }
       continue;
     }
 
@@ -212,6 +222,35 @@ export async function routeProxiedDeliverStep(
             payloads: orderedParentPayloads.map(([, payload]) => payload),
           };
   return { ...context, kind: "continue", remainder };
+}
+
+function createTaskInputDeliveryTarget(input: {
+  readonly childContinuationToken: string;
+  readonly entry: NonNullable<ReturnType<typeof findSessionTaskEntry>>;
+  readonly serializedBundle: unknown;
+  readonly state: Parameters<typeof getAgentHandleStore>[0];
+}): TaskInboundAnswerInput["target"] | undefined {
+  if (input.entry.metadata.mode === "local") {
+    return { continuationToken: input.childContinuationToken, kind: "local" };
+  }
+
+  const handle = (getAgentHandleStore(input.state)?.handles ?? []).find(
+    (candidate) =>
+      candidate.phase === "addressed" &&
+      candidate.identity.id === input.entry.metadata.agentId &&
+      candidate.address.kind === "agent/remote",
+  );
+  if (handle?.phase !== "addressed" || handle.address.kind !== "agent/remote") return undefined;
+
+  return {
+    continuationToken: input.childContinuationToken,
+    forwardPrincipal: handle.address.forwardPrincipal,
+    kind: "remote",
+    name: handle.identity.name,
+    resolverId: handle.address.resolverId,
+    serializedBundle: input.serializedBundle,
+    url: handle.address.url,
+  };
 }
 
 // Answers to a task that finished mid-flight rejoin the parent-local

--- a/packages/eve/src/execution/route-child-delivery.ts
+++ b/packages/eve/src/execution/route-child-delivery.ts
@@ -45,7 +45,6 @@ export async function routeDeliverToChildren(input: {
   for (const request of payload.task?.inputRequests ?? []) {
     const recorded = await recordTaskInputRequestStep({
       hookPayload: request.hookPayload,
-      serializedContext,
       sessionState,
       taskId: request.taskId,
     });
@@ -62,12 +61,13 @@ export async function routeDeliverToChildren(input: {
   }
 
   for (const request of payload.task?.authorizationEvents ?? []) {
-    const accepted = await acceptTaskAuthorizationEventStep({
+    const authorization = await acceptTaskAuthorizationEventStep({
       hookPayload: request.hookPayload,
       sessionState,
       taskId: request.taskId,
     });
-    if (!accepted) continue;
+    sessionState = authorization.sessionState;
+    if (!authorization.accepted) continue;
     const emitted = await emitRecordedTaskAuthorizationEventStep({
       hookPayload: request.hookPayload,
       parentWritable: input.parentWritable,

--- a/packages/eve/src/execution/subagent-hitl-proxy.ts
+++ b/packages/eve/src/execution/subagent-hitl-proxy.ts
@@ -63,7 +63,6 @@ export async function emitProxiedInputRequest(input: {
 /** One proxied-child bucket of a routed deliver payload. */
 export interface RoutedChildDelivery {
   readonly childContinuationToken: string;
-  readonly childResponseUrl?: string;
   readonly payload: { readonly inputResponses: readonly InputResponse[] };
   /** Parent-visible request IDs safe to retire once this bucket is forwarded. */
   readonly retireRequestIds: readonly string[];
@@ -85,7 +84,6 @@ export interface RoutedDeliverPayload {
 /** In-progress accumulation for one `forChildren` bucket. */
 interface ChildResponseBucket {
   readonly childContinuationToken: string;
-  readonly childResponseUrl?: string;
   /** Parent-visible request IDs answered in this bucket. */
   readonly parentRequestIds: string[];
   readonly responses: InputResponse[];
@@ -121,7 +119,7 @@ export function routeDeliverPayload(input: {
     const bucketKey =
       route.taskId === undefined
         ? route.childContinuationToken
-        : `${route.childContinuationToken}\0${route.childResponseUrl ?? "local"}\0${route.taskId}`;
+        : `${route.childContinuationToken}\0${route.taskId}`;
     const existing = responsesByChild.get(bucketKey);
 
     if (existing === undefined) {
@@ -130,7 +128,6 @@ export function routeDeliverPayload(input: {
         parentRequestIds: [response.requestId],
         responses: [toChildInputResponse(response, route)],
         routes: [route],
-        ...(route.childResponseUrl !== undefined && { childResponseUrl: route.childResponseUrl }),
         ...(route.taskId !== undefined && { taskId: route.taskId }),
       });
     } else {
@@ -143,7 +140,6 @@ export function routeDeliverPayload(input: {
   const forChildren = [...responsesByChild.values()].map(
     ({
       childContinuationToken,
-      childResponseUrl,
       parentRequestIds,
       responses,
       routes,
@@ -168,7 +164,6 @@ export function routeDeliverPayload(input: {
         childContinuationToken,
         payload: { inputResponses: responses },
         retireRequestIds: [...retireRequestIds],
-        ...(childResponseUrl !== undefined && { childResponseUrl }),
         ...(taskId !== undefined && { taskId }),
       };
     },

--- a/packages/eve/src/execution/subagent-start-remote.ts
+++ b/packages/eve/src/execution/subagent-start-remote.ts
@@ -11,6 +11,7 @@ import {
   prepareAgentStart,
   rejectAgentEffect,
 } from "#harness/handles/transitions.js";
+import type { AgentAddress } from "#harness/handles/store.js";
 import { createLogger, logError } from "#internal/logging.js";
 import type { RuntimeRemoteAgentCallActionRequest } from "#runtime/actions/types.js";
 import type { CompiledBundle } from "#runtime/sessions/runtime-context-keys.js";
@@ -91,12 +92,22 @@ export async function startRemoteSubagent(input: {
       remote: resolvedRemote,
       session: input.session,
     });
-    const address = {
+    const resolverId =
+      input.dynamicRemoteAgent === undefined
+        ? action.nodeId
+        : input.dynamicRemoteAgent.credentialsStepId;
+    const address: AgentAddress = {
       callbackBaseUrl,
+      ...(input.taskOwned
+        ? {
+            forwardPrincipal: resolvedRemote.forwardPrincipal,
+            resolverId,
+          }
+        : {}),
       kind: "agent/remote",
       sessionId: child.sessionId,
       url: resolvedRemote.url,
-    } as const;
+    };
     return {
       address,
       callId: action.callId,

--- a/packages/eve/src/execution/tasks/child/steps.ts
+++ b/packages/eve/src/execution/tasks/child/steps.ts
@@ -5,9 +5,16 @@ import type {
   SubagentAuthorizationEventHookPayload,
   SubagentInputRequestHookPayload,
 } from "#channel/types.js";
+import { deserializeContext } from "#context/serialize.js";
+import { resolveRemoteAgentStreamHeaders } from "#execution/remote-agent-dispatch.js";
+import { createTaskInputCapabilityToken } from "#execution/task-input-capability.js";
 import { isTaskWorkflowTargetGone } from "#execution/tasks/workflow-target.js";
+import { createRemoteTaskInputCallbackUrl } from "#execution/workflow-callback-url.js";
 import { resumeHook } from "#internal/workflow/runtime.js";
 import { createLogger } from "#internal/logging.js";
+import { createEveTaskInputRoutePath } from "#protocol/routes.js";
+import type { InputResponse } from "#runtime/input/types.js";
+import { BundleKey } from "#runtime/sessions/runtime-context-keys.js";
 import {
   isTerminalTaskStatus,
   taskAuthorizationRequestId,
@@ -16,6 +23,7 @@ import {
   type TaskInboundAuthorizationEvent,
   type TaskInboundInputRequest,
   type TaskInboundUpdate,
+  type TaskInputDeliveryTarget,
   type TaskView,
 } from "#tasks/types.js";
 
@@ -185,29 +193,45 @@ export async function deliverTaskInputResponsesStep(input: {
   "use step";
 
   const answered = new Set(input.requestIds);
+  const inputResponses = input.answer.inputResponses.filter((response) =>
+    answered.has(response.requestId),
+  );
   const command: SessionCommand = {
-    auth: input.answer.auth as SessionAuthContext | null | undefined,
+    auth: input.answer.auth,
     kind: "send",
-    payload: {
-      inputResponses: input.answer.inputResponses.filter((response) =>
-        answered.has(response.requestId),
-      ),
-    },
+    payload: { inputResponses },
     taskDeliveryId: `${input.answer.taskId}:${[...input.requestIds].sort().join(",")}`,
   };
   try {
-    if (input.answer.childResponseUrl !== undefined) {
-      const response = await fetch(input.answer.childResponseUrl, {
-        body: JSON.stringify({ inputResponses: command.payload.inputResponses }),
-        headers: { "content-type": "application/json" },
-        method: "POST",
-        redirect: "error",
-      });
+    if (input.answer.target.kind === "remote") {
+      const target = input.answer.target;
+      const body: {
+        forwardedPrincipal?: { readonly current: SessionAuthContext };
+        inputResponses: readonly InputResponse[];
+      } = { inputResponses };
+      if (target.forwardPrincipal === true && input.answer.auth !== null) {
+        body.forwardedPrincipal = { current: input.answer.auth };
+      }
+      const response = await fetch(
+        createRemoteTaskInputCallbackUrl(
+          target.url,
+          createEveTaskInputRoutePath(createTaskInputCapabilityToken(target.continuationToken)),
+        ),
+        {
+          body: JSON.stringify(body),
+          headers: {
+            "content-type": "application/json",
+            ...(await resolveTaskInputResponseHeaders(target)),
+          },
+          method: "POST",
+          redirect: "error",
+        },
+      );
       if (response.status === 404) return "unreachable";
       if (!response.ok)
         throw new Error(`Remote task input delivery failed with HTTP ${response.status}.`);
     } else {
-      await resumeHook(input.answer.childContinuationToken, command);
+      await resumeHook(input.answer.target.continuationToken, command);
     }
     return "delivered";
   } catch (error) {
@@ -219,6 +243,19 @@ export async function deliverTaskInputResponsesStep(input: {
     }
     throw error;
   }
+}
+
+async function resolveTaskInputResponseHeaders(
+  target: Extract<TaskInputDeliveryTarget, { readonly kind: "remote" }>,
+): Promise<Record<string, string>> {
+  if (target.resolverId === undefined) return {};
+  const ctx = await deserializeContext({ [BundleKey.name]: target.serializedBundle });
+  return await resolveRemoteAgentStreamHeaders({
+    bundle: ctx.require(BundleKey),
+    name: target.name,
+    resolverId: target.resolverId,
+    url: target.url,
+  });
 }
 
 function formatTaskNotification(view: TaskView): string {

--- a/packages/eve/src/execution/tasks/child/task-input-principal.test.ts
+++ b/packages/eve/src/execution/tasks/child/task-input-principal.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { SessionAuthContext } from "#channel/types.js";
+import { deserializeContext } from "#context/serialize.js";
+import { resolveRemoteAgentStreamHeaders } from "#execution/remote-agent-dispatch.js";
+import { deliverTaskInputResponsesStep } from "#execution/tasks/child/steps.js";
+import type { TaskInboundAnswerInput } from "#tasks/types.js";
+
+const resumeHookMock = vi.fn();
+
+vi.mock("#internal/workflow/runtime.js", () => ({
+  resumeHook: (token: string, payload: unknown) => resumeHookMock(token, payload),
+}));
+vi.mock("#context/serialize.js", () => ({ deserializeContext: vi.fn() }));
+vi.mock("#execution/remote-agent-dispatch.js", () => ({
+  resolveRemoteAgentStreamHeaders: vi.fn(),
+}));
+
+const DIGEST = "0123456789abcdef0123456789abcdef";
+const CHILD_TOKEN = `eve:eve:op:${DIGEST}`;
+const CAPABILITY_TOKEN = `eve:task-input:${DIGEST}`;
+const RESPONDER: SessionAuthContext = {
+  attributes: {},
+  authenticator: "test",
+  principalId: "parent-user",
+  principalType: "user",
+};
+
+afterEach(() => {
+  resumeHookMock.mockReset();
+  vi.mocked(deserializeContext).mockReset();
+  vi.mocked(resolveRemoteAgentStreamHeaders).mockReset();
+  vi.unstubAllGlobals();
+});
+
+describe("task input responder delivery", () => {
+  it("puts the responding parent principal on a local child command", async () => {
+    resumeHookMock.mockResolvedValue(undefined);
+
+    await expect(deliverTaskInputResponsesStep(delivery(answer()))).resolves.toBe("delivered");
+
+    expect(resumeHookMock).toHaveBeenCalledWith(
+      "local-child-token",
+      expect.objectContaining({
+        auth: RESPONDER,
+        payload: { inputResponses: [{ optionId: "approve", requestId: "approval-1" }] },
+      }),
+    );
+  });
+
+  it("uses the remote target's current credentials and forwarding policy", async () => {
+    const bundle = {} as never;
+    vi.mocked(deserializeContext).mockResolvedValue({ require: () => bundle } as never);
+    vi.mocked(resolveRemoteAgentStreamHeaders).mockResolvedValue({
+      authorization: "Bearer current",
+    });
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      deliverTaskInputResponsesStep(
+        delivery(
+          answer({
+            target: {
+              continuationToken: CHILD_TOKEN,
+              forwardPrincipal: true,
+              kind: "remote",
+              name: "child",
+              resolverId: "dynamic/current-child",
+              serializedBundle: { source: "compiled" },
+              url: "https://child.example",
+            },
+          }),
+        ),
+      ),
+    ).resolves.toBe("delivered");
+
+    expect(resolveRemoteAgentStreamHeaders).toHaveBeenCalledWith({
+      bundle,
+      name: "child",
+      resolverId: "dynamic/current-child",
+      url: "https://child.example",
+    });
+    const requestInit = fetchMock.mock.calls[0]?.[1];
+    expect(JSON.parse(String(requestInit?.body))).toEqual({
+      forwardedPrincipal: { current: RESPONDER },
+      inputResponses: [{ optionId: "approve", requestId: "approval-1" }],
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      `https://child.example/eve/v1/task-input/${encodeURIComponent(CAPABILITY_TOKEN)}`,
+      expect.objectContaining({
+        headers: {
+          authorization: "Bearer current",
+          "content-type": "application/json",
+        },
+      }),
+    );
+  });
+});
+
+function answer(overrides: Partial<TaskInboundAnswerInput> = {}): TaskInboundAnswerInput {
+  return {
+    auth: RESPONDER,
+    inputResponses: [{ optionId: "approve", requestId: "approval-1" }],
+    kind: "input-response",
+    target: { continuationToken: "local-child-token", kind: "local" },
+    taskId: "task-1",
+    ...overrides,
+  };
+}
+
+function delivery(answerInput: TaskInboundAnswerInput) {
+  return { answer: answerInput, requestIds: ["approval-1"] };
+}

--- a/packages/eve/src/execution/tasks/child/workflow.test.ts
+++ b/packages/eve/src/execution/tasks/child/workflow.test.ts
@@ -549,12 +549,109 @@ describe("taskRunWorkflow answered input", () => {
 
   function answer(...requestIds: readonly string[]): TaskInboundAnswerInput {
     return {
-      childContinuationToken: "child-token",
+      auth: null,
       inputResponses: requestIds.map((requestId) => ({ requestId, text: "answer" })),
       kind: "input-response",
+      target: { continuationToken: "child-token", kind: "local" },
       taskId: "task_abc123",
     };
   }
+
+  function requireApproval(requestId: string): TaskRunInboundPayload {
+    return {
+      command: {
+        inputRequests: [
+          {
+            action: {
+              callId: "tool-call-1",
+              input: {},
+              kind: "tool-call",
+              toolName: "deploy",
+            },
+            kind: "tool-approval",
+            prompt: "Approve deploy?",
+            requestId,
+          },
+        ],
+        kind: "require-input",
+      },
+      kind: "task-command",
+    };
+  }
+
+  it("keeps an approval retryable until the child reports settlement", async () => {
+    vi.mocked(deliverTaskInputResponsesStep).mockResolvedValue("delivered");
+    const rejectedCandidate: SubagentAuthorizationEventHookPayload = {
+      callId: "call-task",
+      childSessionId: "child-session",
+      event: {
+        data: {
+          candidateId: "candidate-1",
+          outcome: "rejected",
+          reason: "Responder is not allowed to approve this tool.",
+          requestId: "approval-1",
+          responderPrincipalId: "user-1",
+          sequence: 2,
+          stepIndex: 3,
+          turnId: "turn-child",
+        },
+        type: "approval.candidate",
+      },
+      kind: "subagent-authorization-event",
+      subagentName: "research",
+    };
+    const settlement: SubagentAuthorizationEventHookPayload = {
+      callId: "call-task",
+      childSessionId: "child-session",
+      event: {
+        data: {
+          outcome: "approved",
+          requestId: "approval-1",
+          responderPrincipalId: "user-2",
+          sequence: 3,
+          stepIndex: 3,
+          turnId: "turn-child",
+        },
+        type: "approval.settled",
+      },
+      kind: "subagent-authorization-event",
+      subagentName: "research",
+    };
+    mockCommandHook([
+      { command: { kind: "ready" }, kind: "task-command" },
+      requireApproval("approval-1"),
+      answer("approval-1"),
+      rejectedCandidate,
+      answer("approval-1"),
+      settlement,
+      { command: { data: "done", kind: "complete" }, kind: "task-command" },
+    ]);
+
+    await taskRunWorkflow({
+      taskInboxToken: "task-token",
+      initialView: createWorkingView(),
+      parentContinuationToken: "parent-session-token",
+    });
+
+    expect(deliverTaskInputResponsesStep).toHaveBeenCalledTimes(2);
+    expect(appendedStatuses()).toEqual([
+      "working",
+      "working",
+      "input_required",
+      "working",
+      "completed",
+    ]);
+    expect(wakeTaskAuthorizationParentStep).toHaveBeenNthCalledWith(1, {
+      request: { ...rejectedCandidate, kind: "authorization-event" },
+      taskId: "task_abc123",
+      token: "parent-session-token",
+    });
+    expect(wakeTaskAuthorizationParentStep).toHaveBeenNthCalledWith(2, {
+      request: { ...settlement, kind: "authorization-event" },
+      taskId: "task_abc123",
+      token: "parent-session-token",
+    });
+  });
 
   it("forwards the answer to the child before recording it as unblocked", async () => {
     vi.mocked(deliverTaskInputResponsesStep).mockResolvedValue("delivered");

--- a/packages/eve/src/execution/tasks/child/workflow.ts
+++ b/packages/eve/src/execution/tasks/child/workflow.ts
@@ -15,6 +15,7 @@ import { translateTaskInboundPayload } from "#tasks/wire.js";
 import {
   isReadyTaskStatus,
   isTerminalTaskStatus,
+  isTaskInputSettledByDelivery,
   readTaskInputRequestId,
   readTaskUsage,
   type TaskCommand,
@@ -102,15 +103,18 @@ export async function taskRunWorkflow(input: TaskRunWorkflowInput): Promise<void
         next.value.kind === "subagent-authorization-event"
           ? { ...next.value, kind: "authorization-event" }
           : next.value;
-      // Approval lifecycle events (`approval.candidate`/`approval.settled`)
-      // are intra-child responder bookkeeping, not task blockers: only
-      // `authorization.required`/`authorization.completed` may block or
-      // unblock a task. Forwarding them would mint bogus `answered`
-      // commands and race the terminal wake.
-      if (
-        payload.kind === "authorization-event" &&
-        (payload.event.type === "approval.candidate" || payload.event.type === "approval.settled")
-      ) {
+      // A candidate reports one responder attempt. Only approval.settled
+      // clears the approval request, so candidates bypass task transitions.
+      if (payload.kind === "authorization-event" && payload.event.type === "approval.candidate") {
+        if (dispatchAcknowledged && !isTerminalTaskStatus(view.status)) {
+          await wakeTaskAuthorizationParentStep({
+            request: payload,
+            taskId: view.taskId,
+            token: input.parentContinuationToken,
+          });
+        } else {
+          pendingAuthorizationEvents.push(payload);
+        }
         continue;
       }
       const isReadinessCommand =
@@ -239,10 +243,10 @@ async function resolveAnsweredCommand(
 ): Promise<TaskCommand | undefined> {
   if (answer.taskId !== view.taskId) return undefined;
 
-  const outstanding = new Set(
+  const outstanding = new Map(
     view.inputRequests.flatMap((request) => {
       const requestId = readTaskInputRequestId(request);
-      return requestId === undefined ? [] : [requestId];
+      return requestId === undefined ? [] : [[requestId, request] as const];
     }),
   );
   const requestIds = answer.inputResponses
@@ -251,5 +255,12 @@ async function resolveAnsweredCommand(
   if (requestIds.length === 0) return undefined;
 
   const delivery = await deliverTaskInputResponsesStep({ answer, requestIds });
-  return delivery === "delivered" ? { kind: "answered", requestIds } : undefined;
+  if (delivery !== "delivered") return undefined;
+
+  const settledRequestIds = requestIds.filter((requestId) =>
+    isTaskInputSettledByDelivery(outstanding.get(requestId)),
+  );
+  return settledRequestIds.length === 0
+    ? undefined
+    : { kind: "answered", requestIds: settledRequestIds };
 }

--- a/packages/eve/src/execution/tasks/parent/dispatch-task-step.ts
+++ b/packages/eve/src/execution/tasks/parent/dispatch-task-step.ts
@@ -141,6 +141,15 @@ export async function dispatchTaskStep(
             }),
             currentSession: nextSession,
             parentToken: delegated.taskInboxToken,
+            remoteTransport:
+              entry.action.kind === "remote-agent-call"
+                ? {
+                    resolverId:
+                      entry.dynamicRemoteAgent === undefined
+                        ? entry.action.nodeId
+                        : entry.dynamicRemoteAgent.credentialsStepId,
+                  }
+                : undefined,
           });
           break;
         case "start":

--- a/packages/eve/src/execution/tasks/parent/hitl-proxy-steps.ts
+++ b/packages/eve/src/execution/tasks/parent/hitl-proxy-steps.ts
@@ -1,11 +1,15 @@
 import type { SubagentInputRequestHookPayload } from "#channel/types.js";
 import type { SubagentAuthorizationEventHookPayload } from "#channel/types.js";
-import { type DurableSessionState, readDurableSession } from "#execution/durable-session-store.js";
-import { createTaskInputCapabilityToken } from "#execution/task-input-capability.js";
-import { readLatestTaskView } from "#execution/tasks/parent/run-parent.js";
-import { createRemoteTaskInputCallbackUrl } from "#execution/workflow-callback-url.js";
 import {
+  type DurableSessionState,
+  readDurableSession,
+  replaceDurableSessionSnapshot,
+} from "#execution/durable-session-store.js";
+import { readLatestTaskView } from "#execution/tasks/parent/run-parent.js";
+import {
+  clearProxyInputRequestsForTask,
   createTaskInputRequestId,
+  retireProxyInputRequests,
   toProxyInputRequestEntries,
   upsertProxyInputRequestState,
 } from "#harness/proxy-input-requests.js";
@@ -13,13 +17,11 @@ import { getAgentHandleStore } from "#harness/handles/store.js";
 import { removeTaskAgentAddressFromState } from "#harness/handles/transitions.js";
 import { isInputRequest } from "#runtime/input/types.js";
 import { cacheTerminalTaskView, findSessionTaskEntry } from "#tasks/session-index.js";
-import { createEveTaskInputRoutePath } from "#protocol/routes.js";
 import { isTerminalTaskStatus, type TaskView } from "#tasks/types.js";
 
 /** Validates and durably records one task-owned child HITL route batch. */
 export async function recordTaskInputRequestStep(input: {
   readonly hookPayload: SubagentInputRequestHookPayload;
-  readonly serializedContext: Record<string, unknown>;
   readonly sessionState: DurableSessionState;
   readonly taskId: string;
 }): Promise<
@@ -71,7 +73,7 @@ export async function recordTaskInputRequestStep(input: {
   }
 
   const hookPayload = namespaceTaskInputRequests(input.hookPayload, input.taskId);
-  let entries = toProxyInputRequestEntries(hookPayload, input.taskId).map(
+  const entries = toProxyInputRequestEntries(hookPayload, input.taskId).map(
     ([requestId, route], index) => {
       const childRequestId = input.hookPayload.event.requests[index]!.requestId;
       return [
@@ -83,17 +85,6 @@ export async function recordTaskInputRequestStep(input: {
       ] as const;
     },
   );
-  if (handle.address.kind === "agent/remote") {
-    const childResponseUrl = createRemoteTaskInputCallbackUrl(
-      handle.address.url,
-      createEveTaskInputRoutePath(
-        createTaskInputCapabilityToken(input.hookPayload.childContinuationToken),
-      ),
-    );
-    entries = entries.map(
-      ([requestId, route]) => [requestId, { ...route, childResponseUrl }] as const,
-    );
-  }
   const state = upsertProxyInputRequestState({
     entries,
     forChildContinuationToken: input.hookPayload.childContinuationToken,
@@ -134,12 +125,12 @@ export async function acceptTaskAuthorizationEventStep(input: {
   readonly hookPayload: SubagentAuthorizationEventHookPayload;
   readonly sessionState: DurableSessionState;
   readonly taskId: string;
-}): Promise<boolean> {
+}): Promise<{ readonly accepted: boolean; readonly sessionState: DurableSessionState }> {
   "use step";
 
   const durableSession = await readDurableSession(input.sessionState);
   const entry = findSessionTaskEntry(durableSession.state, input.taskId);
-  if (entry === undefined) return false;
+  if (entry === undefined) return { accepted: false, sessionState: input.sessionState };
   const handle = (getAgentHandleStore(durableSession.state)?.handles ?? []).find(
     (candidate) =>
       candidate.phase === "addressed" && candidate.identity.id === entry.metadata.agentId,
@@ -148,15 +139,28 @@ export async function acceptTaskAuthorizationEventStep(input: {
     handle?.phase !== "addressed" ||
     handle.address.sessionId !== input.hookPayload.childSessionId
   ) {
-    return false;
+    return { accepted: false, sessionState: input.sessionState };
   }
   const view = await readLatestTaskView({ taskRunId: entry.taskRunId });
-  return (
-    view !== undefined &&
-    !isTerminalTaskStatus(view.status) &&
-    view.executor?.childSessionId === input.hookPayload.childSessionId &&
-    view.metadata.agentId === entry.metadata.agentId
-  );
+  if (
+    view === undefined ||
+    isTerminalTaskStatus(view.status) ||
+    view.executor?.childSessionId !== input.hookPayload.childSessionId ||
+    view.metadata.agentId !== entry.metadata.agentId
+  ) {
+    return { accepted: false, sessionState: input.sessionState };
+  }
+
+  if (input.hookPayload.event.type !== "approval.settled") {
+    return { accepted: true, sessionState: input.sessionState };
+  }
+  const session = retireProxyInputRequests(durableSession, [
+    createTaskInputRequestId(input.taskId, input.hookPayload.event.data.requestId),
+  ]);
+  return {
+    accepted: true,
+    sessionState: replaceDurableSessionSnapshot({ session, state: input.sessionState }),
+  };
 }
 
 /** Caches terminal task views before their workflow runs can expire. */
@@ -170,16 +174,14 @@ export async function recordTerminalTaskViewsStep(input: {
   let state = durableSession.state;
   for (const view of input.views) {
     state = cacheTerminalTaskView(state, view);
+    state = clearProxyInputRequestsForTask({ ...durableSession, state }, view.taskId).state;
     if (view.executor?.lifecycle === "terminal") {
       state = removeTaskAgentAddressFromState(state, view.metadata.agentId);
     }
   }
   if (state === durableSession.state) return input.sessionState;
-  return {
-    ...input.sessionState,
-    snapshot: {
-      session: { ...durableSession, state },
-      version: input.sessionState.version,
-    },
-  };
+  return replaceDurableSessionSnapshot({
+    session: { ...durableSession, state },
+    state: input.sessionState,
+  });
 }

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -44,7 +44,10 @@ import { defineTool } from "#public/definitions/tool.js";
 import { dispatchRuntimeActionsStep } from "#execution/dispatch-runtime-actions-step.js";
 import { runProxySubagentEventStep } from "#execution/subagent-event-proxy-step.js";
 import { readLatestTaskView, sendTaskInboundPayload } from "#execution/tasks/parent/run-parent.js";
-import { recordTaskInputRequestStep } from "#execution/tasks/parent/hitl-proxy-steps.js";
+import {
+  acceptTaskAuthorizationEventStep,
+  recordTaskInputRequestStep,
+} from "#execution/tasks/parent/hitl-proxy-steps.js";
 import { appendTaskAgentAnnouncement } from "#execution/tasks/parent/agent-views.js";
 import { emitTerminalSessionFailureStep } from "#execution/terminal-session-failure-step.js";
 import { resolveEffectiveOutputSchema } from "#execution/effective-output-schema.js";
@@ -390,6 +393,19 @@ describe("routeProxiedDeliverStep", () => {
           options?.owned === false
             ? undefined
             : {
+                [AGENT_HANDLES_STATE_KEY]: {
+                  handles: [
+                    {
+                      address: {
+                        continuationToken: "child-token",
+                        kind: "agent/local",
+                        sessionId: "child-session",
+                      },
+                      identity: { id: "agent-1", name: "research", nodeId: "node-1" },
+                      phase: "addressed",
+                    },
+                  ],
+                },
                 "eve.tasks": {
                   tasks: [
                     {
@@ -417,26 +433,85 @@ describe("routeProxiedDeliverStep", () => {
     sessionState: createStubSessionState({ hasProxyInputRequests: true }),
   };
 
-  it("hands a task-owned answer to the task run instead of the child", async () => {
-    installSessionStoreMocks([createTaskRouteSession()]);
+  it("keeps a delivered approval routed so another responder can retry", async () => {
+    const session = createTaskRouteSession();
+    installSessionStoreMocks([session, session]);
 
-    const result = await routeProxiedDeliverStep({
+    const first = await routeProxiedDeliverStep({
       ...taskRouteInput,
       parentWritable: createTestWritable(),
     });
-    expect(result).toMatchObject({ kind: "continue", remainder: undefined });
+    const second = await routeProxiedDeliverStep({
+      ...taskRouteInput,
+      parentWritable: createTestWritable(),
+    });
+
+    expect(first).toMatchObject({ kind: "continue", remainder: undefined });
+    expect(second).toMatchObject({ kind: "continue", remainder: undefined });
+    expect(sendTaskInboundPayload).toHaveBeenCalledTimes(2);
     expect(sendTaskInboundPayload).toHaveBeenCalledWith({
       taskInboxToken: "task-token",
       payload: {
-        auth: undefined,
-        childContinuationToken: "child-token",
+        auth: null,
         inputResponses: [{ optionId: "approve", requestId: "request-1" }],
         kind: "input-response",
+        target: { continuationToken: "child-token", kind: "local" },
         taskId: "task-1",
       },
     });
     expect(resumeHookMock).not.toHaveBeenCalled();
+    expect(first.sessionState).toBe(taskRouteInput.sessionState);
+    expect(second.sessionState).toBe(taskRouteInput.sessionState);
+  });
+
+  it("retires the approval route when the child reports settlement", async () => {
+    const session = createTaskRouteSession();
+    installSessionStoreMocks([session]);
+    vi.mocked(readLatestTaskView).mockResolvedValue({
+      executor: { childSessionId: "child-session" },
+      inputRequests: [
+        {
+          action: { callId: "tool-call-1", input: {}, kind: "tool-call", toolName: "deploy" },
+          kind: "tool-approval",
+          prompt: "Approve deploy?",
+          requestId: "request-1",
+        },
+      ],
+      metadata: {
+        agentId: "agent-1",
+        kind: "subagent",
+        mode: "local",
+        name: "research",
+      },
+      status: "input_required",
+      taskId: "task-1",
+    });
+
+    const result = await acceptTaskAuthorizationEventStep({
+      hookPayload: {
+        callId: "call-task",
+        childSessionId: "child-session",
+        event: {
+          data: {
+            outcome: "approved",
+            requestId: "request-1",
+            responderPrincipalId: "user-2",
+            sequence: 3,
+            stepIndex: 3,
+            turnId: "turn-child",
+          },
+          type: "approval.settled",
+        },
+        kind: "subagent-authorization-event",
+        subagentName: "research",
+      },
+      sessionState: taskRouteInput.sessionState,
+      taskId: "task-1",
+    });
+
+    expect(result.accepted).toBe(true);
     expect(getProxyInputRequests(result.sessionState.snapshot?.session.state).size).toBe(0);
+    expect(result.sessionState.hasProxyInputRequests).toBe(false);
   });
 
   it("keeps a response for a task this session does not own on the parent", async () => {
@@ -558,7 +633,6 @@ describe("recordTaskInputRequestStep", () => {
 
     const result = await recordTaskInputRequestStep({
       hookPayload,
-      serializedContext: createSerializedContext(),
       sessionState: createStubSessionState(),
       taskId: "task-1",
     });
@@ -591,7 +665,6 @@ describe("recordTaskInputRequestStep", () => {
 
     const result = await recordTaskInputRequestStep({
       hookPayload,
-      serializedContext: createSerializedContext(),
       sessionState: createStubSessionState(),
       taskId: "foreign-task",
     });

--- a/packages/eve/src/harness/handles/store.ts
+++ b/packages/eve/src/harness/handles/store.ts
@@ -87,6 +87,10 @@ export type AgentAddress =
       readonly sessionId: string;
       readonly url: string;
       readonly callbackBaseUrl: string;
+      /** Current policy for forwarding the responding principal to this task child. */
+      readonly forwardPrincipal?: boolean | undefined;
+      /** Current authored credential resolver; resolved values are never persisted. */
+      readonly resolverId?: string | undefined;
     };
 
 /**
@@ -184,7 +188,9 @@ const addressSchema: z.ZodType<AgentAddress> = z.discriminatedUnion("kind", [
   }),
   z.strictObject({
     callbackBaseUrl: z.url(),
+    forwardPrincipal: z.boolean().optional(),
     kind: z.literal("agent/remote"),
+    resolverId: nonEmptyString.optional(),
     sessionId: nonEmptyString,
     url: z.url(),
   }),

--- a/packages/eve/src/harness/handles/transitions.ts
+++ b/packages/eve/src/harness/handles/transitions.ts
@@ -205,6 +205,26 @@ export function removeTaskAgentAddress(session: HarnessSession, agentId: string)
   return { ...session, state: removeTaskAgentAddressFromState(session.state, agentId) };
 }
 
+/** Updates the transport policy used by later task-input callbacks. */
+export function replaceTaskAgentAddress(
+  session: HarnessSession,
+  input: { readonly address: AgentAddress; readonly agentId: string },
+): HarnessSession {
+  const handles = getAgentHandleStore(session.state)?.handles ?? [];
+  const existing = handles.find(
+    (handle): handle is Extract<AgentHandle, { readonly phase: "addressed" }> =>
+      handle.phase === "addressed" && handle.identity.id === input.agentId,
+  );
+  if (existing === undefined || existing.address === input.address) return session;
+
+  return writeHandles(
+    session,
+    handles.map((handle) =>
+      handle === existing ? { ...existing, address: input.address } : handle,
+    ),
+  );
+}
+
 /** State-only variant used while consuming a terminal task wake. */
 export function removeTaskAgentAddressFromState(
   state: SessionStateMap | undefined,

--- a/packages/eve/src/harness/proxy-input-requests.test.ts
+++ b/packages/eve/src/harness/proxy-input-requests.test.ts
@@ -272,45 +272,4 @@ describe("getProxyInputRequests type safety", () => {
       ["malformed", { childContinuationToken: "child-a", kind: "tool-approval" }],
     ]);
   });
-
-  it("accepts HTTPS child response URLs", () => {
-    expect(readChildResponseUrl("https://remote.example/eve/v1/task-input/token")).toBe(
-      "https://remote.example/eve/v1/task-input/token",
-    );
-  });
-
-  it.each([
-    "http://localhost:3000/eve/v1/task-input/token",
-    "http://worker.localhost:3000/eve/v1/task-input/token",
-    "http://127.0.0.1:3000/eve/v1/task-input/token",
-    "http://127.0.0.2:3000/eve/v1/task-input/token",
-    "http://[::1]:3000/eve/v1/task-input/token",
-    "http://[::ffff:7f00:1]:3000/eve/v1/task-input/token",
-  ])("accepts an HTTP loopback child response URL: %s", (url) => {
-    expect(readChildResponseUrl(url)).toBe(url);
-  });
-
-  it.each([
-    "http://remote.example/eve/v1/task-input/token",
-    "http://10.0.0.1/eve/v1/task-input/token",
-    "http://localhost.example/eve/v1/task-input/token",
-    "ftp://localhost/eve/v1/task-input/token",
-    "not a URL",
-  ])("rejects a non-HTTPS, non-loopback, or malformed child response URL: %s", (url) => {
-    expect(readChildResponseUrl(url)).toBeUndefined();
-  });
 });
-
-function readChildResponseUrl(childResponseUrl: string): string | undefined {
-  return getProxyInputRequests({
-    "eve.runtime.proxyInputRequests": {
-      "task-1:req-1": {
-        childContinuationToken: "child-a",
-        childRequestId: "req-1",
-        childResponseUrl,
-        kind: "question",
-        taskId: "task-1",
-      },
-    },
-  }).get("task-1:req-1")?.childResponseUrl;
-}

--- a/packages/eve/src/harness/proxy-input-requests.ts
+++ b/packages/eve/src/harness/proxy-input-requests.ts
@@ -1,7 +1,6 @@
 import type { SubagentInputRequestHookPayload } from "#channel/types.js";
 import type { HarnessSession, SessionStateMap } from "#harness/types.js";
 import type { InputRequestKind } from "#runtime/input/types.js";
-import { isLoopbackHostname } from "#shared/network-address.js";
 
 const PROXY_INPUT_REQUESTS_KEY = "eve.runtime.proxyInputRequests";
 
@@ -18,8 +17,6 @@ export interface ProxyInputRequest {
   readonly childContinuationToken: string;
   /** Child-local id restored before forwarding a namespaced task response. */
   readonly childRequestId?: string;
-  /** Trusted parent-derived capability URL for a remote task child. */
-  readonly childResponseUrl?: string;
   readonly kind: InputRequestKind;
   /** Present when the route is authorized by a parent-owned durable task. */
   readonly taskId?: string;
@@ -154,10 +151,10 @@ export function retireProxyInputRequests<T extends { readonly state?: SessionSta
 }
 
 /** Removes every proxy route owned by one durable task. */
-export function clearProxyInputRequestsForTask(
-  session: HarnessSession,
+export function clearProxyInputRequestsForTask<T extends { readonly state?: SessionStateMap }>(
+  session: T,
   taskId: string,
-): HarnessSession {
+): T {
   const current = readMap(session.state);
   const next: Record<string, ProxyInputRequest> = {};
   let changed = false;
@@ -199,7 +196,6 @@ export function toProxyInputRequestEntries(
   return payload.event.requests.map((request) => {
     const route: {
       readonly childContinuationToken: string;
-      childResponseUrl?: string;
       readonly kind: InputRequestKind;
       taskId?: string;
     } & { readonly batch: ProxyInputRequestBatch } = {
@@ -259,7 +255,6 @@ function parseProxyInputRequest(value: unknown, requestId: string): ProxyInputRe
   }
   const taskId = "taskId" in value ? value.taskId : undefined;
   const childRequestId = "childRequestId" in value ? value.childRequestId : undefined;
-  const childResponseUrl = "childResponseUrl" in value ? value.childResponseUrl : undefined;
   if (taskId !== undefined && (typeof taskId !== "string" || taskId.length === 0)) {
     return undefined;
   }
@@ -270,18 +265,11 @@ function parseProxyInputRequest(value: unknown, requestId: string): ProxyInputRe
     return undefined;
   }
   if ((taskId === undefined) !== (childRequestId === undefined)) return undefined;
-  if (
-    childResponseUrl !== undefined &&
-    (typeof childResponseUrl !== "string" || !isAllowedChildResponseUrl(childResponseUrl))
-  ) {
-    return undefined;
-  }
   const batch = "batch" in value ? parseProxyInputRequestBatch(value.batch) : undefined;
   const request: {
     batch?: ProxyInputRequestBatch;
     readonly childContinuationToken: string;
     childRequestId?: string;
-    childResponseUrl?: string;
     readonly kind: InputRequestKind;
     taskId?: string;
   } = {
@@ -290,7 +278,6 @@ function parseProxyInputRequest(value: unknown, requestId: string): ProxyInputRe
   };
   if (batch !== undefined && batch.requestIds.includes(requestId)) request.batch = batch;
   if (typeof childRequestId === "string") request.childRequestId = childRequestId;
-  if (typeof childResponseUrl === "string") request.childResponseUrl = childResponseUrl;
   if (typeof taskId === "string") request.taskId = taskId;
   return request;
 }
@@ -312,17 +299,6 @@ function parseProxyInputRequestBatch(value: unknown): ProxyInputRequestBatch | u
 
 function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((entry) => typeof entry === "string");
-}
-
-function isAllowedChildResponseUrl(value: string): boolean {
-  let url: URL;
-  try {
-    url = new URL(value);
-  } catch {
-    return false;
-  }
-  if (url.protocol === "https:") return true;
-  return url.protocol === "http:" && isLoopbackHostname(url.hostname);
 }
 
 function isInputRequestKind(value: unknown): value is InputRequestKind {

--- a/packages/eve/src/public/channels/eve.test.ts
+++ b/packages/eve/src/public/channels/eve.test.ts
@@ -22,6 +22,12 @@ import {
 } from "#context/keys.js";
 import { createMessageCompletedEvent } from "#protocol/message.js";
 
+const handleTaskInputResponseRequestMock = vi.hoisted(() => vi.fn());
+
+vi.mock("#runtime/task-input-response-route.js", () => ({
+  handleTaskInputResponseRequest: (input: unknown) => handleTaskInputResponseRequestMock(input),
+}));
+
 /**
  * Unit coverage for the inbound HTTP route's message-body parser and
  * the upload-policy enforcement layer.
@@ -177,6 +183,21 @@ function createEveContinueHandler(input: EveChannelInput) {
         params: { sessionId: "test-session-id" },
       };
       return (continueRoute as any).handler(req, args);
+    },
+  };
+}
+
+function createEveTaskInputHandler(input: EveChannelInput) {
+  const channel = eveChannel(input);
+  const taskInputRoute = channel.routes.find(
+    (route) => route.method === "POST" && route.path === "/eve/v1/task-input/:token",
+  );
+  if (!taskInputRoute) throw new Error("No task-input POST route found");
+
+  return {
+    async fetch(req: Request, token = "task-capability") {
+      const args: RouteHandlerArgs = { ...createRouteArgs(), params: { token } };
+      return (taskInputRoute as any).handler(req, args);
     },
   };
 }
@@ -2165,6 +2186,41 @@ describe("eveChannel — forwarded principal", () => {
     expect(options.initiatorAuth).toBeUndefined();
   });
 
+  it("authenticates a scoped task-input response and forwards its asserted principal", async () => {
+    handleTaskInputResponseRequestMock.mockReset();
+    handleTaskInputResponseRequestMock.mockResolvedValue(
+      Response.json({ ok: true, status: "accepted" }, { status: 202 }),
+    );
+    const handler = createEveTaskInputHandler({
+      trustedForwarders: () => true,
+      auth: () => ROUTER_CALLER,
+    });
+
+    const response = await handler.fetch(
+      new Request("https://example.com/eve/v1/task-input/task-capability", {
+        body: JSON.stringify({
+          forwardedPrincipal: { current: FORWARDED_CURRENT },
+          inputResponses: [{ optionId: "approve", requestId: "request-1" }],
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    expect(handleTaskInputResponseRequestMock).toHaveBeenCalledWith({
+      auth: {
+        ...FORWARDED_CURRENT,
+        attributes: {
+          ...FORWARDED_CURRENT.attributes,
+          "eve:forwarded-by": ROUTER_CALLER.principalId,
+        },
+      },
+      inputResponses: [{ optionId: "approve", requestId: "request-1" }],
+      token: "task-capability",
+    });
+  });
+
   it("rejects forwarded principal on the continue route", async () => {
     const handler = createEveContinueHandler({
       trustedForwarders: () => true,
@@ -2185,7 +2241,8 @@ describe("eveChannel — forwarded principal", () => {
     expect(response.status).toBe(400);
     expect(handler.send).not.toHaveBeenCalled();
     await expect(response.json()).resolves.toMatchObject({
-      error: "A forwarded principal is only accepted on session creation.",
+      error:
+        "A forwarded principal is only accepted on session creation or scoped task-input responses.",
       ok: false,
     });
   });

--- a/packages/eve/src/public/channels/eve.ts
+++ b/packages/eve/src/public/channels/eve.ts
@@ -43,6 +43,7 @@ import {
   EVE_SESSION_RESET_ROUTE_PATTERN,
   EVE_SESSION_STREAM_ROUTE_PATTERN,
   EVE_SUBAGENT_STREAM_ROUTE_PATTERN,
+  EVE_TASK_INPUT_ROUTE_PATTERN,
   createEveSessionStreamRoutePath,
   createEveSubagentStreamRoutePath,
 } from "#protocol/routes.js";
@@ -67,6 +68,7 @@ import {
 import type { ChannelMethod } from "#public/definitions/channel.js";
 import type { RunMode } from "#shared/run-mode.js";
 import { parseJsonObject, type JsonObject } from "#shared/json.js";
+import { handleTaskInputResponseRequest } from "#runtime/task-input-response-route.js";
 
 const log = createLogger("eve.channel");
 
@@ -155,20 +157,17 @@ export interface EveChannelInput {
   readonly auth: AuthFn<Request> | readonly AuthFn<Request>[];
   /**
    * The trusted-forwarders policy: which transport-authenticated callers may
-   * assert a forwarded principal on the create-session route (the
-   * `forwardedPrincipal` body field a `defineRemoteAgent({ forwardPrincipal:
-   * true })` sender emits). The predicate receives the *verified* route-auth
-   * principal of the forwarder — who is asserting, never what is asserted —
-   * and must match it precisely (for example
+   * assert a forwarded principal on session creation or a scoped task-input
+   * response. The predicate receives the *verified* route-auth principal of
+   * the forwarder — who is asserting, never what is asserted — and must match
+   * it precisely (for example
    * `(forwarder) => forwarder.subject === vercelSubject({ teamSlug, projectName })`).
    * A permissive predicate lets any authenticated forwarder assert any
    * principal.
    *
-   * When a trusted forwarder's assertion is accepted, the forwarded
-   * principal replaces the session principal (`session.auth.current` /
-   * `session.auth.initiator`) exactly as if that user had called this
-   * deployment directly, and the forwarder is recorded on the accepted
-   * contexts as the `eve:forwarded-by` attribute. Omit the option to reject
+   * Session creation seeds `session.auth.current` and `.initiator` from an
+   * accepted assertion; task input replaces only `current`. The forwarder is
+   * recorded as the `eve:forwarded-by` attribute. Omit the option to reject
    * every forwarded assertion with 403.
    */
   readonly trustedForwarders?: TrustedForwarders;
@@ -210,8 +209,9 @@ export interface EveChannel extends Channel {}
 /**
  * Builds the default eve HTTP channel: a {@link defineChannel} instance serving the
  * built-in `/eve/v1` routes (GET inspects the agent, POST creates a session,
- * ID-addressed POST routes deliver follow-ups and controls, and GET streams a
- * session's NDJSON event feed). Every route
+ * ID-addressed POST routes deliver follow-ups and controls, scoped task-input
+ * routes answer a background child, and GET streams a session's NDJSON event
+ * feed). Every route
  * runs {@link EveChannelInput.auth} via {@link routeAuth} before dispatching.
  * Default-export the result as your `agent/channels/eve.ts` channel; reach for
  * {@link defineChannel} directly only for a custom transport.
@@ -355,6 +355,34 @@ export function eveChannel(input: EveChannelInput): EveChannel {
             status: 202,
           },
         );
+      }),
+
+      POST(EVE_TASK_INPUT_ROUTE_PATTERN, async (req, { params }) => {
+        const authResult = await routeAuth(req, input.auth);
+        if (authResult instanceof Response) return authResult;
+
+        const payload = await parseJsonRequest(req);
+        if (payload instanceof Response) return payload;
+        const forwarded = await resolveForwardedPrincipal({
+          trustedForwarders: input.trustedForwarders,
+          forwarder: authResult,
+          payload,
+        });
+        if (forwarded instanceof Response) return forwarded;
+
+        const inputResponses = parseInputResponses(payload.inputResponses);
+        if (inputResponses instanceof Response) return inputResponses;
+        if (inputResponses === undefined) {
+          return Response.json(
+            { error: "Expected a non-empty 'inputResponses' array.", ok: false },
+            { status: 400 },
+          );
+        }
+        return await handleTaskInputResponseRequest({
+          auth: forwarded.auth,
+          inputResponses,
+          token: params.token,
+        });
       }),
 
       POST(EVE_SESSION_ROUTE_PATTERN, async (req, { attachSession, params }) => {
@@ -906,7 +934,11 @@ function parseSessionMessageBody(
   if (tokenRejection !== null) return tokenRejection;
   if (payload.forwardedPrincipal !== undefined) {
     return Response.json(
-      { error: "A forwarded principal is only accepted on session creation.", ok: false },
+      {
+        error:
+          "A forwarded principal is only accepted on session creation or scoped task-input responses.",
+        ok: false,
+      },
       { status: 400 },
     );
   }

--- a/packages/eve/src/public/definitions/remote-agent.ts
+++ b/packages/eve/src/public/definitions/remote-agent.ts
@@ -23,12 +23,14 @@ export interface RemoteAgentDefinition {
    */
   readonly description: string;
   /**
-   * Forwards the dispatching turn's session principal to the remote
-   * deployment as the `forwardedPrincipal` create-session body field, so the
-   * remote session runs as the same end user as the parent (per-user
-   * Connect, local subagents, and further remote hops all see that
-   * principal). Defaults to `false` — forwarding identity to another
-   * deployment is an explicit decision, never ambient.
+   * Forwards the dispatching turn's session principal to the remote deployment
+   * as the `forwardedPrincipal` create-session body field. A background-task
+   * input response also forwards its responding principal through the scoped
+   * task-input route. The remote session therefore runs each affected turn as
+   * the same end user as the parent (per-user Connect, local subagents, and
+   * further remote hops all see that principal). Defaults to `false` —
+   * forwarding identity to another deployment is an explicit decision, never
+   * ambient.
    *
    * Only principal metadata crosses the wire, never tokens or credentials —
    * {@link auth} keeps authenticating *this* deployment to the remote. The

--- a/packages/eve/src/runtime/framework-channels/index.ts
+++ b/packages/eve/src/runtime/framework-channels/index.ts
@@ -11,10 +11,6 @@ import {
   getSessionCallbackChannelNames,
 } from "#runtime/session-callback-route.js";
 import type { ResolvedChannelDefinition } from "#runtime/types.js";
-import {
-  getTaskInputResponseChannelDefinitions,
-  getTaskInputResponseChannelNames,
-} from "#runtime/task-input-response-route.js";
 
 const EVE_CHANNEL_NAME = "eve";
 
@@ -50,7 +46,6 @@ export function getFrameworkChannelDefinitions(): readonly ResolvedChannelDefini
   result.push(
     ...getConnectionCallbackChannelDefinitions(),
     ...getSessionCallbackChannelDefinitions(),
-    ...getTaskInputResponseChannelDefinitions(),
   );
 
   return result;
@@ -61,6 +56,5 @@ export function getAllFrameworkChannelNames(): ReadonlySet<string> {
     EVE_CHANNEL_NAME,
     ...getConnectionCallbackChannelNames(),
     ...getSessionCallbackChannelNames(),
-    ...getTaskInputResponseChannelNames(),
   ]);
 }

--- a/packages/eve/src/runtime/task-input-response-route.test.ts
+++ b/packages/eve/src/runtime/task-input-response-route.test.ts
@@ -1,17 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { SessionAuthContext } from "#channel/types.js";
 import { sendCommandToDelivery } from "#execution/session-command-wire.js";
-import { EVE_TASK_INPUT_ROUTE_PATTERN } from "#protocol/routes.js";
-import type { RouteContext } from "#public/definitions/channel.js";
-import {
-  getTaskInputResponseChannelDefinitions,
-  handleTaskInputResponseRequest,
-} from "#runtime/task-input-response-route.js";
+import { handleTaskInputResponseRequest } from "#runtime/task-input-response-route.js";
 
 const resumeHookMock = vi.fn();
 const DIGEST = "0123456789abcdef0123456789abcdef";
 const CAPABILITY_TOKEN = `eve:task-input:${DIGEST}`;
 const TARGET_TOKEN = `eve:eve:op:${DIGEST}`;
+const RESPONDER: SessionAuthContext = {
+  attributes: {},
+  authenticator: "test",
+  principalId: "user-1",
+  principalType: "user",
+};
 
 vi.mock("#compiled/@workflow/core/runtime.js", () => ({
   resumeHook: (token: string, payload: unknown) => resumeHookMock(token, payload),
@@ -20,63 +22,34 @@ vi.mock("#compiled/@workflow/core/runtime.js", () => ({
 describe("task input response capability", () => {
   beforeEach(() => resumeHookMock.mockReset());
 
-  it("registers one capability-scoped POST route", () => {
-    expect(getTaskInputResponseChannelDefinitions()).toEqual([
-      expect.objectContaining({ method: "POST", urlPath: EVE_TASK_INPUT_ROUTE_PATTERN }),
-    ]);
-  });
-
-  it("resumes only the addressed child input batch", async () => {
+  it("delivers the authenticated responder only to the addressed child", async () => {
     resumeHookMock.mockResolvedValue(undefined);
-    const response = await handleTaskInputResponseRequest(
-      request({ inputResponses: [{ optionId: "approve", requestId: "req-1" }] }),
-      context(CAPABILITY_TOKEN),
-    );
+    const inputResponses = [{ optionId: "approve", requestId: "req-1" }];
+    const response = await handleTaskInputResponseRequest({
+      auth: RESPONDER,
+      inputResponses,
+      token: CAPABILITY_TOKEN,
+    });
 
     expect(response.status).toBe(202);
     expect(resumeHookMock).toHaveBeenCalledWith(
       TARGET_TOKEN,
       sendCommandToDelivery({
+        auth: RESPONDER,
         kind: "send",
-        payload: { inputResponses: [{ optionId: "approve", requestId: "req-1" }] },
+        payload: { inputResponses },
       }),
     );
   });
 
-  it("rejects messages and empty response batches", async () => {
-    for (const body of [{ message: "not allowed" }, { inputResponses: [] }]) {
-      const response = await handleTaskInputResponseRequest(
-        request(body),
-        context(CAPABILITY_TOKEN),
-      );
-      expect(response.status).toBe(400);
-    }
-    expect(resumeHookMock).not.toHaveBeenCalled();
-  });
-
   it("rejects generic workflow hook tokens", async () => {
-    const response = await handleTaskInputResponseRequest(
-      request({ inputResponses: [{ requestId: "req-1", text: "forged" }] }),
-      context("eve:session:victim:inbox"),
-    );
+    const response = await handleTaskInputResponseRequest({
+      auth: RESPONDER,
+      inputResponses: [{ requestId: "req-1", text: "forged" }],
+      token: "eve:session:victim:inbox",
+    });
 
     expect(response.status).toBe(403);
     expect(resumeHookMock).not.toHaveBeenCalled();
   });
 });
-
-function request(body: unknown): Request {
-  return new Request("https://remote.example/eve/v1/task-input/child-token", {
-    body: JSON.stringify(body),
-    headers: { "content-type": "application/json" },
-    method: "POST",
-  });
-}
-
-function context(token: string): RouteContext {
-  return {
-    params: { token },
-    requestIp: null,
-    waitUntil() {},
-  };
-}

--- a/packages/eve/src/runtime/task-input-response-route.ts
+++ b/packages/eve/src/runtime/task-input-response-route.ts
@@ -1,36 +1,16 @@
 import { sendCommandToDelivery } from "#execution/session-command-wire.js";
 import { readTaskInputTargetToken } from "#execution/task-input-capability.js";
 import { resumeHook } from "#internal/workflow/runtime.js";
-import { EVE_TASK_INPUT_ROUTE_PATTERN } from "#protocol/routes.js";
-import type { ChannelMethod, RouteContext } from "#public/definitions/channel.js";
+import type { SessionAuthContext } from "#channel/types.js";
 import type { InputResponse } from "#runtime/input/types.js";
-import type { ResolvedChannelDefinition } from "#runtime/types.js";
 
-const NAME = "eve/v1/task-input/post";
-
-export function getTaskInputResponseChannelDefinitions(): readonly ResolvedChannelDefinition[] {
-  return [
-    {
-      fetch: handleTaskInputResponseRequest,
-      logicalPath: `framework://channels/${NAME}`,
-      method: "POST" satisfies ChannelMethod,
-      name: NAME,
-      sourceId: "eve:framework:task-input-post",
-      sourceKind: "module",
-      urlPath: EVE_TASK_INPUT_ROUTE_PATTERN,
-    },
-  ];
-}
-
-export function getTaskInputResponseChannelNames(): ReadonlySet<string> {
-  return new Set([NAME]);
-}
-
-export async function handleTaskInputResponseRequest(
-  request: Request,
-  ctx: RouteContext,
-): Promise<Response> {
-  const token = ctx.params.token;
+/** Delivers one authenticated response batch through its scoped child capability. */
+export async function handleTaskInputResponseRequest(input: {
+  readonly auth: SessionAuthContext | null;
+  readonly inputResponses: readonly InputResponse[];
+  readonly token: string | undefined;
+}): Promise<Response> {
+  const token = input.token;
   if (typeof token !== "string" || token.length === 0) {
     return Response.json({ error: "Missing task input token.", ok: false }, { status: 400 });
   }
@@ -38,22 +18,13 @@ export async function handleTaskInputResponseRequest(
   if (targetToken === undefined) {
     return Response.json({ error: "Invalid task input token.", ok: false }, { status: 403 });
   }
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return Response.json({ error: "Invalid JSON body.", ok: false }, { status: 400 });
-  }
-  const inputResponses = readInputResponses(body);
-  if (inputResponses === undefined || inputResponses.length === 0) {
-    return Response.json(
-      { error: "Expected a non-empty inputResponses array.", ok: false },
-      { status: 400 },
-    );
-  }
   // Child inboxes outlive deployments; cross the hook in the durable
   // delivery envelope like every other session-inbox producer.
-  const command = sendCommandToDelivery({ kind: "send", payload: { inputResponses } });
+  const command = sendCommandToDelivery({
+    auth: input.auth,
+    kind: "send",
+    payload: { inputResponses: input.inputResponses },
+  });
   try {
     await resumeHook(targetToken, command);
   } catch {
@@ -63,30 +34,4 @@ export async function handleTaskInputResponseRequest(
     );
   }
   return Response.json({ ok: true }, { status: 202 });
-}
-
-function readInputResponses(value: unknown): readonly InputResponse[] | undefined {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
-  const responses = Reflect.get(value, "inputResponses");
-  if (!Array.isArray(responses)) return undefined;
-  const parsed: InputResponse[] = [];
-  for (const response of responses) {
-    if (response === null || typeof response !== "object" || Array.isArray(response))
-      return undefined;
-    const requestId = Reflect.get(response, "requestId");
-    const optionId = Reflect.get(response, "optionId");
-    const text = Reflect.get(response, "text");
-    if (
-      typeof requestId !== "string" ||
-      (optionId !== undefined && typeof optionId !== "string") ||
-      (text !== undefined && typeof text !== "string")
-    ) {
-      return undefined;
-    }
-    const item: { optionId?: string; requestId: string; text?: string } = { requestId };
-    if (typeof optionId === "string") item.optionId = optionId;
-    if (typeof text === "string") item.text = text;
-    parsed.push(item);
-  }
-  return parsed;
 }

--- a/packages/eve/src/tasks/types.ts
+++ b/packages/eve/src/tasks/types.ts
@@ -1,5 +1,5 @@
 import type { JsonValue } from "#shared/json.js";
-import type { SubagentAuthorizationEvent } from "#channel/types.js";
+import type { SessionAuthContext, SubagentAuthorizationEvent } from "#channel/types.js";
 
 /**
  * Task lifecycle contract for `experimental.tasks`.
@@ -132,6 +132,16 @@ export function readTaskInputRequestId(request: TaskInputRequest): string | unde
   if (request === null || typeof request !== "object" || Array.isArray(request)) return undefined;
   const requestId = Reflect.get(request, "requestId");
   return typeof requestId === "string" ? requestId : undefined;
+}
+
+/** Whether accepting a response is enough to clear this request. */
+export function isTaskInputSettledByDelivery(request: unknown): boolean {
+  return (
+    request === null ||
+    typeof request !== "object" ||
+    Array.isArray(request) ||
+    Reflect.get(request, "kind") !== "tool-approval"
+  );
 }
 
 /** Fields shared by every durable task view. */
@@ -310,10 +320,10 @@ export interface TaskInboundUpdate {
 }
 
 /**
- * Arrives when the delegated child emits `authorization.required` or
- * `authorization.completed`. The former exposes an authorization blocker in
- * the task view; the latter clears it. The event is forwarded separately
- * to the parent and is never copied into the view.
+ * Arrives when the delegated child emits an authorization or approval event.
+ * `authorization.required` creates a task blocker; `approval.settled` clears
+ * the matching approval input request. Events are forwarded separately to the
+ * parent and are never copied into the view.
  */
 export interface TaskInboundAuthorizationEvent {
   readonly callId: string;
@@ -329,12 +339,26 @@ export interface TaskInboundAuthorizationEvent {
  * batch it clears is exactly the batch it forwarded — the parent can no
  * longer unblock the child while the run still believes it is blocked.
  */
+export type TaskInputDeliveryTarget =
+  | {
+      readonly continuationToken: string;
+      readonly kind: "local";
+    }
+  | {
+      readonly continuationToken: string;
+      readonly forwardPrincipal: boolean | undefined;
+      readonly kind: "remote";
+      readonly name: string;
+      readonly resolverId: string | undefined;
+      readonly serializedBundle: unknown;
+      readonly url: string;
+    };
+
 export interface TaskInboundAnswerInput {
-  readonly auth?: unknown;
-  readonly childContinuationToken: string;
-  readonly childResponseUrl?: string;
+  readonly auth: SessionAuthContext | null;
   readonly inputResponses: readonly TaskInputResponse[];
   readonly kind: "input-response";
+  readonly target: TaskInputDeliveryTarget;
   readonly taskId: string;
 }
 

--- a/packages/eve/src/tasks/wire.test.ts
+++ b/packages/eve/src/tasks/wire.test.ts
@@ -190,9 +190,10 @@ describe("translateTaskInboundPayload", () => {
   it("leaves answered input to the run, which must deliver before recording it", () => {
     expect(
       translateTaskInboundPayload({
-        childContinuationToken: "child-token",
+        auth: null,
         inputResponses: [{ requestId: "req-1", text: "west" }],
         kind: "input-response",
+        target: { continuationToken: "child-token", kind: "local" },
         taskId: "task-1",
       }),
     ).toBeUndefined();

--- a/packages/eve/src/tasks/wire.ts
+++ b/packages/eve/src/tasks/wire.ts
@@ -63,12 +63,23 @@ export function translateTaskInboundPayload(
         kind: "start-turn",
         taskId: payload.taskId,
       };
-    case "authorization-event": {
-      const requestId = taskAuthorizationRequestId(payload.event);
-      return payload.event.type === "authorization.required"
-        ? { kind: "require-authorization", requestId }
-        : { kind: "answered", requestIds: [requestId] };
-    }
+    case "authorization-event":
+      switch (payload.event.type) {
+        case "authorization.required":
+          return {
+            kind: "require-authorization",
+            requestId: taskAuthorizationRequestId(payload.event),
+          };
+        case "authorization.completed":
+          return {
+            kind: "answered",
+            requestIds: [taskAuthorizationRequestId(payload.event)],
+          };
+        case "approval.settled":
+          return { kind: "answered", requestIds: [payload.event.data.requestId] };
+        case "approval.candidate":
+          return undefined;
+      }
     default:
       return undefined;
   }


### PR DESCRIPTION
### Summary

Related to #2113 and #1084. The remote task-input endpoint already existed at `POST /eve/v1/task-input/:token`; this PR does not add or rename a public route.

Before → after:

- Before: the existing endpoint was registered as a standalone framework route, outside the authored `eveChannel({ auth, trustedForwarders })`. It validated the child capability and resumed the child with `inputResponses`, but no authenticated responder.
- After: the same endpoint is registered by `eveChannel`, which runs `routeAuth` and the existing `trustedForwarders` policy before delegating to the existing `handleTaskInputResponseRequest` delivery handler. The resulting child command carries the effective responder.

The remaining changes preserve two related boundaries. HTTP or hook acceptance means the response was delivered, not that a tool approval settled; rejected responders leave the approval retryable until the child emits `approval.settled`. Dynamic remote continuations also retain only the latest resolver identifier and forwarding policy, then resolve credentials when sending the task response instead of persisting resolved secrets or reusing start-time policy.

The previous `childResponseUrl` and whole serialized-context payload are removed. The remote delivery target contains the child capability, stable address, current policy identifiers, and only the serialized runtime bundle needed to resolve authored credentials.

### Validation

Focused task-input, route-authentication, approval-settlement, proxy-routing, and dynamic-continuation coverage passed after rebasing onto current `main` (205 unit tests and 27 integration tests). The complete unit and integration suites passed on the patch before the patch-equivalent rebase. The existing remote fixture e2e remains unchanged because it already asserts the child-side invariant: the resumed child observes the authenticated `remote-http-child` transport principal.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 3 files · `+11 / -3`

Changeset plus the auth and remote-agent guide updates.

**Implementation** — 19 files · `+376 / -238`

Authenticated ownership of the existing task-input route, one typed delivery target, child-owned approval settlement, and current remote transport policy.

**Tests** — 8 files · `+538 / -103`

Route authentication, responder delivery, approval retry and settlement, proxy routing, and dynamic continuation regressions.
