### PR TITLE
Fix Linq existing-account phone selection

### DIFF
--- a/.changeset/bright-lions-read.md
+++ b/.changeset/bright-lions-read.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Existing Linq account setup now fetches the phone numbers assigned to the partner API token, then lets you select the numbers for your agent.

--- a/docs/channels/linq.mdx
+++ b/docs/channels/linq.mdx
@@ -5,7 +5,7 @@ description: Connect an eve agent to iMessage and SMS through Linq.
 
 Use `linqChannel` to receive and reply to iMessage and SMS conversations through Linq.
 
-Run `eve add channel/linq` to choose Vercel Connect or portable credentials. With Vercel Connect, eve signs you in and creates or links a Vercel project when needed. Then choose whether to create a managed Linq account and line or connect an existing Linq account with its partner API token and phone numbers. eve configures the connector and webhook through Connect:
+Run `eve add channel/linq` to choose Vercel Connect or portable credentials. With Vercel Connect, eve signs you in and creates or links a Vercel project when needed. Then choose whether to create a managed Linq account and line or connect an existing account with its partner API token. eve fetches the phone numbers assigned to that account, and you select the numbers for the agent. eve configures the connector and webhook through Connect:
 
 ```ts title="agent/channels/linq.ts"
 import { connectLinqCredentials } from "@vercel/connect/eve";

--- a/packages/eve/src/setup/integrations/linq/management.test.ts
+++ b/packages/eve/src/setup/integrations/linq/management.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { listLinqPhoneNumbers } from "./management.js";
+
+function response(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("Linq management", () => {
+  it("lists phone numbers assigned to a partner API token", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async () =>
+      response({
+        phone_numbers: [
+          { id: "phone-1", phone_number: "+14155550123" },
+          { id: "phone-2", phone_number: "+14155550124" },
+        ],
+      }),
+    );
+
+    await expect(listLinqPhoneNumbers("linq-token", undefined, { fetch })).resolves.toEqual([
+      "+14155550123",
+      "+14155550124",
+    ]);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.linqapp.com/api/partner/v3/phone_numbers",
+      expect.objectContaining({
+        headers: { accept: "application/json", authorization: "Bearer linq-token" },
+      }),
+    );
+  });
+
+  it("reports an API failure without exposing the partner API token", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => response({}, 401));
+
+    await expect(listLinqPhoneNumbers("linq-token", undefined, { fetch })).rejects.toThrow(
+      "Could not fetch Linq phone numbers (401)",
+    );
+  });
+});

--- a/packages/eve/src/setup/integrations/linq/management.ts
+++ b/packages/eve/src/setup/integrations/linq/management.ts
@@ -1,0 +1,37 @@
+import { z } from "#compiled/zod/index.js";
+
+const LINQ_PARTNER_API_URL = "https://api.linqapp.com/api/partner/v3/phone_numbers";
+
+const PhoneNumbersSchema = z.object({
+  phone_numbers: z.array(z.object({ phone_number: z.string().min(1) })),
+});
+
+export interface LinqManagementDeps {
+  fetch: typeof fetch;
+}
+
+const defaultDeps: LinqManagementDeps = { fetch };
+
+/** Lists the phone numbers assigned to a Linq partner API token. */
+export async function listLinqPhoneNumbers(
+  apiToken: string,
+  signal?: AbortSignal,
+  deps: LinqManagementDeps = defaultDeps,
+): Promise<string[]> {
+  const response = await deps.fetch(LINQ_PARTNER_API_URL, {
+    headers: { accept: "application/json", authorization: `Bearer ${apiToken}` },
+    signal,
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Could not fetch Linq phone numbers (${response.status}). Confirm the partner API token is valid.`,
+    );
+  }
+  const result = PhoneNumbersSchema.safeParse(await response.json());
+  if (!result.success) throw new Error("Linq returned invalid phone number data.");
+  const phoneNumbers = result.data.phone_numbers.map(({ phone_number }) => phone_number);
+  if (phoneNumbers.length === 0) {
+    throw new Error("No phone numbers are assigned to this Linq partner API token.");
+  }
+  return phoneNumbers;
+}

--- a/packages/eve/src/setup/integrations/linq/setup.test.ts
+++ b/packages/eve/src/setup/integrations/linq/setup.test.ts
@@ -7,9 +7,13 @@ vi.mock("#setup/scaffold/index.js", () => ({
   deriveSlackConnectorSlug: vi.fn(async () => "agent"),
 }));
 
-import { prepareLinqSetup } from "./setup.js";
+import { prepareLinqSetup, type LinqSetupDeps } from "./setup.js";
 import { integrationSetupEnvironment } from "../shared/environment.js";
 import { createSetupContexts } from "../shared/ui.js";
+
+function deps(): LinqSetupDeps {
+  return { listPhoneNumbers: vi.fn(async () => ["+14155550123", "+14155550124"]) };
+}
 
 function contexts(answers: Record<string, unknown> = {}) {
   return createSetupContexts({
@@ -30,18 +34,20 @@ describe("Linq setup", () => {
     });
   });
 
-  it("collects an existing Linq account's token and phone numbers", async () => {
+  it("fetches an existing Linq account's agent phone numbers", async () => {
     const context = contexts({
       "linq-account": "existing",
       "linq-existing-api-token": "linq-token",
-      "linq-existing-phone-numbers": " +14155550123, +14155550124 ",
+      "linq-existing-phone-numbers": ["+14155550124"],
     });
+    const setupDeps = deps();
 
-    await expect(prepareLinqSetup(context.prepare)).resolves.toMatchObject({
+    await expect(prepareLinqSetup(context.prepare, setupDeps)).resolves.toMatchObject({
       existingAccount: {
         apiToken: "linq-token",
-        phoneNumbers: ["+14155550123", "+14155550124"],
+        phoneNumbers: ["+14155550124"],
       },
     });
+    expect(setupDeps.listPhoneNumbers).toHaveBeenCalledWith("linq-token", undefined);
   });
 });

--- a/packages/eve/src/setup/integrations/linq/setup.ts
+++ b/packages/eve/src/setup/integrations/linq/setup.ts
@@ -128,7 +128,7 @@ export async function prepareLinqSetup(
     const agentPhoneNumbers = await deps.listPhoneNumbers(apiToken.trim(), context.signal);
     const phoneNumbers = await context.asker.askMany({
       key: "linq-existing-phone-numbers",
-      message: "Choose the phone numbers for your agent (not your personal phone number)",
+      message: "Choose your agent phone numbers",
       options: agentPhoneNumbers.map((phoneNumber) => ({
         id: phoneNumber,
         value: phoneNumber,

--- a/packages/eve/src/setup/integrations/linq/setup.ts
+++ b/packages/eve/src/setup/integrations/linq/setup.ts
@@ -128,7 +128,7 @@ export async function prepareLinqSetup(
     const agentPhoneNumbers = await deps.listPhoneNumbers(apiToken.trim(), context.signal);
     const phoneNumbers = await context.asker.askMany({
       key: "linq-existing-phone-numbers",
-      message: "Choose your agent phone numbers",
+      message: "Choose your agent's phone numbers",
       options: agentPhoneNumbers.map((phoneNumber) => ({
         id: phoneNumber,
         value: phoneNumber,

--- a/packages/eve/src/setup/integrations/linq/setup.ts
+++ b/packages/eve/src/setup/integrations/linq/setup.ts
@@ -6,15 +6,19 @@ import type { VercelProjectReference } from "#setup/project-resolution.js";
 import { deriveSlackConnectorSlug } from "#setup/scaffold/index.js";
 import { writeTextFile } from "#setup/scaffold/files.js";
 
-import {
-  provisionLinqConnector,
-  type LinqExistingAccountCredentials,
-} from "./connect.js";
+import { provisionLinqConnector, type LinqExistingAccountCredentials } from "./connect.js";
+import { listLinqPhoneNumbers } from "./management.js";
 import {
   defineSetupIntegration,
   type SetupApplyContext,
   type SetupPrepareContext,
 } from "../types.js";
+
+export interface LinqSetupDeps {
+  listPhoneNumbers: typeof listLinqPhoneNumbers;
+}
+
+const defaultDeps: LinqSetupDeps = { listPhoneNumbers: listLinqPhoneNumbers };
 
 interface LinqSetupPlan {
   credentials: "connect" | "portable";
@@ -35,17 +39,6 @@ export default linqChannel({
 });
 `;
 
-function validatePhoneNumbers(value: string): string | null {
-  const phoneNumbers = value
-    .split(",")
-    .map((phoneNumber) => phoneNumber.trim())
-    .filter(Boolean);
-  if (phoneNumbers.length === 0) return "Enter at least one phone number.";
-  return phoneNumbers.every((phoneNumber) => /^\+[1-9]\d{1,14}$/.test(phoneNumber))
-    ? null
-    : "Use comma-separated E.164 numbers, for example +14155550123.";
-}
-
 function connectTemplate(uid: string): string {
   return `import { connectLinqCredentials } from "@vercel/connect/eve";
 import { linqChannel } from "eve/channels/linq";
@@ -56,7 +49,10 @@ export default linqChannel({
 `;
 }
 
-export async function prepareLinqSetup(context: SetupPrepareContext): Promise<LinqSetupPlan> {
+export async function prepareLinqSetup(
+  context: SetupPrepareContext,
+  deps: LinqSetupDeps = defaultDeps,
+): Promise<LinqSetupPlan> {
   const credentials = await context.asker.ask(
     select({
       key: "linq-credentials",
@@ -112,7 +108,7 @@ export async function prepareLinqSetup(context: SetupPrepareContext): Promise<Li
             id: "existing",
             value: "existing" as const,
             label: "Use an existing Linq account",
-            hint: "Connect a Linq partner API token and phone numbers",
+            hint: "Connect a Linq partner API token and select agent phone numbers",
           },
         ],
         recommended: "new" as const,
@@ -129,24 +125,25 @@ export async function prepareLinqSetup(context: SetupPrepareContext): Promise<Li
         environment: "LINQ_API_KEY",
       }),
     );
-    const phoneNumbers = await context.asker.ask(
-      text({
-        key: "linq-existing-phone-numbers",
-        message: "Linq phone numbers",
-        placeholder: "+14155550123, +14155550124",
-        required: true,
-        validate: validatePhoneNumbers,
-      }),
-    );
+    const agentPhoneNumbers = await deps.listPhoneNumbers(apiToken.trim(), context.signal);
+    const phoneNumbers = await context.asker.askMany({
+      key: "linq-existing-phone-numbers",
+      message: "Choose the phone numbers for your agent (not your personal phone number)",
+      options: agentPhoneNumbers.map((phoneNumber) => ({
+        id: phoneNumber,
+        value: phoneNumber,
+        label: phoneNumber,
+      })),
+      detected: agentPhoneNumbers,
+      requireSelection: true,
+      required: true,
+    });
     return {
       credentials,
       connectorSlug: connectorSlug.trim(),
       existingAccount: {
         apiToken: apiToken.trim(),
-        phoneNumbers: phoneNumbers
-          .split(",")
-          .map((phoneNumber) => phoneNumber.trim())
-          .filter(Boolean),
+        phoneNumbers,
       },
       project,
     };


### PR DESCRIPTION
### Summary

Existing Linq account setup now fetches phone numbers assigned to the supplied partner API token, then lets you select the numbers for the agent. This replaces manual comma-separated entry and makes it explicit that the selected numbers are agent lines, not a personal phone number.

### Validation

Confirmed API parsing and failure handling with the focused Linq unit tests; also ran `pnpm --filter eve typecheck`, `pnpm lint`, and `pnpm docs:check`.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+6 / -1`

Documents the fetched-number selection flow and includes the release note.

**Implementation** — 2 files · `+64 / -30`

Adds the small Linq partner API client and replaces freeform phone-number input with a selection of fetched account lines.

**Tests** — 2 files · `+53 / -5`

Covers API success and failure handling plus selecting a fetched agent number during setup.
