### PR TITLE
fix(eve): preserve pnpm init release-age bypass

### DIFF
--- a/.changeset/friendly-pnpm-release-age.md
+++ b/.changeset/friendly-pnpm-release-age.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Carry the one-run pnpm minimum-release-age bypass from dependency installation into the `eve init` development handoff so onboarding starts without a redundant policy failure.

--- a/packages/eve/src/cli/commands/init.integration.test.ts
+++ b/packages/eve/src/cli/commands/init.integration.test.ts
@@ -176,6 +176,7 @@ describe("runInitCommand", () => {
     );
     expect(deps.tryInitializeGit).toHaveBeenCalledWith(projectPath);
     expect(deps.spawnPackageManager).toHaveBeenCalledWith("pnpm", projectPath, [
+      "--config.minimum-release-age=0",
       "exec",
       "eve",
       "dev",
@@ -263,13 +264,13 @@ describe("runInitCommand", () => {
       expect.objectContaining({
         command: "codex",
         cwd: projectPath,
-        prompt: expect.stringContaining("pnpm exec eve dev --no-ui"),
+        prompt: expect.stringContaining("pnpm --config.minimum-release-age=0 exec eve dev --no-ui"),
       }),
     );
     const prompt = deps.spawnCodingAgentRepl.mock.calls[0]?.[0].prompt;
     expect(prompt).toBe(
       initAgentReplPrompt({
-        devCommand: "pnpm exec eve dev",
+        devCommand: "pnpm --config.minimum-release-age=0 exec eve dev",
       }),
     );
     expect(prompt).toContain("What should the agent do?");
@@ -364,6 +365,7 @@ describe("runInitCommand", () => {
       );
       expect(deps.tryInitializeGit).toHaveBeenCalledWith(projectPath);
       expect(deps.spawnPackageManager).toHaveBeenCalledWith("pnpm", projectPath, [
+        "--config.minimum-release-age=0",
         "exec",
         "eve",
         "dev",
@@ -467,7 +469,12 @@ describe("runInitCommand", () => {
     ["npm", "package-lock.json", "bun", ["exec", "--", "eve", "dev", "--input", "/model"]],
     ["yarn", "yarn.lock", "npm", ["eve", "dev", "--input", "/model"]],
     ["bun", "bun.lock", "npm", ["x", "eve", "dev", "--input", "/model"]],
-    ["pnpm", "pnpm-lock.yaml", "npm", ["exec", "eve", "dev", "--input", "/model"]],
+    [
+      "pnpm",
+      "pnpm-lock.yaml",
+      "npm",
+      ["--config.minimum-release-age=0", "exec", "eve", "dev", "--input", "/model"],
+    ],
   ] as const)(
     "scaffolds a fresh named project with the ancestor %s lockfile before the launcher",
     async (kind, lockfile, invokingManager, devArguments) => {
@@ -735,6 +742,7 @@ describe("runInitCommand", () => {
       `Git initialization failed during commit: commit refused\nThe Git repository and staged files were preserved at "${projectPath}".\n\nResolve the Git error above, then retry:\n  git -C ${JSON.stringify(projectPath)} commit -m "Initial commit from eve"`,
     );
     expect(deps.spawnPackageManager).toHaveBeenCalledWith("pnpm", projectPath, [
+      "--config.minimum-release-age=0",
       "exec",
       "eve",
       "dev",
@@ -767,6 +775,7 @@ describe("runInitCommand", () => {
       expect.anything(),
     );
     expect(deps.spawnPackageManager).toHaveBeenCalledWith("pnpm", projectPath, [
+      "--config.minimum-release-age=0",
       "exec",
       "eve",
       "dev",
@@ -840,6 +849,7 @@ describe("runInitCommand", () => {
     expect(deps.tryInitializeGit).not.toHaveBeenCalled();
     expect(deps.confirmInitInNonEmptyDirectory).not.toHaveBeenCalled();
     expect(deps.spawnPackageManager).toHaveBeenCalledWith("pnpm", projectRoot, [
+      "--config.minimum-release-age=0",
       "exec",
       "eve",
       "dev",
@@ -1146,6 +1156,9 @@ describe("runInitCommand", () => {
     expect(deps.selectInitHandoff).not.toHaveBeenCalled();
     expect(deps.spawnCodingAgentRepl).not.toHaveBeenCalled();
     expect(deps.spawnPackageManager).not.toHaveBeenCalled();
+    expect(output.messages.join("\n")).toContain(
+      "pnpm --config.minimum-release-age=0 exec eve dev --no-ui",
+    );
   });
 
   it("derives the agent dev handoff command from the existing project's own manager", async () => {
@@ -1182,6 +1195,22 @@ describe("runInitCommand", () => {
     expect(output.errors).toEqual(["Packages: +12", "ERR_PNPM_FETCH_404 not found"]);
     expect(deps.tryInitializeGit).not.toHaveBeenCalled();
     expect(deps.spawnPackageManager).not.toHaveBeenCalled();
+  });
+
+  it("carries the pnpm release-age bypass into the dev handoff", async () => {
+    const parentDirectory = await mkdtemp(join(tmpdir(), "eve-init-dev-release-age-"));
+    const output = logger();
+    const deps = dependencies();
+
+    await expect(
+      runInitCommand(output, parentDirectory, "my-agent", {}, deps),
+    ).resolves.toBeUndefined();
+    expect(deps.spawnPackageManager).toHaveBeenCalledTimes(1);
+    expect(deps.spawnPackageManager).toHaveBeenCalledWith(
+      "pnpm",
+      join(parentDirectory, "my-agent"),
+      ["--config.minimum-release-age=0", "exec", "eve", "dev", "--input", "/model"],
+    );
   });
 
   it("preserves an existing host after install failure and prints the retry command", async () => {

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -131,6 +131,13 @@ function formatWorkspaceRootMutationWarning(mutation: WorkspaceRootMutation): st
   return `Updated workspace root ${target} at ${mutation.path}${suffix}`;
 }
 
+function initDevArguments(packageManager: PackageManagerKind): string[] {
+  const args = [...eveDevArguments(packageManager)];
+  // The immediately preceding install already accepted the project's dependency
+  // graph with this one-run bypass, so the handoff must use the same policy.
+  return packageManager === "pnpm" ? ["--config.minimum-release-age=0", ...args] : args;
+}
+
 /**
  * Adds the agent to an existing project and returns the
  * detected manager, which drives the install and dev handoff.
@@ -564,9 +571,8 @@ export async function runInitCommand(
     }
   }
 
-  const agentDevCommand = [result.packageManager, ...eveDevArguments(result.packageManager)].join(
-    " ",
-  );
+  const baseDevArguments = initDevArguments(result.packageManager);
+  const agentDevCommand = [result.packageManager, ...baseDevArguments].join(" ");
   const agentHandoff = initAgentDevHandoff({
     projectPath: result.projectPath,
     devCommand: agentDevCommand,
@@ -612,9 +618,10 @@ export async function runInitCommand(
   // the command the way run-scripts do, so the handoff line is printed here.
   const freshScaffold = result.kind === "created";
   const devArguments = freshScaffold
-    ? [...eveDevArguments(result.packageManager), "--input", "/model"]
-    : eveDevArguments(result.packageManager);
+    ? [...baseDevArguments, "--input", "/model"]
+    : baseDevArguments;
   logger.log(pc.dim(freshScaffold ? "$ eve dev --input /model" : "$ eve dev"));
+
   if (
     !(await dependencies.spawnPackageManager(
       result.packageManager,

--- a/packages/eve/test/scenarios/eve-init.scenario.test.ts
+++ b/packages/eve/test/scenarios/eve-init.scenario.test.ts
@@ -189,7 +189,16 @@ describe("eve init smoke", () => {
         cwd: canonicalProjectDir,
       },
       {
-        args: ["--dir", canonicalProjectDir, "exec", "eve", "dev", "--input", "/model"],
+        args: [
+          "--dir",
+          canonicalProjectDir,
+          "--config.minimum-release-age=0",
+          "exec",
+          "eve",
+          "dev",
+          "--input",
+          "/model",
+        ],
         cwd: canonicalProjectDir,
       },
     ]);
@@ -371,7 +380,16 @@ describe("eve init smoke", () => {
         cwd: canonicalProjectDir,
       },
       {
-        args: ["--dir", canonicalProjectDir, "exec", "eve", "dev", "--input", "/model"],
+        args: [
+          "--dir",
+          canonicalProjectDir,
+          "--config.minimum-release-age=0",
+          "exec",
+          "eve",
+          "dev",
+          "--input",
+          "/model",
+        ],
         cwd: canonicalProjectDir,
       },
     ]);


### PR DESCRIPTION
### Summary

Closes #2199. `eve init` already disables pnpm's minimum-release-age policy for its dependency install, but the automatic dev handoff dropped that one-run bypass and could reject the same lockfile immediately afterward.

Before → after: `pnpm exec eve dev` → `pnpm --config.minimum-release-age=0 exec eve dev`. The shared handoff arguments cover direct `eve dev` startup and coding-agent instructions; npm, Yarn, Bun, and the project's persisted package-manager policy remain unchanged.

### Validation

Reproduced the pnpm 11.18.0 handoff failure and confirmed the fixed path reaches model-provider onboarding. The focused `eve init` integration suite passes all 57 tests, and its subprocess scenario suite passes all 9 tests while asserting the exact pnpm argv.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

The patch changeset records the visible onboarding fix for the next release.

**Implementation** — 1 file · `+12 / -5`

The bypass stays local to `eve init` and reuses one argument list across both handoff paths.

**Tests** — 2 files · `+52 / -5`

Integration coverage checks the package-manager-specific handoff, while subprocess scenarios verify the exact pnpm invocation produced by the built CLI.
