### PR TITLE
perf: streamline generated authoring guidance

### DIFF
--- a/.changeset/swift-authoring-guidance.md
+++ b/.changeset/swift-authoring-guidance.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+New eve projects now give coding agents direct documentation routes and a bounded authoring loop, including a local recipe for routine typed tools. This reduces redundant project and package discovery while preserving deeper guidance for approvals and other advanced behavior.

--- a/packages/eve/src/setup/scaffold/create/project.ts
+++ b/packages/eve/src/setup/scaffold/create/project.ts
@@ -299,13 +299,64 @@ instructions. Fresh projects use \`agent/instructions.md\`; a project may instea
 use \`agent/instructions.ts\` or files under \`agent/instructions/\`. You do not
 need to read the framework docs for a content-only instructions change.
 
-Before adding or changing eve framework features such as tools, connections,
-channels, skills, subagents, schedules, authentication, or deployment, read the
-relevant guide from the installed eve package docs. In most installs, those docs
-are at \`node_modules/eve/docs/\`. In workspaces or local package installs,
-resolve the installed \`eve\` package location first and read its \`docs/\`
-directory. If package docs are unavailable, use https://eve.dev/docs as a
-fallback.
+Before adding or changing eve framework features, classify the requested
+capability. A self-contained typed tool can use the routine recipe below without
+further discovery. For other changes, open the relevant guide directly from the
+installed eve package docs:
+
+- tools beyond the routine recipe: \`node_modules/eve/docs/tools/overview.mdx\`
+- tool approvals: \`node_modules/eve/docs/tools/human-in-the-loop.md\`
+- connections: \`node_modules/eve/docs/connections/overview.mdx\`
+- channels: \`node_modules/eve/docs/channels/overview.mdx\`
+- skills: \`node_modules/eve/docs/skills.mdx\`
+- subagents: \`node_modules/eve/docs/subagents/index.mdx\`
+- schedules: \`node_modules/eve/docs/schedules.mdx\`
+- authentication: \`node_modules/eve/docs/guides/auth-and-route-protection.md\`
+- deployment: \`node_modules/eve/docs/guides/deployment/overview.md\`
+
+Use a bounded authoring loop:
+
+1. Read this file and the relevant guide's opening example and contract.
+2. Inspect only existing files you will modify or need to imitate.
+3. Stop discovery once the file location, imports, and definition shape are
+   clear. Implement the smallest complete behavior the user requested.
+4. Run one narrow verification. Expand investigation only when it fails or the
+   request needs project-specific integration details.
+
+Do not create a plan or todo list for a contained one-file change. Do not
+recursively glob \`node_modules\`, enumerate the entire docs tree, or read
+unrelated scaffold files when the direct path is known. Package-manager links
+can hide files from recursive glob tools even though direct reads work.
+
+In workspaces or local package installs where \`node_modules/eve\` is absent,
+resolve it with \`realpath node_modules/eve\` or the package manager, then open
+the same path below its \`docs/\` directory. If package docs are unavailable,
+use https://eve.dev/docs as a fallback.
+
+## Routine typed tools
+
+For a self-contained typed action, the standard shape is enough; do not inspect
+unrelated agent config or invent a third-party integration the user did not ask
+for:
+
+\`\`\`ts
+// agent/tools/<tool_name>.ts — the filename supplies the tool name.
+import { defineTool } from "eve/tools";
+import { z } from "zod";
+
+export default defineTool({
+  description: "Describe when the model should call this tool.",
+  inputSchema: z.object({ value: z.string() }),
+  async execute({ value }) {
+    return { value };
+  },
+});
+\`\`\`
+
+Omitting \`approval\` allows calls without human approval, equivalent to
+\`approval: never()\`. Read the tools guide when the implementation needs
+approval, authentication, sandbox access, streaming output, or custom model
+output.
 
 ## Adding integrations
 

--- a/packages/eve/src/setup/scaffold/index.integration.test.ts
+++ b/packages/eve/src/setup/scaffold/index.integration.test.ts
@@ -989,8 +989,16 @@ describe("scaffoldBaseProject", () => {
     expect(agentsMd).toContain("`agent/instructions.ts` or files under `agent/instructions/`");
     expect(agentsMd).toContain("Before adding or changing eve framework features");
     expect(agentsMd).toContain("installed eve package docs");
-    expect(agentsMd).toContain("node_modules/eve/docs/");
-    expect(agentsMd).toContain("resolve the installed `eve` package location");
+    expect(agentsMd).toContain("node_modules/eve/docs/tools/overview.mdx");
+    expect(agentsMd).toContain("node_modules/eve/docs/connections/overview.mdx");
+    expect(agentsMd).toContain("Use a bounded authoring loop");
+    expect(agentsMd).toContain("Stop discovery once the file location");
+    expect(agentsMd).toContain("Do not create a plan or todo list");
+    expect(agentsMd).toContain("recursively glob `node_modules`");
+    expect(agentsMd).toContain("realpath node_modules/eve");
+    expect(agentsMd).toContain("## Routine typed tools");
+    expect(agentsMd).toContain('import { defineTool } from "eve/tools"');
+    expect(agentsMd).toContain("Omitting `approval` allows calls without human approval");
     expect(agentsMd).toContain("eve registry search <query> --json");
     expect(agentsMd).toContain("eve registry view <item>");
     expect(agentsMd).toContain("eve add <item> --non-interactive");


### PR DESCRIPTION
### Summary

Generated `AGENTS.md` now gives coding agents direct guide routes, a bounded inspect–implement–verify loop, and a local recipe for routine typed tools. This prevents recursive package discovery and unnecessary planning while preserving deeper documentation routes for approvals, authentication, sandbox access, streaming, and other advanced behavior. No benchmark cases or graders changed.

On GPT-5.6 Sol's `author-001-weather-tool` case, the original guidance exhausted 12 exploratory calls without producing a file. After the first correctness fix, subsequent iterations reduced agent time from 50.1s to 23.9s (52%), input tokens from 16,837 to 8,762 (48%), and tool invocations from 17 to 10 (41%); the final run passed without reading framework docs. The separate conditional-approval case also passed in 23.4s of agent time and correctly followed the advanced approval guides, checking that the routine recipe does not suppress necessary discovery.

### Validation

Focused scaffold integration coverage passes and asserts the generated routes, bounded loop, routine tool recipe, and approval default. The eve package build, package typecheck, and invariant guard pass; the live Sol benchmark passed for both weather-tool and conditional-approval authoring flows.

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the patch changeset describing the generated authoring-guidance improvement.

**Implementation** — 1 file · `+58 / -7`

Keeps the performance guidance inside the generated project instructions that coding agents receive, without changing runtime behavior or benchmark inputs.

**Tests** — 1 file · `+10 / -2`

Extends focused scaffold assertions to cover the direct guide routes, bounded loop, routine typed-tool recipe, and approval guidance.
