### PR TITLE
Report existing project changes

### DIFF
--- a/.changeset/describe-existing-project-changes.md
+++ b/.changeset/describe-existing-project-changes.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Report agent files, dependencies, and configuration files changed when `eve init` adds an agent to an existing project, including when dependency installation later fails.

--- a/packages/eve/src/cli/commands/init.integration.test.ts
+++ b/packages/eve/src/cli/commands/init.integration.test.ts
@@ -855,8 +855,15 @@ describe("runInitCommand", () => {
       "eve",
       "dev",
     ]);
-    expect(output.messages.join("\n")).toContain("Added an eve agent to ");
-    expect(output.messages.join("\n")).not.toContain("Overrode package.json engines.node");
+    const printed = output.messages.join("\n");
+    expect(printed).toContain("Added an eve agent to ");
+    expect(printed).toContain("Updated existing project:");
+    expect(printed).toContain("Created agent/agent.ts");
+    expect(printed).toContain("Created agent/instructions.md");
+    expect(printed).toContain("Added dependencies: @vercel/connect, ai, eve");
+    expect(printed).toContain(`Updated ${join(projectRoot, "package.json")}`);
+    expect(printed).toContain(`Updated ${join(projectRoot, "pnpm-workspace.yaml")}`);
+    expect(printed).not.toContain("Overrode package.json engines.node");
   });
 
   it("adds an agent to an existing project with model settings selected by init options", async () => {
@@ -1249,6 +1256,11 @@ describe("runInitCommand", () => {
     expect(JSON.parse(await readFile(join(projectRoot, "package.json"), "utf8"))).toMatchObject({
       dependencies: { eve: "^0.6.0" },
     });
+    expect(output.messages.join("\n")).toContain("Updated existing project:");
+    expect(output.messages.join("\n")).toContain("Created agent/agent.ts");
+    expect(output.messages.join("\n")).toContain(
+      "Added dependencies: @vercel/connect, ai, eve, zod",
+    );
   });
 
   it("replays only the actionable npm error, dropping silly/verbose/http/timing noise", async () => {

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -1,5 +1,5 @@
 import { mkdtemp, readdir, rename, rm } from "node:fs/promises";
-import { basename, join, resolve } from "node:path";
+import { basename, join, relative, resolve } from "node:path";
 import { performance } from "node:perf_hooks";
 
 import pc from "picocolors";
@@ -150,7 +150,13 @@ async function addToExistingProject(
   options: InitCommandOptions,
   dependencies: InitCommandDependencies,
   evePackage: EvePackageContract | undefined,
-): Promise<{ packageManager: PackageManagerKind; nodeEngineOverride?: NodeEngineOverride }> {
+): Promise<{
+  configurationFilesChanged: string[];
+  dependenciesAdded: string[];
+  filesWritten: string[];
+  packageManager: PackageManagerKind;
+  nodeEngineOverride?: NodeEngineOverride;
+}> {
   if (options.channelWebNextjs === true) {
     throw new Error(
       "`--channel-web-nextjs` is not supported when adding an agent to an existing project. " +
@@ -172,6 +178,9 @@ async function addToExistingProject(
     evePackage,
   });
   return {
+    configurationFilesChanged: result.configurationFilesChanged,
+    dependenciesAdded: result.dependenciesAdded,
+    filesWritten: result.filesWritten,
     packageManager: manager.kind,
     nodeEngineOverride: result.nodeEngineOverride,
   };
@@ -273,7 +282,10 @@ async function scaffoldProject(
 
 type PreparedInitProject =
   | {
+      configurationFilesChanged: string[];
+      dependenciesAdded: string[];
       failurePolicy: "preserve";
+      filesWritten: string[];
       kind: "added";
       nodeEngineOverride?: NodeEngineOverride;
       packageManager: PackageManagerKind;
@@ -298,6 +310,9 @@ type InitResult = {
   projectPath: string;
 } & (
   | {
+      configurationFilesChanged: string[];
+      dependenciesAdded: string[];
+      filesWritten: string[];
       kind: "added";
       nodeEngineOverride?: NodeEngineOverride;
     }
@@ -330,6 +345,25 @@ function installProgressDetail(
 const NPM_NOISE_LINE = /^\s*npm (?:silly|verbose|http|timing)\b/u;
 const INSTALL_OUTPUT_FALLBACK_LINES = 20;
 
+function reportExistingProjectChanges(
+  logger: InitCliLogger,
+  project: Extract<PreparedInitProject, { kind: "added" }>,
+): void {
+  logger.log("Updated existing project:");
+  for (const path of project.filesWritten) {
+    logger.log(`  Created ${relative(project.projectPath, path)}`);
+  }
+  if (project.dependenciesAdded.length > 0) {
+    logger.log(`  Added dependencies: ${project.dependenciesAdded.join(", ")}`);
+  }
+  for (const path of project.configurationFilesChanged) {
+    logger.log(`  Updated ${path}`);
+  }
+  if (project.nodeEngineOverride !== undefined) {
+    logger.log(pc.yellow(`  ⚠ ${formatNodeEngineOverrideWarning(project.nodeEngineOverride)}`));
+  }
+}
+
 async function runInitSteps(input: {
   dependencies: InitCommandDependencies;
   logger: InitCliLogger;
@@ -343,7 +377,7 @@ async function runInitSteps(input: {
   const initTarget = await resolveInitTarget({ parentDirectory, target });
   const evePackage = resolveInitEvePackageOverride();
 
-  const progress = startCliLiveRow(logger);
+  let progress = startCliLiveRow(logger);
   progress.update("Preparing project");
   try {
     const scaffoldPhase = initTarget.kind === "fresh" ? "creating agent" : "adding agent";
@@ -411,13 +445,19 @@ async function runInitSteps(input: {
       project =
         addition.nodeEngineOverride === undefined
           ? {
+              configurationFilesChanged: addition.configurationFilesChanged,
+              dependenciesAdded: addition.dependenciesAdded,
               failurePolicy: "preserve",
+              filesWritten: addition.filesWritten,
               kind: "added",
               packageManager: addition.packageManager,
               projectPath: initTarget.projectPath,
             }
           : {
+              configurationFilesChanged: addition.configurationFilesChanged,
+              dependenciesAdded: addition.dependenciesAdded,
               failurePolicy: "preserve",
+              filesWritten: addition.filesWritten,
               kind: "added",
               nodeEngineOverride: addition.nodeEngineOverride,
               packageManager: addition.packageManager,
@@ -426,6 +466,11 @@ async function runInitSteps(input: {
     }
     const agentElapsedMs = dependencies.now() - agentStartedAt;
     initLog.debug(`${scaffoldPhase} done`, { ms: agentElapsedMs });
+    if (project.kind === "added") {
+      progress.stop();
+      reportExistingProjectChanges(logger, project);
+      progress = startCliLiveRow(logger);
+    }
 
     progress.update("Installing dependencies", `${project.packageManager} install`);
     initLog.debug(`installing dependencies with ${project.packageManager}`);
@@ -555,9 +600,6 @@ export async function runInitCommand(
     logger.log(
       `${pc.green("✓")} Added an ${EVE_WORDMARK} agent to ${pc.bold(result.projectPath)} ${pc.dim(`in ${formatElapsed(result.agentElapsedMs)}`)}`,
     );
-    if (result.nodeEngineOverride !== undefined) {
-      logger.log(pc.yellow(`⚠ ${formatNodeEngineOverrideWarning(result.nodeEngineOverride)}`));
-    }
   }
   logger.log(
     `${pc.green("✓")} Installed dependencies ${pc.dim(`in ${formatElapsed(result.installElapsedMs)}`)}`,

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -351,7 +351,7 @@ function reportExistingProjectChanges(
 ): void {
   logger.log("Updated existing project:");
   for (const path of project.filesWritten) {
-    logger.log(`  Created ${relative(project.projectPath, path)}`);
+    logger.log(`  Created ${relative(project.projectPath, path).replaceAll("\\", "/")}`);
   }
   if (project.dependenciesAdded.length > 0) {
     logger.log(`  Added dependencies: ${project.dependenciesAdded.join(", ")}`);

--- a/packages/eve/src/setup/scaffold/create/add-to-project.ts
+++ b/packages/eve/src/setup/scaffold/create/add-to-project.ts
@@ -39,6 +39,7 @@ export interface AddAgentToProjectOptions {
 
 export interface AddAgentToProjectResult {
   filesWritten: string[];
+  configurationFilesChanged: string[];
   /** Dependencies added to package.json; ones the project already declares anywhere are left untouched. */
   dependenciesAdded: string[];
   /** Present when an incompatible package.json engines.node value was replaced. */
@@ -171,7 +172,7 @@ export async function addAgentToProject(
   const nodeEngineOverride =
     workspacePatchResult.nodeEngineOverride ?? patchResult.nodeEngineOverride;
 
-  await applyPackageManagerWorkspaceConfiguration({
+  const workspaceConfiguration = await applyPackageManagerWorkspaceConfiguration({
     packageManager,
     projectRoot: options.projectRoot,
   });
@@ -180,5 +181,12 @@ export async function addAgentToProject(
     filesWritten,
     dependenciesAdded: Object.keys(additions).sort(),
     nodeEngineOverride,
+    configurationFilesChanged: [
+      ...(patchResult.changed ? [packageJsonPath] : []),
+      ...(workspacePatchResult.changed && workspacePatchResult.path !== undefined
+        ? [workspacePatchResult.path]
+        : []),
+      ...workspaceConfiguration.filesWritten,
+    ],
   };
 }


### PR DESCRIPTION
### Summary

When `eve init` adds an agent to an existing project, it now reports the agent files, dependencies, and configuration files it changed. The report appears before dependency installation, so it remains available if the installation fails and the existing project is intentionally preserved.

### Before / after

Before, a successful integration only reported that an agent was added:

```console
$ eve init .
✓ Added an eve agent to /path/to/app
✓ Installed dependencies
```

After, eve identifies the completed mutations before it starts installation:

```console
$ eve init .
Updated existing project:
  Created agent/agent.ts
  Created agent/instructions.md
  Added dependencies: @vercel/connect, ai, eve
  Updated /path/to/app/package.json
  Updated /path/to/app/pnpm-workspace.yaml

Installing dependencies...
```

When installation fails, the same report explains what remains in the existing project:

```console
$ eve init .
Updated existing project:
  Created agent/agent.ts
  Created agent/instructions.md
  Added dependencies: @vercel/connect, ai, eve, zod
  Updated /path/to/app/package.json

Installing dependencies...
ERR_PNPM_FETCH_404 Not Found
The eve agent was added, but dependency installation failed.

Do not rerun eve init; the agent is already configured.
```

### Validation

Focused `init` integration coverage verifies the completed-change report for a successful existing-project integration and when its dependency installation fails. TypeScript check also passed locally.

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

The changeset records the completed-change report and its failure-path visibility.

**Implementation** — 2 files · `+57 / -7`

Existing integration results retain the configuration paths they changed, and the CLI reports all completed mutations before installation begins.

**Tests** — 1 file · `+14 / -2`

Focused existing-project coverage verifies the report for successful and failed dependency installation paths.
