### PR TITLE
fix(eve): scope AGENTS.md scaffold docs guidance

### DIFF
--- a/.changeset/focused-instructions-guidance.md
+++ b/.changeset/focused-instructions-guidance.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Tell coding agents that content-only instruction edits do not require reading the framework docs, while preserving docs-first guidance for eve framework changes.

--- a/packages/eve/src/setup/scaffold/create/project.ts
+++ b/packages/eve/src/setup/scaffold/create/project.ts
@@ -293,11 +293,19 @@ dist
 `,
   "AGENTS.md": `# eve Agent App
 
-This project uses the eve framework. Before writing code, read the relevant guide
-from the installed eve package docs. In most installs, those docs are at
-\`node_modules/eve/docs/\`. In workspaces or local package installs, resolve the
-installed \`eve\` package location first and read its \`docs/\` directory. If
-package docs are unavailable, use https://eve.dev/docs as a fallback.
+This project uses the eve framework. For a content-only change to the root agent's
+identity, purpose, tone, or response guidelines, edit its existing authored
+instructions. Fresh projects use \`agent/instructions.md\`; a project may instead
+use \`agent/instructions.ts\` or files under \`agent/instructions/\`. You do not
+need to read the framework docs for a content-only instructions change.
+
+Before adding or changing eve framework features such as tools, connections,
+channels, skills, subagents, schedules, authentication, or deployment, read the
+relevant guide from the installed eve package docs. In most installs, those docs
+are at \`node_modules/eve/docs/\`. In workspaces or local package installs,
+resolve the installed \`eve\` package location first and read its \`docs/\`
+directory. If package docs are unavailable, use https://eve.dev/docs as a
+fallback.
 
 ## Adding integrations
 

--- a/packages/eve/src/setup/scaffold/index.integration.test.ts
+++ b/packages/eve/src/setup/scaffold/index.integration.test.ts
@@ -990,7 +990,7 @@ describe("scaffoldBaseProject", () => {
     expect(agentsMd).toContain("Before adding or changing eve framework features");
     expect(agentsMd).toContain("installed eve package docs");
     expect(agentsMd).toContain("node_modules/eve/docs/");
-    expect(agentsMd).toContain("resolve the\ninstalled `eve` package location");
+    expect(agentsMd).toContain("resolve the installed `eve` package location");
     expect(agentsMd).toContain("eve registry search <query> --json");
     expect(agentsMd).toContain("eve registry view <item>");
     expect(agentsMd).toContain("eve add <item> --non-interactive");

--- a/packages/eve/src/setup/scaffold/index.integration.test.ts
+++ b/packages/eve/src/setup/scaffold/index.integration.test.ts
@@ -984,6 +984,10 @@ describe("scaffoldBaseProject", () => {
       PNPM_WORKSPACE_CONTENT,
     );
     const agentsMd = await readFile(join(projectRoot, "AGENTS.md"), "utf8");
+    expect(agentsMd).toContain("content-only change to the root agent's");
+    expect(agentsMd).toContain("You do not\nneed to read the framework docs");
+    expect(agentsMd).toContain("`agent/instructions.ts` or files under `agent/instructions/`");
+    expect(agentsMd).toContain("Before adding or changing eve framework features");
     expect(agentsMd).toContain("installed eve package docs");
     expect(agentsMd).toContain("node_modules/eve/docs/");
     expect(agentsMd).toContain("resolve the\ninstalled `eve` package location");


### PR DESCRIPTION
### Summary

Fresh projects currently tell coding agents to read the installed eve docs before any code change, which caused content-only edits to trigger broad documentation exploration. Generated `AGENTS.md` now says identity, purpose, tone, and response-guideline edits can update the existing authored instructions directly, while retaining docs-first guidance for tools, connections, channels, skills, subagents, schedules, authentication, and deployment.

A sequential GPT-5.6 Sol guided benchmark improved from **183.7s and 26 tool calls** to **165.7s and 15 tool calls**: **18.0s faster (9.8%)** with **11 fewer tool calls (42.3%)**. The model stopped reading framework documentation.

### Validation

Focused scaffold integration coverage passed 4/4 on the measured working tree, including assertions for the content-only exception and preserved framework guidance. A one-run guided Sol benchmark passed in 165.7s without documentation reads.

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds release metadata for the generated guidance change.

**Implementation** — 1 file · `+13 / -5`

Refines the generated `AGENTS.md` boundary without weakening docs-first guidance for framework work.

**Tests** — 1 file · `+4 / -0`

Locks in both the content-only exception and the framework-feature guidance.
