### PR TITLE
fix(eve): dynamic tools - support destructuring defaults

### DIFF
--- a/.changeset/quiet-callbacks-forward.md
+++ b/.changeset/quiet-callbacks-forward.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix dynamic tool builds when callback parameters use destructuring defaults by forwarding the original arguments through the durable callback wrapper.

--- a/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.test.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.test.ts
@@ -245,6 +245,42 @@ export default defineDynamic({
     });
   });
 
+  it("forwards destructured parameters with defaults", async () => {
+    const source = `
+import { defineDynamic, defineTool } from "eve/tools";
+
+export default defineDynamic({
+  events: {
+    "session.started": async () => ({
+      tool: defineTool({
+        description: "T",
+        inputSchema: { type: "object" },
+        async execute({ dryRun = false }, ctx) {
+          return { dryRun, requestId: ctx.requestId };
+        },
+      }),
+    }),
+  },
+});
+`;
+
+    const { callHandler, code } = await transformAndEval("tools/default-param.ts", source);
+    const tools = await callHandler();
+    const execute = (tools.tool as Record<string, unknown>).execute as Function;
+
+    expect(code).toMatch(
+      /async \(\.\.\.__args\) => await __eve_dynamic_exec_\d+\(\{\}, \.\.\.__args\)/,
+    );
+    await expect(execute({}, { requestId: "req-123" })).resolves.toEqual({
+      dryRun: false,
+      requestId: "req-123",
+    });
+    await expect(execute({ dryRun: true }, { requestId: "req-456" })).resolves.toEqual({
+      dryRun: true,
+      requestId: "req-456",
+    });
+  });
+
   it("__closureVars captures a snapshot at resolver return time", async () => {
     const source = `
 import { defineDynamic, defineTool } from "eve/tools";
@@ -2337,14 +2373,14 @@ import { defineDynamic, defineTool } from "eve/tools";
 
 export default defineDynamic({
   events: {
-    "session.started": async () => {
+    "session.started": async (_input, ctx) => {
       const tag = "typed";
       return {
         tool: defineTool({
           description: "T",
           inputSchema: { type: "object" },
           execute(_input: Record<string, unknown>, ctx: import("eve/tools").ToolContext) {
-            return { tag, hasCtx: ctx !== undefined };
+            return { tag, input: _input, hasCtx: ctx !== undefined };
           },
         }),
       };
@@ -2357,14 +2393,7 @@ export default defineDynamic({
     expect(result).not.toBeNull();
     const code = result!.code;
 
-    // The wrapper call args should be `{ tag }, _input, ctx` — NOT
-    // `{ tag }, _input, unknown>, ctx` which the old naive comma split
-    // would have produced.
-    const wrapperCallMatch = code.match(/__eve_dynamic_exec_\d+\(([^)]+)\)/);
-    expect(wrapperCallMatch).not.toBeNull();
-    const wrapperArgs = wrapperCallMatch![1]!;
-    expect(wrapperArgs).not.toMatch(/\bunknown>\b/);
-    // Should have the hoisted function
-    expect(code).toContain("__eve_dynamic_exec_");
+    expect(code).toContain("const { tag } = __vars");
+    expect(code).toMatch(/\(\.\.\.__args\) => __eve_dynamic_exec_\d+\(\{ tag \}, \.\.\.__args\)/);
   });
 });

--- a/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.ts
@@ -314,19 +314,12 @@ function createLiveWrapper(callback: CallbackInfo, hoistedName: string, closure:
   if (callback.isReference) {
     return `(...__args) => ${hoistedName}(${closure}, ...__args)`;
   }
-  const params = callback.params;
-  const bindings = params
-    ? splitParamsTopLevel(params)
-        .map((parameter) => extractParamBindingName(parameter))
-        .join(", ")
-    : "";
-  const args = bindings ? `${closure}, ${bindings}` : closure;
   const asyncPrefix = callback.isAsync ? "async " : "";
   if (callback.isGenerator) {
-    return `${asyncPrefix}function* (${params}) { yield* ${hoistedName}(${args}); }`;
+    return `${asyncPrefix}function* (...__args) { yield* ${hoistedName}(${closure}, ...__args); }`;
   }
   const awaitPrefix = callback.isAsync ? "await " : "";
-  return `${asyncPrefix}(${params}) => ${awaitPrefix}${hoistedName}(${args})`;
+  return `${asyncPrefix}(...__args) => ${awaitPrefix}${hoistedName}(${closure}, ...__args)`;
 }
 
 function stableModuleId(filename: string): string {


### PR DESCRIPTION
### Summary

The dynamic-tool transform rebuilt callback arguments from parameter source text, so a valid callback such as `async execute({ dryRun = false }, ctx)` became an invalid object literal and caused `eve build` to fail. Live wrappers now forward the original arguments to the hoisted durable callback, leaving destructuring and defaults in the callback parameter list where they are valid. This also preserves callback input values instead of reconstructing them.

### Validation

The regression test reproduced the generated-code parse failure and now evaluates both omitted and explicit destructuring-default values; the full eve unit suite passed with 7,014 tests and one skip.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

A patch changeset records the user-visible build fix for the next eve release.

**Implementation** — 1 file · `+2 / -9`

The fix removes argument reconstruction and keeps forwarding local to the existing live-wrapper generator.

**Tests** — 1 file · `+40 / -11`

Regression coverage executes the reported destructuring-default form and updates typed-parameter coverage for raw forwarding.
