### PR TITLE
test: expand authoring benchmark cases

### DIFF
--- a/apps/benchmarks/README.md
+++ b/apps/benchmarks/README.md
@@ -66,9 +66,10 @@ results cannot be reproduced from committed source and should not be committed a
 
 Without `--models`, publication covers the complete configured model matrix. Use `--models` to
 publish or refresh selected model rows. The published suite currently includes the weather-tool and
-new-project cases; the iMessage case remains available for local runs but is excluded from the
-published matrix. Each cell runs three times. Completed cells are memoized by `@vercel/agent-eval`; pass `--force` only
-when every cell should run again. A successful run writes aggregate results to
+new-project cases. The iMessage, OpenAPI connection, packaged skill, conditional approval, and
+custom channel cases remain available for local runs but are excluded from the published matrix
+until their canonical model runs are ready. Each cell runs three times. Completed cells are memoized
+by `@vercel/agent-eval`; pass `--force` only when every cell should run again. A successful run writes aggregate results to
 `apps/docs/lib/evals/benchmark-results.json`. The public file contains outcomes and timing, not
 transcripts, generated files, command logs, or synthetic world events.
 

--- a/apps/benchmarks/README.md
+++ b/apps/benchmarks/README.md
@@ -65,11 +65,11 @@ Pass `--allow-dirty` only for a local, noncanonical run. It bypasses the clean-t
 results cannot be reproduced from committed source and should not be committed as published data.
 
 Without `--models`, publication covers the complete configured model matrix. Use `--models` to
-publish or refresh selected model rows. The published suite currently includes the weather-tool and
-new-project cases. The iMessage, OpenAPI connection, packaged skill, conditional approval, and
-custom channel cases remain available for local runs but are excluded from the published matrix
-until their canonical model runs are ready. Each cell runs three times. Completed cells are memoized
-by `@vercel/agent-eval`; pass `--force` only when every cell should run again. A successful run writes aggregate results to
+publish or refresh selected model rows. The published suite currently includes weather-tool,
+new-project, OpenAPI connection, packaged skill, conditional approval, and custom channel cases.
+The iMessage case remains available for local runs but is excluded from the published matrix. Each
+cell runs three times. Completed cells are memoized by `@vercel/agent-eval`; pass `--force` only
+when every cell should run again. A successful run writes aggregate results to
 `apps/docs/lib/evals/benchmark-results.json`. The public file contains outcomes and timing, not
 transcripts, generated files, command logs, or synthetic world events.
 

--- a/apps/benchmarks/evals/author-003-openapi-connection/CASE.ts
+++ b/apps/benchmarks/evals/author-003-openapi-connection/CASE.ts
@@ -6,7 +6,7 @@ export default defineAuthoringCase({
   setup: inventoryOpenApiSetup,
   async interact({ send }) {
     await send(
-      "Connect this agent to the inventory service described by the provided `agent/lib/inventory-openapi.ts` contract. Add an OpenAPI connection named `inventory` with base URL `https://inventory.example.com`. It should authenticate as the app with a bearer token from `INVENTORY_API_TOKEN`, and the model should only be able to discover the read-only `getStock` operation, not `reserveStock`.",
+      "Connect this agent to the inventory service described by the provided `agent/lib/inventory-openapi.ts` contract. Add an OpenAPI connection named `inventory` with base URL `https://api.northstar-fulfillment.com`. It should authenticate as the app with a bearer token from `INVENTORY_API_TOKEN`, and the model should only be able to discover the read-only `getStock` operation, not `reserveStock`.",
     );
   },
 });

--- a/apps/benchmarks/evals/author-003-openapi-connection/CASE.ts
+++ b/apps/benchmarks/evals/author-003-openapi-connection/CASE.ts
@@ -1,0 +1,12 @@
+import { defineAuthoringCase, simpleProject } from "../../lib/authoring-case.js";
+import { inventoryOpenApiSetup } from "../../lib/setups/inventory-openapi.js";
+
+export default defineAuthoringCase({
+  startingPoint: simpleProject,
+  setup: inventoryOpenApiSetup,
+  async interact({ send }) {
+    await send(
+      "Connect this agent to the inventory service described by the provided `agent/lib/inventory-openapi.ts` contract. Add an OpenAPI connection named `inventory` with base URL `https://inventory.example.com`. It should authenticate as the app with a bearer token from `INVENTORY_API_TOKEN`, and the model should only be able to discover the read-only `getStock` operation, not `reserveStock`.",
+    );
+  },
+});

--- a/apps/benchmarks/evals/author-003-openapi-connection/EVAL.ts
+++ b/apps/benchmarks/evals/author-003-openapi-connection/EVAL.ts
@@ -9,7 +9,7 @@ test("creates the filesystem-named OpenAPI connection", () => {
   const source = readFileSync(connectionPath, "utf8");
   expect(source).toMatch(/defineOpenAPIConnection\s*\(/);
   expect(source).toMatch(/inventoryOpenApiSpec/);
-  expect(source).toContain("https://inventory.example.com");
+  expect(source).toContain("https://api.northstar-fulfillment.com");
 });
 
 test("keeps credentials out of model control and exposes only getStock", () => {

--- a/apps/benchmarks/evals/author-003-openapi-connection/EVAL.ts
+++ b/apps/benchmarks/evals/author-003-openapi-connection/EVAL.ts
@@ -1,0 +1,21 @@
+import { existsSync, readFileSync } from "node:fs";
+
+import { expect, test } from "vitest";
+
+const connectionPath = "agent/connections/inventory.ts";
+
+test("creates the filesystem-named OpenAPI connection", () => {
+  expect(existsSync(connectionPath)).toBe(true);
+  const source = readFileSync(connectionPath, "utf8");
+  expect(source).toMatch(/defineOpenAPIConnection\s*\(/);
+  expect(source).toMatch(/inventoryOpenApiSpec/);
+  expect(source).toContain("https://inventory.example.com");
+});
+
+test("keeps credentials out of model control and exposes only getStock", () => {
+  const source = readFileSync(connectionPath, "utf8");
+  expect(source).toMatch(/getToken/);
+  expect(source).toMatch(/process\.env(?:\.INVENTORY_API_TOKEN|\[["']INVENTORY_API_TOKEN["']\])/);
+  expect(source).toMatch(/operations\s*:\s*{\s*allow\s*:\s*\[\s*["']getStock["']/s);
+  expect(source).not.toMatch(/allow\s*:\s*\[[^\]]*["']reserveStock["']/s);
+});

--- a/apps/benchmarks/evals/author-004-packaged-skill/CASE.ts
+++ b/apps/benchmarks/evals/author-004-packaged-skill/CASE.ts
@@ -4,7 +4,7 @@ export default defineAuthoringCase({
   startingPoint: simpleProject,
   async interact({ send }) {
     await send(
-      "Add a packaged skill named `incident-response` for investigating production incidents. It should load when a user needs incident triage, guide the agent to establish a timeline, collect evidence, assess impact, and propose mitigations, and include a supporting `references/severity-levels.md` file that defines SEV1 and SEV2. Use the standard packaged skill layout rather than creating a tool.",
+      "Add an eve packaged skill named `incident-response` at `agent/skills/incident-response/SKILL.md` for investigating production incidents. It should load when a user needs incident triage, guide the agent to establish a timeline, collect evidence, assess impact, and propose mitigations, and include `agent/skills/incident-response/references/severity-levels.md` defining SEV1 and SEV2. Use eve's packaged skill layout, not an OpenCode `.opencode/skills` directory and not a tool.",
     );
   },
 });

--- a/apps/benchmarks/evals/author-004-packaged-skill/CASE.ts
+++ b/apps/benchmarks/evals/author-004-packaged-skill/CASE.ts
@@ -1,0 +1,10 @@
+import { defineAuthoringCase, simpleProject } from "../../lib/authoring-case.js";
+
+export default defineAuthoringCase({
+  startingPoint: simpleProject,
+  async interact({ send }) {
+    await send(
+      "Add a packaged skill named `incident-response` for investigating production incidents. It should load when a user needs incident triage, guide the agent to establish a timeline, collect evidence, assess impact, and propose mitigations, and include a supporting `references/severity-levels.md` file that defines SEV1 and SEV2. Use the standard packaged skill layout rather than creating a tool.",
+    );
+  },
+});

--- a/apps/benchmarks/evals/author-004-packaged-skill/EVAL.ts
+++ b/apps/benchmarks/evals/author-004-packaged-skill/EVAL.ts
@@ -1,0 +1,30 @@
+import { existsSync, readFileSync } from "node:fs";
+
+import { expect, test } from "vitest";
+
+const skillRoot = "agent/skills/incident-response";
+
+test("creates a discoverable packaged incident-response skill", () => {
+  const skillPath = `${skillRoot}/SKILL.md`;
+  expect(existsSync(skillPath)).toBe(true);
+  const source = readFileSync(skillPath, "utf8");
+  expect(source).toMatch(/^---[\s\S]*description\s*:/);
+  expect(source).toMatch(/incident|triage/i);
+  expect(source).toMatch(/timeline/i);
+  expect(source).toMatch(/evidence/i);
+  expect(source).toMatch(/impact/i);
+  expect(source).toMatch(/mitigat/i);
+});
+
+test("packages the requested severity reference", () => {
+  const referencePath = `${skillRoot}/references/severity-levels.md`;
+  expect(existsSync(referencePath)).toBe(true);
+  const source = readFileSync(referencePath, "utf8");
+  expect(source).toMatch(/SEV\s*-?\s*1/i);
+  expect(source).toMatch(/SEV\s*-?\s*2/i);
+});
+
+test("does not substitute executable behavior for the skill", () => {
+  expect(existsSync("agent/tools/incident-response.ts")).toBe(false);
+  expect(existsSync("agent/tools/incident_response.ts")).toBe(false);
+});

--- a/apps/benchmarks/evals/author-005-conditional-approval/CASE.ts
+++ b/apps/benchmarks/evals/author-005-conditional-approval/CASE.ts
@@ -1,0 +1,10 @@
+import { defineAuthoringCase, simpleProject } from "../../lib/authoring-case.js";
+
+export default defineAuthoringCase({
+  startingPoint: simpleProject,
+  async interact({ send }) {
+    await send(
+      "Add a `refund_payment` tool that accepts a payment ID and a positive refund amount in US dollars, then returns a confirmation containing both values. Refunds below $100 should run without approval; refunds of $100 or more must require user approval before execution.",
+    );
+  },
+});

--- a/apps/benchmarks/evals/author-005-conditional-approval/EVAL.ts
+++ b/apps/benchmarks/evals/author-005-conditional-approval/EVAL.ts
@@ -46,7 +46,7 @@ function requiresApproval(decision: unknown): boolean {
 }
 
 async function loadDefinition() {
-  return (await import(`../${toolPath}`)).default;
+  return (await import(new URL("../agent/tools/refund_payment.ts", import.meta.url).href)).default;
 }
 
 function refundInput(definition: Awaited<ReturnType<typeof loadDefinition>>, amount: number) {

--- a/apps/benchmarks/evals/author-005-conditional-approval/EVAL.ts
+++ b/apps/benchmarks/evals/author-005-conditional-approval/EVAL.ts
@@ -1,0 +1,61 @@
+import { existsSync, readFileSync } from "node:fs";
+
+import { expect, test } from "vitest";
+
+const toolPath = "agent/tools/refund_payment.ts";
+
+test("creates a typed refund tool that returns both values", async () => {
+  expect(existsSync(toolPath)).toBe(true);
+  expect(readFileSync(toolPath, "utf8")).toMatch(/defineTool\s*\(/);
+
+  const definition = await loadDefinition();
+  const input = refundInput(definition, 42);
+  const output = await definition.execute(input, {});
+  expect(JSON.stringify(output)).toContain("pay_123");
+  expect(JSON.stringify(output)).toContain("42");
+  expect(() => refundInput(definition, 0)).toThrow();
+});
+
+test("requires approval only at or above the threshold", async () => {
+  const definition = await loadDefinition();
+  const policy =
+    typeof definition.approval === "function" ? definition.approval : definition.approval?.request;
+  expect(typeof policy).toBe("function");
+
+  const decision = async (amount: number) =>
+    policy({
+      approvedTools: new Set(),
+      callId: "refund-call",
+      session: {},
+      toolInput: refundInput(definition, amount),
+      toolName: "refund_payment",
+    });
+
+  expect(requiresApproval(await decision(99))).toBe(false);
+  expect(requiresApproval(await decision(100))).toBe(true);
+});
+
+function requiresApproval(decision: unknown): boolean {
+  if (decision === true || decision === "user-approval") return true;
+  return (
+    typeof decision === "object" &&
+    decision !== null &&
+    "type" in decision &&
+    decision.type === "user-approval"
+  );
+}
+
+async function loadDefinition() {
+  return (await import(`../${toolPath}`)).default;
+}
+
+function refundInput(definition: Awaited<ReturnType<typeof loadDefinition>>, amount: number) {
+  for (const input of [
+    { paymentId: "pay_123", amount },
+    { paymentId: "pay_123", amountUsd: amount },
+  ]) {
+    const parsed = definition.inputSchema.safeParse(input);
+    if (parsed.success) return parsed.data;
+  }
+  throw new Error(`The refund schema rejected amount ${amount}.`);
+}

--- a/apps/benchmarks/evals/author-006-custom-channel/CASE.ts
+++ b/apps/benchmarks/evals/author-006-custom-channel/CASE.ts
@@ -1,0 +1,10 @@
+import { defineAuthoringCase, simpleProject } from "../../lib/authoring-case.js";
+
+export default defineAuthoringCase({
+  startingPoint: simpleProject,
+  async interact({ send }) {
+    await send(
+      "Add a custom channel named `support` for an internal support system. It needs a POST route at `/support/:threadId/messages` that reads a JSON `message`, uses the thread ID as the channel continuation address, sends the message with no user auth, and returns the durable session ID as JSON. Queue overlapping messages so an active turn finishes before the next one starts.",
+    );
+  },
+});

--- a/apps/benchmarks/evals/author-006-custom-channel/EVAL.ts
+++ b/apps/benchmarks/evals/author-006-custom-channel/EVAL.ts
@@ -14,10 +14,11 @@ test("creates the filesystem-named support channel and route", () => {
 
 test("maps each support thread to a session and returns its id", () => {
   const source = readFileSync(channelPath, "utf8");
-  expect(source).toMatch(/request\.json\s*\(/);
-  expect(source).toMatch(/from\s*\(\s*params\.threadId\s*\)/);
-  expect(source).toMatch(/\.send\s*\([^)]*message/s);
+  expect(source).toMatch(/\w+\.json\s*\(/);
+  expect(source).toMatch(/params\.threadId/);
+  expect(source).toMatch(/from\s*\(/);
+  expect(source).toMatch(/\.send\s*\(/);
   expect(source).toMatch(/auth\s*:\s*null/);
   expect(source).toMatch(/sessionId/);
-  expect(source).toMatch(/Response\.json/);
+  expect(source).toMatch(/Response(?:\.json|\s*\()/);
 });

--- a/apps/benchmarks/evals/author-006-custom-channel/EVAL.ts
+++ b/apps/benchmarks/evals/author-006-custom-channel/EVAL.ts
@@ -1,0 +1,23 @@
+import { existsSync, readFileSync } from "node:fs";
+
+import { expect, test } from "vitest";
+
+const channelPath = "agent/channels/support.ts";
+
+test("creates the filesystem-named support channel and route", () => {
+  expect(existsSync(channelPath)).toBe(true);
+  const source = readFileSync(channelPath, "utf8");
+  expect(source).toMatch(/defineChannel\s*\(/);
+  expect(source).toMatch(/POST\s*\(\s*["']\/support\/:threadId\/messages["']/);
+  expect(source).toMatch(/turnPolicy\s*:\s*["']queue["']/);
+});
+
+test("maps each support thread to a session and returns its id", () => {
+  const source = readFileSync(channelPath, "utf8");
+  expect(source).toMatch(/request\.json\s*\(/);
+  expect(source).toMatch(/from\s*\(\s*params\.threadId\s*\)/);
+  expect(source).toMatch(/\.send\s*\([^)]*message/s);
+  expect(source).toMatch(/auth\s*:\s*null/);
+  expect(source).toMatch(/sessionId/);
+  expect(source).toMatch(/Response\.json/);
+});

--- a/apps/benchmarks/lib/benchmark-config.test.mjs
+++ b/apps/benchmarks/lib/benchmark-config.test.mjs
@@ -23,6 +23,10 @@ test("publishes only compatibility-validated models", () => {
   assert.deepEqual(publishedBenchmark.caseIds, [
     "author-001-weather-tool",
     "author-002-new-project",
+    "author-003-openapi-connection",
+    "author-004-packaged-skill",
+    "author-005-conditional-approval",
+    "author-006-custom-channel",
   ]);
   assert.throws(
     () => findPublishedBenchmarkModel("grok-4-6"),

--- a/apps/benchmarks/lib/benchmark-config.ts
+++ b/apps/benchmarks/lib/benchmark-config.ts
@@ -90,7 +90,14 @@ export const publishedBenchmarkModels = benchmarkModels.filter(
 );
 
 export const publishedBenchmark = {
-  caseIds: ["author-001-weather-tool", "author-002-new-project"],
+  caseIds: [
+    "author-001-weather-tool",
+    "author-002-new-project",
+    "author-003-openapi-connection",
+    "author-004-packaged-skill",
+    "author-005-conditional-approval",
+    "author-006-custom-channel",
+  ],
   runs: 3,
 } as const;
 

--- a/apps/benchmarks/lib/setups/inventory-openapi.test.mjs
+++ b/apps/benchmarks/lib/setups/inventory-openapi.test.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { inventoryOpenApiSetup } from "./inventory-openapi.ts";
+
+test("seeds the inventory OpenAPI contract into the project", async () => {
+  const commands = [];
+  const writes = [];
+  await inventoryOpenApiSetup.onSession({
+    run: async (command) => commands.push(command),
+    write: async (path, content) => writes.push({ path, content }),
+  });
+
+  assert.deepEqual(commands, ["mkdir -p agent/lib"]);
+  assert.equal(writes[0]?.path, "agent/lib/inventory-openapi.ts");
+  assert.match(writes[0]?.content ?? "", /operationId: "getStock"/u);
+  assert.match(writes[0]?.content ?? "", /operationId: "reserveStock"/u);
+});

--- a/apps/benchmarks/lib/setups/inventory-openapi.ts
+++ b/apps/benchmarks/lib/setups/inventory-openapi.ts
@@ -1,0 +1,45 @@
+import type { AuthoringSetup } from "../authoring-case.js";
+
+const inventoryOpenApiSource = `export const inventoryOpenApiSpec = {
+  openapi: "3.0.3",
+  info: { title: "Inventory API", version: "1.0.0" },
+  paths: {
+    "/stock/{sku}": {
+      get: {
+        operationId: "getStock",
+        parameters: [
+          {
+            name: "sku",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        responses: { "200": { description: "Current stock" } },
+      },
+    },
+    "/stock/{sku}/reserve": {
+      post: {
+        operationId: "reserveStock",
+        parameters: [
+          {
+            name: "sku",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        responses: { "200": { description: "Reservation result" } },
+      },
+    },
+  },
+};
+`;
+
+export const inventoryOpenApiSetup: AuthoringSetup = {
+  id: "inventory-openapi-v1",
+  async onSession({ run, write }) {
+    await run("mkdir -p agent/lib");
+    await write("agent/lib/inventory-openapi.ts", inventoryOpenApiSource);
+  },
+};

--- a/apps/benchmarks/scripts/export-results.test.mjs
+++ b/apps/benchmarks/scripts/export-results.test.mjs
@@ -38,7 +38,7 @@ test("exports missing cells without publishing private artifacts", () => {
     const output = JSON.parse(raw);
 
     assert.equal(output.schemaVersion, 1);
-    assert.equal(output.suite.caseCount, 2);
+    assert.equal(output.suite.caseCount, 6);
     assert.match(output.suite.caseFingerprint, /^[0-9a-f]{64}$/u);
     assert.equal(output.experiments.length, 12);
     assert.deepEqual(
@@ -52,7 +52,7 @@ test("exports missing cells without publishing private artifacts", () => {
         "Gemini 3.1 Pro Preview",
       ],
     );
-    assert.equal(output.results.length, 24);
+    assert.equal(output.results.length, 72);
     assert.ok(output.results.every((result) => result.status === "missing"));
     for (const privateField of ["transcript", "commands", "worldEvents", "files"]) {
       assert.equal(raw.includes(`"${privateField}"`), false);


### PR DESCRIPTION
### Summary

Adds four self-contained authoring cases for core eve workflows that were not represented by the scaffold and weather-tool benchmarks: an allow-listed OpenAPI connection, a packaged skill with a supporting reference, a conditionally approved tool, and a queued custom HTTP channel. The suite now publishes all six cases across every supported OpenCode model and both treatments. The OpenAPI contract is seeded locally, and graders accept equivalent valid channel implementations while enforcing the behavioral contract.

### Validation

The benchmark suite and typecheck pass. Canonical publication against `origin/main` completed all 72 cells (six models, two treatments, six cases, three runs); the docs aggregate and focused result tests also pass.

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package — not applicable; this changes private benchmark cases
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+4 / -3`

Updates the private benchmark runbook for the expanded canonical suite.

**Implementation** — 2 files · `+53 / -1`

Promotes the cases into canonical publication and seeds a deterministic local OpenAPI contract.

**Tests** — 11 files · `+202 / -2`

Defines the four prompts and deterministic graders, plus focused configuration and setup coverage.
