### PR TITLE
Update Agentcard connection template

### DIFF
--- a/apps/docs/lib/integrations/connection-setup.test.ts
+++ b/apps/docs/lib/integrations/connection-setup.test.ts
@@ -34,7 +34,7 @@ describe("Agentcard connection setup", () => {
     const setup = buildConnectionSetup(integration);
     const quickStart = setup.variants["mcp:user"];
 
-    expect(quickStart).toContain('description: "Agentcard tools and data"');
+    expect(quickStart).toContain("Agentcard: the agent's wallet.");
     expect(quickStart).toContain('auth: connect("agentcard")');
     expect(setup.configureVariants["mcp:user"]).toContain("vercel connect create agentcard");
     expect(setup.configureVariants["mcp:user"]).not.toContain("--name");

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -340,7 +340,7 @@
       "name": "connection/agentcard",
       "type": "registry:item",
       "title": "Agentcard",
-      "description": "Shop at real merchants with consent-gated single-use virtual cards.",
+      "description": "let agents buy online",
       "meta": {
         "eve": {
           "setup": {

--- a/apps/docs/registry/connections/agentcard.ts
+++ b/apps/docs/registry/connections/agentcard.ts
@@ -1,8 +1,53 @@
-import { defineMcpClientConnection } from "eve/connections";
 import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+const APPROVAL_GATED = ["create_card", "get_card_details", "remove_added_card"];
 
 export default defineMcpClientConnection({
   url: "https://mcp.agentcard.sh/mcp",
-  description: "Agentcard tools and data",
-  auth: connect("agentcard"),
+  description:
+    "Agentcard: the agent's wallet. Shop and check out at real merchants (DoorDash, Good Eggs, flights) with the conversational `buy` tool (thread conversation_id on follow-ups), issue a single-use virtual card to pay at any checkout, let the user add their own card, and manage the cash that funds it: balance, top-ups, transactions, KYC, human support.",
+  auth: connect(process.env.AGENTCARD_CONNECTOR ?? "agentcard"),
+  tools: {
+    allow: [
+      // Shopping
+      "buy",
+      "get_instructions",
+      "buy_list_merchants",
+      "buy_connect",
+      "buy_connect_status",
+      "buy_unlink_merchant",
+      "manage_subscription",
+      // Cash
+      "get_balance",
+      "add_funds",
+      "list_transactions",
+      // Issued cards: pay at any checkout
+      "create_card",
+      "get_card_details",
+      "get_card_balance",
+      "list_cards",
+      "close_card",
+      // The user's own card, no prefunding or KYC
+      "add_card",
+      "list_added_cards",
+      "remove_added_card",
+      "get_wallet_link",
+      // Account
+      "whoami",
+      "start_kyc",
+      "get_kyc_status",
+      "submit_kyc_document",
+      "check_kyc_document",
+      "submit_kyc_fields",
+      // Human support
+      "start_support_chat",
+      "send_support_message",
+      "read_support_chat",
+    ],
+  },
+  approval: ({ toolName }) =>
+    APPROVAL_GATED.includes(toolName.split("__").pop() ?? toolName)
+      ? "user-approval"
+      : "not-applicable",
 });

--- a/packages/eve-catalog/src/index.test.ts
+++ b/packages/eve-catalog/src/index.test.ts
@@ -76,9 +76,10 @@ describe("integration catalog", () => {
   });
 
   it("uses Agentcard's streamable HTTP MCP endpoint", () => {
-    expect(getIntegrationEntry("agentcard")!.connection!.mcp!.url).toBe(
-      "https://mcp.agentcard.sh/mcp",
-    );
+    const agentcard = getIntegrationEntry("agentcard")!;
+
+    expect(agentcard.tagline).toBe("let agents buy online");
+    expect(agentcard.connection!.mcp!.url).toBe("https://mcp.agentcard.sh/mcp");
   });
 
   it("uses Linear's streamable HTTP MCP endpoint", () => {

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -404,10 +404,11 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     slug: "agentcard",
     name: "Agentcard",
     kind: "connection",
-    tagline: "Shop at real merchants with consent-gated single-use virtual cards.",
+    tagline: "let agents buy online",
     surfaces: { scaffoldable: false, registry: true, gallery: true },
     connection: {
-      description: "Agentcard tools and data",
+      description:
+        "Agentcard: the agent's wallet. Shop and check out at real merchants (DoorDash, Good Eggs, flights) with the conversational `buy` tool (thread conversation_id on follow-ups), issue a single-use virtual card to pay at any checkout, let the user add their own card, and manage the cash that funds it: balance, top-ups, transactions, KYC, human support.",
       mcp: { url: "https://mcp.agentcard.sh/mcp" },
     },
   },


### PR DESCRIPTION
### Summary

Updates the Agentcard registry template with the supported shopping, cash, card, account, and support tools. Sensitive card operations now require user approval, the connector can be overridden with `AGENTCARD_CONNECTOR` and otherwise remains `agentcard`, and the gallery tagline is now “let agents buy online.”

### Validation

The docs and catalog unit suites passed with 183 tests. The connection registry validator and registry TypeScript project also passed.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

A changeset is not required because this only updates the docs registry and internal catalog.

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 3 files · `+52 / -6`

Updates the installable connection template and the registry/catalog metadata that present it.

**Tests** — 2 files · `+5 / -4`

Keeps the generated setup and catalog tagline assertions aligned with the updated integration.
