### PR TITLE
fix(eve): prefer the host root vercel.json services over the linked project root's

### DIFF
--- a/.changeset/vercel-json-host-root.md
+++ b/.changeset/vercel-json-host-root.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix `vercel.json` services detection when a Vercel Root Directory is configured. The framework integrations now read `vercel.json` from the framework app root first, so a `services` declaration next to the app wins over the linked repository root's `vercel.json` — matching where Vercel itself reads the file from.

--- a/packages/eve/src/shared/vercel-services.integration.test.ts
+++ b/packages/eve/src/shared/vercel-services.integration.test.ts
@@ -137,6 +137,32 @@ describe("ensureEveVercelServicesConfig", () => {
     expect(result).toEqual({ mode: "root" });
   });
 
+  it("prefers the host root vercel.json services over the linked project root's", async () => {
+    const projectRoot = await createTempHostRoot();
+    const hostRoot = join(projectRoot, "apps", "web");
+    await mkdir(join(projectRoot, ".vercel"), { recursive: true });
+    await writeFile(join(projectRoot, ".vercel", "project.json"), "{}\n");
+    await mkdir(hostRoot, { recursive: true });
+    await writeFile(join(projectRoot, "vercel.json"), `${JSON.stringify({})}\n`);
+    await writeFile(
+      join(hostRoot, "vercel.json"),
+      `${JSON.stringify({
+        services: {
+          web: { root: ".", framework: "nuxtjs" },
+          eve: { root: "agent", framework: "eve" },
+        },
+      })}\n`,
+    );
+
+    const result = await ensureEveVercelServicesConfig({
+      appRoot: hostRoot,
+      frameworkName: "Test",
+      hostRoot: hostRoot,
+    });
+
+    expect(result).toEqual({ mode: "root" });
+  });
+
   it("generates nothing when vercel.json declares services including eve", async () => {
     const hostRoot = await createTempHostRoot();
     await writeFile(

--- a/packages/eve/src/shared/vercel-services.ts
+++ b/packages/eve/src/shared/vercel-services.ts
@@ -325,7 +325,17 @@ export async function ensureEveVercelServicesConfig(input: {
 }): Promise<EnsureEveVercelServicesConfigResult> {
   const vercelDirectory = await findClosestLinkedVercelDirectory(input.hostRoot);
   const projectRoot = vercelDirectory === undefined ? input.hostRoot : dirname(vercelDirectory);
-  const rootVercelConfig = await readVercelJsonConfig(join(projectRoot, VERCEL_JSON_FILE_NAME));
+  // With a Vercel Root Directory, vercel.json lives in the root directory
+  // (the host root) while the .vercel link lives at the repository root, so
+  // the host root declaration wins over the linked project root's.
+  const hostRootVercelConfig = await readVercelJsonConfig(
+    join(input.hostRoot, VERCEL_JSON_FILE_NAME),
+  );
+  const rootVercelConfig =
+    projectRoot === input.hostRoot ||
+    Object.keys(createServiceConfigRecord(hostRootVercelConfig.services)).length > 0
+      ? hostRootVercelConfig
+      : await readVercelJsonConfig(join(projectRoot, VERCEL_JSON_FILE_NAME));
   const rootServices = createServiceConfigRecord(rootVercelConfig.services);
 
   if (Object.keys(rootServices).length > 0) {


### PR DESCRIPTION
### Summary

Closes #2275.

With a Vercel Root Directory layout, `ensureEveVercelServicesConfig` resolved `vercel.json` from the linked Vercel project root only: it walked up from the framework app to the closest `.vercel/project.json` (which `vercel link` creates at the repository root in a monorepo) and read `vercel.json` there — never from the app root. Since Vercel itself reads `vercel.json` from the Root Directory, a `services` declaration sitting next to the app was silently ignored: the SvelteKit and Nuxt integrations injected a duplicate generated eve service into the Build Output, or hard-failed with "vercel.json already defines services" when the repository root declared services for another project.

The fix reads the host root's `vercel.json` first and lets its `services` declaration win over the linked project root's, matching where Vercel resolves the file. The linked-project-root fallback is preserved for host roots that declare no services, and single-app repos (host root == project root) behave exactly as before.

Affects the SvelteKit and Nuxt integrations (and the proposed React Router integration, which depends on this fix and follows in a separate PR). Cloud services builds are currently masked from the bug because the platform materializes the Root Directory's `vercel.json` at the container root; local and CI flows (`VERCEL=1` framework builds, `vercel build`, prebuilt workflows) hit it directly — see the reproduction in #2275.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/shared/vercel-services` — 12 passed, including the new regression case ("prefers the host root vercel.json services over the linked project root's").
- `pnpm --filter eve exec vitest run --config vitest.scenario.config.ts test/scenarios/framework-sveltekit-build.scenario.test.ts` — passed (generated-mode consumer unchanged).
- `pnpm lint`, `pnpm typecheck`, `pnpm guard:invariants` — passed.
- End-to-end against the public reproduction (https://github.com/malewis5/vercel-json-host-root-repro): `eve@0.39.1` injects a duplicate generated service when a repo-root `.vercel` link exists; a package built from this branch detects the app's declared services (`mode: root`) and injects nothing, locally and on a Vercel deployment.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Changeset describing the behavior change for release notes.

**Implementation** — 1 file · `+11 / -1`

The lookup-order change in `ensureEveVercelServicesConfig`, with a comment on the Root Directory layout it corrects.

**Tests** — 1 file · `+26 / -0`

Regression coverage: host-root `services` win over the linked project root's `vercel.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
