### PR TITLE
feat(eve): opt into scaffold release age exceptions

### DIFF
--- a/.changeset/opt-in-release-age-exceptions.md
+++ b/.changeset/opt-in-release-age-exceptions.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add a hidden `eve init --release-age-exceptions` option for scaffolding pnpm release-age exclusions for eve, AI SDK, Vercel, and workflow dependencies when needed.

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -64,6 +64,8 @@ export interface InitCommandOptions {
   model?: string;
   /** Reasoning effort written to the root agent config. Set by `--reasoning`. */
   reasoning?: AgentReasoningDefinition;
+  /** Add eve dependencies to pnpm's release-age exclusion list. */
+  releaseAgeExceptions?: boolean;
 }
 
 export interface InitCommandDependencies {
@@ -236,6 +238,7 @@ async function scaffoldProject(
       overwriteExisting,
       workspaceProbeDirectory: projectPath,
       packageManager,
+      releaseAgeExceptions: options.releaseAgeExceptions,
       onWorkspaceRootMutation: (mutation: WorkspaceRootMutation) => {
         workspaceRootMutations.push(mutation);
       },

--- a/packages/eve/src/cli/run.test.ts
+++ b/packages/eve/src/cli/run.test.ts
@@ -321,6 +321,7 @@ describe("eve init compatibility flags", () => {
     expect(help).toContain("-y, --yes");
     expect(help).toContain("--model <model>");
     expect(help).toContain("--reasoning <effort>");
+    expect(help).not.toContain("--release-age-exceptions");
   });
 
   it("forwards model settings to the init command", async () => {
@@ -334,8 +335,23 @@ describe("eve init compatibility flags", () => {
 
     expect(runInitCommand).toHaveBeenCalledWith(logger, resolve(process.cwd()), "my-agent", {
       channelWebNextjs: undefined,
+      releaseAgeExceptions: undefined,
       model: "openai/gpt-5.6-sol",
       reasoning: "high",
+    });
+  });
+
+  it("forwards hidden release-age exceptions to the init command", async () => {
+    const logger = { error: vi.fn(), log: vi.fn() };
+    runInitCommand.mockClear();
+
+    await runCli(["init", "my-agent", "--release-age-exceptions"], logger);
+
+    expect(runInitCommand).toHaveBeenCalledWith(logger, resolve(process.cwd()), "my-agent", {
+      channelWebNextjs: undefined,
+      releaseAgeExceptions: true,
+      model: undefined,
+      reasoning: undefined,
     });
   });
 

--- a/packages/eve/src/cli/run.ts
+++ b/packages/eve/src/cli/run.ts
@@ -1,4 +1,9 @@
-import { Command, CommanderError, InvalidArgumentError } from "#compiled/commander/index.js";
+import {
+  Command,
+  CommanderError,
+  InvalidArgumentError,
+  Option,
+} from "#compiled/commander/index.js";
 import { registerBuildCommand, type BuildHost } from "#cli/commands/build.js";
 import { devBootPhase, type DevBootProgressReporter } from "#internal/dev-boot-progress.js";
 import { resolveApplicationRoot } from "#internal/application/paths.js";
@@ -234,6 +239,12 @@ function createCliProgram(
     .command("init [target]")
     .description("Create a new eve agent, or add one to an existing project directory.")
     .option("--channel-web-nextjs", "Add the Web Chat application (Next.js)")
+    .addOption(
+      new Option(
+        "--release-age-exceptions",
+        "Add eve dependencies to pnpm's release-age exclusion list",
+      ).hideHelp(),
+    )
     .option("--model <model>", "Set the agent model (provider/model-id)")
     .option(
       "--reasoning <effort>",
@@ -246,6 +257,7 @@ function createCliProgram(
         target: string | undefined,
         options: {
           channelWebNextjs?: boolean;
+          releaseAgeExceptions?: boolean;
           model?: string;
           reasoning?: AgentReasoningDefinition;
           yes?: boolean;
@@ -258,6 +270,7 @@ function createCliProgram(
         const { runInitCommand } = await import("#cli/commands/init.js");
         await runInitCommand(logger, applicationContext.root, target, {
           channelWebNextjs: options.channelWebNextjs,
+          releaseAgeExceptions: options.releaseAgeExceptions,
           model: options.model,
           reasoning: options.reasoning,
         });

--- a/packages/eve/src/setup/primitives/pm/pnpm.ts
+++ b/packages/eve/src/setup/primitives/pm/pnpm.ts
@@ -14,6 +14,18 @@ export const PNPM_WORKSPACE_PATH = "pnpm-workspace.yaml";
 export const PNPM_WORKSPACE_MEMBERSHIP_ARGUMENTS = ["list", "--depth", "-1", "--json"] as const;
 
 const SHARP_BUILD_POLICY = "  sharp: false";
+const RELEASE_AGE_EXCLUSIONS = [
+  "@ai-sdk/*",
+  "@rolldown/*",
+  "@vercel/*",
+  "@workflow/*",
+  "ai",
+  "experimental-ai-sdk-code-mode",
+  "eve",
+  "nitro",
+  "rolldown",
+  "workflow",
+] as const;
 
 export const PNPM_WORKSPACE_CONTENT = [
   "minimumReleaseAgeStrict: true",
@@ -21,6 +33,17 @@ export const PNPM_WORKSPACE_CONTENT = [
   SHARP_BUILD_POLICY,
   "",
 ].join("\n");
+
+function formatReleaseAgeExclusion(exclusion: string): string {
+  return `  - ${exclusion.includes("*") ? JSON.stringify(exclusion) : exclusion}`;
+}
+
+function releaseAgeExclusionName(line: string): string {
+  return line
+    .trim()
+    .replace(/^-\s+/u, "")
+    .replace(/^["']|["']$/gu, "");
+}
 
 function findYamlBlockEnd(lines: readonly string[], startIndex: number): number {
   let blockEnd = startIndex + 1;
@@ -30,6 +53,33 @@ function findYamlBlockEnd(lines: readonly string[], startIndex: number): number 
     blockEnd += 1;
   }
   return blockEnd;
+}
+
+function withReleaseAgeExceptions(source: string): string {
+  const normalized = source.endsWith("\n") ? source : `${source}\n`;
+  const lines = normalized.split("\n");
+  const excludeIndex = lines.findIndex((line) => line === "minimumReleaseAgeExclude:");
+
+  if (excludeIndex < 0) {
+    const prefix = normalized.trim().length === 0 ? "" : `${normalized}\n`;
+    return `${prefix}minimumReleaseAgeExclude:\n${RELEASE_AGE_EXCLUSIONS.map(formatReleaseAgeExclusion).join("\n")}\n`;
+  }
+
+  const blockEnd = findYamlBlockEnd(lines, excludeIndex);
+  const existingExclusions = new Set(
+    lines.slice(excludeIndex + 1, blockEnd).map(releaseAgeExclusionName),
+  );
+  const missingExclusions = RELEASE_AGE_EXCLUSIONS.filter(
+    (exclusion) => !existingExclusions.has(exclusion),
+  );
+  if (missingExclusions.length === 0) return source;
+
+  let insertAt = blockEnd;
+  while (insertAt > excludeIndex + 1 && lines[insertAt - 1] === "") {
+    insertAt -= 1;
+  }
+  lines.splice(insertAt, 0, ...missingExclusions.map(formatReleaseAgeExclusion));
+  return lines.join("\n");
 }
 
 function withPnpmWorkspacePolicy(source: string): string {
@@ -56,14 +106,22 @@ function withPnpmWorkspacePolicy(source: string): string {
   return policyLines.join("\n");
 }
 
-async function ensurePnpmWorkspacePolicy(filePath: string): Promise<"skipped" | "written"> {
+async function ensurePnpmWorkspacePolicy(
+  filePath: string,
+  releaseAgeExceptions: boolean,
+): Promise<"skipped" | "written"> {
   if (!(await pathExists(filePath))) {
-    await writeFile(filePath, PNPM_WORKSPACE_CONTENT, "utf8");
+    const content = releaseAgeExceptions
+      ? withReleaseAgeExceptions(PNPM_WORKSPACE_CONTENT)
+      : PNPM_WORKSPACE_CONTENT;
+    await writeFile(filePath, content, "utf8");
     return "written";
   }
 
   const current = await readFile(filePath, "utf8");
-  const next = withPnpmWorkspacePolicy(current);
+  const next = withPnpmWorkspacePolicy(
+    releaseAgeExceptions ? withReleaseAgeExceptions(current) : current,
+  );
   if (next === current) {
     return "skipped";
   }
@@ -231,7 +289,10 @@ export const pnpmPackageManager = {
     const workspaceMembershipResult = await ensurePnpmWorkspaceIncludesProject(workspaceProbeRoot);
     const workspaceRoot = findClaimingAncestorPnpmWorkspaceRoot(workspaceProbeRoot);
     const filePath = join(workspaceRoot ?? projectRoot, PNPM_WORKSPACE_PATH);
-    const policyResult = await ensurePnpmWorkspacePolicy(filePath);
+    const policyResult = await ensurePnpmWorkspacePolicy(
+      filePath,
+      options?.releaseAgeExceptions === true,
+    );
     const result =
       workspaceMembershipResult === "written" || policyResult === "written" ? "written" : "skipped";
     return result === "written"

--- a/packages/eve/src/setup/primitives/pm/types.ts
+++ b/packages/eve/src/setup/primitives/pm/types.ts
@@ -21,6 +21,8 @@ export interface PackageManagerConfigurationOptions {
    * before being moved into place.
    */
   readonly workspaceProbeRoot?: string;
+  /** Adds scaffold-specific packages to pnpm's release-age exclusion list. */
+  readonly releaseAgeExceptions?: boolean;
 }
 
 export interface PackageManagerInstallOptions {

--- a/packages/eve/src/setup/scaffold/create/project.ts
+++ b/packages/eve/src/setup/scaffold/create/project.ts
@@ -361,6 +361,8 @@ export interface ScaffoldBaseProjectOptions {
    * Defaults to pnpm.
    */
   packageManager?: PackageManagerKind;
+  /** Adds eve's dependencies to pnpm's release-age exclusion list. */
+  releaseAgeExceptions?: boolean;
   targetDirectory?: string;
   overwriteExisting?: boolean;
   onOverwriteFile?: (filePath: string) => void | Promise<void>;
@@ -450,6 +452,7 @@ export async function scaffoldBaseProject(options: ScaffoldBaseProjectOptions): 
   await applyPackageManagerWorkspaceConfiguration({
     packageManager,
     projectRoot: targetRoot,
+    releaseAgeExceptions: options.releaseAgeExceptions,
     workspaceProbeRoot,
     onWorkspaceRootMutation: options.onWorkspaceRootMutation,
   });

--- a/packages/eve/src/setup/scaffold/workspace-root.ts
+++ b/packages/eve/src/setup/scaffold/workspace-root.ts
@@ -198,6 +198,7 @@ export async function applyPackageManagerWorkspaceConfiguration(input: {
   readonly packageManager: PackageManagerKind;
   readonly projectRoot: string;
   readonly workspaceProbeRoot?: string;
+  readonly releaseAgeExceptions?: boolean;
   readonly onWorkspaceRootMutation?: (mutation: WorkspaceRootMutation) => void | Promise<void>;
 }): Promise<{
   filesSkipped: string[];
@@ -213,7 +214,10 @@ export async function applyPackageManagerWorkspaceConfiguration(input: {
         );
   const packageManagerResult = await getPackageManagerStrategy(
     input.packageManager,
-  ).applyProjectConfiguration(input.projectRoot, { workspaceProbeRoot });
+  ).applyProjectConfiguration(input.projectRoot, {
+    releaseAgeExceptions: input.releaseAgeExceptions,
+    workspaceProbeRoot,
+  });
   const filesWritten = [
     ...(workspaceConfigPath === undefined ? [] : [workspaceConfigPath]),
     ...packageManagerResult.filesWritten,


### PR DESCRIPTION
### Summary

Stacked on #2328. `eve init --release-age-exceptions` is a hidden opt-in that adds pnpm release-age exclusions for eve, AI SDK, Vercel (including `@vercel/connect`), and workflow dependencies. Normal scaffolds keep #2328's strict release-age policy, and existing project/channel setup does not add exclusions.

### Validation

The focused `src/cli/run.test.ts` unit suite passes, including acceptance and help hiding for the flag. The integration tier and package typecheck are currently blocked by unrelated missing/stale generated workflow and compiled dependency artifacts; their diagnostics do not reference this diff.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

The changeset records the hidden opt-in behavior for release notes.

**Implementation** — 6 files · `+92 / -6`

Threads the opt-in from the hidden CLI flag through fresh pnpm scaffolding and restores the focused exclusion-list reconciliation.

**Tests** — 1 file · `+16 / -0`

Covers forwarding the hidden flag and confirms it stays out of normal help output.
