### PR TITLE
fix(eve): resume clients after connection auth

### DIFF
--- a/.changeset/tidy-plums-resume.md
+++ b/.changeset/tidy-plums-resume.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Keep active client streams attached across authorization parking boundaries so connection callbacks resume browser chats automatically.

--- a/docs/guides/client/streaming.mdx
+++ b/docs/guides/client/streaming.mdx
@@ -124,7 +124,7 @@ client-resolvable `http(s)` and `data:` URLs.
 
 `authorization.required` is different from the normal `session.waiting` boundary. It means a connection needs OAuth or another authorization challenge before the parked turn can continue. Chat UIs should render the authorization prompt, disable ordinary text input for that session, and persist the event with the rest of the chat history.
 
-If you support refresh while an authorization prompt is pending, keep the session cursor from the started session and rehydrate the saved events on load. Do not treat a missing `session.waiting` after `authorization.required` as a finished conversation; the callback or a structured decline should resume the same eve session.
+The stream can emit an interim `session.waiting` while the authorization callback is pending. An active `send()` or `respond()` response stays attached across that parking boundary until the authorization resolves and the resumed turn reaches its next boundary. If you support refresh while an authorization prompt is pending, keep the session cursor from the started session and rehydrate the saved events on load; the callback or a structured decline resumes the same eve session.
 
 ## Reconnection
 

--- a/packages/eve/src/client/session.test.ts
+++ b/packages/eve/src/client/session.test.ts
@@ -800,7 +800,7 @@ describe("ClientSession", () => {
     ]);
   });
 
-  it("keeps following an active turn while authorization is pending", async () => {
+  it("keeps following an active turn across an authorization parking boundary", async () => {
     let streamRequest = 0;
     const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (_request, init) => {
       if ((init?.method ?? "GET") === "POST") {
@@ -809,13 +809,19 @@ describe("ClientSession", () => {
 
       streamRequest += 1;
       if (streamRequest === 1) {
-        return createStreamResponse([{ type: "authorization.required", data: {} }]);
+        return createStreamResponse([
+          { type: "authorization.required", data: { name: "linear" } },
+          {
+            type: "session.waiting",
+            data: { continuationToken: "session-id", wait: "next-user-message" },
+          },
+        ]);
       }
       if (streamRequest <= 7) {
         return createStreamResponse([]);
       }
       return createStreamResponse([
-        { type: "authorization.completed", data: {} },
+        { type: "authorization.completed", data: { name: "linear", outcome: "authorized" } },
         {
           type: "session.waiting",
           data: { continuationToken: "session-id", wait: "next-user-message" },
@@ -829,6 +835,7 @@ describe("ClientSession", () => {
       const eventTypes = await collectEventTypes(await session.send("first"));
       expect(eventTypes).toEqual([
         "authorization.required",
+        "session.waiting",
         "authorization.completed",
         "session.waiting",
       ]);
@@ -837,7 +844,7 @@ describe("ClientSession", () => {
     }
 
     expect(fetchMock).toHaveBeenCalledTimes(9);
-    expect(session.state.streamIndex).toBe(3);
+    expect(session.state.streamIndex).toBe(4);
   });
 
   it("honors an explicit idle reconnect limit for an active turn", async () => {

--- a/packages/eve/src/client/session.ts
+++ b/packages/eve/src/client/session.ts
@@ -181,6 +181,7 @@ export class ClientSession {
     input: SendTurnPayload,
   ): AsyncGenerator<MessageStreamEvent> {
     let eventCount = 0;
+    const pendingAuthorizations = new Set<string>();
     try {
       for await (const event of this.#readStream({
         headers: input.headers,
@@ -190,8 +191,18 @@ export class ClientSession {
         streamReconnectPolicy: input.streamReconnectPolicy,
       })) {
         eventCount += 1;
+        if (event.type === "authorization.required") {
+          pendingAuthorizations.add(event.data.name);
+        } else if (event.type === "authorization.completed") {
+          pendingAuthorizations.delete(event.data.name);
+        }
         yield event;
-        if (isCurrentTurnBoundaryEvent(event)) break;
+        if (
+          isCurrentTurnBoundaryEvent(event) &&
+          (event.type !== "session.waiting" || pendingAuthorizations.size === 0)
+        ) {
+          break;
+        }
       }
     } finally {
       this.#state = {


### PR DESCRIPTION
### Summary

Related to #737. Active client responses currently stop at the first `session.waiting`, but connection authorization parks with that boundary before the callback-driven turn emits `authorization.completed`; browser chats therefore miss the resumed turn. The client now keeps the response attached while any authorization is unresolved, then settles at the resumed turn's next boundary. Ordinary waiting boundaries and terminal session boundaries are unchanged.

### Validation

Reproduced the production event order in focused client coverage and confirmed both waiting boundaries, callback completion, and cursor advancement; the complete eve unit suite passes with 6,908 tests and 1 skipped test.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+6 / -1`

Clarifies the authorization parking boundary and adds patch release notes for the user-visible fix.

**Implementation** — 1 file · `+12 / -1`

Keeps the behavior local to active response streams by tracking unresolved connection names while preserving all other boundary handling.

**Tests** — 1 file · `+11 / -4`

Updates the existing authorization reconnect regression to match the callback flow's real two-boundary event order.
