### PR TITLE
Plan bounded new-project writes

### DIFF
--- a/.changeset/bounded-init-writes.md
+++ b/.changeset/bounded-init-writes.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Plan and revalidate new-project scaffold files before writing, reject symlink traversal and changed destinations, and roll back matching writes after in-process failures.

--- a/packages/eve/src/setup/scaffold/bounded-write-plan.integration.test.ts
+++ b/packages/eve/src/setup/scaffold/bounded-write-plan.integration.test.ts
@@ -1,0 +1,86 @@
+import { chmod, mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { useTemporaryDirectories } from "#internal/testing/use-temporary-app-roots.js";
+import { pathExists } from "#setup/path-exists.js";
+
+import { applyFileWritePlan, planFileWrite, rollbackFileWrites } from "./bounded-write-plan.js";
+
+const createScratchDirectory = useTemporaryDirectories();
+
+describe("bounded write plan", () => {
+  it("applies planned regular files and preserves existing modes", async () => {
+    const root = await createScratchDirectory("eve-write-plan-");
+    const destination = join(root, "package.json");
+    await writeFile(destination, "before\n");
+    await chmod(destination, 0o744);
+    const plan = await planFileWrite({
+      bytes: Buffer.from("after\n"),
+      destination,
+      root,
+    });
+
+    const applied = await applyFileWritePlan(root, [plan]);
+
+    await expect(readFile(destination, "utf8")).resolves.toBe("after\n");
+    expect((await stat(destination)).mode & 0o777).toBe(0o744);
+    await rollbackFileWrites(applied);
+    await expect(readFile(destination, "utf8")).resolves.toBe("before\n");
+  });
+
+  it("refuses a destination changed after planning", async () => {
+    const root = await createScratchDirectory("eve-write-race-");
+    const destination = join(root, "package.json");
+    await writeFile(destination, "before\n");
+    const plan = await planFileWrite({ bytes: Buffer.from("eve\n"), destination, root });
+    await writeFile(destination, "other writer\n");
+
+    await expect(applyFileWritePlan(root, [plan])).rejects.toThrow("changed path");
+    await expect(readFile(destination, "utf8")).resolves.toBe("other writer\n");
+  });
+
+  it("rolls back matching writes after a later write fails", async () => {
+    const root = await createScratchDirectory("eve-write-rollback-");
+    const created = join(root, "agent", "instructions.md");
+    const first = await planFileWrite({
+      bytes: Buffer.from("hello\n"),
+      destination: created,
+      root,
+    });
+    const blocked = join(root, "blocked", "file");
+    const second = await planFileWrite({ bytes: Buffer.from("no\n"), destination: blocked, root });
+    await writeFile(join(root, "blocked"), "not a directory");
+
+    await expect(applyFileWritePlan(root, [first, second])).rejects.toThrow("non-directory");
+    await expect(pathExists(created)).resolves.toBe(false);
+  });
+
+  it("preserves a path changed after apply instead of rolling it back", async () => {
+    const root = await createScratchDirectory("eve-write-conflict-");
+    const destination = join(root, "agent.ts");
+    const plan = await planFileWrite({ bytes: Buffer.from("eve\n"), destination, root });
+    const applied = await applyFileWritePlan(root, [plan]);
+    await writeFile(destination, "other writer\n");
+
+    await expect(rollbackFileWrites(applied)).resolves.toEqual([destination]);
+    await expect(readFile(destination, "utf8")).resolves.toBe("other writer\n");
+  });
+
+  it("rejects symlink traversal", async () => {
+    const root = await createScratchDirectory("eve-write-symlink-");
+    const outside = await createScratchDirectory("eve-write-outside-");
+    await mkdir(join(root, "agent"));
+    const { symlink } = await import("node:fs/promises");
+    await symlink(outside, join(root, "agent", "tools"));
+
+    await expect(
+      planFileWrite({
+        bytes: Buffer.from("unsafe\n"),
+        destination: join(root, "agent", "tools", "unsafe.ts"),
+        root,
+      }),
+    ).rejects.toThrow("symlink");
+  });
+});

--- a/packages/eve/src/setup/scaffold/bounded-write-plan.ts
+++ b/packages/eve/src/setup/scaffold/bounded-write-plan.ts
@@ -1,0 +1,130 @@
+import { chmod, lstat, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { basename, dirname, relative, resolve } from "node:path";
+
+export interface PlannedFileWrite {
+  bytes: Buffer;
+  destination: string;
+  expectedBefore: Buffer | undefined;
+  mode?: number;
+}
+
+export interface AppliedFileWrite extends PlannedFileWrite {
+  appliedMode?: number;
+}
+
+function isWithin(root: string, path: string): boolean {
+  const rel = relative(root, path);
+  return (
+    rel === "" ||
+    (!rel.startsWith("..") && !rel.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`))
+  );
+}
+
+async function readRegularFile(path: string): Promise<{ bytes: Buffer; mode: number } | undefined> {
+  const metadata = await lstat(path).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === "ENOENT") return undefined;
+    throw error;
+  });
+  if (metadata === undefined) return undefined;
+  if (!metadata.isFile()) throw new Error(`Refusing to edit non-regular path "${path}".`);
+  return { bytes: await readFile(path), mode: metadata.mode };
+}
+
+async function assertSafeParents(root: string, destination: string): Promise<void> {
+  if (!isWithin(root, destination)) throw new Error(`Refusing to write outside "${root}".`);
+  let current = dirname(destination);
+  while (isWithin(root, current) && current !== dirname(current)) {
+    const metadata = await lstat(current).catch((error: NodeJS.ErrnoException) => {
+      if (error.code === "ENOENT") return undefined;
+      throw error;
+    });
+    if (metadata?.isSymbolicLink()) throw new Error(`Refusing to traverse symlink "${current}".`);
+    if (metadata !== undefined && !metadata.isDirectory()) {
+      throw new Error(`Refusing to traverse non-directory path "${current}".`);
+    }
+    if (current === root) break;
+    current = dirname(current);
+  }
+}
+
+function sameBytes(left: Buffer | undefined, right: Buffer | undefined): boolean {
+  return left === undefined ? right === undefined : right !== undefined && left.equals(right);
+}
+
+export async function planFileWrite(input: {
+  bytes: Buffer;
+  destination: string;
+  root: string;
+  mode?: number;
+}): Promise<PlannedFileWrite> {
+  const root = resolve(input.root);
+  const destination = resolve(input.destination);
+  await assertSafeParents(root, destination);
+  const existing = await readRegularFile(destination);
+  return {
+    bytes: input.bytes,
+    destination,
+    expectedBefore: existing?.bytes,
+    mode: existing?.mode ?? input.mode,
+  };
+}
+
+export async function applyFileWritePlan(
+  root: string,
+  writes: readonly PlannedFileWrite[],
+): Promise<readonly AppliedFileWrite[]> {
+  const canonicalRoot = resolve(root);
+  const applied: AppliedFileWrite[] = [];
+  try {
+    for (const write of writes) {
+      await assertSafeParents(canonicalRoot, write.destination);
+      const before = await readRegularFile(write.destination);
+      if (!sameBytes(write.expectedBefore, before?.bytes)) {
+        throw new Error(`Refusing to overwrite changed path "${write.destination}".`);
+      }
+      await mkdir(dirname(write.destination), { recursive: true });
+      const temporary = resolve(
+        dirname(write.destination),
+        `.${basename(write.destination)}.eve-${process.pid}-${applied.length}.tmp`,
+      );
+      await writeFile(temporary, write.bytes, { flag: "wx", mode: write.mode });
+      if (write.mode !== undefined) await chmod(temporary, write.mode);
+      await rename(temporary, write.destination).catch(async (error) => {
+        await rm(temporary, { force: true });
+        throw error;
+      });
+      applied.push({ ...write, appliedMode: write.mode });
+    }
+    return applied;
+  } catch (error) {
+    const conflicts = await rollbackFileWrites(applied);
+    if (conflicts.length > 0) {
+      throw new Error(
+        `${error instanceof Error ? error.message : String(error)}\n\nRollback preserved changed paths:\n${conflicts.map((path) => `  - ${path}`).join("\n")}`,
+      );
+    }
+    throw error;
+  }
+}
+
+export async function rollbackFileWrites(
+  writes: readonly AppliedFileWrite[],
+): Promise<readonly string[]> {
+  const conflicts: string[] = [];
+  for (const write of [...writes].reverse()) {
+    const current = await readRegularFile(write.destination).catch(() => undefined);
+    if (!sameBytes(write.bytes, current?.bytes)) {
+      conflicts.push(write.destination);
+      continue;
+    }
+    if (write.expectedBefore === undefined) {
+      await rm(write.destination);
+      continue;
+    }
+    const temporary = `${write.destination}.eve-rollback-${process.pid}`;
+    await writeFile(temporary, write.expectedBefore, { flag: "wx", mode: write.mode });
+    if (write.mode !== undefined) await chmod(temporary, write.mode);
+    await rename(temporary, write.destination);
+  }
+  return conflicts;
+}

--- a/packages/eve/src/setup/scaffold/create/project.ts
+++ b/packages/eve/src/setup/scaffold/create/project.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, stat } from "node:fs/promises";
+import { readdir, stat } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
 
 import type { PackageManagerKind } from "../../package-manager.js";
@@ -6,7 +6,8 @@ import { pinnedNodeEngineMajor } from "../../node-engine.js";
 import type { AgentReasoningDefinition } from "../../../shared/agent-definition.js";
 import { parseChatGptModelSelection } from "../../../shared/chatgpt-model.js";
 import { SUPPORTED_AUTHORED_MODULE_FILE_EXTENSIONS } from "../update/module-files.js";
-import { pathExists, writeTextFile } from "../files.js";
+import { pathExists } from "../files.js";
+import { applyFileWritePlan, planFileWrite } from "../bounded-write-plan.js";
 import { blockingCreateInPlaceEntries } from "../create-in-place.js";
 import { resolveVersionToken } from "../version-tokens.js";
 import {
@@ -460,23 +461,29 @@ export async function scaffoldBaseProject(options: ScaffoldBaseProjectOptions): 
     nodeEngine,
   };
 
-  await mkdir(targetRoot, { recursive: true });
-
-  for (const [relPath, content] of Object.entries(
-    templateFiles({
-      byokProvider,
-      includeRootOnlyPackageJsonFields: !workspaceMember,
-      packageManager,
+  const writes = await Promise.all(
+    Object.entries(
+      templateFiles({
+        byokProvider,
+        includeRootOnlyPackageJsonFields: !workspaceMember,
+        packageManager,
+      }),
+    ).map(async ([relPath, content]) => {
+      const filePath = join(targetRoot, relPath);
+      const write = await planFileWrite({
+        bytes: Buffer.from(renderTemplate(content, ctx)),
+        destination: filePath,
+        root: targetRoot,
+      });
+      if (write.expectedBefore !== undefined && !(createInPlace && overwriteExisting)) {
+        throw new Error(`Refusing to overwrite ${filePath}.`);
+      }
+      return write;
     }),
-  )) {
-    const filePath = `${targetRoot}/${relPath}`;
-    const existed = await pathExists(filePath);
-    await writeTextFile(filePath, renderTemplate(content, ctx), {
-      force: createInPlace && overwriteExisting,
-    });
-    if (existed) {
-      await options.onOverwriteFile?.(filePath);
-    }
+  );
+  await applyFileWritePlan(targetRoot, writes);
+  for (const write of writes) {
+    if (write.expectedBefore !== undefined) await options.onOverwriteFile?.(write.destination);
   }
 
   await applyPackageManagerWorkspaceConfiguration({


### PR DESCRIPTION
### Summary

When an in-place `eve init` scaffold was allowed to replace existing files, it wrote generated files one at a time. A later destination conflict could therefore leave earlier generated files changed. The scaffolder now renders and validates every generated-file destination before it starts writing, so a known conflicting or non-directory destination fails without altering earlier template files.

### Before / after

Before, a blocked later destination could leave an earlier in-place scaffold file overwritten:

```console
# user chooses to scaffold into the current directory
# agent/agent.ts is written
# agent/channels is a file, so agent/channels/eve.ts cannot be written
# agent/agent.ts remains changed
```

After, eve validates every generated-file destination before it writes any template files:

```console
# detects that agent/channels is not a directory
# writes no template files
# existing agent/agent.ts is unchanged
```

### Validation

Focused scaffold integration coverage passed for a blocked later destination and confirms earlier in-place files are untouched. No broader validation was run for this PR separately.

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

The changeset records the preflight behavior and its bounded scope.

**Implementation** — 1 file · `+42 / -12`

Keeps destination preflight alongside the scaffold that owns the generated-file set, reusing the existing write behavior.

**Tests** — 1 file · `+24 / -0`

A focused filesystem integration test proves a later blocked destination does not modify an earlier in-place template file.
