### PR TITLE
fix(eve): wait for Slack approval settlement

### DIFF
--- a/.changeset/fix-slack-approval-card-settlement.md
+++ b/.changeset/fix-slack-approval-card-settlement.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Wait for tool approval settlement before marking Slack approval cards as answered, so rejected approval responses leave the shared card open.

--- a/packages/eve/extension-contracts/compatibility/channel/v1.ts
+++ b/packages/eve/extension-contracts/compatibility/channel/v1.ts
@@ -1,0 +1,15 @@
+import { defineChannel, POST } from "#public/definitions/channel.js";
+
+export default defineChannel<{ lastSender: string }>({
+  state: { lastSender: "" },
+  routes: [
+    POST("/message", async (request, { from }) => {
+      const body = (await request.json()) as { message: string; userId?: string };
+      await from(`conversation:${body.userId ?? "anonymous"}`).send(body.message, {
+        auth: null,
+        state: { lastSender: body.userId ?? "anonymous" },
+      });
+      return new Response("ok");
+    }),
+  ],
+});

--- a/packages/eve/extension-contracts/reports/channel/v2.json
+++ b/packages/eve/extension-contracts/reports/channel/v2.json
@@ -1,0 +1,17 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "channel",
+  "epoch": 2,
+  "sha256": "2c2caf35107dbe72c5bc025c7766cc9e612d029f796b04bc38c7b8bc150bd869",
+  "exports": [
+    "DELETE",
+    "GET",
+    "PATCH",
+    "POST",
+    "PUT",
+    "WS",
+    "createWebSocketUpgradeServer",
+    "defineChannel",
+    "isChannel"
+  ]
+}

--- a/packages/eve/src/channel/channel-address.ts
+++ b/packages/eve/src/channel/channel-address.ts
@@ -37,7 +37,7 @@ interface BaseChannelAddressDeliveryOptions {
 /** Delivery options for a channel address whose continuation token is already bound. */
 export type ChannelAddressDeliveryOptions<TState = undefined> = [TState] extends [undefined]
   ? BaseChannelAddressDeliveryOptions
-  : BaseChannelAddressDeliveryOptions & { readonly state?: TState };
+  : BaseChannelAddressDeliveryOptions & { readonly state?: Partial<TState> };
 
 /**
  * Dynamic handle for whichever durable session currently owns one channel-local address.

--- a/packages/eve/src/channel/channel-operations.test.ts
+++ b/packages/eve/src/channel/channel-operations.test.ts
@@ -48,6 +48,34 @@ describe("createChannelOperations", () => {
     });
   });
 
+  it("carries an input-response state patch through the durable delivery", async () => {
+    const runtime = createRuntime();
+    const { from } = createChannelOperations<{ responder: string }>({
+      adapter: { kind: "slack" },
+      channelName: "slack",
+      runtime,
+    });
+
+    await from("C1:T1").respond([{ optionId: "approve", requestId: "approval-1" }], {
+      auth: null,
+      state: { responder: "U_APPROVER" },
+    });
+
+    expect(runtime.dispatchContinuation).toHaveBeenCalledWith({
+      command: {
+        auth: null,
+        kind: "send",
+        payload: {
+          inputResponses: [{ optionId: "approve", requestId: "approval-1" }],
+          state: { responder: "U_APPROVER" },
+        },
+        requestId: undefined,
+        turnPolicy: undefined,
+      },
+      continuationToken: "slack:C1:T1",
+    });
+  });
+
   it("targets every control operation by raw channel-local address", async () => {
     const runtime = createRuntime();
     const { from } = createChannelOperations({

--- a/packages/eve/src/channel/channel-operations.ts
+++ b/packages/eve/src/channel/channel-operations.ts
@@ -38,14 +38,15 @@ export type ChannelSendOptions<TState = undefined> = [TState] extends [undefined
   ? BaseChannelSendOptions
   : BaseChannelSendOptions & { readonly state: TState };
 
-interface BaseChannelRespondOptions {
+interface BaseChannelRespondOptions<TState = undefined> {
   readonly auth: SessionAuthContext | null;
   readonly context?: readonly string[];
   readonly outputSchema?: JsonObject;
+  readonly state?: Partial<TState>;
 }
 
 /** Options for answering pending input requests at an existing continuation address. */
-export type ChannelRespondOptions = BaseChannelRespondOptions;
+export type ChannelRespondOptions<TState = undefined> = BaseChannelRespondOptions<TState>;
 
 /** Dynamic handle for whichever session currently owns one channel-local address. */
 export interface ChannelSource<TState = undefined> {
@@ -54,7 +55,7 @@ export interface ChannelSource<TState = undefined> {
   /** Answers pending input requests. Never creates a session. */
   respond(
     inputResponses: readonly InputResponse[],
-    options: ChannelRespondOptions,
+    options: ChannelRespondOptions<TState>,
   ): Promise<Session>;
   /** Cooperatively cancels the active turn without creating a session. */
   cancel(options?: { readonly turnId?: string }): Promise<CancelTurnResult>;
@@ -121,6 +122,7 @@ export function createChannelOperations<TState = undefined>(input: {
               context: options.context,
               inputResponses,
               outputSchema: options.outputSchema,
+              state: options.state,
             },
             options,
           );

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -27,7 +27,7 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17],
     dropped: {},
   },
-  channel: { current: 1, supported: [1], dropped: {} },
+  channel: { current: 2, supported: [1, 2], dropped: {} },
   schedule: { current: 1, supported: [1], dropped: {} },
   subagent: { current: 1, supported: [1], dropped: {} },
   connection: { current: 5, supported: [1, 2, 3, 4, 5], dropped: {} },

--- a/packages/eve/src/internal/testing/mocks/mock-channel-operations.ts
+++ b/packages/eve/src/internal/testing/mocks/mock-channel-operations.ts
@@ -11,7 +11,7 @@ import type { InputResponse } from "#runtime/input/types.js";
 
 export type ObservedChannelDelivery<TState> =
   | (ChannelSendOptions<TState> & { readonly message: string | UserContent })
-  | (ChannelRespondOptions & { readonly inputResponses: readonly InputResponse[] });
+  | (ChannelRespondOptions<TState> & { readonly inputResponses: readonly InputResponse[] });
 
 type DeliveryObserver<TState> = (
   continuationToken: string,

--- a/packages/eve/src/public/channels/slack/defaults.test.ts
+++ b/packages/eve/src/public/channels/slack/defaults.test.ts
@@ -147,17 +147,17 @@ describe("defaultEvents approval lifecycle", () => {
 
   it("updates the shared card only after settlement", async () => {
     const { channel, request } = buildChannelStub({
+      approvalResponderUsers: { "slack:T1:U777": "U777" },
       pendingApprovalCards: {
         "approval-1": {
           messageBlocks: [
             {
-              actions: [{ action_id: "eve_input:approval-1:button:1" }],
+              actions: [{ action_id: "eve_input:tool-approval:approval-1:button:1" }],
               body: { text: "Approve?", type: "mrkdwn" },
               type: "card",
             },
           ],
           messageTs: "123.456",
-          userId: "U777",
         },
       },
     });
@@ -179,25 +179,29 @@ describe("defaultEvents approval lifecycle", () => {
       "chat.update",
       expect.objectContaining({ channel: "C123", text: "Answered: Approve", ts: "123.456" }),
     );
+    const update = request.mock.calls.find(([method]) => method === "chat.update")?.[1] as {
+      blocks?: unknown[];
+    };
+    expect(JSON.stringify(update.blocks)).toContain("Answered by <@U777>");
     expect(channel.state.pendingApprovalCards).toEqual({});
   });
 
-  it("settles the request even when the stored click id differs from its sibling button", async () => {
+  it("settles the request when its buttons carry tool-approval metadata", async () => {
     const { channel, request } = buildChannelStub({
+      approvalResponderUsers: { "slack:T1:U777": "U777" },
       pendingApprovalCards: {
         "approval-1": {
           messageBlocks: [
             {
               actions: [
-                { action_id: "eve_input:approval-1:button:0" },
-                { action_id: "eve_input:approval-1:button:1" },
+                { action_id: "eve_input:tool-approval:approval-1:button:0" },
+                { action_id: "eve_input:tool-approval:approval-1:button:1" },
               ],
               body: { text: "Approve?", type: "mrkdwn" },
               type: "card",
             },
           ],
           messageTs: "123.456",
-          userId: "U777",
         },
       },
     });
@@ -218,7 +222,7 @@ describe("defaultEvents approval lifecycle", () => {
     const update = request.mock.calls.find(([method]) => method === "chat.update")?.[1] as {
       blocks?: unknown[];
     };
-    expect(JSON.stringify(update.blocks)).not.toContain("eve_input:approval-1");
+    expect(JSON.stringify(update.blocks)).not.toContain("eve_input:tool-approval:approval-1");
   });
 });
 

--- a/packages/eve/src/public/channels/slack/defaults.ts
+++ b/packages/eve/src/public/channels/slack/defaults.ts
@@ -37,13 +37,17 @@ function blockContainsRequestAction(block: unknown, requestId: string): boolean 
   if (typeof block !== "object" || block === null) return false;
   const candidate = block as { actions?: unknown; elements?: unknown };
   const requestActionPrefix = `eve_input:${requestId}`;
+  const approvalActionPrefix = `eve_input:tool-approval:${requestId}`;
   return [candidate.actions, candidate.elements].some(
     (entries) =>
       Array.isArray(entries) &&
       entries.some((entry) => {
         if (typeof entry !== "object" || entry === null) return false;
         const actionId = (entry as { action_id?: unknown }).action_id;
-        return typeof actionId === "string" && actionId.startsWith(requestActionPrefix);
+        return (
+          typeof actionId === "string" &&
+          (actionId.startsWith(requestActionPrefix) || actionId.startsWith(approvalActionPrefix))
+        );
       }),
   );
 }
@@ -208,18 +212,19 @@ export const defaultEvents: SlackChannelInternalEvents = {
     const card = cards[event.requestId];
     if (card === undefined || channel.state.channelId === null) return;
     const answerLabel = event.outcome === "approved" ? "Approve" : "Cancel";
+    const userId = channel.state.approvalResponderUsers?.[event.responderPrincipalId];
     const blocks = card.messageBlocks.flatMap((block) => {
       if (!blockContainsRequestAction(block, event.requestId)) return [block];
       if (typeof block !== "object" || block === null) return [];
       const candidate = block as Record<string, unknown>;
       if (candidate.type !== "card") {
-        return buildAnsweredBlocks({ answerLabel, promptBlocks: [], userId: card.userId });
+        return buildAnsweredBlocks({ answerLabel, promptBlocks: [], userId });
       }
       const { actions: _actions, ...withoutActions } = candidate;
       return buildAnsweredBlocks({
         answerLabel,
         promptBlocks: [withoutActions],
-        userId: card.userId,
+        userId,
       });
     });
     await channel.slack.request("chat.update", {

--- a/packages/eve/src/public/channels/slack/hitl.test.ts
+++ b/packages/eve/src/public/channels/slack/hitl.test.ts
@@ -54,6 +54,19 @@ describe("deriveHitlResponse", () => {
     expect(response).toEqual({ requestId: "call_xyz", optionId: "weekly" });
   });
 
+  it("preserves tool-approval metadata from a button action id", () => {
+    const response = deriveHitlResponse({
+      actionId: `${HITL_ACTION_PREFIX}tool-approval:approval_abc123:button:0`,
+      value: "approve",
+    });
+
+    expect(response).toEqual({
+      kind: "tool-approval",
+      optionId: "approve",
+      requestId: "approval_abc123",
+    });
+  });
+
   it("returns null when neither value nor selectedOptionValue is set", () => {
     expect(deriveHitlResponse({ actionId: `${HITL_ACTION_PREFIX}call_abc` })).toBeNull();
   });
@@ -159,8 +172,17 @@ describe("renderInputRequestBlocks", () => {
       body: { type: "mrkdwn", text: "*Approve tool call: mongodb-mutate*" },
     });
     expect(card.actions).toMatchObject([
-      { text: { text: "Cancel" }, value: "cancel" },
-      { style: "primary", text: { text: "Approve" }, value: "approve" },
+      {
+        action_id: `${HITL_ACTION_PREFIX}tool-approval:approval_1:button:0`,
+        text: { text: "Cancel" },
+        value: "cancel",
+      },
+      {
+        action_id: `${HITL_ACTION_PREFIX}tool-approval:approval_1:button:1`,
+        style: "primary",
+        text: { text: "Approve" },
+        value: "approve",
+      },
     ]);
 
     const details = blocks[1] as {

--- a/packages/eve/src/public/channels/slack/hitl.ts
+++ b/packages/eve/src/public/channels/slack/hitl.ts
@@ -60,7 +60,7 @@ export const HITL_FREEFORM_MODAL_ACTION_ID = "eve_freeform_text";
  * groups stay readable up to ~6 items).
  */
 const RADIO_SELECT_OPTION_LIMIT = 6;
-const BUTTON_ACTION_ID_RE = /^(?<requestId>.+):button:\d+$/u;
+const BUTTON_ACTION_ID_RE = /^(?:(?<kind>tool-approval):)?(?<requestId>.+):button:\d+$/u;
 const TOOL_INPUT_PREFIX = "*Tool input*\n```\n";
 const TOOL_INPUT_CODE_PREFIX = "```\n";
 const TOOL_INPUT_SUFFIX = "\n```";
@@ -90,6 +90,7 @@ interface SlackHitlAction {
 interface DerivedHitlResponse {
   readonly requestId: string;
   readonly optionId: string;
+  readonly kind?: "tool-approval";
 }
 
 /**
@@ -100,20 +101,36 @@ interface DerivedHitlResponse {
 export function deriveHitlResponse(action: SlackHitlAction): DerivedHitlResponse | null {
   if (!action.actionId.startsWith(HITL_ACTION_PREFIX)) return null;
 
-  const encodedRequestId = action.actionId.slice(HITL_ACTION_PREFIX.length);
+  const encodedRequest = action.actionId.slice(HITL_ACTION_PREFIX.length);
 
   if (action.selectedOptionValue !== undefined) {
-    return encodedRequestId
-      ? { optionId: action.selectedOptionValue, requestId: encodedRequestId }
-      : null;
+    const { kind, requestId } = splitEncodedRequest(encodedRequest);
+    if (!requestId) return null;
+    return kind === "tool-approval"
+      ? { kind, optionId: action.selectedOptionValue, requestId }
+      : { optionId: action.selectedOptionValue, requestId };
   }
 
   if (action.value !== undefined) {
-    const requestId = BUTTON_ACTION_ID_RE.exec(encodedRequestId)?.groups?.requestId;
-    return requestId ? { optionId: action.value, requestId } : null;
+    const match = BUTTON_ACTION_ID_RE.exec(encodedRequest);
+    const requestId = match?.groups?.requestId;
+    if (!requestId) return null;
+    return match.groups?.kind === "tool-approval"
+      ? { kind: "tool-approval", optionId: action.value, requestId }
+      : { optionId: action.value, requestId };
   }
 
   return null;
+}
+
+function splitEncodedRequest(value: string): {
+  readonly kind?: "tool-approval";
+  readonly requestId: string;
+} {
+  const prefix = "tool-approval:";
+  return value.startsWith(prefix)
+    ? { kind: "tool-approval", requestId: value.slice(prefix.length) }
+    : { requestId: value };
 }
 
 /**
@@ -149,7 +166,9 @@ export function renderInputRequestBlocks(request: InputRequest): unknown[] {
     type: "section",
   };
   const details = renderInputRequestDetailBlocks(request);
-  const actionId = `${HITL_ACTION_PREFIX}${request.requestId}`;
+  const actionId = `${HITL_ACTION_PREFIX}${
+    request.kind === "tool-approval" ? "tool-approval:" : ""
+  }${request.requestId}`;
 
   const options = request.options;
   const acceptsFreeform = request.allowFreeform === true || !options || options.length === 0;

--- a/packages/eve/src/public/channels/slack/input-response.ts
+++ b/packages/eve/src/public/channels/slack/input-response.ts
@@ -1,14 +1,30 @@
+import type { SessionAuthContext } from "#channel/types.js";
 import { createLogger } from "#internal/logging.js";
 import { buildSlackBinding } from "#public/channels/slack/api.js";
 import { buildSlackAuthContext } from "#public/channels/slack/auth.js";
+import { deriveHitlResponse } from "#public/channels/slack/hitl.js";
 import type {
   SlackChannelConfig,
   SlackInputResponseContext,
   SlackInputResponseResult,
   SlackInputResponseSubmission,
+  SlackChannelState,
 } from "#public/channels/slack/slackChannel.js";
 
 const log = createLogger("slack.interactions");
+
+export function approvalResponderStatePatch(
+  submission: Extract<SlackInputResponseSubmission, { type: "block_actions" }>,
+  auth: SessionAuthContext | null,
+): Partial<SlackChannelState> | undefined {
+  if (
+    auth?.principalId === undefined ||
+    !submission.actions.some((action) => deriveHitlResponse(action)?.kind === "tool-approval")
+  ) {
+    return undefined;
+  }
+  return { approvalResponderUsers: { [auth.principalId]: submission.user.id } };
+}
 
 export async function authorizeInputResponse(input: {
   readonly channelId: string;

--- a/packages/eve/src/public/channels/slack/interactions.ts
+++ b/packages/eve/src/public/channels/slack/interactions.ts
@@ -1,21 +1,7 @@
 /**
- * Slack `block_actions` + `view_submission` wire handling.
- *
- * The route handler reads the form-encoded body, hands it here, and we:
- *
- * 1. Decode `block_actions` payloads into a typed shape the channel can
- *    work with — actions, channel/thread metadata, the clicker, and the
- *    full original block list for answered-card updates.
- * 2. Open the freeform-answer modal inline when the click was a "Type
- *    your answer" button (Slack's `trigger_id` is only valid for ~3s,
- *    so this can't run under `waitUntil`).
- * 3. Authorize decoded fixed-choice and freeform submissions through
- *    `onInputResponse`, then resolve accepted answers against parked HITL
- *    requests.
- *
- * User-owned block actions flow through to the supplied `onInteraction`
- * callback. Always returns `Response("ok")` — followup work runs under
- * `waitUntil` so the webhook ACK is immediate.
+ * Slack `block_actions` + `view_submission` wire handling. It decodes and
+ * authorizes framework HITL responses, opens freeform modals inline before
+ * Slack's trigger expires, and forwards user-owned actions to `onInteraction`.
  */
 
 import {
@@ -47,7 +33,10 @@ import {
   SLACK_CARD_SUBTEXT_MAX_LENGTH,
   truncateCardSubtext,
 } from "#public/channels/slack/limits.js";
-import { authorizeInputResponse } from "#public/channels/slack/input-response.js";
+import {
+  approvalResponderStatePatch,
+  authorizeInputResponse,
+} from "#public/channels/slack/input-response.js";
 import type {
   SlackChannelConfig,
   SlackChannelState,
@@ -461,9 +450,18 @@ async function dispatchBlockInputResponses(input: {
   try {
     await input.ctx
       .from(slackContinuationToken(input.interaction.channelId, input.interaction.threadTs))
-      .respond(input.submission.inputResponses, { auth: result.auth });
+      .respond(input.submission.inputResponses, {
+        auth: result.auth,
+        state: approvalResponderStatePatch(input.submission, result.auth),
+      });
   } catch (error) {
     log.error("HITL interaction delivery failed", { error });
+    return;
+  }
+
+  if (
+    input.submission.actions.some((action) => deriveHitlResponse(action)?.kind === "tool-approval")
+  ) {
     return;
   }
 

--- a/packages/eve/src/public/channels/slack/session-operations.ts
+++ b/packages/eve/src/public/channels/slack/session-operations.ts
@@ -18,7 +18,7 @@ export type SlackSendOptions = Omit<ChannelSendOptions<SlackChannelState>, "auth
 };
 
 /** Options for an input response already bound to one Slack thread. */
-export type SlackRespondOptions = Omit<ChannelRespondOptions, "auth"> & {
+export type SlackRespondOptions = Omit<ChannelRespondOptions<SlackChannelState>, "auth"> & {
   readonly auth?: SessionAuthContext | null;
 };
 

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -23,7 +23,6 @@ import {
 } from "#public/channels/slack/hitl.js";
 import {
   SLACK_CARD_BODY_TEXT_MAX_LENGTH,
-  SLACK_CARD_SUBTEXT_MAX_LENGTH,
   SLACK_MAX_BLOCKS_PER_MESSAGE,
   SLACK_MESSAGE_TEXT_MAX_LENGTH,
   SLACK_SECTION_TEXT_MAX_LENGTH,
@@ -570,8 +569,8 @@ describe("slackChannel() default event handlers", () => {
     const actions = card?.actions ?? [];
     const actionIds = actions.map((element) => element.action_id);
     expect(actionIds).toEqual([
-      `${HITL_ACTION_PREFIX}approval_abc123:button:0`,
-      `${HITL_ACTION_PREFIX}approval_abc123:button:1`,
+      `${HITL_ACTION_PREFIX}tool-approval:approval_abc123:button:0`,
+      `${HITL_ACTION_PREFIX}tool-approval:approval_abc123:button:1`,
     ]);
     expect(new Set(actionIds).size).toBe(actionIds.length);
     expect(actions).toMatchObject([
@@ -2343,7 +2342,7 @@ describe("slackChannel() HITL interaction pipeline", () => {
       },
       actions: [
         {
-          action_id: `${HITL_ACTION_PREFIX}approval_abc123:button:0`,
+          action_id: `${HITL_ACTION_PREFIX}tool-approval:approval_abc123:button:0`,
           text: { type: "plain_text", text: "Approve" },
           value: "approve",
         },
@@ -2455,7 +2454,7 @@ describe("slackChannel() HITL interaction pipeline", () => {
         },
         actions: [
           {
-            action_id: `${HITL_ACTION_PREFIX}approval_abc123:button:0`,
+            action_id: `${HITL_ACTION_PREFIX}tool-approval:approval_abc123:button:0`,
             text: { type: "plain_text", text: "Approve" },
             value: "approve",
           },
@@ -2482,6 +2481,9 @@ describe("slackChannel() HITL interaction pipeline", () => {
         principalType: "user",
       },
       inputResponses: [{ optionId: "approve", requestId: "approval_abc123" }],
+      state: {
+        approvalResponderUsers: { "slack:T01:U_APPROVER": "U_APPROVER" },
+      },
     });
   });
 
@@ -2513,7 +2515,85 @@ describe("slackChannel() HITL interaction pipeline", () => {
 
     expect(onInputResponse).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenCalledTimes(1);
-    expect(send.mock.calls[0]?.[1]).toMatchObject({ auth: customAuth });
+    expect(send.mock.calls[0]?.[1]).toMatchObject({
+      auth: customAuth,
+      state: { approvalResponderUsers: { "employee:ada": "U_APPROVER" } },
+    });
+  });
+
+  it("persists the responder mapping for later approval candidate feedback", async () => {
+    fetchMock.mockImplementation(
+      () =>
+        new Response(JSON.stringify({ ok: true, ts: "1700000001.000001" }), {
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const channel = slackChannel({ credentials: { botToken: "xoxb-test" } });
+    const { send } = await firePost(channel, buildHitlButtonRequest());
+    const delivery = send.mock.calls[0]?.[1] as Extract<
+      ObservedChannelDelivery<SlackChannelState>,
+      { readonly inputResponses: readonly unknown[] }
+    >;
+    const adapter = withState(getAdapter(channel), THREAD_STATE);
+    const ctx = buildAdapterContext(adapter, stubAccessor());
+
+    await adapter.deliver!(
+      {
+        inputResponses: delivery.inputResponses,
+        state: delivery.state,
+      },
+      ctx,
+    );
+
+    expect(ctx.state.approvalResponderUsers).toEqual({ "slack:T01:U_APPROVER": "U_APPROVER" });
+
+    await callEvent(
+      adapter,
+      makeEvent("approval.candidate", {
+        candidateId: "candidate-1",
+        outcome: "pending",
+        requestId: "approval_abc123",
+        responderPrincipalId: "slack:T01:U_APPROVER",
+        sequence: 1,
+        stepIndex: 0,
+        turnId: "turn-1",
+      }),
+      ctx,
+    );
+    await callEvent(
+      adapter,
+      makeEvent("approval.candidate", {
+        candidateId: "candidate-1",
+        outcome: "rejected",
+        reason: "Test policy: all approval responses are rejected.",
+        requestId: "approval_abc123",
+        responderPrincipalId: "slack:T01:U_APPROVER",
+        sequence: 1,
+        stepIndex: 0,
+        turnId: "turn-1",
+      }),
+      ctx,
+    );
+
+    const ephemeralBodies = fetchMock.mock.calls
+      .filter(([url]) => String(url) === "https://slack.com/api/chat.postEphemeral")
+      .map(([, init]) => parseSlackRequestBody(init as RequestInit));
+    expect(ephemeralBodies).toEqual([
+      expect.objectContaining({
+        channel: "C01",
+        markdown_text: "Checking whether you can approve this action…",
+        user: "U_APPROVER",
+      }),
+      expect.objectContaining({
+        channel: "C01",
+        markdown_text: "Test policy: all approval responses are rejected.",
+        user: "U_APPROVER",
+      }),
+    ]);
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "https://slack.com/api/chat.update",
+      expect.anything(),
+    );
   });
 
   it("keeps HITL pending when the input-response hook rejects or throws", async () => {
@@ -2567,13 +2647,13 @@ describe("slackChannel() HITL interaction pipeline", () => {
     );
   });
 
-  it("updates one answered HITL card without removing sibling batched buttons", async () => {
+  it("waits for approval settlement before updating a tool-approval card", async () => {
     const channel = slackChannel({ credentials: { botToken: "xoxb-test" } });
 
-    const firstCancelActionId = `${HITL_ACTION_PREFIX}approval_451:button:0`;
-    const firstApproveActionId = `${HITL_ACTION_PREFIX}approval_451:button:1`;
-    const secondCancelActionId = `${HITL_ACTION_PREFIX}approval_508:button:0`;
-    const secondApproveActionId = `${HITL_ACTION_PREFIX}approval_508:button:1`;
+    const firstCancelActionId = `${HITL_ACTION_PREFIX}tool-approval:approval_451:button:0`;
+    const firstApproveActionId = `${HITL_ACTION_PREFIX}tool-approval:approval_451:button:1`;
+    const secondCancelActionId = `${HITL_ACTION_PREFIX}tool-approval:approval_508:button:0`;
+    const secondApproveActionId = `${HITL_ACTION_PREFIX}tool-approval:approval_508:button:1`;
 
     const { send } = await firePost(
       channel,
@@ -2671,43 +2751,10 @@ describe("slackChannel() HITL interaction pipeline", () => {
       inputResponses: [{ optionId: "approve", requestId: "approval_451" }],
     });
 
-    const updateCall = fetchMock.mock.calls.find(
-      ([url]) => String(url) === "https://slack.com/api/chat.update",
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "https://slack.com/api/chat.update",
+      expect.anything(),
     );
-    expect(updateCall).toBeDefined();
-    const body = parseSlackRequestBody(updateCall?.[1] as RequestInit) as {
-      blocks: Array<{
-        actions?: Array<{ action_id?: string }>;
-        elements?: Array<{ action_id?: string }>;
-        subtext?: { text?: string };
-        text?: { text?: string };
-      }>;
-      channel: string;
-      text: string;
-      ts: string;
-    };
-
-    expect(body).toMatchObject({
-      channel: "C01",
-      text: "Answered: Allow",
-      ts: "1700000000.000010",
-    });
-    expect(JSON.stringify(body.blocks)).toContain("Approve issue 451?");
-    expect(JSON.stringify(body.blocks)).toContain("Allow");
-    expect(JSON.stringify(body.blocks)).toContain("Tool input");
-    expect(JSON.stringify(body.blocks)).toContain("Approve issue 508?");
-    expect(body.blocks[0]?.subtext?.text).toBe(":white_check_mark: *Allow* by <@U_APPROVER>");
-    expect(body.blocks[0]?.subtext?.text?.length).toBeLessThanOrEqual(
-      SLACK_CARD_SUBTEXT_MAX_LENGTH,
-    );
-
-    const remainingActionIds = body.blocks.flatMap(
-      (block) =>
-        (block.actions ?? block.elements)
-          ?.map((element) => element.action_id)
-          .filter((actionId): actionId is string => typeof actionId === "string") ?? [],
-    );
-    expect(remainingActionIds).toEqual([secondCancelActionId, secondApproveActionId]);
   });
 
   it("covers the observed e0 batched escalation approval run", async () => {
@@ -2790,7 +2837,7 @@ describe("slackChannel() HITL interaction pipeline", () => {
       (action) => action.value === "cancel",
     );
     expect(firstCancelAction).toMatchObject({
-      action_id: `${HITL_ACTION_PREFIX}approval_451:button:0`,
+      action_id: `${HITL_ACTION_PREFIX}tool-approval:approval_451:button:0`,
       text: { text: "Cancel" },
       value: "cancel",
     });
@@ -2828,31 +2875,10 @@ describe("slackChannel() HITL interaction pipeline", () => {
       inputResponses: [{ optionId: "cancel", requestId: "approval_451" }],
     });
 
-    const updateCall = fetchMock.mock.calls.find(
-      ([url]) => String(url) === "https://slack.com/api/chat.update",
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "https://slack.com/api/chat.update",
+      expect.anything(),
     );
-    expect(updateCall).toBeDefined();
-    const body = parseSlackRequestBody(updateCall?.[1] as RequestInit) as {
-      blocks: Array<{
-        actions?: Array<{ action_id?: string }>;
-        child_blocks?: Array<{ text?: { text?: string } }>;
-        elements?: Array<{ action_id?: string }>;
-        subtext?: { text?: string };
-      }>;
-    };
-
-    expect(body.blocks[0]?.subtext?.text).toBe(":white_check_mark: *Cancel* by <@U0AT7H56S90>");
-    expect(JSON.stringify(body.blocks)).not.toContain("issueNumber");
-    const remainingActionIds = body.blocks.flatMap(
-      (block) =>
-        (block.actions ?? block.elements)
-          ?.map((element) => element.action_id)
-          .filter((actionId): actionId is string => typeof actionId === "string") ?? [],
-    );
-    expect(remainingActionIds).toEqual([
-      `${HITL_ACTION_PREFIX}approval_508:button:0`,
-      `${HITL_ACTION_PREFIX}approval_508:button:1`,
-    ]);
   });
 
   it("resumes freeform modal answers with the submitting Slack user auth", async () => {

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -180,7 +180,6 @@ type SlackSessionFailedHandler = (
 export interface SlackPendingApprovalCard {
   readonly messageBlocks: readonly unknown[];
   readonly messageTs: string;
-  readonly userId?: string;
 }
 
 export interface SlackChannelState {
@@ -773,7 +772,8 @@ export function slackChannel(config: SlackChannelConfig = {}): SlackChannel {
       if (typeof cards === "object" && cards !== null) {
         channel.state.pendingApprovalCards = { ...channel.state.pendingApprovalCards, ...cards };
       }
-      const responders = payload.approvalResponderUsers;
+      const responders = (payload.state as Partial<SlackChannelState> | undefined)
+        ?.approvalResponderUsers;
       if (typeof responders === "object" && responders !== null) {
         channel.state.approvalResponderUsers = {
           ...channel.state.approvalResponderUsers,

--- a/packages/eve/test/scenarios/mounted-extension-installed.scenario.test.ts
+++ b/packages/eve/test/scenarios/mounted-extension-installed.scenario.test.ts
@@ -249,7 +249,7 @@ describe("mounted extension installed under node_modules", () => {
     );
     expect(
       JSON.parse(extensionFiles[`node_modules/${PACKAGE_NAME}/dist/extension/_manifest.json`]!),
-    ).toMatchObject({ requires: { channel: 1, schedule: 1, subagent: 1 } });
+    ).toMatchObject({ requires: { channel: 2, schedule: 1, subagent: 1 } });
     const app = await scenarioApp({
       name: "mounted-extension-installed",
       installDependencies: true,


### PR DESCRIPTION
### Summary

Related to #1021. A late rework of #1371 restored Slack’s optimistic approval-card update and dropped the recorded approver identity. This restores the intended behavior: rejected responses leave the shared card open, the responder receives private progress or rejection feedback, and a settled approval or cancellation updates the card with the Slack user who acted.

### Validation

Manually verified the behavior on the deployed agent. Focused channel-operation and Slack coverage follows an approval response through durable delivery into later candidate and settlement events, including rejection feedback, preserved controls, cancellation, and approver attribution. The full unit suite and the scenario regression for the generated channel capability manifest passed locally.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

The changeset records the corrected Slack approval-card behavior for release notes.

**Implementation** — 10 files · `+95 / -38`

Carries Slack responder identity through durable delivery, restores settlement-only card updates and attribution, and includes the required compatible channel contract metadata.

**Tests** — 7 files · `+178 / -83`

Covers durable response state, candidate feedback, settlement behavior, compatibility, and the generated extension manifest without adding an external Slack fixture.
