### PR TITLE
fix(eve): avoid per-item registry title requests

### DIFF
--- a/.changeset/fresh-registries-smile.md
+++ b/.changeset/fresh-registries-smile.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Registry browsing now uses titles returned by the catalog, avoiding a separate request for every displayed item.

--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -368,7 +368,7 @@
     "react": "catalog:",
     "react-test-renderer": "19.2.6",
     "semver": "7.8.4",
-    "shadcn": "4.16.1",
+    "shadcn": "4.18.0",
     "svelte": "^5.0.0",
     "turndown": "7.2.4",
     "vite": "^8.1.5",

--- a/packages/eve/scripts/vendor-compiled/declarations/shadcn-registry.d.ts
+++ b/packages/eve/scripts/vendor-compiled/declarations/shadcn-registry.d.ts
@@ -20,6 +20,7 @@ export interface AddRegistryItemsOptions {
 export interface RegistrySearchItem {
   registry: string;
   name: string;
+  title?: string;
   addCommandArgument: string;
   type?: string;
   description?: string;

--- a/packages/eve/src/cli/commands/registry.test.ts
+++ b/packages/eve/src/cli/commands/registry.test.ts
@@ -867,43 +867,32 @@ describe("registry commands", () => {
     expect(logger.logs).toContain("Added @other to package.json.");
   });
 
-  it("loads real item titles in parallel for a page of search results", async () => {
+  it("uses titles returned with a page of search results", async () => {
     searchRegistries.mockResolvedValue({
       items: [
         {
           registry: "https://eve.dev/r/registry.json",
           name: "channel/photon-imessage",
+          title: "Photon iMessage",
           addCommandArgument: "https://eve.dev/r/channel/photon-imessage.json",
         },
         {
           registry: "@acme",
           name: "extension/ai-sdk-tools",
+          title: "AI SDK Tools",
           addCommandArgument: "@acme/ai-sdk-tools",
         },
       ],
       pagination: { total: 2, offset: 0, limit: 2, hasMore: false },
     });
-    const resolvers = new Map<string, (value: unknown[]) => void>();
-    getRegistryItems.mockImplementation(
-      ([address]: string[]) =>
-        new Promise((resolve) => {
-          resolvers.set(address!, resolve);
-        }),
-    );
 
-    const catalog = browseRegistryCatalog("/project", { query: "sdk" });
-
-    await vi.waitFor(() => expect(getRegistryItems).toHaveBeenCalledTimes(2));
-    resolvers.get("https://eve.dev/r/channel/photon-imessage.json")?.([
-      { title: "Photon iMessage" },
-    ]);
-    resolvers.get("@acme/ai-sdk-tools")?.([{ title: "AI SDK Tools" }]);
-    await expect(catalog).resolves.toMatchObject({
+    await expect(browseRegistryCatalog("/project", { query: "sdk" })).resolves.toMatchObject({
       items: [
         { name: "channel/photon-imessage", title: "Photon iMessage" },
         { name: "extension/ai-sdk-tools", title: "AI SDK Tools" },
       ],
     });
+    expect(getRegistryItems).not.toHaveBeenCalled();
     expect(searchRegistries).toHaveBeenCalledWith(
       ["https://eve.dev/r/registry.json"],
       expect.objectContaining({ limit: 100, query: "sdk" }),

--- a/packages/eve/src/cli/commands/registry.ts
+++ b/packages/eve/src/cli/commands/registry.ts
@@ -356,34 +356,20 @@ async function searchRegistryCatalog(
   return { config, result, resultsBySource, sources, metadataByAddress };
 }
 
-function registryManifestTitle(manifest: unknown): string | undefined {
-  if (typeof manifest !== "object" || manifest === null || Array.isArray(manifest))
-    return undefined;
-  const title = (manifest as { title?: unknown }).title;
-  return typeof title === "string" ? title : undefined;
-}
-
 /** Browses all configured catalogs, or one namespace or URL source. */
 export async function browseRegistryCatalog(
   appRoot: string,
   options: { query?: string; source?: string } = {},
 ): Promise<RegistryCatalogResult> {
-  const { config, result } = await searchRegistryCatalog(appRoot, options);
-  const manifests = await Promise.all(
-    result.items.map(async (item) => {
-      const [manifest] = await getRegistryItems([item.addCommandArgument], { config });
-      return manifest;
-    }),
-  );
+  const { result } = await searchRegistryCatalog(appRoot, options);
   return {
-    items: result.items.map((item: RegistrySearchItem, index) => {
+    items: result.items.map((item: RegistrySearchItem) => {
       const catalogItem: RegistryCatalogItem = {
         address: item.registry === OFFICIAL_CATALOG ? item.name : item.addCommandArgument,
         name: item.name,
         source: item.registry === OFFICIAL_CATALOG ? "Vercel" : item.registry,
       };
-      const title = registryManifestTitle(manifests[index]);
-      if (title !== undefined) catalogItem.title = title;
+      if (item.title !== undefined) catalogItem.title = item.title;
       if (item.type !== undefined) catalogItem.type = item.type;
       if (item.description !== undefined) catalogItem.description = item.description;
       return catalogItem;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1397,8 +1397,8 @@ importers:
         specifier: 7.8.4
         version: 7.8.4
       shadcn:
-        specifier: 4.16.1
-        version: 4.16.1(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(typescript@7.0.2)
+        specifier: 4.18.0
+        version: 4.18.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(typescript@7.0.2)
       svelte:
         specifier: ^5.0.0
         version: 5.56.1(@typescript-eslint/types@8.59.4)
@@ -13911,8 +13911,8 @@ packages:
     engines: {node: '>=20.18.1'}
     hasBin: true
 
-  shadcn@4.16.1:
-    resolution: {integrity: sha512-XLFzfNNIUPlUlyheFEzj0H4Vnhi9nI0nl3Nfgg8HYXW1FkUVhVT1X+mgmOUW8aWL5SeG0A+yJIV5fm3Hr9MVkQ==}
+  shadcn@4.18.0:
+    resolution: {integrity: sha512-tUFZgkYmfVNQVm3xX7lhSzOvDsp+O14ac5dwgXIr5mIsr79ISueb/Mu+ZtWMz0DH6v77u4eYyvbQ9TTMpSn3aw==}
     engines: {node: '>=20.18.1'}
     hasBin: true
 
@@ -16600,7 +16600,7 @@ snapshots:
       open: 8.4.2
       picomatch: 4.0.5
       systeminformation: 5.33.0
-      undici: 7.28.0
+      undici: 7.29.0
       which: 4.0.0
       yocto-spinner: 1.2.2
 
@@ -22330,7 +22330,7 @@ snapshots:
       ms: 2.1.3
       picocolors: 1.1.1
       tar-stream: 3.1.7
-      undici: 7.28.0
+      undici: 7.29.0
       xdg-app-paths: 5.1.0
       zod: 4.4.3
     transitivePeerDependencies:
@@ -23517,7 +23517,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.28.0
+      undici: 7.29.0
       whatwg-mimetype: 4.0.0
 
   cheminfo-types@1.15.0: {}
@@ -28764,7 +28764,7 @@ snapshots:
       chardet: 2.2.0
       cheerio: 1.2.0
       iconv-lite: 0.7.2
-      undici: 7.28.0
+      undici: 7.29.0
 
   open@11.0.0:
     dependencies:
@@ -30585,7 +30585,7 @@ snapshots:
       - supports-color
       - typescript
 
-  shadcn@4.16.1(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(typescript@7.0.2):
+  shadcn@4.18.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(typescript@7.0.2):
     dependencies:
       '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/parser': 7.29.7
@@ -30611,11 +30611,12 @@ snapshots:
       postcss-selector-parser: 7.1.4
       prompts: 2.4.2
       recast: 0.23.12
+      socks: 2.8.9
       stringify-object: 5.0.0
       tailwind-merge: 3.6.0
       ts-morph: 26.0.0
       tsconfig-paths: 4.2.0
-      undici: 7.28.0
+      undici: 7.29.0
       validate-npm-package-name: 7.0.2
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)


### PR DESCRIPTION
### Summary

Registry browsing now uses titles returned by shadcn catalog searches instead of fetching every listed item manifest. This removes the N+1 request flow while preserving registry-provided title casing.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/cli/commands/registry.test.ts`
- `pnpm --filter eve build:compiled`
- `oxfmt --check packages/eve/src/cli/commands/registry.ts packages/eve/src/cli/commands/registry.test.ts packages/eve/scripts/vendor-compiled/declarations/shadcn-registry.d.ts .changeset/fresh-registries-smile.md`
- `oxlint packages/eve/src/cli/commands/registry.ts packages/eve/src/cli/commands/registry.test.ts`
- `git diff --check`

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
