### PR TITLE
feat(eve): summarize initialized projects after running `eve init`

### DIFF
--- a/.changeset/init-ready-summary.md
+++ b/.changeset/init-ready-summary.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Successful `eve init` runs now summarize the generated path, model, instructions file, and dependency installation.
+Coding-agent `eve init` runs now report the selected model and generated instructions file without changing the interactive human flow.

--- a/.changeset/init-ready-summary.md
+++ b/.changeset/init-ready-summary.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Successful `eve init` runs now summarize the generated path, model, instructions file, and dependency installation.

--- a/packages/eve/src/cli/commands/agent-instructions.test.ts
+++ b/packages/eve/src/cli/commands/agent-instructions.test.ts
@@ -2,6 +2,8 @@ import { readdirSync } from "node:fs";
 
 import { describe, expect, it } from "vitest";
 
+import { stripAnsi } from "#cli/ui/terminal-text.js";
+
 import {
   HANDOFF_SECTIONS,
   initAgentDevHandoff,
@@ -56,10 +58,12 @@ describe("initAgentInstructions", () => {
 
 describe("initAgentReadySummary", () => {
   it("reports the model and generated instructions path", () => {
-    expect(initAgentReadySummary(undefined, "/app")).toBe(
+    expect(stripAnsi(initAgentReadySummary(undefined, "/app"))).toBe(
       "✓ Model zai/glm-5.2 (eve default)\n✓ Instructions /app/agent/instructions.md",
     );
-    expect(initAgentReadySummary("openai/gpt-5.5", "/app")).toContain("✓ Model openai/gpt-5.5\n");
+    expect(stripAnsi(initAgentReadySummary("openai/gpt-5.5", "/app"))).toContain(
+      "✓ Model openai/gpt-5.5\n",
+    );
   });
 });
 

--- a/packages/eve/src/cli/commands/agent-instructions.test.ts
+++ b/packages/eve/src/cli/commands/agent-instructions.test.ts
@@ -6,6 +6,7 @@ import {
   HANDOFF_SECTIONS,
   initAgentDevHandoff,
   initAgentInstructions,
+  initAgentReadySummary,
   initAgentReplPrompt,
   initExtensionHandoff,
   initExtensionInstructions,
@@ -50,6 +51,15 @@ describe("initAgentInstructions", () => {
     expect(instructions).toContain("@vercel/connect/eve");
     // Both surfaces name the product, so neither path is left to hand-rolled tokens.
     expect(instructions.match(/Vercel Connect/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("initAgentReadySummary", () => {
+  it("reports the model and generated instructions path", () => {
+    expect(initAgentReadySummary(undefined, "/app")).toBe(
+      "✓ Model zai/glm-5.2 (eve default)\n✓ Instructions /app/agent/instructions.md",
+    );
+    expect(initAgentReadySummary("openai/gpt-5.5", "/app")).toContain("✓ Model openai/gpt-5.5\n");
   });
 });
 

--- a/packages/eve/src/cli/commands/agent-instructions.ts
+++ b/packages/eve/src/cli/commands/agent-instructions.ts
@@ -1,4 +1,9 @@
 import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import pc from "picocolors";
+
+import { DEFAULT_AGENT_MODEL_ID } from "#shared/default-agent-model.js";
 
 // The two coding-agent prompts are one onboarding flow in two phases, composed
 // from the section files in `agent-prompt/`. The setup guide runs before
@@ -53,6 +58,16 @@ function compose(
  */
 export function initAgentInstructions(): string {
   return compose(SETUP_SECTIONS, { devCommand: "npx eve dev" });
+}
+
+/** Concise scaffold facts printed only when a coding agent launched `eve init`. */
+export function initAgentReadySummary(model: string | undefined, projectPath: string): string {
+  const selectedModel = model ?? DEFAULT_AGENT_MODEL_ID;
+  const defaultLabel = model === undefined ? pc.dim(" (eve default)") : "";
+  return [
+    `${pc.green("✓")} Model ${pc.bold(selectedModel)}${defaultLabel}`,
+    `${pc.green("✓")} Instructions ${pc.bold(join(projectPath, "agent/instructions.md"))}`,
+  ].join("\n");
 }
 
 /** The post-scaffold handoff printed after a coding agent runs `eve init`. */

--- a/packages/eve/src/cli/commands/init.integration.test.ts
+++ b/packages/eve/src/cli/commands/init.integration.test.ts
@@ -187,7 +187,7 @@ describe("runInitCommand", () => {
     // Substring assertions keep the expectations color-agnostic; picocolors
     // decides at import time whether the strings carry escape codes. The boot
     // banner is the CLI program's pre-action hook, not the command's output.
-    expect(output.messages).toHaveLength(4);
+    expect(output.messages).toHaveLength(5);
     expect(output.messages[0]).toContain("Preparing project...");
     expect(output.messages[1]).toContain("✓");
     expect(output.messages[1]).toContain("Created an eve agent in ");
@@ -195,7 +195,10 @@ describe("runInitCommand", () => {
     expect(output.messages[1]).toContain("in 467ms");
     expect(output.messages[2]).toContain("Installed dependencies");
     expect(output.messages[2]).toContain("in 13.2s");
-    expect(output.messages[3]).toContain("$ eve dev");
+    expect(output.messages[3]).toBe(
+      `\nProject ready:\n  Path: ${projectPath}\n  Model: ${DEFAULT_AGENT_MODEL_ID} (eve default)\n  Instructions: ${join(projectPath, "agent/instructions.md")}\n  Dependencies: installed with pnpm`,
+    );
+    expect(output.messages[4]).toContain("$ eve dev");
   });
 
   it("creates a new agent with model settings selected by init options", async () => {
@@ -214,6 +217,8 @@ describe("runInitCommand", () => {
     const projectPath = join(parentDirectory, "my-agent");
     const agentSource = await readFile(join(projectPath, "agent/agent.ts"), "utf8");
     expect(agentSource).toContain('model: "openai/gpt-5.5"');
+    expect(output.messages.join("\n")).toContain("Model: openai/gpt-5.5\n");
+    expect(output.messages.join("\n")).not.toContain("openai/gpt-5.5 (eve default)");
     expect(agentSource).toContain('reasoning: "high"');
     expect(deps.validateModelSlug).toHaveBeenCalledWith(
       expect.stringContaining(".eve-init-"),

--- a/packages/eve/src/cli/commands/init.integration.test.ts
+++ b/packages/eve/src/cli/commands/init.integration.test.ts
@@ -187,7 +187,7 @@ describe("runInitCommand", () => {
     // Substring assertions keep the expectations color-agnostic; picocolors
     // decides at import time whether the strings carry escape codes. The boot
     // banner is the CLI program's pre-action hook, not the command's output.
-    expect(output.messages).toHaveLength(5);
+    expect(output.messages).toHaveLength(4);
     expect(output.messages[0]).toContain("Preparing project...");
     expect(output.messages[1]).toContain("✓");
     expect(output.messages[1]).toContain("Created an eve agent in ");
@@ -195,16 +195,15 @@ describe("runInitCommand", () => {
     expect(output.messages[1]).toContain("in 467ms");
     expect(output.messages[2]).toContain("Installed dependencies");
     expect(output.messages[2]).toContain("in 13.2s");
-    expect(output.messages[3]).toBe(
-      `\nProject ready:\n  Path: ${projectPath}\n  Model: ${DEFAULT_AGENT_MODEL_ID} (eve default)\n  Instructions: ${join(projectPath, "agent/instructions.md")}\n  Dependencies: installed with pnpm`,
-    );
-    expect(output.messages[4]).toContain("$ eve dev");
+    expect(output.messages[3]).toContain("$ eve dev");
+    expect(output.messages.join("\n")).not.toContain("Instructions ");
   });
 
   it("creates a new agent with model settings selected by init options", async () => {
     const parentDirectory = await mkdtemp(join(tmpdir(), "eve-init-model-"));
     const output = logger();
     const deps = dependencies();
+    deps.isCodingAgentLaunch.mockResolvedValue(true);
 
     await runInitCommand(
       output,
@@ -217,8 +216,10 @@ describe("runInitCommand", () => {
     const projectPath = join(parentDirectory, "my-agent");
     const agentSource = await readFile(join(projectPath, "agent/agent.ts"), "utf8");
     expect(agentSource).toContain('model: "openai/gpt-5.5"');
-    expect(output.messages.join("\n")).toContain("Model: openai/gpt-5.5\n");
-    expect(output.messages.join("\n")).not.toContain("openai/gpt-5.5 (eve default)");
+    const messages = stripAnsi(output.messages.join("\n"));
+    expect(messages).toContain("✓ Model openai/gpt-5.5");
+    expect(messages).not.toContain("openai/gpt-5.5 (eve default)");
+    expect(messages).toContain(`✓ Instructions ${join(projectPath, "agent/instructions.md")}`);
     expect(agentSource).toContain('reasoning: "high"');
     expect(deps.validateModelSlug).toHaveBeenCalledWith(
       expect.stringContaining(".eve-init-"),
@@ -1169,9 +1170,10 @@ describe("runInitCommand", () => {
     expect(deps.selectInitHandoff).not.toHaveBeenCalled();
     expect(deps.spawnCodingAgentRepl).not.toHaveBeenCalled();
     expect(deps.spawnPackageManager).not.toHaveBeenCalled();
-    expect(output.messages.join("\n")).toContain(
-      "pnpm --config.minimum-release-age=0 exec eve dev --no-ui",
-    );
+    const messages = stripAnsi(output.messages.join("\n"));
+    expect(messages).toContain(`✓ Model ${DEFAULT_AGENT_MODEL_ID} (eve default)`);
+    expect(messages).toContain(`✓ Instructions ${join(projectPath, "agent/instructions.md")}`);
+    expect(messages).toContain("pnpm --config.minimum-release-age=0 exec eve dev --no-ui");
   });
 
   it("derives the agent dev handoff command from the existing project's own manager", async () => {

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -605,18 +605,6 @@ export async function runInitCommand(
     `${pc.green("✓")} Installed dependencies ${pc.dim(`in ${formatElapsed(result.installElapsedMs)}`)}`,
   );
 
-  const selectedModel = options.model ?? DEFAULT_AGENT_MODEL_ID;
-  logger.log(
-    [
-      "",
-      "Project ready:",
-      `  Path: ${result.projectPath}`,
-      `  Model: ${selectedModel}${options.model === undefined ? " (eve default)" : ""}`,
-      `  Instructions: ${join(result.projectPath, "agent/instructions.md")}`,
-      `  Dependencies: installed with ${result.packageManager}`,
-    ].join("\n"),
-  );
-
   if (result.kind === "created" && result.gitResult.kind === "failed") {
     logger.error(
       pc.yellow(
@@ -640,6 +628,13 @@ export async function runInitCommand(
   });
 
   if (result.agentLaunched) {
+    const selectedModel = options.model ?? DEFAULT_AGENT_MODEL_ID;
+    logger.log(
+      `${pc.green("✓")} Model ${pc.bold(selectedModel)}${options.model === undefined ? pc.dim(" (eve default)") : ""}`,
+    );
+    logger.log(
+      `${pc.green("✓")} Instructions ${pc.bold(join(result.projectPath, "agent/instructions.md"))}`,
+    );
     logger.log(agentHandoff);
     return;
   }

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -605,6 +605,18 @@ export async function runInitCommand(
     `${pc.green("✓")} Installed dependencies ${pc.dim(`in ${formatElapsed(result.installElapsedMs)}`)}`,
   );
 
+  const selectedModel = options.model ?? DEFAULT_AGENT_MODEL_ID;
+  logger.log(
+    [
+      "",
+      "Project ready:",
+      `  Path: ${result.projectPath}`,
+      `  Model: ${selectedModel}${options.model === undefined ? " (eve default)" : ""}`,
+      `  Instructions: ${join(result.projectPath, "agent/instructions.md")}`,
+      `  Dependencies: installed with ${result.packageManager}`,
+    ].join("\n"),
+  );
+
   if (result.kind === "created" && result.gitResult.kind === "failed") {
     logger.error(
       pc.yellow(

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -41,6 +41,7 @@ import {
 } from "#setup/scaffold/create/project.js";
 
 import { initAgentDevHandoff, initAgentReplPrompt } from "./agent-instructions.js";
+import { initAgentReadySummary } from "./agent-instructions.js";
 import { confirmInitInNonEmptyDirectory } from "./init-confirm.js";
 import {
   cleanupFreshInitTarget,
@@ -628,13 +629,7 @@ export async function runInitCommand(
   });
 
   if (result.agentLaunched) {
-    const selectedModel = options.model ?? DEFAULT_AGENT_MODEL_ID;
-    logger.log(
-      `${pc.green("✓")} Model ${pc.bold(selectedModel)}${options.model === undefined ? pc.dim(" (eve default)") : ""}`,
-    );
-    logger.log(
-      `${pc.green("✓")} Instructions ${pc.bold(join(result.projectPath, "agent/instructions.md"))}`,
-    );
+    logger.log(initAgentReadySummary(options.model, result.projectPath));
     logger.log(agentHandoff);
     return;
   }


### PR DESCRIPTION
### Summary

A successful `eve init` did not provide one authoritative summary of what it generated, so coding agents inspected `agent.ts`, `package.json`, channel files, and project trees to recover the path, model, instructions location, and installation state. Successful init runs now print those facts in a compact `Project ready` block and distinguish the eve default model from an explicit `--model` selection reducing sequential tool calls for agents.

### Validation

Focused helper and structural unit coverage passed 9/9, including the 700-line source invariant; typecheck also passed. Earlier focused init integration coverage passed 3/3 for default and explicit model summaries, and a one-run guided Sol benchmark passed in 178.7s with 14 tool calls.

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds release metadata for the new init output.

**Implementation** — 2 files · `+17 / -0`

Keeps agent-only summary formatting with the existing handoff concern while leaving `init.ts` focused on control flow and below the source-size cap.

**Tests** — 2 files · `+20 / -3`

Covers helper formatting plus the human, default-model agent, and explicit-model agent paths.


