### PR TITLE
fix(eve): dynamic tools - make callback replay durable

### DIFF
--- a/.changeset/durable-dynamic-tool-callbacks.md
+++ b/.changeset/durable-dynamic-tool-callbacks.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Make dynamic tool approval, execution, and output callbacks durable across cold starts. Non-serializable callback captures now fail with an actionable error instead of losing values during replay.

--- a/docs/guides/dynamic-capabilities.md
+++ b/docs/guides/dynamic-capabilities.md
@@ -132,7 +132,7 @@ approval checks.
 
 ## Dynamic tools
 
-Pass `defineDynamic` an `events` object whose handlers return either a single `defineTool(...)`, a `Record<string, defineTool(...)>`, or `null` for no tools. Wrap every entry in `defineTool()`. The wrapper stamps them so their `execute` functions survive workflow step boundaries.
+Pass `defineDynamic` an `events` object whose handlers return either a single `defineTool(...)`, a `Record<string, defineTool(...)>`, or `null` for no tools. Wrap every entry in `defineTool()`. eve records durable descriptors for `execute`, approval request and response policies, and `toModelOutput`, so a parked call can reconstruct the same callbacks in a fresh process.
 
 Dynamic tool executors receive the same `ToolContext` as static authored tools, including inline provider auth through `ctx.getToken(provider)` and `ctx.requireAuth(provider)`.
 
@@ -160,11 +160,13 @@ export default defineDynamic({
 });
 ```
 
-### Prefer an inline `execute` function
+### Author replayable callbacks
 
-Write `execute` as an inline function expression, arrow, or method shorthand placed directly as the property value. The bundler transform stores the function and its closure variables for durable replay without rerunning the resolver.
+Write callback properties as inline function expressions, arrows, method shorthand, or module-level function references. eve transforms authored modules that import `defineTool`, including helper modules outside `agent/tools/`, and stores each callback's referenced closure values independently.
 
-The transform does not detect `execute: myFn`, `execute: makeFn()`, or executors created inside an imported dependency. For a `session.started` tool, eve can reconstruct these live functions by rerunning the owning resolver after a durable resume. Keep session resolvers idempotent and avoid unnecessary side effects. A `turn.started` tool still requires an inline executor to survive a fresh runtime.
+Closure values must be JSON-serializable. Plain objects, arrays, strings, finite numbers, booleans, and `null` are supported; `undefined` object properties are omitted. Functions, class instances, `Date`, `Map`, symbols, non-finite numbers, and cyclic values fail resolution with the tool name and callback phase instead of being serialized lossily.
+
+Call expressions such as `execute: makeExecutor()` are not transformed. Put the callback body directly in `defineTool()` inside an authored module; eve-provided factories may also supply pre-registered callbacks. eve rejects a dynamic tool if any present callback lacks durable metadata, and replay never reruns the current resolver to recover one.
 
 ### Naming
 
@@ -181,13 +183,13 @@ A dynamic tool or skill whose name matches an **authored** one **overrides** it 
 
 ### Events
 
-| Event             | Resolver runs                              | Tools available for             |
-| ----------------- | ------------------------------------------ | ------------------------------- |
-| `session.started` | At session start; sometimes after a pause¹ | Every model call in the session |
-| `turn.started`    | Once per turn                              | Every model call in the turn    |
-| `step.started`    | Before each model call                     | That model call                 |
+| Event             | Resolver runs                                         | Tools available for             |
+| ----------------- | ----------------------------------------------------- | ------------------------------- |
+| `session.started` | At session start; may be redelivered during recovery¹ | Every model call in the session |
+| `turn.started`    | Once per turn                                         | Every model call in the turn    |
+| `step.started`    | Before each model call                                | That model call                 |
 
-¹ If a session pauses to wait for approval or other input, eve may run the resolver again when the session continues. Design session resolvers so they can safely run more than once. They do not run before every model call.
+¹ Workflow recovery can redeliver a resolver event, so keep resolvers idempotent. Replaying a parked callback does not depend on running the resolver again.
 
 ### Execution order
 

--- a/packages/eve/src/context/build-dynamic-tools.ts
+++ b/packages/eve/src/context/build-dynamic-tools.ts
@@ -3,120 +3,125 @@ import type { HarnessToolMap } from "#harness/types.js";
 import type { ContextReader } from "#context/key.js";
 import {
   SessionDynamicToolMetadataKey,
+  StepDynamicToolMetadataKey,
   TurnDynamicToolMetadataKey,
-  LiveStepToolsKey,
+  type DurableDynamicToolMetadata,
 } from "#context/keys.js";
-import type { DurableDynamicToolMetadata } from "#context/keys.js";
 import { createToolExecuteWithAuth } from "#execution/tool-auth.js";
 import { createLogger } from "#internal/logging.js";
 import type {
   ApprovalContext,
-  ApprovalResponseDecision,
   ApprovalResponseContext,
+  ApprovalResponseDecision,
   ApprovalStatus,
 } from "#public/definitions/approval.js";
+import type { DurableDynamicCallbackReference } from "#shared/durable-dynamic-tool-callbacks.js";
 import { toInputSchema, toOutputSchema } from "#shared/tool-schema.js";
 
 const log = createLogger("dynamic-tools");
 
 function lookupStepFunction(stepId: string): ((...args: unknown[]) => unknown) | null {
-  try {
-    const registry = (globalThis as Record<symbol, Map<string, Function> | undefined>)[
-      Symbol.for("@workflow/core//registeredSteps")
-    ];
-    if (registry === undefined) return null;
-    const fn = registry.get(stepId);
-    return fn ? (fn as (...args: unknown[]) => unknown) : null;
-  } catch {
-    return null;
-  }
+  const registry = (globalThis as Record<symbol, Map<string, Function> | undefined>)[
+    Symbol.for("@workflow/core//registeredSteps")
+  ];
+  const callback = registry?.get(stepId);
+  return callback ? (callback as (...args: unknown[]) => unknown) : null;
 }
 
-function replayTools(metadata: readonly DurableDynamicToolMetadata[]): HarnessToolDefinition[] {
-  const tools: HarnessToolDefinition[] = [];
-
-  for (const m of metadata) {
-    if (!m.executeStepFnName || !m.closureVars) {
-      log.warn(
-        `Dynamic tool "${m.name}" has no registered step function — ` +
-          "skipping on this step. The bundler transform may not have processed this tool file.",
-      );
-      continue;
-    }
-
-    const stepFn = lookupStepFunction(m.executeStepFnName);
-    if (!stepFn) {
-      log.warn(
-        `Dynamic tool "${m.name}" references step function "${m.executeStepFnName}" ` +
-          "which is not registered — skipping on this step.",
-      );
-      continue;
-    }
-
-    tools.push({
-      description: m.description,
-      execute: createToolExecuteWithAuth({
-        scope: m.name,
-        execute: (input, ctx) => stepFn(m.closureVars, input, ctx),
-      }),
-      inputSchema: toInputSchema(m.inputSchema),
-      name: m.name,
-      approval: buildReplayedApproval(m),
-      outputSchema: toOutputSchema(m.outputSchema),
-    });
-  }
-
-  return tools;
+function missingCallbackError(
+  metadata: DurableDynamicToolMetadata,
+  phase: keyof DurableDynamicToolMetadata["callbacks"],
+  reference: DurableDynamicCallbackReference,
+): Error {
+  return new Error(
+    `Dynamic tool "${metadata.name}" cannot replay its ${phase} callback because ` +
+      `step function "${reference.stepId}" is not registered. Rebuild the agent and ensure ` +
+      "the callback is created at module scope or transformed from authored source.",
+  );
 }
 
 function buildReplayedApproval(
   metadata: DurableDynamicToolMetadata,
 ): HarnessToolDefinition["approval"] | undefined {
-  if (metadata.approvalStepFnName === undefined) {
-    return undefined;
-  }
+  const requestReference = metadata.callbacks.approvalRequest;
+  if (requestReference === undefined) return undefined;
 
-  const approvalStepFn = lookupStepFunction(metadata.approvalStepFnName);
-  if (approvalStepFn === null) {
-    log.warn(
-      `Dynamic tool "${metadata.name}" references approval function "${metadata.approvalStepFnName}" ` +
-        "which is not registered — requiring approval by default.",
-    );
-    return () => "user-approval";
-  }
+  const request = lookupStepFunction(requestReference.stepId);
+  const requestPolicy =
+    request === null
+      ? async () => {
+          log.error(missingCallbackError(metadata, "approvalRequest", requestReference).message);
+          return "user-approval" as const;
+        }
+      : async (context: ApprovalContext) =>
+          (await request(requestReference.closure, context)) as ApprovalStatus;
 
-  const policy = async (approvalCtx: ApprovalContext) =>
-    (await approvalStepFn(metadata.closureVars ?? {}, approvalCtx)) as ApprovalStatus;
-  if (metadata.approvalResponseStepFnName === undefined) return policy;
+  const responseReference = metadata.callbacks.approvalResponse;
+  if (responseReference === undefined) return requestPolicy;
 
-  const responseStepFn = lookupStepFunction(metadata.approvalResponseStepFnName);
-  if (responseStepFn === null) {
-    log.warn(
-      `Dynamic tool "${metadata.name}" references response authorizer ` +
-        `"${metadata.approvalResponseStepFnName}" which is not registered — rejecting responses.`,
-    );
-    return {
-      request: policy,
-      response: async () => ({
-        reason: "Approval response authorization is temporarily unavailable.",
-        status: "rejected" as const,
-      }),
-    };
-  }
-
+  const response = lookupStepFunction(responseReference.stepId);
   return {
-    request: policy,
-    response: async (responseCtx: ApprovalResponseContext) =>
-      (await responseStepFn(metadata.closureVars ?? {}, responseCtx)) as ApprovalResponseDecision,
+    request: requestPolicy,
+    response:
+      response === null
+        ? async () => {
+            const error = missingCallbackError(metadata, "approvalResponse", responseReference);
+            log.error(error.message);
+            return {
+              reason: error.message,
+              status: "rejected" as const,
+            };
+          }
+        : async (context: ApprovalResponseContext) =>
+            (await response(responseReference.closure, context)) as ApprovalResponseDecision,
   };
 }
 
+/** Reconstructs every callback exclusively from its durable descriptor. */
+export function replayDynamicTools(
+  metadata: readonly DurableDynamicToolMetadata[],
+): HarnessToolDefinition[] {
+  return metadata.map((entry) => {
+    const executeReference = entry.callbacks.execute;
+    const execute = lookupStepFunction(executeReference.stepId);
+    const toModelOutputReference = entry.callbacks.toModelOutput;
+    const toModelOutput =
+      toModelOutputReference === undefined
+        ? undefined
+        : lookupStepFunction(toModelOutputReference.stepId);
+
+    return {
+      description: entry.description,
+      execute: createToolExecuteWithAuth({
+        scope: entry.name,
+        execute: (input, context) => {
+          if (execute === null) {
+            throw missingCallbackError(entry, "execute", executeReference);
+          }
+          return execute(executeReference.closure, input, context);
+        },
+      }),
+      inputSchema: toInputSchema(entry.inputSchema),
+      name: entry.name,
+      approval: buildReplayedApproval(entry),
+      outputSchema: toOutputSchema(entry.outputSchema),
+      ...(toModelOutputReference === undefined
+        ? {}
+        : {
+            toModelOutput: (output: unknown) => {
+              if (toModelOutput === null) {
+                throw missingCallbackError(entry, "toModelOutput", toModelOutputReference);
+              }
+              return toModelOutput!(toModelOutputReference.closure, output);
+            },
+          }),
+    };
+  });
+}
+
 /**
- * Builds live dynamic tool definitions. Narrower scopes appear first
- * so they win on name collision (the tool-loop uses `??=` for dedup).
- *
- * Step tools are live closures (re-resolved every step via
- * `LiveStepToolsKey`). Session and turn tools replay durable metadata.
+ * Builds live dynamic tool definitions. Narrower scopes appear first so they
+ * win on name collision (the tool loop uses `??=` for deduplication).
  */
 export function buildResponseAuthorizationTools(input: {
   readonly authoredTools: HarnessToolMap;
@@ -133,8 +138,8 @@ export function buildResponseAuthorizationTools(input: {
 }
 
 export function buildDynamicTools(ctx: ContextReader): readonly HarnessToolDefinition[] {
-  const step = ctx.get(LiveStepToolsKey) ?? [];
-  const turn = replayTools(ctx.get(TurnDynamicToolMetadataKey) ?? []);
-  const session = replayTools(ctx.get(SessionDynamicToolMetadataKey) ?? []);
+  const step = replayDynamicTools(ctx.get(StepDynamicToolMetadataKey) ?? []);
+  const turn = replayDynamicTools(ctx.get(TurnDynamicToolMetadataKey) ?? []);
+  const session = replayDynamicTools(ctx.get(SessionDynamicToolMetadataKey) ?? []);
   return [...step, ...turn, ...session];
 }

--- a/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { asSchema, jsonSchema } from "ai";
+import { asSchema } from "ai";
 import { describe, expect, it, vi } from "vitest";
 
 import type { DynamicToolEntry } from "#shared/dynamic-tool-definition.js";
@@ -18,8 +18,8 @@ vi.mock("#context/build-callback-context.js", () => ({
 const {
   replayDynamicSessionTools,
   dispatchDynamicToolEvent,
-  hydrateDynamicSessionTools,
   refreshDynamicSessionToolsForRuntimeRevision,
+  validateDurableDynamicToolCallbacks,
 } = await import("#context/dynamic-tool-lifecycle.js");
 const { buildDynamicTools, buildResponseAuthorizationTools } =
   await import("#context/build-dynamic-tools.js");
@@ -27,12 +27,13 @@ const { buildDynamicTools, buildResponseAuthorizationTools } =
 import { ContextContainer } from "#context/container.js";
 import { deserializeContext, serializeContext } from "#context/serialize.js";
 import {
-  LiveStepToolsKey,
   SessionIdKey,
   SessionDynamicToolMetadataKey,
   SessionDynamicToolRuntimeRevisionKey,
+  StepDynamicToolMetadataKey,
   TurnDynamicToolMetadataKey,
 } from "#context/keys.js";
+import { stampDurableDynamicToolCallbacks } from "#shared/durable-dynamic-tool-callbacks.js";
 import type { ResolvedDynamicToolResolver } from "#runtime/types.js";
 import { createSessionStartedEvent, type UnstampedMessageStreamEvent } from "#protocol/message.js";
 
@@ -98,21 +99,35 @@ describe("dynamic tool naming", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// safeSerialize behavior (re-implemented for isolated testing)
-// ---------------------------------------------------------------------------
-
-function safeSerialize(obj: Record<string, unknown>): Record<string, unknown> {
-  try {
-    return JSON.parse(JSON.stringify(obj));
-  } catch {
-    return {};
+describe("durable callback capture validation", () => {
+  function validateExecuteCapture(closure: unknown) {
+    getOrCreateStepRegistry(Symbol.for("@workflow/core//registeredSteps")).set(
+      "capture-execute",
+      () => null,
+    );
+    const entry = defineTool({
+      description: "captured tool",
+      inputSchema: { type: "object" },
+      execute: async () => null,
+    });
+    stampDurableDynamicToolCallbacks(entry, {
+      execute: { closure: closure as JsonObject, stepId: "capture-execute" },
+    });
+    return validateDurableDynamicToolCallbacks("captured", entry);
   }
-}
 
-describe("safeSerialize", () => {
-  it("preserves plain JSON-serializable values", () => {
-    const result = safeSerialize({
+  it("preserves JSON values and explicitly omits undefined object properties", () => {
+    const callbacks = validateExecuteCapture({
+      str: "hello",
+      num: 42,
+      bool: true,
+      nested: { key: "value" },
+      arr: [1, 2, 3],
+      nil: null,
+      omitted: undefined,
+    });
+
+    expect(callbacks.execute.closure).toEqual({
       str: "hello",
       num: 42,
       bool: true,
@@ -120,78 +135,27 @@ describe("safeSerialize", () => {
       arr: [1, 2, 3],
       nil: null,
     });
-
-    expect(result).toEqual({
-      str: "hello",
-      num: 42,
-      bool: true,
-      nested: { key: "value" },
-      arr: [1, 2, 3],
-      nil: null,
-    });
   });
 
-  it("silently drops function values", () => {
-    const result = safeSerialize({
-      name: "tenant-a",
-      callback: () => "ignored",
-      apiUrl: "https://api.example.com",
-    });
-
-    expect(result).toEqual({
-      name: "tenant-a",
-      apiUrl: "https://api.example.com",
-    });
-    expect(result.callback).toBeUndefined();
+  it.each([
+    ["function", { value: () => null }],
+    ["Date", { value: new Date("2024-01-01T00:00:00.000Z") }],
+    ["Map", { value: new Map([["key", "value"]]) }],
+    ["class instance", { value: new (class Capture {})() }],
+    ["symbol", { value: Symbol("capture") }],
+    ["NaN", { value: Number.NaN }],
+  ])("rejects a %s capture with the tool and phase", (_label, closure) => {
+    expect(() => validateExecuteCapture(closure)).toThrow(
+      'Dynamic tool "captured" callback "execute" has a non-serializable capture',
+    );
   });
 
-  it("silently drops undefined values", () => {
-    const result = safeSerialize({
-      name: "test",
-      missing: undefined,
-    });
-
-    expect(result).toEqual({
-      name: "test",
-    });
-  });
-
-  it("silently drops symbol values", () => {
-    const result = safeSerialize({
-      name: "test",
-      sym: Symbol("test"),
-    });
-
-    expect(result).toEqual({
-      name: "test",
-    });
-  });
-
-  it("returns empty object for circular references", () => {
+  it("rejects cyclic captures", () => {
     const circular: Record<string, unknown> = { name: "test" };
     circular.self = circular;
-
-    const result = safeSerialize(circular);
-    expect(result).toEqual({});
-  });
-
-  it("strips prototype chain from class instances", () => {
-    class Config {
-      name = "test";
-      getValue() {
-        return this.name;
-      }
-    }
-
-    const result = safeSerialize({ config: new Config() });
-    expect(result).toEqual({ config: { name: "test" } });
-    expect(typeof (result.config as Record<string, unknown>).getValue).toBe("undefined");
-  });
-
-  it("preserves Date as ISO string", () => {
-    const date = new Date("2024-01-01T00:00:00.000Z");
-    const result = safeSerialize({ date });
-    expect(result.date).toBe("2024-01-01T00:00:00.000Z");
+    expect(() => validateExecuteCapture(circular)).toThrow(
+      'Dynamic tool "captured" callback "execute" has a non-serializable capture',
+    );
   });
 });
 
@@ -209,54 +173,29 @@ function getOrCreateStepRegistry(sym: symbol): Map<string, Function> {
 }
 
 describe("replayDynamicSessionTools", () => {
-  it("skips metadata entries without executeStepFnName", () => {
-    const metadata: DurableDynamicToolMetadata[] = [
-      {
-        name: "missing-fn",
-        description: "No step fn",
-        inputSchema: { type: "object" },
-        resolverSlug: "test",
-        entryKey: "tool",
-        // executeStepFnName and closureVars are undefined
-      },
-    ];
+  function metadata(
+    name: string,
+    stepId: string,
+    closure: JsonObject = {},
+  ): DurableDynamicToolMetadata {
+    return {
+      callbacks: { execute: { closure, stepId } },
+      description: `${name} description`,
+      entryKey: name,
+      inputSchema: { type: "object" },
+      name,
+      resolverSlug: "test",
+    };
+  }
 
-    const tools = replayDynamicSessionTools(metadata, []);
-    expect(tools).toHaveLength(0);
-  });
-
-  it("skips metadata entries without closureVars", () => {
-    const metadata: DurableDynamicToolMetadata[] = [
-      {
-        name: "no-vars",
-        description: "Has step fn but no closure vars",
-        inputSchema: { type: "object" },
-        resolverSlug: "test",
-        entryKey: "tool",
-        executeStepFnName: "eve:dynamic-tool//__eve_dynamic_exec_99",
-        // closureVars is undefined
-      },
-    ];
-
-    const tools = replayDynamicSessionTools(metadata, []);
-    expect(tools).toHaveLength(0);
-  });
-
-  it("skips entries where step function is not registered", () => {
-    const metadata: DurableDynamicToolMetadata[] = [
-      {
-        name: "unregistered",
-        description: "Step fn not in registry",
-        inputSchema: { type: "object" },
-        resolverSlug: "test",
-        entryKey: "tool",
-        executeStepFnName: "eve:dynamic-tool//__eve_nonexistent",
-        closureVars: { someVar: "value" },
-      },
-    ];
-
-    const tools = replayDynamicSessionTools(metadata, []);
-    expect(tools).toHaveLength(0);
+  it("fails execution closed when the registered callback is unavailable", async () => {
+    const [tool] = replayDynamicSessionTools(
+      [metadata("unregistered", "eve:dynamic-tool//missing")],
+      [],
+    );
+    await expect(tool!.execute!({}, executeOptions)).rejects.toThrow(
+      'Dynamic tool "unregistered" cannot replay its execute callback',
+    );
   });
 
   it("reconstructs tool with registered step function and closure vars", async () => {
@@ -272,22 +211,15 @@ describe("replayDynamicSessionTools", () => {
     registry.set(stepId, stepFn);
 
     try {
-      const metadata: DurableDynamicToolMetadata[] = [
-        {
-          name: "replay-tool",
-          description: "Replayed tool",
-          inputSchema: { type: "object" },
-          resolverSlug: "test",
-          entryKey: "tool",
-          executeStepFnName: stepId,
-          closureVars: { apiUrl: "https://api.example.com", tenantName: "Acme" },
-        },
-      ];
+      const durable = metadata("replay-tool", stepId, {
+        apiUrl: "https://api.example.com",
+        tenantName: "Acme",
+      });
 
-      const tools = replayDynamicSessionTools(metadata, []);
+      const tools = replayDynamicSessionTools([durable], []);
       expect(tools).toHaveLength(1);
       expect(tools[0]!.name).toBe("replay-tool");
-      expect(tools[0]!.description).toBe("Replayed tool");
+      expect(tools[0]!.description).toBe("replay-tool description");
 
       // Execute the replayed tool — mock provides the callback context
       const tool = tools[0]!;
@@ -317,19 +249,7 @@ describe("replayDynamicSessionTools", () => {
 
     try {
       const closureVars = { counter: 1, label: "v1" };
-      const metadata: DurableDynamicToolMetadata[] = [
-        {
-          name: "snapshot-tool",
-          description: "Snapshot test",
-          inputSchema: { type: "object" },
-          resolverSlug: "snap",
-          entryKey: "tool",
-          executeStepFnName: stepId,
-          closureVars,
-        },
-      ];
-
-      const tools = replayDynamicSessionTools(metadata, []);
+      const tools = replayDynamicSessionTools([metadata("snapshot-tool", stepId, closureVars)], []);
 
       const tool = tools[0]!;
       tool.execute!({}, executeOptions);
@@ -359,72 +279,18 @@ describe("replayDynamicSessionTools", () => {
     registry.set(stepIdB, fnB);
 
     try {
-      const metadata: DurableDynamicToolMetadata[] = [
-        {
-          name: "tenant__query",
-          description: "Query",
-          inputSchema: { type: "object" },
-          resolverSlug: "tenant",
-          entryKey: "query",
-          executeStepFnName: stepIdA,
-          closureVars: { tenant: "acme" },
-        },
-        {
-          name: "tenant__export",
-          description: "Export",
-          inputSchema: { type: "object" },
-          resolverSlug: "tenant",
-          entryKey: "export",
-          executeStepFnName: stepIdB,
-          closureVars: { tenant: "acme" },
-        },
+      const durable = [
+        metadata("tenant__query", stepIdA, { tenant: "acme" }),
+        metadata("tenant__export", stepIdB, { tenant: "acme" }),
       ];
 
-      const tools = replayDynamicSessionTools(metadata, []);
+      const tools = replayDynamicSessionTools(durable, []);
       expect(tools).toHaveLength(2);
       expect(tools[0]!.name).toBe("tenant__query");
       expect(tools[1]!.name).toBe("tenant__export");
     } finally {
       registry.delete(stepIdA);
       registry.delete(stepIdB);
-    }
-  });
-
-  it("skips only the broken entries — valid ones still work", () => {
-    const registrySym = Symbol.for("@workflow/core//registeredSteps");
-    const registry = getOrCreateStepRegistry(registrySym);
-
-    const validStepId = "eve:dynamic-tool//__eve_dynamic_exec_partial_ok";
-    registry.set(validStepId, () => ({ ok: true }));
-
-    try {
-      const metadata: DurableDynamicToolMetadata[] = [
-        {
-          name: "broken",
-          description: "Missing step fn",
-          inputSchema: { type: "object" },
-          resolverSlug: "test",
-          entryKey: "broken",
-          executeStepFnName: "eve:dynamic-tool//__nonexistent",
-          closureVars: {},
-        },
-        {
-          name: "valid",
-          description: "Working tool",
-          inputSchema: { type: "object" },
-          resolverSlug: "test",
-          entryKey: "valid",
-          executeStepFnName: validStepId,
-          closureVars: { key: "value" },
-        },
-      ];
-
-      const tools = replayDynamicSessionTools(metadata, []);
-      // Only the valid tool should be reconstructed
-      expect(tools).toHaveLength(1);
-      expect(tools[0]!.name).toBe("valid");
-    } finally {
-      registry.delete(validStepId);
     }
   });
 });
@@ -488,14 +354,8 @@ let stepCounter = 0;
 
 function simulateColdStart(ctx: ContextContainer): void {
   for (const metadata of ctx.get(SessionDynamicToolMetadataKey) ?? []) {
-    if (metadata.executeStepFnName?.startsWith("eve:framework-dynamic:")) {
-      testRegistry.delete(metadata.executeStepFnName);
-    }
-    if (metadata.approvalStepFnName !== undefined) {
-      testRegistry.delete(metadata.approvalStepFnName);
-    }
-    if (metadata.approvalResponseStepFnName !== undefined) {
-      testRegistry.delete(metadata.approvalResponseStepFnName);
+    for (const callback of Object.values(metadata.callbacks)) {
+      testRegistry.delete(callback.stepId);
     }
   }
   ctx.clearVirtualContext();
@@ -507,18 +367,66 @@ function simulateColdStart(ctx: ContextContainer): void {
  */
 function createReplayableTool(
   description = "stub",
-  executeFn: (...args: unknown[]) => unknown = () => ({ ok: true }),
+  executeFn: (input: Record<string, unknown>) => unknown = () => ({ ok: true }),
 ): DynamicToolEntry {
   const stepId = `test-step-${++stepCounter}`;
-  testRegistry.set(stepId, (_vars: unknown, input: unknown) => executeFn(input));
+  testRegistry.set(stepId, (_vars: unknown, input: unknown) =>
+    executeFn(input as Record<string, unknown>),
+  );
   const entry = defineTool({
     description,
     inputSchema: { type: "object" },
     execute: async (input: Record<string, unknown>): Promise<unknown> => executeFn(input),
   });
-  Object.assign(entry, {
-    __executeStepFn: { stepId },
-    __closureVars: {},
+  stampDurableDynamicToolCallbacks(entry, {
+    execute: { closure: {}, stepId },
+  });
+  return entry;
+}
+
+function stampTestTool(entry: DynamicToolEntry): DynamicToolEntry {
+  const executeStepId = `test-step-${++stepCounter}`;
+  testRegistry.set(executeStepId, (_closure: unknown, input: unknown, context: unknown) =>
+    entry.execute(
+      input as Record<string, unknown>,
+      context as Parameters<DynamicToolEntry["execute"]>[1],
+    ),
+  );
+  const request = entry.approval === undefined ? undefined : resolveApprovalPolicy(entry.approval);
+  const response =
+    entry.approval === undefined || typeof entry.approval === "function"
+      ? undefined
+      : entry.approval.response;
+  const approvalRequestStepId = request === undefined ? undefined : `test-step-${++stepCounter}`;
+  const approvalResponseStepId = response === undefined ? undefined : `test-step-${++stepCounter}`;
+  const toModelOutputStepId =
+    entry.toModelOutput === undefined ? undefined : `test-step-${++stepCounter}`;
+  if (request !== undefined) {
+    testRegistry.set(approvalRequestStepId!, (_closure: unknown, context: unknown) =>
+      request(context as ApprovalContext),
+    );
+  }
+  if (response !== undefined) {
+    testRegistry.set(approvalResponseStepId!, (_closure: unknown, context: unknown) =>
+      response(context as never),
+    );
+  }
+  if (entry.toModelOutput !== undefined) {
+    testRegistry.set(toModelOutputStepId!, (_closure: unknown, output: unknown) =>
+      entry.toModelOutput!(output),
+    );
+  }
+  stampDurableDynamicToolCallbacks(entry, {
+    execute: { closure: {}, stepId: executeStepId },
+    ...(approvalRequestStepId === undefined
+      ? {}
+      : { approvalRequest: { closure: {}, stepId: approvalRequestStepId } }),
+    ...(approvalResponseStepId === undefined
+      ? {}
+      : { approvalResponse: { closure: {}, stepId: approvalResponseStepId } }),
+    ...(toModelOutputStepId === undefined
+      ? {}
+      : { toModelOutput: { closure: {}, stepId: toModelOutputStepId } }),
   });
   return entry;
 }
@@ -585,7 +493,7 @@ describe("dispatchDynamicToolEvent", () => {
 
   it("reuses registered session callbacks without rerunning the resolver", async () => {
     let ctx = createCtx();
-    const handler = vi.fn(() => ({ tool: createFrameworkTool("cached live tool") }));
+    const handler = vi.fn(() => ({ tool: createReplayableTool("cached durable tool") }));
     const resolver = createResolver("live", ["session.started"], handler);
     ctx.set(SessionDynamicToolRuntimeRevisionKey, "deployment:dpl_current");
 
@@ -597,262 +505,27 @@ describe("dispatchDynamicToolEvent", () => {
     });
     ctx = await deserializeContext(serializeContext(ctx));
 
-    await hydrateDynamicSessionTools({
-      ctx,
-      resolvers: [resolver],
-      messages: [],
-      event: createSessionStartedEvent(),
-    });
-
     expect(handler).toHaveBeenCalledOnce();
     expect(buildDynamicTools(ctx).map((tool) => tool.name)).toEqual(["tool"]);
   });
 
-  it("rebuilds a missing approval callback after a same-revision cold start", async () => {
+  it("does not rerun a resolver when a registered callback is missing", async () => {
     const ctx = createCtx();
-    const stepId = `test-step-${++stepCounter}`;
-    const stableStepId = `test-step-${++stepCounter}`;
-    testRegistry.set(stepId, () => ({ ok: true }));
-    testRegistry.set(stableStepId, () => ({ ok: true }));
-    let approvalStepFnName: string | undefined;
-    let resolutionCount = 0;
-    const handler = vi.fn(() => {
-      resolutionCount++;
-      const entry = defineTool({
-        description: resolutionCount === 1 ? "approval policy" : "changed approval policy",
-        inputSchema: { type: "object" },
-        approval: () => "not-applicable" as const,
-        execute: async (): Promise<unknown> => ({ ok: true }),
-      });
-      Object.assign(entry, {
-        __executeStepFn: { stepId },
-        __closureVars: {},
-      });
-      return { governed: entry };
-    });
-    const resolver = createResolver("governed", ["session.started"], handler);
-    const stableHandler = vi.fn(() => {
-      const entry = defineTool({
-        description: "stable tool",
-        inputSchema: { type: "object" },
-        execute: async (): Promise<unknown> => ({ ok: true }),
-      });
-      Object.assign(entry, {
-        __executeStepFn: { stepId: stableStepId },
-        __closureVars: {},
-      });
-      return { stable: entry };
-    });
-    const stableResolver = createResolver("stable", ["session.started"], stableHandler);
-
-    try {
-      await dispatchDynamicToolEvent({
-        ctx,
-        resolvers: [resolver, stableResolver],
-        messages: [],
-        event: makeEvent("session.started"),
-      });
-      ctx.set(SessionDynamicToolRuntimeRevisionKey, "deployment:dpl_current");
-
-      approvalStepFnName = ctx.get(SessionDynamicToolMetadataKey)?.[0]?.approvalStepFnName;
-      expect(approvalStepFnName).toBe(
-        `eve:dynamic-tool-approval:${ctx.get(SessionIdKey)}:governed:governed`,
-      );
-      simulateColdStart(ctx);
-
-      await hydrateDynamicSessionTools({
-        ctx,
-        resolvers: [
-          createResolver("governed", ["session.started"], handler),
-          createResolver("stable", ["session.started"], stableHandler),
-        ],
-        messages: [],
-        event: createSessionStartedEvent(),
-      });
-
-      expect(handler).toHaveBeenCalledTimes(2);
-      expect(stableHandler).toHaveBeenCalledOnce();
-      expect(ctx.get(SessionDynamicToolMetadataKey)?.map((entry) => entry.name)).toEqual([
-        "governed",
-        "stable",
-      ]);
-      const tool = buildDynamicTools(ctx)[0]!;
-      expect(tool.description).toBe("approval policy");
-      await expect(
-        resolveApprovalPolicy(tool.approval!)(createApprovalContext({ toolName: tool.name })),
-      ).resolves.toBe("not-applicable");
-    } finally {
-      testRegistry.delete(stepId);
-      testRegistry.delete(stableStepId);
-      if (approvalStepFnName !== undefined) testRegistry.delete(approvalStepFnName);
-    }
-  });
-
-  it("rejects ownership changes while hydrating session callbacks", async () => {
-    const ctx = createCtx();
-    const original = [
-      createResolver("alpha", ["session.started"], () => ({ a: createFrameworkTool() })),
-      createResolver("beta", ["session.started"], () => ({ b: createFrameworkTool() })),
-    ];
+    const handler = vi.fn(() => ({ tool: createReplayableTool() }));
+    const resolver = createResolver("live", ["session.started"], handler);
     await dispatchDynamicToolEvent({
       ctx,
-      resolvers: original,
+      resolvers: [resolver],
       messages: [],
       event: makeEvent("session.started"),
     });
     simulateColdStart(ctx);
 
-    await expect(
-      hydrateDynamicSessionTools({
-        ctx,
-        resolvers: [
-          createResolver("alpha", ["session.started"], () => ({ a: createFrameworkTool() })),
-          createResolver("beta", ["session.started"], () => ({ a: createFrameworkTool() })),
-        ],
-        messages: [],
-        event: createSessionStartedEvent(),
-      }),
-    ).rejects.toThrow('Dynamic tool "a" from resolver "beta" collides');
-  });
-
-  it("keeps replay callbacks isolated between sessions", async () => {
-    const sessionIds = ["session-a", "session-b"] as const;
-    const resolver = createResolver("governed", ["session.started"], (_event, resolveCtx) => {
-      const sessionId = (resolveCtx as { session: { id: string } }).session.id;
-      return {
-        governed: defineTool({
-          description: "session policy",
-          inputSchema: { type: "object" },
-          approval: () => (sessionId === "session-a" ? "not-applicable" : "user-approval"),
-          execute: async (): Promise<unknown> => ({ sessionId }),
-        }),
-      };
-    });
-
-    const contexts = sessionIds.map((sessionId) => createCtx(sessionId));
-    for (const ctx of contexts) {
-      await dispatchDynamicToolEvent({
-        ctx,
-        resolvers: [resolver],
-        messages: [],
-        event: makeEvent("session.started"),
-      });
-    }
-
-    const sessionATool = buildDynamicTools(contexts[0]!)[0]!;
-    const sessionBTool = buildDynamicTools(contexts[1]!)[0]!;
-    await expect(
-      resolveApprovalPolicy(sessionATool.approval!)(
-        createApprovalContext({ toolName: sessionATool.name }),
-      ),
-    ).resolves.toBe("not-applicable");
-    await expect(
-      resolveApprovalPolicy(sessionBTool.approval!)(
-        createApprovalContext({ toolName: sessionBTool.name }),
-      ),
-    ).resolves.toBe("user-approval");
-  });
-
-  it("evicts callback groups deterministically and rehydrates them on demand", async () => {
-    const session = createCtx("bounded-session");
-    let version = 0;
-    const handler = vi.fn(() => {
-      const current = ++version;
-      return {
-        governed: defineTool({
-          description: `version ${current}`,
-          inputSchema: { type: "object" },
-          approval: () => (current === 1 ? "user-approval" : "not-applicable"),
-          execute: async (): Promise<unknown> => current,
-        }),
-      };
-    });
-    const resolver = createResolver("bounded", ["session.started"], handler);
-
-    await dispatchDynamicToolEvent({
-      ctx: session,
-      resolvers: [resolver],
-      messages: [],
-      event: makeEvent("session.started"),
-    });
-    await dispatchDynamicToolEvent({
-      ctx: session,
-      resolvers: [resolver],
-      messages: [],
-      event: makeEvent("session.started"),
-    });
-
-    for (let index = 0; index < 255; index++) {
-      await dispatchDynamicToolEvent({
-        ctx: createCtx(`bounded-filler-${index}`),
-        resolvers: [
-          createResolver("filler", ["session.started"], () => ({
-            tool: createFrameworkTool(),
-          })),
-        ],
-        messages: [],
-        event: makeEvent("session.started"),
-      });
-    }
-
-    const retained = buildDynamicTools(session)[0]!;
-    await expect(retained.execute!({}, executeOptions)).resolves.toBe(2);
-    await expect(
-      resolveApprovalPolicy(retained.approval!)(createApprovalContext({ toolName: retained.name })),
-    ).resolves.toBe("not-applicable");
-
-    await dispatchDynamicToolEvent({
-      ctx: createCtx("bounded-evictor"),
-      resolvers: [
-        createResolver("evictor", ["session.started"], () => ({
-          tool: createFrameworkTool(),
-        })),
-      ],
-      messages: [],
-      event: makeEvent("session.started"),
-    });
-
-    expect(buildDynamicTools(session)).toEqual([]);
-    await expect(retained.execute!({}, executeOptions)).resolves.toBe(2);
-
-    await hydrateDynamicSessionTools({
-      ctx: session,
-      resolvers: [resolver],
-      messages: [],
-      event: createSessionStartedEvent(),
-    });
-    await expect(buildDynamicTools(session)[0]!.execute!({}, executeOptions)).resolves.toBe(3);
-  });
-
-  it("preserves metadata and retries when cold hydration fails", async () => {
-    const ctx = createCtx();
-    const handler = vi
-      .fn()
-      .mockImplementationOnce(() => ({ tool: createFrameworkTool("live tool") }))
-      .mockRejectedValue(new Error("temporary resolver failure"));
-    const resolver = createResolver("live", ["session.started"], handler);
-
-    await dispatchDynamicToolEvent({
-      ctx,
-      resolvers: [resolver],
-      messages: [],
-      event: makeEvent("session.started"),
-    });
-    ctx.set(SessionDynamicToolRuntimeRevisionKey, "deployment:dpl_current");
-    const originalMetadata = ctx.get(SessionDynamicToolMetadataKey);
-
-    for (let attempt = 0; attempt < 2; attempt++) {
-      simulateColdStart(ctx);
-      await hydrateDynamicSessionTools({
-        ctx,
-        resolvers: [createResolver("live", ["session.started"], handler)],
-        messages: [],
-        event: createSessionStartedEvent(),
-      });
-      expect(ctx.get(SessionDynamicToolMetadataKey)).toEqual(originalMetadata);
-    }
-
-    expect(handler).toHaveBeenCalledTimes(3);
+    const [tool] = buildDynamicTools(ctx);
+    await expect(tool!.execute!({}, executeOptions)).rejects.toThrow(
+      "cannot replay its execute callback",
+    );
+    expect(handler).toHaveBeenCalledOnce();
   });
 
   it("clears removed session resolvers on a new runtime revision", async () => {
@@ -899,11 +572,13 @@ describe("dispatchDynamicToolEvent", () => {
       type: "object",
     };
     const resolver = createResolver("connection", ["step.started"], () => ({
-      remote: defineTool({
-        description: "remote tool",
-        inputSchema,
-        execute: async (): Promise<unknown> => ({ ok: true }),
-      }),
+      remote: stampTestTool(
+        defineTool({
+          description: "remote tool",
+          inputSchema,
+          execute: async (): Promise<unknown> => ({ ok: true }),
+        }),
+      ),
     }));
 
     await dispatchDynamicToolEvent({
@@ -970,11 +645,13 @@ describe("dispatchDynamicToolEvent", () => {
     const ctx = createCtx();
     const resolver = {
       ...createResolver("search", ["step.started"], () => ({
-        query: defineTool({
-          description: "search records",
-          inputSchema: { type: "object" },
-          execute: async (_input, toolCtx) => ({ toolName: toolCtx.toolName }),
-        }),
+        query: stampTestTool(
+          defineTool({
+            description: "search records",
+            inputSchema: { type: "object" },
+            execute: async (_input, toolCtx) => ({ toolName: toolCtx.toolName }),
+          }),
+        ),
       })),
       extensionNamespace: "warehouse",
     };
@@ -998,14 +675,16 @@ describe("dispatchDynamicToolEvent", () => {
     const getToken = vi.fn(async () => ({ token: "step-token" }));
     const auth = { getToken, principalType: "app" as const };
     const resolver = createResolver("oauth", ["step.started"], () => ({
-      probe: defineTool({
-        description: "resolve auth",
-        inputSchema: { type: "object" },
-        execute: async (_input, toolCtx) => {
-          const { token } = await toolCtx.getToken(auth);
-          return { token };
-        },
-      }),
+      probe: stampTestTool(
+        defineTool({
+          description: "resolve auth",
+          inputSchema: { type: "object" },
+          execute: async (_input, toolCtx) => {
+            const { token } = await toolCtx.getToken(auth);
+            return { token };
+          },
+        }),
+      ),
     }));
 
     await dispatchDynamicToolEvent({
@@ -1032,7 +711,7 @@ describe("dispatchDynamicToolEvent", () => {
 
     await dispatchDynamicToolEvent({ ctx, event, messages: [], resolvers: [resolver] });
     ctx.clearVirtualContext();
-    expect(buildDynamicTools(ctx)).toEqual([]);
+    expect(buildDynamicTools(ctx).map((tool) => tool.name)).toEqual(["query"]);
 
     await dispatchDynamicToolEvent({ ctx, event, messages: [], resolvers: [resolver] });
     expect(buildDynamicTools(ctx)[0]?.description).toBe("cached");
@@ -1151,7 +830,7 @@ describe("dispatchDynamicToolEvent", () => {
     expect(buildDynamicTools(ctx)).toHaveLength(2);
   });
 
-  it("rehydrates session tools from durable metadata on a fresh step", async () => {
+  it("replays session tools from durable metadata on a fresh step", async () => {
     const ctx = createCtx();
 
     // Register a step function so replayDynamicSessionTools can
@@ -1166,16 +845,18 @@ describe("dispatchDynamicToolEvent", () => {
     registry.set(stepId, stepFn);
 
     try {
-      // Build a resolver whose tool entry carries bundler-injected fields
+      // Build a resolver whose tool entry carries a durable callback descriptor.
       const resolver = createResolver("tenant", ["session.started"], () => {
         const entry = defineTool({
           description: "tenant query",
           inputSchema: { type: "object" },
           execute: async () => ({ ok: true }),
         });
-        Object.assign(entry, {
-          __executeStepFn: { stepId },
-          __closureVars: { apiUrl: "https://api.example.com" },
+        stampDurableDynamicToolCallbacks(entry, {
+          execute: {
+            closure: { apiUrl: "https://api.example.com" },
+            stepId,
+          },
         });
         return { query: entry };
       });
@@ -1189,7 +870,7 @@ describe("dispatchDynamicToolEvent", () => {
       });
       expect(buildDynamicTools(ctx)).toHaveLength(1);
       expect(ctx.get(SessionDynamicToolMetadataKey)).toHaveLength(1);
-      expect(ctx.get(SessionDynamicToolMetadataKey)![0]!.executeStepFnName).toBe(stepId);
+      expect(ctx.get(SessionDynamicToolMetadataKey)![0]!.callbacks.execute.stepId).toBe(stepId);
 
       // Simulate workflow step boundary: clear virtual context.
       // Durable metadata survives — buildDynamicTools reads from durable keys.
@@ -1228,9 +909,8 @@ describe("dispatchDynamicToolEvent", () => {
           inputSchema: { type: "object" },
           execute: async () => ({ ok: true }),
         });
-        Object.assign(entry, {
-          __executeStepFn: { stepId },
-          __closureVars: {},
+        stampDurableDynamicToolCallbacks(entry, {
+          execute: { closure: {}, stepId },
         });
         return { probe: entry };
       });
@@ -1333,11 +1013,7 @@ function createFrameworkTool(
   description = "framework stub",
   executeFn: (input: Record<string, unknown>) => unknown = () => ({ ok: true }),
 ): DynamicToolEntry {
-  return defineTool({
-    description,
-    inputSchema: { type: "object" },
-    execute: async (input: Record<string, unknown>): Promise<unknown> => executeFn(input),
-  });
+  return createReplayableTool(description, executeFn);
 }
 
 describe("framework dynamic tools (no bundler transform)", () => {
@@ -1357,10 +1033,8 @@ describe("framework dynamic tools (no bundler transform)", () => {
 
     const metadata = ctx.get(SessionDynamicToolMetadataKey);
     expect(metadata).toHaveLength(1);
-    expect(metadata![0]!.executeStepFnName).toBe(
-      `eve:framework-dynamic:${ctx.get(SessionIdKey)}:fwk:search`,
-    );
-    expect(metadata![0]!.closureVars).toEqual({});
+    expect(metadata![0]!.callbacks.execute.stepId).toMatch(/^test-step-/);
+    expect(metadata![0]!.callbacks.execute.closure).toEqual({});
 
     const tools = buildDynamicTools(ctx);
     expect(tools).toHaveLength(1);
@@ -1393,7 +1067,7 @@ describe("framework dynamic tools (no bundler transform)", () => {
 
     const metadata = ctx.get(TurnDynamicToolMetadataKey);
     expect(metadata).toHaveLength(1);
-    expect(metadata![0]!.executeStepFnName).toBe("eve:framework-dynamic:helper:assist");
+    expect(metadata![0]!.callbacks.execute.stepId).toMatch(/^test-step-/);
 
     ctx.clearVirtualContext();
 
@@ -1450,12 +1124,14 @@ describe("framework dynamic tools (no bundler transform)", () => {
   it("propagates approval from a step-scoped entry into the harness tool", async () => {
     const ctx = createCtx();
     const approvalFn = vi.fn(() => "user-approval" as const);
-    const entry: DynamicToolEntry = defineTool({
-      description: "destructive op",
-      inputSchema: { type: "object" },
-      approval: approvalFn,
-      execute: async (): Promise<unknown> => ({ ok: true }),
-    });
+    const entry: DynamicToolEntry = stampTestTool(
+      defineTool({
+        description: "destructive op",
+        inputSchema: { type: "object" },
+        approval: approvalFn,
+        execute: async (): Promise<unknown> => ({ ok: true }),
+      }),
+    );
     const resolver = createResolver("connection", ["step.started"], () => ({ risky: entry }));
     testRegistry.delete("eve:framework-dynamic:connection:risky");
     testRegistry.delete("eve:dynamic-tool-approval:connection:risky");
@@ -1470,9 +1146,10 @@ describe("framework dynamic tools (no bundler transform)", () => {
     const tools = buildDynamicTools(ctx);
     expect(tools).toHaveLength(1);
     expect(tools[0]!.name).toBe("risky");
-    expect(tools[0]!.approval).toBe(approvalFn);
     const approvalCtx = createApprovalContext({ toolName: "risky" });
-    expect(resolveApprovalPolicy(tools[0]!.approval!)(approvalCtx)).toBe("user-approval");
+    await expect(resolveApprovalPolicy(tools[0]!.approval!)(approvalCtx)).resolves.toBe(
+      "user-approval",
+    );
     expect(testRegistry.has("eve:framework-dynamic:connection:risky")).toBe(false);
     expect(testRegistry.has("eve:dynamic-tool-approval:connection:risky")).toBe(false);
   });
@@ -1480,12 +1157,14 @@ describe("framework dynamic tools (no bundler transform)", () => {
   it("replays approval from session-scoped dynamic tools", async () => {
     const ctx = createCtx();
     const approvalFn = vi.fn(async () => "user-approval" as const);
-    const entry: DynamicToolEntry = defineTool({
-      description: "destructive op",
-      inputSchema: { type: "object" },
-      approval: approvalFn,
-      execute: async (): Promise<unknown> => ({ ok: true }),
-    });
+    const entry: DynamicToolEntry = stampTestTool(
+      defineTool({
+        description: "destructive op",
+        inputSchema: { type: "object" },
+        approval: approvalFn,
+        execute: async (): Promise<unknown> => ({ ok: true }),
+      }),
+    );
     const resolver = createResolver("session_guard", ["session.started"], () => ({
       guarded: entry,
     }));
@@ -1510,18 +1189,19 @@ describe("framework dynamic tools (no bundler transform)", () => {
     expect(approvalFn).toHaveBeenCalledExactlyOnceWith(approvalCtx);
   });
 
-  it("replays turn metadata written before request/response policy naming", async () => {
+  it("replays phase-specific turn metadata", async () => {
     const ctx = createCtx();
     const approval = vi.fn(() => "user-approval" as const);
     testRegistry.set("legacy-turn-execute", () => ({ ok: true }));
     testRegistry.set("legacy-turn-approval", approval);
     ctx.set(TurnDynamicToolMetadataKey, [
       {
-        approvalStepFnName: "legacy-turn-approval",
-        closureVars: {},
+        callbacks: {
+          approvalRequest: { closure: {}, stepId: "legacy-turn-approval" },
+          execute: { closure: {}, stepId: "legacy-turn-execute" },
+        },
         description: "legacy guarded tool",
         entryKey: "legacy:guarded",
-        executeStepFnName: "legacy-turn-execute",
         inputSchema: { type: "object" },
         name: "guarded",
         resolverSlug: "legacy",
@@ -1538,25 +1218,32 @@ describe("framework dynamic tools (no bundler transform)", () => {
 
   it("uses the first dynamic definition for response authorization", () => {
     const ctx = createCtx();
-    ctx.set(LiveStepToolsKey, [
+    testRegistry.set("step-execute", () => null);
+    testRegistry.set("step-request", () => "user-approval");
+    testRegistry.set("step-response", async () => ({ status: "allowed" }) as const);
+    ctx.set(StepDynamicToolMetadataKey, [
       {
-        approval: {
-          request: () => "user-approval",
-          response: async () => ({ status: "allowed" }) as const,
+        callbacks: {
+          approvalRequest: { closure: {}, stepId: "step-request" },
+          approvalResponse: { closure: {}, stepId: "step-response" },
+          execute: { closure: {}, stepId: "step-execute" },
         },
         description: "step",
-        execute: () => null,
-        inputSchema: jsonSchema({ type: "object" }),
+        entryKey: "step:guarded",
+        inputSchema: { type: "object" },
         name: "guarded",
+        resolverSlug: "step",
       },
     ]);
     ctx.set(SessionDynamicToolMetadataKey, [
       {
-        approvalResponseStepFnName: "session-authorizer",
-        approvalStepFnName: "session-policy",
+        callbacks: {
+          approvalRequest: { closure: {}, stepId: "session-policy" },
+          approvalResponse: { closure: {}, stepId: "session-authorizer" },
+          execute: { closure: {}, stepId: "session-execute" },
+        },
         description: "session",
         entryKey: "session:guarded",
-        executeStepFnName: "session-execute",
         inputSchema: { type: "object" },
         name: "guarded",
         resolverSlug: "session",
@@ -1571,7 +1258,7 @@ describe("framework dynamic tools (no bundler transform)", () => {
     expect(tools.get("guarded")?.description).toBe("step");
   });
 
-  it("rehydrates an untransformed executor and approval policies after a cold start", async () => {
+  it("rejects an untransformed tool atomically without resolver hydration", async () => {
     const ctx = createCtx();
     const execute = vi.fn(async () => ({ ok: true }));
     const request = vi.fn(async () => "user-approval" as const);
@@ -1592,58 +1279,12 @@ describe("framework dynamic tools (no bundler transform)", () => {
       messages: [],
       resolvers: [resolver],
     });
-    ctx.set(SessionDynamicToolRuntimeRevisionKey, "deployment:dpl_current");
-
-    simulateColdStart(ctx);
-    await hydrateDynamicSessionTools({
-      ctx,
-      event: createSessionStartedEvent(),
-      messages: [],
-      resolvers: [createResolver("session_guard", ["session.started"], handler)],
-    });
-
-    expect(handler).toHaveBeenCalledTimes(2);
-    const tool = buildDynamicTools(ctx)[0]!;
-    await expect(tool.execute!({}, executeOptions)).resolves.toEqual({ ok: true });
-    expect(execute).toHaveBeenCalledOnce();
-
-    const approval = tool.approval;
-    if (approval === undefined || typeof approval === "function") {
-      throw new Error("Expected rehydrated approval configuration.");
-    }
-    const approvalCtx = createApprovalContext({ toolName: "guarded" });
-    await expect(approval.request(approvalCtx)).resolves.toBe("user-approval");
-    expect(request).toHaveBeenCalledExactlyOnceWith(approvalCtx);
-
-    const responseCtx = {
-      auth: {
-        getToken: vi.fn(),
-        requireAuth: () => {
-          throw new Error("not implemented");
-        },
-      },
-      request: {
-        callId: "call_1",
-        requestId: "approval_1",
-        toolInput: { owner: "vercel", repo: "eve" },
-        toolName: "guarded",
-      },
-      response: { decision: "approve" as const },
-      responder: {
-        attributes: {},
-        authenticator: "slack",
-        principalId: "U123",
-        principalType: "user",
-      },
-      session: {
-        id: "test-session",
-        initiator: null,
-        turn: { id: "test-turn", sequence: 0 },
-      },
-    };
-
-    await expect(approval.response!(responseCtx)).resolves.toEqual({ status: "allowed" });
-    expect(response).toHaveBeenCalledExactlyOnceWith(responseCtx);
+    expect(handler).toHaveBeenCalledOnce();
+    expect(ctx.get(SessionDynamicToolMetadataKey)).toEqual([]);
+    expect(buildDynamicTools(ctx)).toEqual([]);
+    expect(execute).not.toHaveBeenCalled();
+    expect(request).not.toHaveBeenCalled();
+    expect(response).not.toHaveBeenCalled();
   });
 
   it("propagates outputSchema from dynamic entries into harness tools and metadata", async () => {
@@ -1654,12 +1295,14 @@ describe("framework dynamic tools (no bundler transform)", () => {
       required: ["ok"],
       type: "object",
     };
-    const entry: DynamicToolEntry = defineTool({
-      description: "typed op",
-      inputSchema: { type: "object" },
-      outputSchema,
-      execute: async (): Promise<unknown> => ({ ok: true }),
-    });
+    const entry: DynamicToolEntry = stampTestTool(
+      defineTool({
+        description: "typed op",
+        inputSchema: { type: "object" },
+        outputSchema,
+        execute: async (): Promise<unknown> => ({ ok: true }),
+      }),
+    );
     const resolver = createResolver("connection", ["session.started"], () => ({ typed: entry }));
 
     await dispatchDynamicToolEvent({

--- a/packages/eve/src/context/dynamic-tool-lifecycle.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.ts
@@ -1,62 +1,35 @@
 import type { ModelMessage } from "ai";
 
-import type { HarnessToolDefinition } from "#harness/execute-tool.js";
-import {
-  resolveApprovalPolicy,
-  type ApprovalContext,
-  type ApprovalResponseContext,
-} from "#public/definitions/approval.js";
-import type { DynamicToolEntry } from "#shared/dynamic-tool-definition.js";
-import type { UnstampedMessageStreamEvent, SessionStartedStreamEvent } from "#protocol/message.js";
-import {
-  ALLOWED_DYNAMIC_TOOL_EVENTS,
-  isBrandedToolEntry,
-} from "#shared/dynamic-tool-definition.js";
-import type { ResolvedDynamicToolResolver } from "#runtime/types.js";
-import { createLogger } from "#internal/logging.js";
-import {
-  serializeInputSchema,
-  serializeOutputSchema,
-  toInputSchema,
-  toOutputSchema,
-} from "#shared/tool-schema.js";
-import { toErrorMessage } from "#shared/errors.js";
+import { replayDynamicTools } from "#context/build-dynamic-tools.js";
 import type { ContextContainer } from "#context/container.js";
 import type { ContextKey } from "#context/key.js";
 import {
   SessionDynamicToolMetadataKey,
   SessionDynamicToolRuntimeRevisionKey,
-  SessionIdKey,
+  StepDynamicToolMetadataKey,
   TurnDynamicToolMetadataKey,
-  LiveStepToolsKey,
+  type DurableDynamicToolMetadata,
 } from "#context/keys.js";
-import type { DurableDynamicToolMetadata } from "#context/keys.js";
 import { buildResolveContext } from "#context/dynamic-resolve-context.js";
-import { createToolExecuteWithAuth } from "#execution/tool-auth.js";
+import type { HarnessToolDefinition } from "#harness/execute-tool.js";
+import { createLogger } from "#internal/logging.js";
+import type { SessionStartedStreamEvent, UnstampedMessageStreamEvent } from "#protocol/message.js";
+import type { DynamicToolEntry } from "#shared/dynamic-tool-definition.js";
+import {
+  ALLOWED_DYNAMIC_TOOL_EVENTS,
+  isBrandedToolEntry,
+} from "#shared/dynamic-tool-definition.js";
+import {
+  readDurableDynamicToolCallbacks,
+  type DurableDynamicCallbackReference,
+  type DurableDynamicToolCallbacks,
+} from "#shared/durable-dynamic-tool-callbacks.js";
+import { toErrorMessage } from "#shared/errors.js";
+import { parseJsonObject } from "#shared/json.js";
+import { serializeInputSchema, serializeOutputSchema } from "#shared/tool-schema.js";
+import type { ResolvedDynamicToolResolver } from "#runtime/types.js";
 
 const log = createLogger("dynamic-tools");
-
-// ---------------------------------------------------------------------------
-// Tool entry conversion
-// ---------------------------------------------------------------------------
-
-function toHarnessToolDefinition(name: string, entry: DynamicToolEntry): HarnessToolDefinition {
-  return {
-    description: entry.description,
-    execute: createToolExecuteWithAuth({
-      scope: name,
-      execute: (input, ctx) =>
-        entry.execute(input as Record<string, unknown>, ctx as Parameters<typeof entry.execute>[1]),
-    }),
-    inputSchema: toInputSchema(entry.inputSchema),
-    name,
-    approval: entry.approval,
-    outputSchema: toOutputSchema(entry.outputSchema),
-    ...(entry.toModelOutput !== undefined
-      ? { toModelOutput: entry.toModelOutput as (output: unknown) => unknown }
-      : {}),
-  };
-}
 
 function qualifyDynamicToolNames(
   resolver: ResolvedDynamicToolResolver,
@@ -64,156 +37,28 @@ function qualifyDynamicToolNames(
   entries: Readonly<Record<string, DynamicToolEntry>>,
 ): Array<{ name: string; entryKey: string; entry: DynamicToolEntry }> {
   const keys = Object.keys(entries);
-  const result: Array<{ name: string; entryKey: string; entry: DynamicToolEntry }> = [];
-
-  if (keys.length === 0) return result;
-
-  // A single returned defineTool is named after the file slug; a map names each
-  // entry by its bare key (authors namespace keys themselves if needed).
+  if (keys.length === 0) return [];
   if (isSingle) {
-    result.push({ name: resolver.slug, entryKey: keys[0]!, entry: entries[keys[0]!]! });
-    return result;
+    const entryKey = keys[0]!;
+    return [{ name: resolver.slug, entryKey, entry: entries[entryKey]! }];
   }
 
-  // Map entries from an extension resolver are prefixed with the mount
-  // namespace so extension-produced tools are namespaced like the extension's
-  // static tools. The single-tool case above already uses the namespaced slug.
   const prefix =
-    resolver.extensionNamespace !== undefined ? `${resolver.extensionNamespace}__` : "";
-  for (const key of keys) {
-    result.push({ name: `${prefix}${key}`, entryKey: key, entry: entries[key]! });
-  }
-  return result;
+    resolver.extensionNamespace === undefined ? "" : `${resolver.extensionNamespace}__`;
+  return keys.map((entryKey) => ({
+    entry: entries[entryKey]!,
+    entryKey,
+    name: `${prefix}${entryKey}`,
+  }));
 }
 
-// ---------------------------------------------------------------------------
-// Tool replay from durable metadata
-// ---------------------------------------------------------------------------
-
-/**
- * Reconstructs tool definitions from durable metadata using
- * registered step functions. No resolver re-invocation — the
- * execute function is looked up by step ID and called with stored
- * closure vars.
- */
+/** Kept as the session-specific entry point for existing runtime consumers. */
 export function replayDynamicSessionTools(
   metadata: readonly DurableDynamicToolMetadata[],
   _resolvers: readonly ResolvedDynamicToolResolver[],
 ): readonly HarnessToolDefinition[] {
-  const tools: HarnessToolDefinition[] = [];
-
-  for (const m of metadata) {
-    if (!m.executeStepFnName || !m.closureVars) {
-      log.warn(
-        `Dynamic tool "${m.name}" has no registered step function — ` +
-          "skipping on this step. The bundler transform may not have processed this tool file.",
-      );
-      continue;
-    }
-
-    const stepFn = lookupStepFunction(m.executeStepFnName);
-    if (!stepFn) {
-      log.warn(
-        `Dynamic tool "${m.name}" references step function "${m.executeStepFnName}" ` +
-          "which is not registered — skipping on this step.",
-      );
-      continue;
-    }
-
-    tools.push({
-      description: m.description,
-      execute: createToolExecuteWithAuth({
-        scope: m.name,
-        execute: (input, ctx) => stepFn(m.closureVars, input, ctx),
-      }),
-      inputSchema: toInputSchema(m.inputSchema),
-      name: m.name,
-      outputSchema: toOutputSchema(m.outputSchema),
-    });
-  }
-
-  return tools;
+  return replayDynamicTools(metadata);
 }
-
-// ---------------------------------------------------------------------------
-// Step function lookup + serialization helpers
-// ---------------------------------------------------------------------------
-
-function getStepRegistry(): Map<string, Function> {
-  const key = Symbol.for("@workflow/core//registeredSteps");
-  const g = globalThis as Record<symbol, Map<string, Function> | undefined>;
-  let registry = g[key];
-  if (registry === undefined) {
-    registry = new Map();
-    g[key] = registry;
-  }
-  return registry;
-}
-
-function lookupStepFunction(stepId: string): ((...args: unknown[]) => unknown) | null {
-  try {
-    const fn = getStepRegistry().get(stepId);
-    return fn ? (fn as (...args: unknown[]) => unknown) : null;
-  } catch {
-    return null;
-  }
-}
-
-function hasMissingProcessCallback(metadata: DurableDynamicToolMetadata): boolean {
-  return (
-    (metadata.executeStepFnName?.startsWith("eve:framework-dynamic:") === true &&
-      lookupStepFunction(metadata.executeStepFnName) === null) ||
-    (metadata.approvalStepFnName !== undefined &&
-      lookupStepFunction(metadata.approvalStepFnName) === null) ||
-    (metadata.approvalResponseStepFnName !== undefined &&
-      lookupStepFunction(metadata.approvalResponseStepFnName) === null)
-  );
-}
-
-const MAX_PROCESS_CALLBACK_GROUPS = 256;
-interface ProcessCallbackGroup {
-  readonly id: string;
-  readonly callbackIds: Set<string>;
-}
-const processCallbackQueue: ProcessCallbackGroup[] = [];
-const processCallbackGroups = new Map<string, ProcessCallbackGroup>();
-
-function registerProcessCallbacks(groupId: string, callbacks: ReadonlyMap<string, Function>): void {
-  const registry = getStepRegistry();
-  const previous = processCallbackGroups.get(groupId);
-  if (previous !== undefined) {
-    for (const callbackId of previous.callbackIds) registry.delete(callbackId);
-  }
-
-  if (callbacks.size === 0) {
-    processCallbackGroups.delete(groupId);
-    return;
-  }
-
-  const group = { id: groupId, callbackIds: new Set(callbacks.keys()) };
-  processCallbackGroups.set(groupId, group);
-  processCallbackQueue.push(group);
-  for (const [callbackId, callback] of callbacks) registry.set(callbackId, callback);
-
-  while (processCallbackQueue.length > MAX_PROCESS_CALLBACK_GROUPS) {
-    const evicted = processCallbackQueue.shift()!;
-    if (processCallbackGroups.get(evicted.id) !== evicted) continue;
-    processCallbackGroups.delete(evicted.id);
-    for (const callbackId of evicted.callbackIds) registry.delete(callbackId);
-  }
-}
-
-function safeSerialize(obj: Record<string, unknown>): Record<string, unknown> {
-  try {
-    return JSON.parse(JSON.stringify(obj));
-  } catch {
-    return {};
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Scoped key routing
-// ---------------------------------------------------------------------------
 
 function durableKeyForEvent(
   eventType: string,
@@ -223,18 +68,11 @@ function durableKeyForEvent(
       return SessionDynamicToolMetadataKey;
     case "turn.started":
       return TurnDynamicToolMetadataKey;
+    case "step.started":
+      return StepDynamicToolMetadataKey;
     default:
       return undefined;
   }
-}
-
-// ---------------------------------------------------------------------------
-// Resolve: run resolver handlers, capture closures, write durable metadata
-// ---------------------------------------------------------------------------
-
-interface ResolveResult {
-  readonly metadata: readonly DurableDynamicToolMetadata[];
-  readonly liveTools: readonly HarnessToolDefinition[];
 }
 
 function readDynamicToolResult(
@@ -262,147 +100,189 @@ function readDynamicToolResult(
   return { entries, isSingle: false };
 }
 
+function validateReference(input: {
+  readonly name: string;
+  readonly phase: keyof DurableDynamicToolCallbacks;
+  readonly reference: DurableDynamicCallbackReference | undefined;
+  readonly required: boolean;
+}): DurableDynamicCallbackReference | undefined {
+  if (input.reference === undefined) {
+    if (input.required) {
+      throw new Error(
+        `Dynamic tool "${input.name}" callback "${input.phase}" does not have a durable descriptor. ` +
+          "Author the callback inline in transformed source or use an eve durable callback helper.",
+      );
+    }
+    return undefined;
+  }
+  const unknownKeys = Object.keys(input.reference).filter(
+    (key) => key !== "closure" && key !== "stepId",
+  );
+  if (unknownKeys.length > 0) {
+    throw new Error(
+      `Dynamic tool "${input.name}" has invalid ${input.phase} callback metadata: unknown key(s) ${unknownKeys.join(", ")}.`,
+    );
+  }
+  if (typeof input.reference.stepId !== "string" || input.reference.stepId.length === 0) {
+    throw new Error(
+      `Dynamic tool "${input.name}" has invalid ${input.phase} callback metadata: stepId must be a non-empty string.`,
+    );
+  }
+  let closure: DurableDynamicCallbackReference["closure"];
+  try {
+    closure = parseJsonObject(input.reference.closure);
+  } catch (error) {
+    throw new Error(
+      `Dynamic tool "${input.name}" callback "${input.phase}" has a non-serializable capture. ${toErrorMessage(error)}`,
+    );
+  }
+  const registry = (globalThis as Record<symbol, Map<string, Function> | undefined>)[
+    Symbol.for("@workflow/core//registeredSteps")
+  ];
+  if (registry?.has(input.reference.stepId) !== true) {
+    throw new Error(
+      `Dynamic tool "${input.name}" callback "${input.phase}" references ` +
+        `"${input.reference.stepId}", but that step function is not registered. ` +
+        "Author the callback inline in transformed source or register it from an eve callback helper.",
+    );
+  }
+  return { closure, stepId: input.reference.stepId };
+}
+
+export function validateDurableDynamicToolCallbacks(
+  name: string,
+  entry: DynamicToolEntry,
+): DurableDynamicToolCallbacks {
+  const raw = readDurableDynamicToolCallbacks(entry) ?? {};
+  const unknownKeys = Object.keys(raw).filter(
+    (key) =>
+      key !== "execute" &&
+      key !== "approvalRequest" &&
+      key !== "approvalResponse" &&
+      key !== "toModelOutput",
+  );
+  if (unknownKeys.length > 0) {
+    throw new Error(
+      `Dynamic tool "${name}" has unknown durable callback phase(s): ${unknownKeys.join(", ")}.`,
+    );
+  }
+
+  const hasApproval = entry.approval !== undefined;
+  const hasApprovalResponse =
+    entry.approval !== undefined &&
+    typeof entry.approval !== "function" &&
+    entry.approval.response !== undefined;
+  const execute = validateReference({
+    name,
+    phase: "execute",
+    reference: raw.execute,
+    required: true,
+  })!;
+  const approvalRequest = validateReference({
+    name,
+    phase: "approvalRequest",
+    reference: raw.approvalRequest,
+    required: hasApproval,
+  });
+  const approvalResponse = validateReference({
+    name,
+    phase: "approvalResponse",
+    reference: raw.approvalResponse,
+    required: hasApprovalResponse,
+  });
+  const toModelOutput = validateReference({
+    name,
+    phase: "toModelOutput",
+    reference: raw.toModelOutput,
+    required: entry.toModelOutput !== undefined,
+  });
+
+  const callbacks: {
+    execute: DurableDynamicCallbackReference;
+    approvalRequest?: DurableDynamicCallbackReference;
+    approvalResponse?: DurableDynamicCallbackReference;
+    toModelOutput?: DurableDynamicCallbackReference;
+  } = { execute };
+  if (approvalRequest !== undefined) callbacks.approvalRequest = approvalRequest;
+  if (approvalResponse !== undefined) callbacks.approvalResponse = approvalResponse;
+  if (toModelOutput !== undefined) callbacks.toModelOutput = toModelOutput;
+  return callbacks;
+}
+
+function createMetadata(input: {
+  readonly entry: DynamicToolEntry;
+  readonly entryKey: string;
+  readonly name: string;
+  readonly resolver: ResolvedDynamicToolResolver;
+}): DurableDynamicToolMetadata {
+  return {
+    callbacks: validateDurableDynamicToolCallbacks(input.name, input.entry),
+    description: input.entry.description,
+    entryKey: input.entryKey,
+    inputSchema: serializeInputSchema(input.entry.inputSchema),
+    name: input.name,
+    outputSchema: serializeOutputSchema(input.entry.outputSchema),
+    resolverSlug: input.resolver.slug,
+  };
+}
+
+interface ResolvedDynamicToolEvent {
+  readonly metadata: readonly DurableDynamicToolMetadata[];
+}
+
 async function resolveToolsFromEvent(
   ctx: ContextContainer,
   resolvers: readonly ResolvedDynamicToolResolver[],
   event: UnstampedMessageStreamEvent,
   messages: readonly ModelMessage[],
-): Promise<ResolveResult> {
+): Promise<ResolvedDynamicToolEvent> {
   const outcomes = await Promise.allSettled(
     resolvers.map(async (resolver) => {
       const handler = resolver.events[event.type];
       if (handler === undefined) return null;
-
-      const resolveCtx = buildResolveContext(ctx, messages);
-      const rawResult = await handler(event, resolveCtx);
+      const rawResult = await handler(event, buildResolveContext(ctx, messages));
       if (rawResult === null || rawResult === undefined) return null;
       const { entries, isSingle } = readDynamicToolResult(resolver, rawResult);
-      return { resolver, entries, isSingle };
+      const named = qualifyDynamicToolNames(resolver, isSingle, entries);
+      return {
+        metadata: named.map(({ name, entryKey, entry }) =>
+          createMetadata({ entry, entryKey, name, resolver }),
+        ),
+        resolver,
+      };
     }),
   );
 
   const metadata: DurableDynamicToolMetadata[] = [];
-  const liveTools: HarnessToolDefinition[] = [];
-  // Tracks which resolver claimed each name so two dynamic resolvers can't
-  // silently shadow each other (a dynamic tool overriding an authored one is
-  // allowed and handled at merge time).
   const dynamicToolOwners = new Map<string, string>();
-
   for (const outcome of outcomes) {
     if (outcome.status === "rejected") {
-      log.error(`Dynamic tool resolver (${event.type}) threw — skipping.`, {
+      log.error(`Dynamic tool resolver (${event.type}) failed — skipping its complete result.`, {
         error: toErrorMessage(outcome.reason),
       });
       continue;
     }
     if (outcome.value === null) continue;
 
-    const { resolver, entries, isSingle } = outcome.value;
-    const named = qualifyDynamicToolNames(resolver, isSingle, entries);
-    const processCallbacks = new Map<string, Function>();
-    for (const { name, entryKey, entry } of named) {
-      const previousOwner = dynamicToolOwners.get(name);
-      if (previousOwner !== undefined && previousOwner !== resolver.slug) {
+    for (const entry of outcome.value.metadata) {
+      const previousOwner = dynamicToolOwners.get(entry.name);
+      if (previousOwner !== undefined && previousOwner !== outcome.value.resolver.slug) {
         throw new Error(
-          `Dynamic tool "${name}" from resolver "${resolver.slug}" collides with dynamic resolver "${previousOwner}". Namespace the map key manually, e.g. "${resolver.slug}__${name}".`,
+          `Dynamic tool "${entry.name}" from resolver "${outcome.value.resolver.slug}" collides with dynamic resolver "${previousOwner}". Namespace the map key manually.`,
         );
       }
-      dynamicToolOwners.set(name, resolver.slug);
-
-      liveTools.push(toHarnessToolDefinition(name, entry));
-      if (event.type === "step.started") {
-        continue;
-      }
-
-      const stepFn =
-        "__executeStepFn" in entry
-          ? (entry as { __executeStepFn?: { stepId?: string } }).__executeStepFn
-          : undefined;
-      const closureVars =
-        "__closureVars" in entry
-          ? (entry as { __closureVars?: Record<string, unknown> }).__closureVars
-          : undefined;
-
-      let executeStepFnName = stepFn?.stepId;
-      let serializedClosureVars =
-        closureVars !== undefined ? safeSerialize(closureVars) : undefined;
-
-      const callbackScope = event.type === "session.started" ? `${ctx.require(SessionIdKey)}:` : "";
-      if (executeStepFnName === undefined) {
-        const syntheticId = `eve:framework-dynamic:${callbackScope}${resolver.slug}:${entryKey}`;
-        const originalExecute = entry.execute.bind(entry);
-        processCallbacks.set(syntheticId, (_closureVars: unknown, input: unknown, ctx: unknown) =>
-          originalExecute(
-            input as Record<string, unknown>,
-            ctx as Parameters<typeof entry.execute>[1],
-          ),
-        );
-        executeStepFnName = syntheticId;
-        serializedClosureVars = {};
-      }
-
-      let approvalStepFnName: string | undefined;
-      let approvalResponseStepFnName: string | undefined;
-      if (entry.approval !== undefined) {
-        approvalStepFnName = `eve:dynamic-tool-approval:${callbackScope}${resolver.slug}:${entryKey}`;
-        const originalApproval = resolveApprovalPolicy(entry.approval).bind(entry);
-        processCallbacks.set(approvalStepFnName, (_closureVars: unknown, approvalCtx: unknown) =>
-          originalApproval(approvalCtx as ApprovalContext),
-        );
-
-        const responsePolicy =
-          typeof entry.approval === "function" ? undefined : entry.approval.response;
-        if (responsePolicy !== undefined) {
-          approvalResponseStepFnName = `eve:dynamic-tool-approval-response:${callbackScope}${resolver.slug}:${entryKey}`;
-          processCallbacks.set(
-            approvalResponseStepFnName,
-            (_closureVars: unknown, responseCtx: unknown) =>
-              responsePolicy(responseCtx as ApprovalResponseContext),
-          );
-        }
-      }
-
-      metadata.push({
-        name,
-        description: entry.description,
-        inputSchema: serializeInputSchema(entry.inputSchema),
-        outputSchema: serializeOutputSchema(entry.outputSchema),
-        resolverSlug: resolver.slug,
-        entryKey,
-        executeStepFnName,
-        approvalStepFnName,
-        approvalResponseStepFnName,
-        closureVars: serializedClosureVars,
-      });
+      dynamicToolOwners.set(entry.name, outcome.value.resolver.slug);
     }
-
-    if (event.type === "session.started") {
-      registerProcessCallbacks(`${ctx.require(SessionIdKey)}:${resolver.slug}`, processCallbacks);
-    } else {
-      for (const [callbackId, callback] of processCallbacks) {
-        getStepRegistry().set(callbackId, callback);
-      }
-    }
+    metadata.push(...outcome.value.metadata);
   }
-
-  return { metadata, liveTools };
+  return { metadata };
 }
-
-// ---------------------------------------------------------------------------
-// Dispatch: route to the scope-appropriate durable key
-// ---------------------------------------------------------------------------
 
 const resolvedStepTools = new WeakMap<
   ContextContainer,
-  { readonly coordinate: string; readonly tools: readonly HarnessToolDefinition[] }
+  { readonly coordinate: string; readonly metadata: readonly DurableDynamicToolMetadata[] }
 >();
 
-/**
- * Dispatches a stream event to dynamic tool resolvers. Each
- * resolver's metadata replaces its slot (by slug) in the
- * scope-appropriate durable key. The tool-loop calls
- * {@link buildDynamicTools} to assemble the effective toolset.
- */
 /** Resolves step-scoped tools once for one internal policy/model pass. */
 export async function resolveStepDynamicTools(input: {
   readonly ctx: ContextContainer;
@@ -419,21 +299,19 @@ export async function resolveStepDynamicTools(input: {
       : undefined;
   const cached = resolvedStepTools.get(input.ctx);
   if (coordinate !== undefined && cached?.coordinate === coordinate) {
-    input.ctx.setVirtualContext(LiveStepToolsKey, cached.tools);
+    input.ctx.set(StepDynamicToolMetadataKey, cached.metadata);
     return;
   }
 
   const matching = input.resolvers.filter((resolver) =>
     resolver.eventNames.includes("step.started"),
   );
-  const { liveTools } =
+  const { metadata } =
     matching.length === 0
-      ? { liveTools: [] }
+      ? { metadata: [] }
       : await resolveToolsFromEvent(input.ctx, matching, input.event, input.messages);
-  input.ctx.setVirtualContext(LiveStepToolsKey, liveTools);
-  if (coordinate !== undefined) {
-    resolvedStepTools.set(input.ctx, { coordinate, tools: liveTools });
-  }
+  input.ctx.set(StepDynamicToolMetadataKey, metadata);
+  if (coordinate !== undefined) resolvedStepTools.set(input.ctx, { coordinate, metadata });
 }
 
 export async function dispatchDynamicToolEvent(input: {
@@ -442,46 +320,33 @@ export async function dispatchDynamicToolEvent(input: {
   readonly event: UnstampedMessageStreamEvent;
   readonly messages: readonly ModelMessage[];
 }): Promise<void> {
-  const { ctx, resolvers, event, messages } = input;
-
-  if (!ALLOWED_DYNAMIC_TOOL_EVENTS.has(event.type)) return;
-
-  if (event.type === "step.started") {
+  if (!ALLOWED_DYNAMIC_TOOL_EVENTS.has(input.event.type)) return;
+  if (input.event.type === "step.started") {
     await resolveStepDynamicTools(input);
     return;
   }
 
-  const matching = resolvers.filter((r) => r.eventNames.includes(event.type));
-  if (matching.length === 0) {
-    if (event.type === "session.started") {
-      ctx.set(SessionDynamicToolMetadataKey, []);
-    }
-    return;
-  }
-
-  const { metadata } = await resolveToolsFromEvent(ctx, matching, event, messages);
-
-  // Session/turn: store durable metadata for cross-step replay via
-  // the bundler's registered step functions.
-  const durableKey = durableKeyForEvent(event.type);
+  if (input.event.type === "turn.started") input.ctx.set(StepDynamicToolMetadataKey, []);
+  const matching = input.resolvers.filter((resolver) =>
+    resolver.eventNames.includes(input.event.type),
+  );
+  const { metadata } =
+    matching.length === 0
+      ? { metadata: [] }
+      : await resolveToolsFromEvent(input.ctx, matching, input.event, input.messages);
+  const durableKey = durableKeyForEvent(input.event.type);
   if (durableKey === undefined) return;
 
-  if (event.type === "session.started") {
-    ctx.set(SessionDynamicToolMetadataKey, metadata);
+  if (input.event.type === "session.started") {
+    input.ctx.set(SessionDynamicToolMetadataKey, metadata);
     return;
   }
-
-  const slugs = new Set(matching.map((r) => r.slug));
-  const existing = ctx.get(durableKey) ?? [];
-  const kept = existing.filter((m) => !slugs.has(m.resolverSlug));
-  ctx.set(durableKey, [...kept, ...metadata]);
+  const slugs = new Set(matching.map((resolver) => resolver.slug));
+  const kept = (input.ctx.get(durableKey) ?? []).filter((entry) => !slugs.has(entry.resolverSlug));
+  input.ctx.set(durableKey, [...kept, ...metadata]);
 }
 
-/**
- * Re-resolves session-scoped dynamic tools when a durable session reaches a
- * different runtime revision. The refresh is internal: lifecycle consumers
- * still observe exactly one `session.started` event for the session.
- */
+/** Refreshes session-scoped definitions only when the deployed code revision changes. */
 export async function refreshDynamicSessionToolsForRuntimeRevision(input: {
   readonly ctx: ContextContainer;
   readonly resolvers: readonly ResolvedDynamicToolResolver[];
@@ -489,10 +354,7 @@ export async function refreshDynamicSessionToolsForRuntimeRevision(input: {
   readonly messages: readonly ModelMessage[];
   readonly runtimeRevision: string;
 }): Promise<void> {
-  if (input.ctx.get(SessionDynamicToolRuntimeRevisionKey) === input.runtimeRevision) {
-    return;
-  }
-
+  if (input.ctx.get(SessionDynamicToolRuntimeRevisionKey) === input.runtimeRevision) return;
   const matching = input.resolvers.filter((resolver) =>
     resolver.eventNames.includes("session.started"),
   );
@@ -500,41 +362,6 @@ export async function refreshDynamicSessionToolsForRuntimeRevision(input: {
     matching.length === 0
       ? { metadata: [] }
       : await resolveToolsFromEvent(input.ctx, matching, input.event, input.messages);
-
   input.ctx.set(SessionDynamicToolMetadataKey, metadata);
   input.ctx.set(SessionDynamicToolRuntimeRevisionKey, input.runtimeRevision);
-}
-
-/** Re-registers missing process-local session callbacks in a fresh runtime. */
-export async function hydrateDynamicSessionTools(input: {
-  readonly ctx: ContextContainer;
-  readonly resolvers: readonly ResolvedDynamicToolResolver[];
-  readonly event: SessionStartedStreamEvent;
-  readonly messages: readonly ModelMessage[];
-}): Promise<void> {
-  const storedMetadata = input.ctx.get(SessionDynamicToolMetadataKey) ?? [];
-  const missing = storedMetadata.filter(hasMissingProcessCallback);
-  if (missing.length === 0) return;
-
-  const owners = new Set(missing.map((entry) => entry.resolverSlug));
-  const matching = input.resolvers.filter(
-    (resolver) => resolver.eventNames.includes("session.started") && owners.has(resolver.slug),
-  );
-  const { metadata } =
-    matching.length === 0
-      ? { metadata: [] }
-      : await resolveToolsFromEvent(input.ctx, matching, input.event, input.messages);
-  const durableOwners = new Map(storedMetadata.map((entry) => [entry.name, entry.resolverSlug]));
-  const resolvedOwners = new Map(metadata.map((entry) => [entry.name, entry.resolverSlug]));
-  if (metadata.some((entry) => durableOwners.get(entry.name) !== entry.resolverSlug)) {
-    throw new Error("Dynamic session tool callback hydration changed durable ownership.");
-  }
-  if (
-    missing.some(
-      (entry) =>
-        resolvedOwners.get(entry.name) !== entry.resolverSlug || hasMissingProcessCallback(entry),
-    )
-  ) {
-    log.warn("Dynamic session tool callback hydration did not reproduce durable ownership.");
-  }
 }

--- a/packages/eve/src/context/keys.ts
+++ b/packages/eve/src/context/keys.ts
@@ -19,7 +19,7 @@ import type {
 } from "#channel/types.js";
 import { ContextKey } from "#context/key.js";
 import type { InstrumentationChannelDeliveryRef } from "#harness/instrumentation/lifecycle.js";
-import type { HarnessToolDefinition } from "#harness/execute-tool.js";
+import type { DurableDynamicToolCallbacks } from "#shared/durable-dynamic-tool-callbacks.js";
 import type { DynamicSubagentAgentConfig } from "#runtime/subagents/dynamic-agent-config.js";
 import type { DynamicRemoteAgentConfig } from "#runtime/subagents/dynamic-remote-agent-config.js";
 import type { SandboxAccess } from "#sandbox/state.js";
@@ -153,16 +153,13 @@ export const LiveStepDynamicModelSelectionKey = new ContextKey<LiveDynamicModelS
 // ---------------------------------------------------------------------------
 
 export interface DurableDynamicToolMetadata {
+  readonly callbacks: DurableDynamicToolCallbacks;
   readonly name: string;
   readonly description: string;
   readonly inputSchema: JsonObject;
   readonly outputSchema?: JsonObject;
   readonly resolverSlug: string;
   readonly entryKey: string;
-  readonly executeStepFnName?: string;
-  readonly approvalStepFnName?: string;
-  readonly approvalResponseStepFnName?: string;
-  readonly closureVars?: Record<string, unknown>;
 }
 
 /**
@@ -189,13 +186,10 @@ export const TurnDynamicToolMetadataKey = new ContextKey<readonly DurableDynamic
   "eve.turnDynamicToolMetadata",
 );
 
-/**
- * Virtual (non-serialized) live step-scoped tool definitions from
- * `step.started` resolvers. Carries original execute closures so
- * framework tools (which lack bundler step-function metadata) work.
- * Re-resolved every step — no cross-step persistence needed.
- */
-export const LiveStepToolsKey = new ContextKey<HarnessToolDefinition[]>("eve.liveStepTools");
+/** Step-scoped dynamic tool metadata, replaced before each model step. */
+export const StepDynamicToolMetadataKey = new ContextKey<readonly DurableDynamicToolMetadata[]>(
+  "eve.stepDynamicToolMetadata",
+);
 
 export type DurableDynamicSubagentSelection =
   | {

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -42,6 +42,10 @@ import { dispatchTurnStep } from "#execution/dispatch-turn-step.js";
 import { projectToDurableSession } from "#execution/session.js";
 import { buildRuntimeIdentity, createExecutionNodeStep } from "#execution/node-step.js";
 import { defineTool } from "#public/definitions/tool.js";
+import {
+  registerDurableDynamicCallback,
+  stampDurableDynamicCallback,
+} from "#shared/durable-dynamic-tool-callbacks.js";
 import { dispatchRuntimeActionsStep } from "#execution/dispatch-runtime-actions-step.js";
 import { runProxySubagentEventStep } from "#execution/subagent-event-proxy-step.js";
 import { readLatestTaskView, sendTaskInboundPayload } from "#execution/tasks/parent/run-parent.js";
@@ -2311,14 +2315,24 @@ describe("turnStep", () => {
         originalClearVirtualContext.call(this);
       },
     );
+    const approval = stampDurableDynamicCallback(() => "not-applicable" as const, {
+      closure: {},
+      stepId: "test:current-tool/approval",
+    });
+    const execute = stampDurableDynamicCallback(async () => ({ ok: true }), {
+      closure: {},
+      stepId: "test:current-tool/execute",
+    });
+    registerDurableDynamicCallback("test:current-tool/approval", () => "not-applicable");
+    registerDurableDynamicCallback("test:current-tool/execute", async () => ({ ok: true }));
     const handler = vi.fn(() => {
       lifecycleOrder.push("refresh");
       return {
         current_tool: defineTool({
           description: "Current deployment tool",
           inputSchema: { type: "object" },
-          approval: () => "not-applicable" as const,
-          execute: async () => ({ ok: true }),
+          approval,
+          execute,
         }),
       };
     });
@@ -2386,10 +2400,11 @@ describe("turnStep", () => {
     ctx.set(SessionDynamicToolRuntimeRevisionKey, "deployment:dpl_old");
     ctx.set(SessionDynamicToolMetadataKey, [
       {
-        closureVars: {},
+        callbacks: {
+          execute: { closure: {}, stepId: "eve:dynamic-tool//old" },
+        },
         description: "Stale deployment tool",
         entryKey: "old_tool",
-        executeStepFnName: "eve:dynamic-tool//old",
         inputSchema: { type: "object" },
         name: "old_tool",
         resolverSlug: "old",

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -17,7 +17,6 @@ import {
 } from "#context/dynamic-subagent-lifecycle.js";
 import {
   dispatchDynamicToolEvent,
-  hydrateDynamicSessionTools,
   refreshDynamicSessionToolsForRuntimeRevision,
 } from "#context/dynamic-tool-lifecycle.js";
 import {
@@ -376,12 +375,6 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
           runtimeRevision: dynamicRuntimeRevision,
         }),
       ]);
-      await hydrateDynamicSessionTools({
-        ctx,
-        resolvers: dynamicToolResolvers,
-        event: refreshEvent,
-        messages: initialSession.history,
-      });
     }
   } catch (error) {
     await failChannelDeliveries(error);

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -18,7 +18,6 @@ import {
   ChannelInstrumentationKey,
   InitiatorAuthKey,
   LiveStepDynamicModelSelectionKey,
-  LiveStepToolsKey,
   ParentSessionKey,
   SandboxKey,
   SessionKey,
@@ -26,6 +25,7 @@ import {
   SessionDynamicInstructionsKey,
   SessionDynamicModelReferenceKey,
   SessionDynamicSubagentSelectionsKey,
+  StepDynamicToolMetadataKey,
   TurnTaskDeliveryKey,
 } from "#context/keys.js";
 import { SCHEDULE_APP_AUTH } from "#channel/schedule-auth.js";
@@ -1954,7 +1954,7 @@ describe("createToolLoopHarness", () => {
       toolResults: [],
     });
 
-    const approval = vi.fn(() => "user-approval" as const);
+    const approval = vi.fn((_context: unknown) => "user-approval" as const);
     const ctx = new ContextContainer();
     ctx.set(SessionKey, {
       auth: {
@@ -1969,13 +1969,25 @@ describe("createToolLoopHarness", () => {
       sessionId: "test-session",
       turn: { id: "turn-test", sequence: 0 },
     });
-    ctx.setVirtualContext(LiveStepToolsKey, [
+    const registryKey = Symbol.for("@workflow/core//registeredSteps");
+    const globals = globalThis as Record<symbol, Map<string, Function> | undefined>;
+    const registry = globals[registryKey] ?? new Map<string, Function>();
+    globals[registryKey] = registry;
+    registry.set("test-step-execute", () => ({ ok: true }));
+    registry.set("test-step-approval", (_closure: unknown, approvalContext: unknown) =>
+      approval(approvalContext as never),
+    );
+    ctx.set(StepDynamicToolMetadataKey, [
       {
+        callbacks: {
+          approvalRequest: { closure: {}, stepId: "test-step-approval" },
+          execute: { closure: {}, stepId: "test-step-execute" },
+        },
         description: "Get TfL line status.",
-        execute: vi.fn().mockResolvedValue({ ok: true }),
-        inputSchema: jsonSchema({ type: "object" }),
+        entryKey: "tfl__getLineStatus",
+        inputSchema: { type: "object" },
         name: "tfl__getLineStatus",
-        approval,
+        resolverSlug: "tfl",
       },
     ]);
 

--- a/packages/eve/src/internal/authored-module-loader.ts
+++ b/packages/eve/src/internal/authored-module-loader.ts
@@ -285,7 +285,7 @@ export async function bundleAuthoredModuleMapForGeneration(input: {
       id: input.moduleMapPath,
       source: moduleMapSource,
     }),
-    createDynamicCapabilityTransformPlugin({ dynamicTools: false }),
+    createDynamicCapabilityTransformPlugin(),
     createAuthoredDirectiveGuardPlugin(),
     extensionScopePlugin,
     createAuthoredRelativeExtensionResolverPlugin({ extensions: RESOLVE_EXTENSIONS }),

--- a/packages/eve/src/internal/workflow-bundle/dynamic-capability-transform-plugin.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-capability-transform-plugin.ts
@@ -10,8 +10,7 @@ export function createDynamicCapabilityTransformPlugin(
   return {
     async transform(code: string, id: string) {
       const normalizedId = id.replaceAll("\\", "/");
-      const transformDynamicTools =
-        options.dynamicTools !== false && normalizedId.includes("/tools/");
+      const transformDynamicTools = options.dynamicTools !== false;
       const transformDynamicRemoteAgents =
         options.dynamicRemoteAgents !== false && normalizedId.includes("/subagents/");
       if (!transformDynamicTools && !transformDynamicRemoteAgents) {

--- a/packages/eve/src/internal/workflow-bundle/dynamic-tool-ast-references.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-tool-ast-references.ts
@@ -13,19 +13,25 @@ export type DynamicToolAstNode = {
   declarations?: DynamicToolAstNode[];
   end?: number;
   expression?: DynamicToolAstNode | null;
+  generator?: boolean;
   id?: { name?: string; start?: number; end?: number } | null;
   init?: DynamicToolAstNode | null;
+  imported?: { name?: string; value?: unknown } | null;
   key?: DynamicToolAstNode | null;
   kind?: string;
   left?: DynamicToolAstNode | null;
+  local?: { name?: string } | null;
   method?: boolean;
   name?: string;
   params?: DynamicToolAstNode[];
   properties?: DynamicToolAstNode[];
   right?: DynamicToolAstNode | null;
+  source?: { value?: unknown } | null;
+  specifiers?: DynamicToolAstNode[];
   start?: number;
   type?: string;
   value?: DynamicToolAstNode | unknown;
+  elements?: Array<DynamicToolAstNode | null>;
 };
 
 type IdentifierContext = "binding" | "reference";

--- a/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.test.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, beforeEach } from "vitest";
 
 import { transformDynamicToolExecute } from "./dynamic-tool-transform.js";
+import {
+  collectDurableDynamicToolCallbacks,
+  stampDurableDynamicToolCallbacks,
+} from "#shared/durable-dynamic-tool-callbacks.js";
 
 // ---------------------------------------------------------------------------
 // Helpers for evaluating transformed code
@@ -44,8 +48,17 @@ async function transformAndEval(
     return def;
   };
 
-  const defineTool = (entry: Record<string, unknown>) =>
-    Object.assign(entry, { [Symbol.for("eve:tool-brand")]: true });
+  const defineTool = (entry: Record<string, unknown>) => {
+    stampDurableDynamicToolCallbacks(
+      entry,
+      collectDurableDynamicToolCallbacks({
+        approval: entry.approval as never,
+        execute: entry.execute as never,
+        toModelOutput: entry.toModelOutput as never,
+      }),
+    );
+    return Object.assign(entry, { [Symbol.for("eve:tool-brand")]: true });
+  };
 
   // Evaluate in a function scope to provide our stubs. The transform
   // prepends its own __eveStepRegistry setup, so we don't need to add it.
@@ -67,7 +80,7 @@ async function transformAndEval(
   };
 }
 
-// Clear step registry between tests so counter-based names don't collide
+// Clear step registrations between tests so each assertion observes only its module.
 beforeEach(() => {
   const sym = Symbol.for("@workflow/core//registeredSteps");
   const reg = (globalThis as Record<symbol, Map<string, Function> | undefined>)[sym];
@@ -79,6 +92,68 @@ beforeEach(() => {
 // ===========================================================================
 
 describe("transformDynamicToolExecute — evaluation", () => {
+  it("stamps independent durable descriptors for every callback phase", async () => {
+    const source = `
+import { defineDynamic, defineTool } from "eve/tools";
+
+export default defineDynamic({
+  events: {
+    "session.started": async () => {
+      const executePrefix = "execute";
+      const requestReason = "confirm";
+      const allowedResponder = "user-123";
+      const projectionPrefix = "visible";
+      return {
+        guarded: defineTool({
+          description: "Guarded",
+          inputSchema: { type: "object" },
+          approval: {
+            request(ctx) {
+              return ctx.toolInput.force ? { type: "user-approval", reason: requestReason } : "not-applicable";
+            },
+            response(ctx) {
+              return ctx.responder.principalId === allowedResponder
+                ? { status: "allowed" }
+                : { status: "rejected", reason: "wrong responder" };
+            },
+          },
+          execute(input) {
+            return executePrefix + ":" + input.value;
+          },
+          toModelOutput(output) {
+            return { type: "text", value: projectionPrefix + ":" + output };
+          },
+        }),
+      };
+    },
+  },
+});
+`;
+
+    const { callHandler, registry } = await transformAndEval("tools/all-phases.ts", source);
+    const tools = await callHandler();
+    const guarded = tools.guarded as Record<string | symbol, unknown>;
+    const callbacks = guarded[Symbol.for("eve:durable-dynamic-tool-callbacks")] as Record<
+      string,
+      { stepId: string; closure: Record<string, unknown> }
+    >;
+
+    expect(Object.keys(callbacks)).toEqual([
+      "execute",
+      "approvalRequest",
+      "approvalResponse",
+      "toModelOutput",
+    ]);
+    expect(callbacks.execute!.closure).toEqual({ executePrefix: "execute" });
+    expect(callbacks.approvalRequest!.closure).toEqual({ requestReason: "confirm" });
+    expect(callbacks.approvalResponse!.closure).toEqual({ allowedResponder: "user-123" });
+    expect(callbacks.toModelOutput!.closure).toEqual({ projectionPrefix: "visible" });
+    expect(new Set(Object.values(callbacks).map((callback) => callback.stepId)).size).toBe(4);
+    for (const callback of Object.values(callbacks)) {
+      expect(registry.has(callback.stepId)).toBe(true);
+    }
+  });
+
   it("wrapper calls hoisted function with correct closure vars", async () => {
     const source = `
 import { defineDynamic, defineTool } from "eve/tools";
@@ -139,7 +214,7 @@ export default defineDynamic({
 
     const { callHandler } = await transformAndEval("tools/snapshot.ts", source);
     const tools = await callHandler();
-    const tool = tools.tool as Record<string, unknown>;
+    const tool = tools.tool as Record<string | symbol, unknown>;
 
     // __closureVars should have a snapshot of the config
     const closureVars = tool.__closureVars as Record<string, unknown>;
@@ -1026,7 +1101,7 @@ export default defineDynamic({
     expect(tools.feature_a).toBeUndefined();
   });
 
-  it("closure vars with non-serializable values: functions are dropped on replay", async () => {
+  it("preserves non-serializable captures for strict lifecycle validation", async () => {
     const source = `
 import { defineDynamic, defineTool } from "eve/tools";
 
@@ -1049,16 +1124,18 @@ export default defineDynamic({
 
     const { callHandler } = await transformAndEval("tools/non-serial.ts", source);
     const tools = await callHandler();
-    const tool = tools.tool as Record<string, unknown>;
+    const tool = tools.tool as Record<string | symbol, unknown>;
 
     // Live call works because helper is a real closure
     const liveResult = (tool.execute as Function)({ n: 5 });
     expect(liveResult).toBe("test:10");
 
-    // But __closureVars loses the function on JSON round-trip
-    const serialized = JSON.parse(JSON.stringify(tool.__closureVars));
-    expect(serialized.label).toBe("test");
-    expect(serialized.helper).toBeUndefined();
+    const callbacks = tool[Symbol.for("eve:durable-dynamic-tool-callbacks")] as Record<
+      string,
+      { closure: Record<string, unknown> }
+    >;
+    expect(callbacks.execute!.closure.label).toBe("test");
+    expect(callbacks.execute!.closure.helper).toBeTypeOf("function");
   });
 
   it("execute param named same as handler param does not collide", async () => {
@@ -1711,7 +1788,7 @@ export default defineDynamic({
     expect(result).toBeNull();
   });
 
-  it("returns null for static defineTool without events", async () => {
+  it("stamps defineTool callbacks independently of the containing module shape", async () => {
     const source = `
 import { defineTool } from "eve/tools";
 
@@ -1723,7 +1800,82 @@ export default defineTool({
   },
 });
 `;
-    expect(await transformDynamicToolExecute("tools/weather.ts", source)).toBeNull();
+    const result = await transformDynamicToolExecute("tools/weather.ts", source);
+    expect(result?.code).toContain("eve:durable-dynamic-callback");
+  });
+
+  it("transforms aliased defineTool imports", async () => {
+    const source = `
+import { defineDynamic, defineTool as tool } from "eve/tools";
+
+export default defineDynamic({
+  events: {
+    "session.started": () => ({
+      aliased: tool({
+        description: "Aliased",
+        inputSchema: { type: "object" },
+        execute(input) { return input.value; },
+      }),
+    }),
+  },
+});
+`;
+
+    const result = await transformDynamicToolExecute("lib/aliased-factory.ts", source);
+    expect(result?.code).toContain("aliased: tool({");
+    expect(result?.code).toContain("execute: __eveStampDynamicCallback");
+  });
+
+  it("supports module-level function references", async () => {
+    const source = `
+import { defineDynamic, defineTool } from "eve/tools";
+
+function executeMarker(input) {
+  return "module:" + input.value;
+}
+
+export default defineDynamic({
+  events: {
+    "session.started": () => ({
+      marker: defineTool({
+        description: "Marker",
+        inputSchema: { type: "object" },
+        execute: executeMarker,
+      }),
+    }),
+  },
+});
+`;
+
+    const { callHandler, registry } = await transformAndEval("lib/module-reference.ts", source);
+    const tools = await callHandler();
+    const marker = tools.marker as Record<string | symbol, unknown>;
+    const callbacks = marker[Symbol.for("eve:durable-dynamic-tool-callbacks")] as Record<
+      string,
+      { closure: Record<string, unknown>; stepId: string }
+    >;
+    const execute = callbacks.execute!;
+
+    expect(execute.closure).toEqual({});
+    expect(registry.get(execute.stepId)!(execute.closure, { value: "ok" })).toBe("module:ok");
+  });
+
+  it("preserves async generator callbacks", async () => {
+    const source = `
+import { defineTool } from "eve/tools";
+export default defineTool({
+  description: "Stream markers",
+  inputSchema: {},
+  async *execute() {
+    yield { phase: "started" };
+    yield { phase: "finished" };
+  },
+});
+`;
+
+    const result = await transformDynamicToolExecute("agent/tools/stream.ts", source);
+    expect(result?.code).toContain("execute: __eveStampDynamicCallback(async function*");
+    expect(result?.code).toContain("async function* __eve_dynamic_exec_");
   });
 
   it("returns null for files without defineDynamic", async () => {
@@ -1752,6 +1904,32 @@ export default defineDynamic({
 // ===========================================================================
 
 describe("transformDynamicToolExecute — structural invariants", () => {
+  it("keeps callback ids stable when an unrelated module is transformed", async () => {
+    const target = `
+import { defineTool } from "eve/tools";
+export default defineTool({
+  description: "Target",
+  inputSchema: {},
+  execute() { return "target"; },
+});
+`;
+    const unrelated = `
+import { defineTool } from "eve/tools";
+export default defineTool({
+  description: "Unrelated",
+  inputSchema: {},
+  execute() { return "unrelated"; },
+});
+`;
+
+    const before = await transformDynamicToolExecute("agent/lib/target.ts", target);
+    await transformDynamicToolExecute("agent/lib/unrelated.ts", unrelated);
+    const after = await transformDynamicToolExecute("agent/lib/target.ts", target);
+    const ids = (code: string) => [...new Set(code.match(/eve:dynamic-tool\/\/[^"\s]+/g) ?? [])];
+
+    expect(ids(after!.code)).toEqual(ids(before!.code));
+  });
+
   it("every hoisted function has balanced braces", async () => {
     const source = `
 import { defineDynamic, defineTool } from "eve/tools";

--- a/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.test.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.test.ts
@@ -154,6 +154,59 @@ export default defineDynamic({
     }
   });
 
+  it("preserves top-level function-form approval properties", async () => {
+    const source = `
+import { defineDynamic, defineTool } from "eve/tools";
+
+function referencedApproval() {
+  return "user-approval";
+}
+
+export default defineDynamic({
+  events: {
+    "session.started": async () => ({
+      arrow: defineTool({
+        description: "Arrow approval",
+        inputSchema: { type: "object" },
+        approval: () => "user-approval",
+        execute: async () => "ok",
+      }),
+      method: defineTool({
+        description: "Method approval",
+        inputSchema: { type: "object" },
+        approval() {
+          return "user-approval";
+        },
+        execute: async () => "ok",
+      }),
+      referenced: defineTool({
+        description: "Referenced approval",
+        inputSchema: { type: "object" },
+        approval: referencedApproval,
+        execute: async () => "ok",
+      }),
+    }),
+  },
+});
+`;
+
+    const { callHandler } = await transformAndEval("tools/function-approval.ts", source);
+    const tools = await callHandler();
+
+    for (const entry of Object.values(tools)) {
+      const tool = entry as Record<string | symbol, unknown>;
+      expect(tool.request).toBeUndefined();
+      expect(tool.approval).toBeTypeOf("function");
+      expect(await (tool.approval as Function)({})).toBe("user-approval");
+      expect(tool[Symbol.for("eve:durable-dynamic-tool-callbacks")]).toMatchObject({
+        approvalRequest: {
+          closure: {},
+          stepId: expect.stringContaining("/approvalRequest/"),
+        },
+      });
+    }
+  });
+
   it("wrapper calls hoisted function with correct closure vars", async () => {
     const source = `
 import { defineDynamic, defineTool } from "eve/tools";

--- a/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.ts
@@ -1,29 +1,11 @@
 /**
- * Compiler transform for dynamic tool files.
- *
- * Hoists inline `execute` functions from `defineDynamic`
- * event handler return values to module-scope named functions
- * registered in the global step registry. The workflow SDK then
- * handles serialization and replay.
- *
- * The walker enters nested functions (helpers, callbacks, IIFEs) so
- * patterns like `function buildTool(n) { return { execute() {} } }`
- * are supported. For each execute found, scope variables from every
- * enclosing function between the handler and the execute are
- * collected. Only variables the execute body actually references are
- * captured — this avoids TDZ errors from later declarations.
- *
- * At each call site the inline execute is replaced with:
- * - A wrapper that passes referenced scope values as `__vars`
- * - `__executeStepFn`: reference to the hoisted function
- * - `__closureVars`: snapshot for durable serialization
- *
- * Limitation: `execute` must be an inline function literal (function
- * expression, arrow, or method shorthand). Variable references
- * (`execute: myFn`) and call results (`execute: makeFn()`) are not
- * detected — the transform returns null and the tool works on the
- * first workflow step but is not replayable.
+ * Stamps callbacks passed to authored `defineTool()` calls with stable replay
+ * descriptors. Each callback is hoisted independently, registered under a
+ * module-and-source-coordinate id, and receives only the lexical values its
+ * body references.
  */
+
+import { createHash } from "node:crypto";
 
 import { parseWithNitroRolldownAst } from "#internal/bundler/nitro-rolldown.js";
 import {
@@ -33,37 +15,21 @@ import {
   walkNode,
 } from "#internal/workflow-bundle/dynamic-tool-ast-references.js";
 
-interface HandlerInfo {
-  /** The handler function AST node */
-  handlerNode: AstNode;
-  /** Start of the handler function body (the `{`) */
-  bodyStart: number;
-  /** Collected variable names declared in the handler scope */
-  scopeVars: readonly string[];
-  /** Handler parameter names (event, ctx) */
-  paramNames: readonly string[];
-  /** Execute functions found inside the return value */
-  executes: readonly ExecuteInfo[];
-}
+type CallbackPhase = "approvalRequest" | "approvalResponse" | "execute" | "toModelOutput";
 
-interface ExecuteInfo {
-  /** Full property range (execute: function(...) { ... }) */
-  propStart: number;
-  propEnd: number;
-  /** The function source (params + body) */
-  fnSource: string;
-  /** Whether the function is async */
-  isAsync: boolean;
-  /** Generated name for the hoisted function */
-  hoistedName: string;
-  /** Parameter source */
-  params: string;
-  /** Body source (block statement including braces) */
-  body: string;
-  /** Function body AST used to identify actual identifier references */
-  bodyNode: AstNode;
-  /** Scope entries from nested functions between handler and this execute */
-  nestedScopes: readonly ScopeEntry[];
+interface CallbackInfo {
+  readonly body: string;
+  readonly bodyNode: AstNode;
+  readonly isAsync: boolean;
+  readonly isGenerator: boolean;
+  readonly isReference: boolean;
+  readonly nestedScopes: readonly ScopeEntry[];
+  readonly params: string;
+  readonly phase: CallbackPhase;
+  readonly propEnd: number;
+  readonly propStart: number;
+  readonly sourceEnd: number;
+  readonly sourceStart: number;
 }
 
 interface ScopeEntry {
@@ -71,546 +37,427 @@ interface ScopeEntry {
   readonly vars: readonly string[];
 }
 
-let transformCounter = 0;
-
 /**
- * Transforms a dynamic tool file:
- * 1. Hoists execute functions to module scope with "use step"
- * 2. Captures handler-scope variables via __vars parameter
- * 3. Adds "use step" to event handlers so the workflow SDK caches
- *    the handler's return value (resolver runs once per scope)
- *
- * Returns null if the file doesn't contain a dynamic tool pattern.
+ * Transforms every `defineTool()` call imported from an eve authoring entry
+ * point. This includes tools created in authored helper modules, not only the
+ * file containing `defineDynamic()`.
  */
 export async function transformDynamicToolExecute(
   filename: string,
   source: string,
 ): Promise<{ code: string } | null> {
-  if (!source.includes("defineDynamic")) {
-    return null;
-  }
-  if (!source.includes("events")) {
-    return null;
-  }
-  if (!source.includes("execute")) {
-    return null;
-  }
+  if (!source.includes("defineTool")) return null;
 
-  const ast = await parseSource(filename, source);
-  const handlers = findDynamicToolHandlers(source, ast);
+  const ast = (await parseWithNitroRolldownAst(filename, source)) as AstNode;
+  const defineToolAliases = findDefineToolAliases(ast);
+  if (defineToolAliases.size === 0) return null;
 
-  if (handlers.every((h) => h.executes.length === 0)) {
-    return null;
-  }
-
-  return applyTransform(source, handlers);
+  const callbacks: CallbackInfo[] = [];
+  walkForCallbacks(source, ast, callbacks, [], defineToolAliases);
+  return callbacks.length === 0 ? null : applyTransform(filename, source, callbacks);
 }
 
-// Keep the old export name for backward compatibility with the plugin
+// Keep the old export name for backward compatibility with the plugin.
 export { transformDynamicToolExecute as transformDynamicToolAwait };
 
-async function parseSource(filename: string, source: string): Promise<AstNode> {
-  return (await parseWithNitroRolldownAst(filename, source)) as AstNode;
-}
-
-// ---------------------------------------------------------------------------
-// AST analysis
-// ---------------------------------------------------------------------------
-
-function findDynamicToolHandlers(source: string, ast: AstNode): HandlerInfo[] {
-  const handlers: HandlerInfo[] = [];
-
+function findDefineToolAliases(ast: AstNode): ReadonlySet<string> {
+  const aliases = new Set<string>();
   walkNode(ast, (node) => {
-    if (
-      node.type === "CallExpression" &&
-      node.callee?.type === "Identifier" &&
-      node.callee.name === "defineDynamic" &&
-      node.arguments?.length === 1
-    ) {
-      const arg = node.arguments[0]!;
-      if (arg.type === "ObjectExpression") {
-        const eventsProp = findProperty(arg, "events");
-        if (eventsProp?.value && (eventsProp.value as AstNode).type === "ObjectExpression") {
-          collectHandlers(source, eventsProp.value as AstNode, handlers);
-        }
-      }
+    if (node.type !== "ImportDeclaration") return true;
+    const source = node.source?.value;
+    if (typeof source !== "string" || (source !== "eve" && !source.startsWith("eve/"))) {
       return false;
     }
-    return true;
+    for (const specifier of node.specifiers ?? []) {
+      if (
+        specifier.type === "ImportSpecifier" &&
+        (specifier.imported?.name ?? specifier.imported?.value) === "defineTool" &&
+        specifier.local?.name
+      ) {
+        aliases.add(specifier.local.name);
+      }
+    }
+    return false;
   });
-
-  return handlers;
+  return aliases;
 }
 
-function collectHandlers(source: string, eventsObj: AstNode, handlers: HandlerInfo[]): void {
-  for (const prop of eventsObj.properties ?? []) {
-    if (prop.type !== "Property") continue;
-    const handler = prop.value as AstNode | undefined;
-    if (!handler) continue;
-
-    if (handler.type !== "ArrowFunctionExpression" && handler.type !== "FunctionExpression") {
-      continue;
-    }
-
-    const bodyNode = handler.body as AstNode | undefined;
-    if (!bodyNode) continue;
-
-    const bodyStart = findBlockBodyStart(bodyNode);
-    if (bodyStart === null) continue;
-
-    const paramNames = extractParamNames(handler);
-    const scopeVars = collectScopeVarDeclarations(bodyNode);
-    const executes = findExecuteFunctions(source, bodyNode);
-
-    if (executes.length > 0) {
-      handlers.push({
-        handlerNode: handler,
-        bodyStart,
-        scopeVars,
-        paramNames,
-        executes,
-      });
-    }
-  }
-}
-
-function findBlockBodyStart(node: AstNode): number | null {
-  if (node.type === "BlockStatement" && node.start !== undefined) {
-    return node.start;
-  }
-  if (
-    typeof node.body === "object" &&
-    !Array.isArray(node.body) &&
-    node.body?.type === "BlockStatement" &&
-    node.body.start !== undefined
-  ) {
-    return node.body.start;
-  }
-  return null;
-}
-
-function extractParamNames(fn: AstNode): string[] {
-  const names: string[] = [];
-  for (const param of fn.params ?? []) {
-    if (param.type === "Identifier" && param.name) {
-      names.push(param.name);
-    }
-  }
-  return names;
-}
-
-/**
- * Collects all variable declarations at the top level of a function
- * body (const, let, var). These are the potential closure variables
- * that execute functions might reference.
- */
-function collectScopeVarDeclarations(bodyNode: AstNode): string[] {
-  const vars: string[] = [];
-  collectVarsRecursive(bodyNode, vars);
-  return vars;
-}
-
-function collectVarsRecursive(node: AstNode | null | undefined, vars: string[]): void {
+function walkForCallbacks(
+  source: string,
+  node: AstNode | null | undefined,
+  results: CallbackInfo[],
+  nestedScopes: readonly ScopeEntry[],
+  defineToolAliases: ReadonlySet<string>,
+): void {
   if (!node) return;
 
-  // Stop at function boundaries — don't capture execute-local vars
-  if (
-    node.type === "FunctionExpression" ||
-    node.type === "ArrowFunctionExpression" ||
-    node.type === "FunctionDeclaration"
-  ) {
+  if (isFunction(node)) {
+    const bodyNode = node.body as AstNode | undefined;
+    if (!bodyNode) return;
+    const extended = [
+      ...nestedScopes,
+      {
+        params: extractParamNames(node),
+        vars: collectScopeVarDeclarations(bodyNode),
+      },
+    ];
+    walkForCallbacks(source, bodyNode, results, extended, defineToolAliases);
     return;
   }
 
-  if (node.type === "VariableDeclaration") {
-    for (const decl of node.declarations ?? []) {
-      collectDeclaredNames(decl, vars);
+  if (
+    node.type === "CallExpression" &&
+    node.callee?.type === "Identifier" &&
+    node.callee.name !== undefined &&
+    defineToolAliases.has(node.callee.name) &&
+    node.arguments?.length === 1 &&
+    node.arguments[0]?.type === "ObjectExpression"
+  ) {
+    collectToolCallbacks(source, node.arguments[0], results, nestedScopes);
+    return;
+  }
+
+  for (const value of Object.values(node)) {
+    if (Array.isArray(value)) {
+      for (const child of value) {
+        if (isAstNode(child)) {
+          walkForCallbacks(source, child, results, nestedScopes, defineToolAliases);
+        }
+      }
+    } else if (isAstNode(value)) {
+      walkForCallbacks(source, value, results, nestedScopes, defineToolAliases);
     }
-  }
-
-  // Also capture for-loop variable declarations (ForStatement.init,
-  // ForInStatement.left, ForOfStatement.left)
-  if (node.type === "ForStatement" && node.init) {
-    collectVarsRecursive(node.init, vars);
-  }
-  const nodeAny = node as Record<string, unknown>;
-  if ((node.type === "ForInStatement" || node.type === "ForOfStatement") && node.left) {
-    collectVarsRecursive(node.left, vars);
-  }
-
-  // Recurse into child nodes
-  if (Array.isArray(node.body)) {
-    for (const child of node.body) collectVarsRecursive(child, vars);
-  } else if (node.body && typeof node.body === "object" && "type" in node.body) {
-    collectVarsRecursive(node.body as AstNode, vars);
-  }
-  if (node.declarations) {
-    for (const decl of node.declarations) collectVarsRecursive(decl, vars);
-  }
-  if (node.expression) collectVarsRecursive(node.expression, vars);
-  if (Array.isArray(nodeAny.consequent)) {
-    for (const c of nodeAny.consequent) collectVarsRecursive(c as AstNode, vars);
-  } else if (nodeAny.consequent) {
-    collectVarsRecursive(nodeAny.consequent as AstNode, vars);
-  }
-  if (nodeAny.alternate) collectVarsRecursive(nodeAny.alternate as AstNode, vars);
-  if (nodeAny.block) collectVarsRecursive(nodeAny.block as AstNode, vars);
-  if (nodeAny.handler) collectVarsRecursive(nodeAny.handler as AstNode, vars);
-  if (nodeAny.finalizer) collectVarsRecursive(nodeAny.finalizer as AstNode, vars);
-  if (nodeAny.cases && Array.isArray(nodeAny.cases)) {
-    for (const c of nodeAny.cases) collectVarsRecursive(c as AstNode, vars);
   }
 }
 
-function collectDeclaredNames(node: AstNode, names: string[]): void {
-  if (node.type === "VariableDeclarator") {
-    collectPatternNames(node.id as AstNode | null, names);
+function collectToolCallbacks(
+  source: string,
+  tool: AstNode,
+  results: CallbackInfo[],
+  nestedScopes: readonly ScopeEntry[],
+): void {
+  collectCallbackProperty(source, findProperty(tool, "execute"), "execute", results, nestedScopes);
+  collectCallbackProperty(
+    source,
+    findProperty(tool, "toModelOutput"),
+    "toModelOutput",
+    results,
+    nestedScopes,
+  );
+
+  const approval = findProperty(tool, "approval");
+  const approvalValue = approval?.value as AstNode | undefined;
+  if (approvalValue?.type === "ObjectExpression") {
+    collectCallbackProperty(
+      source,
+      findProperty(approvalValue, "request"),
+      "approvalRequest",
+      results,
+      nestedScopes,
+    );
+    collectCallbackProperty(
+      source,
+      findProperty(approvalValue, "response"),
+      "approvalResponse",
+      results,
+      nestedScopes,
+    );
+  } else {
+    collectCallbackProperty(source, approval, "approvalRequest", results, nestedScopes);
   }
+}
+
+function collectCallbackProperty(
+  source: string,
+  property: AstNode | undefined,
+  phase: CallbackPhase,
+  results: CallbackInfo[],
+  nestedScopes: readonly ScopeEntry[],
+): void {
+  if (property?.type !== "Property" || property.start === undefined || property.end === undefined) {
+    return;
+  }
+  const value = property.value as AstNode | undefined;
+  if (!value || value.start === undefined || value.end === undefined) return;
+
+  if (isFunction(value) || property.method === true) {
+    const bodyNode = value.body as AstNode | undefined;
+    if (!bodyNode) return;
+    results.push({
+      body: extractFnBody(source, value),
+      bodyNode,
+      isAsync: value.async === true,
+      isGenerator: value.generator === true,
+      isReference: false,
+      nestedScopes,
+      params: extractFnParams(source, value),
+      phase,
+      propEnd: property.end,
+      propStart: property.start,
+      sourceEnd: value.end,
+      sourceStart: value.start,
+    });
+    return;
+  }
+
+  if (value.type === "Identifier") {
+    results.push({
+      body: `{ return ${source.slice(value.start, value.end)}(...__args); }`,
+      bodyNode: value,
+      isAsync: false,
+      isGenerator: false,
+      isReference: true,
+      nestedScopes,
+      params: "...__args",
+      phase,
+      propEnd: property.end,
+      propStart: property.start,
+      sourceEnd: value.end,
+      sourceStart: value.start,
+    });
+  }
+}
+
+function applyTransform(
+  filename: string,
+  source: string,
+  callbacks: readonly CallbackInfo[],
+): { code: string } {
+  const replacements: Array<{ start: number; end: number; text: string }> = [];
+  const hoistedFunctions: string[] = [];
+  const registrations: string[] = [];
+  const moduleId = stableModuleId(filename);
+
+  for (const callback of callbacks) {
+    const referencedNames = collectReferencedIdentifierNames(callback.bodyNode);
+    const candidateVars = callback.nestedScopes.flatMap((scope) => [
+      ...scope.params,
+      ...scope.vars,
+    ]);
+    const callbackParamNames = extractCallbackParamNames(callback.params);
+    const allVars = dedupeShadowed(candidateVars).filter(
+      (name) => !callbackParamNames.has(name) && referencedNames.has(name),
+    );
+    const closure = allVars.length > 0 ? `{ ${allVars.join(", ")} }` : "{}";
+    const coordinate = `${String(callback.sourceStart)}-${String(callback.sourceEnd)}`;
+    const safePhase = callback.phase.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
+    const hoistedName =
+      callback.phase === "execute"
+        ? `__eve_dynamic_exec_${callback.sourceStart}`
+        : `__eve_dynamic_${safePhase}_${callback.sourceStart}`;
+    const stepId = `eve:dynamic-tool//${moduleId}/${callback.phase}/${coordinate}`;
+    const originalParams = callback.params;
+    const hoistedParams = originalParams ? `__vars, ${originalParams}` : "__vars";
+    const varsDestructure = allVars.length > 0 ? `const ${closure} = __vars;\n  ` : "";
+    const bodyContent = callback.body.slice(1, -1).trim();
+    const asyncPrefix = callback.isAsync ? "async " : "";
+    const generatorStar = callback.isGenerator ? "*" : "";
+
+    hoistedFunctions.push(
+      `${asyncPrefix}function${generatorStar} ${hoistedName}(${hoistedParams}) {\n` +
+        `  ${varsDestructure}${bodyContent}\n` +
+        `}`,
+    );
+    registrations.push(`${hoistedName}.stepId = ${JSON.stringify(stepId)};`);
+    registrations.push(`__eveStepRegistry.set(${JSON.stringify(stepId)}, ${hoistedName});`);
+
+    const wrapper = createLiveWrapper(callback, hoistedName, closure);
+    const stamped = `__eveStampDynamicCallback(${wrapper}, ${JSON.stringify(stepId)}, ${closure})`;
+    const propertyName =
+      callback.phase === "approvalRequest"
+        ? "request"
+        : callback.phase === "approvalResponse"
+          ? "response"
+          : callback.phase;
+    const replacement = [`${propertyName}: ${stamped}`];
+    if (callback.phase === "execute") {
+      // Retained for generated-output compatibility while durable runtime
+      // metadata uses the phase-specific descriptor above.
+      replacement.push(`__executeStepFn: ${hoistedName}`, `__closureVars: ${closure}`);
+    }
+    replacements.push({
+      end: callback.propEnd,
+      start: callback.propStart,
+      text: replacement.join(",\n          "),
+    });
+  }
+
+  let code = source;
+  for (const replacement of replacements.sort((left, right) => right.start - left.start)) {
+    code = code.slice(0, replacement.start) + replacement.text + code.slice(replacement.end);
+  }
+
+  const registrySetup = [
+    `var __eveStepRegistrySym = Symbol.for("@workflow/core//registeredSteps");`,
+    `if (!globalThis[__eveStepRegistrySym]) globalThis[__eveStepRegistrySym] = new Map();`,
+    `var __eveStepRegistry = globalThis[__eveStepRegistrySym];`,
+    `var __eveDurableCallbackSym = Symbol.for("eve:durable-dynamic-callback");`,
+    `function __eveStampDynamicCallback(callback, stepId, closure) {`,
+    `  Object.defineProperty(callback, __eveDurableCallbackSym, { configurable: true, value: { stepId, closure } });`,
+    `  return callback;`,
+    `}`,
+  ].join("\n");
+  const suffix = [...hoistedFunctions, ...registrations].join("\n");
+  return { code: `${registrySetup}\n${code}\n\n${suffix}\n` };
+}
+
+function createLiveWrapper(callback: CallbackInfo, hoistedName: string, closure: string): string {
+  if (callback.isReference) {
+    return `(...__args) => ${hoistedName}(${closure}, ...__args)`;
+  }
+  const params = callback.params;
+  const bindings = params
+    ? splitParamsTopLevel(params)
+        .map((parameter) => extractParamBindingName(parameter))
+        .join(", ")
+    : "";
+  const args = bindings ? `${closure}, ${bindings}` : closure;
+  const asyncPrefix = callback.isAsync ? "async " : "";
+  if (callback.isGenerator) {
+    return `${asyncPrefix}function* (${params}) { yield* ${hoistedName}(${args}); }`;
+  }
+  const awaitPrefix = callback.isAsync ? "await " : "";
+  return `${asyncPrefix}(${params}) => ${awaitPrefix}${hoistedName}(${args})`;
+}
+
+function stableModuleId(filename: string): string {
+  let normalized = filename.replaceAll("\\", "/").replace(/[?#].*$/, "");
+  const nodeModules = normalized.lastIndexOf("/node_modules/");
+  if (nodeModules >= 0) {
+    normalized = normalized.slice(nodeModules + "/node_modules/".length);
+  } else {
+    const cwd = process.cwd().replaceAll("\\", "/");
+    if (normalized.startsWith(`${cwd}/`)) normalized = normalized.slice(cwd.length + 1);
+  }
+
+  return createHash("sha256").update(normalized).digest("hex").slice(0, 32);
+}
+
+function dedupeShadowed(names: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+  for (let index = names.length - 1; index >= 0; index--) {
+    const name = names[index]!;
+    if (seen.has(name)) continue;
+    seen.add(name);
+    deduped.unshift(name);
+  }
+  return deduped;
+}
+
+function collectScopeVarDeclarations(bodyNode: AstNode): string[] {
+  const names: string[] = [];
+  walkNode(bodyNode, (node) => {
+    if (node !== bodyNode && isFunction(node)) return false;
+    if (node.type === "VariableDeclarator") collectPatternNames(node.id as AstNode | null, names);
+    if (node.type === "FunctionDeclaration" && node.id?.name) names.push(node.id.name);
+    return true;
+  });
+  return names;
 }
 
 function collectPatternNames(pattern: AstNode | null, names: string[]): void {
   if (!pattern) return;
-
   if (pattern.type === "Identifier" && pattern.name) {
     names.push(pattern.name);
     return;
   }
-
-  // Destructured: const { a, b } = ...
   if (pattern.type === "ObjectPattern") {
-    for (const prop of pattern.properties ?? []) {
-      if (prop.type === "Property") {
-        collectPatternNames(prop.value as AstNode | null, names);
-      } else if (prop.type === "RestElement") {
-        collectPatternNames(prop.argument as AstNode | null, names);
-      }
+    for (const property of pattern.properties ?? []) {
+      collectPatternNames(
+        property.type === "RestElement"
+          ? (property.argument as AstNode | null)
+          : (property.value as AstNode | null),
+        names,
+      );
     }
   }
-
-  // Destructured: const [a, b] = ...
   if (pattern.type === "ArrayPattern") {
-    for (const el of (pattern as AstNode & { elements?: (AstNode | null)[] }).elements ?? []) {
-      if (el) collectPatternNames(el, names);
-    }
+    for (const element of pattern.elements ?? []) collectPatternNames(element, names);
+  }
+  if (pattern.type === "AssignmentPattern") {
+    collectPatternNames(pattern.left as AstNode | null, names);
   }
 }
 
-/**
- * Finds execute function properties inside object expressions in the
- * handler's return value.
- */
-function findExecuteFunctions(source: string, bodyNode: AstNode): ExecuteInfo[] {
-  const results: ExecuteInfo[] = [];
-  walkForExecuteProps(source, bodyNode, results, []);
-  return results;
-}
-
-function walkForExecuteProps(
-  source: string,
-  node: AstNode | null | undefined,
-  results: ExecuteInfo[],
-  nestedScopes: readonly ScopeEntry[],
-): void {
-  if (!node) return;
-
-  // When crossing a function boundary, collect the function's params
-  // and body-level vars as a new scope entry, then continue walking
-  // inside. This lets us hoist execute functions from helpers, .map()
-  // callbacks, etc. — the wrapper captures all enclosing scope vars.
-  if (
-    node.type === "FunctionExpression" ||
-    node.type === "ArrowFunctionExpression" ||
-    node.type === "FunctionDeclaration"
-  ) {
-    const fnParams = extractParamNames(node);
-    const bodyNode = node.body as AstNode | undefined;
-    if (!bodyNode) return;
-    const fnVars = collectScopeVarDeclarations(bodyNode);
-    const extended = [...nestedScopes, { params: fnParams, vars: fnVars }];
-    // Walk into the function body with the extended scope chain
-    if (bodyNode.type === "BlockStatement") {
-      walkForExecuteProps(source, bodyNode, results, extended);
-    } else {
-      // Arrow with expression body: () => ({ execute() {} })
-      walkForExecuteProps(source, bodyNode, results, extended);
-    }
-    return;
-  }
-
-  // Only match `execute` inside a `defineTool(...)` call — not on bare objects.
-  if (
-    node.type === "CallExpression" &&
-    node.callee?.type === "Identifier" &&
-    node.callee.name === "defineTool" &&
-    node.arguments?.length === 1 &&
-    (node.arguments[0] as AstNode).type === "ObjectExpression"
-  ) {
-    const toolArg = node.arguments[0] as AstNode;
-    for (const prop of toolArg.properties ?? []) {
-      if (
-        prop.type === "Property" &&
-        !prop.computed &&
-        prop.key?.type === "Identifier" &&
-        prop.key.name === "execute" &&
-        prop.start !== undefined &&
-        prop.end !== undefined
-      ) {
-        const fn = prop.value as AstNode;
-        if (!fn || fn.start === undefined || fn.end === undefined) continue;
-
-        const isFn = fn.type === "FunctionExpression" || fn.type === "ArrowFunctionExpression";
-        const isMethod = prop.method === true;
-
-        if (isFn || isMethod) {
-          const params = extractFnParams(source, fn);
-          const body = extractFnBody(source, fn);
-          const bodyNode = fn.body as AstNode | undefined;
-          const isAsync = fn.async === true;
-
-          if (bodyNode) {
-            results.push({
-              propStart: prop.start,
-              propEnd: prop.end,
-              fnSource: source.slice(fn.start, fn.end),
-              isAsync,
-              params,
-              body,
-              bodyNode,
-              hoistedName: `__eve_dynamic_exec_${transformCounter++}`,
-              nestedScopes,
-            });
-          }
-        }
-      }
-    }
-    // Don't recurse into defineTool() arguments again — we already processed them.
-    return;
-  }
-
-  // Recurse into child nodes, threading the scope chain through
-  const walk = (child: AstNode | null | undefined) =>
-    walkForExecuteProps(source, child, results, nestedScopes);
-
-  if (Array.isArray(node.body)) {
-    for (const child of node.body) walk(child);
-  } else if (node.body && typeof node.body === "object" && "type" in node.body) {
-    walk(node.body as AstNode);
-  }
-  if (node.properties) {
-    for (const prop of node.properties) {
-      if (prop.value && typeof prop.value === "object" && "type" in (prop.value as AstNode)) {
-        walk(prop.value as AstNode);
-      }
-    }
-  }
-  if (node.callee) walk(node.callee);
-  if (node.arguments) {
-    for (const arg of node.arguments) walk(arg);
-  }
-  if (node.expression) walk(node.expression);
-  if (node.argument) walk(node.argument);
-  if (node.init) walk(node.init);
-  if (node.left) walk(node.left);
-  if (node.right) walk(node.right);
-  if (node.declarations) {
-    for (const decl of node.declarations) walk(decl);
-  }
-  const nodeAny = node as Record<string, unknown>;
-  if (Array.isArray(nodeAny.consequent)) {
-    for (const c of nodeAny.consequent) walk(c as AstNode);
-  } else if (nodeAny.consequent) {
-    walk(nodeAny.consequent as AstNode);
-  }
-  if (nodeAny.alternate) walk(nodeAny.alternate as AstNode);
-  if (nodeAny.block) walk(nodeAny.block as AstNode);
-  if (nodeAny.handler) walk(nodeAny.handler as AstNode);
-  if (nodeAny.finalizer) walk(nodeAny.finalizer as AstNode);
-  if (nodeAny.cases && Array.isArray(nodeAny.cases)) {
-    for (const c of nodeAny.cases) walk(c as AstNode);
-  }
+function extractParamNames(fn: AstNode): string[] {
+  const names: string[] = [];
+  for (const parameter of fn.params ?? []) collectPatternNames(parameter, names);
+  return names;
 }
 
 function extractFnParams(source: string, fn: AstNode): string {
   if (!fn.params || fn.params.length === 0) return "";
   const first = fn.params[0]!;
   const last = fn.params[fn.params.length - 1]!;
-  if (first.start === undefined || last.end === undefined) return "";
-  return source.slice(first.start, last.end);
+  return first.start === undefined || last.end === undefined
+    ? ""
+    : source.slice(first.start, last.end);
 }
 
 function extractFnBody(source: string, fn: AstNode): string {
   const body = fn.body as AstNode | undefined;
   if (!body || body.start === undefined || body.end === undefined) return "{}";
   const raw = source.slice(body.start, body.end);
-  if (fn.type === "ArrowFunctionExpression" && body.type !== "BlockStatement") {
-    return `{ return ${raw}; }`;
-  }
-  return raw;
+  return fn.type === "ArrowFunctionExpression" && body.type !== "BlockStatement"
+    ? `{ return ${raw}; }`
+    : raw;
 }
 
-// ---------------------------------------------------------------------------
-// Transform application
-// ---------------------------------------------------------------------------
-
-function applyTransform(source: string, handlers: HandlerInfo[]): { code: string } {
-  const replacements: Array<{ start: number; end: number; text: string }> = [];
-  const hoistedFunctions: string[] = [];
-  const registrations: string[] = [];
-  const allExecNames: string[] = [];
-
-  for (const handler of handlers) {
-    for (const exec of handler.executes) {
-      // Build the full set of candidate vars: handler scope + nested scopes
-      const candidateVars = [
-        ...handler.paramNames,
-        ...handler.scopeVars,
-        ...exec.nestedScopes.flatMap((s) => [...s.params, ...s.vars]),
-      ];
-
-      // Deduplicate, keeping last occurrence (inner scope shadows outer)
-      const seen = new Set<string>();
-      const deduped: string[] = [];
-      for (let i = candidateVars.length - 1; i >= 0; i--) {
-        if (!seen.has(candidateVars[i]!)) {
-          seen.add(candidateVars[i]!);
-          deduped.unshift(candidateVars[i]!);
-        }
-      }
-
-      // Only capture vars the execute body actually references. This
-      // avoids TDZ errors when the execute is inside a nested function
-      // that runs before later handler-level declarations are initialized.
-      const referencedNames = collectReferencedIdentifierNames(exec.bodyNode);
-
-      // Exclude names that collide with the execute function's own
-      // parameters — the hoisted function already has those as formal
-      // params, and a `const { name } = __vars` would be a duplicate
-      // binding SyntaxError.
-      const execParamNames = extractExecuteParamNames(exec.params);
-
-      const allVars = deduped.filter(
-        (name) => !execParamNames.has(name) && referencedNames.has(name),
-      );
-
-      const varsObj = allVars.length > 0 ? `{ ${allVars.join(", ")} }` : "{}";
-
-      const asyncPrefix = exec.isAsync ? "async " : "";
-      const varsDestructure = allVars.length > 0 ? `const ${varsObj} = __vars;\n  ` : "";
-      const originalParams = exec.params;
-      const hoistedParams = originalParams ? `__vars, ${originalParams}` : "__vars";
-      const bodyContent = exec.body.slice(1, -1).trim();
-      const stepId = `eve:dynamic-tool//${exec.hoistedName}`;
-
-      hoistedFunctions.push(
-        `${asyncPrefix}function ${exec.hoistedName}(${hoistedParams}) {\n` +
-          `  ${varsDestructure}${bodyContent}\n` +
-          `}`,
-      );
-
-      registrations.push(`${exec.hoistedName}.stepId = ${JSON.stringify(stepId)};`);
-      registrations.push(`__eveStepRegistry.set(${JSON.stringify(stepId)}, ${exec.hoistedName});`);
-      allExecNames.push(exec.hoistedName);
-
-      const wrapperParams = originalParams || "";
-      const paramNames = originalParams
-        ? splitParamsTopLevel(originalParams)
-            .map((p) => extractParamBindingName(p))
-            .join(", ")
-        : "";
-      const wrapperArgs = paramNames ? `${varsObj}, ${paramNames}` : varsObj;
-      const wrapperAsync = exec.isAsync ? "async " : "";
-      const wrapperAwait = exec.isAsync ? "await " : "";
-
-      replacements.push({
-        start: exec.propStart,
-        end: exec.propEnd,
-        text: [
-          `execute: ${wrapperAsync}(${wrapperParams}) => ${wrapperAwait}${exec.hoistedName}(${wrapperArgs})`,
-          `__executeStepFn: ${exec.hoistedName}`,
-          `__closureVars: ${varsObj}`,
-        ].join(",\n          "),
-      });
-    }
-  }
-
-  const sorted = [...replacements].sort((a, b) => b.start - a.start);
-
-  let result = source;
-
-  for (const edit of sorted) {
-    result = result.slice(0, edit.start) + edit.text + result.slice(edit.end);
-  }
-
-  // Prepend global step registry access — use var + if for
-  // compatibility with all bundler output modes.
-  const registrySetup = [
-    `var __eveStepRegistrySym = Symbol.for("@workflow/core//registeredSteps");`,
-    `if (!globalThis[__eveStepRegistrySym]) globalThis[__eveStepRegistrySym] = new Map();`,
-    `var __eveStepRegistry = globalThis[__eveStepRegistrySym];`,
-  ].join("\n");
-  result = `${registrySetup}\n${result}`;
-
-  // Append hoisted functions + registrations
-  const suffix = [...hoistedFunctions, ...registrations];
-  if (suffix.length > 0) {
-    result = `${result}\n\n${suffix.join("\n")}\n`;
-  }
-
-  return { code: result };
-}
-
-/**
- * Splits a parameter string on top-level commas, respecting nested
- * angle brackets (`<>`), parentheses, square brackets, and curly
- * braces. Commas inside `Record<string, unknown>` or
- * `import("...").Foo` are not treated as parameter separators.
- */
 function splitParamsTopLevel(raw: string): string[] {
   const parts: string[] = [];
   let depth = 0;
   let start = 0;
-  for (let i = 0; i < raw.length; i++) {
-    const ch = raw[i]!;
-    if (ch === "<" || ch === "(" || ch === "[" || ch === "{") depth++;
-    else if (ch === ">" || ch === ")" || ch === "]" || ch === "}") depth--;
-    else if (ch === "," && depth === 0) {
-      parts.push(raw.slice(start, i));
-      start = i + 1;
+  for (let index = 0; index < raw.length; index++) {
+    const character = raw[index]!;
+    if (character === "<" || character === "(" || character === "[" || character === "{") {
+      depth++;
+    } else if (character === ">" || character === ")" || character === "]" || character === "}") {
+      depth--;
+    } else if (character === "," && depth === 0) {
+      parts.push(raw.slice(start, index));
+      start = index + 1;
     }
   }
   parts.push(raw.slice(start));
   return parts;
 }
 
-/**
- * Extracts the runtime binding name from a single parameter string
- * like `input`, `_input: Record<string, unknown>`, or `{ msg }`.
- * Strips type annotations (after top-level `:`) and defaults
- * (after top-level `=`).
- */
-function extractParamBindingName(param: string): string {
-  const trimmed = param.trim();
+function extractParamBindingName(parameter: string): string {
+  const trimmed = parameter.trim();
   let depth = 0;
-  for (let i = 0; i < trimmed.length; i++) {
-    const ch = trimmed[i]!;
-    if (ch === "<" || ch === "(" || ch === "[" || ch === "{") depth++;
-    else if (ch === ">" || ch === ")" || ch === "]" || ch === "}") depth--;
-    else if (depth === 0 && (ch === ":" || ch === "=")) {
-      return trimmed.slice(0, i).trim();
+  for (let index = 0; index < trimmed.length; index++) {
+    const character = trimmed[index]!;
+    if (character === "<" || character === "(" || character === "[" || character === "{") {
+      depth++;
+    } else if (character === ">" || character === ")" || character === "]" || character === "}") {
+      depth--;
+    } else if (depth === 0 && (character === ":" || character === "=")) {
+      return trimmed.slice(0, index).trim();
     }
   }
   return trimmed;
 }
 
-/**
- * Extracts binding names from a raw execute parameter string.
- */
-function extractExecuteParamNames(paramString: string): Set<string> {
-  if (!paramString) return new Set();
-  const names = new Set<string>();
-  for (const part of splitParamsTopLevel(paramString)) {
-    const name = extractParamBindingName(part);
-    if (name) names.add(name);
+function extractCallbackParamNames(params: string): Set<string> {
+  const names: string[] = [];
+  if (!params) return new Set();
+  for (const parameter of splitParamsTopLevel(params)) {
+    const binding = extractParamBindingName(parameter);
+    if (binding.startsWith("...")) names.push(binding.slice(3));
+    else names.push(binding);
   }
-  return names;
+  return new Set(names);
+}
+
+function isFunction(node: AstNode): boolean {
+  return (
+    node.type === "ArrowFunctionExpression" ||
+    node.type === "FunctionDeclaration" ||
+    node.type === "FunctionExpression"
+  );
+}
+
+function isAstNode(value: unknown): value is AstNode {
+  return value !== null && typeof value === "object" && typeof (value as AstNode).type === "string";
 }

--- a/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.ts
@@ -16,6 +16,7 @@ import {
 } from "#internal/workflow-bundle/dynamic-tool-ast-references.js";
 
 type CallbackPhase = "approvalRequest" | "approvalResponse" | "execute" | "toModelOutput";
+type CallbackPropertyName = "approval" | "execute" | "request" | "response" | "toModelOutput";
 
 interface CallbackInfo {
   readonly body: string;
@@ -26,6 +27,7 @@ interface CallbackInfo {
   readonly nestedScopes: readonly ScopeEntry[];
   readonly params: string;
   readonly phase: CallbackPhase;
+  readonly propertyName: CallbackPropertyName;
   readonly propEnd: number;
   readonly propStart: number;
   readonly sourceEnd: number;
@@ -136,10 +138,18 @@ function collectToolCallbacks(
   results: CallbackInfo[],
   nestedScopes: readonly ScopeEntry[],
 ): void {
-  collectCallbackProperty(source, findProperty(tool, "execute"), "execute", results, nestedScopes);
+  collectCallbackProperty(
+    source,
+    findProperty(tool, "execute"),
+    "execute",
+    "execute",
+    results,
+    nestedScopes,
+  );
   collectCallbackProperty(
     source,
     findProperty(tool, "toModelOutput"),
+    "toModelOutput",
     "toModelOutput",
     results,
     nestedScopes,
@@ -152,6 +162,7 @@ function collectToolCallbacks(
       source,
       findProperty(approvalValue, "request"),
       "approvalRequest",
+      "request",
       results,
       nestedScopes,
     );
@@ -159,11 +170,12 @@ function collectToolCallbacks(
       source,
       findProperty(approvalValue, "response"),
       "approvalResponse",
+      "response",
       results,
       nestedScopes,
     );
   } else {
-    collectCallbackProperty(source, approval, "approvalRequest", results, nestedScopes);
+    collectCallbackProperty(source, approval, "approvalRequest", "approval", results, nestedScopes);
   }
 }
 
@@ -171,6 +183,7 @@ function collectCallbackProperty(
   source: string,
   property: AstNode | undefined,
   phase: CallbackPhase,
+  propertyName: CallbackPropertyName,
   results: CallbackInfo[],
   nestedScopes: readonly ScopeEntry[],
 ): void {
@@ -192,6 +205,7 @@ function collectCallbackProperty(
       nestedScopes,
       params: extractFnParams(source, value),
       phase,
+      propertyName,
       propEnd: property.end,
       propStart: property.start,
       sourceEnd: value.end,
@@ -210,6 +224,7 @@ function collectCallbackProperty(
       nestedScopes,
       params: "...__args",
       phase,
+      propertyName,
       propEnd: property.end,
       propStart: property.start,
       sourceEnd: value.end,
@@ -263,13 +278,7 @@ function applyTransform(
 
     const wrapper = createLiveWrapper(callback, hoistedName, closure);
     const stamped = `__eveStampDynamicCallback(${wrapper}, ${JSON.stringify(stepId)}, ${closure})`;
-    const propertyName =
-      callback.phase === "approvalRequest"
-        ? "request"
-        : callback.phase === "approvalResponse"
-          ? "response"
-          : callback.phase;
-    const replacement = [`${propertyName}: ${stamped}`];
+    const replacement = [`${callback.propertyName}: ${stamped}`];
     if (callback.phase === "execute") {
       // Retained for generated-output compatibility while durable runtime
       // metadata uses the phase-specific descriptor above.

--- a/packages/eve/src/public/definitions/tool.ts
+++ b/packages/eve/src/public/definitions/tool.ts
@@ -20,6 +20,10 @@ import {
   type DynamicEvents,
   type DynamicSentinel,
 } from "#shared/dynamic-tool-definition.js";
+import {
+  collectDurableDynamicToolCallbacks,
+  stampDurableDynamicToolCallbacks,
+} from "#shared/durable-dynamic-tool-callbacks.js";
 
 type ApprovalContextInput<TInput> = unknown extends TInput ? Record<string, unknown> : TInput;
 type DynamicEventMapHandler<TEvents extends DynamicEvents> = Extract<
@@ -245,6 +249,14 @@ export function defineTool<TInput = unknown, TOutput = unknown>(
     );
   }
   Object.assign(definition, { [TOOL_BRAND]: true });
+  stampDurableDynamicToolCallbacks(
+    definition,
+    collectDurableDynamicToolCallbacks({
+      approval: definition.approval as Approval<never> | undefined,
+      execute: definition.execute,
+      toModelOutput: definition.toModelOutput,
+    }),
+  );
   stampDefinitionKey(definition, `tool:${definition.description}`);
   return definition;
 }

--- a/packages/eve/src/public/tools/approval/approval-helpers.test.ts
+++ b/packages/eve/src/public/tools/approval/approval-helpers.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { always, never, once } from "#public/tools/approval/approval-helpers.js";
+import { readDurableDynamicCallback } from "#shared/durable-dynamic-tool-callbacks.js";
+
+function getStepRegistry(): Map<string, Function> {
+  return (globalThis as Record<symbol, Map<string, Function> | undefined>)[
+    Symbol.for("@workflow/core//registeredSteps")
+  ]!;
+}
+
+describe("dynamic tool approval helpers", () => {
+  it.each([
+    ["always", always(), "user-approval"],
+    ["never", never(), "not-applicable"],
+  ] as const)("gives %s a stable replay descriptor", async (_name, policy, expected) => {
+    const reference = readDurableDynamicCallback(policy);
+    expect(reference).toEqual({
+      closure: {},
+      stepId: expect.stringMatching(/^eve:dynamic-tool-helper\/\/approval\//),
+    });
+
+    expect(await getStepRegistry().get(reference!.stepId)!(reference!.closure, {})).toBe(expected);
+  });
+
+  it("replays once against the current approval context", async () => {
+    const reference = readDurableDynamicCallback(once())!;
+    const replay = getStepRegistry().get(reference.stepId)!;
+
+    expect(
+      await replay(reference.closure, {
+        approvedTools: new Set(),
+        toolName: "guarded",
+      }),
+    ).toBe("user-approval");
+    expect(
+      await replay(reference.closure, {
+        approvedTools: new Set(["guarded"]),
+        toolName: "guarded",
+      }),
+    ).toBe("not-applicable");
+  });
+});

--- a/packages/eve/src/public/tools/approval/approval-helpers.ts
+++ b/packages/eve/src/public/tools/approval/approval-helpers.ts
@@ -1,11 +1,42 @@
-import type { ApprovalPolicy } from "#public/definitions/approval.js";
+import type { ApprovalContext, ApprovalPolicy } from "#public/definitions/approval.js";
+import type { JsonObject } from "#shared/json.js";
+import {
+  registerDurableDynamicCallback,
+  stampDurableDynamicCallback,
+} from "#shared/durable-dynamic-tool-callbacks.js";
+
+const ALWAYS_STEP_ID = "eve:dynamic-tool-helper//approval/always/v1";
+const NEVER_STEP_ID = "eve:dynamic-tool-helper//approval/never/v1";
+const ONCE_STEP_ID = "eve:dynamic-tool-helper//approval/once/v1";
+
+function alwaysApproval(_closure: JsonObject): "user-approval" {
+  return "user-approval";
+}
+
+function neverApproval(_closure: JsonObject): "not-applicable" {
+  return "not-applicable";
+}
+
+function onceApproval(
+  _closure: JsonObject,
+  context: ApprovalContext,
+): "not-applicable" | "user-approval" {
+  return context.approvedTools.has(context.toolName) ? "not-applicable" : "user-approval";
+}
+
+registerDurableDynamicCallback(ALWAYS_STEP_ID, alwaysApproval);
+registerDurableDynamicCallback(NEVER_STEP_ID, neverApproval);
+registerDurableDynamicCallback(ONCE_STEP_ID, onceApproval);
 
 /**
  * Returns an `approval` callback that always requires user approval before
  * the tool executes.
  */
 export function always<TInput = unknown>(): ApprovalPolicy<TInput> {
-  return () => "user-approval";
+  return stampDurableDynamicCallback(() => "user-approval", {
+    closure: {},
+    stepId: ALWAYS_STEP_ID,
+  });
 }
 
 /**
@@ -13,7 +44,10 @@ export function always<TInput = unknown>(): ApprovalPolicy<TInput> {
  * the tool executes.
  */
 export function never<TInput = unknown>(): ApprovalPolicy<TInput> {
-  return () => "not-applicable";
+  return stampDurableDynamicCallback(() => "not-applicable", {
+    closure: {},
+    stepId: NEVER_STEP_ID,
+  });
 }
 
 /**
@@ -24,6 +58,9 @@ export function never<TInput = unknown>(): ApprovalPolicy<TInput> {
  * the bare tool name, so it ignores compound approval keys.
  */
 export function once<TInput = unknown>(): ApprovalPolicy<TInput> {
-  return ({ approvedTools, toolName }) =>
-    approvedTools.has(toolName) ? "not-applicable" : "user-approval";
+  return stampDurableDynamicCallback(
+    ({ approvedTools, toolName }) =>
+      approvedTools.has(toolName) ? "not-applicable" : "user-approval",
+    { closure: {}, stepId: ONCE_STEP_ID },
+  );
 }

--- a/packages/eve/src/runtime/framework-tools/connection-search-dynamic.test.ts
+++ b/packages/eve/src/runtime/framework-tools/connection-search-dynamic.test.ts
@@ -19,6 +19,7 @@ import {
   type DynamicResolveContext,
   type DynamicToolSet,
 } from "#shared/dynamic-tool-definition.js";
+import { readDurableDynamicToolCallbacks } from "#shared/durable-dynamic-tool-callbacks.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Msg = any;
@@ -391,6 +392,61 @@ describe("connection_search", () => {
         challenge: { url: "https://idp.example.com/authorize" },
       },
     ]);
+  });
+
+  it("replays authorization from the step-scoped durable execute descriptor", async () => {
+    const salesforce: ResolvedConnectionDefinition = {
+      ...connection("salesforce"),
+      authorization: {
+        completeAuthorization: async () => ({ token: "unused" }),
+        getToken: async () => {
+          throw new ConnectionAuthorizationRequiredError("salesforce");
+        },
+        principalType: "user",
+        startAuthorization: async () => ({
+          challenge: { url: "https://idp.example.com/authorize" },
+        }),
+      },
+    };
+    const connectionRegistry = registry({
+      connections: [salesforce],
+      loadTools: {
+        salesforce: async () => {
+          throw new ConnectionAuthorizationRequiredError("salesforce");
+        },
+      },
+    });
+    const ctx = new ContextContainer();
+    ctx.set(ConnectionRegistryKey, connectionRegistry);
+    ctx.set(SessionIdKey, "session-auth-replay");
+    ctx.set(CallbackBaseUrlKey, "https://agent.example.com");
+    ctx.set(AuthKey, {
+      attributes: {},
+      authenticator: "test-idp",
+      issuer: "test-idp",
+      principalId: "user-1",
+      principalType: "user",
+    });
+
+    const result = await contextStorage.run(ctx, async () => {
+      const resolve = getConnectionSearchResolver().events["step.started"]!;
+      const tools = (await resolve({}, {
+        channel: {},
+        messages: [],
+        session: { auth: { current: null, initiator: null }, id: "session-auth-replay" },
+      } satisfies DynamicResolveContext)) as DynamicToolSet;
+      const reference = readDurableDynamicToolCallbacks(tools["connection_search"]!)!.execute!;
+      const registry = (globalThis as Record<symbol, Map<string, Function> | undefined>)[
+        Symbol.for("@workflow/core//registeredSteps")
+      ]!;
+
+      return await registry.get(reference.stepId)!(reference.closure, {
+        connection: "salesforce",
+        keywords: "accounts",
+      });
+    });
+
+    expect(isAuthorizationSignal(result)).toBe(true);
   });
 });
 

--- a/packages/eve/src/runtime/framework-tools/connection-search-dynamic.ts
+++ b/packages/eve/src/runtime/framework-tools/connection-search-dynamic.ts
@@ -15,8 +15,18 @@ import {
   isConnectionAuthorizationRequiredError,
 } from "#public/connections/errors.js";
 import { defineDynamic, defineTool } from "#public/definitions/tool.js";
+import type { ToolContext } from "#public/definitions/tool.js";
+import {
+  resolveApprovalPolicy,
+  type ApprovalContext,
+  type ApprovalResponseContext,
+} from "#public/definitions/approval.js";
 import type { JsonValue } from "#public/types/json.js";
 import type { JsonObject } from "#shared/json.js";
+import {
+  registerDurableDynamicCallback,
+  stampDurableDynamicToolCallbacks,
+} from "#shared/durable-dynamic-tool-callbacks.js";
 import { writeCachedToken } from "#runtime/connections/authorization-tokens.js";
 import { principalKey, resolveConnectionPrincipal } from "#runtime/connections/principal.js";
 import { resolveConnectionAuthorization } from "#runtime/connections/resolve-authorization.js";
@@ -394,6 +404,138 @@ export function extractDiscoveredTools(
   return [...byQualifiedName.values()];
 }
 
+const CONNECTION_SEARCH_EXECUTE_STEP_ID = "eve:framework-dynamic//connection-search/execute/v1";
+const DISCOVERED_TOOL_EXECUTE_STEP_ID =
+  "eve:framework-dynamic//connection-search/discovered-execute/v1";
+const DISCOVERED_TOOL_APPROVAL_REQUEST_STEP_ID =
+  "eve:framework-dynamic//connection-search/discovered-approval-request/v1";
+const DISCOVERED_TOOL_APPROVAL_RESPONSE_STEP_ID =
+  "eve:framework-dynamic//connection-search/discovered-approval-response/v1";
+
+function readDiscoveredToolClosure(closure: JsonObject): {
+  readonly connectionName: string;
+  readonly toolName: string;
+} {
+  const connectionName = closure.connectionName;
+  const toolName = closure.toolName;
+  if (typeof connectionName !== "string" || typeof toolName !== "string") {
+    throw new Error("Discovered connection tool callback metadata is invalid.");
+  }
+  return { connectionName, toolName };
+}
+
+async function executeDiscoveredConnectionTool(
+  closure: JsonObject,
+  input: Record<string, unknown>,
+  executeCtx: ToolContext,
+): Promise<unknown> {
+  const { connectionName, toolName } = readDiscoveredToolClosure(closure);
+  const registry = loadContext().get(ConnectionRegistryKey);
+  if (registry === undefined) {
+    throw new Error("Connection registry is unavailable while replaying a discovered tool.");
+  }
+  const conn = registry
+    .getConnections()
+    .find((candidate) => candidate.connectionName === connectionName);
+  const interactiveAuth = (await resolveInteractiveAuth(registry, connectionName)) as
+    | InteractiveAuthorizationDefinition<JsonValue>
+    | undefined;
+
+  let justCompletedAuth = false;
+  if (interactiveAuth) {
+    const authResult = consumeAuthorizationResult(connectionName);
+    if (authResult) {
+      justCompletedAuth = true;
+      const ctx = loadContext();
+      const principal =
+        authResult.principal ?? resolveConnectionPrincipal(connectionName, interactiveAuth);
+      const token = await interactiveAuth.completeAuthorization({
+        callbackUrl: authResult.hookUrl,
+        connection: { url: conn?.url ?? "" },
+        principal,
+        resume: authResult.resume,
+        callback: authResult.callback,
+      });
+      writeCachedToken(ctx, connectionName, principalKey(principal), token);
+    }
+  }
+
+  try {
+    const client = registry.getClient(connectionName);
+    return await client.executeTool(toolName, input, {
+      abortSignal: executeCtx.abortSignal,
+    });
+  } catch (error) {
+    if (!isConnectionAuthorizationRequiredError(error) || !interactiveAuth) throw error;
+    if (justCompletedAuth) {
+      throw new ConnectionAuthorizationFailedError(connectionName, {
+        retryable: false,
+        reason: "token_rejected_after_authorization",
+        message: `Connection "${connectionName}" rejected the token immediately after authorization.`,
+      });
+    }
+
+    const attempt = createAuthorizationAttempt(connectionName);
+    if (!attempt) throw error;
+    const principal = resolveConnectionPrincipal(connectionName, interactiveAuth);
+    const callbackUrl = resolveAuthorizationCallbackUrl({
+      authorization: interactiveAuth,
+      callbackUrl: attempt.hookUrl,
+    });
+    const { challenge, resume } = await interactiveAuth.startAuthorization({
+      callbackUrl,
+      connection: { url: conn?.url ?? "" },
+      principal,
+    });
+    return requestAuthorization([
+      {
+        attemptId: attempt.attemptId,
+        name: connectionName,
+        challenge: stampChallengeDisplayName(challenge, interactiveAuth),
+        hookUrl: callbackUrl,
+        principal,
+        resume,
+      },
+    ]);
+  }
+}
+
+async function requestDiscoveredConnectionToolApproval(
+  closure: JsonObject,
+  context: ApprovalContext,
+) {
+  const { connectionName } = readDiscoveredToolClosure(closure);
+  const approval = loadContext().get(ConnectionRegistryKey)?.getConnectionApproval(connectionName);
+  return approval === undefined ? "not-applicable" : await resolveApprovalPolicy(approval)(context);
+}
+
+async function authorizeDiscoveredConnectionToolApproval(
+  closure: JsonObject,
+  context: ApprovalResponseContext,
+) {
+  const { connectionName } = readDiscoveredToolClosure(closure);
+  const approval = loadContext().get(ConnectionRegistryKey)?.getConnectionApproval(connectionName);
+  const response =
+    approval === undefined || typeof approval === "function" ? undefined : approval.response;
+  return response === undefined
+    ? { reason: "Approval response authorization is unavailable.", status: "rejected" as const }
+    : await response(context);
+}
+
+registerDurableDynamicCallback(
+  CONNECTION_SEARCH_EXECUTE_STEP_ID,
+  (_closure: JsonObject, input: ConnectionSearchInput) => executeConnectionSearch(input),
+);
+registerDurableDynamicCallback(DISCOVERED_TOOL_EXECUTE_STEP_ID, executeDiscoveredConnectionTool);
+registerDurableDynamicCallback(
+  DISCOVERED_TOOL_APPROVAL_REQUEST_STEP_ID,
+  requestDiscoveredConnectionToolApproval,
+);
+registerDurableDynamicCallback(
+  DISCOVERED_TOOL_APPROVAL_RESPONSE_STEP_ID,
+  authorizeDiscoveredConnectionToolApproval,
+);
+
 // The step-scoped definition re-derives its tools from conversation history.
 // After compaction removes old search results, those tools naturally disappear.
 const connectionSearchDynamicDefinition = defineDynamic({
@@ -417,7 +559,7 @@ const connectionSearchDynamicDefinition = defineDynamic({
 
       const tools: Record<string, object> = {};
 
-      tools["connection_search"] = defineTool({
+      const connectionSearchTool = defineTool({
         description:
           "Search for tools across your connections. " +
           "Discovered tools become directly callable by their qualified name " +
@@ -429,13 +571,18 @@ const connectionSearchDynamicDefinition = defineDynamic({
         },
         outputSchema: CONNECTION_SEARCH_OUTPUT_SCHEMA,
       });
+      stampDurableDynamicToolCallbacks(connectionSearchTool, {
+        execute: { closure: {}, stepId: CONNECTION_SEARCH_EXECUTE_STEP_ID },
+      });
+      tools["connection_search"] = connectionSearchTool;
 
       for (const result of discovered) {
         const connectionName = result.connection;
         const toolName = result.tool!;
         const approval = registry.getConnectionApproval(connectionName);
 
-        tools[qualifiedConnectionToolName(connectionName, toolName)] = defineTool({
+        const closure = { connectionName, toolName };
+        const discoveredTool = defineTool({
           description: result.description,
           inputSchema: (result.inputSchema ?? {
             type: "object",
@@ -443,80 +590,31 @@ const connectionSearchDynamicDefinition = defineDynamic({
           approval,
           outputSchema: result.outputSchema as JsonObject | undefined,
           async execute(input: Record<string, unknown>, executeCtx) {
-            const reg = loadContext().get(ConnectionRegistryKey)!;
-            const conn = reg.getConnections().find((c) => c.connectionName === connectionName);
-            const interactiveAuth = (await resolveInteractiveAuth(reg, connectionName)) as
-              | InteractiveAuthorizationDefinition<JsonValue>
-              | undefined;
-
-            let justCompletedAuth = false;
-            if (interactiveAuth) {
-              const authResult = consumeAuthorizationResult(connectionName);
-              if (authResult) {
-                justCompletedAuth = true;
-                const ctx = loadContext();
-                const principal =
-                  authResult.principal ??
-                  resolveConnectionPrincipal(connectionName, interactiveAuth);
-                const token = await interactiveAuth.completeAuthorization({
-                  callbackUrl: authResult.hookUrl,
-                  connection: { url: conn?.url ?? "" },
-                  principal,
-                  resume: authResult.resume,
-                  callback: authResult.callback,
-                });
-                writeCachedToken(ctx, connectionName, principalKey(principal), token);
-              }
-            }
-
-            try {
-              const client = reg.getClient(connectionName);
-              return await client.executeTool(toolName, input, {
-                abortSignal: executeCtx.abortSignal,
-              });
-            } catch (err) {
-              if (!isConnectionAuthorizationRequiredError(err) || !interactiveAuth) {
-                throw err;
-              }
-
-              // Loop guard: if we just completed authorization this turn and
-              // the token is still rejected, the grant is broken — fail
-              // terminally instead of re-prompting endlessly.
-              if (justCompletedAuth) {
-                throw new ConnectionAuthorizationFailedError(connectionName, {
-                  retryable: false,
-                  reason: "token_rejected_after_authorization",
-                  message: `Connection "${connectionName}" rejected the token immediately after authorization.`,
-                });
-              }
-
-              const attempt = createAuthorizationAttempt(connectionName);
-              if (!attempt) throw err;
-
-              const principal = resolveConnectionPrincipal(connectionName, interactiveAuth);
-              const callbackUrl = resolveAuthorizationCallbackUrl({
-                authorization: interactiveAuth,
-                callbackUrl: attempt.hookUrl,
-              });
-              const { challenge, resume } = await interactiveAuth.startAuthorization({
-                callbackUrl,
-                connection: { url: conn?.url ?? "" },
-                principal,
-              });
-
-              return requestAuthorization([
-                {
-                  attemptId: attempt.attemptId,
-                  name: connectionName,
-                  challenge: stampChallengeDisplayName(challenge, interactiveAuth),
-                  hookUrl: callbackUrl,
-                  principal,
-                  resume,
-                },
-              ]);
-            }
+            return await executeDiscoveredConnectionTool(closure, input, executeCtx);
           },
         });
+        stampDurableDynamicToolCallbacks(discoveredTool, {
+          execute: { closure, stepId: DISCOVERED_TOOL_EXECUTE_STEP_ID },
+          ...(approval === undefined
+            ? {}
+            : {
+                approvalRequest: {
+                  closure,
+                  stepId: DISCOVERED_TOOL_APPROVAL_REQUEST_STEP_ID,
+                },
+              }),
+          ...(approval === undefined ||
+          typeof approval === "function" ||
+          approval.response === undefined
+            ? {}
+            : {
+                approvalResponse: {
+                  closure,
+                  stepId: DISCOVERED_TOOL_APPROVAL_RESPONSE_STEP_ID,
+                },
+              }),
+        });
+        tools[qualifiedConnectionToolName(connectionName, toolName)] = discoveredTool;
       }
 
       return tools;

--- a/packages/eve/src/shared/durable-dynamic-tool-callbacks.ts
+++ b/packages/eve/src/shared/durable-dynamic-tool-callbacks.ts
@@ -1,0 +1,125 @@
+import type { Approval } from "#public/definitions/approval.js";
+import { resolveApprovalPolicy } from "#public/definitions/approval.js";
+import type { JsonObject } from "#shared/json.js";
+
+export interface DurableDynamicCallbackReference {
+  readonly stepId: string;
+  readonly closure: JsonObject;
+}
+
+export interface DurableDynamicToolCallbacks {
+  readonly execute: DurableDynamicCallbackReference;
+  readonly approvalRequest?: DurableDynamicCallbackReference;
+  readonly approvalResponse?: DurableDynamicCallbackReference;
+  readonly toModelOutput?: DurableDynamicCallbackReference;
+}
+
+const DURABLE_CALLBACK_REFERENCE = Symbol.for("eve:durable-dynamic-callback");
+export const DURABLE_DYNAMIC_TOOL_CALLBACKS = Symbol.for("eve:durable-dynamic-tool-callbacks");
+const STEP_REGISTRY = Symbol.for("@workflow/core//registeredSteps");
+
+type Callback = (...args: never[]) => unknown;
+
+function getStepRegistry(): Map<string, Function> {
+  const global = globalThis as Record<symbol, Map<string, Function> | undefined>;
+  const existing = global[STEP_REGISTRY];
+  if (existing !== undefined) return existing;
+
+  const registry = new Map<string, Function>();
+  global[STEP_REGISTRY] = registry;
+  return registry;
+}
+
+/** Registers one module-stable replay entry point. Re-registration replaces the same code-owned id. */
+export function registerDurableDynamicCallback<TArgs extends unknown[], TResult>(
+  stepId: string,
+  callback: (closure: JsonObject, ...args: TArgs) => TResult,
+): void {
+  if (stepId.length === 0) {
+    throw new Error("A durable dynamic callback step id cannot be empty.");
+  }
+  getStepRegistry().set(stepId, callback);
+}
+
+/** Marks a live callback with the descriptor needed to reconstruct it after a cold start. */
+export function stampDurableDynamicCallback<TCallback extends Callback>(
+  callback: TCallback,
+  reference: DurableDynamicCallbackReference,
+): TCallback {
+  Object.defineProperty(callback, DURABLE_CALLBACK_REFERENCE, {
+    configurable: true,
+    value: reference,
+  });
+  return callback;
+}
+
+/** Creates a live callback backed by the same registered function used during durable replay. */
+export function createDurableDynamicCallback<TArgs extends unknown[], TResult>(input: {
+  readonly closure: JsonObject;
+  readonly callback: (closure: JsonObject, ...args: TArgs) => TResult;
+  readonly stepId: string;
+}): (...args: TArgs) => TResult {
+  registerDurableDynamicCallback(input.stepId, input.callback);
+  const callback = (...args: TArgs) => input.callback(input.closure, ...args);
+  return stampDurableDynamicCallback(callback, {
+    closure: input.closure,
+    stepId: input.stepId,
+  });
+}
+
+export function readDurableDynamicCallback(
+  callback: unknown,
+): DurableDynamicCallbackReference | undefined {
+  if (typeof callback !== "function") return undefined;
+  return Reflect.get(callback, DURABLE_CALLBACK_REFERENCE) as
+    | DurableDynamicCallbackReference
+    | undefined;
+}
+
+/** Copies phase-specific callback descriptors onto a branded tool definition. */
+export function stampDurableDynamicToolCallbacks(
+  definition: object,
+  callbacks: Partial<DurableDynamicToolCallbacks>,
+): void {
+  Object.defineProperty(definition, DURABLE_DYNAMIC_TOOL_CALLBACKS, {
+    configurable: true,
+    value: callbacks,
+  });
+}
+
+export function collectDurableDynamicToolCallbacks(input: {
+  readonly approval?: Approval<never>;
+  readonly execute: Callback;
+  readonly toModelOutput?: Callback;
+}): Partial<DurableDynamicToolCallbacks> {
+  const approvalRequest =
+    input.approval === undefined
+      ? undefined
+      : readDurableDynamicCallback(resolveApprovalPolicy(input.approval));
+  const approvalResponse =
+    input.approval === undefined || typeof input.approval === "function"
+      ? undefined
+      : readDurableDynamicCallback(input.approval.response);
+
+  const execute = readDurableDynamicCallback(input.execute);
+  const toModelOutput = readDurableDynamicCallback(input.toModelOutput);
+  const callbacks: {
+    execute?: DurableDynamicCallbackReference;
+    approvalRequest?: DurableDynamicCallbackReference;
+    approvalResponse?: DurableDynamicCallbackReference;
+    toModelOutput?: DurableDynamicCallbackReference;
+  } = {};
+  if (execute !== undefined) callbacks.execute = execute;
+  if (approvalRequest !== undefined) callbacks.approvalRequest = approvalRequest;
+  if (approvalResponse !== undefined) callbacks.approvalResponse = approvalResponse;
+  if (toModelOutput !== undefined) callbacks.toModelOutput = toModelOutput;
+  return callbacks;
+}
+
+export function readDurableDynamicToolCallbacks(
+  definition: object,
+): Partial<DurableDynamicToolCallbacks> | undefined {
+  return (definition as Record<symbol, unknown>)[DURABLE_DYNAMIC_TOOL_CALLBACKS] as
+    | Partial<DurableDynamicToolCallbacks>
+    | undefined;
+}

--- a/packages/eve/src/shared/dynamic-tool-definition.ts
+++ b/packages/eve/src/shared/dynamic-tool-definition.ts
@@ -86,10 +86,8 @@ export interface DynamicToolEntry<TInput = Record<string, unknown>, TOutput = an
   /**
    * Optional per-call approval gate, mirroring the authored-tool
    * `approval` contract: return `"user-approval"` to require user approval
-   * before the call executes. Only honored for step-scoped dynamic
-   * tools, whose live `execute` closures survive into the harness;
-   * session/turn-scoped tools replay from durable metadata and cannot
-   * carry a function across replay.
+   * before the call executes. Dynamic approval request and response callbacks
+   * use the same durable descriptor boundary as `execute` and `toModelOutput`.
    */
   readonly approval?: Approval;
 }

--- a/packages/eve/test/scenarios/dynamic-tool-cold-replay.scenario.test.ts
+++ b/packages/eve/test/scenarios/dynamic-tool-cold-replay.scenario.test.ts
@@ -1,0 +1,211 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { Client } from "../../src/client/index.js";
+import {
+  type ScenarioAppDescriptor,
+  useScenarioApp,
+} from "../../src/internal/testing/scenario-app.js";
+import {
+  DEV_SERVER_SCENARIO_TIMEOUT_MS,
+  TRANSACTIONAL_REBUILD_DESCRIPTOR,
+} from "./dev-server-descriptors.js";
+import { startEveDev, waitForCondition } from "./dev-server-harness.js";
+
+const scenarioApp = useScenarioApp();
+
+const DURABLE_FACTORY_SOURCE = `import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { defineTool as tool } from "eve/tools";
+import { z } from "zod";
+
+interface MarkerService {
+  readonly createdInPid: number;
+  readonly key: string;
+}
+
+const services = new Map<string, MarkerService>();
+
+function writeMarker(phase: string, key: string, extra: Record<string, unknown> = {}): void {
+  writeFileSync(
+    join(process.cwd(), ".dynamic-" + phase + "-" + key + ".json"),
+    JSON.stringify({ ...extra, key, phase, pid: process.pid }),
+  );
+}
+
+export function createDurableMarkerTool(key: string) {
+  services.set(key, { createdInPid: process.pid, key });
+
+  return tool({
+    description: "Durable marker tool " + key + ".",
+    inputSchema: z.object({ label: z.string().optional() }),
+    approval: {
+      request(context) {
+        writeMarker("approval-request", key, { callId: context.callId });
+        return "user-approval";
+      },
+      response(context) {
+        writeMarker("approval-response", key, { decision: context.response.decision });
+        return { status: "allowed" };
+      },
+    },
+    execute(input) {
+      const service = services.get(key);
+      if (service === undefined) throw new Error("Missing live marker service for " + key + ".");
+      const output = {
+        key,
+        label: input.label ?? "unlabeled",
+        pid: process.pid,
+        rawSecret: "raw-secret-" + key,
+        serviceCreatedInPid: service.createdInPid,
+      };
+      writeMarker("execute", key, output);
+      return output;
+    },
+    toModelOutput(output) {
+      writeMarker("projection", key, {
+        outputPid: output.pid,
+        serviceCreatedInPid: output.serviceCreatedInPid,
+      });
+      return { type: "text", value: "projected-" + key };
+    },
+  });
+}
+`;
+
+const DYNAMIC_TOOLS_SOURCE = `import { appendFileSync } from "node:fs";
+import { join } from "node:path";
+import { defineDynamic } from "eve/tools";
+import { createDurableMarkerTool } from "../lib/durable-factory.ts";
+
+const guardedMarker = createDurableMarkerTool("guarded");
+const companionMarker = createDurableMarkerTool("companion");
+
+export default defineDynamic({
+  events: {
+    "session.started": () => {
+      appendFileSync(join(process.cwd(), ".dynamic-resolver-runs"), process.pid + "\\n");
+      return {
+        guarded_marker: guardedMarker,
+        companion_marker: companionMarker,
+      };
+    },
+  },
+});
+`;
+
+const DYNAMIC_TOOL_COLD_REPLAY_DESCRIPTOR: ScenarioAppDescriptor = {
+  ...TRANSACTIONAL_REBUILD_DESCRIPTOR,
+  name: "dynamic-tool-cold-replay",
+  files: {
+    ...Object.fromEntries(
+      Object.entries(TRANSACTIONAL_REBUILD_DESCRIPTOR.files).filter(
+        ([path]) => path !== "agent/tools/get_weather.ts" && !path.startsWith("agent/skills/"),
+      ),
+    ),
+    "agent/lib/durable-factory.ts": DURABLE_FACTORY_SOURCE,
+    "agent/tools/durable-dynamic.ts": DYNAMIC_TOOLS_SOURCE,
+  },
+};
+
+interface Marker {
+  readonly key: string;
+  readonly phase: string;
+  readonly pid: number;
+  readonly serviceCreatedInPid?: number;
+}
+
+async function readMarker(appRoot: string, phase: string, key: string): Promise<Marker> {
+  return JSON.parse(
+    await readFile(join(appRoot, `.dynamic-${phase}-${key}.json`), "utf8"),
+  ) as Marker;
+}
+
+describe("dynamic tool cold replay", () => {
+  it(
+    "resumes every callback phase from an imported factory in a fresh process",
+    async () => {
+      const app = await scenarioApp(DYNAMIC_TOOL_COLD_REPLAY_DESCRIPTOR);
+      const pinnedEnv = {
+        VERCEL_DEPLOYMENT_ID: "dynamic-tool-cold-replay",
+        WORKFLOW_INLINE_OWNERSHIP_LEASE_SECONDS: "1",
+      };
+      let server = await startEveDev(app.appRoot, { env: pinnedEnv });
+
+      try {
+        const client = new Client({ host: server.url });
+        const created = await client.sessions.create({ message: "Hello." });
+        await expect(created.response.result()).resolves.toMatchObject({
+          inputRequests: [],
+          status: "waiting",
+        });
+
+        const waiting = await (
+          await created.session.send("Call tools in parallel: guarded_marker, companion_marker")
+        ).result();
+        expect(waiting.status).toBe("waiting");
+        expect(
+          waiting.inputRequests,
+          `Expected two approval requests.\n\nevents:\n${JSON.stringify(waiting.events, null, 2)}\n\nstdout:\n${server.stdout()}\n\nstderr:\n${server.stderr()}`,
+        ).toHaveLength(2);
+
+        const firstRequest = await readMarker(app.appRoot, "approval-request", "guarded");
+        const resolverRunsBeforeRestart = (
+          await readFile(join(app.appRoot, ".dynamic-resolver-runs"), "utf8")
+        )
+          .trim()
+          .split("\n");
+        expect(resolverRunsBeforeRestart).toHaveLength(1);
+        const sessionState = created.session.state;
+
+        await server.crash();
+        await waitForCondition(async () => {
+          try {
+            await readFile(join(app.appRoot, ".eve", "dev-server-state.v1.json"));
+            return false;
+          } catch (error) {
+            return error instanceof Error && "code" in error && error.code === "ENOENT";
+          }
+        }, "The crashed development server did not release its state record.");
+        server = await startEveDev(app.appRoot, { env: pinnedEnv });
+
+        const resumedSession = new Client({ host: server.url }).sessions.attach(
+          sessionState.sessionId,
+          { streamIndex: sessionState.streamIndex },
+        );
+        const resumed = await (
+          await resumedSession.respond(
+            waiting.inputRequests.map((request) => ({
+              optionId: "approve",
+              requestId: request.requestId,
+            })),
+          )
+        ).result();
+        expect(resumed.status).toBe("waiting");
+
+        for (const key of ["guarded", "companion"]) {
+          const response = await readMarker(app.appRoot, "approval-response", key);
+          const execute = await readMarker(app.appRoot, "execute", key);
+          const projection = await readMarker(app.appRoot, "projection", key);
+
+          expect(response.pid).not.toBe(firstRequest.pid);
+          expect(execute.pid).toBe(response.pid);
+          expect(execute.serviceCreatedInPid).toBe(execute.pid);
+          expect(projection.pid).toBe(execute.pid);
+        }
+
+        const resolverRunsAfterRestart = (
+          await readFile(join(app.appRoot, ".dynamic-resolver-runs"), "utf8")
+        )
+          .trim()
+          .split("\n");
+        expect(resolverRunsAfterRestart).toEqual(resolverRunsBeforeRestart);
+      } finally {
+        await server.stop();
+      }
+    },
+    DEV_SERVER_SCENARIO_TIMEOUT_MS,
+  );
+});


### PR DESCRIPTION
### Summary

Closes #2345. Dynamic tools previously persisted only part of their callback behavior, so a cold continuation could lose approval, response authorization, execution, or output projection and could expose raw output when projection disappeared. This change gives every present callback an independent `{ stepId, closure }` descriptor, transforms `defineTool()` calls across authored helper modules, validates captures at resolution, and reconstructs session-, turn-, and step-scoped tools through one fail-closed replay path.

eve-owned approval helpers and `connection_search` use the same module-stable registration path. The transform preserves top-level function-form `approval` properties while mapping structured approval callbacks to `request` and `response`. Resolver redelivery remains possible workflow behavior, but callback replay no longer depends on it; this PR intentionally adds no memory types and leaves parked-call origin routing to the follow-up work.

### Validation

Validated with the full unit suite (6,923 passing), the post-review F0/F1 unit suites (358 passing), `tool-auth.integration.test.ts` (23 passing), and a packed scenario that parks approval, SIGKILLs the first server, then resumes approval response, execution, and projection in a second process without rerunning the resolver. The full integration run passed 656 of 659 tests; three sandbox-dependent cancellation cases failed because the local microsandbox database referenced four already-applied migration files that were unavailable, unrelated to this change.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+17 / -10`

Updates the dynamic-tool durability contract and records the patch release behavior.

**Implementation** — 13 files · `+1026 / -1076`

Replaces the split hydration/process-fallback paths with phase-specific descriptors, strict capture validation, stable authored-module transforms, and one replay implementation. The balanced rewrite removes the legacy flat metadata while covering framework-owned callbacks through the same mechanism.

**Tests** — 7 files · `+819 / -711`

Replaces fallback-oriented lifecycle expectations with fail-closed replay coverage, expands transform cases across every callback phase and factory shape, and adds the real two-process continuation scenario. The additional deletion against current `main` removes its now-obsolete hydration regression because durable replay no longer re-resolves callbacks; the review regression covers arrow, method-shorthand, and identifier-form approvals.
