### PR TITLE
fix(eve): reconcile Web Chat tsconfig

### DIFF
--- a/.changeset/web-chat-tsconfig.md
+++ b/.changeset/web-chat-tsconfig.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Reconcile the Next.js TypeScript configuration after adding Web Chat to an existing agent.

--- a/packages/eve/scripts/vendor-compiled/declarations/jsonc-parser.d.ts
+++ b/packages/eve/scripts/vendor-compiled/declarations/jsonc-parser.d.ts
@@ -10,4 +10,27 @@ export interface ParseOptions {
   readonly disallowComments?: boolean | undefined;
 }
 
+export interface Edit {
+  readonly offset: number;
+  readonly length: number;
+  readonly content: string;
+}
+
+export interface FormattingOptions {
+  readonly insertSpaces?: boolean;
+  readonly tabSize?: number;
+  readonly eol?: string;
+}
+
+export interface ModificationOptions {
+  readonly formattingOptions?: FormattingOptions;
+}
+
 export declare function parse(text: string, errors?: ParseError[], options?: ParseOptions): unknown;
+export declare function modify(
+  text: string,
+  path: (string | number)[],
+  value: unknown,
+  options: ModificationOptions,
+): Edit[];
+export declare function applyEdits(text: string, edits: Edit[]): string;

--- a/packages/eve/src/setup/scaffold/index.integration.test.ts
+++ b/packages/eve/src/setup/scaffold/index.integration.test.ts
@@ -718,6 +718,7 @@ describe("ensureChannel", () => {
     const projectRoot = await createTempDir();
     const pagePath = join(projectRoot, "app/page.tsx");
     const packageJsonPath = join(projectRoot, "package.json");
+    const tsconfigPath = join(projectRoot, "tsconfig.json");
     await mkdir(join(projectRoot, "app"), { recursive: true });
     await writeFile(pagePath, "registry-installed\n", "utf8");
     await writeFile(
@@ -734,6 +735,25 @@ describe("ensureChannel", () => {
       )}\n`,
       "utf8",
     );
+    await writeFile(
+      tsconfigPath,
+      `${JSON.stringify(
+        {
+          compilerOptions: {
+            module: "esnext",
+            moduleResolution: "bundler",
+            paths: { "#/*": ["./agent/*"] },
+            strict: true,
+            target: "ES2022",
+            types: ["node"],
+          },
+          include: ["agent/**/*.ts", "evals/**/*.ts"],
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
 
     const result = await ensureChannel({
       projectRoot,
@@ -744,6 +764,7 @@ describe("ensureChannel", () => {
     });
 
     expect(result.action).toBe("overwritten");
+    expect(result.filesWritten).toContain(tsconfigPath);
     await expect(readFile(pagePath, "utf8")).resolves.toBe("registry-installed\n");
     const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as {
       dependencies: Record<string, string>;
@@ -759,6 +780,33 @@ describe("ensureChannel", () => {
         test: "vitest",
       },
     });
+    const tsconfig = JSON.parse(await readFile(tsconfigPath, "utf8")) as {
+      compilerOptions: {
+        paths: Record<string, string[]>;
+        plugins: { name: string }[];
+        target: string;
+        types: string[];
+      };
+      include: string[];
+    };
+    expect(tsconfig.compilerOptions).toMatchObject({
+      paths: {
+        "#/*": ["./agent/*"],
+        "@/*": ["./*"],
+      },
+      target: "ES2022",
+      types: ["node"],
+    });
+    expect(tsconfig.compilerOptions.plugins).toContainEqual({ name: "next" });
+    expect(tsconfig.include).toEqual(
+      expect.arrayContaining([
+        "agent/**/*.ts",
+        "evals/**/*.ts",
+        "next-env.d.ts",
+        "**/*.ts",
+        "**/*.tsx",
+      ]),
+    );
   });
 });
 

--- a/packages/eve/src/setup/scaffold/update/channels.ts
+++ b/packages/eve/src/setup/scaffold/update/channels.ts
@@ -26,6 +26,7 @@ import {
   type WebAuthentication,
   type WebPackageVersions,
 } from "./web-options.js";
+import { reconcileWebTsConfig } from "./web-tsconfig.js";
 
 export type { WebAuthentication, WebPackageVersions } from "./web-options.js";
 
@@ -558,6 +559,11 @@ async function ensureWebChannel(
         filesOverwritten.push(filePath);
       }
     }
+  }
+
+  const webTsConfigPath = join(options.projectRoot, "tsconfig.json");
+  if (await reconcileWebTsConfig(webTsConfigPath)) {
+    filesWritten.push(webTsConfigPath);
   }
 
   competingNextConfigFiles.push(...(await findCompetingNextConfigFiles(options.projectRoot)));

--- a/packages/eve/src/setup/scaffold/update/web-tsconfig.ts
+++ b/packages/eve/src/setup/scaffold/update/web-tsconfig.ts
@@ -1,0 +1,111 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+import {
+  applyEdits,
+  modify,
+  type ParseError,
+  parse as parseJsonc,
+} from "#compiled/jsonc-parser/index.js";
+
+import { pathExists } from "../files.js";
+import { WEB_APP_TEMPLATE_FILES } from "../create/web-template.js";
+
+const FORMATTING_OPTIONS = {
+  insertSpaces: true,
+  tabSize: 2,
+  eol: "\n",
+} as const;
+
+type JsonObject = Record<string, unknown>;
+
+export async function reconcileWebTsConfig(path: string): Promise<boolean> {
+  const templateSource = WEB_APP_TEMPLATE_FILES["tsconfig.json"];
+  if (!(await pathExists(path))) {
+    await writeFile(path, templateSource, "utf8");
+    return true;
+  }
+
+  const source = await readFile(path, "utf8");
+  const config = parseConfig(source, path);
+  const template = parseConfig(templateSource, "Web Chat tsconfig template");
+  const compilerOptions = objectValue(config.compilerOptions);
+  const templateCompilerOptions = objectValue(template.compilerOptions);
+  let nextSource = source;
+
+  const setValue = (propertyPath: (string | number)[], value: unknown): void => {
+    nextSource = applyEdits(
+      nextSource,
+      modify(nextSource, propertyPath, value, { formattingOptions: FORMATTING_OPTIONS }),
+    );
+  };
+
+  if (config.$schema === undefined) {
+    setValue(["$schema"], template.$schema);
+  }
+
+  for (const [key, value] of Object.entries(templateCompilerOptions)) {
+    if (key === "paths") {
+      setValue(["compilerOptions", "paths", "@/*"], ["./*"]);
+      continue;
+    }
+    if (key === "lib") {
+      setValue(["compilerOptions", key], mergeStringArrays(compilerOptions[key], value));
+      continue;
+    }
+    if (key === "plugins") {
+      setValue(["compilerOptions", key], mergeUniqueValues(compilerOptions[key], value));
+      continue;
+    }
+    if (compilerOptions[key] === undefined) {
+      setValue(["compilerOptions", key], value);
+    }
+  }
+
+  setValue(["include"], mergeStringArrays(config.include, template.include));
+  setValue(["exclude"], mergeStringArrays(config.exclude, template.exclude));
+
+  if (nextSource === source) return false;
+  await writeFile(path, nextSource, "utf8");
+  return true;
+}
+
+function parseConfig(source: string, label: string): JsonObject {
+  const errors: ParseError[] = [];
+  const parsed = parseJsonc(source, errors, { allowTrailingComma: true });
+  if (errors.length > 0 || !isObject(parsed)) {
+    throw new Error(`Cannot configure Web Chat because ${label} is not valid JSONC.`);
+  }
+  return parsed;
+}
+
+function objectValue(value: unknown): JsonObject {
+  return isObject(value) ? value : {};
+}
+
+function isObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function mergeStringArrays(current: unknown, required: unknown): string[] {
+  const currentValues = Array.isArray(current)
+    ? current.filter((value): value is string => typeof value === "string")
+    : [];
+  const requiredValues = Array.isArray(required)
+    ? required.filter((value): value is string => typeof value === "string")
+    : [];
+  return [...new Set([...currentValues, ...requiredValues])];
+}
+
+function mergeUniqueValues(current: unknown, required: unknown): unknown[] {
+  const values = [
+    ...(Array.isArray(current) ? current : []),
+    ...(Array.isArray(required) ? required : []),
+  ];
+  const seen = new Set<string>();
+  return values.filter((value) => {
+    const key = JSON.stringify(value);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}


### PR DESCRIPTION
### Summary

Stacked on #2211. When the registry adds Web Chat to an existing eve agent, it preserves the agent-only `tsconfig.json`, leaving generated `@/*` imports unresolved and excluding the UI from typechecking. This merges the required Next.js compiler options, root alias, and source patterns while preserving existing compiler settings, custom aliases, and agent includes. JSONC edits preserve authored comments, and direct Web Chat scaffolding keeps its existing behavior.

### Validation

Reproduced the registry-installed upgrade path in the scaffold integration suite and confirmed all 64 scaffold integration tests pass, including preservation of existing aliases and compiler settings alongside the new `@/*` mapping and TSX includes.

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the release changeset for the user-visible scaffold repair.

**Implementation** — 3 files · `+140 / -0`

Keeps reconciliation isolated to Web Chat setup and extends the existing internal JSONC wrapper only with the edit APIs needed to preserve authored configuration.

**Tests** — 1 file · `+48 / -0`

Extends the registry-install regression to cover a realistic agent-only tsconfig, preserved custom settings, alias resolution, and UI source inclusion.
