### PR TITLE
feat(eve): add local progress reports

### DIFF
--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -416,6 +416,8 @@ export interface SessionCapabilities {
    *    approvals and `ask_question` prompts the model has already emitted.
    */
   readonly requestInput?: boolean;
+  /** Internal channel opt-in for presentation-only progress reporting. */
+  readonly progress?: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/eve/src/execution/node-step.ts
+++ b/packages/eve/src/execution/node-step.ts
@@ -18,6 +18,7 @@ import {
   type RuntimeModelResolutionScope,
 } from "#runtime/agent/resolve-model.js";
 import type { RuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
+import { REPORT_PROGRESS_TOOL } from "#runtime/framework-tools/progress.js";
 import {
   AGENT_TOOL_DESCRIPTION,
   AGENT_TOOL_NAME,
@@ -98,7 +99,7 @@ export function createExecutionNodeStep(input: CreateExecutionNodeStepInput): St
           input.modelResolutionScope,
           input.node.turnAgent.dynamicModel,
         );
-  const tools = createNodeHarnessTools({ node: input.node });
+  const tools = createNodeHarnessTools({ capabilities: input.capabilities, node: input.node });
   const instrumentation = getInstrumentationRuntime();
   const step = createToolLoopHarness({
     abortSignal: input.abortSignal,
@@ -190,6 +191,7 @@ function createRuntimeDynamicModelEventDispatcher(
  * Tools without `execute` (provider-managed) get entries with schema but no execute.
  */
 export function createNodeHarnessTools(input: {
+  readonly capabilities?: SessionCapabilities;
   readonly node: ResolvedRuntimeAgentNode;
 }): HarnessToolMap {
   const tools = new Map<string, HarnessToolDefinition>();
@@ -203,6 +205,10 @@ export function createNodeHarnessTools(input: {
     if (definition !== null) {
       tools.set(tool.name, definition);
     }
+  }
+
+  if (input.capabilities?.progress === true && !tools.has(REPORT_PROGRESS_TOOL.name)) {
+    tools.set(REPORT_PROGRESS_TOOL.name, REPORT_PROGRESS_TOOL);
   }
 
   if (

--- a/packages/eve/src/execution/report-progress.test.ts
+++ b/packages/eve/src/execution/report-progress.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ContextContainer, contextStorage } from "#context/container.js";
+import { SessionKey, type Session } from "#context/keys.js";
+import { reportProgress } from "#execution/report-progress.js";
+import { sessionCommandHookToken } from "#execution/session-command-token.js";
+import { resumeHook } from "#internal/workflow/runtime.js";
+
+vi.mock("#compiled/@workflow/core/runtime.js", () => ({ resumeHook: vi.fn() }));
+
+function runWithSession(session: Session, callback: () => Promise<unknown>) {
+  const context = new ContextContainer();
+  context.set(SessionKey, session);
+  return contextStorage.run(context, callback);
+}
+
+describe("reportProgress", () => {
+  it("queues a root report on the root stable command inbox", async () => {
+    await runWithSession(
+      {
+        auth: { current: null, initiator: null },
+        sessionId: "root",
+        turn: { id: "turn_1", sequence: 1 },
+      },
+      () => reportProgress({ callId: "call_1", message: "  Running tests\n" }),
+    );
+
+    expect(resumeHook).toHaveBeenCalledWith(
+      sessionCommandHookToken("root"),
+      expect.objectContaining({
+        kind: "progress",
+        events: [
+          expect.objectContaining({
+            entityId: "agent:root",
+            report: expect.objectContaining({ message: "Running tests" }),
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("uses framework lineage to route a nested local child to the root", async () => {
+    await runWithSession(
+      {
+        auth: { current: null, initiator: null },
+        parent: {
+          callId: "child_call",
+          rootSessionId: "root",
+          sessionId: "parent",
+          turn: { id: "parent_turn", sequence: 1 },
+        },
+        sessionId: "child",
+        turn: { id: "turn_2", sequence: 2 },
+      },
+      () => reportProgress({ callId: "call_2", message: "Checking fixtures" }),
+    );
+
+    expect(resumeHook).toHaveBeenLastCalledWith(
+      sessionCommandHookToken("root"),
+      expect.objectContaining({
+        events: [expect.objectContaining({ entityId: "agent:child" })],
+      }),
+    );
+  });
+
+  it("rejects an empty report before queueing", async () => {
+    await expect(
+      runWithSession(
+        {
+          auth: { current: null, initiator: null },
+          sessionId: "root",
+          turn: { id: "turn", sequence: 0 },
+        },
+        () => reportProgress({ callId: "call", message: " \n " }),
+      ),
+    ).rejects.toThrow("Provide a non-empty `message`.");
+  });
+});

--- a/packages/eve/src/execution/report-progress.ts
+++ b/packages/eve/src/execution/report-progress.ts
@@ -1,0 +1,48 @@
+import { loadContext } from "#context/container.js";
+import { SessionKey } from "#context/keys.js";
+import { sessionCommandHookToken } from "#execution/session-command-token.js";
+import { normalizeProgressText, type ProgressCommandV1 } from "#execution/session-progress.js";
+import { resumeHook } from "#internal/workflow/runtime.js";
+
+/**
+ * Queues an authored progress report on the root session's stable inbox.
+ *
+ * Local children already carry the root session id in framework-owned lineage,
+ * so this deliberately derives the local route instead of persisting a target.
+ */
+export async function reportProgress(input: {
+  readonly callId: string;
+  readonly message: unknown;
+}): Promise<{ readonly status: "queued" }> {
+  const message = typeof input.message === "string" ? normalizeProgressText(input.message) : "";
+  if (message === "") throw new Error("Provide a non-empty `message`.");
+
+  const session = loadContext().require(SessionKey);
+  const rootSessionId = session.parent?.rootSessionId ?? session.sessionId;
+  const id = `report:${session.sessionId}:${session.turn.id}:${input.callId}`;
+  const command: ProgressCommandV1 = {
+    commandId: id,
+    events: [
+      {
+        entityId: `agent:${session.sessionId}`,
+        eventId: id,
+        kind: "report",
+        report: { id: input.callId, message, reportedAt: new Date().toISOString() },
+        source: {
+          depth: 0,
+          id: `agent:${session.sessionId}`,
+          kind: "subagent",
+          label: "Working",
+          name: "agent",
+          parentId: session.parent === undefined ? undefined : `call:${session.parent.callId}`,
+          phase: "running",
+          turnId: session.turn.id,
+        },
+      },
+    ],
+    kind: "progress",
+    version: 1,
+  };
+  await resumeHook(sessionCommandHookToken(rootSessionId), command);
+  return { status: "queued" };
+}

--- a/packages/eve/src/execution/session-progress.test.ts
+++ b/packages/eve/src/execution/session-progress.test.ts
@@ -114,6 +114,28 @@ describe("reduceProgressCommand", () => {
     expect(next.recentActivity).toHaveLength(2);
   });
 
+  it("retains a fast report by materializing its framework-stamped source", () => {
+    const snapshot = reduce({
+      commandId: "command_1",
+      events: [
+        {
+          entityId: "agent:child",
+          eventId: "report_1",
+          kind: "report",
+          report: { id: "report_1", message: "Starting", reportedAt: turn.startedAt },
+          source: { ...entity, id: "agent:child", kind: "subagent", name: "child" },
+        },
+      ],
+      kind: "progress",
+      version: 1,
+    });
+
+    expect(snapshot.entities["agent:child"]).toMatchObject({
+      currentReport: { message: "Starting" },
+      phase: "running",
+    });
+  });
+
   it("normalizes untrusted reports and retains only the most recent activity", () => {
     const message = `  running\u0000\n${"x".repeat(MAX_PROGRESS_TEXT_LENGTH + 1)} `;
     expect(normalizeProgressText(message)).toHaveLength(MAX_PROGRESS_TEXT_LENGTH);

--- a/packages/eve/src/execution/session-progress.ts
+++ b/packages/eve/src/execution/session-progress.ts
@@ -82,6 +82,8 @@ export type ProgressEventV1 =
       readonly eventId: string;
       readonly entityId: string;
       readonly report: ProgressReportV1;
+      /** Framework-stamped fallback when a report wins its lifecycle race. */
+      readonly source?: Omit<ProgressEntityV1, "currentReport">;
     };
 
 export function createProgressSnapshot(): ProgressSnapshotV1 {
@@ -148,7 +150,7 @@ function reduceEvent(snapshot: ProgressSnapshotV1, event: ProgressEventV1): Prog
       );
     }
     case "report": {
-      const entity = snapshot.entities[event.entityId];
+      const entity = snapshot.entities[event.entityId] ?? event.source;
       if (entity === undefined || isTerminal(entity.phase)) return snapshot;
       const report = { ...event.report, message: normalizeProgressText(event.report.message) };
       return addActivity(

--- a/packages/eve/src/runtime/framework-tools/progress.ts
+++ b/packages/eve/src/runtime/framework-tools/progress.ts
@@ -1,0 +1,16 @@
+import { z } from "#compiled/zod/index.js";
+
+import { reportProgress } from "#execution/report-progress.js";
+import type { HarnessToolDefinition } from "#harness/execute-tool.js";
+
+export const REPORT_PROGRESS_TOOL_NAME = "report_progress";
+
+export const REPORT_PROGRESS_TOOL: HarnessToolDefinition = {
+  description: "Report brief current activity to the configured channel.",
+  execute: async (input: { readonly message: unknown }, options) =>
+    await reportProgress({ callId: options.toolCallId, message: input.message }),
+  inputSchema: z.strictObject({
+    message: z.string().min(1).describe("Brief description of the work currently in progress."),
+  }),
+  name: REPORT_PROGRESS_TOOL_NAME,
+};


### PR DESCRIPTION
### Summary

Related to #1673. This third draft-stack PR adds dormant local `report_progress` production without creating a runtime-action lane or remote callback protocol.

When a future root channel enables the private progress capability, root and local descendants route direct tool reports to the root session’s stable inbox using framework-owned lineage. Reports include framework-stamped source state, so an early report remains visible until structural lifecycle production lands. Current channels do not grant the capability, so the tool remains absent in production.

### Validation

Focused unit coverage verifies root and nested-local routing, input validation, early-report source materialization, reducer behavior, and capability-gated node tool construction with `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/execution/report-progress.test.ts src/execution/session-progress.test.ts src/execution/node-step.test.ts`; `pnpm --filter eve exec tsc --noEmit --pretty false` also passed.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable: the capability is not enabled by any production channel.

**Implementation** — 5 files · `+115 / -2`

Adds the direct tool executor, lineage-based local routing, conditional registration, and fallback source semantics while preserving the existing runtime-action transport.

**Tests** — 2 files · `+61 / -0`

Exercises local routing and the reducer race where an authored report arrives before a structural event.
