### PR TITLE
fix(eve): trace ESM-only extension dependencies

### DIFF
--- a/.changeset/tidy-dodos-import.md
+++ b/.changeset/tidy-dodos-import.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Allow extension-owned external dependencies to use ESM-only packages that do not expose a CommonJS entry.

--- a/packages/eve/src/internal/nitro/host/extension-external-dependency-plugin.test.ts
+++ b/packages/eve/src/internal/nitro/host/extension-external-dependency-plugin.test.ts
@@ -30,4 +30,12 @@ describe("extension external dependency plugin", () => {
       ]),
     ).toEqual({ zod: expect.stringMatching(/zod[/\\].*index\.(?:c?js|mjs)$/) });
   });
+
+  it("resolves ESM-only packages without a require export", () => {
+    expect(
+      resolveExtensionExternalDependencyPaths([
+        { externalDependencies: ["emulate"], sourceRoot: process.cwd() },
+      ]),
+    ).toEqual({ emulate: expect.stringMatching(/emulate[/\\]dist[/\\]api\.js$/) });
+  });
 });

--- a/packages/eve/src/internal/nitro/host/extension-external-dependency-plugin.ts
+++ b/packages/eve/src/internal/nitro/host/extension-external-dependency-plugin.ts
@@ -1,6 +1,6 @@
-import { realpathSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { createRequire } from "node:module";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 interface BundlerPluginShape {
   readonly name: string;
@@ -43,7 +43,7 @@ export function resolveExtensionExternalDependencyPaths(
   for (const [dependency, anchors] of collectDependencyAnchors(mounts)) {
     for (const anchor of anchors) {
       try {
-        resolvedPaths[dependency] = createRequire(anchor).resolve(dependency);
+        resolvedPaths[dependency] = resolveDependencyEntry(dependency, anchor);
         break;
       } catch {}
     }
@@ -54,6 +54,61 @@ export function resolveExtensionExternalDependencyPaths(
     }
   }
   return resolvedPaths;
+}
+
+function resolveDependencyEntry(dependency: string, anchor: string): string {
+  const require = createRequire(anchor);
+  try {
+    return require.resolve(dependency);
+  } catch (error) {
+    const packageJsonPath = require.resolve
+      .paths(dependency)
+      ?.map((searchPath) => join(searchPath, dependency, "package.json"))
+      .find(existsSync);
+    if (packageJsonPath === undefined) {
+      throw error;
+    }
+
+    const pkg = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+      exports?: unknown;
+      main?: unknown;
+      module?: unknown;
+    };
+    const entry =
+      resolveImportExport(pkg.exports) ?? stringValue(pkg.module) ?? stringValue(pkg.main);
+    if (entry === undefined) {
+      throw error;
+    }
+    return resolve(dirname(packageJsonPath), entry);
+  }
+}
+
+function resolveImportExport(exports: unknown): string | undefined {
+  if (typeof exports === "string") {
+    return exports;
+  }
+  if (Array.isArray(exports)) {
+    return exports.map(resolveImportExport).find((entry) => entry !== undefined);
+  }
+  if (exports === null || typeof exports !== "object") {
+    return undefined;
+  }
+
+  const conditions = exports as Record<string, unknown>;
+  if ("." in conditions) {
+    return resolveImportExport(conditions["."]);
+  }
+  for (const condition of ["node", "import", "default"]) {
+    const entry = resolveImportExport(conditions[condition]);
+    if (entry !== undefined) {
+      return entry;
+    }
+  }
+  return undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
 }
 
 function collectDependencyAnchors(


### PR DESCRIPTION
### Summary

Extension-owned external dependencies could not be packaged when a dependency exposed an ESM `import` entry but no CommonJS `require` entry. eve now falls back to the package manifest and traces its root `node`, `import`, or `default` export, preserving the existing resolution path for CommonJS-compatible packages.

This unblocks extensions such as the Stagehand example in #2265 without adding package-specific behavior or Browserbase dependencies to eve or its tests.

### Validation

Focused unit coverage confirms both existing CommonJS-compatible resolution and the ESM-only fallback using the generic `emulate` package.

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

The changeset records the externally visible packaging fix for extension authors.

**Implementation** — 1 file · `+56 / -4`

Keeps the fallback local to extension dependency tracing and adds no runtime dependency.

**Tests** — 1 file · `+8 / -0`

Adds focused regression coverage with an existing generic ESM-only package.
