### PR TITLE
test: allow `eve init <agent-name>` outside of workspace in project creation benchmark

### DIFF
--- a/apps/benchmarks/evals/author-002-new-project/CASE.ts
+++ b/apps/benchmarks/evals/author-002-new-project/CASE.ts
@@ -2,9 +2,10 @@ import { defineAuthoringCase, emptyProject } from "../../lib/authoring-case.js";
 
 export default defineAuthoringCase({
   startingPoint: emptyProject,
+  projectDirectory: "wayfinder",
   async interact({ send }) {
     await send(
-      "Create a new eve project directly in the current working directory for a concise travel assistant called Wayfinder. Do not create a subdirectory: initialize the current directory (for example, with `eve init .`). It should use the default model and be ready to build.",
+      "Create a new eve project named `wayfinder` for a concise travel assistant called Wayfinder. It should use the default model and be ready to build.",
     );
   },
 });

--- a/apps/benchmarks/evals/author-002-new-project/EVAL.ts
+++ b/apps/benchmarks/evals/author-002-new-project/EVAL.ts
@@ -4,7 +4,7 @@ import { expect, test } from "vitest";
 
 import { subjectDefaultAgentModel } from "./grader.js";
 
-test("creates a complete eve project in place", () => {
+test("creates a complete eve project", () => {
   expect(existsSync("agent/agent.ts")).toBe(true);
   expect(existsSync("agent/channels/eve.ts")).toBe(true);
   expect(existsSync("agent/instructions.md")).toBe(true);

--- a/apps/benchmarks/lib/authoring-case.ts
+++ b/apps/benchmarks/lib/authoring-case.ts
@@ -41,6 +41,8 @@ export interface AuthoringInteractionContext {
 
 export interface AuthoringCase {
   readonly startingPoint: AuthoringStartingPoint;
+  /** Directory created by the agent, relative to the starting workspace. */
+  readonly projectDirectory?: string;
   readonly setup?: AuthoringSetup;
   readonly interact: (context: AuthoringInteractionContext) => Promise<void>;
 }

--- a/apps/benchmarks/lib/harness-agent.ts
+++ b/apps/benchmarks/lib/harness-agent.ts
@@ -145,6 +145,10 @@ export function createAuthoringAgent(subject: {
           },
         });
 
+        const projectWorkspace =
+          authoringCase.projectDirectory === undefined
+            ? workspace
+            : `${workspace}/${authoringCase.projectDirectory}`;
         const context = setupContext(activeSandbox, workspace);
         await context.write(
           `${AGENT_EVAL_DIRECTORY}/results.json`,
@@ -176,8 +180,8 @@ export function createAuthoringAgent(subject: {
         log("[grade] running deterministic assertions");
         const test = await resultOf(
           activeSandbox,
-          `vitest run ${workspace}/${AGENT_EVAL_DIRECTORY}/EVAL.test.ts`,
-          workspace,
+          `ln -s ${workspace}/${AGENT_EVAL_DIRECTORY} .eve-grader && trap 'rm -f .eve-grader' EXIT && vitest run .eve-grader/EVAL.test.ts`,
+          projectWorkspace,
         );
         const scriptsResults = Object.fromEntries(
           await Promise.all(
@@ -186,7 +190,7 @@ export function createAuthoringAgent(subject: {
               const result = await resultOf(
                 activeSandbox!,
                 `npm run ${shellQuote(script)}`,
-                workspace,
+                projectWorkspace,
               );
               return [
                 script,

--- a/apps/benchmarks/lib/load-authoring-case.test.mjs
+++ b/apps/benchmarks/lib/load-authoring-case.test.mjs
@@ -21,6 +21,11 @@ for (const entry of await readdir(evalsRoot, { withFileTypes: true })) {
   });
 }
 
+test("loads the named project output directory", async () => {
+  const authoringCase = await loadAuthoringCase(resolve(evalsRoot, "author-002-new-project"));
+  assert.equal(authoringCase.projectDirectory, "wayfinder");
+});
+
 test("requires an iMessage phone-number request before supplying the number", async () => {
   const authoringCase = await loadAuthoringCase(resolve(evalsRoot, "author-000-imessage"));
   const prompts = [];


### PR DESCRIPTION
### Summary

The new-project authoring benchmark forced agents to initialize the harness workspace in place, even though the normal project-creation flow is `eve init <name>`. The case now requests `wayfinder` as a named project, and authoring cases can declare the relative project directory where grading and validation should run.

In the sequential GPT-5.6 Sol guided benchmark, project creation improved from **288.4s and 37 tool calls** to **183.7s and 26 tool calls**: **104.7s faster (36.3%)** with **11 fewer tool calls (29.7%)**.

### Validation

The benchmark package typechecked, and its focused non-export test suites passed 20/20. A one-run guided GPT-5.6 Sol benchmark passed from the nested `wayfinder` project in 183.7s.

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

A changeset is not applicable because this changes only the private benchmark harness and case.

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 2 files · `+9 / -3`

Adds a case-owned project-directory boundary and runs grading and package scripts from it.

**Tests** — 3 files · `+8 / -2`

Updates the project-creation eval and verifies that its declared output directory loads correctly.
