### PR TITLE
feat(docs): agent readiness - publish discovery and trust surfaces

### DIFF
--- a/apps/docs/app/[lang]/(home)/components/home-content.tsx
+++ b/apps/docs/app/[lang]/(home)/components/home-content.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { canonicalAlternates, canonicalRoutes } from "@/lib/geistdocs/canonical";
+import { createHomeStructuredData } from "@/lib/geistdocs/home-structured-data";
 import { pageTitleMetadata, siteTitle } from "@/lib/geistdocs/metadata-title";
 import { staticOgImage } from "@/lib/geistdocs/og";
 import { ArchitectureDiagram } from "./architecture";
@@ -14,12 +15,17 @@ const titleMetadata = pageTitleMetadata(siteTitle);
 
 export const homeMetadata: Metadata = {
   ...titleMetadata,
+  applicationName: "eve",
   description: tagline,
+  keywords: ["eve", "eve agent framework", "durable AI agents", "filesystem-first agents"],
   alternates: canonicalAlternates(canonicalRoutes.home),
   openGraph: {
     ...titleMetadata.openGraph,
     description: tagline,
     images: [staticOgImage],
+    siteName: "eve",
+    type: "website",
+    url: canonicalRoutes.home,
   },
   twitter: {
     ...titleMetadata.twitter,
@@ -29,15 +35,28 @@ export const homeMetadata: Metadata = {
   },
 };
 
-export const HomeContent = () => (
-  <div className="mx-auto w-full max-w-[1080px] pb-32">
-    <section className="relative isolate flex min-h-[80vh] flex-col items-center justify-center gap-y-5 px-4 pt-24 pb-12 text-center sm:px-12 sm:pb-16 sm:pt-42">
-      <HeroAudience tagline={tagline} />
-    </section>
-    <FileTree />
-    <NextjsInterop />
-    <ArchitectureDiagram />
-    <FeatureGrid />
-    <CTA />
-  </div>
-);
+export const HomeContent = () => {
+  const structuredData = createHomeStructuredData();
+
+  return (
+    <>
+      <script
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(structuredData).replace(/</g, "\\u003c"),
+        }}
+        id="eve-home-structured-data"
+        type="application/ld+json"
+      />
+      <main className="mx-auto w-full max-w-[1080px] pb-32">
+        <section className="relative isolate flex min-h-[80vh] flex-col items-center justify-center gap-y-5 px-4 pt-24 pb-12 text-center sm:px-12 sm:pb-16 sm:pt-42">
+          <HeroAudience tagline={tagline} />
+        </section>
+        <FileTree />
+        <NextjsInterop />
+        <ArchitectureDiagram />
+        <FeatureGrid />
+        <CTA />
+      </main>
+    </>
+  );
+};

--- a/apps/docs/app/[lang]/(trust)/about/page.tsx
+++ b/apps/docs/app/[lang]/(trust)/about/page.tsx
@@ -1,0 +1,7 @@
+import { createTrustPageMetadata, TrustPage } from "@/components/geistdocs/trust-page";
+
+export const metadata = createTrustPageMetadata("about");
+
+const AboutPage = () => <TrustPage slug="about" />;
+
+export default AboutPage;

--- a/apps/docs/app/[lang]/(trust)/contact/page.tsx
+++ b/apps/docs/app/[lang]/(trust)/contact/page.tsx
@@ -1,0 +1,7 @@
+import { createTrustPageMetadata, TrustPage } from "@/components/geistdocs/trust-page";
+
+export const metadata = createTrustPageMetadata("contact");
+
+const ContactPage = () => <TrustPage slug="contact" />;
+
+export default ContactPage;

--- a/apps/docs/app/[lang]/(trust)/privacy/page.tsx
+++ b/apps/docs/app/[lang]/(trust)/privacy/page.tsx
@@ -1,0 +1,7 @@
+import { createTrustPageMetadata, TrustPage } from "@/components/geistdocs/trust-page";
+
+export const metadata = createTrustPageMetadata("privacy");
+
+const PrivacyPage = () => <TrustPage slug="privacy" />;
+
+export default PrivacyPage;

--- a/apps/docs/app/[lang]/layout.tsx
+++ b/apps/docs/app/[lang]/layout.tsx
@@ -4,6 +4,7 @@ import { Navbar } from "@vercel/geistdocs/navbar";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { GeistdocsProvider } from "@/components/geistdocs/provider";
+import { SiteFooterLinks } from "@/components/geistdocs/site-footer-links";
 import { config } from "@/lib/geistdocs/config";
 import { mono, sans } from "@/lib/geistdocs/fonts";
 import { staticOgImage } from "@/lib/geistdocs/og";
@@ -45,6 +46,7 @@ const Layout = async ({ children, params }: LayoutProps<"/[lang]">) => {
         <GeistdocsProvider basePath={config.basePath} lang={lang}>
           <Navbar config={config} />
           {children}
+          <SiteFooterLinks />
           <Footer />
         </GeistdocsProvider>
       </body>

--- a/apps/docs/app/[lang]/llms.mdx/[[...slug]]/route.ts
+++ b/apps/docs/app/[lang]/llms.mdx/[[...slug]]/route.ts
@@ -9,7 +9,7 @@ import {
 } from "@/lib/analytics/events";
 import { trackServerEvent } from "@/lib/analytics/server";
 import { applyMarkdownRouteCanonical } from "@/lib/geistdocs/markdown-canonical";
-import { getMarkdownRequestedPath } from "@/lib/geistdocs/markdown-path";
+import { getMarkdownRequestedPath, markdownNotFoundOptions } from "@/lib/geistdocs/markdown-path";
 import { geistdocsSource } from "@/lib/geistdocs/source";
 import { getSiteOrigin } from "@/lib/geistdocs/url";
 import { integrationSource } from "@/lib/integrations/source";
@@ -17,7 +17,7 @@ import { integrationSource } from "@/lib/integrations/source";
 export const revalidate = false;
 
 const markdownRoute = createDocsMarkdownRoute({
-  notFound: { getRequestedPath: getMarkdownRequestedPath },
+  notFound: markdownNotFoundOptions,
   sources: [geistdocsSource, integrationSource],
 });
 

--- a/apps/docs/app/[lang]/sitemap.md/route.ts
+++ b/apps/docs/app/[lang]/sitemap.md/route.ts
@@ -5,6 +5,7 @@ import { transformSitemapMarkdown } from "@/lib/geistdocs/sitemap-transform";
 import { geistdocsSource } from "@/lib/geistdocs/source";
 import { integrationSource } from "@/lib/integrations/source";
 import { templateManifest } from "@/lib/templates/manifest";
+import { trustPages } from "@/lib/trust/pages";
 
 export const revalidate = false;
 export const dynamic = "error";
@@ -20,6 +21,32 @@ const sitemapRoute = createSitemapMarkdownRoute({
           pageUrl: url,
           tree: geistdocsSource.source.getPageTree(lang),
         }) ?? title,
+      resources: [
+        ...trustPages.map((page) => ({
+          description: page.description,
+          href: `/${page.slug}`,
+          title: page.title,
+          type: "Trust",
+        })),
+        {
+          description: "Machine-readable contract for the eve.dev documentation helper API.",
+          href: "/openapi.json",
+          title: "eve.dev OpenAPI specification",
+          type: "API specification",
+        },
+        {
+          description: "Operating guidance and authoritative discovery links for agents.",
+          href: "/agents.md",
+          title: "eve agent instructions",
+          type: "Agent guidance",
+        },
+        {
+          description: "Curated index for choosing the smallest relevant eve documentation set.",
+          href: "/llms.txt",
+          title: "eve documentation index for LLMs",
+          type: "Agent guidance",
+        },
+      ],
       templates: templateManifest,
     }),
 });

--- a/apps/docs/app/[lang]/trust-markdown/[slug]/route.ts
+++ b/apps/docs/app/[lang]/trust-markdown/[slug]/route.ts
@@ -1,0 +1,37 @@
+import { isSupportedLanguage, supportedLanguages } from "@/lib/geistdocs/languages";
+import { getTrustPage, trustPageMarkdown, trustPages } from "@/lib/trust/pages";
+
+export const revalidate = false;
+
+export const generateStaticParams = () =>
+  supportedLanguages.flatMap((lang) => trustPages.map(({ slug }) => ({ lang, slug })));
+
+export const GET = async (
+  request: Request,
+  context: RouteContext<"/[lang]/trust-markdown/[slug]">,
+) => {
+  const { lang, slug } = await context.params;
+  const page = isSupportedLanguage(lang) ? getTrustPage(slug) : undefined;
+  if (!page) {
+    return new Response(
+      "# Page Not Found\n\nThe requested eve project page does not exist. Browse [/llms.txt](/llms.txt) or [/sitemap.md](/sitemap.md).\n",
+      {
+        status: 404,
+        headers: {
+          "Content-Type": "text/markdown; charset=utf-8",
+          Vary: "Accept",
+          "X-Robots-Tag": "noindex",
+        },
+      },
+    );
+  }
+
+  const canonicalUrl = new URL(`/${page.slug}`, request.url).toString();
+  return new Response(trustPageMarkdown(page), {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: `<${canonicalUrl}>; rel="canonical"`,
+      Vary: "Accept",
+    },
+  });
+};

--- a/apps/docs/app/api/[...path]/route.ts
+++ b/apps/docs/app/api/[...path]/route.ts
@@ -1,0 +1,10 @@
+import { apiRouteNotFoundResponse } from "@/lib/api/errors";
+
+const notFound = (request: Request) => apiRouteNotFoundResponse(request);
+
+export const GET = notFound;
+export const POST = notFound;
+export const PUT = notFound;
+export const PATCH = notFound;
+export const DELETE = notFound;
+export const OPTIONS = notFound;

--- a/apps/docs/app/api/chat/route.ts
+++ b/apps/docs/app/api/chat/route.ts
@@ -1,5 +1,11 @@
 import { createChatRoute } from "@vercel/geistdocs/routes/chat";
 import {
+  methodNotAllowedResponse,
+  normalizeApiErrorResponse,
+  optionsResponse,
+  parseJsonRequestBody,
+} from "@/lib/api/errors";
+import {
   analyticsEvents,
   getAskAiContext,
   getDocsSurface,
@@ -17,9 +23,14 @@ const chatRoute = createChatRoute({
 });
 
 export const POST = async (request: Request) => {
-  const analyticsRequest = request.clone();
+  const parsed = await parseJsonRequestBody(request.clone(), {
+    code: "invalid_chat_request",
+    resolution: "Send AI SDK UI messages using the request schema in /openapi.json.",
+  });
+  if (!parsed.ok) return parsed.response;
+
   const response = await chatRoute.POST(request);
-  const body: unknown = await analyticsRequest.json().catch(() => null);
+  const body = parsed.body;
 
   if (typeof body === "object" && body !== null && "messages" in body) {
     const messages = Array.isArray(body.messages) ? body.messages : [];
@@ -41,5 +52,17 @@ export const POST = async (request: Request) => {
     });
   }
 
-  return response;
+  return normalizeApiErrorResponse(response, {
+    code: response.status === 400 ? "invalid_chat_request" : "chat_failed",
+    resolution:
+      response.status === 400
+        ? "Send AI SDK UI messages using the request schema in /openapi.json."
+        : "Retry later or use /api/search for deterministic documentation retrieval.",
+  });
 };
+
+export const GET = (request: Request) => methodNotAllowedResponse(request, ["POST"]);
+export const PUT = GET;
+export const PATCH = GET;
+export const DELETE = GET;
+export const OPTIONS = () => optionsResponse(["POST"]);

--- a/apps/docs/app/api/route.ts
+++ b/apps/docs/app/api/route.ts
@@ -1,0 +1,10 @@
+import { apiRouteNotFoundResponse } from "@/lib/api/errors";
+
+const notFound = (request: Request) => apiRouteNotFoundResponse(request);
+
+export const GET = notFound;
+export const POST = notFound;
+export const PUT = notFound;
+export const PATCH = notFound;
+export const DELETE = notFound;
+export const OPTIONS = notFound;

--- a/apps/docs/app/api/search/route.ts
+++ b/apps/docs/app/api/search/route.ts
@@ -1,9 +1,30 @@
 import { createSearchRoute } from "@vercel/geistdocs/routes/search";
+import { apiErrorResponse, methodNotAllowedResponse, optionsResponse } from "@/lib/api/errors";
 import { config } from "@/lib/geistdocs/config";
 import { geistdocsSource } from "@/lib/geistdocs/source";
 import { integrationSource } from "@/lib/integrations/source";
 
-export const GET = createSearchRoute({
+const searchRoute = createSearchRoute({
   config,
   sources: [geistdocsSource, integrationSource],
 });
+
+export const GET = async (request: Request) => {
+  try {
+    return await searchRoute(request);
+  } catch (error) {
+    console.error("Documentation search API error:", error);
+    return apiErrorResponse({
+      code: "search_failed",
+      message: "The documentation index could not be searched.",
+      resolution: "Retry the request or browse /llms.txt for direct documentation links.",
+      status: 500,
+    });
+  }
+};
+
+export const POST = (request: Request) => methodNotAllowedResponse(request, ["GET"]);
+export const PUT = POST;
+export const PATCH = POST;
+export const DELETE = POST;
+export const OPTIONS = () => optionsResponse(["GET"]);

--- a/apps/docs/app/global-not-found.tsx
+++ b/apps/docs/app/global-not-found.tsx
@@ -9,17 +9,26 @@ export const metadata: Metadata = {
 const GlobalNotFound = () => (
   <html lang="en">
     <body className="flex min-h-screen items-center justify-center bg-background-100 px-6 text-gray-1000">
-      <main className="max-w-md text-center">
+      <main className="max-w-xl text-center">
         <h1 className="text-heading-32">Page not found</h1>
         <p className="mt-3 text-copy-16 text-gray-900">
-          The requested page does not exist. Browse the eve documentation to continue.
+          The requested page does not exist. Use the documentation map or agent index to find the
+          current eve page.
         </p>
-        <a
-          className="mt-6 inline-flex rounded-md border px-4 py-2 text-label-14"
-          href="/docs/getting-started"
-        >
-          Browse documentation
-        </a>
+        <nav aria-label="Page recovery" className="mt-6 flex flex-wrap justify-center gap-3">
+          <a className="inline-flex rounded-md border px-4 py-2 text-label-14" href="/sitemap.md">
+            Documentation map
+          </a>
+          <a className="inline-flex rounded-md border px-4 py-2 text-label-14" href="/llms.txt">
+            Agent index
+          </a>
+          <a
+            className="inline-flex rounded-md border px-4 py-2 text-label-14"
+            href="/docs/getting-started"
+          >
+            Getting started
+          </a>
+        </nav>
       </main>
     </body>
   </html>

--- a/apps/docs/app/openapi.json/route.ts
+++ b/apps/docs/app/openapi.json/route.ts
@@ -1,0 +1,8 @@
+import { openApiDocument } from "@/lib/api/openapi";
+
+export const revalidate = false;
+
+export const GET = () =>
+  Response.json(openApiDocument, {
+    headers: { "Cache-Control": "public, max-age=0, s-maxage=3600" },
+  });

--- a/apps/docs/app/sitemap.ts
+++ b/apps/docs/app/sitemap.ts
@@ -14,6 +14,7 @@ import { geistdocsSource } from "@/lib/geistdocs/source";
 import { getSiteOrigin } from "@/lib/geistdocs/url";
 import { integrations } from "@/lib/integrations/data";
 import { templateManifest } from "@/lib/templates/manifest";
+import { trustPages } from "@/lib/trust/pages";
 
 const getLastModified = (data: unknown): Date | undefined => {
   if (!data || typeof data !== "object" || !("lastModified" in data)) return;
@@ -47,6 +48,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
       ...integrations.map(({ slug }) => ({ pathname: integrationPath(slug) })),
       { pathname: canonicalRoutes.templates },
       ...templateManifest.map(({ slug }) => ({ pathname: templatePath(slug) })),
+      ...trustPages.map(({ slug }) => ({ pathname: `/${slug}` })),
     ],
   });
 }

--- a/apps/docs/components/geistdocs/site-footer-links.tsx
+++ b/apps/docs/components/geistdocs/site-footer-links.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+import { trustPages } from "@/lib/trust/pages";
+
+const projectLinks = [
+  ...trustPages.map((page) => ({ href: `/${page.slug}`, label: page.title })),
+  { href: "/openapi.json", label: "Documentation API" },
+  { href: "https://github.com/vercel/eve", label: "GitHub" },
+];
+
+export const SiteFooterLinks = () => (
+  <nav
+    aria-label="eve project information"
+    className="mx-auto w-full max-w-[1448px] border-t px-6 pt-10"
+  >
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <span className="font-medium text-gray-1000 text-label-14">eve project</span>
+      <ul className="flex flex-wrap gap-x-5 gap-y-2 text-label-14">
+        {projectLinks.map((link) => (
+          <li key={link.href}>
+            <Link className="text-gray-900 transition-colors hover:text-gray-1000" href={link.href}>
+              {link.label}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </nav>
+);

--- a/apps/docs/components/geistdocs/trust-page.tsx
+++ b/apps/docs/components/geistdocs/trust-page.tsx
@@ -1,0 +1,78 @@
+import type { Metadata } from "next";
+import { canonicalAlternates } from "@/lib/geistdocs/canonical";
+import { pageTitleMetadata } from "@/lib/geistdocs/metadata-title";
+import { staticOgImage } from "@/lib/geistdocs/og";
+import { getTrustPage, type TrustPageSlug } from "@/lib/trust/pages";
+
+export const createTrustPageMetadata = (slug: TrustPageSlug): Metadata => {
+  const page = getTrustPage(slug);
+  if (!page) throw new Error(`Unknown trust page: ${slug}`);
+  const titleMetadata = pageTitleMetadata(page.title);
+
+  return {
+    ...titleMetadata,
+    description: page.description,
+    alternates: canonicalAlternates(`/${page.slug}`, {
+      types: { "text/markdown": `/${page.slug}.md` },
+    }),
+    openGraph: {
+      ...titleMetadata.openGraph,
+      description: page.description,
+      images: [staticOgImage],
+      type: "website",
+      url: `/${page.slug}`,
+    },
+    twitter: {
+      ...titleMetadata.twitter,
+      card: "summary_large_image",
+      description: page.description,
+      images: [staticOgImage],
+    },
+  };
+};
+
+export const TrustPage = ({ slug }: { slug: TrustPageSlug }) => {
+  const page = getTrustPage(slug);
+  if (!page) throw new Error(`Unknown trust page: ${slug}`);
+
+  return (
+    <main className="mx-auto w-full max-w-3xl px-6 py-16 sm:py-24">
+      <header>
+        <h1 className="text-heading-40 text-gray-1000 sm:text-heading-48">{page.title}</h1>
+        <p className="mt-5 text-balance text-copy-18 text-gray-900">{page.intro}</p>
+      </header>
+      <div className="mt-12 space-y-12">
+        {page.sections.map((section) => {
+          const headingId = `${page.slug}-${section.heading}`.toLowerCase().replaceAll(" ", "-");
+          return (
+            <section key={section.heading} aria-labelledby={headingId}>
+              <h2 className="text-heading-24 text-gray-1000" id={headingId}>
+                {section.heading}
+              </h2>
+              <div className="mt-4 space-y-4 text-copy-16 text-gray-900">
+                {section.paragraphs.map((paragraph) => (
+                  <p key={paragraph}>{paragraph}</p>
+                ))}
+              </div>
+              {section.links ? (
+                <ul className="mt-5 space-y-3">
+                  {section.links.map((link) => (
+                    <li key={link.href}>
+                      <a
+                        className="font-medium text-gray-1000 underline decoration-gray-400 underline-offset-4 transition-colors hover:decoration-gray-1000"
+                        href={link.href}
+                      >
+                        {link.label}
+                      </a>
+                      <span className="text-gray-900"> — {link.description}</span>
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+            </section>
+          );
+        })}
+      </div>
+    </main>
+  );
+};

--- a/apps/docs/geistdocs.tsx
+++ b/apps/docs/geistdocs.tsx
@@ -33,6 +33,22 @@ export const suggestions = [
 ];
 
 export const agent = {
+  api: {
+    openApiUrl: "/openapi.json",
+  },
+  links: [
+    { label: "About eve", href: "/about", description: "Project identity and scope" },
+    {
+      label: "Contact the eve project",
+      href: "/contact",
+      description: "Community, issue, contribution, and security channels",
+    },
+    {
+      label: "Privacy on eve.dev",
+      href: "/privacy",
+      description: "Site analytics, Ask AI, and the governing Vercel Privacy Notice",
+    },
+  ],
   product: {
     name: "eve",
     description:
@@ -52,7 +68,7 @@ export const agent = {
     "Use /llms.txt as a concise task-oriented index and /sitemap.md as the exhaustive page map.",
     "Use /llms-full.txt only when you need the complete documentation corpus for offline indexing or a large context window.",
     "Fetch individual docs or integration pages with a .md or .mdx extension for focused page-level context. Template pages are HTML discovery pages and do not expose this alternate Markdown route.",
-    "Treat eve.dev as framework documentation, not a shared API, authorization server, MCP server, or A2A server. Every deployed eve app exposes its own /eve/v1 routes and authentication policy; external API, OpenAPI, and MCP URLs in the docs may describe third-party connections or examples.",
+    "Treat eve.dev as framework documentation, not a shared eve runtime API, authorization server, MCP server, or A2A server. The /openapi.json contract covers only the site's documentation search and Ask AI helpers. Every deployed eve app exposes its own /eve/v1 routes and authentication policy; external API, OpenAPI, and MCP URLs in the docs may describe third-party connections or examples.",
     "Do not assume API, authentication, OpenAPI, or MCP support unless it is listed in this file.",
   ],
 };

--- a/apps/docs/lib/api/errors.test.ts
+++ b/apps/docs/lib/api/errors.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import {
+  apiErrorResponse,
+  apiRouteNotFoundResponse,
+  methodNotAllowedResponse,
+  normalizeApiErrorResponse,
+  optionsResponse,
+  parseJsonRequestBody,
+} from "./errors";
+
+describe("API error responses", () => {
+  it("returns a stable machine-readable envelope", async () => {
+    const response = apiErrorResponse({
+      code: "invalid_request",
+      message: "The request is invalid.",
+      resolution: "Check /openapi.json and try again.",
+      status: 400,
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("content-type")).toBe("application/json; charset=utf-8");
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "invalid_request",
+        message: "The request is invalid.",
+        resolution: "Check /openapi.json and try again.",
+      },
+    });
+  });
+
+  it("describes unsupported methods and advertises the allowed methods", async () => {
+    const response = methodNotAllowedResponse(
+      new Request("https://eve.dev/api/chat", { method: "GET" }),
+      ["POST"],
+    );
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get("allow")).toBe("POST, OPTIONS");
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: "method_not_allowed",
+        message: "GET is not supported for /api/chat.",
+      },
+    });
+  });
+
+  it("normalizes upstream JSON errors without changing successful streams", async () => {
+    const upstream = Response.json({ error: "messages must be an array" }, { status: 400 });
+    const normalized = await normalizeApiErrorResponse(upstream, {
+      code: "invalid_chat_request",
+      resolution: "Send UI messages using the schema in /openapi.json.",
+    });
+    const stream = new Response("data: ok", { headers: { "content-type": "text/event-stream" } });
+
+    await expect(normalized.json()).resolves.toEqual({
+      error: {
+        code: "invalid_chat_request",
+        message: "messages must be an array",
+        resolution: "Send UI messages using the schema in /openapi.json.",
+      },
+    });
+    await expect(
+      normalizeApiErrorResponse(stream, { code: "unused", resolution: "unused" }),
+    ).resolves.toBe(stream);
+  });
+
+  it("rejects malformed JSON before an API handler processes it", async () => {
+    const result = await parseJsonRequestBody(
+      new Request("https://eve.dev/api/chat", { method: "POST", body: "{" }),
+      {
+        code: "invalid_chat_request",
+        resolution: "Use the schema in /openapi.json.",
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.response.status).toBe(400);
+    await expect(result.response.json()).resolves.toEqual({
+      error: {
+        code: "invalid_chat_request",
+        message: "The request body must contain valid JSON.",
+        resolution: "Use the schema in /openapi.json.",
+      },
+    });
+  });
+
+  it("returns a bodyless options response", async () => {
+    const response = optionsResponse(["GET"]);
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("allow")).toBe("GET, OPTIONS");
+    expect(await response.text()).toBe("");
+  });
+
+  it("returns structured JSON for unknown API routes", async () => {
+    const response = apiRouteNotFoundResponse(new Request("https://eve.dev/api/unknown"));
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "api_route_not_found",
+        message: "No eve.dev API route matches /api/unknown.",
+        resolution: "Use an endpoint listed in /openapi.json.",
+      },
+    });
+  });
+});

--- a/apps/docs/lib/api/errors.ts
+++ b/apps/docs/lib/api/errors.ts
@@ -1,0 +1,119 @@
+export interface ApiErrorBody {
+  error: {
+    code: string;
+    message: string;
+    resolution: string;
+  };
+}
+
+interface ApiErrorOptions {
+  code: string;
+  message: string;
+  resolution: string;
+  status: number;
+  headers?: HeadersInit;
+}
+
+export const apiErrorResponse = ({
+  code,
+  message,
+  resolution,
+  status,
+  headers: initialHeaders,
+}: ApiErrorOptions): Response => {
+  const headers = new Headers(initialHeaders);
+  headers.set("Cache-Control", "no-store");
+  headers.set("Content-Type", "application/json; charset=utf-8");
+
+  return new Response(
+    JSON.stringify({ error: { code, message, resolution } } satisfies ApiErrorBody),
+    {
+      status,
+      headers,
+    },
+  );
+};
+
+type ParsedJsonBody = { body: unknown; ok: true } | { ok: false; response: Response };
+
+export const parseJsonRequestBody = async (
+  request: Request,
+  { code, resolution }: Pick<ApiErrorOptions, "code" | "resolution">,
+): Promise<ParsedJsonBody> => {
+  try {
+    return { body: await request.json(), ok: true };
+  } catch {
+    return {
+      ok: false,
+      response: apiErrorResponse({
+        code,
+        message: "The request body must contain valid JSON.",
+        resolution,
+        status: 400,
+      }),
+    };
+  }
+};
+
+export const methodNotAllowedResponse = (request: Request, allowedMethods: string[]): Response => {
+  const allow = [...allowedMethods, "OPTIONS"];
+  const { pathname } = new URL(request.url);
+
+  return apiErrorResponse({
+    code: "method_not_allowed",
+    message: `${request.method} is not supported for ${pathname}.`,
+    resolution: `Use ${allowedMethods.join(" or ")} as described in /openapi.json.`,
+    status: 405,
+    headers: { Allow: allow.join(", ") },
+  });
+};
+
+export const optionsResponse = (allowedMethods: string[]): Response =>
+  new Response(null, {
+    status: 204,
+    headers: { Allow: [...allowedMethods, "OPTIONS"].join(", ") },
+  });
+
+export const apiRouteNotFoundResponse = (request: Request): Response => {
+  const { pathname } = new URL(request.url);
+  return apiErrorResponse({
+    code: "api_route_not_found",
+    message: `No eve.dev API route matches ${pathname}.`,
+    resolution: "Use an endpoint listed in /openapi.json.",
+    status: 404,
+  });
+};
+
+const readUpstreamMessage = async (response: Response): Promise<string | undefined> => {
+  if (!response.headers.get("content-type")?.includes("application/json")) return;
+
+  const body: unknown = await response
+    .clone()
+    .json()
+    .catch(() => null);
+  if (!body || typeof body !== "object" || !("error" in body)) return;
+  if (typeof body.error === "string") return body.error;
+  if (
+    body.error &&
+    typeof body.error === "object" &&
+    "message" in body.error &&
+    typeof body.error.message === "string"
+  ) {
+    return body.error.message;
+  }
+};
+
+export const normalizeApiErrorResponse = async (
+  response: Response,
+  { code, resolution }: Pick<ApiErrorOptions, "code" | "resolution">,
+): Promise<Response> => {
+  if (response.ok) return response;
+
+  const message =
+    (await readUpstreamMessage(response)) ??
+    (response.statusText || "The request could not be completed.");
+  const headers = new Headers(response.headers);
+  headers.delete("Content-Length");
+
+  return apiErrorResponse({ code, message, resolution, status: response.status, headers });
+};

--- a/apps/docs/lib/api/openapi.test.ts
+++ b/apps/docs/lib/api/openapi.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { openApiDocument } from "./openapi";
+
+describe("eve.dev OpenAPI document", () => {
+  it("describes the deployed documentation endpoints with unique operation IDs", () => {
+    expect(openApiDocument.openapi).toBe("3.1.1");
+    expect(openApiDocument.info.title).toContain("eve.dev");
+    expect(openApiDocument.paths).toHaveProperty("/api/search.get");
+    expect(openApiDocument.paths).toHaveProperty("/api/chat.post");
+
+    const operations = Object.values(openApiDocument.paths).flatMap((path) => Object.values(path));
+    const operationIds = operations.map((operation) => operation.operationId);
+
+    expect(new Set(operationIds).size).toBe(operationIds.length);
+    expect(operationIds).toEqual(["searchEveDocumentation", "askEveDocumentation"]);
+    for (const operation of operations) {
+      expect(operation.description.length).toBeGreaterThan(40);
+      expect(operation.responses).toBeDefined();
+    }
+  });
+
+  it("types every parameter, request body, response, and structured error field", () => {
+    const search = openApiDocument.paths["/api/search"].get;
+    const chat = openApiDocument.paths["/api/chat"].post;
+    const error = openApiDocument.components.schemas.ErrorResponse;
+
+    expect(search.parameters.map(({ name }) => name)).toEqual(["query", "locale", "tag"]);
+    expect(search.parameters.every((parameter) => parameter.schema.type)).toBe(true);
+    expect(chat.requestBody.content["application/json"].schema.$ref).toBe(
+      "#/components/schemas/ChatRequest",
+    );
+    expect(chat.responses["200"].content["text/event-stream"].schema.type).toBe("string");
+    expect(error.properties.error.required).toEqual(["code", "message", "resolution"]);
+  });
+
+  it("does not claim that eve.dev is an eve runtime API", () => {
+    expect(openApiDocument.info.description).toContain("not the runtime API");
+    expect(openApiDocument.paths).not.toHaveProperty("/eve/v1");
+  });
+});

--- a/apps/docs/lib/api/openapi.ts
+++ b/apps/docs/lib/api/openapi.ts
@@ -1,0 +1,224 @@
+const errorResponse = (description: string) => ({
+  description,
+  content: {
+    "application/json": {
+      schema: { $ref: "#/components/schemas/ErrorResponse" },
+    },
+  },
+});
+
+export const openApiDocument = {
+  openapi: "3.1.1",
+  info: {
+    title: "eve.dev Documentation API",
+    version: "1.0.0",
+    description:
+      "Search the public eve documentation or ask the eve documentation assistant. This contract describes eve.dev helper endpoints, not the runtime API exposed by an eve application.",
+    license: {
+      name: "Apache-2.0",
+      identifier: "Apache-2.0",
+    },
+  },
+  servers: [{ url: "https://eve.dev", description: "Production documentation site" }],
+  externalDocs: {
+    description: "eve documentation index",
+    url: "https://eve.dev/llms.txt",
+  },
+  tags: [
+    {
+      name: "Documentation",
+      description: "Read-only discovery and assistance for public eve documentation.",
+    },
+  ],
+  paths: {
+    "/api/search": {
+      get: {
+        operationId: "searchEveDocumentation",
+        summary: "Search eve documentation",
+        description:
+          "Returns ranked passages and pages from the public eve documentation and integration directory. An omitted or empty query returns an empty array.",
+        tags: ["Documentation"],
+        security: [],
+        parameters: [
+          {
+            name: "query",
+            in: "query",
+            description: "Text to search for. Use concrete eve API names or task terms.",
+            required: false,
+            schema: { type: "string" },
+          },
+          {
+            name: "locale",
+            in: "query",
+            description: "Documentation locale. eve.dev currently publishes English content.",
+            required: false,
+            schema: { type: "string", enum: ["en"], default: "en" },
+          },
+          {
+            name: "tag",
+            in: "query",
+            description: "Comma-separated search tags when the index defines them.",
+            required: false,
+            schema: { type: "string" },
+          },
+        ],
+        responses: {
+          "200": {
+            description: "Ranked documentation results.",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/SearchResult" },
+                },
+              },
+            },
+          },
+          "405": errorResponse("The HTTP method is not supported."),
+          "500": errorResponse("The documentation index could not be searched."),
+        },
+      },
+    },
+    "/api/chat": {
+      post: {
+        operationId: "askEveDocumentation",
+        summary: "Ask the eve documentation assistant",
+        description:
+          "Streams an AI SDK UI message response grounded in public eve documentation. Use the search operation when a deterministic ranked result is sufficient.",
+        tags: ["Documentation"],
+        security: [],
+        requestBody: {
+          required: true,
+          description: "The AI SDK UI message conversation and optional current-page context.",
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/ChatRequest" },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "An AI SDK UI message stream encoded as server-sent events.",
+            headers: {
+              "x-vercel-ai-ui-message-stream": {
+                description: "Identifies the AI SDK UI message stream protocol version.",
+                schema: { type: "string" },
+              },
+            },
+            content: {
+              "text/event-stream": {
+                schema: { type: "string", description: "AI SDK UI message stream events." },
+              },
+            },
+          },
+          "400": errorResponse("The chat request does not match the required message shape."),
+          "405": errorResponse("The HTTP method is not supported."),
+          "500": errorResponse("The documentation assistant could not complete the request."),
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      ErrorResponse: {
+        type: "object",
+        additionalProperties: false,
+        required: ["error"],
+        properties: {
+          error: {
+            type: "object",
+            additionalProperties: false,
+            required: ["code", "message", "resolution"],
+            properties: {
+              code: { type: "string", description: "Stable machine-readable error code." },
+              message: { type: "string", description: "Human-readable failure description." },
+              resolution: { type: "string", description: "Concrete next action for the caller." },
+            },
+          },
+        },
+      },
+      HighlightedText: {
+        type: "object",
+        additionalProperties: false,
+        required: ["type", "content"],
+        properties: {
+          type: { type: "string", const: "text" },
+          content: { type: "string" },
+          styles: {
+            type: "object",
+            additionalProperties: false,
+            properties: { highlight: { type: "boolean" } },
+          },
+        },
+      },
+      SearchResult: {
+        type: "object",
+        additionalProperties: false,
+        required: ["id", "url", "type", "content"],
+        properties: {
+          id: { type: "string", description: "Stable search-index result identifier." },
+          url: { type: "string", description: "Site-relative canonical documentation URL." },
+          type: { type: "string", enum: ["page", "heading", "text"] },
+          content: { type: "string", description: "Matching title, heading, or passage." },
+          breadcrumbs: { type: "array", items: { type: "string" } },
+          contentWithHighlights: {
+            type: "array",
+            deprecated: true,
+            description: "Legacy segmented highlights. Prefer content.",
+            items: { $ref: "#/components/schemas/HighlightedText" },
+          },
+        },
+      },
+      UiMessagePart: {
+        type: "object",
+        required: ["type"],
+        properties: {
+          type: { type: "string", description: "AI SDK UI message part discriminator." },
+          text: { type: "string", description: "Text for a text message part." },
+        },
+        additionalProperties: true,
+      },
+      UiMessage: {
+        type: "object",
+        required: ["id", "role", "parts"],
+        properties: {
+          id: { type: "string" },
+          role: { type: "string", enum: ["system", "user", "assistant"] },
+          parts: {
+            type: "array",
+            minItems: 1,
+            items: { $ref: "#/components/schemas/UiMessagePart" },
+          },
+        },
+        additionalProperties: true,
+      },
+      PageContext: {
+        type: "object",
+        additionalProperties: false,
+        required: ["title", "url", "content"],
+        properties: {
+          title: { type: "string" },
+          url: { type: "string" },
+          content: { type: "string", description: "Markdown for the current documentation page." },
+        },
+      },
+      ChatRequest: {
+        type: "object",
+        additionalProperties: false,
+        required: ["messages"],
+        properties: {
+          messages: {
+            type: "array",
+            minItems: 1,
+            items: { $ref: "#/components/schemas/UiMessage" },
+          },
+          currentRoute: {
+            type: "string",
+            description: "Site-relative route used to focus documentation retrieval.",
+          },
+          pageContext: { $ref: "#/components/schemas/PageContext" },
+        },
+      },
+    },
+  },
+} satisfies Record<string, unknown>;

--- a/apps/docs/lib/geistdocs/home-structured-data.test.ts
+++ b/apps/docs/lib/geistdocs/home-structured-data.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { createHomeStructuredData } from "./home-structured-data";
+
+describe("homepage structured data", () => {
+  it("identifies the site, distributable framework, and source without invented company details", () => {
+    const data = createHomeStructuredData();
+    const types = data["@graph"].map((entry) => entry["@type"]);
+    const software = data["@graph"].find((entry) => entry["@type"] === "SoftwareApplication");
+
+    expect(types).toEqual(["WebSite", "SoftwareApplication", "SoftwareSourceCode"]);
+    expect(software).toMatchObject({
+      name: "eve",
+      applicationCategory: "DeveloperApplication",
+      isAccessibleForFree: true,
+      license: "https://www.apache.org/licenses/LICENSE-2.0.html",
+      url: "https://eve.dev",
+    });
+    expect(JSON.stringify(data)).not.toContain("Organization");
+  });
+});

--- a/apps/docs/lib/geistdocs/home-structured-data.ts
+++ b/apps/docs/lib/geistdocs/home-structured-data.ts
@@ -1,0 +1,45 @@
+const EVE_ORIGIN = "https://eve.dev";
+const EVE_DESCRIPTION =
+  "A filesystem-first, Apache-2.0 framework for building durable backend AI agents that run on Vercel or self-hosted infrastructure.";
+
+export const createHomeStructuredData = () => ({
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebSite",
+      "@id": `${EVE_ORIGIN}/#website`,
+      name: "eve Documentation",
+      alternateName: "eve agent framework documentation",
+      description: EVE_DESCRIPTION,
+      inLanguage: "en",
+      url: EVE_ORIGIN,
+    },
+    {
+      "@type": "SoftwareApplication",
+      "@id": `${EVE_ORIGIN}/#software`,
+      name: "eve",
+      alternateName: "eve agent framework",
+      applicationCategory: "DeveloperApplication",
+      applicationSubCategory: "AI agent framework",
+      description: EVE_DESCRIPTION,
+      downloadUrl: "https://www.npmjs.com/package/eve",
+      isAccessibleForFree: true,
+      license: "https://www.apache.org/licenses/LICENSE-2.0.html",
+      operatingSystem: "Cross-platform",
+      sameAs: ["https://github.com/vercel/eve", "https://www.npmjs.com/package/eve"],
+      url: EVE_ORIGIN,
+    },
+    {
+      "@type": "SoftwareSourceCode",
+      "@id": `${EVE_ORIGIN}/#source`,
+      codeRepository: "https://github.com/vercel/eve",
+      description: EVE_DESCRIPTION,
+      license: "https://www.apache.org/licenses/LICENSE-2.0.html",
+      name: "eve source code",
+      programmingLanguage: ["TypeScript", "Markdown"],
+      runtimePlatform: "Node.js",
+      targetProduct: { "@id": `${EVE_ORIGIN}/#software` },
+      url: "https://github.com/vercel/eve",
+    },
+  ],
+});

--- a/apps/docs/lib/geistdocs/llms-index.test.ts
+++ b/apps/docs/lib/geistdocs/llms-index.test.ts
@@ -8,6 +8,7 @@ describe("createLlmsIndex", () => {
     expect(output).toMatch(/^# eve\n\n> /);
     expect(output).not.toMatch(/^---/);
     expect(output).toContain("## Introduction");
+    expect(output).toContain("## When to use eve");
     expect(output).toContain("## Build");
     expect(output).toContain("## Integrate");
     expect(output).toContain("## Operate");
@@ -21,8 +22,12 @@ describe("createLlmsIndex", () => {
 
     expect(output).toContain("node_modules/eve/docs/");
     expect(output).toContain(
-      "It is not a shared API, authorization server, MCP server, or A2A server",
+      "It is not a shared eve runtime API, authorization server, MCP server, or A2A server",
     );
+    expect(output).toContain("https://eve.dev/openapi.json");
+    expect(output).toContain("https://eve.dev/about.md");
+    expect(output).toContain("https://eve.dev/contact.md");
+    expect(output).toContain("https://eve.dev/privacy.md");
     expect(output).toContain("https://eve.dev/sitemap.md");
     expect(output).toContain("https://eve.dev/agents.md");
     expect(output).toContain("https://eve.dev/llms-full.txt");

--- a/apps/docs/lib/geistdocs/llms-index.ts
+++ b/apps/docs/lib/geistdocs/llms-index.ts
@@ -6,9 +6,15 @@ export const createLlmsIndex = (): string => `# eve
 
 Use this file to choose the smallest relevant documentation set. Use \`/sitemap.md\` for the exhaustive page map and \`/llms-full.txt\` only for offline indexing or a large context window. For an installed project, prefer \`node_modules/eve/docs/\`: those docs match the installed eve version, while eve.dev documents the latest release.
 
-eve.dev publishes framework documentation. It is not a shared API, authorization server, MCP server, or A2A server. Every deployed eve app exposes its own \`/eve/v1\` routes and authentication policy. External API, OpenAPI, and MCP URLs in these docs describe third-party connections or examples unless stated otherwise.
+eve.dev publishes framework documentation. It is not a shared eve runtime API, authorization server, MCP server, or A2A server. The site exposes only the documentation search and Ask AI helpers described by \`/openapi.json\`. Every deployed eve app exposes its own \`/eve/v1\` routes and authentication policy. External API, OpenAPI, and MCP URLs in these docs describe third-party connections or examples unless stated otherwise.
 
 Documentation links below point directly to Markdown. Remove the \`.md\` suffix for the canonical HTML page.
+
+## When to use eve
+
+Use eve when you need a backend AI agent that must keep durable session state, survive interruptions, wait for human input, run in an isolated sandbox, or serve the same agent through HTTP and messaging channels. eve is also a fit when you want agent capabilities to be reviewable as files, need deployment on either Vercel or self-hosted infrastructure, or want built-in eval and observability hooks around a long-running agent.
+
+Do not use eve.dev as a hosted agent endpoint. Build and deploy an eve application when an agent needs to receive messages or call tools. For a short, stateless model call inside an established application, the AI SDK may be the smaller surface.
 
 ## Introduction
 
@@ -76,12 +82,19 @@ Documentation links below point directly to Markdown. Remove the \`.md\` suffix 
 
 ## API Reference and Discovery
 
+- [eve.dev OpenAPI Specification](${EVE_ORIGIN}/openapi.json): Discover the read-only documentation search and Ask AI helper endpoints with typed request, response, and error schemas.
 - [TypeScript API Reference](${EVE_ORIGIN}/docs/reference/typescript-api.md): Find public \`define*\` helpers, runtime context, and import paths.
 - [CLI Reference](${EVE_ORIGIN}/docs/reference/cli.md): Find every eve command and option.
 - [Responsible Use](${EVE_ORIGIN}/docs/responsible-use.md): Review deployer responsibilities and safeguards.
 - [Documentation Map](${EVE_ORIGIN}/sitemap.md): Browse every documentation, integration, and template page with type and summary metadata.
 - [Agent Instructions](${EVE_ORIGIN}/agents.md): Read operational guidance for coding agents working with eve.
 - [Full Documentation Corpus](${EVE_ORIGIN}/llms-full.txt): Load all docs and integration content for offline indexing or a large context window.
+
+## Site and Project Information
+
+- [About eve](${EVE_ORIGIN}/about.md): Verify the framework's identity, source, license, beta status, and documentation scope.
+- [Contact the eve Project](${EVE_ORIGIN}/contact.md): Choose the correct channel for help, issues, contributions, conduct concerns, or private security reports.
+- [Privacy on eve.dev](${EVE_ORIGIN}/privacy.md): Understand site analytics, Ask AI processing, and the governing Vercel Privacy Notice.
 
 ## Optional
 

--- a/apps/docs/lib/geistdocs/markdown-path.test.ts
+++ b/apps/docs/lib/geistdocs/markdown-path.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getMarkdownRequestedPath } from "./markdown-path";
+import { getMarkdownRequestedPath, markdownNotFoundOptions } from "./markdown-path";
 
 describe("getMarkdownRequestedPath", () => {
   it("restores flattened docs paths", () => {
@@ -16,5 +16,10 @@ describe("getMarkdownRequestedPath", () => {
 
   it("maps the shared route root to the docs root", () => {
     expect(getMarkdownRequestedPath({ slug: [] })).toBe("/docs");
+  });
+
+  it("returns a real 404 for missing Markdown pages", () => {
+    expect(markdownNotFoundOptions.status).toBe(404);
+    expect(markdownNotFoundOptions.getRequestedPath).toBe(getMarkdownRequestedPath);
   });
 });

--- a/apps/docs/lib/geistdocs/markdown-path.ts
+++ b/apps/docs/lib/geistdocs/markdown-path.ts
@@ -1,2 +1,7 @@
 export const getMarkdownRequestedPath = ({ slug }: { slug: string[] }): string =>
   slug[0] === "integrations" ? `/${slug.join("/")}` : ["/docs", ...slug].join("/");
+
+export const markdownNotFoundOptions = {
+  getRequestedPath: getMarkdownRequestedPath,
+  status: 404,
+} as const;

--- a/apps/docs/lib/geistdocs/markdown-routes.test.ts
+++ b/apps/docs/lib/geistdocs/markdown-routes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { markdownRoutes } from "./markdown-routes";
+import { markdownRoutes, supportsMarkdownNegotiation } from "./markdown-routes";
 
 const integrationsRoute = markdownRoutes.find(({ from }) => from === "/integrations/*path");
 
@@ -23,4 +23,37 @@ describe("markdownRoutes", () => {
       to: "/[lang]/llms.mdx/*path",
     });
   });
+
+  it("maps trust pages to their shared Markdown source", () => {
+    expect(markdownRoutes).toContainEqual({
+      from: "/about",
+      to: "/[lang]/trust-markdown/about",
+    });
+    expect(markdownRoutes).toContainEqual({
+      from: "/contact",
+      to: "/[lang]/trust-markdown/contact",
+    });
+    expect(markdownRoutes).toContainEqual({
+      from: "/privacy",
+      to: "/[lang]/trust-markdown/privacy",
+    });
+  });
+
+  it.each([
+    "/docs/getting-started",
+    "/docs/getting-started.md",
+    "/integrations/slack",
+    "/about",
+    "/contact.md",
+    "/en/privacy",
+  ])("recognizes negotiated path %s", (pathname) => {
+    expect(supportsMarkdownNegotiation(pathname)).toBe(true);
+  });
+
+  it.each(["/", "/templates", "/openapi.json", "/missing"])(
+    "does not negotiate unrelated path %s",
+    (pathname) => {
+      expect(supportsMarkdownNegotiation(pathname)).toBe(false);
+    },
+  );
 });

--- a/apps/docs/lib/geistdocs/markdown-routes.ts
+++ b/apps/docs/lib/geistdocs/markdown-routes.ts
@@ -1,6 +1,24 @@
 import type { GeistdocsMarkdownRoute } from "@vercel/geistdocs/proxy";
+import { supportedLanguages } from "./languages";
 
 export const markdownRoutes: GeistdocsMarkdownRoute[] = [
   { from: "/docs/*path", to: "/[lang]/llms.mdx/*path" },
   { from: "/integrations/*path", to: "/[lang]/llms.mdx/integrations/*path" },
+  { from: "/about", to: "/[lang]/trust-markdown/about" },
+  { from: "/contact", to: "/[lang]/trust-markdown/contact" },
+  { from: "/privacy", to: "/[lang]/trust-markdown/privacy" },
 ];
+
+const MARKDOWN_EXTENSION_PATTERN = /\.mdx?$/;
+
+export const supportsMarkdownNegotiation = (requestedPathname: string): boolean => {
+  const segments = requestedPathname.split("/").filter(Boolean);
+  if (segments[0] && supportedLanguages.includes(segments[0])) segments.shift();
+  const pathname = `/${segments.join("/")}`.replace(MARKDOWN_EXTENSION_PATTERN, "") || "/";
+
+  return markdownRoutes.some(({ from }) => {
+    if (!from.endsWith("/*path")) return pathname === from;
+    const base = from.slice(0, -"/*path".length);
+    return pathname === base || pathname.startsWith(`${base}/`);
+  });
+};

--- a/apps/docs/lib/geistdocs/sitemap-transform.test.ts
+++ b/apps/docs/lib/geistdocs/sitemap-transform.test.ts
@@ -5,6 +5,14 @@ const transform = (markdown: string) =>
   transformSitemapMarkdown(markdown, {
     resolveTitle: (title, url) =>
       title === "Overview" && url === "/docs/channels/overview" ? "Channels" : title,
+    resources: [
+      {
+        description: "Machine-readable contract for the documentation helper API.",
+        href: "/openapi.json",
+        title: "eve.dev OpenAPI specification",
+        type: "API specification",
+      },
+    ],
     templates: [
       { slug: "chat", title: "Chat agent template", description: "A persisted chat agent." },
     ],
@@ -37,6 +45,15 @@ describe("transformSitemapMarkdown", () => {
 
     expect(output).toContain(
       "- [Chat agent template](/templates/chat) | Type: Example | Summary: A persisted chat agent. | Canonical: /templates/chat",
+    );
+  });
+
+  it("lists project and machine-readable resources by name", () => {
+    const output = transform("# Documentation Sitemap");
+
+    expect(output).toContain("## Project and machine resources");
+    expect(output).toContain(
+      "- [eve.dev OpenAPI specification](/openapi.json) | Type: API specification | Summary: Machine-readable contract for the documentation helper API. | Canonical: /openapi.json",
     );
   });
 });

--- a/apps/docs/lib/geistdocs/sitemap-transform.ts
+++ b/apps/docs/lib/geistdocs/sitemap-transform.ts
@@ -4,8 +4,16 @@ interface TemplateDiscoveryEntry {
   title: string;
 }
 
+interface ResourceDiscoveryEntry {
+  description: string;
+  href: string;
+  title: string;
+  type: string;
+}
+
 interface TransformSitemapOptions {
   resolveTitle: (title: string, url: string) => string;
+  resources: ResourceDiscoveryEntry[];
   templates: TemplateDiscoveryEntry[];
 }
 
@@ -35,7 +43,7 @@ const addCanonical = (metadata: string, url: string): string =>
 
 export const transformSitemapMarkdown = (
   markdown: string,
-  { resolveTitle, templates }: TransformSitemapOptions,
+  { resolveTitle, resources, templates }: TransformSitemapOptions,
 ): string => {
   const transformed = markdown.replace(
     SITEMAP_ENTRY_PATTERN,
@@ -51,5 +59,10 @@ export const transformSitemapMarkdown = (
       `- [${template.title}](/templates/${template.slug}) | Type: Example | Summary: ${template.description} | Canonical: /templates/${template.slug}`,
   );
 
-  return `${transformed.trimEnd()}\n\n## Templates\n\n${templateLines.join("\n")}\n`;
+  const resourceLines = resources.map(
+    (resource) =>
+      `- [${resource.title}](${resource.href}) | Type: ${resource.type} | Summary: ${resource.description} | Canonical: ${resource.href}`,
+  );
+
+  return `${transformed.trimEnd()}\n\n## Project and machine resources\n\n${resourceLines.join("\n")}\n\n## Templates\n\n${templateLines.join("\n")}\n`;
 };

--- a/apps/docs/lib/geistdocs/sitemap.test.ts
+++ b/apps/docs/lib/geistdocs/sitemap.test.ts
@@ -5,11 +5,14 @@ const sourceDate = new Date("2026-07-20T12:00:00.000Z");
 
 const sources = [
   { pathname: "/" },
+  { pathname: "/about" },
+  { pathname: "/contact" },
   { pathname: "/docs/getting-started", lastModified: sourceDate },
   { pathname: "/docs/getting-started", lastModified: new Date("2026-08-01") },
   { pathname: "/evals" },
   { pathname: "/integrations" },
   { pathname: "/integrations/slack" },
+  { pathname: "/privacy" },
   { pathname: "/templates" },
   { pathname: "/templates/eve-chat-template" },
   { pathname: "/docs/channels" },
@@ -31,10 +34,13 @@ describe("createCanonicalSitemap", () => {
 
     expect(sitemap.map(({ url }) => url)).toEqual([
       "https://eve.dev/",
+      "https://eve.dev/about",
+      "https://eve.dev/contact",
       "https://eve.dev/docs/getting-started",
       "https://eve.dev/evals",
       "https://eve.dev/integrations",
       "https://eve.dev/integrations/slack",
+      "https://eve.dev/privacy",
       "https://eve.dev/templates",
       "https://eve.dev/templates/eve-chat-template",
     ]);

--- a/apps/docs/lib/geistdocs/sitemap.ts
+++ b/apps/docs/lib/geistdocs/sitemap.ts
@@ -17,12 +17,18 @@ interface CreateCanonicalSitemapOptions {
 }
 
 const alternateRepresentationPattern = /\.(?:md|mdx|txt|xml)$/i;
+const indexableTopLevelPaths = new Set([
+  "/about",
+  "/contact",
+  "/evals",
+  "/integrations",
+  "/privacy",
+  "/templates",
+]);
 
 const isIndexableHtmlPath = (pathname: string): boolean =>
   pathname === "/" ||
-  pathname === "/evals" ||
-  pathname === "/integrations" ||
-  pathname === "/templates" ||
+  indexableTopLevelPaths.has(pathname) ||
   /^\/docs\/.+/.test(pathname) ||
   /^\/integrations\/[^/]+$/.test(pathname) ||
   /^\/templates\/[^/]+$/.test(pathname);

--- a/apps/docs/lib/geistdocs/vary.test.ts
+++ b/apps/docs/lib/geistdocs/vary.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { appendVaryAccept } from "./vary";
+
+describe("negotiated response Vary header", () => {
+  it("preserves framework tokens and adds Accept once", () => {
+    const response = new Response(null, {
+      headers: { Vary: "rsc, next-router-state-tree" },
+    });
+
+    appendVaryAccept(response);
+    appendVaryAccept(response);
+
+    expect(response.headers.get("vary")).toBe("rsc, next-router-state-tree, Accept");
+  });
+});

--- a/apps/docs/lib/geistdocs/vary.ts
+++ b/apps/docs/lib/geistdocs/vary.ts
@@ -1,0 +1,12 @@
+export const appendVaryAccept = (response: Response): Response => {
+  const tokens = (response.headers.get("Vary") ?? "")
+    .split(",")
+    .map((token) => token.trim())
+    .filter(Boolean);
+
+  if (!tokens.some((token) => token.toLowerCase() === "accept")) {
+    response.headers.set("Vary", [...tokens, "Accept"].join(", "));
+  }
+
+  return response;
+};

--- a/apps/docs/lib/trust/pages.test.ts
+++ b/apps/docs/lib/trust/pages.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { getTrustPage, trustPageMarkdown, trustPagePlainText, trustPages } from "./pages";
+
+describe("trust pages", () => {
+  it("publishes one substantive page for every advertised trust route", () => {
+    expect(trustPages.map((page) => page.slug)).toEqual(["about", "contact", "privacy"]);
+    expect(new Set(trustPages.map((page) => page.slug)).size).toBe(trustPages.length);
+
+    for (const page of trustPages) {
+      expect(trustPagePlainText(page).length).toBeGreaterThan(500);
+      expect(page.sections.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("renders self-contained Markdown from the same source as HTML", () => {
+    const contact = getTrustPage("contact");
+    expect(contact).toBeDefined();
+    if (!contact) return;
+
+    const markdown = trustPageMarkdown(contact);
+    expect(markdown).toMatch(/^# Contact the eve project/);
+    expect(markdown).toContain("## Security reports");
+    expect(markdown).toContain("mailto:responsible.disclosure@vercel.com");
+  });
+
+  it("does not invent an unknown trust page", () => {
+    expect(getTrustPage("terms")).toBeUndefined();
+  });
+});

--- a/apps/docs/lib/trust/pages.ts
+++ b/apps/docs/lib/trust/pages.ts
@@ -1,0 +1,207 @@
+export type TrustPageSlug = "about" | "contact" | "privacy";
+
+interface TrustPageLink {
+  description: string;
+  href: string;
+  label: string;
+}
+
+interface TrustPageSection {
+  heading: string;
+  links?: TrustPageLink[];
+  paragraphs: string[];
+}
+
+export interface TrustPageData {
+  description: string;
+  intro: string;
+  sections: TrustPageSection[];
+  slug: TrustPageSlug;
+  title: string;
+}
+
+export const trustPages: TrustPageData[] = [
+  {
+    slug: "about",
+    title: "About eve",
+    description:
+      "Learn what the eve framework is, who maintains it, how it is licensed, and where to verify its source and release status.",
+    intro:
+      "eve is a filesystem-first framework for durable backend AI agents. You author an agent as a directory containing instructions, tools, skills, connections, channels, subagents, schedules, and other capabilities. eve compiles that directory into a runtime that can run on Vercel or self-hosted infrastructure.",
+    sections: [
+      {
+        heading: "Project and license",
+        paragraphs: [
+          "Vercel develops eve as an open-source project. The framework is distributed through the npm package named eve, and its source is published in the vercel/eve repository. The code is licensed under Apache License 2.0. The repository is the authoritative place to inspect implementation details, release history, contribution requirements, and reported issues.",
+          "eve is currently in beta. Public APIs, documentation, and behavior may change before general availability. The current documentation describes the latest published release; an installed package also includes version-matched documentation under node_modules/eve/docs.",
+        ],
+        links: [
+          {
+            label: "eve source repository",
+            href: "https://github.com/vercel/eve",
+            description: "Source, releases, issues, and contribution history.",
+          },
+          {
+            label: "eve on npm",
+            href: "https://www.npmjs.com/package/eve",
+            description: "Published package versions and package metadata.",
+          },
+          {
+            label: "Apache License 2.0",
+            href: "https://github.com/vercel/eve/blob/main/LICENSE",
+            description: "The repository's license text.",
+          },
+        ],
+      },
+      {
+        heading: "Documentation scope",
+        paragraphs: [
+          "eve.dev documents the framework and provides a search endpoint and documentation assistant. It is not a shared eve runtime, authorization server, or MCP server. Every deployed eve application owns its runtime URL, enabled channels, authentication policy, data, and operational controls.",
+        ],
+      },
+    ],
+  },
+  {
+    slug: "contact",
+    title: "Contact the eve project",
+    description:
+      "Find the correct public or private channel for eve questions, bug reports, feature requests, contributions, conduct concerns, and security reports.",
+    intro:
+      "The eve project uses different channels for community questions, reproducible product reports, contributions, and confidential security disclosures. Choose the channel that matches the request so maintainers receive the context they need without exposing sensitive information.",
+    sections: [
+      {
+        heading: "Questions and project discussion",
+        paragraphs: [
+          "Use GitHub Discussions for help with an eve project, design questions, ideas, and examples you want to share with the community. Search existing discussions first and include the eve version, deployment target, relevant configuration, and the smallest safe reproduction when those details affect the question.",
+        ],
+        links: [
+          {
+            label: "GitHub Discussions",
+            href: "https://github.com/vercel/eve/discussions",
+            description: "Community help, design discussion, and examples.",
+          },
+        ],
+      },
+      {
+        heading: "Bugs, features, and contributions",
+        paragraphs: [
+          "Use the repository issue templates for reproducible bugs and feature requests. Do not create a public issue for a suspected vulnerability or include credentials, private prompts, customer data, or access tokens. If you plan to contribute code or documentation, read the contribution guide before opening a pull request; it defines setup, testing, signing, and DCO requirements.",
+        ],
+        links: [
+          {
+            label: "Issue templates",
+            href: "https://github.com/vercel/eve/issues/new/choose",
+            description: "Report a bug or propose a feature.",
+          },
+          {
+            label: "Contribution guide",
+            href: "https://github.com/vercel/eve/blob/main/CONTRIBUTING.md",
+            description: "Repository setup and pull request requirements.",
+          },
+          {
+            label: "Code of Conduct",
+            href: "https://github.com/vercel/eve/blob/main/CODE_OF_CONDUCT.md",
+            description: "Community participation and conduct reporting.",
+          },
+        ],
+      },
+      {
+        heading: "Security reports",
+        paragraphs: [
+          "Report suspected security vulnerabilities privately to Vercel's responsible disclosure address. Include the affected version, impact, reproduction steps, and any mitigation you have already applied. Do not open a public issue until the report has been reviewed and disclosure is coordinated.",
+        ],
+        links: [
+          {
+            label: "responsible.disclosure@vercel.com",
+            href: "mailto:responsible.disclosure@vercel.com",
+            description: "Private security vulnerability reports.",
+          },
+          {
+            label: "Security policy",
+            href: "https://github.com/vercel/eve/blob/main/SECURITY.md",
+            description: "The repository's security reporting instructions.",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    slug: "privacy",
+    title: "Privacy on eve.dev",
+    description:
+      "Understand which Vercel privacy notice governs eve.dev and what happens when you use site analytics or the Ask AI documentation feature.",
+    intro:
+      "eve.dev is a Vercel-operated documentation site for the open-source eve framework. Vercel's Privacy Notice governs information processed when you visit this site or interact with its services. The notice explains applicability, collected information, uses, disclosures, retention, international transfers, privacy rights, and contact methods.",
+    sections: [
+      {
+        heading: "Documentation visits and performance data",
+        paragraphs: [
+          "The site includes Vercel Web Analytics and Speed Insights. Web Analytics records aggregate usage such as page views, routes, referrers, coarse location, browser, device, and operating system information. Vercel documents Web Analytics as cookie-free and designed around anonymized, aggregated data. Speed Insights collects real-user performance measurements such as page loading, responsiveness, and visual stability metrics.",
+          "The linked Vercel documentation describes the current data points and controls for those services. The Vercel Privacy Notice remains the controlling statement for Vercel's processing and for requests about privacy rights.",
+        ],
+        links: [
+          {
+            label: "Vercel Privacy Notice",
+            href: "https://vercel.com/legal/privacy-notice",
+            description: "The privacy notice governing Vercel sites and services.",
+          },
+          {
+            label: "Web Analytics privacy and compliance",
+            href: "https://vercel.com/docs/analytics/privacy-policy",
+            description: "Data collected by Vercel Web Analytics.",
+          },
+          {
+            label: "Speed Insights metrics",
+            href: "https://vercel.com/docs/speed-insights/metrics",
+            description: "Real-user performance data points.",
+          },
+        ],
+      },
+      {
+        heading: "Ask AI",
+        paragraphs: [
+          "When you use Ask AI, the site sends your conversation and any page context you attach to a documentation assistant operated for eve.dev so it can generate a response. Do not submit secrets, access tokens, private source code, confidential prompts, personal data, or other information that does not belong in a support request. You can read the documentation directly without using Ask AI.",
+        ],
+      },
+      {
+        heading: "Your deployed eve applications",
+        paragraphs: [
+          "This page applies to eve.dev, not to applications built with eve. An eve deployer chooses models, tools, channels, storage, authentication, observability, and infrastructure. That deployer is responsible for explaining its own data practices and meeting the privacy, security, and legal requirements that apply to its users and workloads.",
+        ],
+      },
+    ],
+  },
+];
+
+export const getTrustPage = (slug: string): TrustPageData | undefined =>
+  trustPages.find((page) => page.slug === slug);
+
+export const trustPagePlainText = (page: TrustPageData): string =>
+  [
+    page.title,
+    page.description,
+    page.intro,
+    ...page.sections.flatMap((section) => [
+      section.heading,
+      ...section.paragraphs,
+      ...(section.links ?? []).flatMap((link) => [link.label, link.description]),
+    ]),
+  ].join(" ");
+
+export const trustPageMarkdown = (page: TrustPageData): string => {
+  const sections = page.sections.map((section) => {
+    const links = section.links?.map(
+      (link) => `- [${link.label}](${link.href}): ${link.description}`,
+    );
+    return [
+      `## ${section.heading}`,
+      "",
+      ...section.paragraphs,
+      ...(links ? ["", ...links] : []),
+    ].join("\n\n");
+  });
+
+  return [`# ${page.title}`, "", `> ${page.description}`, "", page.intro, "", ...sections].join(
+    "\n",
+  );
+};

--- a/apps/docs/proxy.ts
+++ b/apps/docs/proxy.ts
@@ -2,8 +2,9 @@ import { createProxy } from "@vercel/geistdocs/proxy";
 import { NextResponse, type NextFetchEvent, type NextRequest } from "next/server";
 import { config as geistdocsConfig } from "@/lib/geistdocs/config";
 import { removeProxyMarkdownCanonical } from "@/lib/geistdocs/markdown-canonical";
-import { markdownRoutes } from "@/lib/geistdocs/markdown-routes";
+import { markdownRoutes, supportsMarkdownNegotiation } from "@/lib/geistdocs/markdown-routes";
 import { trackMdRequest } from "@/lib/geistdocs/md-tracking";
+import { appendVaryAccept } from "@/lib/geistdocs/vary";
 
 const geistdocsProxy = createProxy({
   config: geistdocsConfig,
@@ -12,8 +13,12 @@ const geistdocsProxy = createProxy({
   before: ({ request }) => (request.nextUrl.pathname === "/nights" ? NextResponse.next() : null),
 });
 
-const proxy = async (request: NextRequest, context: NextFetchEvent) =>
-  removeProxyMarkdownCanonical(await geistdocsProxy(request, context));
+const proxy = async (request: NextRequest, context: NextFetchEvent) => {
+  const response = removeProxyMarkdownCanonical(await geistdocsProxy(request, context));
+  return supportsMarkdownNegotiation(request.nextUrl.pathname)
+    ? appendVaryAccept(response)
+    : response;
+};
 
 export const config = {
   // These routes need the locale rewrite even though the general matcher ignores static extensions.


### PR DESCRIPTION
### Summary

Related to #2286. The current eve.dev surface leaves agents without a machine-readable API contract, consistent recovery and error semantics, or clear trust and discovery endpoints. This publishes a scoped OpenAPI contract for the documentation helpers, stable JSON errors and 404s, Accept Markdown negotiation, homepage structured data, and substantive trust pages while explicitly leaving OAuth, MCP, and runtime responsibilities to each deployed eve app.

### Validation

All 188 docs unit tests passed, the docs content checks and production build completed, Redocly validated the OpenAPI 3.1.1 document, 23 production-build endpoint assertions passed, and desktop plus 390px mobile browser checks found no console errors or horizontal overflow.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

A changeset is not applicable because this changes only the docs application.

### Diff size

**Docs** — 2 files · `+221 / -1`

Adds agent-use guidance and factual trust-page copy while keeping eve.dev's scope distinct from deployed eve applications.

**Implementation** — 27 files · `+793 / -35`

Covers the scoped API contract and error handling, content negotiation, trust-page rendering, metadata, and machine-discovery wiring.

Key files:

- `apps/docs/lib/api/openapi.ts` defines the public documentation-helper contract.
- `apps/docs/lib/api/errors.ts` owns the stable machine-readable error envelope.

**Tests** — 10 files · `+282 / -3`

Covers structured data, OpenAPI shape, JSON errors, Markdown negotiation and 404s, trust content, and both sitemap formats.
