### PR TITLE
fix(eve): configure Web Chat after registry install

### DIFF
--- a/.changeset/calm-web-scripts.md
+++ b/.changeset/calm-web-scripts.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Update the project scripts after `eve add channel/web` so `pnpm dev` starts the generated Next.js app.

--- a/packages/eve/src/setup/scaffold/index.integration.test.ts
+++ b/packages/eve/src/setup/scaffold/index.integration.test.ts
@@ -714,6 +714,53 @@ describe("ensureChannel", () => {
       packageJsonUpdated: [],
     });
   });
+
+  test("finishes package setup after the registry installs Web Chat", async () => {
+    const projectRoot = await createTempDir();
+    const pagePath = join(projectRoot, "app/page.tsx");
+    const packageJsonPath = join(projectRoot, "package.json");
+    await mkdir(join(projectRoot, "app"), { recursive: true });
+    await writeFile(pagePath, "registry-installed\n", "utf8");
+    await writeFile(
+      packageJsonPath,
+      `${JSON.stringify(
+        {
+          name: "demo",
+          type: "module",
+          scripts: { test: "vitest" },
+          dependencies: { next: "16.3.0-preview.6" },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const result = await ensureChannel({
+      projectRoot,
+      kind: "web",
+      configureVercelServices: false,
+      skipDependencyMutation: true,
+      webPackageVersions: TEST_WEB_PACKAGE_VERSIONS,
+    });
+
+    expect(result.action).toBe("overwritten");
+    await expect(readFile(pagePath, "utf8")).resolves.toBe("registry-installed\n");
+    const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as {
+      dependencies: Record<string, string>;
+      scripts: Record<string, string>;
+    };
+    expect(packageJson.dependencies).toEqual({ next: "16.3.0-preview.6" });
+    expect(packageJson).toMatchObject({
+      scripts: {
+        build: "next build",
+        "build:eve": "eve build",
+        dev: "next dev",
+        start: "next start",
+        test: "vitest",
+      },
+    });
+  });
 });
 
 describe("isNextJsProject", () => {

--- a/packages/eve/src/setup/scaffold/update/channels.ts
+++ b/packages/eve/src/setup/scaffold/update/channels.ts
@@ -459,7 +459,7 @@ export interface EnsureChannelOptions {
   /** When false, Web Chat leaves Vercel Services config unwritten for preview-only scaffolds. */
   configureVercelServices?: boolean;
   onWorkspaceRootMutation?: (mutation: WorkspaceRootMutation) => void | Promise<void>;
-  /** Dependencies are already owned and installed by a registry item. */
+  /** Web Chat files and dependencies are already installed by a registry item. */
   skipDependencyMutation?: boolean;
 }
 
@@ -478,7 +478,11 @@ async function ensureWebChannel(
   const packageJsonPath = join(options.projectRoot, "package.json");
   const webEntryPath = join(options.projectRoot, "app/page.tsx");
   const webEntryAlreadyExists = await pathExists(webEntryPath);
-  if (!options.force && (await isNextJsProject(options.projectRoot))) {
+  if (
+    !options.force &&
+    !options.skipDependencyMutation &&
+    (await isNextJsProject(options.projectRoot))
+  ) {
     return {
       kind: "web",
       action: "skipped",


### PR DESCRIPTION
### Summary

Stacked on #2363. After the registry installs Web Chat, setup saw its generated `next` dependency and treated the project as a pre-existing Next.js app. Setup now recognizes the registry-owned install, adds the generated scripts, and preserves the files and dependencies the registry installed.

### Validation

Ran the focused Web Chat scaffold integration test and verified the generated Web Chat template remains current with `pnpm --filter eve run check:web-template`.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Records the Web Chat script correction in release notes.

**Implementation** — 1 file · `+6 / -2`

Keeps the existing-Next.js protection for user-owned apps while allowing the registry-owned setup to finish.

**Tests** — 1 file · `+47 / -0`

Reproduces the registry-installed state and verifies setup adds scripts without changing its files or dependencies.
