### PR TITLE
feat(eve): own subagent workflow tools in the framework

### DIFF
--- a/.changeset/workflow-backed-task-subagents.md
+++ b/.changeset/workflow-backed-task-subagents.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Run each subagent delegation behind `experimental.tasks` as its own Workflow-backed tool execution while preserving the existing durable task receipts and local or remote agent behavior.

--- a/SPIKE.md
+++ b/SPIKE.md
@@ -1,0 +1,105 @@
+# Subagents as Workflow tools spike
+
+**Conclusion: this prototype is on eve's production delegation path: when the
+root agent enables `experimental.tasks`, each local or remote subagent call is
+started through its own Workflow-backed `defineTool` definition before both
+transports converge on the durable task lifecycle.**
+
+## Runtime path
+
+1. `turnStep` reads `resolvedAgent.config.experimental.tasks`. The turn
+   workflow selects `dispatchTaskStep` only when that value is `true`; plain
+   mode continues to select `dispatchRuntimeActionsStep`.
+2. The local and remote framework-tool modules each own a branded `defineTool`
+   value. Graph resolution does not load or register either definition. The
+   existing model-visible subagent descriptors still emit `runtimeAction`,
+   which is the parent session's park/resume boundary.
+3. `dispatchTaskStep` leaves rejections and task-control calls in the parent
+   step. It classifies each delegation once, then the local or remote launcher
+   starts the matching framework definition's executor with the model-authored
+   input and a private, serializable invocation context.
+4. `runtime/framework-tools/subagent/local.ts` and `remote.ts` own the
+   `defineTool` values. Their Workflow executors remain under `execution`, the
+   compiler-scanned domain, and receive distinct compiler-assigned `workflowId`
+   values. This split keeps definition-time Zod and branding code out
+   of each compiled Workflow program while preserving the real `defineTool`
+   contract. Each dispatch attempt starts an addressable, transport-specific
+   Workflow run.
+5. Each tool workflow invokes the shared admission step only after transport
+   selection. That step
+   rehydrates the current parent session, verifies that the pending action and
+   serialized tool input still match the original plan entry, asserts that the
+   entry matches the selected transport, and executes it without reclassifying
+   a continuation as a fresh start.
+6. The subagent admission step creates the task run before the child start,
+   starts the real local eve runtime or remote transport, persists the child
+   address, and returns the normal working-task receipt. The task run remains
+   the sole writer for progress, input, completion, failure, and cancellation.
+
+The Workflow tool run ends after dispatch admission. It does not wait for the
+background task to finish, so it neither duplicates the task lifecycle nor
+holds a second task inbox.
+
+## HITL boundary
+
+The durable task run is the shared owner of `working -> input_required ->
+working`. The child transport is not shared:
+
+- A local child sends `input.requested` to the task inbox with `resumeHook` and
+  receives the answer on its child continuation hook.
+- A remote child posts `task.input-requested` to the task callback URL and
+  receives the answer through its `/eve/v1/task-input/:token` HTTP capability.
+
+The parent namespaces and records either request only after validating the
+task-owned child address. A human answer returns to the task run first; the task
+run forwards it to the local hook or remote response URL and leaves
+`input_required` only after that delivery succeeds. The production turn step
+now invokes the remote task-event publisher; previously that publisher and the
+remote callback/answer routes existed but the publisher had no production
+caller.
+
+## Verified behavior
+
+- The focused Workflow integration test proves the local and remote definitions
+  have distinct Workflow IDs, then starts the local executor, a durable task
+  run, and a real local eve child session. It asserts that all three run IDs are
+  distinct and that the parent receives the normal task receipt and addressed
+  child handle.
+- The existing dispatch integration suite executes the production tool step
+  against both local and remote targets. It keeps only the executor/network
+  boundaries mocked and covers admission, start failures, continuation
+  availability, mid-batch handle removal, and remote delivery semantics.
+- Focused callback tests prove a remote `input.requested` event is posted by the
+  child turn, accepted by the parent callback route, and can carry approval
+  candidate and settlement events over the same transport.
+- The workflow-step unit test proves that the resolved
+  `config.experimental.tasks` value reaches the durable park result only when
+  enabled. The turn-workflow unit test then proves that this value selects
+  `dispatchTaskStep`; the existing plain-mode case continues to select
+  `dispatchRuntimeActionsStep`.
+- The task-dispatch integration proves that task mode selects the matching
+  local or remote framework definition, while plain mode stays on
+  `dispatchRuntimeActionsStep`.
+
+## Scope boundary
+
+This is an internal architecture prototype, not a new public authoring API.
+The harness still records subagent calls as `runtimeAction` requests, because
+that is how model tool calls park and resume today. The prototype changes the
+task-mode execution substrate behind that request: the production dispatcher
+now starts the Workflow executor owned by an ordinary branded `defineTool`
+definition for each delegation.
+
+Task-control tools are intentionally not Workflow-backed subagent tools: they
+operate on the parent session's task index and do not invoke an agent. Plain
+mode is unchanged. A public lowering that removes `runtimeAction` entirely
+would be a separate API change with a larger harness contract and is not
+required to validate this execution model.
+
+The wrapper Workflow start is an external side effect inside the retryable task
+dispatch step. Task and child admission remain replay-safe because their
+identities are deterministic, but this spike does not deduplicate or retain the
+wrapper run ID: a retry after `start()` succeeds can leave an extra completed
+wrapper run. A production contract that requires exactly one observable tool
+run per call needs a persisted idempotency boundary the current Workflow
+`start()` API does not expose.

--- a/packages/eve/src/execution/dispatch-runtime-actions-shared.ts
+++ b/packages/eve/src/execution/dispatch-runtime-actions-shared.ts
@@ -177,6 +177,86 @@ export async function prepareRuntimeActionDispatch(input: {
    */
   readonly taskControls: boolean;
 }): Promise<PreparedRuntimeActionDispatch | undefined> {
+  const preflight = await prepareRuntimeActionDispatchPreflight(input);
+  if (preflight === undefined) return undefined;
+
+  const plan = planDispatch({
+    actions: preflight.prepared.batch.actions,
+    bundle: preflight.prepared.bundle,
+    ctx: preflight.ctx,
+    session: preflight.prepared.session,
+    taskControls: input.taskControls,
+  });
+
+  const session = await provisionSharedSandbox({
+    bundle: preflight.prepared.bundle,
+    ctx: preflight.ctx,
+    plan,
+    session: preflight.prepared.session,
+  });
+
+  return {
+    ...preflight.prepared,
+    fanoutSize: plan.filter((entry) => entry.kind === "start" && entry.target.kind === "local")
+      .length,
+    plan,
+    session,
+  };
+}
+
+/**
+ * Rehydrates current dispatch state while retaining the batch's original plan.
+ * Workflow-backed entries use this after a sibling mutates the session so a
+ * continuation cannot be reclassified as an unrelated fresh start.
+ */
+export async function rehydrateRuntimeActionDispatch(input: {
+  readonly fanoutSize: number;
+  readonly plan: readonly DispatchPlanEntry[];
+  readonly serializedContext: Record<string, unknown>;
+  readonly sessionState: DurableSessionState;
+}): Promise<PreparedRuntimeActionDispatch | undefined> {
+  const preflight = await prepareRuntimeActionDispatchPreflight(input);
+  if (preflight === undefined) return undefined;
+  // No sandbox provisioning here: initial preparation already did it once for
+  // this batch, and re-running it per entry would create a second sandbox.
+  return { ...preflight.prepared, fanoutSize: input.fanoutSize, plan: input.plan };
+}
+
+/**
+ * Provisions the shared sandbox when the plan needs one. Split out of
+ * preflight because the plan decides it and the plan is built by the
+ * caller; both entry points — initial preparation and per-entry
+ * rehydration — must observe the enriched session it produces.
+ */
+async function provisionSharedSandbox(input: {
+  readonly bundle: CompiledBundle;
+  readonly ctx: Awaited<ReturnType<typeof deserializeContext>>;
+  readonly plan: readonly DispatchPlanEntry[];
+  readonly session: RuntimeSession;
+}): Promise<RuntimeSession> {
+  if (!planSharesSandbox({ bundle: input.bundle, plan: input.plan })) {
+    return input.session;
+  }
+  try {
+    const scoped = await withContextScope(input.ctx, input.session, async (enrichedSession) => {
+      await input.ctx.require(SandboxKey).get();
+      return { result: undefined, session: enrichedSession };
+    });
+    return scoped.session;
+  } finally {
+    input.ctx.clearVirtualContext();
+  }
+}
+
+type RuntimeActionDispatchPreflight = {
+  readonly ctx: Awaited<ReturnType<typeof deserializeContext>>;
+  readonly prepared: Omit<PreparedRuntimeActionDispatch, "fanoutSize" | "plan">;
+};
+
+async function prepareRuntimeActionDispatchPreflight(input: {
+  readonly serializedContext: Record<string, unknown>;
+  readonly sessionState: DurableSessionState;
+}): Promise<RuntimeActionDispatchPreflight | undefined> {
   const durableSession = await readDurableSession(input.sessionState);
   const batch = getPendingRuntimeActionBatch(durableSession.state);
 
@@ -197,44 +277,28 @@ export async function prepareRuntimeActionDispatch(input: {
 
   // A corrupt handle store and rejected actions must resolve before sandbox
   // initialization, which can provision backend resources and run onSession.
+  // Initial preparation runs before any sibling; workflow rehydration repeats
+  // the validation against the session state the previous entry returned.
   getAgentHandleStore(durableSession.state);
-  const plan = planDispatch({
-    actions: batch.actions,
-    bundle,
-    ctx,
-    session,
-    taskControls: input.taskControls,
-  });
 
   const sandboxSessionId = resolveActiveSandboxSessionId(adapter.state, session.sessionId);
-  if (planSharesSandbox({ bundle, plan })) {
-    try {
-      const scoped = await withContextScope(ctx, session, async (enrichedSession) => {
-        await ctx.require(SandboxKey).get();
-        return { result: undefined, session: enrichedSession };
-      });
-      session = scoped.session;
-    } finally {
-      ctx.clearVirtualContext();
-    }
-  }
 
   return {
-    adapter,
-    adapterCtx: buildAdapterContext(adapter, ctx),
-    auth: ctx.get(AuthKey) ?? null,
-    batch,
-    bundle,
-    capabilities: ctx.get(CapabilitiesKey),
-    channelMetadata: ctx.get(ChannelInstrumentationKey),
-    fanoutSize: plan.filter((entry) => entry.kind === "start" && entry.target.kind === "local")
-      .length,
-    initiatorAuth: ctx.get(InitiatorAuthKey) ?? null,
-    parentTraceContext: readSessionTraceContext(input.serializedContext, session.sessionId),
-    plan,
-    sandboxSessionId,
-    serializedContext: input.serializedContext,
-    session,
+    ctx,
+    prepared: {
+      adapter,
+      adapterCtx: buildAdapterContext(adapter, ctx),
+      auth: ctx.get(AuthKey) ?? null,
+      batch,
+      bundle,
+      capabilities: ctx.get(CapabilitiesKey),
+      channelMetadata: ctx.get(ChannelInstrumentationKey),
+      initiatorAuth: ctx.get(InitiatorAuthKey) ?? null,
+      parentTraceContext: readSessionTraceContext(input.serializedContext, session.sessionId),
+      sandboxSessionId,
+      serializedContext: input.serializedContext,
+      session,
+    },
   };
 }
 

--- a/packages/eve/src/execution/dispatch-runtime-actions-step.integration.test.ts
+++ b/packages/eve/src/execution/dispatch-runtime-actions-step.integration.test.ts
@@ -8,6 +8,10 @@ import type { DurableSessionState } from "#execution/durable-session-store.js";
 import { dispatchRuntimeActionsStep } from "#execution/dispatch-runtime-actions-step.js";
 import { dispatchTaskStep } from "#execution/tasks/parent/dispatch-task-step.js";
 import {
+  dispatchLocalSubagentWorkflow,
+  dispatchRemoteSubagentWorkflow,
+} from "#execution/tasks/parent/subagent/dispatch.js";
+import {
   resolvePendingRuntimeActions,
   setPendingRuntimeActionBatch,
 } from "#harness/runtime-actions.js";
@@ -71,6 +75,67 @@ vi.mock("#execution/session.js", () => ({
   hydrateDurableSession: mocks.hydrateDurableSession,
   mintSubagentContinuationToken: (seed: string) => `subagent:${seed}`,
 }));
+
+// This suite owns the local/remote transport boundary through mocks below.
+// Execute each Workflow tool's shared admission step in-process so those mocks
+// remain visible; the dedicated local integration test owns the real Workflow
+// run boundary and verifies the two definitions compile independently.
+vi.mock("#execution/tasks/parent/subagent/local.js", async () => {
+  return {
+    isLocalSubagentWorkflowEntry: vi.fn((entry) =>
+      entry.kind === "start"
+        ? entry.target.kind === "local"
+        : entry.action.kind === "subagent-call",
+    ),
+  };
+});
+
+vi.mock("#execution/tasks/parent/subagent/remote.js", async () => {
+  return {
+    isRemoteSubagentWorkflowEntry: vi.fn((entry) =>
+      entry.kind === "start"
+        ? entry.target.kind === "remote"
+        : entry.action.kind === "remote-agent-call",
+    ),
+  };
+});
+
+vi.mock("#execution/tasks/parent/subagent/dispatch.js", async () => {
+  const [{ dispatchSubagentWorkflowToolStep }, { PERSISTENT_SUBAGENT_TOOL_INPUT_SCHEMA }] =
+    await Promise.all([
+      import("#execution/tasks/parent/subagent/dispatch-step.js"),
+      import("#runtime/subagents/registry.js"),
+    ]);
+
+  return {
+    dispatchLocalSubagentWorkflow: vi.fn(async ({ entry, fanoutSize, runtimeInput }) => {
+      const action = entry.kind === "resume" ? entry.action : entry.target.action;
+      return {
+        result: await dispatchSubagentWorkflowToolStep({
+          entry,
+          fanoutSize,
+          runtimeInput,
+          toolInput: PERSISTENT_SUBAGENT_TOOL_INPUT_SCHEMA.parse(action.input),
+          transport: "local",
+        }),
+        workflowRunId: "local-workflow-tool-test-run",
+      };
+    }),
+    dispatchRemoteSubagentWorkflow: vi.fn(async ({ entry, fanoutSize, runtimeInput }) => {
+      const action = entry.kind === "resume" ? entry.action : entry.target.action;
+      return {
+        result: await dispatchSubagentWorkflowToolStep({
+          entry,
+          fanoutSize,
+          runtimeInput,
+          toolInput: PERSISTENT_SUBAGENT_TOOL_INPUT_SCHEMA.parse(action.input),
+          transport: "remote",
+        }),
+        workflowRunId: "remote-workflow-tool-test-run",
+      };
+    }),
+  };
+});
 
 vi.mock("#execution/workflow-runtime.js", () => ({
   createWorkflowRuntime: () => ({
@@ -412,6 +477,54 @@ describe("dispatchRuntimeActionsStep child starts", () => {
         taskRunId: "task-run-1",
       }),
     ]);
+    expect(dispatchLocalSubagentWorkflow).toHaveBeenCalledWith(
+      expect.not.objectContaining({ tool: expect.anything() }),
+    );
+  });
+
+  it("routes a tasks-mode remote child through the remote Workflow definition", async () => {
+    const session = createStartSession({ kind: "remote" });
+    installContext(
+      session,
+      { definition: REMOTE_REGISTRY_DEFINITION, nodeId: "remote/research" },
+      true,
+    );
+    vi.spyOn(taskRunControl, "sendTaskCommandToOwner").mockResolvedValue({
+      runId: "task-run-1",
+    });
+
+    const result = await dispatchTaskStep({
+      callbackBaseUrl: "https://caller.example.com",
+      parentContinuationToken: "turn-inbox",
+      parentWritable: createWritable(),
+      serializedContext: {},
+      sessionState: BASE_STATE,
+    });
+    const state = readResultSessionState(result, session);
+
+    expect(mocks.startRemoteAgentSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callbackBaseUrl: "https://caller.example.com",
+        callbackToken: expect.stringMatching(/^task:task_[^:]+:[a-f0-9]{32}$/),
+      }),
+    );
+    expect(result.results[0]).toMatchObject({
+      backgroundTask: { status: "working" },
+      kind: "subagent-result",
+      output: { status: "working" },
+    });
+    expect(getAgentHandleStore(state)?.handles[0]).toMatchObject({
+      address: {
+        callbackBaseUrl: "https://caller.example.com",
+        kind: "agent/remote",
+        sessionId: "remote-session-123456789012",
+        url: "https://registry.example.com",
+      },
+      phase: "addressed",
+    });
+    expect(dispatchRemoteSubagentWorkflow).toHaveBeenCalledWith(
+      expect.not.objectContaining({ tool: expect.anything() }),
+    );
   });
 
   it("silently rejects a tasks-mode start that failed before index admission", async () => {
@@ -908,51 +1021,77 @@ describe("dispatchRuntimeActionsStep agent delivery", () => {
     });
   });
 
-  it("reports AGENT_UNREACHABLE when the handle disappears mid-batch instead of starting a fresh agent", async () => {
-    // Two continuations to one agentId in a single batch: the first delivery
-    // fails permanently and deletes the handle, so the second — planned as a
-    // resume while the handle still existed — must fail rather than fall
-    // back to an unplanned fresh start.
-    const session = setPendingRuntimeActionBatch({
-      actions: [1, 2].map((n) => ({
-        callId: `call-${n}`,
-        description: "Research",
-        input: { agentId: LOCAL_PARKED_HANDLE.identity.id, message: `continue ${n}` },
-        kind: "subagent-call" as const,
-        name: "research",
-        nodeId: "subagents/research",
-        subagentName: "research",
-      })),
-      event: { sequence: 1, stepIndex: 2, turnId: "turn-1" },
-      responseMessages: [],
-      session: createBaseSession(LOCAL_PARKED_HANDLE),
-    });
-    installContext(session);
-    mocks.dispatchSession.mockResolvedValue({ status: "session_not_active" });
+  it.each([
+    {
+      dispatch: dispatchRuntimeActionsStep,
+      secondCode: "AGENT_UNREACHABLE",
+      tasks: false,
+      title: "plain dispatch",
+    },
+    {
+      dispatch: dispatchTaskStep,
+      secondCode: "AGENT_BUSY",
+      tasks: true,
+      title: "workflow-tool task dispatch",
+    },
+  ])(
+    "does not start a fresh agent through $title when the handle disappears mid-batch",
+    async ({ dispatch, secondCode, tasks }) => {
+      // Two continuations to one agentId in a single batch: the first delivery
+      // fails permanently and deletes the handle, so the second — planned as a
+      // resume while the handle still existed — must fail rather than fall
+      // back to an unplanned fresh start.
+      const handle: AgentHandle = tasks
+        ? {
+            address: LOCAL_PARKED_HANDLE.address,
+            identity: LOCAL_PARKED_HANDLE.identity,
+            phase: "addressed",
+          }
+        : LOCAL_PARKED_HANDLE;
+      const session = setPendingRuntimeActionBatch({
+        actions: [1, 2].map((n) => ({
+          callId: `call-${n}`,
+          description: "Research",
+          input: { agentId: LOCAL_PARKED_HANDLE.identity.id, message: `continue ${n}` },
+          kind: "subagent-call" as const,
+          name: "research",
+          nodeId: "subagents/research",
+          subagentName: "research",
+        })),
+        event: { sequence: 1, stepIndex: 2, turnId: "turn-1" },
+        responseMessages: [],
+        session: createBaseSession(handle),
+      });
+      installContext(session, undefined, tasks);
+      mocks.readDurableSession.mockImplementation(
+        async (state) => state.snapshot?.session ?? session,
+      );
+      mocks.dispatchSession.mockResolvedValue({ status: "session_not_active" });
 
-    const result = await dispatchRuntimeActionsStep({
-      parentContinuationToken: "turn-inbox",
-      parentWritable: createWritable(),
-      serializedContext: {},
-      sessionState: BASE_STATE,
-    });
+      const result = await dispatch({
+        parentContinuationToken: "turn-inbox",
+        parentWritable: createWritable(),
+        serializedContext: {},
+        sessionState: BASE_STATE,
+      });
 
-    expect(mocks.dispatchSession).toHaveBeenCalledTimes(1);
-    expect(mocks.createSession).not.toHaveBeenCalled();
-    expect(result.results).toEqual([
-      expect.objectContaining({
-        isError: true,
-        output: expect.objectContaining({ code: "AGENT_UNREACHABLE" }),
-      }),
-      expect.objectContaining({
-        isError: true,
-        output: expect.objectContaining({ code: "AGENT_UNREACHABLE" }),
-      }),
-    ]);
-    expect(getAgentHandleStore(readResultSessionState(result, session))).toEqual({
-      handles: [],
-    });
-  });
+      expect(result.results).toEqual([
+        expect.objectContaining({
+          isError: true,
+          output: expect.objectContaining({ code: "AGENT_UNREACHABLE" }),
+        }),
+        expect.objectContaining({
+          isError: true,
+          output: expect.objectContaining({ code: secondCode }),
+        }),
+      ]);
+      expect(mocks.dispatchSession).toHaveBeenCalledTimes(1);
+      expect(mocks.createSession).not.toHaveBeenCalled();
+      expect(getAgentHandleStore(readResultSessionState(result, session))).toEqual({
+        handles: [],
+      });
+    },
+  );
 
   it("continues a stored remote handle and maps a permanent failure to AGENT_UNREACHABLE", async () => {
     const session = createPendingSession({
@@ -1179,7 +1318,9 @@ function installContext(
   const bundle = {
     compiledArtifactsSource: {},
     resolvedAgent: { config: tasks ? { experimental: { tasks: true } } : {} },
-    subagentRegistry: { subagentsByNodeId },
+    subagentRegistry: {
+      subagentsByNodeId,
+    },
     turnAgent: {
       id: "test-agent",
       instructions: [],

--- a/packages/eve/src/execution/session-callback-step.test.ts
+++ b/packages/eve/src/execution/session-callback-step.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   fireSessionCallbackStep,
+  fireTaskEventCallbackStep,
   fireTaskUpdateCallbackStep,
 } from "#execution/session-callback-step.js";
 
@@ -351,3 +352,79 @@ function createSerializedContext(): Record<string, unknown> {
     "eve.sessionId": "remote-session",
   };
 }
+
+describe("fireTaskEventCallbackStep", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("posts a remote child's input request to its task callback", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fireTaskEventCallbackStep({
+      callback: {
+        callId: "call-task",
+        subagentName: "research",
+        taskId: "task_1",
+        token: "task:task_1:0123456789abcdef0123456789abcdef",
+        url: "https://caller.example.com/eve/v1/callback/task%3Atask_1%3A0123456789abcdef0123456789abcdef",
+      },
+      childContinuationToken: "child-command-token",
+      childSessionId: "remote-child-session",
+      event: {
+        data: {
+          requests: [
+            {
+              action: {
+                callId: "ask-region",
+                input: {},
+                kind: "tool-call",
+                toolName: "ask_question",
+              },
+              kind: "question",
+              prompt: "Which region?",
+              requestId: "request-region",
+            },
+          ],
+          sequence: 4,
+          stepIndex: 2,
+          turnId: "turn-child",
+        },
+        type: "input.requested",
+      },
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://caller.example.com/eve/v1/callback/task%3Atask_1%3A0123456789abcdef0123456789abcdef",
+      expect.objectContaining({
+        body: JSON.stringify({
+          callId: "call-task",
+          childContinuationToken: "child-command-token",
+          childSessionId: "remote-child-session",
+          event: {
+            requests: [
+              {
+                action: {
+                  callId: "ask-region",
+                  input: {},
+                  kind: "tool-call",
+                  toolName: "ask_question",
+                },
+                kind: "question",
+                prompt: "Which region?",
+                requestId: "request-region",
+              },
+            ],
+            sequence: 4,
+            stepIndex: 2,
+            turnId: "turn-child",
+          },
+          kind: "task.input-requested",
+          subagentName: "research",
+          taskId: "task_1",
+        }),
+      }),
+    );
+  });
+});

--- a/packages/eve/src/execution/tasks/child/steps.test.ts
+++ b/packages/eve/src/execution/tasks/child/steps.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { deliverTaskInputResponsesStep } from "#execution/tasks/child/steps.js";
+
+describe("deliverTaskInputResponsesStep", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("posts only the answered requests to a remote child's response capability", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      deliverTaskInputResponsesStep({
+        answer: {
+          childContinuationToken: "remote-child-token",
+          childResponseUrl: "https://remote.example/eve/v1/task-input/capability",
+          inputResponses: [
+            { requestId: "request-1", text: "first answer" },
+            { optionId: "approve", requestId: "request-2" },
+          ],
+          kind: "input-response",
+          taskId: "task-1",
+        },
+        requestIds: ["request-2"],
+      }),
+    ).resolves.toBe("delivered");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith("https://remote.example/eve/v1/task-input/capability", {
+      body: JSON.stringify({
+        inputResponses: [{ optionId: "approve", requestId: "request-2" }],
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+      redirect: "error",
+    });
+  });
+});

--- a/packages/eve/src/execution/tasks/parent/dispatch-task-step.ts
+++ b/packages/eve/src/execution/tasks/parent/dispatch-task-step.ts
@@ -1,47 +1,30 @@
 /**
- * Task-mode sibling of `dispatchRuntimeActionsStep`, selected by the turn
- * workflow when the agent enables `experimental.tasks`.
+ * Task-mode sibling of `dispatchRuntimeActionsStep`, selected only when the
+ * root agent enables `experimental.tasks`.
  *
- * Same plan → dispatch → emit skeleton, but every delegation is wrapped in
- * the durable task lifecycle: the task record and its inbox token
- * exist *before* the child dispatch side effect (`beginDelegatedTask`),
- * continuations pass the availability check and enter the parent session's
- * task index first, and the task settles against the dispatch outcome.
- * Children report through their task's inbox token rather than the
- * parent turn inbox, and every start dispatches a conversation-mode
- * (persistent) child so the background task stays resumable.
- *
- * Task-control calls (`task_peek` / `task_cancel` / `task_update`) execute
- * inline in this step, which holds the session ownership index and world
- * access they need.
+ * Local and remote delegations start their transport-specific internal
+ * `defineTool` executors as distinct Workflow runs. Each run re-enters the
+ * shared task lifecycle only after transport selection, so the durable task
+ * run remains the sole lifecycle writer while local hooks and remote HTTP
+ * callbacks stay separate. Task-control calls execute inline because they
+ * operate on the parent session rather than invoking a subagent.
  */
 
 import {
-  type DispatchOutcome,
-  dispatchToTaskAgentAddress,
-} from "#execution/agent-handle-dispatch.js";
-import { createAgentContinuationBundle } from "#execution/agent-continuation-bundle.js";
-import {
-  emitSubagentCalled,
   prepareRuntimeActionDispatch,
+  rehydrateRuntimeActionDispatch,
   type RuntimeActionDispatchInput,
   type RuntimeActionDispatchResult,
-  startSubagent,
 } from "#execution/dispatch-runtime-actions-shared.js";
 import { createDurableSessionState } from "#execution/durable-session-store.js";
-import {
-  beginDelegatedTask,
-  type DelegatedTask,
-  settleDelegatedDispatch,
-} from "#execution/tasks/parent/delegate.js";
 import { executeTaskControlAction } from "#execution/tasks/parent/dispatch.js";
 import {
-  checkTaskContinuationAvailability,
-  describeTaskDispatch,
-  persistContinuationTaskInParentSession,
-  settleTaskDispatchError,
-  type PersistedContinuationTask,
-} from "#execution/tasks/parent/continuation-dispatch.js";
+  dispatchLocalSubagentWorkflow,
+  dispatchRemoteSubagentWorkflow,
+  type SubagentWorkflowDispatch,
+} from "#execution/tasks/parent/subagent/dispatch.js";
+import { isLocalSubagentWorkflowEntry } from "#execution/tasks/parent/subagent/local.js";
+import { isRemoteSubagentWorkflowEntry } from "#execution/tasks/parent/subagent/remote.js";
 import type { RuntimeActionResult } from "#runtime/actions/types.js";
 
 export async function dispatchTaskStep(
@@ -49,174 +32,71 @@ export async function dispatchTaskStep(
 ): Promise<RuntimeActionDispatchResult> {
   "use step";
 
-  const prepared = await prepareRuntimeActionDispatch({
+  const initial = await prepareRuntimeActionDispatch({
     serializedContext: input.serializedContext,
     sessionState: input.sessionState,
     taskControls: true,
   });
-  if (prepared === undefined) {
+  if (initial === undefined) {
     return { results: [], sessionState: input.sessionState, pendingTasks: [] };
   }
-
-  const { batch, bundle, session } = prepared;
-  // Acquired only once preflight can no longer throw, so a planning failure
-  // never leaks the writer lock.
-  const writer = input.parentWritable.getWriter();
-
-  let nextSession = session;
+  let sessionState = input.sessionState;
   const results: RuntimeActionResult[] = [];
-  const pendingTasks: DelegatedTask[] = [];
+  const pendingTasks: Array<RuntimeActionDispatchResult["pendingTasks"][number]> = [];
 
-  try {
-    for (const entry of prepared.plan) {
-      if (entry.kind === "reject") {
-        results.push(entry.result);
-        continue;
-      }
-
-      if (entry.kind === "task-control") {
-        const control = await executeTaskControlAction({
-          action: entry.action,
-          adapter: prepared.adapter,
-          bundle,
-          parentStepIndex: batch.event.stepIndex,
-          parentTurnId: batch.event.turnId,
-          serializedContext: prepared.serializedContext,
-          session: nextSession,
-        });
-        nextSession = control.session;
-        if (control.pendingTask !== undefined) pendingTasks.push(control.pendingTask);
-        results.push(control.result);
-        continue;
-      }
-
-      if (entry.kind === "resume") {
-        const busy = await checkTaskContinuationAvailability({
-          action: entry.action,
-          agentId: entry.agentId,
-          parentStepIndex: batch.event.stepIndex,
-          parentTurnId: batch.event.turnId,
-          session: nextSession,
-        });
-        if (busy !== undefined) {
-          results.push(busy);
-          continue;
-        }
-      }
-
-      const delegated = await beginDelegatedTask({
-        ...describeTaskDispatch({
-          action: entry.kind === "resume" ? entry.action : entry.target.action,
-          agentId: entry.kind === "resume" ? entry.agentId : undefined,
-          parentSessionId: session.sessionId,
-          parentTurnId: batch.event.turnId,
-          session: nextSession,
-        }),
-        parentSessionId: session.sessionId,
-        parentStepIndex: batch.event.stepIndex,
-        parentTurnId: batch.event.turnId,
-        session: nextSession,
-      });
-      let persistedContinuation: PersistedContinuationTask | undefined;
-      if (entry.kind === "resume") {
-        persistedContinuation = await persistContinuationTaskInParentSession({
-          action: entry.action,
-          agentId: entry.agentId,
-          delegated,
-          session: nextSession,
-        });
-        nextSession = persistedContinuation?.session ?? nextSession;
-      }
-
-      let outcome: DispatchOutcome;
-      switch (entry.kind) {
-        case "resume":
-          outcome = await dispatchToTaskAgentAddress({
-            action: entry.action,
-            agentId: entry.agentId,
-            bundle: createAgentContinuationBundle({
-              action: entry.action,
-              bundle,
-              dynamicRemoteAgent: entry.dynamicRemoteAgent,
-            }),
-            currentSession: nextSession,
-            parentToken: delegated.taskInboxToken,
-          });
-          break;
-        case "start":
-          outcome = await startSubagent({
-            auth: prepared.auth,
-            batchEvent: batch.event,
-            bundle,
-            callbackBaseUrl: input.callbackBaseUrl,
-            capabilities: prepared.capabilities,
-            channelMetadata: prepared.channelMetadata,
-            currentSession: nextSession,
-            fanoutSize: prepared.fanoutSize,
-            initiatorAuth: prepared.initiatorAuth,
-            parentContinuationToken: delegated.taskInboxToken,
-            parentTraceContext: prepared.parentTraceContext,
-            // Background tasks require resumable children, so task mode
-            // always dispatches conversation-mode (persistent) sessions;
-            // `experimental.subagentPersistentSessions` never produces a
-            // third mode here.
-            persistentSessions: true,
-            sandboxSessionId: prepared.sandboxSessionId,
-            serializedContext: prepared.serializedContext,
-            session,
-            taskOwned: true,
-            target: entry.target,
-          });
-          break;
-      }
-
-      nextSession = outcome.session;
-      if (outcome.kind === "error") {
-        results.push(
-          await settleTaskDispatchError({
-            delegated,
-            outcome,
-            persisted: persistedContinuation,
-          }),
-        );
-        if (persistedContinuation !== undefined) pendingTasks.push(delegated);
-        continue;
-      }
-
-      if (persistedContinuation !== undefined) {
-        results.push(persistedContinuation.receipt);
-      } else {
-        const settled = await settleDelegatedDispatch({
-          callId: outcome.callId,
-          session: nextSession,
-          subagentName: outcome.toolName,
-          task: delegated,
-        });
-        nextSession = settled.session;
-        results.push(settled.receipt);
-      }
-      pendingTasks.push(delegated);
-
-      await emitSubagentCalled({
-        adapter: prepared.adapter,
-        adapterCtx: prepared.adapterCtx,
-        batchEvent: batch.event,
-        entry,
-        outcome,
-        sessionId: session.sessionId,
-        writer,
-      });
+  for (const entry of initial.plan) {
+    if (entry.kind === "reject") {
+      results.push(entry.result);
+      continue;
     }
-  } finally {
-    writer.releaseLock();
+
+    if (entry.kind === "task-control") {
+      const prepared = await rehydrateRuntimeActionDispatch({
+        fanoutSize: initial.fanoutSize,
+        plan: initial.plan,
+        serializedContext: input.serializedContext,
+        sessionState,
+      });
+      if (prepared === undefined) {
+        throw new Error(
+          `Task dispatch lost its pending batch before call "${entry.action.callId}".`,
+        );
+      }
+      const control = await executeTaskControlAction({
+        action: entry.action,
+        bundle: prepared.bundle,
+        parentStepIndex: prepared.batch.event.stepIndex,
+        parentTurnId: prepared.batch.event.turnId,
+        session: prepared.session,
+      });
+      results.push(control.result);
+      if (control.pendingTask !== undefined) pendingTasks.push(control.pendingTask);
+      if (control.session !== prepared.session) {
+        sessionState = createDurableSessionState({ session: control.session });
+      }
+      continue;
+    }
+
+    let dispatched: SubagentWorkflowDispatch;
+    if (isLocalSubagentWorkflowEntry(entry)) {
+      dispatched = await dispatchLocalSubagentWorkflow({
+        entry,
+        fanoutSize: initial.fanoutSize,
+        runtimeInput: { ...input, sessionState },
+      });
+    } else if (isRemoteSubagentWorkflowEntry(entry)) {
+      dispatched = await dispatchRemoteSubagentWorkflow({
+        entry,
+        fanoutSize: initial.fanoutSize,
+        runtimeInput: { ...input, sessionState },
+      });
+    } else {
+      throw new Error("Task dispatch produced an unclassified subagent transport.");
+    }
+    results.push(...dispatched.result.results);
+    pendingTasks.push(...dispatched.result.pendingTasks);
+    sessionState = dispatched.result.sessionState;
   }
 
-  return {
-    results,
-    sessionState:
-      nextSession === session
-        ? input.sessionState
-        : createDurableSessionState({ session: nextSession }),
-    pendingTasks,
-  };
+  return { pendingTasks, results, sessionState };
 }

--- a/packages/eve/src/execution/tasks/parent/subagent/dispatch-step.ts
+++ b/packages/eve/src/execution/tasks/parent/subagent/dispatch-step.ts
@@ -1,0 +1,224 @@
+import { isDeepStrictEqual } from "node:util";
+
+import {
+  type DispatchOutcome,
+  dispatchToTaskAgentAddress,
+} from "#execution/agent-handle-dispatch.js";
+import { createAgentContinuationBundle } from "#execution/agent-continuation-bundle.js";
+import {
+  emitSubagentCalled,
+  rehydrateRuntimeActionDispatch,
+  startSubagent,
+  type RuntimeActionDispatchInput,
+  type RuntimeActionDispatchResult,
+} from "#execution/dispatch-runtime-actions-shared.js";
+import { createDurableSessionState } from "#execution/durable-session-store.js";
+import {
+  checkTaskContinuationAvailability,
+  describeTaskDispatch,
+  persistContinuationTaskInParentSession,
+  settleTaskDispatchError,
+  type PersistedContinuationTask,
+} from "#execution/tasks/parent/continuation-dispatch.js";
+import {
+  beginDelegatedTask,
+  type DelegatedTask,
+  settleDelegatedDispatch,
+} from "#execution/tasks/parent/delegate.js";
+import type { LocalSubagentWorkflowEntry } from "#execution/tasks/parent/subagent/local.js";
+import type { RemoteSubagentWorkflowEntry } from "#execution/tasks/parent/subagent/remote.js";
+import type { RuntimeActionResult } from "#runtime/actions/types.js";
+import { PERSISTENT_SUBAGENT_TOOL_INPUT_SCHEMA } from "#runtime/subagents/registry.js";
+import { z } from "#compiled/zod/index.js";
+
+type SubagentWorkflowEntry = LocalSubagentWorkflowEntry | RemoteSubagentWorkflowEntry;
+type SubagentWorkflowInput = z.infer<typeof PERSISTENT_SUBAGENT_TOOL_INPUT_SCHEMA>;
+
+/**
+ * Re-enters the shared task lifecycle after a local or remote Workflow
+ * definition has selected the transport. The transport assertion keeps this
+ * convergence point from silently accepting an entry routed to the wrong tool.
+ */
+export async function dispatchSubagentWorkflowToolStep(input: {
+  readonly entry: SubagentWorkflowEntry;
+  readonly fanoutSize: number;
+  readonly runtimeInput: RuntimeActionDispatchInput;
+  readonly toolInput: SubagentWorkflowInput;
+  readonly transport: "local" | "remote";
+}): Promise<RuntimeActionDispatchResult> {
+  "use step";
+
+  const action = input.entry.kind === "resume" ? input.entry.action : input.entry.target.action;
+  const actualTransport =
+    input.entry.kind === "start"
+      ? input.entry.target.kind
+      : input.entry.action.kind === "subagent-call"
+        ? "local"
+        : "remote";
+  if (actualTransport !== input.transport) {
+    throw new Error(
+      `Subagent workflow transport mismatch: expected ${input.transport}, received ${actualTransport}.`,
+    );
+  }
+
+  const prepared = await rehydrateRuntimeActionDispatch({
+    fanoutSize: input.fanoutSize,
+    plan: [input.entry],
+    serializedContext: input.runtimeInput.serializedContext,
+    sessionState: input.runtimeInput.sessionState,
+  });
+  if (prepared === undefined) {
+    throw new Error(
+      `${input.transport} subagent workflow "${action.callId}" has no pending batch.`,
+    );
+  }
+
+  const pendingAction = prepared.batch.actions.find(
+    (candidate) => candidate.callId === action.callId,
+  );
+  if (pendingAction === undefined) {
+    throw new Error(`${input.transport} subagent call "${action.callId}" is not pending.`);
+  }
+  if (!isDeepStrictEqual(pendingAction, action)) {
+    throw new Error(`${input.transport} subagent call "${action.callId}" changed after planning.`);
+  }
+  if (!isDeepStrictEqual(action.input, input.toolInput)) {
+    throw new Error(
+      `${input.transport} subagent call "${action.callId}" received mismatched input.`,
+    );
+  }
+
+  const { batch, bundle, session } = prepared;
+  let currentSession = prepared.session;
+  const writer = input.runtimeInput.parentWritable.getWriter();
+  try {
+    if (input.entry.kind === "resume") {
+      const busy = await checkTaskContinuationAvailability({
+        action: input.entry.action,
+        agentId: input.entry.agentId,
+        parentStepIndex: batch.event.stepIndex,
+        parentTurnId: batch.event.turnId,
+        session: currentSession,
+      });
+      if (busy !== undefined) {
+        return {
+          pendingTasks: [],
+          results: [busy],
+          sessionState: input.runtimeInput.sessionState,
+        };
+      }
+    }
+
+    const delegated = await beginDelegatedTask({
+      ...describeTaskDispatch({
+        action,
+        agentId: input.entry.kind === "resume" ? input.entry.agentId : undefined,
+        parentSessionId: session.sessionId,
+        parentTurnId: batch.event.turnId,
+        session: currentSession,
+      }),
+      parentSessionId: session.sessionId,
+      parentStepIndex: batch.event.stepIndex,
+      parentTurnId: batch.event.turnId,
+      session: currentSession,
+    });
+
+    let persistedContinuation: PersistedContinuationTask | undefined;
+    if (input.entry.kind === "resume") {
+      persistedContinuation = await persistContinuationTaskInParentSession({
+        action: input.entry.action,
+        agentId: input.entry.agentId,
+        delegated,
+        session: currentSession,
+      });
+      currentSession = persistedContinuation?.session ?? currentSession;
+    }
+
+    let outcome: DispatchOutcome;
+    switch (input.entry.kind) {
+      case "resume":
+        outcome = await dispatchToTaskAgentAddress({
+          action: input.entry.action,
+          agentId: input.entry.agentId,
+          bundle: createAgentContinuationBundle({
+            action: input.entry.action,
+            bundle,
+            dynamicRemoteAgent:
+              "dynamicRemoteAgent" in input.entry ? input.entry.dynamicRemoteAgent : undefined,
+          }),
+          currentSession,
+          parentToken: delegated.taskInboxToken,
+        });
+        break;
+      case "start":
+        outcome = await startSubagent({
+          auth: prepared.auth,
+          batchEvent: batch.event,
+          bundle,
+          callbackBaseUrl: input.runtimeInput.callbackBaseUrl,
+          capabilities: prepared.capabilities,
+          channelMetadata: prepared.channelMetadata,
+          currentSession,
+          fanoutSize: prepared.fanoutSize,
+          initiatorAuth: prepared.initiatorAuth,
+          parentContinuationToken: delegated.taskInboxToken,
+          parentTraceContext: prepared.parentTraceContext,
+          sandboxSessionId: prepared.sandboxSessionId,
+          // Task children must remain addressable after the dispatching turn ends.
+          persistentSessions: true,
+          serializedContext: prepared.serializedContext,
+          session,
+          taskOwned: true,
+          target: input.entry.target,
+        });
+        break;
+    }
+
+    currentSession = outcome.session;
+    let pendingTask: DelegatedTask | undefined;
+    let result: RuntimeActionResult;
+    if (outcome.kind === "error") {
+      pendingTask = persistedContinuation === undefined ? undefined : delegated;
+      result = await settleTaskDispatchError({
+        delegated,
+        outcome,
+        persisted: persistedContinuation,
+      });
+    } else {
+      pendingTask = delegated;
+      if (persistedContinuation !== undefined) {
+        result = persistedContinuation.receipt;
+      } else {
+        const settled = await settleDelegatedDispatch({
+          callId: outcome.callId,
+          session: currentSession,
+          subagentName: outcome.toolName,
+          task: delegated,
+        });
+        currentSession = settled.session;
+        result = settled.receipt;
+      }
+
+      await emitSubagentCalled({
+        adapter: prepared.adapter,
+        adapterCtx: prepared.adapterCtx,
+        batchEvent: batch.event,
+        entry: input.entry,
+        outcome,
+        sessionId: session.sessionId,
+        writer,
+      });
+    }
+
+    return {
+      pendingTasks: pendingTask === undefined ? [] : [pendingTask],
+      results: [result],
+      sessionState:
+        currentSession === prepared.session
+          ? input.runtimeInput.sessionState
+          : createDurableSessionState({ session: currentSession }),
+    };
+  } finally {
+    writer.releaseLock();
+  }
+}

--- a/packages/eve/src/execution/tasks/parent/subagent/dispatch.ts
+++ b/packages/eve/src/execution/tasks/parent/subagent/dispatch.ts
@@ -1,0 +1,78 @@
+import type {
+  RuntimeActionDispatchInput,
+  RuntimeActionDispatchResult,
+} from "#execution/dispatch-runtime-actions-shared.js";
+import {
+  type LocalSubagentWorkflowContext,
+  type LocalSubagentWorkflowEntry,
+  type LocalSubagentWorkflowInput,
+} from "#execution/tasks/parent/subagent/local.js";
+import {
+  type RemoteSubagentWorkflowContext,
+  type RemoteSubagentWorkflowEntry,
+  type RemoteSubagentWorkflowInput,
+} from "#execution/tasks/parent/subagent/remote.js";
+import { start, type WorkflowMetadata } from "#internal/workflow/runtime.js";
+import { localSubagentWorkflowTool } from "#runtime/framework-tools/subagent/local.js";
+import { remoteSubagentWorkflowTool } from "#runtime/framework-tools/subagent/remote.js";
+import { PERSISTENT_SUBAGENT_TOOL_INPUT_SCHEMA } from "#runtime/subagents/registry.js";
+
+export interface SubagentWorkflowDispatch {
+  readonly result: RuntimeActionDispatchResult;
+  readonly workflowRunId: string;
+}
+
+/** Starts the local subagent definition's Workflow executor. */
+export async function dispatchLocalSubagentWorkflow(input: {
+  readonly entry: LocalSubagentWorkflowEntry;
+  readonly fanoutSize: number;
+  readonly runtimeInput: RuntimeActionDispatchInput;
+}): Promise<SubagentWorkflowDispatch> {
+  const action = input.entry.kind === "resume" ? input.entry.action : input.entry.target.action;
+  const run = await start<
+    [LocalSubagentWorkflowInput, LocalSubagentWorkflowContext],
+    RuntimeActionDispatchResult
+  >(readWorkflowMetadata(localSubagentWorkflowTool.execute, "Local"), [
+    PERSISTENT_SUBAGENT_TOOL_INPUT_SCHEMA.parse(action.input),
+    {
+      entry: input.entry,
+      fanoutSize: input.fanoutSize,
+      runtimeInput: input.runtimeInput,
+    },
+  ]);
+
+  return { result: await run.returnValue, workflowRunId: run.runId };
+}
+
+/** Starts the remote subagent definition's Workflow executor. */
+export async function dispatchRemoteSubagentWorkflow(input: {
+  readonly entry: RemoteSubagentWorkflowEntry;
+  readonly fanoutSize: number;
+  readonly runtimeInput: RuntimeActionDispatchInput;
+}): Promise<SubagentWorkflowDispatch> {
+  const action = input.entry.kind === "resume" ? input.entry.action : input.entry.target.action;
+  const run = await start<
+    [RemoteSubagentWorkflowInput, RemoteSubagentWorkflowContext],
+    RuntimeActionDispatchResult
+  >(readWorkflowMetadata(remoteSubagentWorkflowTool.execute, "Remote"), [
+    PERSISTENT_SUBAGENT_TOOL_INPUT_SCHEMA.parse(action.input),
+    {
+      entry: input.entry,
+      fanoutSize: input.fanoutSize,
+      runtimeInput: input.runtimeInput,
+    },
+  ]);
+
+  return { result: await run.returnValue, workflowRunId: run.runId };
+}
+
+function readWorkflowMetadata(value: unknown, label: "Local" | "Remote"): WorkflowMetadata {
+  if (
+    typeof value !== "function" ||
+    !("workflowId" in value) ||
+    typeof value.workflowId !== "string"
+  ) {
+    throw new Error(`${label} subagent tool executor was not compiled as a Workflow function.`);
+  }
+  return { workflowId: value.workflowId };
+}

--- a/packages/eve/src/execution/tasks/parent/subagent/local.integration.test.ts
+++ b/packages/eve/src/execution/tasks/parent/subagent/local.integration.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import { getRun } from "#internal/workflow/runtime.js";
+
+import { createDurableSessionState } from "#execution/durable-session-store.js";
+import { dispatchLocalSubagentWorkflow } from "#execution/tasks/parent/subagent/dispatch.js";
+import { getAgentHandleStore } from "#harness/handles/store.js";
+import { setPendingRuntimeActionBatch } from "#harness/runtime-actions.js";
+import type { HarnessSession } from "#harness/types.js";
+import { createTestRuntime } from "#internal/testing/app-harness.js";
+import { createBundledRuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
+import { localSubagentWorkflowTool } from "#runtime/framework-tools/subagent/local.js";
+import { remoteSubagentWorkflowTool } from "#runtime/framework-tools/subagent/remote.js";
+import { ROOT_RUNTIME_AGENT_NODE_ID } from "#runtime/graph.js";
+import { isBrandedToolEntry } from "#shared/dynamic-tool-definition.js";
+
+describe("local subagent workflow tool", () => {
+  it("is compiled independently from the remote subagent workflow", () => {
+    expect(isBrandedToolEntry(localSubagentWorkflowTool)).toBe(true);
+    expect(isBrandedToolEntry(remoteSubagentWorkflowTool)).toBe(true);
+    expect(readWorkflowId(localSubagentWorkflowTool.execute)).not.toBe(
+      readWorkflowId(remoteSubagentWorkflowTool.execute),
+    );
+  });
+
+  it("starts a distinct Workflow that dispatches a real local child and task run", async () => {
+    const runtime = createTestRuntime({ agent: { name: "subagent-workflow-tool" } });
+
+    await runtime.run(async () => {
+      const action = {
+        callId: "call-workflow-tool",
+        description: "General-purpose agent",
+        input: { message: "Reply with exactly `workflow-tool-child-ok`." },
+        kind: "subagent-call" as const,
+        name: "agent",
+        nodeId: ROOT_RUNTIME_AGENT_NODE_ID,
+        subagentName: "agent",
+      };
+      const session: HarnessSession = setPendingRuntimeActionBatch({
+        actions: [action],
+        event: { sequence: 1, stepIndex: 0, turnId: "turn-workflow-tool" },
+        responseMessages: [],
+        session: {
+          agent: { modelReference: { id: "openai/gpt-5.4" }, system: "", tools: [] },
+          compaction: { recentWindowSize: 10, threshold: 100_000 },
+          continuationToken: "http:subagent-workflow-tool",
+          history: [],
+          sessionId: "parent-subagent-workflow-tool",
+        },
+      });
+      const parentWritable = new WritableStream<Uint8Array>({ write() {} });
+
+      const dispatched = await dispatchLocalSubagentWorkflow({
+        entry: {
+          kind: "start",
+          target: { action, kind: "local", source: { type: "runtime" } },
+        },
+        fanoutSize: 1,
+        runtimeInput: {
+          parentContinuationToken: "turn-inbox-subagent-workflow-tool",
+          parentWritable,
+          serializedContext: {
+            "eve.auth": null,
+            "eve.bundle": { source: createBundledRuntimeCompiledArtifactsSource() },
+            "eve.channel": { kind: "http", state: {} },
+            "eve.continuationToken": session.continuationToken,
+            "eve.mode": "conversation",
+          },
+          sessionState: createDurableSessionState({ session }),
+        },
+      });
+      const result = dispatched.result.results[0];
+      const pendingTask = dispatched.result.pendingTasks[0];
+      const handle = getAgentHandleStore(dispatched.result.sessionState.snapshot?.session.state)
+        ?.handles[0];
+      if (pendingTask === undefined) throw new Error("Workflow tool returned no pending task.");
+      if (handle === undefined) throw new Error("Workflow tool returned no local agent handle.");
+      if (handle.phase !== "addressed") {
+        throw new Error(`Workflow tool returned a child in phase "${handle.phase}".`);
+      }
+
+      try {
+        expect(result).toMatchObject({
+          backgroundTask: { status: "working", taskId: pendingTask.taskId },
+          callId: action.callId,
+          kind: "subagent-result",
+          output: { status: "working", taskId: pendingTask.taskId },
+        });
+        expect(pendingTask).toMatchObject({
+          taskRunId: expect.any(String),
+        });
+        expect(handle).toMatchObject({
+          address: { kind: "agent/self", sessionId: expect.any(String) },
+          identity: { name: "agent" },
+          phase: "addressed",
+        });
+        expect(
+          new Set([dispatched.workflowRunId, pendingTask.taskRunId, handle.address.sessionId]).size,
+        ).toBe(3);
+        await expect(getRun(dispatched.workflowRunId).status).resolves.toBe("completed");
+      } finally {
+        await getRun(handle.address.sessionId)
+          .cancel()
+          .catch(() => {});
+        await getRun(pendingTask.taskRunId)
+          .cancel()
+          .catch(() => {});
+      }
+    });
+  }, 60_000);
+});
+
+function readWorkflowId(value: unknown): string {
+  if (
+    typeof value !== "function" ||
+    !("workflowId" in value) ||
+    typeof value.workflowId !== "string"
+  ) {
+    throw new Error("Expected a compiled Workflow function.");
+  }
+  return value.workflowId;
+}

--- a/packages/eve/src/execution/tasks/parent/subagent/local.ts
+++ b/packages/eve/src/execution/tasks/parent/subagent/local.ts
@@ -1,0 +1,53 @@
+import type { z } from "#compiled/zod/index.js";
+import type {
+  DispatchPlanEntry,
+  DispatchStartTarget,
+  RuntimeActionDispatchInput,
+  RuntimeActionDispatchResult,
+} from "#execution/dispatch-runtime-actions-shared.js";
+import { dispatchSubagentWorkflowToolStep } from "#execution/tasks/parent/subagent/dispatch-step.js";
+import type { RuntimeSubagentCallActionRequest } from "#runtime/actions/types.js";
+import type { PERSISTENT_SUBAGENT_TOOL_INPUT_SCHEMA } from "#runtime/subagents/registry.js";
+
+type ResumeEntry = Extract<DispatchPlanEntry, { readonly kind: "resume" }>;
+type StartEntry = Extract<DispatchPlanEntry, { readonly kind: "start" }>;
+
+export type LocalSubagentWorkflowEntry =
+  | (Omit<ResumeEntry, "action" | "dynamicRemoteAgent"> & {
+      readonly action: RuntimeSubagentCallActionRequest;
+    })
+  | (Omit<StartEntry, "target"> & {
+      readonly target: Extract<DispatchStartTarget, { readonly kind: "local" }>;
+    });
+
+export type LocalSubagentWorkflowInput = z.infer<typeof PERSISTENT_SUBAGENT_TOOL_INPUT_SCHEMA>;
+
+export interface LocalSubagentWorkflowContext {
+  readonly entry: LocalSubagentWorkflowEntry;
+  readonly fanoutSize: number;
+  readonly runtimeInput: RuntimeActionDispatchInput;
+}
+
+/** Runs one local subagent admission as an independently addressable Workflow. */
+export async function executeLocalSubagentWorkflow(
+  toolInput: LocalSubagentWorkflowInput,
+  context: LocalSubagentWorkflowContext,
+): Promise<RuntimeActionDispatchResult> {
+  "use workflow";
+
+  return await dispatchSubagentWorkflowToolStep({
+    entry: context.entry,
+    fanoutSize: context.fanoutSize,
+    runtimeInput: context.runtimeInput,
+    toolInput,
+    transport: "local",
+  });
+}
+
+export function isLocalSubagentWorkflowEntry(
+  entry: Extract<DispatchPlanEntry, { readonly kind: "resume" | "start" }>,
+): entry is LocalSubagentWorkflowEntry {
+  return entry.kind === "start"
+    ? entry.target.kind === "local"
+    : entry.action.kind === "subagent-call";
+}

--- a/packages/eve/src/execution/tasks/parent/subagent/remote.ts
+++ b/packages/eve/src/execution/tasks/parent/subagent/remote.ts
@@ -1,0 +1,53 @@
+import type { z } from "#compiled/zod/index.js";
+import type {
+  DispatchPlanEntry,
+  DispatchStartTarget,
+  RuntimeActionDispatchInput,
+  RuntimeActionDispatchResult,
+} from "#execution/dispatch-runtime-actions-shared.js";
+import { dispatchSubagentWorkflowToolStep } from "#execution/tasks/parent/subagent/dispatch-step.js";
+import type { RuntimeRemoteAgentCallActionRequest } from "#runtime/actions/types.js";
+import type { PERSISTENT_SUBAGENT_TOOL_INPUT_SCHEMA } from "#runtime/subagents/registry.js";
+
+type ResumeEntry = Extract<DispatchPlanEntry, { readonly kind: "resume" }>;
+type StartEntry = Extract<DispatchPlanEntry, { readonly kind: "start" }>;
+
+export type RemoteSubagentWorkflowEntry =
+  | (Omit<ResumeEntry, "action"> & {
+      readonly action: RuntimeRemoteAgentCallActionRequest;
+    })
+  | (Omit<StartEntry, "target"> & {
+      readonly target: Extract<DispatchStartTarget, { readonly kind: "remote" }>;
+    });
+
+export type RemoteSubagentWorkflowInput = z.infer<typeof PERSISTENT_SUBAGENT_TOOL_INPUT_SCHEMA>;
+
+export interface RemoteSubagentWorkflowContext {
+  readonly entry: RemoteSubagentWorkflowEntry;
+  readonly fanoutSize: number;
+  readonly runtimeInput: RuntimeActionDispatchInput;
+}
+
+/** Runs one remote subagent admission as an independently addressable Workflow. */
+export async function executeRemoteSubagentWorkflow(
+  toolInput: RemoteSubagentWorkflowInput,
+  context: RemoteSubagentWorkflowContext,
+): Promise<RuntimeActionDispatchResult> {
+  "use workflow";
+
+  return await dispatchSubagentWorkflowToolStep({
+    entry: context.entry,
+    fanoutSize: context.fanoutSize,
+    runtimeInput: context.runtimeInput,
+    toolInput,
+    transport: "remote",
+  });
+}
+
+export function isRemoteSubagentWorkflowEntry(
+  entry: Extract<DispatchPlanEntry, { readonly kind: "resume" | "start" }>,
+): entry is RemoteSubagentWorkflowEntry {
+  return entry.kind === "start"
+    ? entry.target.kind === "remote"
+    : entry.action.kind === "remote-agent-call";
+}

--- a/packages/eve/src/execution/turn-workflow.test.ts
+++ b/packages/eve/src/execution/turn-workflow.test.ts
@@ -5,6 +5,7 @@ import { SessionDynamicModelReferenceKey } from "#context/keys.js";
 import { cancelDescendantTurnsStep } from "#execution/cancel-descendant-turns-step.js";
 import { dispatchRuntimeActionsStep } from "#execution/dispatch-runtime-actions-step.js";
 import { dispatchWorkflowRuntimeActionsStep } from "#execution/dispatch-workflow-runtime-actions-step.js";
+import { dispatchTaskStep } from "#execution/tasks/parent/dispatch-task-step.js";
 import type { DurableSessionState } from "#execution/durable-session-store.js";
 import { runProxySubagentEventStep } from "#execution/subagent-event-proxy-step.js";
 import { turnWorkflow } from "#execution/turn-workflow.js";
@@ -44,6 +45,10 @@ vi.mock("./workflow-steps.js", () => ({
 
 vi.mock("./dispatch-runtime-actions-step.js", () => ({
   dispatchRuntimeActionsStep: vi.fn(),
+}));
+
+vi.mock("./tasks/parent/dispatch-task-step.js", () => ({
+  dispatchTaskStep: vi.fn(),
 }));
 
 vi.mock("./dispatch-workflow-runtime-actions-step.js", () => ({
@@ -652,6 +657,75 @@ describe("turnWorkflow", () => {
       }),
     );
     now.mockRestore();
+  });
+
+  it("uses the workflow-tool task dispatcher only when turnStep reports tasks enabled", async () => {
+    const pendingState = createSessionState({ continuationToken: "http:tasks" });
+    const completedState = createSessionState({ continuationToken: "http:tasks" });
+    installInbox([]);
+    vi.mocked(dispatchTaskStep).mockResolvedValue({
+      pendingTasks: [],
+      results: [
+        {
+          backgroundTask: { status: "working", taskId: "task-1" },
+          callId: "call-1",
+          kind: "subagent-result",
+          origin: "child",
+          outcome: {
+            kind: "parked",
+            result: { kind: "succeeded", output: "delegated" },
+            usageDelta: {
+              cacheReadTokens: 0,
+              cacheWriteTokens: 0,
+              inputTokens: 0,
+              outputTokens: 0,
+            },
+          },
+          output: { agentId: "agent-1", status: "working", taskId: "task-1" },
+          subagentName: "delegate",
+        },
+      ],
+      sessionState: pendingState,
+    });
+    vi.mocked(turnStep)
+      .mockResolvedValueOnce({
+        action: "park",
+        hasPendingAuthorization: false,
+        hasPendingInputBatch: false,
+        pendingRuntimeActionKeys: ["subagent-call:delegate:call-1"],
+        serializedContext: { state: "pending" },
+        sessionState: pendingState,
+        tasksEnabled: true,
+      })
+      .mockResolvedValueOnce({
+        action: "done",
+        output: "task receipt consumed",
+        serializedContext: { state: "done" },
+        sessionState: completedState,
+      });
+
+    const { input, parentWritable } = createInput({
+      driverCapabilities: { turnInbox: true },
+      sessionState: pendingState,
+    });
+    await turnWorkflow(input);
+
+    expect(dispatchTaskStep).toHaveBeenCalledWith({
+      callbackBaseUrl: "https://eve.example.com",
+      parentContinuationToken: "turn-token:inbox",
+      parentWritable,
+      serializedContext: { state: "pending" },
+      sessionState: pendingState,
+    });
+    expect(dispatchRuntimeActionsStep).not.toHaveBeenCalled();
+    const resumedInput = vi.mocked(turnStep).mock.calls[1]?.[0].input;
+    expect(resumedInput?.kind).toBe("runtime-action-result");
+    if (resumedInput?.kind !== "runtime-action-result") {
+      throw new Error("Expected the task receipt to resume the turn.");
+    }
+    expect(resumedInput.results[0]).toMatchObject({
+      backgroundTask: { status: "working", taskId: "task-1" },
+    });
   });
 
   it("waits for dispatch adoption before cascading a cancellation", async () => {

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -337,7 +337,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
 
     return {
       action: "park",
-      ...derivePendingState(rekeyed),
+      ...derivePendingState(rekeyed, tasksEnabled),
       serializedContext: nextSerializedContext,
       sessionState: nextState,
       tasksEnabled,
@@ -627,7 +627,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
       };
     }
 
-    const pending = derivePendingState(stepResult.session);
+    const pending = derivePendingState(stepResult.session, tasksEnabled);
 
     // `settledTurn` is the harness's explicit settlement verdict. Pending
     // state may predate this turn, while newly created parks omit the verdict.
@@ -673,13 +673,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
  * Derives the pending-state fields the turn workflow needs to choose
  * the right `NextDriverAction` arm at the park boundary.
  */
-function derivePendingState(session: HarnessSession): {
-  readonly authorizationAttemptIds?: readonly string[];
-  readonly authorizationNames?: readonly string[];
-  readonly hasPendingAuthorization: boolean;
-  readonly hasPendingInputBatch: boolean;
-  readonly pendingRuntimeActionKeys?: readonly string[];
-} {
+function derivePendingState(session: HarnessSession, tasksEnabled: boolean) {
   const batch = getPendingRuntimeActionBatch(session.state);
   const pendingAuth = getPendingAuthorization(session.state);
   const base = {
@@ -694,6 +688,7 @@ function derivePendingState(session: HarnessSession): {
     return {
       ...base,
       pendingRuntimeActionKeys: batch.actions.map((action) => getRuntimeActionRequestKey(action)),
+      tasksEnabled: tasksEnabled ? (true as const) : undefined,
     };
   }
   return base;

--- a/packages/eve/src/runtime/framework-tools/subagent/local.ts
+++ b/packages/eve/src/runtime/framework-tools/subagent/local.ts
@@ -1,0 +1,21 @@
+import {
+  executeLocalSubagentWorkflow,
+  type LocalSubagentWorkflowInput,
+} from "#execution/tasks/parent/subagent/local.js";
+import type { ToolDefinition } from "#public/definitions/tool.js";
+import { defineTool } from "#public/definitions/tool.js";
+import { PERSISTENT_SUBAGENT_TOOL_INPUT_SCHEMA } from "#runtime/subagents/registry.js";
+
+export type LocalSubagentWorkflowTool = ToolDefinition<
+  LocalSubagentWorkflowInput,
+  Awaited<ReturnType<typeof executeLocalSubagentWorkflow>>
+>;
+
+// Public tools receive a live ToolContext. This framework-owned Workflow is
+// started by workflowId with a serializable private context.
+export const localSubagentWorkflowTool: LocalSubagentWorkflowTool = defineTool({
+  description: "Dispatch a local subagent as a durable background task.",
+  execute: executeLocalSubagentWorkflow as LocalSubagentWorkflowTool["execute"] &
+    typeof executeLocalSubagentWorkflow,
+  inputSchema: PERSISTENT_SUBAGENT_TOOL_INPUT_SCHEMA,
+});

--- a/packages/eve/src/runtime/framework-tools/subagent/remote.ts
+++ b/packages/eve/src/runtime/framework-tools/subagent/remote.ts
@@ -1,0 +1,21 @@
+import {
+  executeRemoteSubagentWorkflow,
+  type RemoteSubagentWorkflowInput,
+} from "#execution/tasks/parent/subagent/remote.js";
+import type { ToolDefinition } from "#public/definitions/tool.js";
+import { defineTool } from "#public/definitions/tool.js";
+import { PERSISTENT_SUBAGENT_TOOL_INPUT_SCHEMA } from "#runtime/subagents/registry.js";
+
+export type RemoteSubagentWorkflowTool = ToolDefinition<
+  RemoteSubagentWorkflowInput,
+  Awaited<ReturnType<typeof executeRemoteSubagentWorkflow>>
+>;
+
+// Public tools receive a live ToolContext. This framework-owned Workflow is
+// started by workflowId with a serializable private context.
+export const remoteSubagentWorkflowTool: RemoteSubagentWorkflowTool = defineTool({
+  description: "Dispatch a remote subagent as a durable background task.",
+  execute: executeRemoteSubagentWorkflow as RemoteSubagentWorkflowTool["execute"] &
+    typeof executeRemoteSubagentWorkflow,
+  inputSchema: PERSISTENT_SUBAGENT_TOOL_INPUT_SCHEMA,
+});

--- a/packages/eve/src/runtime/session-callback-route.test.ts
+++ b/packages/eve/src/runtime/session-callback-route.test.ts
@@ -145,6 +145,58 @@ describe("session callback route", () => {
   });
 
   it.each([
+    {
+      data: {
+        candidateId: "candidate-1",
+        outcome: "pending",
+        requestId: "approval-1",
+        responderPrincipalId: "slack:T1:U1",
+        sequence: 4,
+        stepIndex: 2,
+        turnId: "turn-child",
+      },
+      type: "approval.candidate",
+    },
+    {
+      data: {
+        outcome: "approved",
+        requestId: "approval-1",
+        responderPrincipalId: "slack:T1:U1",
+        sequence: 5,
+        stepIndex: 2,
+        turnId: "turn-child",
+      },
+      type: "approval.settled",
+    },
+  ] as const)("forwards remote task $type events to the owning task hook", async (event) => {
+    resumeHookMock.mockResolvedValue(undefined);
+    const response = await handleSessionCallbackRequest(
+      new Request(`https://app.example.com/eve/v1/callback/${TASK_TOKEN}`, {
+        body: JSON.stringify({
+          callId: "call-task",
+          childContinuationToken: "remote-child-token",
+          childSessionId: "child-session",
+          event,
+          kind: "task.authorization",
+          subagentName: "research",
+          taskId: TASK_ID,
+        }),
+        method: "POST",
+      }),
+      createRouteContext({ token: TASK_TOKEN }),
+    );
+
+    expect(response.status).toBe(202);
+    expect(resumeHookMock).toHaveBeenCalledWith(TASK_TOKEN, {
+      callId: "call-task",
+      childSessionId: "child-session",
+      event,
+      kind: "authorization-event",
+      subagentName: "research",
+    });
+  });
+
+  it.each([
     ["parent turn token", "turn-inbox", TASK_ID],
     ["different task token", TASK_TOKEN, "task_other"],
   ])("rejects task events carried by a %s", async (_label, token, taskId) => {

--- a/packages/eve/src/runtime/session-callback-route.ts
+++ b/packages/eve/src/runtime/session-callback-route.ts
@@ -63,6 +63,30 @@ const taskAuthorizationEventSchema: z.ZodType<SubagentAuthorizationEvent> = z.di
   [
     z.looseObject({
       data: z.looseObject({
+        candidateId: z.string(),
+        outcome: z.enum(["pending", "rejected", "failed", "timed-out", "stale"]),
+        reason: z.string().optional(),
+        requestId: z.string(),
+        responderPrincipalId: z.string(),
+        sequence: eventCoordinateSchema,
+        stepIndex: eventCoordinateSchema,
+        turnId: z.string(),
+      }),
+      type: z.literal("approval.candidate"),
+    }),
+    z.looseObject({
+      data: z.looseObject({
+        outcome: z.enum(["approved", "cancelled"]),
+        requestId: z.string(),
+        responderPrincipalId: z.string(),
+        sequence: eventCoordinateSchema,
+        stepIndex: eventCoordinateSchema,
+        turnId: z.string(),
+      }),
+      type: z.literal("approval.settled"),
+    }),
+    z.looseObject({
+      data: z.looseObject({
         attemptId: z.string().optional(),
         authorization: authorizationChallengeSchema.optional(),
         description: z.string(),


### PR DESCRIPTION
### Summary

Related to #1084. With `experimental.tasks`, local and remote subagent calls become framework-owned `defineTool(...)` definitions whose `execute` values are separately compiled Workflow functions.

Before → after: task-mode delegation ran inside one parent dispatch step → task dispatch now selects the local or remote framework tool definition and starts its compiler-assigned Workflow before re-entering the existing durable task lifecycle.

The definitions live under `runtime/framework-tools/subagent`; the Workflow executors stay under `execution`, the compiler-scanned domain. That split matters: combining `defineTool` and a workflow directive in one source module embeds Zod and framework registration code in *every* Workflow function payload (~2.09 MB per function when measured on the original spike).

The model-visible subagent contract is unchanged. Local and remote executors stay separate through transport selection, then share task admission. The durable task run remains the sole lifecycle writer — local HITL over the child continuation hook, remote HITL over the task callback capability.

### Rebased onto main, and what that changed

This replaces #2167, which targeted a frozen base off `tasks-v4/03-runtime` (`37314a9f`, not an ancestor of `main`). Replaying onto `main` picked up 76 commits of drift and settled four things worth a reviewer's eye:

- **`task-event-callback.ts` keeps main's version.** The spike's `forwardTaskCallbackEvent` emitted locally *and* forwarded; main's `forwardTaskEventToSessionCallback` suppresses local emission so two TUIs can't both present the same HITL request. Main's behavior wins; the spike's `fireTaskEventCallbackStep` test is kept as added coverage main was missing.
- **Shared sandbox provisioning moved.** Main provisions from the plan inside `prepareRuntimeActionDispatch`, but this change splits planning out of preflight. Provisioning is now a helper called once per batch — deliberately *not* on per-entry rehydration, which would create a second sandbox (caught by `opens a shared parent sandbox for a background-task child`).
- **`sandboxSessionId`** is threaded into the workflow tool's `startSubagent` call, and `executeTaskControlAction` keeps main's `adapter`/`serializedContext` parameters.
- **`tasksEnabled` stays `boolean`** on the park result rather than narrowing to `true`.

The 12 spike commits are consolidated into one, since several superseded each other (prototype → inline → framework-owned).

### Known residual

The wrapper Workflow `start()` is at-least-once if the outer dispatch step retries after it succeeds. Task and child identities stay deterministic, so admission is replay-safe, but no wrapper-run idempotency key is persisted.

### Validation

Unit (652 files, 6841 passed, 1 skipped), integration (91 files, 661 passed), typecheck, build, lint, format, and `guard:invariants` all pass. `SPIKE.md` records the runtime path and boundaries.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
