### PR TITLE
fix: isolate authoring benchmark artifacts to reduce distraction for benchmark agents

### DIFF
--- a/apps/benchmarks/lib/harness-agent.ts
+++ b/apps/benchmarks/lib/harness-agent.ts
@@ -225,6 +225,7 @@ export function createAuthoringAgent(subject: {
             ? workspace
             : `${workspace}/${authoringCase.projectDirectory}`;
         const context = setupContext(activeSandbox, workspace);
+        const graderContext = setupContext(activeSandbox, projectWorkspace);
         await prepareGraderDirectory(context);
         await context.write(
           `${AGENT_EVAL_DIRECTORY}/results.json`,
@@ -235,19 +236,19 @@ export function createAuthoringAgent(subject: {
           JSON.stringify(transcript),
         );
         await Promise.all([
-          context.write(
+          graderContext.write(
             `${POST_RUN_GRADER_DIRECTORY}/EVAL.test.ts`,
             readFileSync(`${fixturePath}/EVAL.ts`, "utf8"),
           ),
-          context.write(
+          graderContext.write(
             `${POST_RUN_GRADER_DIRECTORY}/grader.ts`,
             readFileSync(new URL("./grader.ts", import.meta.url), "utf8"),
           ),
-          context.write(
+          graderContext.write(
             `${POST_RUN_GRADER_DIRECTORY}/paths.ts`,
             readFileSync(new URL("./paths.ts", import.meta.url), "utf8"),
           ),
-          context.write(
+          graderContext.write(
             `${POST_RUN_GRADER_DIRECTORY}/protocol.ts`,
             readFileSync(new URL("./protocol.ts", import.meta.url), "utf8"),
           ),

--- a/apps/benchmarks/lib/harness-agent.ts
+++ b/apps/benchmarks/lib/harness-agent.ts
@@ -27,6 +27,7 @@ import type { AuthoringTokenUsage, AuthoringTranscriptEntry } from "./protocol.j
 import { BenchmarkTimings } from "./timing.js";
 
 const HARNESS_BRIDGE_PORT = 4172;
+const POST_RUN_GRADER_DIRECTORY = ".eve-grader";
 const BOOTSTRAP_VERSION = "v8";
 // A turn that stops producing output should end the turn, not the eval: the
 // remaining turns still run and the graders still see what the agent did.
@@ -235,19 +236,19 @@ export function createAuthoringAgent(subject: {
         );
         await Promise.all([
           context.write(
-            `${AGENT_EVAL_DIRECTORY}/EVAL.test.ts`,
+            `${POST_RUN_GRADER_DIRECTORY}/EVAL.test.ts`,
             readFileSync(`${fixturePath}/EVAL.ts`, "utf8"),
           ),
           context.write(
-            `${AGENT_EVAL_DIRECTORY}/grader.ts`,
+            `${POST_RUN_GRADER_DIRECTORY}/grader.ts`,
             readFileSync(new URL("./grader.ts", import.meta.url), "utf8"),
           ),
           context.write(
-            `${AGENT_EVAL_DIRECTORY}/paths.ts`,
+            `${POST_RUN_GRADER_DIRECTORY}/paths.ts`,
             readFileSync(new URL("./paths.ts", import.meta.url), "utf8"),
           ),
           context.write(
-            `${AGENT_EVAL_DIRECTORY}/protocol.ts`,
+            `${POST_RUN_GRADER_DIRECTORY}/protocol.ts`,
             readFileSync(new URL("./protocol.ts", import.meta.url), "utf8"),
           ),
         ]);
@@ -256,7 +257,7 @@ export function createAuthoringAgent(subject: {
         const test = await timings.measure("validation.grader", () =>
           resultOf(
             activeSandbox!,
-            `ln -s ${AGENT_EVAL_DIRECTORY} .eve-grader && trap 'rm -f .eve-grader' EXIT && vitest run .eve-grader/EVAL.test.ts`,
+            `vitest run ${POST_RUN_GRADER_DIRECTORY}/EVAL.test.ts`,
             projectWorkspace,
           ),
         );

--- a/apps/benchmarks/lib/harness-agent.ts
+++ b/apps/benchmarks/lib/harness-agent.ts
@@ -256,7 +256,7 @@ export function createAuthoringAgent(subject: {
         const test = await timings.measure("validation.grader", () =>
           resultOf(
             activeSandbox!,
-            `ln -s ${workspace}/${AGENT_EVAL_DIRECTORY} .eve-grader && trap 'rm -f .eve-grader' EXIT && vitest run .eve-grader/EVAL.test.ts`,
+            `ln -s ${AGENT_EVAL_DIRECTORY} .eve-grader && trap 'rm -f .eve-grader' EXIT && vitest run .eve-grader/EVAL.test.ts`,
             projectWorkspace,
           ),
         );
@@ -544,7 +544,12 @@ async function bootstrapSubject(
   if (workspaceKind === "scaffolded") {
     workspaceCommands.push(`cd ${shellQuote(workspace)} && AI_AGENT=benchmark eve init .`);
   }
-  workspaceCommands.push("command -v vitest >/dev/null");
+  // Grader files must not change what subject commands observe in the project directory.
+  workspaceCommands.push(
+    `rm -rf ${AGENT_EVAL_DIRECTORY} && mkdir -p ${AGENT_EVAL_DIRECTORY}`,
+    `printf '{"private":true,"type":"module"}\\n' >${AGENT_EVAL_DIRECTORY}/package.json`,
+    "command -v vitest >/dev/null",
+  );
   if (workspaceKind === "scaffolded") {
     workspaceCommands.push(`test -f ${workspace}/package.json`);
   }


### PR DESCRIPTION
### Summary

Authoring benchmark grader files were accidentally created under the agent-visible workspace, so `eve init .` saw `__agent_eval__` instead of an empty project and models repeatedly moved, deleted, and reconstructed benchmark infrastructure. Benchmark state now stays under `/tmp/eve-grader`; the Vitest grader files are materialized under `.eve-grader/` only after the agent finishes, so validation cannot influence the task and does not rely on symlink support.

The clean GPT-5.6 Sol guided run reduced tool calls from **37 to 28** (**9 fewer, 24.3%**), including init attempts from roughly three to one. Its valid single-run duration was **301.4s versus the prior 288.4s mean (+13.0s)**, so this PR claims the behavioral/tool-call improvement but not a wall-clock win from that noisy sample.

### Validation

The benchmark package typechecked and its focused non-export suites passed 19/19. A one-run GPT-5.6 Terra named-project benchmark passed in 165.7s with 18 tool calls, confirming the post-run grader directory is rooted correctly for nested projects.

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

Tests and a changeset are not applicable beyond the exercised private harness path; no published package changes.

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 1 file · `+15 / -9`

Keeps benchmark artifacts outside the subject workspace and invalidates cached sandbox bootstraps.

**Tests** — 0 files · `+0 / -0`

The change is validated through the benchmark harness itself rather than a separate fixture.


