### PR TITLE
fix(website): use tabular benchmark numerals in dynamic og

### DIFF
--- a/apps/docs/lib/evals/og-image.tsx
+++ b/apps/docs/lib/evals/og-image.tsx
@@ -15,7 +15,20 @@ const fonts = Promise.all([
   readFile(join(fontDirectory, "geist-sans-semibold.ttf")),
 ]);
 
-const formatRate = (rate: number | null): string => (rate === null ? "—" : `${Math.round(rate)}%`);
+const Rate = ({ value }: { value: number | null }) => {
+  if (value === null) return <div style={{ display: "flex" }}>—</div>;
+
+  return (
+    <div style={{ display: "flex" }}>
+      {[...String(Math.round(value))].map((digit, index) => (
+        <div key={index} style={{ display: "flex", justifyContent: "center", width: 14 }}>
+          {digit}
+        </div>
+      ))}
+      <div style={{ display: "flex", justifyContent: "center", width: 18 }}>%</div>
+    </div>
+  );
+};
 
 const latestResults = (rows: BenchmarkRow[]): BenchmarkRow[] =>
   [...rows].sort(
@@ -95,7 +108,7 @@ export const createEvalsOgImage = async (rows: BenchmarkRow[]): Promise<ImageRes
           <div style={{ display: "flex", justifyContent: "flex-end", width: 84 }}>Base</div>
           <div style={{ display: "flex", justifyContent: "flex-end", width: 104 }}>Guided</div>
         </div>
-        {results.map((row) => (
+        {results.map((row, index) => (
           <div
             key={row.groupId}
             style={{
@@ -105,6 +118,7 @@ export const createEvalsOgImage = async (rows: BenchmarkRow[]): Promise<ImageRes
               fontSize: 24,
               height: 52,
               letterSpacing: "-0.025em",
+              opacity: index < 5 ? 1 : 2 ** (4 - index),
               width: "100%",
             }}
           >
@@ -122,39 +136,29 @@ export const createEvalsOgImage = async (rows: BenchmarkRow[]): Promise<ImageRes
               style={{
                 color: "#888888",
                 display: "flex",
-                fontVariantNumeric: "tabular-nums",
+                fontSize: 24,
                 justifyContent: "flex-end",
+                letterSpacing: 0,
                 width: 84,
               }}
             >
-              {formatRate(row.baselineSuccessRate)}
+              <Rate value={row.baselineSuccessRate} />
             </div>
             <div
               style={{
                 display: "flex",
-                fontVariantNumeric: "tabular-nums",
+                fontSize: 24,
                 fontWeight: 500,
                 justifyContent: "flex-end",
+                letterSpacing: 0,
                 width: 104,
               }}
             >
-              {formatRate(row.guidedSuccessRate)}
+              <Rate value={row.guidedSuccessRate} />
             </div>
           </div>
         ))}
       </div>
-
-      <div
-        style={{
-          background: "linear-gradient(to bottom, transparent 0%, black 100%)",
-          bottom: 0,
-          display: "flex",
-          height: 230,
-          position: "absolute",
-          right: 0,
-          width: 600,
-        }}
-      />
     </div>,
     {
       ...evalsOgImageSize,

--- a/apps/docs/lib/evals/og-image.tsx
+++ b/apps/docs/lib/evals/og-image.tsx
@@ -122,7 +122,7 @@ export const createEvalsOgImage = async (rows: BenchmarkRow[]): Promise<ImageRes
               style={{
                 color: "#888888",
                 display: "flex",
-                fontFeatureSettings: '"tnum" 1',
+                fontVariantNumeric: "tabular-nums",
                 justifyContent: "flex-end",
                 width: 84,
               }}
@@ -132,7 +132,7 @@ export const createEvalsOgImage = async (rows: BenchmarkRow[]): Promise<ImageRes
             <div
               style={{
                 display: "flex",
-                fontFeatureSettings: '"tnum" 1',
+                fontVariantNumeric: "tabular-nums",
                 fontWeight: 500,
                 justifyContent: "flex-end",
                 width: 104,

--- a/apps/docs/lib/evals/og-image.tsx
+++ b/apps/docs/lib/evals/og-image.tsx
@@ -122,6 +122,7 @@ export const createEvalsOgImage = async (rows: BenchmarkRow[]): Promise<ImageRes
               style={{
                 color: "#888888",
                 display: "flex",
+                fontFeatureSettings: '"tnum" 1',
                 justifyContent: "flex-end",
                 width: 84,
               }}
@@ -131,6 +132,7 @@ export const createEvalsOgImage = async (rows: BenchmarkRow[]): Promise<ImageRes
             <div
               style={{
                 display: "flex",
+                fontFeatureSettings: '"tnum" 1',
                 fontWeight: 500,
                 justifyContent: "flex-end",
                 width: 104,


### PR DESCRIPTION
### Summary

Follow-up to #2387 based on maintainer feedback. Satori did not apply Geist's OpenType tabular-numeral metrics when rendering the benchmark social card, so the percentage columns now place each digit in an explicit fixed-width slot. The bottom fade now uses uniform row opacity instead of an overlay gradient, preserving each faded glyph's apparent height.

### Validation

Rendered the 1200×628 OpenGraph PNG through the local Next.js route and visually confirmed that equal-length percentages such as `71%` and `90%` occupy the same width while the final rows retain full-height glyphs. Automated tests and documentation are not applicable to this visual-only adjustment.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 1 file · `+22 / -16`

Keeps the renderer-specific numeral spacing and fade behavior local to the benchmark social card.

**Tests** — 0 files · `+0 / -0`

Not applicable for this visual-only adjustment.
