### PR TITLE
feat: add bounded synthetic stream follower

### DIFF
--- a/.changeset/synthetic-first-event-follow.md
+++ b/.changeset/synthetic-first-event-follow.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Let HTTP agents opt into a bounded synthetic live follower that reads the first event of each newly created session for writer-to-reader latency telemetry without delaying the create response.

--- a/docs/channels/eve.mdx
+++ b/docs/channels/eve.mdx
@@ -162,6 +162,19 @@ export default eveChannel({
 
 `onMessage` must return an auth result. Return `title` alongside `auth` to set the title when the dispatch starts a run. A successful canonical eve HTTP message always dispatches and therefore always produces or continues a session.
 
+### Synthetic first-event follower
+
+Set `syntheticFollowFirstEvent: true` to measure the durable stream's writer-to-reader latency for newly created HTTP sessions. After session creation, eve schedules a background live follower, reads one event, and immediately cancels it. The session-create response does not await the read, and the follower never stays attached while a conversation is parked.
+
+```ts title="agent/channels/eve.ts"
+export default eveChannel({
+  auth: [vercelOidc(), localDev()],
+  syntheticFollowFirstEvent: true,
+});
+```
+
+This activates the framework's live-follow telemetry for the first durable event. It is a synthetic server-side reader: it measures durable write-to-read transport time, not browser rendering or downstream channel delivery. The option affects only newly created sessions on the eve HTTP channel; follow-ups and sessions created by other channels are unchanged.
+
 ## Clients
 
 The browser side of this API lives in the [Frontend](../guides/frontend/overview) docs, where `useEveAgent` drives the eve channel from React UI.

--- a/packages/eve/src/public/channels/eve.test.ts
+++ b/packages/eve/src/public/channels/eve.test.ts
@@ -100,7 +100,10 @@ function createRouteArgs(): RouteHandlerArgs {
  */
 function createEveCreateHandler(
   input: EveChannelInput,
-  options: { readonly activeSessionId?: string } = {},
+  options: {
+    readonly activeSessionId?: string;
+    readonly events?: ReadableStream;
+  } = {},
 ) {
   const channel = eveChannel(input);
   const createRoute = channel.routes.find(
@@ -131,18 +134,26 @@ function createEveCreateHandler(
       title: runInput.title,
     } satisfies MockSendOptions);
     return {
-      events: new ReadableStream(),
+      events: options.events ?? new ReadableStream(),
       sessionId: "test-session-id",
     };
   });
+  const backgroundTasks: Promise<unknown>[] = [];
 
   return {
+    backgroundTasks,
     createSession,
     resolveSession,
     send: mockSend,
     async fetch(req: Request) {
       const args = attachRouteSessionCreator(
-        { ...createRouteArgs(), resolveSession },
+        {
+          ...createRouteArgs(),
+          resolveSession,
+          waitUntil(task) {
+            backgroundTasks.push(task);
+          },
+        },
         createSession as never,
       );
       return (createRoute as any).handler(req, args);
@@ -955,6 +966,93 @@ describe("eveChannel — create session (text)", () => {
     expect(response.status).toBe(202);
     expect(handler.send).toHaveBeenCalledTimes(1);
     expect(handler.send.mock.calls[0]?.[0]).toBe("hi");
+    expect(handler.backgroundTasks).toHaveLength(0);
+  });
+
+  it("observes one live event in background work when enabled", async () => {
+    let cancelReason: unknown;
+    const events = new ReadableStream({
+      pull(controller) {
+        controller.enqueue(
+          createMessageCompletedEvent({
+            message: "hello",
+            sequence: 0,
+            stepIndex: 0,
+            turnId: "turn-0",
+          }),
+        );
+      },
+      cancel(reason) {
+        cancelReason = reason;
+      },
+    });
+    const handler = createEveCreateHandler(
+      { auth: none(), syntheticFollowFirstEvent: true },
+      { events },
+    );
+
+    const response = await handler.fetch(createJsonMessageRequest({ message: "hi" }));
+
+    expect(response.status).toBe(202);
+    expect(handler.backgroundTasks).toHaveLength(1);
+    await expect(handler.backgroundTasks[0]).resolves.toBeUndefined();
+    expect(cancelReason).toBe("synthetic first-event observation complete");
+  });
+
+  it("returns before a synthetic follower receives its first event", async () => {
+    let source: ReadableStreamDefaultController | undefined;
+    const events = new ReadableStream({
+      start(controller) {
+        source = controller;
+      },
+    });
+    const handler = createEveCreateHandler(
+      { auth: none(), syntheticFollowFirstEvent: true },
+      { events },
+    );
+
+    const response = await Promise.race([
+      handler.fetch(createJsonMessageRequest({ message: "hi" })),
+      new Promise<"blocked">((resolve) => setTimeout(() => resolve("blocked"), 100)),
+    ]);
+
+    expect(response).not.toBe("blocked");
+    expect((response as Response).status).toBe(202);
+    expect(handler.backgroundTasks).toHaveLength(1);
+    source?.enqueue(
+      createMessageCompletedEvent({
+        message: "hello",
+        sequence: 0,
+        stepIndex: 0,
+        turnId: "turn-0",
+      }),
+    );
+    await expect(handler.backgroundTasks[0]).resolves.toBeUndefined();
+  });
+
+  it("cancels a synthetic follower after its deadline", async () => {
+    vi.useFakeTimers();
+    let cancelReason: unknown;
+    const events = new ReadableStream({
+      pull() {},
+      cancel(reason) {
+        cancelReason = reason;
+      },
+    });
+    const handler = createEveCreateHandler(
+      { auth: none(), syntheticFollowFirstEvent: true },
+      { events },
+    );
+
+    try {
+      const response = await handler.fetch(createJsonMessageRequest({ message: "hi" }));
+      expect(response.status).toBe(202);
+      await vi.advanceTimersByTimeAsync(10_000);
+      await expect(handler.backgroundTasks[0]).resolves.toBeUndefined();
+      expect(cancelReason).toBe("synthetic first-event observation complete");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("accepts task mode for callback-driven session creation", async () => {

--- a/packages/eve/src/public/channels/eve.ts
+++ b/packages/eve/src/public/channels/eve.ts
@@ -186,6 +186,13 @@ export interface EveChannelInput {
   /** Policy for follow-up messages that arrive while a turn is active. */
   readonly turnPolicy?: TurnPolicy;
   /**
+   * Starts a bounded synthetic live follower for each newly created HTTP session.
+   * The follower reads one event in background work, then immediately cancels. Use
+   * this to measure durable writer-to-reader latency without extending the response
+   * path or following a parked conversation indefinitely.
+   */
+  readonly syntheticFollowFirstEvent?: boolean;
+  /**
    * Pre-dispatch hook for inbound eve HTTP messages. Runs after route auth and body
    * parsing, before runtime dispatch.
    */
@@ -343,6 +350,10 @@ export function eveChannel(input: EveChannelInput): EveChannel {
             { error: "Failed to create the session.", errorId, ok: false },
             { status: 500 },
           );
+        }
+
+        if (input.syntheticFollowFirstEvent === true) {
+          args.waitUntil(readFirstLiveEvent(handle.events));
         }
 
         return Response.json(
@@ -1037,6 +1048,24 @@ function rejectSessionContinuationToken(payload: Record<string, unknown>): Respo
         { status: 400 },
       )
     : null;
+}
+
+async function readFirstLiveEvent(stream: ReadableStream<MessageStreamEvent>): Promise<void> {
+  const reader = stream.getReader();
+  const timeout = Symbol("synthetic-follow-timeout");
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      reader.read(),
+      new Promise<typeof timeout>((resolve) => {
+        timer = setTimeout(() => resolve(timeout), 10_000);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+    void reader.cancel("synthetic first-event observation complete").catch(() => {});
+    reader.releaseLock();
+  }
 }
 
 function requireSessionId(params: Readonly<Record<string, string>>): string | Response {


### PR DESCRIPTION
## Summary & Motivation

Normal HTTP session creation discards `RunHandle.events`, so the durable stream's live-read path is never exercised in production and writer-to-reader latency goes unmeasured. `syntheticFollowFirstEvent` opts an eve HTTP channel into a background follower that reads one event and cancels, bounded by a 10s deadline so a parked conversation never holds a reader open.

## Test Plan

Unit tests added; typecheck, lint, fmt, and docs:check pass.
