### PR TITLE
Add local project doctor

### DIFF
--- a/.changeset/local-doctor.md
+++ b/.changeset/local-doctor.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add a local-only `eve doctor` command that checks Node.js, canonical project discovery, package-manager conflicts, dependency installation, and Git state without network calls or mutations.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,6 +1,6 @@
 ---
 title: "CLI"
-description: "Reference for every eve CLI command: init, set, info, build, start, dev, logs, trace, link, deploy, eval, channels, and extension."
+description: "Reference for every eve CLI command: init, doctor, set, info, build, start, dev, logs, trace, link, deploy, eval, channels, and extension."
 ---
 
 Relevant `eve` commands can run from the application root or any directory beneath it. Running `eve` with no command runs `eve init` when the current directory is not an eve project, or `eve dev` when it is.
@@ -11,6 +11,7 @@ Relevant `eve` commands can run from the application root or any directory benea
 | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | `eve`                         | Initialize the current directory, or start development when it is already an eve project                                           |
 | `eve init [target]`           | Create a new agent, or add an agent to an existing project                                                                         |
+| `eve doctor [path]`           | Diagnose local Node.js, project, package, dependency, and Git state without network calls or changes                               |
 | `eve info`                    | Print the resolved application, including static instructions and discovered capabilities, routes, artifact paths, and diagnostics |
 | `eve build`                   | Compile `.eve/` artifacts and build the host output; prints the output directory                                                   |
 | `eve start`                   | Serve the built `.output/` app; prints the listening URL                                                                           |
@@ -41,14 +42,14 @@ eve init [target] [--model <provider/model-id>] [--reasoning <effort>] [--channe
 
 Creates a new agent app or adds an agent to an existing app. Always installs dependencies. New directories also initialize Git.
 
-| Target                                                                     | What happens                                                                                                                                                             |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `eve init my-agent`                                                        | Creates an agent project in `my-agent/`                                                                                                                                  |
-| `eve init` or `eve init .` in an empty directory                           | Creates an agent project in the current directory                                                                                                                        |
-| `eve init` or `eve init .` in a non-empty directory without `package.json` | Asks whether to scaffold in the current directory or a named subdirectory. Using the current directory preserves unrelated files but overwrites files at generated paths |
-| `eve init .` in an existing project                                        | Adds `agent/` plus missing `eve`, `ai`, and `zod` dependencies. Requires `package.json` and no existing `agent/` files                                                   |
+| Target                                                         | What happens                                                                                             |
+| -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `eve init my-agent`                                            | Creates an agent project in `my-agent/`                                                                  |
+| `eve init` or `eve init .` in an empty directory               | Creates an agent project in the current directory                                                        |
+| `eve init` or `eve init .` in an arbitrary non-empty directory | Stops before writing and lists the content that prevents initialization                                  |
+| `eve init .` in an existing package project                    | Previews and confirms `agent/`, dependency, and supported workspace edits before installing dependencies |
 
-Coding-agent launches and non-interactive terminals cannot answer the location prompt and fail before writing. Pass a new directory name, such as `eve init my-agent`, in those environments.
+Use `eve init . --yes` to confirm a previewed existing-package integration without a TTY. The confirmed edits become durable before installation starts. If installation fails, keep the edits and retry the package-manager command that eve reports; do not rerun `eve init`.
 
 After scaffolding, a human terminal usually continues into `eve dev`. If a coding-agent REPL is on `PATH`, the handoff menu can open it instead or exit without starting either process. Coding-agent launches print the next steps instead of opening the TUI, so the session does not get stuck. Fresh projects use the parent workspace's package manager when there is one; otherwise they use the manager that launched `eve init`.
 
@@ -57,6 +58,7 @@ After scaffolding, a human terminal usually continues into `eve dev`. If a codin
 | `--model <model>`      | string | `zai/glm-5.2`    | Set the root agent's AI Gateway model ID.                                                                                |
 | `--reasoning <effort>` | enum   | provider default | Set reasoning to `none`, `minimal`, `low`, `medium`, `high`, or `xhigh`. `provider-default` leaves the field unauthored. |
 | `--channel-web-nextjs` | flag   | off              | Add the Web Chat app (Next.js). Not for existing projects — run `eve add channel/web` there instead.                     |
+| `-y, --yes`            | flag   | off              | Confirm the previewed edits when adding eve to an existing package project without a TTY.                                |
 
 ## `eve extension`
 
@@ -134,6 +136,18 @@ Coding agents should use `eve add <item> --non-interactive`, adding `--yes` to a
 When setup is skipped, cancelled, or needs more input after installation, eve prints or returns the matching `eve add <item> --skip-install` continuation. It reruns the selected components' declared flows without reinstalling registry files.
 
 `eve registry add` records configured sources in `package.json#registries`. `eve registry list` aggregates the official catalog and all configured sources by default. `eve registry search` also includes [skills.sh](https://skills.sh), available without configuration at `@skills`, and groups results by source with each source's available result count. Search returns up to 10 matches per source by default; pass `--limit <count>` to request between 1 and 100. Either command can browse one supplied URL or namespace. Official and other universal items with explicit file targets do not require shadcn project configuration.
+
+## `eve doctor`
+
+```bash
+eve doctor [path] [--json]
+```
+
+Runs local checks without authentication, network calls, project compilation, or filesystem changes. It checks the active Node.js version, canonical project discovery, package-manager selection and conflicting lockfiles, dependency installation, and Git repository and remote state. The command runs every applicable check instead of stopping at the first problem.
+
+Warnings and unknown results exit `0`; failures exit nonzero. Git and remotes are optional for local development, so their absence is a warning rather than a failure, but Git is required to commit changes and a remote is required to push or share them. Human output colors pass, warning, failure, and unknown status symbols when the terminal supports color. `--json` prints the same diagnostics as JSON without progress or ANSI output. The JSON shape may change during eve's pre-1.0 development and does not include a schema version.
+
+`eve doctor` does not compile authored source because the compiler does not yet expose a proven no-write inspection path. Run `eve build` separately to validate compilation.
 
 ## `eve info`
 

--- a/packages/eve/scripts/vendor-compiled/declarations/semver.d.ts
+++ b/packages/eve/scripts/vendor-compiled/declarations/semver.d.ts
@@ -14,6 +14,7 @@ export interface SemVerApi {
   Range: new (range: string) => Range;
   intersects(rangeA: string, rangeB: string): boolean;
   minVersion(range: string): SemVer | null;
+  satisfies(version: string, range: string): boolean;
   subset(candidateRange: string, requiredRange: string): boolean;
   validRange(range: string): string | null;
 }

--- a/packages/eve/src/cli/commands/doctor.test.ts
+++ b/packages/eve/src/cli/commands/doctor.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { runDoctorCommand } from "./doctor.js";
+
+afterEach(() => {
+  process.exitCode = undefined;
+});
+
+describe("runDoctorCommand", () => {
+  it("writes JSON only to the logger output and exits nonzero for failures", async () => {
+    const logger = { log: vi.fn() };
+
+    await runDoctorCommand(logger, "/path/that/does/not/exist", { json: true });
+
+    expect(logger.log).toHaveBeenCalledOnce();
+    const parsed = JSON.parse(logger.log.mock.calls[0]![0]) as {
+      diagnostics: Array<{ id: string }>;
+    };
+    expect(parsed.diagnostics).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: "project.discovery" })]),
+    );
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/packages/eve/src/cli/commands/doctor.ts
+++ b/packages/eve/src/cli/commands/doctor.ts
@@ -1,0 +1,18 @@
+import { resolve } from "node:path";
+
+import { runLocalDoctor } from "#doctor/doctor.js";
+import { renderDoctorHuman, renderDoctorJson } from "#doctor/render.js";
+
+export interface DoctorLogger {
+  log(message: string): void;
+}
+
+export async function runDoctorCommand(
+  logger: DoctorLogger,
+  path: string | undefined,
+  options: { json?: boolean },
+): Promise<void> {
+  const result = await runLocalDoctor(resolve(path ?? process.cwd()));
+  logger.log(options.json ? renderDoctorJson(result) : renderDoctorHuman(result));
+  if (result.summary.fail > 0) process.exitCode = 1;
+}

--- a/packages/eve/src/cli/commands/extension-init.ts
+++ b/packages/eve/src/cli/commands/extension-init.ts
@@ -9,6 +9,10 @@ import { EVE_WORDMARK } from "#cli/banner.js";
 import { formatElapsed } from "#cli/format-elapsed.js";
 import { startCliLiveRow } from "#cli/ui/live-row.js";
 import { createLogger, isLogLevelEnabled } from "#internal/logging.js";
+import {
+  DEFAULT_EVE_PACKAGE_CONTRACT,
+  type EvePackageContract,
+} from "#setup/eve-package-contract.js";
 import { formatNodeEngineOverrideWarning } from "#setup/node-engine.js";
 import {
   detectInvokingPackageManager,
@@ -24,10 +28,6 @@ import {
 } from "#setup/primitives/index.js";
 import type { ProcessOutputLine } from "#setup/primitives/process-output.js";
 import { blockingCreateInPlaceEntries } from "#setup/scaffold/create-in-place.js";
-import {
-  DEFAULT_EVE_PACKAGE_CONTRACT,
-  type EvePackageContract,
-} from "#setup/scaffold/create/project.js";
 import { scaffoldExtensionProject } from "#setup/scaffold/index.js";
 import type { WorkspaceRootMutation } from "#setup/scaffold/workspace-root.js";
 

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -11,6 +11,10 @@ import { startCliLiveRow } from "#cli/ui/live-row.js";
 import { createLogger, isLogLevelEnabled } from "#internal/logging.js";
 import { DEFAULT_AGENT_MODEL_ID } from "#shared/default-agent-model.js";
 import type { AgentReasoningDefinition } from "#shared/agent-definition.js";
+import {
+  DEFAULT_EVE_PACKAGE_CONTRACT,
+  type EvePackageContract,
+} from "#setup/eve-package-contract.js";
 import { formatNodeEngineOverrideWarning, type NodeEngineOverride } from "#setup/node-engine.js";
 import {
   detectInvokingPackageManager,
@@ -35,10 +39,6 @@ import {
   isPackageManagerWorkspaceMember,
   type WorkspaceRootMutation,
 } from "#setup/scaffold/workspace-root.js";
-import {
-  DEFAULT_EVE_PACKAGE_CONTRACT,
-  type EvePackageContract,
-} from "#setup/scaffold/create/project.js";
 
 import { initAgentDevHandoff, initAgentReplPrompt } from "./agent-instructions.js";
 import { confirmInitInNonEmptyDirectory } from "./init-confirm.js";

--- a/packages/eve/src/cli/run.ts
+++ b/packages/eve/src/cli/run.ts
@@ -263,6 +263,15 @@ function createCliProgram(
       },
     );
 
+  program
+    .command("doctor [path]")
+    .description("Diagnose the local eve environment and project without making changes.")
+    .option("--json", "Output diagnostics as JSON")
+    .action(async (path: string | undefined, options: { json?: boolean }) => {
+      const { runDoctorCommand } = await import("#cli/commands/doctor.js");
+      await runDoctorCommand(logger, path, options);
+    });
+
   applicationCommand(program.command("set"), applicationContext)
     .description("Change root agent model settings.")
     .option("--model <model>", "Set the agent model (provider/model-id)")

--- a/packages/eve/src/doctor/collectors.ts
+++ b/packages/eve/src/doctor/collectors.ts
@@ -1,0 +1,115 @@
+import { execFile } from "node:child_process";
+import { access, readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+import { resolveDiscoveryProject } from "#discover/project.js";
+import { detectPackageManager } from "#setup/package-manager.js";
+
+import type {
+  DependencyFacts,
+  DiscoveryFacts,
+  GitFacts,
+  NodeFacts,
+  PackageManagerFacts,
+} from "./types.js";
+
+const runFile = promisify(execFile);
+const LOCKFILES = [
+  "pnpm-lock.yaml",
+  "package-lock.json",
+  "yarn.lock",
+  "bun.lock",
+  "bun.lockb",
+] as const;
+
+export async function collectDiscoveryFacts(path: string): Promise<DiscoveryFacts> {
+  try {
+    return { kind: "resolved", project: await resolveDiscoveryProject(path) };
+  } catch (error) {
+    return { kind: "unresolved", message: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+export function collectNodeFacts(): NodeFacts {
+  return process.execPath === ""
+    ? { kind: "unavailable", message: "Node.js executable is unavailable." }
+    : { kind: "available", executable: process.execPath, version: process.versions.node };
+}
+
+export async function collectPackageManagerFacts(appRoot: string): Promise<PackageManagerFacts> {
+  try {
+    const manager = await detectPackageManager(appRoot);
+    const entries = new Set(await readdir(appRoot));
+    const lockfiles = LOCKFILES.filter((name) => entries.has(name));
+    const managers = new Set(
+      lockfiles.map((name) =>
+        name === "pnpm-lock.yaml"
+          ? "pnpm"
+          : name === "package-lock.json"
+            ? "npm"
+            : name === "yarn.lock"
+              ? "yarn"
+              : "bun",
+      ),
+    );
+    return {
+      kind: "observed",
+      manager: manager.kind,
+      source: manager.source,
+      lockfiles,
+      conflict: managers.size > 1,
+    };
+  } catch (error) {
+    return { kind: "unavailable", message: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+export async function collectDependencyFacts(appRoot: string): Promise<DependencyFacts> {
+  try {
+    const packageJsonPath = join(appRoot, "package.json");
+    const parsed = JSON.parse(await readFile(packageJsonPath, "utf8")) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    const names = [
+      ...Object.keys(parsed.dependencies ?? {}),
+      ...Object.keys(parsed.devDependencies ?? {}),
+    ];
+    if (names.length === 0) return { kind: "not-applicable" };
+    await access(join(appRoot, "node_modules"));
+    return { kind: "installed" };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return { kind: "missing" };
+    return { kind: "unavailable", message: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+async function git(appRoot: string, args: readonly string[]): Promise<string> {
+  return (await runFile("git", [...args], { cwd: appRoot, timeout: 5_000 })).stdout.trim();
+}
+
+export async function collectGitFacts(appRoot: string): Promise<GitFacts> {
+  try {
+    const repository = await git(appRoot, ["rev-parse", "--is-inside-work-tree"]).catch(
+      (error: NodeJS.ErrnoException) => {
+        if (error.code === "ENOENT") throw error;
+        return "false";
+      },
+    );
+    if (repository !== "true") return { kind: "not-repository" };
+    const revision = await git(appRoot, ["rev-parse", "HEAD"]).catch(() => undefined);
+    const branch = await git(appRoot, ["symbolic-ref", "--short", "HEAD"]).catch(() => undefined);
+    const remotes = (await git(appRoot, ["remote"]).catch(() => "")).split("\n").filter(Boolean);
+    return {
+      kind: "repository",
+      head: revision === undefined ? "unborn" : branch === undefined ? "detached" : "attached",
+      branch,
+      revision,
+      dirty: (await git(appRoot, ["status", "--porcelain"])) !== "",
+      remotes,
+    };
+  } catch (error) {
+    return { kind: "unavailable", message: error instanceof Error ? error.message : String(error) };
+  }
+}

--- a/packages/eve/src/doctor/doctor.integration.test.ts
+++ b/packages/eve/src/doctor/doctor.integration.test.ts
@@ -1,0 +1,68 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useTemporaryDirectories } from "#internal/testing/use-temporary-app-roots.js";
+
+import { runLocalDoctor } from "./doctor.js";
+
+const createScratchDirectory = useTemporaryDirectories();
+
+afterEach(() => {
+  process.exitCode = undefined;
+  vi.unstubAllEnvs();
+});
+
+describe("runLocalDoctor", () => {
+  it("collects independent local results without requiring Git or network", async () => {
+    const appRoot = await createScratchDirectory("eve-doctor-");
+    await mkdir(join(appRoot, "agent"));
+    await writeFile(join(appRoot, "agent", "instructions.md"), "You are helpful.\n");
+    await writeFile(
+      join(appRoot, "package.json"),
+      `${JSON.stringify({ dependencies: { eve: "latest" }, packageManager: "pnpm@11" })}\n`,
+    );
+    await writeFile(join(appRoot, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
+    await writeFile(join(appRoot, "package-lock.json"), "{}\n");
+
+    const result = await runLocalDoctor(join(appRoot, "agent"));
+
+    expect(result.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "project.discovery", status: "pass" }),
+        expect.objectContaining({ id: "package.manager", status: "warn" }),
+        expect.objectContaining({ id: "package.dependencies", status: "fail" }),
+        expect.objectContaining({ id: "git.repository", status: "warn" }),
+      ]),
+    );
+  });
+
+  it("reports unavailable Git tooling instead of a missing repository", async () => {
+    const appRoot = await createScratchDirectory("eve-doctor-no-git-");
+    await mkdir(join(appRoot, "agent"));
+    await writeFile(join(appRoot, "agent", "instructions.md"), "You are helpful.\n");
+    await writeFile(join(appRoot, "package.json"), '{ "packageManager": "pnpm@11" }\n');
+    vi.stubEnv("PATH", "");
+
+    const result = await runLocalDoctor(appRoot);
+
+    expect(result.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "git.repository", status: "unknown" }),
+        expect.objectContaining({ id: "git.remote", status: "unknown" }),
+      ]),
+    );
+  });
+
+  it("continues rendering Node facts when discovery fails", async () => {
+    const path = await createScratchDirectory("eve-doctor-empty-");
+    const result = await runLocalDoctor(path);
+
+    expect(result.diagnostics.map((diagnostic) => diagnostic.id)).toEqual([
+      "runtime.node",
+      "project.discovery",
+    ]);
+    expect(result.summary.fail).toBeGreaterThan(0);
+  });
+});

--- a/packages/eve/src/doctor/doctor.ts
+++ b/packages/eve/src/doctor/doctor.ts
@@ -1,0 +1,55 @@
+import { resolveEvePackageContract } from "#setup/eve-package-contract.js";
+
+import {
+  collectDependencyFacts,
+  collectDiscoveryFacts,
+  collectGitFacts,
+  collectNodeFacts,
+  collectPackageManagerFacts,
+} from "./collectors.js";
+import {
+  dependencyDiagnostic,
+  discoveryDiagnostic,
+  gitDiagnostics,
+  nodeDiagnostic,
+  packageManagerDiagnostic,
+} from "./policies.js";
+import type { Diagnostic, DiagnosticStatus } from "./types.js";
+
+export interface DoctorResult {
+  summary: Record<DiagnosticStatus, number>;
+  diagnostics: readonly Diagnostic[];
+}
+
+export async function runLocalDoctor(path: string): Promise<DoctorResult> {
+  const discovery = await collectDiscoveryFacts(path);
+  const diagnostics: Diagnostic[] = [
+    nodeDiagnostic(collectNodeFacts(), resolveEvePackageContract().nodeEngine),
+    discoveryDiagnostic(discovery),
+  ];
+  if (discovery.kind === "resolved") {
+    const [packageManager, dependencies, git] = await Promise.all([
+      collectPackageManagerFacts(discovery.project.appRoot),
+      collectDependencyFacts(discovery.project.appRoot),
+      collectGitFacts(discovery.project.appRoot),
+    ]);
+    diagnostics.push(packageManagerDiagnostic(packageManager));
+    diagnostics.push(
+      dependencyDiagnostic(
+        dependencies,
+        packageManager.kind === "observed" ? packageManager.manager : "pnpm",
+      ),
+    );
+    diagnostics.push(...gitDiagnostics(git));
+  }
+  return {
+    diagnostics,
+    summary: diagnostics.reduce<Record<DiagnosticStatus, number>>(
+      (summary, diagnostic) => {
+        summary[diagnostic.status] += 1;
+        return summary;
+      },
+      { pass: 0, warn: 0, fail: 0, unknown: 0 },
+    ),
+  };
+}

--- a/packages/eve/src/doctor/policies.test.ts
+++ b/packages/eve/src/doctor/policies.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  dependencyDiagnostic,
+  discoveryDiagnostic,
+  gitDiagnostics,
+  nodeDiagnostic,
+} from "./policies.js";
+
+describe("doctor policies", () => {
+  it("never presents unavailable evidence as a pass", () => {
+    expect(nodeDiagnostic({ kind: "unavailable", message: "missing" }, ">=24").status).toBe("fail");
+    expect(
+      gitDiagnostics({ kind: "unavailable", message: "git failed" }).every(
+        (diagnostic) => diagnostic.status === "unknown",
+      ),
+    ).toBe(true);
+  });
+
+  it("uses the supplied eve Node.js engine range", () => {
+    expect(
+      nodeDiagnostic({ kind: "available", executable: "node", version: "24.5.0" }, ">=24.5.0"),
+    ).toMatchObject({
+      status: "pass",
+    });
+    expect(
+      nodeDiagnostic({ kind: "available", executable: "node", version: "24.4.0" }, ">=24.5.0"),
+    ).toMatchObject({
+      status: "fail",
+      summary: "Node.js 24.4.0 is unsupported; eve requires Node.js >=24.5.0.",
+    });
+  });
+
+  it("keeps Git optional for local development", () => {
+    expect(gitDiagnostics({ kind: "not-repository" })).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "git.repository", status: "warn" }),
+        expect.objectContaining({ id: "git.remote", status: "warn" }),
+      ]),
+    );
+  });
+
+  it("explains the impact and gives the dependency retry command", () => {
+    expect(dependencyDiagnostic({ kind: "missing" }, "npm")).toMatchObject({
+      id: "package.dependencies",
+      status: "fail",
+      summary: "Project dependencies are not installed; commands that load project code may fail.",
+      remediation: [{ kind: "command", command: "npm install" }],
+    });
+  });
+
+  it("does not expose project layout in user-facing discovery output", () => {
+    expect(
+      discoveryDiagnostic({
+        kind: "resolved",
+        project: { agentRoot: "/project/agent", appRoot: "/project", layout: "nested" },
+      }),
+    ).toMatchObject({ summary: "Found eve project at /project." });
+  });
+
+  it("explains why optional Git setup may still matter", () => {
+    expect(gitDiagnostics({ kind: "not-repository" })).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "git.repository",
+          summary: expect.stringContaining("cannot commit or share changes"),
+        }),
+        expect.objectContaining({
+          id: "git.remote",
+          summary: expect.stringContaining("cannot push or share this repository"),
+        }),
+      ]),
+    );
+  });
+});

--- a/packages/eve/src/doctor/policies.ts
+++ b/packages/eve/src/doctor/policies.ts
@@ -1,0 +1,171 @@
+import semver from "#compiled/semver/index.js";
+
+import type {
+  DependencyFacts,
+  Diagnostic,
+  DiscoveryFacts,
+  GitFacts,
+  NodeFacts,
+  PackageManagerFacts,
+} from "./types.js";
+
+export function nodeDiagnostic(facts: NodeFacts, nodeEngine: string): Diagnostic {
+  if (facts.kind === "unavailable") {
+    return { id: "runtime.node", status: "fail", summary: facts.message, remediation: [] };
+  }
+  const supported = semver.satisfies(facts.version, nodeEngine);
+  return supported
+    ? {
+        id: "runtime.node",
+        status: "pass",
+        summary: `Node.js ${facts.version} is available at ${facts.executable}.`,
+        remediation: [],
+      }
+    : {
+        id: "runtime.node",
+        status: "fail",
+        summary: `Node.js ${facts.version} is unsupported; eve requires Node.js ${nodeEngine}.`,
+        remediation: [
+          { kind: "message", message: `Install a Node.js version matching ${nodeEngine}.` },
+        ],
+      };
+}
+
+export function discoveryDiagnostic(facts: DiscoveryFacts): Diagnostic {
+  return facts.kind === "resolved"
+    ? {
+        id: "project.discovery",
+        status: "pass",
+        summary: `Found eve project at ${facts.project.appRoot}.`,
+        remediation: [],
+      }
+    : {
+        id: "project.discovery",
+        status: "fail",
+        summary: facts.message,
+        remediation: [{ kind: "command", command: "eve init <path>" }],
+      };
+}
+
+export function packageManagerDiagnostic(facts: PackageManagerFacts): Diagnostic {
+  if (facts.kind === "unavailable") {
+    return { id: "package.manager", status: "unknown", summary: facts.message, remediation: [] };
+  }
+  if (facts.conflict) {
+    return {
+      id: "package.manager",
+      status: "warn",
+      summary: `Selected ${facts.manager}, but multiple package-manager lockfiles are present: ${facts.lockfiles.join(", ")}.`,
+      remediation: [
+        {
+          kind: "message",
+          message: "Remove stale lockfiles after confirming the intended package manager.",
+        },
+      ],
+    };
+  }
+  return {
+    id: "package.manager",
+    status: "pass",
+    summary: `Selected ${facts.manager} as the package manager (${facts.source}).`,
+    remediation: [],
+  };
+}
+
+export function dependencyDiagnostic(facts: DependencyFacts, manager: string): Diagnostic {
+  switch (facts.kind) {
+    case "installed":
+      return {
+        id: "package.dependencies",
+        status: "pass",
+        summary: "Project dependencies are installed.",
+        remediation: [],
+      };
+    case "not-applicable":
+      return {
+        id: "package.dependencies",
+        status: "pass",
+        summary: "The project declares no dependencies.",
+        remediation: [],
+      };
+    case "missing":
+      return {
+        id: "package.dependencies",
+        status: "fail",
+        summary:
+          "Project dependencies are not installed; commands that load project code may fail.",
+        remediation: [{ kind: "command", command: `${manager} install` }],
+      };
+    case "unavailable":
+      return {
+        id: "package.dependencies",
+        status: "unknown",
+        summary: facts.message,
+        remediation: [],
+      };
+  }
+}
+
+export function gitDiagnostics(facts: GitFacts): Diagnostic[] {
+  if (facts.kind === "unavailable") {
+    return [
+      { id: "git.repository", status: "unknown", summary: facts.message, remediation: [] },
+      {
+        id: "git.remote",
+        status: "unknown",
+        summary: "Git remotes could not be inspected.",
+        remediation: [],
+      },
+    ];
+  }
+  if (facts.kind === "not-repository") {
+    return [
+      {
+        id: "git.repository",
+        status: "warn",
+        summary:
+          "This project is not a Git repository. Local development works, but you cannot commit or share changes yet.",
+        remediation: [{ kind: "command", command: "git init" }],
+      },
+      {
+        id: "git.remote",
+        status: "warn",
+        summary:
+          "No Git remote is configured. Local development works, but you cannot push or share this repository.",
+        remediation: [],
+      },
+    ];
+  }
+  return [
+    {
+      id: "git.repository",
+      status: facts.head === "unborn" ? "warn" : "pass",
+      summary:
+        facts.head === "unborn"
+          ? "Git repository has no commits yet; commit the project before sharing it."
+          : facts.head === "detached"
+            ? `Git repository is at detached revision ${facts.revision}; switch to a branch before committing changes.`
+            : `Git repository is on branch ${facts.branch}${facts.dirty ? " with local changes" : ""}.`,
+      remediation:
+        facts.head === "unborn"
+          ? [{ kind: "command", command: 'git add . && git commit -m "Initial commit"' }]
+          : facts.head === "detached"
+            ? [{ kind: "command", command: "git switch -c <branch>" }]
+            : [],
+    },
+    facts.remotes.length === 0
+      ? {
+          id: "git.remote",
+          status: "warn",
+          summary:
+            "No Git remote is configured. Local development works, but you cannot push or share this repository.",
+          remediation: [],
+        }
+      : {
+          id: "git.remote",
+          status: "pass",
+          summary: `Git remotes: ${facts.remotes.join(", ")}.`,
+          remediation: [],
+        },
+  ];
+}

--- a/packages/eve/src/doctor/render.test.ts
+++ b/packages/eve/src/doctor/render.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { createCliTheme } from "#cli/ui/output.js";
+
+import { renderDoctorHuman, renderDoctorJson } from "./render.js";
+
+const result = {
+  summary: { pass: 1, warn: 1, fail: 0, unknown: 0 },
+  diagnostics: [
+    { id: "runtime.node", status: "pass" as const, summary: "Node is available.", remediation: [] },
+    {
+      id: "git.remote",
+      status: "warn" as const,
+      summary: "No remote; local development is unaffected.",
+      remediation: [],
+    },
+  ],
+};
+
+describe("doctor rendering", () => {
+  it("renders a human checklist and summary", () => {
+    expect(renderDoctorHuman(result, createCliTheme({ color: false }))).toBe(
+      "eve Doctor\n==========\nLocal environment and project checks. No network calls or changes.\n\nEnvironment\n✓ Node is available.\n\nGit\n! No remote; local development is unaffected.\n\n0 failures, 1 warnings, 0 unknown",
+    );
+  });
+
+  it("colors status symbols and command remediation in a terminal", () => {
+    const colored = renderDoctorHuman(
+      {
+        summary: { pass: 0, warn: 0, fail: 1, unknown: 0 },
+        diagnostics: [
+          {
+            id: "package.dependencies",
+            status: "fail",
+            summary: "Dependencies are missing.",
+            remediation: [{ kind: "command", command: "pnpm install" }],
+          },
+        ],
+      },
+      createCliTheme({ color: true }),
+    );
+
+    expect(colored).toContain("\u001B[36mPackages\u001B[39m");
+    expect(colored).toContain("\u001B[31m✗\u001B[39m");
+    expect(colored).toContain("\u001B[34mpnpm install\u001B[39m");
+  });
+
+  it("renders only the machine result without a schema version", () => {
+    const json = JSON.parse(renderDoctorJson(result)) as Record<string, unknown>;
+    expect(json).toEqual(result);
+    expect(json).not.toHaveProperty("schemaVersion");
+  });
+});

--- a/packages/eve/src/doctor/render.ts
+++ b/packages/eve/src/doctor/render.ts
@@ -1,0 +1,73 @@
+import { createCliTheme, renderCliBanner, type CliTheme } from "#cli/ui/output.js";
+
+import type { DoctorResult } from "./doctor.js";
+import type { Diagnostic, DiagnosticStatus } from "./types.js";
+
+const SYMBOLS = { pass: "✓", warn: "!", fail: "✗", unknown: "?" } as const;
+const SECTION_TITLES = ["Environment", "Packages", "Git"] as const;
+
+function sectionFor(diagnostic: Diagnostic): (typeof SECTION_TITLES)[number] {
+  if (diagnostic.id.startsWith("runtime.") || diagnostic.id.startsWith("project.")) {
+    return "Environment";
+  }
+  if (diagnostic.id.startsWith("package.")) return "Packages";
+  return "Git";
+}
+
+function statusText(theme: CliTheme, status: DiagnosticStatus, text: string): string {
+  switch (status) {
+    case "pass":
+      return theme.success(text);
+    case "warn":
+      return theme.warning(text);
+    case "fail":
+      return theme.danger(text);
+    case "unknown":
+      return theme.muted(text);
+  }
+}
+
+function remediationText(theme: CliTheme, diagnostic: Diagnostic): string[] {
+  return diagnostic.remediation.map((item) =>
+    item.kind === "command"
+      ? `    ${theme.muted("Run:")} ${theme.info(item.command)}`
+      : `    ${item.message}`,
+  );
+}
+
+export function renderDoctorHuman(
+  result: DoctorResult,
+  theme: CliTheme = createCliTheme(),
+): string {
+  const lines = SECTION_TITLES.flatMap((section) => {
+    const diagnostics = result.diagnostics.filter(
+      (diagnostic) => sectionFor(diagnostic) === section,
+    );
+    if (diagnostics.length === 0) return [];
+    return [
+      theme.accent(section),
+      ...diagnostics.flatMap((diagnostic) => [
+        `${statusText(theme, diagnostic.status, SYMBOLS[diagnostic.status])} ${diagnostic.summary}`,
+        ...remediationText(theme, diagnostic),
+      ]),
+      "",
+    ];
+  });
+  lines.push(
+    theme.muted(
+      `${result.summary.fail} failures, ${result.summary.warn} warnings, ${result.summary.unknown} unknown`,
+    ),
+  );
+  return [
+    renderCliBanner(theme, {
+      subtitle: "Local environment and project checks. No network calls or changes.",
+      title: "eve Doctor",
+    }),
+    "",
+    lines.join("\n"),
+  ].join("\n");
+}
+
+export function renderDoctorJson(result: DoctorResult): string {
+  return JSON.stringify(result, null, 2);
+}

--- a/packages/eve/src/doctor/types.ts
+++ b/packages/eve/src/doctor/types.ts
@@ -1,0 +1,51 @@
+import type { ResolvedDiscoveryProject } from "#discover/project.js";
+import type { PackageManagerKind, PackageManagerSource } from "#setup/package-manager.js";
+
+export type DiagnosticStatus = "pass" | "warn" | "fail" | "unknown";
+
+export type Remediation =
+  | { kind: "command"; command: string }
+  | { kind: "message"; message: string };
+
+export interface Diagnostic {
+  id: string;
+  status: DiagnosticStatus;
+  summary: string;
+  remediation: readonly Remediation[];
+}
+
+export type DiscoveryFacts =
+  | { kind: "resolved"; project: ResolvedDiscoveryProject }
+  | { kind: "unresolved"; message: string };
+
+export type NodeFacts =
+  | { kind: "available"; executable: string; version: string }
+  | { kind: "unavailable"; message: string };
+
+export type PackageManagerFacts =
+  | {
+      kind: "observed";
+      manager: PackageManagerKind;
+      source: PackageManagerSource;
+      lockfiles: readonly string[];
+      conflict: boolean;
+    }
+  | { kind: "unavailable"; message: string };
+
+export type DependencyFacts =
+  | { kind: "installed" }
+  | { kind: "missing" }
+  | { kind: "not-applicable" }
+  | { kind: "unavailable"; message: string };
+
+export type GitFacts =
+  | { kind: "not-repository" }
+  | {
+      kind: "repository";
+      head: "unborn" | "attached" | "detached";
+      branch?: string;
+      revision?: string;
+      dirty: boolean;
+      remotes: readonly string[];
+    }
+  | { kind: "unavailable"; message: string };

--- a/packages/eve/src/setup/eve-package-contract.ts
+++ b/packages/eve/src/setup/eve-package-contract.ts
@@ -1,0 +1,24 @@
+import { resolveVersionToken } from "./scaffold/version-tokens.js";
+
+/** The eve package metadata that generated projects and local diagnostics consume together. */
+export interface EvePackageContract {
+  /** eve dependency version or npm specifier written to the generated package. */
+  version: string;
+  /** The matching eve release's authored `package.json` `engines.node` value. */
+  nodeEngine: string;
+}
+
+export const DEFAULT_EVE_PACKAGE_CONTRACT: EvePackageContract = {
+  version: "__EVE_PACKAGE_DEPENDENCY_VERSION__",
+  nodeEngine: "__NODE_ENGINE__",
+};
+
+/** Resolves a stamped or explicitly supplied eve package contract. */
+export function resolveEvePackageContract(
+  contract: EvePackageContract = DEFAULT_EVE_PACKAGE_CONTRACT,
+): EvePackageContract {
+  return {
+    version: resolveVersionToken("evePackage.version", contract.version),
+    nodeEngine: resolveVersionToken("evePackage.nodeEngine", contract.nodeEngine),
+  };
+}

--- a/packages/eve/src/setup/scaffold/create/add-to-project.ts
+++ b/packages/eve/src/setup/scaffold/create/add-to-project.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 
 import type { PackageManagerKind } from "../../package-manager.js";
 import type { NodeEngineOverride } from "../../node-engine.js";
+import { resolveEvePackageContract, type EvePackageContract } from "../../eve-package-contract.js";
 import type { AgentReasoningDefinition } from "../../../shared/agent-definition.js";
 import { pathExists, writeTextFile } from "../files.js";
 import { patchPackageJson, type PackageJsonPatch } from "../update/package-json.js";
@@ -18,8 +19,6 @@ import {
   DEFAULT_CONNECT_PACKAGE_VERSION,
   DEFAULT_ZOD_PACKAGE_VERSION,
   formatEveDependencySpecifier,
-  resolveEvePackageContract,
-  type EvePackageContract,
 } from "./project.js";
 
 export interface AddAgentToProjectOptions {

--- a/packages/eve/src/setup/scaffold/create/extension.ts
+++ b/packages/eve/src/setup/scaffold/create/extension.ts
@@ -3,6 +3,11 @@ import { basename, resolve } from "node:path";
 
 import type { PackageManagerKind } from "../../package-manager.js";
 import { pinnedNodeEngineMajor } from "../../node-engine.js";
+import {
+  DEFAULT_EVE_PACKAGE_CONTRACT,
+  resolveEvePackageContract,
+  type EvePackageContract,
+} from "../../eve-package-contract.js";
 import { pathExists, writeTextFile } from "../files.js";
 import { blockingCreateInPlaceEntries } from "../create-in-place.js";
 import { resolveVersionToken } from "../version-tokens.js";
@@ -14,11 +19,8 @@ import {
 } from "../workspace-root.js";
 import {
   CURRENT_DIRECTORY_PROJECT_NAME,
-  DEFAULT_EVE_PACKAGE_CONTRACT,
   DEFAULT_ZOD_PACKAGE_VERSION,
-  resolveEvePackageContract,
   ROOT_ONLY_PACKAGE_JSON_TEMPLATE_SUFFIX,
-  type EvePackageContract,
 } from "./project.js";
 
 const DEFAULT_TYPESCRIPT_PACKAGE_VERSION = "__TYPESCRIPT_VERSION__";

--- a/packages/eve/src/setup/scaffold/create/project.ts
+++ b/packages/eve/src/setup/scaffold/create/project.ts
@@ -3,6 +3,7 @@ import { basename, join, resolve } from "node:path";
 
 import type { PackageManagerKind } from "../../package-manager.js";
 import { pinnedNodeEngineMajor } from "../../node-engine.js";
+import { resolveEvePackageContract, type EvePackageContract } from "../../eve-package-contract.js";
 import type { AgentReasoningDefinition } from "../../../shared/agent-definition.js";
 import { parseChatGptModelSelection } from "../../../shared/chatgpt-model.js";
 import { SUPPORTED_AUTHORED_MODULE_FILE_EXTENSIONS } from "../update/module-files.js";
@@ -24,34 +25,7 @@ export const DEFAULT_CONNECT_PACKAGE_VERSION = "__VERCEL_CONNECT_VERSION__";
 export const DEFAULT_ZOD_PACKAGE_VERSION = "__ZOD_VERSION__";
 const DEFAULT_TYPESCRIPT_PACKAGE_VERSION = "__TYPESCRIPT_VERSION__";
 
-/**
- * The eve package metadata that generated projects consume together. Keeping
- * the dependency version and Node.js requirement in one value prevents a
- * scaffold from installing one eve release while declaring another release's
- * runtime contract.
- */
-export interface EvePackageContract {
-  /** eve dependency version or npm specifier written to the generated package. */
-  version: string;
-  /** The matching eve release's authored `package.json` `engines.node` value. */
-  nodeEngine: string;
-}
-
-export const DEFAULT_EVE_PACKAGE_CONTRACT: EvePackageContract = {
-  version: "__EVE_PACKAGE_DEPENDENCY_VERSION__",
-  nodeEngine: "__NODE_ENGINE__",
-};
-
-/** Resolves a stamped or explicitly supplied eve package contract. */
-export function resolveEvePackageContract(
-  contract: EvePackageContract = DEFAULT_EVE_PACKAGE_CONTRACT,
-): EvePackageContract {
-  return {
-    version: resolveVersionToken("evePackage.version", contract.version),
-    nodeEngine: resolveVersionToken("evePackage.nodeEngine", contract.nodeEngine),
-  };
-}
-
+export type { EvePackageContract } from "../../eve-package-contract.js";
 interface TemplateContext {
   appName: string;
   model: string;

--- a/packages/eve/src/setup/scaffold/update/channels.ts
+++ b/packages/eve/src/setup/scaffold/update/channels.ts
@@ -5,6 +5,7 @@ import { appendEnv } from "../../append-env.js";
 
 import type { PackageManagerKind } from "../../package-manager.js";
 import { pinnedNodeEngineMajor, type NodeEngineOverride } from "../../node-engine.js";
+import { resolveEvePackageContract } from "../../eve-package-contract.js";
 import { pathExists, writeTextFile } from "../files.js";
 import { resolveVersionToken } from "../version-tokens.js";
 import {
@@ -15,7 +16,7 @@ import {
 } from "../workspace-root.js";
 import { getSupportedModuleBaseName, matchesSupportedModuleBaseName } from "./module-files.js";
 import { patchPackageJson, type PackageJsonPatch } from "./package-json.js";
-import { CURRENT_DIRECTORY_PROJECT_NAME, resolveEvePackageContract } from "../create/project.js";
+import { CURRENT_DIRECTORY_PROJECT_NAME } from "../create/project.js";
 import {
   WEB_APP_SIGN_IN_WITH_VERCEL_TEMPLATE_FILES,
   WEB_APP_TEMPLATE_FILES,

--- a/packages/eve/src/setup/scaffold/update/web-options.ts
+++ b/packages/eve/src/setup/scaffold/update/web-options.ts
@@ -1,4 +1,7 @@
-import { DEFAULT_EVE_PACKAGE_CONTRACT, type EvePackageContract } from "../create/project.js";
+import {
+  DEFAULT_EVE_PACKAGE_CONTRACT,
+  type EvePackageContract,
+} from "../../eve-package-contract.js";
 
 const DEFAULT_AI_PACKAGE_VERSION = "__AI_SDK_VERSION__";
 const DEFAULT_BETTER_AUTH_PACKAGE_VERSION = "__BETTER_AUTH_VERSION__";


### PR DESCRIPTION
### Summary

This final PR in the onboarding stack adds `eve doctor [path]`, a local, read-only diagnostic command for an eve project. It runs applicable checks without network access or mutations, reports failures without stopping at the first one, and supports human or JSON output. Human output groups environment, package, and Git checks under blue section headings; the Node check derives its semver range from eve’s canonical package contract.

### Before / after

Before, diagnosing a local setup required manually running and interpreting separate commands:

```console
$ node --version
$ pnpm install
$ git status
$ git remote -v
$ eve build
```

After, one command reports local runtime, project discovery, package-manager, dependency, and Git state:

```console
$ eve doctor
Environment
✓ Node.js 24.x is available at /path/to/node.
✓ Found eve project at /path/to/project.

Packages
✗ Project dependencies are not installed; commands that load project code may fail.
    Run: pnpm install

Git
! No Git remote is configured. Local development works, but you cannot push or share this repository.
```

Automation can consume the same results without terminal formatting:

```console
$ eve doctor --json
{
  "summary": { "pass": 2, "warn": 1, "fail": 1, "unknown": 0 },
  "diagnostics": []
}
```

### Validation

Unit coverage verifies diagnostic policy and rendering, while integration coverage verifies independent local checks continue when Git is absent and discovery fails. No broader validation was run for this PR separately.

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [ ] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+27 / -8`

The CLI reference documents command scope, exit behavior, JSON output, and the deliberate no-compilation boundary; the changeset records the release behavior.

**Implementation** — 16 files · `+539 / -43`

The new doctor module separates fact collection, policy, and rendering so local checks remain composable and every applicable diagnostic can run independently. A small shared package-contract module keeps doctor and scaffolding on the same Node.js engine requirement.

**Tests** — 4 files · `+220 / -0`

Unit and integration coverage exercise policies, terminal and JSON rendering, command exit status, independent-check behavior, unavailable Git tooling, sectioned human output, and Node-engine boundaries.
