### PR TITLE
feat(eve): add experimental embedded application API

### DIFF
--- a/.changeset/tidy-spiders-embed.md
+++ b/.changeset/tidy-spiders-embed.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add an experimental `eve/embedded` proof of concept for compiling, running, and building one application-owned agent definition without an `agent/` source tree. The entrypoint has no compatibility guarantee and currently supports one local executor per process.

--- a/apps/fixtures/embedded-triage-cli/.gitignore
+++ b/apps/fixtures/embedded-triage-cli/.gitignore
@@ -1,0 +1,2 @@
+.eve/
+.output/

--- a/apps/fixtures/embedded-triage-cli/README.md
+++ b/apps/fixtures/embedded-triage-cli/README.md
@@ -1,0 +1,17 @@
+# Embedded support triage CLI
+
+This private fixture is an architectural spike that embeds eve behind a support-ticket triage CLI. It has no `agent/` directory. The application defines one embedded agent in `embedded-agent.mjs`, runs it through a local durable Workflow executor, and produces schema-constrained JSON.
+
+From the repository root, run the sample ticket:
+
+```sh
+pnpm --filter embedded-triage-cli embedded-triage run ./sample-ticket.json
+```
+
+Build the production application:
+
+```sh
+pnpm --filter embedded-triage-cli embedded-triage build
+```
+
+The build uses eve's production application pipeline and includes the Workflow flow handler. This spike does not prove a remote deployment, external idempotency, concurrent embedded executors, multiple agents, human input, or sandbox and authentication ownership. The `eve/embedded` API is experimental and has no compatibility guarantee.

--- a/apps/fixtures/embedded-triage-cli/bin/eve-source-loader.mjs
+++ b/apps/fixtures/embedded-triage-cli/bin/eve-source-loader.mjs
@@ -1,0 +1,14 @@
+import { registerHooks } from "node:module";
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    try {
+      return nextResolve(specifier, context);
+    } catch (error) {
+      if (error?.code !== "ERR_MODULE_NOT_FOUND" || !specifier.endsWith(".js")) {
+        throw error;
+      }
+      return nextResolve(`${specifier.slice(0, -3)}.ts`, context);
+    }
+  },
+});

--- a/apps/fixtures/embedded-triage-cli/bin/triage.mjs
+++ b/apps/fixtures/embedded-triage-cli/bin/triage.mjs
@@ -8,15 +8,25 @@ import { buildEmbeddedApplication, createEmbeddedLocalExecutor } from "eve/embed
 
 const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const entrypoint = "embedded-agent.mjs";
+const help = `Usage: embedded-triage <command>
+
+Commands:
+  run <ticket.json>  Triage the support ticket in a JSON file
+  build              Build the production application
+
+Options:
+  -h, --help         Show this help message`;
 const [command, argument, ...extraArguments] = process.argv.slice(2);
 
 try {
-  if (command === "run" && argument !== undefined && extraArguments.length === 0) {
+  if ((command === "-h" || command === "--help") && argument === undefined) {
+    console.log(help);
+  } else if (command === "run" && argument !== undefined && extraArguments.length === 0) {
     await runTicket(argument);
   } else if (command === "build" && argument === undefined) {
     await buildApplication();
   } else {
-    throw new Error("Usage: embedded-triage run <ticket.json>\n       embedded-triage build");
+    throw new Error(`${help}\n\nRun "embedded-triage --help" for usage information.`);
   }
 } catch (error) {
   console.error(`Ticket triage failed: ${error instanceof Error ? error.message : String(error)}`);

--- a/apps/fixtures/embedded-triage-cli/bin/triage.mjs
+++ b/apps/fixtures/embedded-triage-cli/bin/triage.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { buildEmbeddedApplication, createEmbeddedLocalExecutor } from "eve/embedded";
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const entrypoint = "embedded-agent.mjs";
+const [command, argument, ...extraArguments] = process.argv.slice(2);
+
+try {
+  if (command === "run" && argument !== undefined && extraArguments.length === 0) {
+    await runTicket(argument);
+  } else if (command === "build" && argument === undefined) {
+    await buildApplication();
+  } else {
+    throw new Error("Usage: embedded-triage run <ticket.json>\n       embedded-triage build");
+  }
+} catch (error) {
+  console.error(`Ticket triage failed: ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+}
+
+async function runTicket(ticketPath) {
+  const ticket = JSON.parse(await readFile(resolve(process.cwd(), ticketPath), "utf8"));
+  if (typeof ticket !== "object" || ticket === null || Array.isArray(ticket)) {
+    throw new Error("The ticket file must contain a JSON object.");
+  }
+
+  console.error("Triaging support ticket...");
+  const executor = await createEmbeddedLocalExecutor({ appRoot, entrypoint });
+  try {
+    const completed = await executor.run({ input: ticket });
+    process.stdout.write(`${JSON.stringify(completed.result, null, 2)}\n`);
+    console.error("Support ticket triage complete.");
+  } finally {
+    await executor.close();
+  }
+}
+
+async function buildApplication() {
+  console.error("Building support triage application...");
+  const built = await buildEmbeddedApplication({ appRoot, entrypoint });
+  process.stdout.write(`${built.outputDirectory}\n`);
+  console.error("Support triage application build complete.");
+}

--- a/apps/fixtures/embedded-triage-cli/embedded-agent.mjs
+++ b/apps/fixtures/embedded-triage-cli/embedded-agent.mjs
@@ -1,0 +1,32 @@
+import { defineEmbeddedAgent } from "eve/embedded";
+import { mockModel } from "eve/evals";
+
+const triage = {
+  category: "authentication",
+  priority: "high",
+  summary: "Customer cannot sign in after resetting their password.",
+};
+
+export default defineEmbeddedAgent({
+  instructions:
+    "Triage the supplied support ticket. Return its category, priority, and a concise summary.",
+  model: mockModel(({ tools }) => {
+    if (tools.some((tool) => tool.name === "final_output")) {
+      return {
+        toolCalls: [{ id: "triage-result", input: triage, name: "final_output" }],
+      };
+    }
+    return "Preparing support ticket triage.";
+  }),
+  modelContextWindowTokens: 32_000,
+  outputSchema: {
+    additionalProperties: false,
+    properties: {
+      category: { enum: ["authentication", "billing", "bug", "other"], type: "string" },
+      priority: { enum: ["low", "medium", "high", "urgent"], type: "string" },
+      summary: { type: "string" },
+    },
+    required: ["category", "priority", "summary"],
+    type: "object",
+  },
+});

--- a/apps/fixtures/embedded-triage-cli/package.json
+++ b/apps/fixtures/embedded-triage-cli/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "embedded-triage-cli",
+  "private": true,
+  "bin": {
+    "embedded-triage": "./bin/triage.mjs"
+  },
+  "type": "module",
+  "scripts": {
+    "embedded-triage": "node --experimental-strip-types --conditions=eve-source --import ./bin/eve-source-loader.mjs ./bin/triage.mjs"
+  },
+  "dependencies": {
+    "eve": "workspace:*"
+  }
+}

--- a/apps/fixtures/embedded-triage-cli/sample-ticket.json
+++ b/apps/fixtures/embedded-triage-cli/sample-ticket.json
@@ -1,0 +1,5 @@
+{
+  "id": "SUP-1042",
+  "subject": "Cannot sign in after password reset",
+  "body": "I reset my password this morning, but the new password is rejected every time I try to sign in."
+}

--- a/docs/reference/typescript-api.md
+++ b/docs/reference/typescript-api.md
@@ -3,7 +3,7 @@ title: "TypeScript API Reference"
 description: "The define* helpers, the runtime ctx, and where each one is imported from."
 ---
 
-This is the public surface of the `eve` package: the `define*` helpers you author with, the `ctx` they receive at runtime, and the import path for each. The full contract lives in `packages/eve/src/public/index.ts`; anything not exported there is a framework internal.
+This is the supported public surface of the `eve` package: the `define*` helpers you author with, the `ctx` they receive at runtime, and the import path for each. The stable authoring contract lives in `packages/eve/src/public/index.ts`; separately documented experimental entrypoints are not part of that contract.
 
 Identity comes from the filesystem, not a field you set. A tool at `agent/tools/get_weather.ts` is `get_weather`, and a connection at `agent/connections/linear.ts` is `linear`, so no definition carries a `name` or `id`.
 
@@ -50,7 +50,10 @@ export default defineTool({
 | `defineEval`                                          | `eve/evals`                                          | `evals/*.eval.ts`                                                          | [Evals](../evals/overview)                             |
 | `defineEvalConfig`                                    | `eve/evals`                                          | `evals/evals.config.ts`                                                    | [Evals](../evals/overview)                             |
 | `mockModel`                                           | `eve/evals`                                          | Deterministic fixture agent models                                         | [Evals](../evals/overview)                             |
+| `defineEmbeddedAgent`                                 | `eve/embedded`                                       | Experimental application-owned agent entrypoint                            | See the warning below                                  |
 | `useEveAgent`                                         | `eve/react`, `eve/vue`, `eve/svelte`                 | frontend                                                                   | [Frontend](../guides/frontend/overview)                |
+
+> **Experimental embedded spike:** `eve/embedded` also exports `buildEmbeddedApplication` and `createEmbeddedLocalExecutor`. This proof of concept supports one default-exported agent, one local executor per process, JSON task input, and structured task output. It does not define compatibility, multi-agent registries, human input, authentication, deployment behavior, or sandbox ownership. Do not use it as a supported application integration API.
 
 A few additional helpers round out the set: `defineGlobTool`, `defineGrepTool`, `disableTool`, `experimental_workflow`, and `webSearch` from `eve/tools` (see [Built-in tools](../concepts/built-in-tools)), `sleep` from `eve/tools/sleep`, the route verbs `GET`/`POST`/`PUT`/`PATCH`/`DELETE`/`WS` from `eve/channels`, the approval policies `always`/`once`/`never` from `eve/tools/approval`, and the channel auth helpers `localDev`/`vercelOidc`/`placeholderAuth` from `eve/channels/auth`. To wrap a framework-provided tool, import its definition from `eve/tools/defaults` (`bash`, `readFile`, `writeFile`, `glob`, `grep`, `webFetch`, `todo`, `loadSkill`). `AgentReasoningDefinition` is exported from `eve` for the top-level `defineAgent({ reasoning })` setting. `AgentLimitsDefinition` is exported for `defineAgent({ limits })`. `AgentWorkflowDefinition` and `AgentWorkflowWorldDefinition` are exported from `eve` for the `defineAgent({ experimental: { workflow } })` config shape. `ExperimentalWorkflowToolInput`, `WebSearchToolInput`, and `WebSearchProvider` are exported from `eve/tools` for their corresponding tool configuration helpers.
 
@@ -91,6 +94,7 @@ A few additional helpers round out the set: `defineGlobTool`, `defineGrepTool`, 
 | `eve/instrumentation`                                       | `defineInstrumentation`, `isChannel`                                                                      |
 | `eve/models/openai`                                         | `chatgpt`, deprecated `experimental_chatgpt`                                                              |
 | `eve/evals`                                                 | `defineEval`, `defineEvalConfig`, `mockModel`, eval types                                                 |
+| `eve/embedded`                                              | Experimental single-agent definition, local executor, and production builder                              |
 | `eve/evals/expect`                                          | `includes`, `equals`, `matches`, `similarity`                                                             |
 | `eve/evals/reporters`                                       | `Braintrust`, `JUnit`, `EvalReporter`                                                                     |
 | `eve/evals/loaders`                                         | `loadJson`, `loadYaml`                                                                                    |

--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -161,8 +161,15 @@
       "import": "./dist/src/public/sandbox/vercel.js",
       "default": "./dist/src/public/sandbox/vercel.js"
     },
+    "./embedded": {
+      "types": "./dist/src/experimental/embedded/index.d.ts",
+      "eve-source": "./src/experimental/embedded/index.ts",
+      "import": "./dist/src/experimental/embedded/index.js",
+      "default": "./dist/src/experimental/embedded/index.js"
+    },
     "./evals": {
       "types": "./dist/src/evals/index.d.ts",
+      "eve-source": "./src/evals/index.ts",
       "import": "./dist/src/evals/index.js",
       "default": "./dist/src/evals/index.js"
     },

--- a/packages/eve/src/compiler/artifacts.ts
+++ b/packages/eve/src/compiler/artifacts.ts
@@ -104,7 +104,7 @@ interface WriteCompilerArtifactsInput {
 /**
  * Result of writing compiler-owned artifacts.
  */
-interface WriteCompilerArtifactsResult {
+export interface WriteCompilerArtifactsResult {
   compiledManifest: CompiledAgentManifest;
   diagnosticsArtifact: DiscoveryDiagnosticsArtifact;
   metadata: CompileMetadata;
@@ -198,25 +198,25 @@ export function createCompileMetadata(input: {
   };
 }
 
-/** Writes compiler-owned artifacts and records their stable published locations. */
-export async function writeCompilerArtifacts(
-  input: WriteCompilerArtifactsInput,
-): Promise<WriteCompilerArtifactsResult> {
+/** Writes an already-compiled manifest with normal production artifact metadata. */
+export async function writePrecompiledCompilerArtifacts(input: {
+  readonly appRoot: string;
+  readonly artifactLocations: CompilerArtifactLocations;
+  readonly compiledManifest: CompiledAgentManifest;
+  readonly diagnostics: readonly DiscoverDiagnostic[];
+  readonly discoveryManifest: AgentSourceManifest;
+}): Promise<WriteCompilerArtifactsResult> {
   const paths = resolveCompilerArtifactPathsAt(input.appRoot, input.artifactLocations.writeRoot);
   const publishedPaths = resolveCompilerArtifactPathsAt(
     input.appRoot,
     input.artifactLocations.publishedRoot,
   );
   const diagnosticsArtifact = createDiscoveryDiagnosticsArtifact(input.diagnostics);
-  const compiledManifest = await materializeWorkspaceResources({
-    compileDirectoryPath: paths.compileDirectoryPath,
-    manifest: await compileAgentManifest(input.manifest),
-  });
-  const compiledManifestJson = serializeArtifactJson(compiledManifest);
-  const discoveryManifestJson = serializeArtifactJson(input.manifest);
+  const compiledManifestJson = serializeArtifactJson(input.compiledManifest);
+  const discoveryManifestJson = serializeArtifactJson(input.discoveryManifest);
   const diagnosticsArtifactJson = serializeArtifactJson(diagnosticsArtifact);
   const moduleMapSource = createCompiledModuleMapSource({
-    manifest: compiledManifest,
+    manifest: input.compiledManifest,
     moduleMapPath: publishedPaths.moduleMapPath,
   });
   const metadata = createCompileMetadata({
@@ -227,29 +227,45 @@ export async function writeCompilerArtifacts(
     moduleMapSource,
     paths: publishedPaths,
   });
-  const metadataJson = serializeArtifactJson(metadata);
 
-  await mkdir(paths.discoveryDirectoryPath, {
-    recursive: true,
-  });
-  await mkdir(paths.compileDirectoryPath, {
-    recursive: true,
-  });
+  await Promise.all([
+    mkdir(paths.discoveryDirectoryPath, { recursive: true }),
+    mkdir(paths.compileDirectoryPath, { recursive: true }),
+  ]);
   await Promise.all([
     writeFile(paths.compiledManifestPath, compiledManifestJson),
     writeFile(paths.diagnosticsPath, diagnosticsArtifactJson),
     writeFile(paths.discoveryManifestPath, discoveryManifestJson),
     writeFile(paths.moduleMapPath, moduleMapSource),
-    writeFile(paths.compileMetadataPath, metadataJson),
+    writeFile(paths.compileMetadataPath, serializeArtifactJson(metadata)),
   ]);
 
   return {
-    compiledManifest,
+    compiledManifest: input.compiledManifest,
     diagnosticsArtifact,
     metadata,
     moduleMapSource,
     paths,
   };
+}
+
+/** Writes compiler-owned artifacts and records their stable published locations. */
+export async function writeCompilerArtifacts(
+  input: WriteCompilerArtifactsInput,
+): Promise<WriteCompilerArtifactsResult> {
+  const paths = resolveCompilerArtifactPathsAt(input.appRoot, input.artifactLocations.writeRoot);
+  const compiledManifest = await materializeWorkspaceResources({
+    compileDirectoryPath: paths.compileDirectoryPath,
+    manifest: await compileAgentManifest(input.manifest),
+  });
+
+  return await writePrecompiledCompilerArtifacts({
+    appRoot: input.appRoot,
+    artifactLocations: input.artifactLocations,
+    compiledManifest,
+    diagnostics: input.diagnostics,
+    discoveryManifest: input.manifest,
+  });
 }
 
 function createContentHash(content: string): string {

--- a/packages/eve/src/compiler/normalize-manifest.ts
+++ b/packages/eve/src/compiler/normalize-manifest.ts
@@ -40,11 +40,18 @@ import { compileToolEntry } from "#compiler/normalize-tool.js";
  */
 export async function compileAgentManifest(
   manifest: AgentSourceManifest,
+  options: { readonly agentConfigDefinition?: unknown } = {},
 ): Promise<CompiledAgentManifest> {
   const context: ManifestCompileContext = {
     modelCatalog: createCompiledRuntimeModelCatalogLoader(manifest.appRoot),
   };
-  const compiledNode = await compileAgentNodeManifest(manifest, context);
+  const compiledNode = await compileAgentNodeManifest(
+    manifest,
+    context,
+    Object.hasOwn(options, "agentConfigDefinition")
+      ? { agentConfigDefinition: options.agentConfigDefinition }
+      : {},
+  );
   const subagentGraph = await compileSubagentGraph({
     appRoot: manifest.appRoot,
     compileAgentNodeManifest,

--- a/packages/eve/src/experimental/embedded/build.test.ts
+++ b/packages/eve/src/experimental/embedded/build.test.ts
@@ -1,0 +1,61 @@
+import { resolve } from "node:path";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const buildApplicationFromResolvedRootMock = vi.fn();
+const compileEmbeddedAgentMock = vi.fn();
+
+vi.mock("#internal/nitro/host/build-application.js", () => ({
+  buildApplicationFromResolvedRoot: buildApplicationFromResolvedRootMock,
+}));
+
+vi.mock("./compile.js", () => ({
+  compileEmbeddedAgent: compileEmbeddedAgentMock,
+}));
+
+describe("buildEmbeddedApplication", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("builds the resolved app root and forwards workspace artifact locations", async () => {
+    const appRoot = resolve("embedded-app");
+    const artifactLocations = {
+      publishedRoot: resolve("embedded-app/.output/.eve"),
+      writeRoot: resolve("embedded-app/.eve/builds/test/compiler/.eve"),
+    };
+    const compileResult = { manifest: {} };
+
+    compileEmbeddedAgentMock.mockResolvedValueOnce(compileResult);
+    buildApplicationFromResolvedRootMock.mockImplementationOnce(
+      async (
+        _appRoot: string,
+        _options: unknown,
+        compile: (input: { artifactLocations: typeof artifactLocations }) => Promise<unknown>,
+      ) => {
+        await expect(compile({ artifactLocations })).resolves.toBe(compileResult);
+        return resolve("embedded-app/.output");
+      },
+    );
+
+    const { buildEmbeddedApplication } = await import("./build.js");
+    await expect(
+      buildEmbeddedApplication({
+        appRoot: "embedded-app",
+        entrypoint: "embedded-agent.mjs",
+        skipVercelSandboxPrewarm: true,
+      }),
+    ).resolves.toEqual({ outputDirectory: resolve("embedded-app/.output") });
+
+    expect(buildApplicationFromResolvedRootMock).toHaveBeenCalledWith(
+      appRoot,
+      { skipVercelSandboxPrewarm: true },
+      expect.any(Function),
+    );
+    expect(compileEmbeddedAgentMock).toHaveBeenCalledWith({
+      appRoot,
+      artifactLocations,
+      entrypoint: "embedded-agent.mjs",
+    });
+  });
+});

--- a/packages/eve/src/experimental/embedded/build.ts
+++ b/packages/eve/src/experimental/embedded/build.ts
@@ -1,0 +1,34 @@
+import { resolve } from "node:path";
+
+import { buildApplicationFromResolvedRoot } from "#internal/nitro/host/build-application.js";
+import { compileEmbeddedAgent } from "./compile.js";
+
+export interface BuildEmbeddedApplicationInput {
+  readonly appRoot: string;
+  readonly entrypoint: string;
+  readonly skipVercelSandboxPrewarm?: boolean;
+}
+
+export interface BuildEmbeddedApplicationResult {
+  readonly outputDirectory: string;
+}
+
+export async function buildEmbeddedApplication(
+  input: BuildEmbeddedApplicationInput,
+): Promise<BuildEmbeddedApplicationResult> {
+  const appRoot = resolve(input.appRoot);
+  const outputDirectory = await buildApplicationFromResolvedRoot(
+    appRoot,
+    {
+      skipVercelSandboxPrewarm: input.skipVercelSandboxPrewarm ?? false,
+    },
+    ({ artifactLocations }) =>
+      compileEmbeddedAgent({
+        appRoot,
+        artifactLocations,
+        entrypoint: input.entrypoint,
+      }),
+  );
+
+  return { outputDirectory };
+}

--- a/packages/eve/src/experimental/embedded/compile.integration.test.ts
+++ b/packages/eve/src/experimental/embedded/compile.integration.test.ts
@@ -1,0 +1,111 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { compiledAgentManifestSchema } from "#compiler/manifest.js";
+import { compiledModuleMapSchema } from "#compiler/module-map.js";
+import { compileEmbeddedAgent } from "./compile.js";
+import { loadEmbeddedAgentEntrypoint } from "./definition.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((path) => rm(path, { force: true, recursive: true })),
+  );
+});
+
+describe("embedded agent compilation", () => {
+  it("loads a strict branded default export and emits production artifacts", async () => {
+    const appRoot = await createApp();
+    const result = await compileEmbeddedAgent({ appRoot, entrypoint: "embedded-agent.mjs" });
+
+    expect(compiledAgentManifestSchema.parse(result.manifest)).toMatchObject({
+      agentRoot: result.project.agentRoot,
+      appRoot: result.project.appRoot,
+      config: {
+        model: { id: "openai/gpt-5.4-mini" },
+        source: {
+          logicalPath: "embedded-agent.mjs",
+          sourceId: "embedded:config:embedded-agent.mjs",
+        },
+      },
+      instructions: [
+        {
+          content: "Classify the ticket.",
+          logicalPath: "instructions.md",
+          role: "system",
+          sourceKind: "markdown",
+        },
+      ],
+    });
+    expect(result.metadata.status).toBe("ready");
+    expect(result.diagnostics).toEqual([]);
+
+    const moduleMapSource = await readFile(result.paths.moduleMapPath, "utf8");
+    expect(moduleMapSource).toContain('from "../../embedded-agent.mjs"');
+    const imported = await import(
+      `${pathToFileURL(result.paths.moduleMapPath).href}?test=${Date.now()}`
+    );
+    const moduleMap = compiledModuleMapSchema.parse(imported.default);
+    expect(
+      moduleMap.nodes.__root__?.modules["embedded:config:embedded-agent.mjs"]?.default,
+    ).toMatchObject({ model: "openai/gpt-5.4-mini" });
+    expect(
+      result.moduleMap.nodes.__root__?.modules["embedded:config:embedded-agent.mjs"],
+    ).toBeDefined();
+  });
+
+  it("rejects missing, unbranded, malformed, and escaping entrypoints", async () => {
+    const appRoot = await createApp();
+    await writeFile(join(appRoot, "missing-default.mjs"), "export const value = 1;\n");
+    await writeFile(
+      join(appRoot, "unbranded.mjs"),
+      "export default { model: 'openai/gpt-5.4-mini' };\n",
+    );
+    await writeFile(
+      join(appRoot, "malformed.mjs"),
+      brandedModuleSource("Classify.", "{ model: 'openai/gpt-5.4-mini', unknown: true }"),
+    );
+
+    await expect(
+      loadEmbeddedAgentEntrypoint({ appRoot, entrypoint: "missing-default.mjs" }),
+    ).rejects.toThrow('entrypoint "missing-default.mjs"');
+    await expect(
+      loadEmbeddedAgentEntrypoint({ appRoot, entrypoint: "unbranded.mjs" }),
+    ).rejects.toThrow("defineEmbeddedAgent");
+    await expect(
+      loadEmbeddedAgentEntrypoint({ appRoot, entrypoint: "malformed.mjs" }),
+    ).rejects.toThrow("malformed");
+    await expect(
+      loadEmbeddedAgentEntrypoint({ appRoot, entrypoint: "../outside.mjs" }),
+    ).rejects.toThrow("under the application root");
+  });
+});
+
+async function createApp(): Promise<string> {
+  const appRoot = await mkdtemp(join(tmpdir(), "eve-embedded-test-"));
+  temporaryDirectories.push(appRoot);
+  await writeFile(
+    join(appRoot, "package.json"),
+    JSON.stringify({ name: "embedded-test", type: "module" }),
+  );
+  await writeFile(
+    join(appRoot, "embedded-agent.mjs"),
+    brandedModuleSource("Classify the ticket.", "{ model: 'openai/gpt-5.4-mini' }"),
+  );
+  return appRoot;
+}
+
+function brandedModuleSource(instructions: string, definitionSource: string): string {
+  return `const definition = ${definitionSource};
+Object.defineProperties(definition, {
+  [Symbol.for("eve.experimental.embedded-agent")]: { value: true },
+  [Symbol.for("eve.experimental.embedded-agent.instructions")]: { value: ${JSON.stringify(instructions)} },
+});
+export default definition;
+`;
+}

--- a/packages/eve/src/experimental/embedded/compile.ts
+++ b/packages/eve/src/experimental/embedded/compile.ts
@@ -1,0 +1,95 @@
+import { basename, isAbsolute, relative, resolve } from "node:path";
+
+import {
+  type CompilerArtifactLocations,
+  writePrecompiledCompilerArtifacts,
+} from "#compiler/artifacts.js";
+import type { CompileAgentResult } from "#compiler/compile-agent.js";
+import { compiledAgentManifestSchema } from "#compiler/manifest.js";
+import type { CompiledModuleMap } from "#compiler/module-map.js";
+import { compileAgentManifest } from "#compiler/normalize-manifest.js";
+import { createAgentSourceManifest, createModuleSourceRef } from "#discover/manifest.js";
+import { ROOT_COMPILED_AGENT_NODE_ID } from "#compiler/manifest.js";
+import { loadEmbeddedAgentEntrypoint } from "./definition.js";
+
+const EMBEDDED_INSTRUCTIONS_LOGICAL_PATH = "instructions.md";
+
+export interface CompileEmbeddedAgentResult extends CompileAgentResult {
+  readonly moduleMap: CompiledModuleMap;
+}
+
+export async function compileEmbeddedAgent(input: {
+  readonly appRoot: string;
+  readonly artifactLocations?: CompilerArtifactLocations;
+  readonly entrypoint: string;
+}): Promise<CompileEmbeddedAgentResult> {
+  const loaded = await loadEmbeddedAgentEntrypoint({
+    appRoot: input.appRoot,
+    entrypoint: input.entrypoint,
+  });
+  const appRoot = loaded.appRoot;
+  const entrypointLogicalPath = relative(appRoot, loaded.entrypointPath).replaceAll("\\", "/");
+  if (
+    entrypointLogicalPath === "" ||
+    entrypointLogicalPath.startsWith("..") ||
+    isAbsolute(entrypointLogicalPath)
+  ) {
+    throw new Error(`Expected embedded entrypoint "${input.entrypoint}" to be under "${appRoot}".`);
+  }
+
+  const configModule = createModuleSourceRef({
+    logicalPath: entrypointLogicalPath,
+    sourceId: `embedded:config:${entrypointLogicalPath}`,
+  });
+  const discoveryManifest = createAgentSourceManifest({
+    agentId: basename(appRoot),
+    agentRoot: appRoot,
+    appRoot,
+    configModule,
+    instructions: [
+      {
+        definition: { content: loaded.instructions, role: "system" },
+        logicalPath: EMBEDDED_INSTRUCTIONS_LOGICAL_PATH,
+        sourceId: `embedded:instructions:${EMBEDDED_INSTRUCTIONS_LOGICAL_PATH}`,
+        sourceKind: "markdown",
+      },
+    ],
+  });
+  const compiledManifest = compiledAgentManifestSchema.parse(
+    await compileAgentManifest(discoveryManifest, {
+      agentConfigDefinition: loaded.definition,
+    }),
+  );
+  const artifactLocations = input.artifactLocations ?? {
+    publishedRoot: resolve(appRoot, ".eve"),
+    writeRoot: resolve(appRoot, ".eve"),
+  };
+  const written = await writePrecompiledCompilerArtifacts({
+    appRoot,
+    artifactLocations,
+    compiledManifest,
+    diagnostics: [],
+    discoveryManifest,
+  });
+
+  return {
+    diagnostics: [],
+    manifest: written.compiledManifest,
+    metadata: written.metadata,
+    moduleMap: {
+      nodes: {
+        [ROOT_COMPILED_AGENT_NODE_ID]: {
+          modules: {
+            [configModule.sourceId]: loaded.moduleNamespace,
+          },
+        },
+      },
+    },
+    paths: written.paths,
+    project: {
+      agentRoot: appRoot,
+      appRoot,
+      layout: "flat",
+    },
+  };
+}

--- a/packages/eve/src/experimental/embedded/definition.test.ts
+++ b/packages/eve/src/experimental/embedded/definition.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+
+import { defineEmbeddedAgent, type EmbeddedAgentDefinition } from "./definition.js";
+
+describe("defineEmbeddedAgent", () => {
+  it("returns a runtime agent definition with non-enumerable embedded metadata", () => {
+    const definition = defineEmbeddedAgent({
+      instructions: "Classify the ticket.",
+      model: "openai/gpt-5.4-mini",
+    });
+
+    expect(definition).toEqual({ model: "openai/gpt-5.4-mini" });
+    expect(Object.keys(definition)).toEqual(["model"]);
+    expect(Object.getOwnPropertySymbols(definition)).toHaveLength(2);
+    expectTypeOf(definition).toMatchTypeOf<Omit<EmbeddedAgentDefinition, "instructions">>();
+  });
+
+  it("requires string instructions at runtime", () => {
+    expect(() =>
+      defineEmbeddedAgent({
+        instructions: 42,
+        model: "openai/gpt-5.4-mini",
+      } as unknown as EmbeddedAgentDefinition),
+    ).toThrow('string "instructions" field');
+  });
+});

--- a/packages/eve/src/experimental/embedded/definition.test.ts
+++ b/packages/eve/src/experimental/embedded/definition.test.ts
@@ -18,9 +18,9 @@ describe("defineEmbeddedAgent", () => {
   it("requires string instructions at runtime", () => {
     expect(() =>
       defineEmbeddedAgent({
-        instructions: 42,
+        instructions: 42 as never,
         model: "openai/gpt-5.4-mini",
-      } as unknown as EmbeddedAgentDefinition),
+      } as EmbeddedAgentDefinition),
     ).toThrow('string "instructions" field');
   });
 });

--- a/packages/eve/src/experimental/embedded/definition.ts
+++ b/packages/eve/src/experimental/embedded/definition.ts
@@ -1,0 +1,138 @@
+import { realpath } from "node:fs/promises";
+import { isAbsolute, relative, resolve } from "node:path";
+
+import { normalizeAgentDefinition } from "#internal/authored-definition/core.js";
+import { loadAuthoredModuleNamespace } from "#internal/authored-module-loader.js";
+import type { AgentDefinition } from "#public/definitions/agent.js";
+import type { ExactDefinition } from "#public/definitions/exact.js";
+
+const EMBEDDED_AGENT_BRAND = Symbol.for("eve.experimental.embedded-agent");
+const EMBEDDED_AGENT_INSTRUCTIONS = Symbol.for("eve.experimental.embedded-agent.instructions");
+
+export type EmbeddedAgentDefinition = AgentDefinition & {
+  readonly instructions: string;
+};
+
+export type DefinedEmbeddedAgent<
+  TDefinition extends EmbeddedAgentDefinition = EmbeddedAgentDefinition,
+> = Omit<TDefinition, "instructions"> & {
+  readonly [EMBEDDED_AGENT_BRAND]: true;
+};
+
+export interface LoadedEmbeddedAgentEntrypoint {
+  readonly appRoot: string;
+  readonly definition: AgentDefinition;
+  readonly entrypointPath: string;
+  readonly instructions: string;
+  readonly moduleNamespace: Readonly<Record<string, unknown>>;
+}
+
+export function defineEmbeddedAgent<TDefinition extends EmbeddedAgentDefinition>(
+  definition: ExactDefinition<TDefinition, EmbeddedAgentDefinition>,
+): DefinedEmbeddedAgent<TDefinition>;
+export function defineEmbeddedAgent(
+  definition: EmbeddedAgentDefinition,
+): DefinedEmbeddedAgent<EmbeddedAgentDefinition> {
+  if (typeof definition !== "object" || definition === null) {
+    throw new Error("Expected defineEmbeddedAgent(...) to receive an object definition.");
+  }
+  if (typeof definition.instructions !== "string") {
+    throw new Error('Expected defineEmbeddedAgent(...) to receive a string "instructions" field.');
+  }
+
+  const { instructions, ...agentDefinition } = definition;
+  Object.defineProperties(agentDefinition, {
+    [EMBEDDED_AGENT_BRAND]: { value: true },
+    [EMBEDDED_AGENT_INSTRUCTIONS]: { value: instructions },
+  });
+  return agentDefinition as DefinedEmbeddedAgent<EmbeddedAgentDefinition>;
+}
+
+export async function loadEmbeddedAgentEntrypoint(input: {
+  readonly appRoot: string;
+  readonly entrypoint: string;
+}): Promise<LoadedEmbeddedAgentEntrypoint> {
+  const requestedAppRoot = resolve(input.appRoot);
+  const requestedEntrypointPath = resolve(requestedAppRoot, input.entrypoint);
+  const requestedRelativeEntrypoint = relative(requestedAppRoot, requestedEntrypointPath);
+  if (
+    requestedRelativeEntrypoint === "" ||
+    requestedRelativeEntrypoint.startsWith("..") ||
+    isAbsolute(requestedRelativeEntrypoint)
+  ) {
+    throw embeddedEntrypointError(
+      input.entrypoint,
+      `The entrypoint must resolve to a file under the application root "${requestedAppRoot}".`,
+    );
+  }
+
+  const appRoot = await resolveRealPath(requestedAppRoot, input.entrypoint, "application root");
+  const entrypointPath = await resolveRealPath(
+    requestedEntrypointPath,
+    input.entrypoint,
+    "entrypoint",
+  );
+  const relativeEntrypoint = relative(appRoot, entrypointPath);
+  if (
+    relativeEntrypoint === "" ||
+    relativeEntrypoint.startsWith("..") ||
+    isAbsolute(relativeEntrypoint)
+  ) {
+    throw embeddedEntrypointError(
+      input.entrypoint,
+      `The entrypoint must resolve to a file under the application root "${appRoot}".`,
+    );
+  }
+
+  let moduleNamespace: Record<string, unknown>;
+  try {
+    moduleNamespace = await loadAuthoredModuleNamespace(entrypointPath);
+  } catch (error) {
+    throw embeddedEntrypointError(input.entrypoint, "Failed to load the entrypoint.", error);
+  }
+
+  if (!Object.hasOwn(moduleNamespace, "default")) {
+    throw embeddedEntrypointError(input.entrypoint, "The entrypoint must have a default export.");
+  }
+
+  const definition = moduleNamespace.default;
+  if (
+    typeof definition !== "object" ||
+    definition === null ||
+    Reflect.get(definition, EMBEDDED_AGENT_BRAND) !== true ||
+    typeof Reflect.get(definition, EMBEDDED_AGENT_INSTRUCTIONS) !== "string"
+  ) {
+    throw embeddedEntrypointError(
+      input.entrypoint,
+      "The default export must be produced by defineEmbeddedAgent(...).",
+    );
+  }
+
+  const message = `Expected the embedded agent default export from "${input.entrypoint}" to match the public eve agent shape.`;
+  let normalizedDefinition: AgentDefinition;
+  try {
+    normalizedDefinition = normalizeAgentDefinition(definition, message) as AgentDefinition;
+  } catch (error) {
+    throw embeddedEntrypointError(input.entrypoint, "The default export is malformed.", error);
+  }
+
+  return {
+    appRoot,
+    definition: normalizedDefinition,
+    entrypointPath,
+    instructions: Reflect.get(definition, EMBEDDED_AGENT_INSTRUCTIONS) as string,
+    moduleNamespace,
+  };
+}
+
+async function resolveRealPath(path: string, entrypoint: string, kind: string): Promise<string> {
+  try {
+    return await realpath(path);
+  } catch (error) {
+    throw embeddedEntrypointError(entrypoint, `Failed to resolve the ${kind} at "${path}".`, error);
+  }
+}
+
+function embeddedEntrypointError(entrypoint: string, message: string, cause?: unknown): Error {
+  return new Error(`Invalid embedded agent entrypoint "${entrypoint}": ${message}`, { cause });
+}

--- a/packages/eve/src/experimental/embedded/index.ts
+++ b/packages/eve/src/experimental/embedded/index.ts
@@ -1,0 +1,5 @@
+export {
+  defineEmbeddedAgent,
+  type DefinedEmbeddedAgent,
+  type EmbeddedAgentDefinition,
+} from "./definition.js";

--- a/packages/eve/src/experimental/embedded/index.ts
+++ b/packages/eve/src/experimental/embedded/index.ts
@@ -1,4 +1,9 @@
 export {
+  buildEmbeddedApplication,
+  type BuildEmbeddedApplicationInput,
+  type BuildEmbeddedApplicationResult,
+} from "./build.js";
+export {
   defineEmbeddedAgent,
   type DefinedEmbeddedAgent,
   type EmbeddedAgentDefinition,

--- a/packages/eve/src/experimental/embedded/index.ts
+++ b/packages/eve/src/experimental/embedded/index.ts
@@ -8,3 +8,10 @@ export {
   type DefinedEmbeddedAgent,
   type EmbeddedAgentDefinition,
 } from "./definition.js";
+export {
+  createEmbeddedLocalExecutor,
+  EmbeddedLocalExecutorError,
+  type CreateEmbeddedLocalExecutorInput,
+  type EmbeddedLocalExecutor,
+  type EmbeddedLocalExecutorRunResult,
+} from "./local-executor.js";

--- a/packages/eve/src/experimental/embedded/local-executor.integration.test.ts
+++ b/packages/eve/src/experimental/embedded/local-executor.integration.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+
+const compileEmbeddedAgent = vi.hoisted(() => vi.fn());
+vi.mock("./compile.js", () => ({ compileEmbeddedAgent }));
+
+import { createEmbeddedLocalExecutor } from "./local-executor.js";
+
+describe("embedded local executor lifecycle", () => {
+  it("rejects a concurrent executor and releases its lock after initialization fails", async () => {
+    const initialization = Promise.withResolvers<never>();
+    compileEmbeddedAgent.mockReturnValueOnce(initialization.promise);
+
+    const first = createEmbeddedLocalExecutor({ appRoot: process.cwd(), entrypoint: "agent.ts" });
+    const firstRejection = expect(first).rejects.toThrow("compile failed");
+    await vi.waitFor(() => expect(compileEmbeddedAgent).toHaveBeenCalledTimes(1));
+
+    await expect(
+      createEmbeddedLocalExecutor({ appRoot: process.cwd(), entrypoint: "agent.ts" }),
+    ).rejects.toMatchObject({ code: "embedded_executor_already_running" });
+
+    initialization.reject(new Error("compile failed"));
+    await firstRejection;
+
+    compileEmbeddedAgent.mockRejectedValueOnce(new Error("second compile failed"));
+    await expect(
+      createEmbeddedLocalExecutor({ appRoot: process.cwd(), entrypoint: "agent.ts" }),
+    ).rejects.toThrow("second compile failed");
+  });
+});

--- a/packages/eve/src/experimental/embedded/local-executor.test.ts
+++ b/packages/eve/src/experimental/embedded/local-executor.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createResultCompletedEvent,
+  createSessionCompletedEvent,
+  createSessionFailedEvent,
+  createSessionWaitingEvent,
+  stampMessageStreamEvent,
+  type MessageStreamEvent,
+  type UnstampedMessageStreamEvent,
+} from "#protocol/message.js";
+import {
+  canonicalizeEmbeddedInput,
+  EmbeddedLocalExecutorError,
+  projectEmbeddedRunEvents,
+} from "./local-executor.js";
+
+function eventStream(
+  events: readonly UnstampedMessageStreamEvent[],
+): ReadableStream<MessageStreamEvent> {
+  return new ReadableStream({
+    start(controller) {
+      for (const event of events) controller.enqueue(stampMessageStreamEvent(event));
+      controller.close();
+    },
+  });
+}
+
+function resultEvent(result: string) {
+  return createResultCompletedEvent({ result, sequence: 1, stepIndex: 0, turnId: "turn_1" });
+}
+
+describe("embedded local executor input projection", () => {
+  it("serializes JSON with recursively sorted object keys", () => {
+    expect(canonicalizeEmbeddedInput({ z: 1, a: { y: 2, b: 3 }, list: [{ d: 4, c: 5 }] })).toBe(
+      '{"a":{"b":3,"y":2},"list":[{"c":5,"d":4}],"z":1}',
+    );
+  });
+});
+
+describe("embedded local executor event projection", () => {
+  it("returns exactly one structured result at terminal completion", async () => {
+    await expect(
+      projectEmbeddedRunEvents(
+        eventStream([resultEvent("triaged"), createSessionCompletedEvent()]),
+      ),
+    ).resolves.toMatchObject({ result: "triaged" });
+  });
+
+  it("rejects a result that is not valid JSON", async () => {
+    const event = createResultCompletedEvent({
+      result: Number.NaN as never,
+      sequence: 1,
+      stepIndex: 0,
+      turnId: "turn_1",
+    });
+
+    await expect(
+      projectEmbeddedRunEvents(eventStream([event, createSessionCompletedEvent()])),
+    ).rejects.toMatchObject({
+      code: "embedded_run_invalid_result",
+      name: "EmbeddedLocalExecutorError",
+    } satisfies Partial<EmbeddedLocalExecutorError>);
+  });
+
+  it.each([
+    {
+      code: "embedded_run_waiting",
+      events: [createSessionWaitingEvent("session_1")],
+    },
+    {
+      code: "embedded_run_failed",
+      events: [
+        createSessionFailedEvent({
+          code: "model_failed",
+          message: "Model failed.",
+          sessionId: "session_1",
+        }),
+      ],
+    },
+    {
+      code: "embedded_run_missing_result",
+      events: [createSessionCompletedEvent()],
+    },
+    {
+      code: "embedded_run_duplicate_result",
+      events: [resultEvent("first"), resultEvent("second")],
+    },
+    {
+      code: "embedded_run_nonterminal",
+      events: [resultEvent("orphaned")],
+    },
+  ])("rejects $code", async ({ code, events }) => {
+    await expect(projectEmbeddedRunEvents(eventStream(events))).rejects.toMatchObject({
+      code,
+      name: "EmbeddedLocalExecutorError",
+    } satisfies Partial<EmbeddedLocalExecutorError>);
+  });
+});

--- a/packages/eve/src/experimental/embedded/local-executor.ts
+++ b/packages/eve/src/experimental/embedded/local-executor.ts
@@ -15,6 +15,7 @@ import { WorkflowBundleBuilder } from "#internal/workflow-bundle/builder.js";
 import {
   deriveEveWorkflowQueuePrefix,
   installEveWorkflowQueueNamespace,
+  restoreEveWorkflowQueueNamespace,
   WORKFLOW_QUEUE_NAMESPACE_ENV,
 } from "#internal/workflow/queue-namespace.js";
 import { setWorld } from "#internal/workflow/runtime.js";
@@ -167,13 +168,9 @@ export async function createEmbeddedLocalExecutor(
         } catch (error) {
           cleanupError = error;
         }
-        if (process.env[WORKFLOW_QUEUE_NAMESPACE_ENV] === installedQueueNamespace) {
-          if (previousQueueNamespace === undefined) {
-            delete process.env[WORKFLOW_QUEUE_NAMESPACE_ENV];
-          } else {
-            process.env[WORKFLOW_QUEUE_NAMESPACE_ENV] = previousQueueNamespace;
-          }
-        }
+        restoreEveWorkflowQueueNamespace(previousQueueNamespace, {
+          ifCurrent: installedQueueNamespace,
+        });
         try {
           await rm(workspace, {
             force: true,
@@ -198,10 +195,9 @@ export async function createEmbeddedLocalExecutor(
   } catch (error) {
     setWorld(undefined);
     await world?.close?.().catch(() => {});
-    if (process.env[WORKFLOW_QUEUE_NAMESPACE_ENV] === installedQueueNamespace) {
-      if (previousQueueNamespace === undefined) delete process.env[WORKFLOW_QUEUE_NAMESPACE_ENV];
-      else process.env[WORKFLOW_QUEUE_NAMESPACE_ENV] = previousQueueNamespace;
-    }
+    restoreEveWorkflowQueueNamespace(previousQueueNamespace, {
+      ifCurrent: installedQueueNamespace,
+    });
     try {
       await rm(workspace, {
         force: true,

--- a/packages/eve/src/experimental/embedded/local-executor.ts
+++ b/packages/eve/src/experimental/embedded/local-executor.ts
@@ -1,8 +1,9 @@
-import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
+import { registerStepFunction } from "#compiled/@workflow/core/private.js";
 import { createWorld } from "#compiled/@workflow/world-local/index.js";
 import { SCHEDULE_ADAPTER } from "#channel/schedule.js";
 import type { MessageStreamEvent } from "#protocol/message.js";
@@ -108,14 +109,15 @@ export async function createEmbeddedLocalExecutor(
       rootDir: resolvePackageRoot(),
       watch: false,
     }).build();
+    await registerEmbeddedWorkflowSteps(workflowBuildDirectory);
 
     const runtimeSession = createRuntimeSession(`embedded-local-${crypto.randomUUID()}`);
     world = createWorld({ dataDir: dataDirectory, tag: `embedded-${crypto.randomUUID()}` });
     await world.start?.();
+    setWorld(world);
 
     await withRuntimeSession(runtimeSession, async () => {
       const bundleUrl = pathToFileURL(join(workflowBuildDirectory, "workflows.mjs"));
-      bundleUrl.searchParams.set("executor", crypto.randomUUID());
       const module = (await import(bundleUrl.href)) as {
         readonly POST?: (request: Request) => Promise<Response>;
       };
@@ -131,7 +133,6 @@ export async function createEmbeddedLocalExecutor(
           await withRuntimeSession(runtimeSession, async () => await module.POST!(request)),
       );
     });
-    setWorld(world);
 
     return {
       async run(runInput) {
@@ -152,6 +153,7 @@ export async function createEmbeddedLocalExecutor(
             mode: "task",
           });
           const projected = await projectEmbeddedRunEvents(handle.events);
+          await new Promise((resolve) => setTimeout(resolve, 250));
           return { sessionId: handle.sessionId, ...projected };
         });
       },
@@ -173,7 +175,12 @@ export async function createEmbeddedLocalExecutor(
           }
         }
         try {
-          await rm(workspace, { force: true, recursive: true });
+          await rm(workspace, {
+            force: true,
+            maxRetries: 5,
+            recursive: true,
+            retryDelay: 100,
+          });
         } catch (error) {
           cleanupError ??= error;
         } finally {
@@ -196,7 +203,12 @@ export async function createEmbeddedLocalExecutor(
       else process.env[WORKFLOW_QUEUE_NAMESPACE_ENV] = previousQueueNamespace;
     }
     try {
-      await rm(workspace, { force: true, recursive: true });
+      await rm(workspace, {
+        force: true,
+        maxRetries: 5,
+        recursive: true,
+        retryDelay: 100,
+      });
     } finally {
       embeddedExecutorGlobal[EMBEDDED_EXECUTOR_OWNER] = false;
     }
@@ -269,6 +281,28 @@ export async function projectEmbeddedRunEvents(
 
 export function canonicalizeEmbeddedInput(value: JsonValue): string {
   return JSON.stringify(sortJsonValue(parseJsonValue(value)));
+}
+
+async function registerEmbeddedWorkflowSteps(workflowBuildDirectory: string): Promise<void> {
+  const manifest = JSON.parse(
+    await readFile(join(workflowBuildDirectory, "manifest.json"), "utf8"),
+  ) as {
+    readonly steps?: Readonly<
+      Record<string, Readonly<Record<string, { readonly stepId?: string }>>>
+    >;
+  };
+
+  for (const [modulePath, exports] of Object.entries(manifest.steps ?? {})) {
+    const module = (await import(
+      pathToFileURL(join(resolvePackageRoot(), modulePath)).href
+    )) as Readonly<Record<string, unknown>>;
+    for (const [exportName, metadata] of Object.entries(exports)) {
+      const step = module[exportName];
+      if (typeof step === "function" && typeof metadata.stepId === "string") {
+        registerStepFunction(metadata.stepId, step as Parameters<typeof registerStepFunction>[1]);
+      }
+    }
+  }
 }
 
 function sortJsonValue(value: JsonValue): JsonValue {

--- a/packages/eve/src/experimental/embedded/local-executor.ts
+++ b/packages/eve/src/experimental/embedded/local-executor.ts
@@ -1,0 +1,285 @@
+import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { createWorld } from "#compiled/@workflow/world-local/index.js";
+import { SCHEDULE_ADAPTER } from "#channel/schedule.js";
+import type { MessageStreamEvent } from "#protocol/message.js";
+import type { JsonValue } from "#shared/json.js";
+import { parseJsonValue } from "#shared/json.js";
+import { writeCompiledArtifactsFiles } from "#internal/application/compiled-artifacts.js";
+import { resolvePackageRoot } from "#internal/application/package.js";
+import { WorkflowBundleBuilder } from "#internal/workflow-bundle/builder.js";
+import {
+  deriveEveWorkflowQueuePrefix,
+  installEveWorkflowQueueNamespace,
+  WORKFLOW_QUEUE_NAMESPACE_ENV,
+} from "#internal/workflow/queue-namespace.js";
+import { setWorld } from "#internal/workflow/runtime.js";
+import { createWorkflowRuntime } from "#execution/workflow-runtime.js";
+import { createBundledRuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
+import { createRuntimeSession, withRuntimeSession } from "#runtime/sessions/runtime-session.js";
+import { compileEmbeddedAgent } from "./compile.js";
+
+const EMBEDDED_EXECUTOR_OWNER = Symbol.for("eve.experimental.embedded-local-executor-owner");
+interface EmbeddedExecutorGlobal {
+  [EMBEDDED_EXECUTOR_OWNER]?: boolean;
+}
+const embeddedExecutorGlobal = globalThis as typeof globalThis & EmbeddedExecutorGlobal;
+
+export interface CreateEmbeddedLocalExecutorInput {
+  readonly appRoot: string;
+  readonly entrypoint: string;
+  readonly dataDirectory?: string;
+}
+
+export interface EmbeddedLocalExecutorRunResult {
+  readonly sessionId: string;
+  readonly events: readonly MessageStreamEvent[];
+  readonly result: JsonValue;
+}
+
+export interface EmbeddedLocalExecutor {
+  run(input: { readonly input: JsonValue }): Promise<EmbeddedLocalExecutorRunResult>;
+  close(): Promise<void>;
+}
+
+export class EmbeddedLocalExecutorError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.code = code;
+    this.name = "EmbeddedLocalExecutorError";
+  }
+}
+
+export async function createEmbeddedLocalExecutor(
+  input: CreateEmbeddedLocalExecutorInput,
+): Promise<EmbeddedLocalExecutor> {
+  if (embeddedExecutorGlobal[EMBEDDED_EXECUTOR_OWNER] === true) {
+    throw new EmbeddedLocalExecutorError(
+      "embedded_executor_already_running",
+      "Only one embedded local executor can run in this process. Close the active executor before creating another.",
+    );
+  }
+  embeddedExecutorGlobal[EMBEDDED_EXECUTOR_OWNER] = true;
+
+  let workspace: string;
+  try {
+    workspace = await mkdtemp(join(tmpdir(), "eve-embedded-executor-"));
+  } catch (error) {
+    embeddedExecutorGlobal[EMBEDDED_EXECUTOR_OWNER] = false;
+    throw error;
+  }
+  const dataDirectory = input.dataDirectory
+    ? resolve(input.dataDirectory)
+    : join(workspace, "workflow-world");
+  const previousQueueNamespace = process.env[WORKFLOW_QUEUE_NAMESPACE_ENV];
+  let world: Awaited<ReturnType<typeof createWorld>> | undefined;
+  let installedQueueNamespace: string | undefined;
+  let closed = false;
+
+  try {
+    await mkdir(dataDirectory, { recursive: true });
+    const compileResult = await compileEmbeddedAgent({
+      appRoot: resolve(input.appRoot),
+      artifactLocations: {
+        publishedRoot: join(workspace, "compiler"),
+        writeRoot: join(workspace, "compiler"),
+      },
+      entrypoint: input.entrypoint,
+    });
+    const agentName = compileResult.manifest.config.name;
+    installedQueueNamespace = installEveWorkflowQueueNamespace(agentName);
+
+    const generated = await writeCompiledArtifactsFiles({
+      compileResult,
+      defaultWorkflowWorld: "local",
+      outDir: join(workspace, "artifacts"),
+    });
+    const workflowBuildDirectory = join(workspace, "workflow");
+    await new WorkflowBundleBuilder({
+      agentName,
+      appRoot: compileResult.project.appRoot,
+      compiledArtifactsBootstrapPath: generated.bootstrapPath,
+      outDir: workflowBuildDirectory,
+      rootDir: resolvePackageRoot(),
+      watch: false,
+    }).build();
+
+    const runtimeSession = createRuntimeSession(`embedded-local-${crypto.randomUUID()}`);
+    world = createWorld({ dataDir: dataDirectory, tag: `embedded-${crypto.randomUUID()}` });
+    await world.start?.();
+
+    await withRuntimeSession(runtimeSession, async () => {
+      const bundleUrl = pathToFileURL(join(workflowBuildDirectory, "workflows.mjs"));
+      bundleUrl.searchParams.set("executor", crypto.randomUUID());
+      const module = (await import(bundleUrl.href)) as {
+        readonly POST?: (request: Request) => Promise<Response>;
+      };
+      if (typeof module.POST !== "function") {
+        throw new EmbeddedLocalExecutorError(
+          "embedded_workflow_handler_missing",
+          "The generated eve Workflow bundle did not export its POST flow handler.",
+        );
+      }
+      world!.registerHandler(
+        deriveEveWorkflowQueuePrefix(agentName),
+        async (request) =>
+          await withRuntimeSession(runtimeSession, async () => await module.POST!(request)),
+      );
+    });
+    setWorld(world);
+
+    return {
+      async run(runInput) {
+        if (closed) {
+          throw new EmbeddedLocalExecutorError(
+            "embedded_executor_closed",
+            "This embedded local executor is closed. Create a new executor before running another task.",
+          );
+        }
+        return await withRuntimeSession(runtimeSession, async () => {
+          const runtime = createWorkflowRuntime({
+            compiledArtifactsSource: createBundledRuntimeCompiledArtifactsSource(),
+          });
+          const handle = await runtime.createSession({
+            adapter: SCHEDULE_ADAPTER,
+            auth: null,
+            input: { message: canonicalizeEmbeddedInput(runInput.input) },
+            mode: "task",
+          });
+          const projected = await projectEmbeddedRunEvents(handle.events);
+          return { sessionId: handle.sessionId, ...projected };
+        });
+      },
+      async close() {
+        if (closed) return;
+        closed = true;
+        setWorld(undefined);
+        let cleanupError: unknown;
+        try {
+          await world?.close?.();
+        } catch (error) {
+          cleanupError = error;
+        }
+        if (process.env[WORKFLOW_QUEUE_NAMESPACE_ENV] === installedQueueNamespace) {
+          if (previousQueueNamespace === undefined) {
+            delete process.env[WORKFLOW_QUEUE_NAMESPACE_ENV];
+          } else {
+            process.env[WORKFLOW_QUEUE_NAMESPACE_ENV] = previousQueueNamespace;
+          }
+        }
+        try {
+          await rm(workspace, { force: true, recursive: true });
+        } catch (error) {
+          cleanupError ??= error;
+        } finally {
+          embeddedExecutorGlobal[EMBEDDED_EXECUTOR_OWNER] = false;
+        }
+        if (cleanupError !== undefined) {
+          throw new EmbeddedLocalExecutorError(
+            "embedded_executor_cleanup_failed",
+            "The embedded local executor closed, but eve could not remove all owned runtime resources.",
+            { cause: cleanupError },
+          );
+        }
+      },
+    };
+  } catch (error) {
+    setWorld(undefined);
+    await world?.close?.().catch(() => {});
+    if (process.env[WORKFLOW_QUEUE_NAMESPACE_ENV] === installedQueueNamespace) {
+      if (previousQueueNamespace === undefined) delete process.env[WORKFLOW_QUEUE_NAMESPACE_ENV];
+      else process.env[WORKFLOW_QUEUE_NAMESPACE_ENV] = previousQueueNamespace;
+    }
+    try {
+      await rm(workspace, { force: true, recursive: true });
+    } finally {
+      embeddedExecutorGlobal[EMBEDDED_EXECUTOR_OWNER] = false;
+    }
+    throw error;
+  }
+}
+
+export async function projectEmbeddedRunEvents(
+  stream: ReadableStream<MessageStreamEvent>,
+): Promise<{ readonly events: readonly MessageStreamEvent[]; readonly result: JsonValue }> {
+  const reader = stream.getReader();
+  const events: MessageStreamEvent[] = [];
+  let result: JsonValue | undefined;
+  let resultCount = 0;
+
+  try {
+    while (true) {
+      const next = await reader.read();
+      if (next.done) {
+        throw new EmbeddedLocalExecutorError(
+          "embedded_run_nonterminal",
+          "The embedded eve task event stream ended without session.completed or session.failed.",
+        );
+      }
+      const event = next.value;
+      events.push(event);
+
+      if (event.type === "result.completed") {
+        resultCount += 1;
+        if (resultCount > 1) {
+          throw new EmbeddedLocalExecutorError(
+            "embedded_run_duplicate_result",
+            "The embedded eve task emitted more than one result.completed event.",
+          );
+        }
+        try {
+          result = parseJsonValue(event.data.result);
+        } catch (error) {
+          throw new EmbeddedLocalExecutorError(
+            "embedded_run_invalid_result",
+            "The embedded eve task emitted a result.completed event whose result was not valid JSON.",
+            { cause: error },
+          );
+        }
+      } else if (event.type === "session.waiting" || event.type === "input.requested") {
+        throw new EmbeddedLocalExecutorError(
+          "embedded_run_waiting",
+          "The embedded eve task requested human input, but embedded local tasks cannot wait for input.",
+        );
+      } else if (event.type === "session.failed") {
+        throw new EmbeddedLocalExecutorError(
+          "embedded_run_failed",
+          `The embedded eve task failed (${event.data.code}): ${event.data.message}`,
+        );
+      } else if (event.type === "session.completed") {
+        if (resultCount !== 1 || result === undefined) {
+          throw new EmbeddedLocalExecutorError(
+            "embedded_run_missing_result",
+            "The embedded eve task completed without exactly one result.completed event. Configure an output schema that produces one structured result.",
+          );
+        }
+        return { events, result };
+      }
+    }
+  } finally {
+    await reader.cancel().catch(() => {});
+    reader.releaseLock();
+  }
+}
+
+export function canonicalizeEmbeddedInput(value: JsonValue): string {
+  return JSON.stringify(sortJsonValue(parseJsonValue(value)));
+}
+
+function sortJsonValue(value: JsonValue): JsonValue {
+  if (Array.isArray(value)) return value.map(sortJsonValue);
+  if (value !== null && typeof value === "object") {
+    const object = value as { readonly [key: string]: JsonValue };
+    return Object.fromEntries(
+      Object.keys(object)
+        .sort()
+        .map((key) => [key, sortJsonValue(object[key]!)]),
+    );
+  }
+  return value;
+}

--- a/packages/eve/src/internal/nitro/host/build-application.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/host/build-application.scenario.test.ts
@@ -194,6 +194,51 @@ describe("buildApplication", () => {
     vi.unstubAllEnvs();
   });
 
+  it("builds from a resolved root with an injected workspace compiler", async () => {
+    vi.stubEnv("VERCEL", "");
+    const appRoot = await createScratchDirectory("eve-build-application-injected-");
+    const compile = vi.fn(async () => createPreparedHost(appRoot).compileResult);
+
+    prepareProductionApplicationHostMock.mockImplementationOnce(
+      async (
+        workspace: ApplicationBuildWorkspace,
+        injectedCompile: (input: {
+          artifactLocations: { publishedRoot: string; writeRoot: string };
+        }) => Promise<PreparedApplicationHost["compileResult"]>,
+      ) => {
+        await mkdir(join(workspace.compiler.artifactsDir, "compile"), { recursive: true });
+        await injectedCompile({
+          artifactLocations: {
+            publishedRoot: join(workspace.publication.output.finalDir, ".eve"),
+            writeRoot: workspace.compiler.artifactsDir,
+          },
+        });
+        return createPreparedHost(workspace.appRoot);
+      },
+    );
+    createProductionApplicationNitroMock.mockImplementationOnce(
+      async (_preparedHost: PreparedApplicationHost, options: { outputDir: string }) =>
+        createNitroStub(options.outputDir),
+    );
+
+    const { buildApplicationFromResolvedRoot } =
+      await import("#internal/nitro/host/build-application.js");
+    const result = await buildApplicationFromResolvedRoot(
+      appRoot,
+      DEPLOYABLE_BUILD_OPTIONS,
+      compile,
+    );
+
+    expect(result).toBe(join(appRoot, ".output"));
+    expect(resolveDiscoveryProjectMock).not.toHaveBeenCalled();
+    expect(compile).toHaveBeenCalledWith({
+      artifactLocations: {
+        publishedRoot: join(appRoot, ".output", ".eve"),
+        writeRoot: expect.stringContaining(join(appRoot, ".eve", "builds")),
+      },
+    });
+  });
+
   it("builds without publishing stable runtime compiler artifacts", async () => {
     vi.stubEnv("VERCEL", "");
     const appRoot = await createScratchDirectory("eve-build-application-single-");

--- a/packages/eve/src/internal/nitro/host/build-application.ts
+++ b/packages/eve/src/internal/nitro/host/build-application.ts
@@ -34,7 +34,10 @@ import { emitVercelAgentSummary } from "#internal/nitro/host/build-vercel-agent-
 import { tryReadExtensionBuildConfig } from "#internal/nitro/host/build-extension.js";
 import { copyHostMiddlewareFunctions } from "#internal/nitro/host/copy-host-middleware.js";
 import { normalizeVercelServiceCrons } from "#internal/nitro/host/normalize-vercel-service-crons.js";
-import { prepareProductionApplicationHost } from "#internal/nitro/host/prepare-application-host.js";
+import {
+  prepareProductionApplicationHost,
+  type ProductionApplicationCompiler,
+} from "#internal/nitro/host/prepare-application-host.js";
 import { runVercelBuildPrewarm } from "#internal/nitro/host/vercel-build-prewarm.js";
 import type { ApplicationBuildOptions } from "#internal/nitro/host/types.js";
 import { findClosestVercelOutputDirectory } from "#shared/vercel-output-directory.js";
@@ -339,11 +342,33 @@ export async function buildApplication(
   const project = await measureBuildPhase(profiler, "project.resolve", () =>
     resolveDiscoveryProject(rootDir),
   );
+  return buildResolvedApplication(project.appRoot, options, undefined, profiler, profileOutputPath);
+}
+
+/**
+ * Builds an application whose root and compiler have already been resolved by
+ * an internal authoring adapter.
+ */
+export async function buildApplicationFromResolvedRoot(
+  appRoot: string,
+  options: ApplicationBuildOptions,
+  compile: ProductionApplicationCompiler,
+): Promise<string> {
+  const profileOutputPath =
+    options.profileOutputPath === undefined ? undefined : resolve(options.profileOutputPath);
+  const profiler = profileOutputPath === undefined ? undefined : new ApplicationBuildProfiler();
+  return buildResolvedApplication(appRoot, options, compile, profiler, profileOutputPath);
+}
+
+async function buildResolvedApplication(
+  appRoot: string,
+  options: ApplicationBuildOptions,
+  compile: ProductionApplicationCompiler | undefined,
+  profiler: ApplicationBuildProfiler | undefined,
+  profileOutputPath: string | undefined,
+): Promise<string> {
   const workspace = await measureBuildPhase(profiler, "workspace.create", () =>
-    createApplicationBuildWorkspace(
-      project.appRoot,
-      options.vercelServiceOutput?.serviceOutputDirectory,
-    ),
+    createApplicationBuildWorkspace(appRoot, options.vercelServiceOutput?.serviceOutputDirectory),
   );
 
   // A recoverable publication failure leaves the lock journal pointing at
@@ -352,7 +377,7 @@ export async function buildApplication(
   let preserveWorkspaceForRecovery = false;
   let outputDirectory: string;
   try {
-    outputDirectory = await buildApplicationInWorkspace(workspace, options, profiler);
+    outputDirectory = await buildApplicationInWorkspace(workspace, options, profiler, compile);
   } catch (error) {
     preserveWorkspaceForRecovery = error instanceof RecoverablePublicationError;
     throw error;
@@ -379,9 +404,10 @@ async function buildApplicationInWorkspace(
   workspace: ApplicationBuildWorkspace,
   options: ApplicationBuildOptions,
   profiler: ApplicationBuildProfiler | undefined,
+  compile: ProductionApplicationCompiler | undefined,
 ): Promise<string> {
   const preparedHost = await measureBuildPhase(profiler, "host.prepare", () =>
-    prepareProductionApplicationHost(workspace),
+    prepareProductionApplicationHost(workspace, compile),
   );
   const isVercelBuild = Boolean(process.env.VERCEL);
 

--- a/packages/eve/src/internal/nitro/host/prepare-application-host.ts
+++ b/packages/eve/src/internal/nitro/host/prepare-application-host.ts
@@ -1,3 +1,4 @@
+import type { CompilerArtifactLocations } from "#compiler/artifacts.js";
 import { compileAgentInWorkspace, type CompileAgentResult } from "#compiler/compile-agent.js";
 import { createScheduleRegistrations } from "#runtime/schedules/register.js";
 import { resolveSchedules } from "#runtime/schedules/resolve-schedule.js";
@@ -105,15 +106,23 @@ export async function prepareDevelopmentApplicationHost(
  * locations point at the published output (`<finalDir>/.eve`), where
  * publication later installs them.
  */
+export type ProductionApplicationCompiler = (input: {
+  readonly artifactLocations: CompilerArtifactLocations;
+}) => Promise<CompileAgentResult>;
+
 export async function prepareProductionApplicationHost(
   workspace: ApplicationBuildWorkspace,
+  compile: ProductionApplicationCompiler = ({ artifactLocations }) =>
+    compileAgentInWorkspace({
+      artifactLocations,
+      startPath: workspace.appRoot,
+    }),
 ): Promise<PreparedApplicationHost> {
-  const compileResult = await compileAgentInWorkspace({
+  const compileResult = await compile({
     artifactLocations: {
       publishedRoot: join(workspace.publication.output.finalDir, ".eve"),
       writeRoot: workspace.compiler.artifactsDir,
     },
-    startPath: workspace.appRoot,
   });
   const schedules = await resolveSchedules({ manifest: compileResult.manifest });
 

--- a/packages/eve/src/internal/workflow/queue-namespace.ts
+++ b/packages/eve/src/internal/workflow/queue-namespace.ts
@@ -36,3 +36,21 @@ export function installEveWorkflowQueueNamespace(agentName: string): string {
   process.env[WORKFLOW_QUEUE_NAMESPACE_ENV] = namespace;
   return namespace;
 }
+
+/** Restores a namespace captured before an invocation-owned Workflow runtime. */
+export function restoreEveWorkflowQueueNamespace(
+  namespace: string | undefined,
+  options: { readonly ifCurrent?: string } = {},
+): void {
+  if (
+    options.ifCurrent !== undefined &&
+    process.env[WORKFLOW_QUEUE_NAMESPACE_ENV] !== options.ifCurrent
+  ) {
+    return;
+  }
+  if (namespace === undefined) {
+    delete process.env[WORKFLOW_QUEUE_NAMESPACE_ENV];
+  } else {
+    process.env[WORKFLOW_QUEUE_NAMESPACE_ENV] = namespace;
+  }
+}

--- a/packages/eve/test/scenarios/embedded-application.scenario.test.ts
+++ b/packages/eve/test/scenarios/embedded-application.scenario.test.ts
@@ -1,0 +1,67 @@
+import { execFile } from "node:child_process";
+import { access, readFile, rm } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { resolvePnpmInvocation } from "#internal/process/pnpm.js";
+
+const execFileAsync = promisify(execFile);
+const repositoryRoot = resolve(import.meta.dirname, "../../../..");
+const fixtureRoot = join(repositoryRoot, "apps/fixtures/embedded-triage-cli");
+const outputDirectory = join(fixtureRoot, ".output");
+const generatedDirectory = join(fixtureRoot, ".eve");
+
+async function runFixture(...args: string[]) {
+  const invocation = resolvePnpmInvocation([
+    "--filter",
+    "embedded-triage-cli",
+    "embedded-triage",
+    ...args,
+  ]);
+  return await execFileAsync(invocation.command, [...invocation.args], {
+    cwd: repositoryRoot,
+    env: { ...process.env, EVE_MOCK_AUTHORED_MODELS: "", NODE_ENV: "production" },
+    maxBuffer: 20 * 1024 * 1024,
+    shell: invocation.shell,
+  });
+}
+
+describe("embedded triage application", () => {
+  beforeAll(async () => {
+    await Promise.all(
+      [generatedDirectory, outputDirectory].map(async (directory) =>
+        rm(directory, { force: true, recursive: true }),
+      ),
+    );
+  });
+  afterAll(async () => {
+    await Promise.all(
+      [generatedDirectory, outputDirectory].map(async (directory) =>
+        rm(directory, { force: true, recursive: true }),
+      ),
+    );
+  });
+
+  it("runs a real local task and builds the production workflow application", async () => {
+    await expect(access(join(fixtureRoot, "agent"))).rejects.toMatchObject({ code: "ENOENT" });
+
+    const run = await runFixture("run", "./sample-ticket.json");
+    expect(JSON.parse(run.stdout)).toEqual({
+      category: "authentication",
+      priority: "high",
+      summary: "Customer cannot sign in after resetting their password.",
+    });
+    expect(run.stderr).toContain("Triaging support ticket...");
+    expect(run.stderr).toContain("Support ticket triage complete.");
+
+    const build = await runFixture("build");
+    expect(build.stdout.trim()).toBe(outputDirectory);
+    const serverSource = await readFile(join(outputDirectory, "server/index.mjs"), "utf8");
+    expect(serverSource).toContain('route: "/.well-known/workflow/v1/flow"');
+    expect(serverSource).toContain("embedded:config:embedded-agent.mjs");
+    expect(serverSource).toContain("compiled-artifacts-bootstrap.mjs");
+    await expect(access(join(fixtureRoot, "agent"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -399,6 +399,12 @@ importers:
         specifier: 'catalog:'
         version: 7.0.2
 
+  apps/fixtures/embedded-triage-cli:
+    dependencies:
+      eve:
+        specifier: workspace:*
+        version: link:../../../packages/eve
+
   apps/fixtures/weather-agent:
     dependencies:
       eve:

--- a/research/embedded-applications-spike.md
+++ b/research/embedded-applications-spike.md
@@ -1,0 +1,51 @@
+---
+issue: "2221"
+status: proposed
+last_updated: "2026-08-18"
+---
+
+# Embedded application spike
+
+## Decision
+
+Test whether one application-owned agent definition can use eve's compiler,
+Workflow runtime, and production builder without an `agent/` source tree.
+Expose the proof through an experimental `eve/embedded` entrypoint with no
+compatibility guarantee.
+
+The spike supports one statically imported default export:
+
+```ts
+import { defineEmbeddedAgent } from "eve/embedded";
+
+export default defineEmbeddedAgent({
+  instructions: "Classify the support ticket.",
+  model: "openai/gpt-5.4-mini",
+  outputSchema: {
+    properties: { category: { type: "string" } },
+    required: ["category"],
+    type: "object",
+  },
+});
+```
+
+A host can run the definition through a local Workflow World or send it through
+the existing production builder. Compilation emits the normal manifest,
+module map, metadata, Workflow bundle, and `/.well-known/workflow/v1/flow`
+handler. JSON task input is encoded as a canonical user message, and task
+completion requires exactly one structured `result.completed` event.
+
+## Boundaries
+
+- Only one embedded definition is supported. There is no registry or agent
+  selection contract.
+- Only one local executor can own the process-global Workflow World at a time.
+- Human input is rejected. Authentication, idempotency, lookup, cancellation
+  ownership, sandbox ownership, and revision pinning are not defined.
+- The production builder proves artifact generation, not deployment or remote
+  execution.
+- Existing eve callback and infrastructure routes remain unchanged.
+
+The fixture at `apps/fixtures/embedded-triage-cli` is the executable proof. A
+follow-up decision must delete the spike, retain it as an internal example, or
+replace it with a reviewed programmatic registry and headless execution design.


### PR DESCRIPTION
### Summary

Related to #2221. This experimental spike lets an application own one embedded eve agent definition, execute structured durable tasks locally, and produce the normal production Workflow artifacts without creating an `agent/` tree. It deliberately leaves multi-agent registries, human input, deployment semantics, and compatibility guarantees undefined. #2247 is an incremental follow-up that clarifies the definition shape by separating the root agent config from embedded resources.

### Validation

Validated through the stacked head with the focused embedded definition unit suite, compilation integration suite, and application scenario, including local structured output and production Workflow artifact generation.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 4 files · `+78 / -1`

Documents the experimental boundary, fixture workflow, and release-facing behavior.

**Implementation** — 12 files · `+719 / -31`

Adds the embedded definition, compiler adapter, local executor, production builder integration, and package entrypoint while reusing existing compiler and Workflow surfaces.

**Tests** — 13 files · `+563 / -0`

Covers definition branding and validation, compilation, local execution, production building, and the executable triage fixture across unit, integration, and scenario tiers.
