### PR TITLE
chore(eve): context - centralize projected history

### DIFF
--- a/.changeset/calm-history-views.md
+++ b/.changeset/calm-history-views.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Route model-facing session history through one prepared view so dynamic resolvers, compaction, instrumentation, and model calls receive a consistent conversation without changing durable history.

--- a/packages/eve/src/execution/history-view.ts
+++ b/packages/eve/src/execution/history-view.ts
@@ -1,0 +1,26 @@
+import type { HarnessSession } from "#harness/types.js";
+import {
+  createHistoryViewPreparer,
+  identityHistoryViewProjector,
+  type PreparedHistoryView,
+} from "#shared/history-view.js";
+
+export interface ExecutionHistoryView {
+  readonly initial: PreparedHistoryView;
+  readonly messages: (session: HarnessSession) => PreparedHistoryView["messages"];
+  readonly prepare: (session: HarnessSession) => PreparedHistoryView;
+  readonly projector: typeof identityHistoryViewProjector;
+}
+
+export function createExecutionHistoryView(session: HarnessSession): ExecutionHistoryView {
+  const projector = identityHistoryViewProjector;
+  const prepareHistory = createHistoryViewPreparer({ projector });
+  const prepare = (next: HarnessSession) => prepareHistory(next.history, next.state);
+
+  return {
+    initial: prepare(session),
+    messages: (next) => prepare(next).messages,
+    prepare,
+    projector,
+  };
+}

--- a/packages/eve/src/execution/node-step.ts
+++ b/packages/eve/src/execution/node-step.ts
@@ -28,6 +28,7 @@ import {
   isTaskToolAvailable,
 } from "#runtime/framework-tools/tasks.js";
 import type { ResolvedRuntimeAgentNode } from "#runtime/graph.js";
+import type { HistoryViewProjector, PreparedHistoryView } from "#shared/history-view.js";
 
 import type { PreparedRuntimeTool } from "#runtime/sessions/turn.js";
 import {
@@ -75,6 +76,8 @@ export interface CreateExecutionNodeStepInput {
    */
   readonly createRuntime: CreateRuntime;
   readonly handleEvent?: HandleEventFn;
+  readonly historyProjector?: HistoryViewProjector;
+  readonly historyView?: PreparedHistoryView;
   readonly mode: RunMode;
   readonly modelResolutionScope: RuntimeModelResolutionScope;
   readonly node: ResolvedRuntimeAgentNode;
@@ -109,6 +112,8 @@ export function createExecutionNodeStep(input: CreateExecutionNodeStepInput): St
     workflowMaxSubagents: input.workflowMaxSubagents,
     webSearchProvider: input.node.agent.webSearchProvider,
     handleEvent: input.handleEvent,
+    historyProjector: input.historyProjector,
+    historyView: input.historyView,
     instrumentation,
     mode: input.mode,
     onCompaction: preserveFrameworkStateOnCompaction,

--- a/packages/eve/src/execution/tasks/parent/agent-views.test.ts
+++ b/packages/eve/src/execution/tasks/parent/agent-views.test.ts
@@ -117,6 +117,17 @@ describe("task-derived agent availability", () => {
     await expect(appendTaskAgentAnnouncement(next)).resolves.toBe(next);
   });
 
+  it("deduplicates task announcements against the prepared history view", async () => {
+    vi.mocked(readLatestTaskView).mockResolvedValue(task("task_0", "working"));
+    const session = createSession(["run-0"]);
+    const withRawAnnouncement = await appendTaskAgentAnnouncement(session);
+
+    const next = await appendTaskAgentAnnouncement(withRawAnnouncement, []);
+
+    expect(next.history).toHaveLength(withRawAnnouncement.history.length + 1);
+    expect(next.history.at(-1)).toEqual(withRawAnnouncement.history.at(-1));
+  });
+
   it("rejects two nonterminal tasks bound to one child agent", async () => {
     vi.mocked(readLatestTaskView)
       .mockResolvedValueOnce(task("task_0", "working"))

--- a/packages/eve/src/execution/tasks/parent/agent-views.ts
+++ b/packages/eve/src/execution/tasks/parent/agent-views.ts
@@ -1,3 +1,5 @@
+import type { ModelMessage } from "ai";
+
 import type { HarnessSession } from "#harness/types.js";
 import { resolveAgentsAnnouncement, type AgentView } from "#harness/handles/prompt.js";
 import { formatAgentStatus, getAgentHandleStore } from "#harness/handles/store.js";
@@ -53,11 +55,12 @@ export async function readTaskAgentViews(session: HarnessSession): Promise<reado
 /** Appends the changed task-agent projection before the next model call. */
 export async function appendTaskAgentAnnouncement(
   session: HarnessSession,
+  messages: readonly ModelMessage[] = session.history,
 ): Promise<HarnessSession> {
   const agentViews = await readTaskAgentViews(session);
   const announcement = resolveAgentsAnnouncement({
     agentViews,
-    messages: session.history,
+    messages,
     store: getAgentHandleStore(session.state),
   });
   return announcement === undefined

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -1,3 +1,4 @@
+import type { ModelMessage } from "ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { ChannelAdapter, ChannelAdapterContext } from "#channel/adapter.js";
@@ -10,6 +11,7 @@ import {
   DynamicSubagentAgentConfigKey,
   ModeKey,
   SessionCallbackKey,
+  SessionDynamicSubagentRuntimeRevisionKey,
   SessionDynamicSubagentSelectionsKey,
   SessionDynamicModelReferenceKey,
   SessionDynamicToolMetadataKey,
@@ -72,6 +74,18 @@ vi.mock("./tasks/parent/run-parent.js", () => ({
 vi.mock("./tasks/parent/agent-views.js", () => ({
   appendTaskAgentAnnouncement: vi.fn(async (session) => session),
 }));
+
+const mockIdentityHistoryViewProjector = vi.hoisted(() =>
+  vi.fn(({ messages }: { readonly messages: readonly ModelMessage[] }) => messages),
+);
+vi.mock("#shared/history-view.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("#shared/history-view.js")>();
+  return {
+    ...actual,
+    identityHistoryViewProjector: (input: { readonly messages: readonly ModelMessage[] }) =>
+      mockIdentityHistoryViewProjector(input),
+  };
+});
 
 function installSessionStoreMocks(
   sessions: Awaited<ReturnType<typeof readDurableSession>>[],
@@ -226,6 +240,8 @@ afterEach(() => {
   vi.mocked(sendTaskInboundPayload).mockResolvedValue("delivered");
   vi.mocked(appendTaskAgentAnnouncement).mockReset();
   vi.mocked(appendTaskAgentAnnouncement).mockImplementation(async (session) => session);
+  mockIdentityHistoryViewProjector.mockReset();
+  mockIdentityHistoryViewProjector.mockImplementation(({ messages }) => messages);
 });
 
 describe("routeProxiedDeliverStep", () => {
@@ -1377,6 +1393,279 @@ describe("dispatchRuntimeActionsStep", () => {
 });
 
 describe("turnStep", () => {
+  it("prepares resumed-session history before dynamic runtime refresh", async () => {
+    const hidden = { content: "HIDE_FROM_RUNTIME_REFRESH", role: "user" as const };
+    mockIdentityHistoryViewProjector.mockImplementation(({ messages }) =>
+      messages.filter((message) => message !== hidden),
+    );
+    const toolHandler = vi.fn(
+      (_event: unknown, _context: { readonly messages: readonly ModelMessage[] }) => null,
+    );
+    const subagentHandler = vi.fn(
+      (_event: unknown, _context: { readonly messages: readonly ModelMessage[] }) => null,
+    );
+    const dynamicToolResolver = {
+      eventNames: ["session.started"],
+      events: { "session.started": toolHandler },
+      logicalPath: "agent/tools/runtime.ts",
+      slug: "runtime",
+      sourceId: "test:runtime",
+      sourceKind: "module",
+    } as never;
+    const dynamicSubagentResolver = {
+      eventNames: ["session.started"],
+      events: { "session.started": subagentHandler },
+      logicalPath: "agent/subagents/runtime/agent.ts",
+      name: "runtime-agent",
+      nodeId: "subagents/runtime-agent",
+      sourceId: "test:runtime-agent",
+      sourceKind: "module",
+    } as never;
+    const compiledBundle = {
+      adapterRegistry: {
+        adaptersByKind: new Map([[threadContextAdapter.kind, threadContextAdapter]]),
+      },
+      compiledArtifactsSource: {} as never,
+      graph: {
+        nodesByNodeId: new Map(),
+        root: {
+          sandboxRegistry: { sandbox: null },
+          turnAgent: TestTurnAgent,
+        },
+      },
+      moduleMap: { nodes: {} },
+      hookRegistry: createEmptyHookRegistry(),
+      resolvedAgent: { config: {}, dynamicToolResolvers: [dynamicToolResolver] },
+      subagentRegistry: { dynamicResolvers: [dynamicSubagentResolver] },
+      toolRegistry: {},
+      turnAgent: TestTurnAgent,
+    } as never;
+    vi.mocked(getCompiledRuntimeAgentBundle).mockResolvedValue(compiledBundle);
+    const session = createStubSession({
+      history: [
+        { content: "first", role: "user" },
+        hidden,
+        { content: "second", role: "assistant" },
+      ],
+      state: {
+        "eve.harness.emission": {
+          sequence: 1,
+          sessionStarted: true,
+          stepIndex: 0,
+          turnId: "",
+        },
+      },
+    });
+    installSessionStoreMocks([session]);
+
+    const ctx = new ContextContainer();
+    ctx.set(AuthKey, null);
+    ctx.set(BundleKey, compiledBundle);
+    ctx.set(ChannelKey, threadContextAdapter);
+    ctx.set(ContinuationTokenKey, "http:thread-context");
+    ctx.set(ModeKey, "conversation");
+    ctx.set(SessionIdKey, "session-1");
+    ctx.set(SessionDynamicSubagentRuntimeRevisionKey, "deployment:dpl_old");
+    ctx.set(SessionDynamicToolRuntimeRevisionKey, "deployment:dpl_old");
+
+    let harnessHistory: readonly ModelMessage[] = [];
+    let rawHistory: readonly ModelMessage[] = [];
+    vi.mocked(createExecutionNodeStep).mockImplementation((input) => {
+      harnessHistory = input.historyView?.messages ?? [];
+      return async (stepSession): Promise<StepResult> => {
+        rawHistory = stepSession.history;
+        return { next: { done: true, output: "ok" }, session: stepSession };
+      };
+    });
+    vi.stubEnv("VERCEL_DEPLOYMENT_ID", "dpl_new");
+
+    await turnStep({
+      input: { kind: "deliver", payloads: [{ message: "follow up" }] },
+      parentWritable: createTestWritable(),
+      serializedContext: serializeContext(ctx),
+      sessionState: createStubSessionState({
+        emissionState: {
+          sequence: 1,
+          sessionStarted: true,
+          stepIndex: 0,
+          turnId: "",
+        },
+      }),
+    });
+
+    const expectedView = [
+      { content: "first", role: "user" },
+      { content: "second", role: "assistant" },
+    ];
+    expect(toolHandler.mock.calls[0]?.[1]).toMatchObject({ messages: expectedView });
+    expect(subagentHandler.mock.calls[0]?.[1]).toMatchObject({ messages: expectedView });
+    expect(harnessHistory).toEqual(expectedView);
+    expect(rawHistory).toEqual(session.history);
+    expect(rawHistory).toContain(hidden);
+  });
+
+  it("fails history projection before authored delivery or runtime callbacks run", async () => {
+    const deliver = vi.fn(() => ({ message: "delivered" }));
+    const adapter: ChannelAdapter = { kind: "projection-failure", deliver };
+    const dynamicToolHandler = vi.fn(() => null);
+    const compiledBundle = {
+      adapterRegistry: { adaptersByKind: new Map([[adapter.kind, adapter]]) },
+      compiledArtifactsSource: {} as never,
+      graph: {
+        nodesByNodeId: new Map(),
+        root: { sandboxRegistry: { sandbox: null }, turnAgent: TestTurnAgent },
+      },
+      moduleMap: { nodes: {} },
+      hookRegistry: createEmptyHookRegistry(),
+      resolvedAgent: {
+        config: {},
+        dynamicToolResolvers: [
+          {
+            eventNames: ["session.started"],
+            events: { "session.started": dynamicToolHandler },
+            logicalPath: "agent/tools/failure.ts",
+            slug: "failure",
+            sourceId: "test:failure",
+            sourceKind: "module",
+          },
+        ],
+      },
+      subagentRegistry: {},
+      toolRegistry: {},
+      turnAgent: TestTurnAgent,
+    } as never;
+    vi.mocked(getCompiledRuntimeAgentBundle).mockResolvedValue(compiledBundle);
+    installSessionStoreMocks([createStubSession({ history: [{ content: "raw", role: "user" }] })]);
+    mockIdentityHistoryViewProjector.mockImplementation(() => {
+      throw new Error("projection failed");
+    });
+    vi.mocked(createExecutionNodeStep).mockClear();
+
+    const ctx = new ContextContainer();
+    ctx.set(AuthKey, null);
+    ctx.set(BundleKey, compiledBundle);
+    ctx.set(ChannelKey, adapter);
+    ctx.set(ContinuationTokenKey, "projection-failure");
+    ctx.set(ModeKey, "conversation");
+    ctx.set(SessionIdKey, "session-1");
+
+    await expect(
+      turnStep({
+        input: { kind: "deliver", payloads: [{ message: "hello" }] },
+        parentWritable: createTestWritable(),
+        serializedContext: serializeContext(ctx),
+        sessionState: createStubSessionState(),
+      }),
+    ).rejects.toThrow("projection failed");
+    expect(deliver).not.toHaveBeenCalled();
+    expect(dynamicToolHandler).not.toHaveBeenCalled();
+    expect(createExecutionNodeStep).not.toHaveBeenCalled();
+    expect(workflowWritesByNamespace.get(DEFAULT_WORKFLOW_STREAM_NAMESPACE) ?? []).toEqual([]);
+  });
+
+  it("hydrates resumed dynamic tool callbacks from projected history", async () => {
+    const hidden = { content: "HIDE_FROM_HYDRATION", role: "user" as const };
+    mockIdentityHistoryViewProjector.mockImplementation(({ messages }) =>
+      messages.filter((message) => message !== hidden),
+    );
+    const handler = vi.fn(
+      (_event: unknown, _context: { readonly messages: readonly ModelMessage[] }) => ({
+        hydrated: defineTool({
+          description: "Hydrated tool",
+          execute: async () => "ok",
+          inputSchema: { type: "object" },
+        }),
+      }),
+    );
+    const resolverSlug = "hydration_projection";
+    const compiledBundle = {
+      adapterRegistry: {
+        adaptersByKind: new Map([[threadContextAdapter.kind, threadContextAdapter]]),
+      },
+      compiledArtifactsSource: {} as never,
+      graph: {
+        nodesByNodeId: new Map(),
+        root: { sandboxRegistry: { sandbox: null }, turnAgent: TestTurnAgent },
+      },
+      moduleMap: { nodes: {} },
+      hookRegistry: createEmptyHookRegistry(),
+      resolvedAgent: {
+        config: {},
+        dynamicToolResolvers: [
+          {
+            eventNames: ["session.started"],
+            events: { "session.started": handler },
+            logicalPath: "agent/tools/hydration.ts",
+            slug: resolverSlug,
+            sourceId: "test:hydration",
+            sourceKind: "module",
+          },
+        ],
+      },
+      subagentRegistry: {},
+      toolRegistry: {},
+      turnAgent: TestTurnAgent,
+    } as never;
+    vi.mocked(getCompiledRuntimeAgentBundle).mockResolvedValue(compiledBundle);
+    installSessionStoreMocks([
+      createStubSession({
+        history: [{ content: "visible", role: "user" }, hidden],
+        state: {
+          "eve.harness.emission": {
+            sequence: 1,
+            sessionStarted: true,
+            stepIndex: 0,
+            turnId: "",
+          },
+        },
+      }),
+    ]);
+    vi.mocked(createExecutionNodeStep).mockImplementation(() => async (session) => ({
+      next: { done: true, output: "ok" },
+      session,
+    }));
+    vi.stubEnv("VERCEL_DEPLOYMENT_ID", "dpl_same");
+
+    const ctx = new ContextContainer();
+    ctx.set(AuthKey, null);
+    ctx.set(BundleKey, compiledBundle);
+    ctx.set(ChannelKey, threadContextAdapter);
+    ctx.set(ContinuationTokenKey, "http:thread-context");
+    ctx.set(ModeKey, "conversation");
+    ctx.set(SessionIdKey, "session-1");
+    ctx.set(SessionDynamicToolRuntimeRevisionKey, "deployment:dpl_same");
+    ctx.set(SessionDynamicToolMetadataKey, [
+      {
+        closureVars: {},
+        description: "Hydrated tool",
+        entryKey: "hydrated",
+        executeStepFnName: `eve:framework-dynamic:session-1:${resolverSlug}:hydrated`,
+        inputSchema: { type: "object" },
+        name: "hydrated",
+        resolverSlug,
+      },
+    ]);
+
+    await turnStep({
+      input: { kind: "deliver", payloads: [{ message: "continue" }] },
+      parentWritable: createTestWritable(),
+      serializedContext: serializeContext(ctx),
+      sessionState: createStubSessionState({
+        emissionState: {
+          sequence: 1,
+          sessionStarted: true,
+          stepIndex: 0,
+          turnId: "",
+        },
+      }),
+    });
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler.mock.calls[0]?.[1]).toMatchObject({
+      messages: [{ content: "visible", role: "user" }],
+    });
+  });
+
   it("routes remote task HITL only to the parent callback", async () => {
     const inputRequested = vi.fn();
     const remoteTaskAdapter: ChannelAdapter = {
@@ -2514,7 +2803,15 @@ describe("turnStep", () => {
       principal: { type: "app" } as const,
       resume: { nonce: "n1" },
     };
+    const hidden = { content: "HIDE_FROM_AUTH_CONTINUATION", role: "user" as const };
+    mockIdentityHistoryViewProjector.mockImplementation(({ messages }) =>
+      messages.filter((message) => message !== hidden),
+    );
+    const instructionHandler = vi.fn(
+      (_event: unknown, _context: { readonly messages: readonly ModelMessage[] }) => null,
+    );
     const session = createStubSession({
+      history: [{ content: "visible", role: "user" }, hidden],
       state: setPendingAuthorization({ retained: "yes" }, { challenges: [challenge] }),
     });
     installSessionStoreMocks([session]);
@@ -2532,7 +2829,22 @@ describe("turnStep", () => {
       },
       moduleMap: { nodes: {} },
       hookRegistry: createEmptyHookRegistry(),
-      resolvedAgent: { config: {} },
+      resolvedAgent: {
+        config: {},
+        dynamicInstructionsResolvers: [
+          {
+            eventNames: ["session.started", "turn.started"],
+            events: {
+              "session.started": instructionHandler,
+              "turn.started": instructionHandler,
+            },
+            logicalPath: "agent/instructions/auth.ts",
+            slug: "auth",
+            sourceId: "test:auth",
+            sourceKind: "module",
+          },
+        ],
+      },
       subagentRegistry: {},
       toolRegistry: {},
       turnAgent: TestTurnAgent,
@@ -2578,6 +2890,13 @@ describe("turnStep", () => {
     const persistedSession = vi.mocked(createDurableSessionState).mock.calls.at(-1)?.[0].session;
     expect(persistedSession?.state?.retained).toBe("yes");
     expect(getPendingAuthorization(persistedSession?.state)).toBeUndefined();
+    expect(instructionHandler).toHaveBeenCalledTimes(2);
+    for (const call of instructionHandler.mock.calls) {
+      expect(call[1]).toMatchObject({
+        messages: [{ content: "visible", role: "user" }],
+      });
+    }
+    expect(persistedSession?.history).toContain(hidden);
   });
 });
 

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -96,6 +96,7 @@ import { resolveEffectiveAgentRuntime } from "#execution/effective-agent-config.
 import { recordSubagentUsageSpans } from "#execution/subagent-usage-span.js";
 import { reconcileSessionContinuationToken } from "#execution/reconcile-session-continuation-token.js";
 import { hydrateDurableSession, refreshSessionFromTurnAgent } from "#execution/session.js";
+import { createExecutionHistoryView } from "#execution/history-view.js";
 import { resolveRuntimeCompiledArtifactsVersionedCacheKey } from "#runtime/cache-key.js";
 import { createWorkflowRuntime } from "#execution/workflow-runtime.js";
 import { isTaskToolAvailable, TASK_UPDATE_TOOL_NAME } from "#runtime/framework-tools/tasks.js";
@@ -241,6 +242,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
     durable: durableSession,
     turnAgent: effectiveAgent.turnAgent,
   });
+  const history = createExecutionHistoryView(initialSession);
   const instrumentation = getInstrumentationRuntime();
   const initialEmissionState = getHarnessEmissionState(initialSession.state);
 
@@ -364,7 +366,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
           ctx,
           resolvers: dynamicSubagentResolvers,
           event: refreshEvent,
-          messages: initialSession.history,
+          messages: history.initial.messages,
           persistentSessions: persistentSubagentSessions,
           runtimeRevision: dynamicRuntimeRevision,
         }),
@@ -372,7 +374,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
           ctx,
           resolvers: dynamicToolResolvers,
           event: refreshEvent,
-          messages: initialSession.history,
+          messages: history.initial.messages,
           runtimeRevision: dynamicRuntimeRevision,
         }),
       ]);
@@ -380,7 +382,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
         ctx,
         resolvers: dynamicToolResolvers,
         event: refreshEvent,
-        messages: initialSession.history,
+        messages: history.initial.messages,
       });
     }
   } catch (error) {
@@ -466,7 +468,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
       if (completedAuths) {
         let emissionState = getHarnessEmissionState(schemaSession.state);
         if (isHarnessBetweenTurns(schemaSession)) {
-          prepareDynamicInstructionPreamble(ctx, schemaSession.history);
+          prepareDynamicInstructionPreamble(ctx, history.messages(schemaSession));
           let instructionMessages: readonly import("ai").ModelMessage[] = [];
           const traceContext = await prepareWorkflowPreambleTrace({
             ctx,
@@ -525,7 +527,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
           turnAgent: effectiveAgent.turnAgent,
         });
         const modelSession = tasksEnabled
-          ? await appendTaskAgentAnnouncement(refreshedSession)
+          ? await appendTaskAgentAnnouncement(refreshedSession, history.messages(refreshedSession))
           : refreshedSession;
 
         const step = createExecutionNodeStep({
@@ -535,6 +537,8 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
           compactOnly: input.input?.kind === "compact",
           createRuntime: createWorkflowRuntime,
           handleEvent,
+          historyProjector: history.projector,
+          historyView: history.prepare(modelSession),
           mode,
           modelResolutionScope: {
             moduleMap: bundle.moduleMap,

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -684,6 +684,90 @@ function createGatewayModelCallError(input: {
 }
 
 describe("createToolLoopHarness", () => {
+  it("uses one projected history view for step consumers while preserving raw history", async () => {
+    setupMockAgent({
+      finishReason: "stop",
+      response: { messages: [{ content: "Hello!", role: "assistant" }] },
+      text: "Hello!",
+      toolCalls: [],
+      toolResults: [],
+      usage: { inputTokens: 123 },
+    });
+
+    const hidden = { content: "HIDE_FROM_CONSUMERS", role: "user" as const };
+    const projector = vi.fn(({ messages }: { messages: readonly ModelMessage[] }) =>
+      messages.filter((message) => message !== hidden),
+    );
+    const stepEventMessages: Array<readonly ModelMessage[]> = [];
+    const handleEvent: HarnessEmitFn = async (event, messages) => {
+      if (event.type === "step.started") {
+        stepEventMessages.push(messages ?? []);
+      }
+    };
+    const dynamicModelMessages: Array<readonly ModelMessage[]> = [];
+    const runStep = createToolLoopHarness(
+      createTestConfig("conversation", handleEvent, {
+        dispatchDynamicModelEvent: async ({ messages }) => {
+          dynamicModelMessages.push(messages);
+        },
+        historyProjector: projector,
+      }),
+    );
+    const session = createTestSession({
+      history: [
+        { content: "first", role: "user" },
+        hidden,
+        { content: "second", role: "assistant" },
+      ],
+    });
+
+    const result = await contextStorage.run(new ContextContainer(), () =>
+      runStep(session, { message: "third" }),
+    );
+    const expectedView = [
+      { content: "first", role: "user" },
+      { content: "second", role: "assistant" },
+      { content: "third", role: "user" },
+    ];
+    const agent = vi.mocked(ToolLoopAgent).mock.results[0]?.value;
+
+    expect(dynamicModelMessages).toEqual([expectedView]);
+    expect(stepEventMessages).toEqual([expectedView]);
+    expect(agent.stream).toHaveBeenCalledWith(expect.objectContaining({ messages: expectedView }));
+    expect(result.session.history).toEqual([
+      { content: "first", role: "user" },
+      hidden,
+      { content: "second", role: "assistant" },
+      { content: "third", role: "user" },
+      { content: "Hello!", role: "assistant" },
+    ]);
+    expect(result.session.compaction).toMatchObject({
+      lastKnownInputTokens: 123,
+      lastKnownPromptMessageCount: expectedView.length,
+    });
+    expect(projector.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("stops before lifecycle callbacks and the model when history projection fails", async () => {
+    const handleEvent = vi.fn();
+    const dispatchDynamicModelEvent = vi.fn();
+    const runStep = createToolLoopHarness(
+      createTestConfig("conversation", handleEvent, {
+        dispatchDynamicModelEvent,
+        historyProjector: () => {
+          throw new Error("projection failed");
+        },
+      }),
+    );
+
+    await expect(runStep(createTestSession(), { message: "Hi" })).rejects.toThrow(
+      "projection failed",
+    );
+    expect(handleEvent).not.toHaveBeenCalled();
+    expect(dispatchDynamicModelEvent).not.toHaveBeenCalled();
+    expect(ToolLoopAgent).not.toHaveBeenCalled();
+  });
+
   it("parks when model finishes with stop", async () => {
     setupMockAgent({
       finishReason: "stop",
@@ -5827,22 +5911,35 @@ describe("createToolLoopHarness", () => {
     });
 
     const { emit } = createEventCollector();
-    const session = createPendingBashApprovalSession();
+    const hidden = { content: "HIDE_FROM_APPROVAL_RESUME", role: "user" as const };
+    const pendingSession = createPendingBashApprovalSession();
+    const session = {
+      ...pendingSession,
+      history: [hidden, ...pendingSession.history],
+    };
 
     const harness = createToolLoopHarness(
-      createTestConfig("conversation", emit, { tools: new Map() }),
+      createTestConfig("conversation", emit, {
+        historyProjector: ({ messages }) => messages.filter((message) => message !== hidden),
+        tools: new Map(),
+      }),
     );
-    const result = await harness(session, {
-      inputResponses: [{ optionId: "approve", requestId: "approval-1" }],
-    });
+    const result = await contextStorage.run(new ContextContainer(), () =>
+      harness(session, {
+        inputResponses: [{ optionId: "approve", requestId: "approval-1" }],
+      }),
+    );
 
     expect(result.session.history.map((msg) => msg.role)).toEqual([
+      "user",
       "assistant",
       "tool",
       "tool",
       "assistant",
     ]);
-    const approvalMessage = result.session.history[1];
+    const agent = vi.mocked(ToolLoopAgent).mock.results[0]?.value;
+    expect(vi.mocked(agent!.stream).mock.calls[0]?.[0].messages).not.toContain(hidden);
+    const approvalMessage = result.session.history[2];
     expect(Array.isArray(approvalMessage?.content)).toBe(true);
     const approvalParts = approvalMessage?.content as Array<Record<string, unknown>>;
     expect(approvalParts).toHaveLength(1);
@@ -5853,7 +5950,7 @@ describe("createToolLoopHarness", () => {
       type: "tool-approval-response",
     });
 
-    const toolResultMessage = result.session.history[2];
+    const toolResultMessage = result.session.history[3];
     expect(Array.isArray(toolResultMessage?.content)).toBe(true);
     const toolResultParts = toolResultMessage?.content as Array<Record<string, unknown>>;
     expect(toolResultParts).toHaveLength(1);
@@ -8762,9 +8859,9 @@ describe("createToolLoopHarness", () => {
       "session.started",
       "turn.started",
       "message.received",
-      "step.started",
       "compaction.requested",
       "compaction.completed",
+      "step.started",
       "message.completed",
       "step.completed",
       "turn.completed",
@@ -8785,6 +8882,61 @@ describe("createToolLoopHarness", () => {
       sessionId: "test-session",
       turnId: "turn_0",
     });
+  });
+
+  it("selects the model from the pre-compaction view and dispatches step consumers after rewrite", async () => {
+    vi.mocked(shouldCompact).mockReturnValue(true);
+    const compactedHistory: ModelMessage[] = [
+      { content: "Summary of our conversation so far:", role: "user" },
+      { content: "summary", role: "assistant" },
+      { content: "current", role: "user" },
+    ];
+    vi.mocked(compactMessages).mockResolvedValue(compactedHistory);
+    setupMockAgent({
+      finishReason: "stop",
+      response: { messages: [{ content: "done", role: "assistant" }] },
+      text: "done",
+      toolCalls: [],
+      toolResults: [],
+    });
+
+    const hidden = { content: "HIDE_FROM_COMPACTION", role: "user" as const };
+    const preCompactionModelViews: Array<readonly ModelMessage[]> = [];
+    const stepViews: Array<readonly ModelMessage[]> = [];
+    const emit: HarnessEmitFn = async (event, messages) => {
+      if (event.type === "step.started") stepViews.push(messages ?? []);
+    };
+    const runStep = createToolLoopHarness(
+      createTestConfig("conversation", emit, {
+        dispatchDynamicModelEvent: async ({ messages }) => {
+          preCompactionModelViews.push(messages);
+        },
+        historyProjector: ({ messages }) => messages.filter((message) => message !== hidden),
+        resolveModel: vi
+          .fn()
+          .mockResolvedValue({ modelId: "gpt-4", provider: "openai" } as LanguageModel),
+      }),
+    );
+    const session = createTestSession({
+      history: [
+        { content: "visible", role: "user" },
+        hidden,
+        { content: "reply", role: "assistant" },
+      ],
+    });
+
+    await contextStorage.run(new ContextContainer(), () =>
+      runStep(session, { message: "current" }),
+    );
+
+    const preCompactionView = [
+      { content: "visible", role: "user" },
+      { content: "reply", role: "assistant" },
+      { content: "current", role: "user" },
+    ];
+    expect(preCompactionModelViews).toEqual([preCompactionView]);
+    expect(vi.mocked(compactMessages).mock.calls[0]?.[0]).toEqual(preCompactionView);
+    expect(stepViews).toEqual([compactedHistory]);
   });
 
   it("clears static and dynamic user instructions without rerunning lifecycle events", async () => {
@@ -8849,9 +9001,11 @@ describe("createToolLoopHarness", () => {
 
     const { emit, events } = createEventCollector();
     const onCompaction = vi.fn(() => []);
+    const hidden = { content: "Hidden internal context.", role: "user" as const };
     const runStep = createToolLoopHarness(
       createTestConfig("conversation", emit, {
         compactOnly: true,
+        historyProjector: ({ messages }) => messages.filter((message) => message !== hidden),
         onCompaction,
         resolveModel: vi
           .fn()
@@ -8867,6 +9021,7 @@ describe("createToolLoopHarness", () => {
       },
       history: [
         { content: "Static user instructions.", role: "user" },
+        hidden,
         { content: "Dynamic user instructions.", role: "user" },
         { content: "old reply", role: "assistant" },
       ],
@@ -10557,9 +10712,19 @@ describe("createToolLoopHarness", () => {
         },
       });
 
-      const config = createTestConfig("conversation", emit);
+      const hidden = { content: "HIDE_FROM_INSTRUMENTATION", role: "user" as const };
+      const config = createTestConfig("conversation", emit, {
+        historyProjector: ({ messages }) => messages.filter((message) => message !== hidden),
+      });
       const runStep = createToolLoopHarness(config);
-      await contextStorage.run(ctx, () => runStep(createTestSession(), { message: "hi" }));
+      await contextStorage.run(ctx, () =>
+        runStep(
+          createTestSession({
+            history: [{ content: "visible", role: "user" }, hidden],
+          }),
+          { message: "hi" },
+        ),
+      );
 
       const agentCall = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0] as {
         runtimeContext?: Record<string, unknown>;
@@ -10567,6 +10732,12 @@ describe("createToolLoopHarness", () => {
       };
       expect(resolveRuntimeContext).toHaveBeenCalledExactlyOnceWith(
         expect.objectContaining({
+          modelInput: expect.objectContaining({
+            messages: [
+              { content: "visible", role: "user" },
+              { content: "hi", role: "user" },
+            ],
+          }),
           step: { index: 0 },
           turn: { id: "turn_0", sequence: 0 },
         }),
@@ -11113,9 +11284,14 @@ describe("createToolLoopHarness", () => {
           resolvers: [resolver],
         });
       };
-      const runStep = createToolLoopHarness(createTestConfig("conversation", handleEvent));
+      const hidden = { content: "Hidden context.", role: "user" as const };
+      const runStep = createToolLoopHarness(
+        createTestConfig("conversation", handleEvent, {
+          historyProjector: ({ messages }) => messages.filter((message) => message !== hidden),
+        }),
+      );
       const session = createTestSession({
-        history: [{ content: "Static context.", role: "user" }],
+        history: [{ content: "Static context.", role: "user" }, hidden],
       });
 
       const result = await contextStorage.run(ctx, () => runStep(session, { message: "Hello." }));
@@ -11130,6 +11306,7 @@ describe("createToolLoopHarness", () => {
       ]);
       expect(result.session.history).toEqual([
         { content: "Static context.", role: "user" },
+        hidden,
         { content: "Session context.", role: "user" },
         { content: "Turn context.", role: "user" },
         { content: "Hello.", role: "user" },

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -242,6 +242,7 @@ import {
 } from "#runtime/framework-tools/final-output.js";
 import type { RuntimeModelReference } from "#runtime/agent/bootstrap.js";
 import type { RunMode } from "#shared/run-mode.js";
+import { createHistoryViewPreparer } from "#shared/history-view.js";
 import {
   type CompactionConfig,
   type HarnessSession,
@@ -619,6 +620,15 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     turnSpan?: Span,
   ): Promise<StepResult> {
     let session = initialSession;
+    const prepareHistory = createHistoryViewPreparer({
+      previous: config.historyView,
+      projector: config.historyProjector,
+    });
+    prepareHistory(session.history, session.state);
+    const projectHistory = (
+      messages: readonly ModelMessage[],
+      state: HarnessSession["state"],
+    ): readonly ModelMessage[] => prepareHistory(messages, state).messages;
 
     // Store the turn span context on the session so continuation steps
     // can restore the parent trace across step boundaries.
@@ -746,7 +756,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
               turnId: activeTurnId(emissionState),
             },
             force: true,
-            messages: [...session.history],
+            messages: [...projectHistory(session.history, session.state)],
             model: resolvedModel.model,
             onCompaction: config.onCompaction,
             resolveModel: config.resolveModel,
@@ -828,7 +838,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
           stepIndex: emissionState.stepIndex,
           turnId: emissionState.turnId,
         }),
-        messages: resolvedRuntimeActions.messages,
+        messages: projectHistory(resolvedRuntimeActions.messages, session.state),
       });
     }
     const coordinated = await coordinateApprovalDelivery({
@@ -986,7 +996,10 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         hasStepInput(input)
       ) {
         if (store !== undefined) {
-          prepareDynamicInstructionPreamble(store, parkedSession.history);
+          prepareDynamicInstructionPreamble(
+            store,
+            projectHistory(parkedSession.history, parkedSession.state),
+          );
         }
         let instructionMessages: ModelMessage[] = [];
         try {
@@ -1092,7 +1105,10 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     let instructionMessages: ModelMessage[] = [];
     if (emit && hasStepInput(input)) {
       if (store !== undefined) {
-        prepareDynamicInstructionPreamble(store, pending.session.history);
+        prepareDynamicInstructionPreamble(
+          store,
+          projectHistory(pending.session.history, pending.session.state),
+        );
       }
       try {
         const traceContext = await preparePreambleTrace();
@@ -1161,7 +1177,10 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     if (config.persistentSubagentSessions === true) {
       const store = getAgentHandleStore(session.state);
       if (store?.handles.some((handle) => handle.phase === "addressed") !== true) {
-        const announcement = resolveAgentsAnnouncement({ messages, store });
+        const announcement = resolveAgentsAnnouncement({
+          messages: projectHistory(messages, session.state),
+          store,
+        });
         if (announcement !== undefined) {
           messages.push({ content: announcement, role: "user" });
         }
@@ -1185,6 +1204,8 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       messages.push({ content, role: "user" });
     }
 
+    let projectedMessages = projectHistory(messages, session.state);
+
     // --- Model + tools ------------------------------------------------------
 
     // Direct harness unit tests may run without an ambient context.
@@ -1202,7 +1223,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
             },
             type: "step.started",
           } as UnstampedMessageStreamEvent,
-          messages,
+          messages: projectedMessages,
         });
       }
       resolvedModel = await resolveActiveRuntimeModel({
@@ -1216,14 +1237,6 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     session = resolvedModel.session;
     const model = resolvedModel.model;
 
-    if (emit) {
-      await emitStepStarted(
-        emit,
-        emissionState,
-        requireSessionModelReference(session).id,
-        messages,
-      );
-    }
     const cachePath = detectPromptCachePath(model);
     const marker = cachePath.kind === "anthropic-direct" ? getAnthropicCacheMarker() : undefined;
 
@@ -1233,18 +1246,32 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     // `messages` (which the harness uses to rebuild session history).
     const attributionHeaders = buildGatewayAttributionHeaders(model, config.runtimeIdentity);
 
-    ({ messages, session } = await maybeCompact({
+    const compaction = await maybeCompact({
       abortSignal: config.abortSignal,
       emit,
       emissionState,
-      messages,
+      messages: [...projectedMessages],
       model,
       onCompaction: config.onCompaction,
       resolveModel: config.resolveModel,
       runtimeIdentity: config.runtimeIdentity,
       session,
       telemetry: enrichTelemetry(otelSettings, agentName) ?? undefined,
-    }));
+    });
+    session = compaction.session;
+    if (compaction.compacted) {
+      messages = compaction.messages;
+    }
+    projectedMessages = projectHistory(messages, session.state);
+
+    if (emit) {
+      await emitStepStarted(
+        emit,
+        emissionState,
+        requireSessionModelReference(session).id,
+        projectedMessages,
+      );
+    }
 
     const approvedTools = getApprovedTools(session);
 
@@ -1271,7 +1298,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     // model call only. The result is transient — `messages` itself
     // remains ref-only so it can flow into `session.history` without
     // bloating every future step boundary.
-    const hydratedMessages = await hydrateSandboxAttachments(messages);
+    const hydratedMessages = await hydrateSandboxAttachments(projectedMessages);
 
     // AI SDK rejects role:"system" in `messages` — route system entries
     // from durable history to `instructions` instead.
@@ -1651,7 +1678,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       config,
       emit,
       emissionState,
-      messages,
+      messages: projectedMessages,
       session,
     });
     if (limitResult !== null) {
@@ -1910,6 +1937,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       emit,
       emissionState,
       delegatedCaller: taskUpdatesEnabled,
+      modelPromptMessageCount: projectedMessages.length,
       promptMessages: messages,
       result,
       runStep,
@@ -2429,6 +2457,7 @@ async function handleStepResult(input: {
   readonly emit?: ToolLoopHarnessConfig["handleEvent"];
   readonly emissionState: ReturnType<typeof getHarnessEmissionState>;
   readonly delegatedCaller: boolean;
+  readonly modelPromptMessageCount: number;
   readonly promptMessages: readonly ModelMessage[];
   readonly result: HarnessStepResult;
   readonly runStep: StepFn;
@@ -2481,7 +2510,11 @@ async function handleStepResult(input: {
 
   const baseSession: HarnessSession = {
     ...session,
-    compaction: createNextCompactionConfig(session.compaction, promptMessages, result),
+    compaction: createNextCompactionConfig(
+      session.compaction,
+      input.modelPromptMessageCount,
+      result,
+    ),
   };
 
   const workflowContinuationSecurity =
@@ -3092,7 +3125,7 @@ function parkOnWorkflowInterrupt(input: {
 
 function createNextCompactionConfig(
   current: CompactionConfig,
-  promptMessages: readonly ModelMessage[],
+  promptMessageCount: number,
   result: HarnessStepResult,
 ): CompactionConfig {
   const next: {
@@ -3109,7 +3142,7 @@ function createNextCompactionConfig(
 
   if (result.usage?.inputTokens !== undefined) {
     next.lastKnownInputTokens = result.usage.inputTokens;
-    next.lastKnownPromptMessageCount = promptMessages.length;
+    next.lastKnownPromptMessageCount = promptMessageCount;
   }
 
   return next;
@@ -3136,13 +3169,17 @@ async function maybeCompact(input: {
   readonly runtimeIdentity?: ToolLoopHarnessConfig["runtimeIdentity"];
   readonly session: HarnessSession;
   readonly telemetry?: TelemetryOptions;
-}): Promise<{ readonly messages: ModelMessage[]; readonly session: HarnessSession }> {
+}): Promise<{
+  readonly compacted: boolean;
+  readonly messages: ModelMessage[];
+  readonly session: HarnessSession;
+}> {
   const { emit, emissionState } = input;
   let messages = input.messages;
   const session = input.session;
 
   if (input.force !== true && !shouldCompact(messages, session.compaction)) {
-    return { messages, session };
+    return { compacted: false, messages, session };
   }
 
   const compaction = await resolveCompactionModel({
@@ -3192,7 +3229,7 @@ async function maybeCompact(input: {
     );
   }
 
-  return { messages, session };
+  return { compacted: true, messages, session };
 }
 
 /**

--- a/packages/eve/src/harness/types.ts
+++ b/packages/eve/src/harness/types.ts
@@ -15,6 +15,7 @@ import type { WebSearchProvider } from "#shared/web-search.js";
 import type { AgentReasoningDefinition } from "#shared/agent-definition.js";
 import type { HarnessToolDefinition } from "#harness/execute-tool.js";
 import type { HarnessInstrumentation } from "#harness/instrumentation/runtime.js";
+import type { HistoryViewProjector, PreparedHistoryView } from "#shared/history-view.js";
 
 /**
  * Serializable tool definition stored on the session.
@@ -293,6 +294,10 @@ export interface ToolLoopHarnessConfig {
   /** AI Gateway provider selected for the framework `web_search` tool. */
   readonly webSearchProvider?: WebSearchProvider;
   readonly handleEvent?: HandleEventFn;
+  /** Projects raw durable history before it crosses a message-bearing boundary. */
+  readonly historyProjector?: HistoryViewProjector;
+  /** Execution-prepared view of the history supplied to the first harness step. */
+  readonly historyView?: PreparedHistoryView;
   /**
    * Internal lifecycle hooks injected into each actual model attempt.
    * Omitted in production until an instrumentation runtime opts in.

--- a/packages/eve/src/shared/history-view.test.ts
+++ b/packages/eve/src/shared/history-view.test.ts
@@ -1,0 +1,57 @@
+import type { ModelMessage } from "ai";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createHistoryViewPreparer,
+  identityHistoryViewProjector,
+  prepareHistoryView,
+} from "#shared/history-view.js";
+
+const messages: ModelMessage[] = [
+  { content: "first", role: "user" },
+  { content: "second", role: "assistant" },
+];
+
+describe("prepareHistoryView", () => {
+  it("preserves the exact history array with the identity projector", () => {
+    const prepared = prepareHistoryView({ messages });
+
+    expect(prepared.messages).toBe(messages);
+    expect(prepared.messages).toEqual(messages);
+    expect(identityHistoryViewProjector({ messages, state: undefined })).toBe(messages);
+  });
+
+  it("reuses a prepared view until its raw messages or session state changes", () => {
+    const state = { retained: true };
+    const projector = vi.fn(({ messages: source }: { messages: readonly ModelMessage[] }) =>
+      source.filter((message) => message.content !== "second"),
+    );
+    const prepare = createHistoryViewPreparer({ projector });
+    const first = prepare(messages, state);
+    const reused = prepare(messages, state);
+
+    expect(reused).toBe(first);
+    expect(projector).toHaveBeenCalledOnce();
+
+    const nextMessages = [...messages, { content: "third", role: "user" as const }];
+    const next = prepare(nextMessages, state);
+    expect(next).not.toBe(first);
+    expect(projector).toHaveBeenCalledTimes(2);
+
+    prepare(nextMessages, { retained: true });
+    expect(projector).toHaveBeenCalledTimes(3);
+  });
+
+  it("propagates projector failures without producing a partial view", () => {
+    const error = new Error("projection failed");
+
+    expect(() =>
+      prepareHistoryView({
+        messages,
+        projector: () => {
+          throw error;
+        },
+      }),
+    ).toThrow(error);
+  });
+});

--- a/packages/eve/src/shared/history-view.ts
+++ b/packages/eve/src/shared/history-view.ts
@@ -1,0 +1,57 @@
+import type { ModelMessage } from "ai";
+
+export interface HistoryViewProjectionInput {
+  readonly messages: readonly ModelMessage[];
+  readonly state: Readonly<Record<string, unknown>> | undefined;
+}
+
+export type HistoryViewProjector = (input: HistoryViewProjectionInput) => readonly ModelMessage[];
+
+export interface PreparedHistoryView {
+  readonly messages: readonly ModelMessage[];
+  readonly sourceMessages: readonly ModelMessage[];
+  readonly sourceState: Readonly<Record<string, unknown>> | undefined;
+}
+
+export const identityHistoryViewProjector: HistoryViewProjector = ({ messages }) => messages;
+
+export function createHistoryViewPreparer(input?: {
+  readonly previous?: PreparedHistoryView;
+  readonly projector?: HistoryViewProjector;
+}): (
+  messages: readonly ModelMessage[],
+  state: Readonly<Record<string, unknown>> | undefined,
+) => PreparedHistoryView {
+  let previous = input?.previous;
+
+  return (messages, state) => {
+    previous = prepareHistoryView({
+      messages,
+      previous,
+      projector: input?.projector,
+      state,
+    });
+    return previous;
+  };
+}
+
+export function prepareHistoryView(input: {
+  readonly messages: readonly ModelMessage[];
+  readonly previous?: PreparedHistoryView;
+  readonly projector?: HistoryViewProjector;
+  readonly state?: Readonly<Record<string, unknown>>;
+}): PreparedHistoryView {
+  if (
+    input.previous?.sourceMessages === input.messages &&
+    input.previous.sourceState === input.state
+  ) {
+    return input.previous;
+  }
+
+  const projector = input.projector ?? identityHistoryViewProjector;
+  return {
+    messages: projector({ messages: input.messages, state: input.state }),
+    sourceMessages: input.messages,
+    sourceState: input.state,
+  };
+}


### PR DESCRIPTION
### Summary

Closes #2344. Related to #1510 and #1581.

Session history currently reaches model- and author-facing consumers through several independent paths, so a transformation at model assembly can leave earlier runtime resolvers, compaction, instrumentation, and continuation flows observing a different conversation.

This change adds one internal prepared-history seam at execution entry and threads its identity view through runtime refresh and hydration, dynamic resolution, approval and authorization continuations, task announcements, compaction and token accounting, instrumentation, and model input. The prepared view is reused while the source history and state references are unchanged; raw durable history remains the persistence source.

Compaction ordering is explicit: dynamic model selection receives the pre-compaction view, compaction operates on that view, and `step.started` plus downstream consumers receive a recomputed post-compaction view. The default projector is identity-only, so this foundation adds no public authoring API or intended behavior change.

### Validation

- `pnpm test:unit` passed all 660 unit-test files: 6,930 tests passed and 1 was skipped.
- A focused eight-file unit run covering the prepared-history seam, workflow entry, node threading, task announcements, tool-loop behavior, compaction, instrumentation, and the file-length invariant passed all 304 tests.
- `pnpm typecheck`, `pnpm lint`, and `pnpm guard:invariants` passed. Lint reported the existing unsafe-optional-chaining warning in `teamsChannel.test.ts` and no errors.
- `pnpm fmt` completed, and a targeted `pnpm exec oxfmt --check` confirmed all 12 changed files are formatted.
- `pnpm test:integration` passed 88 of 90 files and 656 of 659 tests. Three sandbox-dependent tests could not complete because the local microsandbox database references four applied migration files that are absent from the installed runtime; two surfaced `Sandbox provisioning failed` and one timed out waiting for the same child-sandbox path. The remaining integration suite passed.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

Docs: 1 file, +5/-0. Adds the required patch changeset for the published `eve` package.

Implementation: 7 files, +168/-31. Adds the prepared-history seam and routes execution and harness consumers through it.

Tests: 4 files, +577/-13. Covers identity and failure behavior, caching, runtime refresh and hydration, continuations, compaction ordering, instrumentation, token accounting, model input, and raw-history preservation.

Total: 12 files, +750/-44.
