### PR TITLE
feat(eve): publish structural progress events

### DIFF
--- a/packages/eve/src/channel/progress-callback.test.ts
+++ b/packages/eve/src/channel/progress-callback.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { parseProgressCallback } from "#channel/progress-callback.js";
+
+describe("parseProgressCallback", () => {
+  it("accepts an absolute public callback whose path carries its token", () => {
+    expect(
+      parseProgressCallback({
+        token: "root-token",
+        url: "https://agent.example.com/eve/v1/callback/root-token",
+        version: 1,
+      }),
+    ).toEqual({
+      token: "root-token",
+      url: "https://agent.example.com/eve/v1/callback/root-token",
+      version: 1,
+    });
+  });
+
+  it("rejects mismatched tokens and reserved callback hosts", () => {
+    expect(() =>
+      parseProgressCallback({
+        token: "other-token",
+        url: "https://agent.example.com/eve/v1/callback/root-token",
+        version: 1,
+      }),
+    ).toThrow("token must match");
+    expect(() =>
+      parseProgressCallback({
+        token: "root-token",
+        url: "http://169.254.169.254/eve/v1/callback/root-token",
+        version: 1,
+      }),
+    ).toThrow("private or reserved");
+  });
+});

--- a/packages/eve/src/channel/progress-callback.ts
+++ b/packages/eve/src/channel/progress-callback.ts
@@ -1,0 +1,29 @@
+import { z } from "#compiled/zod/index.js";
+
+import type { ProgressCallbackV1 } from "#channel/types.js";
+import { createEveCallbackRoutePath } from "#protocol/routes.js";
+import { isReservedIpAddress } from "#shared/network-address.js";
+
+const schema = z
+  .object({ token: z.string().min(1), url: z.string().min(1), version: z.literal(1) })
+  .strict();
+
+export function parseProgressCallback(value: unknown): ProgressCallbackV1 | undefined {
+  if (value === undefined) return undefined;
+  const parsed = schema.safeParse(value);
+  if (!parsed.success) throw new Error("Expected progressCallback version 1.");
+  let url: URL;
+  try {
+    url = new URL(parsed.data.url);
+  } catch {
+    throw new Error("Progress callback url must be absolute.");
+  }
+  const prefix = createEveCallbackRoutePath("");
+  const token = url.pathname.slice(url.pathname.lastIndexOf(prefix) + prefix.length);
+  if (url.pathname.lastIndexOf(prefix) < 0 || decodeURIComponent(token) !== parsed.data.token) {
+    throw new Error("Progress callback url token must match callback token.");
+  }
+  if (isReservedIpAddress(url.hostname))
+    throw new Error("Progress callback url host must not be a private or reserved address.");
+  return parsed.data;
+}

--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -204,6 +204,13 @@ export type SessionCommand =
       readonly turnPolicy?: TurnPolicy;
     }
   | { readonly kind: "cancel"; readonly taskId?: string; readonly turnId?: string }
+  | {
+      /** Internal-only presentation command; authored channel APIs never create this shape. */
+      readonly kind: "progress";
+      readonly version: 1;
+      readonly commandId: string;
+      readonly events: readonly import("#execution/session-progress.js").ProgressEventV1[];
+    }
   | { readonly kind: "compact" }
   | { readonly kind: "clear" }
   | { readonly kind: "reset"; readonly reason?: string };
@@ -222,11 +229,13 @@ export type SessionCommandResult<TCommand extends SessionCommand = SessionComman
     ? SessionSendCommandResult
     : TCommand extends { readonly kind: "cancel" }
       ? CancelTurnResult
-      : TCommand extends { readonly kind: "compact" }
-        ? CompactSessionResult
-        : TCommand extends { readonly kind: "clear" }
-          ? ClearSessionResult
-          : ResetSessionResult;
+      : TCommand extends { readonly kind: "progress" }
+        ? { readonly status: "accepted" }
+        : TCommand extends { readonly kind: "compact" }
+          ? CompactSessionResult
+          : TCommand extends { readonly kind: "clear" }
+            ? ClearSessionResult
+            : ResetSessionResult;
 
 export interface DispatchContinuationInput<TCommand extends SessionCommand = SessionCommand> {
   readonly command: TCommand;
@@ -407,6 +416,8 @@ export interface SessionCapabilities {
    *    approvals and `ask_question` prompts the model has already emitted.
    */
   readonly requestInput?: boolean;
+  /** Internal channel opt-in for presentation-only progress. */
+  readonly progress?: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -380,6 +380,12 @@ export type HookPayload =
  * terminal session result. Conversation sessions use this as their first turn's
  * caller; each continuation supplies the caller for that turn.
  */
+export interface ProgressCallbackV1 {
+  readonly token: string;
+  readonly url: string;
+  readonly version: 1;
+}
+
 export interface SessionCallback {
   readonly callId: string;
   readonly subagentName: string;
@@ -465,6 +471,7 @@ export interface RunInput {
    * the caller for their own turn.
    */
   readonly callback?: SessionCallback;
+  readonly progressCallback?: ProgressCallbackV1;
   /**
    * Session continuation token for delivery and hook creation. Channels can
    * re-key the session during the first turn via

--- a/packages/eve/src/context/keys.ts
+++ b/packages/eve/src/context/keys.ts
@@ -9,6 +9,7 @@ import type { LanguageModel, ModelMessage, SystemModelMessage } from "ai";
 import type { JsonObject } from "#shared/json.js";
 import type {
   ChannelInstrumentationProjection,
+  ProgressCallbackV1,
   ChannelDeliveryMetadata,
   SessionAuthContext,
   SessionCallback,
@@ -98,6 +99,7 @@ export const SubagentDepthKey = new ContextKey<number>("eve.subagentDepth");
  * dispatch so HITL readiness flows through a conversation chain.
  */
 export const CapabilitiesKey = new ContextKey<SessionCapabilities>("eve.capabilities");
+export const ProgressCallbackKey = new ContextKey<ProgressCallbackV1>("eve.progressCallback");
 
 /**
  * Optional framework-owned caller callback captured when the session is created.

--- a/packages/eve/src/execution/dispatch-runtime-actions-shared.ts
+++ b/packages/eve/src/execution/dispatch-runtime-actions-shared.ts
@@ -17,6 +17,7 @@ import {
   AuthKey,
   CapabilitiesKey,
   ChannelInstrumentationKey,
+  ProgressCallbackKey,
   InitiatorAuthKey,
   SandboxKey,
 } from "#context/keys.js";
@@ -154,6 +155,7 @@ export interface PreparedRuntimeActionDispatch {
   readonly fanoutSize: number;
   readonly initiatorAuth: Parameters<typeof buildSubagentRunInput>[0]["initiatorAuth"];
   readonly parentTraceContext: Parameters<typeof buildSubagentRunInput>[0]["parentTraceContext"];
+  readonly progressCallback?: import("#channel/types.js").ProgressCallbackV1;
   readonly sandboxSessionId: string;
   readonly serializedContext: Record<string, unknown>;
   readonly plan: readonly DispatchPlanEntry[];
@@ -232,6 +234,7 @@ export async function prepareRuntimeActionDispatch(input: {
     initiatorAuth: ctx.get(InitiatorAuthKey) ?? null,
     parentTraceContext: readSessionTraceContext(input.serializedContext, session.sessionId),
     plan,
+    progressCallback: ctx.get(ProgressCallbackKey),
     sandboxSessionId,
     serializedContext: input.serializedContext,
     session,
@@ -495,6 +498,7 @@ export async function startSubagent(input: {
   readonly parentContinuationToken: string | undefined;
   readonly parentTraceContext: Parameters<typeof buildSubagentRunInput>[0]["parentTraceContext"];
   readonly persistentSessions: boolean;
+  readonly progressCallback?: import("#channel/types.js").ProgressCallbackV1;
   readonly sandboxSessionId: string;
   readonly serializedContext: Record<string, unknown>;
   readonly session: RuntimeSession;
@@ -525,6 +529,7 @@ export async function startSubagent(input: {
         parentContinuationToken: input.parentContinuationToken,
         parentTraceContext,
         persistentSessions: input.persistentSessions,
+        progressCallback: input.progressCallback,
         sandboxSessionId: input.sandboxSessionId,
         session: input.session,
         source: input.target.source,
@@ -537,12 +542,14 @@ export async function startSubagent(input: {
         batchEvent: input.batchEvent,
         bundle: input.bundle,
         callbackBaseUrl: input.callbackBaseUrl,
+        capabilities: input.capabilities,
         currentSession: input.currentSession,
         dynamicRemoteAgent: input.target.dynamicRemoteAgent,
         initiatorAuth: input.initiatorAuth,
         parentContinuationToken: input.parentContinuationToken,
         parentTraceContext,
         persistentSessions: input.persistentSessions,
+        progressCallback: input.progressCallback,
         session: input.session,
         taskOwned: input.taskOwned,
       });

--- a/packages/eve/src/execution/parked-delivery-wait.test.ts
+++ b/packages/eve/src/execution/parked-delivery-wait.test.ts
@@ -166,6 +166,30 @@ describe("nextTurnDelivery", () => {
     ]);
   });
 
+  it("handles progress while parked without routing or starting a turn", async () => {
+    const handleProgress = vi.fn().mockResolvedValue(undefined);
+    const inbox = createMockInbox([
+      {
+        result: {
+          done: false,
+          value: { commandId: "progress_1", events: [], kind: "progress", version: 1 },
+        },
+        source: "session",
+      },
+      { result: { done: true, value: undefined }, source: "session" },
+    ]);
+
+    const next = await nextTurnDelivery({
+      ...waitInput(inbox),
+      awaitAuthorizationCallbacks: false,
+      progressHandler: { handleProgress },
+    });
+
+    expect(next).toEqual({ kind: "closed" });
+    expect(handleProgress).toHaveBeenCalledOnce();
+    expect(routeDeliverToChildren).not.toHaveBeenCalled();
+  });
+
   it("reports a closed authorization hook", async () => {
     const inbox = createMockInbox([
       { result: { done: true, value: undefined }, source: "authorization" },

--- a/packages/eve/src/execution/parked-delivery-wait.ts
+++ b/packages/eve/src/execution/parked-delivery-wait.ts
@@ -1,6 +1,7 @@
 import type { DeliverHookPayload, DeliverPayload } from "#channel/types.js";
 import { routeDeliverToChildren } from "#execution/route-child-delivery.js";
 import type { SessionCommandInbox } from "#execution/session-command-inbox.js";
+import type { SessionProgressHandler } from "#execution/session-progress.js";
 import type { SessionStateCursor } from "#execution/session-state-cursor.js";
 import { reportDroppedWirePayloadStep } from "#execution/report-dropped-wire-payload-step.js";
 import {
@@ -67,6 +68,7 @@ export async function nextTurnDelivery(input: {
   readonly commandInbox: SessionCommandInbox;
   readonly deferDeliveries?: boolean;
   readonly driverWritable: WritableStream<Uint8Array>;
+  readonly progressHandler?: SessionProgressHandler;
   readonly seenTaskDeliveries?: Set<string>;
   readonly stateCursor: SessionStateCursor;
 }): Promise<NextTurnInstruction> {
@@ -89,6 +91,7 @@ async function awaitNextTurnDelivery(input: {
   readonly commandInbox: SessionCommandInbox;
   readonly deferDeliveries?: boolean;
   readonly driverWritable: WritableStream<Uint8Array>;
+  readonly progressHandler?: SessionProgressHandler;
   readonly seenTaskDeliveries?: Set<string>;
   readonly stateCursor: SessionStateCursor;
 }): Promise<NextTurnInstruction> {
@@ -101,6 +104,7 @@ async function awaitNextTurnDelivery(input: {
       cancelledTaskIds,
       commandInbox: input.commandInbox,
       deferDeliveries: input.deferDeliveries,
+      progressHandler: input.progressHandler,
       seenTaskDeliveries,
     });
 
@@ -144,6 +148,7 @@ async function waitForNextSessionAction(input: {
   readonly cancelledTaskIds: Set<string>;
   readonly commandInbox: SessionCommandInbox;
   readonly deferDeliveries?: boolean;
+  readonly progressHandler?: SessionProgressHandler;
   readonly seenTaskDeliveries: Set<string>;
 }): Promise<NextSessionAction> {
   const pendingSessionControl = input.bufferedSessionControls.shift();
@@ -221,6 +226,11 @@ async function waitForNextSessionAction(input: {
         );
         input.bufferedDeliveries.splice(0, input.bufferedDeliveries.length, ...kept);
       }
+      continue;
+    }
+
+    if (decoded.kind === "progress") {
+      await input.progressHandler?.handleProgress(decoded);
       continue;
     }
 

--- a/packages/eve/src/execution/remote-agent-dispatch.ts
+++ b/packages/eve/src/execution/remote-agent-dispatch.ts
@@ -52,6 +52,7 @@ export async function startRemoteAgentSession(input: {
   readonly auth?: SessionAuthContext | null;
   readonly callbackBaseUrl: string | undefined;
   readonly callbackToken?: string;
+  readonly progressCallback?: import("#channel/types.js").ProgressCallbackV1;
   /** The root initiator's principal, forwarded alongside {@link auth}. */
   readonly initiatorAuth?: SessionAuthContext | null;
   /**
@@ -89,6 +90,7 @@ export async function startRemoteAgentSession(input: {
       url: string;
     };
     forwardedPrincipal?: ForwardedPrincipal;
+    progressCallback?: import("#channel/types.js").ProgressCallbackV1;
     message: string;
     mode: "conversation" | "task";
     operationId?: string;
@@ -114,6 +116,7 @@ export async function startRemoteAgentSession(input: {
     outputSchema:
       normalizeRequestedOutputSchema(input.action.input.outputSchema) ?? input.remote.outputSchema,
   };
+  if (input.progressCallback !== undefined) requestBody.progressCallback = input.progressCallback;
   if (forwardedPrincipal !== undefined) {
     requestBody.forwardedPrincipal = forwardedPrincipal;
   }

--- a/packages/eve/src/execution/runtime-context.ts
+++ b/packages/eve/src/execution/runtime-context.ts
@@ -13,6 +13,7 @@ import {
   ModeKey,
   ParentSessionKey,
   ParentTraceContextKey,
+  ProgressCallbackKey,
   SessionCallbackKey,
   SubagentDepthKey,
 } from "#context/keys.js";
@@ -65,9 +66,8 @@ export function buildRunContext(input: {
     ctx.set(ChannelDeliveryKey, run.delivery);
   }
 
-  if (run.callback !== undefined) {
-    ctx.set(SessionCallbackKey, run.callback);
-  }
+  if (run.callback !== undefined) ctx.set(SessionCallbackKey, run.callback);
+  if (run.progressCallback !== undefined) ctx.set(ProgressCallbackKey, run.progressCallback);
 
   if (run.parent !== undefined) {
     ctx.set(ParentSessionKey, run.parent);

--- a/packages/eve/src/execution/session-callback-request.ts
+++ b/packages/eve/src/execution/session-callback-request.ts
@@ -3,6 +3,7 @@ const SESSION_CALLBACK_TIMEOUT_MS = 30_000;
 /** Posts one framework callback payload with the shared callback transport policy. */
 export async function postSessionCallbackRequest(input: {
   readonly body: unknown;
+  readonly timeoutMs?: number;
   readonly url: string;
 }): Promise<Response> {
   return await fetch(input.url, {
@@ -15,6 +16,6 @@ export async function postSessionCallbackRequest(input: {
     // 3xx-bounce the framework to an internal/metadata address after the
     // path/token check has already passed.
     redirect: "error",
-    signal: AbortSignal.timeout(SESSION_CALLBACK_TIMEOUT_MS),
+    signal: AbortSignal.timeout(input.timeoutMs ?? SESSION_CALLBACK_TIMEOUT_MS),
   });
 }

--- a/packages/eve/src/execution/session-progress-renderer-step.test.ts
+++ b/packages/eve/src/execution/session-progress-renderer-step.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { createProgressSnapshot } from "#execution/session-progress.js";
+import { renderSessionProgressStep } from "#execution/session-progress-renderer-step.js";
+
+describe("renderSessionProgressStep", () => {
+  it("returns driver-owned state independently of turn context", async () => {
+    const snapshot = createProgressSnapshot();
+    await expect(renderSessionProgressStep({ previousRenderCount: 2, snapshot })).resolves.toEqual({
+      renderCount: 3,
+      snapshot,
+    });
+  });
+});

--- a/packages/eve/src/execution/session-progress-renderer-step.ts
+++ b/packages/eve/src/execution/session-progress-renderer-step.ts
@@ -1,0 +1,15 @@
+import type { ProgressSnapshotV1 } from "#execution/session-progress.js";
+
+export interface SessionProgressRenderState {
+  readonly renderCount: number;
+  readonly snapshot: ProgressSnapshotV1;
+}
+
+/** Test-only presentation boundary used to prove driver-owned progress state. */
+export async function renderSessionProgressStep(input: {
+  readonly previousRenderCount: number;
+  readonly snapshot: ProgressSnapshotV1;
+}): Promise<SessionProgressRenderState> {
+  "use step";
+  return { renderCount: input.previousRenderCount + 1, snapshot: input.snapshot };
+}

--- a/packages/eve/src/execution/session-progress.test.ts
+++ b/packages/eve/src/execution/session-progress.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createProgressSnapshot,
+  MAX_PROGRESS_DEDUPLICATION_IDS,
+  MAX_PROGRESS_ENTITIES,
+  MAX_PROGRESS_EVENTS_PER_COMMAND,
+  MAX_PROGRESS_TEXT_LENGTH,
+  normalizeProgressText,
+  parseProgressCommandV1,
+  reduceProgressCommand,
+  type ProgressCommandV1,
+} from "#execution/session-progress.js";
+
+const turn = {
+  id: "turn:root:one",
+  phase: "running" as const,
+  sequence: 0,
+  startedAt: "2026-08-19T12:00:00.000Z",
+};
+
+function command(events: ProgressCommandV1["events"], commandId = "command_1") {
+  return { commandId, events, kind: "progress" as const, version: 1 as const };
+}
+
+describe("reduceProgressCommand", () => {
+  it("reduces turn and entity lifecycle", () => {
+    const snapshot = reduceProgressCommand(
+      createProgressSnapshot(),
+      command([
+        { eventId: "turn-start", kind: "turn", turn },
+        {
+          entity: {
+            id: "action:root:call_1",
+            kind: "tool",
+            label: "Search issues",
+            phase: "running",
+            turnId: turn.id,
+          },
+          eventId: "tool-start",
+          kind: "entity",
+        },
+      ]),
+    );
+
+    expect(snapshot.revision).toBe(1);
+    expect(snapshot.turns[turn.id]).toEqual(turn);
+    expect(snapshot.entities["action:root:call_1"]).toMatchObject({
+      label: "Search issues",
+      phase: "running",
+    });
+  });
+
+  it("deduplicates replayed commands and events", () => {
+    const first = command([{ eventId: "turn-start", kind: "turn", turn }]);
+    const once = reduceProgressCommand(createProgressSnapshot(), first);
+
+    expect(reduceProgressCommand(once, first)).toBe(once);
+    expect(reduceProgressCommand(once, command(first.events, "command_2")).revision).toBe(1);
+  });
+
+  it.each(["completed", "failed", "cancelled"] as const)(
+    "settles remaining turn entities when the turn is %s",
+    (phase) => {
+      const active = reduceProgressCommand(
+        createProgressSnapshot(),
+        command([
+          { eventId: "turn-start", kind: "turn", turn },
+          {
+            entity: {
+              id: "detached-parent-action",
+              kind: "subagent",
+              label: "Background worker",
+              phase: "running",
+              turnId: turn.id,
+            },
+            eventId: "action-start",
+            kind: "entity",
+          },
+        ]),
+      );
+      const settled = reduceProgressCommand(
+        active,
+        command(
+          [
+            {
+              eventId: `turn-${phase}`,
+              kind: "turn",
+              turn: { ...turn, phase, settledAt: turn.startedAt },
+            },
+          ],
+          `command-${phase}`,
+        ),
+      );
+
+      expect(settled.entities["detached-parent-action"]?.phase).toBe(phase);
+    },
+  );
+
+  it("rejects late running entities owned by a terminal turn", () => {
+    const settled = reduceProgressCommand(
+      createProgressSnapshot(),
+      command([
+        { eventId: "turn-start", kind: "turn", turn },
+        {
+          eventId: "turn-end",
+          kind: "turn",
+          turn: { ...turn, phase: "completed", settledAt: turn.startedAt },
+        },
+      ]),
+    );
+    const late = reduceProgressCommand(
+      settled,
+      command(
+        [
+          {
+            entity: {
+              id: "late-tool",
+              kind: "tool",
+              label: "Late work",
+              phase: "running",
+              turnId: turn.id,
+            },
+            eventId: "late-tool",
+            kind: "entity",
+          },
+        ],
+        "late-command",
+      ),
+    );
+
+    expect(late.entities["late-tool"]).toBeUndefined();
+    expect(late.revision).toBe(settled.revision);
+  });
+
+  it("does not reopen terminal lifecycle", () => {
+    const settled = reduceProgressCommand(
+      createProgressSnapshot(),
+      command([
+        { eventId: "turn-start", kind: "turn", turn },
+        {
+          eventId: "turn-end",
+          kind: "turn",
+          turn: { ...turn, phase: "completed", settledAt: "2026-08-19T12:00:01.000Z" },
+        },
+      ]),
+    );
+    const next = reduceProgressCommand(
+      settled,
+      command([{ eventId: "late", kind: "turn", turn }], "late-command"),
+    );
+
+    expect(next.turns[turn.id]?.phase).toBe("completed");
+  });
+
+  it("advances revision after event deduplication reaches capacity", () => {
+    let snapshot = createProgressSnapshot();
+    for (let index = 0; index < MAX_PROGRESS_DEDUPLICATION_IDS; index += 1) {
+      snapshot = reduceProgressCommand(
+        snapshot,
+        command(
+          [
+            {
+              entity: {
+                id: "tool",
+                kind: "tool",
+                label: `Update ${String(index)}`,
+                phase: "running",
+                turnId: turn.id,
+              },
+              eventId: `event_${String(index)}`,
+              kind: "entity",
+            },
+          ],
+          `command_${String(index)}`,
+        ),
+      );
+    }
+    const revision = snapshot.revision;
+    const next = reduceProgressCommand(
+      snapshot,
+      command(
+        [
+          {
+            entity: {
+              id: "tool",
+              kind: "tool",
+              label: "After saturation",
+              phase: "running",
+              turnId: turn.id,
+            },
+            eventId: "event_after_saturation",
+            kind: "entity",
+          },
+        ],
+        "command_after_saturation",
+      ),
+    );
+
+    expect(next.revision).toBe(revision + 1);
+    expect(next.entities["tool"]?.label).toBe("After saturation");
+    expect(next.seenEventIds).toHaveLength(MAX_PROGRESS_DEDUPLICATION_IDS);
+  });
+
+  it("validates the complete progress wire vocabulary", () => {
+    expect(
+      parseProgressCommandV1(command([{ eventId: "turn", kind: "turn", turn }])),
+    ).toBeDefined();
+    expect(
+      parseProgressCommandV1(
+        command([
+          {
+            entity: {
+              id: "tool",
+              kind: "future-invalid-kind" as "tool",
+              label: "Working",
+              phase: "unknown" as "running",
+              turnId: turn.id,
+            },
+            eventId: "invalid",
+            kind: "entity",
+          },
+        ]),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("bounds command and event deduplication", () => {
+    let snapshot = createProgressSnapshot();
+    for (let index = 0; index <= MAX_PROGRESS_DEDUPLICATION_IDS; index += 1) {
+      snapshot = reduceProgressCommand(
+        snapshot,
+        command(
+          [
+            {
+              entity: {
+                id: `tool_${String(index)}`,
+                kind: "tool",
+                label: "Working",
+                phase: "running",
+                turnId: turn.id,
+              },
+              eventId: `event_${String(index)}`,
+              kind: "entity",
+            },
+          ],
+          `command_${String(index)}`,
+        ),
+      );
+    }
+
+    expect(snapshot.seenCommandIds).toHaveLength(MAX_PROGRESS_DEDUPLICATION_IDS);
+    expect(snapshot.seenEventIds).toHaveLength(MAX_PROGRESS_DEDUPLICATION_IDS);
+  });
+
+  it("bounds entities and events accepted from one command", () => {
+    const events = Array.from(
+      { length: MAX_PROGRESS_ENTITIES + MAX_PROGRESS_EVENTS_PER_COMMAND },
+      (_, index) => ({
+        entity: {
+          id: `tool_${String(index)}`,
+          kind: "tool" as const,
+          label: "Working",
+          phase: "running" as const,
+          turnId: turn.id,
+        },
+        eventId: `event_${String(index)}`,
+        kind: "entity" as const,
+      }),
+    );
+    let snapshot = createProgressSnapshot();
+    for (let offset = 0; offset < events.length; offset += MAX_PROGRESS_EVENTS_PER_COMMAND) {
+      snapshot = reduceProgressCommand(
+        snapshot,
+        command(events.slice(offset, offset + MAX_PROGRESS_EVENTS_PER_COMMAND), `batch_${offset}`),
+      );
+    }
+    expect(Object.keys(snapshot.entities)).toHaveLength(MAX_PROGRESS_ENTITIES);
+
+    const oneCommand = reduceProgressCommand(
+      createProgressSnapshot(),
+      command(events, "oversized"),
+    );
+    expect(Object.keys(oneCommand.entities)).toHaveLength(MAX_PROGRESS_EVENTS_PER_COMMAND);
+  });
+
+  it("normalizes bounded untrusted text at the reducer boundary", () => {
+    const message = `  one\n\ttwo\u0000 ${"x".repeat(MAX_PROGRESS_TEXT_LENGTH)} `;
+    expect(normalizeProgressText(message)).toHaveLength(MAX_PROGRESS_TEXT_LENGTH);
+    expect(normalizeProgressText(message)).not.toMatch(/[\u0000-\u001F\u007F]/);
+    const snapshot = reduceProgressCommand(
+      createProgressSnapshot(),
+      command([
+        {
+          entity: {
+            id: "tool",
+            kind: "tool",
+            label: message,
+            phase: "running",
+            turnId: turn.id,
+          },
+          eventId: "untrusted",
+          kind: "entity",
+        },
+      ]),
+    );
+    expect(snapshot.entities["tool"]?.label).toBe(normalizeProgressText(message));
+  });
+});

--- a/packages/eve/src/execution/session-progress.ts
+++ b/packages/eve/src/execution/session-progress.ts
@@ -1,0 +1,235 @@
+import { z } from "#compiled/zod/index.js";
+
+export const MAX_PROGRESS_DEDUPLICATION_IDS = 1_000;
+export const MAX_PROGRESS_ENTITIES = 500;
+export const MAX_PROGRESS_EVENTS_PER_COMMAND = 100;
+export const MAX_PROGRESS_TEXT_LENGTH = 500;
+export const MAX_PROGRESS_TURNS = 100;
+
+export type ProgressPhase = "queued" | "running" | "blocked" | "completed" | "failed" | "cancelled";
+
+type TerminalProgressPhase = Extract<ProgressPhase, "completed" | "failed" | "cancelled">;
+
+export interface ProgressTurnV1 {
+  readonly id: string;
+  readonly sequence: number;
+  readonly phase: ProgressPhase;
+  readonly startedAt: string;
+  readonly settledAt?: string;
+}
+
+export interface ProgressEntityV1 {
+  readonly id: string;
+  readonly turnId: string;
+  readonly kind: "tool" | "subagent" | "remote-agent" | "skill" | "blocker";
+  readonly label: string;
+  readonly phase: ProgressPhase;
+}
+
+/** Complete bounded status state owned by the session driver. */
+export interface ProgressSnapshotV1 {
+  readonly version: 1;
+  readonly revision: number;
+  readonly turns: Readonly<Record<string, ProgressTurnV1>>;
+  readonly entities: Readonly<Record<string, ProgressEntityV1>>;
+  readonly seenCommandIds: readonly string[];
+  readonly seenEventIds: readonly string[];
+}
+
+/** Driver-owned presentation boundary; renderers receive no turn or channel context. */
+export interface SessionProgressHandler {
+  handleProgress(command: ProgressCommandV1): Promise<void>;
+}
+
+export interface ProgressCommandV1 {
+  readonly kind: "progress";
+  readonly version: 1;
+  readonly commandId: string;
+  readonly events: readonly ProgressEventV1[];
+}
+
+export type ProgressEventV1 =
+  | {
+      readonly kind: "turn";
+      readonly eventId: string;
+      readonly turn: ProgressTurnV1;
+    }
+  | {
+      readonly kind: "entity";
+      readonly eventId: string;
+      readonly entity: ProgressEntityV1;
+    };
+
+const progressPhaseSchema = z.enum([
+  "queued",
+  "running",
+  "blocked",
+  "completed",
+  "failed",
+  "cancelled",
+]);
+const progressTurnSchema = z
+  .object({
+    id: z.string().min(1),
+    phase: progressPhaseSchema,
+    sequence: z.number().int().nonnegative(),
+    settledAt: z.string().optional(),
+    startedAt: z.string().min(1),
+  })
+  .strict();
+const progressEntitySchema = z
+  .object({
+    id: z.string().min(1),
+    kind: z.enum(["tool", "subagent", "remote-agent", "skill", "blocker"]),
+    label: z.string(),
+    phase: progressPhaseSchema,
+    turnId: z.string().min(1),
+  })
+  .strict();
+export const progressCommandV1Schema = z
+  .object({
+    commandId: z.string().min(1),
+    events: z
+      .array(
+        z.discriminatedUnion("kind", [
+          z
+            .object({
+              eventId: z.string().min(1),
+              kind: z.literal("turn"),
+              turn: progressTurnSchema,
+            })
+            .strict(),
+          z
+            .object({
+              entity: progressEntitySchema,
+              eventId: z.string().min(1),
+              kind: z.literal("entity"),
+            })
+            .strict(),
+        ]),
+      )
+      .max(MAX_PROGRESS_EVENTS_PER_COMMAND),
+    kind: z.literal("progress"),
+    version: z.literal(1),
+  })
+  .strict();
+
+export function parseProgressCommandV1(value: unknown): ProgressCommandV1 | undefined {
+  const parsed = progressCommandV1Schema.safeParse(value);
+  return parsed.success ? (parsed.data as ProgressCommandV1) : undefined;
+}
+
+export function progressTurnId(sessionId: string, turnId: string): string {
+  return `turn:${sessionId}:${turnId}`;
+}
+
+export function progressActionId(sessionId: string, callId: string): string {
+  return `action:${sessionId}:${callId}`;
+}
+
+export function createProgressSnapshot(): ProgressSnapshotV1 {
+  return {
+    entities: {},
+    revision: 0,
+    seenCommandIds: [],
+    seenEventIds: [],
+    turns: {},
+    version: 1,
+  };
+}
+
+/** Applies a progress command exactly once while keeping terminal state monotonic. */
+export function reduceProgressCommand(
+  snapshot: ProgressSnapshotV1,
+  command: ProgressCommandV1,
+): ProgressSnapshotV1 {
+  if (snapshot.seenCommandIds.includes(command.commandId)) return snapshot;
+
+  let next: ProgressSnapshotV1 = {
+    ...snapshot,
+    seenCommandIds: appendBounded(snapshot.seenCommandIds, command.commandId),
+  };
+  let stateChanged = false;
+  for (const event of command.events.slice(0, MAX_PROGRESS_EVENTS_PER_COMMAND)) {
+    if (next.seenEventIds.includes(event.eventId)) continue;
+    const reduced = reduceEvent(next, event);
+    if (reduced !== next) stateChanged = true;
+    next = {
+      ...reduced,
+      seenEventIds: appendBounded(reduced.seenEventIds, event.eventId),
+    };
+  }
+  return stateChanged ? { ...next, revision: next.revision + 1 } : next;
+}
+
+function reduceEvent(snapshot: ProgressSnapshotV1, event: ProgressEventV1): ProgressSnapshotV1 {
+  if (event.kind === "turn") {
+    const current = snapshot.turns[event.turn.id];
+    if (current !== undefined && isTerminal(current.phase)) return snapshot;
+    const turn =
+      current === undefined ? event.turn : { ...event.turn, startedAt: current.startedAt };
+    const entities = isTerminal(turn.phase)
+      ? settleTurnEntities(snapshot.entities, turn.id, turn.phase)
+      : snapshot.entities;
+    return {
+      ...snapshot,
+      entities,
+      turns: appendBoundedRecord(snapshot.turns, turn.id, turn, MAX_PROGRESS_TURNS),
+    };
+  }
+
+  const owner = snapshot.turns[event.entity.turnId];
+  if (owner !== undefined && isTerminal(owner.phase)) return snapshot;
+  const current = snapshot.entities[event.entity.id];
+  if (current !== undefined && isTerminal(current.phase)) return snapshot;
+  const incoming = { ...event.entity, label: normalizeProgressText(event.entity.label) };
+  const entity = current === undefined ? incoming : { ...current, ...incoming };
+  return {
+    ...snapshot,
+    entities: appendBoundedRecord(snapshot.entities, entity.id, entity, MAX_PROGRESS_ENTITIES),
+  };
+}
+
+function settleTurnEntities(
+  entities: ProgressSnapshotV1["entities"],
+  turnId: string,
+  phase: TerminalProgressPhase,
+): ProgressSnapshotV1["entities"] {
+  let next: Record<string, ProgressEntityV1> | undefined;
+  for (const [id, entity] of Object.entries(entities)) {
+    if (entity.turnId !== turnId || isTerminal(entity.phase)) continue;
+    next ??= { ...entities };
+    next[id] = { ...entity, phase };
+  }
+  return next ?? entities;
+}
+
+function appendBoundedRecord<T>(
+  values: Readonly<Record<string, T>>,
+  key: string,
+  value: T,
+  max: number,
+): Readonly<Record<string, T>> {
+  const next = { ...values, [key]: value };
+  const overflow = Object.keys(next).length - max;
+  if (overflow <= 0) return next;
+  for (const oldKey of Object.keys(next).slice(0, overflow)) delete next[oldKey];
+  return next;
+}
+
+function isTerminal(phase: ProgressPhase): phase is TerminalProgressPhase {
+  return phase === "completed" || phase === "failed" || phase === "cancelled";
+}
+
+function appendBounded<T>(items: readonly T[], item: T): readonly T[] {
+  return [...items, item].slice(-MAX_PROGRESS_DEDUPLICATION_IDS);
+}
+
+/** Collapses control characters and whitespace before untrusted text reaches a renderer. */
+export function normalizeProgressText(text: string): string {
+  return text
+    .replace(/[\u0000-\u001F\u007F]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, MAX_PROGRESS_TEXT_LENGTH);
+}

--- a/packages/eve/src/execution/structural-progress.test.ts
+++ b/packages/eve/src/execution/structural-progress.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ContextContainer } from "#context/container.js";
+import { CapabilitiesKey, SessionKey, type Session } from "#context/keys.js";
+import { sessionCommandHookToken } from "#execution/session-command-token.js";
+import { createProgressSnapshot, reduceProgressCommand } from "#execution/session-progress.js";
+import {
+  projectStructuralProgress,
+  publishStructuralProgress,
+} from "#execution/structural-progress.js";
+import { resumeHook } from "#internal/workflow/runtime.js";
+import type { MessageStreamEvent } from "#protocol/message.js";
+
+vi.mock("#compiled/@workflow/core/runtime.js", () => ({ resumeHook: vi.fn() }));
+
+const root: Session = {
+  auth: { current: null, initiator: null },
+  sessionId: "root",
+  turn: { id: "turn_2", sequence: 2 },
+};
+
+type EventDataByType = {
+  [TEvent in MessageStreamEvent as TEvent["type"]]: TEvent extends { data: infer TData }
+    ? TData
+    : never;
+};
+
+function stamped<T extends MessageStreamEvent["type"]>(
+  type: T,
+  data: EventDataByType[T],
+  id: string,
+): MessageStreamEvent {
+  return { data, meta: { at: "2026-08-19T12:00:00.000Z", id }, type } as MessageStreamEvent;
+}
+
+describe("projectStructuralProgress", () => {
+  it("projects turn and tool lifecycle with session-qualified identities", () => {
+    const commands = [
+      projectStructuralProgress(root, stamped("turn.started", { sequence: 2, turnId: "t2" }, "1")),
+      projectStructuralProgress(
+        root,
+        stamped(
+          "actions.requested",
+          {
+            actions: [{ callId: "c1", input: {}, kind: "tool-call", toolName: "search" }],
+            sequence: 2,
+            stepIndex: 0,
+            turnId: "t2",
+          },
+          "2",
+        ),
+      ),
+      projectStructuralProgress(
+        root,
+        stamped(
+          "action.result",
+          {
+            result: { callId: "c1", kind: "tool-result", output: "done", toolName: "search" },
+            sequence: 2,
+            status: "completed",
+            stepIndex: 0,
+            turnId: "t2",
+          },
+          "3",
+        ),
+      ),
+    ];
+    let snapshot = createProgressSnapshot();
+    for (const command of commands) snapshot = reduceProgressCommand(snapshot, command!);
+
+    expect(snapshot.turns["turn:root:t2"]?.phase).toBe("running");
+    expect(snapshot.entities["action:root:c1"]).toMatchObject({
+      kind: "tool",
+      label: "search",
+      phase: "completed",
+    });
+  });
+
+  it("settles the parent action when delegation detaches into a background task", () => {
+    const command = projectStructuralProgress(
+      root,
+      stamped(
+        "action.result",
+        {
+          result: {
+            backgroundTask: { status: "working", taskId: "task_1" },
+            callId: "child_call",
+            kind: "subagent-result",
+            origin: "child",
+            outcome: {
+              kind: "parked",
+              result: { kind: "succeeded", output: "delegated" },
+              usageDelta: {
+                cacheReadTokens: 0,
+                cacheWriteTokens: 0,
+                inputTokens: 0,
+                outputTokens: 0,
+              },
+            },
+            output: "working",
+            subagentName: "worker",
+          },
+          sequence: 2,
+          status: "completed",
+          stepIndex: 0,
+          turnId: "t2",
+        },
+        "background-receipt",
+      ),
+    );
+
+    expect(command?.events[0]).toMatchObject({
+      entity: { id: "action:root:child_call", phase: "completed" },
+    });
+  });
+
+  it("projects blockers but excludes narration and output", () => {
+    const blocked = projectStructuralProgress(
+      root,
+      stamped(
+        "input.requested",
+        {
+          requests: [
+            {
+              action: { callId: "c1", input: {}, kind: "tool-call", toolName: "deploy" },
+              kind: "tool-approval",
+              prompt: "Approve deployment?",
+              requestId: "r1",
+            },
+          ],
+          sequence: 2,
+          stepIndex: 0,
+          turnId: "t2",
+        },
+        "block",
+      ),
+    );
+    expect(blocked?.events[0]).toMatchObject({
+      entity: { kind: "blocker", label: "Approve deployment?", phase: "blocked" },
+    });
+    expect(
+      projectStructuralProgress(
+        root,
+        stamped(
+          "message.appended",
+          {
+            messageDelta: "secret",
+            messageSoFar: "secret",
+            sequence: 2,
+            stepIndex: 0,
+            turnId: "t2",
+          },
+          "delta",
+        ),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("publishes only when the root channel enables progress", async () => {
+    const context = new ContextContainer();
+    context.set(SessionKey, root);
+    const event = stamped("turn.started", { sequence: 2, turnId: "t2" }, "publish");
+
+    await publishStructuralProgress(context, event);
+    expect(resumeHook).not.toHaveBeenCalled();
+    context.set(CapabilitiesKey, { progress: true });
+    await publishStructuralProgress(context, event);
+    expect(resumeHook).toHaveBeenCalledWith(
+      sessionCommandHookToken("root"),
+      expect.objectContaining({ kind: "progress" }),
+    );
+  });
+});

--- a/packages/eve/src/execution/structural-progress.ts
+++ b/packages/eve/src/execution/structural-progress.ts
@@ -1,0 +1,222 @@
+import type { ContextContainer } from "#context/container.js";
+import { CapabilitiesKey, SessionKey, type Session } from "#context/keys.js";
+import { submitProgressCommand } from "#execution/submit-progress.js";
+import {
+  normalizeProgressText,
+  progressActionId,
+  progressTurnId,
+  type ProgressCommandV1,
+  type ProgressEntityV1,
+  type ProgressEventV1,
+  type ProgressPhase,
+} from "#execution/session-progress.js";
+import type { MessageStreamEvent } from "#protocol/message.js";
+import type { RuntimeActionRequest, RuntimeActionResult } from "#runtime/actions/types.js";
+
+/** Projects one durable lifecycle event into compact status state. */
+export function projectStructuralProgress(
+  session: Session,
+  event: MessageStreamEvent,
+): ProgressCommandV1 | undefined {
+  const events = projectEvents(session, event);
+  if (events.length === 0) return undefined;
+  return {
+    commandId: `structural:${session.sessionId}:${event.meta.id}`,
+    events,
+    kind: "progress",
+    version: 1,
+  };
+}
+
+/** Best-effort observer used only by progress-enabled sessions. */
+export async function publishStructuralProgress(
+  ctx: ContextContainer,
+  event: MessageStreamEvent,
+): Promise<void> {
+  if (ctx.get(CapabilitiesKey)?.progress !== true) return;
+  const session = ctx.require(SessionKey);
+  const command = projectStructuralProgress(session, event);
+  if (command === undefined) return;
+
+  try {
+    await submitProgressCommand(ctx, command, { remoteTimeoutMs: 1_000 });
+  } catch {
+    // Presentation cannot fail the agent's actual work.
+  }
+}
+
+function projectEvents(session: Session, event: MessageStreamEvent): readonly ProgressEventV1[] {
+  switch (event.type) {
+    case "turn.started":
+      return [
+        {
+          eventId: eventId(session, event),
+          kind: "turn",
+          turn: {
+            id: progressTurnId(session.sessionId, event.data.turnId),
+            phase: "running",
+            sequence: event.data.sequence,
+            startedAt: event.meta.at,
+          },
+        },
+      ];
+    case "turn.completed":
+      return [turnSettlement(session, event, "completed")];
+    case "turn.failed":
+      return [turnSettlement(session, event, "failed")];
+    case "turn.cancelled":
+      return [turnSettlement(session, event, "cancelled")];
+    case "actions.requested":
+      return event.data.actions.map((action) => ({
+        entity: actionEntity(session, event.data.turnId, action, "running"),
+        eventId: eventId(session, event, action.callId),
+        kind: "entity",
+      }));
+    case "action.result":
+      return [
+        {
+          entity: actionEntity(
+            session,
+            event.data.turnId,
+            resultAsAction(event.data.result),
+            resultPhase(event.data.result, event.data.status),
+          ),
+          eventId: eventId(session, event, event.data.result.callId),
+          kind: "entity",
+        },
+      ];
+    case "input.requested":
+      return event.data.requests.map((request) => ({
+        entity: blocker(
+          session,
+          event.data.turnId,
+          `input:${session.sessionId}:${request.requestId}`,
+          request.prompt,
+          "blocked",
+        ),
+        eventId: eventId(session, event, request.requestId),
+        kind: "entity",
+      }));
+    case "input.resolved":
+      return event.data.resolutions.map((resolution) => ({
+        entity: blocker(
+          session,
+          event.data.turnId,
+          `input:${session.sessionId}:${resolution.requestId}`,
+          resolution.kind,
+          resolution.outcome === "invalid" ? "failed" : "completed",
+        ),
+        eventId: eventId(session, event, resolution.requestId),
+        kind: "entity",
+      }));
+    case "authorization.required":
+    case "authorization.completed": {
+      const id = event.data.attemptId ?? `${event.data.turnId}:${event.data.name}`;
+      const required = event.type === "authorization.required";
+      return [
+        {
+          entity: blocker(
+            session,
+            event.data.turnId,
+            `authorization:${session.sessionId}:${id}`,
+            required ? event.data.description : event.data.name,
+            required ? "blocked" : event.data.outcome === "authorized" ? "completed" : "failed",
+          ),
+          eventId: eventId(session, event),
+          kind: "entity",
+        },
+      ];
+    }
+    default:
+      return [];
+  }
+}
+
+function turnSettlement(
+  session: Session,
+  event: Extract<MessageStreamEvent, { type: "turn.cancelled" | "turn.completed" | "turn.failed" }>,
+  phase: Extract<ProgressPhase, "cancelled" | "completed" | "failed">,
+): ProgressEventV1 {
+  return {
+    eventId: eventId(session, event),
+    kind: "turn",
+    turn: {
+      id: progressTurnId(session.sessionId, event.data.turnId),
+      phase,
+      sequence: event.data.sequence,
+      settledAt: event.meta.at,
+      startedAt: event.meta.at,
+    },
+  };
+}
+
+function actionEntity(
+  session: Session,
+  turnId: string,
+  action: RuntimeActionRequest,
+  phase: ProgressPhase,
+): ProgressEntityV1 {
+  const base = {
+    id: progressActionId(session.sessionId, action.callId),
+    phase,
+    turnId: progressTurnId(session.sessionId, turnId),
+  };
+  switch (action.kind) {
+    case "load-skill":
+      return { ...base, kind: "skill", label: "Loading skill" };
+    case "remote-agent-call":
+      return { ...base, kind: "remote-agent", label: action.name };
+    case "subagent-call":
+      return { ...base, kind: "subagent", label: action.name };
+    case "tool-call":
+      return { ...base, kind: "tool", label: action.toolName };
+  }
+}
+
+function blocker(
+  session: Session,
+  turnId: string,
+  id: string,
+  label: string,
+  phase: ProgressPhase,
+): ProgressEntityV1 {
+  return {
+    id,
+    kind: "blocker",
+    label: normalizeProgressText(label),
+    phase,
+    turnId: progressTurnId(session.sessionId, turnId),
+  };
+}
+
+function resultAsAction(result: RuntimeActionResult): RuntimeActionRequest {
+  switch (result.kind) {
+    case "load-skill-result":
+      return { callId: result.callId, input: {}, kind: "load-skill" };
+    case "subagent-result":
+      return {
+        callId: result.callId,
+        description: result.subagentName,
+        input: {},
+        kind: "subagent-call",
+        name: result.subagentName,
+        nodeId: "",
+        subagentName: result.subagentName,
+      };
+    case "tool-result":
+      return { callId: result.callId, input: {}, kind: "tool-call", toolName: result.toolName };
+  }
+}
+
+function resultPhase(
+  _result: RuntimeActionResult,
+  status: "completed" | "failed" | "rejected",
+): ProgressPhase {
+  // A background receipt settles the parent action. The detached child's own
+  // turn and entities continue carrying active progress under the same group.
+  return status === "completed" ? "completed" : "failed";
+}
+
+function eventId(session: Session, event: MessageStreamEvent, suffix?: string): string {
+  return `stream:${session.sessionId}:${event.meta.id}${suffix === undefined ? "" : `:${suffix}`}`;
+}

--- a/packages/eve/src/execution/subagent-start-local.ts
+++ b/packages/eve/src/execution/subagent-start-local.ts
@@ -35,6 +35,7 @@ export async function startLocalSubagent(input: {
   readonly initiatorAuth: Parameters<typeof buildSubagentRunInput>[0]["initiatorAuth"];
   readonly parentContinuationToken: string | undefined;
   readonly parentTraceContext: Parameters<typeof buildSubagentRunInput>[0]["parentTraceContext"];
+  readonly progressCallback?: Parameters<typeof buildSubagentRunInput>[0]["progressCallback"];
   readonly persistentSessions: boolean;
   readonly sandboxSessionId: string;
   readonly session: RuntimeSession;
@@ -59,6 +60,7 @@ export async function startLocalSubagent(input: {
     parentContinuationToken: input.parentContinuationToken,
     parentTraceContext: input.parentTraceContext,
     persistentSessions: input.persistentSessions,
+    progressCallback: input.progressCallback,
     sandboxSessionId: input.sandboxSessionId,
     session: input.session,
     source,

--- a/packages/eve/src/execution/subagent-start-remote.test.ts
+++ b/packages/eve/src/execution/subagent-start-remote.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createRootProgressCallback,
+  resolveRemoteProgressCallback,
+} from "#execution/subagent-start-remote.js";
+
+const session = {
+  agent: {
+    compaction: { recentWindowSize: 1, threshold: 1 },
+    modelReference: "x",
+    system: "",
+    tools: [],
+  },
+  compaction: { recentWindowSize: 1, threshold: 1 },
+  continuationToken: "parent",
+  history: [],
+  sessionId: "root",
+} as never;
+
+describe("createRootProgressCallback", () => {
+  it("targets the root session command token", () => {
+    expect(createRootProgressCallback(session, "https://agent.example.com")).toEqual({
+      token: "eve:session:root:inbox",
+      url: "https://agent.example.com/eve/v1/callback/eve%3Asession%3Aroot%3Ainbox",
+      version: 1,
+    });
+  });
+
+  it("remains absent when the root channel did not enable progress", () => {
+    expect(
+      resolveRemoteProgressCallback({
+        callbackBaseUrl: "https://agent.example.com",
+        enabled: false,
+        session,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not replace the callback inherited by a descendant", () => {
+    expect(
+      createRootProgressCallback(
+        Object.assign({}, session, { rootSessionId: "root", sessionId: "child" }),
+        "https://agent.example.com",
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/packages/eve/src/execution/subagent-start-remote.ts
+++ b/packages/eve/src/execution/subagent-start-remote.ts
@@ -1,5 +1,8 @@
 import type { DispatchOutcome, RuntimeSession } from "#execution/agent-handle-dispatch.js";
 import { createRemoteAgentStartFailureResult } from "#execution/dispatch-action-failures.js";
+import { sessionCommandHookToken } from "#execution/session-command-token.js";
+import { createWorkflowCallbackUrl } from "#execution/workflow-callback-url.js";
+import { createEveCallbackRoutePath } from "#protocol/routes.js";
 import { mintStartOperation } from "#execution/dispatch-start-operation.js";
 import {
   resolveRemoteAgentForAction,
@@ -17,6 +20,31 @@ import type { CompiledBundle } from "#runtime/sessions/runtime-context-keys.js";
 
 const log = createLogger("execution.subagent-start-remote");
 
+export function createRootProgressCallback(
+  session: RuntimeSession,
+  callbackBaseUrl: string,
+): Parameters<typeof startRemoteAgentSession>[0]["progressCallback"] {
+  if (session.rootSessionId !== undefined) return undefined;
+  const token = sessionCommandHookToken(session.sessionId);
+  return {
+    token,
+    url: createWorkflowCallbackUrl(callbackBaseUrl, createEveCallbackRoutePath(token)),
+    version: 1,
+  };
+}
+
+export function resolveRemoteProgressCallback(input: {
+  readonly callbackBaseUrl: string;
+  readonly enabled: boolean;
+  readonly inherited?: Parameters<typeof startRemoteAgentSession>[0]["progressCallback"];
+  readonly session: RuntimeSession;
+}): Parameters<typeof startRemoteAgentSession>[0]["progressCallback"] {
+  if (input.inherited !== undefined) return input.inherited;
+  return input.enabled
+    ? createRootProgressCallback(input.session, input.callbackBaseUrl)
+    : undefined;
+}
+
 /** Starts one remote subagent after dispatch planning has selected its target. */
 export async function startRemoteSubagent(input: {
   readonly action: RuntimeRemoteAgentCallActionRequest;
@@ -24,6 +52,7 @@ export async function startRemoteSubagent(input: {
   readonly batchEvent: { readonly sequence: number; readonly turnId: string };
   readonly bundle: CompiledBundle;
   readonly callbackBaseUrl: string | undefined;
+  readonly capabilities?: import("#channel/types.js").SessionCapabilities;
   readonly currentSession: RuntimeSession;
   readonly dynamicRemoteAgent?: NonNullable<
     Parameters<typeof resolveRemoteAgentForAction>[0]["dynamicRemoteAgent"]
@@ -32,6 +61,7 @@ export async function startRemoteSubagent(input: {
   readonly parentContinuationToken: string | undefined;
   readonly parentTraceContext: Parameters<typeof startRemoteAgentSession>[0]["parentTraceContext"];
   readonly persistentSessions: boolean;
+  readonly progressCallback?: Parameters<typeof startRemoteAgentSession>[0]["progressCallback"];
   readonly session: RuntimeSession;
   readonly taskOwned: boolean;
 }): Promise<DispatchOutcome> {
@@ -88,6 +118,12 @@ export async function startRemoteSubagent(input: {
       operationId: operation.id,
       parentTraceContext: input.parentTraceContext,
       persistentSessions: input.persistentSessions,
+      progressCallback: resolveRemoteProgressCallback({
+        callbackBaseUrl,
+        enabled: input.capabilities?.progress === true,
+        inherited: input.progressCallback,
+        session: input.session,
+      }),
       remote: resolvedRemote,
       session: input.session,
     });

--- a/packages/eve/src/execution/subagent-tool.ts
+++ b/packages/eve/src/execution/subagent-tool.ts
@@ -95,6 +95,7 @@ export function buildSubagentRunInput(input: {
   /** Hook token owned by the workflow currently waiting for this child. */
   readonly parentContinuationToken?: string;
   readonly parentTraceContext?: SessionTraceContext;
+  readonly progressCallback?: import("#channel/types.js").ProgressCallbackV1;
   /**
    * Whether the parent agent opted into
    * `experimental.subagentPersistentSessions`. Persistent children run in
@@ -181,6 +182,7 @@ export function buildSubagentRunInput(input: {
       },
     },
     parentTraceContext: input.parentTraceContext,
+    progressCallback: input.progressCallback,
     subagentDepth: subagentDepth.nextChildDepth,
   };
 

--- a/packages/eve/src/execution/submit-progress.test.ts
+++ b/packages/eve/src/execution/submit-progress.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ContextContainer } from "#context/container.js";
+import { ProgressCallbackKey, SessionKey } from "#context/keys.js";
+import { submitProgressCommand } from "#execution/submit-progress.js";
+import { resumeHook } from "#internal/workflow/runtime.js";
+
+vi.mock("#compiled/@workflow/core/runtime.js", () => ({ resumeHook: vi.fn() }));
+
+const command = { commandId: "one", events: [], kind: "progress" as const, version: 1 as const };
+
+function context() {
+  const context = new ContextContainer();
+  context.set(SessionKey, {
+    auth: { current: null, initiator: null },
+    parent: {
+      callId: "call",
+      rootSessionId: "root",
+      sessionId: "parent",
+      turn: { id: "turn", sequence: 0 },
+    },
+    sessionId: "child",
+    turn: { id: "child-turn", sequence: 0 },
+  });
+  return context;
+}
+
+describe("submitProgressCommand", () => {
+  it("routes local descendants to the root session inbox", async () => {
+    await submitProgressCommand(context(), command);
+    expect(resumeHook).toHaveBeenCalledWith("eve:session:root:inbox", command);
+  });
+
+  it("uses the inherited callback and caller-selected timeout", async () => {
+    const timeout = vi.spyOn(AbortSignal, "timeout");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 503 })),
+    );
+    const ctx = context();
+    ctx.set(ProgressCallbackKey, {
+      token: "root-token",
+      url: "https://root.example.com/eve/v1/callback/root-token",
+      version: 1,
+    });
+    await expect(submitProgressCommand(ctx, command, { remoteTimeoutMs: 1_000 })).rejects.toThrow(
+      "HTTP 503",
+    );
+    expect(timeout).toHaveBeenCalledWith(1_000);
+  });
+});

--- a/packages/eve/src/execution/submit-progress.ts
+++ b/packages/eve/src/execution/submit-progress.ts
@@ -1,0 +1,30 @@
+import type { ContextContainer } from "#context/container.js";
+import { ProgressCallbackKey, SessionKey } from "#context/keys.js";
+import { postSessionCallbackRequest } from "#execution/session-callback-request.js";
+import { sessionCommandHookToken } from "#execution/session-command-token.js";
+import type { ProgressCommandV1 } from "#execution/session-progress.js";
+import { resumeHook } from "#internal/workflow/runtime.js";
+
+/** Submits one progress command over the inherited remote route or local root inbox. */
+export async function submitProgressCommand(
+  context: ContextContainer,
+  command: ProgressCommandV1,
+  options: { readonly remoteTimeoutMs?: number } = {},
+): Promise<void> {
+  const callback = context.get(ProgressCallbackKey);
+  if (callback !== undefined) {
+    const response = await postSessionCallbackRequest({
+      body: { command, kind: "session.progress", version: 1 },
+      timeoutMs: options.remoteTimeoutMs,
+      url: callback.url,
+    });
+    if (!response.ok) throw new Error(`Progress callback failed with HTTP ${response.status}.`);
+    return;
+  }
+
+  const session = context.require(SessionKey);
+  await resumeHook(
+    sessionCommandHookToken(session.parent?.rootSessionId ?? session.sessionId),
+    command,
+  );
+}

--- a/packages/eve/src/execution/turn-control-receiver.test.ts
+++ b/packages/eve/src/execution/turn-control-receiver.test.ts
@@ -228,14 +228,12 @@ describe("TurnControlReceiver", () => {
   it("drops an unknown wire version loudly and keeps consuming the inbox", async () => {
     installControlHook([parkResult()], true);
     const bufferedDeliveries: DeliverHookPayload[] = [];
-
     const action = await runReceiver(bufferedDeliveries, {
       commandInbox: createCommandInbox([
         { kind: "deliver", payloads: [{ message: "from the future" }], version: 99 } as never,
         { kind: "send", payload: { message: "still delivered" } },
       ]),
     });
-
     expect(action.kind).toBe("park");
     expect(reportDroppedWirePayloadStep).toHaveBeenCalledOnce();
     expect(bufferedDeliveries).toEqual([
@@ -248,6 +246,27 @@ describe("TurnControlReceiver", () => {
         turnPolicy: undefined,
       },
     ]);
+  });
+
+  it("handles progress during an active turn without steering or buffering a delivery", async () => {
+    installControlHook([parkResult()], true);
+    const handleProgress = vi.fn().mockResolvedValue(undefined);
+    const bufferedDeliveries: DeliverHookPayload[] = [];
+    const action = await runReceiver(bufferedDeliveries, {
+      commandInbox: createCommandInbox([
+        { commandId: "progress_1", events: [], kind: "progress", version: 1 },
+      ]),
+      progressHandler: { handleProgress },
+    });
+    expect(action.kind).toBe("park");
+    expect(handleProgress).toHaveBeenCalledWith({
+      commandId: "progress_1",
+      events: [],
+      kind: "progress",
+      version: 1,
+    });
+    expect(bufferedDeliveries).toEqual([]);
+    expect(forwardTurnCancellationStep).not.toHaveBeenCalled();
   });
 
   it("forwards cancel and reset through the active turn's private hook", async () => {
@@ -280,6 +299,9 @@ function runReceiver(
   options: {
     readonly bufferedSessionControls?: Array<"clear" | "compact" | "expired" | "reset">;
     readonly commandInbox?: SessionCommandInbox;
+    readonly progressHandler?: {
+      handleProgress(command: { readonly kind: "progress" }): Promise<void>;
+    };
     readonly seenTaskDeliveries?: Set<string>;
   } = {},
 ): ReturnType<TurnControlReceiver["waitForAction"]> {
@@ -288,6 +310,7 @@ function runReceiver(
     bufferedSessionControls: options.bufferedSessionControls ?? [],
     commandInbox: options.commandInbox ?? createCommandInbox(),
     expectedTurnId: "turn_0",
+    progressHandler: options.progressHandler,
     seenTaskDeliveries: options.seenTaskDeliveries,
     token: "turn-control",
   });

--- a/packages/eve/src/execution/turn-control-receiver.ts
+++ b/packages/eve/src/execution/turn-control-receiver.ts
@@ -7,6 +7,7 @@ import { forwardTurnDeliveryStep } from "#execution/forward-turn-delivery-step.j
 import { closeHookIterator, disposeHook } from "#execution/hook-ownership.js";
 import type { NextDriverAction } from "#execution/next-driver-action.js";
 import type { SessionCommandInbox } from "#execution/session-command-inbox.js";
+import type { SessionProgressHandler } from "#execution/session-progress.js";
 import { turnCancellationHookToken } from "#execution/turn-cancellation-token.js";
 import { reportDroppedWirePayloadStep } from "#execution/report-dropped-wire-payload-step.js";
 import {
@@ -30,6 +31,7 @@ export class TurnControlReceiver {
   private readonly expectedTurnId: string;
   private readonly cancelledTaskIds: Set<string>;
   private readonly seenTaskDeliveries: Set<string>;
+  private readonly progressHandler: SessionProgressHandler | undefined;
   private pendingControl: Promise<IteratorResult<TurnControlPayload>> | null = null;
 
   constructor(input: {
@@ -38,6 +40,7 @@ export class TurnControlReceiver {
     readonly cancelledTaskIds?: Set<string>;
     readonly commandInbox: SessionCommandInbox;
     readonly expectedTurnId: string;
+    readonly progressHandler?: SessionProgressHandler;
     readonly seenTaskDeliveries?: Set<string>;
     readonly token: string;
   }) {
@@ -45,6 +48,7 @@ export class TurnControlReceiver {
     this.bufferedSessionControls = input.bufferedSessionControls;
     this.cancelledTaskIds = input.cancelledTaskIds ?? new Set();
     this.commandInbox = input.commandInbox;
+    this.progressHandler = input.progressHandler;
     this.seenTaskDeliveries = input.seenTaskDeliveries ?? new Set();
     this.control = createHook<TurnControlPayload>({ token: input.token });
     this.controlIterator = this.control[Symbol.asyncIterator]();
@@ -97,6 +101,10 @@ export class TurnControlReceiver {
     }
     if (command.kind === "session-timeout") {
       this.bufferedSessionControls.push("expired");
+      return undefined;
+    }
+    if (command.kind === "progress") {
+      await this.progressHandler?.handleProgress(command);
       return undefined;
     }
     if (command.kind === "cancel") {

--- a/packages/eve/src/execution/turn-dispatch.ts
+++ b/packages/eve/src/execution/turn-dispatch.ts
@@ -3,6 +3,7 @@ import { dispatchTurnStep } from "#execution/dispatch-turn-step.js";
 import { TurnControlReceiver } from "#execution/turn-control-receiver.js";
 import type { DurableSessionState } from "#execution/durable-session-store.js";
 import type { SessionCommandInbox } from "#execution/session-command-inbox.js";
+import type { SessionProgressHandler } from "#execution/session-progress.js";
 import type { TurnDriverAction } from "#execution/turn-control-receiver.js";
 import type { RunMode } from "#shared/run-mode.js";
 import { activeTurnId } from "#harness/active-turn-id.js";
@@ -32,6 +33,7 @@ export async function dispatchAndAwaitTurn(input: {
   readonly commandInbox: SessionCommandInbox;
   readonly mode: RunMode;
   readonly parentWritable: WritableStream<Uint8Array>;
+  readonly progressHandler?: SessionProgressHandler;
   readonly serializedContext: Record<string, unknown>;
   readonly seenTaskDeliveries?: Set<string>;
   readonly sessionState: DurableSessionState;
@@ -42,6 +44,7 @@ export async function dispatchAndAwaitTurn(input: {
     cancelledTaskIds: input.cancelledTaskIds,
     commandInbox: input.commandInbox,
     expectedTurnId: activeTurnId(input.sessionState.emissionState),
+    progressHandler: input.progressHandler,
     seenTaskDeliveries: input.seenTaskDeliveries ?? new Set(),
     token: input.controlToken,
   });

--- a/packages/eve/src/execution/wire/session-inbox-contract.ts
+++ b/packages/eve/src/execution/wire/session-inbox-contract.ts
@@ -1,5 +1,5 @@
 /** Every explicit session-inbox wire version still supported by producers. */
-export const SESSION_INBOX_WIRE_VERSIONS = [1] as const;
+export const SESSION_INBOX_WIRE_VERSIONS = [1, 2] as const;
 
 export type SessionInboxWireVersion = (typeof SESSION_INBOX_WIRE_VERSIONS)[number];
 

--- a/packages/eve/src/execution/wire/session-inbox-encoder.ts
+++ b/packages/eve/src/execution/wire/session-inbox-encoder.ts
@@ -8,6 +8,10 @@ import {
   type SessionInboxWireV1,
 } from "#execution/wire/session-inbox-wire.v1.js";
 import {
+  encodeSessionCommandV2,
+  type SessionInboxWireV2,
+} from "#execution/wire/session-inbox-wire.v2.js";
+import {
   isSessionInboxWireVersion,
   SessionInboxWireError,
   type SessionInboxWireTarget,
@@ -18,17 +22,19 @@ import { encodeSessionCommandV0 } from "#execution/wire/session-inbox-wire.v0.js
 type SessionInboxCommand = DeliverHookPayload | SessionCommand | SessionTimeoutHookPayload;
 
 /** Current wire type consumed after migration. */
-export type SessionInboxWire = SessionInboxWireV1;
+export type SessionInboxWire = SessionInboxWireV2;
 
 type LegacySessionInboxWireTarget = Extract<SessionInboxWireTarget, { readonly version: 0 }>;
 type VersionedSessionInboxEncoder = (command: SessionInboxCommand) => unknown;
 
 const versionedEncoders = {
   1: encodeSessionCommandV1,
+  2: encodeSessionCommandV2,
 } satisfies Record<SessionInboxWireVersion, VersionedSessionInboxEncoder>;
 
 /** Encodes a command for the selected session-inbox consumer. */
 function encode(command: SessionInboxCommand, target: { readonly version: 1 }): SessionInboxWireV1;
+function encode(command: SessionInboxCommand, target: { readonly version: 2 }): SessionInboxWireV2;
 function encode(
   command: SessionInboxCommand,
   target: { readonly version: SessionInboxWireVersion },
@@ -40,16 +46,16 @@ function encode(
 function encode(
   command: SessionInboxCommand,
   target: SessionInboxWireTarget,
-): SessionInboxWireV1 | Record<string, unknown>;
+): SessionInboxWireV2 | Record<string, unknown>;
 function encode(
   command: SessionInboxCommand,
   target: SessionInboxWireTarget,
-): SessionInboxWireV1 | Record<string, unknown> {
+): SessionInboxWireV2 | Record<string, unknown> {
   if (target.version === 0) {
     return encodeSessionCommandV0(encodeSessionCommandV1(command), target.variant);
   }
   if (isSessionInboxWireVersion(target.version)) {
-    return versionedEncoders[target.version](command) as SessionInboxWireV1;
+    return versionedEncoders[target.version](command) as SessionInboxWireV2;
   }
   throw new SessionInboxWireError(
     `Cannot encode session inbox payload for unknown wire version ${JSON.stringify((target as { version?: unknown }).version)}.`,

--- a/packages/eve/src/execution/wire/session-inbox-wire.ts
+++ b/packages/eve/src/execution/wire/session-inbox-wire.ts
@@ -12,8 +12,11 @@ import {
   SESSION_INBOX_WIRE_VERSION,
   SessionInboxWireError,
 } from "#execution/wire/session-inbox-contract.js";
-import type { SessionInboxWire } from "#execution/wire/session-inbox-encoder.js";
 import { sessionInboxWireV0Migration } from "#execution/wire/session-inbox-wire.v0.js";
+import {
+  sessionInboxWireV1Migration,
+  type SessionInboxWireV2,
+} from "#execution/wire/session-inbox-wire.v2.js";
 
 /**
  * The session inbox wire family: every payload persisted to a session's
@@ -31,14 +34,20 @@ import { sessionInboxWireV0Migration } from "#execution/wire/session-inbox-wire.
 export type DecodedSessionInbox =
   | DeliverHookPayload
   | SessionTimeoutHookPayload
-  | Extract<SessionCommand, { readonly kind: "cancel" | "clear" | "compact" | "reset" }>;
+  | Extract<
+      SessionCommand,
+      { readonly kind: "cancel" | "clear" | "compact" | "progress" | "reset" }
+    >;
 
 export { SessionInboxWireError } from "#execution/wire/session-inbox-contract.js";
 
 /** Prefixes chain and schema failures alike, so messages read as one voice. */
 const WIRE_LABEL = "session inbox payload";
 
-const sessionInboxMigrations: readonly VersionMigration[] = [sessionInboxWireV0Migration];
+const sessionInboxMigrations: readonly VersionMigration[] = [
+  sessionInboxWireV0Migration,
+  sessionInboxWireV1Migration,
+];
 
 /**
  * Decodes a persisted inbox payload or throws {@link SessionInboxWireError}.
@@ -61,20 +70,20 @@ function decode(value: unknown): DecodedSessionInbox {
     throw new SessionInboxWireError(error instanceof Error ? error.message : String(error));
   }
 
-  const wire = migrated as Partial<SessionInboxWire>;
+  const wire = migrated as Partial<SessionInboxWireV2>;
   if (wire.version !== SESSION_INBOX_WIRE_VERSION) {
     throw new SessionInboxWireError(
       `${WIRE_LABEL} declares version ${JSON.stringify(wire.version)}, expected ${SESSION_INBOX_WIRE_VERSION}.`,
     );
   }
-  return normalizeWire(wire as SessionInboxWire);
+  return normalizeWire(wire as SessionInboxWireV2);
 }
 
 /** Workflow-safe consumer facade. */
 export const sessionInboxWire = { decode } as const;
 
 /** Strips wire-only fields (`version`, the deliver mirror) for consumption. */
-function normalizeWire(wire: SessionInboxWire): DecodedSessionInbox {
+function normalizeWire(wire: SessionInboxWireV2): DecodedSessionInbox {
   switch (wire.kind) {
     case "deliver":
       return {
@@ -97,6 +106,13 @@ function normalizeWire(wire: SessionInboxWire): DecodedSessionInbox {
       return { kind: "reset", reason: wire.reason };
     case "cancel":
       return { kind: "cancel", taskId: wire.taskId, turnId: wire.turnId };
+    case "progress":
+      return {
+        commandId: wire.commandId,
+        events: wire.events,
+        kind: "progress",
+        version: 1,
+      };
     default:
       throw new SessionInboxWireError(
         `${WIRE_LABEL} has an unrecognized kind ${JSON.stringify((wire as { kind?: unknown }).kind)}.`,

--- a/packages/eve/src/execution/wire/session-inbox-wire.v1.test.ts
+++ b/packages/eve/src/execution/wire/session-inbox-wire.v1.test.ts
@@ -182,7 +182,7 @@ describe("session inbox wire v1", () => {
   });
 
   it.each([
-    ["a future wire version", { kind: "deliver", payloads: [], version: 2 }],
+    ["a future wire version", { kind: "deliver", payloads: [], version: 3 }],
     ["a non-numeric version", { kind: "deliver", payloads: [], version: "1" }],
     ["an unrecognized kind", { kind: "mystery", version: 1 }],
   ])("rejects %s instead of reinterpreting it", (_name, payload) => {

--- a/packages/eve/src/execution/wire/session-inbox-wire.v2.test.ts
+++ b/packages/eve/src/execution/wire/session-inbox-wire.v2.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { sessionInboxWire as encoder } from "#execution/wire/session-inbox-encoder.js";
+import { sessionInboxWire as decoder } from "#execution/wire/session-inbox-wire.js";
+import { sessionInboxWireV2Schema } from "#execution/wire/session-inbox-wire.v2.js";
+
+describe("session inbox wire v2", () => {
+  it("accepts only version 2", () => {
+    expect(sessionInboxWireV2Schema.safeParse({ kind: "clear", version: 2 }).success).toBe(true);
+    expect(sessionInboxWireV2Schema.safeParse({ kind: "clear", version: 1 }).success).toBe(false);
+  });
+
+  it("encodes and decodes progress commands", () => {
+    const command = {
+      commandId: "progress-1",
+      events: [],
+      kind: "progress" as const,
+      version: 1 as const,
+    };
+    const wire = encoder.encode(command, { version: 2 });
+    expect(wire).toEqual({ ...command, version: 2 });
+    expect(decoder.decode(wire)).toEqual(command);
+  });
+
+  it("migrates version 1 controls", () => {
+    expect(decoder.decode({ kind: "clear", version: 1 })).toEqual({ kind: "clear" });
+  });
+});

--- a/packages/eve/src/execution/wire/session-inbox-wire.v2.ts
+++ b/packages/eve/src/execution/wire/session-inbox-wire.v2.ts
@@ -1,0 +1,59 @@
+import { z } from "#compiled/zod/index.js";
+
+import type {
+  DeliverHookPayload,
+  SessionCommand,
+  SessionTimeoutHookPayload,
+} from "#channel/types.js";
+import { progressCommandV1Schema } from "#execution/session-progress.js";
+import type { VersionMigration } from "#execution/durable-session-migrations/chain.js";
+import { SessionInboxWireError } from "#execution/wire/session-inbox-contract.js";
+import {
+  encodeSessionCommandV1,
+  sessionInboxWireV1Schema,
+} from "#execution/wire/session-inbox-wire.v1.js";
+import { formatValidationError } from "#runtime/validation.js";
+
+const VERSION = 2;
+const version = z.literal(VERSION);
+const v1 = sessionInboxWireV1Schema.options;
+
+/** Version 2 adds the framework-internal progress command. */
+export const sessionInboxWireV2Schema = z.discriminatedUnion("kind", [
+  v1[0].extend({ version }),
+  v1[1].extend({ version }),
+  v1[2].extend({ version }),
+  v1[3].extend({ version }),
+  v1[4].extend({ version }),
+  v1[5].extend({ version }),
+  progressCommandV1Schema.extend({ version }),
+]);
+
+export type SessionInboxWireV2 = z.infer<typeof sessionInboxWireV2Schema>;
+
+export const sessionInboxWireV1Migration: VersionMigration = {
+  from: 1,
+  to: 2,
+  migrate(value) {
+    if (value === null || typeof value !== "object") {
+      throw new TypeError("Expected session inbox wire version 1 to be an object.");
+    }
+    return { ...value, version: VERSION };
+  },
+};
+
+export function encodeSessionCommandV2(
+  command: DeliverHookPayload | SessionCommand | SessionTimeoutHookPayload,
+): SessionInboxWireV2 {
+  const wire =
+    command.kind === "progress"
+      ? { ...command, version: VERSION }
+      : { ...encodeSessionCommandV1(command), version: VERSION };
+  const parsed = sessionInboxWireV2Schema.safeParse(wire);
+  if (!parsed.success) {
+    throw new SessionInboxWireError(
+      `Produced a session inbox payload that does not match wire version ${VERSION}: ${formatValidationError(parsed.error)}`,
+    );
+  }
+  return parsed.data;
+}

--- a/packages/eve/src/execution/workflow-entry.test.ts
+++ b/packages/eve/src/execution/workflow-entry.test.ts
@@ -26,6 +26,7 @@ import { settleCancelledTurnStep } from "#execution/settle-cancelled-turn-step.j
 import { emitTerminalSessionFailureStep } from "#execution/terminal-session-failure-step.js";
 import type { SessionInboxPayload } from "#execution/session-command-inbox.js";
 import { sessionCommandHookToken } from "#execution/session-command-token.js";
+import { renderSessionProgressStep } from "#execution/session-progress-renderer-step.js";
 
 vi.mock("#compiled/@workflow/core/index.js", () => ({
   createHook: vi.fn(),
@@ -101,6 +102,13 @@ vi.mock("./settle-cancelled-turn-step.js", () => ({
 
 vi.mock("./session-timeout-control.js", () => ({
   createSessionTimeoutControl: vi.fn(),
+}));
+
+vi.mock("./session-progress-renderer-step.js", () => ({
+  renderSessionProgressStep: vi.fn(async ({ previousRenderCount, snapshot }) => ({
+    renderCount: previousRenderCount + 1,
+    snapshot,
+  })),
 }));
 
 function createSessionStateForMock(
@@ -211,6 +219,56 @@ describe("workflowEntry", () => {
       serializedContext: expect.any(Object),
       sessionState,
     });
+  });
+
+  it("reduces and renders parked progress without dispatching another turn", async () => {
+    const sessionState = createBaseSessionState();
+    vi.mocked(createSessionStep).mockResolvedValue(createSessionStepResultForMock(sessionState));
+    installHookMocks({
+      stableHook: {
+        values: [
+          {
+            commandId: "progress_1",
+            events: [
+              {
+                eventId: "turn_start",
+                kind: "turn",
+                turn: {
+                  id: "turn:wrun_test_123:turn_0",
+                  phase: "running",
+                  sequence: 0,
+                  startedAt: "2026-01-01T00:00:01.000Z",
+                },
+              },
+            ],
+            kind: "progress",
+            version: 1,
+          },
+          { kind: "reset" },
+        ],
+      },
+      turnControls: [turnResult({ action: "park", sessionState })],
+    });
+
+    await expect(
+      workflowEntry({
+        input: { message: "hello" },
+        serializedContext: createSerializedContext({
+          "eve.capabilities": { progress: true },
+        }),
+      }),
+    ).resolves.toEqual({ output: "" });
+
+    expect(renderSessionProgressStep).toHaveBeenCalledWith({
+      previousRenderCount: 0,
+      snapshot: expect.objectContaining({
+        revision: 1,
+        turns: expect.objectContaining({
+          "turn:wrun_test_123:turn_0": expect.objectContaining({ phase: "running" }),
+        }),
+      }),
+    });
+    expect(dispatchTurnStep).toHaveBeenCalledOnce();
   });
 
   it("exits a conflicting initial continuation before dispatching the first turn", async () => {

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -47,6 +47,12 @@ import { readSerializedSubagentDepth } from "#harness/subagent-depth.js";
 import type { DynamicSubagentAgentConfig } from "#runtime/subagents/dynamic-agent-config.js";
 import type { TokenUsage } from "#shared/token-usage.js";
 import { isTaskOwnedSerializedContext } from "#execution/tasks/child/instructions.js";
+import {
+  createProgressSnapshot,
+  reduceProgressCommand,
+  type SessionProgressHandler,
+} from "#execution/session-progress.js";
+import { renderSessionProgressStep } from "#execution/session-progress-renderer-step.js";
 
 const SAFE_OUTER_WORKFLOW_FAILURE_MESSAGE =
   "Agent workflow failed. Inspect the private session trace for details.";
@@ -354,6 +360,7 @@ async function runDriverLoop(input: {
         commandInbox,
         deferDeliveries: input.mode === "task" && expectedAttemptIds.size > 0,
         driverWritable: input.driverWritable,
+        progressHandler,
         seenTaskDeliveries,
         stateCursor,
       });
@@ -413,6 +420,20 @@ async function runDriverLoop(input: {
     serializedContext: input.serializedContext,
     sessionState: input.sessionState,
   });
+  let progressState = { renderCount: 0, snapshot: createProgressSnapshot() };
+  const progressHandler: SessionProgressHandler | undefined =
+    input.capabilities?.progress === true
+      ? {
+          async handleProgress(command) {
+            const snapshot = reduceProgressCommand(progressState.snapshot, command);
+            if (snapshot.revision === progressState.snapshot.revision) return;
+            progressState = await renderSessionProgressStep({
+              previousRenderCount: progressState.renderCount,
+              snapshot,
+            });
+          },
+        }
+      : undefined;
 
   // Control-hook disposal is deferred one turn — see DispatchedTurn.
   let disposeSettledTurnControl: (() => Promise<void>) | undefined;
@@ -440,6 +461,7 @@ async function runDriverLoop(input: {
       delivery,
       mode: input.mode,
       parentWritable: input.driverWritable,
+      progressHandler,
       serializedContext,
       seenTaskDeliveries,
       sessionState: stateCursor.sessionState,

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -99,6 +99,7 @@ import { hydrateDurableSession, refreshSessionFromTurnAgent } from "#execution/s
 import { resolveRuntimeCompiledArtifactsVersionedCacheKey } from "#runtime/cache-key.js";
 import { createWorkflowRuntime } from "#execution/workflow-runtime.js";
 import { isTaskToolAvailable, TASK_UPDATE_TOOL_NAME } from "#runtime/framework-tools/tasks.js";
+import { publishStructuralProgress } from "#execution/structural-progress.js";
 
 const TASK_DONE_WITH_PENDING_INPUT_ERROR_MESSAGE =
   "Task mode cannot complete while input requests remain pending.";
@@ -446,6 +447,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
       event: emitted,
       messages: messages ?? [],
     });
+    await publishStructuralProgress(ctx, emitted);
   };
 
   const mode = ctx.require(ModeKey);

--- a/packages/eve/src/public/channels/eve.ts
+++ b/packages/eve/src/public/channels/eve.ts
@@ -1,6 +1,7 @@
 import { type FilePart, type TextPart, type UserContent } from "ai";
 
 import type {
+  ProgressCallbackV1,
   SessionAuthContext,
   SessionCallback,
   SessionCapabilities,
@@ -13,6 +14,7 @@ import type { ResetResponse } from "#protocol/reset-session.js";
 import type { Session } from "#channel/session.js";
 import { resolveForwardedPrincipal, type TrustedForwarders } from "#channel/forwarded-principal.js";
 import { parseSessionCallback } from "#channel/session-callback.js";
+import { parseProgressCallback } from "#channel/progress-callback.js";
 import { isRuntimeSessionOwnershipConflictError } from "#execution/runtime-errors.js";
 import { hasInternalRefScheme } from "#internal/attachments/url-refs.js";
 import { createLogger, logError } from "#internal/logging.js";
@@ -310,13 +312,18 @@ export function eveChannel(input: EveChannelInput): EveChannel {
           );
         }
 
+        const capabilities = {
+          ...(body.capabilities ?? (body.mode === "task" ? {} : { requestInput: true })),
+        };
+        if (body.progressCallback !== undefined) capabilities.progress = true;
+
         let handle: Awaited<ReturnType<typeof createSession>>;
         try {
           handle = await createSession({
             auth: messageResult.auth,
-            capabilities:
-              body.capabilities ?? (body.mode === "task" ? undefined : { requestInput: true }),
+            capabilities,
             callback: body.callback,
+            progressCallback: body.progressCallback,
             continuationToken: operationToken,
             initiatorAuth: forwarded.accepted ? forwarded.initiatorAuth : undefined,
             input: {
@@ -816,6 +823,7 @@ function defaultOnMessage(ctx: EveMessageContext): EveMessageResult {
 interface ParsedCreateBody {
   callback?: SessionCallback;
   capabilities?: SessionCapabilities;
+  progressCallback?: ProgressCallbackV1;
   message: string | UserContent;
   mode?: RunMode;
   context?: readonly string[];
@@ -862,6 +870,16 @@ function parseCreateBody(payload: Record<string, unknown>): ParsedCreateBody | R
   const capabilities = parseCapabilitiesField(payload.capabilities);
   if (capabilities instanceof Response) return capabilities;
 
+  let progressCallback: ProgressCallbackV1 | undefined;
+  try {
+    progressCallback = parseProgressCallback(payload.progressCallback);
+  } catch (error) {
+    return Response.json(
+      { error: error instanceof Error ? error.message : "Invalid progress callback.", ok: false },
+      { status: 400 },
+    );
+  }
+
   const mode = parseModeField(payload.mode);
   if (mode instanceof Response) return mode;
 
@@ -890,6 +908,7 @@ function parseCreateBody(payload: Record<string, unknown>): ParsedCreateBody | R
     mode,
     context,
     outputSchema,
+    progressCallback,
   };
   if (typeof rawOperationId === "string") result.operationId = rawOperationId;
   return result;

--- a/packages/eve/src/runtime/session-callback-route.test.ts
+++ b/packages/eve/src/runtime/session-callback-route.test.ts
@@ -475,6 +475,65 @@ describe("session callback route", () => {
     expect(resumeHookMock).not.toHaveBeenCalled();
   });
 
+  it("routes a versioned progress command to the authenticated callback token", async () => {
+    resumeHookMock.mockResolvedValue(undefined);
+    const command = {
+      commandId: "progress_1",
+      events: [],
+      kind: "progress",
+      version: 1,
+    };
+    const response = await handleSessionCallbackRequest(
+      new Request("https://app.example.com/eve/v1/callback/root-token", {
+        body: JSON.stringify({ command, kind: "session.progress", version: 1 }),
+        method: "POST",
+      }),
+      createRouteContext({ token: "root-token" }),
+    );
+
+    expect(response.status).toBe(202);
+    expect(resumeHookMock).toHaveBeenCalledWith("root-token", command);
+  });
+
+  it("rejects malformed progress events without resuming the hook", async () => {
+    const response = await handleSessionCallbackRequest(
+      new Request("https://app.example.com/eve/v1/callback/root-token", {
+        body: JSON.stringify({
+          command: {
+            commandId: "progress_1",
+            events: [{ kind: "entity" }],
+            kind: "progress",
+            version: 1,
+          },
+          kind: "session.progress",
+          version: 1,
+        }),
+        method: "POST",
+      }),
+      createRouteContext({ token: "root-token" }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(resumeHookMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown progress versions without resuming the hook", async () => {
+    const response = await handleSessionCallbackRequest(
+      new Request("https://app.example.com/eve/v1/callback/root-token", {
+        body: JSON.stringify({
+          command: { commandId: "progress_1", events: [], kind: "progress", version: 2 },
+          kind: "session.progress",
+          version: 2,
+        }),
+        method: "POST",
+      }),
+      createRouteContext({ token: "root-token" }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(resumeHookMock).not.toHaveBeenCalled();
+  });
+
   it("resumes a failed conversation turn as an error result carrying its outcome", async () => {
     resumeHookMock.mockResolvedValue(undefined);
 

--- a/packages/eve/src/runtime/session-callback-route.ts
+++ b/packages/eve/src/runtime/session-callback-route.ts
@@ -18,6 +18,7 @@ import type {
   TaskInboundUpdate,
 } from "#tasks/types.js";
 import { readTaskIdFromInboxToken } from "#tasks/task-id.js";
+import { parseProgressCommandV1, type ProgressCommandV1 } from "#execution/session-progress.js";
 
 export const HTTP_SESSION_CALLBACK_CHANNEL_NAME_PREFIX = "eve/v1/callback";
 
@@ -208,6 +209,17 @@ export async function handleSessionCallbackRequest(
     return Response.json({ error: "Invalid JSON body.", ok: false }, { status: 400 });
   }
 
+  const progress = projectProgressCallback(body);
+  if (progress instanceof Response) return progress;
+  if (progress !== undefined) {
+    try {
+      await resumeHook(token, progress.command);
+    } catch {
+      return Response.json({ error: "Session callback not pending.", ok: false }, { status: 404 });
+    }
+    return Response.json({ ok: true }, { status: 202 });
+  }
+
   const taskEvent = projectTaskEvent(body, token);
   if (taskEvent instanceof Response) return taskEvent;
   if (taskEvent !== undefined) {
@@ -256,6 +268,21 @@ export async function handleSessionCallbackRequest(
   }
 
   return Response.json({ ok: true }, { status: 202 });
+}
+
+function projectProgressCallback(
+  value: unknown,
+): { readonly command: ProgressCommandV1 } | Response | undefined {
+  if (callbackKind(value) !== "session.progress") return undefined;
+  if (value === null || typeof value !== "object") return undefined;
+  const command = parseProgressCommandV1(Reflect.get(value, "command"));
+  if (Reflect.get(value, "version") !== 1 || command === undefined) {
+    return Response.json(
+      { error: "Invalid progress callback version or command.", ok: false },
+      { status: 400 },
+    );
+  }
+  return { command };
 }
 
 function callbackKind(value: unknown): unknown {


### PR DESCRIPTION
### Summary

Related to #1673. This stacked PR observes the smallest structural vocabulary needed for compact status: turn lifecycle, actions and delegation, and input or authorization blockers. Root and descendant events become presentation commands only when the root channel enables progress; narration, reasoning, tool output, and user responses remain excluded.

Authored reports, hierarchy, and retained activity are deferred to later presentation work.

### Validation

Focused tests verify turn and tool settlement, blocker projection, capability gating, exclusion of streamed narration, background-receipt settlement, and integration at the central event boundary.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

No changeset is needed because no production channel enables progress yet.

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 2 files · `+224 / -0`

Adds one channel-neutral lifecycle projector, invokes it from the existing central event path, and delegates local/remote submission to the shared transport helper.

**Tests** — 1 file · `+173 / -0`

Covers the selected vocabulary and explicit exclusion boundary.
