### PR TITLE
fix(eve): default otel propagators to auto

### DIFF
--- a/.changeset/bright-traces-propagate.md
+++ b/.changeset/bright-traces-propagate.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Use `@vercel/otel`'s automatic context propagators when no custom propagators are configured.

--- a/packages/eve/src/tracing/otel-declaration.ts
+++ b/packages/eve/src/tracing/otel-declaration.ts
@@ -51,7 +51,7 @@ export interface OtelOptions {
    * processor.
    */
   readonly sampler?: SamplerOrName;
-  /** Composed into one propagator. All inject; the first to extract wins. */
+  /** Composed into one propagator. All inject; the first to extract wins. Defaults to `auto`. */
   readonly propagators?: readonly PropagatorOrName[];
   /**
    * OpenTelemetry `Instrumentation` instances passed through to

--- a/packages/eve/src/tracing/otel-registration.test.ts
+++ b/packages/eve/src/tracing/otel-registration.test.ts
@@ -43,8 +43,8 @@ describe("registerOtelPipeline", () => {
 
     const configuration = registerOTel.mock.calls.at(-1)?.[0] as Record<string, unknown>;
     expect("traceSampler" in configuration).toBe(false);
-    // Absent propagators keep `"none"`; eve's private ownership marker follows it.
-    expect(configuration["propagators"]).toEqual(["none", expect.any(Object)]);
+    // Absent propagators keep @vercel/otel's automatic defaults; eve's marker follows them.
+    expect(configuration["propagators"]).toEqual(["auto", expect.any(Object)]);
   });
 
   it("filters the private registration span from authored processors", () => {

--- a/packages/eve/src/tracing/otel-registration.ts
+++ b/packages/eve/src/tracing/otel-registration.ts
@@ -120,7 +120,7 @@ export function registerOtelPipeline(input: {
     autoDetectResources: false,
     idGenerator,
     instrumentations: pipeline.instrumentations ?? [],
-    propagators: [...(pipeline.propagators ?? ["none"]), markerPropagator],
+    propagators: [...(pipeline.propagators ?? ["auto"]), markerPropagator],
     serviceName: input.serviceName,
     spanProcessors: pipeline.spanProcessors.map((processor) =>
       isSpanProcessor(processor) ? new PrivateSpanFilteringProcessor([processor]) : processor,


### PR DESCRIPTION
### Summary

Closes #2252. eve currently replaces `@vercel/otel`'s automatic propagators with `none` when no custom propagators are configured, which prevents trace context from reaching agent spans. The OTel pipeline now retains the upstream `auto` default while preserving explicitly authored propagators and the existing behavior of not registering a pipeline when no OTel destination is active.

### Validation

The focused OTel registration unit suite confirms that an omitted propagator configuration resolves to `auto` and that explicit propagators remain unchanged.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the patch release note for the corrected default.

**Implementation** — 2 files · `+2 / -2`

Keeps the behavior change local to OTel registration and documents the public option default.

**Tests** — 1 file · `+2 / -2`

Updates the focused regression assertion from `none` to `auto`.
