### PR TITLE
fix(eve): hide private Slack run titles

### DIFF
--- a/.changeset/slack-private-run-title.md
+++ b/.changeset/slack-private-run-title.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Use `Private message` as the Slack run title for DMs and private channels so sensitive message text never appears in run titles.

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -125,7 +125,7 @@ Check the delivery path in order so you can identify where a Slack event stops:
 
 ### Message hooks
 
-Message hooks return `{ auth }` to dispatch, `null` to drop, or `{ auth, context }` to inject background into history. Return `title` alongside `auth` to set the title when the dispatch starts a run. When omitted, the title continues to use the triggering message text.
+Message hooks return `{ auth }` to dispatch, `null` to drop, or `{ auth, context }` to inject background into history. Public conversations use the returned `title`, or the triggering message text when `title` is omitted. DMs and private channels always use `Private message` so the run title does not expose message details.
 
 - `onMessage(ctx, message)` handles Slack `message` events. eve drops messages authored by the installed app before this hook runs, preventing self-reply loops. Messages from other bots remain visible; check `message.author?.isBot` when those should also be ignored. `ctx.isBotMentioned()` and `ctx.isSubscribed()` support mention and active-thread policies.
 - `onAppMention(ctx, message)` handles only `app_mention` and takes precedence over `onMessage`. Its default derives workspace-scoped auth and posts `Thinking…`.

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -1181,10 +1181,14 @@ describe("slackChannel() inbound mention pipeline", () => {
 
   beforeEach(() => {
     process.env.SLACK_SIGNING_SECRET = SIGNING_SECRET;
-    fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ ok: true, ts: "1700000001.000001" }), {
-        headers: { "content-type": "application/json" },
-      }),
+    fetchMock = vi.fn(async (request: string | URL | Request) =>
+      String(request).includes("conversations.info")
+        ? new Response(JSON.stringify({ ok: true, channel: { is_private: false } }), {
+            headers: { "content-type": "application/json" },
+          })
+        : new Response(JSON.stringify({ ok: true, ts: "1700000001.000001" }), {
+            headers: { "content-type": "application/json" },
+          }),
     );
     vi.stubGlobal("fetch", fetchMock);
   });
@@ -1485,19 +1489,52 @@ describe("slackChannel() inbound mention pipeline", () => {
     expect(input.title).toBe("hello");
   });
 
-  it("uses the run title returned by onAppMention without changing the message", async () => {
+  it("uses the run title returned by onAppMention for a public channel", async () => {
     const channel = slackChannel({
       credentials: { botToken: "xoxb-test" },
       onAppMention: () => ({ auth: null, title: "Run" }),
     });
 
-    const { body } = buildMentionBody({ text: "private message text" });
+    const { body } = buildMentionBody({ text: "public message text" });
     const { send } = await firePost(channel, buildSignedRequest({ body }));
 
     expect(send).toHaveBeenCalledTimes(1);
     const [, input] = send.mock.calls[0]!;
     expect(input.title).toBe("Run");
-    expect(input.message).toContain("<content>\nprivate message text\n</content>");
+    expect(input.message).toContain("<content>\npublic message text\n</content>");
+  });
+
+  it("uses an opaque run title for private channel mentions", async () => {
+    fetchMock.mockImplementation(async (request: string | URL | Request) =>
+      String(request).includes("conversations.info")
+        ? new Response(JSON.stringify({ ok: true, channel: { is_private: true } }), {
+            headers: { "content-type": "application/json" },
+          })
+        : new Response(JSON.stringify({ ok: true, messages: [] }), {
+            headers: { "content-type": "application/json" },
+          }),
+    );
+    let isPrivate: boolean | undefined;
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-test" },
+      async onAppMention(ctx) {
+        isPrivate = await ctx.isDMOrPrivateChannel();
+        return { auth: null, title: "sensitive message" };
+      },
+    });
+
+    const { body } = buildMentionBody({ text: "sensitive message" });
+    const { send } = await firePost(channel, buildSignedRequest({ body }));
+
+    expect(isPrivate).toBe(true);
+    expect(
+      fetchMock.mock.calls.filter(([request]) => String(request).includes("conversations.info")),
+    ).toHaveLength(1);
+    expect(send).toHaveBeenCalledTimes(1);
+    const [, input] = send.mock.calls[0]!;
+    expect(input.title).toBe("Private message");
+    expect(input.title).not.toContain("sensitive message");
+    expect(input.message).toContain("<content>\nsensitive message\n</content>");
   });
 
   it("uses only this app's reply as the incremental thread context boundary", async () => {
@@ -2216,13 +2253,13 @@ describe("slackChannel() inbound direct message pipeline", () => {
     const opts = options as { auth: unknown; state: { channelId: string } };
     expect(opts.auth).toMatchObject({ principalId: "U01", authenticator: "test" });
     expect(opts.state.channelId).toBe(channelId);
-    expect(options.title).toBe("hello");
+    expect(options.title).toBe("Private message");
   });
 
-  it("uses the run title returned by onDirectMessage", async () => {
+  it("uses an opaque run title for direct messages", async () => {
     const channel = slackChannel({
       credentials: { botToken: "xoxb-test" },
-      onDirectMessage: () => ({ auth: null, title: "Private support case" }),
+      onDirectMessage: () => ({ auth: null, title: "sensitive message" }),
     });
 
     const { body } = buildDirectMessageBody({ text: "sensitive message" });
@@ -2230,7 +2267,8 @@ describe("slackChannel() inbound direct message pipeline", () => {
 
     expect(send).toHaveBeenCalledTimes(1);
     const [, options] = send.mock.calls[0]!;
-    expect(options.title).toBe("Private support case");
+    expect(options.title).toBe("Private message");
+    expect(options.title).not.toContain("sensitive message");
     expect(options.message).toContain("<content>\nsensitive message\n</content>");
   });
 

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -79,6 +79,7 @@ export type {
 } from "#public/channels/slack/session-operations.js";
 
 const log = createLogger("slack.channel");
+const PRIVATE_SLACK_RUN_TITLE = "Private message";
 
 type EventData<T extends UnstampedMessageStreamEvent["type"]> =
   Extract<UnstampedMessageStreamEvent, { type: T }> extends { data: infer D } ? D : undefined;
@@ -1131,17 +1132,19 @@ async function dispatchSlackMessage(input: {
       triggeringUserId: author?.userId ?? null,
     },
   });
+  let privateConversation: Promise<boolean> | undefined;
+  const isDMOrPrivateChannel = () =>
+    (privateConversation ??= isPrivateSlackConversation({
+      channelId: input.message.channelId,
+      raw: input.message.raw,
+      request: slack.request,
+    }));
   const ctx: SlackInboundMessageContext = {
     ...sessionOperations,
     isBotMentioned: () =>
       input.kind === "app_mention" ||
       (input.botUserId !== undefined && input.message.text.includes(`<@${input.botUserId}`)),
-    isDMOrPrivateChannel: () =>
-      isPrivateSlackConversation({
-        channelId: input.message.channelId,
-        raw: input.message.raw,
-        request: slack.request,
-      }),
+    isDMOrPrivateChannel,
     isSubscribed: async () => (await sessionOperations.resolveSession()) !== undefined,
     slack,
     thread,
@@ -1161,6 +1164,7 @@ async function dispatchSlackMessage(input: {
   await deliverSlackMessage({
     credentials: input.credentials,
     kind: input.kind,
+    isPrivateConversation: await isDMOrPrivateChannel(),
     message: input.message,
     result,
     sessionOperations,
@@ -1256,6 +1260,7 @@ async function verifyInbound(
 async function deliverSlackMessage(input: {
   readonly sessionOperations: SlackSessionOperations;
   readonly credentials: SlackChannelCredentials | undefined;
+  readonly isPrivateConversation: boolean;
   readonly kind: string;
   readonly message: SlackMessage;
   readonly result: Exclude<SlackInboundResult, null>;
@@ -1292,7 +1297,9 @@ async function deliverSlackMessage(input: {
     );
 
     const channelContext = input.result.context ?? [];
-    const title = input.result.title ?? message.markdown;
+    const title = input.isPrivateConversation
+      ? PRIVATE_SLACK_RUN_TITLE
+      : (input.result.title ?? message.markdown);
     const sendOptions: SlackSendOptions =
       channelContext.length === 0
         ? { auth: input.result.auth, title }


### PR DESCRIPTION
### Summary

Closes #2237. Accepted DMs and private-channel messages now always use the exact run title `Private message`; the full content still reaches the model, but neither the default message title nor an authored title can expose it in the run list. Public Slack conversations preserve existing title behavior.

### Validation

Focused Slack tests passed 95 cases, covering DMs, private-channel mentions, public authored titles, and reuse of one privacy lookup when the handler also calls `ctx.isDMOrPrivateChannel()`.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+6 / -1`

Documents the fixed private title and records the release-facing behavior change.

**Implementation** — 1 file · `+14 / -7`

Applies the opaque title at delivery and memoizes the privacy helper for each accepted message.

**Tests** — 1 file · `+49 / -11`

Covers private title enforcement, public title preservation, message delivery, and lookup reuse.
