### PR TITLE
feat(eve): UX for Teams approval authz flow

### DIFF
--- a/.changeset/refresh-cold-dynamic-approvals.md
+++ b/.changeset/refresh-cold-dynamic-approvals.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Rebuild untransformed session-scoped dynamic tool executors and approval policies on durable continuations so dependency-created tools remain available after replay.

--- a/.changeset/teams-approval-settlement.md
+++ b/.changeset/teams-approval-settlement.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Update Teams tool-approval cards only after approval settlement, with the outcome and the Teams responder who acted.

--- a/docs/channels/teams.mdx
+++ b/docs/channels/teams.mdx
@@ -56,6 +56,8 @@ A human-in-the-loop (HITL) `input.requested` event renders as an Adaptive Card. 
 
 By default, submissions use the Teams identity of the user who clicked the card. If you customize `onMessage` for an allowlist, configure the same policy in `onInputResponse`; eve otherwise rejects HITL submissions rather than bypassing the message gate.
 
+When a tool approval settles, eve replaces its Adaptive Card with the outcome and responder name. A response rejected by an approval policy leaves the shared card unchanged.
+
 For invokes that aren't HITL, handle them in `onInvoke(ctx, activity)`.
 
 ### Proactive sessions

--- a/docs/guides/dynamic-capabilities.md
+++ b/docs/guides/dynamic-capabilities.md
@@ -160,9 +160,11 @@ export default defineDynamic({
 });
 ```
 
-### `execute` must be an inline function
+### Prefer an inline `execute` function
 
-Write `execute` as an inline function expression, arrow, or method shorthand placed directly as the property value. The bundler transform does not detect `execute: myFn` or `execute: makeFn()`, so those tools work on the first step but do not survive replay (re-running a step after a crash or resume; see [Execution model & durability](../concepts/execution-model-and-durability)). On later steps the transform reconstructs each `execute` from its stored closure variables instead of re-running the resolver, which is why it has to be inline.
+Write `execute` as an inline function expression, arrow, or method shorthand placed directly as the property value. The bundler transform stores the function and its closure variables for durable replay without rerunning the resolver.
+
+The transform does not detect `execute: myFn`, `execute: makeFn()`, or executors created inside an imported dependency. For a `session.started` tool, eve can reconstruct these live functions by rerunning the owning resolver after a durable resume. Keep session resolvers idempotent and avoid unnecessary side effects. A `turn.started` tool still requires an inline executor to survive a fresh runtime.
 
 ### Naming
 
@@ -179,11 +181,13 @@ A dynamic tool or skill whose name matches an **authored** one **overrides** it 
 
 ### Events
 
-| Event             | Resolver runs          | Tools available for             |
-| ----------------- | ---------------------- | ------------------------------- |
-| `session.started` | Once per session       | Every model call in the session |
-| `turn.started`    | Once per turn          | Every model call in the turn    |
-| `step.started`    | Before each model call | That model call                 |
+| Event             | Resolver runs                              | Tools available for             |
+| ----------------- | ------------------------------------------ | ------------------------------- |
+| `session.started` | At session start; sometimes after a pause¹ | Every model call in the session |
+| `turn.started`    | Once per turn                              | Every model call in the turn    |
+| `step.started`    | Before each model call                     | That model call                 |
+
+¹ If a session pauses to wait for approval or other input, eve may run the resolver again when the session continues. Design session resolvers so they can safely run more than once. They do not run before every model call.
 
 ### Execution order
 

--- a/packages/eve/src/context/build-dynamic-tools.ts
+++ b/packages/eve/src/context/build-dynamic-tools.ts
@@ -1,6 +1,6 @@
 import type { HarnessToolDefinition } from "#harness/execute-tool.js";
 import type { HarnessToolMap } from "#harness/types.js";
-import type { ContextKey } from "#context/key.js";
+import type { ContextReader } from "#context/key.js";
 import {
   SessionDynamicToolMetadataKey,
   TurnDynamicToolMetadataKey,
@@ -116,12 +116,11 @@ function buildReplayedApproval(
  * so they win on name collision (the tool-loop uses `??=` for dedup).
  *
  * Step tools are live closures (re-resolved every step via
- * `LiveStepToolsKey`). Session/turn tools are replayed from durable
- * metadata via the bundler's registered step functions.
+ * `LiveStepToolsKey`). Session and turn tools replay durable metadata.
  */
 export function buildResponseAuthorizationTools(input: {
   readonly authoredTools: HarnessToolMap;
-  readonly context?: { get<T>(key: ContextKey<T>): T | undefined };
+  readonly context?: ContextReader;
 }): HarnessToolMap {
   const tools = new Map<string, HarnessToolDefinition>();
   for (const tool of input.context === undefined ? [] : buildDynamicTools(input.context)) {
@@ -133,9 +132,7 @@ export function buildResponseAuthorizationTools(input: {
   return tools;
 }
 
-export function buildDynamicTools(ctx: {
-  get<T>(key: ContextKey<T>): T | undefined;
-}): readonly HarnessToolDefinition[] {
+export function buildDynamicTools(ctx: ContextReader): readonly HarnessToolDefinition[] {
   const step = ctx.get(LiveStepToolsKey) ?? [];
   const turn = replayTools(ctx.get(TurnDynamicToolMetadataKey) ?? []);
   const session = replayTools(ctx.get(SessionDynamicToolMetadataKey) ?? []);

--- a/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
@@ -18,12 +18,14 @@ vi.mock("#context/build-callback-context.js", () => ({
 const {
   replayDynamicSessionTools,
   dispatchDynamicToolEvent,
+  hydrateDynamicSessionTools,
   refreshDynamicSessionToolsForRuntimeRevision,
 } = await import("#context/dynamic-tool-lifecycle.js");
 const { buildDynamicTools, buildResponseAuthorizationTools } =
   await import("#context/build-dynamic-tools.js");
 
 import { ContextContainer } from "#context/container.js";
+import { deserializeContext, serializeContext } from "#context/serialize.js";
 import {
   LiveStepToolsKey,
   SessionIdKey,
@@ -450,9 +452,10 @@ function createResolver(
   };
 }
 
-function createCtx(): ContextContainer {
+let contextCounter = 0;
+function createCtx(sessionId = `test-session-${++contextCounter}`): ContextContainer {
   const ctx = new ContextContainer();
-  ctx.set(SessionIdKey, "test-session");
+  ctx.set(SessionIdKey, sessionId);
   return ctx;
 }
 
@@ -482,6 +485,21 @@ function makeEvent(type: string): UnstampedMessageStreamEvent {
 const registrySym = Symbol.for("@workflow/core//registeredSteps");
 const testRegistry = getOrCreateStepRegistry(registrySym);
 let stepCounter = 0;
+
+function simulateColdStart(ctx: ContextContainer): void {
+  for (const metadata of ctx.get(SessionDynamicToolMetadataKey) ?? []) {
+    if (metadata.executeStepFnName?.startsWith("eve:framework-dynamic:")) {
+      testRegistry.delete(metadata.executeStepFnName);
+    }
+    if (metadata.approvalStepFnName !== undefined) {
+      testRegistry.delete(metadata.approvalStepFnName);
+    }
+    if (metadata.approvalResponseStepFnName !== undefined) {
+      testRegistry.delete(metadata.approvalResponseStepFnName);
+    }
+  }
+  ctx.clearVirtualContext();
+}
 
 /**
  * Creates a tool entry with bundler-injected step function fields so
@@ -563,6 +581,278 @@ describe("dispatchDynamicToolEvent", () => {
     });
 
     expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("reuses registered session callbacks without rerunning the resolver", async () => {
+    let ctx = createCtx();
+    const handler = vi.fn(() => ({ tool: createFrameworkTool("cached live tool") }));
+    const resolver = createResolver("live", ["session.started"], handler);
+    ctx.set(SessionDynamicToolRuntimeRevisionKey, "deployment:dpl_current");
+
+    await dispatchDynamicToolEvent({
+      ctx,
+      resolvers: [resolver],
+      messages: [],
+      event: makeEvent("session.started"),
+    });
+    ctx = await deserializeContext(serializeContext(ctx));
+
+    await hydrateDynamicSessionTools({
+      ctx,
+      resolvers: [resolver],
+      messages: [],
+      event: createSessionStartedEvent(),
+    });
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(buildDynamicTools(ctx).map((tool) => tool.name)).toEqual(["tool"]);
+  });
+
+  it("rebuilds a missing approval callback after a same-revision cold start", async () => {
+    const ctx = createCtx();
+    const stepId = `test-step-${++stepCounter}`;
+    const stableStepId = `test-step-${++stepCounter}`;
+    testRegistry.set(stepId, () => ({ ok: true }));
+    testRegistry.set(stableStepId, () => ({ ok: true }));
+    let approvalStepFnName: string | undefined;
+    let resolutionCount = 0;
+    const handler = vi.fn(() => {
+      resolutionCount++;
+      const entry = defineTool({
+        description: resolutionCount === 1 ? "approval policy" : "changed approval policy",
+        inputSchema: { type: "object" },
+        approval: () => "not-applicable" as const,
+        execute: async (): Promise<unknown> => ({ ok: true }),
+      });
+      Object.assign(entry, {
+        __executeStepFn: { stepId },
+        __closureVars: {},
+      });
+      return { governed: entry };
+    });
+    const resolver = createResolver("governed", ["session.started"], handler);
+    const stableHandler = vi.fn(() => {
+      const entry = defineTool({
+        description: "stable tool",
+        inputSchema: { type: "object" },
+        execute: async (): Promise<unknown> => ({ ok: true }),
+      });
+      Object.assign(entry, {
+        __executeStepFn: { stepId: stableStepId },
+        __closureVars: {},
+      });
+      return { stable: entry };
+    });
+    const stableResolver = createResolver("stable", ["session.started"], stableHandler);
+
+    try {
+      await dispatchDynamicToolEvent({
+        ctx,
+        resolvers: [resolver, stableResolver],
+        messages: [],
+        event: makeEvent("session.started"),
+      });
+      ctx.set(SessionDynamicToolRuntimeRevisionKey, "deployment:dpl_current");
+
+      approvalStepFnName = ctx.get(SessionDynamicToolMetadataKey)?.[0]?.approvalStepFnName;
+      expect(approvalStepFnName).toBe(
+        `eve:dynamic-tool-approval:${ctx.get(SessionIdKey)}:governed:governed`,
+      );
+      simulateColdStart(ctx);
+
+      await hydrateDynamicSessionTools({
+        ctx,
+        resolvers: [
+          createResolver("governed", ["session.started"], handler),
+          createResolver("stable", ["session.started"], stableHandler),
+        ],
+        messages: [],
+        event: createSessionStartedEvent(),
+      });
+
+      expect(handler).toHaveBeenCalledTimes(2);
+      expect(stableHandler).toHaveBeenCalledOnce();
+      expect(ctx.get(SessionDynamicToolMetadataKey)?.map((entry) => entry.name)).toEqual([
+        "governed",
+        "stable",
+      ]);
+      const tool = buildDynamicTools(ctx)[0]!;
+      expect(tool.description).toBe("approval policy");
+      await expect(
+        resolveApprovalPolicy(tool.approval!)(createApprovalContext({ toolName: tool.name })),
+      ).resolves.toBe("not-applicable");
+    } finally {
+      testRegistry.delete(stepId);
+      testRegistry.delete(stableStepId);
+      if (approvalStepFnName !== undefined) testRegistry.delete(approvalStepFnName);
+    }
+  });
+
+  it("rejects ownership changes while hydrating session callbacks", async () => {
+    const ctx = createCtx();
+    const original = [
+      createResolver("alpha", ["session.started"], () => ({ a: createFrameworkTool() })),
+      createResolver("beta", ["session.started"], () => ({ b: createFrameworkTool() })),
+    ];
+    await dispatchDynamicToolEvent({
+      ctx,
+      resolvers: original,
+      messages: [],
+      event: makeEvent("session.started"),
+    });
+    simulateColdStart(ctx);
+
+    await expect(
+      hydrateDynamicSessionTools({
+        ctx,
+        resolvers: [
+          createResolver("alpha", ["session.started"], () => ({ a: createFrameworkTool() })),
+          createResolver("beta", ["session.started"], () => ({ a: createFrameworkTool() })),
+        ],
+        messages: [],
+        event: createSessionStartedEvent(),
+      }),
+    ).rejects.toThrow('Dynamic tool "a" from resolver "beta" collides');
+  });
+
+  it("keeps replay callbacks isolated between sessions", async () => {
+    const sessionIds = ["session-a", "session-b"] as const;
+    const resolver = createResolver("governed", ["session.started"], (_event, resolveCtx) => {
+      const sessionId = (resolveCtx as { session: { id: string } }).session.id;
+      return {
+        governed: defineTool({
+          description: "session policy",
+          inputSchema: { type: "object" },
+          approval: () => (sessionId === "session-a" ? "not-applicable" : "user-approval"),
+          execute: async (): Promise<unknown> => ({ sessionId }),
+        }),
+      };
+    });
+
+    const contexts = sessionIds.map((sessionId) => createCtx(sessionId));
+    for (const ctx of contexts) {
+      await dispatchDynamicToolEvent({
+        ctx,
+        resolvers: [resolver],
+        messages: [],
+        event: makeEvent("session.started"),
+      });
+    }
+
+    const sessionATool = buildDynamicTools(contexts[0]!)[0]!;
+    const sessionBTool = buildDynamicTools(contexts[1]!)[0]!;
+    await expect(
+      resolveApprovalPolicy(sessionATool.approval!)(
+        createApprovalContext({ toolName: sessionATool.name }),
+      ),
+    ).resolves.toBe("not-applicable");
+    await expect(
+      resolveApprovalPolicy(sessionBTool.approval!)(
+        createApprovalContext({ toolName: sessionBTool.name }),
+      ),
+    ).resolves.toBe("user-approval");
+  });
+
+  it("evicts callback groups deterministically and rehydrates them on demand", async () => {
+    const session = createCtx("bounded-session");
+    let version = 0;
+    const handler = vi.fn(() => {
+      const current = ++version;
+      return {
+        governed: defineTool({
+          description: `version ${current}`,
+          inputSchema: { type: "object" },
+          approval: () => (current === 1 ? "user-approval" : "not-applicable"),
+          execute: async (): Promise<unknown> => current,
+        }),
+      };
+    });
+    const resolver = createResolver("bounded", ["session.started"], handler);
+
+    await dispatchDynamicToolEvent({
+      ctx: session,
+      resolvers: [resolver],
+      messages: [],
+      event: makeEvent("session.started"),
+    });
+    await dispatchDynamicToolEvent({
+      ctx: session,
+      resolvers: [resolver],
+      messages: [],
+      event: makeEvent("session.started"),
+    });
+
+    for (let index = 0; index < 255; index++) {
+      await dispatchDynamicToolEvent({
+        ctx: createCtx(`bounded-filler-${index}`),
+        resolvers: [
+          createResolver("filler", ["session.started"], () => ({
+            tool: createFrameworkTool(),
+          })),
+        ],
+        messages: [],
+        event: makeEvent("session.started"),
+      });
+    }
+
+    const retained = buildDynamicTools(session)[0]!;
+    await expect(retained.execute!({}, executeOptions)).resolves.toBe(2);
+    await expect(
+      resolveApprovalPolicy(retained.approval!)(createApprovalContext({ toolName: retained.name })),
+    ).resolves.toBe("not-applicable");
+
+    await dispatchDynamicToolEvent({
+      ctx: createCtx("bounded-evictor"),
+      resolvers: [
+        createResolver("evictor", ["session.started"], () => ({
+          tool: createFrameworkTool(),
+        })),
+      ],
+      messages: [],
+      event: makeEvent("session.started"),
+    });
+
+    expect(buildDynamicTools(session)).toEqual([]);
+    await expect(retained.execute!({}, executeOptions)).resolves.toBe(2);
+
+    await hydrateDynamicSessionTools({
+      ctx: session,
+      resolvers: [resolver],
+      messages: [],
+      event: createSessionStartedEvent(),
+    });
+    await expect(buildDynamicTools(session)[0]!.execute!({}, executeOptions)).resolves.toBe(3);
+  });
+
+  it("preserves metadata and retries when cold hydration fails", async () => {
+    const ctx = createCtx();
+    const handler = vi
+      .fn()
+      .mockImplementationOnce(() => ({ tool: createFrameworkTool("live tool") }))
+      .mockRejectedValue(new Error("temporary resolver failure"));
+    const resolver = createResolver("live", ["session.started"], handler);
+
+    await dispatchDynamicToolEvent({
+      ctx,
+      resolvers: [resolver],
+      messages: [],
+      event: makeEvent("session.started"),
+    });
+    ctx.set(SessionDynamicToolRuntimeRevisionKey, "deployment:dpl_current");
+    const originalMetadata = ctx.get(SessionDynamicToolMetadataKey);
+
+    for (let attempt = 0; attempt < 2; attempt++) {
+      simulateColdStart(ctx);
+      await hydrateDynamicSessionTools({
+        ctx,
+        resolvers: [createResolver("live", ["session.started"], handler)],
+        messages: [],
+        event: createSessionStartedEvent(),
+      });
+      expect(ctx.get(SessionDynamicToolMetadataKey)).toEqual(originalMetadata);
+    }
+
+    expect(handler).toHaveBeenCalledTimes(3);
   });
 
   it("clears removed session resolvers on a new runtime revision", async () => {
@@ -1067,7 +1357,9 @@ describe("framework dynamic tools (no bundler transform)", () => {
 
     const metadata = ctx.get(SessionDynamicToolMetadataKey);
     expect(metadata).toHaveLength(1);
-    expect(metadata![0]!.executeStepFnName).toBe("eve:framework-dynamic:fwk:search");
+    expect(metadata![0]!.executeStepFnName).toBe(
+      `eve:framework-dynamic:${ctx.get(SessionIdKey)}:fwk:search`,
+    );
     expect(metadata![0]!.closureVars).toEqual({});
 
     const tools = buildDynamicTools(ctx);
@@ -1075,7 +1367,6 @@ describe("framework dynamic tools (no bundler transform)", () => {
     expect(tools[0]!.name).toBe("search");
 
     // Simulate step boundary — virtual context cleared, durable survives
-    ctx.clearVirtualContext();
 
     const replayedTools = buildDynamicTools(ctx);
     expect(replayedTools).toHaveLength(1);
@@ -1133,8 +1424,6 @@ describe("framework dynamic tools (no bundler transform)", () => {
     const metadata = ctx.get(SessionDynamicToolMetadataKey);
     expect(metadata).toHaveLength(2);
 
-    ctx.clearVirtualContext();
-
     const tools = buildDynamicTools(ctx);
     expect(tools).toHaveLength(2);
     expect(tools.map((t) => t.name).sort()).toEqual(["query", "search"]);
@@ -1152,8 +1441,6 @@ describe("framework dynamic tools (no bundler transform)", () => {
       messages: [],
       event: makeEvent("session.started"),
     });
-
-    ctx.clearVirtualContext();
 
     const tools = buildDynamicTools(ctx);
     expect(tools).toHaveLength(1);
@@ -1209,8 +1496,6 @@ describe("framework dynamic tools (no bundler transform)", () => {
       messages: [],
       event: makeEvent("session.started"),
     });
-
-    ctx.clearVirtualContext();
 
     const tools = buildDynamicTools(ctx);
     expect(tools).toHaveLength(1);
@@ -1286,21 +1571,20 @@ describe("framework dynamic tools (no bundler transform)", () => {
     expect(tools.get("guarded")?.description).toBe("step");
   });
 
-  it("replays response authorization from session-scoped dynamic tools", async () => {
+  it("rehydrates an untransformed executor and approval policies after a cold start", async () => {
     const ctx = createCtx();
+    const execute = vi.fn(async () => ({ ok: true }));
+    const request = vi.fn(async () => "user-approval" as const);
     const response = vi.fn(async () => ({ status: "allowed" }) as const);
-    const entry: DynamicToolEntry = defineTool({
-      approval: {
-        request: async () => "user-approval" as const,
-        response,
-      },
-      description: "destructive op",
-      execute: async (): Promise<unknown> => ({ ok: true }),
-      inputSchema: { type: "object" },
-    });
-    const resolver = createResolver("session_guard", ["session.started"], () => ({
-      guarded: entry,
+    const handler = vi.fn(() => ({
+      guarded: defineTool({
+        approval: { request, response },
+        description: "dependency-created destructive op",
+        execute,
+        inputSchema: { type: "object" },
+      }),
     }));
+    const resolver = createResolver("session_guard", ["session.started"], handler);
 
     await dispatchDynamicToolEvent({
       ctx,
@@ -1308,12 +1592,29 @@ describe("framework dynamic tools (no bundler transform)", () => {
       messages: [],
       resolvers: [resolver],
     });
-    ctx.clearVirtualContext();
+    ctx.set(SessionDynamicToolRuntimeRevisionKey, "deployment:dpl_current");
 
-    const approval = buildDynamicTools(ctx)[0]!.approval;
+    simulateColdStart(ctx);
+    await hydrateDynamicSessionTools({
+      ctx,
+      event: createSessionStartedEvent(),
+      messages: [],
+      resolvers: [createResolver("session_guard", ["session.started"], handler)],
+    });
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    const tool = buildDynamicTools(ctx)[0]!;
+    await expect(tool.execute!({}, executeOptions)).resolves.toEqual({ ok: true });
+    expect(execute).toHaveBeenCalledOnce();
+
+    const approval = tool.approval;
     if (approval === undefined || typeof approval === "function") {
-      throw new Error("Expected replayed approval configuration.");
+      throw new Error("Expected rehydrated approval configuration.");
     }
+    const approvalCtx = createApprovalContext({ toolName: "guarded" });
+    await expect(approval.request(approvalCtx)).resolves.toBe("user-approval");
+    expect(request).toHaveBeenCalledExactlyOnceWith(approvalCtx);
+
     const responseCtx = {
       auth: {
         getToken: vi.fn(),
@@ -1371,8 +1672,6 @@ describe("framework dynamic tools (no bundler transform)", () => {
     const metadata = ctx.get(SessionDynamicToolMetadataKey);
     expect(metadata?.[0]?.outputSchema).toEqual(outputSchema);
 
-    ctx.clearVirtualContext();
-
     const tools = buildDynamicTools(ctx);
     expect(tools).toHaveLength(1);
     expect(serializeOutputSchema(tools[0]!.outputSchema as ToolSchema)).toEqual(outputSchema);
@@ -1414,7 +1713,6 @@ describe("framework dynamic tools (no bundler transform)", () => {
       event: makeEvent("session.started"),
     });
 
-    ctx.clearVirtualContext();
     let tools = buildDynamicTools(ctx);
     const result1 = await tools[0]!.execute!({}, executeOptions);
     expect(result1).toEqual({ version: 1 });
@@ -1427,7 +1725,6 @@ describe("framework dynamic tools (no bundler transform)", () => {
       event: makeEvent("session.started"),
     });
 
-    ctx.clearVirtualContext();
     tools = buildDynamicTools(ctx);
     expect(tools[0]!.description).toBe("v2");
     const result2 = await tools[0]!.execute!({}, executeOptions);

--- a/packages/eve/src/context/dynamic-tool-lifecycle.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.ts
@@ -26,6 +26,7 @@ import type { ContextKey } from "#context/key.js";
 import {
   SessionDynamicToolMetadataKey,
   SessionDynamicToolRuntimeRevisionKey,
+  SessionIdKey,
   TurnDynamicToolMetadataKey,
   LiveStepToolsKey,
 } from "#context/keys.js";
@@ -158,8 +159,48 @@ function lookupStepFunction(stepId: string): ((...args: unknown[]) => unknown) |
   }
 }
 
-function registerStepFunction(stepId: string, fn: Function): void {
-  getStepRegistry().set(stepId, fn);
+function hasMissingProcessCallback(metadata: DurableDynamicToolMetadata): boolean {
+  return (
+    (metadata.executeStepFnName?.startsWith("eve:framework-dynamic:") === true &&
+      lookupStepFunction(metadata.executeStepFnName) === null) ||
+    (metadata.approvalStepFnName !== undefined &&
+      lookupStepFunction(metadata.approvalStepFnName) === null) ||
+    (metadata.approvalResponseStepFnName !== undefined &&
+      lookupStepFunction(metadata.approvalResponseStepFnName) === null)
+  );
+}
+
+const MAX_PROCESS_CALLBACK_GROUPS = 256;
+interface ProcessCallbackGroup {
+  readonly id: string;
+  readonly callbackIds: Set<string>;
+}
+const processCallbackQueue: ProcessCallbackGroup[] = [];
+const processCallbackGroups = new Map<string, ProcessCallbackGroup>();
+
+function registerProcessCallbacks(groupId: string, callbacks: ReadonlyMap<string, Function>): void {
+  const registry = getStepRegistry();
+  const previous = processCallbackGroups.get(groupId);
+  if (previous !== undefined) {
+    for (const callbackId of previous.callbackIds) registry.delete(callbackId);
+  }
+
+  if (callbacks.size === 0) {
+    processCallbackGroups.delete(groupId);
+    return;
+  }
+
+  const group = { id: groupId, callbackIds: new Set(callbacks.keys()) };
+  processCallbackGroups.set(groupId, group);
+  processCallbackQueue.push(group);
+  for (const [callbackId, callback] of callbacks) registry.set(callbackId, callback);
+
+  while (processCallbackQueue.length > MAX_PROCESS_CALLBACK_GROUPS) {
+    const evicted = processCallbackQueue.shift()!;
+    if (processCallbackGroups.get(evicted.id) !== evicted) continue;
+    processCallbackGroups.delete(evicted.id);
+    for (const callbackId of evicted.callbackIds) registry.delete(callbackId);
+  }
 }
 
 function safeSerialize(obj: Record<string, unknown>): Record<string, unknown> {
@@ -187,16 +228,6 @@ function durableKeyForEvent(
   }
 }
 
-// ---------------------------------------------------------------------------
-// Build: assemble live tools from all scoped durable keys
-// ---------------------------------------------------------------------------
-
-/**
- * Builds live dynamic tool definitions from session + turn + step
- * durable metadata keys. Session-scoped tools appear first, then
- * turn, then step. The tool-loop calls this right before the model
- * call — no virtual key needed.
- */
 // ---------------------------------------------------------------------------
 // Resolve: run resolver handlers, capture closures, write durable metadata
 // ---------------------------------------------------------------------------
@@ -268,6 +299,7 @@ async function resolveToolsFromEvent(
 
     const { resolver, entries, isSingle } = outcome.value;
     const named = qualifyDynamicToolNames(resolver, isSingle, entries);
+    const processCallbacks = new Map<string, Function>();
     for (const { name, entryKey, entry } of named) {
       const previousOwner = dynamicToolOwners.get(name);
       if (previousOwner !== undefined && previousOwner !== resolver.slug) {
@@ -295,14 +327,11 @@ async function resolveToolsFromEvent(
       let serializedClosureVars =
         closureVars !== undefined ? safeSerialize(closureVars) : undefined;
 
-      // Framework tools skip the bundler AST transform, so they carry
-      // no __executeStepFn/__closureVars. Register the live execute
-      // closure in the step registry so session/turn-scoped metadata
-      // can replay them the same way as authored tools.
+      const callbackScope = event.type === "session.started" ? `${ctx.require(SessionIdKey)}:` : "";
       if (executeStepFnName === undefined) {
-        const syntheticId = `eve:framework-dynamic:${resolver.slug}:${entryKey}`;
+        const syntheticId = `eve:framework-dynamic:${callbackScope}${resolver.slug}:${entryKey}`;
         const originalExecute = entry.execute.bind(entry);
-        registerStepFunction(syntheticId, (_closureVars: unknown, input: unknown, ctx: unknown) =>
+        processCallbacks.set(syntheticId, (_closureVars: unknown, input: unknown, ctx: unknown) =>
           originalExecute(
             input as Record<string, unknown>,
             ctx as Parameters<typeof entry.execute>[1],
@@ -315,17 +344,17 @@ async function resolveToolsFromEvent(
       let approvalStepFnName: string | undefined;
       let approvalResponseStepFnName: string | undefined;
       if (entry.approval !== undefined) {
-        approvalStepFnName = `eve:dynamic-tool-approval:${resolver.slug}:${entryKey}`;
+        approvalStepFnName = `eve:dynamic-tool-approval:${callbackScope}${resolver.slug}:${entryKey}`;
         const originalApproval = resolveApprovalPolicy(entry.approval).bind(entry);
-        registerStepFunction(approvalStepFnName, (_closureVars: unknown, approvalCtx: unknown) =>
+        processCallbacks.set(approvalStepFnName, (_closureVars: unknown, approvalCtx: unknown) =>
           originalApproval(approvalCtx as ApprovalContext),
         );
 
         const responsePolicy =
           typeof entry.approval === "function" ? undefined : entry.approval.response;
         if (responsePolicy !== undefined) {
-          approvalResponseStepFnName = `eve:dynamic-tool-approval-response:${resolver.slug}:${entryKey}`;
-          registerStepFunction(
+          approvalResponseStepFnName = `eve:dynamic-tool-approval-response:${callbackScope}${resolver.slug}:${entryKey}`;
+          processCallbacks.set(
             approvalResponseStepFnName,
             (_closureVars: unknown, responseCtx: unknown) =>
               responsePolicy(responseCtx as ApprovalResponseContext),
@@ -345,6 +374,14 @@ async function resolveToolsFromEvent(
         approvalResponseStepFnName,
         closureVars: serializedClosureVars,
       });
+    }
+
+    if (event.type === "session.started") {
+      registerProcessCallbacks(`${ctx.require(SessionIdKey)}:${resolver.slug}`, processCallbacks);
+    } else {
+      for (const [callbackId, callback] of processCallbacks) {
+        getStepRegistry().set(callbackId, callback);
+      }
     }
   }
 
@@ -466,4 +503,38 @@ export async function refreshDynamicSessionToolsForRuntimeRevision(input: {
 
   input.ctx.set(SessionDynamicToolMetadataKey, metadata);
   input.ctx.set(SessionDynamicToolRuntimeRevisionKey, input.runtimeRevision);
+}
+
+/** Re-registers missing process-local session callbacks in a fresh runtime. */
+export async function hydrateDynamicSessionTools(input: {
+  readonly ctx: ContextContainer;
+  readonly resolvers: readonly ResolvedDynamicToolResolver[];
+  readonly event: SessionStartedStreamEvent;
+  readonly messages: readonly ModelMessage[];
+}): Promise<void> {
+  const storedMetadata = input.ctx.get(SessionDynamicToolMetadataKey) ?? [];
+  const missing = storedMetadata.filter(hasMissingProcessCallback);
+  if (missing.length === 0) return;
+
+  const owners = new Set(missing.map((entry) => entry.resolverSlug));
+  const matching = input.resolvers.filter(
+    (resolver) => resolver.eventNames.includes("session.started") && owners.has(resolver.slug),
+  );
+  const { metadata } =
+    matching.length === 0
+      ? { metadata: [] }
+      : await resolveToolsFromEvent(input.ctx, matching, input.event, input.messages);
+  const durableOwners = new Map(storedMetadata.map((entry) => [entry.name, entry.resolverSlug]));
+  const resolvedOwners = new Map(metadata.map((entry) => [entry.name, entry.resolverSlug]));
+  if (metadata.some((entry) => durableOwners.get(entry.name) !== entry.resolverSlug)) {
+    throw new Error("Dynamic session tool callback hydration changed durable ownership.");
+  }
+  if (
+    missing.some(
+      (entry) =>
+        resolvedOwners.get(entry.name) !== entry.resolverSlug || hasMissingProcessCallback(entry),
+    )
+  ) {
+    log.warn("Dynamic session tool callback hydration did not reproduce durable ownership.");
+  }
 }

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -2294,13 +2294,25 @@ describe("turnStep", () => {
 
   it("refreshes session-scoped dynamic tools from the current deployment", async () => {
     vi.stubEnv("VERCEL_DEPLOYMENT_ID", "dpl_new");
-    const handler = vi.fn(() => ({
-      current_tool: defineTool({
-        description: "Current deployment tool",
-        inputSchema: { type: "object" },
-        execute: async () => ({ ok: true }),
-      }),
-    }));
+    const lifecycleOrder: string[] = [];
+    const originalClearVirtualContext = ContextContainer.prototype.clearVirtualContext;
+    vi.spyOn(ContextContainer.prototype, "clearVirtualContext").mockImplementation(
+      function (this: ContextContainer) {
+        lifecycleOrder.push("clear");
+        originalClearVirtualContext.call(this);
+      },
+    );
+    const handler = vi.fn(() => {
+      lifecycleOrder.push("refresh");
+      return {
+        current_tool: defineTool({
+          description: "Current deployment tool",
+          inputSchema: { type: "object" },
+          approval: () => "not-applicable" as const,
+          execute: async () => ({ ok: true }),
+        }),
+      };
+    });
     const dynamicToolResolver = {
       eventNames: ["session.started"],
       events: { "session.started": handler },
@@ -2334,10 +2346,13 @@ describe("turnStep", () => {
     } as never;
     vi.mocked(getCompiledRuntimeAgentBundle).mockResolvedValue(compiledBundle);
     vi.mocked(createExecutionNodeStep).mockImplementation(() => {
-      return async (session): Promise<StepResult> => ({
-        next: { done: true, output: "ok" },
-        session,
-      });
+      return async (session): Promise<StepResult> => {
+        lifecycleOrder.push("execute");
+        return {
+          next: { done: true, output: "ok" },
+          session,
+        };
+      };
     });
 
     const session = createStubSession({
@@ -2390,6 +2405,7 @@ describe("turnStep", () => {
     });
 
     expect(handler).toHaveBeenCalledOnce();
+    expect(lifecycleOrder).toEqual(["refresh", "clear", "execute"]);
     expect(result.serializedContext[SessionDynamicToolRuntimeRevisionKey.name]).toBe(
       "deployment:dpl_new",
     );

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -17,6 +17,7 @@ import {
 } from "#context/dynamic-subagent-lifecycle.js";
 import {
   dispatchDynamicToolEvent,
+  hydrateDynamicSessionTools,
   refreshDynamicSessionToolsForRuntimeRevision,
 } from "#context/dynamic-tool-lifecycle.js";
 import {
@@ -103,14 +104,8 @@ const TASK_DONE_WITH_PENDING_INPUT_ERROR_MESSAGE =
   "Task mode cannot complete while input requests remain pending.";
 
 /**
- * Result of one durable harness step, consumed by the turn workflow.
- *
- * `park` carries the pending fields needed to choose a
- * {@link import("#execution/next-driver-action.js").NextDriverAction} without re-reading state.
- *
- * `cancelled` converts the harness's cancellation throw into a *returned*
- * result so workflow-core never classifies the abort as a step failure or
- * retries it; the epilogue runs in `settleCancelledTurnStep`.
+ * Result of one durable harness step. `cancelled` is returned so workflow-core
+ * does not retry it; `park` carries the pending state needed by the next action.
  */
 export type DurableStepResult =
   | {
@@ -206,13 +201,8 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
     // Outside a workflow context (e.g. tests) — getHookUrl will return undefined.
   }
 
-  // Authorization callback. If the delivery carries an
-  // `authorizationCallback` and there's a pending authorization on
-  // session state, extract it, build AuthorizationResult entries, and
-  // populate PendingAuthorizationResultKey so tools can complete auth.
-  // Strip the callback from the delivery so the adapter doesn't see it.
-  // Completion event names are collected here; emission happens after
-  // the `emit` function is created below.
+  // Resolve authorization callbacks before the adapter sees the delivery.
+  // Completion events are emitted after `emit` is created below.
   const pendingAuth = getPendingAuthorization(durableSession.state);
   let completedAuths: ReturnType<typeof matchAuthorizationCallbacks>["matches"] | undefined;
   if (pendingAuth && input.input?.kind === "deliver") {
@@ -386,6 +376,12 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
           runtimeRevision: dynamicRuntimeRevision,
         }),
       ]);
+      await hydrateDynamicSessionTools({
+        ctx,
+        resolvers: dynamicToolResolvers,
+        event: refreshEvent,
+        messages: initialSession.history,
+      });
     }
   } catch (error) {
     await failChannelDeliveries(error);

--- a/packages/eve/src/public/channels/teams/api.test.ts
+++ b/packages/eve/src/public/channels/teams/api.test.ts
@@ -103,6 +103,28 @@ describe("Teams Connector API wrapper", () => {
     expect(requests[3]!.body).toEqual({ type: "typing" });
   });
 
+  it("reports Connector update failures with the response body and target", async () => {
+    const apiFetch = vi.fn(async () =>
+      Response.json(
+        { error: { code: "BadArgument", message: "Activity cannot be updated." } },
+        { status: 400 },
+      ),
+    );
+
+    await expect(
+      updateTeamsActivity({
+        activityId: "ACTIVITY_1",
+        body: { text: "updated", type: "message" },
+        conversationId: "CONV",
+        credentials: { tokenProvider: () => "connector-token" },
+        fetch: apiFetch,
+        serviceUrl: "https://smba.example.test/teams",
+      }),
+    ).rejects.toThrow(
+      'Teams update activity failed with HTTP 400 for conversation "CONV" activity "ACTIVITY_1": {"error":{"code":"BadArgument","message":"Activity cannot be updated."}}',
+    );
+  });
+
   it("exposes a raw Connector request helper", async () => {
     const apiFetch = vi.fn(async () => Response.json({ ok: true }));
     await callTeamsConnectorApi({

--- a/packages/eve/src/public/channels/teams/api.ts
+++ b/packages/eve/src/public/channels/teams/api.ts
@@ -324,7 +324,9 @@ export async function updateTeamsActivity(
     )}`,
   });
   if (!response.ok) {
-    throw new Error(`Teams update activity failed with HTTP ${response.status}.`);
+    throw new Error(
+      `Teams update activity failed with HTTP ${response.status} for conversation "${input.conversationId}" activity "${input.activityId}": ${formatConnectorErrorBody(response.body)}`,
+    );
   }
   return toPostedActivity(response.body);
 }
@@ -395,6 +397,12 @@ function toPostedActivity(body: unknown): TeamsPostedActivity {
     id: typeof raw.id === "string" ? raw.id : "",
     raw: body,
   };
+}
+
+function formatConnectorErrorBody(body: unknown): string {
+  const value = typeof body === "string" ? body : JSON.stringify(body);
+  if (value === undefined || value.length === 0) return "empty response body";
+  return value.length <= 1_000 ? value : `${value.slice(0, 997)}...`;
 }
 
 function trimTrailingSlash(value: string): string {

--- a/packages/eve/src/public/channels/teams/defaults.test.ts
+++ b/packages/eve/src/public/channels/teams/defaults.test.ts
@@ -12,6 +12,7 @@ function buildChannelStub(state: Partial<TeamsChannelState> = {}) {
   const update = vi.fn().mockResolvedValue(undefined);
   const channel = {
     adaptiveCardVersion: "1.5",
+    teams: { replyToActivityId: undefined } as Partial<TeamsEventContext["teams"]>,
     thread: { post, startTyping, update } as Partial<TeamsEventContext["thread"]>,
     state: {
       bot: null,
@@ -39,6 +40,68 @@ function authRequiredEvent(overrides: { displayName?: string } = {}) {
     turnId: "turn_0",
   };
 }
+
+describe("defaultEvents approval lifecycle", () => {
+  it("records a posted tool approval card for settlement", async () => {
+    const { channel, post } = buildChannelStub();
+
+    await defaultEvents["input.requested"]!(
+      {
+        requests: [
+          {
+            action: { callId: "call-1", input: {}, kind: "tool-call", toolName: "deploy" },
+            kind: "tool-approval",
+            options: [
+              { id: "approve", label: "Approve" },
+              { id: "cancel", label: "Cancel" },
+            ],
+            prompt: "Approve deployment?",
+            requestId: "approval_1",
+          },
+        ],
+        sequence: 1,
+        stepIndex: 0,
+        turnId: "turn-1",
+      },
+      channel,
+      sessionCtx,
+    );
+
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(channel.state.pendingApprovalCards).toEqual({
+      approval_1: { activityId: "act1", prompt: "Approve deployment?" },
+    });
+  });
+
+  it("replaces the settled approval card with the responder's identity", async () => {
+    const { channel, update } = buildChannelStub({
+      approvalResponderAccounts: { "teams:TENANT:USER": { id: "USER", name: "Ada" } },
+      pendingApprovalCards: {
+        approval_1: { activityId: "approval-card", prompt: "Approve deployment?" },
+      },
+    });
+
+    await defaultEvents["approval.settled"]!(
+      {
+        outcome: "approved",
+        requestId: "approval_1",
+        responderPrincipalId: "teams:TENANT:USER",
+        sequence: 1,
+        stepIndex: 0,
+        turnId: "turn-1",
+      },
+      channel,
+      sessionCtx,
+    );
+
+    expect(update).toHaveBeenCalledWith(
+      "approval-card",
+      expect.objectContaining({ attachments: expect.any(Array) }),
+    );
+    expect(JSON.stringify(update.mock.calls[0]?.[1])).toContain("Answered: Approved by Ada");
+    expect(channel.state.pendingApprovalCards).toEqual({});
+  });
+});
 
 describe("defaultEvents authorization.required", () => {
   it("renders the title-cased connection name when the challenge has no displayName", async () => {

--- a/packages/eve/src/public/channels/teams/defaults.ts
+++ b/packages/eve/src/public/channels/teams/defaults.ts
@@ -69,13 +69,39 @@ export const defaultEvents: TeamsChannelEvents = {
 
   async "input.requested"(event, channel, _ctx) {
     for (const request of event.requests) {
-      await channel.thread.post(
+      const posted = await channel.thread.post(
         renderInputRequestMessage(request, {
           adaptiveCardVersion: channel.adaptiveCardVersion,
           replyToActivityId: channel.teams.replyToActivityId,
         }),
       );
+      if (request.kind === "tool-approval" && posted.id) {
+        channel.state.pendingApprovalCards = {
+          ...channel.state.pendingApprovalCards,
+          [request.requestId]: { activityId: posted.id, prompt: request.prompt },
+        };
+      }
     }
+  },
+
+  async "approval.settled"(event, channel, _ctx) {
+    const cards = channel.state.pendingApprovalCards ?? {};
+    const card = cards[event.requestId];
+    if (card === undefined) return;
+    const account = channel.state.approvalResponderAccounts?.[event.responderPrincipalId];
+    const label = event.outcome === "approved" ? "Approved" : "Cancelled";
+    const actor = account?.name ?? account?.id;
+    await channel.thread.update(
+      card.activityId,
+      renderAnsweredInputRequestMessage({
+        includeText: false,
+        label: actor === undefined ? label : `${label} by ${actor}`,
+        prompt: card.prompt,
+      }),
+    );
+    const next = { ...cards };
+    delete next[event.requestId];
+    channel.state.pendingApprovalCards = next;
   },
 
   async "message.completed"(event, channel, _ctx) {

--- a/packages/eve/src/public/channels/teams/hitl.test.ts
+++ b/packages/eve/src/public/channels/teams/hitl.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, it } from "vitest";
 
 import {
   deriveTeamsInputResponses,
+  isTeamsToolApprovalResponseActivity,
   readTeamsInputReplyToActivityId,
   renderInputRequestMessage,
   TEAMS_HITL_CHOICE_INPUT_ID,
   TEAMS_HITL_DATA_KEY,
   TEAMS_HITL_FREEFORM_INPUT_ID,
+  TEAMS_HITL_PROMPT_KEY,
+  TEAMS_HITL_REQUEST_KIND_KEY,
 } from "#public/channels/teams/hitl.js";
 import { parseTeamsActivity } from "#public/channels/teams/inbound.js";
 import type { InputRequest } from "#runtime/input/types.js";
@@ -37,7 +40,11 @@ describe("Teams HITL helpers", () => {
     };
 
     expect(card.actions?.[0]?.data).toMatchObject({
-      [TEAMS_HITL_DATA_KEY]: { replyToActivityId: "ROOT" },
+      [TEAMS_HITL_DATA_KEY]: {
+        [TEAMS_HITL_PROMPT_KEY]: "Approve deploy?",
+        [TEAMS_HITL_REQUEST_KIND_KEY]: "tool-approval",
+        replyToActivityId: "ROOT",
+      },
     });
   });
 
@@ -78,6 +85,21 @@ describe("Teams HITL helpers", () => {
     expect(invoke ? deriveTeamsInputResponses(invoke) : []).toEqual([
       { requestId: "REQ", text: "freeform" },
     ]);
+    expect(invoke ? isTeamsToolApprovalResponseActivity(invoke) : false).toBe(false);
+  });
+
+  it("identifies tool approval submissions", () => {
+    const activity = parseTeamsActivity(
+      activityWithValue({
+        [TEAMS_HITL_DATA_KEY]: {
+          [TEAMS_HITL_REQUEST_KIND_KEY]: "tool-approval",
+          optionId: "approve",
+          requestId: "REQ",
+        },
+      }),
+    );
+
+    expect(activity ? isTeamsToolApprovalResponseActivity(activity) : false).toBe(true);
   });
 });
 

--- a/packages/eve/src/public/channels/teams/hitl.ts
+++ b/packages/eve/src/public/channels/teams/hitl.ts
@@ -30,6 +30,12 @@ export const TEAMS_HITL_CHOICE_INPUT_ID = "eve_option";
 /** Text input id used for freeform HITL requests. */
 export const TEAMS_HITL_FREEFORM_INPUT_ID = "eve_freeform_text";
 
+/** Request kind carried on approval actions so lifecycle handling can distinguish them from questions. */
+export const TEAMS_HITL_REQUEST_KIND_KEY = "kind";
+
+/** Prompt carried on approval actions so a response can recover its card record. */
+export const TEAMS_HITL_PROMPT_KEY = "prompt";
+
 /** Renders one input request as a Teams message body containing an Adaptive Card. */
 export function renderInputRequestMessage(
   request: InputRequest,
@@ -92,10 +98,12 @@ export function renderInputRequestAttachment(
 
 /** Renders an answered Teams card that replaces a pending HITL prompt. */
 export function renderAnsweredInputRequestMessage(input: {
+  readonly includeText?: boolean;
   readonly label?: string;
   readonly prompt: string;
 }): TeamsMessageBody {
-  return {
+  const text = input.label ? `Answered: ${input.label}` : "Answered";
+  const result: TeamsMessageBody = {
     attachments: [
       {
         content: parseJsonObject({
@@ -106,12 +114,7 @@ export function renderAnsweredInputRequestMessage(input: {
               type: "TextBlock",
               wrap: true,
             },
-            {
-              color: "good",
-              text: input.label ? `Answered: ${input.label}` : "Answered",
-              type: "TextBlock",
-              wrap: true,
-            },
+            { color: "good", text, type: "TextBlock", wrap: true },
           ],
           type: "AdaptiveCard",
           version: "1.5",
@@ -119,13 +122,29 @@ export function renderAnsweredInputRequestMessage(input: {
         contentType: TEAMS_ADAPTIVE_CARD_CONTENT_TYPE,
       },
     ],
-    text: input.label ? `Answered: ${input.label}` : "Answered",
   };
+  if (input.includeText !== false) return { ...result, text };
+  return result;
 }
 
 /** Returns true when a Teams activity carries an eve HITL submit payload. */
 export function isTeamsInputResponseActivity(activity: TeamsActivity): boolean {
   return deriveTeamsInputResponses(activity).length > 0;
+}
+
+/** Returns whether an eve HITL activity answers a tool approval. */
+export function isTeamsToolApprovalResponseActivity(activity: TeamsActivity): boolean {
+  const value = readActivityValue(activity);
+  const payload = value && readHitlPayload(value);
+  return payload?.[TEAMS_HITL_REQUEST_KIND_KEY] === "tool-approval";
+}
+
+/** Reads the original prompt from a tool-approval submit activity. */
+export function readTeamsToolApprovalPrompt(activity: TeamsActivity): string | undefined {
+  const value = readActivityValue(activity);
+  const payload = value && readHitlPayload(value);
+  const prompt = payload?.[TEAMS_HITL_PROMPT_KEY];
+  return typeof prompt === "string" && prompt.length > 0 ? prompt : undefined;
 }
 
 /**
@@ -223,6 +242,10 @@ function renderActions(
 ): readonly Record<string, unknown>[] {
   const payload = (optionId?: string): Record<string, unknown> => {
     const value: Record<string, unknown> = { requestId: request.requestId };
+    if (request.kind === "tool-approval") {
+      value[TEAMS_HITL_REQUEST_KIND_KEY] = "tool-approval";
+      value[TEAMS_HITL_PROMPT_KEY] = request.prompt;
+    }
     if (replyToActivityId !== undefined) value.replyToActivityId = replyToActivityId;
     if (optionId !== undefined) value.optionId = optionId;
     return value;

--- a/packages/eve/src/public/channels/teams/index.ts
+++ b/packages/eve/src/public/channels/teams/index.ts
@@ -82,6 +82,8 @@ export {
 export {
   deriveTeamsInputResponses,
   isTeamsInputResponseActivity,
+  isTeamsToolApprovalResponseActivity,
+  readTeamsToolApprovalPrompt,
   renderAnsweredInputRequestMessage,
   renderInputRequestAttachment,
   renderInputRequestMessage,
@@ -90,6 +92,8 @@ export {
   TEAMS_HITL_CHOICE_INPUT_ID,
   TEAMS_HITL_DATA_KEY,
   TEAMS_HITL_FREEFORM_INPUT_ID,
+  TEAMS_HITL_REQUEST_KIND_KEY,
+  TEAMS_HITL_PROMPT_KEY,
 } from "#public/channels/teams/hitl.js";
 
 export {

--- a/packages/eve/src/public/channels/teams/teamsChannel.test.ts
+++ b/packages/eve/src/public/channels/teams/teamsChannel.test.ts
@@ -1,9 +1,52 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { callAdapterEventHandler } from "#channel/adapter.js";
+import { buildAdapterContext } from "#channel/adapter-context.js";
 import { isCompiledChannel, type CompiledChannel } from "#channel/compiled-channel.js";
+import { ContextContainer, contextStorage } from "#context/container.js";
+import { SessionKey } from "#context/keys.js";
 import { isHttpRouteDefinition } from "#channel/routes.js";
-import { mockChannelContext } from "#internal/testing/mocks/mock-channel-operations.js";
+import {
+  mockChannelContext,
+  type ObservedChannelDelivery,
+} from "#internal/testing/mocks/mock-channel-operations.js";
+import type { UnstampedMessageStreamEvent } from "#protocol/message.js";
 import { teamsChannel, type TeamsChannelState } from "#public/channels/teams/index.js";
+
+function adapter(channel: unknown) {
+  return asCompiled<TeamsChannelState>(channel).adapter;
+}
+
+function makeEvent<T extends UnstampedMessageStreamEvent["type"]>(
+  type: T,
+  data: unknown,
+): UnstampedMessageStreamEvent {
+  return { type, data } as UnstampedMessageStreamEvent;
+}
+
+function stubAccessor() {
+  return { get: () => undefined, set: () => {} } as any;
+}
+
+const stubAlsContext = (() => {
+  const ctx = new ContextContainer();
+  ctx.setVirtualContext(SessionKey, {
+    sessionId: "test-session",
+    auth: { current: null, initiator: null },
+    turn: { id: "test-turn", sequence: 0 },
+  });
+  return ctx;
+})();
+
+function callEvent(
+  teamsAdapter: ReturnType<typeof adapter>,
+  event: UnstampedMessageStreamEvent,
+  ctx: ReturnType<typeof buildAdapterContext>,
+) {
+  return contextStorage.run(stubAlsContext, () =>
+    callAdapterEventHandler(teamsAdapter, event, ctx),
+  );
+}
 
 function asCompiled<T = unknown>(channel: unknown): CompiledChannel<T> {
   if (!isCompiledChannel(channel)) {
@@ -191,7 +234,7 @@ describe("teamsChannel", () => {
     expect(send).not.toHaveBeenCalled();
   });
 
-  it("resumes invoke HITL responses with the clicker's auth and recorded thread", async () => {
+  it("resumes tool approvals with the clicker's auth and durable Teams identity", async () => {
     const channel = teamsChannel({ credentials: { webhookVerifier: () => true } });
     const { response, send } = await firePost(channel, {
       ...baseActivity({ conversationType: "channel" }),
@@ -203,6 +246,7 @@ describe("teamsChannel", () => {
           data: {
             eve_input: {
               replyToActivityId: "THREAD_ROOT",
+              kind: "tool-approval",
               requestId: "REQ",
               optionId: "approve",
             },
@@ -217,8 +261,130 @@ describe("teamsChannel", () => {
       expect.objectContaining({
         auth: expect.objectContaining({ subject: "AAD_USER" }),
         inputResponses: [{ optionId: "approve", requestId: "REQ" }],
+        state: {
+          approvalResponderAccounts: {
+            "teams:TENANT:USER": expect.objectContaining({ id: "USER", name: "Ada" }),
+          },
+        },
       }),
     );
+  });
+
+  it("updates a posted approval card after a durable cancel settlement", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockResolvedValue(new Response(JSON.stringify({ id: "updated-card" })));
+    const channel = teamsChannel({
+      api: { fetch: fetchMock },
+      credentials: { tokenProvider: () => "test-token", webhookVerifier: () => true },
+    });
+    const teamsAdapter = adapter(channel);
+    const ctx = buildAdapterContext(teamsAdapter, stubAccessor());
+
+    ctx.state.bot = { id: "BOT" };
+    ctx.state.conversationId = "19:conversation@thread.tacv2;messageid=THREAD_ROOT";
+    ctx.state.conversationType = "channel";
+    ctx.state.replyToActivityId = "THREAD_ROOT";
+    ctx.state.serviceUrl = "https://smba.example.test/teams";
+    ctx.state.tenantId = "TENANT";
+
+    await callEvent(
+      teamsAdapter,
+      makeEvent("input.requested", {
+        requests: [
+          {
+            action: { callId: "call-1", input: {}, kind: "tool-call", toolName: "deploy" },
+            kind: "tool-approval",
+            options: [
+              { id: "approve", label: "Approve" },
+              { id: "cancel", label: "Cancel" },
+            ],
+            prompt: "Approve deployment?",
+            requestId: "approval_1",
+          },
+        ],
+        sequence: 1,
+        stepIndex: 0,
+        turnId: "turn-1",
+      }),
+      ctx,
+    );
+
+    expect(ctx.state.pendingApprovalCards).toEqual({});
+
+    const { send } = await firePost(channel, {
+      ...baseActivity({ conversationType: "channel" }),
+      conversation: {
+        conversationType: "channel",
+        id: "19:conversation@thread.tacv2;messageid=THREAD_ROOT",
+      },
+      from: { id: "USER", name: "Ada" },
+      replyToId: "approval-card",
+      name: "adaptiveCard/action",
+      type: "invoke",
+      value: {
+        action: {
+          data: {
+            eve_input: {
+              kind: "tool-approval",
+              prompt: "Approve deployment?",
+              optionId: "cancel",
+              replyToActivityId: "THREAD_ROOT",
+              requestId: "approval_1",
+            },
+          },
+        },
+      },
+    });
+    const delivery = send.mock.calls[0]?.[1] as Extract<
+      ObservedChannelDelivery<TeamsChannelState>,
+      { readonly inputResponses: readonly unknown[] }
+    >;
+    await teamsAdapter.deliver!(
+      { inputResponses: delivery.inputResponses, state: delivery.state },
+      ctx,
+    );
+    expect(ctx.state.pendingApprovalCards).toEqual({
+      approval_1: { activityId: "approval-card", prompt: "Approve deployment?" },
+    });
+
+    await callEvent(
+      teamsAdapter,
+      makeEvent("approval.settled", {
+        outcome: "cancelled",
+        requestId: "approval_1",
+        responderPrincipalId: "teams:TENANT:USER",
+        sequence: 1,
+        stepIndex: 1,
+        turnId: "turn-1",
+      }),
+      ctx,
+    );
+
+    const updateCall = fetchMock.mock.calls.find(
+      ([url, init]) =>
+        String(url).endsWith(
+          "/v3/conversations/19%3Aconversation%40thread.tacv2/activities/approval-card",
+        ) && (init as RequestInit).method === "PUT",
+    );
+    expect(updateCall).toBeDefined();
+    const updateBody = JSON.parse(String((updateCall?.[1] as RequestInit).body)) as {
+      channelData?: unknown;
+      conversation?: unknown;
+      from?: unknown;
+      recipient?: unknown;
+      replyToId?: string;
+      text?: string;
+      type?: string;
+    };
+    expect(updateBody).toMatchObject({ type: "message" });
+    expect(updateBody.channelData).toBeUndefined();
+    expect(updateBody.conversation).toBeUndefined();
+    expect(updateBody.from).toBeUndefined();
+    expect(updateBody.recipient).toBeUndefined();
+    expect(updateBody.replyToId).toBeUndefined();
+    expect(updateBody.text).toBeUndefined();
   });
 
   it("handles unmentioned message-form HITL responses before the mention gate", async () => {

--- a/packages/eve/src/public/channels/teams/teamsChannel.ts
+++ b/packages/eve/src/public/channels/teams/teamsChannel.ts
@@ -1,3 +1,4 @@
+import { defaultDeliverResult } from "#channel/adapter.js";
 import type { TeamsInstrumentationMetadata } from "#public/channels/teams/index.js";
 import type { ChannelFrom, ChannelResolveSession } from "#channel/channel-operations.js";
 import type { SessionHandle } from "#channel/session.js";
@@ -42,7 +43,9 @@ import {
 import {
   deriveTeamsInputResponses,
   isTeamsInputResponseActivity,
+  isTeamsToolApprovalResponseActivity,
   readTeamsInputReplyToActivityId,
+  readTeamsToolApprovalPrompt,
   teamsInvokeResponse,
 } from "#public/channels/teams/hitl.js";
 import {
@@ -86,6 +89,11 @@ export interface TeamsChannelContext extends TeamsContext {
 export interface TeamsEventContext extends TeamsChannelContext, ChannelContinuationOps {}
 
 /** JSON-serializable Teams channel state. */
+export interface TeamsPendingApprovalCard {
+  readonly activityId: string;
+  readonly prompt: string;
+}
+
 export interface TeamsChannelState {
   /** Bot account captured from the inbound activity recipient. */
   bot: TeamsChannelAccount | null;
@@ -102,6 +110,8 @@ export interface TeamsChannelState {
   triggeringUser: TeamsChannelAccount | null;
   /** Activity id for the default connection-auth card, when posted. */
   pendingAuthActivityId?: string | null;
+  pendingApprovalCards?: Record<string, TeamsPendingApprovalCard>;
+  approvalResponderAccounts?: Record<string, TeamsChannelAccount>;
 }
 
 /** Teams channel credentials. */
@@ -166,6 +176,8 @@ type TeamsSessionFailedHandler = (
 
 /** Event handlers supported by `teamsChannel({ events })`. */
 export interface TeamsChannelEvents {
+  readonly "approval.candidate"?: TeamsEventHandler<"approval.candidate">;
+  readonly "approval.settled"?: TeamsEventHandler<"approval.settled">;
   readonly "turn.started"?: TeamsEventHandler<"turn.started">;
   readonly "actions.requested"?: TeamsEventHandler<"actions.requested">;
   readonly "action.partial"?: TeamsEventHandler<"action.partial">;
@@ -298,6 +310,25 @@ export function teamsChannel(config: TeamsChannelConfig = {}): TeamsChannel {
 
     context(state, session) {
       return rebuildTeamsContext(state, session, config);
+    },
+
+    deliver(payload, channel) {
+      const state = payload.state as Partial<TeamsChannelState> | undefined;
+      const cards = state?.pendingApprovalCards;
+      if (cards !== undefined) {
+        channel.state.pendingApprovalCards = {
+          ...cards,
+          ...channel.state.pendingApprovalCards,
+        };
+      }
+      const responders = state?.approvalResponderAccounts;
+      if (responders !== undefined) {
+        channel.state.approvalResponderAccounts = {
+          ...channel.state.approvalResponderAccounts,
+          ...responders,
+        };
+      }
+      return defaultDeliverResult(payload);
     },
 
     routes: [
@@ -535,10 +566,12 @@ function buildTeamsHandle(input: {
       const address = requireAddress();
       return updateTeamsActivity({
         ...api,
-        body: buildOutboundActivity(state, activity),
+        body: buildUpdateActivity(state, activity),
         credentials,
         activityId,
-        conversationId: address.conversationId,
+        conversationId: normalizeTeamsContinuationAddress({
+          conversationId: address.conversationId,
+        }).conversationId,
         serviceUrl: address.serviceUrl,
       });
     },
@@ -669,6 +702,7 @@ async function dispatchInputResponses(input: {
   try {
     await input.from(resolveInputContinuationToken(input.activity, state)).respond(inputResponses, {
       auth: result.auth,
+      state: approvalResponseStatePatch(input.activity, result.auth),
     });
   } catch (error) {
     log.error("Teams input response delivery failed", { error });
@@ -709,6 +743,29 @@ function resolveInputContinuationToken(
   });
 }
 
+function approvalResponseStatePatch(
+  activity: TeamsInvokeActivity | TeamsMessageActivity,
+  auth: SessionAuthContext | null,
+): Partial<TeamsChannelState> | undefined {
+  if (auth?.principalId === undefined || !isTeamsToolApprovalResponseActivity(activity)) {
+    return undefined;
+  }
+  const requestId = deriveTeamsInputResponses(activity)[0]?.requestId;
+  const activityId = activity.replyToId;
+  if (requestId === undefined || activityId === undefined) {
+    return { approvalResponderAccounts: { [auth.principalId]: activity.from } };
+  }
+  return {
+    approvalResponderAccounts: { [auth.principalId]: activity.from },
+    pendingApprovalCards: {
+      [requestId]: {
+        activityId,
+        prompt: readTeamsToolApprovalPrompt(activity) ?? "Tool approval",
+      },
+    },
+  };
+}
+
 function defaultOnInputResponse(
   _ctx: TeamsContext,
   activity: TeamsInvokeActivity | TeamsMessageActivity,
@@ -726,6 +783,8 @@ function initialTeamsState(): TeamsChannelState {
     channelId: null,
     conversationId: null,
     conversationType: null,
+    approvalResponderAccounts: {},
+    pendingApprovalCards: {},
     pendingAuthActivityId: null,
     replyToActivityId: null,
     serviceUrl: null,
@@ -763,6 +822,26 @@ function buildOutboundActivity(
     replyToId: state.replyToActivityId ?? undefined,
     type: "message",
   };
+}
+
+function buildUpdateActivity(
+  _state: TeamsChannelState,
+  message: TeamsMessageBody | TeamsOutboundActivity | string,
+): TeamsOutboundActivity {
+  if (typeof message !== "string" && "type" in message && message.type === "typing") {
+    throw new Error("teamsChannel: cannot replace an activity with a typing indicator.");
+  }
+  const body = normalizeTeamsPostInput(message);
+  const {
+    channelData: _channelData,
+    conversation: _conversation,
+    from: _from,
+    recipient: _recipient,
+    replyToId: _replyToId,
+    type: _type,
+    ...content
+  } = body as TeamsOutboundActivity;
+  return { ...content, type: "message" };
 }
 
 function mergeChannelData(


### PR DESCRIPTION
### Summary

UX pass for Teams approval flow. Approval cards now remain pending until `approval.settled`, then update in place with the approved or cancelled outcome and the Teams user who acted. Rejected approval responses leave the shared card unchanged.

<img width="955" height="807" alt="Screenshot 2026-08-18 at 2 34 23 PM" src="https://github.com/user-attachments/assets/bc4f6825-a7d2-4925-9734-e3a7412861d1" />


### Validation

Focused Teams coverage verifies approval-card recording, durable responder identity, settlement updates, and standard HITL decoding. The focused suite, typecheck, invariant guard, and docs checks passed locally.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+7 / -0`

Documents settled-card behavior and records the patch release note.

**Implementation** — 4 files · `+74 / -2`

Adds the Teams lifecycle state and settlement rendering while keeping candidate rejection private.

**Tests** — 3 files · `+90 / -2`

Covers card tracking, responder identity, settlement rendering, and approval action metadata.
