### PR TITLE
fix(eve): return to add categories on escape

### DIFF
--- a/.changeset/add-escape-navigation.md
+++ b/.changeset/add-escape-navigation.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+The `eve dev` TUI now returns to the /add category picker when you press Esc from a category's integration list, instead of dismissing /add.

--- a/packages/eve/src/setup/flows/registry.test.ts
+++ b/packages/eve/src/setup/flows/registry.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 
 import { createFakePrompter } from "#internal/testing/fake-prompter.js";
 
+import { WizardCancelledError } from "#setup/step.js";
+
 import { RegistryFlowFailedError, runRegistryFlow, type RegistryFlowDeps } from "./registry.js";
 
 const APP_ROOT = "/tmp/agent";
@@ -443,6 +445,26 @@ describe("runRegistryFlow", () => {
   it("returns to the category hub from a registry list", async () => {
     const answers = ["category:channel", "action:back", "action:done"];
     const fake = createFakePrompter({ single: () => answers.shift()! });
+
+    await expect(
+      runRegistryFlow({ appRoot: APP_ROOT, prompter: fake.prompter, deps: deps() }),
+    ).resolves.toEqual({ kind: "done", addedItems: [], items: [], facts: [], output: [] });
+
+    expect(fake.selectMessages).toEqual([
+      "Add an integration",
+      "Browse channels",
+      "Add an integration",
+    ]);
+  });
+
+  it("returns to the category hub when the registry list is cancelled", async () => {
+    const answers = ["category:channel", "action:done"];
+    const fake = createFakePrompter({
+      single: (options) => {
+        if (options.message === "Browse channels") throw new WizardCancelledError();
+        return answers.shift()!;
+      },
+    });
 
     await expect(
       runRegistryFlow({ appRoot: APP_ROOT, prompter: fake.prompter, deps: deps() }),

--- a/packages/eve/src/setup/flows/registry.ts
+++ b/packages/eve/src/setup/flows/registry.ts
@@ -318,17 +318,23 @@ export async function runRegistryFlow(input: {
       const categoryItems = itemsForCategory(catalog.items, selectedCategory);
       const rows = itemRows(categoryItems);
       rows.push({ value: BACK, label: "Back", trailingAction: true });
-      const selected = await input.prompter.select<RegistryRow>({
-        message: categoryFor(selectedCategory)?.browseLabel ?? "Browse integrations",
-        options: rows,
-        search: true,
-        placeholder: "Search integrations or enter an item address",
-        searchAction: {
-          label: (query) => `Add “${query}”`,
-          value: (query) => `${ADDRESS_PREFIX}${query.trim()}`,
-        },
-        hintLayout: "inline",
-      });
+      let selected: RegistryRow;
+      try {
+        selected = await input.prompter.select<RegistryRow>({
+          message: categoryFor(selectedCategory)?.browseLabel ?? "Browse integrations",
+          options: rows,
+          search: true,
+          placeholder: "Search integrations or enter an item address",
+          searchAction: {
+            label: (query) => `Add “${query}”`,
+            value: (query) => `${ADDRESS_PREFIX}${query.trim()}`,
+          },
+          hintLayout: "inline",
+        });
+      } catch (error) {
+        if (error instanceof WizardCancelledError) continue;
+        throw error;
+      }
       if (selected === BACK) continue;
       const resolved = selected.startsWith(ADDRESS_PREFIX)
         ? await resolveAddressItem(


### PR DESCRIPTION
### Summary

Pressing Esc from a `/add` category’s integration list now returns to the category picker instead of dismissing `/add`. Esc at the category picker still dismisses the command.

### Validation

- `pnpm --filter eve build:compiled`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/setup/flows/registry.test.ts`
- `pnpm --filter eve exec tsc --noEmit -p tsconfig.json`

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
