### PR TITLE
feat(eve): render Slack progress activity

### DIFF
--- a/.changeset/tidy-slack-activity.md
+++ b/.changeset/tidy-slack-activity.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add `slackActivityProgress()`, an optional update-in-place Slack activity message that groups root and descendant work by originating turn and recovers message identity from Slack metadata.

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -385,7 +385,21 @@ export default slackChannel({
 });
 ```
 
-The renderer updates Slack's assistant-thread status from turn, tool, delegation, and blocker events. Progress from local and compatible remote subagents routes to the root Slack thread without starting another parent turn. Blockers take priority, parallel work is summarized, and the status clears after the represented work settles. Without `progress`, Slack keeps the default event-based typing behavior described above.
+The renderer updates Slack's assistant-thread status from turn, tool, delegation, and blocker events. Progress from local and compatible remote subagents routes to the root Slack thread without starting another parent turn. Blockers take priority, parallel work is summarized, and the status clears after the represented work settles.
+
+Add `slackActivityProgress()` when the thread should also retain one activity message per originating root turn:
+
+```ts title="agent/channels/slack.ts"
+import { slackActivityProgress, slackChannel, slackStatusProgress } from "eve/channels/slack";
+
+export default slackChannel({
+  progress: {
+    renderers: [slackStatusProgress(), slackActivityProgress()],
+  },
+});
+```
+
+The activity renderer groups descendant work under the root turn that started it, keeps updating the same message while background work continues, and retains the settled result in the thread. It tags messages with Slack metadata so a replay can recover the existing message instead of posting a duplicate. Without `progress`, Slack keeps the default event-based typing behavior described above.
 
 Outbound text preserves bare `@` tokens as literal text. To mention a user, embed Slack's `<@USER_ID>` syntax directly or use `channel.thread.mentionUser(userId)`.
 

--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -472,6 +472,8 @@ export interface RunInput {
    */
   readonly callback?: SessionCallback;
   readonly progressCallback?: ProgressCallbackV1;
+  /** Framework-owned originating root turn for progress artifact grouping. */
+  readonly progressGroupId?: string;
   /**
    * Session continuation token for delivery and hook creation. Channels can
    * re-key the session during the first turn via

--- a/packages/eve/src/context/keys.ts
+++ b/packages/eve/src/context/keys.ts
@@ -100,6 +100,8 @@ export const SubagentDepthKey = new ContextKey<number>("eve.subagentDepth");
  */
 export const CapabilitiesKey = new ContextKey<SessionCapabilities>("eve.capabilities");
 export const ProgressCallbackKey = new ContextKey<ProgressCallbackV1>("eve.progressCallback");
+/** Root turn whose channel artifact owns descendant progress. */
+export const ProgressGroupKey = new ContextKey<string>("eve.progressGroup");
 
 /**
  * Optional framework-owned caller callback captured when the session is created.

--- a/packages/eve/src/execution/dispatch-runtime-actions-shared.ts
+++ b/packages/eve/src/execution/dispatch-runtime-actions-shared.ts
@@ -18,6 +18,7 @@ import {
   CapabilitiesKey,
   ChannelInstrumentationKey,
   ProgressCallbackKey,
+  ProgressGroupKey,
   InitiatorAuthKey,
   SandboxKey,
 } from "#context/keys.js";
@@ -156,6 +157,7 @@ export interface PreparedRuntimeActionDispatch {
   readonly initiatorAuth: Parameters<typeof buildSubagentRunInput>[0]["initiatorAuth"];
   readonly parentTraceContext: Parameters<typeof buildSubagentRunInput>[0]["parentTraceContext"];
   readonly progressCallback?: import("#channel/types.js").ProgressCallbackV1;
+  readonly progressGroupId: string;
   readonly sandboxSessionId: string;
   readonly serializedContext: Record<string, unknown>;
   readonly plan: readonly DispatchPlanEntry[];
@@ -235,6 +237,7 @@ export async function prepareRuntimeActionDispatch(input: {
     parentTraceContext: readSessionTraceContext(input.serializedContext, session.sessionId),
     plan,
     progressCallback: ctx.get(ProgressCallbackKey),
+    progressGroupId: ctx.get(ProgressGroupKey) ?? `turn:${session.sessionId}:${batch.event.turnId}`,
     sandboxSessionId,
     serializedContext: input.serializedContext,
     session,
@@ -499,6 +502,7 @@ export async function startSubagent(input: {
   readonly parentTraceContext: Parameters<typeof buildSubagentRunInput>[0]["parentTraceContext"];
   readonly persistentSessions: boolean;
   readonly progressCallback?: import("#channel/types.js").ProgressCallbackV1;
+  readonly progressGroupId: string;
   readonly sandboxSessionId: string;
   readonly serializedContext: Record<string, unknown>;
   readonly session: RuntimeSession;
@@ -530,6 +534,7 @@ export async function startSubagent(input: {
         parentTraceContext,
         persistentSessions: input.persistentSessions,
         progressCallback: input.progressCallback,
+        progressGroupId: input.progressGroupId,
         sandboxSessionId: input.sandboxSessionId,
         session: input.session,
         source: input.target.source,
@@ -550,6 +555,7 @@ export async function startSubagent(input: {
         parentTraceContext,
         persistentSessions: input.persistentSessions,
         progressCallback: input.progressCallback,
+        progressGroupId: input.progressGroupId,
         session: input.session,
         taskOwned: input.taskOwned,
       });

--- a/packages/eve/src/execution/dispatch-runtime-actions-step.ts
+++ b/packages/eve/src/execution/dispatch-runtime-actions-step.ts
@@ -92,6 +92,8 @@ export async function dispatchRuntimeActionsStep(
             parentContinuationToken: input.parentContinuationToken,
             parentTraceContext: prepared.parentTraceContext,
             persistentSessions,
+            progressCallback: prepared.progressCallback,
+            progressGroupId: prepared.progressGroupId,
             sandboxSessionId: prepared.sandboxSessionId,
             serializedContext: prepared.serializedContext,
             session,

--- a/packages/eve/src/execution/remote-agent-dispatch.test.ts
+++ b/packages/eve/src/execution/remote-agent-dispatch.test.ts
@@ -199,6 +199,37 @@ describe("startRemoteAgentSession", () => {
     });
   });
 
+  it("forwards the originating progress group", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        Response.json(
+          { ok: true, sessionId: "remote-session", status: "accepted" },
+          { status: 202 },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await startRemoteAgentSession({
+      action: createAction(),
+      callbackBaseUrl: "https://caller.example.com",
+      progressGroupId: "turn:root:root-turn",
+      remote: createRemoteAgent(),
+      session: {
+        agent: { modelReference: { id: "mock/test" }, system: "", tools: [] },
+        compaction: { recentWindowSize: 10, threshold: 100000 },
+        continuationToken: "eve:parent-token",
+        history: [],
+        sessionId: "parent-session",
+        state: {},
+      },
+    });
+
+    expect(JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string).progressGroupId).toBe(
+      "turn:root:root-turn",
+    );
+  });
+
   it("posts the formatted subagent message and callback metadata", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(

--- a/packages/eve/src/execution/remote-agent-dispatch.ts
+++ b/packages/eve/src/execution/remote-agent-dispatch.ts
@@ -53,6 +53,7 @@ export async function startRemoteAgentSession(input: {
   readonly callbackBaseUrl: string | undefined;
   readonly callbackToken?: string;
   readonly progressCallback?: import("#channel/types.js").ProgressCallbackV1;
+  readonly progressGroupId?: string;
   /** The root initiator's principal, forwarded alongside {@link auth}. */
   readonly initiatorAuth?: SessionAuthContext | null;
   /**
@@ -91,6 +92,7 @@ export async function startRemoteAgentSession(input: {
     };
     forwardedPrincipal?: ForwardedPrincipal;
     progressCallback?: import("#channel/types.js").ProgressCallbackV1;
+    progressGroupId?: string;
     message: string;
     mode: "conversation" | "task";
     operationId?: string;
@@ -117,6 +119,7 @@ export async function startRemoteAgentSession(input: {
       normalizeRequestedOutputSchema(input.action.input.outputSchema) ?? input.remote.outputSchema,
   };
   if (input.progressCallback !== undefined) requestBody.progressCallback = input.progressCallback;
+  if (input.progressGroupId !== undefined) requestBody.progressGroupId = input.progressGroupId;
   if (forwardedPrincipal !== undefined) {
     requestBody.forwardedPrincipal = forwardedPrincipal;
   }

--- a/packages/eve/src/execution/report-progress.ts
+++ b/packages/eve/src/execution/report-progress.ts
@@ -1,5 +1,5 @@
 import { loadContext } from "#context/container.js";
-import { ProgressCallbackKey, SessionKey } from "#context/keys.js";
+import { ProgressCallbackKey, ProgressGroupKey, SessionKey } from "#context/keys.js";
 import { postSessionCallbackRequest } from "#execution/session-callback-request.js";
 import { sessionCommandHookToken } from "#execution/session-command-token.js";
 import {
@@ -29,6 +29,7 @@ export async function reportProgress(input: {
         kind: "report",
         report: { id: input.callId, message, reportedAt: now },
         turn: {
+          groupId: context.get(ProgressGroupKey),
           id: progressTurnId(session.sessionId, session.turn.id),
           phase: "running",
           sequence: session.turn.sequence,

--- a/packages/eve/src/execution/runtime-context.ts
+++ b/packages/eve/src/execution/runtime-context.ts
@@ -14,6 +14,7 @@ import {
   ParentSessionKey,
   ParentTraceContextKey,
   ProgressCallbackKey,
+  ProgressGroupKey,
   SessionCallbackKey,
   SubagentDepthKey,
 } from "#context/keys.js";
@@ -68,6 +69,7 @@ export function buildRunContext(input: {
 
   if (run.callback !== undefined) ctx.set(SessionCallbackKey, run.callback);
   if (run.progressCallback !== undefined) ctx.set(ProgressCallbackKey, run.progressCallback);
+  if (run.progressGroupId !== undefined) ctx.set(ProgressGroupKey, run.progressGroupId);
 
   if (run.parent !== undefined) {
     ctx.set(ParentSessionKey, run.parent);

--- a/packages/eve/src/execution/session-progress.test.ts
+++ b/packages/eve/src/execution/session-progress.test.ts
@@ -202,6 +202,20 @@ describe("reduceProgressCommand", () => {
     ).toBeUndefined();
   });
 
+  it("accepts bounded root-turn grouping on the wire", () => {
+    expect(
+      parseProgressCommandV1(
+        command([
+          {
+            eventId: "grouped-turn",
+            kind: "turn",
+            turn: { ...turn, groupId: "turn:root:root-turn" },
+          },
+        ]),
+      ),
+    ).toBeDefined();
+  });
+
   it("bounds command and event deduplication", () => {
     let snapshot = createProgressSnapshot();
     for (let index = 0; index <= MAX_PROGRESS_DEDUPLICATION_IDS; index += 1) {

--- a/packages/eve/src/execution/session-progress.ts
+++ b/packages/eve/src/execution/session-progress.ts
@@ -17,6 +17,7 @@ export interface ProgressReportV1 {
 }
 
 export interface ProgressTurnV1 {
+  readonly groupId?: string;
   readonly id: string;
   readonly sequence: number;
   readonly phase: ProgressPhase;
@@ -26,6 +27,7 @@ export interface ProgressTurnV1 {
 }
 
 export interface ProgressEntityV1 {
+  readonly groupId?: string;
   readonly id: string;
   readonly turnId: string;
   readonly kind: "tool" | "subagent" | "remote-agent" | "skill" | "blocker";
@@ -86,6 +88,7 @@ const progressReportSchema = z
   .strict();
 const progressTurnSchema = z
   .object({
+    groupId: z.string().min(1).max(500).optional(),
     id: z.string().min(1),
     phase: progressPhaseSchema,
     report: progressReportSchema.optional(),
@@ -96,6 +99,7 @@ const progressTurnSchema = z
   .strict();
 const progressEntitySchema = z
   .object({
+    groupId: z.string().min(1).max(500).optional(),
     id: z.string().min(1),
     kind: z.enum(["tool", "subagent", "remote-agent", "skill", "blocker"]),
     label: z.string(),

--- a/packages/eve/src/execution/structural-progress.ts
+++ b/packages/eve/src/execution/structural-progress.ts
@@ -1,5 +1,5 @@
 import type { ContextContainer } from "#context/container.js";
-import { CapabilitiesKey, SessionKey, type Session } from "#context/keys.js";
+import { CapabilitiesKey, ProgressGroupKey, SessionKey, type Session } from "#context/keys.js";
 import { submitProgressCommand } from "#execution/submit-progress.js";
 import {
   normalizeProgressText,
@@ -17,8 +17,9 @@ import type { RuntimeActionRequest, RuntimeActionResult } from "#runtime/actions
 export function projectStructuralProgress(
   session: Session,
   event: MessageStreamEvent,
+  progressGroupId?: string,
 ): ProgressCommandV1 | undefined {
-  const events = projectEvents(session, event);
+  const events = projectEvents(session, event, progressGroupId);
   if (events.length === 0) return undefined;
   return {
     commandId: `structural:${session.sessionId}:${event.meta.id}`,
@@ -35,7 +36,7 @@ export async function publishStructuralProgress(
 ): Promise<void> {
   if (ctx.get(CapabilitiesKey)?.progress !== true) return;
   const session = ctx.require(SessionKey);
-  const command = projectStructuralProgress(session, event);
+  const command = projectStructuralProgress(session, event, ctx.get(ProgressGroupKey));
   if (command === undefined) return;
 
   try {
@@ -45,7 +46,11 @@ export async function publishStructuralProgress(
   }
 }
 
-function projectEvents(session: Session, event: MessageStreamEvent): readonly ProgressEventV1[] {
+function projectEvents(
+  session: Session,
+  event: MessageStreamEvent,
+  progressGroupId?: string,
+): readonly ProgressEventV1[] {
   switch (event.type) {
     case "turn.started":
       return [
@@ -53,6 +58,7 @@ function projectEvents(session: Session, event: MessageStreamEvent): readonly Pr
           eventId: eventId(session, event),
           kind: "turn",
           turn: {
+            groupId: progressGroupId,
             id: progressTurnId(session.sessionId, event.data.turnId),
             phase: "running",
             sequence: event.data.sequence,
@@ -61,14 +67,14 @@ function projectEvents(session: Session, event: MessageStreamEvent): readonly Pr
         },
       ];
     case "turn.completed":
-      return [turnSettlement(session, event, "completed")];
+      return [turnSettlement(session, event, "completed", progressGroupId)];
     case "turn.failed":
-      return [turnSettlement(session, event, "failed")];
+      return [turnSettlement(session, event, "failed", progressGroupId)];
     case "turn.cancelled":
-      return [turnSettlement(session, event, "cancelled")];
+      return [turnSettlement(session, event, "cancelled", progressGroupId)];
     case "actions.requested":
       return event.data.actions.map((action) => ({
-        entity: actionEntity(session, event.data.turnId, action, "running"),
+        entity: actionEntity(session, event.data.turnId, action, "running", progressGroupId),
         eventId: eventId(session, event, action.callId),
         kind: "entity",
       }));
@@ -80,6 +86,7 @@ function projectEvents(session: Session, event: MessageStreamEvent): readonly Pr
             event.data.turnId,
             resultAsAction(event.data.result),
             resultPhase(event.data.result, event.data.status),
+            progressGroupId,
           ),
           eventId: eventId(session, event, event.data.result.callId),
           kind: "entity",
@@ -93,6 +100,7 @@ function projectEvents(session: Session, event: MessageStreamEvent): readonly Pr
           `input:${session.sessionId}:${request.requestId}`,
           request.prompt,
           "blocked",
+          progressGroupId,
         ),
         eventId: eventId(session, event, request.requestId),
         kind: "entity",
@@ -105,6 +113,7 @@ function projectEvents(session: Session, event: MessageStreamEvent): readonly Pr
           `input:${session.sessionId}:${resolution.requestId}`,
           resolution.kind,
           resolution.outcome === "invalid" ? "failed" : "completed",
+          progressGroupId,
         ),
         eventId: eventId(session, event, resolution.requestId),
         kind: "entity",
@@ -121,6 +130,7 @@ function projectEvents(session: Session, event: MessageStreamEvent): readonly Pr
             `authorization:${session.sessionId}:${id}`,
             required ? event.data.description : event.data.name,
             required ? "blocked" : event.data.outcome === "authorized" ? "completed" : "failed",
+            progressGroupId,
           ),
           eventId: eventId(session, event),
           kind: "entity",
@@ -136,11 +146,13 @@ function turnSettlement(
   session: Session,
   event: Extract<MessageStreamEvent, { type: "turn.cancelled" | "turn.completed" | "turn.failed" }>,
   phase: Extract<ProgressPhase, "cancelled" | "completed" | "failed">,
+  groupId?: string,
 ): ProgressEventV1 {
   return {
     eventId: eventId(session, event),
     kind: "turn",
     turn: {
+      groupId,
       id: progressTurnId(session.sessionId, event.data.turnId),
       phase,
       sequence: event.data.sequence,
@@ -155,8 +167,10 @@ function actionEntity(
   turnId: string,
   action: RuntimeActionRequest,
   phase: ProgressPhase,
+  groupId?: string,
 ): ProgressEntityV1 {
   const base = {
+    groupId,
     id: progressActionId(session.sessionId, action.callId),
     phase,
     turnId: progressTurnId(session.sessionId, turnId),
@@ -179,8 +193,10 @@ function blocker(
   id: string,
   label: string,
   phase: ProgressPhase,
+  groupId?: string,
 ): ProgressEntityV1 {
   return {
+    groupId,
     id,
     kind: "blocker",
     label: normalizeProgressText(label),

--- a/packages/eve/src/execution/subagent-start-local.ts
+++ b/packages/eve/src/execution/subagent-start-local.ts
@@ -36,6 +36,7 @@ export async function startLocalSubagent(input: {
   readonly parentContinuationToken: string | undefined;
   readonly parentTraceContext: Parameters<typeof buildSubagentRunInput>[0]["parentTraceContext"];
   readonly progressCallback?: Parameters<typeof buildSubagentRunInput>[0]["progressCallback"];
+  readonly progressGroupId: string;
   readonly persistentSessions: boolean;
   readonly sandboxSessionId: string;
   readonly session: RuntimeSession;
@@ -61,6 +62,7 @@ export async function startLocalSubagent(input: {
     parentTraceContext: input.parentTraceContext,
     persistentSessions: input.persistentSessions,
     progressCallback: input.progressCallback,
+    progressGroupId: input.progressGroupId,
     sandboxSessionId: input.sandboxSessionId,
     session: input.session,
     source,

--- a/packages/eve/src/execution/subagent-start-remote.ts
+++ b/packages/eve/src/execution/subagent-start-remote.ts
@@ -62,6 +62,7 @@ export async function startRemoteSubagent(input: {
   readonly parentTraceContext: Parameters<typeof startRemoteAgentSession>[0]["parentTraceContext"];
   readonly persistentSessions: boolean;
   readonly progressCallback?: Parameters<typeof startRemoteAgentSession>[0]["progressCallback"];
+  readonly progressGroupId: string;
   readonly session: RuntimeSession;
   readonly taskOwned: boolean;
 }): Promise<DispatchOutcome> {
@@ -118,6 +119,7 @@ export async function startRemoteSubagent(input: {
       operationId: operation.id,
       parentTraceContext: input.parentTraceContext,
       persistentSessions: input.persistentSessions,
+      progressGroupId: input.progressGroupId,
       progressCallback: resolveRemoteProgressCallback({
         callbackBaseUrl,
         enabled: input.capabilities?.progress === true,

--- a/packages/eve/src/execution/subagent-tool.test.ts
+++ b/packages/eve/src/execution/subagent-tool.test.ts
@@ -61,6 +61,19 @@ describe("buildSubagentRunInput", () => {
     expect(runInput.capabilities).toEqual({ requestInput: true });
   });
 
+  it("forwards the originating progress group to the child run input", () => {
+    const { runInput } = buildRuntimeSubagentRunInput({
+      action: makeAction(),
+      auth: null,
+      batchEvent: { sequence: 0, turnId: "turn-0" },
+      initiatorAuth: null,
+      progressGroupId: "turn:root:root-turn",
+      session: makeSession(),
+    });
+
+    expect(runInput.progressGroupId).toBe("turn:root:root-turn");
+  });
+
   it("leaves capabilities undefined when the parent has none", () => {
     const { runInput } = buildRuntimeSubagentRunInput({
       action: makeAction(),

--- a/packages/eve/src/execution/subagent-tool.ts
+++ b/packages/eve/src/execution/subagent-tool.ts
@@ -96,6 +96,7 @@ export function buildSubagentRunInput(input: {
   readonly parentContinuationToken?: string;
   readonly parentTraceContext?: SessionTraceContext;
   readonly progressCallback?: import("#channel/types.js").ProgressCallbackV1;
+  readonly progressGroupId?: string;
   /**
    * Whether the parent agent opted into
    * `experimental.subagentPersistentSessions`. Persistent children run in
@@ -183,6 +184,7 @@ export function buildSubagentRunInput(input: {
     },
     parentTraceContext: input.parentTraceContext,
     progressCallback: input.progressCallback,
+    progressGroupId: input.progressGroupId,
     subagentDepth: subagentDepth.nextChildDepth,
   };
 

--- a/packages/eve/src/execution/tasks/parent/dispatch-task-step.ts
+++ b/packages/eve/src/execution/tasks/parent/dispatch-task-step.ts
@@ -161,6 +161,8 @@ export async function dispatchTaskStep(
             // `experimental.subagentPersistentSessions` never produces a
             // third mode here.
             persistentSessions: true,
+            progressCallback: prepared.progressCallback,
+            progressGroupId: prepared.progressGroupId,
             sandboxSessionId: prepared.sandboxSessionId,
             serializedContext: prepared.serializedContext,
             session,

--- a/packages/eve/src/public/channels/eve.ts
+++ b/packages/eve/src/public/channels/eve.ts
@@ -324,6 +324,7 @@ export function eveChannel(input: EveChannelInput): EveChannel {
             capabilities,
             callback: body.callback,
             progressCallback: body.progressCallback,
+            progressGroupId: body.progressGroupId,
             continuationToken: operationToken,
             initiatorAuth: forwarded.accepted ? forwarded.initiatorAuth : undefined,
             input: {
@@ -824,6 +825,7 @@ interface ParsedCreateBody {
   callback?: SessionCallback;
   capabilities?: SessionCapabilities;
   progressCallback?: ProgressCallbackV1;
+  progressGroupId?: string;
   message: string | UserContent;
   mode?: RunMode;
   context?: readonly string[];
@@ -880,6 +882,22 @@ function parseCreateBody(payload: Record<string, unknown>): ParsedCreateBody | R
     );
   }
 
+  const progressGroupId = payload.progressGroupId;
+  if (
+    progressGroupId !== undefined &&
+    (typeof progressGroupId !== "string" ||
+      progressGroupId.length === 0 ||
+      progressGroupId.length > 500)
+  ) {
+    return Response.json(
+      {
+        error: "Expected 'progressGroupId' to be a non-empty string of at most 500 characters.",
+        ok: false,
+      },
+      { status: 400 },
+    );
+  }
+
   const mode = parseModeField(payload.mode);
   if (mode instanceof Response) return mode;
 
@@ -909,6 +927,7 @@ function parseCreateBody(payload: Record<string, unknown>): ParsedCreateBody | R
     context,
     outputSchema,
     progressCallback,
+    progressGroupId,
   };
   if (typeof rawOperationId === "string") result.operationId = rawOperationId;
   return result;

--- a/packages/eve/src/public/channels/slack/activity-progress.test.ts
+++ b/packages/eve/src/public/channels/slack/activity-progress.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { reduceProgressCommand, createProgressSnapshot } from "#execution/session-progress.js";
+import {
+  activityMessages,
+  buildSlackProgressRenderers,
+  slackActivityProgress,
+  slackStatusProgress,
+} from "#public/channels/slack/progress.js";
+
+function snapshot() {
+  return reduceProgressCommand(createProgressSnapshot(), {
+    commandId: "structural",
+    events: [
+      {
+        eventId: "root",
+        kind: "turn",
+        turn: {
+          id: "turn:root:t1",
+          phase: "running",
+          sequence: 0,
+          startedAt: "2026-08-19T12:00:00.000Z",
+        },
+      },
+      {
+        eventId: "child",
+        kind: "turn",
+        turn: {
+          groupId: "turn:root:t1",
+          id: "turn:child:t1",
+          phase: "running",
+          sequence: 0,
+          startedAt: "2026-08-19T12:00:01.000Z",
+        },
+      },
+      {
+        entity: {
+          groupId: "turn:root:t1",
+          id: "action:child:c1",
+          kind: "tool",
+          label: "Read <secrets> & verify",
+          phase: "running",
+          turnId: "turn:child:t1",
+        },
+        eventId: "tool",
+        kind: "entity",
+      },
+    ],
+    kind: "progress",
+    version: 1,
+  });
+}
+
+describe("Slack activity progress", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("groups descendant work under the originating root turn and escapes mrkdwn controls", () => {
+    expect(activityMessages(snapshot())).toEqual(
+      new Map([["turn:root:t1", "• Read &lt;secrets&gt; &amp; verify"]]),
+    );
+  });
+
+  it("creates one metadata-tagged message and updates it in place", async () => {
+    const requests: Array<{ operation: string; body: URLSearchParams }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+        const operation = String(url).split("/").at(-1)!;
+        const body = new URLSearchParams(String(init?.body ?? ""));
+        requests.push({ body, operation });
+        if (operation === "conversations.replies") {
+          return Response.json({ ok: true, messages: [] });
+        }
+        return Response.json({ ok: true, ts: "1700.1" });
+      }),
+    );
+    const [renderer] = buildSlackProgressRenderers({
+      botToken: "xoxb-test",
+      renderers: [slackActivityProgress()],
+    });
+    const state = await renderer!.render({
+      destination: { channelId: "C1", threadTs: "T1" },
+      snapshot: snapshot(),
+      state: undefined,
+    });
+    const completed = reduceProgressCommand(snapshot(), {
+      commandId: "done",
+      events: [
+        {
+          entity: {
+            groupId: "turn:root:t1",
+            id: "action:child:c1",
+            kind: "tool",
+            label: "Read secrets",
+            phase: "completed",
+            turnId: "turn:child:t1",
+          },
+          eventId: "tool-done",
+          kind: "entity",
+        },
+      ],
+      kind: "progress",
+      version: 1,
+    });
+    await renderer!.render({
+      destination: { channelId: "C1", threadTs: "T1" },
+      snapshot: completed,
+      state,
+    });
+
+    expect(requests.map((request) => request.operation)).toEqual([
+      "conversations.replies",
+      "chat.postMessage",
+      "chat.update",
+    ]);
+    expect(requests[1]?.body.get("metadata")).toContain("eve_progress");
+    expect(requests[2]?.body.get("ts")).toBe("1700.1");
+  });
+
+  it("reposts a deleted activity message", async () => {
+    const operations: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL | Request) => {
+        const operation = String(url).split("/").at(-1)!;
+        operations.push(operation);
+        if (operation === "chat.update")
+          return Response.json({ error: "message_not_found", ok: false });
+        return Response.json({ ok: true, ts: "replacement" });
+      }),
+    );
+    const [renderer] = buildSlackProgressRenderers({
+      botToken: "xoxb-test",
+      renderers: [slackActivityProgress()],
+    });
+    const state = { messages: { "turn:root:t1": { text: "old", ts: "deleted" } } };
+    await expect(
+      renderer!.render({
+        destination: { channelId: "C1", threadTs: "T1" },
+        snapshot: snapshot(),
+        state,
+      }),
+    ).resolves.toEqual({
+      messages: {
+        "turn:root:t1": { text: "• Read &lt;secrets&gt; &amp; verify", ts: "replacement" },
+      },
+    });
+    expect(operations).toEqual(["chat.update", "chat.postMessage"]);
+  });
+
+  it("recovers message identity from Slack metadata and composes with status", async () => {
+    const operations: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL | Request) => {
+        const operation = String(url).split("/").at(-1)!;
+        operations.push(operation);
+        if (operation === "conversations.replies") {
+          return Response.json({
+            messages: [
+              {
+                metadata: {
+                  event_payload: { group_id: "turn:root:t1" },
+                  event_type: "eve_progress",
+                },
+                text: "old",
+                ts: "1700.1",
+              },
+            ],
+            ok: true,
+          });
+        }
+        return Response.json({ ok: true, ts: "1700.1" });
+      }),
+    );
+    const renderers = buildSlackProgressRenderers({
+      botToken: "xoxb-test",
+      renderers: [slackStatusProgress(), slackActivityProgress()],
+    });
+    for (const renderer of renderers) {
+      await renderer.render({
+        destination: { channelId: "C1", threadTs: "T1" },
+        snapshot: snapshot(),
+        state: undefined,
+      });
+    }
+
+    expect(operations).toContain("assistant.threads.setStatus");
+    expect(operations).toContain("chat.update");
+    expect(operations).not.toContain("chat.postMessage");
+  });
+});

--- a/packages/eve/src/public/channels/slack/index.ts
+++ b/packages/eve/src/public/channels/slack/index.ts
@@ -70,6 +70,7 @@ export {
 export { defaultSlackAuth } from "#public/channels/slack/defaults.js";
 
 export {
+  slackActivityProgress,
   slackStatusProgress,
   type SlackProgressRenderer,
 } from "#public/channels/slack/progress.js";

--- a/packages/eve/src/public/channels/slack/progress.ts
+++ b/packages/eve/src/public/channels/slack/progress.ts
@@ -1,13 +1,20 @@
 import type { ChannelProgressRenderer } from "#channel/adapter.js";
-import type { ProgressEntityV1, ProgressSnapshotV1 } from "#execution/session-progress.js";
+import type {
+  ProgressEntityV1,
+  ProgressSnapshotV1,
+  ProgressTurnV1,
+} from "#execution/session-progress.js";
 import { callSlackApi, type SlackBotToken } from "#public/channels/slack/api.js";
 import { truncateTypingStatus } from "#public/channels/slack/limits.js";
 
 const SLACK_STATUS_PROGRESS_RENDERER_ID = "slack.status.v1";
+const SLACK_ACTIVITY_PROGRESS_RENDERER_ID = "slack.activity.v1";
 const SLACK_PROGRESS_RENDERER = Symbol("eve.slack.progress-renderer");
 
 export interface SlackProgressRenderer {
-  readonly id: typeof SLACK_STATUS_PROGRESS_RENDERER_ID;
+  readonly id:
+    | typeof SLACK_STATUS_PROGRESS_RENDERER_ID
+    | typeof SLACK_ACTIVITY_PROGRESS_RENDERER_ID;
   readonly [SLACK_PROGRESS_RENDERER]: true;
 }
 
@@ -15,9 +22,18 @@ interface SlackStatusProgressState {
   readonly status: string;
 }
 
+interface SlackActivityProgressState {
+  readonly messages: Readonly<Record<string, { readonly text: string; readonly ts: string }>>;
+}
+
 /** Creates the compact Slack assistant-thread progress renderer. */
 export function slackStatusProgress(): SlackProgressRenderer {
   return { [SLACK_PROGRESS_RENDERER]: true, id: SLACK_STATUS_PROGRESS_RENDERER_ID };
+}
+
+/** Creates one update-in-place Slack activity message per originating root turn. */
+export function slackActivityProgress(): SlackProgressRenderer {
+  return { [SLACK_PROGRESS_RENDERER]: true, id: SLACK_ACTIVITY_PROGRESS_RENDERER_ID };
 }
 
 export function hasSlackStatusProgress(
@@ -41,6 +57,8 @@ export function buildSlackProgressRenderers(input: {
     switch (renderer.id) {
       case SLACK_STATUS_PROGRESS_RENDERER_ID:
         return createSlackStatusRenderer(input.botToken);
+      case SLACK_ACTIVITY_PROGRESS_RENDERER_ID:
+        return createSlackActivityRenderer(input.botToken);
     }
   });
 }
@@ -78,6 +96,173 @@ function createSlackStatusRenderer(botToken: SlackBotToken | undefined): Channel
       return { status } satisfies SlackStatusProgressState;
     },
   };
+}
+
+function createSlackActivityRenderer(botToken: SlackBotToken | undefined): ChannelProgressRenderer {
+  return {
+    id: SLACK_ACTIVITY_PROGRESS_RENDERER_ID,
+    async render({ destination, snapshot, state }) {
+      const channelId = destination["channelId"];
+      const threadTs = destination["threadTs"];
+      if (typeof channelId !== "string" || typeof threadTs !== "string" || threadTs === "") {
+        return state;
+      }
+      const previous = isActivityState(state) ? state.messages : {};
+      const desired = activityMessages(snapshot);
+      const messages = Object.fromEntries(
+        Object.entries(previous).filter(([groupId]) => desired.has(groupId)),
+      );
+      for (const [groupId, text] of desired) {
+        const current =
+          previous[groupId] ??
+          (await recoverActivityMessage({ botToken, channelId, groupId, threadTs }));
+        if (current?.text === text) {
+          messages[groupId] = current;
+          continue;
+        }
+        const body =
+          current === undefined
+            ? {
+                channel: channelId,
+                metadata: {
+                  event_payload: { group_id: groupId },
+                  event_type: "eve_progress",
+                },
+                text,
+                thread_ts: threadTs,
+              }
+            : { channel: channelId, text, ts: current.ts };
+        let response = await callSlackApi({
+          body,
+          botToken,
+          operation: current === undefined ? "chat.postMessage" : "chat.update",
+        });
+        if (
+          response.ok !== true &&
+          current !== undefined &&
+          response.error === "message_not_found"
+        ) {
+          response = await callSlackApi({
+            body: {
+              channel: channelId,
+              metadata: {
+                event_payload: { group_id: groupId },
+                event_type: "eve_progress",
+              },
+              text,
+              thread_ts: threadTs,
+            },
+            botToken,
+            operation: "chat.postMessage",
+          });
+        }
+        if (response.ok !== true) {
+          throw new Error(`Slack activity message failed: ${response.error ?? "unknown_error"}`);
+        }
+        const ts = response.ts ?? current?.ts;
+        if (typeof ts !== "string" || ts === "") {
+          throw new Error("Slack activity message response did not include ts.");
+        }
+        messages[groupId] = { text, ts };
+      }
+      return { messages } satisfies SlackActivityProgressState;
+    },
+  };
+}
+
+async function recoverActivityMessage(input: {
+  readonly botToken: SlackBotToken | undefined;
+  readonly channelId: string;
+  readonly groupId: string;
+  readonly threadTs: string;
+}): Promise<{ readonly text: string; readonly ts: string } | undefined> {
+  const response = await callSlackApi({
+    body: { channel: input.channelId, inclusive: true, limit: 100, ts: input.threadTs },
+    botToken: input.botToken,
+    operation: "conversations.replies",
+  });
+  if (response.ok !== true || !Array.isArray(response.messages)) return undefined;
+  for (const message of response.messages) {
+    if (message === null || typeof message !== "object") continue;
+    const metadata = Reflect.get(message, "metadata");
+    const payload =
+      metadata !== null && typeof metadata === "object"
+        ? Reflect.get(metadata, "event_payload")
+        : undefined;
+    if (
+      metadata !== null &&
+      typeof metadata === "object" &&
+      Reflect.get(metadata, "event_type") === "eve_progress" &&
+      payload !== null &&
+      typeof payload === "object" &&
+      Reflect.get(payload, "group_id") === input.groupId
+    ) {
+      const ts = Reflect.get(message, "ts");
+      const text = Reflect.get(message, "text");
+      if (typeof ts === "string") return { text: typeof text === "string" ? text : "", ts };
+    }
+  }
+  return undefined;
+}
+
+export function activityMessages(snapshot: ProgressSnapshotV1): ReadonlyMap<string, string> {
+  const turnGroups = new Map<string, string>();
+  const grouped = new Map<string, { entities: ProgressEntityV1[]; turns: ProgressTurnV1[] }>();
+  for (const turn of Object.values(snapshot.turns)) {
+    const groupId = turn.groupId ?? turn.id;
+    turnGroups.set(turn.id, groupId);
+    const group = grouped.get(groupId) ?? { entities: [], turns: [] };
+    group.turns.push(turn);
+    grouped.set(groupId, group);
+  }
+  for (const entity of Object.values(snapshot.entities)) {
+    const groupId = entity.groupId ?? turnGroups.get(entity.turnId) ?? entity.turnId;
+    const group = grouped.get(groupId) ?? { entities: [], turns: [] };
+    group.entities.push(entity);
+    grouped.set(groupId, group);
+  }
+
+  return new Map(
+    [...grouped].map(([groupId, group]) => {
+      const lines = group.entities
+        .slice(-12)
+        .map((entity) => `${phaseIcon(entity.phase)} ${escapeSlackText(entity.label)}`);
+      const report = group.turns.findLast((turn) => turn.report !== undefined)?.report;
+      if (report !== undefined) lines.push(`↳ ${escapeSlackText(report.message)}`);
+      if (lines.length === 0) {
+        const phase = group.turns.at(-1)?.phase ?? "running";
+        lines.push(`${phaseIcon(phase)} Working`);
+      }
+      return [groupId, lines.join("\n")] as const;
+    }),
+  );
+}
+
+function phaseIcon(phase: ProgressEntityV1["phase"]): string {
+  switch (phase) {
+    case "blocked":
+      return "⏸";
+    case "completed":
+      return "✓";
+    case "failed":
+      return "✗";
+    case "cancelled":
+      return "–";
+    default:
+      return "•";
+  }
+}
+
+function escapeSlackText(text: string): string {
+  return text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+}
+
+function isActivityState(value: unknown): value is SlackActivityProgressState {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof Reflect.get(value, "messages") === "object"
+  );
 }
 
 export function selectSlackProgressStatus(snapshot: ProgressSnapshotV1): string {


### PR DESCRIPTION
### Summary

Related to #1673. This stacked PR adds `slackActivityProgress()`, which owns one update-in-place activity message per originating root turn. Root, local, nested, remote, synchronous, and background work carry the root turn's group identity; the renderer keeps updating that artifact after the root model turn settles, retains settled activity, escapes untrusted text, and caps displayed items.

The renderer composes with `slackStatusProgress()`. Slack metadata recovers message identity after replay, and a deleted message is recreated rather than leaving renderer state stuck.

### Validation

Focused coverage verifies renderer composition, root/descendant grouping, local and remote group propagation, message creation and in-place update, metadata recovery, deleted-message recreation, escaping, report rendering, and background settlement. TypeScript, invariant checks, extension-contract checks, and docs checks pass.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+20 / -1`

Adds the release note and combined status/activity configuration with lifecycle behavior.

**Implementation** — 16 files · `+266 / -11`

Most changes propagate one bounded root-turn group identifier through existing local and remote delegation; the Slack implementation owns rendering, recovery, and provider identity.

**Tests** — 3 files · `+236 / -0`

Covers provider effects, recovery, composition, escaping, and local/remote grouping.
