### PR TITLE
feat(docs): add homepage structured data

### DIFF
--- a/apps/docs/app/[lang]/(home)/components/home-content.tsx
+++ b/apps/docs/app/[lang]/(home)/components/home-content.tsx
@@ -12,6 +12,51 @@ import { NextjsInterop } from "./nextjs-interop";
 const tagline = "Like Next.js for agents. Build durable agents with one folder.";
 const titleMetadata = pageTitleMetadata(siteTitle);
 
+const structuredData = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "SoftwareApplication",
+      "@id": "https://eve.dev/#software",
+      name: "eve",
+      url: "https://eve.dev/",
+      description: "A filesystem-first framework for durable backend AI agents that run anywhere.",
+      applicationCategory: "DeveloperApplication",
+      applicationSubCategory: "AI agent framework",
+      operatingSystem: "Any",
+      isAccessibleForFree: true,
+      license: "https://github.com/vercel/eve/blob/main/LICENSE",
+      downloadUrl: "https://www.npmjs.com/package/eve",
+      softwareHelp: "https://eve.dev/docs/getting-started",
+      creator: {
+        "@id": "https://vercel.com/#organization",
+      },
+      sameAs: ["https://github.com/vercel/eve", "https://www.npmjs.com/package/eve"],
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://vercel.com/#organization",
+      name: "Vercel",
+      url: "https://vercel.com/",
+      sameAs: ["https://github.com/vercel"],
+    },
+    {
+      "@type": "WebSite",
+      "@id": "https://eve.dev/#website",
+      name: "eve",
+      url: "https://eve.dev/",
+      description:
+        "Documentation for eve, a filesystem-first framework for durable backend AI agents.",
+      about: {
+        "@id": "https://eve.dev/#software",
+      },
+      publisher: {
+        "@id": "https://vercel.com/#organization",
+      },
+    },
+  ],
+};
+
 export const homeMetadata: Metadata = {
   ...titleMetadata,
   description: tagline,
@@ -30,14 +75,23 @@ export const homeMetadata: Metadata = {
 };
 
 export const HomeContent = () => (
-  <div className="mx-auto w-full max-w-[1080px] pb-32">
-    <section className="relative isolate flex min-h-[80vh] flex-col items-center justify-center gap-y-5 px-4 pt-24 pb-12 text-center sm:px-12 sm:pb-16 sm:pt-42">
-      <HeroAudience tagline={tagline} />
-    </section>
-    <FileTree />
-    <NextjsInterop />
-    <ArchitectureDiagram />
-    <FeatureGrid />
-    <CTA />
-  </div>
+  <>
+    <script
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(structuredData).replace(/</g, "\\u003c"),
+      }}
+      id="home-structured-data"
+      type="application/ld+json"
+    />
+    <div className="mx-auto w-full max-w-[1080px] pb-32">
+      <section className="relative isolate flex min-h-[80vh] flex-col items-center justify-center gap-y-5 px-4 pt-24 pb-12 text-center sm:px-12 sm:pb-16 sm:pt-42">
+        <HeroAudience tagline={tagline} />
+      </section>
+      <FileTree />
+      <NextjsInterop />
+      <ArchitectureDiagram />
+      <FeatureGrid />
+      <CTA />
+    </div>
+  </>
 );


### PR DESCRIPTION
### Summary

The eve homepage does not expose machine-readable product identity, so agents and structured-data consumers must infer its relationship to the framework, documentation site, and Vercel. This adds a linked JSON-LD graph for the eve software, eve.dev website, and Vercel organization using repository-backed claims and safe serialization.

### Validation

`pnpm --filter eve-docs test:unit` passed all 156 tests, and a production Next.js build completed after syncing template data. The prerendered homepage contains the expected `application/ld+json` payload.

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

No issue is linked because this small docs-site improvement came directly from an external agent-readiness review. Tests and a changeset are not required for the static docs-site metadata change.

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 1 file · `+64 / -10`

Adds the three linked schema entities and wraps the existing homepage content so the JSON-LD script is emitted alongside it.

**Tests** — 0 files · `+0 / -0`

Existing docs-site tests and the production build cover this static rendering change.
