### PR TITLE
Preserve inherited package command output

### DIFF
--- a/.changeset/structured-package-process.md
+++ b/.changeset/structured-package-process.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Capture package-manager command identity, termination, bounded redacted output, and workspace probes as structured process results for consistent setup diagnostics.
+Capture package-manager command identity, termination, bounded in-memory output, and workspace probes as structured process results for consistent setup diagnostics.

--- a/.changeset/structured-package-process.md
+++ b/.changeset/structured-package-process.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Capture package-manager command identity, termination, bounded redacted output, and workspace probes as structured process results for consistent setup diagnostics.

--- a/packages/eve/src/cli/commands/deploy.integration.test.ts
+++ b/packages/eve/src/cli/commands/deploy.integration.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { createFakePrompter } from "#internal/testing/fake-prompter.js";
+import { packageInstallResult } from "#internal/testing/package-process.js";
 import type { DeployProjectDeps } from "#setup/boxes/deploy-project.js";
 import type { DeploymentInfo } from "#setup/project-resolution.js";
 
@@ -49,8 +50,8 @@ function createDeployProjectDeps() {
       kind: "pnpm",
       source: "default",
     })),
-    runPackageManagerInstall: vi.fn<DeployProjectDeps["runPackageManagerInstall"]>(
-      async () => true,
+    runPackageManagerInstall: vi.fn<DeployProjectDeps["runPackageManagerInstall"]>(async () =>
+      packageInstallResult(),
     ),
     detectDeployment: vi.fn<DeployProjectDeps["detectDeployment"]>(async () => DEPLOYED),
     syncHostFrameworkPreset: vi.fn<DeployProjectDeps["syncHostFrameworkPreset"]>(async () => {}),

--- a/packages/eve/src/cli/commands/extension-init.integration.test.ts
+++ b/packages/eve/src/cli/commands/extension-init.integration.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { packageInstallResult } from "#internal/testing/package-process.js";
 import { detectPackageManager } from "#setup/package-manager.js";
 import {
   scaffoldExtensionProject,
@@ -66,7 +67,7 @@ function dependencies(
       };
       return scaffoldExtensionProject(merged);
     },
-    runPackageManagerInstall: vi.fn(async () => true),
+    runPackageManagerInstall: vi.fn(async () => packageInstallResult()),
     tryInitializeGit: vi.fn(async () => gitResult),
   };
 }

--- a/packages/eve/src/cli/commands/extension-init.ts
+++ b/packages/eve/src/cli/commands/extension-init.ts
@@ -18,6 +18,7 @@ import {
 import { pathExists } from "#setup/path-exists.js";
 import { parseProjectName } from "#setup/project-name.js";
 import {
+  packageManagerInstallFailureMessage,
   packageManagerInstallSucceeded,
   runPackageManagerInstall,
 } from "#setup/primitives/index.js";
@@ -308,6 +309,10 @@ export async function runExtensionInitCommand(
       const failureOutput =
         installFailureOutput.length > 0 ? installFailureOutput : recentInstallOutput;
       for (const line of failureOutput) logger.error(line);
+      if (failureOutput.length === 0) {
+        const message = packageManagerInstallFailureMessage(installResult);
+        if (message !== undefined) logger.error(message);
+      }
       throw new Error(`Failed to install dependencies in "${projectPath}".`);
     }
     initLog.debug("dependencies installed", { ms: installElapsedMs });

--- a/packages/eve/src/cli/commands/extension-init.ts
+++ b/packages/eve/src/cli/commands/extension-init.ts
@@ -17,7 +17,10 @@ import {
 } from "#setup/package-manager.js";
 import { pathExists } from "#setup/path-exists.js";
 import { parseProjectName } from "#setup/project-name.js";
-import { runPackageManagerInstall } from "#setup/primitives/index.js";
+import {
+  packageManagerInstallSucceeded,
+  runPackageManagerInstall,
+} from "#setup/primitives/index.js";
 import type { ProcessOutputLine } from "#setup/primitives/process-output.js";
 import { blockingCreateInPlaceEntries } from "#setup/scaffold/create-in-place.js";
 import {
@@ -280,7 +283,7 @@ export async function runExtensionInitCommand(
     const installStartedAt = dependencies.now();
     const installFailureOutput: string[] = [];
     const recentInstallOutput: string[] = [];
-    const installed = await dependencies.runPackageManagerInstall(packageManager, projectPath, {
+    const installResult = await dependencies.runPackageManagerInstall(packageManager, projectPath, {
       bypassMinimumReleaseAge: true,
       progressDetails: process.stdout.isTTY === true && !debug,
       onOutput: (line) => {
@@ -299,7 +302,7 @@ export async function runExtensionInitCommand(
       },
     });
     installElapsedMs = dependencies.now() - installStartedAt;
-    if (!installed) {
+    if (!packageManagerInstallSucceeded(installResult)) {
       initLog.debug("dependency installation failed", { ms: installElapsedMs });
       progress.stop();
       const failureOutput =

--- a/packages/eve/src/cli/commands/init.integration.test.ts
+++ b/packages/eve/src/cli/commands/init.integration.test.ts
@@ -1223,8 +1223,7 @@ describe("runInitCommand", () => {
       result: {
         command: { executable: "pnpm", args: ["install"], cwd: parentDirectory },
         termination: { kind: "spawn-error", code: "ENOENT", message: "spawn pnpm ENOENT" },
-        output: [],
-        truncatedBytes: 0,
+        stdout: "",
       },
     });
 

--- a/packages/eve/src/cli/commands/init.integration.test.ts
+++ b/packages/eve/src/cli/commands/init.integration.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { MockScreen } from "#cli/dev/tui/test/mock-terminal.js";
 import { stripAnsi } from "#cli/ui/terminal-text.js";
+import { packageInstallResult, packageProcessResult } from "#internal/testing/package-process.js";
 import { DEFAULT_AGENT_MODEL_ID } from "#shared/default-agent-model.js";
 import { detectPackageManager } from "#setup/package-manager.js";
 import {
@@ -111,10 +112,10 @@ function dependencies(
         ...options,
         webPackageVersions: { ...WEB_VERSIONS, ...options.webPackageVersions },
       }),
-    runPackageManagerInstall: vi.fn(async () => true),
+    runPackageManagerInstall: vi.fn(async () => packageInstallResult()),
     selectInitHandoff: vi.fn(async () => "eve-dev"),
     spawnCodingAgentRepl: vi.fn(async () => true),
-    spawnPackageManager: vi.fn(async () => true),
+    spawnPackageManager: vi.fn(async () => packageProcessResult()),
     tryInitializeGit: vi.fn(async () => gitResult),
     validateModelSlug: vi.fn(async () => null),
   };
@@ -953,7 +954,7 @@ describe("runInitCommand", () => {
     await mkdir(projectRoot, { recursive: true });
     const output = logger();
     const deps = dependencies();
-    deps.runPackageManagerInstall.mockResolvedValue(false);
+    deps.runPackageManagerInstall.mockResolvedValue(packageInstallResult(1));
 
     await expect(runInitCommand(output, projectRoot, ".", {}, deps)).rejects.toThrow("restored");
 
@@ -1184,7 +1185,7 @@ describe("runInitCommand", () => {
     deps.runPackageManagerInstall.mockImplementation(async (_kind, _projectPath, options) => {
       options?.onOutput?.({ stream: "stdout", text: "Packages: +12" });
       options?.onOutput?.({ stream: "stderr", text: "ERR_PNPM_FETCH_404 not found" });
-      return false;
+      return packageInstallResult(1);
     });
 
     await expect(runInitCommand(output, parentDirectory, "my-agent", {}, deps)).rejects.toThrow(
@@ -1218,7 +1219,7 @@ describe("runInitCommand", () => {
     const projectRoot = await createHostProject(parentDirectory);
     const output = logger();
     const deps = dependencies();
-    deps.runPackageManagerInstall.mockResolvedValue(false);
+    deps.runPackageManagerInstall.mockResolvedValue(packageInstallResult(1));
 
     await expect(runInitCommand(output, projectRoot, ".", {}, deps)).rejects.toThrow(
       `install dependencies with pnpm in "${projectRoot}"`,
@@ -1247,7 +1248,7 @@ describe("runInitCommand", () => {
         stream: "stderr",
         text: "npm error ERESOLVE unable to resolve dependency tree",
       });
-      return false;
+      return packageInstallResult(1);
     });
 
     await expect(runInitCommand(output, parentDirectory, "my-agent", {}, deps)).rejects.toThrow(
@@ -1270,7 +1271,7 @@ describe("runInitCommand", () => {
         options?.onOutput?.({ stream: "stderr", text: `npm silly step ${index}` });
       }
       options?.onOutput?.({ stream: "stderr", text: "" });
-      return false;
+      return packageInstallResult(1);
     });
 
     await expect(runInitCommand(output, parentDirectory, "my-agent", {}, deps)).rejects.toThrow(
@@ -1288,7 +1289,7 @@ describe("runInitCommand", () => {
     const deps = dependencies();
     deps.runPackageManagerInstall.mockImplementation(async (_kind, _projectPath, options) => {
       options?.onOutput?.({ stream: "stdout", text: "Progress: resolved 62, reused 62, done" });
-      return true;
+      return packageInstallResult();
     });
 
     const previous = process.env.EVE_LOG_LEVEL;
@@ -1322,7 +1323,7 @@ describe("runInitCommand", () => {
     const parentDirectory = await mkdtemp(join(tmpdir(), "eve-init-debug-failure-"));
     const output = logger();
     const deps = dependencies();
-    deps.runPackageManagerInstall.mockResolvedValue(false);
+    deps.runPackageManagerInstall.mockResolvedValue(packageInstallResult(1));
 
     const previous = process.env.EVE_LOG_LEVEL;
     process.env.EVE_LOG_LEVEL = "debug";
@@ -1374,7 +1375,7 @@ describe("runInitCommand", () => {
         text: "npm http fetch GET https://registry.npmjs.org/@vercel%2fconnect attempt 1 failed with ENOTFOUND",
       });
       options?.onOutput?.({ stream: "stdout", text: `Downloading ${"package".repeat(20)}` });
-      return true;
+      return packageInstallResult();
     });
 
     try {

--- a/packages/eve/src/cli/commands/init.integration.test.ts
+++ b/packages/eve/src/cli/commands/init.integration.test.ts
@@ -1214,6 +1214,27 @@ describe("runInitCommand", () => {
     );
   });
 
+  it("prints a spawn failure when installation produces no child output", async () => {
+    const parentDirectory = await mkdtemp(join(tmpdir(), "eve-init-spawn-fail-"));
+    const output = logger();
+    const deps = dependencies();
+    deps.runPackageManagerInstall.mockResolvedValue({
+      kind: "installed",
+      result: {
+        command: { executable: "pnpm", args: ["install"], cwd: parentDirectory },
+        termination: { kind: "spawn-error", code: "ENOENT", message: "spawn pnpm ENOENT" },
+        output: [],
+        truncatedBytes: 0,
+      },
+    });
+
+    await expect(runInitCommand(output, parentDirectory, "my-agent", {}, deps)).rejects.toThrow(
+      "Failed to install dependencies",
+    );
+
+    expect(output.errors).toEqual(["Could not start pnpm: spawn pnpm ENOENT"]);
+  });
+
   it("preserves an existing host after install failure and prints the retry command", async () => {
     const parentDirectory = await mkdtemp(join(tmpdir(), "eve-init-host-install-fail-"));
     const projectRoot = await createHostProject(parentDirectory);

--- a/packages/eve/src/cli/commands/init.integration.test.ts
+++ b/packages/eve/src/cli/commands/init.integration.test.ts
@@ -1232,7 +1232,7 @@ describe("runInitCommand", () => {
       "Failed to install dependencies",
     );
 
-    expect(output.errors).toEqual(["Could not start pnpm: spawn pnpm ENOENT"]);
+    expect(output.errors).toEqual(["pnpm was not found. Install it before running this step."]);
   });
 
   it("preserves an existing host after install failure and prints the retry command", async () => {

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -20,6 +20,8 @@ import {
 import { pathExists } from "#setup/path-exists.js";
 import {
   eveDevArguments,
+  packageManagerInstallSucceeded,
+  resultSucceeded,
   runPackageManagerInstall,
   spawnPackageManager,
 } from "#setup/primitives/index.js";
@@ -429,7 +431,7 @@ async function runInitSteps(input: {
     const installStartedAt = dependencies.now();
     const installFailureOutput: string[] = [];
     const recentInstallOutput: string[] = [];
-    const installed = await dependencies.runPackageManagerInstall(
+    const installResult = await dependencies.runPackageManagerInstall(
       project.packageManager,
       project.projectPath,
       {
@@ -454,7 +456,7 @@ async function runInitSteps(input: {
       },
     );
     const installElapsedMs = dependencies.now() - installStartedAt;
-    if (!installed) {
+    if (!packageManagerInstallSucceeded(installResult)) {
       initLog.debug("dependency installation failed", { ms: installElapsedMs });
       progress.stop();
       const failureOutput =
@@ -623,11 +625,13 @@ export async function runInitCommand(
   logger.log(pc.dim(freshScaffold ? "$ eve dev --input /model" : "$ eve dev"));
 
   if (
-    !(await dependencies.spawnPackageManager(
-      result.packageManager,
-      result.projectPath,
-      devArguments,
-    ))
+    !resultSucceeded(
+      await dependencies.spawnPackageManager(
+        result.packageManager,
+        result.projectPath,
+        devArguments,
+      ),
+    )
   ) {
     throw new Error(`Development server exited unsuccessfully in "${result.projectPath}".`);
   }

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -20,6 +20,7 @@ import {
 import { pathExists } from "#setup/path-exists.js";
 import {
   eveDevArguments,
+  packageManagerInstallFailureMessage,
   packageManagerInstallSucceeded,
   resultSucceeded,
   runPackageManagerInstall,
@@ -462,6 +463,10 @@ async function runInitSteps(input: {
       const failureOutput =
         installFailureOutput.length > 0 ? installFailureOutput : recentInstallOutput;
       for (const line of failureOutput) logger.error(line);
+      if (failureOutput.length === 0) {
+        const message = packageManagerInstallFailureMessage(installResult);
+        if (message !== undefined) logger.error(message);
+      }
 
       if (project.failurePolicy !== "preserve") {
         const cleaned = await cleanupFreshInitTarget(

--- a/packages/eve/src/internal/testing/package-process.ts
+++ b/packages/eve/src/internal/testing/package-process.ts
@@ -7,8 +7,7 @@ export function packageProcessResult(code = 0): PackageManagerProcessResult {
   return {
     command: { executable: "pnpm", args: ["install"], cwd: "/app" },
     termination: { kind: "exit", code },
-    output: [],
-    truncatedBytes: 0,
+    stdout: "",
   };
 }
 

--- a/packages/eve/src/internal/testing/package-process.ts
+++ b/packages/eve/src/internal/testing/package-process.ts
@@ -1,0 +1,17 @@
+import type {
+  PackageManagerInstallResult,
+  PackageManagerProcessResult,
+} from "#setup/primitives/index.js";
+
+export function packageProcessResult(code = 0): PackageManagerProcessResult {
+  return {
+    command: { executable: "pnpm", args: ["install"], cwd: "/app" },
+    termination: { kind: "exit", code },
+    output: [],
+    truncatedBytes: 0,
+  };
+}
+
+export function packageInstallResult(code = 0): PackageManagerInstallResult {
+  return { kind: "installed", result: packageProcessResult(code) };
+}

--- a/packages/eve/src/setup/boxes/deploy-project.test.ts
+++ b/packages/eve/src/setup/boxes/deploy-project.test.ts
@@ -4,6 +4,7 @@ import { HumanActionRequiredError } from "#setup/human-action.js";
 import type { DeploymentInfo } from "#setup/project-resolution.js";
 
 import { createFakePrompter } from "#internal/testing/fake-prompter.js";
+import { packageInstallResult } from "#internal/testing/package-process.js";
 
 import type { Prompter } from "../prompter.js";
 import { createDefaultSetupState, type SetupState } from "../state.js";
@@ -30,8 +31,8 @@ function createDeps() {
       kind: "pnpm",
       source: "default",
     })),
-    runPackageManagerInstall: vi.fn<DeployProjectDeps["runPackageManagerInstall"]>(
-      async () => true,
+    runPackageManagerInstall: vi.fn<DeployProjectDeps["runPackageManagerInstall"]>(async () =>
+      packageInstallResult(),
     ),
     detectDeployment: vi.fn<DeployProjectDeps["detectDeployment"]>(async () => DEPLOYED),
     syncHostFrameworkPreset: vi.fn<DeployProjectDeps["syncHostFrameworkPreset"]>(async () => {}),
@@ -271,7 +272,7 @@ describe("deployProject box", () => {
 
   it("surfaces failed dependency installation before any deploy", async () => {
     const deps = createDeps();
-    deps.runPackageManagerInstall.mockResolvedValue(false);
+    deps.runPackageManagerInstall.mockResolvedValue(packageInstallResult(1));
     const box = headlessBox({ deps });
 
     await expect(runHeadless([box], pendingState(), silentSink)).rejects.toThrow(

--- a/packages/eve/src/setup/boxes/deploy-project.ts
+++ b/packages/eve/src/setup/boxes/deploy-project.ts
@@ -1,7 +1,10 @@
 import { createPromptCommandOutput, withPhase, type ChannelSetupLog } from "#setup/cli/index.js";
 import { HumanActionRequiredError } from "#setup/human-action.js";
 import { detectPackageManager } from "#setup/package-manager.js";
-import { runPackageManagerInstall } from "#setup/primitives/pm/run.js";
+import {
+  packageManagerInstallSucceeded,
+  runPackageManagerInstall,
+} from "#setup/primitives/pm/run.js";
 import { runVercel } from "#setup/primitives/run-vercel.js";
 
 import {
@@ -155,13 +158,13 @@ export function deployProject(
 
       if (!state.deploymentDependenciesInstalled) {
         const packageManager = await deps.detectPackageManager(projectPath);
-        const installed = await withPhase(
+        const installResult = await withPhase(
           log,
           `Installing project dependencies before deployment (${packageManager.kind} install)...`,
           () =>
             deps.runPackageManagerInstall(packageManager.kind, projectPath, { onOutput, signal }),
         );
-        if (!installed) {
+        if (!packageManagerInstallSucceeded(installResult)) {
           signal?.throwIfAborted();
           throw new Error("Dependency installation failed. Deployment did not start.");
         }

--- a/packages/eve/src/setup/flows/deploy.test.ts
+++ b/packages/eve/src/setup/flows/deploy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { createFakePrompter } from "#internal/testing/fake-prompter.js";
+import { packageInstallResult } from "#internal/testing/package-process.js";
 import type { DeployProjectDeps } from "#setup/boxes/deploy-project.js";
 import type { LinkProjectDeps } from "#setup/boxes/link-project.js";
 import type { ResolveProvisioningDeps } from "#setup/boxes/resolve-provisioning.js";
@@ -26,8 +27,8 @@ function createDeployProjectDeps(probe: DeploymentInfo = DEPLOYED) {
       kind: "pnpm",
       source: "default",
     })),
-    runPackageManagerInstall: vi.fn<DeployProjectDeps["runPackageManagerInstall"]>(
-      async () => true,
+    runPackageManagerInstall: vi.fn<DeployProjectDeps["runPackageManagerInstall"]>(async () =>
+      packageInstallResult(),
     ),
     detectDeployment: vi.fn<DeployProjectDeps["detectDeployment"]>(async () => probe),
     syncHostFrameworkPreset: vi.fn<DeployProjectDeps["syncHostFrameworkPreset"]>(async () => {}),

--- a/packages/eve/src/setup/flows/install-vercel-cli.test.ts
+++ b/packages/eve/src/setup/flows/install-vercel-cli.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { createFakePrompter } from "#internal/testing/fake-prompter.js";
+import { packageProcessResult } from "#internal/testing/package-process.js";
 import type { DetectedPackageManager } from "#setup/package-manager.js";
 
 import { runInstallVercelCliFlow, type InstallVercelCliDeps } from "./install-vercel-cli.js";
@@ -36,8 +37,8 @@ function run(
 
 describe("runInstallVercelCliFlow", () => {
   it("short-circuits when the CLI already resolves and never installs", async () => {
-    const spawnPackageManager = vi.fn<InstallVercelCliDeps["spawnPackageManager"]>(
-      async () => true,
+    const spawnPackageManager = vi.fn<InstallVercelCliDeps["spawnPackageManager"]>(async () =>
+      packageProcessResult(),
     );
     await expect(
       run({ getVercelAuthStatus: statusProbe("logged-out") }, spawnPackageManager),
@@ -46,8 +47,8 @@ describe("runInstallVercelCliFlow", () => {
   });
 
   it("installs globally with the project's package manager, then re-probes", async () => {
-    const spawnPackageManager = vi.fn<InstallVercelCliDeps["spawnPackageManager"]>(
-      async () => true,
+    const spawnPackageManager = vi.fn<InstallVercelCliDeps["spawnPackageManager"]>(async () =>
+      packageProcessResult(),
     );
     // cli-missing before; logged-out (i.e. CLI now present) after.
     await expect(
@@ -66,8 +67,8 @@ describe("runInstallVercelCliFlow", () => {
       async (): Promise<DetectedPackageManager> => ({ kind: "yarn", source: "lockfile" }),
     );
     const runVercel = vi.fn<InstallVercelCliDeps["runVercel"]>(async () => true);
-    const spawnPackageManager = vi.fn<InstallVercelCliDeps["spawnPackageManager"]>(
-      async () => true,
+    const spawnPackageManager = vi.fn<InstallVercelCliDeps["spawnPackageManager"]>(async () =>
+      packageProcessResult(),
     );
 
     await expect(
@@ -123,8 +124,8 @@ describe("runInstallVercelCliFlow", () => {
   });
 
   it("reports failed when the install exits non-zero", async () => {
-    const spawnPackageManager = vi.fn<InstallVercelCliDeps["spawnPackageManager"]>(
-      async () => false,
+    const spawnPackageManager = vi.fn<InstallVercelCliDeps["spawnPackageManager"]>(async () =>
+      packageProcessResult(1),
     );
     await expect(
       run({ getVercelAuthStatus: statusProbe("cli-missing") }, spawnPackageManager),
@@ -132,8 +133,8 @@ describe("runInstallVercelCliFlow", () => {
   });
 
   it("reports failed when the install exits clean but the CLI still isn't on PATH", async () => {
-    const spawnPackageManager = vi.fn<InstallVercelCliDeps["spawnPackageManager"]>(
-      async () => true,
+    const spawnPackageManager = vi.fn<InstallVercelCliDeps["spawnPackageManager"]>(async () =>
+      packageProcessResult(),
     );
     // Still cli-missing after a "successful" global install (bin not on PATH).
     await expect(
@@ -142,8 +143,8 @@ describe("runInstallVercelCliFlow", () => {
   });
 
   it("uses the npm global form for an npm project", async () => {
-    const spawnPackageManager = vi.fn<InstallVercelCliDeps["spawnPackageManager"]>(
-      async () => true,
+    const spawnPackageManager = vi.fn<InstallVercelCliDeps["spawnPackageManager"]>(async () =>
+      packageProcessResult(),
     );
     await run(
       {

--- a/packages/eve/src/setup/flows/install-vercel-cli.ts
+++ b/packages/eve/src/setup/flows/install-vercel-cli.ts
@@ -1,6 +1,6 @@
 import { createPromptCommandOutput } from "#setup/cli/index.js";
 import { detectPackageManager, type PackageManagerKind } from "#setup/package-manager.js";
-import { runVercel, spawnPackageManager } from "#setup/primitives/index.js";
+import { resultSucceeded, runVercel, spawnPackageManager } from "#setup/primitives/index.js";
 import { getVercelAuthStatus } from "#setup/vercel-project.js";
 
 import type { Prompter } from "../prompter.js";
@@ -119,14 +119,21 @@ export async function runInstallVercelCliFlow(input: {
     });
   } else {
     const manager = await deps.detectPackageManager(appRoot);
-    ok = await withSpinner(prompter, `Installing the Vercel CLI with ${manager.kind}…`, () =>
-      deps.spawnPackageManager(manager.kind, appRoot, globalInstallArguments(manager.kind), {
-        onOutput,
-        signal,
-        // A global install never prompts; closing stdin keeps it from contending
-        // with the TUI's raw-mode key consumer.
-        nonInteractive: true,
-      }),
+    ok = await withSpinner(prompter, `Installing the Vercel CLI with ${manager.kind}…`, async () =>
+      resultSucceeded(
+        await deps.spawnPackageManager(
+          manager.kind,
+          appRoot,
+          globalInstallArguments(manager.kind),
+          {
+            onOutput,
+            signal,
+            // A global install never prompts; closing stdin keeps it from contending
+            // with the TUI's raw-mode key consumer.
+            nonInteractive: true,
+          },
+        ),
+      ),
     );
   }
   if (signal?.aborted === true) return { kind: "cancelled" };

--- a/packages/eve/src/setup/integrations/shared/scaffold.ts
+++ b/packages/eve/src/setup/integrations/shared/scaffold.ts
@@ -1,6 +1,9 @@
 import { createPromptCommandOutput, withPhase, type ChannelSetupLog } from "#setup/cli/index.js";
 import { detectPackageManager } from "#setup/package-manager.js";
-import { runPackageManagerInstall } from "#setup/primitives/pm/run.js";
+import {
+  packageManagerInstallSucceeded,
+  runPackageManagerInstall,
+} from "#setup/primitives/pm/run.js";
 
 /** Effects used to install dependencies added by an integration scaffold. */
 export interface IntegrationScaffoldDeps {
@@ -22,7 +25,7 @@ export async function installScaffoldDependencies(input: {
   if (!input.changed || input.skip) return;
   const deps = input.deps ?? defaultDeps;
   const packageManager = await deps.detectPackageManager(input.projectPath);
-  const installed = await withPhase(
+  const installResult = await withPhase(
     input.log,
     `Installing channel dependencies (${packageManager.kind} install)...`,
     () =>
@@ -31,7 +34,7 @@ export async function installScaffoldDependencies(input: {
         signal: input.signal,
       }),
   );
-  if (installed) return;
+  if (packageManagerInstallSucceeded(installResult)) return;
   input.log.warning(
     `Dependency installation failed. The new channel stays unloadable until \`${packageManager.kind} install\` or a deploy succeeds.`,
   );

--- a/packages/eve/src/setup/primitives/index.ts
+++ b/packages/eve/src/setup/primitives/index.ts
@@ -1,5 +1,6 @@
 export {
   eveDevArguments,
+  packageManagerInstallFailureMessage,
   packageManagerInstallSucceeded,
   runPackageManagerInstall,
   runPnpmInstall,

--- a/packages/eve/src/setup/primitives/index.ts
+++ b/packages/eve/src/setup/primitives/index.ts
@@ -1,13 +1,22 @@
 export {
   eveDevArguments,
+  packageManagerInstallSucceeded,
   runPackageManagerInstall,
   runPnpmInstall,
   spawnPackageManager,
   spawnPnpm,
+  type PackageManagerInstallResult,
   type RunInstallOptions,
   type RunPackageManagerOptions,
   type RunPnpmOptions,
 } from "./pm/run.js";
+export {
+  MAX_STREAMING_SECRET_LENGTH,
+  resultSucceeded,
+  type PackageManagerProcessResult,
+  type PackageManagerProcessTermination,
+  type ProcessOutputChunk,
+} from "./pm/process-result.js";
 export {
   getPackageManagerStrategy,
   type PackageManagerConfigurationResult,

--- a/packages/eve/src/setup/primitives/index.ts
+++ b/packages/eve/src/setup/primitives/index.ts
@@ -15,7 +15,6 @@ export {
   resultSucceeded,
   type PackageManagerProcessResult,
   type PackageManagerProcessTermination,
-  type ProcessOutputChunk,
 } from "./pm/process-result.js";
 export {
   getPackageManagerStrategy,

--- a/packages/eve/src/setup/primitives/index.ts
+++ b/packages/eve/src/setup/primitives/index.ts
@@ -11,7 +11,6 @@ export {
   type RunPnpmOptions,
 } from "./pm/run.js";
 export {
-  MAX_STREAMING_SECRET_LENGTH,
   resultSucceeded,
   type PackageManagerProcessResult,
   type PackageManagerProcessTermination,

--- a/packages/eve/src/setup/primitives/pm/process-result.test.ts
+++ b/packages/eve/src/setup/primitives/pm/process-result.test.ts
@@ -1,54 +1,31 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
-import {
-  createPackageProcessOutputCollector,
-  resultSucceeded,
-  type ProcessOutputChunk,
-} from "./process-result.js";
+import { createPackageProcessStdoutCollector, resultSucceeded } from "./process-result.js";
 
 const command = { executable: "npm", args: ["install"], cwd: "/app" };
 
-function collect(
-  options: { maxRetainedBytes?: number; onOutput?: (chunk: ProcessOutputChunk) => void } = {},
-) {
-  return createPackageProcessOutputCollector({ command, ...options });
+function collect(options: { maxCapturedBytes?: number } = {}) {
+  return createPackageProcessStdoutCollector({ command, ...options });
 }
 
 describe("package process results", () => {
-  it("preserves split UTF-8 code points with one decoder per stream", () => {
+  it("preserves split UTF-8 code points", () => {
     const collector = collect();
     const encoded = Buffer.from("ready 🚀\n");
 
-    collector.write("stdout", encoded.subarray(0, 8));
-    collector.write("stdout", encoded.subarray(8));
+    collector.write(encoded.subarray(0, 8));
+    collector.write(encoded.subarray(8));
     collector.end();
 
-    expect(collector.result({ kind: "exit", code: 0 }).output).toEqual([
-      { emittedSequence: 0, stream: "stdout", text: "ready " },
-      { emittedSequence: 1, stream: "stdout", text: "🚀\n" },
-    ]);
+    expect(collector.result({ kind: "exit", code: 0 }).stdout).toBe("ready 🚀\n");
   });
 
-  it("streams raw output while retaining only the byte bound", () => {
-    const onOutput = vi.fn();
-    const collector = collect({ maxRetainedBytes: 5, onOutput });
-    collector.write("stdout", Buffer.from("123456789"));
+  it("bounds captured stdout without splitting a UTF-8 code point", () => {
+    const collector = collect({ maxCapturedBytes: 7 });
+    collector.write(Buffer.from("ready 🚀"));
     collector.end();
 
-    const result = collector.result({ kind: "exit", code: 0 });
-    expect(result.output.map((chunk) => chunk.text).join("")).toBe("12345");
-    expect(result.truncatedBytes).toBe(4);
-    expect(onOutput.mock.calls.map(([chunk]) => chunk.text).join("")).toBe("123456789");
-  });
-
-  it("does not split a retained UTF-8 code point at the byte bound", () => {
-    const collector = collect({ maxRetainedBytes: 7 });
-    collector.write("stdout", Buffer.from("ready 🚀"));
-    collector.end();
-
-    const result = collector.result({ kind: "exit", code: 0 });
-    expect(result.output.map((chunk) => chunk.text).join("")).toBe("ready ");
-    expect(result.truncatedBytes).toBe(4);
+    expect(collector.result({ kind: "exit", code: 0 }).stdout).toBe("ready ");
   });
 
   it("distinguishes every termination kind from success", () => {

--- a/packages/eve/src/setup/primitives/pm/process-result.test.ts
+++ b/packages/eve/src/setup/primitives/pm/process-result.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   createPackageProcessOutputCollector,
-  MAX_STREAMING_SECRET_LENGTH,
   resultSucceeded,
   type ProcessOutputChunk,
 } from "./process-result.js";
@@ -25,41 +24,12 @@ describe("package process results", () => {
     collector.end();
 
     expect(collector.result({ kind: "exit", code: 0 }).output).toEqual([
-      { emittedSequence: 0, stream: "stdout", text: "ready 🚀\n" },
+      { emittedSequence: 0, stream: "stdout", text: "ready " },
+      { emittedSequence: 1, stream: "stdout", text: "🚀\n" },
     ]);
   });
 
-  it("redacts environment secrets split across chunks before every sink", () => {
-    vi.stubEnv("TEST_API_TOKEN", "secret-value-123456");
-    const onOutput = vi.fn();
-    const collector = collect({ onOutput });
-
-    collector.write("stderr", Buffer.from("token=secret-value-"));
-    collector.write("stderr", Buffer.from("123456\n"));
-    collector.end();
-
-    const result = collector.result({ kind: "exit", code: 1 });
-    expect(result.output.map((chunk) => chunk.text).join("")).toBe("token=[REDACTED]\n");
-    expect(onOutput.mock.calls.map(([chunk]) => chunk.text).join("")).toBe("token=[REDACTED]\n");
-    vi.unstubAllEnvs();
-  });
-
-  it("redacts credential URLs and authorization headers", () => {
-    const collector = collect();
-    collector.write(
-      "stderr",
-      Buffer.from(
-        "https://user:password@example.com\nAuthorization: Bearer abcdefghijklmnopqrstuvwxyz\n",
-      ),
-    );
-    collector.end();
-
-    expect(collector.result({ kind: "exit", code: 1 }).output[0]?.text).toBe(
-      "https://user:[REDACTED]@example.com\nAuthorization: Bearer [REDACTED]\n",
-    );
-  });
-
-  it("bounds retained bytes while continuing to stream all redacted output", () => {
+  it("streams raw output while retaining only the byte bound", () => {
     const onOutput = vi.fn();
     const collector = collect({ maxRetainedBytes: 5, onOutput });
     collector.write("stdout", Buffer.from("123456789"));
@@ -69,6 +39,16 @@ describe("package process results", () => {
     expect(result.output.map((chunk) => chunk.text).join("")).toBe("12345");
     expect(result.truncatedBytes).toBe(4);
     expect(onOutput.mock.calls.map(([chunk]) => chunk.text).join("")).toBe("123456789");
+  });
+
+  it("does not split a retained UTF-8 code point at the byte bound", () => {
+    const collector = collect({ maxRetainedBytes: 7 });
+    collector.write("stdout", Buffer.from("ready 🚀"));
+    collector.end();
+
+    const result = collector.result({ kind: "exit", code: 0 });
+    expect(result.output.map((chunk) => chunk.text).join("")).toBe("ready ");
+    expect(result.truncatedBytes).toBe(4);
   });
 
   it("distinguishes every termination kind from success", () => {
@@ -84,10 +64,5 @@ describe("package process results", () => {
         collector.result({ kind: "spawn-error", code: "ENOENT", message: "missing" }),
       ),
     ).toBe(false);
-  });
-
-  it("exports a finite streaming secret limit", () => {
-    expect(MAX_STREAMING_SECRET_LENGTH).toBeGreaterThanOrEqual(128);
-    expect(MAX_STREAMING_SECRET_LENGTH).toBeLessThanOrEqual(1024);
   });
 });

--- a/packages/eve/src/setup/primitives/pm/process-result.test.ts
+++ b/packages/eve/src/setup/primitives/pm/process-result.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createPackageProcessOutputCollector,
+  MAX_STREAMING_SECRET_LENGTH,
+  resultSucceeded,
+  type ProcessOutputChunk,
+} from "./process-result.js";
+
+const command = { executable: "npm", args: ["install"], cwd: "/app" };
+
+function collect(
+  options: { maxRetainedBytes?: number; onOutput?: (chunk: ProcessOutputChunk) => void } = {},
+) {
+  return createPackageProcessOutputCollector({ command, ...options });
+}
+
+describe("package process results", () => {
+  it("preserves split UTF-8 code points with one decoder per stream", () => {
+    const collector = collect();
+    const encoded = Buffer.from("ready 🚀\n");
+
+    collector.write("stdout", encoded.subarray(0, 8));
+    collector.write("stdout", encoded.subarray(8));
+    collector.end();
+
+    expect(collector.result({ kind: "exit", code: 0 }).output).toEqual([
+      { emittedSequence: 0, stream: "stdout", text: "ready 🚀\n" },
+    ]);
+  });
+
+  it("redacts environment secrets split across chunks before every sink", () => {
+    vi.stubEnv("TEST_API_TOKEN", "secret-value-123456");
+    const onOutput = vi.fn();
+    const collector = collect({ onOutput });
+
+    collector.write("stderr", Buffer.from("token=secret-value-"));
+    collector.write("stderr", Buffer.from("123456\n"));
+    collector.end();
+
+    const result = collector.result({ kind: "exit", code: 1 });
+    expect(result.output.map((chunk) => chunk.text).join("")).toBe("token=[REDACTED]\n");
+    expect(onOutput.mock.calls.map(([chunk]) => chunk.text).join("")).toBe("token=[REDACTED]\n");
+    vi.unstubAllEnvs();
+  });
+
+  it("redacts credential URLs and authorization headers", () => {
+    const collector = collect();
+    collector.write(
+      "stderr",
+      Buffer.from(
+        "https://user:password@example.com\nAuthorization: Bearer abcdefghijklmnopqrstuvwxyz\n",
+      ),
+    );
+    collector.end();
+
+    expect(collector.result({ kind: "exit", code: 1 }).output[0]?.text).toBe(
+      "https://user:[REDACTED]@example.com\nAuthorization: Bearer [REDACTED]\n",
+    );
+  });
+
+  it("bounds retained bytes while continuing to stream all redacted output", () => {
+    const onOutput = vi.fn();
+    const collector = collect({ maxRetainedBytes: 5, onOutput });
+    collector.write("stdout", Buffer.from("123456789"));
+    collector.end();
+
+    const result = collector.result({ kind: "exit", code: 0 });
+    expect(result.output.map((chunk) => chunk.text).join("")).toBe("12345");
+    expect(result.truncatedBytes).toBe(4);
+    expect(onOutput.mock.calls.map(([chunk]) => chunk.text).join("")).toBe("123456789");
+  });
+
+  it("distinguishes every termination kind from success", () => {
+    const collector = collect();
+    collector.end();
+
+    expect(resultSucceeded(collector.result({ kind: "exit", code: 0 }))).toBe(true);
+    expect(resultSucceeded(collector.result({ kind: "exit", code: 1 }))).toBe(false);
+    expect(resultSucceeded(collector.result({ kind: "signal", signal: "SIGTERM" }))).toBe(false);
+    expect(resultSucceeded(collector.result({ kind: "aborted" }))).toBe(false);
+    expect(
+      resultSucceeded(
+        collector.result({ kind: "spawn-error", code: "ENOENT", message: "missing" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("exports a finite streaming secret limit", () => {
+    expect(MAX_STREAMING_SECRET_LENGTH).toBeGreaterThanOrEqual(128);
+    expect(MAX_STREAMING_SECRET_LENGTH).toBeLessThanOrEqual(1024);
+  });
+});

--- a/packages/eve/src/setup/primitives/pm/process-result.ts
+++ b/packages/eve/src/setup/primitives/pm/process-result.ts
@@ -1,0 +1,133 @@
+import { StringDecoder } from "node:string_decoder";
+
+import type { ProcessOutputStream } from "../process-output.js";
+
+export const MAX_STREAMING_SECRET_LENGTH = 256;
+const MIN_ENV_SECRET_LENGTH = 8;
+const MAX_RETAINED_OUTPUT_BYTES = 64 * 1024;
+const REDACTED = "[REDACTED]";
+
+export interface ProcessOutputChunk {
+  emittedSequence: number;
+  stream: ProcessOutputStream;
+  text: string;
+}
+
+export type PackageManagerProcessTermination =
+  | { kind: "exit"; code: number }
+  | { kind: "signal"; signal: string }
+  | { kind: "aborted"; reason?: string }
+  | { kind: "spawn-error"; code?: string; message: string };
+
+export interface PackageManagerProcessResult {
+  command: { executable: string; args: readonly string[]; cwd: string };
+  termination: PackageManagerProcessTermination;
+  output: readonly ProcessOutputChunk[];
+  truncatedBytes: number;
+}
+
+export function resultSucceeded(result: PackageManagerProcessResult): boolean {
+  return result.termination.kind === "exit" && result.termination.code === 0;
+}
+
+const CREDENTIAL_ENV_KEY = /(?:TOKEN|PASSWORD|PASSWD|SECRET|AUTH|API_KEY|NPM_TOKEN)$/iu;
+const TOKEN_PATTERN =
+  /\b(?:npm_[A-Za-z0-9]{16,240}|(?:gh[opusr]|github_pat)_[A-Za-z0-9_]{16,240}|(?:sk|vercel)_[A-Za-z0-9_-]{16,240})\b/gu;
+const AUTHORIZATION_PATTERN = /\b(authorization\s*[:=]\s*(?:bearer|basic)\s+)[^\s,;]{8,256}/giu;
+const CREDENTIAL_URL_PATTERN = /\b(https?:\/\/[^\s/@:]+:)[^\s/@]{1,256}@/giu;
+
+function credentialEnvironmentValues(): string[] {
+  return Object.entries(process.env).flatMap(([key, value]) => {
+    if (
+      value === undefined ||
+      value.length < MIN_ENV_SECRET_LENGTH ||
+      value.length > MAX_STREAMING_SECRET_LENGTH ||
+      !CREDENTIAL_ENV_KEY.test(key)
+    ) {
+      return [];
+    }
+    return [value];
+  });
+}
+
+function redact(text: string, environmentValues: readonly string[]): string {
+  let redacted = text
+    .replace(CREDENTIAL_URL_PATTERN, `$1${REDACTED}@`)
+    .replace(AUTHORIZATION_PATTERN, `$1${REDACTED}`)
+    .replace(TOKEN_PATTERN, REDACTED);
+  for (const value of environmentValues) redacted = redacted.replaceAll(value, REDACTED);
+  return redacted;
+}
+
+export interface PackageProcessOutputCollector {
+  end(): void;
+  result(termination: PackageManagerProcessTermination): PackageManagerProcessResult;
+  write(stream: ProcessOutputStream, chunk: Buffer): void;
+}
+
+export function createPackageProcessOutputCollector(input: {
+  command: PackageManagerProcessResult["command"];
+  maxRetainedBytes?: number;
+  onOutput?: (chunk: ProcessOutputChunk) => void;
+}): PackageProcessOutputCollector {
+  const maxRetainedBytes = input.maxRetainedBytes ?? MAX_RETAINED_OUTPUT_BYTES;
+  const environmentValues = credentialEnvironmentValues();
+  const decoders = { stdout: new StringDecoder("utf8"), stderr: new StringDecoder("utf8") };
+  const pending = { stdout: "", stderr: "" };
+  const output: ProcessOutputChunk[] = [];
+  let retainedBytes = 0;
+  let truncatedBytes = 0;
+  let emittedSequence = 0;
+
+  function emit(stream: ProcessOutputStream, decoded: string): void {
+    if (decoded === "") return;
+    const text = redact(decoded, environmentValues);
+    const chunk = { emittedSequence: emittedSequence++, stream, text };
+    input.onOutput?.(chunk);
+
+    const decodedBytes = Buffer.byteLength(decoded);
+    const remaining = Math.max(0, maxRetainedBytes - retainedBytes);
+    if (decodedBytes <= remaining) {
+      output.push(chunk);
+      retainedBytes += decodedBytes;
+      return;
+    }
+
+    let retainedSource = "";
+    let retainedSourceBytes = 0;
+    for (const character of decoded) {
+      const characterBytes = Buffer.byteLength(character);
+      if (retainedSourceBytes + characterBytes > remaining) break;
+      retainedSource += character;
+      retainedSourceBytes += characterBytes;
+    }
+    if (retainedSource !== "")
+      output.push({ ...chunk, text: redact(retainedSource, environmentValues) });
+    retainedBytes += retainedSourceBytes;
+    truncatedBytes += decodedBytes - retainedSourceBytes;
+  }
+
+  function flushEligible(stream: ProcessOutputStream): void {
+    const eligibleLength = pending[stream].length - (MAX_STREAMING_SECRET_LENGTH - 1);
+    if (eligibleLength <= 0) return;
+    emit(stream, pending[stream].slice(0, eligibleLength));
+    pending[stream] = pending[stream].slice(eligibleLength);
+  }
+
+  return {
+    write(stream, chunk) {
+      pending[stream] += decoders[stream].write(chunk);
+      flushEligible(stream);
+    },
+    end() {
+      for (const stream of ["stdout", "stderr"] satisfies ProcessOutputStream[]) {
+        pending[stream] += decoders[stream].end();
+        emit(stream, pending[stream]);
+        pending[stream] = "";
+      }
+    },
+    result(termination) {
+      return { command: input.command, termination, output, truncatedBytes };
+    },
+  };
+}

--- a/packages/eve/src/setup/primitives/pm/process-result.ts
+++ b/packages/eve/src/setup/primitives/pm/process-result.ts
@@ -1,15 +1,6 @@
 import { StringDecoder } from "node:string_decoder";
 
-import type { ProcessOutputStream } from "../process-output.js";
-
-const MAX_RETAINED_OUTPUT_BYTES = 64 * 1024;
-
-/** Raw package-manager output. It may contain sensitive user or lifecycle-script data. */
-export interface ProcessOutputChunk {
-  emittedSequence: number;
-  stream: ProcessOutputStream;
-  text: string;
-}
+const MAX_CAPTURED_STDOUT_BYTES = 64 * 1024;
 
 export type PackageManagerProcessTermination =
   | { kind: "exit"; code: number }
@@ -20,70 +11,47 @@ export type PackageManagerProcessTermination =
 export interface PackageManagerProcessResult {
   command: { executable: string; args: readonly string[]; cwd: string };
   termination: PackageManagerProcessTermination;
-  /** Byte-bounded, in-memory output. It must not be persisted or included in diagnostics. */
-  output: readonly ProcessOutputChunk[];
-  truncatedBytes: number;
+  /** Byte-bounded stdout for commands whose caller needs to interpret it. */
+  stdout: string;
 }
 
 export function resultSucceeded(result: PackageManagerProcessResult): boolean {
   return result.termination.kind === "exit" && result.termination.code === 0;
 }
 
-export interface PackageProcessOutputCollector {
+export interface PackageProcessStdoutCollector {
   end(): void;
   result(termination: PackageManagerProcessTermination): PackageManagerProcessResult;
-  write(stream: ProcessOutputStream, chunk: Buffer): void;
+  write(chunk: Buffer): void;
 }
 
-export function createPackageProcessOutputCollector(input: {
+export function createPackageProcessStdoutCollector(input: {
   command: PackageManagerProcessResult["command"];
-  maxRetainedBytes?: number;
-  onOutput?: (chunk: ProcessOutputChunk) => void;
-}): PackageProcessOutputCollector {
-  const maxRetainedBytes = input.maxRetainedBytes ?? MAX_RETAINED_OUTPUT_BYTES;
-  const decoders = { stdout: new StringDecoder("utf8"), stderr: new StringDecoder("utf8") };
-  const output: ProcessOutputChunk[] = [];
-  let retainedBytes = 0;
-  let truncatedBytes = 0;
-  let emittedSequence = 0;
+  maxCapturedBytes?: number;
+}): PackageProcessStdoutCollector {
+  const maxCapturedBytes = input.maxCapturedBytes ?? MAX_CAPTURED_STDOUT_BYTES;
+  const decoder = new StringDecoder("utf8");
+  let stdout = "";
+  let capturedBytes = 0;
 
-  function emit(stream: ProcessOutputStream, text: string): void {
-    if (text === "") return;
-    const chunk = { emittedSequence: emittedSequence++, stream, text };
-    input.onOutput?.(chunk);
-
-    const decodedBytes = Buffer.byteLength(text);
-    const remaining = Math.max(0, maxRetainedBytes - retainedBytes);
-    if (decodedBytes <= remaining) {
-      output.push(chunk);
-      retainedBytes += decodedBytes;
-      return;
-    }
-
-    let retainedText = "";
-    let retainedTextBytes = 0;
+  function capture(text: string): void {
     for (const character of text) {
       const characterBytes = Buffer.byteLength(character);
-      if (retainedTextBytes + characterBytes > remaining) break;
-      retainedText += character;
-      retainedTextBytes += characterBytes;
+      if (capturedBytes + characterBytes > maxCapturedBytes) return;
+      stdout += character;
+      capturedBytes += characterBytes;
     }
-    if (retainedText !== "") output.push({ ...chunk, text: retainedText });
-    retainedBytes += retainedTextBytes;
-    truncatedBytes += decodedBytes - retainedTextBytes;
   }
 
   return {
-    write(stream, chunk) {
-      emit(stream, decoders[stream].write(chunk));
+    write(chunk) {
+      capture(decoder.write(chunk));
     },
     end() {
-      for (const stream of ["stdout", "stderr"] satisfies ProcessOutputStream[]) {
-        emit(stream, decoders[stream].end());
-      }
+      capture(decoder.end());
     },
     result(termination) {
-      return { command: input.command, termination, output, truncatedBytes };
+      return { command: input.command, termination, stdout };
     },
   };
 }

--- a/packages/eve/src/setup/primitives/pm/process-result.ts
+++ b/packages/eve/src/setup/primitives/pm/process-result.ts
@@ -2,11 +2,9 @@ import { StringDecoder } from "node:string_decoder";
 
 import type { ProcessOutputStream } from "../process-output.js";
 
-export const MAX_STREAMING_SECRET_LENGTH = 256;
-const MIN_ENV_SECRET_LENGTH = 8;
 const MAX_RETAINED_OUTPUT_BYTES = 64 * 1024;
-const REDACTED = "[REDACTED]";
 
+/** Raw package-manager output. It may contain sensitive user or lifecycle-script data. */
 export interface ProcessOutputChunk {
   emittedSequence: number;
   stream: ProcessOutputStream;
@@ -22,41 +20,13 @@ export type PackageManagerProcessTermination =
 export interface PackageManagerProcessResult {
   command: { executable: string; args: readonly string[]; cwd: string };
   termination: PackageManagerProcessTermination;
+  /** Byte-bounded, in-memory output. It must not be persisted or included in diagnostics. */
   output: readonly ProcessOutputChunk[];
   truncatedBytes: number;
 }
 
 export function resultSucceeded(result: PackageManagerProcessResult): boolean {
   return result.termination.kind === "exit" && result.termination.code === 0;
-}
-
-const CREDENTIAL_ENV_KEY = /(?:TOKEN|PASSWORD|PASSWD|SECRET|AUTH|API_KEY|NPM_TOKEN)$/iu;
-const TOKEN_PATTERN =
-  /\b(?:npm_[A-Za-z0-9]{16,240}|(?:gh[opusr]|github_pat)_[A-Za-z0-9_]{16,240}|(?:sk|vercel)_[A-Za-z0-9_-]{16,240})\b/gu;
-const AUTHORIZATION_PATTERN = /\b(authorization\s*[:=]\s*(?:bearer|basic)\s+)[^\s,;]{8,256}/giu;
-const CREDENTIAL_URL_PATTERN = /\b(https?:\/\/[^\s/@:]+:)[^\s/@]{1,256}@/giu;
-
-function credentialEnvironmentValues(): string[] {
-  return Object.entries(process.env).flatMap(([key, value]) => {
-    if (
-      value === undefined ||
-      value.length < MIN_ENV_SECRET_LENGTH ||
-      value.length > MAX_STREAMING_SECRET_LENGTH ||
-      !CREDENTIAL_ENV_KEY.test(key)
-    ) {
-      return [];
-    }
-    return [value];
-  });
-}
-
-function redact(text: string, environmentValues: readonly string[]): string {
-  let redacted = text
-    .replace(CREDENTIAL_URL_PATTERN, `$1${REDACTED}@`)
-    .replace(AUTHORIZATION_PATTERN, `$1${REDACTED}`)
-    .replace(TOKEN_PATTERN, REDACTED);
-  for (const value of environmentValues) redacted = redacted.replaceAll(value, REDACTED);
-  return redacted;
 }
 
 export interface PackageProcessOutputCollector {
@@ -71,21 +41,18 @@ export function createPackageProcessOutputCollector(input: {
   onOutput?: (chunk: ProcessOutputChunk) => void;
 }): PackageProcessOutputCollector {
   const maxRetainedBytes = input.maxRetainedBytes ?? MAX_RETAINED_OUTPUT_BYTES;
-  const environmentValues = credentialEnvironmentValues();
   const decoders = { stdout: new StringDecoder("utf8"), stderr: new StringDecoder("utf8") };
-  const pending = { stdout: "", stderr: "" };
   const output: ProcessOutputChunk[] = [];
   let retainedBytes = 0;
   let truncatedBytes = 0;
   let emittedSequence = 0;
 
-  function emit(stream: ProcessOutputStream, decoded: string): void {
-    if (decoded === "") return;
-    const text = redact(decoded, environmentValues);
+  function emit(stream: ProcessOutputStream, text: string): void {
+    if (text === "") return;
     const chunk = { emittedSequence: emittedSequence++, stream, text };
     input.onOutput?.(chunk);
 
-    const decodedBytes = Buffer.byteLength(decoded);
+    const decodedBytes = Buffer.byteLength(text);
     const remaining = Math.max(0, maxRetainedBytes - retainedBytes);
     if (decodedBytes <= remaining) {
       output.push(chunk);
@@ -93,37 +60,26 @@ export function createPackageProcessOutputCollector(input: {
       return;
     }
 
-    let retainedSource = "";
-    let retainedSourceBytes = 0;
-    for (const character of decoded) {
+    let retainedText = "";
+    let retainedTextBytes = 0;
+    for (const character of text) {
       const characterBytes = Buffer.byteLength(character);
-      if (retainedSourceBytes + characterBytes > remaining) break;
-      retainedSource += character;
-      retainedSourceBytes += characterBytes;
+      if (retainedTextBytes + characterBytes > remaining) break;
+      retainedText += character;
+      retainedTextBytes += characterBytes;
     }
-    if (retainedSource !== "")
-      output.push({ ...chunk, text: redact(retainedSource, environmentValues) });
-    retainedBytes += retainedSourceBytes;
-    truncatedBytes += decodedBytes - retainedSourceBytes;
-  }
-
-  function flushEligible(stream: ProcessOutputStream): void {
-    const eligibleLength = pending[stream].length - (MAX_STREAMING_SECRET_LENGTH - 1);
-    if (eligibleLength <= 0) return;
-    emit(stream, pending[stream].slice(0, eligibleLength));
-    pending[stream] = pending[stream].slice(eligibleLength);
+    if (retainedText !== "") output.push({ ...chunk, text: retainedText });
+    retainedBytes += retainedTextBytes;
+    truncatedBytes += decodedBytes - retainedTextBytes;
   }
 
   return {
     write(stream, chunk) {
-      pending[stream] += decoders[stream].write(chunk);
-      flushEligible(stream);
+      emit(stream, decoders[stream].write(chunk));
     },
     end() {
       for (const stream of ["stdout", "stderr"] satisfies ProcessOutputStream[]) {
-        pending[stream] += decoders[stream].end();
-        emit(stream, pending[stream]);
-        pending[stream] = "";
+        emit(stream, decoders[stream].end());
       }
     },
     result(termination) {

--- a/packages/eve/src/setup/primitives/pm/run.scenario.test.ts
+++ b/packages/eve/src/setup/primitives/pm/run.scenario.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest";
 import { useTemporaryDirectories } from "#internal/testing/use-temporary-app-roots.js";
 import { pathExists } from "#setup/path-exists.js";
 
-import { runPackageManagerInstall } from "./run.js";
+import { packageManagerInstallSucceeded, runPackageManagerInstall } from "./run.js";
 
 const createScratchDirectory = useTemporaryDirectories();
 
@@ -53,10 +53,12 @@ describe("runPackageManagerInstall (real pnpm)", () => {
     });
 
     const { lines, onOutput } = collectOutput();
-    await expect(
-      runPackageManagerInstall("pnpm", memberRoot, { onOutput }),
+    expect(
+      packageManagerInstallSucceeded(
+        await runPackageManagerInstall("pnpm", memberRoot, { onOutput }),
+      ),
       lines.join("\n"),
-    ).resolves.toBe(true);
+    ).toBe(true);
 
     await expect(pathExists(join(memberRoot, "node_modules", "scratch-lib"))).resolves.toBe(true);
     // The workspace owns the lockfile; a standalone (`--ignore-workspace`)
@@ -93,10 +95,12 @@ describe("runPackageManagerInstall (real pnpm)", () => {
     await mkdir(join(nestedRoot, "node_modules"), { recursive: true });
 
     const { lines, onOutput } = collectOutput();
-    await expect(
-      runPackageManagerInstall("pnpm", nestedRoot, { onOutput }),
+    expect(
+      packageManagerInstallSucceeded(
+        await runPackageManagerInstall("pnpm", nestedRoot, { onOutput }),
+      ),
       lines.join("\n"),
-    ).resolves.toBe(true);
+    ).toBe(true);
 
     await expect(pathExists(join(nestedRoot, "node_modules", "scratch-local-dep"))).resolves.toBe(
       true,

--- a/packages/eve/src/setup/primitives/pm/run.ts
+++ b/packages/eve/src/setup/primitives/pm/run.ts
@@ -5,7 +5,7 @@ import { armProcessAbort } from "../process-abort.js";
 import { createProcessOutputBuffer, type ProcessOutputHandler } from "../process-output.js";
 import { getPackageManagerStrategy } from "./index.js";
 import {
-  createPackageProcessOutputCollector,
+  createPackageProcessStdoutCollector,
   type PackageManagerProcessResult,
   type PackageManagerProcessTermination,
   resultSucceeded,
@@ -23,6 +23,8 @@ export interface RunPackageManagerOptions {
   onOutput?: ProcessOutputHandler;
   /** Aborts the package-manager subprocess when setup is interrupted. */
   signal?: AbortSignal;
+  /** Retains bounded stdout for a caller that must interpret a command's output. */
+  captureStdout?: boolean;
   /** Closes stdin so the child cannot contend with a parent-owned TUI. */
   nonInteractive?: boolean;
 }
@@ -53,18 +55,18 @@ export function spawnPackageManager(
     cwd: projectRoot,
   };
   if (options.signal?.aborted === true) {
-    const collector = createPackageProcessOutputCollector({ command });
-    collector.end();
-    return Promise.resolve(collector.result(abortedTermination(options.signal)));
+    return Promise.resolve({
+      command,
+      termination: abortedTermination(options.signal),
+      stdout: "",
+    });
   }
 
   return new Promise((resolvePromise) => {
     const captureOutput = options.onOutput !== undefined || options.nonInteractive === true;
     const lineBuffer = options.onOutput && createProcessOutputBuffer(options.onOutput);
-    const collector = createPackageProcessOutputCollector({
-      command,
-      onOutput: (chunk) => lineBuffer?.write(chunk.stream, Buffer.from(chunk.text)),
-    });
+    const stdoutCollector =
+      options.captureStdout === true ? createPackageProcessStdoutCollector({ command }) : undefined;
     let child;
     try {
       child = spawn(invocation.command, [...invocation.args], {
@@ -76,26 +78,30 @@ export function spawnPackageManager(
         signal: options.signal,
       });
     } catch (error) {
-      collector.end();
       lineBuffer?.flush();
       const failure = error as NodeJS.ErrnoException;
-      resolvePromise(
-        collector.result({ kind: "spawn-error", code: failure.code, message: failure.message }),
-      );
+      resolvePromise({
+        command,
+        termination: { kind: "spawn-error", code: failure.code, message: failure.message },
+        stdout: "",
+      });
       return;
     }
     const disarmAbort = armProcessAbort(child, options.signal);
-    child.stdout?.on("data", (chunk: Buffer) => collector.write("stdout", chunk));
-    child.stderr?.on("data", (chunk: Buffer) => collector.write("stderr", chunk));
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdoutCollector?.write(chunk);
+      lineBuffer?.write("stdout", chunk);
+    });
+    child.stderr?.on("data", (chunk: Buffer) => lineBuffer?.write("stderr", chunk));
 
     let settled = false;
     function settle(termination: PackageManagerProcessTermination): void {
       if (settled) return;
       settled = true;
       disarmAbort();
-      collector.end();
+      stdoutCollector?.end();
       lineBuffer?.flush();
-      resolvePromise(collector.result(termination));
+      resolvePromise(stdoutCollector?.result(termination) ?? { command, termination, stdout: "" });
     }
 
     child.on("error", (error: NodeJS.ErrnoException) => {
@@ -139,13 +145,6 @@ export function packageManagerInstallFailureMessage(
   return undefined;
 }
 
-function outputText(result: PackageManagerProcessResult, stream: "stdout" | "stderr"): string {
-  return result.output
-    .filter((chunk) => chunk.stream === stream)
-    .map((chunk) => chunk.text)
-    .join("");
-}
-
 /** Installs project dependencies and keeps workspace-probe evidence distinct. */
 export async function runPackageManagerInstall(
   kind: PackageManagerKind,
@@ -163,10 +162,10 @@ export async function runPackageManagerInstall(
       kind,
       projectRoot,
       PNPM_WORKSPACE_MEMBERSHIP_ARGUMENTS,
-      { ...options, nonInteractive: true },
+      { ...options, captureStdout: true, nonInteractive: true },
     );
     if (!resultSucceeded(probe)) return { kind: "workspace-probe-failed", result: probe };
-    const claimed = pnpmWorkspaceClaimsProject(outputText(probe, "stdout"), projectRoot);
+    const claimed = pnpmWorkspaceClaimsProject(probe.stdout, projectRoot);
     if (claimed === undefined) return { kind: "workspace-probe-unrecognized", result: probe };
     if (!claimed) installOptions = { ...options, ignoreWorkspace: true };
   }

--- a/packages/eve/src/setup/primitives/pm/run.ts
+++ b/packages/eve/src/setup/primitives/pm/run.ts
@@ -19,7 +19,7 @@ import type { PackageManagerInstallOptions } from "./types.js";
 
 /** Output routing options for setup-owned package manager commands. */
 export interface RunPackageManagerOptions {
-  /** Streams redacted command output to a parent-owned renderer. */
+  /** Streams raw command output to a parent-owned local renderer. */
   onOutput?: ProcessOutputHandler;
   /** Aborts the package-manager subprocess when setup is interrupted. */
   signal?: AbortSignal;

--- a/packages/eve/src/setup/primitives/pm/run.ts
+++ b/packages/eve/src/setup/primitives/pm/run.ts
@@ -59,6 +59,7 @@ export function spawnPackageManager(
   }
 
   return new Promise((resolvePromise) => {
+    const captureOutput = options.onOutput !== undefined || options.nonInteractive === true;
     const lineBuffer = options.onOutput && createProcessOutputBuffer(options.onOutput);
     const collector = createPackageProcessOutputCollector({
       command,
@@ -68,7 +69,9 @@ export function spawnPackageManager(
     try {
       child = spawn(invocation.command, [...invocation.args], {
         cwd: projectRoot,
-        stdio: [options.nonInteractive ? "ignore" : "inherit", "pipe", "pipe"],
+        stdio: captureOutput
+          ? [options.nonInteractive ? "ignore" : "inherit", "pipe", "pipe"]
+          : "inherit",
         shell: invocation.shell,
         signal: options.signal,
       });

--- a/packages/eve/src/setup/primitives/pm/run.ts
+++ b/packages/eve/src/setup/primitives/pm/run.ts
@@ -129,7 +129,9 @@ export function packageManagerInstallFailureMessage(
   result: PackageManagerInstallResult,
 ): string | undefined {
   if (result.result.termination.kind === "spawn-error") {
-    return `Could not start ${result.result.command.executable}: ${result.result.termination.message}`;
+    return result.result.termination.code === "ENOENT"
+      ? `${result.result.command.executable} was not found. Install it before running this step.`
+      : `Could not start ${result.result.command.executable}: ${result.result.termination.message}`;
   }
   if (result.kind === "workspace-probe-unrecognized") {
     return "Could not determine whether the ancestor pnpm workspace includes this project.";

--- a/packages/eve/src/setup/primitives/pm/run.ts
+++ b/packages/eve/src/setup/primitives/pm/run.ts
@@ -124,6 +124,19 @@ export function packageManagerInstallSucceeded(result: PackageManagerInstallResu
   return result.kind === "installed" && resultSucceeded(result.result);
 }
 
+/** Returns an actionable explanation when a package-manager command produced no output. */
+export function packageManagerInstallFailureMessage(
+  result: PackageManagerInstallResult,
+): string | undefined {
+  if (result.result.termination.kind === "spawn-error") {
+    return `Could not start ${result.result.command.executable}: ${result.result.termination.message}`;
+  }
+  if (result.kind === "workspace-probe-unrecognized") {
+    return "Could not determine whether the ancestor pnpm workspace includes this project.";
+  }
+  return undefined;
+}
+
 function outputText(result: PackageManagerProcessResult, stream: "stdout" | "stderr"): string {
   return result.output
     .filter((chunk) => chunk.stream === stream)

--- a/packages/eve/src/setup/primitives/pm/run.ts
+++ b/packages/eve/src/setup/primitives/pm/run.ts
@@ -5,6 +5,12 @@ import { armProcessAbort } from "../process-abort.js";
 import { createProcessOutputBuffer, type ProcessOutputHandler } from "../process-output.js";
 import { getPackageManagerStrategy } from "./index.js";
 import {
+  createPackageProcessOutputCollector,
+  type PackageManagerProcessResult,
+  type PackageManagerProcessTermination,
+  resultSucceeded,
+} from "./process-result.js";
+import {
   hasAncestorPnpmWorkspace,
   PNPM_WORKSPACE_MEMBERSHIP_ARGUMENTS,
   pnpmWorkspaceClaimsProject,
@@ -13,189 +19,121 @@ import type { PackageManagerInstallOptions } from "./types.js";
 
 /** Output routing options for setup-owned package manager commands. */
 export interface RunPackageManagerOptions {
-  /** Streams command output to a parent-owned renderer instead of writing outside it. */
+  /** Streams redacted command output to a parent-owned renderer. */
   onOutput?: ProcessOutputHandler;
   /** Aborts the package-manager subprocess when setup is interrupted. */
   signal?: AbortSignal;
-  /**
-   * Closes stdin so the child cannot prompt — required when a repainting TUI
-   * owns the terminal in raw mode, where an inherited stdin would let the child
-   * contend for keystrokes.
-   */
+  /** Closes stdin so the child cannot contend with a parent-owned TUI. */
   nonInteractive?: boolean;
-}
-
-/**
- * stdin is closed under {@link RunPackageManagerOptions.nonInteractive}; stdout
- * and stderr pipe to `onOutput` when present, else inherit the terminal. The
- * fully-inherited default keeps its `"inherit"` shorthand so it stays identical
- * to the prior behavior.
- */
-function stdioForRun(
-  options: RunPackageManagerOptions,
-): "inherit" | ["ignore" | "inherit", "pipe" | "inherit", "pipe" | "inherit"] {
-  if (options.onOutput) {
-    return [options.nonInteractive ? "ignore" : "inherit", "pipe", "pipe"];
-  }
-  return options.nonInteractive ? ["ignore", "inherit", "inherit"] : "inherit";
 }
 
 /** @deprecated Use {@link RunPackageManagerOptions}. */
 export type RunPnpmOptions = RunPackageManagerOptions;
 
-/** Runs the selected package manager in `projectRoot`. */
+function abortedTermination(signal: AbortSignal | undefined): PackageManagerProcessTermination {
+  const reason = signal?.reason;
+  return reason === undefined
+    ? { kind: "aborted" }
+    : { kind: "aborted", reason: reason instanceof Error ? reason.message : String(reason) };
+}
+
+/** Runs one package-manager command and returns its complete process evidence. */
 export function spawnPackageManager(
   kind: PackageManagerKind,
   projectRoot: string,
   args: readonly string[],
   options: RunPackageManagerOptions = {},
-): Promise<boolean> {
-  if (options.signal?.aborted === true) return Promise.resolve(false);
-  return new Promise<boolean>((resolvePromise) => {
-    const strategy = getPackageManagerStrategy(kind);
-    const managerArgs = strategy.prepareArguments(projectRoot, args);
-    const invocation = strategy.resolveInvocation(managerArgs);
-    const outputBuffer = options.onOutput && createProcessOutputBuffer(options.onOutput);
-    const child = spawn(invocation.command, [...invocation.args], {
-      cwd: projectRoot,
-      stdio: stdioForRun(options),
-      shell: invocation.shell,
-      signal: options.signal,
+): Promise<PackageManagerProcessResult> {
+  const strategy = getPackageManagerStrategy(kind);
+  const managerArgs = strategy.prepareArguments(projectRoot, args);
+  const invocation = strategy.resolveInvocation(managerArgs);
+  const command = {
+    executable: invocation.command,
+    args: [...invocation.args],
+    cwd: projectRoot,
+  };
+  if (options.signal?.aborted === true) {
+    const collector = createPackageProcessOutputCollector({ command });
+    collector.end();
+    return Promise.resolve(collector.result(abortedTermination(options.signal)));
+  }
+
+  return new Promise((resolvePromise) => {
+    const lineBuffer = options.onOutput && createProcessOutputBuffer(options.onOutput);
+    const collector = createPackageProcessOutputCollector({
+      command,
+      onOutput: (chunk) => lineBuffer?.write(chunk.stream, Buffer.from(chunk.text)),
     });
+    let child;
+    try {
+      child = spawn(invocation.command, [...invocation.args], {
+        cwd: projectRoot,
+        stdio: [options.nonInteractive ? "ignore" : "inherit", "pipe", "pipe"],
+        shell: invocation.shell,
+        signal: options.signal,
+      });
+    } catch (error) {
+      collector.end();
+      lineBuffer?.flush();
+      const failure = error as NodeJS.ErrnoException;
+      resolvePromise(
+        collector.result({ kind: "spawn-error", code: failure.code, message: failure.message }),
+      );
+      return;
+    }
     const disarmAbort = armProcessAbort(child, options.signal);
-    child.stdout?.on("data", (chunk: Buffer) => outputBuffer?.write("stdout", chunk));
-    child.stderr?.on("data", (chunk: Buffer) => outputBuffer?.write("stderr", chunk));
+    child.stdout?.on("data", (chunk: Buffer) => collector.write("stdout", chunk));
+    child.stderr?.on("data", (chunk: Buffer) => collector.write("stderr", chunk));
 
     let settled = false;
-    function settle(ok: boolean): void {
+    function settle(termination: PackageManagerProcessTermination): void {
       if (settled) return;
       settled = true;
-      outputBuffer?.flush();
-      resolvePromise(ok);
-    }
-    function reportFailure(message: string): void {
-      if (options.onOutput) {
-        options.onOutput({ stream: "stderr", text: message });
-      } else {
-        process.stderr.write(`\n${message}\n`);
-      }
+      disarmAbort();
+      collector.end();
+      lineBuffer?.flush();
+      resolvePromise(collector.result(termination));
     }
 
     child.on("error", (error: NodeJS.ErrnoException) => {
       if (options.signal?.aborted === true || error.name === "AbortError") {
-        return;
-      } else if (error.code === "ENOENT") {
-        disarmAbort();
-        reportFailure(`${kind} not found. Install it before running this step.`);
-        settle(false);
+        settle(abortedTermination(options.signal));
       } else {
-        disarmAbort();
-        reportFailure(`${kind} ${args.join(" ")} failed: ${error.message}`);
-        settle(false);
+        settle({ kind: "spawn-error", code: error.code, message: error.message });
       }
     });
-    child.on("close", (code) => {
-      disarmAbort();
-      settle(options.signal?.aborted === true ? false : code === 0);
+    child.on("close", (code, signal) => {
+      if (options.signal?.aborted === true) settle(abortedTermination(options.signal));
+      else if (typeof signal === "string") settle({ kind: "signal", signal });
+      else settle({ kind: "exit", code: code ?? 1 });
     });
   });
 }
 
 export interface RunInstallOptions extends RunPackageManagerOptions, PackageManagerInstallOptions {}
 
-interface PackageManagerCaptureResult {
-  ok: boolean;
-  stdout: string;
+export type PackageManagerInstallResult =
+  | { kind: "installed"; result: PackageManagerProcessResult }
+  | { kind: "workspace-probe-failed"; result: PackageManagerProcessResult }
+  | { kind: "workspace-probe-unrecognized"; result: PackageManagerProcessResult };
+
+export function packageManagerInstallSucceeded(result: PackageManagerInstallResult): boolean {
+  return result.kind === "installed" && resultSucceeded(result.result);
 }
 
-function capturePackageManager(
-  kind: PackageManagerKind,
-  projectRoot: string,
-  args: readonly string[],
-  options: RunPackageManagerOptions,
-): Promise<PackageManagerCaptureResult> {
-  if (options.signal?.aborted === true) {
-    return Promise.resolve({ ok: false, stdout: "" });
-  }
-  return new Promise<PackageManagerCaptureResult>((resolvePromise) => {
-    const strategy = getPackageManagerStrategy(kind);
-    const managerArgs = strategy.prepareArguments(projectRoot, args);
-    const invocation = strategy.resolveInvocation(managerArgs);
-    const child = spawn(invocation.command, [...invocation.args], {
-      cwd: projectRoot,
-      stdio: ["ignore", "pipe", "pipe"],
-      shell: invocation.shell,
-      signal: options.signal,
-    });
-    const disarmAbort = armProcessAbort(child, options.signal);
-    const stdout: Buffer[] = [];
-    const outputBuffer = options.onOutput && createProcessOutputBuffer(options.onOutput);
-    child.stdout?.on("data", (chunk: Buffer) => stdout.push(chunk));
-    child.stderr?.on("data", (chunk: Buffer) => outputBuffer?.write("stderr", chunk));
-
-    let settled = false;
-    function settle(ok: boolean): void {
-      if (settled) return;
-      settled = true;
-      outputBuffer?.flush();
-      resolvePromise({ ok, stdout: Buffer.concat(stdout).toString("utf8") });
-    }
-    function reportFailure(message: string): void {
-      if (options.onOutput) {
-        options.onOutput({ stream: "stderr", text: message });
-      } else {
-        process.stderr.write(`\n${message}\n`);
-      }
-    }
-    function replayCapturedStdout(): void {
-      const captured = Buffer.concat(stdout);
-      if (captured.length === 0) return;
-      if (outputBuffer) {
-        outputBuffer.write("stdout", captured);
-        outputBuffer.flush();
-      } else {
-        process.stdout.write(captured);
-      }
-    }
-
-    child.on("error", (error: NodeJS.ErrnoException) => {
-      if (options.signal?.aborted === true || error.name === "AbortError") {
-        return;
-      } else {
-        disarmAbort();
-        replayCapturedStdout();
-        reportFailure(
-          error.code === "ENOENT"
-            ? `${kind} not found. Install it before running this step.`
-            : `${kind} ${args.join(" ")} failed: ${error.message}`,
-        );
-        settle(false);
-      }
-    });
-    child.on("close", (code) => {
-      disarmAbort();
-      if (!settled && code !== 0 && options.signal?.aborted !== true) {
-        replayCapturedStdout();
-        reportFailure(`${kind} ${args.join(" ")} exited with code ${code ?? "unknown"}.`);
-      }
-      settle(options.signal?.aborted === true ? false : code === 0);
-    });
-  });
+function outputText(result: PackageManagerProcessResult, stream: "stdout" | "stderr"): string {
+  return result.output
+    .filter((chunk) => chunk.stream === stream)
+    .map((chunk) => chunk.text)
+    .join("");
 }
 
-/**
- * Installs project dependencies using the selected package-manager strategy.
- *
- * pnpm resolves an unclaimed nested project as part of an ancestor workspace,
- * where `install` can exit successfully without touching the project and can
- * run the ancestor's lifecycle scripts. Membership is therefore established
- * before installation, so exactly one correctly scoped install runs.
- */
+/** Installs project dependencies and keeps workspace-probe evidence distinct. */
 export async function runPackageManagerInstall(
   kind: PackageManagerKind,
   projectRoot: string,
   options: RunInstallOptions = {},
-): Promise<boolean> {
+): Promise<PackageManagerInstallResult> {
   const strategy = getPackageManagerStrategy(kind);
   let installOptions = options;
   if (
@@ -203,26 +141,26 @@ export async function runPackageManagerInstall(
     options.ignoreWorkspace !== true &&
     hasAncestorPnpmWorkspace(projectRoot)
   ) {
-    const membership = await capturePackageManager(
+    const probe = await spawnPackageManager(
       kind,
       projectRoot,
       PNPM_WORKSPACE_MEMBERSHIP_ARGUMENTS,
-      options,
+      { ...options, nonInteractive: true },
     );
-    if (!membership.ok) return false;
-    const claimed = pnpmWorkspaceClaimsProject(membership.stdout, projectRoot);
-    if (claimed === undefined) {
-      options.onOutput?.({
-        stream: "stderr",
-        text: "Could not determine whether the ancestor pnpm workspace includes this project.",
-      });
-      return false;
-    }
-    if (!claimed) {
-      installOptions = { ...options, ignoreWorkspace: true };
-    }
+    if (!resultSucceeded(probe)) return { kind: "workspace-probe-failed", result: probe };
+    const claimed = pnpmWorkspaceClaimsProject(outputText(probe, "stdout"), projectRoot);
+    if (claimed === undefined) return { kind: "workspace-probe-unrecognized", result: probe };
+    if (!claimed) installOptions = { ...options, ignoreWorkspace: true };
   }
-  return spawnPackageManager(kind, projectRoot, strategy.installArguments(installOptions), options);
+  return {
+    kind: "installed",
+    result: await spawnPackageManager(
+      kind,
+      projectRoot,
+      strategy.installArguments(installOptions),
+      options,
+    ),
+  };
 }
 
 /** The argv that runs the locally installed eve binary's `dev` command. */
@@ -230,19 +168,17 @@ export function eveDevArguments(kind: PackageManagerKind): readonly string[] {
   return getPackageManagerStrategy(kind).devArguments();
 }
 
-/** Compatibility wrapper for callers that still explicitly require pnpm. */
 export function spawnPnpm(
   projectRoot: string,
   args: readonly string[],
   options: RunPackageManagerOptions = {},
-): Promise<boolean> {
+): Promise<PackageManagerProcessResult> {
   return spawnPackageManager("pnpm", projectRoot, args, options);
 }
 
-/** Compatibility wrapper for callers that still explicitly require pnpm. */
 export function runPnpmInstall(
   projectRoot: string,
   options: RunPackageManagerOptions = {},
-): Promise<boolean> {
+): Promise<PackageManagerInstallResult> {
   return runPackageManagerInstall("pnpm", projectRoot, options);
 }

--- a/packages/eve/src/setup/primitives/run-pnpm.test.ts
+++ b/packages/eve/src/setup/primitives/run-pnpm.test.ts
@@ -72,7 +72,7 @@ describe("runPnpmInstall", () => {
     expect(mockedSpawn).toHaveBeenCalledWith(
       "pnpm",
       ["--dir", "/tmp/eve-agent", "install", "--no-frozen-lockfile"],
-      expect.objectContaining({ cwd: "/tmp/eve-agent", stdio: ["inherit", "pipe", "pipe"] }),
+      expect.objectContaining({ cwd: "/tmp/eve-agent", stdio: "inherit" }),
     );
   });
 
@@ -86,7 +86,7 @@ describe("runPnpmInstall", () => {
     expect(mockedSpawn).toHaveBeenLastCalledWith(
       "pnpm",
       ["--dir", "/tmp/eve-agent", "install", "--no-frozen-lockfile"],
-      expect.objectContaining({ cwd: "/tmp/eve-agent", stdio: ["inherit", "pipe", "pipe"] }),
+      expect.objectContaining({ cwd: "/tmp/eve-agent", stdio: "inherit" }),
     );
   });
 
@@ -100,7 +100,7 @@ describe("runPnpmInstall", () => {
     expect(mockedSpawn).toHaveBeenLastCalledWith(
       "pnpm",
       ["--dir", "/tmp/eve-agent", "install", "--no-frozen-lockfile", "--ignore-workspace"],
-      expect.objectContaining({ cwd: "/tmp/eve-agent", stdio: ["inherit", "pipe", "pipe"] }),
+      expect.objectContaining({ cwd: "/tmp/eve-agent", stdio: "inherit" }),
     );
   });
 
@@ -219,7 +219,7 @@ describe("pnpmPackageManager", () => {
 });
 
 describe("spawnPnpm", () => {
-  test("runs the given pnpm argv in the project directory", async () => {
+  test("inherits output when no parent renderer is supplied", async () => {
     expect(
       resultSucceeded(await spawnPnpm("/tmp/eve-agent", ["exec", "eve", "dev", "--no-ui"])),
     ).toBe(true);
@@ -227,7 +227,17 @@ describe("spawnPnpm", () => {
     expect(mockedSpawn).toHaveBeenCalledWith(
       "pnpm",
       ["--dir", "/tmp/eve-agent", "exec", "eve", "dev", "--no-ui"],
-      expect.objectContaining({ cwd: "/tmp/eve-agent", stdio: ["inherit", "pipe", "pipe"] }),
+      expect.objectContaining({ cwd: "/tmp/eve-agent", stdio: "inherit" }),
+    );
+  });
+
+  test("pipes output when stdin is non-interactive without a parent renderer", async () => {
+    await spawnPnpm("/tmp/eve-agent", ["install"], { nonInteractive: true });
+
+    expect(mockedSpawn).toHaveBeenCalledWith(
+      "pnpm",
+      ["--dir", "/tmp/eve-agent", "install"],
+      expect.objectContaining({ stdio: ["ignore", "pipe", "pipe"] }),
     );
   });
 

--- a/packages/eve/src/setup/primitives/run-pnpm.test.ts
+++ b/packages/eve/src/setup/primitives/run-pnpm.test.ts
@@ -9,6 +9,8 @@ import {
   runPnpmInstall,
   spawnPnpm,
 } from "./run-pnpm.js";
+import { packageManagerInstallSucceeded } from "./pm/run.js";
+import { resultSucceeded } from "./pm/process-result.js";
 import { pnpmPackageManager } from "./pm/pnpm.js";
 
 vi.mock("node:child_process", async (importOriginal) => ({
@@ -64,13 +66,13 @@ afterEach(() => {
 
 describe("runPnpmInstall", () => {
   test("updates an existing lockfile after scaffolded dependencies change", async () => {
-    await expect(runPnpmInstall("/tmp/eve-agent")).resolves.toBe(true);
+    expect(packageManagerInstallSucceeded(await runPnpmInstall("/tmp/eve-agent"))).toBe(true);
 
     expect(mockedSpawn).toHaveBeenCalledTimes(1);
     expect(mockedSpawn).toHaveBeenCalledWith(
       "pnpm",
       ["--dir", "/tmp/eve-agent", "install", "--no-frozen-lockfile"],
-      expect.objectContaining({ cwd: "/tmp/eve-agent", stdio: "inherit" }),
+      expect.objectContaining({ cwd: "/tmp/eve-agent", stdio: ["inherit", "pipe", "pipe"] }),
     );
   });
 
@@ -78,13 +80,13 @@ describe("runPnpmInstall", () => {
     mockedExistsSync.mockImplementation((path) => path === "/tmp/pnpm-workspace.yaml");
     mockMembershipProbe(["/tmp", "/tmp/eve-agent"]);
 
-    await expect(runPnpmInstall("/tmp/eve-agent")).resolves.toBe(true);
+    expect(packageManagerInstallSucceeded(await runPnpmInstall("/tmp/eve-agent"))).toBe(true);
 
     expect(mockedSpawn).toHaveBeenCalledTimes(2);
     expect(mockedSpawn).toHaveBeenLastCalledWith(
       "pnpm",
       ["--dir", "/tmp/eve-agent", "install", "--no-frozen-lockfile"],
-      expect.objectContaining({ cwd: "/tmp/eve-agent", stdio: "inherit" }),
+      expect.objectContaining({ cwd: "/tmp/eve-agent", stdio: ["inherit", "pipe", "pipe"] }),
     );
   });
 
@@ -92,13 +94,13 @@ describe("runPnpmInstall", () => {
     mockedExistsSync.mockImplementation((path) => path === "/tmp/pnpm-workspace.yaml");
     mockMembershipProbe(["/tmp"]);
 
-    await expect(runPnpmInstall("/tmp/eve-agent")).resolves.toBe(true);
+    expect(packageManagerInstallSucceeded(await runPnpmInstall("/tmp/eve-agent"))).toBe(true);
 
     expect(mockedSpawn).toHaveBeenCalledTimes(2);
     expect(mockedSpawn).toHaveBeenLastCalledWith(
       "pnpm",
       ["--dir", "/tmp/eve-agent", "install", "--no-frozen-lockfile", "--ignore-workspace"],
-      expect.objectContaining({ cwd: "/tmp/eve-agent", stdio: "inherit" }),
+      expect.objectContaining({ cwd: "/tmp/eve-agent", stdio: ["inherit", "pipe", "pipe"] }),
     );
   });
 
@@ -112,7 +114,7 @@ describe("runPnpmInstall", () => {
     child.stderr.emit("data", Buffer.from("WARN deprecated package\n"));
     child.emit("close", 0);
 
-    await expect(result).resolves.toBe(true);
+    expect(packageManagerInstallSucceeded(await result)).toBe(true);
     expect(mockedSpawn).toHaveBeenCalledWith(
       "pnpm",
       ["--dir", "/tmp/eve-agent", "install", "--no-frozen-lockfile"],
@@ -134,10 +136,9 @@ describe("runPnpmInstall", () => {
     child.stdout.emit("data", Buffer.from("workspace parse failed\n"));
     child.emit("close", 1);
 
-    await expect(result).resolves.toBe(false);
+    expect((await result).kind).toBe("workspace-probe-failed");
     expect(onOutput.mock.calls.map(([line]) => line)).toEqual([
       { stream: "stdout", text: "workspace parse failed" },
-      { stream: "stderr", text: "pnpm list --depth -1 --json exited with code 1." },
     ]);
   });
 });
@@ -153,9 +154,11 @@ describe("runPackageManagerInstall", () => {
     ["yarn", ["install"]],
     ["bun", ["install"]],
   ] as const)("maps the release-age bypass onto %s", async (kind, expectedArgs) => {
-    await expect(
-      runPackageManagerInstall(kind, "/tmp/app", { bypassMinimumReleaseAge: true }),
-    ).resolves.toBe(true);
+    expect(
+      packageManagerInstallSucceeded(
+        await runPackageManagerInstall(kind, "/tmp/app", { bypassMinimumReleaseAge: true }),
+      ),
+    ).toBe(true);
 
     expect(mockedSpawn).toHaveBeenCalledWith(
       kind,
@@ -165,9 +168,11 @@ describe("runPackageManagerInstall", () => {
   });
 
   test("requests npm output before registry operations complete", async () => {
-    await expect(
-      runPackageManagerInstall("npm", "/tmp/app", { progressDetails: true }),
-    ).resolves.toBe(true);
+    expect(
+      packageManagerInstallSucceeded(
+        await runPackageManagerInstall("npm", "/tmp/app", { progressDetails: true }),
+      ),
+    ).toBe(true);
 
     expect(mockedSpawn).toHaveBeenCalledWith(
       "npm",
@@ -215,14 +220,14 @@ describe("pnpmPackageManager", () => {
 
 describe("spawnPnpm", () => {
   test("runs the given pnpm argv in the project directory", async () => {
-    await expect(spawnPnpm("/tmp/eve-agent", ["exec", "eve", "dev", "--no-ui"])).resolves.toBe(
-      true,
-    );
+    expect(
+      resultSucceeded(await spawnPnpm("/tmp/eve-agent", ["exec", "eve", "dev", "--no-ui"])),
+    ).toBe(true);
 
     expect(mockedSpawn).toHaveBeenCalledWith(
       "pnpm",
       ["--dir", "/tmp/eve-agent", "exec", "eve", "dev", "--no-ui"],
-      expect.objectContaining({ cwd: "/tmp/eve-agent", stdio: "inherit" }),
+      expect.objectContaining({ cwd: "/tmp/eve-agent", stdio: ["inherit", "pipe", "pipe"] }),
     );
   });
 
@@ -245,14 +250,7 @@ describe("spawnPnpm", () => {
     error.name = "AbortError";
     error.code = "ABORT_ERR";
     child.emit("error", error);
-    let settled = false;
-    void result.then(() => {
-      settled = true;
-    });
-    await Promise.resolve();
-    expect(settled).toBe(false);
+    await expect(result).resolves.toMatchObject({ termination: { kind: "aborted" } });
     child.emit("close", null);
-
-    await expect(result).resolves.toBe(false);
   });
 });

--- a/packages/eve/src/setup/primitives/run-pnpm.test.ts
+++ b/packages/eve/src/setup/primitives/run-pnpm.test.ts
@@ -136,7 +136,9 @@ describe("runPnpmInstall", () => {
     child.stdout.emit("data", Buffer.from("workspace parse failed\n"));
     child.emit("close", 1);
 
-    expect((await result).kind).toBe("workspace-probe-failed");
+    const install = await result;
+    expect(install.kind).toBe("workspace-probe-failed");
+    expect(install.result.stdout).toBe("workspace parse failed\n");
     expect(onOutput.mock.calls.map(([line]) => line)).toEqual([
       { stream: "stdout", text: "workspace parse failed" },
     ]);


### PR DESCRIPTION
### Summary

Replaces boolean package-manager outcomes with structured command results, so setup flows can distinguish an install that failed after producing its own output from a command that never started. Callers retain existing package-manager output for ordinary failures; when no child process could produce output, `eve init` and `eve extension init` now report the actionable launch failure instead of directing users to an error that does not exist.

### Before / after

Before, a missing package manager left no actionable error to resolve:

```console
$ eve init my-agent
# ...
Failed to install dependencies.

Resolve the package-manager error above, then retry:
  eve init my-agent
```

After, the same command identifies the failed executable:

```console
$ eve init my-agent
# ...
pnpm was not found. Install it before running this step.
Failed to install dependencies.

Resolve the package-manager error above, then retry:
  eve init my-agent
```

### Validation

Focused `init` integration coverage passed, including the no-output spawn-failure regression. The package-manager primitive unit suite, TypeScript check, and lint also passed locally; the environment reported its Node 22 versus required Node 24 warning.

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

The changeset records the structured package-process diagnostics behavior.

**Implementation** — 8 files · `+233 / -185`

The process-result boundary consolidates package-manager execution evidence and updates its consumers without adding a runtime dependency.

**Tests** — 10 files · `+162 / -61`

Focused caller, primitive, and real-pnpm coverage verifies result handling, output behavior, and the launch-failure regression.
