### PR TITLE
Confirm existing package integration

### DIFF
--- a/.changeset/confirmed-package-integration.md
+++ b/.changeset/confirmed-package-integration.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Preview and confirm existing-package integration edits, apply supported package and workspace changes through the bounded write plan, and keep those edits if dependency installation fails.

--- a/packages/eve/src/cli/commands/init-confirm.test.ts
+++ b/packages/eve/src/cli/commands/init-confirm.test.ts
@@ -35,6 +35,7 @@ describe("confirmExistingPackageIntegration", () => {
     ).resolves.toBeUndefined();
 
     expect(message).toBe("Apply these edits?");
+    expect(description).toContain("• Create agent/agent.ts");
     expect(description).toContain("remain if installation fails");
   });
 

--- a/packages/eve/src/cli/commands/init-confirm.test.ts
+++ b/packages/eve/src/cli/commands/init-confirm.test.ts
@@ -35,7 +35,7 @@ describe("confirmExistingPackageIntegration", () => {
     ).resolves.toBeUndefined();
 
     expect(message).toBe("Apply these edits?");
-    expect(description).toContain("• Create agent/agent.ts");
+    expect(description).toContain("Planned edits\n\n• Create agent/agent.ts");
     expect(description).toContain("remain if installation fails");
   });
 

--- a/packages/eve/src/cli/commands/init-confirm.test.ts
+++ b/packages/eve/src/cli/commands/init-confirm.test.ts
@@ -18,9 +18,11 @@ describe("confirmExistingPackageIntegration", () => {
 
   it("confirms the durable-edit and install checkpoint in a TTY", async () => {
     let description = "";
+    let message = "";
     const fake = createFakePrompter({
       single: (options) => {
         description = options.description ?? "";
+        message = options.message;
         return true;
       },
     });
@@ -32,6 +34,7 @@ describe("confirmExistingPackageIntegration", () => {
       }),
     ).resolves.toBeUndefined();
 
+    expect(message).toBe("Apply these edits?");
     expect(description).toContain("remain if installation fails");
   });
 

--- a/packages/eve/src/cli/commands/init-confirm.test.ts
+++ b/packages/eve/src/cli/commands/init-confirm.test.ts
@@ -16,12 +16,13 @@ describe("confirmExistingPackageIntegration", () => {
     ).rejects.toThrow("Planned edits:\n  - Create agent/agent.ts\n  - Add dependencies: ai, eve");
   });
 
-  it("confirms the durable-edit and install checkpoint in a TTY", async () => {
+  it("defaults to applying the visible plan in a TTY", async () => {
     let message = "";
     let details: readonly string[] = [];
     const fake = createFakePrompter({
       single: (options) => {
         message = options.message;
+        expect(options.initialValue).toBe(true);
         details = options.details ?? [];
         return true;
       },

--- a/packages/eve/src/cli/commands/init-confirm.test.ts
+++ b/packages/eve/src/cli/commands/init-confirm.test.ts
@@ -17,14 +17,12 @@ describe("confirmExistingPackageIntegration", () => {
   });
 
   it("confirms the durable-edit and install checkpoint in a TTY", async () => {
-    let description = "";
     let message = "";
-    let metadata: readonly { label: string; value: string }[] = [];
+    let details: readonly string[] = [];
     const fake = createFakePrompter({
       single: (options) => {
-        description = options.description ?? "";
         message = options.message;
-        metadata = options.metadata ?? [];
+        details = options.details ?? [];
         return true;
       },
     });
@@ -37,10 +35,13 @@ describe("confirmExistingPackageIntegration", () => {
     ).resolves.toBeUndefined();
 
     expect(message).toBe("Apply these edits?");
-    expect(metadata).toEqual([
-      { label: "Planned edits", value: "• Create agent/agent.ts\n• Add dependencies: ai, eve" },
+    expect(details).toEqual([
+      "Planned edits",
+      "• Create agent/agent.ts",
+      "• Add dependencies: ai, eve",
+      "",
+      "These edits and package-manager side effects remain if installation fails.",
     ]);
-    expect(description).toContain("remain if installation fails");
   });
 
   it("cancels without applying the supplied plan", async () => {

--- a/packages/eve/src/cli/commands/init-confirm.test.ts
+++ b/packages/eve/src/cli/commands/init-confirm.test.ts
@@ -39,8 +39,6 @@ describe("confirmExistingPackageIntegration", () => {
       "Planned edits",
       "• Create agent/agent.ts",
       "• Add dependencies: ai, eve",
-      "",
-      "These edits and package-manager side effects remain if installation fails.",
     ]);
   });
 

--- a/packages/eve/src/cli/commands/init-confirm.test.ts
+++ b/packages/eve/src/cli/commands/init-confirm.test.ts
@@ -19,10 +19,12 @@ describe("confirmExistingPackageIntegration", () => {
   it("confirms the durable-edit and install checkpoint in a TTY", async () => {
     let description = "";
     let message = "";
+    let metadata: readonly { label: string; value: string }[] = [];
     const fake = createFakePrompter({
       single: (options) => {
         description = options.description ?? "";
         message = options.message;
+        metadata = options.metadata ?? [];
         return true;
       },
     });
@@ -35,7 +37,9 @@ describe("confirmExistingPackageIntegration", () => {
     ).resolves.toBeUndefined();
 
     expect(message).toBe("Apply these edits?");
-    expect(description).toContain("Planned edits\n\n• Create agent/agent.ts");
+    expect(metadata).toEqual([
+      { label: "Planned edits", value: "• Create agent/agent.ts\n• Add dependencies: ai, eve" },
+    ]);
     expect(description).toContain("remain if installation fails");
   });
 

--- a/packages/eve/src/cli/commands/init-confirm.test.ts
+++ b/packages/eve/src/cli/commands/init-confirm.test.ts
@@ -1,83 +1,48 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
-import { createFakePrompter, type FakePrompterConfig } from "#internal/testing/fake-prompter.js";
+import { createFakePrompter } from "#internal/testing/fake-prompter.js";
 
-import { confirmInitInNonEmptyDirectory, type InitConfirmDependencies } from "./init-confirm.js";
+import { confirmExistingPackageIntegration } from "./init-confirm.js";
 
-function dependencies(input: {
-  interactive: boolean;
-  onSelect?: FakePrompterConfig["single"];
-  onText?: FakePrompterConfig["text"];
-}): InitConfirmDependencies {
-  const fake = createFakePrompter({ single: input.onSelect, text: input.onText });
-  return {
-    createPrompter: vi.fn(() => fake.prompter),
-    hasInteractiveTerminal: vi.fn(() => input.interactive),
-  };
-}
+const summary = ["Create agent/agent.ts", "Add dependencies: ai, eve"];
 
-describe("confirmInitInNonEmptyDirectory", () => {
-  it("selects the current directory with an overwrite warning", async () => {
-    const deps = dependencies({
-      interactive: true,
-      onSelect: (options) => {
-        expect(options).toMatchObject({
-          message: "Where should eve initialize the project?",
-          description:
-            "The current directory isn't empty. Found: README.md, src, notes.txt, draft.md, data.json, and 1 more.",
-          initialValue: "subdirectory",
-        });
-        expect(options.options).toEqual([
-          {
-            value: "subdirectory",
-            label: "Create a new subdirectory",
-            hint: "Keep the current directory unchanged",
-          },
-          {
-            value: "current-directory",
-            label: "Use the current directory",
-            hint: "Overwrite files at generated paths",
-            accent: "warning",
-          },
-        ]);
-        return "current-directory";
+describe("confirmExistingPackageIntegration", () => {
+  it("prints the plan and --yes recovery without a TTY", async () => {
+    await expect(
+      confirmExistingPackageIntegration(summary, {
+        createPrompter: () => createFakePrompter().prompter,
+        hasInteractiveTerminal: () => false,
+      }),
+    ).rejects.toThrow("Planned edits:\n  - Create agent/agent.ts\n  - Add dependencies: ai, eve");
+  });
+
+  it("confirms the durable-edit and install checkpoint in a TTY", async () => {
+    let description = "";
+    const fake = createFakePrompter({
+      single: (options) => {
+        description = options.description ?? "";
+        return true;
       },
     });
 
     await expect(
-      confirmInitInNonEmptyDirectory(
-        ["README.md", "src", "notes.txt", "draft.md", "data.json", "archive"],
-        deps,
-      ),
-    ).resolves.toEqual({ kind: "current-directory" });
+      confirmExistingPackageIntegration(summary, {
+        createPrompter: () => fake.prompter,
+        hasInteractiveTerminal: () => true,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(description).toContain("remain if installation fails");
   });
 
-  it("asks for and normalizes a new subdirectory name", async () => {
-    const deps = dependencies({
-      interactive: true,
-      onSelect: () => "subdirectory",
-      onText: (options) => {
-        expect(options).toMatchObject({
-          message: "Subdirectory name",
-          defaultValue: "my-agent",
-        });
-        expect(options.validate?.("../escape")).toBeDefined();
-        return "  research-agent  ";
-      },
-    });
+  it("cancels without applying the supplied plan", async () => {
+    const fake = createFakePrompter({ single: () => false });
 
-    await expect(confirmInitInNonEmptyDirectory(["README.md"], deps)).resolves.toEqual({
-      kind: "subdirectory",
-      name: "research-agent",
-    });
-  });
-
-  it("refuses a non-interactive scaffold instead of opening a prompt", async () => {
-    const deps = dependencies({ interactive: false });
-
-    await expect(confirmInitInNonEmptyDirectory(["README.md"], deps)).rejects.toThrow(
-      "Cannot choose where to initialize the non-empty current directory without an interactive terminal. Found: README.md. Pass a new directory name, for example: eve init my-agent.",
-    );
-    expect(deps.createPrompter).not.toHaveBeenCalled();
+    await expect(
+      confirmExistingPackageIntegration(summary, {
+        createPrompter: () => fake.prompter,
+        hasInteractiveTerminal: () => true,
+      }),
+    ).rejects.toThrow("no files were changed");
   });
 });

--- a/packages/eve/src/cli/commands/init-confirm.ts
+++ b/packages/eve/src/cli/commands/init-confirm.ts
@@ -40,7 +40,7 @@ export async function confirmExistingPackageIntegration(
       { value: true, label: "Apply edits and install dependencies" },
       { value: false, label: "Cancel", accent: "warning" },
     ],
-    initialValue: false,
+    initialValue: true,
   });
   if (!confirmed) throw new Error("Existing-project integration cancelled; no files were changed.");
 }

--- a/packages/eve/src/cli/commands/init-confirm.ts
+++ b/packages/eve/src/cli/commands/init-confirm.ts
@@ -38,7 +38,7 @@ export async function confirmExistingPackageIntegration(
     details: ["Planned edits", ...summary.map((line) => `• ${line}`)],
     options: [
       { value: true, label: "Apply edits and install dependencies" },
-      { value: false, label: "Cancel", accent: "warning" },
+      { value: false, label: "Cancel" },
     ],
     initialValue: true,
   });

--- a/packages/eve/src/cli/commands/init-confirm.ts
+++ b/packages/eve/src/cli/commands/init-confirm.ts
@@ -35,7 +35,8 @@ export async function confirmExistingPackageIntegration(
   const prompter = dependencies.createPrompter();
   const confirmed = await prompter.select<boolean>({
     message: "Apply these edits?",
-    description: `Planned edits\n\n${summary.map((line) => `• ${line}`).join("\n")}\n\nThese edits and package-manager side effects remain if installation fails.`,
+    description: "These edits and package-manager side effects remain if installation fails.",
+    metadata: [{ label: "Planned edits", value: summary.map((line) => `• ${line}`).join("\n") }],
     options: [
       { value: true, label: "Apply edits and install dependencies" },
       { value: false, label: "Cancel", accent: "warning" },

--- a/packages/eve/src/cli/commands/init-confirm.ts
+++ b/packages/eve/src/cli/commands/init-confirm.ts
@@ -34,11 +34,11 @@ export async function confirmExistingPackageIntegration(
   }
   const prompter = dependencies.createPrompter();
   const confirmed = await prompter.select<boolean>({
-    message: "Apply these existing-project edits?",
+    message: "Apply these edits?",
     description: `${summary.join("; ")}. These edits and package-manager side effects remain if installation fails.`,
     options: [
       { value: true, label: "Apply edits and install dependencies" },
-      { value: false, label: "Cancel" },
+      { value: false, label: "Cancel", accent: "warning" },
     ],
     initialValue: false,
   });

--- a/packages/eve/src/cli/commands/init-confirm.ts
+++ b/packages/eve/src/cli/commands/init-confirm.ts
@@ -35,7 +35,7 @@ export async function confirmExistingPackageIntegration(
   const prompter = dependencies.createPrompter();
   const confirmed = await prompter.select<boolean>({
     message: "Apply these edits?",
-    description: `${summary.map((line) => `• ${line}`).join("\n")}\n\nThese edits and package-manager side effects remain if installation fails.`,
+    description: `Planned edits\n\n${summary.map((line) => `• ${line}`).join("\n")}\n\nThese edits and package-manager side effects remain if installation fails.`,
     options: [
       { value: true, label: "Apply edits and install dependencies" },
       { value: false, label: "Cancel", accent: "warning" },

--- a/packages/eve/src/cli/commands/init-confirm.ts
+++ b/packages/eve/src/cli/commands/init-confirm.ts
@@ -35,8 +35,12 @@ export async function confirmExistingPackageIntegration(
   const prompter = dependencies.createPrompter();
   const confirmed = await prompter.select<boolean>({
     message: "Apply these edits?",
-    description: "These edits and package-manager side effects remain if installation fails.",
-    metadata: [{ label: "Planned edits", value: summary.map((line) => `• ${line}`).join("\n") }],
+    details: [
+      "Planned edits",
+      ...summary.map((line) => `• ${line}`),
+      "",
+      "These edits and package-manager side effects remain if installation fails.",
+    ],
     options: [
       { value: true, label: "Apply edits and install dependencies" },
       { value: false, label: "Cancel", accent: "warning" },

--- a/packages/eve/src/cli/commands/init-confirm.ts
+++ b/packages/eve/src/cli/commands/init-confirm.ts
@@ -23,6 +23,28 @@ function formatEntries(entries: readonly string[]): string {
   return `${visible}${suffix}`;
 }
 
+export async function confirmExistingPackageIntegration(
+  summary: readonly string[],
+  dependencies: InitConfirmDependencies = defaultDependencies,
+): Promise<void> {
+  if (!dependencies.hasInteractiveTerminal()) {
+    throw new Error(
+      `Existing-package integration requires confirmation. Planned edits:\n${summary.map((line) => `  - ${line}`).join("\n")}\n\nRe-run with --yes to apply these edits. Package-manager changes will remain if installation fails.`,
+    );
+  }
+  const prompter = dependencies.createPrompter();
+  const confirmed = await prompter.select<boolean>({
+    message: "Apply these existing-project edits?",
+    description: `${summary.join("; ")}. These edits and package-manager side effects remain if installation fails.`,
+    options: [
+      { value: true, label: "Apply edits and install dependencies" },
+      { value: false, label: "Cancel" },
+    ],
+    initialValue: false,
+  });
+  if (!confirmed) throw new Error("Existing-project integration cancelled; no files were changed.");
+}
+
 export async function confirmInitInNonEmptyDirectory(
   entries: readonly string[],
   dependencies: InitConfirmDependencies = defaultDependencies,

--- a/packages/eve/src/cli/commands/init-confirm.ts
+++ b/packages/eve/src/cli/commands/init-confirm.ts
@@ -35,12 +35,7 @@ export async function confirmExistingPackageIntegration(
   const prompter = dependencies.createPrompter();
   const confirmed = await prompter.select<boolean>({
     message: "Apply these edits?",
-    details: [
-      "Planned edits",
-      ...summary.map((line) => `• ${line}`),
-      "",
-      "These edits and package-manager side effects remain if installation fails.",
-    ],
+    details: ["Planned edits", ...summary.map((line) => `• ${line}`)],
     options: [
       { value: true, label: "Apply edits and install dependencies" },
       { value: false, label: "Cancel", accent: "warning" },

--- a/packages/eve/src/cli/commands/init-confirm.ts
+++ b/packages/eve/src/cli/commands/init-confirm.ts
@@ -35,7 +35,7 @@ export async function confirmExistingPackageIntegration(
   const prompter = dependencies.createPrompter();
   const confirmed = await prompter.select<boolean>({
     message: "Apply these edits?",
-    description: `${summary.join("; ")}. These edits and package-manager side effects remain if installation fails.`,
+    description: `${summary.map((line) => `• ${line}`).join("\n")}\n\nThese edits and package-manager side effects remain if installation fails.`,
     options: [
       { value: true, label: "Apply edits and install dependencies" },
       { value: false, label: "Cancel", accent: "warning" },

--- a/packages/eve/src/cli/commands/init.integration.test.ts
+++ b/packages/eve/src/cli/commands/init.integration.test.ts
@@ -11,6 +11,8 @@ import { DEFAULT_AGENT_MODEL_ID } from "#shared/default-agent-model.js";
 import { detectPackageManager } from "#setup/package-manager.js";
 import {
   addAgentToProject,
+  applyAddAgentToProjectPlan,
+  planAddAgentToProject,
   type AddAgentToProjectOptions,
 } from "#setup/scaffold/create/add-to-project.js";
 import {
@@ -91,6 +93,8 @@ function dependencies(
       }
       return addAgentToProject(merged);
     },
+    applyAddAgentToProjectPlan,
+    confirmExistingPackageIntegration: vi.fn(async () => {}),
     confirmInitInNonEmptyDirectory: vi.fn(async () => ({ kind: "current-directory" })),
     // Stubbed to "no visible manager" so assertions do not depend on which
     // manager launched the test runner itself.
@@ -100,6 +104,12 @@ function dependencies(
     isCodingAgentLaunch: vi.fn(async () => false),
     now: vi.fn(() => 0),
     detectPackageManager,
+    planAddAgentToProject: (options: AddAgentToProjectOptions) =>
+      planAddAgentToProject({
+        ...BASE_VERSIONS,
+        ...options,
+        evePackage: options.evePackage ?? BASE_VERSIONS.evePackage,
+      }),
     scaffoldBaseProject: (options: ScaffoldBaseProjectOptions) => {
       const merged = { ...BASE_VERSIONS, ...options };
       if (options.evePackage === undefined) {

--- a/packages/eve/src/cli/commands/init.integration.test.ts
+++ b/packages/eve/src/cli/commands/init.integration.test.ts
@@ -68,6 +68,9 @@ function logger(): InitCliLogger & { messages: string[]; errors: string[] } {
 function dependencies(
   gitResult: GitInitResult = { kind: "initialized" },
 ): InitCommandDependencies & {
+  confirmExistingPackageIntegration: ReturnType<
+    typeof vi.fn<InitCommandDependencies["confirmExistingPackageIntegration"]>
+  >;
   confirmInitInNonEmptyDirectory: ReturnType<
     typeof vi.fn<InitCommandDependencies["confirmInitInNonEmptyDirectory"]>
   >;

--- a/packages/eve/src/cli/commands/init.integration.test.ts
+++ b/packages/eve/src/cli/commands/init.integration.test.ts
@@ -1052,6 +1052,41 @@ describe("runInitCommand", () => {
     expect(deps.spawnPackageManager).toHaveBeenCalledWith("bun", projectRoot, ["x", "eve", "dev"]);
   });
 
+  it("adds an existing package to an unclaimed pnpm workspace before installation", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "eve-init-existing-pnpm-unclaimed-"));
+    const projectRoot = join(workspaceRoot, "agents", "host-app");
+    await mkdir(projectRoot, { recursive: true });
+    await writeFile(
+      join(workspaceRoot, "package.json"),
+      `${JSON.stringify({ private: true, engines: { node: "22.x" } }, null, 2)}\n`,
+      "utf8",
+    );
+    await writeFile(join(workspaceRoot, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n", "utf8");
+    await writeFile(join(projectRoot, "package.json"), '{ "name": "host-app" }\n', "utf8");
+    const output = logger();
+    const deps = dependencies();
+    let summary: readonly string[] = [];
+    deps.confirmExistingPackageIntegration.mockImplementation(async (planned) => {
+      summary = planned;
+    });
+
+    await runInitCommand(output, projectRoot, ".", {}, deps);
+
+    expect(summary).toContain(`Add this package to ${join(workspaceRoot, "pnpm-workspace.yaml")}`);
+    expect(summary).toContain(`Update workspace package.json engines.node to 24.x`);
+    await expect(readFile(join(workspaceRoot, "pnpm-workspace.yaml"), "utf8")).resolves.toContain(
+      "  - agents/*\n",
+    );
+    expect(JSON.parse(await readFile(join(workspaceRoot, "package.json"), "utf8"))).toMatchObject({
+      engines: { node: "24.x" },
+    });
+    expect(deps.runPackageManagerInstall).toHaveBeenCalledWith(
+      "pnpm",
+      projectRoot,
+      expect.anything(),
+    );
+  });
+
   it("adds an agent to an existing pnpm workspace member without nested root-only policy", async () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), "eve-init-existing-pnpm-workspace-"));
     const appsDirectory = join(workspaceRoot, "apps");

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -360,13 +360,12 @@ async function runInitSteps(input: {
 }): Promise<InitResult> {
   const { dependencies, logger, options, parentDirectory, target } = input;
   const debug = isLogLevelEnabled("debug");
-  const agentLaunched = await dependencies.isCodingAgentLaunch();
-  const initTarget = await resolveInitTarget({ parentDirectory, target });
-  const evePackage = resolveInitEvePackageOverride();
-
   let progress = startCliLiveRow(logger);
   progress.update("Preparing project");
   try {
+    const agentLaunched = await dependencies.isCodingAgentLaunch();
+    const initTarget = await resolveInitTarget({ parentDirectory, target });
+    const evePackage = resolveInitEvePackageOverride();
     const scaffoldPhase = initTarget.kind === "fresh" ? "creating agent" : "adding agent";
     progress.update(initTarget.kind === "fresh" ? "Creating agent" : "Adding agent");
     initLog.debug(scaffoldPhase);

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -165,6 +165,7 @@ async function addToExistingProject(
   options: InitCommandOptions,
   dependencies: InitCommandDependencies,
   evePackage: EvePackageContract | undefined,
+  beforeConfirmation: () => void,
 ): Promise<{ packageManager: PackageManagerKind; nodeEngineOverride?: NodeEngineOverride }> {
   if (options.channelWebNextjs === true) {
     throw new Error(
@@ -187,6 +188,7 @@ async function addToExistingProject(
     evePackage,
   });
   if (!options.yes) {
+    beforeConfirmation();
     await dependencies.confirmExistingPackageIntegration(plan.summary);
   }
   const result = await dependencies.applyAddAgentToProjectPlan(plan);
@@ -362,7 +364,7 @@ async function runInitSteps(input: {
   const initTarget = await resolveInitTarget({ parentDirectory, target });
   const evePackage = resolveInitEvePackageOverride();
 
-  const progress = startCliLiveRow(logger);
+  let progress = startCliLiveRow(logger);
   progress.update("Preparing project");
   try {
     const scaffoldPhase = initTarget.kind === "fresh" ? "creating agent" : "adding agent";
@@ -426,7 +428,10 @@ async function runInitSteps(input: {
         options,
         dependencies,
         evePackage,
+        () => progress.stop(),
       );
+      progress = startCliLiveRow(logger);
+      progress.update("Adding agent");
       project =
         addition.nodeEngineOverride === undefined
           ? {

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -27,7 +27,11 @@ import {
   spawnPackageManager,
 } from "#setup/primitives/index.js";
 import type { ProcessOutputLine } from "#setup/primitives/process-output.js";
-import { addAgentToProject } from "#setup/scaffold/create/add-to-project.js";
+import {
+  addAgentToProject,
+  applyAddAgentToProjectPlan,
+  planAddAgentToProject,
+} from "#setup/scaffold/create/add-to-project.js";
 import { ensureChannel, scaffoldBaseProject } from "#setup/scaffold/index.js";
 import { WizardCancelledError } from "#setup/step.js";
 import { validateModelSlug } from "#setup/flows/model-source-change.js";
@@ -41,7 +45,10 @@ import {
 } from "#setup/scaffold/create/project.js";
 
 import { initAgentDevHandoff, initAgentReplPrompt } from "./agent-instructions.js";
-import { confirmInitInNonEmptyDirectory } from "./init-confirm.js";
+import {
+  confirmExistingPackageIntegration,
+  confirmInitInNonEmptyDirectory,
+} from "./init-confirm.js";
 import {
   cleanupFreshInitTarget,
   workspaceFailureNote,
@@ -63,10 +70,15 @@ export interface InitCommandOptions {
   model?: string;
   /** Reasoning effort written to the root agent config. Set by `--reasoning`. */
   reasoning?: AgentReasoningDefinition;
+  /** Applies a previewed existing-package integration without a TTY prompt. */
+  yes?: boolean;
 }
 
 export interface InitCommandDependencies {
   addAgentToProject: typeof addAgentToProject;
+  applyAddAgentToProjectPlan: typeof applyAddAgentToProjectPlan;
+  planAddAgentToProject: typeof planAddAgentToProject;
+  confirmExistingPackageIntegration: typeof confirmExistingPackageIntegration;
   confirmInitInNonEmptyDirectory: typeof confirmInitInNonEmptyDirectory;
   detectInvokingPackageManager: typeof detectInvokingPackageManager;
   detectPackageManager: typeof detectPackageManager;
@@ -84,6 +96,8 @@ export interface InitCommandDependencies {
 
 const defaultDependencies: InitCommandDependencies = {
   addAgentToProject,
+  applyAddAgentToProjectPlan,
+  confirmExistingPackageIntegration,
   confirmInitInNonEmptyDirectory,
   detectInvokingPackageManager,
   detectPackageManager,
@@ -91,6 +105,7 @@ const defaultDependencies: InitCommandDependencies = {
   isCodingAgentLaunch,
   now: () => performance.now(),
   runPackageManagerInstall,
+  planAddAgentToProject,
   scaffoldBaseProject,
   selectInitHandoff,
   spawnCodingAgentRepl,
@@ -164,13 +179,17 @@ async function addToExistingProject(
   }
 
   const manager = await dependencies.detectPackageManager(targetPath);
-  const result = await dependencies.addAgentToProject({
+  const plan = await dependencies.planAddAgentToProject({
     projectRoot: targetPath,
     model: options.model ?? DEFAULT_AGENT_MODEL_ID,
     reasoning: options.reasoning,
     packageManager: manager.kind,
     evePackage,
   });
+  if (!options.yes) {
+    await dependencies.confirmExistingPackageIntegration(plan.summary);
+  }
+  const result = await dependencies.applyAddAgentToProjectPlan(plan);
   return {
     packageManager: manager.kind,
     nodeEngineOverride: result.nodeEngineOverride,

--- a/packages/eve/src/cli/run.test.ts
+++ b/packages/eve/src/cli/run.test.ts
@@ -321,6 +321,21 @@ describe("eve init compatibility flags", () => {
       channelWebNextjs: undefined,
       model: "openai/gpt-5.6-sol",
       reasoning: "high",
+      yes: undefined,
+    });
+  });
+
+  it("forwards explicit existing-package confirmation to init", async () => {
+    const logger = { error: vi.fn(), log: vi.fn() };
+    runInitCommand.mockClear();
+
+    await runCli(["init", ".", "--yes"], logger);
+
+    expect(runInitCommand).toHaveBeenCalledWith(logger, resolve(process.cwd()), ".", {
+      channelWebNextjs: undefined,
+      model: undefined,
+      reasoning: undefined,
+      yes: true,
     });
   });
 

--- a/packages/eve/src/cli/run.ts
+++ b/packages/eve/src/cli/run.ts
@@ -239,7 +239,7 @@ function createCliProgram(
       "Set reasoning (provider-default|none|minimal|low|medium|high|xhigh)",
       parseReasoningOption,
     )
-    .option("-y, --yes", "Accepted for compatibility; has no effect")
+    .option("-y, --yes", "Confirm previewed existing-package integration edits")
     .action(
       async (
         target: string | undefined,
@@ -250,15 +250,12 @@ function createCliProgram(
           yes?: boolean;
         },
       ) => {
-        if (options.yes) {
-          logger.error("warning: --yes has no effect for eve init.");
-        }
-
         const { runInitCommand } = await import("#cli/commands/init.js");
         await runInitCommand(logger, applicationContext.root, target, {
           channelWebNextjs: options.channelWebNextjs,
           model: options.model,
           reasoning: options.reasoning,
+          yes: options.yes,
         });
       },
     );

--- a/packages/eve/src/setup/primitives/pm/pnpm.ts
+++ b/packages/eve/src/setup/primitives/pm/pnpm.ts
@@ -229,6 +229,24 @@ function withPnpmWorkspacePackagePattern(source: string, pattern: string): strin
   return lines.join("\n");
 }
 
+export function preparePnpmWorkspaceIncludesProject(input: {
+  projectRoot: string;
+  source: string;
+  workspaceRoot: string;
+}): string {
+  const patterns = parsePnpmWorkspacePackagePatterns(input.source);
+  if (
+    patterns === undefined ||
+    workspacePatternsClaimProject(patterns, input.workspaceRoot, input.projectRoot)
+  ) {
+    return input.source;
+  }
+  return withPnpmWorkspacePackagePattern(
+    input.source,
+    workspacePatternForProject(input.workspaceRoot, input.projectRoot),
+  );
+}
+
 export async function ensurePnpmWorkspaceIncludesProject(
   projectRoot: string,
 ): Promise<"skipped" | "written"> {
@@ -236,16 +254,10 @@ export async function ensurePnpmWorkspaceIncludesProject(
   if (workspaceRoot === undefined || resolve(workspaceRoot) === resolve(projectRoot)) {
     return "skipped";
   }
-  if (findClaimingAncestorPnpmWorkspaceRoot(projectRoot) === workspaceRoot) {
-    return "skipped";
-  }
 
   const filePath = join(workspaceRoot, PNPM_WORKSPACE_PATH);
   const current = await readFile(filePath, "utf8");
-  const next = withPnpmWorkspacePackagePattern(
-    current,
-    workspacePatternForProject(workspaceRoot, projectRoot),
-  );
+  const next = preparePnpmWorkspaceIncludesProject({ projectRoot, source: current, workspaceRoot });
   if (next === current) return "skipped";
   await writeFile(filePath, next, "utf8");
   return "written";

--- a/packages/eve/src/setup/primitives/pm/pnpm.ts
+++ b/packages/eve/src/setup/primitives/pm/pnpm.ts
@@ -116,6 +116,11 @@ function withReleaseAgeExclusions(source: string): string {
   return lines.join("\n");
 }
 
+export function preparePnpmWorkspacePolicy(source: string | undefined): string {
+  if (source === undefined) return PNPM_WORKSPACE_CONTENT;
+  return withReleaseAgeExclusions(withSharpBuildPolicy(source));
+}
+
 async function ensurePnpmWorkspacePolicy(filePath: string): Promise<"skipped" | "written"> {
   if (!(await pathExists(filePath))) {
     await writeFile(filePath, PNPM_WORKSPACE_CONTENT, "utf8");
@@ -123,7 +128,7 @@ async function ensurePnpmWorkspacePolicy(filePath: string): Promise<"skipped" | 
   }
 
   const current = await readFile(filePath, "utf8");
-  const next = withReleaseAgeExclusions(withSharpBuildPolicy(current));
+  const next = preparePnpmWorkspacePolicy(current);
   if (next === current) {
     return "skipped";
   }

--- a/packages/eve/src/setup/prompter.ts
+++ b/packages/eve/src/setup/prompter.ts
@@ -99,6 +99,8 @@ export interface SelectMetadata {
 /** Options common to every {@link Prompter.select} call. */
 export interface SelectCommonOptions<T extends PrompterValue> {
   message: string;
+  /** Normal-foreground lines rendered above the question and its options. */
+  details?: readonly string[];
   /** Inert context rendered beneath the question heading and above its options. */
   description?: string;
   /** Labeled facts rendered beneath the description and above the options. */
@@ -471,6 +473,9 @@ export function createPrompter(): Prompter {
     ): Promise<T | T[]> {
       log.settle();
       printNotices(opts.notices);
+      for (const line of opts.details ?? []) {
+        process.stdout.write(formatRailLine(line, pc, process.stdout));
+      }
       if (opts.description !== undefined) {
         process.stdout.write(formatRailLine(pc.dim(opts.description), pc, process.stdout));
       }

--- a/packages/eve/src/setup/scaffold/bounded-write-plan.ts
+++ b/packages/eve/src/setup/scaffold/bounded-write-plan.ts
@@ -4,6 +4,7 @@ import { basename, dirname, relative, resolve } from "node:path";
 export interface PlannedFileWrite {
   bytes: Buffer;
   destination: string;
+  root: string;
   expectedBefore: Buffer | undefined;
   mode?: number;
 }
@@ -64,6 +65,7 @@ export async function planFileWrite(input: {
   return {
     bytes: input.bytes,
     destination,
+    root,
     expectedBefore: existing?.bytes,
     mode: existing?.mode ?? input.mode,
   };
@@ -73,11 +75,11 @@ export async function applyFileWritePlan(
   root: string,
   writes: readonly PlannedFileWrite[],
 ): Promise<readonly AppliedFileWrite[]> {
-  const canonicalRoot = resolve(root);
+  resolve(root);
   const applied: AppliedFileWrite[] = [];
   try {
     for (const write of writes) {
-      await assertSafeParents(canonicalRoot, write.destination);
+      await assertSafeParents(write.root, write.destination);
       const before = await readRegularFile(write.destination);
       if (!sameBytes(write.expectedBefore, before?.bytes)) {
         throw new Error(`Refusing to overwrite changed path "${write.destination}".`);

--- a/packages/eve/src/setup/scaffold/create/add-to-project.ts
+++ b/packages/eve/src/setup/scaffold/create/add-to-project.ts
@@ -4,13 +4,20 @@ import { join } from "node:path";
 import type { PackageManagerKind } from "../../package-manager.js";
 import type { NodeEngineOverride } from "../../node-engine.js";
 import type { AgentReasoningDefinition } from "../../../shared/agent-definition.js";
-import { pathExists, writeTextFile } from "../files.js";
-import { patchPackageJson, type PackageJsonPatch } from "../update/package-json.js";
-import { resolveVersionToken } from "../version-tokens.js";
+import { pathExists } from "../files.js";
 import {
-  applyPackageManagerWorkspaceConfiguration,
+  applyFileWritePlan,
+  planFileWrite,
+  type AppliedFileWrite,
+  type PlannedFileWrite,
+} from "../bounded-write-plan.js";
+import { preparePackageJsonPatch, type PackageJsonPatch } from "../update/package-json.js";
+import { resolveVersionToken } from "../version-tokens.js";
+import { preparePnpmWorkspacePolicy } from "../../primitives/pm/pnpm.js";
+import {
   isPackageManagerWorkspaceMember,
-  patchWorkspaceRootPackageJson,
+  packageManagerRootOnlyPackageJsonPatch,
+  workspaceRootPackageJsonPath,
 } from "../workspace-root.js";
 import {
   agentTemplateFiles,
@@ -26,10 +33,6 @@ export interface AddAgentToProjectOptions {
   projectRoot: string;
   model: string;
   reasoning?: AgentReasoningDefinition;
-  /**
-   * The host project's package manager, which owns any manager-specific
-   * generated project configuration. Defaults to pnpm.
-   */
   packageManager?: PackageManagerKind;
   evePackage?: EvePackageContract;
   aiPackageVersion?: string;
@@ -37,11 +40,18 @@ export interface AddAgentToProjectOptions {
   zodPackageVersion?: string;
 }
 
+export interface AddAgentToProjectPlan {
+  dependenciesAdded: readonly string[];
+  nodeEngineOverride?: NodeEngineOverride;
+  projectRoot: string;
+  summary: readonly string[];
+  writes: readonly PlannedFileWrite[];
+}
+
 export interface AddAgentToProjectResult {
+  appliedWrites: readonly AppliedFileWrite[];
   filesWritten: string[];
-  /** Dependencies added to package.json; ones the project already declares anywhere are left untouched. */
   dependenciesAdded: string[];
-  /** Present when an incompatible package.json engines.node value was replaced. */
   nodeEngineOverride?: NodeEngineOverride;
 }
 
@@ -58,60 +68,47 @@ function isJsonObject(value: unknown): value is Record<string, unknown> {
 
 function hasDeclaredDependency(packageJson: unknown, dependencyName: string): boolean {
   if (!isJsonObject(packageJson)) return false;
-  for (const field of DEPENDENCY_FIELDS) {
+  return DEPENDENCY_FIELDS.some((field) => {
     const block = packageJson[field];
-    if (isJsonObject(block) && typeof block[dependencyName] === "string") {
-      return true;
-    }
-  }
-  return false;
+    return isJsonObject(block) && typeof block[dependencyName] === "string";
+  });
 }
 
-/**
- * Adds an eve agent to an existing package: writes the `agent/` files, adds
- * missing runtime dependencies, reconciles `engines.node` with eve's
- * requirement, and applies the selected package manager's project
- * configuration. Other host configuration (tsconfig, scripts, ignore files)
- * remains untouched. All conflicts are gathered and reported before anything
- * is written.
- */
-export async function addAgentToProject(
+export async function planAddAgentToProject(
   options: AddAgentToProjectOptions,
-): Promise<AddAgentToProjectResult> {
+): Promise<AddAgentToProjectPlan> {
   const packageManager = options.packageManager ?? "pnpm";
   const packageJsonPath = join(options.projectRoot, "package.json");
   if (!(await pathExists(packageJsonPath))) {
     throw new Error(
-      `Cannot add an eve agent to "${options.projectRoot}" because it has no package.json. ` +
-        "Run `eve init <name>` to create a new project instead.",
+      `Cannot add an eve agent to "${options.projectRoot}" because it has no package.json.`,
     );
   }
 
+  let packageJsonRaw: string;
   let packageJson: unknown;
   try {
-    packageJson = JSON.parse(await readFile(packageJsonPath, "utf8"));
+    packageJsonRaw = await readFile(packageJsonPath, "utf8");
+    packageJson = JSON.parse(packageJsonRaw);
   } catch (error) {
-    const detail = error instanceof Error ? error.message : String(error);
     throw new Error(
-      `Cannot add an eve agent because "${packageJsonPath}" is not valid JSON. No files were changed. Fix the file, then retry eve init. ${detail}`,
+      `Cannot add an eve agent because "${packageJsonPath}" is not valid JSON. No files were changed. ${error instanceof Error ? error.message : String(error)}`,
     );
   }
 
   const files = agentTemplateFiles(options.model, options.reasoning);
-  const conflicts: string[] = [];
-  for (const relativePath of Object.keys(files)) {
-    if (await pathExists(join(options.projectRoot, relativePath))) {
-      conflicts.push(relativePath);
-    }
-  }
+  const conflicts = (
+    await Promise.all(
+      Object.keys(files).map(async (relativePath) =>
+        (await pathExists(join(options.projectRoot, relativePath))) ? relativePath : undefined,
+      ),
+    )
+  ).filter((path): path is string => path !== undefined);
   if (conflicts.length === 0 && (await pathExists(join(options.projectRoot, "agent")))) {
     conflicts.push("agent/");
   }
   if (conflicts.length > 0) {
-    throw new Error(
-      `Cannot add an eve agent to "${options.projectRoot}" because it already has: ` +
-        `${conflicts.join(", ")}.`,
-    );
+    throw new Error(`Cannot add an eve agent because it already has: ${conflicts.join(", ")}.`);
   }
 
   const evePackage = resolveEvePackageContract(options.evePackage);
@@ -119,9 +116,6 @@ export async function addAgentToProject(
     "aiPackageVersion",
     options.aiPackageVersion ?? DEFAULT_AI_PACKAGE_VERSION,
   );
-  // Channels and connections scaffolded later (`eve add channel/slack`,
-  // possibly while `eve dev` is running) import `@vercel/connect`; shipping
-  // it from init means adding them never introduces a missing dependency.
   const connectVersion = resolveVersionToken(
     "connectPackageVersion",
     options.connectPackageVersion ?? DEFAULT_CONNECT_PACKAGE_VERSION,
@@ -130,55 +124,127 @@ export async function addAgentToProject(
     "zodPackageVersion",
     options.zodPackageVersion ?? DEFAULT_ZOD_PACKAGE_VERSION,
   );
-
-  const filesWritten: string[] = [];
-  for (const [relativePath, content] of Object.entries(files)) {
-    const filePath = join(options.projectRoot, relativePath);
-    await writeTextFile(filePath, content);
-    filesWritten.push(filePath);
-  }
-
-  const wanted: Record<string, string> = {
+  const wanted = {
     "@vercel/connect": connectVersion,
     ai: aiVersion,
     eve: formatEveDependencySpecifier(evePackage.version),
     zod: zodVersion,
   };
-  const additions: Record<string, string> = {};
-  for (const [name, version] of Object.entries(wanted)) {
-    if (!hasDeclaredDependency(packageJson, name)) {
-      additions[name] = version;
-    }
-  }
+  const additions = Object.fromEntries(
+    Object.entries(wanted).filter(([name]) => !hasDeclaredDependency(packageJson, name)),
+  );
   const patch: PackageJsonPatch = {};
-  if (Object.keys(additions).length > 0) {
-    patch.dependencies = additions;
-  }
-  const workspaceMember = isPackageManagerWorkspaceMember(packageManager, options.projectRoot);
-  if (!workspaceMember) {
+  if (Object.keys(additions).length > 0) patch.dependencies = additions;
+  if (!isPackageManagerWorkspaceMember(packageManager, options.projectRoot)) {
     patch.nodeEngineRequirement = evePackage.nodeEngine;
   }
-  const patchResult = await patchPackageJson(packageJsonPath, patch);
-
-  const workspacePatchResult = await patchWorkspaceRootPackageJson(
+  const preparedPackageJson = preparePackageJsonPatch(packageJsonRaw, patch);
+  const workspacePackageJsonPath = workspaceRootPackageJsonPath(
     packageManager,
     options.projectRoot,
-    {
-      aiPackageVersion: aiVersion,
-      nodeEngineRequirement: evePackage.nodeEngine,
-    },
   );
-  const nodeEngineOverride =
-    workspacePatchResult.nodeEngineOverride ?? patchResult.nodeEngineOverride;
-
-  await applyPackageManagerWorkspaceConfiguration({
-    packageManager,
-    projectRoot: options.projectRoot,
-  });
-
+  const workspacePackageJsonBefore =
+    workspacePackageJsonPath === undefined
+      ? undefined
+      : await readFile(workspacePackageJsonPath, "utf8");
+  const preparedWorkspacePackageJson =
+    workspacePackageJsonBefore === undefined
+      ? undefined
+      : preparePackageJsonPatch(
+          workspacePackageJsonBefore,
+          packageManagerRootOnlyPackageJsonPatch(packageManager, {
+            aiPackageVersion: aiVersion,
+            nodeEngineRequirement: evePackage.nodeEngine,
+          }),
+        );
+  const pnpmWorkspacePath = join(options.projectRoot, "pnpm-workspace.yaml");
+  const pnpmWorkspaceBefore =
+    packageManager === "pnpm" &&
+    !isPackageManagerWorkspaceMember(packageManager, options.projectRoot)
+      ? await readFile(pnpmWorkspacePath, "utf8").catch((error: NodeJS.ErrnoException) => {
+          if (error.code === "ENOENT") return undefined;
+          throw error;
+        })
+      : undefined;
+  const pnpmWorkspaceAfter =
+    packageManager === "pnpm" &&
+    !isPackageManagerWorkspaceMember(packageManager, options.projectRoot)
+      ? preparePnpmWorkspacePolicy(pnpmWorkspaceBefore)
+      : undefined;
+  const writes = await Promise.all([
+    ...Object.entries(files).map(([relativePath, content]) =>
+      planFileWrite({
+        bytes: Buffer.from(content),
+        destination: join(options.projectRoot, relativePath),
+        root: options.projectRoot,
+      }),
+    ),
+    ...(preparedPackageJson.changed
+      ? [
+          planFileWrite({
+            bytes: preparedPackageJson.bytes,
+            destination: packageJsonPath,
+            root: options.projectRoot,
+          }),
+        ]
+      : []),
+    ...(preparedWorkspacePackageJson?.changed === true && workspacePackageJsonPath !== undefined
+      ? [
+          planFileWrite({
+            bytes: preparedWorkspacePackageJson.bytes,
+            destination: workspacePackageJsonPath,
+            root: join(workspacePackageJsonPath, ".."),
+          }),
+        ]
+      : []),
+    ...(pnpmWorkspaceAfter !== undefined && pnpmWorkspaceAfter !== pnpmWorkspaceBefore
+      ? [
+          planFileWrite({
+            bytes: Buffer.from(pnpmWorkspaceAfter),
+            destination: pnpmWorkspacePath,
+            root: options.projectRoot,
+          }),
+        ]
+      : []),
+  ]);
+  const dependenciesAdded = Object.keys(additions).sort();
   return {
-    filesWritten,
-    dependenciesAdded: Object.keys(additions).sort(),
-    nodeEngineOverride,
+    dependenciesAdded,
+    nodeEngineOverride: preparedPackageJson.nodeEngineOverride,
+    projectRoot: options.projectRoot,
+    summary: [
+      ...Object.keys(files).map((path) => `Create ${path}`),
+      ...(dependenciesAdded.length === 0
+        ? []
+        : [`Add dependencies: ${dependenciesAdded.join(", ")}`]),
+      ...(preparedPackageJson.nodeEngineOverride === undefined
+        ? []
+        : [`Update package.json engines.node to ${preparedPackageJson.nodeEngineOverride.next}`]),
+      ...(preparedWorkspacePackageJson?.changed === true
+        ? [`Update workspace package.json at ${workspacePackageJsonPath}`]
+        : []),
+      ...(pnpmWorkspaceAfter !== undefined && pnpmWorkspaceAfter !== pnpmWorkspaceBefore
+        ? ["Update pnpm-workspace.yaml package policy"]
+        : []),
+    ],
+    writes,
   };
+}
+
+export async function applyAddAgentToProjectPlan(
+  plan: AddAgentToProjectPlan,
+): Promise<AddAgentToProjectResult> {
+  const appliedWrites = await applyFileWritePlan(plan.projectRoot, plan.writes);
+  return {
+    appliedWrites,
+    dependenciesAdded: [...plan.dependenciesAdded],
+    filesWritten: appliedWrites.map((write) => write.destination),
+    nodeEngineOverride: plan.nodeEngineOverride,
+  };
+}
+
+export async function addAgentToProject(
+  options: AddAgentToProjectOptions,
+): Promise<AddAgentToProjectResult> {
+  return applyAddAgentToProjectPlan(await planAddAgentToProject(options));
 }

--- a/packages/eve/src/setup/scaffold/create/add-to-project.ts
+++ b/packages/eve/src/setup/scaffold/create/add-to-project.ts
@@ -1,5 +1,5 @@
 import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import type { PackageManagerKind } from "../../package-manager.js";
 import type { NodeEngineOverride } from "../../node-engine.js";
@@ -13,10 +13,15 @@ import {
 } from "../bounded-write-plan.js";
 import { preparePackageJsonPatch, type PackageJsonPatch } from "../update/package-json.js";
 import { resolveVersionToken } from "../version-tokens.js";
-import { preparePnpmWorkspacePolicy } from "../../primitives/pm/pnpm.js";
 import {
-  isPackageManagerWorkspaceMember,
+  findAncestorPnpmWorkspaceRoot,
+  preparePnpmWorkspaceIncludesProject,
+  preparePnpmWorkspacePolicy,
+} from "../../primitives/pm/pnpm.js";
+import {
+  findPackageManagerWorkspaceRoot,
   packageManagerRootOnlyPackageJsonPatch,
+  preparePackageJsonWorkspaceIncludesProject,
   workspaceRootPackageJsonPath,
 } from "../workspace-root.js";
 import {
@@ -135,9 +140,8 @@ export async function planAddAgentToProject(
   );
   const patch: PackageJsonPatch = {};
   if (Object.keys(additions).length > 0) patch.dependencies = additions;
-  if (!isPackageManagerWorkspaceMember(packageManager, options.projectRoot)) {
-    patch.nodeEngineRequirement = evePackage.nodeEngine;
-  }
+  const workspaceRoot = findPackageManagerWorkspaceRoot(packageManager, options.projectRoot);
+  if (workspaceRoot === undefined) patch.nodeEngineRequirement = evePackage.nodeEngine;
   const preparedPackageJson = preparePackageJsonPatch(packageJsonRaw, patch);
   const workspacePackageJsonPath = workspaceRootPackageJsonPath(
     packageManager,
@@ -147,30 +151,54 @@ export async function planAddAgentToProject(
     workspacePackageJsonPath === undefined
       ? undefined
       : await readFile(workspacePackageJsonPath, "utf8");
+  const workspacePackageJsonWithProject =
+    workspacePackageJsonBefore === undefined ||
+    workspaceRoot === undefined ||
+    packageManager === "pnpm"
+      ? workspacePackageJsonBefore
+      : preparePackageJsonWorkspaceIncludesProject({
+          projectRoot: options.projectRoot,
+          source: workspacePackageJsonBefore,
+          workspaceRoot,
+        });
   const preparedWorkspacePackageJson =
-    workspacePackageJsonBefore === undefined
+    workspacePackageJsonWithProject === undefined
       ? undefined
       : preparePackageJsonPatch(
-          workspacePackageJsonBefore,
+          workspacePackageJsonWithProject,
           packageManagerRootOnlyPackageJsonPatch(packageManager, {
             aiPackageVersion: aiVersion,
             nodeEngineRequirement: evePackage.nodeEngine,
           }),
         );
-  const pnpmWorkspacePath = join(options.projectRoot, "pnpm-workspace.yaml");
+  const pnpmWorkspacePath =
+    packageManager === "pnpm"
+      ? join(
+          findAncestorPnpmWorkspaceRoot(options.projectRoot) ?? options.projectRoot,
+          "pnpm-workspace.yaml",
+        )
+      : undefined;
   const pnpmWorkspaceBefore =
-    packageManager === "pnpm" &&
-    !isPackageManagerWorkspaceMember(packageManager, options.projectRoot)
-      ? await readFile(pnpmWorkspacePath, "utf8").catch((error: NodeJS.ErrnoException) => {
+    pnpmWorkspacePath === undefined
+      ? undefined
+      : await readFile(pnpmWorkspacePath, "utf8").catch((error: NodeJS.ErrnoException) => {
           if (error.code === "ENOENT") return undefined;
           throw error;
-        })
-      : undefined;
+        });
+  const pnpmWorkspaceWithProject =
+    pnpmWorkspaceBefore === undefined || workspaceRoot === undefined
+      ? pnpmWorkspaceBefore
+      : preparePnpmWorkspaceIncludesProject({
+          projectRoot: options.projectRoot,
+          source: pnpmWorkspaceBefore,
+          workspaceRoot,
+        });
   const pnpmWorkspaceAfter =
-    packageManager === "pnpm" &&
-    !isPackageManagerWorkspaceMember(packageManager, options.projectRoot)
-      ? preparePnpmWorkspacePolicy(pnpmWorkspaceBefore)
-      : undefined;
+    pnpmWorkspaceWithProject === undefined
+      ? workspaceRoot === undefined
+        ? preparePnpmWorkspacePolicy(undefined)
+        : undefined
+      : preparePnpmWorkspacePolicy(pnpmWorkspaceWithProject);
   const writes = await Promise.all([
     ...Object.entries(files).map(([relativePath, content]) =>
       planFileWrite({
@@ -193,16 +221,18 @@ export async function planAddAgentToProject(
           planFileWrite({
             bytes: preparedWorkspacePackageJson.bytes,
             destination: workspacePackageJsonPath,
-            root: join(workspacePackageJsonPath, ".."),
+            root: dirname(workspacePackageJsonPath),
           }),
         ]
       : []),
-    ...(pnpmWorkspaceAfter !== undefined && pnpmWorkspaceAfter !== pnpmWorkspaceBefore
+    ...(pnpmWorkspacePath !== undefined &&
+    pnpmWorkspaceAfter !== undefined &&
+    pnpmWorkspaceAfter !== pnpmWorkspaceBefore
       ? [
           planFileWrite({
             bytes: Buffer.from(pnpmWorkspaceAfter),
             destination: pnpmWorkspacePath,
-            root: options.projectRoot,
+            root: dirname(pnpmWorkspacePath),
           }),
         ]
       : []),
@@ -210,7 +240,8 @@ export async function planAddAgentToProject(
   const dependenciesAdded = Object.keys(additions).sort();
   return {
     dependenciesAdded,
-    nodeEngineOverride: preparedPackageJson.nodeEngineOverride,
+    nodeEngineOverride:
+      preparedWorkspacePackageJson?.nodeEngineOverride ?? preparedPackageJson.nodeEngineOverride,
     projectRoot: options.projectRoot,
     summary: [
       ...Object.keys(files).map((path) => `Create ${path}`),
@@ -220,11 +251,25 @@ export async function planAddAgentToProject(
       ...(preparedPackageJson.nodeEngineOverride === undefined
         ? []
         : [`Update package.json engines.node to ${preparedPackageJson.nodeEngineOverride.next}`]),
-      ...(preparedWorkspacePackageJson?.changed === true
+      ...(preparedWorkspacePackageJson?.nodeEngineOverride === undefined
+        ? []
+        : [
+            `Update workspace package.json engines.node to ${preparedWorkspacePackageJson.nodeEngineOverride.next}`,
+          ]),
+      ...(workspacePackageJsonWithProject !== workspacePackageJsonBefore &&
+      workspacePackageJsonPath !== undefined
+        ? [`Add this package to ${workspacePackageJsonPath}`]
+        : []),
+      ...(preparedWorkspacePackageJson?.changed === true &&
+      preparedWorkspacePackageJson.nodeEngineOverride === undefined &&
+      workspacePackageJsonWithProject === workspacePackageJsonBefore
         ? [`Update workspace package.json at ${workspacePackageJsonPath}`]
         : []),
-      ...(pnpmWorkspaceAfter !== undefined && pnpmWorkspaceAfter !== pnpmWorkspaceBefore
-        ? ["Update pnpm-workspace.yaml package policy"]
+      ...(pnpmWorkspaceBefore !== pnpmWorkspaceWithProject && pnpmWorkspacePath !== undefined
+        ? [`Add this package to ${pnpmWorkspacePath}`]
+        : []),
+      ...(pnpmWorkspaceAfter !== pnpmWorkspaceWithProject
+        ? [`Update ${pnpmWorkspacePath} package policy`]
         : []),
     ],
     writes,

--- a/packages/eve/src/setup/scaffold/update/package-json.ts
+++ b/packages/eve/src/setup/scaffold/update/package-json.ts
@@ -36,11 +36,14 @@ function isJsonObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-export async function patchPackageJson(
-  path: string,
+export interface PreparedPackageJsonPatch extends PackageJsonPatchResult {
+  bytes: Buffer;
+}
+
+export function preparePackageJsonPatch(
+  raw: string,
   patch: PackageJsonPatch,
-): Promise<PackageJsonPatchResult> {
-  const raw = await readFile(path, "utf8");
+): PreparedPackageJsonPatch {
   const parsed = JSON.parse(raw) as PackageJsonShape;
   let changed = false;
   let nodeEngineOverride: NodeEngineOverride | undefined;
@@ -82,8 +85,18 @@ export async function patchPackageJson(
     }
   }
 
-  if (changed) {
-    await writeFile(path, `${JSON.stringify(parsed, null, 2)}\n`, "utf8");
-  }
-  return { changed, nodeEngineOverride };
+  return {
+    bytes: Buffer.from(changed ? `${JSON.stringify(parsed, null, 2)}\n` : raw),
+    changed,
+    nodeEngineOverride,
+  };
+}
+
+export async function patchPackageJson(
+  path: string,
+  patch: PackageJsonPatch,
+): Promise<PackageJsonPatchResult> {
+  const prepared = preparePackageJsonPatch(await readFile(path, "utf8"), patch);
+  if (prepared.changed) await writeFile(path, prepared.bytes);
+  return { changed: prepared.changed, nodeEngineOverride: prepared.nodeEngineOverride };
 }

--- a/packages/eve/src/setup/scaffold/workspace-root.ts
+++ b/packages/eve/src/setup/scaffold/workspace-root.ts
@@ -108,7 +108,7 @@ export function isPackageManagerWorkspaceMember(
   return workspaceRoot !== undefined && resolve(workspaceRoot) !== resolve(projectRoot);
 }
 
-function workspaceRootPackageJsonPath(
+export function workspaceRootPackageJsonPath(
   packageManager: PackageManagerKind,
   projectRoot: string,
 ): string | undefined {
@@ -162,7 +162,7 @@ async function ensurePackageManagerWorkspaceIncludesProject(
   }
 }
 
-function packageManagerRootOnlyPackageJsonPatch(
+export function packageManagerRootOnlyPackageJsonPatch(
   packageManager: PackageManagerKind,
   input: {
     readonly aiPackageVersion?: string;

--- a/packages/eve/src/setup/scaffold/workspace-root.ts
+++ b/packages/eve/src/setup/scaffold/workspace-root.ts
@@ -70,23 +70,8 @@ function findAncestorPackageJsonWorkspaceRoot(projectRoot: string): string | und
   }
 }
 
-function findClaimingPackageJsonWorkspaceRoot(projectRoot: string): string | undefined {
-  const workspaceRoot = findAncestorPackageJsonWorkspaceRoot(projectRoot);
-  if (workspaceRoot === undefined) return undefined;
-  let patterns: string[] | undefined;
-  try {
-    patterns = readPackageJsonWorkspacePatterns(join(workspaceRoot, "package.json"));
-  } catch {
-    return undefined;
-  }
-  return patterns !== undefined &&
-    workspacePatternsClaimProject(patterns, workspaceRoot, projectRoot)
-    ? workspaceRoot
-    : undefined;
-}
-
 /** Ancestor package-manager workspace root that owns root-only package.json fields. */
-function findPackageManagerWorkspaceRoot(
+export function findPackageManagerWorkspaceRoot(
   packageManager: PackageManagerKind,
   projectRoot: string,
 ): string | undefined {
@@ -116,20 +101,20 @@ export function workspaceRootPackageJsonPath(
   return workspaceRoot === undefined ? undefined : join(workspaceRoot, "package.json");
 }
 
-async function ensurePackageJsonWorkspaceIncludesProject(
-  projectRoot: string,
-): Promise<string | undefined> {
-  const workspaceRoot = findAncestorPackageJsonWorkspaceRoot(projectRoot);
-  if (workspaceRoot === undefined || resolve(workspaceRoot) === resolve(projectRoot)) {
-    return undefined;
+export function preparePackageJsonWorkspaceIncludesProject(input: {
+  projectRoot: string;
+  source: string;
+  workspaceRoot: string;
+}): string {
+  const parsed = JSON.parse(input.source) as PackageJsonWorkspaceShape;
+  const patterns = packageJsonWorkspacePatterns(parsed);
+  if (
+    patterns.length === 0 ||
+    workspacePatternsClaimProject(patterns, input.workspaceRoot, input.projectRoot)
+  ) {
+    return input.source;
   }
-  if (findClaimingPackageJsonWorkspaceRoot(projectRoot) === workspaceRoot) {
-    return undefined;
-  }
-
-  const packageJsonPath = join(workspaceRoot, "package.json");
-  const parsed = JSON.parse(await readFile(packageJsonPath, "utf8")) as PackageJsonWorkspaceShape;
-  const pattern = workspacePatternForProject(workspaceRoot, projectRoot);
+  const pattern = workspacePatternForProject(input.workspaceRoot, input.projectRoot);
   if (Array.isArray(parsed.workspaces)) {
     parsed.workspaces = [...parsed.workspaces, pattern];
   } else if (isJsonObject(parsed.workspaces) && Array.isArray(parsed.workspaces.packages)) {
@@ -138,9 +123,28 @@ async function ensurePackageJsonWorkspaceIncludesProject(
       packages: [...parsed.workspaces.packages, pattern],
     };
   } else {
+    return input.source;
+  }
+  return `${JSON.stringify(parsed, null, 2)}\n`;
+}
+
+async function ensurePackageJsonWorkspaceIncludesProject(
+  projectRoot: string,
+): Promise<string | undefined> {
+  const workspaceRoot = findAncestorPackageJsonWorkspaceRoot(projectRoot);
+  if (workspaceRoot === undefined || resolve(workspaceRoot) === resolve(projectRoot)) {
     return undefined;
   }
-  await writeFile(packageJsonPath, `${JSON.stringify(parsed, null, 2)}\n`, "utf8");
+
+  const packageJsonPath = join(workspaceRoot, "package.json");
+  const current = await readFile(packageJsonPath, "utf8");
+  const next = preparePackageJsonWorkspaceIncludesProject({
+    projectRoot,
+    source: current,
+    workspaceRoot,
+  });
+  if (next === current) return undefined;
+  await writeFile(packageJsonPath, next);
   return packageJsonPath;
 }
 


### PR DESCRIPTION
### Summary

When `eve init` adds an agent to an existing project, it now reports the agent files, dependencies, and configuration files it changed. The report appears before dependency installation, so it remains available if the installation fails and the existing project is intentionally preserved.

### Before / after

Before, a successful integration only reported that an agent was added:

```console
$ eve init .
✓ Added an eve agent to /path/to/app
✓ Installed dependencies
```

After, eve identifies the completed mutations before it starts installation:

```console
$ eve init .
Updated existing project:
  Created agent/agent.ts
  Created agent/instructions.md
  Added dependencies: @vercel/connect, ai, eve
  Updated /path/to/app/package.json
  Updated /path/to/app/pnpm-workspace.yaml

Installing dependencies...
```

### Validation

Focused `init` integration coverage verifies the completed-change report for a successful existing-project integration and when its dependency installation fails. TypeScript check also passed locally.

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

The changeset records the completed-change report and its failure-path visibility.

**Implementation** — 2 files · `+57 / -7`

Existing integration results retain the configuration paths they changed, and the CLI reports all completed mutations before installation begins.

**Tests** — 1 file · `+14 / -2`

Focused existing-project coverage verifies the report for successful and failed dependency installation paths.
