### PR TITLE
fix(docs): preserve sidebar position when expanding sections

### DIFF
--- a/patches/@vercel__geistdocs@1.20.2.patch
+++ b/patches/@vercel__geistdocs@1.20.2.patch
@@ -1,0 +1,31 @@
+diff --git a/dist/internal/sidebar.js b/dist/internal/sidebar.js
+index eedcfef1f4a0657c91a5b626194d964bd7c97029..6c0f3767de684af2c97376bb8abff89106ef087d 100644
+--- a/dist/internal/sidebar.js
++++ b/dist/internal/sidebar.js
+@@ -120,7 +120,7 @@ const useOpenedFolders = (nodes, activeUrl, openFirstLevel, scope) => {
+             return current.filter((openId) => !closing.has(openId));
+         });
+     };
+-    return { opened, toggleFolder };
++    return { desiredOpenIds, opened, toggleFolder };
+ };
+ const SidebarSeparatorRow = ({ depth, item, }) => (_jsxs("li", { className: cn("mt-4 flex items-center gap-2 px-2 pt-2 pb-1 text-gray-900 text-label-13 first:mt-0 [&_svg]:size-4", depth > 0 && "ml-3"), children: [item.icon ? _jsx("span", { className: "shrink-0", children: item.icon }) : null, _jsx("span", { className: "min-w-0 truncate", children: item.name })] }));
+ const SidebarTreeItems = ({ depth, nodes, parentPath, state, }) => (_jsx(_Fragment, { children: nodes.map((node, index) => (_jsx(SidebarTreeNode, { depth: depth, node: node, path: [...parentPath, index], state: state }, getSidebarNodeId(node, [...parentPath, index], state.idScope)))) }));
+@@ -175,7 +175,7 @@ const SidebarTree = ({ activeUrl, idScope, nodes, onNavigate, openFirstLevel = f
+     const generatedId = useId().replace(UNSAFE_ID_CHARACTERS, "");
+     const resolvedIdScope = idScope ?? `sidebar-${generatedId}`;
+     const listRef = useRef(null);
+-    const { opened, toggleFolder } = useOpenedFolders(nodes, activeUrl, openFirstLevel, resolvedIdScope);
++    const { desiredOpenIds, opened, toggleFolder } = useOpenedFolders(nodes, activeUrl, openFirstLevel, resolvedIdScope);
+     const state = {
+         activeUrl,
+         idPrefix: `sidebar-${generatedId}`,
+@@ -184,7 +184,7 @@ const SidebarTree = ({ activeUrl, idScope, nodes, onNavigate, openFirstLevel = f
+         opened,
+         toggleFolder,
+     };
+-    useActiveItemScroll(listRef, activeUrl, scrollActive && visible, opened.join(":"));
++    useActiveItemScroll(listRef, activeUrl, scrollActive && visible, desiredOpenIds.join(":"));
+     return (_jsx("ul", { className: "m-0 flex list-none flex-col gap-px p-0", ref: listRef, children: _jsx(SidebarTreeItems, { depth: 0, nodes: nodes, parentPath: [], state: state }) }));
+ };
+ const SidebarRootList = ({ activeSection, activeUrl, groups, onSelect, visible, }) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,9 @@ catalogs:
       specifier: 4.4.3
       version: 4.4.3
 
+patchedDependencies:
+  '@vercel/geistdocs@1.20.2': b98cd90045920100945e2ab1190b496f86745add673b2385a6d106c0316b04c4
+
 importers:
 
   .:
@@ -176,7 +179,7 @@ importers:
         version: 2.0.1(@sveltejs/kit@2.63.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(next@16.3.0-preview.6(@babel/core@7.29.0(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nuxt@4.4.6(eddae254238b412d8a46133f9d7579b6))(react@19.2.6)(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vue@3.5.35(typescript@6.0.3))
       '@vercel/geistdocs':
         specifier: 1.20.2
-        version: 1.20.2(d893428d03ae3b7d30829ca960a66077)
+        version: 1.20.2(patch_hash=b98cd90045920100945e2ab1190b496f86745add673b2385a6d106c0316b04c4)(d893428d03ae3b7d30829ca960a66077)
       '@vercel/speed-insights':
         specifier: 2.0.0
         version: 2.0.0(@sveltejs/kit@2.63.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(next@16.3.0-preview.6(@babel/core@7.29.0(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nuxt@4.4.6(eddae254238b412d8a46133f9d7579b6))(react@19.2.6)(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vue@3.5.35(typescript@6.0.3))
@@ -22060,7 +22063,7 @@ snapshots:
       etag: 1.8.1
       fs-extra: 11.1.0
 
-  '@vercel/geistdocs@1.20.2(d893428d03ae3b7d30829ca960a66077)':
+  '@vercel/geistdocs@1.20.2(patch_hash=b98cd90045920100945e2ab1190b496f86745add673b2385a6d106c0316b04c4)(d893428d03ae3b7d30829ca960a66077)':
     dependencies:
       '@ai-sdk/react': 3.0.193(react@19.2.6)(zod@4.4.3)
       '@clack/prompts': 0.11.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -64,3 +64,7 @@ minimumReleaseAgeExclude:
   - "@workflow/*"
   - nitro
   - workflow
+
+patchedDependencies:
+  # Folder toggles must not rerun active-page scrolling and move the sidebar away from the folder.
+  "@vercel/geistdocs@1.20.2": patches/@vercel__geistdocs@1.20.2.patch


### PR DESCRIPTION
### Summary

Expanding a docs sidebar section reran Geistdocs' active-page scroll effect, moving the sidebar away from the section the reader had just opened. This patches Geistdocs so active-page scrolling still runs for route-driven ancestor changes, but not for user-driven folder toggles. Collapsed-by-default sections and active-page positioning are otherwise unchanged.

### Validation

Reproduced the jump before the patch and confirmed at desktop and mobile widths that expanding the last visible section preserves both its expanded state and the sidebar scroll position, with no mobile horizontal overflow. The docs unit suite passes (161 tests); a production build compiled and typechecked successfully but could not finish prerendering because template sync data requires network access.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 3 files · `+40 / -2`

The runtime change is a focused pnpm patch to Geistdocs; the remaining changes register and lock that patch until the dependency includes the fix upstream.

**Tests** — 0 files · `+0 / -0`

The regression is interaction-specific and was validated in the running docs site at desktop and mobile widths.
