### PR TITLE
feat(eve): classify messaging channel audiences

### DIFF
--- a/.changeset/fuzzy-dogs-chat.md
+++ b/.changeset/fuzzy-dogs-chat.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Classify built-in messaging channel metadata by conversation audience.

--- a/docs/guides/instrumentation.md
+++ b/docs/guides/instrumentation.md
@@ -58,6 +58,8 @@ You are responsible for ensuring any observability or eval provider is approved 
 
 The third configurable surface, [runtime context events](#runtime-context), attaches per-model-call values to these spans.
 
+Built-in messaging channels classify their instrumentation metadata with an `audience`: `public`, `private`, or `unknown`. Slack public channels and Chat SDK workspace-visible threads are public; direct and private conversations are private; platform surfaces without enough visibility evidence remain unknown.
+
 ## Channel delivery traces
 
 Instrumentation providers receive `channel.delivery.started` followed by

--- a/packages/eve/src/public/channels/chat-sdk/audience.ts
+++ b/packages/eve/src/public/channels/chat-sdk/audience.ts
@@ -1,0 +1,27 @@
+import type { SerializedThread } from "#compiled/chat/index.js";
+import type { ChannelAudience } from "#shared/channel-audience.js";
+import type {
+  ChatSdkChannelState,
+  ChatSdkInstrumentationMetadata,
+} from "#public/channels/chat-sdk/chatSdkChannel.js";
+
+export function chatSdkInstrumentationMetadata(
+  state: ChatSdkChannelState,
+): ChatSdkInstrumentationMetadata {
+  return {
+    adapterName: state.thread?.adapterName ?? null,
+    audience: chatSdkAudience(state.thread),
+    channelId: state.thread?.channelId ?? null,
+    isDM: state.thread?.isDM ?? null,
+    threadId: state.thread?.id ?? null,
+  };
+}
+
+function chatSdkAudience(thread: SerializedThread | null): ChannelAudience {
+  if (thread?.isDM === true) return "private";
+  if (thread?.channelVisibility === "workspace") return "public";
+  if (thread?.channelVisibility === "private" || thread?.channelVisibility === "external") {
+    return "private";
+  }
+  return "unknown";
+}

--- a/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.test.ts
+++ b/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.test.ts
@@ -137,6 +137,29 @@ async function firePost(
 }
 
 describe("chatSdkChannel", () => {
+  it.each([
+    [{ isDM: true, channelVisibility: "unknown" }, "private"],
+    [{ isDM: false, channelVisibility: "workspace" }, "public"],
+    [{ isDM: false, channelVisibility: "private" }, "private"],
+  ] as const)("projects the $audience audience", (thread, audience) => {
+    const bridge = chatSdkChannel({
+      adapters: { test: testAdapter() },
+      state: memoryState(),
+      userName: "bot",
+    });
+    const adapter = getAdapter(bridge.channel);
+    if (!adapter.state) throw new Error("Expected Chat SDK state.");
+    adapter.state.thread = {
+      _type: "chat:Thread",
+      adapterName: "test",
+      channelId: CHANNEL_ID,
+      id: THREAD_ID,
+      ...thread,
+    };
+
+    expect(adapter.instrumentation?.metadata?.(adapter.state)).toMatchObject({ audience });
+  });
+
   it("mounts GET and POST webhook routes per Chat SDK adapter", () => {
     const bridge = chatSdkChannel({
       adapters: {

--- a/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.ts
+++ b/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.ts
@@ -43,6 +43,8 @@ import {
   type RouteHandlerArgs,
   type Session,
 } from "#public/definitions/channel.js";
+import { chatSdkInstrumentationMetadata } from "#public/channels/chat-sdk/audience.js";
+import type { ChannelAudience } from "#shared/channel-audience.js";
 
 const log = createLogger("chat-sdk.channel");
 const DEFAULT_ROUTE = "/eve/v1";
@@ -100,6 +102,7 @@ export interface ChatSdkReceiveTarget {
  * Channel-owned metadata exposed to eve instrumentation.
  */
 export interface ChatSdkInstrumentationMetadata extends Record<string, unknown> {
+  readonly audience: ChannelAudience;
   readonly adapterName: string | null;
   readonly channelId: string | null;
   readonly isDM: boolean | null;
@@ -290,7 +293,7 @@ export function chatSdkChannel<TAdapters extends ChatSdkAdapters>(
     kindHint: "chat-sdk",
     turnPolicy: config.turnPolicy,
     state: initialState(),
-    metadata: metadataFromState,
+    metadata: chatSdkInstrumentationMetadata,
     context(state) {
       return {
         bot,
@@ -575,15 +578,6 @@ async function bridgeSend<TAdapters extends ChatSdkAdapters>(
 
 function initialState(): ChatSdkChannelState {
   return { thread: null };
-}
-
-function metadataFromState(state: ChatSdkChannelState): ChatSdkInstrumentationMetadata {
-  return {
-    adapterName: state.thread?.adapterName ?? null,
-    channelId: state.thread?.channelId ?? null,
-    isDM: state.thread?.isDM ?? null,
-    threadId: state.thread?.id ?? null,
-  };
 }
 
 function threadFromState<TAdapters extends ChatSdkAdapters>(

--- a/packages/eve/src/public/channels/discord/audience.ts
+++ b/packages/eve/src/public/channels/discord/audience.ts
@@ -1,0 +1,18 @@
+import type { ChannelAudience } from "#shared/channel-audience.js";
+import type { DiscordChannelState } from "#public/channels/discord/discordChannel.js";
+import type { DiscordInstrumentationMetadata } from "#public/channels/discord/index.js";
+
+export function discordAudience(channelType: number | undefined): ChannelAudience {
+  if (channelType === 1 || channelType === 3 || channelType === 12) return "private";
+  return "unknown";
+}
+
+export function discordInstrumentationMetadata(
+  state: DiscordChannelState,
+): DiscordInstrumentationMetadata {
+  return {
+    audience: state.audience ?? "unknown",
+    channelId: state.channelId,
+    guildId: state.guildId,
+  };
+}

--- a/packages/eve/src/public/channels/discord/discordChannel.test.ts
+++ b/packages/eve/src/public/channels/discord/discordChannel.test.ts
@@ -52,6 +52,14 @@ function callEvent(
   return contextStorage.run(stubAlsContext, () => callAdapterEventHandler(adapter, event, ctx));
 }
 
+describe("discordChannel() audience metadata", () => {
+  it.each(["private", "unknown"] as const)("projects the %s audience", (audience) => {
+    const adapter = withState(getAdapter(discordChannel()), { audience });
+
+    expect(adapter.instrumentation?.metadata?.(adapter.state)).toMatchObject({ audience });
+  });
+});
+
 function captureAccessor(initialContinuationToken: string): {
   accessor: any;
   writes: Array<[string, unknown]>;
@@ -543,6 +551,7 @@ describe("discordChannel() default event handlers", () => {
       auth: null,
       message: "start",
       state: {
+        audience: "unknown",
         applicationId: null,
         channelId: "C01",
         conversationId: null,

--- a/packages/eve/src/public/channels/discord/discordChannel.ts
+++ b/packages/eve/src/public/channels/discord/discordChannel.ts
@@ -52,6 +52,8 @@ import { readNonEmptyString } from "#shared/guards.js";
 import { parseJsonObject, type JsonObject } from "#shared/json.js";
 import { defineChannel, POST, type Channel } from "#public/definitions/channel.js";
 import type { ValidatedInputResponse } from "#runtime/input/types.js";
+import type { ChannelAudience } from "#shared/channel-audience.js";
+import { discordAudience, discordInstrumentationMetadata } from "./audience.js";
 
 const log = createLogger("discord.channel");
 
@@ -71,6 +73,7 @@ export interface DiscordEventContext extends DiscordChannelContext, ChannelConti
 
 /** JSON-serializable Discord channel state. */
 export interface DiscordChannelState {
+  audience?: ChannelAudience;
   /** Discord channel id. */
   channelId: string | null;
   /** Discord message id once anchored, or an interaction placeholder before the first reply. */
@@ -211,7 +214,6 @@ export interface DiscordChannel extends Channel<
   DiscordReceiveTarget,
   DiscordInstrumentationMetadata
 > {}
-
 /** Discord channel factory for HTTP Interactions and proactive channel messages. */
 export function discordChannel(config: DiscordChannelConfig = {}): DiscordChannel {
   const onCommand = config.onCommand ?? defaultOnCommand;
@@ -226,7 +228,7 @@ export function discordChannel(config: DiscordChannelConfig = {}): DiscordChanne
     kindHint: "discord",
     turnPolicy: config.turnPolicy,
     state: initialDiscordState(),
-    metadata: (state) => ({ channelId: state.channelId, guildId: state.guildId }),
+    metadata: discordInstrumentationMetadata,
 
     context(state, session) {
       return rebuildDiscordContext(state, session, config);
@@ -299,6 +301,7 @@ export function discordChannel(config: DiscordChannelConfig = {}): DiscordChanne
       return from(discordContinuationToken(channelId, conversationId)).send(input.message, {
         auth: input.auth,
         state: {
+          audience: "unknown",
           applicationId: null,
           channelId,
           conversationId: conversationId || null,
@@ -640,6 +643,7 @@ function stateFromInteraction(
   },
 ): DiscordChannelState {
   return {
+    audience: discordAudience(interaction.channelType),
     applicationId: interaction.applicationId,
     channelId: interaction.channelId,
     conversationId: options.conversationId,
@@ -652,6 +656,7 @@ function stateFromInteraction(
 
 function initialDiscordState(): DiscordChannelState {
   return {
+    audience: "unknown",
     applicationId: null,
     channelId: null,
     conversationId: null,

--- a/packages/eve/src/public/channels/discord/inbound.test.ts
+++ b/packages/eve/src/public/channels/discord/inbound.test.ts
@@ -11,6 +11,7 @@ describe("parseDiscordInteraction", () => {
     const interaction = parseDiscordInteraction({
       application_id: "APP1",
       channel_id: "C01",
+      channel: { type: 1 },
       data: {
         id: "CMD1",
         name: "ask",
@@ -31,6 +32,7 @@ describe("parseDiscordInteraction", () => {
     expect(interaction?.type).toBe(2);
     if (interaction?.type !== 2) throw new Error("Expected command interaction.");
     expect(interaction.commandName).toBe("ask");
+    expect(interaction.channelType).toBe(1);
     expect(interaction.options).toEqual([
       { name: "message", options: [], value: "hello from discord" },
     ]);

--- a/packages/eve/src/public/channels/discord/inbound.ts
+++ b/packages/eve/src/public/channels/discord/inbound.ts
@@ -48,6 +48,7 @@ export interface DiscordMember {
 export interface DiscordInteractionBase {
   readonly applicationId: string;
   readonly channelId: string;
+  readonly channelType?: number;
   readonly guildId?: string;
   readonly id: string;
   readonly member?: DiscordMember;
@@ -223,9 +224,11 @@ function parseInteractionBase(raw: Record<string, unknown>): DiscordInteractionB
   }
   const user = parseInteractionUser(raw);
   if (!user) return null;
+  const channel = isObject(raw.channel) ? raw.channel : undefined;
   return {
     applicationId: raw.application_id,
     channelId: raw.channel_id,
+    channelType: typeof channel?.type === "number" ? channel.type : undefined,
     guildId: isNonEmptyString(raw.guild_id) ? raw.guild_id : undefined,
     id: raw.id,
     member: parseMember(raw.member),

--- a/packages/eve/src/public/channels/discord/index.ts
+++ b/packages/eve/src/public/channels/discord/index.ts
@@ -11,6 +11,7 @@ export type { ModelMessage } from "ai";
  * Discord sessions, used for tracing and observability.
  */
 export interface DiscordInstrumentationMetadata extends Record<string, unknown> {
+  readonly audience: import("#shared/channel-audience.js").ChannelAudience;
   /** Originating Discord channel id, or `null` when unavailable. */
   readonly channelId: string | null;
   /** Originating Discord guild id, or `null` when the interaction was not in a guild. */

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -358,6 +358,14 @@ describe("slackChannel()", () => {
 
     expect(channel).toMatchObject({ turnPolicy: "queue" });
   });
+
+  it("projects the durable audience into instrumentation metadata", () => {
+    const adapter = withState(getAdapter(slackChannel()), { audience: "private" });
+
+    expect(adapter.instrumentation?.metadata?.(adapter.state)).toMatchObject({
+      audience: "private",
+    });
+  });
 });
 
 describe("slackChannel() default event handlers", () => {
@@ -1337,6 +1345,7 @@ describe("slackChannel() inbound mention pipeline", () => {
       }),
       message: "Imperative follow-up",
       state: {
+        audience: "unknown",
         channelId: "C_BOUND",
         teamId: "T01",
         threadTs: "1700000000.000300",
@@ -1531,6 +1540,7 @@ describe("slackChannel() inbound mention pipeline", () => {
     expect(send).toHaveBeenCalledTimes(1);
     const [, input] = send.mock.calls[0]!;
     expect(input.title).toBe("Run");
+    expect(input.state).toMatchObject({ audience: "public" });
     expect(input.message).toContain("<content>\npublic message text\n</content>");
   });
 
@@ -1563,6 +1573,7 @@ describe("slackChannel() inbound mention pipeline", () => {
     expect(send).toHaveBeenCalledTimes(1);
     const [, input] = send.mock.calls[0]!;
     expect(input.title).toBe("Private message");
+    expect(input.state).toMatchObject({ audience: "private" });
     expect(input.title).not.toContain("sensitive message");
     expect(input.message).toContain("<content>\nsensitive message\n</content>");
   });

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -74,6 +74,7 @@ import {
 } from "#public/channels/upload-policy.js";
 import { verifySlackRequest, type SlackWebhookVerifier } from "#public/channels/slack/verify.js";
 import { defineChannel, POST, type Channel } from "#public/definitions/channel.js";
+import type { ChannelAudience } from "#shared/channel-audience.js";
 import { markEventHandled } from "./utils.js";
 
 export type {
@@ -189,6 +190,8 @@ export interface SlackPendingApprovalCard {
 }
 
 export interface SlackChannelState {
+  /** Audience classification captured before the session is dispatched. */
+  audience?: ChannelAudience;
   /** Slack channel id seeded by the inbound mention. */
   channelId: string | null;
   /** Slack thread root ts. */
@@ -238,6 +241,7 @@ export interface SlackChannelState {
  * can attach extra span attributes.
  */
 export interface SlackInstrumentationMetadata extends Record<string, unknown> {
+  readonly audience: ChannelAudience;
   readonly channelId: string | null;
   readonly teamId: string | null;
   readonly threadTs: string | null;
@@ -755,6 +759,7 @@ export function slackChannel(config: SlackChannelConfig = {}): SlackChannel {
     kindHint: "slack",
     turnPolicy: config.turnPolicy,
     state: {
+      audience: "unknown",
       channelId: null as string | null,
       threadTs: null as string | null,
       teamId: null as string | null,
@@ -770,6 +775,7 @@ export function slackChannel(config: SlackChannelConfig = {}): SlackChannel {
     fetchFile: slackFetchFile,
     metadata(state): SlackInstrumentationMetadata {
       return {
+        audience: state.audience ?? "unknown",
         channelId: state.channelId,
         teamId: state.teamId,
         threadTs: state.threadTs,
@@ -1116,6 +1122,13 @@ async function dispatchSlackMessage(input: {
     teamId: input.message.teamId,
   });
   const author = input.message.author;
+  const channelState: SlackChannelState = {
+    audience: "unknown",
+    channelId: input.message.channelId,
+    teamId: input.message.teamId ?? null,
+    threadTs: input.message.threadTs,
+    triggeringUserId: author?.userId ?? null,
+  };
   const sessionOperations = bindSlackSessionOperations({
     address: continuationToken,
     defaultAuth:
@@ -1132,12 +1145,7 @@ async function dispatchSlackMessage(input: {
           }),
     from: input.from,
     resolveSession: input.resolveSession,
-    state: {
-      channelId: input.message.channelId,
-      teamId: input.message.teamId ?? null,
-      threadTs: input.message.threadTs,
-      triggeringUserId: author?.userId ?? null,
-    },
+    state: channelState,
   });
   let privateConversation: Promise<boolean> | undefined;
   const isDMOrPrivateChannel = () =>
@@ -1168,10 +1176,13 @@ async function dispatchSlackMessage(input: {
   }
   if (result === null || result === undefined) return;
 
+  const isPrivateConversation = await isDMOrPrivateChannel();
+  channelState.audience =
+    input.kind === "direct_message" || isPrivateConversation ? "private" : "public";
   await deliverSlackMessage({
     credentials: input.credentials,
     kind: input.kind,
-    isPrivateConversation: await isDMOrPrivateChannel(),
+    isPrivateConversation,
     message: input.message,
     result,
     sessionOperations,

--- a/packages/eve/src/public/channels/teams/index.ts
+++ b/packages/eve/src/public/channels/teams/index.ts
@@ -7,6 +7,7 @@ export type { ModelMessage } from "ai";
  * null when the inbound activity did not include it.
  */
 export interface TeamsInstrumentationMetadata extends Record<string, unknown> {
+  readonly audience: import("#shared/channel-audience.js").ChannelAudience;
   readonly channelId: string | null;
   readonly conversationType: string | null;
   readonly teamId: string | null;

--- a/packages/eve/src/public/channels/teams/teamsChannel.test.ts
+++ b/packages/eve/src/public/channels/teams/teamsChannel.test.ts
@@ -122,6 +122,20 @@ describe("teamsChannel", () => {
     expect(channel.adapter.kind).toBe("teams");
   });
 
+  it.each([
+    ["personal", "private"],
+    ["groupChat", "private"],
+    ["channel", "unknown"],
+  ] as const)("maps %s conversations to the %s audience", (conversationType, audience) => {
+    const teamsAdapter = adapter(teamsChannel());
+    if (!teamsAdapter.state) throw new Error("Expected Teams state.");
+    teamsAdapter.state.conversationType = conversationType;
+
+    expect(teamsAdapter.instrumentation?.metadata?.(teamsAdapter.state)).toMatchObject({
+      audience,
+    });
+  });
+
   it("dispatches verified personal messages with Teams state", async () => {
     const channel = teamsChannel({
       credentials: { webhookVerifier: () => true },

--- a/packages/eve/src/public/channels/teams/teamsChannel.ts
+++ b/packages/eve/src/public/channels/teams/teamsChannel.ts
@@ -61,6 +61,7 @@ import { verifyTeamsRequest, type TeamsWebhookVerifier } from "#public/channels/
 import { readNonEmptyString } from "#shared/guards.js";
 import { parseJsonObject, type JsonObject } from "#shared/json.js";
 import { defineChannel, POST, type Channel } from "#public/definitions/channel.js";
+import type { ChannelAudience } from "#shared/channel-audience.js";
 
 const log = createLogger("teams.channel");
 
@@ -303,6 +304,7 @@ export function teamsChannel(config: TeamsChannelConfig = {}): TeamsChannel {
     state: initialTeamsState(),
     fetchFile: createTeamsFetchFile(filesPolicy),
     metadata: (state) => ({
+      audience: teamsAudience(state.conversationType),
       channelId: state.channelId,
       conversationType: state.conversationType,
       teamId: state.teamId,
@@ -430,6 +432,11 @@ export function teamsChannel(config: TeamsChannelConfig = {}): TeamsChannel {
 
     events: mergedEvents,
   });
+}
+
+function teamsAudience(conversationType: string | null): ChannelAudience {
+  if (conversationType === "personal" || conversationType === "groupChat") return "private";
+  return "unknown";
 }
 
 function rebuildTeamsContext(

--- a/packages/eve/src/public/channels/telegram/audience.ts
+++ b/packages/eve/src/public/channels/telegram/audience.ts
@@ -1,0 +1,26 @@
+import type { ChannelAudience } from "#shared/channel-audience.js";
+import type { TelegramInstrumentationMetadata } from "#public/channels/telegram/index.js";
+import type { TelegramChannelState } from "#public/channels/telegram/telegramChannel.js";
+
+export function telegramInstrumentationMetadata(
+  state: TelegramChannelState,
+): TelegramInstrumentationMetadata {
+  return {
+    audience: telegramAudience(state.chatType),
+    chatId: state.chatId,
+    chatType: state.chatType,
+    triggeringUserId: state.triggeringUserId ?? null,
+  };
+}
+
+function telegramAudience(chatType: TelegramChannelState["chatType"]): ChannelAudience {
+  if (
+    chatType === "private" ||
+    chatType === "group" ||
+    chatType === "supergroup" ||
+    chatType === "channel"
+  ) {
+    return "private";
+  }
+  return "unknown";
+}

--- a/packages/eve/src/public/channels/telegram/index.ts
+++ b/packages/eve/src/public/channels/telegram/index.ts
@@ -7,6 +7,7 @@ export type { ModelMessage } from "ai";
  * inbound update populates it.
  */
 export interface TelegramInstrumentationMetadata extends Record<string, unknown> {
+  readonly audience: import("#shared/channel-audience.js").ChannelAudience;
   readonly chatId: string | null;
   readonly chatType: import("#public/channels/telegram/inbound.js").TelegramChatType | null;
   readonly triggeringUserId: string | null;

--- a/packages/eve/src/public/channels/telegram/telegramChannel.test.ts
+++ b/packages/eve/src/public/channels/telegram/telegramChannel.test.ts
@@ -142,6 +142,17 @@ describe("telegramChannel() inbound route", () => {
     ).toEqual([{ method: "POST", path: "/eve/v1/telegram" }]);
   });
 
+  it.each([
+    ["private", "private"],
+    ["group", "private"],
+    ["supergroup", "private"],
+    [null, "unknown"],
+  ] as const)("maps %s chats to the %s audience", (chatType, audience) => {
+    const adapter = withState(getAdapter(telegramChannel()), { chatType });
+
+    expect(adapter.instrumentation?.metadata?.(adapter.state)).toMatchObject({ audience });
+  });
+
   it("dispatches verified private messages with Telegram auth and chat-wide token", async () => {
     const channel = telegramChannel({
       api: { fetch: fakeTelegramFetch() },

--- a/packages/eve/src/public/channels/telegram/telegramChannel.ts
+++ b/packages/eve/src/public/channels/telegram/telegramChannel.ts
@@ -54,6 +54,7 @@ import {
   type TelegramWebhookVerifier,
 } from "#public/channels/telegram/verify.js";
 import { defineChannel, POST, type Channel } from "#public/definitions/channel.js";
+import { telegramInstrumentationMetadata } from "#public/channels/telegram/audience.js";
 import { parseJsonObject, type JsonObject } from "#shared/json.js";
 
 const log = createLogger("telegram.channel");
@@ -219,11 +220,7 @@ export function telegramChannel(config: TelegramChannelConfig = {}): TelegramCha
     kindHint: "telegram",
     turnPolicy: config.turnPolicy,
     state: initialTelegramState(config.botUsername),
-    metadata: (state) => ({
-      chatId: state.chatId,
-      chatType: state.chatType,
-      triggeringUserId: state.triggeringUserId ?? null,
-    }),
+    metadata: telegramInstrumentationMetadata,
     fetchFile: createTelegramFetchFile({
       api: config.api,
       credentials: config.credentials,

--- a/packages/eve/src/public/channels/twilio/twilioChannel.test.ts
+++ b/packages/eve/src/public/channels/twilio/twilioChannel.test.ts
@@ -179,6 +179,14 @@ describe("twilioChannel() inbound text pipeline", () => {
     }
   });
 
+  it("classifies phone conversations as direct", () => {
+    const adapter = getAdapter(twilioChannel({ allowFrom: "*" }));
+
+    expect(adapter.instrumentation?.metadata?.(adapter.state)).toMatchObject({
+      audience: "private",
+    });
+  });
+
   it("mounts message, voice, and transcription routes below the base route", () => {
     const channel = twilioChannel({ allowFrom: "*", route: "/twilio" });
     expect(channel.routes.map((route) => ({ method: route.method, path: route.path }))).toEqual([

--- a/packages/eve/src/public/channels/twilio/twilioChannel.ts
+++ b/packages/eve/src/public/channels/twilio/twilioChannel.ts
@@ -45,6 +45,7 @@ import {
 import { type TwilioAuthToken, type TwilioWebhookUrl } from "#public/channels/twilio/verify.js";
 import { readNonEmptyString } from "#shared/guards.js";
 import { defineChannel, GET, POST, type Channel } from "#public/definitions/channel.js";
+import type { ChannelAudience } from "#shared/channel-audience.js";
 
 const log = createLogger("twilio.channel");
 
@@ -78,6 +79,7 @@ export interface TwilioChannelState {
 
 /** Per-session instrumentation snapshot for Twilio runtime telemetry. Reports the active phone-number pair and the most recent message and call SIDs. */
 export interface TwilioInstrumentationMetadata extends Record<string, unknown> {
+  readonly audience: ChannelAudience;
   readonly from: string | null;
   readonly lastCallSid: string | null;
   readonly lastMessageSid: string | null;
@@ -309,6 +311,7 @@ export function twilioChannel(config: TwilioChannelConfig): TwilioChannel {
     },
     metadata(state): TwilioInstrumentationMetadata {
       return {
+        audience: "private",
         from: state.from,
         lastCallSid: state.lastCallSid ?? null,
         lastMessageSid: state.lastMessageSid ?? null,


### PR DESCRIPTION
### Summary

Related to #2331. This is the second PR in the audience stack. Slack, Discord, Teams, Telegram, Twilio, Chat SDK, and Photon-backed conversations now project `public`, `private`, or `unknown` from durable platform evidence.

Classification is intentionally conservative: public platform surfaces map to `public`; direct messages and visibility-restricted groups or channels map to `private`; ambiguous guild, team-channel, and proactive destinations remain `unknown` rather than making observability-only network requests.

### Validation

Focused coverage exercises public, private, and unknown mappings across the built-in messaging adapters, including Slack public/private delivery state and Chat SDK visibility. The full unit suite and type-check pass on the complete stack.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for the commit (`git commit --signoff`)
