### PR TITLE
feat(website) add dynamic social cards for agent benchmarks

### DIFF
--- a/apps/docs/app/[lang]/evals/opengraph-image.tsx
+++ b/apps/docs/app/[lang]/evals/opengraph-image.tsx
@@ -1,0 +1,12 @@
+import { benchmarkResults, benchmarkRows } from "@/lib/evals/results";
+import { createEvalsOgImage } from "@/lib/evals/og-image";
+
+export const size = {
+  width: 1200,
+  height: 628,
+};
+export const contentType = "image/png";
+
+const EvalsOpenGraphImage = () => createEvalsOgImage(benchmarkRows(benchmarkResults));
+
+export default EvalsOpenGraphImage;

--- a/apps/docs/app/[lang]/evals/twitter-image.tsx
+++ b/apps/docs/app/[lang]/evals/twitter-image.tsx
@@ -1,0 +1,12 @@
+import { benchmarkResults, benchmarkRows } from "@/lib/evals/results";
+import { createEvalsOgImage } from "@/lib/evals/og-image";
+
+export const size = {
+  width: 1200,
+  height: 628,
+};
+export const contentType = "image/png";
+
+const EvalsTwitterImage = () => createEvalsOgImage(benchmarkRows(benchmarkResults));
+
+export default EvalsTwitterImage;

--- a/apps/docs/lib/evals/og-image.tsx
+++ b/apps/docs/lib/evals/og-image.tsx
@@ -1,0 +1,173 @@
+import { LogoEve } from "@vercel/geistdocs/assets/logos/logo-eve";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { ImageResponse } from "next/og";
+import type { BenchmarkRow } from "./results";
+
+const evalsOgImageSize = {
+  width: 1200,
+  height: 628,
+};
+
+const fontDirectory = join(process.cwd(), "app/[lang]/og/[...slug]");
+const fonts = Promise.all([
+  readFile(join(fontDirectory, "geist-sans-regular.ttf")),
+  readFile(join(fontDirectory, "geist-sans-semibold.ttf")),
+]);
+
+const formatRate = (rate: number | null): string => (rate === null ? "—" : `${Math.round(rate)}%`);
+
+const latestResults = (rows: BenchmarkRow[]): BenchmarkRow[] =>
+  [...rows].sort(
+    (left, right) =>
+      (right.guidedSuccessRate ?? -1) - (left.guidedSuccessRate ?? -1) ||
+      (right.baselineSuccessRate ?? -1) - (left.baselineSuccessRate ?? -1) ||
+      left.modelDisplayName.localeCompare(right.modelDisplayName),
+  );
+
+export const createEvalsOgImage = async (rows: BenchmarkRow[]): Promise<ImageResponse> => {
+  const [regularFont, semiboldFont] = await fonts;
+  const results = latestResults(rows);
+
+  return new ImageResponse(
+    <div
+      style={{
+        background: "black",
+        color: "white",
+        display: "flex",
+        fontFamily: "Geist",
+        height: "100%",
+        position: "relative",
+        width: "100%",
+      }}
+    >
+      <div
+        style={{
+          color: "white",
+          display: "flex",
+          left: 60,
+          position: "absolute",
+          top: 60,
+        }}
+      >
+        <LogoEve height={30} />
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          fontSize: 76,
+          fontWeight: 400,
+          left: 60,
+          letterSpacing: "-0.06em",
+          lineHeight: 0.95,
+          position: "absolute",
+          top: 241,
+        }}
+      >
+        <div style={{ display: "flex" }}>Agent</div>
+        <div style={{ display: "flex" }}>Benchmarks</div>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          left: 600,
+          position: "absolute",
+          top: 163,
+          width: 540,
+        }}
+      >
+        <div
+          style={{
+            borderBottom: "1px solid #333333",
+            color: "#777777",
+            display: "flex",
+            fontSize: 18,
+            fontWeight: 500,
+            paddingBottom: 12,
+            width: "100%",
+          }}
+        >
+          <div style={{ display: "flex", flex: 1 }}>Model</div>
+          <div style={{ display: "flex", justifyContent: "flex-end", width: 84 }}>Base</div>
+          <div style={{ display: "flex", justifyContent: "flex-end", width: 104 }}>Guided</div>
+        </div>
+        {results.map((row) => (
+          <div
+            key={row.groupId}
+            style={{
+              alignItems: "center",
+              borderBottom: "1px solid #222222",
+              display: "flex",
+              fontSize: 24,
+              height: 52,
+              letterSpacing: "-0.025em",
+              width: "100%",
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                flex: 1,
+                overflow: "hidden",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {row.modelDisplayName}
+            </div>
+            <div
+              style={{
+                color: "#888888",
+                display: "flex",
+                justifyContent: "flex-end",
+                width: 84,
+              }}
+            >
+              {formatRate(row.baselineSuccessRate)}
+            </div>
+            <div
+              style={{
+                display: "flex",
+                fontWeight: 500,
+                justifyContent: "flex-end",
+                width: 104,
+              }}
+            >
+              {formatRate(row.guidedSuccessRate)}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div
+        style={{
+          background: "linear-gradient(to bottom, transparent 0%, black 100%)",
+          bottom: 0,
+          display: "flex",
+          height: 230,
+          position: "absolute",
+          right: 0,
+          width: 600,
+        }}
+      />
+    </div>,
+    {
+      ...evalsOgImageSize,
+      fonts: [
+        {
+          name: "Geist",
+          data: regularFont,
+          weight: 400,
+        },
+        {
+          name: "Geist",
+          data: semiboldFont,
+          weight: 500,
+        },
+      ],
+    },
+  );
+};


### PR DESCRIPTION
### Summary

The eval benchmarks page currently falls back to the generic eve social image. This adds dedicated Open Graph and X cards that present the latest benchmark results alongside the eve wordmark and an “Agent Benchmarks” title. The table is generated from the same published benchmark data as the page, with baseline and guided results ordered consistently and lower entries fading into the background.

<img width="1200" height="628" alt="image" src="https://github.com/user-attachments/assets/0efd0b5a-69c7-4d9a-a32e-d1776bbbf202" />


### Validation

Built the docs app for production, which completed TypeScript checking and static generation and registered both image routes. Manually confirmed `/evals` emits absolute Open Graph and X image metadata and that both endpoints return a 1200×628 PNG.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 3 files · `+197 / -0`

Adds the shared data-driven image renderer and the Open Graph and X metadata image entry points. Most of the implementation defines the 1200×628 social-card composition using `next/og`.

**Tests** — 0 files · `+0 / -0`

No automated test was added because the behavior is Next.js metadata route wiring and image rendering; it was covered by the production docs build and direct endpoint inspection.
