### PR TITLE
fix(registry): install compatible Vercel CLI

### DIFF
--- a/.changeset/calm-trigger-event-cli-dependency.md
+++ b/.changeset/calm-trigger-event-cli-dependency.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+GitHub, Linear Agent, and Linq registry items now install Vercel CLI 58.5.1 or newer for guided setup. Linq setup no longer tries to infer CLI compatibility from connector creation errors.

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -1387,7 +1387,8 @@
           "implementation": "native"
         }
       },
-      "dependencies": ["@vercel/connect@>=0.6.0"]
+      "dependencies": ["@vercel/connect@>=0.6.0"],
+      "devDependencies": ["vercel@>=58.5.1"]
     },
     {
       "name": "channel/linear-agent",
@@ -1407,7 +1408,8 @@
           "implementation": "native"
         }
       },
-      "dependencies": ["@vercel/connect"]
+      "dependencies": ["@vercel/connect"],
+      "devDependencies": ["vercel@>=58.5.1"]
     },
     {
       "name": "channel/web",
@@ -1878,6 +1880,7 @@
       "title": "Linq",
       "description": "Connect an eve agent to iMessage and SMS through Linq with guided Connect or portable setup.",
       "dependencies": ["@vercel/connect@>=0.9.0"],
+      "devDependencies": ["vercel@>=58.5.1"],
       "meta": {
         "eve": {
           "setup": {

--- a/packages/eve/src/setup/integrations/linq/connect.test.ts
+++ b/packages/eve/src/setup/integrations/linq/connect.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { ChannelSetupLog } from "#setup/cli/index.js";
-import { HumanActionRequiredError } from "#setup/human-action.js";
-
 import { parseCreatedLinqConnector, provisionLinqConnector } from "./connect.js";
 
 function log(): ChannelSetupLog {
@@ -29,32 +27,6 @@ describe("Linq Connect provisioning", () => {
         JSON.stringify({ ...createdConnector, data: { phoneNumbers: ["+14155550123"] } }),
       ),
     ).toEqual({ id: "scl_linq", uid: "linq/agent", phoneNumber: "+14155550123" });
-  });
-
-  it("requests a Vercel CLI upgrade when trigger options are unsupported", async () => {
-    const runVercelCaptureStdout = vi.fn(async () => ({
-      ok: false as const,
-      stdout: "",
-      stderr:
-        "Vercel CLI 56.4.1 (Node.js 24.18.0)\nError: unknown or unexpected option: --trigger-event",
-    }));
-
-    await expect(
-      provisionLinqConnector({
-        log: log(),
-        project: { orgId: "team_123", projectId: "prj_123" },
-        projectRoot: "/project",
-        slug: "agent",
-        deps: { runVercel: vi.fn(), runVercelCaptureStdout },
-      }),
-    ).rejects.toEqual(
-      new HumanActionRequiredError({
-        kind: "vercel-cli-upgrade",
-        command: "vercel upgrade",
-        reason:
-          "The installed Vercel CLI does not support the trigger options Linq setup needs. Upgrade it and retry.",
-      }),
-    );
   });
 
   it("creates a connector for an existing Linq account without exposing its token in argv", async () => {

--- a/packages/eve/src/setup/integrations/linq/connect.ts
+++ b/packages/eve/src/setup/integrations/linq/connect.ts
@@ -1,7 +1,6 @@
 import type { ChannelSetupLog } from "#setup/cli/index.js";
 import { createPromptCommandOutput, withPhase } from "#setup/cli/index.js";
 import type { ProcessOutputHandler } from "#setup/primitives/process-output.js";
-import { HumanActionRequiredError } from "#setup/human-action.js";
 import { replaceConnectTrigger } from "#setup/connect-provisioning.js";
 import type { VercelProjectReference } from "#setup/project-resolution.js";
 import {
@@ -54,15 +53,6 @@ export function parseCreatedLinqConnector(stdout: string): LinqConnectorRef | un
 
 function requireCreatedConnector(result: RunVercelCaptureResult): LinqConnectorRef {
   if (!result.ok) {
-    const output = `${result.stderr ?? ""}\n${result.stdout}`;
-    if (/(?:unknown|unexpected|invalid).*--trigger-event/iu.test(output)) {
-      throw new HumanActionRequiredError({
-        kind: "vercel-cli-upgrade",
-        command: "vercel upgrade",
-        reason:
-          "The installed Vercel CLI does not support the trigger options Linq setup needs. Upgrade it and retry.",
-      });
-    }
     const detail = [result.stderr, result.stdout].find(
       (value): value is string => value !== undefined && value.trim().length > 0,
     );


### PR DESCRIPTION
### Summary

Install Vercel CLI `>=58.5.1` as a project dev dependency for the GitHub, Linear Agent, and Linq registry items. Their guided setup flows pass `--trigger-event`, which first shipped in that CLI release, so normal `eve add` setup uses a compatible project-local CLI.

This also removes Linq's reactive parsing of connector-creation errors for an old CLI; registry installation is now the compatibility mechanism.

### Validation

- Confirmed the `vercel@58.4.4` npm tarball lacks `--trigger-event` and `vercel@58.5.1` contains it
- `cd packages/eve && node_modules/.bin/vitest run --config vitest.unit.config.ts src/setup/integrations/linq/connect.test.ts`
- `pnpm exec oxfmt …` could not run because its workspace install invoked the unrelated `eve-self-modification` prepare build, which currently fails against stale generated vendor types

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
