### PR TITLE
Add Agentcard connection

### DIFF
--- a/.changeset/agentcard-connection.md
+++ b/.changeset/agentcard-connection.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add the native Agentcard MCP connection to the registry through Vercel Connect.

--- a/apps/docs/lib/integrations/connection-setup.test.ts
+++ b/apps/docs/lib/integrations/connection-setup.test.ts
@@ -28,6 +28,19 @@ describe("Browser Use connection setup", () => {
   });
 });
 
+describe("Agentcard connection setup", () => {
+  it("uses the standard connector name for the native Vercel Connect service", () => {
+    const integration = getIntegration("agentcard")!;
+    const setup = buildConnectionSetup(integration);
+    const quickStart = setup.variants["mcp:user"];
+
+    expect(quickStart).toContain('description: "Agentcard tools and data"');
+    expect(quickStart).toContain('auth: connect("agentcard")');
+    expect(setup.configureVariants["mcp:user"]).toContain("vercel connect create agentcard");
+    expect(setup.configureVariants["mcp:user"]).not.toContain("--name");
+  });
+});
+
 describe("Kernel extension setup", () => {
   it("uses Kernel's eve extension with Vercel Connect", () => {
     const integration = getIntegration("kernel")!;

--- a/apps/docs/lib/integrations/connection-setup.ts
+++ b/apps/docs/lib/integrations/connection-setup.ts
@@ -84,7 +84,6 @@ const buildSnippet = (
   if (headerLines.length > 0) {
     fields.push(`  headers: () => ({`, ...headerLines, `  }),`);
   }
-
   return [
     `// agent/connections/${integration.slug}.ts`,
     ...imports,

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -1604,6 +1604,12 @@ const connectionPresentations: Record<string, ConnectionPresentation> = {
     configureNote:
       "Browser Use runs tasks in managed cloud browsers. Add approval gates or tool filters before allowing unattended browser actions.",
   },
+  agentcard: {
+    logo: "agentcard",
+    docsHref: "/docs/connections/mcp",
+    keywords: ["mcp", "shopping", "checkout", "payments", "virtual cards", "commerce", "connect"],
+    authModes: ["user"],
+  },
   vercel: {
     logo: "vercel",
     docsHref: "https://vercel.com/docs/agent-resources/vercel-mcp",

--- a/apps/docs/lib/integrations/logos.tsx
+++ b/apps/docs/lib/integrations/logos.tsx
@@ -181,6 +181,17 @@ export const vercelLogo = (props: LogoProps) => (
   </svg>
 );
 
+export const agentcardLogo = (props: LogoProps) => (
+  <svg viewBox="0 0 214 152" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path
+      clipRule="evenodd"
+      d="M16 0H197.333C208 0 213.333 5.33333 213.333 16V136C213.333 146.667 208 152 197.333 152H16C5.33333 152 0 146.667 0 136V16C0 5.33333 5.33333 0 16 0ZM50.6667 33.3333H162.667V37.3333H50.6667V33.3333ZM50.6667 114.667H162.667V118.667H50.6667V114.667ZM50.6667 37.3333H54.6667V114.667H50.6667V37.3333ZM158.667 37.3333H162.667V114.667H158.667V37.3333ZM54.6667 78.6667H158.667V82.6667H54.6667V78.6667ZM104 37.3333H108V78.6667H104V37.3333Z"
+      fill="currentColor"
+      fillRule="evenodd"
+    />
+  </svg>
+);
+
 export const linearLogo = (props: LogoProps) => (
   <svg fill="none" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" {...props}>
     <path
@@ -686,6 +697,7 @@ export const logos = {
   teams: teamsLogo,
   telegram: telegramLogo,
   twilio: twilioLogo,
+  agentcard: agentcardLogo,
   vercel: vercelLogo,
   linear: linearLogo,
   context: contextLogo,

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -396,6 +396,39 @@
       ]
     },
     {
+      "name": "connection/agentcard",
+      "type": "registry:item",
+      "title": "Agentcard",
+      "description": "Shop at real merchants with consent-gated single-use virtual cards.",
+      "meta": {
+        "eve": {
+          "setup": {
+            "command": "eve",
+            "package": "eve",
+            "bin": "eve",
+            "args": [
+              "integration",
+              "connect",
+              "agentcard",
+              "agentcard",
+              "agentcard"
+            ]
+          },
+          "requires": ">=0.29.0"
+        }
+      },
+      "dependencies": [
+        "@vercel/connect"
+      ],
+      "files": [
+        {
+          "path": "registry/connections/agentcard.ts",
+          "type": "registry:file",
+          "target": "agent/connections/agentcard.ts"
+        }
+      ]
+    },
+    {
       "name": "connection/airtable",
       "type": "registry:item",
       "title": "Airtable",

--- a/apps/docs/registry/connections/agentcard.ts
+++ b/apps/docs/registry/connections/agentcard.ts
@@ -1,0 +1,8 @@
+import { defineMcpClientConnection } from "eve/connections";
+import { connect } from "@vercel/connect/eve";
+
+export default defineMcpClientConnection({
+  url: "https://mcp.agentcard.sh/mcp",
+  description: "Agentcard tools and data",
+  auth: connect("agentcard"),
+});

--- a/packages/eve-catalog/src/index.test.ts
+++ b/packages/eve-catalog/src/index.test.ts
@@ -75,6 +75,12 @@ describe("integration catalog", () => {
     expect(getIntegrationEntry("vercel")!.connection!.mcp!.url).toBe("https://mcp.vercel.com");
   });
 
+  it("uses Agentcard's streamable HTTP MCP endpoint", () => {
+    expect(getIntegrationEntry("agentcard")!.connection!.mcp!.url).toBe(
+      "https://mcp.agentcard.sh/mcp",
+    );
+  });
+
   it("uses Linear's streamable HTTP MCP endpoint", () => {
     expect(getIntegrationEntry("linear")!.connection!.mcp!.url).toBe("https://mcp.linear.app/mcp");
   });

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -401,6 +401,17 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     },
   },
   {
+    slug: "agentcard",
+    name: "Agentcard",
+    kind: "connection",
+    tagline: "Shop at real merchants with consent-gated single-use virtual cards.",
+    surfaces: { scaffoldable: false, registry: true, gallery: true },
+    connection: {
+      description: "Agentcard tools and data",
+      mcp: { url: "https://mcp.agentcard.sh/mcp" },
+    },
+  },
+  {
     slug: "airtable",
     name: "Airtable",
     kind: "connection",


### PR DESCRIPTION
### Summary

Adds Agentcard as an installable eve MCP connection using the native Vercel Connect provider. The connection follows the same naming convention as other registry packages: service `agentcard`, canonical connector name `agentcard`, and an install-time `connect("agentcard")` placeholder that eve replaces with the actual connector UID returned by Vercel.

### Validation

Confirmed the Agentcard endpoint, description, standard connector name, and generated setup command with focused unit coverage, then built and validated the complete public registry with `pnpm --filter eve-docs registry:check`.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the release note changeset for the native Agentcard registry integration.

**Implementation** — 6 files · `+76 / -1`

Registers Agentcard across the shared catalog, gallery presentation, logo map, registry manifest, and native connection source. The one-line deletion keeps generated setup on the existing slug-based connector naming path.

**Tests** — 2 files · `+19 / -0`

Covers the Agentcard endpoint, standard connector placeholder, description, and generated setup command.
