### PR TITLE
docs(eve): document audience-aware tracing

### DIFF
--- a/docs/guides/instrumentation.md
+++ b/docs/guides/instrumentation.md
@@ -63,7 +63,7 @@ export default otel({
 });
 ```
 
-Zero-config `eve dev` also admits `unknown` so local HTTP/TUI sessions remain observable. It still rejects conversations classified as `direct` or `restricted`.
+Zero-config `eve dev` also admits `unknown` so local HTTP/TUI sessions remain observable. It still rejects conversations classified as `private`.
 
 `tracePolicy` only decides whether a trace is created. Every accepted trace still passes through the export pipeline. Configure `exportPolicy` to redact content, drop spans, or drop and replace attributes before one destination receives them.
 
@@ -222,7 +222,7 @@ Without an `instrumentation.ts`, `eve dev` records spans to disk — one trace p
 - [`/traces`](dev-tui#logs-and-traces) in the dev TUI: a live trace viewer that replays captured content as a conversation.
 - [`eve traces`](../reference/cli#eve-traces): a span tree in the terminal, `eve traces ls` to list. Works after `eve dev` exits.
 
-Local traces retain model and tool content for public and unclassified local HTTP/TUI sessions. Conversations classified as `direct` or `restricted` are not traced by default. If a custom `tracePolicy` admits them, configure the local trace export policy when their content should be redacted.
+Local traces retain model and tool content for public and unclassified local HTTP/TUI sessions. Conversations classified as `private` are not traced by default. If a custom `tracePolicy` admits them, configure the local trace export policy when their content should be redacted.
 
 Writing `instrumentation.ts` replaces this: your `setup` takes over and nothing is recorded locally. For span attributes, retention, and the `EVE_TRACES*` variables, see [`eve traces`](../reference/cli#eve-traces).
 

--- a/docs/guides/instrumentation.md
+++ b/docs/guides/instrumentation.md
@@ -46,13 +46,53 @@ Use the `setup` callback to register your OTel provider (for example `registerOT
 
 Any OTel-compatible backend works (Braintrust, PostHog, Raindrop, Arize, Honeycomb, Datadog, Jaeger). Install the exporter package you need and configure it in the callback. The [PostHog AI Observability integration](/integrations/posthog-instrumentation) provides a ready-to-install exporter and optional user identification.
 
-Three more fields control what the AI SDK records inside those spans (see the AI SDK's [telemetry reference](https://ai-sdk.dev/docs/ai-sdk-core/telemetry)):
+The legacy single-file `defineInstrumentation()` API exposes two capture fields for exporters registered directly in `setup` (see the AI SDK's [telemetry reference](https://ai-sdk.dev/docs/ai-sdk-core/telemetry)):
 
 - `recordInputs` records full message history on each step span. It defaults to `false`; set it to `true` to include input content.
 - `recordOutputs` records model outputs on spans. It defaults to `false`; set it to `true` to include output content.
+
+The provider API records complete spans for accepted traces and applies policies before each destination receives them.
+
+Trace creation and export are configured separately. `otel({ tracePolicy })` is the process-wide head gate; by default eve records only conversations classified as `public`:
+
+```ts title="agent/instrumentation/otel.ts"
+import { otel } from "eve/instrumentation/otel";
+
+export default otel({
+  tracePolicy: ({ audience }) => audience === "public",
+});
+```
+
+`tracePolicy` only decides whether a trace is created. Every accepted trace still passes through the export pipeline. Configure `exportPolicy` to redact content, drop spans, or drop and replace attributes before one destination receives them.
+
+Use the public redaction policies to remove content based on the derived audience, and compose them with span and attribute policies without mutating what another destination receives:
+
+```ts title="agent/instrumentation/agent-runs.ts"
+import {
+  agentRuns,
+  composeSpanExportPolicies,
+  redactSpanInputs,
+  redactSpanOutputs,
+} from "eve/instrumentation/otel";
+
+export default agentRuns({
+  exportPolicy: composeSpanExportPolicies(
+    redactSpanInputs(({ audience }) => audience !== "public"),
+    redactSpanOutputs(({ audience }) => audience !== "public"),
+    {
+      span: ({ name }) => name !== "internal.cache.refresh",
+      attribute: ({ key }) =>
+        key === "user.email" ? { action: "replace", value: "[redacted]" } : { action: "keep" },
+    },
+  ),
+});
+```
+
+Composed policies run in declaration order, so the span and attribute policy above receives the facade produced by the input and output redactors. A trace policy that admits another audience does not bypass this export pipeline; the export pipeline can still redact it.
+
 - `functionId` overrides the function name on spans (defaults to the agent name).
 
-eve records metadata without model or tool inputs and outputs by default. Enable either content category only after reviewing the exporter and its data-retention path.
+Review the exporter and its data-retention path before widening either the trace policy or export policy.
 
 You are responsible for ensuring any observability or eval provider is approved for the data exported to it.
 
@@ -180,7 +220,7 @@ Without an `instrumentation.ts`, `eve dev` records spans to disk — one trace p
 - [`/traces`](dev-tui#logs-and-traces) in the dev TUI: a live trace viewer that replays captured content as a conversation.
 - [`eve traces`](../reference/cli#eve-traces): a span tree in the terminal, `eve traces ls` to list. Works after `eve dev` exits.
 
-Local traces omit model and tool inputs and outputs by default. Set `EVE_TRACES_CONTENT=on` in `.env.local` to capture that content.
+Local traces retain public model and tool content. Non-public conversations are not traced by default. If a custom `tracePolicy` admits them, configure the local trace export policy when their content should be redacted.
 
 Writing `instrumentation.ts` replaces this: your `setup` takes over and nothing is recorded locally. For span attributes, retention, and the `EVE_TRACES*` variables, see [`eve traces`](../reference/cli#eve-traces).
 

--- a/docs/guides/instrumentation.md
+++ b/docs/guides/instrumentation.md
@@ -63,6 +63,8 @@ export default otel({
 });
 ```
 
+Zero-config `eve dev` also admits `unknown` so local HTTP/TUI sessions remain observable. It still rejects conversations classified as `direct` or `restricted`.
+
 `tracePolicy` only decides whether a trace is created. Every accepted trace still passes through the export pipeline. Configure `exportPolicy` to redact content, drop spans, or drop and replace attributes before one destination receives them.
 
 Use the public redaction policies to remove content based on the derived audience, and compose them with span and attribute policies without mutating what another destination receives:
@@ -220,7 +222,7 @@ Without an `instrumentation.ts`, `eve dev` records spans to disk — one trace p
 - [`/traces`](dev-tui#logs-and-traces) in the dev TUI: a live trace viewer that replays captured content as a conversation.
 - [`eve traces`](../reference/cli#eve-traces): a span tree in the terminal, `eve traces ls` to list. Works after `eve dev` exits.
 
-Local traces retain public model and tool content. Non-public conversations are not traced by default. If a custom `tracePolicy` admits them, configure the local trace export policy when their content should be redacted.
+Local traces retain model and tool content for public and unclassified local HTTP/TUI sessions. Conversations classified as `direct` or `restricted` are not traced by default. If a custom `tracePolicy` admits them, configure the local trace export policy when their content should be redacted.
 
 Writing `instrumentation.ts` replaces this: your `setup` takes over and nothing is recorded locally. For span attributes, retention, and the `EVE_TRACES*` variables, see [`eve traces`](../reference/cli#eve-traces).
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -304,7 +304,7 @@ One parent turn can dispatch several subagents into the same window, so a child'
 
 Every span carries a real duration except `agent.session`: an idle session never closes, so it is recorded as a zero-duration marker and the span tree shows its descendant extent instead. A turn's span is written when the turn settles, so a running turn shows only its steps.
 
-Model and tool-call spans omit their inputs and outputs by default. Set `EVE_TRACES_CONTENT=on` to capture system prompts, prompt messages, and response text for models, plus call arguments and results for tools. Each captured value is capped at 32 KB.
+Public-conversation spans include system prompts, prompt messages, model responses, and tool arguments and results. Each captured value is capped at 32 KB. Non-public conversations are not traced by default; authored trace and export policies can opt them in without exposing their content.
 
 Step spans carry token counts, and cost when Vercel AI Gateway served the call. Both follow the [OTel GenAI semantic conventions](https://github.com/open-telemetry/semantic-conventions-genai) (`gen_ai.usage.*`), so a third-party backend reads them without mapping.
 
@@ -312,13 +312,12 @@ Step spans carry token counts, and cost when Vercel AI Gateway served the call. 
 
 eve sweeps the store when a session finishes and when the dev server starts, evicting oldest-first past the bounds below — except that the newest traces and anything written in the last five minutes are always kept, so a sweep will exceed the size budget rather than drop a trace you just recorded. Set the bounds in `.env.local`, which `eve dev` loads automatically; each accepts `off` to disable it individually.
 
-| Variable                     | Default              | Effect                                                                              |
-| ---------------------------- | -------------------- | ----------------------------------------------------------------------------------- |
-| `EVE_TRACES`                 | on                   | `off` stops writing traces and stops sweeping                                       |
-| `EVE_TRACES_CONTENT`         | off                  | `on` captures model prompt/response and tool input/output attributes on local spans |
-| `EVE_TRACES_MAX_AGE_MS`      | `604800000` (7d)     | Age after which a trace may be evicted                                              |
-| `EVE_TRACES_MAX_TOTAL_BYTES` | `536870912` (512 MB) | Size budget for the whole store                                                     |
-| `EVE_TRACES_RETAIN_COUNT`    | `20`                 | Newest traces kept regardless of age or size                                        |
+| Variable                     | Default              | Effect                                        |
+| ---------------------------- | -------------------- | --------------------------------------------- |
+| `EVE_TRACES`                 | on                   | `off` stops writing traces and stops sweeping |
+| `EVE_TRACES_MAX_AGE_MS`      | `604800000` (7d)     | Age after which a trace may be evicted        |
+| `EVE_TRACES_MAX_TOTAL_BYTES` | `536870912` (512 MB) | Size budget for the whole store               |
+| `EVE_TRACES_RETAIN_COUNT`    | `20`                 | Newest traces kept regardless of age or size  |
 
 ## `eve link`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -304,7 +304,7 @@ One parent turn can dispatch several subagents into the same window, so a child'
 
 Every span carries a real duration except `agent.session`: an idle session never closes, so it is recorded as a zero-duration marker and the span tree shows its descendant extent instead. A turn's span is written when the turn settles, so a running turn shows only its steps.
 
-Public-conversation spans include system prompts, prompt messages, model responses, and tool arguments and results. Each captured value is capped at 32 KB. Non-public conversations are not traced by default; authored trace and export policies can opt them in without exposing their content.
+Public and unclassified local HTTP/TUI spans include system prompts, prompt messages, model responses, and tool arguments and results. Each captured value is capped at 32 KB. Conversations classified as direct or restricted are not traced by default; authored trace and export policies can opt them in and redact their content.
 
 Step spans carry token counts, and cost when Vercel AI Gateway served the call. Both follow the [OTel GenAI semantic conventions](https://github.com/open-telemetry/semantic-conventions-genai) (`gen_ai.usage.*`), so a third-party backend reads them without mapping.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -304,7 +304,7 @@ One parent turn can dispatch several subagents into the same window, so a child'
 
 Every span carries a real duration except `agent.session`: an idle session never closes, so it is recorded as a zero-duration marker and the span tree shows its descendant extent instead. A turn's span is written when the turn settles, so a running turn shows only its steps.
 
-Public and unclassified local HTTP/TUI spans include system prompts, prompt messages, model responses, and tool arguments and results. Each captured value is capped at 32 KB. Conversations classified as direct or restricted are not traced by default; authored trace and export policies can opt them in and redact their content.
+Public and unclassified local HTTP/TUI spans include system prompts, prompt messages, model responses, and tool arguments and results. Each captured value is capped at 32 KB. Conversations classified as private are not traced by default; authored trace and export policies can opt them in and redact their content.
 
 Step spans carry token counts, and cost when Vercel AI Gateway served the call. Both follow the [OTel GenAI semantic conventions](https://github.com/open-telemetry/semantic-conventions-genai) (`gen_ai.usage.*`), so a third-party backend reads them without mapping.
 


### PR DESCRIPTION
### Summary

Documents the audience-aware tracing API separately from the implementation stack because `otel()`, `otelIntegration()`, and provider-directory instrumentation remain behind `experimental.instrumentationProviders`.

The guide covers the public-only default trace gate, ordered export-policy composition, audience-aware input/output redactors, span and attribute filtering, and the resulting local trace defaults. The CLI reference is updated to match public-only local trace capture.

This PR is intentionally based on `main` and is not part of stack #2336. The documented API is implemented by #2335.

### Validation

- Docs structure validation: passed
- Import snippet validation: passed
- MDX compilation: passed

### Checklist

- [x] Documentation-only change
- [x] Flag-gated API is isolated from the implementation stack
- [x] DCO sign-off passes
