### PR TITLE
fix(eve): fail closed on mangled empty-delivery markers and unattended retry filler

### DIFF
--- a/.changeset/empty-delivery-fail-closed.md
+++ b/.changeset/empty-delivery-fail-closed.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Treat a reply that is nothing but a sentinel-shaped tag as the empty-delivery marker, so a mangled token — a corrupted tag name, a closing or paired form, different casing or separators, stray whitespace, attributes, wrapping backticks, or trailing punctuation — is silenced instead of delivered to a channel as literal control text. The exact sentinel keeps its existing match-anywhere behavior, and a reply that merely mentions the marker is still delivered.

--- a/.changeset/empty-response-nudge-silence-aware.md
+++ b/.changeset/empty-response-nudge-silence-aware.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Lead the empty-response retry nudge with the conditional-delivery marker instead of an instruction to answer, so unattended runs stop recovering into conversational filler such as "I now have all the data I need." The nudge is unchanged when conditional delivery is not enabled for the turn.

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -899,6 +899,77 @@ describe("createToolLoopHarness", () => {
     },
   );
 
+  // A near-miss must fail closed: production emitted `<evedev-empty-delivery/>`
+  // and the exact-match sentinel check let the literal control token through to
+  // the channel's `message.completed` default. Kept out of the it.each above
+  // because that table enumerates *exact* sentinel spellings, which are matched
+  // anywhere in the message; a corrupted token only counts as the whole message,
+  // so it cannot be fed the same `internal ${sentinel} trailing` fixture.
+  it("parks without delivery when a terminal response is only a corrupted sentinel", async () => {
+    const corrupted = "<evedev-empty-delivery/>";
+    setupMockAgent({
+      finishReason: "stop",
+      response: { messages: [{ content: corrupted, role: "assistant" }] },
+      text: corrupted,
+      toolCalls: [],
+      toolResults: [],
+    });
+
+    const { emit, events } = createEventCollector();
+    const runStep = createToolLoopHarness(createTestConfig("conversation", emit));
+
+    const result = await runStep(createTestSession(), { message: "Hi" });
+
+    expect(result.next).toBeNull();
+    expect(result.session.history).toEqual([{ content: "Hi", role: "user" }]);
+    // Intentional silence is a terminal outcome, not an empty response: the
+    // step must not trip the empty-response reissue.
+    expect(vi.mocked(ToolLoopAgent).mock.calls.length).toBe(1);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({ message: null }),
+        type: "message.completed",
+      }),
+    );
+  });
+
+  // `resolveAssistantStepText` reads only the *last* assistant message while
+  // the emission side sees the step's whole text run. Discarding the response
+  // wholesale therefore erased an earlier, genuinely delivered reply from
+  // durable history even though nothing about it was a marker.
+  it("keeps an earlier assistant reply in history when only the last message is the sentinel", async () => {
+    const report = "Here is the report.";
+    setupMockAgent({
+      finishReason: "stop",
+      response: {
+        messages: [
+          { content: report, role: "assistant" },
+          { content: EMPTY_DELIVERY_SENTINEL, role: "assistant" },
+        ],
+      },
+      text: EMPTY_DELIVERY_SENTINEL,
+      toolCalls: [],
+      toolResults: [],
+    });
+
+    const { emit, events } = createEventCollector();
+    const runStep = createToolLoopHarness(createTestConfig("conversation", emit));
+
+    const result = await runStep(createTestSession(), { message: "Hi" });
+
+    expect(result.next).toBeNull();
+    expect(result.session.history).toContainEqual({ content: report, role: "assistant" });
+    // Delivery is still suppressed, so both sides agree the turn said nothing
+    // to the user — they just no longer disagree about whether the earlier
+    // reply ever existed.
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({ message: null }),
+        type: "message.completed",
+      }),
+    );
+  });
+
   it("keeps executable tools directly available to the model", async () => {
     setupMockAgent({
       finishReason: "stop",
@@ -5180,6 +5251,23 @@ describe("createToolLoopHarness", () => {
           content: expect.stringContaining(EMPTY_DELIVERY_SENTINEL),
           role: "user",
         });
+
+        // The nudge must lead with the silence option rather than demanding an
+        // answer: no human is present on a schedule run, and an "Answer now"
+        // lead reliably elicited conversational filler ("I now have all the
+        // data I need.") that then shipped to the channel.
+        //
+        // "Otherwise answer" and "never reply with filler" are load-bearing
+        // wording from buildEmptyResponseNudge, not incidental phrasing — the
+        // assertions pin the *order* of the two options and the explicit
+        // filler ban, so a reword that reinstates an answer-first lead fails.
+        const nudge = reissueMessages.at(-1)?.content as string;
+        const markerOption = nudge.indexOf(EMPTY_DELIVERY_SENTINEL);
+        const answerOption = nudge.indexOf("Otherwise answer");
+        expect(markerOption).toBeGreaterThanOrEqual(0);
+        expect(answerOption).toBeGreaterThanOrEqual(0);
+        expect(markerOption).toBeLessThan(answerOption);
+        expect(nudge).toContain("never reply with filler");
       } finally {
         warnSpy.mockRestore();
       }

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -2432,14 +2432,37 @@ function rethrowNoOutputAsEmptyResponse(error: unknown): never {
  * (its toolset change busts the prompt cache anyway), this one trails as
  * a user note to keep the cached prefix valid.
  */
-const EMPTY_RESPONSE_NUDGE =
-  "Your previous reply was empty and was not delivered. Answer now from the tool results above; do not re-run tools or mention this notice.";
+const EMPTY_RESPONSE_LEAD = "Your previous reply was empty and was not delivered.";
 
+const EMPTY_RESPONSE_NUDGE = `${EMPTY_RESPONSE_LEAD} Answer now from the tool results above; do not re-run tools or mention this notice.`;
+
+/**
+ * Silence-aware variant of {@link EMPTY_RESPONSE_NUDGE}. When conditional
+ * delivery is on, appending "Answer now…" and only then mentioning the
+ * marker reads as a human asking for a reply — in schedule app-auth runs
+ * (no human present) that reliably produced conversational filler, and
+ * channels received "I now have all the data I need." as the delivered
+ * message. Leading with the marker, and naming the filler shapes as
+ * forbidden, keeps the retry aligned with
+ * {@link CONDITIONAL_DELIVERY_INSTRUCTION}'s contract.
+ *
+ * Still a trailing user note rather than a system note: `extraSystemNote` is
+ * how a chained recovery repeats its own call shape (see
+ * {@link RecoveryRetryCallOptions}), so claiming it here would clobber the
+ * unsupported-tool recovery's note and invalidate the cached prompt prefix.
+ */
 function buildEmptyResponseNudge(emptyDeliveryEnabled: boolean): string {
   if (!emptyDeliveryEnabled) {
     return EMPTY_RESPONSE_NUDGE;
   }
-  return `${EMPTY_RESPONSE_NUDGE} If the current task explicitly requires conditional delivery and there is nothing to report, reply with exactly ${EMPTY_DELIVERY_SENTINEL}.`;
+  return (
+    `${EMPTY_RESPONSE_LEAD} If the current task explicitly makes delivery conditional and ` +
+    `there is nothing new to report, reply with exactly ${EMPTY_DELIVERY_SENTINEL} and no ` +
+    "other text. Otherwise answer from the tool results above with the user-facing response " +
+    "itself. Either way, do not re-run tools, do not mention this notice, and never reply " +
+    "with filler such as an acknowledgement that you have the data or an announcement that a " +
+    "report follows."
+  );
 }
 
 /**
@@ -2516,6 +2539,20 @@ async function handleStepResult(input: {
     result.finishReason !== "tool-calls" &&
     result.toolCalls.length === 0 &&
     hasEmptyDeliverySentinel(resolvedStepOutput);
+  // `resolveAssistantStepText` reads only the *last* assistant message, while
+  // `emitStreamContent` matches against the step's whole text run. On a step
+  // that replied twice — ["Here is the report.", "<eve-empty-delivery/>"] —
+  // that split dropped the earlier, genuinely delivered reply from durable
+  // history along with the marker. Only discard the response wholesale when
+  // the marker message is demonstrably the entire response.
+  //
+  // The two sides still read different strings, so a *near-miss* marker
+  // concatenated with real text is silenced here but delivered there. Closing
+  // that would mean teaching emission about assistant-message boundaries,
+  // which the stream does not carry: it exposes text-part ids, and one
+  // assistant message can span several of them.
+  const soleAssistantResponse =
+    result.response.messages.filter((message) => message.role === "assistant").length <= 1;
   const invalidInputToolErrors = getInvalidToolCallInputErrors({
     toolCalls: result.toolCalls as TypedToolCall<ToolSet>[],
   });
@@ -2527,14 +2564,15 @@ async function handleStepResult(input: {
     ...result.toolCalls.filter(isInvalidToolCall).map((toolCall) => toolCall.toolCallId),
     ...invalidInputToolErrors.map((toolError) => toolError.toolCallId),
   ]);
-  const rawResponseMessages = emptyDelivery
-    ? []
-    : appendMissingToolResultMessages({
-        append: invalidInputToolErrors.map((toolError) =>
-          createToolResultMessagePartFromToolError(toolError),
-        ),
-        responseMessages: result.response.messages,
-      });
+  const rawResponseMessages =
+    emptyDelivery && soleAssistantResponse
+      ? []
+      : appendMissingToolResultMessages({
+          append: invalidInputToolErrors.map((toolError) =>
+            createToolResultMessagePartFromToolError(toolError),
+          ),
+          responseMessages: result.response.messages,
+        });
   const stepOutput = emptyDelivery ? null : resolvedStepOutput;
 
   const providerExecutedOutcomeIds = new Set<string>();

--- a/packages/eve/src/shared/empty-delivery.test.ts
+++ b/packages/eve/src/shared/empty-delivery.test.ts
@@ -15,10 +15,88 @@ describe("hasEmptyDeliverySentinel", () => {
     expect(hasEmptyDeliverySentinel(`before ${EMPTY_DELIVERY_SENTINEL} after`)).toBe(true);
   });
 
-  it("rejects absent, empty, and partial sentinels", () => {
-    expect(hasEmptyDeliverySentinel("<eve-empty-delivery>")).toBe(false);
-    expect(hasEmptyDeliverySentinel("")).toBe(false);
+  // Near-misses used to be rejected, which failed open: a production model
+  // typed `<evedev-empty-delivery/>` and the literal control token was
+  // delivered into a team channel. A message that is nothing but a
+  // sentinel-shaped tag now counts as the marker, so a mangled token becomes
+  // silence instead of channel text.
+  it.each([
+    ["a corrupted tag name", "<evedev-empty-delivery/>"],
+    ["a space before the slash", "<eve-empty-delivery />"],
+    ["upper case", "<EVE-EMPTY-DELIVERY/>"],
+    ["a missing self-closing slash", "<eve-empty-delivery>"],
+    ["a closing-tag form", "</eve-empty-delivery>"],
+    ["a paired open/close form", "<eve-empty-delivery></eve-empty-delivery>"],
+    ["a corrupted paired form", "<EVEDEV-EMPTY-DELIVERY></EVEDEV-EMPTY-DELIVERY>"],
+    ["a hyphenated corruption", "<eve-dev-empty-delivery/>"],
+    ["underscore separators", "<eve_empty_delivery/>"],
+    ["attributes", '<eve-empty-delivery reason="nothing new"/>'],
+    ["surrounding whitespace", "  \n<eve-empty-delivery/>\n  "],
+    ["an internal newline", "<eve-empty-delivery\n/>"],
+    ["an HTML-escaped near-miss", "&lt;evedev-empty-delivery&gt;"],
+    ["inner whitespace", "< eve-empty-delivery / >"],
+    ["inline backticks", "`<evedev-empty-delivery/>`"],
+    ["a fenced code block", "```\n<evedev-empty-delivery/>\n```"],
+    ["a fenced block with an info string", "```xml\n<eve-empty-delivery/>\n```"],
+    ["a trailing period", "<eve-empty-delivery/>."],
+    ["a trailing exclamation mark", "<evedev-empty-delivery/>!"],
+  ])("treats %s as the sentinel", (_label, text) => {
+    expect(hasEmptyDeliverySentinel(text)).toBe(true);
+  });
+
+  // The tolerant pattern is anchored to the whole normalized message because
+  // callers act on the entire message on a match. Anywhere-matching a fuzzy
+  // pattern would let a reply that merely talks about the marker delete
+  // itself.
+  it.each([
+    [
+      "a reply that mentions a near-miss mid-sentence",
+      "Reply with <eve-empty-delivery> to stay quiet.",
+    ],
+    ["a reply that quotes a corrupted marker", "The tag <evedev-empty-delivery/> is corrupted."],
+    ["an unterminated tag", "<eve-empty-delivery is not a marker"],
+    ["a differently named tag", "<eve-empty/>"],
+    ["a tag that only shares the prefix", "<eve-not-a-sentinel/>"],
+    ["a name that bleeds into a longer word", "<eve-empty-deliveryx/>"],
+    ["an ordinary paired tag", "<div></div>"],
+    ["ordinary markup around real content", "<p>Here is the report.</p>"],
+    ["a marker-shaped tag wrapping content", "<eve-empty-delivery>content</eve-empty-delivery>"],
+    ["a marker paired with an unrelated close", "<eve-empty-delivery></div>"],
+    ["ordinary text", "Here is the report:"],
+    ["the filler an unattended retry used to emit", "I now have all the data I need."],
+    ["an empty string", ""],
+  ])("does not treat %s as the sentinel", (_label, text) => {
+    expect(hasEmptyDeliverySentinel(text)).toBe(false);
+  });
+
+  it("rejects absent sentinels", () => {
     expect(hasEmptyDeliverySentinel(null)).toBe(false);
     expect(hasEmptyDeliverySentinel(undefined)).toBe(false);
+  });
+
+  // The matcher runs on raw model output, so an ambiguous quantifier pair is
+  // a denial-of-service vector. An earlier `\s*\/?\s*` spelling took ~6s on a
+  // 120k-char tag; these shapes all backtrack against the current pattern and
+  // must stay linear.
+  it.each([
+    [
+      "trailing whitespace inside a tag",
+      (size: number) => `<eve-empty-delivery${" ".repeat(size)}`,
+    ],
+    [
+      "leading slash and space runs",
+      (size: number) => `< ${"/ ".repeat(size / 2)}eve-empty-delivery`,
+    ],
+    ["a flooded tag-name class", (size: number) => `<eve${"-".repeat(size)}empty-delivery`],
+    ["repeated name suffixes", (size: number) => `<eve${"empty-delivery".repeat(size / 14)}`],
+    [
+      "a repeated paired form",
+      (size: number) =>
+        `<eve${"empty-delivery".repeat(size / 28)}><eve${"empty-delivery".repeat(size / 28)}`,
+    ],
+  ])("rejects %s in linear time", (_label, build) => {
+    const start = performance.now();
+    expect(hasEmptyDeliverySentinel(build(200_000))).toBe(false);
+    expect(performance.now() - start).toBeLessThan(1_000);
   });
 });

--- a/packages/eve/src/shared/empty-delivery.ts
+++ b/packages/eve/src/shared/empty-delivery.ts
@@ -3,9 +3,95 @@ const HTML_ESCAPED_EMPTY_DELIVERY_SENTINEL = "&lt;eve-empty-delivery/&gt;";
 
 export const CONDITIONAL_DELIVERY_INSTRUCTION = `Conditional delivery\nOnly when the current task explicitly makes delivery conditional and there is nothing new to report, reply with exactly ${EMPTY_DELIVERY_SENTINEL} and no other text. This includes results already delivered or incorporated into an earlier response; do not send an acknowledgement of that redundancy. Do not use this marker for ordinary conversations, after input or approval responses, or to omit commentary from a response that still needs delivery. Never return an empty response; use the marker to intentionally deliver nothing.`;
 
+/**
+ * A whole message that is one bracketed tag, optionally followed by a second
+ * one so the paired `<tag></tag>` form is covered.
+ *
+ * `[^<>]*` cannot cross a bracket, so every part has exactly one way to
+ * match and the pattern stays linear on any input — this runs on raw model
+ * output, so an ambiguous quantifier pair here would be a denial-of-service
+ * vector rather than a style nit.
+ */
+const LONE_TAG_MESSAGE = /^<([^<>]*)>(?:\s*<([^<>]*)>)?$/;
+
+/**
+ * The inside of a tag that means the empty-delivery marker. Tolerates the
+ * ways a model mangles the reserved token while clearly intending it: a
+ * leading `/` (closing-tag form), inner whitespace, any casing, `_` instead
+ * of `-`, a corrupted tag name that still starts with `eve` and ends in
+ * `empty-delivery` (production emitted `<evedev-empty-delivery/>`), and
+ * anything after the name — a self-closing `/`, or attributes.
+ *
+ * Spelled `(?:\s*\/)?\s*` rather than `\s*\/?\s*`: the latter's adjacent
+ * whitespace quantifiers are ambiguous and backtrack quadratically. The
+ * trailing `(?![a-z0-9_-])` keeps the name from bleeding into a longer word
+ * without an end anchor, so the one variable-length quantifier here only
+ * ever costs O(n) split attempts of O(1) work each.
+ */
+const SENTINEL_TAG_BODY = /^(?:\s*\/)?\s*eve[a-z0-9_-]*empty[-_]delivery(?![a-z0-9_-])/i;
+
+/** Fence wrappers a model reaches for when it "quotes" the marker, longest first. */
+const CODE_FENCES = ["```", "``", "`"] as const;
+/** An info string on the opening fence, e.g. the `xml` in an ```` ```xml ```` block. */
+const CODE_FENCE_INFO_STRING = /^[a-z]{1,12}\r?\n/i;
+/** Sentence punctuation a model appends when it treats the marker as prose. */
+const TRAILING_PUNCTUATION = /[.!\s]+$/;
+
+function unwrapCodeFence(text: string): string {
+  for (const fence of CODE_FENCES) {
+    if (text.length > fence.length * 2 && text.startsWith(fence) && text.endsWith(fence)) {
+      return text.slice(fence.length, -fence.length).replace(CODE_FENCE_INFO_STRING, "").trim();
+    }
+  }
+  return text;
+}
+
+/**
+ * Reduces a candidate reply to the bare token a tolerant match can read:
+ * strips surrounding whitespace, a code fence, trailing sentence
+ * punctuation, and HTML-escaped angle brackets. Every step is a bounded
+ * string operation or an anchored linear pattern.
+ */
+function normalizeSentinelCandidate(text: string): string {
+  const unfenced = unwrapCodeFence(text.trim().replace(TRAILING_PUNCTUATION, ""));
+  return unfenced.replace(TRAILING_PUNCTUATION, "").replaceAll("&lt;", "<").replaceAll("&gt;", ">");
+}
+
+/**
+ * True when the message is nothing but a sentinel-shaped tag.
+ *
+ * The marker is an internal control token, so a near-miss must fail closed
+ * into silence. Before this existed the matcher was two exact `includes()`
+ * checks, and `<evedev-empty-delivery/>` fell through to the channel's
+ * `message.completed` default — posting the literal control token into a
+ * team channel.
+ *
+ * Anchored to the whole (normalized) message rather than matched anywhere,
+ * because every caller acts on the *entire* message when this returns true:
+ * `emitStreamContent` nulls the completion and `handleStepResult` drops the
+ * step's assistant output. A fuzzy anywhere-match would let a legitimate
+ * reply that merely discusses the marker suppress itself. The exact
+ * sentinel keeps its anywhere semantics in {@link hasEmptyDeliverySentinel}
+ * — a model that emits it byte-for-byte mid-message meant to stay silent.
+ */
+function isSentinelShapedMessage(text: string): boolean {
+  const match = LONE_TAG_MESSAGE.exec(normalizeSentinelCandidate(text));
+  if (match === null) {
+    return false;
+  }
+  return match
+    .slice(1)
+    .filter((body) => body !== undefined)
+    .every((body) => SENTINEL_TAG_BODY.test(body));
+}
+
 export function hasEmptyDeliverySentinel(text: string | null | undefined): boolean {
+  if (text === null || text === undefined) {
+    return false;
+  }
   return (
-    text?.includes(EMPTY_DELIVERY_SENTINEL) === true ||
-    text?.includes(HTML_ESCAPED_EMPTY_DELIVERY_SENTINEL) === true
+    text.includes(EMPTY_DELIVERY_SENTINEL) ||
+    text.includes(HTML_ESCAPED_EMPTY_DELIVERY_SENTINEL) ||
+    isSentinelShapedMessage(text)
   );
 }


### PR DESCRIPTION
### Summary

A downstream production agent posted the literal string `<evedev-empty-delivery/>` into a team Slack channel: a model mistyped the empty-delivery marker, the exact-match sentinel check missed it, and the control token was delivered as an ordinary message. Investigating that incident surfaced a second, related failure in the empty-response retry path. This PR fixes both — the sentinel now fails closed where it previously failed open — and pins each fix with regression tests.

### Bug 1 — a mangled marker is delivered as channel text

`hasEmptyDeliverySentinel` was two exact `includes()` checks. A model that *means* silence but corrupts the token fell through to the channel's `message.completed` default, and the token went out as the message.

| Model's entire reply | Before | After |
|---|---|---|
| `<eve-empty-delivery/>` | silenced | silenced (unchanged) |
| `<evedev-empty-delivery/>` (the incident) | **posted to the channel** | silenced |
| `<eve-empty-delivery></eve-empty-delivery>` | **posted** | silenced |
| `` `<evedev-empty-delivery/>`. `` (fenced, trailing dot) | **posted** | silenced |
| "The tag `<evedev-empty-delivery/>` is corrupted." | delivered | delivered (unchanged) |

The fix: a reply that is *nothing but* a sentinel-shaped tag now counts as the marker — a corrupted `eve*` name, closing or paired forms, casing, `_` separators, inner whitespace, attributes, HTML-escaped brackets, wrapping backticks or a code fence, and trailing sentence punctuation. The exact sentinel keeps its existing match-anywhere behavior.

### Bug 2 — unattended retries recover into conversational filler

When a scheduled app-auth run (no human present) replied empty, the recovery nudge led with "Answer now from the tool results above." Models complied: "I now have all the data I need." was delivered as the channel message — contradicting the conditional-delivery instruction injected as a system message in that same turn.

The fix: with conditional delivery enabled, the nudge leads with the marker option, offers answering second, and names filler as forbidden. It is unchanged when conditional delivery is off.

Also fixed while here: `rawResponseMessages` is now cleared only when the step's response contains a single assistant message. `resolveAssistantStepText` reads only the *last* assistant message, so a step that replied twice used to erase the earlier, genuinely delivered reply from durable history along with the marker.

### Design decisions worth review attention

- **The tolerant arm is anchored to the whole message; the exact arm stays match-anywhere.** Every caller suppresses the entire message on a match, so an anywhere-matching fuzzy pattern would let a reply that merely *discusses* the marker suppress itself. The existing tests pinning the exact arm's anywhere semantics are untouched.
- **The pattern is deliberately spelled for linear time.** It reads raw model output, and the natural single-pattern spelling — `\s*` on both sides of an optional `/` — backtracks quadratically (~6s on a 120k-character tag). Two anchored passes (a `[^<>]*` tag shape and a lookahead-terminated body) remove the ambiguity structurally. Tests pin the linearity, not just the behavior.
- **One existing test expectation is inverted on purpose.** `<eve-empty-delivery>` (missing slash) was previously asserted as *not* the sentinel; treating it as one is the point of this change, and the test carries a comment saying so.
- **The nudge remains a trailing `user` message.** The in-code comment documents why: `extraSystemNote` is owned by chained tool-recovery for its own call shape, and a system prepend would invalidate the provider's cached prompt prefix.

### Known limitations (called out in code rather than papered over)

- A *near-miss* marker concatenated with real prose in a rare two-assistant-message step is still silenced on the history side but delivered on the emission side; closing that needs assistant-message boundaries the stream does not carry, since it exposes text-part ids and one message can span several.
- Pre-existing and unchanged here: a terminal step with provider-executed tool calls can still carry the marker into `stepOutput`.

### Validation

- Reproduced both incident failures — the mangled marker delivered as channel text, and the unattended retry recovering into filler — and pinned each with focused regression tests, including the history regression where a marker step erased a sibling assistant reply.
- The near-miss table covers 19 mangled spellings that must be silenced against 13 replies that mention or resemble the marker and must still be delivered.
- 5 adversarial inputs assert linear-time rejection at 200k characters.
- The full eve unit suite passes: 7,053 tests. The behavior that reached production is model output, so no automated test exercises a real provider; the runtime paths are covered through the harness.

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

The marker is an internal control token with no published documentation, so the changesets are the only user-facing prose this needs. Closes #2388, which reports both bugs with the observed production shapes.

### Diff size

**Docs** — 2 files · `+10 / -0`

Two patch changesets, one per user-visible behavior change.

**Implementation** — 2 files · `+137 / -13`

The matcher accounts for most of it. Roughly half of `empty-delivery.ts` is comment explaining why the tolerant arm is anchored while the exact sentinel is not, and why the pattern is spelled to avoid catastrophic backtracking — both are non-obvious constraints that a future simplification would otherwise undo. The tool-loop change is small: the nudge text and the single-assistant-message condition on discarding a response.

**Tests** — 2 files · `+169 / -3`

Larger than the fix because the interesting property is a boundary, not a case: tables enumerate mangled spellings that must be silenced against near-misses that must still be delivered. The linearity assertions are separate, since a matcher this permissive is only safe if it cannot be made to backtrack.
