### PR TITLE
perf(eve): speed up fresh npm init

### DIFF
--- a/.changeset/quick-npm-init.md
+++ b/.changeset/quick-npm-init.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Speed up fresh standalone npm scaffolds by skipping npm's resolution of unused optional peer dependencies. Existing projects and ancestor workspaces retain normal peer dependency resolution.

--- a/packages/eve/src/cli/commands/init.integration.test.ts
+++ b/packages/eve/src/cli/commands/init.integration.test.ts
@@ -706,6 +706,28 @@ describe("runInitCommand", () => {
     },
   );
 
+  it("keeps npm peer resolution for a fresh ancestor workspace member", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "eve-init-npm-workspace-member-"));
+    const appsDirectory = join(workspaceRoot, "apps");
+    await mkdir(appsDirectory, { recursive: true });
+    await writeFile(
+      join(workspaceRoot, "package.json"),
+      `${JSON.stringify({ private: true, workspaces: ["apps/*"] }, null, 2)}\n`,
+      "utf8",
+    );
+    await writeFile(join(workspaceRoot, "package-lock.json"), "", "utf8");
+    const output = logger();
+    const deps = dependencies();
+
+    await runInitCommand(output, appsDirectory, "my-agent", {}, deps);
+
+    expect(deps.runPackageManagerInstall).toHaveBeenCalledWith(
+      "npm",
+      join(appsDirectory, "my-agent"),
+      expect.objectContaining({ skipPeerDependencyResolution: false }),
+    );
+  });
+
   it("adds Web Chat to an npm-owned fresh scaffold without pnpm configuration", async () => {
     const parentDirectory = await mkdtemp(join(tmpdir(), "eve-init-agent-web-npm-"));
     const output = logger();
@@ -720,7 +742,7 @@ describe("runInitCommand", () => {
     expect(deps.runPackageManagerInstall).toHaveBeenCalledWith(
       "npm",
       projectPath,
-      expect.anything(),
+      expect.objectContaining({ skipPeerDependencyResolution: true }),
     );
     expect(deps.spawnPackageManager).toHaveBeenCalledWith("npm", projectPath, [
       "exec",
@@ -1019,7 +1041,7 @@ describe("runInitCommand", () => {
       expect(deps.runPackageManagerInstall).toHaveBeenCalledWith(
         kind,
         projectRoot,
-        expect.anything(),
+        expect.objectContaining({ skipPeerDependencyResolution: false }),
       );
       expect(deps.spawnPackageManager).toHaveBeenCalledWith(kind, projectRoot, [...devArguments]);
     },

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -485,6 +485,13 @@ async function runInitSteps(input: {
         // The scaffold pins versions younger than typical release-age cooldown
         // windows; gating them would fail every fresh bootstrap.
         bypassMinimumReleaseAge: true,
+        // npm otherwise resolves hundreds of unused optional peers exposed by
+        // Nitro's integration ecosystem. Keep normal peer validation when eve
+        // adds to an existing project or installs inside an ancestor workspace.
+        skipPeerDependencyResolution:
+          project.kind === "created" &&
+          project.packageManager === "npm" &&
+          !project.workspaceMember,
         progressDetails: process.stdout.isTTY === true && !debug,
         onOutput: (line) => {
           if (line.text.trim() !== "") {

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -485,13 +485,7 @@ async function runInitSteps(input: {
         // The scaffold pins versions younger than typical release-age cooldown
         // windows; gating them would fail every fresh bootstrap.
         bypassMinimumReleaseAge: true,
-        // npm otherwise resolves hundreds of unused optional peers exposed by
-        // Nitro's integration ecosystem. Keep normal peer validation when eve
-        // adds to an existing project or installs inside an ancestor workspace.
-        skipPeerDependencyResolution:
-          project.kind === "created" &&
-          project.packageManager === "npm" &&
-          !project.workspaceMember,
+        skipPeerDependencyResolution: project.kind === "created" && !project.workspaceMember,
         progressDetails: process.stdout.isTTY === true && !debug,
         onOutput: (line) => {
           if (line.text.trim() !== "") {

--- a/packages/eve/src/setup/primitives/pm/npm.ts
+++ b/packages/eve/src/setup/primitives/pm/npm.ts
@@ -9,6 +9,7 @@ export const npmPackageManager = {
   installArguments: (options) => [
     "install",
     ...(options.bypassMinimumReleaseAge === true ? ["--min-release-age=0"] : []),
+    ...(options.skipPeerDependencyResolution === true ? ["--legacy-peer-deps"] : []),
     ...(options.progressDetails === true ? ["--loglevel=silly"] : []),
   ],
   prepareArguments: (_projectRoot, args) => args,

--- a/packages/eve/src/setup/primitives/pm/types.ts
+++ b/packages/eve/src/setup/primitives/pm/types.ts
@@ -28,6 +28,8 @@ export interface PackageManagerInstallOptions {
   readonly bypassMinimumReleaseAge?: boolean;
   /** Resolves the project standalone even when an ancestor workspace exists. */
   readonly ignoreWorkspace?: boolean;
+  /** Skips peer dependency resolution for an eve-owned standalone scaffold when supported. */
+  readonly skipPeerDependencyResolution?: boolean;
   /** Requests verbose package-manager output for a live progress display. */
   readonly progressDetails?: boolean;
 }

--- a/packages/eve/src/setup/primitives/run-pnpm.test.ts
+++ b/packages/eve/src/setup/primitives/run-pnpm.test.ts
@@ -169,6 +169,22 @@ describe("runPackageManagerInstall", () => {
     );
   });
 
+  test("skips npm peer dependency resolution when requested", async () => {
+    expect(
+      packageManagerInstallSucceeded(
+        await runPackageManagerInstall("npm", "/tmp/app", {
+          skipPeerDependencyResolution: true,
+        }),
+      ),
+    ).toBe(true);
+
+    expect(mockedSpawn).toHaveBeenCalledWith(
+      "npm",
+      ["install", "--legacy-peer-deps"],
+      expect.objectContaining({ cwd: "/tmp/app" }),
+    );
+  });
+
   test("requests npm output before registry operations complete", async () => {
     expect(
       packageManagerInstallSucceeded(

--- a/packages/eve/test/scenarios/eve-init.scenario.test.ts
+++ b/packages/eve/test/scenarios/eve-init.scenario.test.ts
@@ -262,7 +262,7 @@ describe("eve init smoke", () => {
     await expect(pathExists(join(projectDir, "package-lock.json"))).resolves.toBe(true);
     expect(await fakeNpm.readCalls()).toEqual([
       {
-        args: ["install", "--min-release-age=0"],
+        args: ["install", "--min-release-age=0", "--legacy-peer-deps"],
         cwd: canonicalProjectDir,
       },
       {


### PR DESCRIPTION
### Summary

Fresh npm-owned `eve init` projects spend most of dependency installation resolving optional peers that are never installed. This passes `--legacy-peer-deps` only for standalone projects whose complete initial manifest eve owns; existing projects and ancestor workspaces retain npm's normal peer resolution.

The trade-off is that npm will not validate or auto-install peer dependencies during that first standalone install. The scaffold explicitly declares eve's required `ai` peer, focused coverage limits the bypass to eve-owned manifests, and subsequent ordinary npm installs continue using normal peer behavior. Longer term, narrowing Nitro's optional-peer graph upstream would avoid needing this workaround.

A generated `package-lock.json` plus `npm ci` is a possible alternative: it could preserve peer validation at release time, make the initial graph deterministic, and preliminary cold-cache profiling completed in about 2s. It was not chosen here because the lock must remain synchronized with release-stamped scaffold versions and valid across every supported OS and architecture; during profiling, npm rejected one generated lock because it omitted a platform-specific Rolldown binding. Adopting that approach would require a dedicated cross-platform lockfile generation and validation pipeline, while still excluding existing projects, workspace members, and local package-spec overrides.

### Validation

Packed the branch before and after the policy change and ran three alternating `eve init` benchmarks with an isolated empty npm cache per run.

| Variant | Run 1 | Run 2 | Run 3 | Median |
| --- | ---: | ---: | ---: | ---: |
| Before | 41.7s | 45.3s | 41.8s | **41.8s** |
| After | 5.2s | 6.8s | 5.3s | **5.3s** |

The median improved by 87.3%, making dependency installation 7.9× faster. Manifest lookups fell from 262 to 100; both variants produced the same 98-entry lockfile graph and passed `npm ls --all`. Focused package-manager and structural unit coverage passed with 21 tests, init integration coverage passed with 59 tests, and the npm `eve init` scenario passed, along with the eve typecheck and invariant guard.

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

A patch changeset records the faster fresh npm scaffold behavior.

**Implementation** — 3 files · `+4 / -0`

Adds one package-manager install policy, maps it to npm's flag, and enables it only for standalone fresh scaffolds.

**Tests** — 3 files · `+41 / -3`

Covers npm argument translation and verifies the exact scenario command, while preserving normal peer resolution for existing projects and workspace members.
