### PR TITLE
fix(eve): make task wake delivery conditional

### DIFF
--- a/.changeset/quiet-task-wakes.md
+++ b/.changeset/quiet-task-wakes.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Let parent agents process background-task notifications without requiring a user-visible channel message. Human messages and input responses remain required delivery.

--- a/e2e/fixtures/fixture-tasks/agent/agent.ts
+++ b/e2e/fixtures/fixture-tasks/agent/agent.ts
@@ -8,6 +8,8 @@ import {
 } from "eve/evals";
 
 const TASK_ID_PATTERN = /task_[a-z0-9]+/iu;
+const EMPTY_DELIVERY_SENTINEL = "<eve-empty-delivery/>";
+const CONDITIONAL_DELIVERY_MARKER = "Conditional delivery";
 
 function respond(request: MockModelRequest): MockModelResponse | string {
   // Framework agent-list notes are model context, not scenario turns.
@@ -42,6 +44,13 @@ function respond(request: MockModelRequest): MockModelResponse | string {
   }
   if (message.includes("TASK-C8-REMOTE-CHILD")) return runRemoteGate(request);
   if (message.startsWith("Background task ")) {
+    if (request.userMessages.includes("TASK-WAKE-CONDITIONAL-DELIVERY")) {
+      return request.messages.some(
+        (entry) => entry.role === "system" && entry.text.includes(CONDITIONAL_DELIVERY_MARKER),
+      )
+        ? EMPTY_DELIVERY_SENTINEL
+        : "TASK-WAKE-WAS-NOT-CONDITIONAL";
+    }
     // Scenarios that act on wake notifications route to their script;
     // every other scenario acknowledges them without running tools.
     // The exclusivity race delegates so a completion notification that
@@ -55,6 +64,7 @@ function respond(request: MockModelRequest): MockModelResponse | string {
 
   if (message === "TASK-FANOUT-PARENT-UPDATES") return fanoutTasks(request, 10);
   if (message === "TASK-PARENT-WAKE-UPDATES") return fanoutTasks(request, 3);
+  if (message === "TASK-WAKE-CONDITIONAL-DELIVERY") return startConditionalWakeWorker(request);
   if (message === "TASK-FAN-IN") return fanInTasks(request);
   if (message === "TASK-UPDATE-SETUP") return startTaskUpdateChild(request);
   if (message === "TASK-CANCEL-SETUP") return setupCancelWorker(request);
@@ -117,6 +127,21 @@ function startTaskUpdateChild(request: MockModelRequest): MockModelResponse | st
     };
   }
   return "TASK-UPDATE-STARTED";
+}
+
+function startConditionalWakeWorker(request: MockModelRequest): MockModelResponse | string {
+  if (resultById(request, "task-conditional-wake-worker") === undefined) {
+    return {
+      toolCalls: [
+        {
+          id: "task-conditional-wake-worker",
+          input: { message: "TASK-WAKE-CONDITIONAL-CHILD" },
+          name: "busy-worker",
+        },
+      ],
+    };
+  }
+  return "TASK-WAKE-CONDITIONAL-STARTED";
 }
 
 function sendTaskUpdate(request: MockModelRequest): MockModelResponse | string {

--- a/e2e/fixtures/fixture-tasks/evals/task.parent.wake.emitted-ready.conditional-delivery.eval.ts
+++ b/e2e/fixtures/fixture-tasks/evals/task.parent.wake.emitted-ready.conditional-delivery.eval.ts
@@ -1,0 +1,51 @@
+import { satisfies } from "eve/evals/expect";
+
+import { defineTaskEval } from "./task-transition.js";
+import { requireBackgroundTaskId, requireSessionStreamIndex } from "./shared.js";
+
+/** A ready-task wake runs the parent model but does not require a channel message. */
+export default defineTaskEval({
+  description:
+    "A completed background task wakes the parent with conditional delivery and can remain silent.",
+  transition: {
+    primary: "task.parent.wake.emitted-ready",
+    setup: [
+      "task.dispatch.start.accepted-acknowledged",
+      "task.lifecycle.complete.accepted-nonterminal",
+    ],
+    dimensions: { transport: "local", parentPhase: "parked" },
+  },
+  async test(t) {
+    const started = await t.send("TASK-WAKE-CONDITIONAL-DELIVERY");
+    started.expectOk();
+    started.messageIncludes("TASK-WAKE-CONDITIONAL-STARTED");
+    const taskId = requireBackgroundTaskId(started);
+
+    const sessionId = started.sessionId;
+    const live = t.target.watchTurn(sessionId, {
+      startIndex: requireSessionStreamIndex(t, "Conditional task wake"),
+    });
+    const wake = await live.result();
+
+    wake.expectOk();
+    wake.eventsSatisfy("the completed task notification started the wake turn", (events) =>
+      events.some(
+        (event) =>
+          event.type === "message.received" &&
+          event.data.message.includes(`Background task ${taskId}`),
+      ),
+    );
+    wake.event("message.completed", {
+      count: 1,
+      data: (data) => data.finishReason !== "tool-calls" && data.message === null,
+    });
+    wake.notEvent("message.completed", {
+      data: (data) => data.finishReason !== "tool-calls" && data.message !== null,
+    });
+    await t.require(
+      wake.message,
+      satisfies((message) => message === undefined, "the task wake delivers no channel message"),
+    );
+    t.noFailedActions();
+  },
+});

--- a/packages/eve/src/context/keys.ts
+++ b/packages/eve/src/context/keys.ts
@@ -70,6 +70,8 @@ export const SessionIdKey = new ContextKey<string>("eve.sessionId");
 export const ContinuationTokenKey = new ContextKey<string>("eve.continuationToken");
 export const ChannelRequestIdKey = new ContextKey<string>("eve.channelRequestId");
 export const ChannelDeliveryKey = new ContextKey<ChannelDeliveryMetadata>("eve.channelDelivery");
+/** Whether the active turn began from a task-addressed durable delivery. */
+export const TurnTaskDeliveryKey = new ContextKey<boolean>("eve.turnTaskDelivery");
 export interface ActiveChannelDelivery {
   readonly agentName?: string;
   readonly delivery: InstrumentationChannelDeliveryRef;

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { ChannelAdapter, ChannelAdapterContext } from "#channel/adapter.js";
 import type { DeliverPayload, SubagentInputRequestHookPayload } from "#channel/types.js";
-import { ContextContainer, loadContext } from "#context/container.js";
+import { ContextContainer, contextStorage, loadContext } from "#context/container.js";
 import { ContextKey } from "#context/key.js";
 import {
   AuthKey,
@@ -15,6 +15,7 @@ import {
   SessionDynamicToolMetadataKey,
   SessionDynamicToolRuntimeRevisionKey,
   SessionIdKey,
+  TurnTaskDeliveryKey,
 } from "#context/keys.js";
 import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
 import { serializeContext } from "#context/serialize.js";
@@ -2011,6 +2012,37 @@ describe("turnStep", () => {
     expect(createDurableSessionState).toHaveBeenLastCalledWith({
       session: expect.objectContaining({ sessionId: "turn-step-session" }),
     });
+  });
+
+  it("sets and resets task-delivery provenance from durable deliveries", async () => {
+    const observedTaskDeliveries: unknown[] = [];
+    const session = createStubSession();
+    installSessionStoreMocks([session, session]);
+    vi.mocked(createExecutionNodeStep).mockImplementation(() => {
+      return async (stepSession): Promise<StepResult> => {
+        observedTaskDeliveries.push(contextStorage.getStore()?.get(TurnTaskDeliveryKey));
+        return { next: { done: true, output: "ok" }, session: stepSession };
+      };
+    });
+
+    const first = await turnStep({
+      input: {
+        kind: "deliver",
+        payloads: [{ message: "Background task task_1 is completed." }],
+        taskDeliveryId: "task_1:ready:completed",
+      },
+      parentWritable: createTestWritable(),
+      serializedContext: createSerializedContext(),
+      sessionState: createStubSessionState(),
+    });
+    await turnStep({
+      input: { kind: "deliver", payloads: [{ message: "What happened?" }] },
+      parentWritable: createTestWritable(),
+      serializedContext: first.serializedContext,
+      sessionState: first.sessionState,
+    });
+
+    expect(observedTaskDeliveries).toEqual([true, false]);
   });
 
   it("projects a requested sleep onto the durable step result", async () => {

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -25,6 +25,7 @@ import {
   ModeKey,
   SessionDynamicSubagentRuntimeRevisionKey,
   SessionDynamicToolRuntimeRevisionKey,
+  TurnTaskDeliveryKey,
 } from "#context/keys.js";
 import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
 import { runStep } from "#context/run-step.js";
@@ -175,6 +176,9 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
 
   let durableSession = await readDurableSession(input.sessionState);
   const ctx = await deserializeContext(input.serializedContext);
+  if (rawInput.input?.kind === "deliver") {
+    ctx.set(TurnTaskDeliveryKey, rawInput.input.taskDeliveryId !== undefined);
+  }
   const adapter = ctx.require(ChannelKey);
   const bundle = ctx.require(BundleKey);
   const tasksEnabled = bundle.resolvedAgent.config?.experimental?.tasks === true;
@@ -308,16 +312,13 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
     resolved = { runtimeActionResults: input.input.results };
   }
 
-  // Pin adapter-state mutations back onto ctx so they survive the
-  // step boundary.
+  // Persist adapter-state mutations across the step boundary.
   if (input.input?.kind === "deliver") {
     const updatedAdapter = { ...adapter, state: { ...adapterCtx.state } };
     setChannelContext(ctx, updatedAdapter);
   }
 
-  // Adapter handled the delivery inline (e.g. a Slack interaction
-  // that only edits a message). Re-park without a model turn; skip
-  // the snapshot write when the session itself is unchanged.
+  // Adapter handled the delivery inline; re-park and skip unchanged snapshot writes.
   if (input.input?.kind === "deliver" && resolved === undefined) {
     await contextStorage.run(ctx, () =>
       instrumentChannelDelivery({
@@ -575,8 +576,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
     };
   }
 
-  // Re-stamp the in-memory session's continuation token in case a
-  // handler called `session.continuation.rekey(...)` (eg. Slack auto-anchor).
+  // Re-stamp if a handler called `session.continuation.rekey(...)` (eg. Slack auto-anchor).
   const rekeyed = reconcileSessionContinuationToken(ctx, stepResult.session);
   const nextSerializedContext = serializeContext(ctx);
   stepResult = { ...stepResult, session: rekeyed };

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -26,6 +26,7 @@ import {
   SessionDynamicInstructionsKey,
   SessionDynamicModelReferenceKey,
   SessionDynamicSubagentSelectionsKey,
+  TurnTaskDeliveryKey,
 } from "#context/keys.js";
 import { SCHEDULE_APP_AUTH } from "#channel/schedule-auth.js";
 import { decodeSandboxRef, isSandboxRefUrl } from "#internal/attachments/sandbox-refs.js";
@@ -11013,6 +11014,23 @@ describe("createToolLoopHarness", () => {
       expect(instructions).toBe("You are a test assistant.");
     });
 
+    it("adds conditional-delivery guidance to a top-level framework wake", async () => {
+      setupMockAgent(defaultModelResult());
+      const runStep = createToolLoopHarness(createTestConfig("conversation"));
+      const ctx = new ContextContainer();
+      ctx.set(TurnTaskDeliveryKey, true);
+
+      await contextStorage.run(ctx, () =>
+        runStep(createTestSession(), { message: "Background task task_1 is completed." }),
+      );
+
+      const { instructions } = getLastAgentSettings();
+      expect(instructions).toEqual({
+        role: "system",
+        content: `You are a test assistant.\n\n${CONDITIONAL_DELIVERY_INSTRUCTION}`,
+      });
+    });
+
     it("does not add conditional-delivery guidance to a human continuation", async () => {
       setupMockAgent(defaultModelResult());
       const runStep = createToolLoopHarness(createTestConfig("conversation"));
@@ -11032,14 +11050,15 @@ describe("createToolLoopHarness", () => {
       expect(instructions).toBe("You are a test assistant.");
     });
 
-    it("does not add conditional-delivery guidance to a delegated run", async () => {
+    it("does not add conditional-delivery guidance to a task-owned conversation child", async () => {
       setupMockAgent(defaultModelResult());
-      const runStep = createToolLoopHarness(createTestConfig("task"));
-      const ctx = createScheduleContext();
+      const runStep = createToolLoopHarness(createTestConfig("conversation"));
+      const ctx = new ContextContainer();
+      ctx.set(TurnTaskDeliveryKey, true);
       setDelegatedParent(ctx);
 
       await contextStorage.run(ctx, () =>
-        runStep(createTestSession(), { message: "Handle delegated work." }),
+        runStep(createTestSession(), { message: "Resume after HITL." }),
       );
 
       const { instructions } = getLastAgentSettings();

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -36,6 +36,7 @@ import {
   ParentSessionKey,
   ParentTraceContextKey,
   SessionCallbackKey,
+  TurnTaskDeliveryKey,
 } from "#context/keys.js";
 import {
   buildDynamicInstructionMessages,
@@ -1226,10 +1227,16 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     const approvedTools = getApprovedTools(session);
 
     const emptyDeliveryEnabled =
+      // A structured-output run must always produce its declared result.
       session.outputSchema === undefined &&
+      // Eligibility requires durable framework provenance from the active context.
       ctx !== undefined &&
-      isScheduleAppAuth(ctx.get(AuthKey)) &&
-      ctx.get(ParentSessionKey) === undefined;
+      // A child must always return its result to its parent, even when framework-triggered.
+      ctx.get(ParentSessionKey) === undefined &&
+      // A schedule-initiated root turn may have nothing worth delivering.
+      (isScheduleAppAuth(ctx.get(AuthKey)) ||
+        // A task-notification root turn may act on the wake without messaging the user.
+        ctx.get(TurnTaskDeliveryKey) === true);
 
     // --- Execute via ToolLoopAgent ------------------------------------------
 

--- a/research/subagents-as-tasks-implementation.md
+++ b/research/subagents-as-tasks-implementation.md
@@ -175,7 +175,9 @@ deliberately; they get their own plans if anything nontrivial surfaces.
    nonterminal tasks, with at most one such task per child session; busy agents remain visible in
    `<agents>` with their active task id and status.
 2. **Wake policy.** Terminal and `input_required` transitions wake a parked parent through the
-   session delivery path; they are the only wake triggers.
+   session delivery path; they are the only wake triggers. The resulting parent turn is
+   conditionally delivered: the model sees the framework notification, but it may intentionally
+   produce no channel message.
 3. **Continuation to a busy child.** An `agentId` continuation to a `working` task surfaces `AGENT_BUSY` as a tool
    error, matching handle-continuation semantics. Queuing on the task run is deferred; it is
    the reversible follow-up if busy errors prove noisy in practice.

--- a/research/tools-as-tasks.md
+++ b/research/tools-as-tasks.md
@@ -1,7 +1,7 @@
 ---
 issue: https://github.com/vercel/eve/issues/1084
 status: draft
-last_updated: "2026-08-01"
+last_updated: "2026-08-17"
 ---
 
 # Subagents as tasks
@@ -295,7 +295,9 @@ local and remote children alike:
 
 The proposed routing policy makes terminal updates and `input_required` wake a parked parent
 session. During an active turn, inbound task events wait for the next safe step boundary. They
-never interrupt an active model call.
+never interrupt an active model call. A task notification starts a conditionally delivered parent
+turn: the model sees the notification and may act on it, but eve does not require a user-visible
+channel message. A human message or input response remains required delivery.
 
 ```mermaid
 sequenceDiagram
@@ -404,7 +406,7 @@ than MCP compatibility.
    run's stream index remain internal?
 2. What retention and TTL apply to terminal records and unanswered `input_required` tasks?
 3. What is the cross-deployment version negotiation for task callbacks during rolling deploys?
-4. Which task events enter model context, and how are repeated progress messages coalesced?
+4. How are repeated progress messages coalesced before they start parent model turns?
 5. How are child token usage and remaining parent budgets accounted after a background child
    completes on a later turn?
 


### PR DESCRIPTION
### Summary

Related to #635. Every background-task wake currently enters the parent model loop through the ordinary output path, which pressures the model to produce a user-visible channel message even when the notification needs no response.

Before → after: the task notification used the ordinary root output path; now the turn step projects its existing `taskDeliveryId` into internal context so the root harness can offer the empty-delivery sentinel. No new delivery mode is added to the durable command or public API. The parent still sees every notification, while human messages, HITL responses, and delegated child results remain required delivery.

This does not coalesce task notifications or reduce parent model turns.

### Validation

The fixture-owned eval observes the completed-task notification through the typed `message.received.data.message`, then requires `message: null` and no channel output. The focused harness test also models the task-owned child as its real persistent `conversation` session and confirms parent lineage keeps empty delivery disabled. The eval passes in the local Workflow, Postgres, and Vercel fixture worlds, and the focused test passes locally.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 3 files · `+13 / -4`

Updates the task wake contract in both research plans and adds the release note.

**Implementation** — 3 files · `+18 / -9`

Projects existing task-delivery provenance into turn context and documents every guard at the root harness's empty-delivery boundary.

**Tests** — 4 files · `+132 / -5`

The fixture eval supplies the end-to-end regression. Focused unit coverage protects provenance reset, root wake delivery, and the real task-owned conversation-child exclusion.
