### PR TITLE
feat(eve): add Stagehand v4 extension template

### DIFF
--- a/apps/templates/stagehand-extension/README.md
+++ b/apps/templates/stagehand-extension/README.md
@@ -1,0 +1,20 @@
+# Stagehand extension template
+
+This package demonstrates a native eve extension that imports the published
+Stagehand v4 SDK directly. It does not copy Stagehand source or require a
+wrapper command.
+
+The extension declares `@browserbasehq/stagehand` in
+`eve.extension.externalDependencies` because Stagehand loads its browser
+extension from package-relative assets at runtime. eve preserves the complete
+Stagehand package automatically when a consuming agent is built.
+
+Build the extension locally:
+
+```bash
+pnpm --filter @eve-template/stagehand-extension build
+```
+
+Set `BROWSERBASE_API_KEY` and optionally `BROWSERBASE_PROJECT_ID` to use a
+Browserbase session. Without those variables, the extension launches a local
+browser. `STAGEHAND_BROWSER` can explicitly select `local` or `browserbase`.

--- a/apps/templates/stagehand-extension/extension/extension.ts
+++ b/apps/templates/stagehand-extension/extension/extension.ts
@@ -1,0 +1,3 @@
+import { defineExtension } from "eve/extension";
+
+export default defineExtension();

--- a/apps/templates/stagehand-extension/extension/instructions/browser.md
+++ b/apps/templates/stagehand-extension/extension/instructions/browser.md
@@ -1,0 +1,7 @@
+Use the Stagehand tools to control one persistent browser.
+
+- Use `snapshot` to inspect the active page.
+- Use `run` for navigation and multi-step browser operations.
+- Use `screenshot` when visual inspection is useful.
+
+Do not launch another browser from `run` code.

--- a/apps/templates/stagehand-extension/extension/lib/session.ts
+++ b/apps/templates/stagehand-extension/extension/lib/session.ts
@@ -1,0 +1,62 @@
+import {
+  browserbase,
+  localBrowser,
+  Stagehand,
+  type StagehandBrowser,
+} from "@browserbasehq/stagehand";
+
+interface StagehandResources {
+  browser: StagehandBrowser;
+  stagehand: Stagehand;
+}
+
+let resourcesPromise: Promise<StagehandResources> | undefined;
+
+export async function getStagehandResources(): Promise<StagehandResources> {
+  const resources = await (resourcesPromise ??= createStagehandResources());
+  if (!resources.browser.closed) {
+    return resources;
+  }
+
+  resourcesPromise = createStagehandResources();
+  return resourcesPromise;
+}
+
+async function createStagehandResources(): Promise<StagehandResources> {
+  const browser = await createBrowser();
+  try {
+    const stagehand = await Stagehand.create({ browser });
+    return { browser, stagehand };
+  } catch (error) {
+    await browser.close().catch(() => undefined);
+    throw error;
+  }
+}
+
+async function createBrowser(): Promise<StagehandBrowser> {
+  const requestedBrowser = process.env.STAGEHAND_BROWSER;
+  if (
+    requestedBrowser !== undefined &&
+    requestedBrowser !== "local" &&
+    requestedBrowser !== "browserbase"
+  ) {
+    throw new Error('STAGEHAND_BROWSER must be either "local" or "browserbase".');
+  }
+
+  const apiKey = process.env.BROWSERBASE_API_KEY;
+  const browserType = requestedBrowser ?? (apiKey ? "browserbase" : "local");
+  if (browserType === "local") {
+    return localBrowser.launch({ headless: false });
+  }
+  if (!apiKey) {
+    throw new Error('BROWSERBASE_API_KEY is required when STAGEHAND_BROWSER="browserbase".');
+  }
+
+  return browserbase.launch({
+    apiKey,
+    ...(process.env.BROWSERBASE_PROJECT_ID
+      ? { projectId: process.env.BROWSERBASE_PROJECT_ID }
+      : {}),
+    keepAlive: true,
+  });
+}

--- a/apps/templates/stagehand-extension/extension/tools/run.ts
+++ b/apps/templates/stagehand-extension/extension/tools/run.ts
@@ -1,0 +1,44 @@
+import type { ExperimentalBatchContext } from "@browserbasehq/stagehand";
+import { defineTool } from "eve/tools";
+import { z } from "zod";
+
+import { getStagehandResources } from "../lib/session.js";
+
+export default defineTool({
+  description:
+    "Run JavaScript against the active Stagehand page. The code can use page, context, act, observe, and extract, and must return its result.",
+  inputSchema: z.object({
+    code: z.string().min(1),
+  }),
+  async execute({ code }) {
+    const { stagehand } = await getStagehandResources();
+    const result = await stagehand.experimentalBatch(executeCode, code);
+    return stringifyResult(result);
+  },
+});
+
+async function executeCode(batch: ExperimentalBatchContext, code: string): Promise<unknown> {
+  const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor as new (
+    ...args: string[]
+  ) => (...args: unknown[]) => Promise<unknown>;
+  const execute = new AsyncFunction(
+    "page",
+    "context",
+    "act",
+    "observe",
+    "extract",
+    `"use strict";\n${code}`,
+  );
+  return execute(batch.page, batch.context, batch.act, batch.observe, batch.extract);
+}
+
+function stringifyResult(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  try {
+    return JSON.stringify(value, null, 2) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/apps/templates/stagehand-extension/extension/tools/screenshot.ts
+++ b/apps/templates/stagehand-extension/extension/tools/screenshot.ts
@@ -1,0 +1,38 @@
+import { defineTool } from "eve/tools";
+import { z } from "zod";
+
+import { getStagehandResources } from "../lib/session.js";
+
+export default defineTool({
+  description: "Capture a screenshot of the active Stagehand page.",
+  inputSchema: z.object({
+    fullPage: z.boolean().default(false),
+    type: z.enum(["png", "jpeg"]).default("png"),
+    quality: z.number().int().min(0).max(100).optional(),
+  }),
+  async execute({ fullPage, type, quality }) {
+    const { browser } = await getStagehandResources();
+    const page = (await browser.context.activePage()) ?? (await browser.context.newPage());
+    const options: Parameters<typeof page.screenshot>[0] = {
+      fullPage,
+      type,
+    };
+    if (type === "jpeg" && quality !== undefined) {
+      options.quality = quality;
+    }
+    const bytes = await page.screenshot(options);
+    return {
+      data: Buffer.from(bytes).toString("base64"),
+      mimeType: type === "jpeg" ? "image/jpeg" : "image/png",
+    };
+  },
+  toModelOutput({ data, mimeType }) {
+    return {
+      type: "content",
+      value: [
+        { type: "text", text: "Screenshot captured." },
+        { type: "file", data: { type: "data", data }, mediaType: mimeType },
+      ],
+    };
+  },
+});

--- a/apps/templates/stagehand-extension/extension/tools/snapshot.ts
+++ b/apps/templates/stagehand-extension/extension/tools/snapshot.ts
@@ -1,0 +1,17 @@
+import { defineTool } from "eve/tools";
+import { z } from "zod";
+
+import { getStagehandResources } from "../lib/session.js";
+
+export default defineTool({
+  description: "Return the accessibility snapshot for the active Stagehand page.",
+  inputSchema: z.object({
+    includeIframes: z.boolean().default(true),
+  }),
+  async execute({ includeIframes }) {
+    const { browser } = await getStagehandResources();
+    const page = (await browser.context.activePage()) ?? (await browser.context.newPage());
+    const snapshot = await page.snapshot({ includeIframes });
+    return snapshot.formattedTree;
+  },
+});

--- a/apps/templates/stagehand-extension/package.json
+++ b/apps/templates/stagehand-extension/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@eve-template/stagehand-extension",
+  "version": "0.0.0",
+  "private": true,
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.mjs"
+    },
+    "./tools": {
+      "types": "./dist/tools/index.d.ts",
+      "default": "./dist/tools/index.mjs"
+    }
+  },
+  "scripts": {
+    "build": "eve extension build",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@browserbasehq/stagehand": "4.0.1",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "eve": "workspace:*",
+    "typescript": "catalog:"
+  },
+  "peerDependencies": {
+    "eve": "*"
+  },
+  "engines": {
+    "node": ">=24"
+  },
+  "eve": {
+    "extension": {
+      "source": "./extension",
+      "dist": "./dist/extension",
+      "externalDependencies": [
+        "@browserbasehq/stagehand"
+      ]
+    }
+  }
+}

--- a/apps/templates/stagehand-extension/tsconfig.json
+++ b/apps/templates/stagehand-extension/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["extension/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -421,7 +421,7 @@ importers:
         version: 0.41.2
       '@vercel/connect':
         specifier: 'catalog:'
-        version: 0.4.3(@ai-sdk/mcp@2.0.29(zod@4.4.3))(@auth/core@0.41.2)(@chat-adapter/slack@4.34.0(ai@7.0.58(zod@4.4.3))(bufferutil@4.1.0)(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(zod@4.4.3))(ai@7.0.58(zod@4.4.3))(eve@packages+eve)
+        version: 0.4.3(@ai-sdk/mcp@2.0.29(zod@4.4.3))(@auth/core@0.41.2)(@chat-adapter/slack@4.34.0(ai@7.0.58(zod@4.4.3))(bufferutil@4.1.0)(supports-color@10.2.2)(zod@4.4.3))(ai@7.0.58(zod@4.4.3))(eve@packages+eve)
       ai:
         specifier: 'catalog:'
         version: 7.0.58(zod@4.4.3)
@@ -565,6 +565,25 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(vite@8.1.5(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+
+  apps/templates/stagehand-extension:
+    dependencies:
+      '@browserbasehq/stagehand':
+        specifier: 4.0.1
+        version: 4.0.1(supports-color@10.2.2)
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      eve:
+        specifier: workspace:*
+        version: link:../../../packages/eve
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
 
   e2e/fixtures/agent-basic-runtime:
     dependencies:
@@ -1892,6 +1911,10 @@ packages:
         optional: true
       puppeteer-core:
         optional: true
+
+  '@browserbasehq/stagehand@4.0.1':
+    resolution: {integrity: sha512-nWeXNp6dg8Hw4OnMzNrDfmtWQwPJO8jaRTa9HBemMm6D3872NxyzRxCJ4175AhGG4Qkvc2LuZFQCvif3yu0Rew==}
+    engines: {node: '>=22.18.0'}
 
   '@bufbuild/protobuf@2.13.0':
     resolution: {integrity: sha512-acq7c49vxfm1ggJ95P70TX7ABDM0vxr1SYD3BB0o0jnBLB4OAqeHyKuN+cD3w80gXEDQ2zxHpR6CUeA+O/aU9g==}
@@ -3721,6 +3744,12 @@ packages:
 
   '@opentelemetry/core@2.7.1':
     resolution: {integrity: sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.9.0':
+    resolution: {integrity: sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -8674,6 +8703,7 @@ packages:
   chrome-launcher@1.2.1:
     resolution: {integrity: sha512-qmFR5PLMzHyuNJHwOloHPAHhbaNglkfeV/xDtt5b7xiFFyU1I+AZZX0PYseMuhenJSSirgxELYIbswcoc+5H4A==}
     engines: {node: '>=12.13.0'}
+    hasBin: true
 
   chromium-edge-launcher@0.3.0:
     resolution: {integrity: sha512-p03azHlGjtyRvFEee3cyvtsRYdniSkwjkzmM/KmVnqT5d7QkkwpJBhis/zCLMYdQMVJ5tt140TBNqqrZPaWeFA==}
@@ -10975,6 +11005,7 @@ packages:
   is-docker@2.2.1:
     resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
     engines: {node: '>=8'}
+    hasBin: true
 
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
@@ -16207,6 +16238,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@browserbasehq/stagehand@4.0.1(supports-color@10.2.2)':
+    dependencies:
+      '@browserbasehq/sdk': 2.16.0
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      chrome-launcher: 1.2.1(supports-color@10.2.2)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   '@bufbuild/protobuf@2.13.0': {}
 
   '@bytecodealliance/preview2-shim@0.17.6': {}
@@ -16428,6 +16470,21 @@ snapshots:
       - supports-color
       - utf-8-validate
       - zod
+
+  '@chat-adapter/slack@4.34.0(ai@7.0.58(zod@4.4.3))(bufferutil@4.1.0)(supports-color@10.2.2)(zod@4.4.3)':
+    dependencies:
+      '@chat-adapter/shared': 4.34.0(ai@7.0.58(zod@4.4.3))(supports-color@10.2.2)(zod@4.4.3)
+      '@slack/socket-mode': 2.0.7(bufferutil@4.1.0)(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@slack/web-api': 7.19.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      chat: 4.34.0(ai@7.0.58(zod@4.4.3))(supports-color@10.2.2)(zod@4.4.3)
+    transitivePeerDependencies:
+      - ai
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+      - zod
+    optional: true
 
   '@chat-adapter/state-memory@4.34.0(ai@6.0.191(zod@4.4.3))(supports-color@10.2.2)(zod@4.4.3)':
     dependencies:
@@ -18420,6 +18477,11 @@ snapshots:
       '@opentelemetry/semantic-conventions': 1.43.0
 
   '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.43.0
@@ -21876,13 +21938,13 @@ snapshots:
       ai: 6.0.191(zod@4.4.3)
       eve: link:packages/eve
 
-  '@vercel/connect@0.4.3(@ai-sdk/mcp@2.0.29(zod@4.4.3))(@auth/core@0.41.2)(@chat-adapter/slack@4.34.0(ai@7.0.58(zod@4.4.3))(bufferutil@4.1.0)(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(zod@4.4.3))(ai@7.0.58(zod@4.4.3))(eve@packages+eve)':
+  '@vercel/connect@0.4.3(@ai-sdk/mcp@2.0.29(zod@4.4.3))(@auth/core@0.41.2)(@chat-adapter/slack@4.34.0(ai@7.0.58(zod@4.4.3))(bufferutil@4.1.0)(supports-color@10.2.2)(zod@4.4.3))(ai@7.0.58(zod@4.4.3))(eve@packages+eve)':
     dependencies:
       '@vercel/oidc': 3.8.1
     optionalDependencies:
       '@ai-sdk/mcp': 2.0.29(zod@4.4.3)
       '@auth/core': 0.41.2
-      '@chat-adapter/slack': 4.34.0(ai@7.0.58(zod@4.4.3))(bufferutil@4.1.0)(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(zod@4.4.3)
+      '@chat-adapter/slack': 4.34.0(ai@7.0.58(zod@4.4.3))(bufferutil@4.1.0)(supports-color@10.2.2)(zod@4.4.3)
       ai: 7.0.58(zod@4.4.3)
       eve: link:packages/eve
 
@@ -23550,7 +23612,6 @@ snapshots:
       lighthouse-logger: 2.0.2(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   chromium-edge-launcher@0.3.0(supports-color@10.2.2):
     dependencies:
@@ -26881,7 +26942,6 @@ snapshots:
       marky: 1.3.0
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   lightningcss-android-arm64@1.32.0:
     optional: true


### PR DESCRIPTION
### Summary

Adds a native eve extension template for Stagehand v4 that imports `@browserbasehq/stagehand` directly and declares it through `eve.extension.externalDependencies`. Consumers use ordinary `eve build`, `eve dev`, and `eve start` commands; there is no wrapper script or copied Browserbase facade.

The template uses Stagehand's published SDK and exposes its native experimental batch context through `run`, `snapshot`, and `screenshot` tools. #2291 provides the merged generic ESM-only external-dependency tracing needed to package Stagehand's assets.

### Validation

Built and typechecked the template, packed it as an extension, then installed it in a disposable consumer. `eve build` traced `@browserbasehq/stagehand@4.0.1`, `@browserbasehq/sdk`, the Stagehand package manifest, and `dist/assets/stagehand-extension.zip`; importing the traced Stagehand runtime entry also succeeded. No Browserbase service or credentials were required.

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+20 / -0`

The template README explains setup, extension-owned dependency packaging, and the available tools.

**Implementation** — 9 files · `+298 / -5`

Adds the Stagehand extension source and configuration plus the workspace lockfile entries for its pinned SDK dependency.

**Tests** — 0 files · `+0 / -0`

Not applicable; the generic packaging regression is covered in the stacked fix PR, and the template avoids Browserbase-dependent e2e coverage.

