### PR TITLE
fix(eve): prepare Web Chat TypeScript config before install

### DIFF
--- a/.changeset/fix-web-registry-tsconfig.md
+++ b/.changeset/fix-web-registry-tsconfig.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Prepare the TypeScript path alias and Next.js compiler settings before `eve add channel/web` installs the Web Chat registry item, so fresh agent projects build without manual `tsconfig.json` changes.

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -2018,11 +2018,6 @@
           "path": "registry/channel/web/postcss.config.mjs",
           "type": "registry:file",
           "target": "postcss.config.mjs"
-        },
-        {
-          "path": "registry/channel/web/tsconfig.json",
-          "type": "registry:file",
-          "target": "tsconfig.json"
         }
       ]
     },

--- a/apps/docs/scripts/validate-channel-registry.ts
+++ b/apps/docs/scripts/validate-channel-registry.ts
@@ -130,13 +130,19 @@ for (const [index, item] of items.entries()) {
   if (entry === undefined) throw new Error(`Unexpected channel registry item "${item.name}".`);
   const registrySlug = expectedSlugs[index];
 
-  if (
-    entry.slug === "eve" &&
-    item.dependencies?.some((dependency) => dependency === "ai" || dependency.startsWith("ai@"))
-  ) {
-    throw new Error(
-      `Registry item "${item.name}" must preserve the agent's existing AI SDK dependency.`,
-    );
+  if (entry.slug === "eve") {
+    if (
+      item.dependencies?.some((dependency) => dependency === "ai" || dependency.startsWith("ai@"))
+    ) {
+      throw new Error(
+        `Registry item "${item.name}" must preserve the agent's existing AI SDK dependency.`,
+      );
+    }
+    if (item.files?.some((file) => file.target === "tsconfig.json")) {
+      throw new Error(
+        `Registry item "${item.name}" must let eve prepare tsconfig.json before shadcn installs files.`,
+      );
+    }
   }
 
   if (

--- a/packages/eve/scripts/vendor-compiled/declarations/jsonc-parser.d.ts
+++ b/packages/eve/scripts/vendor-compiled/declarations/jsonc-parser.d.ts
@@ -10,4 +10,23 @@ export interface ParseOptions {
   readonly disallowComments?: boolean | undefined;
 }
 
+export interface Edit {
+  readonly offset: number;
+  readonly length: number;
+  readonly content: string;
+}
+
+export interface FormattingOptions {
+  readonly insertSpaces?: boolean;
+  readonly tabSize?: number;
+  readonly eol?: string;
+}
+
 export declare function parse(text: string, errors?: ParseError[], options?: ParseOptions): unknown;
+export declare function modify(
+  text: string,
+  path: (string | number)[],
+  value: unknown,
+  options?: { formattingOptions?: FormattingOptions },
+): Edit[];
+export declare function applyEdits(text: string, edits: Edit[]): string;

--- a/packages/eve/src/cli/commands/registry-project.test.ts
+++ b/packages/eve/src/cli/commands/registry-project.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { addWebRegistryTsconfig } from "./registry-project.js";
+
+describe("addWebRegistryTsconfig", () => {
+  it("adds the shadcn import alias while preserving JSONC", () => {
+    const source = `{
+  // Keep agent files in this project.
+  "compilerOptions": {
+    "types": ["node"],
+    "plugins": [{ "name": "custom" }],
+  },
+  "include": ["agent/**/*.ts"],
+}
+`;
+
+    const updated = addWebRegistryTsconfig(source, "/project/tsconfig.json");
+
+    expect(updated).toContain("// Keep agent files in this project.");
+    expect(updated).toContain('"types": [');
+    expect(updated).toContain('"node"');
+    expect(updated).toContain('"@/*": [');
+    expect(updated).toContain('"./*"');
+    expect(updated).toContain('"agent/**/*.ts"');
+    expect(updated).toContain('"**/*.tsx"');
+    expect(updated).toContain('"name": "custom"');
+    expect(updated).toContain('"name": "next"');
+  });
+
+  it("does not duplicate an existing compatible alias", () => {
+    const source = '{"compilerOptions":{"paths":{"@/*":["./*"]}}}\n';
+
+    const updated = addWebRegistryTsconfig(source, "/project/tsconfig.json");
+
+    expect(updated.match(/"@\/\*"/gu)).toHaveLength(1);
+  });
+
+  it("rejects an incompatible existing alias", () => {
+    const source = '{"compilerOptions":{"paths":{"@/*":["./src/*"]}}}\n';
+
+    expect(() => addWebRegistryTsconfig(source, "/project/tsconfig.json")).toThrow(
+      "already defines @/* without mapping it to ./*",
+    );
+  });
+});

--- a/packages/eve/src/cli/commands/registry-project.ts
+++ b/packages/eve/src/cli/commands/registry-project.ts
@@ -1,7 +1,14 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
+import {
+  applyEdits as applyJsoncEdits,
+  modify as modifyJsonc,
+  type ParseError,
+  parse as parseJsonc,
+} from "#compiled/jsonc-parser/index.js";
 import type { RegistryConfig, RegistrySource } from "#compiled/shadcn-registry/index.js";
+import { WEB_APP_TEMPLATE_FILES } from "#setup/scaffold/create/web-template.js";
 
 interface RegistryPackage {
   path: string;
@@ -79,6 +86,97 @@ function parseRegistryMapping(argument: string): { namespace: string; url: strin
 /** Reads registry namespace mappings from package.json. */
 export async function readRegistryConfig(appRoot: string): Promise<RegistryConfig> {
   return (await readRegistryPackage(appRoot)).config;
+}
+
+const JSONC_FORMATTING = { insertSpaces: true, tabSize: 2, eol: "\n" } as const;
+
+function setJsoncValue(source: string, path: (string | number)[], value: unknown): string {
+  return applyJsoncEdits(
+    source,
+    modifyJsonc(source, path, value, { formattingOptions: JSONC_FORMATTING }),
+  );
+}
+
+export function addWebRegistryTsconfig(source: string, path: string): string {
+  const errors: ParseError[] = [];
+  const parsed = parseJsonc(source, errors, { allowTrailingComma: true });
+  if (errors.length > 0 || typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`Could not add Web Chat because ${path} is not a valid JSON object.`);
+  }
+
+  const document = parsed as {
+    compilerOptions?: {
+      paths?: Record<string, unknown>;
+      plugins?: unknown[];
+      [key: string]: unknown;
+    };
+    include?: string[];
+    exclude?: string[];
+  };
+  const template = JSON.parse(WEB_APP_TEMPLATE_FILES["tsconfig.json"]) as {
+    compilerOptions: Record<string, unknown>;
+    include: string[];
+    exclude: string[];
+  };
+  const configuredAlias = document.compilerOptions?.paths?.["@/*"];
+  if (
+    configuredAlias !== undefined &&
+    (!Array.isArray(configuredAlias) || !configuredAlias.includes("./*"))
+  ) {
+    throw new Error(
+      `Could not add Web Chat because ${path} already defines @/* without mapping it to ./*.`,
+    );
+  }
+
+  let updated = source;
+  for (const [key, value] of Object.entries(template.compilerOptions)) {
+    if (key === "paths" || key === "plugins" || document.compilerOptions?.[key] !== undefined) {
+      continue;
+    }
+    updated = setJsoncValue(updated, ["compilerOptions", key], value);
+  }
+  if (configuredAlias === undefined) {
+    updated = setJsoncValue(updated, ["compilerOptions", "paths", "@/*"], ["./*"]);
+  }
+
+  const plugins = document.compilerOptions?.plugins ?? [];
+  const hasNextPlugin = plugins.some(
+    (plugin) =>
+      typeof plugin === "object" && plugin !== null && "name" in plugin && plugin.name === "next",
+  );
+  if (!hasNextPlugin) {
+    updated = setJsoncValue(
+      updated,
+      ["compilerOptions", "plugins"],
+      [...plugins, { name: "next" }],
+    );
+  }
+  updated = setJsoncValue(
+    updated,
+    ["include"],
+    [...new Set([...(document.include ?? []), ...template.include])],
+  );
+  updated = setJsoncValue(
+    updated,
+    ["exclude"],
+    [...new Set([...(document.exclude ?? []), ...template.exclude])],
+  );
+  return updated;
+}
+
+/** Prepares the TypeScript host configuration shadcn registry items expect. */
+export async function prepareWebRegistryProject(appRoot: string): Promise<void> {
+  const path = join(appRoot, "tsconfig.json");
+  let source: string;
+  try {
+    source = await readFile(path, "utf8");
+  } catch (error) {
+    throw new Error(
+      `Could not add Web Chat because ${path} could not be read: ${errorMessage(error)}`,
+    );
+  }
+  const updated = addWebRegistryTsconfig(source, path);
+  if (updated !== source) await writeFile(path, updated, "utf8");
 }
 
 /** Adds explicit registry namespace mappings to package.json. */

--- a/packages/eve/src/cli/commands/registry.test.ts
+++ b/packages/eve/src/cli/commands/registry.test.ts
@@ -206,6 +206,7 @@ describe("registry commands", () => {
     "installs the official %s item before running its declared setup",
     async (kind) => {
       const logger = createLogger();
+      const prepareWebRegistryProject = vi.fn(async () => {});
       const runSetupCommand = vi.fn(async () => ({ kind: "completed" as const, facts: [] }));
       getRegistryItems.mockResolvedValue([
         {
@@ -226,9 +227,16 @@ describe("registry commands", () => {
         { overwrite: true, yes: true },
         {
           loadSetupCommandRunner: async () => runSetupCommand,
+          prepareWebRegistryProject,
         },
       );
 
+      expect(prepareWebRegistryProject).toHaveBeenCalledTimes(kind === "web" ? 1 : 0);
+      if (kind === "web") {
+        expect(prepareWebRegistryProject.mock.invocationCallOrder[0]).toBeLessThan(
+          addRegistryItems.mock.invocationCallOrder[0]!,
+        );
+      }
       expect(addRegistryItems).toHaveBeenCalledOnce();
       expect(addRegistryItems.mock.invocationCallOrder[0]).toBeLessThan(
         runSetupCommand.mock.invocationCallOrder[0]!,

--- a/packages/eve/src/cli/commands/registry.ts
+++ b/packages/eve/src/cli/commands/registry.ts
@@ -35,7 +35,11 @@ import {
 } from "./registry-presentation.js";
 import type { runRegistrySetupCommand } from "./registry-setup-command.js";
 import { reportHeadlessSetupCompletion, serializeHeadlessSetupEvent } from "./setup-headless.js";
-import { addRegistryMappings, readRegistryConfig } from "./registry-project.js";
+import {
+  addRegistryMappings,
+  prepareWebRegistryProject,
+  readRegistryConfig,
+} from "./registry-project.js";
 export type { RegistryCommandLogger } from "./registry-recovery.js";
 export interface AddCommandOptions {
   skipInstall?: boolean;
@@ -67,6 +71,7 @@ export interface RegistrySetupDependencies {
 export interface AddCommandDependencies extends RegistrySetupDependencies {
   createPrompter?: () => Prompter;
   hasInteractiveTerminal?: () => boolean;
+  prepareWebRegistryProject?: typeof prepareWebRegistryProject;
 }
 
 type RunAddCommandOptions = AddCommandOptions & {
@@ -97,6 +102,7 @@ const defaultAddCommandDependencies: AddCommandDependencies = {
   hasInteractiveTerminal,
   loadSetupCommandRunner: async () =>
     (await import("./registry-setup-command.js")).runRegistrySetupCommand,
+  prepareWebRegistryProject,
 };
 
 const DEFAULT_OFFICIAL_REGISTRY_URL = "https://eve.dev/r";
@@ -534,6 +540,9 @@ export async function runAddCommand(
       return reportCompletion(logger, item, completion, options);
     }
 
+    if (address === itemAddress("channel/web")) {
+      await (dependencies.prepareWebRegistryProject ?? prepareWebRegistryProject)(appRoot);
+    }
     await addRegistryItems([address], {
       config,
       cwd: appRoot,


### PR DESCRIPTION
### Summary

`eve add channel/web` installed Web Chat files that import through `@/`, but shadcn could leave the existing eve `tsconfig.json` without that alias or the required Next.js settings. The command now prepares and validates the project’s JSONC TypeScript configuration before shadcn installs files, preserving existing options and comments while rejecting conflicting `@/*` mappings. The registry no longer ships `tsconfig.json`, so `--overwrite` cannot replace project-owned configuration.

### Validation

Focused registry unit tests pass (56 tests), the eve package typechecks, and the complete docs registry check passes. A production Next.js build of the reported `../eve-scratch/eve-web-1` reproduction also passes after applying the new pre-install transformation. `guard:invariants` remains blocked by symlinks in the unrelated untracked ARC-AGI virtual environment.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the patch release note for the corrected Web Chat installation behavior.

**Implementation** — 5 files · `+140 / -13`

Keeps TypeScript configuration ownership in eve’s pre-install step, removes it from the shadcn payload, and extends the vendored JSONC declaration only with APIs needed to preserve comments during edits.

**Tests** — 2 files · `+53 / -0`

Covers JSONC preservation, compatible and conflicting aliases, and verifies that Web Chat preparation runs before registry installation.
