### PR TITLE
fix(eve): recover expired session sandboxes

### DIFF
--- a/.changeset/bright-sandboxes-recover.md
+++ b/.changeset/bright-sandboxes-recover.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Recreate persisted Vercel session sandboxes when their snapshots have expired instead of returning an unusable sandbox handle.

--- a/packages/eve/src/execution/sandbox/bindings/vercel-errors.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel-errors.ts
@@ -12,6 +12,21 @@ export function isVercelSnapshotUnavailableError(error: unknown): boolean {
   return false;
 }
 
+export function isVercelSnapshotNotFoundError(error: unknown): boolean {
+  for (const candidate of walkErrorChain(error)) {
+    const status =
+      (candidate as { response?: { status?: number } }).response?.status ??
+      (candidate as { status?: number }).status ??
+      (candidate as { statusCode?: number }).statusCode;
+    const code = (candidate as { json?: { error?: { code?: unknown } } }).json?.error?.code;
+    if (status === 410 && code === "snapshot_not_found") {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 export function isVercelSandboxMissingError(error: unknown): boolean {
   for (const candidate of walkErrorChain(error)) {
     const status =

--- a/packages/eve/src/execution/sandbox/bindings/vercel-lookup.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel-lookup.ts
@@ -11,6 +11,7 @@ import type {
 
 export async function getNamedVercelSandbox(input: {
   readonly createOptions: VercelCreateOptions;
+  readonly resume?: boolean;
   readonly sandboxModule: VercelModule;
   readonly sandboxName: string;
 }): Promise<VercelSandbox | null> {
@@ -32,12 +33,13 @@ export async function getNamedVercelSandbox(input: {
 
 async function getVercelSandboxGetOptions(input: {
   readonly createOptions: VercelCreateOptions;
+  readonly resume?: boolean;
   readonly sandboxName: string;
 }): Promise<VercelGetOptions> {
   const baseOptions = {
     fetch: getVercelSandboxFetch(input.createOptions),
     name: input.sandboxName,
-    resume: false,
+    resume: input.resume ?? false,
   };
 
   try {

--- a/packages/eve/src/execution/sandbox/bindings/vercel-session.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel-session.ts
@@ -1,0 +1,204 @@
+import { createLogger } from "#internal/logging.js";
+import type {
+  VercelSandboxSessionCreateContext,
+  VercelSandboxSessionCreateOptions,
+} from "#public/sandbox/vercel-sandbox.js";
+import type {
+  CreateVercelSandbox,
+  VercelSandboxCreateParams,
+} from "#execution/sandbox/bindings/vercel-create-sdk.js";
+import {
+  isVercelSandboxMissingError,
+  isVercelSnapshotNotFoundError,
+  isVercelSnapshotUnavailableError,
+} from "#execution/sandbox/bindings/vercel-errors.js";
+import { getNamedVercelSandbox } from "#execution/sandbox/bindings/vercel-lookup.js";
+import type {
+  VercelCreateOptions,
+  VercelModule,
+  VercelSandbox,
+} from "#execution/sandbox/bindings/vercel-sdk-types.js";
+
+const logger = createLogger("sandbox.vercel");
+
+export type ResolveVercelSessionCreateOptions = (
+  context: VercelSandboxSessionCreateContext,
+) => Promise<VercelSandboxSessionCreateOptions> | VercelSandboxSessionCreateOptions;
+
+export interface EnsureSessionInput {
+  readonly createOptions: VercelCreateOptions;
+  readonly createSandbox: CreateVercelSandbox;
+  readonly existingMetadata?: Record<string, unknown>;
+  readonly resolveSessionCreateOptions?: ResolveVercelSessionCreateOptions;
+  readonly sandboxModule: VercelModule;
+  readonly sessionId: string;
+  readonly sessionKey: string;
+  readonly snapshotId?: string;
+  readonly tags: Record<string, string> | undefined;
+}
+
+export interface VercelSandboxSessionCreateResult {
+  readonly created: boolean;
+  readonly sandbox: VercelSandbox;
+}
+
+export class VercelTemplateSnapshotUnavailableError extends Error {
+  constructor(options?: ErrorOptions) {
+    super("template snapshot unavailable during session create", options);
+  }
+
+  static is(error: unknown): error is VercelTemplateSnapshotUnavailableError {
+    return error instanceof VercelTemplateSnapshotUnavailableError;
+  }
+}
+
+export async function ensureSession(
+  input: EnsureSessionInput,
+): Promise<VercelSandboxSessionCreateResult> {
+  const sandboxName = getVercelSandboxName(input.existingMetadata) ?? input.sessionKey;
+  let existing: VercelSandbox | null;
+  try {
+    existing = await getNamedVercelSandbox({
+      createOptions: input.createOptions,
+      resume: true,
+      sandboxModule: input.sandboxModule,
+      sandboxName,
+    });
+  } catch (error) {
+    if (!isVercelSnapshotNotFoundError(error)) {
+      throw error;
+    }
+
+    // The backing snapshot expired, so the persisted filesystem is already
+    // unrecoverable. Delete-then-recreate under the same name mirrors the
+    // SDK's own `Sandbox.getOrCreate` recovery; concurrent creates for one
+    // session key share its race window and surface a name conflict to the
+    // loser.
+    logger.warn("session sandbox snapshot expired; deleting it and creating a replacement", {
+      sandboxName,
+    });
+    const stale = await getNamedVercelSandbox({
+      createOptions: input.createOptions,
+      sandboxModule: input.sandboxModule,
+      sandboxName,
+    });
+    try {
+      await stale?.delete();
+    } catch (deleteError) {
+      if (!isVercelSandboxMissingError(deleteError)) {
+        throw deleteError;
+      }
+    }
+    existing = null;
+  }
+
+  if (existing !== null) {
+    await ensureVercelSandboxTags(existing, input.tags);
+    return { created: false, sandbox: existing };
+  }
+
+  const sessionCreateOptions = await input.resolveSessionCreateOptions?.({
+    session: { id: input.sessionId },
+  });
+  const createParams = createSessionCreateParams(input, sandboxName, sessionCreateOptions);
+  if (input.tags !== undefined) {
+    createParams.tags = input.tags;
+  }
+
+  try {
+    return {
+      created: true,
+      sandbox: await input.createSandbox({
+        createOptions: createParams,
+        sandboxModule: input.sandboxModule,
+      }),
+    };
+  } catch (error) {
+    if (
+      input.snapshotId !== undefined &&
+      (isVercelSnapshotUnavailableError(error) || isVercelSandboxMissingError(error))
+    ) {
+      throw new VercelTemplateSnapshotUnavailableError({ cause: error });
+    }
+    throw error;
+  }
+}
+
+function createSessionCreateParams(
+  input: EnsureSessionInput,
+  sandboxName: string,
+  sessionCreateOptions: VercelSandboxSessionCreateOptions = {},
+): VercelSandboxCreateParams {
+  const createOptions = { ...input.createOptions, ...sessionCreateOptions } as VercelCreateOptions;
+  if (input.snapshotId === undefined) {
+    return withBaseSetupNetworkPolicy({
+      ...createOptions,
+      name: sandboxName,
+      persistent: true,
+    });
+  }
+
+  /*
+   * Strip `source`, `runtime`, and `image` from author-supplied create options
+   * for the template-backed session path. The framework owns the source there,
+   * and a snapshot source is mutually exclusive with both `runtime` and `image`
+   * (the template snapshot already has the eve image baked in).
+   */
+  const {
+    image: _image,
+    runtime: _runtime,
+    source: _source,
+    ...baseSessionCreateOptions
+  } = createOptions as VercelCreateOptions &
+    Partial<Record<"image" | "runtime" | "source", unknown>>;
+
+  return {
+    ...baseSessionCreateOptions,
+    name: sandboxName,
+    persistent: true,
+    source: { snapshotId: input.snapshotId, type: "snapshot" as const },
+  };
+}
+
+function getVercelSandboxName(metadata: Record<string, unknown> | undefined): string | undefined {
+  const sandboxName = metadata?.sandboxName;
+  return typeof sandboxName === "string" ? sandboxName : undefined;
+}
+
+/*
+ * Shared with the template lifecycle in vercel.ts: templates and sessions
+ * apply the same tag reconciliation, and both fresh-create paths start
+ * permissive so framework base setup runs before the author's network
+ * policy applies.
+ */
+export function withBaseSetupNetworkPolicy(
+  createOptions: VercelSandboxCreateParams,
+): VercelSandboxCreateParams {
+  return { ...createOptions, networkPolicy: "allow-all" };
+}
+
+export async function ensureVercelSandboxTags(
+  sandbox: VercelSandbox,
+  tags: Record<string, string> | undefined,
+): Promise<void> {
+  if (tags === undefined || areVercelSandboxTagsEqual(sandbox.tags, tags)) {
+    return;
+  }
+
+  await sandbox.update({ tags });
+}
+
+function areVercelSandboxTagsEqual(
+  current: Record<string, string> | undefined,
+  next: Record<string, string>,
+): boolean {
+  const currentTags = current ?? {};
+  const currentEntries = Object.entries(currentTags);
+  const nextEntries = Object.entries(next);
+
+  if (currentEntries.length !== nextEntries.length) {
+    return false;
+  }
+
+  return nextEntries.every(([key, value]) => currentTags[key] === value);
+}

--- a/packages/eve/src/execution/sandbox/bindings/vercel.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel.test.ts
@@ -645,7 +645,7 @@ describe("createVercelSandbox", () => {
     expect(get).toHaveBeenCalledWith({
       fetch: expect.any(Function),
       name: "session-key",
-      resume: false,
+      resume: true,
     });
     expect(create).toHaveBeenCalledTimes(1);
     expect(create.mock.calls[0]?.[0]).toMatchObject({
@@ -1067,12 +1067,99 @@ describe("createVercelSandbox", () => {
     expect(sandboxModule.Sandbox.get).toHaveBeenCalledWith({
       fetch: expect.any(Function),
       name: "persisted-sandbox-name",
-      resume: false,
+      resume: true,
     });
     expect(handle.session).toBeDefined();
 
     const state = await handle.captureState();
     expect(state.metadata).toEqual({ sandboxName: "persisted-sandbox-name" });
+  });
+
+  it("replaces a session sandbox when its persisted snapshot is unavailable", async () => {
+    const templateSandbox = createMockSandbox({
+      name: "template-key",
+      snapshotId: "template-snapshot",
+    });
+    const staleSessionSandbox = createMockSandbox({ name: "persisted-sandbox-name" });
+    const replacementSessionSandbox = createMockSandbox({ name: "persisted-sandbox-name" });
+    const snapshotUnavailable = Object.assign(new Error("snapshot_not_found"), {
+      json: { error: { code: "snapshot_not_found" } },
+      response: { status: 410 },
+    });
+    const create = vi.fn().mockResolvedValue(replacementSessionSandbox);
+    const get = vi
+      .fn()
+      .mockImplementation(async ({ name, resume }: { name: string; resume: boolean }) => {
+        if (name === "template-key") return templateSandbox;
+        if (name === "persisted-sandbox-name" && resume) throw snapshotUnavailable;
+        if (name === "persisted-sandbox-name") return staleSessionSandbox;
+        return null;
+      });
+    const sandboxModule = { Sandbox: { create, get } };
+
+    const backend = createTestVercelSandbox({
+      loadSandboxModule: async () => sandboxModule as never,
+    });
+
+    await backend.prewarm({
+      runtimeContext: { appRoot: "/tmp/test-app-root" },
+      seedFiles: [],
+      templateKey: "template-key",
+    });
+
+    const handle = await backend.create({
+      existingMetadata: { sandboxName: "persisted-sandbox-name" },
+      runtimeContext: { appRoot: "/tmp/test-app-root" },
+      sessionKey: "session-key",
+      templateKey: "template-key",
+    });
+
+    expect(staleSessionSandbox.delete).toHaveBeenCalledTimes(1);
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "persisted-sandbox-name",
+        persistent: true,
+        source: { snapshotId: "template-snapshot", type: "snapshot" },
+      }),
+    );
+    expect((await handle.captureState()).metadata).toEqual({
+      sandboxName: "persisted-sandbox-name",
+    });
+  });
+
+  it("does not replace a session sandbox for an unrelated 410 response", async () => {
+    const templateSandbox = createMockSandbox({
+      name: "template-key",
+      snapshotId: "template-snapshot",
+    });
+    const unrelatedGone = Object.assign(new Error("resource gone"), {
+      json: { error: { code: "resource_gone" } },
+      response: { status: 410 },
+    });
+    const create = vi.fn();
+    const get = vi.fn().mockImplementation(async ({ name }: { name: string }) => {
+      if (name === "template-key") return templateSandbox;
+      throw unrelatedGone;
+    });
+    const backend = createTestVercelSandbox({
+      loadSandboxModule: async () => ({ Sandbox: { create, get } }) as never,
+    });
+
+    await backend.prewarm({
+      runtimeContext: { appRoot: "/tmp/test-app-root" },
+      seedFiles: [],
+      templateKey: "template-key",
+    });
+
+    await expect(
+      backend.create({
+        existingMetadata: { sandboxName: "persisted-sandbox-name" },
+        runtimeContext: { appRoot: "/tmp/test-app-root" },
+        sessionKey: "session-key",
+        templateKey: "template-key",
+      }),
+    ).rejects.toThrow("Failed to create sandbox session");
+    expect(create).not.toHaveBeenCalled();
   });
 
   it("stops the session sandbox on shutdown so no VM outlives the server", async () => {
@@ -1173,7 +1260,7 @@ describe("createVercelSandbox", () => {
     expect(sandboxModule.Sandbox.get).toHaveBeenCalledWith({
       fetch: expect.any(Function),
       name: "deleted-sandbox",
-      resume: false,
+      resume: true,
     });
     expect(sandboxModule.Sandbox.create).toHaveBeenCalledTimes(1);
     expect(sandboxModule.Sandbox.create).toHaveBeenCalledWith(

--- a/packages/eve/src/execution/sandbox/bindings/vercel.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel.ts
@@ -41,6 +41,7 @@ import {
 } from "#execution/sandbox/bindings/vercel-create-sdk.js";
 import {
   isVercelSandboxMissingError,
+  isVercelSnapshotNotFoundError,
   isVercelSnapshotUnavailableError,
 } from "#execution/sandbox/bindings/vercel-errors.js";
 import { getNamedVercelSandbox } from "#execution/sandbox/bindings/vercel-lookup.js";
@@ -114,10 +115,7 @@ export function createVercelSandbox(
           tags,
         });
       } catch (error) {
-        if (
-          template !== null &&
-          (isVercelSnapshotUnavailableError(error) || isVercelSandboxMissingError(error))
-        ) {
+        if (template !== null && VercelTemplateSnapshotUnavailableError.is(error)) {
           prewarmedTemplates.delete(template.templateKey);
           const staleTemplate = await getNamedVercelSandbox({
             createOptions,
@@ -377,13 +375,41 @@ interface VercelSandboxSessionCreateResult {
   readonly sandbox: VercelSandbox;
 }
 
+class VercelTemplateSnapshotUnavailableError extends Error {
+  static is(error: unknown): error is VercelTemplateSnapshotUnavailableError {
+    return error instanceof VercelTemplateSnapshotUnavailableError;
+  }
+}
+
 async function ensureSession(input: EnsureSessionInput): Promise<VercelSandboxSessionCreateResult> {
   const sandboxName = getVercelSandboxName(input.existingMetadata) ?? input.sessionKey;
-  const existing = await getNamedVercelSandbox({
-    createOptions: input.createOptions,
-    sandboxModule: input.sandboxModule,
-    sandboxName,
-  });
+  let existing: VercelSandbox | null;
+  try {
+    existing = await getNamedVercelSandbox({
+      createOptions: input.createOptions,
+      resume: true,
+      sandboxModule: input.sandboxModule,
+      sandboxName,
+    });
+  } catch (error) {
+    if (!isVercelSnapshotNotFoundError(error)) {
+      throw error;
+    }
+
+    const stale = await getNamedVercelSandbox({
+      createOptions: input.createOptions,
+      sandboxModule: input.sandboxModule,
+      sandboxName,
+    });
+    try {
+      await stale?.delete();
+    } catch (deleteError) {
+      if (!isVercelSandboxMissingError(deleteError)) {
+        throw deleteError;
+      }
+    }
+    existing = null;
+  }
 
   if (existing !== null) {
     await ensureVercelSandboxTags(existing, input.tags);
@@ -398,13 +424,23 @@ async function ensureSession(input: EnsureSessionInput): Promise<VercelSandboxSe
     createParams.tags = input.tags;
   }
 
-  return {
-    created: true,
-    sandbox: await input.createSandbox({
-      createOptions: createParams,
-      sandboxModule: input.sandboxModule,
-    }),
-  };
+  try {
+    return {
+      created: true,
+      sandbox: await input.createSandbox({
+        createOptions: createParams,
+        sandboxModule: input.sandboxModule,
+      }),
+    };
+  } catch (error) {
+    if (
+      input.snapshotId !== undefined &&
+      (isVercelSnapshotUnavailableError(error) || isVercelSandboxMissingError(error))
+    ) {
+      throw new VercelTemplateSnapshotUnavailableError(undefined, { cause: error });
+    }
+    throw error;
+  }
 }
 
 function createSessionCreateParams(

--- a/packages/eve/src/execution/sandbox/bindings/vercel.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel.ts
@@ -25,8 +25,6 @@ import type {
 import { SandboxTemplateNotProvisionedError } from "#public/definitions/sandbox-backend.js";
 import type {
   VercelSandboxBootstrapUseOptions,
-  VercelSandboxSessionCreateContext,
-  VercelSandboxSessionCreateOptions,
   VercelSandboxSessionUseOptions,
 } from "#public/sandbox/vercel-sandbox.js";
 import { WORKSPACE_ROOT } from "#runtime/workspace/types.js";
@@ -37,14 +35,20 @@ import { streamToBuffer } from "#execution/sandbox/stream-utils.js";
 import {
   createVercelEveImageSandbox,
   type CreateVercelSandbox,
-  type VercelSandboxCreateParams,
 } from "#execution/sandbox/bindings/vercel-create-sdk.js";
 import {
   isVercelSandboxMissingError,
-  isVercelSnapshotNotFoundError,
   isVercelSnapshotUnavailableError,
 } from "#execution/sandbox/bindings/vercel-errors.js";
 import { getNamedVercelSandbox } from "#execution/sandbox/bindings/vercel-lookup.js";
+import {
+  ensureSession,
+  ensureVercelSandboxTags,
+  VercelTemplateSnapshotUnavailableError,
+  withBaseSetupNetworkPolicy,
+  type ResolveVercelSessionCreateOptions,
+  type VercelSandboxSessionCreateResult,
+} from "#execution/sandbox/bindings/vercel-session.js";
 import { normalizeVercelReadStream } from "#execution/sandbox/bindings/vercel-read-stream.js";
 import { resolveSandboxModelPath } from "#shared/skill-paths.js";
 import type {
@@ -57,9 +61,7 @@ export interface CreateVercelSandboxInput {
   readonly createSandbox?: CreateVercelSandbox;
   readonly createOptions?: VercelCreateOptions;
   readonly loadSandboxModule?: () => Promise<VercelModule>;
-  readonly resolveSessionCreateOptions?: (
-    context: VercelSandboxSessionCreateContext,
-  ) => Promise<VercelSandboxSessionCreateOptions> | VercelSandboxSessionCreateOptions;
+  readonly resolveSessionCreateOptions?: ResolveVercelSessionCreateOptions;
 }
 /**
  * Creates the Vercel-backed sandbox backend.
@@ -358,133 +360,6 @@ async function ensureTemplate(input: EnsureTemplateInput): Promise<EnsureTemplat
   };
 }
 
-interface EnsureSessionInput {
-  readonly createOptions: VercelCreateOptions;
-  readonly createSandbox: CreateVercelSandbox;
-  readonly existingMetadata?: Record<string, unknown>;
-  readonly resolveSessionCreateOptions?: CreateVercelSandboxInput["resolveSessionCreateOptions"];
-  readonly sandboxModule: VercelModule;
-  readonly sessionId: string;
-  readonly sessionKey: string;
-  readonly snapshotId?: string;
-  readonly tags: Record<string, string> | undefined;
-}
-
-interface VercelSandboxSessionCreateResult {
-  readonly created: boolean;
-  readonly sandbox: VercelSandbox;
-}
-
-class VercelTemplateSnapshotUnavailableError extends Error {
-  static is(error: unknown): error is VercelTemplateSnapshotUnavailableError {
-    return error instanceof VercelTemplateSnapshotUnavailableError;
-  }
-}
-
-async function ensureSession(input: EnsureSessionInput): Promise<VercelSandboxSessionCreateResult> {
-  const sandboxName = getVercelSandboxName(input.existingMetadata) ?? input.sessionKey;
-  let existing: VercelSandbox | null;
-  try {
-    existing = await getNamedVercelSandbox({
-      createOptions: input.createOptions,
-      resume: true,
-      sandboxModule: input.sandboxModule,
-      sandboxName,
-    });
-  } catch (error) {
-    if (!isVercelSnapshotNotFoundError(error)) {
-      throw error;
-    }
-
-    const stale = await getNamedVercelSandbox({
-      createOptions: input.createOptions,
-      sandboxModule: input.sandboxModule,
-      sandboxName,
-    });
-    try {
-      await stale?.delete();
-    } catch (deleteError) {
-      if (!isVercelSandboxMissingError(deleteError)) {
-        throw deleteError;
-      }
-    }
-    existing = null;
-  }
-
-  if (existing !== null) {
-    await ensureVercelSandboxTags(existing, input.tags);
-    return { created: false, sandbox: existing };
-  }
-
-  const sessionCreateOptions = await input.resolveSessionCreateOptions?.({
-    session: { id: input.sessionId },
-  });
-  const createParams = createSessionCreateParams(input, sandboxName, sessionCreateOptions);
-  if (input.tags !== undefined) {
-    createParams.tags = input.tags;
-  }
-
-  try {
-    return {
-      created: true,
-      sandbox: await input.createSandbox({
-        createOptions: createParams,
-        sandboxModule: input.sandboxModule,
-      }),
-    };
-  } catch (error) {
-    if (
-      input.snapshotId !== undefined &&
-      (isVercelSnapshotUnavailableError(error) || isVercelSandboxMissingError(error))
-    ) {
-      throw new VercelTemplateSnapshotUnavailableError(undefined, { cause: error });
-    }
-    throw error;
-  }
-}
-
-function createSessionCreateParams(
-  input: EnsureSessionInput,
-  sandboxName: string,
-  sessionCreateOptions: VercelSandboxSessionCreateOptions = {},
-): VercelSandboxCreateParams {
-  const createOptions = { ...input.createOptions, ...sessionCreateOptions } as VercelCreateOptions;
-  if (input.snapshotId === undefined) {
-    return withBaseSetupNetworkPolicy({
-      ...createOptions,
-      name: sandboxName,
-      persistent: true,
-    });
-  }
-
-  /*
-   * Strip `source`, `runtime`, and `image` from author-supplied create options
-   * for the template-backed session path. The framework owns the source there,
-   * and a snapshot source is mutually exclusive with both `runtime` and `image`
-   * (the template snapshot already has the eve image baked in).
-   */
-  const {
-    image: _image,
-    runtime: _runtime,
-    source: _source,
-    ...baseSessionCreateOptions
-  } = createOptions as VercelCreateOptions &
-    Partial<Record<"image" | "runtime" | "source", unknown>>;
-
-  return {
-    ...baseSessionCreateOptions,
-    name: sandboxName,
-    persistent: true,
-    source: { snapshotId: input.snapshotId, type: "snapshot" as const },
-  };
-}
-
-function withBaseSetupNetworkPolicy(
-  createOptions: VercelSandboxCreateParams,
-): VercelSandboxCreateParams {
-  return { ...createOptions, networkPolicy: "allow-all" };
-}
-
 function createHandle(
   sandbox: VercelSandbox,
   sessionKey: string,
@@ -637,11 +512,6 @@ function extractAuthorSnapshotId(createOptions: VercelCreateOptions): string | u
   return undefined;
 }
 
-function getVercelSandboxName(metadata: Record<string, unknown> | undefined): string | undefined {
-  const sandboxName = metadata?.sandboxName;
-  return typeof sandboxName === "string" ? sandboxName : undefined;
-}
-
 function resolveVercelSandboxTags(
   userTags: VercelCreateOptions["tags"],
   eveTags: SandboxBackendTags | undefined,
@@ -673,32 +543,6 @@ function resolveVercelSandboxTags(
   }
 
   return tags;
-}
-
-async function ensureVercelSandboxTags(
-  sandbox: VercelSandbox,
-  tags: Record<string, string> | undefined,
-): Promise<void> {
-  if (tags === undefined || areVercelSandboxTagsEqual(sandbox.tags, tags)) {
-    return;
-  }
-
-  await sandbox.update({ tags });
-}
-
-function areVercelSandboxTagsEqual(
-  current: Record<string, string> | undefined,
-  next: Record<string, string>,
-): boolean {
-  const currentTags = current ?? {};
-  const currentEntries = Object.entries(currentTags);
-  const nextEntries = Object.entries(next);
-
-  if (currentEntries.length !== nextEntries.length) {
-    return false;
-  }
-
-  return nextEntries.every(([key, value]) => currentTags[key] === value);
 }
 
 function errorMessage(error: unknown): string {


### PR DESCRIPTION
### Summary

Closes #2373. Persisted Vercel session sandboxes are now looked up with resume enabled, so an expired backing snapshot is detected before eve returns an unusable handle. Only a 410 `snapshot_not_found` response triggers deletion and same-name recreation from the current template; template lookup behavior remains unchanged, and the recovery emits a warning log so replacement of persisted session state is observable in production.

The session lifecycle (`ensureSession`, session create params, the template-snapshot error marker, and the shared tag/network-policy helpers) moved verbatim into `vercel-session.ts` to keep `vercel.ts` under the repository's 700-line source cap.

### Validation

The focused Vercel sandbox unit suite passes all 50 tests, including regression coverage for exact `snapshot_not_found` recovery and for preserving resources on unrelated 410 responses. The full unit tier (including the file-length structural test), workspace formatting, lint, and type checking also pass; lint reports one pre-existing warning in the Teams channel tests.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

A patch changeset describes the corrected recovery behavior; the existing sandbox documentation already promises this behavior.

**Implementation** — 4 files · `+232 / -131`

Mostly a mechanical extraction: `vercel-session.ts` is code moved out of `vercel.ts` to satisfy the line-count cap, not new behavior. The behavioral surface is the resumable lookup, the exact `snapshot_not_found` recovery with a warning log, and the narrowed template-source failure classification.

**Tests** — 1 file · `+90 / -3`

Covers successful resume, missing sandbox replacement, expired snapshot replacement under the persisted sandbox name, and rejection of unrelated 410 responses.
