### PR TITLE
fix(eve): prevent duplicate pending approvals

### DIFF
--- a/.changeset/tidy-pending-approvals.md
+++ b/.changeset/tidy-pending-approvals.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Keep pending tool approvals visible across follow-up turns and prevent those turns from issuing duplicate tool calls.

--- a/docs/tools/human-in-the-loop.md
+++ b/docs/tools/human-in-the-loop.md
@@ -111,7 +111,7 @@ The run picks back up exactly where it parked. Because the pause is durable, not
 
 When a background subagent requests input, eve emits the same `input.requested` event on its parent session. Answering through that parent session routes the response directly to the blocked child without invoking the parent model.
 
-For approval requests, unrelated follow-up text does not deny the tool call. eve keeps the approval pending and holds that text until the approval is answered, then replays it as the next message in the session.
+For approval requests, unrelated follow-up text does not deny the tool call. eve keeps the approval pending and records that pending state in model-visible session history. Follow-up turns may answer with text, but cannot call tools until the approval is resolved. Once it is answered, normal tool use resumes and eve settles the original tool call exactly once.
 
 See [Sessions, runs & streaming](/docs/concepts/sessions-runs-and-streaming) for the full event and resume contract that this builds on.
 

--- a/e2e/fixtures/agent-tools-hitl/evals/hitl/pending-approval-followup-dedup.eval.ts
+++ b/e2e/fixtures/agent-tools-hitl/evals/hitl/pending-approval-followup-dedup.eval.ts
@@ -1,0 +1,58 @@
+import { defineEval } from "eve/evals";
+
+const MARKER = "followup-dedup-H4K8";
+const TOOL_NAME = "gate";
+const FOLLOW_UP_QUESTIONS = [
+  "What is the current status of my request?",
+  "Has the requested action executed yet?",
+  "What are you waiting for before continuing?",
+  "Can you summarize what remains blocked?",
+  "What will happen after I approve the request?",
+] as const;
+
+/** Regression coverage for https://github.com/vercel/eve/issues/2217. */
+export default defineEval({
+  tags: ["real-model"],
+  description: "One pending approval stays singular across many follow-up questions.",
+  async test(t) {
+    const parked = await t.send(`Call the ${TOOL_NAME} tool exactly once with marker "${MARKER}".`);
+    parked.calledTool(TOOL_NAME, { status: "pending", count: 1 });
+    const approval = t.requireInputRequest({
+      display: "confirmation",
+      toolName: TOOL_NAME,
+    });
+
+    for (const question of FOLLOW_UP_QUESTIONS) {
+      const followup = await t.send(question);
+
+      followup.expectOk();
+      followup.usedNoTools();
+      followup.notEvent("input.requested");
+      followup.event("session.waiting", { count: 1 });
+    }
+
+    const approved = await t.respond([
+      {
+        optionId: "approve",
+        requestId: approval.requestId,
+      },
+    ]);
+
+    approved.expectOk();
+    approved.event("action.result", {
+      data: {
+        result: {
+          kind: "tool-result",
+          output: new RegExp(MARKER),
+          toolName: TOOL_NAME,
+        },
+        status: "completed",
+      },
+      count: 1,
+    });
+    t.succeeded();
+    // The original request completes once; each scoped follow-up above proves
+    // that no intervening turn created another tool call or approval.
+    t.calledTool(TOOL_NAME, { count: 1 });
+  },
+});

--- a/packages/eve/src/evals/mock-model.test.ts
+++ b/packages/eve/src/evals/mock-model.test.ts
@@ -66,6 +66,39 @@ describe("mockModel", () => {
     ]);
   });
 
+  it("keeps framework scaffolding out of authored user messages", async () => {
+    const requests: MockModelRequest[] = [];
+    const agents = "[Agents]\n<agents>\n</agents>";
+    const notice = [
+      "[Pending approvals]",
+      "The following tool calls are awaiting approval and have not executed:",
+      '{"requestId":"approval-1","toolName":"gate"}',
+    ].join("\n");
+    const result = await generateText({
+      messages: [
+        { content: "Run the mixed approval flow.", role: "user" },
+        { content: agents, role: "user" },
+        { content: notice, role: "user" },
+      ],
+      model: mockModel((request) => {
+        requests.push(request);
+        return request.lastUserMessage ?? "missing";
+      }),
+    });
+
+    expect(result.text).toBe("Run the mixed approval flow.");
+    expect(requests[0]).toMatchObject({
+      lastUserMessage: "Run the mixed approval flow.",
+      messages: [
+        { role: "user", text: "Run the mixed approval flow." },
+        { role: "user", text: agents },
+        { role: "user", text: notice },
+      ],
+      userMessageCount: 1,
+      userMessages: ["Run the mixed approval flow."],
+    });
+  });
+
   it("supports deterministic tool-call loops", async () => {
     const execute = vi.fn(async ({ city }: { city: string }) => ({ city, condition: "sunny" }));
     const requests: MockModelRequest[] = [];

--- a/packages/eve/src/evals/mock-model.ts
+++ b/packages/eve/src/evals/mock-model.ts
@@ -1,6 +1,9 @@
 import type { LanguageModel } from "ai";
 import { MockLanguageModelV3 } from "ai/test";
 
+import { AGENTS_SNIPPET_LABEL } from "#harness/handles/prompt.js";
+import { isPendingApprovalsSnippet } from "#harness/hitl/approval-prompt.js";
+
 type GenerateOptions = Parameters<MockLanguageModelV3["doGenerate"]>[0];
 type GenerateResult = Awaited<ReturnType<MockLanguageModelV3["doGenerate"]>>;
 type StreamResult = Awaited<ReturnType<MockLanguageModelV3["doStream"]>>;
@@ -47,11 +50,11 @@ export interface MockModelToolResult {
 export interface MockModelRequest {
   /** Every prompt message in order, with text content extracted. */
   readonly messages: readonly MockModelMessage[];
-  /** All user-message text in order. */
+  /** Authored user-message text in order, excluding framework scaffolding. */
   readonly userMessages: readonly string[];
-  /** The latest user-message text, or `null` before the first user message. */
+  /** The latest authored user-message text, or `null` before the first user message. */
   readonly lastUserMessage: string | null;
-  /** Number of user messages in the prompt. */
+  /** Number of authored user messages in the prompt. */
   readonly userMessageCount: number;
   /** Tools available for this model call. */
   readonly tools: readonly MockModelTool[];
@@ -158,7 +161,8 @@ function createRequest(options: GenerateOptions): MockModelRequest {
   }));
   const userMessages = messages
     .filter((message) => message.role === "user")
-    .map((message) => message.text);
+    .map((message) => message.text)
+    .filter((message) => !isFrameworkScaffolding(message));
 
   return {
     lastUserMessage: userMessages.at(-1) ?? null,
@@ -168,6 +172,11 @@ function createRequest(options: GenerateOptions): MockModelRequest {
     userMessageCount: userMessages.length,
     userMessages,
   };
+}
+
+function isFrameworkScaffolding(message: string): boolean {
+  const text = message.trim();
+  return text.startsWith(AGENTS_SNIPPET_LABEL) || isPendingApprovalsSnippet(text);
 }
 
 function extractMessageText(message: GenerateOptions["prompt"][number]): string {

--- a/packages/eve/src/harness/hitl/approval-prompt.test.ts
+++ b/packages/eve/src/harness/hitl/approval-prompt.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PENDING_APPROVALS_LABEL,
+  renderPendingApprovalsSnippet,
+} from "#harness/hitl/approval-prompt.js";
+import type { InputRequest } from "#runtime/input/types.js";
+
+describe("renderPendingApprovalsSnippet", () => {
+  it("projects approval identity without exposing tool input", () => {
+    const content = renderPendingApprovalsSnippet([
+      request("tool-approval", "approval-1", "bash", { secret: "do-not-project" }),
+      request("question", "question-1", "ask_question", { prompt: "Continue?" }),
+    ]);
+
+    expect(content).toBe(
+      [
+        PENDING_APPROVALS_LABEL,
+        "The following tool calls are awaiting approval and have not executed:",
+        '{"requestId":"approval-1","toolName":"bash"}',
+      ].join("\n"),
+    );
+    expect(content).not.toContain("do-not-project");
+    expect(content).not.toContain("question-1");
+  });
+
+  it("omits the notice when no approval is pending", () => {
+    expect(
+      renderPendingApprovalsSnippet([
+        request("question", "question-1", "ask_question", { prompt: "Continue?" }),
+      ]),
+    ).toBeUndefined();
+  });
+});
+
+function request(
+  kind: InputRequest["kind"],
+  requestId: string,
+  toolName: string,
+  input: InputRequest["action"]["input"],
+): InputRequest {
+  return {
+    action: { callId: `${requestId}-call`, input, kind: "tool-call", toolName },
+    kind,
+    prompt: requestId,
+    requestId,
+  };
+}

--- a/packages/eve/src/harness/hitl/approval-prompt.ts
+++ b/packages/eve/src/harness/hitl/approval-prompt.ts
@@ -1,0 +1,30 @@
+import type { InputRequest } from "#runtime/input/types.js";
+import { isApprovalRequest } from "#harness/input-request-class.js";
+
+/** Label prefixing the framework-injected pending-approval notice. */
+export const PENDING_APPROVALS_LABEL = "[Pending approvals]";
+
+/** True when text is the framework-injected pending-approval notice. */
+export function isPendingApprovalsSnippet(text: string): boolean {
+  return text.startsWith(PENDING_APPROVALS_LABEL);
+}
+
+/**
+ * Renders the durable, model-visible projection of unresolved tool approvals.
+ * The harness appends it when the batch is created, so later wakeups reuse the
+ * same history prefix instead of regenerating the notice.
+ */
+export function renderPendingApprovalsSnippet(
+  requests: readonly InputRequest[],
+): string | undefined {
+  const approvals = requests.filter((request) => isApprovalRequest(request));
+  if (approvals.length === 0) return undefined;
+
+  return [
+    PENDING_APPROVALS_LABEL,
+    "The following tool calls are awaiting approval and have not executed:",
+    ...approvals.map((request) =>
+      JSON.stringify({ requestId: request.requestId, toolName: request.action.toolName }),
+    ),
+  ].join("\n");
+}

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -498,6 +498,36 @@ function finalOutputResult(text: string, structured: unknown): Record<string, un
   };
 }
 
+function pendingBashApprovalResult(): Record<string, unknown> {
+  const toolCall = {
+    input: { command: "rm -rf /tmp/demo" },
+    toolCallId: "call-1",
+    toolName: "bash",
+    type: "tool-call" as const,
+  };
+  const approvalRequest = {
+    approvalId: "approval-1",
+    toolCallId: toolCall.toolCallId,
+    type: "tool-approval-request" as const,
+  };
+
+  return {
+    content: [{ ...approvalRequest, toolCall }],
+    finishReason: "tool-calls",
+    response: {
+      messages: [
+        {
+          content: [{ text: "Need approval first.", type: "text" }, toolCall, approvalRequest],
+          role: "assistant",
+        },
+      ],
+    },
+    text: "",
+    toolCalls: [toolCall],
+    toolResults: [],
+  };
+}
+
 function createPendingBashApprovalSession(): HarnessSession {
   return appendPendingInputBatch({
     requests: [
@@ -7089,52 +7119,8 @@ describe("createToolLoopHarness", () => {
     ).toEqual([["call-1"], ["call-2"]]);
   });
 
-  it("emits input.requested for tool approval requests and parks without persisting unresolved messages", async () => {
-    setupMockAgent({
-      content: [
-        {
-          approvalId: "approval-1",
-          toolCall: {
-            input: { command: "rm -rf /tmp/demo" },
-            toolCallId: "call-1",
-            toolName: "bash",
-          },
-          type: "tool-approval-request",
-        },
-      ],
-      finishReason: "tool-calls",
-      response: {
-        messages: [
-          {
-            content: [
-              { text: "Need approval first.", type: "text" },
-              {
-                input: { command: "rm -rf /tmp/demo" },
-                toolCallId: "call-1",
-                toolName: "bash",
-                type: "tool-call",
-              },
-              {
-                approvalId: "approval-1",
-                toolCallId: "call-1",
-                type: "tool-approval-request",
-              },
-            ],
-            role: "assistant",
-          },
-        ],
-      },
-      text: "",
-      toolCalls: [
-        {
-          input: { command: "rm -rf /tmp/demo" },
-          toolCallId: "call-1",
-          toolName: "bash",
-          type: "tool-call",
-        },
-      ],
-      toolResults: [],
-    });
+  it("parks tool approval with one durable model-visible projection", async () => {
+    setupMockAgent(pendingBashApprovalResult());
 
     const { emit, events } = createEventCollector();
     const runStep = createToolLoopHarness(
@@ -7165,9 +7151,17 @@ describe("createToolLoopHarness", () => {
     const result = await runStep(session, { message: "Delete the temp directory." });
 
     expect(result.next).toBeNull();
-    expect(result.session.history).toEqual([
-      { content: "Delete the temp directory.", role: "user" },
-    ]);
+    expect(result.session.history).toHaveLength(2);
+    expect(result.session.history[0]).toEqual({
+      content: "Delete the temp directory.",
+      role: "user",
+    });
+    const projection = result.session.history[1];
+    expect(projection?.role).toBe("user");
+    const serializedProjection = JSON.stringify(projection?.content);
+    expect(serializedProjection).toMatch(/pending/iu);
+    expect(serializedProjection).toContain("approval-1");
+    expect(serializedProjection).toContain("bash");
     expect(getCompatibilityEventTypes(events)).toEqual([
       "session.started",
       "turn.started",
@@ -7336,16 +7330,34 @@ describe("createToolLoopHarness", () => {
     expect(events.filter((event) => event.type === "action.result")).toHaveLength(1);
   });
 
-  it("runs a follow-up user message while the pending tool approval stays open", async () => {
-    const generateCalls: unknown[] = [];
+  it("keeps one pending approval across many follow-up questions", async () => {
+    const isPendingApprovalProjection = (message: ModelMessage) => {
+      const content = JSON.stringify(message.content);
+      return (
+        message.role === "user" &&
+        /pending/iu.test(content) &&
+        content.includes("approval-1") &&
+        content.includes("bash")
+      );
+    };
+    const followupQuestions = [
+      "What is the current status of my request?",
+      "Has the requested action executed yet?",
+      "What are you waiting for before continuing?",
+      "Can you summarize what remains blocked?",
+      "What will happen after I approve the request?",
+    ];
     const agentResults = [
-      {
+      pendingBashApprovalResult(),
+      ...followupQuestions.map((_, index) => ({
         finishReason: "stop",
-        response: { messages: [{ content: "Hello!", role: "assistant" }] },
-        text: "Hello!",
+        response: {
+          messages: [{ content: `Follow-up ${String(index + 1)} answered.`, role: "assistant" }],
+        },
+        text: `Follow-up ${String(index + 1)} answered.`,
         toolCalls: [],
         toolResults: [],
-      },
+      })),
       {
         finishReason: "stop",
         response: {
@@ -7356,125 +7368,89 @@ describe("createToolLoopHarness", () => {
         toolResults: [],
       },
     ] satisfies Record<string, unknown>[];
-    let instanceIndex = 0;
+    setupMockAgentSequence(agentResults);
 
-    vi.mocked(ToolLoopAgent).mockImplementation(function (
-      this: MockAgentInstance,
-      settings: MockAgentSettings,
-    ) {
-      const result = agentResults[instanceIndex];
-      instanceIndex += 1;
-      if (result === undefined) {
-        throw new Error("ToolLoopAgent mock exhausted its scripted results.");
+    const readGenerateMessages = (index: number): ModelMessage[] => {
+      const agent = vi.mocked(ToolLoopAgent).mock.results[index]?.value;
+      const call = agent === undefined ? undefined : vi.mocked(agent.generate).mock.calls[0]?.[0];
+      if (call === undefined) {
+        throw new Error(`ToolLoopAgent instance ${String(index)} did not generate.`);
       }
-      const { onStepFinish, prepareStep } = settings;
-      this.generate = vi.fn().mockImplementation(async (input: { messages: unknown[] }) => {
-        if (prepareStep) {
-          await prepareStep({
-            messages: input.messages,
-            steps: [],
-            stepNumber: 0,
-            model: {},
-            context: undefined,
-          });
-        }
-        generateCalls.push(input.messages);
-        if (onStepFinish) await onStepFinish(result);
-        return createMockGenerateResult(result);
-      });
-      return this;
-    } as MockAgentConstructor);
+      return call.messages;
+    };
 
-    const session = appendPendingInputBatch({
-      requests: [
-        {
-          action: {
-            callId: "call-1",
-            input: { command: "rm -rf /tmp/demo" },
-            kind: "tool-call",
-            toolName: "bash",
-          },
-          allowFreeform: false,
-          display: "confirmation",
-          kind: "tool-approval",
-          options: [
-            { id: "approve", label: "Approve" },
-            { id: "cancel", label: "Cancel" },
-          ],
-          prompt: "Approve tool call: bash",
-          requestId: "approval-1",
-        },
-      ],
-      responseMessages: [
-        {
-          content: [
+    const runStep = createToolLoopHarness(
+      createTestConfig("conversation", undefined, {
+        tools: new Map([
+          [
+            "bash",
             {
-              input: { command: "rm -rf /tmp/demo" },
-              toolCallId: "call-1",
-              toolName: "bash",
-              type: "tool-call",
-            },
-            {
-              approvalId: "approval-1",
-              toolCallId: "call-1",
-              type: "tool-approval-request",
+              description: "Run shell commands",
+              execute: vi.fn().mockResolvedValue("ok"),
+              inputSchema: jsonSchema({ type: "object" }),
+              name: "bash",
             },
           ],
-          role: "assistant",
-        },
-      ],
-      session: createTestSession({
-        agent: {
-          modelReference: { id: "test-model" },
-          system: "You are a test assistant.",
-          tools: [
-            { description: "Run shell commands", name: "bash", inputSchema: { type: "object" } },
-          ],
-        },
+        ]),
       }),
-    });
-    const config = createTestConfig("conversation", undefined, {
-      tools: new Map([
-        [
-          "bash",
-          {
-            description: "Run shell commands",
-            execute: vi.fn().mockResolvedValue("ok"),
-            inputSchema: jsonSchema({ type: "object" }),
-            name: "bash",
-          },
+    );
+    const initialSession = createTestSession({
+      agent: {
+        modelReference: { id: "test-model" },
+        system: "You are a test assistant.",
+        tools: [
+          { description: "Run shell commands", name: "bash", inputSchema: { type: "object" } },
         ],
-      ]),
+      },
+    });
+    const parked = await runStep(initialSession, {
+      message: "Delete the temp directory.",
     });
 
-    // The follow-up message runs as an ordinary turn: the model is called
-    // without the withheld approval batch, and the approval stays open.
-    const firstResult = await createToolLoopHarness(config)(session, {
-      message: "Hi instead.",
-    });
+    expect(parked.next).toBeNull();
+    expect(vi.mocked(ToolLoopAgent).mock.calls[0]?.[0].toolChoice).not.toBe("none");
+    expect(parked.session.history.filter(isPendingApprovalProjection)).toHaveLength(1);
+    expect(hasPendingInputBatch(parked.session.state)).toBe(true);
 
-    expect(firstResult.next).toBeNull();
-    expect(generateCalls).toHaveLength(1);
-    expect((generateCalls[0] as { role: string; content: unknown }[]).at(-1)).toEqual({
-      content: "Hi instead.",
-      role: "user",
-    });
-    expect(
-      (generateCalls[0] as { role: string }[]).every((message) => message.role !== "tool"),
-    ).toBe(true);
-    expect(hasDeferredStepInput(firstResult.session)).toBe(false);
-    expect(hasPendingInputBatch(firstResult.session.state)).toBe(true);
+    // Every follow-up runs as an ordinary turn, but none may open another
+    // tool call while the original approval remains unresolved.
+    let pendingSession = parked.session;
+    for (const [index, question] of followupQuestions.entries()) {
+      const followup = await runStep(pendingSession, {
+        message: question,
+      });
+      const callIndex = index + 1;
+      const messages = readGenerateMessages(callIndex);
+
+      expect(followup.next).toBeNull();
+      expect(vi.mocked(ToolLoopAgent)).toHaveBeenCalledTimes(callIndex + 1);
+      expect(vi.mocked(ToolLoopAgent).mock.calls[callIndex]?.[0]).toMatchObject({
+        toolChoice: "none",
+      });
+      expect(messages.at(-1)).toEqual({ content: question, role: "user" });
+      expect(messages.every((message) => message.role !== "tool")).toBe(true);
+      expect(messages.filter(isPendingApprovalProjection)).toHaveLength(1);
+      expect(messages.findIndex(isPendingApprovalProjection)).toBe(1);
+      expect(followup.session.history.filter(isPendingApprovalProjection)).toHaveLength(1);
+      expect(hasDeferredStepInput(followup.session)).toBe(false);
+      expect(hasPendingInputBatch(followup.session.state)).toBe(true);
+      pendingSession = followup.session;
+    }
 
     // The late denial still restores the withheld batch behind the
     // intervening exchange and resolves it.
-    const deniedResult = await createToolLoopHarness(config)(firstResult.session, {
+    const deniedResult = await runStep(pendingSession, {
       inputResponses: [{ requestId: "approval-1", optionId: "cancel" }],
     });
 
-    expect(generateCalls).toHaveLength(2);
-    expect((generateCalls[1] as { role: string; content: unknown }[]).slice(-2)).toEqual([
+    const denialIndex = followupQuestions.length + 1;
+    const denialMessages = readGenerateMessages(denialIndex);
+    expect(vi.mocked(ToolLoopAgent)).toHaveBeenCalledTimes(denialIndex + 1);
+    expect(vi.mocked(ToolLoopAgent).mock.calls[denialIndex]?.[0].toolChoice).not.toBe("none");
+    expect(denialMessages.slice(-2)).toEqual([
       {
         content: [
+          { text: "Need approval first.", type: "text" },
           {
             input: { command: "rm -rf /tmp/demo" },
             toolCallId: "call-1",
@@ -7510,8 +7486,8 @@ describe("createToolLoopHarness", () => {
         role: "tool",
       },
     ]);
-    expect((generateCalls[1] as { role: string; content: unknown }[])[0]).toEqual({
-      content: "Hi instead.",
+    expect(denialMessages[0]).toEqual({
+      content: "Delete the temp directory.",
       role: "user",
     });
     expect(hasPendingInputBatch(deniedResult.session.state)).toBe(false);

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -124,6 +124,7 @@ import {
   extractQuestionInputRequests,
   extractToolApprovalInputRequests,
 } from "#harness/input-extraction.js";
+import { renderPendingApprovalsSnippet } from "#harness/hitl/approval-prompt.js";
 import { createToolResultMessagePartFromToolError } from "#harness/action-result-helpers.js";
 import { activeTurnId } from "#harness/active-turn-id.js";
 import {
@@ -1472,6 +1473,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
           bridgeIntegration,
         ),
         toolApproval: buildToolApproval(modelTools),
+        toolChoice: hasPendingApprovalBatch(session) ? ("none" as const) : undefined,
         tools: effectiveTools,
       };
       const agent = new ToolLoopAgent(agentSettings);
@@ -2486,6 +2488,13 @@ async function handleStepResult(input: {
     excludedCallIds: new Set([...invalidInputToolCallIds, ...approvalRequestCallIds]),
   });
   const inputRequests: InputRequest[] = [...approvalRequests, ...questionRequests];
+  const pendingApprovals = renderPendingApprovalsSnippet(approvalRequests);
+  const parkedInputHistory: ModelMessage[] = [
+    ...promptMessages,
+    ...(pendingApprovals === undefined
+      ? []
+      : [{ content: pendingApprovals, role: "user" as const }]),
+  ];
   const advertisedRuntimeActionTools = getAdvertisedTools({
     delegatedCaller: input.delegatedCaller,
     session: baseSession,
@@ -2548,7 +2557,7 @@ async function handleStepResult(input: {
         turnId: emissionState.turnId,
       },
       responseMessages,
-      session: { ...baseSession, history: [...promptMessages] },
+      session: { ...baseSession, history: parkedInputHistory },
     });
 
     // The runtime-action batch already owns the shared assistant response.
@@ -2605,7 +2614,7 @@ async function handleStepResult(input: {
         })
         .map((request) => request.requestId),
       responseMessages,
-      session: { ...baseSession, history: [...promptMessages] },
+      session: { ...baseSession, history: parkedInputHistory },
     });
 
     if (emit) {


### PR DESCRIPTION
### Summary

Closes #2217. A single unresolved `create_loop` call appeared in Agent Runs as `approval-1`, `approval-2`, and `approval-3` after follow-up messages woke the session. Before, the harness parked the provider transcript only in pending input state, so the model could not see the unresolved approval and remained allowed to call tools; now it appends one cache-stable `[Pending approvals]` notice to history and makes follow-up turns text-only until the batch resolves. Approval or denial still restores the original transcript exactly once and then re-enables tools; sessions without a pending approval are unchanged. Deterministic mock responders retain the notice in raw prompt messages but exclude framework scaffolding from authored `userMessages`.

### Validation

Focused regression coverage creates one approval, sends five follow-up questions, verifies one stable projection and no further tool calls, then settles the original request once. Final-SHA CI passes the issue-specific real-model eval, both mixed-batch world fixtures, and the remote-child task fixture that caught the mock-boundary edge case; the 6,817-test local unit suite and focused approval integration also passed.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+6 / -1`

Documents the follow-up behavior and adds its release note.

**Implementation** — 3 files · `+54 / -6`

Keeps the runtime fix to one pending-approval renderer and the two harness hook points that persist and enforce it. The shared deterministic mock boundary recognizes the new framework notice without fixture-specific agent changes.

**Tests** — 4 files · `+272 / -157`

Replaces the old single-follow-up test with a five-turn lifecycle test, then adds focused renderer and mock-boundary coverage plus the issue-backed real-model eval.
