### PR TITLE
docs(eve): streamline generated agent routing

### DIFF
--- a/packages/eve/src/setup/scaffold/create/project.ts
+++ b/packages/eve/src/setup/scaffold/create/project.ts
@@ -293,59 +293,28 @@ dist
 `,
   "AGENTS.md": `# eve Agent App
 
-This project uses the eve framework: an agent is a directory of files under \`agent/\`, and eve compiles and runs it.
+The agent is authored in \`agent/\`; eve compiles and runs it. Names come from paths, so \`agent/tools/weather.ts\`, \`agent/connections/crm.ts\`, and \`agent/channels/support.ts\` are named \`weather\`, \`crm\`, and \`support\`.
 
-For a content-only change to the root agent's identity, purpose, tone, or response guidelines, edit its existing authored instructions. Fresh projects use \`agent/instructions.md\`; a project may instead use \`agent/instructions.ts\` or files under \`agent/instructions/\`. You do not need to read the framework docs for a content-only instructions change. A fresh project already has its selected model in \`agent/agent.ts\`; preserve that file unless the user asks to change the model.
+For a content-only change to the root agent's identity, purpose, tone, or response guidelines, edit its authored instructions (usually \`agent/instructions.md\`, sometimes \`agent/instructions.ts\` or \`agent/instructions/\`). Do not read framework docs or change \`agent/agent.ts\` unless the request changes agent-wide configuration.
 
-## Read the docs before writing code
+## Route framework changes
 
-\`\`\`sh
-ls node_modules/eve/docs
-\`\`\`
+Before authoring a framework capability, read its direct installed page for the file location, imports, and definition shape:
 
-Start with \`docs/README.md\`: it maps each task to the page that covers it. Read that page before authoring tools, connections, channels, skills, subagents, schedules, or deployment. In a workspace or local package install, resolve the installed \`eve\` package location first. If the package docs are missing, use https://eve.dev/docs.
+| Request | Read |
+| --- | --- |
+| Project layout | \`node_modules/eve/docs/getting-started.mdx\` |
+| Agent configuration | \`node_modules/eve/docs/agent-config.md\` |
+| Tool or approval policy | \`node_modules/eve/docs/tools/overview.mdx\` or \`tools/human-in-the-loop.md\` |
+| MCP or OpenAPI service | \`node_modules/eve/docs/connections/mcp.mdx\` or \`connections/openapi.mdx\` |
+| Built-in or custom channel | \`node_modules/eve/docs/channels/overview.mdx\` or \`channels/custom.mdx\` |
+| Skill or schedule | \`node_modules/eve/docs/skills.mdx\` or \`schedules.mdx\` |
+| Subagent, sandbox, auth, or client | \`node_modules/eve/docs/subagents/index.mdx\`, \`sandbox.mdx\`, \`guides/auth-and-route-protection.md\`, or \`guides/client/overview.mdx\` |
+| Vercel or other deployment | \`node_modules/eve/docs/guides/deployment/vercel.mdx\` or \`guides/deployment/overview.md\` |
 
-Use a bounded authoring loop:
+Read \`node_modules/eve/docs/README.md\` only when no row fits. Resolve the installed \`eve\` package first in a workspace or local install; if its docs are unavailable, use https://eve.dev/docs. Read the routed page before coding. Inspect only files you will change or imitate; do not enumerate the docs tree or recursively glob \`node_modules\` when the direct path is known.
 
-1. Read the relevant page and inspect only files you will modify or need to imitate.
-2. Stop discovery once the file location, imports, and definition shape are clear. Implement the smallest complete behavior the user requested.
-3. Run one narrow verification. Expand investigation only when it fails or the request needs project-specific details.
-
-Follow links or inspect public types only when the routed page leaves the task unanswered. Do not recursively glob \`node_modules\`, enumerate the entire docs tree, or read unrelated scaffold files when the direct path is known. Package-manager links can hide files from recursive glob tools even though direct reads work.
-
-## Prefer an existing integration
-
-When a task names an external product or service, search the registry before implementing its integration. For a generic capability, author a tool instead.
-
-\`\`\`sh
-eve registry search <query> --json
-eve registry view <item>
-\`\`\`
-
-Prefer items whose \`implementation\` is \`native\`; use Chat SDK adapters when no native channel fits. \`registry view\` links the item's documentation.
-
-Install without driving interactive prompts:
-
-\`\`\`sh
-eve add <item> --non-interactive
-\`\`\`
-
-Exit code 0 means setup completed, 1 failed, and 2 needs an answer or a prerequisite. On exit 2, run the \`next.command\` from the final NDJSON event. For a non-secret question, replace its \`<JSON value>\` answer placeholder with the answer you collected; string values need JSON quotes. Never pass a secret in \`--answer\`. See \`docs/install-integrations.mdx\` for setup prerequisites.
-
-## Use eve for Vercel operations
-
-Use eve to link and deploy Vercel projects:
-
-\`\`\`sh
-eve link --non-interactive --project <name-or-id> [--team <team-id-or-slug>]
-eve deploy --non-interactive --yes [--project <name-or-id>]
-\`\`\`
-
-A setup may report \`eve link\` as a prerequisite; run it, then retry the continuation. When a completed setup event has \`deploymentRequired: true\`, run the \`next\` command it reports.
-
-## Validate the change
-
-Run the validation the task requests. When it does not establish the behavior you changed, run the narrowest relevant check.
+For a named external product, search \`eve registry search <query> --json\`, inspect a candidate with \`eve registry view <item>\`, and install it with \`eve add <item> --non-interactive\`. For a generic capability, author a tool instead. Use \`eve link\` and \`eve deploy\` for Vercel operations. Implement the smallest complete behavior, then run the requested validation or the narrowest relevant check.
 `,
   "CLAUDE.md": `@AGENTS.md
 `,

--- a/packages/eve/src/setup/scaffold/index.integration.test.ts
+++ b/packages/eve/src/setup/scaffold/index.integration.test.ts
@@ -985,26 +985,25 @@ describe("scaffoldBaseProject", () => {
     );
     const agentsMd = await readFile(join(projectRoot, "AGENTS.md"), "utf8");
     expect(agentsMd).toContain("content-only change to the root agent's");
-    expect(agentsMd).toContain("You do not need to read the framework docs");
-    expect(agentsMd).toContain("preserve that file unless the user asks to change the model");
-    expect(agentsMd).toContain("`agent/instructions.ts` or files under `agent/instructions/`");
-    expect(agentsMd).toContain("ls node_modules/eve/docs");
-    expect(agentsMd).toContain("Start with `docs/README.md`: it maps each task");
-    expect(agentsMd).toContain("Use a bounded authoring loop");
-    expect(agentsMd).toContain("Stop discovery once the file location");
-    expect(agentsMd).toContain("Follow links or inspect public types only");
-    expect(agentsMd).toContain("recursively glob `node_modules`");
+    expect(agentsMd).toContain("Do not read framework docs or change `agent/agent.ts`");
+    expect(agentsMd).toContain("`agent/instructions.ts` or `agent/instructions/`");
+    expect(agentsMd).toContain("## Route framework changes");
+    expect(agentsMd).toContain("node_modules/eve/docs/tools/overview.mdx");
+    expect(agentsMd).toContain("tools/human-in-the-loop.md");
+    expect(agentsMd).toContain("node_modules/eve/docs/connections/mcp.mdx");
+    expect(agentsMd).toContain("connections/openapi.mdx");
+    expect(agentsMd).toContain("channels/custom.mdx");
+    expect(agentsMd).toContain("guides/deployment/vercel.mdx");
+    expect(agentsMd).toContain("node_modules/eve/docs/skills.mdx");
+    expect(agentsMd).toContain("schedules.mdx");
+    expect(agentsMd).toContain("Read `node_modules/eve/docs/README.md` only when no row fits");
+    expect(agentsMd).toContain("do not enumerate the docs tree or recursively glob `node_modules`");
     expect(agentsMd).toContain("eve registry search <query> --json");
     expect(agentsMd).toContain("eve registry view <item>");
     expect(agentsMd).toContain("For a generic capability, author a tool instead.");
     expect(agentsMd).toContain("eve add <item> --non-interactive");
-    expect(agentsMd).toContain("Exit code 0 means setup completed");
-    expect(agentsMd).toContain("replace its `<JSON value>` answer placeholder");
-    expect(agentsMd).toContain("docs/install-integrations.mdx");
-    expect(agentsMd).toContain("eve link --non-interactive --project <name-or-id>");
-    expect(agentsMd).toContain("eve deploy --non-interactive --yes");
-    expect(agentsMd).toContain("Use eve to link and deploy Vercel projects");
-    expect(agentsMd).toContain("Run the validation the task requests");
+    expect(agentsMd).toContain("Use `eve link` and `eve deploy` for Vercel operations.");
+    expect(agentsMd).toContain("narrowest relevant check");
     // `vercel deploy` uploads everything a .vercelignore doesn't exclude, and
     // the platform default-ignores only the .env.local variants — eve's dev
     // artifacts and a bare .env must be excluded here or a source deploy


### PR DESCRIPTION
### Summary

Closes #2296. New projects now generate a compact capability router in `AGENTS.md`, sending coding agents directly to the bundled page that defines the requested eve surface instead of starting with broad documentation discovery. The router preserves the fallback index, narrow-inspection guidance, and integration/deployment commands; it does not add benchmark-specific task instructions.

Focused traces recovered a pathological OpenAPI journey that otherwise spent its turn investigating the coding harness rather than eve. The paired three-run comparison preserved all 24 stable-case passes, but did not show a statistically credible aggregate token or agent-time reduction, so this change intentionally claims clearer routing rather than a universal efficiency gain.

### Validation

Ran `pnpm fmt`, `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/setup/scaffold/index.integration.test.ts` (63 passing tests), focused OpenAPI and Vercel deployment benchmarks, and a paired `pnpm benchmark --base 6ee58607 --head 068d73f6 --model claude-sonnet-5 --runs 3 --keep-failures` comparison. The benchmark comparison passed all 24 stable runs on both revisions; iMessage remained flaky and was not used to guide the change.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable; the generated agent guidance is product scaffolding rather than published documentation.

**Implementation** — 1 file · `+16 / -47`

Compacts the scaffolded capability router while retaining the supported routing and fallback behavior.

**Tests** — 1 file · `+15 / -16`

Keeps the scaffold contract aligned with the generated routing guidance.
