### PR TITLE
fix(eve): dynamic tools - replay calls on origin deployment

### DIFF
--- a/.changeset/dynamic-tools-remember.md
+++ b/.changeset/dynamic-tools-remember.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Keep each parked dynamic tool call bound to the definition that admitted it, so a later same-name resolution cannot change its approval, authorization, execution, or model output.
+Keep each parked dynamic tool call bound to its originating deployment and definition, so a deployment or same-name re-resolution cannot change its approval, authorization, execution, or model output.

--- a/.changeset/dynamic-tools-remember.md
+++ b/.changeset/dynamic-tools-remember.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Keep each parked dynamic tool call bound to the definition that admitted it, so a later same-name resolution cannot change its approval, authorization, execution, or model output.

--- a/docs/guides/dynamic-capabilities.md
+++ b/docs/guides/dynamic-capabilities.md
@@ -134,7 +134,7 @@ approval checks.
 
 Pass `defineDynamic` an `events` object whose handlers return either a single `defineTool(...)`, a `Record<string, defineTool(...)>`, or `null` for no tools. Wrap every entry in `defineTool()`. eve records durable descriptors for `execute`, approval request and response policies, and `toModelOutput`, so a parked call can reconstruct the same callbacks in a fresh process.
 
-Once the model emits a dynamic tool call, eve binds that call ID to the resolved definition. Later resolver events and deployments can replace the same-named tool for new calls, but pending approval, authorization, execution, and model-output projection continue with the definition that admitted the parked call. If that origin record is missing or invalid, eve fails the resume instead of routing the call to the current same-named definition.
+Once the model emits a dynamic tool call, eve binds that call ID to the resolved definition and Workflow deployment. Later resolver events and deployments can replace the same-named tool for new calls, but pending approval, authorization, execution, and model-output projection continue on the deployment that admitted the parked call. Unrelated messages use the current deployment. If the origin record is missing or invalid, eve fails the resume instead of routing the call to the current same-named definition.
 
 Dynamic tool executors receive the same `ToolContext` as static authored tools, including inline provider auth through `ctx.getToken(provider)` and `ctx.requireAuth(provider)`.
 

--- a/docs/guides/dynamic-capabilities.md
+++ b/docs/guides/dynamic-capabilities.md
@@ -134,6 +134,8 @@ approval checks.
 
 Pass `defineDynamic` an `events` object whose handlers return either a single `defineTool(...)`, a `Record<string, defineTool(...)>`, or `null` for no tools. Wrap every entry in `defineTool()`. eve records durable descriptors for `execute`, approval request and response policies, and `toModelOutput`, so a parked call can reconstruct the same callbacks in a fresh process.
 
+Once the model emits a dynamic tool call, eve binds that call ID to the resolved definition. Later resolver events and deployments can replace the same-named tool for new calls, but pending approval, authorization, execution, and model-output projection continue with the definition that admitted the parked call. If that origin record is missing or invalid, eve fails the resume instead of routing the call to the current same-named definition.
+
 Dynamic tool executors receive the same `ToolContext` as static authored tools, including inline provider auth through `ctx.getToken(provider)` and `ctx.requireAuth(provider)`.
 
 The example below builds one tool per warehouse table. A map return names each tool by its bare key, so the model sees `orders`, `users`, and so on.

--- a/docs/tools/human-in-the-loop.md
+++ b/docs/tools/human-in-the-loop.md
@@ -107,7 +107,7 @@ Each request includes a `kind` discriminator: `tool-approval`, `question`, or
 `toolName` and `requestId` identify the action and request but do not encode its
 semantics.
 
-The run picks back up exactly where it parked. Because the pause is durable, nothing is held in memory while it waits — the process can restart and the parked turn survives.
+The run picks back up exactly where it parked. Because the pause is durable, nothing is held in memory while it waits — the process can restart and the parked turn survives. For a dynamic tool approval, eve also preserves the exact tool definition that admitted the call. A later resolver event or deployment can replace that tool name for new calls without changing the parked call's approval policy, authorization, execution, or model output.
 
 When a background subagent requests input, eve emits the same `input.requested` event on its parent session. Answering through that parent session routes the response directly to the blocked child without invoking the parent model.
 

--- a/docs/tools/human-in-the-loop.md
+++ b/docs/tools/human-in-the-loop.md
@@ -107,7 +107,7 @@ Each request includes a `kind` discriminator: `tool-approval`, `question`, or
 `toolName` and `requestId` identify the action and request but do not encode its
 semantics.
 
-The run picks back up exactly where it parked. Because the pause is durable, nothing is held in memory while it waits — the process can restart and the parked turn survives. For a dynamic tool approval, eve also preserves the exact tool definition that admitted the call. A later resolver event or deployment can replace that tool name for new calls without changing the parked call's approval policy, authorization, execution, or model output.
+The run picks back up exactly where it parked. Because the pause is durable, nothing is held in memory while it waits — the process can restart and the parked turn survives. For a dynamic tool approval, eve also resumes the Workflow deployment and exact tool definition that admitted the call. A later deployment can replace that tool name for new calls without changing the parked call's approval policy, authorization, execution, or model output.
 
 When a background subagent requests input, eve emits the same `input.requested` event on its parent session. Answering through that parent session routes the response directly to the blocked child without invoking the parent model.
 

--- a/packages/eve/src/context/build-dynamic-tools.ts
+++ b/packages/eve/src/context/build-dynamic-tools.ts
@@ -17,6 +17,10 @@ import type {
 } from "#public/definitions/approval.js";
 import type { DurableDynamicCallbackReference } from "#shared/durable-dynamic-tool-callbacks.js";
 import { toInputSchema, toOutputSchema } from "#shared/tool-schema.js";
+import {
+  readArchivedDynamicToolDefinitions,
+  resolveDynamicToolMetadataForCall,
+} from "#harness/dynamic-tool-call-routing.js";
 
 const log = createLogger("dynamic-tools");
 
@@ -92,6 +96,7 @@ export function replayDynamicTools(
 
     return {
       description: entry.description,
+      dynamicDefinition: entry,
       execute: createToolExecuteWithAuth({
         scope: entry.name,
         execute: (input, context) => {
@@ -131,6 +136,11 @@ export function buildResponseAuthorizationTools(input: {
   for (const tool of input.context === undefined ? [] : buildDynamicTools(input.context)) {
     if (!tools.has(tool.name)) tools.set(tool.name, tool);
   }
+  for (const tool of input.context === undefined
+    ? []
+    : replayDynamicTools(readArchivedDynamicToolDefinitions(input.context))) {
+    if (!tools.has(tool.name)) tools.set(tool.name, tool);
+  }
   for (const [name, tool] of input.authoredTools) {
     if (!tools.has(name)) tools.set(name, tool);
   }
@@ -142,4 +152,24 @@ export function buildDynamicTools(ctx: ContextReader): readonly HarnessToolDefin
   const turn = replayDynamicTools(ctx.get(TurnDynamicToolMetadataKey) ?? []);
   const session = replayDynamicTools(ctx.get(SessionDynamicToolMetadataKey) ?? []);
   return [...step, ...turn, ...session];
+}
+
+/** Resolves a callback-sensitive phase through the call's durable origin. */
+export function resolveDynamicToolDefinitionForCall(input: {
+  readonly callId: string;
+  readonly current: HarnessToolDefinition;
+  readonly knownCall: boolean;
+}): HarnessToolDefinition {
+  const currentMetadata = input.current.dynamicDefinition;
+  const resolved = resolveDynamicToolMetadataForCall({
+    callId: input.callId,
+    current: currentMetadata,
+    knownCall: input.knownCall,
+    toolName: input.current.name,
+  });
+  if (resolved === undefined) return input.current;
+  if (currentMetadata !== undefined && resolved.definitionId === currentMetadata.definitionId) {
+    return input.current;
+  }
+  return replayDynamicTools([resolved])[0]!;
 }

--- a/packages/eve/src/context/build-dynamic-tools.ts
+++ b/packages/eve/src/context/build-dynamic-tools.ts
@@ -136,13 +136,13 @@ export function buildResponseAuthorizationTools(input: {
   for (const tool of input.context === undefined ? [] : buildDynamicTools(input.context)) {
     if (!tools.has(tool.name)) tools.set(tool.name, tool);
   }
+  for (const [name, tool] of input.authoredTools) {
+    if (!tools.has(name)) tools.set(name, tool);
+  }
   for (const tool of input.context === undefined
     ? []
     : replayDynamicTools(readArchivedDynamicToolDefinitions(input.context))) {
     if (!tools.has(tool.name)) tools.set(tool.name, tool);
-  }
-  for (const [name, tool] of input.authoredTools) {
-    if (!tools.has(name)) tools.set(name, tool);
   }
   return tools;
 }
@@ -158,13 +158,13 @@ export function buildDynamicTools(ctx: ContextReader): readonly HarnessToolDefin
 export function resolveDynamicToolDefinitionForCall(input: {
   readonly callId: string;
   readonly current: HarnessToolDefinition;
-  readonly knownCall: boolean;
+  readonly requireOrigin: boolean;
 }): HarnessToolDefinition {
   const currentMetadata = input.current.dynamicDefinition;
   const resolved = resolveDynamicToolMetadataForCall({
     callId: input.callId,
     current: currentMetadata,
-    knownCall: input.knownCall,
+    requireOrigin: input.requireOrigin,
     toolName: input.current.name,
   });
   if (resolved === undefined) return input.current;

--- a/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
@@ -180,11 +180,16 @@ describe("replayDynamicSessionTools", () => {
   ): DurableDynamicToolMetadata {
     return {
       callbacks: { execute: { closure, stepId } },
+      definitionId: `definition:${name}`,
       description: `${name} description`,
       entryKey: name,
+      event: "session.started",
       inputSchema: { type: "object" },
       name,
+      ownerId: "test",
       resolverSlug: "test",
+      runtimeRevision: "runtime:test",
+      sourceId: "agent/tools/test.ts",
     };
   }
 
@@ -432,6 +437,47 @@ function stampTestTool(entry: DynamicToolEntry): DynamicToolEntry {
 }
 
 describe("dispatchDynamicToolEvent", () => {
+  it("derives stable definition identity from provenance and runtime revision", async () => {
+    const ctx = createCtx();
+    const entry = createReplayableTool("stable definition");
+    const resolver = createResolver("stable", ["session.started"], () => ({ tool: entry }));
+    ctx.set(SessionDynamicToolRuntimeRevisionKey, "deployment:dpl_one");
+
+    await dispatchDynamicToolEvent({
+      ctx,
+      resolvers: [resolver],
+      messages: [],
+      event: makeEvent("session.started"),
+    });
+    const first = ctx.get(SessionDynamicToolMetadataKey)![0]!;
+
+    await dispatchDynamicToolEvent({
+      ctx,
+      resolvers: [resolver],
+      messages: [],
+      event: makeEvent("session.started"),
+    });
+    const repeated = ctx.get(SessionDynamicToolMetadataKey)![0]!;
+
+    expect(repeated.definitionId).toBe(first.definitionId);
+    expect(first).toMatchObject({
+      event: "session.started",
+      ownerId: "stable",
+      runtimeRevision: "deployment:dpl_one",
+      sourceId: "test:stable",
+    });
+
+    await refreshDynamicSessionToolsForRuntimeRevision({
+      ctx,
+      resolvers: [resolver],
+      messages: [],
+      event: createSessionStartedEvent(),
+      runtimeRevision: "deployment:dpl_two",
+    });
+
+    expect(ctx.get(SessionDynamicToolMetadataKey)![0]!.definitionId).not.toBe(first.definitionId);
+  });
+
   it("replaces session tools with the current deployment's resolver output", async () => {
     const ctx = createCtx();
     const oldResolver = createResolver("old", ["session.started"], () => ({
@@ -1200,11 +1246,16 @@ describe("framework dynamic tools (no bundler transform)", () => {
           approvalRequest: { closure: {}, stepId: "legacy-turn-approval" },
           execute: { closure: {}, stepId: "legacy-turn-execute" },
         },
+        definitionId: "definition:legacy-turn-guarded",
         description: "legacy guarded tool",
         entryKey: "legacy:guarded",
+        event: "turn.started",
         inputSchema: { type: "object" },
         name: "guarded",
+        ownerId: "legacy",
         resolverSlug: "legacy",
+        runtimeRevision: "runtime:test",
+        sourceId: "agent/tools/legacy.ts",
       },
     ]);
 
@@ -1228,11 +1279,16 @@ describe("framework dynamic tools (no bundler transform)", () => {
           approvalResponse: { closure: {}, stepId: "step-response" },
           execute: { closure: {}, stepId: "step-execute" },
         },
+        definitionId: "definition:step-guarded",
         description: "step",
         entryKey: "step:guarded",
+        event: "step.started",
         inputSchema: { type: "object" },
         name: "guarded",
+        ownerId: "step",
         resolverSlug: "step",
+        runtimeRevision: "runtime:test",
+        sourceId: "agent/tools/step.ts",
       },
     ]);
     ctx.set(SessionDynamicToolMetadataKey, [
@@ -1242,11 +1298,16 @@ describe("framework dynamic tools (no bundler transform)", () => {
           approvalResponse: { closure: {}, stepId: "session-authorizer" },
           execute: { closure: {}, stepId: "session-execute" },
         },
+        definitionId: "definition:session-guarded",
         description: "session",
         entryKey: "session:guarded",
+        event: "session.started",
         inputSchema: { type: "object" },
         name: "guarded",
+        ownerId: "session",
         resolverSlug: "session",
+        runtimeRevision: "runtime:test",
+        sourceId: "agent/tools/session.ts",
       },
     ]);
 

--- a/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
@@ -27,6 +27,7 @@ const { buildDynamicTools, buildResponseAuthorizationTools } =
 import { ContextContainer } from "#context/container.js";
 import { deserializeContext, serializeContext } from "#context/serialize.js";
 import {
+  DynamicToolRuntimeDeploymentIdKey,
   SessionIdKey,
   SessionDynamicToolMetadataKey,
   SessionDynamicToolRuntimeRevisionKey,
@@ -442,6 +443,7 @@ describe("dispatchDynamicToolEvent", () => {
     const entry = createReplayableTool("stable definition");
     const resolver = createResolver("stable", ["session.started"], () => ({ tool: entry }));
     ctx.set(SessionDynamicToolRuntimeRevisionKey, "deployment:dpl_one");
+    ctx.setVirtualContext(DynamicToolRuntimeDeploymentIdKey, "dpl_one");
 
     await dispatchDynamicToolEvent({
       ctx,
@@ -463,6 +465,7 @@ describe("dispatchDynamicToolEvent", () => {
     expect(first).toMatchObject({
       event: "session.started",
       ownerId: "stable",
+      runtimeDeploymentId: "dpl_one",
       runtimeRevision: "deployment:dpl_one",
       sourceId: "test:stable",
     });
@@ -472,6 +475,7 @@ describe("dispatchDynamicToolEvent", () => {
       resolvers: [resolver],
       messages: [],
       event: createSessionStartedEvent(),
+      runtimeDeploymentId: "dpl_two",
       runtimeRevision: "deployment:dpl_two",
     });
 

--- a/packages/eve/src/context/dynamic-tool-lifecycle.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.ts
@@ -6,6 +6,7 @@ import { replayDynamicTools } from "#context/build-dynamic-tools.js";
 import type { ContextContainer } from "#context/container.js";
 import type { ContextKey } from "#context/key.js";
 import {
+  DynamicToolRuntimeDeploymentIdKey,
   SessionDynamicToolMetadataKey,
   SessionDynamicToolRuntimeRevisionKey,
   StepDynamicToolMetadataKey,
@@ -217,6 +218,7 @@ function createMetadata(input: {
   readonly event: "session.started" | "turn.started" | "step.started";
   readonly name: string;
   readonly resolver: ResolvedDynamicToolResolver;
+  readonly runtimeDeploymentId?: string;
   readonly runtimeRevision: string;
 }): DurableDynamicToolMetadata {
   const metadata = {
@@ -229,6 +231,7 @@ function createMetadata(input: {
     ownerId: input.resolver.slug,
     outputSchema: serializeOutputSchema(input.entry.outputSchema),
     resolverSlug: input.resolver.slug,
+    runtimeDeploymentId: input.runtimeDeploymentId,
     runtimeRevision: input.runtimeRevision,
     sourceId: input.resolver.sourceId,
   };
@@ -245,6 +248,7 @@ function createMetadata(input: {
         metadata.inputSchema,
         metadata.outputSchema ?? null,
         metadata.callbacks,
+        metadata.runtimeDeploymentId ?? null,
       ]),
     )
     .digest("base64url")}`;
@@ -261,6 +265,7 @@ async function resolveToolsFromEvent(
   event: UnstampedMessageStreamEvent,
   messages: readonly ModelMessage[],
   runtimeRevision = ctx.get(SessionDynamicToolRuntimeRevisionKey) ?? "runtime:unversioned",
+  runtimeDeploymentId = ctx.get(DynamicToolRuntimeDeploymentIdKey),
 ): Promise<ResolvedDynamicToolEvent> {
   const outcomes = await Promise.allSettled(
     resolvers.map(async (resolver) => {
@@ -278,6 +283,7 @@ async function resolveToolsFromEvent(
             event: event.type as "session.started" | "turn.started" | "step.started",
             name,
             resolver,
+            runtimeDeploymentId,
             runtimeRevision,
           }),
         ),
@@ -385,6 +391,7 @@ export async function refreshDynamicSessionToolsForRuntimeRevision(input: {
   readonly resolvers: readonly ResolvedDynamicToolResolver[];
   readonly event: SessionStartedStreamEvent;
   readonly messages: readonly ModelMessage[];
+  readonly runtimeDeploymentId?: string;
   readonly runtimeRevision: string;
 }): Promise<void> {
   if (input.ctx.get(SessionDynamicToolRuntimeRevisionKey) === input.runtimeRevision) return;
@@ -400,6 +407,7 @@ export async function refreshDynamicSessionToolsForRuntimeRevision(input: {
           input.event,
           input.messages,
           input.runtimeRevision,
+          input.runtimeDeploymentId,
         );
   input.ctx.set(SessionDynamicToolMetadataKey, metadata);
   input.ctx.set(SessionDynamicToolRuntimeRevisionKey, input.runtimeRevision);

--- a/packages/eve/src/context/dynamic-tool-lifecycle.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import type { ModelMessage } from "ai";
 
 import { replayDynamicTools } from "#context/build-dynamic-tools.js";
@@ -212,18 +214,41 @@ export function validateDurableDynamicToolCallbacks(
 function createMetadata(input: {
   readonly entry: DynamicToolEntry;
   readonly entryKey: string;
+  readonly event: "session.started" | "turn.started" | "step.started";
   readonly name: string;
   readonly resolver: ResolvedDynamicToolResolver;
+  readonly runtimeRevision: string;
 }): DurableDynamicToolMetadata {
-  return {
+  const metadata = {
     callbacks: validateDurableDynamicToolCallbacks(input.name, input.entry),
     description: input.entry.description,
     entryKey: input.entryKey,
+    event: input.event,
     inputSchema: serializeInputSchema(input.entry.inputSchema),
     name: input.name,
+    ownerId: input.resolver.slug,
     outputSchema: serializeOutputSchema(input.entry.outputSchema),
     resolverSlug: input.resolver.slug,
+    runtimeRevision: input.runtimeRevision,
+    sourceId: input.resolver.sourceId,
   };
+  const definitionId = `dynamic-tool:${createHash("sha256")
+    .update(
+      JSON.stringify([
+        metadata.sourceId,
+        metadata.ownerId,
+        metadata.runtimeRevision,
+        metadata.event,
+        metadata.entryKey,
+        metadata.name,
+        metadata.description,
+        metadata.inputSchema,
+        metadata.outputSchema ?? null,
+        metadata.callbacks,
+      ]),
+    )
+    .digest("base64url")}`;
+  return { ...metadata, definitionId };
 }
 
 interface ResolvedDynamicToolEvent {
@@ -235,6 +260,7 @@ async function resolveToolsFromEvent(
   resolvers: readonly ResolvedDynamicToolResolver[],
   event: UnstampedMessageStreamEvent,
   messages: readonly ModelMessage[],
+  runtimeRevision = ctx.get(SessionDynamicToolRuntimeRevisionKey) ?? "runtime:unversioned",
 ): Promise<ResolvedDynamicToolEvent> {
   const outcomes = await Promise.allSettled(
     resolvers.map(async (resolver) => {
@@ -246,7 +272,14 @@ async function resolveToolsFromEvent(
       const named = qualifyDynamicToolNames(resolver, isSingle, entries);
       return {
         metadata: named.map(({ name, entryKey, entry }) =>
-          createMetadata({ entry, entryKey, name, resolver }),
+          createMetadata({
+            entry,
+            entryKey,
+            event: event.type as "session.started" | "turn.started" | "step.started",
+            name,
+            resolver,
+            runtimeRevision,
+          }),
         ),
         resolver,
       };
@@ -361,7 +394,13 @@ export async function refreshDynamicSessionToolsForRuntimeRevision(input: {
   const { metadata } =
     matching.length === 0
       ? { metadata: [] }
-      : await resolveToolsFromEvent(input.ctx, matching, input.event, input.messages);
+      : await resolveToolsFromEvent(
+          input.ctx,
+          matching,
+          input.event,
+          input.messages,
+          input.runtimeRevision,
+        );
   input.ctx.set(SessionDynamicToolMetadataKey, metadata);
   input.ctx.set(SessionDynamicToolRuntimeRevisionKey, input.runtimeRevision);
 }

--- a/packages/eve/src/context/keys.ts
+++ b/packages/eve/src/context/keys.ts
@@ -166,6 +166,8 @@ export interface DurableDynamicToolMetadata {
   readonly ownerId: string;
   readonly outputSchema?: JsonObject;
   readonly resolverSlug: string;
+  /** Workflow deployment or development generation that can execute this definition. */
+  readonly runtimeDeploymentId?: string;
   readonly runtimeRevision: string;
   readonly sourceId: string;
   readonly entryKey: string;
@@ -185,6 +187,11 @@ export const SessionDynamicToolMetadataKey = new ContextKey<readonly DurableDyna
  */
 export const SessionDynamicToolRuntimeRevisionKey = new ContextKey<string>(
   "eve.sessionDynamicToolRuntimeRevision",
+);
+
+/** Deployment selected for the current turn; virtual and never serialized on its own. */
+export const DynamicToolRuntimeDeploymentIdKey = new ContextKey<string>(
+  "eve.dynamicToolRuntimeDeploymentId",
 );
 
 /**

--- a/packages/eve/src/context/keys.ts
+++ b/packages/eve/src/context/keys.ts
@@ -19,6 +19,10 @@ import type {
 } from "#channel/types.js";
 import { ContextKey } from "#context/key.js";
 import type { InstrumentationChannelDeliveryRef } from "#harness/instrumentation/lifecycle.js";
+import type {
+  DurableDynamicToolOriginState,
+  DynamicToolOriginCoordinate,
+} from "#harness/dynamic-tool-call-origins.js";
 import type { DurableDynamicToolCallbacks } from "#shared/durable-dynamic-tool-callbacks.js";
 import type { DynamicSubagentAgentConfig } from "#runtime/subagents/dynamic-agent-config.js";
 import type { DynamicRemoteAgentConfig } from "#runtime/subagents/dynamic-remote-agent-config.js";
@@ -154,11 +158,16 @@ export const LiveStepDynamicModelSelectionKey = new ContextKey<LiveDynamicModelS
 
 export interface DurableDynamicToolMetadata {
   readonly callbacks: DurableDynamicToolCallbacks;
+  readonly definitionId: string;
   readonly name: string;
   readonly description: string;
+  readonly event: "session.started" | "turn.started" | "step.started";
   readonly inputSchema: JsonObject;
+  readonly ownerId: string;
   readonly outputSchema?: JsonObject;
   readonly resolverSlug: string;
+  readonly runtimeRevision: string;
+  readonly sourceId: string;
   readonly entryKey: string;
 }
 
@@ -189,6 +198,16 @@ export const TurnDynamicToolMetadataKey = new ContextKey<readonly DurableDynamic
 /** Step-scoped dynamic tool metadata, replaced before each model step. */
 export const StepDynamicToolMetadataKey = new ContextKey<readonly DurableDynamicToolMetadata[]>(
   "eve.stepDynamicToolMetadata",
+);
+
+/** Durable call-id routes for dynamic definitions that may outlive their resolution. */
+export const DynamicToolCallOriginsKey = new ContextKey<DurableDynamicToolOriginState>(
+  "eve.dynamicToolCallOrigins",
+);
+
+/** Current model-call coordinate used when a dynamic call is first admitted. */
+export const DynamicToolCallCoordinateKey = new ContextKey<DynamicToolOriginCoordinate>(
+  "eve.dynamicToolCallCoordinate",
 );
 
 export type DurableDynamicSubagentSelection =

--- a/packages/eve/src/execution/dispatch-turn-step.ts
+++ b/packages/eve/src/execution/dispatch-turn-step.ts
@@ -4,7 +4,14 @@ import {
 } from "#execution/durable-session-migrations/turn-workflow.js";
 import { buildTurnAttributes, readRootSessionId } from "#execution/eve-workflow-attributes.js";
 import { startWorkflowPreferLatest, turnWorkflowReference } from "#execution/workflow-runtime.js";
+import { start } from "#internal/workflow/runtime.js";
 import { normalizeEveAttributes } from "#runtime/attributes/normalize.js";
+import { DynamicToolCallOriginsKey } from "#context/keys.js";
+import {
+  parseDynamicToolOriginState,
+  resolveDynamicToolOriginDeployment,
+} from "#harness/dynamic-tool-call-origins.js";
+import { getPendingInputBatches } from "#harness/pending-input-batches.js";
 
 /** Starts a per-turn child workflow for the current driver session. */
 export async function dispatchTurnStep(
@@ -12,20 +19,65 @@ export async function dispatchTurnStep(
 ): Promise<{ readonly runId: string }> {
   "use step";
 
-  const run = await startWorkflowPreferLatest(
-    turnWorkflowReference,
-    [createTurnWorkflowInput(input)],
-    {
-      allowReservedAttributes: true,
-      attributes: normalizeEveAttributes(
-        buildTurnAttributes({
-          parentSessionId: input.sessionState.sessionId,
-          requestId: input.delivery.kind === "deliver" ? input.delivery.requestId : undefined,
-          rootSessionId: readRootSessionId(input.serializedContext) ?? input.sessionState.sessionId,
-        }),
-      ),
-    },
-  );
+  const args: Parameters<typeof startWorkflowPreferLatest>[1] = [createTurnWorkflowInput(input)];
+  const options = {
+    allowReservedAttributes: true,
+    attributes: normalizeEveAttributes(
+      buildTurnAttributes({
+        parentSessionId: input.sessionState.sessionId,
+        requestId: input.delivery.kind === "deliver" ? input.delivery.requestId : undefined,
+        rootSessionId: readRootSessionId(input.serializedContext) ?? input.sessionState.sessionId,
+      }),
+    ),
+  };
+  const originDeploymentId = resolveOriginDeploymentForDelivery(input);
+  const run =
+    originDeploymentId === undefined
+      ? await startWorkflowPreferLatest(turnWorkflowReference, args, options)
+      : await start(turnWorkflowReference, args, {
+          ...options,
+          deploymentId: originDeploymentId,
+        });
 
   return { runId: run.runId };
+}
+
+function resolveOriginDeploymentForDelivery(input: TurnWorkflowDispatchInput): string | undefined {
+  if (input.delivery.kind !== "deliver") return undefined;
+  const rawOrigins = input.serializedContext[DynamicToolCallOriginsKey.name];
+  if (rawOrigins === undefined) return undefined;
+
+  const requestIds = new Set<string>();
+  const authorizationAttemptIds = new Set<string>();
+  for (const payload of input.delivery.payloads) {
+    for (const response of payload.inputResponses ?? []) requestIds.add(response.requestId);
+    const callback = payload["authorizationCallback"] as
+      | {
+          readonly attemptId?: unknown;
+          readonly connectionName?: unknown;
+          readonly legacy?: unknown;
+        }
+      | undefined;
+    const authorizationId =
+      typeof callback?.attemptId === "string"
+        ? callback.attemptId
+        : callback?.legacy === true && typeof callback.connectionName === "string"
+          ? callback.connectionName
+          : undefined;
+    if (authorizationId !== undefined) authorizationAttemptIds.add(authorizationId);
+  }
+
+  const callIds = new Set(
+    getPendingInputBatches(input.sessionState.snapshot?.session.state).flatMap((batch) =>
+      batch.requests
+        .filter((request) => requestIds.has(request.requestId))
+        .map((request) => request.action.callId),
+    ),
+  );
+  if (callIds.size === 0 && authorizationAttemptIds.size === 0) return undefined;
+
+  return resolveDynamicToolOriginDeployment(parseDynamicToolOriginState(rawOrigins), {
+    authorizationAttemptIds,
+    callIds,
+  });
 }

--- a/packages/eve/src/execution/durable-step-result.ts
+++ b/packages/eve/src/execution/durable-step-result.ts
@@ -1,0 +1,44 @@
+import type { DurableSessionState } from "#execution/durable-session-store.js";
+import type { SettledTurn } from "#harness/types.js";
+import type { TokenUsage } from "#shared/token-usage.js";
+
+/** Result of one durable harness step. */
+export type DurableStepResult =
+  | {
+      readonly action: "continue" | "done";
+      readonly output?: unknown;
+      readonly isError?: boolean;
+      readonly sleepDurationMs?: number;
+      readonly serializedContext: Record<string, unknown>;
+      readonly sessionState: DurableSessionState;
+      /** Session-total token usage; set on `done` when the session spent any. */
+      readonly usage?: TokenUsage;
+      /** Usage the final turn added beyond earlier settled turns. */
+      readonly usageDelta?: TokenUsage;
+    }
+  | {
+      readonly action: "cancelled";
+      readonly serializedContext: Record<string, unknown>;
+      readonly sessionState: DurableSessionState;
+    }
+  | {
+      readonly action: "park";
+      readonly authorizationAttemptIds?: readonly string[];
+      readonly authorizationNames?: readonly string[];
+      readonly hasPendingAuthorization: boolean;
+      readonly hasPendingInputBatch: boolean;
+      readonly pendingRuntimeActionKeys?: readonly string[];
+      /** Selects task dispatch when the agent runs `experimental.tasks`. */
+      readonly tasksEnabled?: boolean;
+      readonly sleepDurationMs?: number;
+      readonly serializedContext: Record<string, unknown>;
+      readonly sessionState: DurableSessionState;
+      readonly settled?: SettledTurn;
+    }
+  | {
+      readonly action: "dispatch-workflow-runtime-actions";
+      readonly pendingRuntimeActionKeys: readonly string[];
+      readonly sleepDurationMs?: number;
+      readonly serializedContext: Record<string, unknown>;
+      readonly sessionState: DurableSessionState;
+    };

--- a/packages/eve/src/execution/dynamic-runtime-identity.ts
+++ b/packages/eve/src/execution/dynamic-runtime-identity.ts
@@ -1,0 +1,21 @@
+import { getWorld } from "#internal/workflow/runtime.js";
+import { resolveRuntimeCompiledArtifactsVersionedCacheKey } from "#runtime/cache-key.js";
+import type { RuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
+
+export async function resolveDynamicRuntimeIdentity(
+  source: RuntimeCompiledArtifactsSource,
+  hasDynamicTools: boolean,
+): Promise<{ deploymentId?: string; revision: string }> {
+  const vercelDeploymentId = process.env.VERCEL_DEPLOYMENT_ID?.trim();
+  const deploymentId =
+    vercelDeploymentId ||
+    (source.kind === "disk" ? source.deploymentId : undefined) ||
+    (hasDynamicTools ? await (await getWorld()).getDeploymentId() : undefined);
+
+  return {
+    deploymentId,
+    revision: vercelDeploymentId
+      ? `deployment:${vercelDeploymentId}`
+      : await resolveRuntimeCompiledArtifactsVersionedCacheKey(source),
+  };
+}

--- a/packages/eve/src/execution/settle-cancelled-turn-step.integration.test.ts
+++ b/packages/eve/src/execution/settle-cancelled-turn-step.integration.test.ts
@@ -2,8 +2,14 @@ import { describe, expect, it } from "vitest";
 
 import { createTestRuntime } from "#internal/testing/app-harness.js";
 import { createBundledRuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
+import { DynamicToolCallOriginsKey, type DurableDynamicToolMetadata } from "#context/keys.js";
 import { createDurableSessionState } from "#execution/durable-session-store.js";
 import { settleCancelledTurnStep } from "#execution/settle-cancelled-turn-step.js";
+import {
+  createDynamicToolOriginState,
+  recordDynamicToolCallOrigin,
+  type DurableDynamicToolOriginState,
+} from "#harness/dynamic-tool-call-origins.js";
 import { setHarnessEmissionState } from "#harness/emission.js";
 import { deriveAgentOperationId } from "#harness/handles/operation-id.js";
 import {
@@ -12,6 +18,7 @@ import {
   getAgentHandleStore,
   type AgentHandle,
 } from "#harness/handles/store.js";
+import { appendPendingInputBatch } from "#harness/input-requests.js";
 import type { HarnessSession } from "#harness/types.js";
 
 /**
@@ -86,8 +93,8 @@ function createCancelledTurnSession(handles: readonly AgentHandle[]): HarnessSes
   );
 }
 
-function buildSerializedContext(): Record<string, unknown> {
-  return {
+function buildSerializedContext(origins?: DurableDynamicToolOriginState): Record<string, unknown> {
+  const serialized: Record<string, unknown> = {
     "eve.auth": null,
     "eve.bundle": { source: createBundledRuntimeCompiledArtifactsSource() },
     "eve.channel": { kind: "http", state: {} },
@@ -95,6 +102,72 @@ function buildSerializedContext(): Record<string, unknown> {
     "eve.mode": "conversation",
     "eve.sessionId": PARENT_SESSION_ID,
   };
+  if (origins !== undefined) serialized[DynamicToolCallOriginsKey.name] = origins;
+  return serialized;
+}
+
+function dynamicDefinition(definitionId: string): DurableDynamicToolMetadata {
+  return {
+    callbacks: {
+      execute: { closure: { definitionId }, stepId: `execute-${definitionId}` },
+    },
+    definitionId,
+    description: `Definition ${definitionId}`,
+    entryKey: "update",
+    event: "turn.started",
+    inputSchema: { type: "object" },
+    name: "update",
+    ownerId: "updates",
+    resolverSlug: "updates",
+    runtimeRevision: "deployment:test",
+    sourceId: "agent/tools/update.ts",
+  };
+}
+
+function originState(): DurableDynamicToolOriginState {
+  let state = recordDynamicToolCallOrigin(
+    createDynamicToolOriginState(),
+    dynamicDefinition("definition-old"),
+    {
+      callId: "call-old",
+      originatingStepIndex: 0,
+      originatingTurnId: "turn-0",
+      toolName: "update",
+    },
+  );
+  state = recordDynamicToolCallOrigin(state, dynamicDefinition("definition-current"), {
+    callId: "call-current",
+    originatingStepIndex: 1,
+    originatingTurnId: "turn-1",
+    toolName: "update",
+  });
+  return state;
+}
+
+function sessionWithPendingOlderCall(): HarnessSession {
+  return appendPendingInputBatch({
+    requests: [
+      {
+        action: {
+          callId: "call-old",
+          input: {},
+          kind: "tool-call",
+          toolName: "update",
+        },
+        allowFreeform: false,
+        display: "confirmation",
+        kind: "tool-approval",
+        options: [
+          { id: "approve", label: "Approve" },
+          { id: "cancel", label: "Cancel" },
+        ],
+        prompt: "Approve older call",
+        requestId: "approval-old",
+      },
+    ],
+    responseMessages: [],
+    session: createCancelledTurnSession([]),
+  });
 }
 
 describe("settleCancelledTurnStep handle store", () => {
@@ -120,6 +193,31 @@ describe("settleCancelledTurnStep handle store", () => {
           },
           PARKED_HANDLE,
         ],
+      });
+    });
+  });
+
+  it("releases only origins owned by the cancelled turn", async () => {
+    const runtime = createTestRuntime({ agent: { name: "settle-cancel-origins" } });
+
+    await runtime.run(async () => {
+      const result = await settleCancelledTurnStep({
+        parentWritable: new WritableStream<Uint8Array>({ write() {} }),
+        serializedContext: buildSerializedContext(originState()),
+        sessionState: createDurableSessionState({ session: sessionWithPendingOlderCall() }),
+      });
+
+      expect(result.serializedContext[DynamicToolCallOriginsKey.name]).toMatchObject({
+        calls: {
+          "call-old": {
+            definitionId: "definition-old",
+            originatingTurnId: "turn-0",
+          },
+        },
+        definitions: {
+          "definition-old": { definitionId: "definition-old" },
+        },
+        version: 1,
       });
     });
   });

--- a/packages/eve/src/execution/settle-cancelled-turn-step.ts
+++ b/packages/eve/src/execution/settle-cancelled-turn-step.ts
@@ -32,6 +32,10 @@ import { getInstrumentationRuntime } from "#harness/instrumentation/runtime.js";
 import { getTurnUsageState, toUsage } from "#harness/turn-tag-state.js";
 import { clearPendingWorkflowInterrupt } from "#harness/workflow-interrupt-state.js";
 import {
+  reconcileDynamicToolOrigins,
+  releaseDynamicToolOriginsForTurn,
+} from "#harness/dynamic-tool-call-routing.js";
+import {
   encodeMessageStreamEvent,
   type UnstampedMessageStreamEvent,
   stampMessageStreamEvent,
@@ -76,6 +80,7 @@ export async function settleCancelledTurnStep(input: {
   });
 
   let emissionState = getHarnessEmissionState(durableSession.state);
+  const cancelledTurnId = activeTurnId(emissionState);
   // A descendant HITL wait already streamed this turn's waiting boundary
   // (the proxy epilogue clears the turn id); re-emitting would fabricate
   // a turn id and duplicate the boundary.
@@ -150,6 +155,8 @@ export async function settleCancelledTurnStep(input: {
       emissionState,
     ),
   );
+  releaseDynamicToolOriginsForTurn(ctx, cancelledTurnId);
+  reconcileDynamicToolOrigins(ctx, cancelledSession.state);
   const totals = getTurnUsageState(session.state)?.session;
 
   const base = {

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -8,6 +8,7 @@ import { ContextKey } from "#context/key.js";
 import {
   AuthKey,
   ContinuationTokenKey,
+  DynamicToolCallOriginsKey,
   DynamicSubagentAgentConfigKey,
   ModeKey,
   SessionCallbackKey,
@@ -18,6 +19,7 @@ import {
   SessionDynamicToolRuntimeRevisionKey,
   SessionIdKey,
   TurnTaskDeliveryKey,
+  type DurableDynamicToolMetadata,
 } from "#context/keys.js";
 import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
 import { serializeContext } from "#context/serialize.js";
@@ -28,6 +30,11 @@ import { TurnCancelledError } from "#harness/turn-cancellation.js";
 import { getPendingAuthorization, setPendingAuthorization } from "#harness/authorization.js";
 import { getProxyInputRequests, upsertProxyInputRequests } from "#harness/proxy-input-requests.js";
 import { appendPendingInputBatch } from "#harness/input-requests.js";
+import {
+  addDynamicToolAuthorizationAttempts,
+  createDynamicToolOriginState,
+  recordDynamicToolCallOrigin,
+} from "#harness/dynamic-tool-call-origins.js";
 import type { HarnessSession, StepResult } from "#harness/types.js";
 import { createEmptyHookRegistry } from "#runtime/hooks/registry.js";
 import { createInputRequestedEvent } from "#protocol/message.js";
@@ -162,6 +169,7 @@ vi.mock("../runtime/sessions/compiled-agent-cache.js", () => ({
 vi.mock("#compiled/@workflow/core/runtime.js", () => ({
   getHookByToken: vi.fn(async (token: string) => currentSessionHook(token)),
   getRun: (...args: unknown[]) => getRunMock(...args),
+  getWorld: vi.fn(async () => ({ getDeploymentId: async () => "deployment-test" })),
   resumeHook: (...args: unknown[]) => resumeHookMock(...args),
   start: (...args: unknown[]) => startMock(...args),
 }));
@@ -650,6 +658,70 @@ describe("dispatchTurnStep", () => {
     };
   }
 
+  function dynamicDefinition(deploymentId: string): DurableDynamicToolMetadata {
+    return {
+      callbacks: { execute: { closure: {}, stepId: `execute-${deploymentId}` } },
+      definitionId: `definition-${deploymentId}`,
+      description: "Update",
+      entryKey: "update",
+      event: "turn.started",
+      inputSchema: { type: "object" },
+      name: "update",
+      ownerId: "updates",
+      resolverSlug: "updates",
+      runtimeDeploymentId: deploymentId,
+      runtimeRevision: `deployment:${deploymentId}`,
+      sourceId: "agent/tools/update.ts",
+    };
+  }
+
+  function createOriginContinuationInput(
+    delivery: Parameters<typeof dispatchTurnStep>[0]["delivery"],
+  ): Parameters<typeof dispatchTurnStep>[0] {
+    const definition = dynamicDefinition("generation-a");
+    const origins = recordDynamicToolCallOrigin(createDynamicToolOriginState(), definition, {
+      callId: "call-a",
+      originatingStepIndex: 0,
+      originatingTurnId: "turn-a",
+      toolName: definition.name,
+    });
+    const session = appendPendingInputBatch({
+      requests: [
+        {
+          action: {
+            callId: "call-a",
+            input: {},
+            kind: "tool-call",
+            toolName: definition.name,
+          },
+          allowFreeform: false,
+          display: "confirmation",
+          kind: "tool-approval",
+          options: [
+            { id: "approve", label: "Approve" },
+            { id: "cancel", label: "Cancel" },
+          ],
+          prompt: "Approve update",
+          requestId: "approval-a",
+        },
+      ],
+      responseMessages: [],
+      session: createStubSession(),
+    });
+    return {
+      ...createTurnInput(),
+      delivery,
+      serializedContext: { [DynamicToolCallOriginsKey.name]: origins },
+      sessionState: {
+        ...createStubSessionState(),
+        snapshot: {
+          session: projectToDurableSession(session),
+          version: DURABLE_SESSION_VERSION,
+        },
+      },
+    };
+  }
+
   it("starts turn workflows on the latest deployment in Vercel production", async () => {
     vi.stubEnv("VERCEL_ENV", "production");
     const input = createTurnInput();
@@ -684,6 +756,114 @@ describe("dispatchTurnStep", () => {
       turnWorkflowReference,
       [createTurnWorkflowInput(input)],
       expect.objectContaining({ deploymentId: "latest" }),
+    );
+  });
+
+  it("routes an approval continuation to its originating deployment", async () => {
+    vi.stubEnv("EVE_DEV", "1");
+    const input = createOriginContinuationInput({
+      kind: "deliver",
+      payloads: [{ inputResponses: [{ optionId: "approve", requestId: "approval-a" }] }],
+    });
+    startMock.mockResolvedValue({ runId: "turn-run" });
+
+    await expect(dispatchTurnStep(input)).resolves.toEqual({ runId: "turn-run" });
+
+    expect(startMock).toHaveBeenCalledWith(
+      turnWorkflowReference,
+      [createTurnWorkflowInput(input)],
+      expect.objectContaining({ deploymentId: "generation-a" }),
+    );
+  });
+
+  it("keeps an unrelated message on latest while an older origin remains pending", async () => {
+    vi.stubEnv("EVE_DEV", "1");
+    const input = createOriginContinuationInput({
+      kind: "deliver",
+      payloads: [{ message: "new work" }],
+    });
+    startMock.mockResolvedValue({ runId: "turn-run" });
+
+    await expect(dispatchTurnStep(input)).resolves.toEqual({ runId: "turn-run" });
+
+    expect(startMock).toHaveBeenCalledWith(
+      turnWorkflowReference,
+      [createTurnWorkflowInput(input)],
+      expect.objectContaining({ deploymentId: "latest" }),
+    );
+  });
+
+  it("routes a legacy authorization callback through its originating deployment", async () => {
+    vi.stubEnv("EVE_DEV", "1");
+    const base = createOriginContinuationInput({ kind: "deliver", payloads: [] });
+    const origins = addDynamicToolAuthorizationAttempts(
+      base.serializedContext[DynamicToolCallOriginsKey.name] as ReturnType<
+        typeof createDynamicToolOriginState
+      >,
+      "call-a",
+      ["github"],
+    );
+    const input = {
+      ...base,
+      delivery: {
+        kind: "deliver" as const,
+        payloads: [
+          {
+            authorizationCallback: {
+              callback: { params: {} },
+              connectionName: "github",
+              legacy: true,
+            },
+          },
+        ],
+      },
+      serializedContext: { [DynamicToolCallOriginsKey.name]: origins },
+    };
+    startMock.mockResolvedValue({ runId: "turn-run" });
+
+    await expect(dispatchTurnStep(input)).resolves.toEqual({ runId: "turn-run" });
+
+    expect(startMock).toHaveBeenCalledWith(
+      turnWorkflowReference,
+      [createTurnWorkflowInput(input)],
+      expect.objectContaining({ deploymentId: "generation-a" }),
+    );
+  });
+
+  it("routes a correlated authorization callback through its originating deployment", async () => {
+    vi.stubEnv("VERCEL_ENV", "production");
+    const base = createOriginContinuationInput({ kind: "deliver", payloads: [] });
+    const origins = addDynamicToolAuthorizationAttempts(
+      base.serializedContext[DynamicToolCallOriginsKey.name] as ReturnType<
+        typeof createDynamicToolOriginState
+      >,
+      "call-a",
+      ["attempt-a"],
+    );
+    const input = {
+      ...base,
+      delivery: {
+        kind: "deliver" as const,
+        payloads: [
+          {
+            authorizationCallback: {
+              attemptId: "attempt-a",
+              callback: { params: {} },
+              connectionName: "github",
+            },
+          },
+        ],
+      },
+      serializedContext: { [DynamicToolCallOriginsKey.name]: origins },
+    };
+    startMock.mockResolvedValue({ runId: "turn-run" });
+
+    await expect(dispatchTurnStep(input)).resolves.toEqual({ runId: "turn-run" });
+
+    expect(startMock).toHaveBeenCalledWith(
+      turnWorkflowReference,
+      [createTurnWorkflowInput(input)],
+      expect.objectContaining({ deploymentId: "generation-a" }),
     );
   });
 

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -2589,11 +2589,16 @@ describe("turnStep", () => {
         callbacks: {
           execute: { closure: {}, stepId: "eve:dynamic-tool//old" },
         },
+        definitionId: "definition:old-tool",
         description: "Stale deployment tool",
         entryKey: "old_tool",
+        event: "session.started",
         inputSchema: { type: "object" },
         name: "old_tool",
+        ownerId: "old",
         resolverSlug: "old",
+        runtimeRevision: "deployment:dpl_old",
+        sourceId: "agent/tools/old.ts",
       },
     ]);
 

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -42,6 +42,7 @@ import {
 } from "#harness/channel-delivery-instrumentation.js";
 import { getInstrumentationRuntime } from "#harness/instrumentation/runtime.js";
 import { preserveSerializedInstrumentationState } from "#harness/instrumentation/state.js";
+import { reconcileDynamicToolOrigins } from "#harness/dynamic-tool-call-routing.js";
 import { RuntimeActionSettlementTimesKey } from "#harness/runtime-action-settlement-state.js";
 import { preserveSerializedAgentTraceState } from "#tracing/agent-trace-context-store.js";
 import { matchAuthorizationCallbacks } from "#execution/authorization-callback-match.js";
@@ -321,6 +322,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
     );
     await instrumentation?.forceFlush();
     const rekeyed = reconcileSessionContinuationToken(ctx, initialSession);
+    reconcileDynamicToolOrigins(ctx, rekeyed.state);
     const nextSerializedContext = serializeContext(ctx);
     const nextState =
       rekeyed === initialSession
@@ -571,6 +573,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
 
   // Re-stamp if a handler called `session.continuation.rekey(...)` (eg. Slack auto-anchor).
   const rekeyed = reconcileSessionContinuationToken(ctx, stepResult.session);
+  reconcileDynamicToolOrigins(ctx, rekeyed.state);
   const nextSerializedContext = serializeContext(ctx);
   stepResult = { ...stepResult, session: rekeyed };
 

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -22,6 +22,7 @@ import {
 import {
   AuthKey,
   CapabilitiesKey,
+  DynamicToolRuntimeDeploymentIdKey,
   ModeKey,
   SessionDynamicSubagentRuntimeRevisionKey,
   SessionDynamicToolRuntimeRevisionKey,
@@ -58,9 +59,8 @@ import {
 } from "#harness/workflow-runtime-action-state.js";
 import { getPendingWorkflowInterrupt } from "#harness/workflow-interrupt-state.js";
 import { getPendingRuntimeActionBatch } from "#harness/runtime-actions.js";
-import type { HarnessSession, SettledTurn, StepInput, StepResult } from "#harness/types.js";
+import type { HarnessSession, StepInput, StepResult } from "#harness/types.js";
 import { getTurnUsageState, takeSessionUsageDelta, toUsage } from "#harness/turn-tag-state.js";
-import type { TokenUsage } from "#shared/token-usage.js";
 import { getRuntimeActionRequestKey } from "#runtime/actions/keys.js";
 import {
   createAuthorizationCompletedEvent,
@@ -79,11 +79,8 @@ import {
 import { resolveWorkflowCallbackBaseUrl } from "#execution/workflow-callback-url.js";
 import { forwardTaskEventToSessionCallback } from "#execution/task-event-callback.js";
 import { resolveEffectiveOutputSchema } from "#execution/effective-output-schema.js";
-import {
-  createDurableSessionState,
-  type DurableSessionState,
-  readDurableSession,
-} from "#execution/durable-session-store.js";
+import { createDurableSessionState, readDurableSession } from "#execution/durable-session-store.js";
+import type { DurableStepResult } from "#execution/durable-step-result.js";
 import type { TurnStepInput } from "#execution/durable-session-migrations/turn-workflow.js";
 import { buildRuntimeIdentity, createExecutionNodeStep } from "#execution/node-step.js";
 import { appendTaskAgentAnnouncement } from "#execution/tasks/parent/agent-views.js";
@@ -97,70 +94,15 @@ import { recordSubagentUsageSpans } from "#execution/subagent-usage-span.js";
 import { reconcileSessionContinuationToken } from "#execution/reconcile-session-continuation-token.js";
 import { hydrateDurableSession, refreshSessionFromTurnAgent } from "#execution/session.js";
 import { createExecutionHistoryView } from "#execution/history-view.js";
-import { resolveRuntimeCompiledArtifactsVersionedCacheKey } from "#runtime/cache-key.js";
 import { createWorkflowRuntime } from "#execution/workflow-runtime.js";
 import { isTaskToolAvailable, TASK_UPDATE_TOOL_NAME } from "#runtime/framework-tools/tasks.js";
+import { resolveDynamicRuntimeIdentity } from "#execution/dynamic-runtime-identity.js";
 
 const TASK_DONE_WITH_PENDING_INPUT_ERROR_MESSAGE =
   "Task mode cannot complete while input requests remain pending.";
 
-/**
- * Result of one durable harness step. `cancelled` is returned so workflow-core
- * does not retry it; `park` carries the pending state needed by the next action.
- */
-export type DurableStepResult =
-  | {
-      readonly action: "continue" | "done";
-      readonly output?: unknown;
-      readonly isError?: boolean;
-      /**
-       * Optional durable pause for the turn workflow to fulfill before
-       * dispatching this result's next action.
-       */
-      readonly sleepDurationMs?: number;
-      readonly serializedContext: Record<string, unknown>;
-      readonly sessionState: DurableSessionState;
-      /** Session-total token usage; set on `done` when the session spent any. */
-      readonly usage?: TokenUsage;
-      /**
-       * Usage the final turn added beyond what earlier settled turns already
-       * reported; feeds the terminal `AgentTurnOutcome` for conversation
-       * children. Task sessions settle once, so their callers read `usage`.
-       */
-      readonly usageDelta?: TokenUsage;
-    }
-  | {
-      readonly action: "cancelled";
-      readonly serializedContext: Record<string, unknown>;
-      readonly sessionState: DurableSessionState;
-    }
-  | {
-      readonly action: "park";
-      readonly authorizationAttemptIds?: readonly string[];
-      readonly authorizationNames?: readonly string[];
-      readonly hasPendingAuthorization: boolean;
-      readonly hasPendingInputBatch: boolean;
-      readonly pendingRuntimeActionKeys?: readonly string[];
-      /**
-       * Selects the dispatch step for `pendingRuntimeActionKeys`:
-       * `dispatchTaskStep` when the agent runs `experimental.tasks`,
-       * `dispatchRuntimeActionsStep` otherwise (including when absent).
-       */
-      readonly tasksEnabled?: boolean;
-      readonly sleepDurationMs?: number;
-      readonly serializedContext: Record<string, unknown>;
-      readonly sessionState: DurableSessionState;
-      readonly settled?: SettledTurn;
-    }
-  | {
-      readonly action: "dispatch-workflow-runtime-actions";
-      readonly pendingRuntimeActionKeys: readonly string[];
-      readonly sleepDurationMs?: number;
-      readonly serializedContext: Record<string, unknown>;
-      readonly sessionState: DurableSessionState;
-    };
-
 export type { TurnStepInput };
+export type { DurableStepResult } from "#execution/durable-step-result.js";
 
 /**
  * Runs one atomic harness step inside a durable `"use step"` boundary.
@@ -350,11 +292,14 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
     turnAgent: effectiveAgent.turnAgent,
   };
   const runtimeIdentity = buildRuntimeIdentity(effectiveNode);
+  let runtimeDeploymentId: string | undefined;
   try {
-    const deploymentId = process.env.VERCEL_DEPLOYMENT_ID?.trim();
-    const dynamicRuntimeRevision = deploymentId
-      ? `deployment:${deploymentId}`
-      : await resolveRuntimeCompiledArtifactsVersionedCacheKey(bundle.compiledArtifactsSource);
+    const dynamicRuntimeIdentity = await resolveDynamicRuntimeIdentity(
+      bundle.compiledArtifactsSource,
+      dynamicToolResolvers.length > 0,
+    );
+    runtimeDeploymentId = dynamicRuntimeIdentity.deploymentId;
+    const dynamicRuntimeRevision = dynamicRuntimeIdentity.revision;
     const sessionStarted = initialEmissionState.sessionStarted;
 
     if (!sessionStarted) {
@@ -376,6 +321,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
           resolvers: dynamicToolResolvers,
           event: refreshEvent,
           messages: history.initial.messages,
+          runtimeDeploymentId,
           runtimeRevision: dynamicRuntimeRevision,
         }),
       ]);
@@ -454,6 +400,9 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
     // or the pending batch would re-park and later re-dispatch.
     throwIfTurnAborted(input.abortSignal);
     stepResult = await runStep(ctx, initialSession, async (enrichedSession) => {
+      if (runtimeDeploymentId !== undefined) {
+        ctx.setVirtualContext(DynamicToolRuntimeDeploymentIdKey, runtimeDeploymentId);
+      }
       let schemaSession = resolveEffectiveOutputSchema({
         agentOutputSchema: effectiveAgent.turnAgent.outputSchema,
         input: resolved,

--- a/packages/eve/src/harness/approval-delivery-coordinator.test.ts
+++ b/packages/eve/src/harness/approval-delivery-coordinator.test.ts
@@ -1,11 +1,22 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { SessionAuthContext } from "#channel/types.js";
+import { replayDynamicTools } from "#context/build-dynamic-tools.js";
+import { ContextContainer, contextStorage } from "#context/container.js";
+import {
+  DynamicToolCallOriginsKey,
+  SessionKey,
+  type DurableDynamicToolMetadata,
+} from "#context/keys.js";
 import { settleDirectApprovalResponse } from "#harness/approval-candidates.js";
 import { coordinateApprovalDelivery } from "#harness/approval-delivery-coordinator.js";
 import { appendPendingInputBatch } from "#harness/pending-input-batches.js";
 import type { HarnessSession } from "#harness/types.js";
 import type { InputRequest } from "#runtime/input/types.js";
+import {
+  createDynamicToolOriginState,
+  recordDynamicToolCallOrigin,
+} from "#harness/dynamic-tool-call-origins.js";
 
 const request: InputRequest = {
   action: { callId: "call-1", input: { marker: "durable" }, kind: "tool-call", toolName: "gate" },
@@ -82,4 +93,85 @@ describe("coordinateApprovalDelivery", () => {
       { optionId: "cancel", requestId: request.requestId },
     ]);
   });
+
+  it("routes response authorization through the originating dynamic definition", async () => {
+    const responseA = vi.fn(() => ({ status: "allowed" as const }));
+    const responseB = vi.fn(() => ({ status: "rejected" as const }));
+    const a = dynamicDefinition("definition-a", responseA);
+    const b = dynamicDefinition("definition-b", responseB);
+    const ctx = new ContextContainer();
+    ctx.set(SessionKey, {
+      auth: { current: responder, initiator: responder },
+      sessionId: "session-1",
+      turn: { id: "turn-b", sequence: 1 },
+    });
+    ctx.set(
+      DynamicToolCallOriginsKey,
+      recordDynamicToolCallOrigin(createDynamicToolOriginState(), a, {
+        callId: request.action.callId,
+        originatingStepIndex: 0,
+        originatingTurnId: "turn-a",
+        toolName: request.action.toolName,
+      }),
+    );
+    const tools = new Map([[request.action.toolName, replayDynamicTools([b])[0]!]]);
+
+    const candidate = await contextStorage.run(ctx, () =>
+      coordinateApprovalDelivery({
+        now: 100,
+        session: parkedSession(),
+        stepInput: {
+          attributedInputResponses: [
+            {
+              auth: responder,
+              response: { optionId: "approve", requestId: request.requestId },
+            },
+          ],
+        },
+        tools,
+      }),
+    );
+    expect(candidate.kind).toBe("continue-coordination");
+
+    const allowed = await contextStorage.run(ctx, () =>
+      coordinateApprovalDelivery({ now: 101, session: candidate.session, tools }),
+    );
+
+    expect(allowed.kind).toBe("continue");
+    expect(allowed.stepInput?.inputResponses).toEqual([
+      { optionId: "approve", requestId: request.requestId },
+    ]);
+    expect(responseA).toHaveBeenCalledOnce();
+    expect(responseB).not.toHaveBeenCalled();
+  });
 });
+
+function dynamicDefinition(
+  definitionId: string,
+  response: () => { readonly status: "allowed" | "rejected" },
+): DurableDynamicToolMetadata {
+  const registryKey = Symbol.for("@workflow/core//registeredSteps");
+  const global = globalThis as Record<symbol, Map<string, Function> | undefined>;
+  const registry = global[registryKey] ?? new Map<string, Function>();
+  global[registryKey] = registry;
+  registry.set(`execute-${definitionId}`, () => null);
+  registry.set(`request-${definitionId}`, () => "user-approval");
+  registry.set(`response-${definitionId}`, response);
+  return {
+    callbacks: {
+      approvalRequest: { closure: {}, stepId: `request-${definitionId}` },
+      approvalResponse: { closure: {}, stepId: `response-${definitionId}` },
+      execute: { closure: {}, stepId: `execute-${definitionId}` },
+    },
+    definitionId,
+    description: definitionId,
+    entryKey: "gate",
+    event: "turn.started",
+    inputSchema: { type: "object" },
+    name: "gate",
+    ownerId: "gate",
+    resolverSlug: "gate",
+    runtimeRevision: definitionId,
+    sourceId: "agent/tools/gate.ts",
+  };
+}

--- a/packages/eve/src/harness/approval-delivery-coordinator.ts
+++ b/packages/eve/src/harness/approval-delivery-coordinator.ts
@@ -29,6 +29,8 @@ import { isApprovalRequest } from "#harness/input-request-class.js";
 import { getPendingInputBatches } from "#harness/pending-input-batches.js";
 import type { HarnessSession, HarnessToolMap, StepInput } from "#harness/types.js";
 import type { InputRequest } from "#runtime/input/types.js";
+import { resolveDynamicToolDefinitionForCall } from "#context/build-dynamic-tools.js";
+import { addAuthorizationAttemptsForDynamicToolCall } from "#harness/dynamic-tool-call-routing.js";
 
 const UNAUTHENTICATED_APPROVAL_FEEDBACK = "Authentication is required to respond to this approval.";
 const TEXT_APPROVAL_FEEDBACK =
@@ -331,7 +333,15 @@ async function authorizeCandidate(input: {
     return { challenges: [], didCommit: false, session };
   }
 
-  const approval = input.tools.get(input.request.action.toolName)?.approval;
+  const currentDefinition = input.tools.get(input.request.action.toolName);
+  const approval =
+    currentDefinition === undefined
+      ? undefined
+      : resolveDynamicToolDefinitionForCall({
+          callId: input.request.action.callId,
+          current: currentDefinition,
+          knownCall: true,
+        }).approval;
   const responsePolicy =
     approval !== undefined && typeof approval !== "function" ? approval.response : undefined;
   if (responsePolicy === undefined) {
@@ -396,6 +406,12 @@ async function authorizeCandidate(input: {
   } catch (error) {
     const authorization = await handleApprovalResponsePolicyError(error).catch(() => undefined);
     if (isAuthorizationSignal(authorization)) {
+      addAuthorizationAttemptsForDynamicToolCall(
+        input.request.action.callId,
+        authorization.challenges.flatMap((challenge) =>
+          challenge.attemptId === undefined ? [] : [challenge.attemptId],
+        ),
+      );
       const providerExpiresAt = authorization.challenges
         .map((entry) => Date.parse(entry.challenge.expiresAt ?? ""))
         .filter(Number.isFinite)

--- a/packages/eve/src/harness/approval-delivery-coordinator.ts
+++ b/packages/eve/src/harness/approval-delivery-coordinator.ts
@@ -340,7 +340,7 @@ async function authorizeCandidate(input: {
       : resolveDynamicToolDefinitionForCall({
           callId: input.request.action.callId,
           current: currentDefinition,
-          knownCall: true,
+          requireOrigin: true,
         }).approval;
   const responsePolicy =
     approval !== undefined && typeof approval !== "function" ? approval.response : undefined;
@@ -408,9 +408,7 @@ async function authorizeCandidate(input: {
     if (isAuthorizationSignal(authorization)) {
       addAuthorizationAttemptsForDynamicToolCall(
         input.request.action.callId,
-        authorization.challenges.flatMap((challenge) =>
-          challenge.attemptId === undefined ? [] : [challenge.attemptId],
-        ),
+        authorization.challenges.map((challenge) => challenge.attemptId ?? challenge.name),
       );
       const providerExpiresAt = authorization.challenges
         .map((entry) => Date.parse(entry.challenge.expiresAt ?? ""))

--- a/packages/eve/src/harness/dynamic-tool-call-origins.test.ts
+++ b/packages/eve/src/harness/dynamic-tool-call-origins.test.ts
@@ -9,9 +9,14 @@ import {
   recordDynamicToolCallOrigin,
   releaseDynamicToolCallOrigin,
   releaseDynamicToolCallOriginsForTurn,
+  resolveDynamicToolOriginDeployment,
 } from "#harness/dynamic-tool-call-origins.js";
 
-function definition(definitionId: string, name = "update"): DurableDynamicToolMetadata {
+function definition(
+  definitionId: string,
+  name = "update",
+  runtimeDeploymentId?: string,
+): DurableDynamicToolMetadata {
   return {
     callbacks: {
       execute: { closure: { value: definitionId }, stepId: `execute-${definitionId}` },
@@ -24,6 +29,7 @@ function definition(definitionId: string, name = "update"): DurableDynamicToolMe
     name,
     ownerId: "tenant-tools",
     resolverSlug: "tenant-tools",
+    runtimeDeploymentId,
     runtimeRevision: "deployment:one",
     sourceId: "agent/tools/tenant.ts",
   };
@@ -125,6 +131,46 @@ describe("dynamic tool call origins", () => {
 
     expect(Object.keys(reconciled.calls)).toEqual(["call-approval", "call-auth"]);
     expect(Object.keys(reconciled.definitions)).toEqual(["approval", "auth"]);
+  });
+
+  it("selects the deployment for the call or authorization attempt being resumed", () => {
+    let state = record(
+      createDynamicToolOriginState(),
+      "call-a",
+      definition("definition-a", "update", "deployment-a"),
+    );
+    state = record(state, "call-b", definition("definition-b", "update", "deployment-b"), "turn-b");
+    state = addDynamicToolAuthorizationAttempts(state, "call-b", ["attempt-b"]);
+
+    expect(
+      resolveDynamicToolOriginDeployment(state, {
+        authorizationAttemptIds: new Set(),
+        callIds: new Set(["call-a"]),
+      }),
+    ).toBe("deployment-a");
+    expect(
+      resolveDynamicToolOriginDeployment(state, {
+        authorizationAttemptIds: new Set(["attempt-b"]),
+        callIds: new Set(),
+      }),
+    ).toBe("deployment-b");
+    expect(() =>
+      resolveDynamicToolOriginDeployment(state, {
+        authorizationAttemptIds: new Set(["attempt-b"]),
+        callIds: new Set(["call-a"]),
+      }),
+    ).toThrow("spans multiple originating deployments");
+  });
+
+  it("fails closed when a matching origin has no deployment", () => {
+    const state = record(createDynamicToolOriginState(), "call-a");
+
+    expect(() =>
+      resolveDynamicToolOriginDeployment(state, {
+        authorizationAttemptIds: new Set(),
+        callIds: new Set(["call-a"]),
+      }),
+    ).toThrow('Dynamic tool call "call-a" does not record an originating deployment');
   });
 
   it("fails closed for unknown versions and malformed references", () => {

--- a/packages/eve/src/harness/dynamic-tool-call-origins.test.ts
+++ b/packages/eve/src/harness/dynamic-tool-call-origins.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+
+import type { DurableDynamicToolMetadata } from "#context/keys.js";
+import {
+  addDynamicToolAuthorizationAttempts,
+  createDynamicToolOriginState,
+  readDynamicToolCallOrigin,
+  reconcileDynamicToolCallOrigins,
+  recordDynamicToolCallOrigin,
+  releaseDynamicToolCallOrigin,
+  releaseDynamicToolCallOriginsForTurn,
+} from "#harness/dynamic-tool-call-origins.js";
+
+function definition(definitionId: string, name = "update"): DurableDynamicToolMetadata {
+  return {
+    callbacks: {
+      execute: { closure: { value: definitionId }, stepId: `execute-${definitionId}` },
+    },
+    definitionId,
+    description: `Definition ${definitionId}`,
+    entryKey: "update",
+    event: "turn.started",
+    inputSchema: { type: "object" },
+    name,
+    ownerId: "tenant-tools",
+    resolverSlug: "tenant-tools",
+    runtimeRevision: "deployment:one",
+    sourceId: "agent/tools/tenant.ts",
+  };
+}
+
+function record(
+  state: ReturnType<typeof createDynamicToolOriginState>,
+  callId: string,
+  snapshot: DurableDynamicToolMetadata = definition("definition-a"),
+  turnId = "turn-a",
+) {
+  return recordDynamicToolCallOrigin(state, snapshot, {
+    callId,
+    originatingStepIndex: 2,
+    originatingTurnId: turnId,
+    toolName: snapshot.name,
+  });
+}
+
+describe("dynamic tool call origins", () => {
+  it("records one call and its referenced definition", () => {
+    const state = record(createDynamicToolOriginState(), "call-a");
+
+    expect(readDynamicToolCallOrigin(state, "call-a")).toEqual({
+      callId: "call-a",
+      definitionId: "definition-a",
+      originatingStepIndex: 2,
+      originatingTurnId: "turn-a",
+      toolName: "update",
+    });
+    expect(state.definitions).toEqual({ "definition-a": definition("definition-a") });
+  });
+
+  it("shares one definition snapshot across calls", () => {
+    const first = record(createDynamicToolOriginState(), "call-a");
+    const second = record(first, "call-b");
+
+    expect(Object.keys(second.calls)).toEqual(["call-a", "call-b"]);
+    expect(Object.keys(second.definitions)).toEqual(["definition-a"]);
+  });
+
+  it("retains a shared definition until its last call is released", () => {
+    const state = record(record(createDynamicToolOriginState(), "call-a"), "call-b");
+    const retained = releaseDynamicToolCallOrigin(state, "call-a");
+    const collected = releaseDynamicToolCallOrigin(retained, "call-b");
+
+    expect(retained.calls).toEqual({
+      "call-b": expect.objectContaining({ definitionId: "definition-a" }),
+    });
+    expect(retained.definitions).toHaveProperty("definition-a");
+    expect(collected).toEqual(createDynamicToolOriginState());
+  });
+
+  it("merges authorization attempt ids without duplicates", () => {
+    const state = record(createDynamicToolOriginState(), "call-a");
+    const first = addDynamicToolAuthorizationAttempts(state, "call-a", ["attempt-a"]);
+    const second = addDynamicToolAuthorizationAttempts(first, "call-a", ["attempt-a", "attempt-b"]);
+
+    expect(second.calls["call-a"]?.authorizationAttemptIds).toEqual(["attempt-a", "attempt-b"]);
+  });
+
+  it("ignores a static tool without a definition snapshot", () => {
+    const state = createDynamicToolOriginState();
+
+    expect(
+      recordDynamicToolCallOrigin(state, undefined, {
+        callId: "call-static",
+        originatingStepIndex: 0,
+        originatingTurnId: "turn-a",
+        toolName: "static",
+      }),
+    ).toBe(state);
+  });
+
+  it("releases only calls owned by a failed or cancelled turn", () => {
+    const state = record(
+      record(createDynamicToolOriginState(), "call-old", definition("old"), "turn-old"),
+      "call-current",
+      definition("current"),
+      "turn-current",
+    );
+
+    const released = releaseDynamicToolCallOriginsForTurn(state, "turn-current");
+
+    expect(Object.keys(released.calls)).toEqual(["call-old"]);
+    expect(Object.keys(released.definitions)).toEqual(["old"]);
+  });
+
+  it("collects origins unreachable from pending approvals or authorization", () => {
+    let state = record(createDynamicToolOriginState(), "call-approval", definition("approval"));
+    state = record(state, "call-auth", definition("auth"));
+    state = record(state, "call-orphan", definition("orphan"));
+    state = addDynamicToolAuthorizationAttempts(state, "call-auth", ["attempt-auth"]);
+
+    const reconciled = reconcileDynamicToolCallOrigins(state, {
+      pendingAuthorizationAttemptIds: new Set(["attempt-auth"]),
+      pendingCallIds: new Set(["call-approval"]),
+    });
+
+    expect(Object.keys(reconciled.calls)).toEqual(["call-approval", "call-auth"]);
+    expect(Object.keys(reconciled.definitions)).toEqual(["approval", "auth"]);
+  });
+
+  it("fails closed for unknown versions and malformed references", () => {
+    expect(() =>
+      readDynamicToolCallOrigin({ calls: {}, definitions: {}, version: 2 } as never, "call-a"),
+    ).toThrow("Unsupported dynamic tool call origin state version");
+
+    expect(() =>
+      readDynamicToolCallOrigin(
+        {
+          calls: {
+            "call-a": {
+              callId: "call-a",
+              definitionId: "missing",
+              originatingStepIndex: 0,
+              originatingTurnId: "turn-a",
+              toolName: "update",
+            },
+          },
+          definitions: {},
+          version: 1,
+        },
+        "call-a",
+      ),
+    ).toThrow('references missing definition "missing"');
+  });
+});

--- a/packages/eve/src/harness/dynamic-tool-call-origins.ts
+++ b/packages/eve/src/harness/dynamic-tool-call-origins.ts
@@ -1,0 +1,225 @@
+import type { DurableDynamicToolMetadata } from "#context/keys.js";
+
+export interface DurableDynamicToolCallOrigin {
+  readonly authorizationAttemptIds?: readonly string[];
+  readonly callId: string;
+  readonly definitionId: string;
+  readonly originatingStepIndex: number;
+  readonly originatingTurnId: string;
+  readonly toolName: string;
+}
+
+export interface DurableDynamicToolOriginState {
+  readonly calls: Readonly<Record<string, DurableDynamicToolCallOrigin>>;
+  readonly definitions: Readonly<Record<string, DurableDynamicToolMetadata>>;
+  readonly version: 1;
+}
+
+export interface DynamicToolCallCoordinate {
+  readonly callId: string;
+  readonly originatingStepIndex: number;
+  readonly originatingTurnId: string;
+  readonly toolName: string;
+}
+
+export type DynamicToolOriginCoordinate = Pick<
+  DynamicToolCallCoordinate,
+  "originatingStepIndex" | "originatingTurnId"
+>;
+
+export function createDynamicToolOriginState(): DurableDynamicToolOriginState {
+  return { calls: {}, definitions: {}, version: 1 };
+}
+
+export function readDynamicToolCallOrigin(
+  state: DurableDynamicToolOriginState,
+  callId: string,
+): DurableDynamicToolCallOrigin | undefined {
+  assertDynamicToolOriginState(state);
+  return state.calls[callId];
+}
+
+export function readDynamicToolOriginDefinition(
+  state: DurableDynamicToolOriginState,
+  callId: string,
+): DurableDynamicToolMetadata | undefined {
+  const origin = readDynamicToolCallOrigin(state, callId);
+  return origin === undefined ? undefined : state.definitions[origin.definitionId];
+}
+
+export function recordDynamicToolCallOrigin(
+  state: DurableDynamicToolOriginState,
+  definition: DurableDynamicToolMetadata | undefined,
+  call: DynamicToolCallCoordinate,
+): DurableDynamicToolOriginState {
+  assertDynamicToolOriginState(state);
+  if (definition === undefined) return state;
+  if (call.toolName !== definition.name) {
+    throw new Error(
+      `Cannot record dynamic tool call "${call.callId}": tool name "${call.toolName}" does not match definition "${definition.name}".`,
+    );
+  }
+
+  const existing = state.calls[call.callId];
+  if (existing !== undefined) {
+    if (existing.definitionId !== definition.definitionId) {
+      throw new Error(
+        `Dynamic tool call "${call.callId}" is already owned by definition "${existing.definitionId}".`,
+      );
+    }
+    return state;
+  }
+
+  const origin: DurableDynamicToolCallOrigin = {
+    callId: call.callId,
+    definitionId: definition.definitionId,
+    originatingStepIndex: call.originatingStepIndex,
+    originatingTurnId: call.originatingTurnId,
+    toolName: call.toolName,
+  };
+  return {
+    calls: { ...state.calls, [call.callId]: origin },
+    definitions: {
+      ...state.definitions,
+      [definition.definitionId]: state.definitions[definition.definitionId] ?? definition,
+    },
+    version: 1,
+  };
+}
+
+export function addDynamicToolAuthorizationAttempts(
+  state: DurableDynamicToolOriginState,
+  callId: string,
+  attemptIds: readonly string[],
+): DurableDynamicToolOriginState {
+  const origin = readDynamicToolCallOrigin(state, callId);
+  if (origin === undefined) {
+    throw new Error(
+      `Cannot attach authorization attempts to dynamic tool call "${callId}": its origin is missing.`,
+    );
+  }
+  const authorizationAttemptIds = [
+    ...new Set([...(origin.authorizationAttemptIds ?? []), ...attemptIds]),
+  ];
+  if (
+    authorizationAttemptIds.length === (origin.authorizationAttemptIds?.length ?? 0) &&
+    authorizationAttemptIds.every((id, index) => id === origin.authorizationAttemptIds?.[index])
+  ) {
+    return state;
+  }
+  return {
+    ...state,
+    calls: {
+      ...state.calls,
+      [callId]: { ...origin, authorizationAttemptIds },
+    },
+  };
+}
+
+export function releaseDynamicToolCallOrigin(
+  state: DurableDynamicToolOriginState,
+  callId: string,
+): DurableDynamicToolOriginState {
+  assertDynamicToolOriginState(state);
+  if (state.calls[callId] === undefined) return state;
+
+  const calls = { ...state.calls };
+  delete calls[callId];
+  return collectUnreferencedDefinitions({ calls, definitions: state.definitions, version: 1 });
+}
+
+export function releaseDynamicToolCallOriginsForTurn(
+  state: DurableDynamicToolOriginState,
+  turnId: string,
+): DurableDynamicToolOriginState {
+  assertDynamicToolOriginState(state);
+  const calls = Object.fromEntries(
+    Object.entries(state.calls).filter(([, origin]) => origin.originatingTurnId !== turnId),
+  );
+  if (Object.keys(calls).length === Object.keys(state.calls).length) return state;
+  return collectUnreferencedDefinitions({ calls, definitions: state.definitions, version: 1 });
+}
+
+export function reconcileDynamicToolCallOrigins(
+  state: DurableDynamicToolOriginState,
+  reachable: {
+    readonly pendingAuthorizationAttemptIds: ReadonlySet<string>;
+    readonly pendingCallIds: ReadonlySet<string>;
+  },
+): DurableDynamicToolOriginState {
+  assertDynamicToolOriginState(state);
+  const calls = Object.fromEntries(
+    Object.entries(state.calls).filter(
+      ([callId, origin]) =>
+        reachable.pendingCallIds.has(callId) ||
+        origin.authorizationAttemptIds?.some((attemptId) =>
+          reachable.pendingAuthorizationAttemptIds.has(attemptId),
+        ) === true,
+    ),
+  );
+  if (Object.keys(calls).length === Object.keys(state.calls).length) return state;
+  return collectUnreferencedDefinitions({ calls, definitions: state.definitions, version: 1 });
+}
+
+function collectUnreferencedDefinitions(
+  state: DurableDynamicToolOriginState,
+): DurableDynamicToolOriginState {
+  const referenced = new Set(Object.values(state.calls).map((origin) => origin.definitionId));
+  const definitions = Object.fromEntries(
+    Object.entries(state.definitions).filter(([definitionId]) => referenced.has(definitionId)),
+  );
+  return { calls: state.calls, definitions, version: 1 };
+}
+
+function assertDynamicToolOriginState(state: DurableDynamicToolOriginState): void {
+  if (typeof state !== "object" || state === null || state.version !== 1) {
+    const version =
+      typeof state === "object" && state !== null && "version" in state
+        ? String(state.version)
+        : "missing";
+    throw new Error(`Unsupported dynamic tool call origin state version "${version}".`);
+  }
+  if (!isRecord(state.calls) || !isRecord(state.definitions)) {
+    throw new Error("Dynamic tool call origin state is malformed.");
+  }
+
+  for (const [definitionId, definition] of Object.entries(state.definitions)) {
+    if (
+      !isRecord(definition) ||
+      definition.definitionId !== definitionId ||
+      typeof definition.name !== "string"
+    ) {
+      throw new Error(`Dynamic tool definition snapshot "${definitionId}" is malformed.`);
+    }
+  }
+  for (const [callId, origin] of Object.entries(state.calls)) {
+    if (
+      !isRecord(origin) ||
+      origin.callId !== callId ||
+      typeof origin.definitionId !== "string" ||
+      typeof origin.originatingStepIndex !== "number" ||
+      !Number.isSafeInteger(origin.originatingStepIndex) ||
+      origin.originatingStepIndex < 0 ||
+      typeof origin.originatingTurnId !== "string" ||
+      typeof origin.toolName !== "string"
+    ) {
+      throw new Error(`Dynamic tool call origin "${callId}" is malformed.`);
+    }
+    if (state.definitions[origin.definitionId] === undefined) {
+      throw new Error(
+        `Dynamic tool call origin "${callId}" references missing definition "${origin.definitionId}".`,
+      );
+    }
+    if (
+      origin.authorizationAttemptIds !== undefined &&
+      (!Array.isArray(origin.authorizationAttemptIds) ||
+        origin.authorizationAttemptIds.some((attemptId) => typeof attemptId !== "string"))
+    ) {
+      throw new Error(`Dynamic tool call origin "${callId}" has malformed authorization attempts.`);
+    }
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/eve/src/harness/dynamic-tool-call-origins.ts
+++ b/packages/eve/src/harness/dynamic-tool-call-origins.ts
@@ -31,6 +31,11 @@ export function createDynamicToolOriginState(): DurableDynamicToolOriginState {
   return { calls: {}, definitions: {}, version: 1 };
 }
 
+export function parseDynamicToolOriginState(value: unknown): DurableDynamicToolOriginState {
+  assertDynamicToolOriginState(value as DurableDynamicToolOriginState);
+  return value as DurableDynamicToolOriginState;
+}
+
 export function readDynamicToolCallOrigin(
   state: DurableDynamicToolOriginState,
   callId: string,
@@ -159,6 +164,41 @@ export function reconcileDynamicToolCallOrigins(
   );
   if (Object.keys(calls).length === Object.keys(state.calls).length) return state;
   return collectUnreferencedDefinitions({ calls, definitions: state.definitions, version: 1 });
+}
+
+export function resolveDynamicToolOriginDeployment(
+  state: DurableDynamicToolOriginState,
+  input: {
+    readonly authorizationAttemptIds: ReadonlySet<string>;
+    readonly callIds: ReadonlySet<string>;
+  },
+): string | undefined {
+  assertDynamicToolOriginState(state);
+  const deployments = new Set<string>();
+  let matched = false;
+  for (const origin of Object.values(state.calls)) {
+    const matchesCall = input.callIds.has(origin.callId);
+    const matchesAuthorization = origin.authorizationAttemptIds?.some((attemptId) =>
+      input.authorizationAttemptIds.has(attemptId),
+    );
+    if (!matchesCall && matchesAuthorization !== true) continue;
+
+    matched = true;
+    const deploymentId = state.definitions[origin.definitionId]?.runtimeDeploymentId;
+    if (deploymentId === undefined) {
+      throw new Error(
+        `Dynamic tool call "${origin.callId}" does not record an originating deployment and cannot safely resume.`,
+      );
+    }
+    deployments.add(deploymentId);
+  }
+  if (deployments.size > 1) {
+    throw new Error(
+      `Dynamic tool continuation spans multiple originating deployments (${[...deployments].join(", ")}). Respond to calls from one deployment at a time.`,
+    );
+  }
+  if (!matched) return undefined;
+  return deployments.values().next().value as string | undefined;
 }
 
 function collectUnreferencedDefinitions(

--- a/packages/eve/src/harness/dynamic-tool-call-routing.integration.test.ts
+++ b/packages/eve/src/harness/dynamic-tool-call-routing.integration.test.ts
@@ -1,0 +1,369 @@
+import { jsonSchema, type LanguageModel, type ModelMessage } from "ai";
+import { MockLanguageModelV4 } from "ai/test";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildDynamicTools,
+  replayDynamicTools,
+  resolveDynamicToolDefinitionForCall,
+} from "#context/build-dynamic-tools.js";
+import { ContextContainer, contextStorage } from "#context/container.js";
+import { deserializeContext, serializeContext } from "#context/serialize.js";
+import {
+  DynamicToolCallOriginsKey,
+  SessionKey,
+  TurnDynamicToolMetadataKey,
+  type DurableDynamicToolMetadata,
+} from "#context/keys.js";
+import {
+  createDynamicToolOriginState,
+  recordDynamicToolCallOrigin,
+} from "#harness/dynamic-tool-call-origins.js";
+import { appendPendingInputBatch } from "#harness/input-requests.js";
+import { getPendingInputBatches } from "#harness/pending-input-batches.js";
+import { createToolLoopHarness } from "#harness/tool-loop.js";
+import { buildToolSetFromDefinitions } from "#harness/tools.js";
+import type { HarnessSession, ToolLoopHarnessConfig } from "#harness/types.js";
+
+const usage = {
+  inputTokens: { cacheRead: undefined, cacheWrite: undefined, noCache: 1, total: 1 },
+  outputTokens: { reasoning: undefined, text: 1, total: 1 },
+};
+
+function definition(input: {
+  readonly definitionId: string;
+  readonly value: string;
+}): DurableDynamicToolMetadata {
+  return {
+    callbacks: {
+      approvalRequest: {
+        closure: { value: input.value },
+        stepId: `approval-${input.definitionId}`,
+      },
+      execute: {
+        closure: { value: input.value },
+        stepId: `execute-${input.definitionId}`,
+      },
+      toModelOutput: {
+        closure: { value: input.value },
+        stepId: `output-${input.definitionId}`,
+      },
+    },
+    definitionId: input.definitionId,
+    description: `Update with ${input.value}`,
+    entryKey: "update",
+    event: "turn.started",
+    inputSchema: { type: "object" },
+    name: "update",
+    ownerId: "updates",
+    resolverSlug: "updates",
+    runtimeRevision: `deployment:${input.value}`,
+    sourceId: "agent/tools/update.ts",
+  };
+}
+
+function pendingSession(): HarnessSession {
+  const call = {
+    input: { id: "item-1" },
+    toolCallId: "call-a",
+    toolName: "update",
+    type: "tool-call" as const,
+  };
+  return appendPendingInputBatch({
+    requests: [
+      {
+        action: {
+          callId: call.toolCallId,
+          input: call.input,
+          kind: "tool-call",
+          toolName: "update",
+        },
+        allowFreeform: false,
+        display: "confirmation",
+        kind: "tool-approval",
+        options: [
+          { id: "approve", label: "Approve" },
+          { id: "cancel", label: "Cancel" },
+        ],
+        prompt: "Approve update",
+        requestId: "approval-a",
+      },
+    ],
+    responseMessages: [
+      {
+        content: [
+          call,
+          { approvalId: "approval-a", toolCallId: call.toolCallId, type: "tool-approval-request" },
+        ],
+        role: "assistant",
+      },
+    ],
+    session: {
+      agent: {
+        modelReference: { id: "dynamic-origin-model" },
+        system: "Test assistant",
+        tools: [{ description: "Update", inputSchema: { type: "object" }, name: "update" }],
+      },
+      compaction: { recentWindowSize: 10, threshold: 100_000 },
+      continuationToken: "http:dynamic-origin",
+      history: [{ content: "Update item-1", role: "user" }],
+      sessionId: "dynamic-origin",
+    },
+  });
+}
+
+function installCallbacks(definitions: readonly DurableDynamicToolMetadata[]) {
+  const registryKey = Symbol.for("@workflow/core//registeredSteps");
+  const global = globalThis as Record<symbol, Map<string, Function> | undefined>;
+  const registry = global[registryKey] ?? new Map<string, Function>();
+  global[registryKey] = registry;
+  const execute = new Map<string, ReturnType<typeof vi.fn>>();
+  for (const entry of definitions) {
+    const value = entry.runtimeRevision.replace("deployment:", "");
+    const callback = vi.fn((closure: { value: string }, toolInput: unknown) => ({
+      definition: closure.value,
+      toolInput,
+    }));
+    execute.set(value, callback);
+    registry.set(entry.callbacks.execute.stepId, callback);
+    registry.set(entry.callbacks.approvalRequest!.stepId, () => "user-approval");
+    registry.set(entry.callbacks.toModelOutput!.stepId, (closure: { value: string }) => ({
+      type: "text",
+      value: `projected:${closure.value}`,
+    }));
+  }
+  return execute;
+}
+
+function findToolResult(messages: readonly ModelMessage[]) {
+  return messages.flatMap((message) =>
+    Array.isArray(message.content)
+      ? message.content.filter((part) => part.type === "tool-result")
+      : [],
+  )[0];
+}
+
+describe("dynamic tool call routing", () => {
+  it("records, restores, and releases a new dynamic call through the real AI SDK loop", async () => {
+    const b = definition({ definitionId: "definition-b", value: "B" });
+    const callbacks = installCallbacks([b]);
+    const ctx = new ContextContainer();
+    ctx.set(SessionKey, {
+      auth: { current: null, initiator: null },
+      sessionId: "dynamic-origin-new-call",
+      turn: { id: "turn-b", sequence: 0 },
+    });
+    ctx.set(TurnDynamicToolMetadataKey, [b]);
+
+    const model = new MockLanguageModelV4({
+      doGenerate: [
+        {
+          content: [
+            {
+              input: JSON.stringify({ id: "item-2" }),
+              toolCallId: "call-b",
+              toolName: "update",
+              type: "tool-call",
+            },
+          ],
+          finishReason: { raw: undefined, unified: "tool-calls" },
+          usage,
+          warnings: [],
+        },
+        {
+          content: [{ text: "Updated.", type: "text" }],
+          finishReason: { raw: undefined, unified: "stop" },
+          usage,
+          warnings: [],
+        },
+      ],
+      modelId: "dynamic-origin-model",
+      provider: "eve-integration-mock",
+    });
+    const config: ToolLoopHarnessConfig = {
+      mode: "conversation",
+      resolveModel: async (): Promise<LanguageModel> => model,
+      tools: new Map(),
+    };
+    const session: HarnessSession = {
+      agent: {
+        modelReference: { id: "dynamic-origin-model" },
+        system: "Test assistant",
+        tools: [{ description: "Update", inputSchema: { type: "object" }, name: "update" }],
+      },
+      compaction: { recentWindowSize: 10, threshold: 100_000 },
+      continuationToken: "http:dynamic-origin-new-call",
+      history: [],
+      sessionId: "dynamic-origin-new-call",
+    };
+
+    const parked = await contextStorage.run(ctx, () =>
+      createToolLoopHarness(config)(session, { message: "Update item-2" }),
+    );
+
+    expect(callbacks.get("B")).not.toHaveBeenCalled();
+    expect(ctx.get(DynamicToolCallOriginsKey)?.calls["call-b"]).toMatchObject({
+      definitionId: "definition-b",
+    });
+    const requestId = getPendingInputBatches(parked.session.state)[0]?.requests[0]?.requestId;
+    expect(requestId).toBeTypeOf("string");
+
+    const restored = await deserializeContext(serializeContext(ctx));
+    await contextStorage.run(restored, () =>
+      createToolLoopHarness(config)(parked.session, {
+        inputResponses: [{ optionId: "approve", requestId: requestId! }],
+      }),
+    );
+
+    expect(callbacks.get("B")).toHaveBeenCalledOnce();
+    expect(findToolResult(model.doGenerateCalls[1]?.prompt ?? [])).toMatchObject({
+      output: { type: "text", value: "projected:B" },
+      toolCallId: "call-b",
+      toolName: "update",
+    });
+    expect(restored.get(DynamicToolCallOriginsKey)).toBeUndefined();
+  });
+
+  it("resumes an approved call with A after same-name definition B becomes current", async () => {
+    const a = definition({ definitionId: "definition-a", value: "A" });
+    const b = definition({ definitionId: "definition-b", value: "B" });
+    const callbacks = installCallbacks([a, b]);
+    const ctx = new ContextContainer();
+    ctx.set(SessionKey, {
+      auth: { current: null, initiator: null },
+      sessionId: "dynamic-origin",
+      turn: { id: "turn-b", sequence: 1 },
+    });
+    ctx.set(TurnDynamicToolMetadataKey, [b]);
+    ctx.set(
+      DynamicToolCallOriginsKey,
+      recordDynamicToolCallOrigin(createDynamicToolOriginState(), a, {
+        callId: "call-a",
+        originatingStepIndex: 0,
+        originatingTurnId: "turn-a",
+        toolName: "update",
+      }),
+    );
+    const restored = await deserializeContext(serializeContext(ctx));
+
+    const model = new MockLanguageModelV4({
+      doGenerate: {
+        content: [{ text: "Updated.", type: "text" }],
+        finishReason: { raw: undefined, unified: "stop" },
+        usage,
+        warnings: [],
+      },
+      modelId: "dynamic-origin-model",
+      provider: "eve-integration-mock",
+    });
+    const config: ToolLoopHarnessConfig = {
+      mode: "conversation",
+      resolveModel: async (): Promise<LanguageModel> => model,
+      tools: new Map(),
+    };
+
+    const resumed = await contextStorage.run(restored, () =>
+      createToolLoopHarness(config)(pendingSession(), {
+        inputResponses: [{ optionId: "approve", requestId: "approval-a" }],
+      }),
+    );
+
+    expect(callbacks.get("A")).toHaveBeenCalledOnce();
+    expect(callbacks.get("B")).not.toHaveBeenCalled();
+    expect(findToolResult(model.doGenerateCalls[0]?.prompt ?? [])).toMatchObject({
+      output: { type: "text", value: "projected:A" },
+      toolCallId: "call-a",
+      toolName: "update",
+    });
+    expect(resumed.session.history.at(-1)).toMatchObject({ role: "assistant" });
+    expect(restored.get(DynamicToolCallOriginsKey)).toBeUndefined();
+
+    const toolSet = buildToolSetFromDefinitions({ tools: buildDynamicTools(restored) });
+    const current = toolSet.update!;
+    const projected = await contextStorage.run(restored, async () => {
+      const output = await current.execute!({ id: "item-2" }, {
+        messages: [],
+        toolCallId: "call-b",
+      } as never);
+      return await current.toModelOutput!({ output, toolCallId: "call-b" } as never);
+    });
+
+    expect(callbacks.get("B")).toHaveBeenCalledOnce();
+    expect(projected).toEqual({ type: "text", value: "projected:B" });
+  });
+
+  it("routes a parked dynamic call past a same-name static replacement", async () => {
+    const a = definition({ definitionId: "definition-a", value: "A" });
+    const callbacks = installCallbacks([a]);
+    const staticExecute = vi.fn(() => ({ definition: "static" }));
+    const staticOutput = vi.fn(() => ({ type: "text" as const, value: "projected:static" }));
+    const ctx = new ContextContainer();
+    ctx.set(SessionKey, {
+      auth: { current: null, initiator: null },
+      sessionId: "dynamic-origin-static-replacement",
+      turn: { id: "turn-b", sequence: 1 },
+    });
+    ctx.set(
+      DynamicToolCallOriginsKey,
+      recordDynamicToolCallOrigin(createDynamicToolOriginState(), a, {
+        callId: "call-a",
+        originatingStepIndex: 0,
+        originatingTurnId: "turn-a",
+        toolName: "update",
+      }),
+    );
+    const toolSet = buildToolSetFromDefinitions({
+      tools: [
+        {
+          description: "Static update",
+          execute: staticExecute,
+          inputSchema: jsonSchema({ type: "object" }),
+          name: "update",
+          toModelOutput: staticOutput,
+        },
+      ],
+    });
+    const update = toolSet.update!;
+
+    const projected = await contextStorage.run(ctx, async () => {
+      const output = await update.execute!({ id: "item-1" }, {
+        messages: [
+          {
+            content: [
+              {
+                input: { id: "item-1" },
+                toolCallId: "call-a",
+                toolName: "update",
+                type: "tool-call",
+              },
+            ],
+            role: "assistant",
+          },
+        ],
+        toolCallId: "call-a",
+      } as never);
+      return await update.toModelOutput!({ output, toolCallId: "call-a" } as never);
+    });
+
+    expect(callbacks.get("A")).toHaveBeenCalledOnce();
+    expect(staticExecute).not.toHaveBeenCalled();
+    expect(staticOutput).not.toHaveBeenCalled();
+    expect(projected).toEqual({ type: "text", value: "projected:A" });
+  });
+
+  it("fails explicitly when a pending call has no durable origin", () => {
+    const b = definition({ definitionId: "definition-b", value: "B" });
+    installCallbacks([b]);
+    const ctx = new ContextContainer();
+
+    expect(() =>
+      contextStorage.run(ctx, () =>
+        resolveDynamicToolDefinitionForCall({
+          callId: "call-a",
+          current: replayDynamicTools([b])[0]!,
+          knownCall: true,
+        }),
+      ),
+    ).toThrow('Dynamic tool call "call-a" is pending, but its originating definition is missing.');
+  });
+});

--- a/packages/eve/src/harness/dynamic-tool-call-routing.integration.test.ts
+++ b/packages/eve/src/harness/dynamic-tool-call-routing.integration.test.ts
@@ -224,6 +224,145 @@ describe("dynamic tool call routing", () => {
     expect(restored.get(DynamicToolCallOriginsKey)).toBeUndefined();
   });
 
+  it("releases a parked origin when approval is denied", async () => {
+    const b = definition({ definitionId: "definition-b", value: "B" });
+    const callbacks = installCallbacks([b]);
+    const ctx = new ContextContainer();
+    ctx.set(SessionKey, {
+      auth: { current: null, initiator: null },
+      sessionId: "dynamic-origin-denied",
+      turn: { id: "turn-b", sequence: 0 },
+    });
+    ctx.set(TurnDynamicToolMetadataKey, [b]);
+    const model = new MockLanguageModelV4({
+      doGenerate: [
+        {
+          content: [
+            {
+              input: JSON.stringify({ id: "item-2" }),
+              toolCallId: "call-b",
+              toolName: "update",
+              type: "tool-call",
+            },
+          ],
+          finishReason: { raw: undefined, unified: "tool-calls" },
+          usage,
+          warnings: [],
+        },
+        {
+          content: [{ text: "Cancelled.", type: "text" }],
+          finishReason: { raw: undefined, unified: "stop" },
+          usage,
+          warnings: [],
+        },
+      ],
+      modelId: "dynamic-origin-model",
+      provider: "eve-integration-mock",
+    });
+    const config: ToolLoopHarnessConfig = {
+      mode: "conversation",
+      resolveModel: async (): Promise<LanguageModel> => model,
+      tools: new Map(),
+    };
+    const session: HarnessSession = {
+      agent: {
+        modelReference: { id: "dynamic-origin-model" },
+        system: "Test assistant",
+        tools: [{ description: "Update", inputSchema: { type: "object" }, name: "update" }],
+      },
+      compaction: { recentWindowSize: 10, threshold: 100_000 },
+      continuationToken: "http:dynamic-origin-denied",
+      history: [],
+      sessionId: "dynamic-origin-denied",
+    };
+
+    const parked = await contextStorage.run(ctx, () =>
+      createToolLoopHarness(config)(session, { message: "Update item-2" }),
+    );
+    const requestId = getPendingInputBatches(parked.session.state)[0]?.requests[0]?.requestId;
+    expect(requestId).toBeTypeOf("string");
+
+    await contextStorage.run(ctx, () =>
+      createToolLoopHarness(config)(parked.session, {
+        inputResponses: [{ optionId: "cancel", requestId: requestId! }],
+      }),
+    );
+
+    expect(callbacks.get("B")).not.toHaveBeenCalled();
+    expect(ctx.get(DynamicToolCallOriginsKey)).toBeUndefined();
+  });
+
+  it("releases a new origin after tool execution fails", async () => {
+    const b = definition({ definitionId: "definition-b", value: "B" });
+    const callbacks = installCallbacks([b]);
+    callbacks.get("B")!.mockImplementation(() => {
+      throw new Error("execution failed");
+    });
+    const ctx = new ContextContainer();
+    ctx.set(SessionKey, {
+      auth: { current: null, initiator: null },
+      sessionId: "dynamic-origin-tool-error",
+      turn: { id: "turn-b", sequence: 0 },
+    });
+    ctx.set(TurnDynamicToolMetadataKey, [b]);
+    const model = new MockLanguageModelV4({
+      doGenerate: [
+        {
+          content: [
+            {
+              input: JSON.stringify({ id: "item-2" }),
+              toolCallId: "call-b",
+              toolName: "update",
+              type: "tool-call",
+            },
+          ],
+          finishReason: { raw: undefined, unified: "tool-calls" },
+          usage,
+          warnings: [],
+        },
+        {
+          content: [{ text: "The update failed.", type: "text" }],
+          finishReason: { raw: undefined, unified: "stop" },
+          usage,
+          warnings: [],
+        },
+      ],
+      modelId: "dynamic-origin-model",
+      provider: "eve-integration-mock",
+    });
+    const config: ToolLoopHarnessConfig = {
+      mode: "conversation",
+      resolveModel: async (): Promise<LanguageModel> => model,
+      tools: new Map(),
+    };
+    const session: HarnessSession = {
+      agent: {
+        modelReference: { id: "dynamic-origin-model" },
+        system: "Test assistant",
+        tools: [{ description: "Update", inputSchema: { type: "object" }, name: "update" }],
+      },
+      compaction: { recentWindowSize: 10, threshold: 100_000 },
+      continuationToken: "http:dynamic-origin-tool-error",
+      history: [],
+      sessionId: "dynamic-origin-tool-error",
+    };
+
+    const parked = await contextStorage.run(ctx, () =>
+      createToolLoopHarness(config)(session, { message: "Update item-2" }),
+    );
+    const requestId = getPendingInputBatches(parked.session.state)[0]?.requests[0]?.requestId;
+    expect(requestId).toBeTypeOf("string");
+
+    await contextStorage.run(ctx, () =>
+      createToolLoopHarness(config)(parked.session, {
+        inputResponses: [{ optionId: "approve", requestId: requestId! }],
+      }),
+    );
+
+    expect(callbacks.get("B")).toHaveBeenCalledOnce();
+    expect(ctx.get(DynamicToolCallOriginsKey)).toBeUndefined();
+  });
+
   it("resumes an approved call with A after same-name definition B becomes current", async () => {
     const a = definition({ definitionId: "definition-a", value: "A" });
     const b = definition({ definitionId: "definition-b", value: "B" });
@@ -361,7 +500,7 @@ describe("dynamic tool call routing", () => {
         resolveDynamicToolDefinitionForCall({
           callId: "call-a",
           current: replayDynamicTools([b])[0]!,
-          knownCall: true,
+          requireOrigin: true,
         }),
       ),
     ).toThrow('Dynamic tool call "call-a" is pending, but its originating definition is missing.');

--- a/packages/eve/src/harness/dynamic-tool-call-routing.ts
+++ b/packages/eve/src/harness/dynamic-tool-call-routing.ts
@@ -1,0 +1,170 @@
+import type { ModelMessage } from "ai";
+
+import type { AlsContext } from "#context/container.js";
+import { contextStorage } from "#context/container.js";
+import type { ContextReader } from "#context/key.js";
+import {
+  DynamicToolCallCoordinateKey,
+  DynamicToolCallOriginsKey,
+  SessionKey,
+  type DurableDynamicToolMetadata,
+} from "#context/keys.js";
+import { getPendingAuthorization } from "#harness/authorization.js";
+import {
+  addDynamicToolAuthorizationAttempts,
+  createDynamicToolOriginState,
+  readDynamicToolCallOrigin,
+  readDynamicToolOriginDefinition,
+  reconcileDynamicToolCallOrigins,
+  recordDynamicToolCallOrigin,
+  releaseDynamicToolCallOrigin,
+  releaseDynamicToolCallOriginsForTurn,
+  type DurableDynamicToolOriginState,
+} from "#harness/dynamic-tool-call-origins.js";
+import { getPendingInputBatches } from "#harness/pending-input-batches.js";
+import type { SessionStateMap } from "#harness/types.js";
+
+export function resolveDynamicToolMetadataForCall(input: {
+  readonly callId: string;
+  readonly current?: DurableDynamicToolMetadata;
+  readonly knownCall: boolean;
+  readonly toolName: string;
+}): DurableDynamicToolMetadata | undefined {
+  const ctx = contextStorage.getStore();
+  if (ctx === undefined) return input.current;
+
+  const state = readOriginState(ctx);
+  const origin = readDynamicToolCallOrigin(state, input.callId);
+  if (origin !== undefined) {
+    if (origin.toolName !== input.toolName) {
+      throw new Error(
+        `Dynamic tool call "${input.callId}" originated as "${origin.toolName}", not "${input.toolName}".`,
+      );
+    }
+    return readDynamicToolOriginDefinition(state, input.callId)!;
+  }
+  if (input.current === undefined) return undefined;
+  if (input.knownCall) {
+    throw new Error(
+      `Dynamic tool call "${input.callId}" is pending, but its originating definition is missing. The call cannot safely resume.`,
+    );
+  }
+
+  const session = ctx.get(SessionKey);
+  const coordinate = ctx.get(DynamicToolCallCoordinateKey) ?? {
+    originatingStepIndex: 0,
+    originatingTurnId: session?.turn.id ?? "turn_unknown",
+  };
+  writeOriginState(
+    ctx,
+    recordDynamicToolCallOrigin(state, input.current, {
+      callId: input.callId,
+      ...coordinate,
+      toolName: input.toolName,
+    }),
+  );
+  return input.current;
+}
+
+export function hasDynamicToolCallInMessages(
+  messages: readonly ModelMessage[] | undefined,
+  callId: string,
+): boolean {
+  for (const message of messages ?? []) {
+    if (!Array.isArray(message.content)) continue;
+    for (const part of message.content) {
+      if (
+        typeof part === "object" &&
+        part !== null &&
+        "toolCallId" in part &&
+        part.toolCallId === callId
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+export function addAuthorizationAttemptsForDynamicToolCall(
+  callId: string,
+  attemptIds: readonly string[],
+): void {
+  if (attemptIds.length === 0) return;
+  const ctx = contextStorage.getStore();
+  if (ctx === undefined || ctx.get(DynamicToolCallOriginsKey) === undefined) return;
+  writeOriginState(
+    ctx,
+    addDynamicToolAuthorizationAttempts(readOriginState(ctx), callId, attemptIds),
+  );
+}
+
+export function releaseDynamicToolCallOrigins(callIds: Iterable<string>): void {
+  const ctx = contextStorage.getStore();
+  if (ctx === undefined || ctx.get(DynamicToolCallOriginsKey) === undefined) return;
+  let state = readOriginState(ctx);
+  for (const callId of callIds) state = releaseDynamicToolCallOrigin(state, callId);
+  writeOriginState(ctx, state);
+}
+
+export function releaseCurrentDynamicToolOriginsForTurn(turnId: string): void {
+  const ctx = contextStorage.getStore();
+  if (ctx === undefined) return;
+  releaseDynamicToolOriginsForTurn(ctx, turnId);
+}
+
+export function releaseDynamicToolOriginsForTurn(ctx: AlsContext, turnId: string): void {
+  if (ctx.get(DynamicToolCallOriginsKey) === undefined) return;
+  writeOriginState(ctx, releaseDynamicToolCallOriginsForTurn(readOriginState(ctx), turnId));
+}
+
+export function clearDynamicToolCallOrigins(ctx: AlsContext): void {
+  ctx.delete(DynamicToolCallOriginsKey);
+}
+
+export function reconcileDynamicToolOrigins(
+  ctx: AlsContext,
+  sessionState: SessionStateMap | undefined,
+): void {
+  if (ctx.get(DynamicToolCallOriginsKey) === undefined) return;
+  const pendingCallIds = new Set(
+    getPendingInputBatches(sessionState).flatMap((batch) =>
+      batch.requests.map((request) => request.action.callId),
+    ),
+  );
+  const pendingAuthorizationAttemptIds = new Set(
+    getPendingAuthorization(sessionState)?.challenges.flatMap((challenge) =>
+      challenge.attemptId === undefined ? [] : [challenge.attemptId],
+    ) ?? [],
+  );
+  writeOriginState(
+    ctx,
+    reconcileDynamicToolCallOrigins(readOriginState(ctx), {
+      pendingAuthorizationAttemptIds,
+      pendingCallIds,
+    }),
+  );
+}
+
+export function readArchivedDynamicToolDefinitions(
+  ctx: ContextReader,
+): readonly DurableDynamicToolMetadata[] {
+  const state = ctx.get(DynamicToolCallOriginsKey);
+  if (state === undefined) return [];
+  readDynamicToolCallOrigin(state, "");
+  return Object.values(state.definitions);
+}
+
+function readOriginState(ctx: AlsContext): DurableDynamicToolOriginState {
+  const state = ctx.get(DynamicToolCallOriginsKey) ?? createDynamicToolOriginState();
+  readDynamicToolCallOrigin(state, "");
+  return state;
+}
+
+function writeOriginState(ctx: AlsContext, state: DurableDynamicToolOriginState): void {
+  if (Object.keys(state.calls).length === 0) {
+    ctx.delete(DynamicToolCallOriginsKey);
+  } else {
+    ctx.set(DynamicToolCallOriginsKey, state);
+  }
+}

--- a/packages/eve/src/harness/dynamic-tool-call-routing.ts
+++ b/packages/eve/src/harness/dynamic-tool-call-routing.ts
@@ -1,5 +1,3 @@
-import type { ModelMessage } from "ai";
-
 import type { AlsContext } from "#context/container.js";
 import { contextStorage } from "#context/container.js";
 import type { ContextReader } from "#context/key.js";
@@ -13,6 +11,7 @@ import { getPendingAuthorization } from "#harness/authorization.js";
 import {
   addDynamicToolAuthorizationAttempts,
   createDynamicToolOriginState,
+  parseDynamicToolOriginState,
   readDynamicToolCallOrigin,
   readDynamicToolOriginDefinition,
   reconcileDynamicToolCallOrigins,
@@ -27,7 +26,7 @@ import type { SessionStateMap } from "#harness/types.js";
 export function resolveDynamicToolMetadataForCall(input: {
   readonly callId: string;
   readonly current?: DurableDynamicToolMetadata;
-  readonly knownCall: boolean;
+  readonly requireOrigin: boolean;
   readonly toolName: string;
 }): DurableDynamicToolMetadata | undefined {
   const ctx = contextStorage.getStore();
@@ -44,7 +43,7 @@ export function resolveDynamicToolMetadataForCall(input: {
     return readDynamicToolOriginDefinition(state, input.callId)!;
   }
   if (input.current === undefined) return undefined;
-  if (input.knownCall) {
+  if (input.requireOrigin) {
     throw new Error(
       `Dynamic tool call "${input.callId}" is pending, but its originating definition is missing. The call cannot safely resume.`,
     );
@@ -64,26 +63,6 @@ export function resolveDynamicToolMetadataForCall(input: {
     }),
   );
   return input.current;
-}
-
-export function hasDynamicToolCallInMessages(
-  messages: readonly ModelMessage[] | undefined,
-  callId: string,
-): boolean {
-  for (const message of messages ?? []) {
-    if (!Array.isArray(message.content)) continue;
-    for (const part of message.content) {
-      if (
-        typeof part === "object" &&
-        part !== null &&
-        "toolCallId" in part &&
-        part.toolCallId === callId
-      ) {
-        return true;
-      }
-    }
-  }
-  return false;
 }
 
 export function addAuthorizationAttemptsForDynamicToolCall(
@@ -133,8 +112,8 @@ export function reconcileDynamicToolOrigins(
     ),
   );
   const pendingAuthorizationAttemptIds = new Set(
-    getPendingAuthorization(sessionState)?.challenges.flatMap((challenge) =>
-      challenge.attemptId === undefined ? [] : [challenge.attemptId],
+    getPendingAuthorization(sessionState)?.challenges.map(
+      (challenge) => challenge.attemptId ?? challenge.name,
     ) ?? [],
   );
   writeOriginState(
@@ -151,14 +130,12 @@ export function readArchivedDynamicToolDefinitions(
 ): readonly DurableDynamicToolMetadata[] {
   const state = ctx.get(DynamicToolCallOriginsKey);
   if (state === undefined) return [];
-  readDynamicToolCallOrigin(state, "");
-  return Object.values(state.definitions);
+  return Object.values(parseDynamicToolOriginState(state).definitions);
 }
 
 function readOriginState(ctx: AlsContext): DurableDynamicToolOriginState {
   const state = ctx.get(DynamicToolCallOriginsKey) ?? createDynamicToolOriginState();
-  readDynamicToolCallOrigin(state, "");
-  return state;
+  return parseDynamicToolOriginState(state);
 }
 
 function writeOriginState(ctx: AlsContext, state: DurableDynamicToolOriginState): void {

--- a/packages/eve/src/harness/execute-tool.ts
+++ b/packages/eve/src/harness/execute-tool.ts
@@ -1,5 +1,6 @@
 import type { FlexibleSchema } from "ai";
 
+import type { DurableDynamicToolMetadata } from "#context/keys.js";
 import type { Approval } from "#public/definitions/approval.js";
 import type { ToolExecuteOptions } from "#shared/tool-definition.js";
 
@@ -29,6 +30,8 @@ export type HarnessRuntimeActionDefinition =
 export interface HarnessToolDefinition {
   readonly approvalKey?: (toolInput: Readonly<Record<string, unknown>>) => string;
   readonly description: string;
+  /** Internal replay snapshot for definitions produced by `defineDynamic`. */
+  readonly dynamicDefinition?: DurableDynamicToolMetadata;
   readonly execute?: (input: any, options: ToolExecuteOptions) => any;
   readonly frameworkAction?: "load-skill";
   readonly inputSchema: FlexibleSchema;

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -2067,11 +2067,16 @@ describe("createToolLoopHarness", () => {
           approvalRequest: { closure: {}, stepId: "test-step-approval" },
           execute: { closure: {}, stepId: "test-step-execute" },
         },
+        definitionId: "definition:tfl-get-line-status",
         description: "Get TfL line status.",
         entryKey: "tfl__getLineStatus",
+        event: "step.started",
         inputSchema: { type: "object" },
         name: "tfl__getLineStatus",
+        ownerId: "tfl",
         resolverSlug: "tfl",
+        runtimeRevision: "runtime:test",
+        sourceId: "agent/tools/tfl.ts",
       },
     ]);
 

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -16,6 +16,7 @@ import { dispatchDynamicInstructionEvent } from "#context/dynamic-instruction-li
 import {
   AuthKey,
   ChannelInstrumentationKey,
+  DynamicToolCallOriginsKey,
   InitiatorAuthKey,
   LiveStepDynamicModelSelectionKey,
   ParentSessionKey,
@@ -8985,7 +8986,9 @@ describe("createToolLoopHarness", () => {
       state,
     });
 
-    const result = await runStep(session);
+    const ctx = new ContextContainer();
+    ctx.set(DynamicToolCallOriginsKey, { calls: {}, definitions: {}, version: 1 });
+    const result = await contextStorage.run(ctx, () => runStep(session));
 
     expect(result.next).toBeNull();
     expect(result.session).toMatchObject({
@@ -9007,6 +9010,7 @@ describe("createToolLoopHarness", () => {
     expect(resolveModel).not.toHaveBeenCalled();
     expect(compactMessages).not.toHaveBeenCalled();
     expect(ToolLoopAgent).not.toHaveBeenCalled();
+    expect(ctx.get(DynamicToolCallOriginsKey)).toBeUndefined();
   });
 
   it("compacts user instructions as ordinary history without starting a model turn", async () => {

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -2731,9 +2731,7 @@ async function handleStepResult(input: {
     const { challenges } = signal;
     addAuthorizationAttemptsForDynamicToolCall(
       callId,
-      challenges.flatMap((challenge) =>
-        challenge.attemptId === undefined ? [] : [challenge.attemptId],
-      ),
+      challenges.map((challenge) => challenge.attemptId ?? challenge.name),
     );
 
     if (emit) {

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -33,11 +33,18 @@ import { contextStorage } from "#context/container.js";
 import {
   AuthKey,
   ChannelInstrumentationKey,
+  DynamicToolCallCoordinateKey,
   ParentSessionKey,
   ParentTraceContextKey,
   SessionCallbackKey,
   TurnTaskDeliveryKey,
 } from "#context/keys.js";
+import {
+  addAuthorizationAttemptsForDynamicToolCall,
+  clearDynamicToolCallOrigins,
+  releaseCurrentDynamicToolOriginsForTurn,
+  releaseDynamicToolCallOrigins,
+} from "#harness/dynamic-tool-call-routing.js";
 import {
   buildDynamicInstructionMessages,
   drainDynamicInstructionUserMessages,
@@ -721,6 +728,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     };
 
     if (config.clearOnly === true) {
+      if (store !== undefined) clearDynamicToolCallOrigins(store);
       session = {
         ...session,
         compaction: {
@@ -1099,6 +1107,10 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         }
       }
     }
+    releaseDynamicToolCallOrigins(
+      pending.rejectedActions?.flatMap((batch) => batch.results.map((result) => result.callId)) ??
+        [],
+    );
 
     // --- Turn preamble ------------------------------------------------------
 
@@ -1272,6 +1284,11 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         projectedMessages,
       );
     }
+
+    ctx?.setVirtualContext(DynamicToolCallCoordinateKey, {
+      originatingStepIndex: emissionState.stepIndex,
+      originatingTurnId: emissionState.turnId,
+    });
 
     const approvedTools = getApprovedTools(session);
 
@@ -1730,6 +1747,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         // so the gateway-wrapped upstream 4xx body would otherwise be
         // invisible to OTel providers.
         const finalError = recoveryResult.error;
+        releaseCurrentDynamicToolOriginsForTurn(emissionState.turnId);
         if (turnSpan) {
           recordErrorOnSpan(turnSpan, finalError);
         }
@@ -2544,6 +2562,7 @@ async function handleStepResult(input: {
     excludedCallIds: invalidInputToolCallIds,
   });
   const approvalRequestCallIds = new Set(approvalRequests.map((request) => request.action.callId));
+  const authSignal = findAuthorizationSignalFromToolResults(result.toolResults);
   const questionRequests = extractQuestionInputRequests({
     toolCalls: result.toolCalls,
     excludedCallIds: new Set([...invalidInputToolCallIds, ...approvalRequestCallIds]),
@@ -2583,6 +2602,11 @@ async function handleStepResult(input: {
         tools: advertisedRuntimeActionTools,
       }),
     );
+
+  releaseSettledDynamicToolCallOrigins(
+    result,
+    new Set([...approvalRequestCallIds, ...(authSignal === undefined ? [] : [authSignal.callId])]),
+  );
 
   if (pendingRuntimeActions.length > 0) {
     // Stamp the live emission state onto the parked session so the
@@ -2702,9 +2726,15 @@ async function handleStepResult(input: {
 
   // --- Park on authorization request ------------------------------------------
 
-  const authSignal = findAuthorizationSignalFromToolResults(result.toolResults);
   if (authSignal) {
-    const { challenges } = authSignal;
+    const { callId, signal } = authSignal;
+    const { challenges } = signal;
+    addAuthorizationAttemptsForDynamicToolCall(
+      callId,
+      challenges.flatMap((challenge) =>
+        challenge.attemptId === undefined ? [] : [challenge.attemptId],
+      ),
+    );
 
     if (emit) {
       for (const superseded of getSupersededAuthorizationChallenges(
@@ -3285,22 +3315,48 @@ async function runModelCallWithRetries<T>(
 
 function findAuthorizationSignalFromToolResults(
   toolResults: readonly TypedToolResult<ToolSet>[] | undefined,
-): AuthorizationSignal | undefined {
+): { readonly callId: string; readonly signal: AuthorizationSignal } | undefined {
   const ctx = contextStorage.getStore();
   if (ctx !== undefined) {
     for (const toolResult of toolResults ?? []) {
       const stashed = readToolInterrupt(ctx, toolResult.toolCallId);
       if (stashed !== undefined && isAuthorizationSignal(stashed)) {
-        return stashed;
+        return { callId: toolResult.toolCallId, signal: stashed };
       }
     }
   }
 
   for (const toolResult of toolResults ?? []) {
     if (isAuthorizationSignal(toolResult.output)) {
-      return toolResult.output;
+      return { callId: toolResult.toolCallId, signal: toolResult.output };
     }
   }
 
   return undefined;
+}
+
+function releaseSettledDynamicToolCallOrigins(
+  result: HarnessStepResult,
+  retainedCallIds: ReadonlySet<string>,
+): void {
+  const settled = new Set<string>();
+  const collect = (part: unknown): void => {
+    if (typeof part !== "object" || part === null) return;
+    const candidate = part as { readonly toolCallId?: unknown; readonly type?: unknown };
+    if (
+      (candidate.type === "tool-result" || candidate.type === "tool-error") &&
+      typeof candidate.toolCallId === "string" &&
+      !retainedCallIds.has(candidate.toolCallId)
+    ) {
+      settled.add(candidate.toolCallId);
+    }
+  };
+  for (const part of result.content ?? []) collect(part);
+  for (const part of result.toolResults ?? []) collect(part);
+  for (const message of result.response.messages) {
+    if (Array.isArray(message.content)) {
+      for (const part of message.content) collect(part);
+    }
+  }
+  releaseDynamicToolCallOrigins(settled);
 }

--- a/packages/eve/src/harness/tools.ts
+++ b/packages/eve/src/harness/tools.ts
@@ -22,12 +22,18 @@ import { stashToolInterrupt } from "#harness/tool-interrupts.js";
 import { normalizeToolJsonOutput, normalizeToolModelOutput } from "#harness/tool-model-output.js";
 import type { ToolExecuteOptions } from "#shared/tool-definition.js";
 import { isAsyncIterable } from "#shared/async-iterable.js";
+import { resolveDynamicToolDefinitionForCall } from "#context/build-dynamic-tools.js";
+import { hasDynamicToolCallInMessages } from "#harness/dynamic-tool-call-routing.js";
 
 type NativeApprovalStatus = Exclude<ApprovalStatus, boolean>;
 
 const toolApprovals = new WeakMap<
   object,
-  (toolInput: unknown, callId: string) => Promise<NativeApprovalStatus>
+  (
+    toolInput: unknown,
+    callId: string,
+    messages: readonly import("ai").ModelMessage[],
+  ) => Promise<NativeApprovalStatus>
 >();
 
 /**
@@ -65,8 +71,9 @@ export function buildToolSet(input: {
       continue;
     }
 
-    const authorToModelOutput = definition.toModelOutput;
     const approval = buildApprovalFn(definition, input);
+    const hasModelOutput =
+      definition.toModelOutput !== undefined || definition.dynamicDefinition !== undefined;
     const aiTool = tool({
       description: definition.description,
       execute: wrapToolExecute(definition),
@@ -87,11 +94,17 @@ export function buildToolSet(input: {
                   value: authorizationPendingModelText(output.connections),
                 };
               }
+              const resolvedDefinition = resolveDynamicToolDefinitionForCall({
+                callId: toolCallId ?? "",
+                current: definition,
+                knownCall: true,
+              });
+              const authorToModelOutput = resolvedDefinition.toModelOutput;
               if (authorToModelOutput !== undefined) {
                 return normalizeToolModelOutput({
                   output: await authorToModelOutput(output),
                   toolCallId,
-                  toolName: definition.name,
+                  toolName: resolvedDefinition.name,
                 });
               }
               if (typeof output === "string") {
@@ -100,11 +113,11 @@ export function buildToolSet(input: {
               return normalizeToolModelOutput({
                 output: { type: "json" as const, value: output ?? null },
                 toolCallId,
-                toolName: definition.name,
+                toolName: resolvedDefinition.name,
               });
             },
           }
-        : authorToModelOutput !== undefined
+        : hasModelOutput
           ? {
               toModelOutput: async ({
                 output,
@@ -112,17 +125,27 @@ export function buildToolSet(input: {
               }: {
                 readonly output: unknown;
                 readonly toolCallId?: string;
-              }) =>
-                normalizeToolModelOutput({
-                  output: await authorToModelOutput(output),
+              }) => {
+                const resolvedDefinition = resolveDynamicToolDefinitionForCall({
+                  callId: toolCallId ?? "",
+                  current: definition,
+                  knownCall: true,
+                });
+                const toModelOutput = resolvedDefinition.toModelOutput;
+                return normalizeToolModelOutput({
+                  output:
+                    toModelOutput === undefined
+                      ? { type: "json" as const, value: output ?? null }
+                      : await toModelOutput(output),
                   toolCallId,
-                  toolName: definition.name,
-                }),
+                  toolName: resolvedDefinition.name,
+                });
+              },
             }
           : {}),
     });
     tools[definition.name] = aiTool;
-    if (definition.approval !== undefined) {
+    if (definition.approval !== undefined || definition.dynamicDefinition !== undefined) {
       toolApprovals.set(aiTool, approval);
     }
   }
@@ -166,10 +189,20 @@ export function buildToolSetFromDefinitions(input: {
 export function wrapToolExecute(
   definition: HarnessToolDefinition,
 ): ((input: any, options: ToolExecuteOptions) => Promise<any> | AsyncIterable<any>) | undefined {
-  const execute = definition.execute;
-  if (execute === undefined) return undefined;
+  if (definition.execute === undefined) return undefined;
 
   return (input, options) => {
+    const resolvedDefinition = resolveDynamicToolDefinitionForCall({
+      callId: options.toolCallId,
+      current: definition,
+      knownCall: hasDynamicToolCallInMessages(options.messages, options.toolCallId),
+    });
+    const execute = resolvedDefinition.execute;
+    if (execute === undefined) {
+      return Promise.reject(
+        new Error(`Dynamic tool "${resolvedDefinition.name}" has no replayable executor.`),
+      );
+    }
     let output: unknown;
     try {
       output = execute(input, options);
@@ -178,11 +211,11 @@ export function wrapToolExecute(
     }
 
     if (isAsyncIterable(output)) {
-      return normalizeToolExecuteIterable(output, definition.name, options);
+      return normalizeToolExecuteIterable(output, resolvedDefinition.name, options);
     }
 
     return Promise.resolve(output).then((value) =>
-      normalizeToolExecuteOutput(value, definition.name, options),
+      normalizeToolExecuteOutput(value, resolvedDefinition.name, options),
     );
   };
 }
@@ -271,18 +304,27 @@ export async function buildToolSetWithProviderTools(input: {
 function buildApprovalFn(
   definition: HarnessToolDefinition,
   input: { readonly approvedTools?: ReadonlySet<string> },
-): (toolInput: unknown, callId: string) => Promise<NativeApprovalStatus> {
-  return async (toolInput: unknown, callId: string) => {
-    if (definition.approval === undefined) return undefined;
+): (
+  toolInput: unknown,
+  callId: string,
+  messages: readonly import("ai").ModelMessage[],
+) => Promise<NativeApprovalStatus> {
+  return async (toolInput: unknown, callId: string, messages) => {
+    const resolvedDefinition = resolveDynamicToolDefinitionForCall({
+      callId,
+      current: definition,
+      knownCall: hasDynamicToolCallInMessages(messages, callId),
+    });
+    if (resolvedDefinition.approval === undefined) return undefined;
 
     const toolInputRecord = isObject(toolInput) ? toolInput : undefined;
 
-    const status = await resolveApprovalPolicy(definition.approval)({
+    const status = await resolveApprovalPolicy(resolvedDefinition.approval)({
       ...buildCallbackContext(),
       approvedTools: input.approvedTools ?? new Set(),
       callId,
       toolInput: toolInputRecord,
-      toolName: definition.name,
+      toolName: resolvedDefinition.name,
     });
     return typeof status === "boolean" ? (status ? "user-approval" : "not-applicable") : status;
   };
@@ -292,11 +334,11 @@ function buildApprovalFn(
 export function buildToolApproval(
   tools: ToolSet,
 ): ToolApprovalConfiguration<ToolSet, Record<string, unknown>> {
-  return async ({ toolCall }) => {
+  return async ({ messages = [], toolCall }) => {
     const toolDefinition = tools[toolCall.toolName];
     if (toolDefinition === undefined) return undefined;
 
     const approval = toolApprovals.get(toolDefinition);
-    return (await approval?.(toolCall.input, toolCall.toolCallId)) as ToolApprovalStatus;
+    return (await approval?.(toolCall.input, toolCall.toolCallId, messages)) as ToolApprovalStatus;
   };
 }

--- a/packages/eve/src/harness/tools.ts
+++ b/packages/eve/src/harness/tools.ts
@@ -23,17 +23,12 @@ import { normalizeToolJsonOutput, normalizeToolModelOutput } from "#harness/tool
 import type { ToolExecuteOptions } from "#shared/tool-definition.js";
 import { isAsyncIterable } from "#shared/async-iterable.js";
 import { resolveDynamicToolDefinitionForCall } from "#context/build-dynamic-tools.js";
-import { hasDynamicToolCallInMessages } from "#harness/dynamic-tool-call-routing.js";
 
 type NativeApprovalStatus = Exclude<ApprovalStatus, boolean>;
 
 const toolApprovals = new WeakMap<
   object,
-  (
-    toolInput: unknown,
-    callId: string,
-    messages: readonly import("ai").ModelMessage[],
-  ) => Promise<NativeApprovalStatus>
+  (toolInput: unknown, callId: string) => Promise<NativeApprovalStatus>
 >();
 
 /**
@@ -94,11 +89,7 @@ export function buildToolSet(input: {
                   value: authorizationPendingModelText(output.connections),
                 };
               }
-              const resolvedDefinition = resolveDynamicToolDefinitionForCall({
-                callId: toolCallId ?? "",
-                current: definition,
-                knownCall: true,
-              });
+              const resolvedDefinition = resolveToolDefinitionForOutput(definition, toolCallId);
               const authorToModelOutput = resolvedDefinition.toModelOutput;
               if (authorToModelOutput !== undefined) {
                 return normalizeToolModelOutput({
@@ -126,11 +117,7 @@ export function buildToolSet(input: {
                 readonly output: unknown;
                 readonly toolCallId?: string;
               }) => {
-                const resolvedDefinition = resolveDynamicToolDefinitionForCall({
-                  callId: toolCallId ?? "",
-                  current: definition,
-                  knownCall: true,
-                });
+                const resolvedDefinition = resolveToolDefinitionForOutput(definition, toolCallId);
                 const toModelOutput = resolvedDefinition.toModelOutput;
                 return normalizeToolModelOutput({
                   output:
@@ -195,7 +182,7 @@ export function wrapToolExecute(
     const resolvedDefinition = resolveDynamicToolDefinitionForCall({
       callId: options.toolCallId,
       current: definition,
-      knownCall: hasDynamicToolCallInMessages(options.messages, options.toolCallId),
+      requireOrigin: false,
     });
     const execute = resolvedDefinition.execute;
     if (execute === undefined) {
@@ -304,16 +291,12 @@ export async function buildToolSetWithProviderTools(input: {
 function buildApprovalFn(
   definition: HarnessToolDefinition,
   input: { readonly approvedTools?: ReadonlySet<string> },
-): (
-  toolInput: unknown,
-  callId: string,
-  messages: readonly import("ai").ModelMessage[],
-) => Promise<NativeApprovalStatus> {
-  return async (toolInput: unknown, callId: string, messages) => {
+): (toolInput: unknown, callId: string) => Promise<NativeApprovalStatus> {
+  return async (toolInput: unknown, callId: string) => {
     const resolvedDefinition = resolveDynamicToolDefinitionForCall({
       callId,
       current: definition,
-      knownCall: hasDynamicToolCallInMessages(messages, callId),
+      requireOrigin: false,
     });
     if (resolvedDefinition.approval === undefined) return undefined;
 
@@ -334,11 +317,30 @@ function buildApprovalFn(
 export function buildToolApproval(
   tools: ToolSet,
 ): ToolApprovalConfiguration<ToolSet, Record<string, unknown>> {
-  return async ({ messages = [], toolCall }) => {
+  return async ({ toolCall }) => {
     const toolDefinition = tools[toolCall.toolName];
     if (toolDefinition === undefined) return undefined;
 
     const approval = toolApprovals.get(toolDefinition);
-    return (await approval?.(toolCall.input, toolCall.toolCallId, messages)) as ToolApprovalStatus;
+    return (await approval?.(toolCall.input, toolCall.toolCallId)) as ToolApprovalStatus;
   };
+}
+
+function resolveToolDefinitionForOutput(
+  definition: HarnessToolDefinition,
+  toolCallId: string | undefined,
+): HarnessToolDefinition {
+  if (toolCallId === undefined) {
+    if (definition.dynamicDefinition !== undefined) {
+      throw new Error(
+        `Dynamic tool "${definition.name}" cannot project output without a tool call id.`,
+      );
+    }
+    return definition;
+  }
+  return resolveDynamicToolDefinitionForCall({
+    callId: toolCallId,
+    current: definition,
+    requireOrigin: true,
+  });
 }

--- a/packages/eve/src/internal/workflow/development-world-client.ts
+++ b/packages/eve/src/internal/workflow/development-world-client.ts
@@ -196,6 +196,7 @@ function createQueueHandler(
         {
           generationId,
           source: createDiskRuntimeCompiledArtifactsSource(runtimeAppRoot, {
+            deploymentId: generationId,
             durableReference: "development-generation",
             moduleMapLoaderPath: resolvePackageSourceFilePath(
               "src/internal/authored-module-map-loader.ts",

--- a/packages/eve/src/runtime/cache-key.scenario.test.ts
+++ b/packages/eve/src/runtime/cache-key.scenario.test.ts
@@ -82,6 +82,22 @@ describe("resolveRuntimeCompiledArtifactsVersionedCacheKey", () => {
       ),
     ).resolves.toEqual(`disk:${appRoot}:authored-source:${moduleMapLoaderPath}`);
   });
+
+  it("keeps deployment-bound sources separate from unbound sources", async () => {
+    const appRoot = await createScratchDirectory("eve-cache-key-");
+    const moduleMapLoaderPath = "/tmp/authored-module-map-loader.mjs";
+
+    await expect(
+      resolveRuntimeCompiledArtifactsVersionedCacheKey(
+        createDiskRuntimeCompiledArtifactsSource(appRoot, {
+          deploymentId: "generation-a",
+          moduleMapLoaderPath,
+        }),
+      ),
+    ).resolves.toEqual(
+      `disk:${appRoot}:authored-source:${moduleMapLoaderPath}:deployment:generation-a`,
+    );
+  });
 });
 
 async function writeCompileMetadata(input: {

--- a/packages/eve/src/runtime/compiled-artifacts-source.ts
+++ b/packages/eve/src/runtime/compiled-artifacts-source.ts
@@ -18,6 +18,8 @@ export interface RuntimeBundledCompiledArtifactsSource {
  */
 export interface RuntimeDiskCompiledArtifactsSource {
   readonly appRoot: string;
+  /** Workflow deployment selected for this immutable artifact source. */
+  readonly deploymentId?: string;
   readonly kind: "disk";
   /**
    * Native filesystem path to the package-owned authored-source module map
@@ -58,6 +60,7 @@ export function createBundledRuntimeCompiledArtifactsSource(): RuntimeBundledCom
 export function createDiskRuntimeCompiledArtifactsSource(
   appRoot: string,
   options: {
+    readonly deploymentId?: string;
     readonly durableReference?: "development-generation";
     readonly moduleMapLoaderPath?: string;
     readonly sandboxAppRoot?: string;
@@ -66,10 +69,12 @@ export function createDiskRuntimeCompiledArtifactsSource(
   if (
     options.moduleMapLoaderPath !== undefined ||
     options.sandboxAppRoot !== undefined ||
-    options.durableReference !== undefined
+    options.durableReference !== undefined ||
+    options.deploymentId !== undefined
   ) {
     return {
       appRoot,
+      deploymentId: options.deploymentId,
       durableReference: options.durableReference,
       kind: "disk",
       moduleMapLoaderPath: options.moduleMapLoaderPath,
@@ -111,9 +116,12 @@ export function getRuntimeCompiledArtifactsCacheKey(
     return "bundled";
   }
 
-  if (source.moduleMapLoaderPath !== undefined) {
-    return `disk:${source.appRoot}:authored-source:${source.moduleMapLoaderPath}`;
-  }
+  const sourceKey =
+    source.moduleMapLoaderPath !== undefined
+      ? `disk:${source.appRoot}:authored-source:${source.moduleMapLoaderPath}`
+      : `disk:${source.appRoot}`;
 
-  return `disk:${source.appRoot}`;
+  return source.deploymentId === undefined
+    ? sourceKey
+    : `${sourceKey}:deployment:${source.deploymentId}`;
 }

--- a/packages/eve/test/scenarios/dynamic-tool-cold-replay.scenario.test.ts
+++ b/packages/eve/test/scenarios/dynamic-tool-cold-replay.scenario.test.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
@@ -12,7 +12,12 @@ import {
   DEV_SERVER_SCENARIO_TIMEOUT_MS,
   TRANSACTIONAL_REBUILD_DESCRIPTOR,
 } from "./dev-server-descriptors.js";
-import { startEveDev, waitForCondition } from "./dev-server-harness.js";
+import {
+  forceDevelopmentRebuild,
+  startEveDev,
+  waitForCondition,
+  withinDeadline,
+} from "./dev-server-harness.js";
 
 const scenarioApp = useScenarioApp();
 
@@ -75,13 +80,14 @@ export function createDurableMarkerTool(key: string) {
 }
 `;
 
-const DYNAMIC_TOOLS_SOURCE = `import { appendFileSync } from "node:fs";
+function createDynamicToolsSource(revision: string): string {
+  return `import { appendFileSync } from "node:fs";
 import { join } from "node:path";
 import { defineDynamic } from "eve/tools";
 import { createDurableMarkerTool } from "../lib/durable-factory.ts";
 
-const guardedMarker = createDurableMarkerTool("guarded");
-const companionMarker = createDurableMarkerTool("companion");
+const guardedMarker = createDurableMarkerTool("guarded-${revision}");
+const companionMarker = createDurableMarkerTool("companion-${revision}");
 
 export default defineDynamic({
   events: {
@@ -95,6 +101,7 @@ export default defineDynamic({
   },
 });
 `;
+}
 
 const DYNAMIC_TOOL_COLD_REPLAY_DESCRIPTOR: ScenarioAppDescriptor = {
   ...TRANSACTIONAL_REBUILD_DESCRIPTOR,
@@ -106,7 +113,7 @@ const DYNAMIC_TOOL_COLD_REPLAY_DESCRIPTOR: ScenarioAppDescriptor = {
       ),
     ),
     "agent/lib/durable-factory.ts": DURABLE_FACTORY_SOURCE,
-    "agent/tools/durable-dynamic.ts": DYNAMIC_TOOLS_SOURCE,
+    "agent/tools/durable-dynamic.ts": createDynamicToolsSource("a"),
   },
 };
 
@@ -125,33 +132,44 @@ async function readMarker(appRoot: string, phase: string, key: string): Promise<
 
 describe("dynamic tool cold replay", () => {
   it(
-    "resumes every callback phase from an imported factory in a fresh process",
+    "retains an originating definition across a rebuilt module and fresh process",
     async () => {
       const app = await scenarioApp(DYNAMIC_TOOL_COLD_REPLAY_DESCRIPTOR);
-      const pinnedEnv = {
-        VERCEL_DEPLOYMENT_ID: "dynamic-tool-cold-replay",
-        WORKFLOW_INLINE_OWNERSHIP_LEASE_SECONDS: "1",
+      const env = { WORKFLOW_INLINE_OWNERSHIP_LEASE_SECONDS: "1" };
+      let server = await startEveDev(app.appRoot, { env });
+      let previousServerOutput = "";
+      const complete = async <T>(operation: Promise<T>, stage: string): Promise<T> => {
+        try {
+          return await withinDeadline(operation, `Timed out during ${stage}.`, 45_000);
+        } catch (error) {
+          throw new Error(
+            `${error instanceof Error ? error.message : String(error)}\n\nprevious server:\n${previousServerOutput}\n\nstdout:\n${server.stdout()}\n\nstderr:\n${server.stderr()}`,
+            { cause: error },
+          );
+        }
       };
-      let server = await startEveDev(app.appRoot, { env: pinnedEnv });
 
       try {
         const client = new Client({ host: server.url });
         const created = await client.sessions.create({ message: "Hello." });
-        await expect(created.response.result()).resolves.toMatchObject({
+        await expect(
+          complete(created.response.result(), "session creation"),
+        ).resolves.toMatchObject({
           inputRequests: [],
           status: "waiting",
         });
 
-        const waiting = await (
-          await created.session.send("Call tools in parallel: guarded_marker, companion_marker")
-        ).result();
+        const waitingResponse = await created.session.send(
+          "Call tools in parallel: guarded_marker, companion_marker",
+        );
+        const waiting = await complete(waitingResponse.result(), "originating approval requests");
         expect(waiting.status).toBe("waiting");
         expect(
           waiting.inputRequests,
           `Expected two approval requests.\n\nevents:\n${JSON.stringify(waiting.events, null, 2)}\n\nstdout:\n${server.stdout()}\n\nstderr:\n${server.stderr()}`,
         ).toHaveLength(2);
 
-        const firstRequest = await readMarker(app.appRoot, "approval-request", "guarded");
+        const firstRequest = await readMarker(app.appRoot, "approval-request", "guarded-a");
         const resolverRunsBeforeRestart = (
           await readFile(join(app.appRoot, ".dynamic-resolver-runs"), "utf8")
         )
@@ -160,6 +178,19 @@ describe("dynamic tool cold replay", () => {
         expect(resolverRunsBeforeRestart).toHaveLength(1);
         const sessionState = created.session.state;
 
+        // Shift every transformed callback's source coordinate and replace the
+        // same model-visible names before resuming the parked generation.
+        await writeFile(
+          join(app.appRoot, "agent", "lib", "durable-factory.ts"),
+          `\n\n${DURABLE_FACTORY_SOURCE}`,
+        );
+        await writeFile(
+          join(app.appRoot, "agent", "tools", "durable-dynamic.ts"),
+          createDynamicToolsSource("b"),
+        );
+        await complete(forceDevelopmentRebuild(server.url), "candidate generation rebuild");
+
+        previousServerOutput = `stdout:\n${server.stdout()}\n\nstderr:\n${server.stderr()}`;
         await server.crash();
         await waitForCondition(async () => {
           try {
@@ -169,23 +200,22 @@ describe("dynamic tool cold replay", () => {
             return error instanceof Error && "code" in error && error.code === "ENOENT";
           }
         }, "The crashed development server did not release its state record.");
-        server = await startEveDev(app.appRoot, { env: pinnedEnv });
+        server = await startEveDev(app.appRoot, { env });
 
         const resumedSession = new Client({ host: server.url }).sessions.attach(
           sessionState.sessionId,
           { streamIndex: sessionState.streamIndex },
         );
-        const resumed = await (
-          await resumedSession.respond(
-            waiting.inputRequests.map((request) => ({
-              optionId: "approve",
-              requestId: request.requestId,
-            })),
-          )
-        ).result();
+        const resumedResponse = await resumedSession.respond(
+          waiting.inputRequests.map((request) => ({
+            optionId: "approve",
+            requestId: request.requestId,
+          })),
+        );
+        const resumed = await complete(resumedResponse.result(), "originating approval resume");
         expect(resumed.status).toBe("waiting");
 
-        for (const key of ["guarded", "companion"]) {
+        for (const key of ["guarded-a", "companion-a"]) {
           const response = await readMarker(app.appRoot, "approval-response", key);
           const execute = await readMarker(app.appRoot, "execute", key);
           const projection = await readMarker(app.appRoot, "projection", key);
@@ -202,6 +232,48 @@ describe("dynamic tool cold replay", () => {
           .trim()
           .split("\n");
         expect(resolverRunsAfterRestart).toEqual(resolverRunsBeforeRestart);
+
+        const nextWaitingResponse = await resumedSession.send(
+          "Call tools in parallel: guarded_marker, companion_marker",
+        );
+        const nextWaiting = await complete(
+          nextWaitingResponse.result(),
+          "replacement approval request",
+        );
+        expect(
+          nextWaiting.inputRequests,
+          `Expected replacement approval requests.\n\nevents:\n${JSON.stringify(nextWaiting.events, null, 2)}\n\nstdout:\n${server.stdout()}\n\nstderr:\n${server.stderr()}`,
+        ).toHaveLength(2);
+        const secondRequest = await readMarker(app.appRoot, "approval-request", "guarded-b");
+        expect(secondRequest.pid).not.toBe(firstRequest.pid);
+
+        const nextResponseStream = await resumedSession.respond(
+          nextWaiting.inputRequests.map((request) => ({
+            optionId: "approve",
+            requestId: request.requestId,
+          })),
+        );
+        const nextResult = await complete(
+          nextResponseStream.result(),
+          "replacement approval resume",
+        );
+        expect(nextResult.status).toBe("waiting");
+
+        for (const key of ["guarded-b", "companion-b"]) {
+          const nextResponse = await readMarker(app.appRoot, "approval-response", key);
+          const nextExecute = await readMarker(app.appRoot, "execute", key);
+          const nextProjection = await readMarker(app.appRoot, "projection", key);
+          expect(nextResponse.pid).toBe(secondRequest.pid);
+          expect(nextExecute.pid).toBe(secondRequest.pid);
+          expect(nextProjection.pid).toBe(secondRequest.pid);
+        }
+
+        const resolverRunsAfterNextTurn = (
+          await readFile(join(app.appRoot, ".dynamic-resolver-runs"), "utf8")
+        )
+          .trim()
+          .split("\n");
+        expect(resolverRunsAfterNextTurn).toHaveLength(2);
       } finally {
         await server.stop();
       }


### PR DESCRIPTION
### Summary

Closes #2346. A parked dynamic tool call could retain its definition snapshot but still resume on the latest Workflow deployment, where its callback code and compiled step IDs may have changed or disappeared. Each admitted call now records its origin deployment, and the long-lived driver routes correlated approval and authorization deliveries back to that exact deployment while unrelated messages continue on the latest deployment. Missing provenance and response batches spanning multiple deployments fail closed; terminal cleanup still reclaims origins, and replay never serializes callback code or invokes the current resolver.

### Validation

The regression scenario parks two calls on generation A, rewrites the factory and resolver to generation B, rebuilds, kills the server, starts a fresh process, and proves A still handles approval, execution, captured service state, and model-output projection before a later turn reuses the call IDs on B. Full unit and integration suites passed; the complete scenario suite's six environment/load-only failures all passed in isolated reruns with clean npm or process state.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 3 files · `+8 / -1`

Documents the origin-deployment guarantee and records the published behavior change.

**Implementation** — 16 files · `+828 / -113`

Adds durable deployment provenance, exact-deployment driver routing, fail-closed correlation, and lifecycle cleanup. The main review seam is the narrow mapping from approval and authorization response IDs to their admitted call origins; runtime callbacks remain ordinary compiled Workflow steps.

**Tests** — 9 files · `+1275 / -30`

Covers definition and deployment replacement, fresh-process recovery, call-ID reuse, authorization correlation, same-name static replacement, cleanup paths, and explicit failure modes. The larger scenario portion is the real dev-server crash/rebuild lifecycle needed to prove the old compiled generation—not an in-memory callback mock—executes after restart.
