### PR TITLE
chore(eve): dynamic tools - centralize runtime contributions

### DIFF
--- a/.changeset/runtime-tool-contributions.md
+++ b/.changeset/runtime-tool-contributions.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Runtime-discovered tools now use the same durable validation, callback replay, collision handling, and lifecycle replacement path as authored dynamic tools. Connection tools discovered through `connection_search` keep their existing model-facing behavior while resuming approval and authorization callbacks reliably after a process restart.

--- a/packages/eve/src/context/build-dynamic-tools.ts
+++ b/packages/eve/src/context/build-dynamic-tools.ts
@@ -3,6 +3,7 @@ import type { HarnessToolMap } from "#harness/types.js";
 import type { ContextReader } from "#context/key.js";
 import {
   SessionDynamicToolMetadataKey,
+  RuntimeToolContributionsKey,
   StepDynamicToolMetadataKey,
   TurnDynamicToolMetadataKey,
   type DurableDynamicToolMetadata,
@@ -145,8 +146,23 @@ export function buildResponseAuthorizationTools(input: {
 }
 
 export function buildDynamicTools(ctx: ContextReader): readonly HarnessToolDefinition[] {
+  const runtimeState = ctx.get(RuntimeToolContributionsKey);
+  if (
+    runtimeState !== undefined &&
+    (runtimeState.version !== 1 || !Array.isArray(runtimeState.contributions))
+  ) {
+    throw new Error("Runtime tool contribution state has an unsupported or malformed version.");
+  }
+  const runtimeContributions = runtimeState?.contributions ?? [];
+  const runtimeMetadata = (event: "session.started" | "turn.started" | "step.started") =>
+    runtimeContributions
+      .filter((contribution) => contribution.coordinate.event === event)
+      .flatMap((contribution) => contribution.metadata);
   const step = replayDynamicTools(ctx.get(StepDynamicToolMetadataKey) ?? []);
+  const runtimeStep = replayDynamicTools(runtimeMetadata("step.started"));
   const turn = replayDynamicTools(ctx.get(TurnDynamicToolMetadataKey) ?? []);
+  const runtimeTurn = replayDynamicTools(runtimeMetadata("turn.started"));
   const session = replayDynamicTools(ctx.get(SessionDynamicToolMetadataKey) ?? []);
-  return [...step, ...turn, ...session];
+  const runtimeSession = replayDynamicTools(runtimeMetadata("session.started"));
+  return [...step, ...runtimeStep, ...turn, ...runtimeTurn, ...session, ...runtimeSession];
 }

--- a/packages/eve/src/context/dynamic-tool-lifecycle.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.ts
@@ -1,7 +1,7 @@
 import type { ModelMessage } from "ai";
 
 import { replayDynamicTools } from "#context/build-dynamic-tools.js";
-import type { ContextContainer } from "#context/container.js";
+import type { AlsContext } from "#context/container.js";
 import type { ContextKey } from "#context/key.js";
 import {
   SessionDynamicToolMetadataKey,
@@ -109,7 +109,12 @@ function validateReference(input: {
   readonly phase: DurableDynamicCallbackPhase;
   readonly stamped: StampedDurableDynamicCallback | undefined;
   readonly required: boolean;
-}): DurableDynamicCallbackReference | undefined {
+}):
+  | {
+      readonly callback: StampedDurableDynamicCallback["callback"];
+      readonly reference: DurableDynamicCallbackReference;
+    }
+  | undefined {
   if (input.stamped === undefined) {
     if (input.required) {
       throw new Error(
@@ -147,18 +152,27 @@ function validateReference(input: {
       `Dynamic tool "${input.name}" callback "${input.phase}" has a non-serializable capture. ${toErrorMessage(error)}`,
     );
   }
-  registerDurableDynamicCallback({
+  return {
     callback: input.stamped.callback,
-    phase: input.phase,
-    toolName: input.name,
-  });
-  return { closure };
+    reference: { closure },
+  };
 }
 
-export function validateDurableDynamicToolCallbacks(
+interface PreparedDurableDynamicCallbackRegistration {
+  readonly callback: StampedDurableDynamicCallback["callback"];
+  readonly phase: DurableDynamicCallbackPhase;
+  readonly toolName: string;
+}
+
+export interface PreparedDurableDynamicToolCallbacks {
+  readonly callbacks: DurableDynamicToolCallbacks;
+  readonly registrations: readonly PreparedDurableDynamicCallbackRegistration[];
+}
+
+export function prepareDurableDynamicToolCallbacks(
   name: string,
   entry: DynamicToolEntry,
-): DurableDynamicToolCallbacks {
+): PreparedDurableDynamicToolCallbacks {
   const raw = readDurableDynamicToolCallbacks(entry) ?? {};
   const unknownPhases = Object.keys(raw).filter(
     (key) =>
@@ -208,28 +222,87 @@ export function validateDurableDynamicToolCallbacks(
     approvalRequest?: DurableDynamicCallbackReference;
     approvalResponse?: DurableDynamicCallbackReference;
     toModelOutput?: DurableDynamicCallbackReference;
-  } = { execute };
-  if (approvalRequest !== undefined) callbacks.approvalRequest = approvalRequest;
-  if (approvalResponse !== undefined) callbacks.approvalResponse = approvalResponse;
-  if (toModelOutput !== undefined) callbacks.toModelOutput = toModelOutput;
-  return callbacks;
+  } = { execute: execute.reference };
+  if (approvalRequest !== undefined) callbacks.approvalRequest = approvalRequest.reference;
+  if (approvalResponse !== undefined) callbacks.approvalResponse = approvalResponse.reference;
+  if (toModelOutput !== undefined) callbacks.toModelOutput = toModelOutput.reference;
+
+  const registrations: PreparedDurableDynamicCallbackRegistration[] = [
+    { callback: execute.callback, phase: "execute", toolName: name },
+  ];
+  if (approvalRequest !== undefined) {
+    registrations.push({
+      callback: approvalRequest.callback,
+      phase: "approvalRequest",
+      toolName: name,
+    });
+  }
+  if (approvalResponse !== undefined) {
+    registrations.push({
+      callback: approvalResponse.callback,
+      phase: "approvalResponse",
+      toolName: name,
+    });
+  }
+  if (toModelOutput !== undefined) {
+    registrations.push({
+      callback: toModelOutput.callback,
+      phase: "toModelOutput",
+      toolName: name,
+    });
+  }
+  return { callbacks, registrations };
 }
 
-function createMetadata(input: {
+export function registerPreparedDurableDynamicToolCallbacks(
+  prepared: PreparedDurableDynamicToolCallbacks,
+): void {
+  for (const registration of prepared.registrations) {
+    registerDurableDynamicCallback(registration);
+  }
+}
+
+export function validateDurableDynamicToolCallbacks(
+  name: string,
+  entry: DynamicToolEntry,
+): DurableDynamicToolCallbacks {
+  const prepared = prepareDurableDynamicToolCallbacks(name, entry);
+  registerPreparedDurableDynamicToolCallbacks(prepared);
+  return prepared.callbacks;
+}
+
+export interface PreparedDynamicToolMetadata {
+  readonly callbacks: PreparedDurableDynamicToolCallbacks;
+  readonly metadata: DurableDynamicToolMetadata;
+}
+
+export function prepareDynamicToolMetadata(input: {
   readonly entry: DynamicToolEntry;
   readonly entryKey: string;
   readonly name: string;
-  readonly resolver: ResolvedDynamicToolResolver;
-}): DurableDynamicToolMetadata {
+  readonly resolverSlug: string;
+}): PreparedDynamicToolMetadata {
+  const callbacks = prepareDurableDynamicToolCallbacks(input.name, input.entry);
   return {
-    callbacks: validateDurableDynamicToolCallbacks(input.name, input.entry),
-    description: input.entry.description,
-    entryKey: input.entryKey,
-    inputSchema: serializeInputSchema(input.entry.inputSchema),
-    name: input.name,
-    outputSchema: serializeOutputSchema(input.entry.outputSchema),
-    resolverSlug: input.resolver.slug,
+    callbacks,
+    metadata: {
+      callbacks: callbacks.callbacks,
+      description: input.entry.description,
+      entryKey: input.entryKey,
+      inputSchema: serializeInputSchema(input.entry.inputSchema),
+      name: input.name,
+      outputSchema: serializeOutputSchema(input.entry.outputSchema),
+      resolverSlug: input.resolverSlug,
+    },
   };
+}
+
+export function registerPreparedDynamicToolMetadata(
+  prepared: readonly PreparedDynamicToolMetadata[],
+): void {
+  for (const entry of prepared) {
+    registerPreparedDurableDynamicToolCallbacks(entry.callbacks);
+  }
 }
 
 interface ResolvedDynamicToolEvent {
@@ -237,7 +310,7 @@ interface ResolvedDynamicToolEvent {
 }
 
 async function resolveToolsFromEvent(
-  ctx: ContextContainer,
+  ctx: AlsContext,
   resolvers: readonly ResolvedDynamicToolResolver[],
   event: UnstampedMessageStreamEvent,
   messages: readonly ModelMessage[],
@@ -251,8 +324,13 @@ async function resolveToolsFromEvent(
       const { entries, isSingle } = readDynamicToolResult(resolver, rawResult);
       const named = qualifyDynamicToolNames(resolver, isSingle, entries);
       return {
-        metadata: named.map(({ name, entryKey, entry }) =>
-          createMetadata({ entry, entryKey, name, resolver }),
+        prepared: named.map(({ name, entryKey, entry }) =>
+          prepareDynamicToolMetadata({
+            entry,
+            entryKey,
+            name,
+            resolverSlug: resolver.slug,
+          }),
         ),
         resolver,
       };
@@ -260,6 +338,7 @@ async function resolveToolsFromEvent(
   );
 
   const metadata: DurableDynamicToolMetadata[] = [];
+  const preparedMetadata: PreparedDynamicToolMetadata[] = [];
   const dynamicToolOwners = new Map<string, string>();
   for (const outcome of outcomes) {
     if (outcome.status === "rejected") {
@@ -270,7 +349,7 @@ async function resolveToolsFromEvent(
     }
     if (outcome.value === null) continue;
 
-    for (const entry of outcome.value.metadata) {
+    for (const { metadata: entry } of outcome.value.prepared) {
       const previousOwner = dynamicToolOwners.get(entry.name);
       if (previousOwner !== undefined && previousOwner !== outcome.value.resolver.slug) {
         throw new Error(
@@ -279,19 +358,21 @@ async function resolveToolsFromEvent(
       }
       dynamicToolOwners.set(entry.name, outcome.value.resolver.slug);
     }
-    metadata.push(...outcome.value.metadata);
+    preparedMetadata.push(...outcome.value.prepared);
+    metadata.push(...outcome.value.prepared.map((entry) => entry.metadata));
   }
+  registerPreparedDynamicToolMetadata(preparedMetadata);
   return { metadata };
 }
 
 const resolvedStepTools = new WeakMap<
-  ContextContainer,
+  AlsContext,
   { readonly coordinate: string; readonly metadata: readonly DurableDynamicToolMetadata[] }
 >();
 
 /** Resolves step-scoped tools once for one internal policy/model pass. */
 export async function resolveStepDynamicTools(input: {
-  readonly ctx: ContextContainer;
+  readonly ctx: AlsContext;
   readonly resolvers: readonly ResolvedDynamicToolResolver[];
   readonly event: UnstampedMessageStreamEvent;
   readonly messages: readonly ModelMessage[];
@@ -321,7 +402,7 @@ export async function resolveStepDynamicTools(input: {
 }
 
 export async function dispatchDynamicToolEvent(input: {
-  readonly ctx: ContextContainer;
+  readonly ctx: AlsContext;
   readonly resolvers: readonly ResolvedDynamicToolResolver[];
   readonly event: UnstampedMessageStreamEvent;
   readonly messages: readonly ModelMessage[];
@@ -358,7 +439,7 @@ export async function dispatchDynamicToolEvent(input: {
  * a crash, or a redeploy), so replay always resolves against current code.
  */
 export async function refreshDynamicSessionToolsForRuntimeRevision(input: {
-  readonly ctx: ContextContainer;
+  readonly ctx: AlsContext;
   readonly resolvers: readonly ResolvedDynamicToolResolver[];
   readonly event: SessionStartedStreamEvent;
   readonly messages: readonly ModelMessage[];

--- a/packages/eve/src/context/keys.ts
+++ b/packages/eve/src/context/keys.ts
@@ -21,6 +21,7 @@ import { ContextKey } from "#context/key.js";
 import type { InstrumentationChannelDeliveryRef } from "#harness/instrumentation/lifecycle.js";
 import type { HandleEventFn } from "#harness/types.js";
 import type { DurableDynamicToolCallbacks } from "#shared/durable-dynamic-tool-callbacks.js";
+import type { DynamicToolEventName } from "#shared/dynamic-tool-definition.js";
 import type { DynamicSubagentAgentConfig } from "#runtime/subagents/dynamic-agent-config.js";
 import type { DynamicRemoteAgentConfig } from "#runtime/subagents/dynamic-remote-agent-config.js";
 import type { SandboxAccess } from "#sandbox/state.js";
@@ -193,6 +194,37 @@ export const TurnDynamicToolMetadataKey = new ContextKey<readonly DurableDynamic
 /** Step-scoped dynamic tool metadata, replaced before each model step. */
 export const StepDynamicToolMetadataKey = new ContextKey<readonly DurableDynamicToolMetadata[]>(
   "eve.stepDynamicToolMetadata",
+);
+
+export type RuntimeToolContributionCoordinate =
+  | { readonly event: Extract<DynamicToolEventName, "session.started"> }
+  | {
+      readonly event: Extract<DynamicToolEventName, "turn.started">;
+      readonly turnId: string;
+    }
+  | {
+      readonly event: Extract<DynamicToolEventName, "step.started">;
+      readonly stepIndex: number;
+      readonly turnId: string;
+    };
+
+export interface DurableRuntimeToolContribution {
+  readonly coordinate: RuntimeToolContributionCoordinate;
+  readonly metadata: readonly DurableDynamicToolMetadata[];
+  readonly ownerId: string;
+  readonly qualificationPrefix?: string;
+  readonly runtimeRevision: string;
+  readonly sourceId: string;
+}
+
+export interface DurableRuntimeToolContributionState {
+  readonly contributions: readonly DurableRuntimeToolContribution[];
+  readonly version: 1;
+}
+
+/** Owner-scoped dynamic tools contributed by framework runtime features. */
+export const RuntimeToolContributionsKey = new ContextKey<DurableRuntimeToolContributionState>(
+  "eve.runtimeToolContributions",
 );
 
 /** Whether this turn executes subagent definitions as durable background tools. */

--- a/packages/eve/src/context/runtime-tool-contribution.test.ts
+++ b/packages/eve/src/context/runtime-tool-contribution.test.ts
@@ -1,0 +1,390 @@
+import { describe, expect, it } from "vitest";
+
+import { buildDynamicTools } from "#context/build-dynamic-tools.js";
+import { ContextContainer } from "#context/container.js";
+import {
+  RuntimeToolContributionsKey,
+  StepDynamicToolMetadataKey,
+  type DurableDynamicToolMetadata,
+} from "#context/keys.js";
+import {
+  contributeRuntimeTools,
+  dispatchRuntimeToolContributors,
+  refreshRuntimeToolContributionsForRuntimeRevision,
+  type RuntimeToolContributionMap,
+  type RuntimeToolContributor,
+} from "#context/runtime-tool-contribution.js";
+import { defineTool } from "#public/definitions/tool.js";
+import type { JsonObject } from "#shared/json.js";
+import {
+  callDurableDynamicCallback,
+  type DurableDynamicCallbackPhase,
+  lookupDurableDynamicCallback,
+  stampDurableDynamicToolCallbacks,
+} from "#shared/durable-dynamic-tool-callbacks.js";
+
+const SESSION_COORDINATE = { event: "session.started" as const };
+const TURN_COORDINATE = { event: "turn.started" as const, turnId: "turn-1" };
+const STEP_EVENT = {
+  data: { modelId: "mock/test", sequence: 0, stepIndex: 0, turnId: "turn-1" },
+  type: "step.started" as const,
+};
+
+function callbackTool(input: {
+  readonly closure?: JsonObject;
+  readonly description?: string;
+  readonly value: string;
+}) {
+  const closure = input.closure ?? { value: input.value };
+  const entry = defineTool({
+    description: input.description ?? input.value,
+    inputSchema: { type: "object" },
+    execute: () => input.value,
+  });
+  stampDurableDynamicToolCallbacks(entry, {
+    execute: {
+      callback: (captured) => captured.value,
+      closure,
+    },
+  });
+  return entry;
+}
+
+function contribute(input: {
+  readonly ctx: ContextContainer;
+  readonly ownerId: string;
+  readonly prefix?: string;
+  readonly tools: RuntimeToolContributionMap | null;
+  readonly coordinate?: typeof SESSION_COORDINATE | typeof TURN_COORDINATE;
+  readonly revision?: string;
+}): void {
+  contributeRuntimeTools({
+    coordinate: input.coordinate ?? SESSION_COORDINATE,
+    ctx: input.ctx,
+    ownerId: input.ownerId,
+    qualificationPrefix: input.prefix,
+    runtimeRevision: input.revision ?? "deployment:one",
+    sourceId: `source:${input.ownerId}`,
+    tools: input.tools,
+  });
+}
+
+function names(ctx: ContextContainer): string[] {
+  return buildDynamicTools(ctx).map((tool) => tool.name);
+}
+
+describe("runtime tool contributions", () => {
+  it("captures keyed branded tools through the durable callback path", () => {
+    const ctx = new ContextContainer();
+    contribute({
+      ctx,
+      ownerId: "catalog",
+      tools: { query: callbackTool({ value: "captured" }) },
+    });
+
+    expect(names(ctx)).toEqual(["query"]);
+    const metadata = ctx.get(RuntimeToolContributionsKey)!.contributions[0]!.metadata[0]!;
+    const callback = lookupDurableDynamicCallback("query", "execute")!;
+    expect(callDurableDynamicCallback(callback, metadata.callbacks.execute.closure)).toBe(
+      "captured",
+    );
+  });
+
+  it("captures approval request, response, execution, and output projection together", () => {
+    const ctx = new ContextContainer();
+    const entry = defineTool({
+      description: "guarded",
+      inputSchema: { type: "object" },
+      approval: {
+        request: () => "user-approval",
+        response: () => ({ status: "allowed" }),
+      },
+      execute: () => ({ private: true }),
+      toModelOutput: () => ({ type: "text", value: "projected" }),
+    });
+    stampDurableDynamicToolCallbacks(entry, {
+      approvalRequest: { callback: () => "user-approval", closure: {} },
+      approvalResponse: {
+        callback: () => ({ status: "allowed" }),
+        closure: {},
+      },
+      execute: { callback: () => ({ private: true }), closure: {} },
+      toModelOutput: {
+        callback: () => ({ type: "text", value: "projected" }),
+        closure: {},
+      },
+    });
+
+    contribute({ ctx, ownerId: "guarded", tools: { guarded: entry } });
+
+    const metadata = ctx.get(RuntimeToolContributionsKey)!.contributions[0]!.metadata[0]!;
+    expect(Object.keys(metadata.callbacks).sort()).toEqual([
+      "approvalRequest",
+      "approvalResponse",
+      "execute",
+      "toModelOutput",
+    ]);
+    for (const phase of Object.keys(metadata.callbacks)) {
+      expect(
+        lookupDurableDynamicCallback("guarded", phase as DurableDynamicCallbackPhase),
+      ).toBeTypeOf("function");
+    }
+  });
+
+  it("qualifies two owners before collision resolution", () => {
+    const ctx = new ContextContainer();
+    contribute({
+      ctx,
+      ownerId: "alpha",
+      prefix: "alpha",
+      tools: { save: callbackTool({ value: "alpha" }) },
+    });
+    contribute({
+      ctx,
+      ownerId: "beta",
+      prefix: "beta",
+      tools: { save: callbackTool({ value: "beta" }) },
+    });
+
+    expect(names(ctx)).toEqual(["alpha__save", "beta__save"]);
+  });
+
+  it("replaces one owner atomically while retaining other owners", () => {
+    const ctx = new ContextContainer();
+    contribute({ ctx, ownerId: "alpha", tools: { old: callbackTool({ value: "old" }) } });
+    contribute({ ctx, ownerId: "beta", tools: { keep: callbackTool({ value: "keep" }) } });
+    contribute({ ctx, ownerId: "alpha", tools: { next: callbackTool({ value: "next" }) } });
+
+    expect(names(ctx)).toEqual(["keep", "next"]);
+    expect(
+      ctx.get(RuntimeToolContributionsKey)!.contributions.map((entry) => entry.ownerId),
+    ).toEqual(["beta", "alpha"]);
+  });
+
+  it("removes only the selected owner for null and empty maps", () => {
+    const ctx = new ContextContainer();
+    contribute({ ctx, ownerId: "alpha", tools: { a: callbackTool({ value: "a" }) } });
+    contribute({ ctx, ownerId: "beta", tools: { b: callbackTool({ value: "b" }) } });
+
+    contribute({ ctx, ownerId: "alpha", tools: null });
+    expect(names(ctx)).toEqual(["b"]);
+    contribute({ ctx, ownerId: "beta", tools: {} });
+    expect(names(ctx)).toEqual([]);
+  });
+
+  it("keeps the previous owner set when the replacement is invalid", () => {
+    const ctx = new ContextContainer();
+    contribute({ ctx, ownerId: "alpha", tools: { old: callbackTool({ value: "old" }) } });
+    const before = ctx.get(RuntimeToolContributionsKey);
+
+    expect(() =>
+      contribute({
+        ctx,
+        ownerId: "alpha",
+        tools: {
+          valid: callbackTool({ value: "valid" }),
+          invalid: { description: "not branded" } as never,
+        },
+      }),
+    ).toThrow(/without defineTool/);
+    expect(ctx.get(RuntimeToolContributionsKey)).toBe(before);
+    expect(names(ctx)).toEqual(["old"]);
+  });
+
+  it("rejects lone tools, invalid names, and double qualification", () => {
+    const ctx = new ContextContainer();
+    const lone = callbackTool({ value: "lone" });
+    expect(() =>
+      Reflect.apply(contributeRuntimeTools, undefined, [
+        {
+          coordinate: SESSION_COORDINATE,
+          ctx,
+          ownerId: "alpha",
+          runtimeRevision: "deployment:one",
+          sourceId: "source:alpha",
+          tools: lone,
+        },
+      ]),
+    ).toThrow(/keyed map/);
+    expect(() => contribute({ ctx, ownerId: "alpha", tools: { "bad name": lone } })).toThrow(
+      /invalid tool name/,
+    );
+    expect(() =>
+      contribute({ ctx, ownerId: "alpha", prefix: "alpha", tools: { alpha__save: lone } }),
+    ).toThrow(/already qualified/);
+  });
+
+  it("rejects same-scope collisions with authored dynamic and runtime owners", () => {
+    const ctx = new ContextContainer();
+    const authored = {
+      callbacks: { execute: { closure: {} } },
+      description: "authored",
+      entryKey: "shared",
+      inputSchema: {},
+      name: "shared",
+      resolverSlug: "authored",
+    } satisfies DurableDynamicToolMetadata;
+    ctx.set(StepDynamicToolMetadataKey, [authored]);
+
+    expect(() =>
+      contributeRuntimeTools({
+        coordinate: { event: "step.started", stepIndex: 0, turnId: "turn-1" },
+        ctx,
+        ownerId: "runtime",
+        runtimeRevision: "deployment:one",
+        sourceId: "source:runtime",
+        tools: { shared: callbackTool({ value: "runtime" }) },
+      }),
+    ).toThrow(/collides with dynamic resolver/);
+
+    ctx.set(StepDynamicToolMetadataKey, []);
+    contributeRuntimeTools({
+      coordinate: { event: "step.started", stepIndex: 0, turnId: "turn-1" },
+      ctx,
+      ownerId: "one",
+      runtimeRevision: "deployment:one",
+      sourceId: "source:one",
+      tools: { shared: callbackTool({ value: "one" }) },
+    });
+    expect(() =>
+      contributeRuntimeTools({
+        coordinate: { event: "step.started", stepIndex: 0, turnId: "turn-1" },
+        ctx,
+        ownerId: "two",
+        runtimeRevision: "deployment:one",
+        sourceId: "source:two",
+        tools: { shared: callbackTool({ value: "two" }) },
+      }),
+    ).toThrow(/collides with runtime contributor/);
+  });
+
+  it("preserves dynamic scope precedence across contribution scopes", () => {
+    const ctx = new ContextContainer();
+    contribute({
+      ctx,
+      ownerId: "session-owner",
+      tools: { shared: callbackTool({ description: "session", value: "session" }) },
+    });
+    contribute({
+      coordinate: TURN_COORDINATE,
+      ctx,
+      ownerId: "turn-owner",
+      tools: { shared: callbackTool({ description: "turn", value: "turn" }) },
+    });
+
+    expect(buildDynamicTools(ctx).map((tool) => tool.description)).toEqual(["turn", "session"]);
+  });
+
+  it("dispatches subscribed contributors and clears expired step owners", async () => {
+    const ctx = new ContextContainer();
+    let calls = 0;
+    const contributor: RuntimeToolContributor = {
+      eventNames: ["step.started"],
+      ownerId: "step-owner",
+      resolve: () => ({ current: callbackTool({ value: String(++calls) }) }),
+      sourceId: "source:step-owner",
+    };
+
+    await dispatchRuntimeToolContributors({
+      contributors: [contributor],
+      ctx,
+      event: STEP_EVENT,
+      messages: [],
+      runtimeRevision: "deployment:one",
+    });
+    expect(names(ctx)).toEqual(["current"]);
+
+    await dispatchRuntimeToolContributors({
+      contributors: [],
+      ctx,
+      event: { ...STEP_EVENT, data: { ...STEP_EVENT.data, stepIndex: 1 } },
+      messages: [],
+      runtimeRevision: "deployment:one",
+    });
+    expect(names(ctx)).toEqual([]);
+  });
+
+  it("refreshes registered sources and removes contributors absent from a new revision", async () => {
+    const ctx = new ContextContainer();
+    contribute({
+      ctx,
+      ownerId: "present",
+      revision: "deployment:old",
+      tools: { old: callbackTool({ value: "old" }) },
+    });
+    contribute({
+      ctx,
+      ownerId: "removed",
+      revision: "deployment:old",
+      tools: { removed: callbackTool({ value: "removed" }) },
+    });
+    const present: RuntimeToolContributor = {
+      eventNames: ["session.started"],
+      ownerId: "present",
+      resolve: () => ({ next: callbackTool({ value: "next" }) }),
+      sourceId: "source:present",
+    };
+
+    await refreshRuntimeToolContributionsForRuntimeRevision({
+      contributors: [present],
+      ctx,
+      runtimeRevision: "deployment:new",
+    });
+
+    expect(names(ctx)).toEqual(["next"]);
+    expect(ctx.get(RuntimeToolContributionsKey)!.contributions).toMatchObject([
+      { ownerId: "present", runtimeRevision: "deployment:new" },
+    ]);
+  });
+
+  it("rehydrates a packaged factory without serializing its live service", async () => {
+    class Service {
+      read(key: string): string {
+        return `live:${key}`;
+      }
+    }
+    const services = new Map([["catalog", new Service()]]);
+    const contributor: RuntimeToolContributor = {
+      eventNames: ["session.started"],
+      ownerId: "packaged",
+      resolve: () => {
+        const entry = callbackTool({ closure: { key: "catalog" }, value: "unused" });
+        stampDurableDynamicToolCallbacks(entry, {
+          execute: {
+            callback: (closure) => services.get(String(closure.key))!.read(String(closure.key)),
+            closure: { key: "catalog" },
+          },
+        });
+        return { packaged: entry };
+      },
+      sourceId: "source:packaged",
+    };
+    const tools = await contributor.resolve({
+      coordinate: SESSION_COORDINATE,
+      ctx: new ContextContainer(),
+      messages: [],
+    });
+    const ctx = new ContextContainer();
+    contributeRuntimeTools({
+      coordinate: SESSION_COORDINATE,
+      ctx,
+      ownerId: contributor.ownerId,
+      runtimeRevision: "deployment:one",
+      sourceId: contributor.sourceId,
+      tools,
+    });
+
+    const metadata = ctx.get(RuntimeToolContributionsKey)!.contributions[0]!.metadata[0]!;
+    expect(metadata.callbacks.execute.closure).toEqual({ key: "catalog" });
+    const callback = lookupDurableDynamicCallback("packaged", "execute")!;
+    expect(callDurableDynamicCallback(callback, metadata.callbacks.execute.closure)).toBe(
+      "live:catalog",
+    );
+  });
+
+  it("fails safely for unknown durable state versions", () => {
+    const ctx = new ContextContainer();
+    ctx.set(RuntimeToolContributionsKey, { contributions: [], version: 2 } as never);
+    expect(() => buildDynamicTools(ctx)).toThrow(/unsupported or malformed version/);
+  });
+});

--- a/packages/eve/src/context/runtime-tool-contribution.test.ts
+++ b/packages/eve/src/context/runtime-tool-contribution.test.ts
@@ -304,6 +304,37 @@ describe("runtime tool contributions", () => {
     expect(names(ctx)).toEqual([]);
   });
 
+  it("normalizes the empty harness turn sentinel before dispatching step contributors", async () => {
+    const ctx = new ContextContainer();
+    let receivedCoordinate: unknown;
+    const contributor: RuntimeToolContributor = {
+      eventNames: ["step.started"],
+      ownerId: "step-owner",
+      resolve: ({ coordinate }) => {
+        receivedCoordinate = coordinate;
+        return null;
+      },
+      sourceId: "source:step-owner",
+    };
+
+    await dispatchRuntimeToolContributors({
+      contributors: [contributor],
+      ctx,
+      event: {
+        ...STEP_EVENT,
+        data: { ...STEP_EVENT.data, sequence: 3, stepIndex: 2, turnId: "" },
+      },
+      messages: [],
+      runtimeRevision: "deployment:one",
+    });
+
+    expect(receivedCoordinate).toEqual({
+      event: "step.started",
+      stepIndex: 2,
+      turnId: "turn_3",
+    });
+  });
+
   it("refreshes registered sources and removes contributors absent from a new revision", async () => {
     const ctx = new ContextContainer();
     contribute({

--- a/packages/eve/src/context/runtime-tool-contribution.ts
+++ b/packages/eve/src/context/runtime-tool-contribution.ts
@@ -1,0 +1,401 @@
+import type { ModelMessage } from "ai";
+
+import type { AlsContext } from "#context/container.js";
+import type { ContextReader } from "#context/key.js";
+import {
+  RuntimeToolContributionsKey,
+  SessionDynamicToolMetadataKey,
+  StepDynamicToolMetadataKey,
+  TurnDynamicToolMetadataKey,
+  type DurableRuntimeToolContribution,
+  type DurableRuntimeToolContributionState,
+  type RuntimeToolContributionCoordinate,
+} from "#context/keys.js";
+import {
+  prepareDynamicToolMetadata,
+  registerPreparedDynamicToolMetadata,
+} from "#context/dynamic-tool-lifecycle.js";
+import { createLogger } from "#internal/logging.js";
+import type { UnstampedMessageStreamEvent } from "#protocol/message.js";
+import {
+  isBrandedToolEntry,
+  type DynamicToolEventName,
+  type DynamicToolSet,
+} from "#shared/dynamic-tool-definition.js";
+import { hasUnregisteredDurableDynamicCallbacks } from "#shared/durable-dynamic-tool-callbacks.js";
+import { toErrorMessage } from "#shared/errors.js";
+import { TOOL_SLUG_PATTERN } from "#discover/grammar.js";
+
+const log = createLogger("runtime-tool-contributions");
+
+export type RuntimeToolContributionMap = DynamicToolSet;
+
+export interface RuntimeToolContributorResolveInput {
+  readonly coordinate: RuntimeToolContributionCoordinate;
+  readonly ctx: AlsContext;
+  readonly messages: readonly ModelMessage[];
+  readonly previous?: DurableRuntimeToolContribution;
+}
+
+export interface RuntimeToolContributor {
+  readonly eventNames: readonly DynamicToolEventName[];
+  readonly ownerId: string;
+  readonly qualificationPrefix?: string;
+  resolve(
+    input: RuntimeToolContributorResolveInput,
+  ):
+    | RuntimeToolContributionMap
+    | null
+    | undefined
+    | Promise<RuntimeToolContributionMap | null | undefined>;
+  readonly sourceId: string;
+}
+
+export interface RuntimeToolContributionInput {
+  readonly coordinate: RuntimeToolContributionCoordinate;
+  readonly ctx: AlsContext;
+  readonly ownerId: string;
+  readonly qualificationPrefix?: string;
+  readonly runtimeRevision: string;
+  readonly sourceId: string;
+  readonly tools: RuntimeToolContributionMap | null | undefined;
+}
+
+class RuntimeToolContributionCollisionError extends Error {}
+
+function readState(ctx: ContextReader): DurableRuntimeToolContributionState {
+  const state = ctx.get(RuntimeToolContributionsKey);
+  if (state === undefined) return { contributions: [], version: 1 };
+  if (
+    typeof state !== "object" ||
+    state === null ||
+    state.version !== 1 ||
+    !Array.isArray(state.contributions)
+  ) {
+    throw new Error("Runtime tool contribution state has an unsupported or malformed version.");
+  }
+  return state;
+}
+
+function requireNonEmpty(value: string, label: string): void {
+  if (value.trim().length === 0) {
+    throw new Error(`Runtime tool contribution ${label} must be a non-empty string.`);
+  }
+}
+
+function validateCoordinate(coordinate: RuntimeToolContributionCoordinate): void {
+  switch (coordinate.event) {
+    case "session.started":
+      return;
+    case "turn.started":
+      requireNonEmpty(coordinate.turnId, "turnId");
+      return;
+    case "step.started":
+      requireNonEmpty(coordinate.turnId, "turnId");
+      if (!Number.isSafeInteger(coordinate.stepIndex) || coordinate.stepIndex < 0) {
+        throw new Error("Runtime tool contribution stepIndex must be a non-negative safe integer.");
+      }
+  }
+}
+
+function isSameScope(
+  contribution: DurableRuntimeToolContribution,
+  coordinate: RuntimeToolContributionCoordinate,
+): boolean {
+  return contribution.coordinate.event === coordinate.event;
+}
+
+function metadataForEvent(ctx: ContextReader, event: DynamicToolEventName) {
+  switch (event) {
+    case "session.started":
+      return ctx.get(SessionDynamicToolMetadataKey) ?? [];
+    case "turn.started":
+      return ctx.get(TurnDynamicToolMetadataKey) ?? [];
+    case "step.started":
+      return ctx.get(StepDynamicToolMetadataKey) ?? [];
+  }
+}
+
+function qualifyToolName(prefix: string | undefined, entryKey: string): string {
+  if (entryKey.length === 0) {
+    throw new Error("Runtime tool contribution keys must be non-empty strings.");
+  }
+  if (prefix !== undefined) {
+    requireNonEmpty(prefix, "qualificationPrefix");
+    if (entryKey.startsWith(`${prefix}__`)) {
+      throw new Error(
+        `Runtime tool contribution key "${entryKey}" is already qualified with "${prefix}". Pass bare map keys so eve qualifies names exactly once.`,
+      );
+    }
+  }
+  const name = prefix === undefined ? entryKey : `${prefix}__${entryKey}`;
+  if (!TOOL_SLUG_PATTERN.test(name)) {
+    throw new Error(
+      `Runtime tool contribution produced invalid tool name "${name}". Expected ASCII letters, digits, underscores, and dashes only, starting with a letter, up to 64 characters.`,
+    );
+  }
+  return name;
+}
+
+function readToolEntries(
+  ownerId: string,
+  tools: RuntimeToolContributionInput["tools"],
+): readonly [string, DynamicToolSet[string]][] {
+  if (tools === null || tools === undefined) return [];
+  if (isBrandedToolEntry(tools)) {
+    throw new Error(
+      `Runtime tool contributor "${ownerId}" returned one defineTool() value. Return a keyed map of defineTool() values instead.`,
+    );
+  }
+  if (typeof tools !== "object" || Array.isArray(tools)) {
+    throw new Error(
+      `Runtime tool contributor "${ownerId}" must return a keyed map of defineTool() values or null.`,
+    );
+  }
+
+  return Object.entries(tools).map(([entryKey, entry]) => {
+    if (!isBrandedToolEntry(entry)) {
+      throw new Error(
+        `Runtime tool contributor "${ownerId}" returned "${entryKey}" without defineTool(). Wrap every runtime tool entry in defineTool().`,
+      );
+    }
+    return [entryKey, entry as DynamicToolSet[string]] as const;
+  });
+}
+
+function collisionOwner(
+  name: string,
+  input: RuntimeToolContributionInput,
+  state: DurableRuntimeToolContributionState,
+): string | undefined {
+  const authored = metadataForEvent(input.ctx, input.coordinate.event).find(
+    (entry) => entry.name === name,
+  );
+  if (authored !== undefined) return `dynamic resolver "${authored.resolverSlug}"`;
+
+  for (const contribution of state.contributions) {
+    if (contribution.ownerId === input.ownerId || !isSameScope(contribution, input.coordinate)) {
+      continue;
+    }
+    if (contribution.metadata.some((entry) => entry.name === name)) {
+      return `runtime contributor "${contribution.ownerId}"`;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Atomically validates, qualifies, captures, and replaces one owner-scoped
+ * set of runtime-contributed tools.
+ */
+export function contributeRuntimeTools(input: RuntimeToolContributionInput): void {
+  requireNonEmpty(input.ownerId, "ownerId");
+  requireNonEmpty(input.runtimeRevision, "runtimeRevision");
+  requireNonEmpty(input.sourceId, "sourceId");
+  validateCoordinate(input.coordinate);
+
+  const state = readState(input.ctx);
+  const entries = readToolEntries(input.ownerId, input.tools);
+  const withoutOwner = state.contributions.filter(
+    (contribution) =>
+      contribution.ownerId !== input.ownerId || !isSameScope(contribution, input.coordinate),
+  );
+  if (entries.length === 0) {
+    input.ctx.set(RuntimeToolContributionsKey, {
+      contributions: withoutOwner,
+      version: 1,
+    });
+    return;
+  }
+
+  const prepared = entries.map(([entryKey, entry]) => {
+    const name = qualifyToolName(input.qualificationPrefix, entryKey);
+    const owner = collisionOwner(name, input, state);
+    if (owner !== undefined) {
+      throw new RuntimeToolContributionCollisionError(
+        `Runtime tool "${name}" from contributor "${input.ownerId}" collides with ${owner}.`,
+      );
+    }
+    return prepareDynamicToolMetadata({
+      entry,
+      entryKey,
+      name,
+      resolverSlug: `runtime:${input.ownerId}`,
+    });
+  });
+
+  const duplicateNames = new Set<string>();
+  for (const entry of prepared) {
+    if (duplicateNames.has(entry.metadata.name)) {
+      throw new RuntimeToolContributionCollisionError(
+        `Runtime tool contributor "${input.ownerId}" produced duplicate tool name "${entry.metadata.name}".`,
+      );
+    }
+    duplicateNames.add(entry.metadata.name);
+  }
+
+  registerPreparedDynamicToolMetadata(prepared);
+  input.ctx.set(RuntimeToolContributionsKey, {
+    contributions: [
+      ...withoutOwner,
+      {
+        coordinate: input.coordinate,
+        metadata: prepared.map((entry) => entry.metadata),
+        ownerId: input.ownerId,
+        qualificationPrefix: input.qualificationPrefix,
+        runtimeRevision: input.runtimeRevision,
+        sourceId: input.sourceId,
+      },
+    ],
+    version: 1,
+  });
+}
+
+/** Clears expired lifecycle scopes before contributors publish the next set. */
+export function prepareRuntimeToolContributionsForEvent(
+  ctx: AlsContext,
+  coordinate: RuntimeToolContributionCoordinate,
+): void {
+  validateCoordinate(coordinate);
+  const state = readState(ctx);
+  const expired =
+    coordinate.event === "session.started"
+      ? new Set<DynamicToolEventName>(["session.started", "turn.started", "step.started"])
+      : coordinate.event === "turn.started"
+        ? new Set<DynamicToolEventName>(["turn.started", "step.started"])
+        : new Set<DynamicToolEventName>(["step.started"]);
+  ctx.set(RuntimeToolContributionsKey, {
+    contributions: state.contributions.filter(
+      (contribution) => !expired.has(contribution.coordinate.event),
+    ),
+    version: 1,
+  });
+}
+
+export function runtimeToolContributionCoordinate(
+  event: UnstampedMessageStreamEvent,
+): RuntimeToolContributionCoordinate | undefined {
+  switch (event.type) {
+    case "session.started":
+      return { event: "session.started" };
+    case "turn.started":
+      return { event: "turn.started", turnId: event.data.turnId };
+    case "step.started":
+      return {
+        event: "step.started",
+        stepIndex: event.data.stepIndex,
+        turnId: event.data.turnId,
+      };
+    default:
+      return undefined;
+  }
+}
+
+/** Resolves and publishes all runtime contributors subscribed to one event. */
+export async function dispatchRuntimeToolContributors(input: {
+  readonly contributors: readonly RuntimeToolContributor[];
+  readonly ctx: AlsContext;
+  readonly event: UnstampedMessageStreamEvent;
+  readonly messages: readonly ModelMessage[];
+  readonly runtimeRevision: string;
+}): Promise<void> {
+  const coordinate = runtimeToolContributionCoordinate(input.event);
+  if (coordinate === undefined) return;
+  prepareRuntimeToolContributionsForEvent(input.ctx, coordinate);
+
+  const matching = input.contributors.filter((contributor) =>
+    contributor.eventNames.includes(coordinate.event),
+  );
+  const outcomes = await Promise.allSettled(
+    matching.map(async (contributor) => ({
+      contributor,
+      tools: await contributor.resolve({
+        coordinate,
+        ctx: input.ctx,
+        messages: input.messages,
+      }),
+    })),
+  );
+
+  for (const outcome of outcomes) {
+    if (outcome.status === "rejected") {
+      log.error(`Runtime tool contributor (${coordinate.event}) failed — skipping its result.`, {
+        error: toErrorMessage(outcome.reason),
+      });
+      continue;
+    }
+    try {
+      contributeRuntimeTools({
+        coordinate,
+        ctx: input.ctx,
+        ownerId: outcome.value.contributor.ownerId,
+        qualificationPrefix: outcome.value.contributor.qualificationPrefix,
+        runtimeRevision: input.runtimeRevision,
+        sourceId: outcome.value.contributor.sourceId,
+        tools: outcome.value.tools,
+      });
+    } catch (error) {
+      if (error instanceof RuntimeToolContributionCollisionError) throw error;
+      log.error(`Runtime tool contributor (${coordinate.event}) failed — skipping its result.`, {
+        error: toErrorMessage(error),
+        ownerId: outcome.value.contributor.ownerId,
+      });
+    }
+  }
+}
+
+/**
+ * Re-resolves persisted contributors after a cold start or runtime revision
+ * change so name-keyed callback bindings point at the current code.
+ */
+export async function refreshRuntimeToolContributionsForRuntimeRevision(input: {
+  readonly contributors: readonly RuntimeToolContributor[];
+  readonly ctx: AlsContext;
+  readonly runtimeRevision: string;
+}): Promise<void> {
+  const snapshot = [...readState(input.ctx).contributions];
+  for (const contribution of snapshot) {
+    const needsRefresh =
+      contribution.runtimeRevision !== input.runtimeRevision ||
+      hasUnregisteredDurableDynamicCallbacks(contribution.metadata);
+    if (!needsRefresh) continue;
+
+    const contributor = input.contributors.find(
+      (candidate) =>
+        candidate.ownerId === contribution.ownerId && candidate.sourceId === contribution.sourceId,
+    );
+    if (contributor === undefined) {
+      if (contribution.runtimeRevision !== input.runtimeRevision) {
+        contributeRuntimeTools({
+          coordinate: contribution.coordinate,
+          ctx: input.ctx,
+          ownerId: contribution.ownerId,
+          qualificationPrefix: contribution.qualificationPrefix,
+          runtimeRevision: input.runtimeRevision,
+          sourceId: contribution.sourceId,
+          tools: null,
+        });
+        continue;
+      }
+      throw new Error(
+        `Runtime tool contributor "${contribution.ownerId}" cannot rebind because source "${contribution.sourceId}" is not registered in this process.`,
+      );
+    }
+
+    const tools = await contributor.resolve({
+      coordinate: contribution.coordinate,
+      ctx: input.ctx,
+      messages: [],
+      previous: contribution,
+    });
+    contributeRuntimeTools({
+      coordinate: contribution.coordinate,
+      ctx: input.ctx,
+      ownerId: contribution.ownerId,
+      qualificationPrefix: contribution.qualificationPrefix,
+      runtimeRevision: input.runtimeRevision,
+      sourceId: contribution.sourceId,
+      tools,
+    });
+  }
+}

--- a/packages/eve/src/context/runtime-tool-contribution.ts
+++ b/packages/eve/src/context/runtime-tool-contribution.ts
@@ -280,12 +280,17 @@ export function runtimeToolContributionCoordinate(
       return { event: "session.started" };
     case "turn.started":
       return { event: "turn.started", turnId: event.data.turnId };
-    case "step.started":
+    case "step.started": {
+      // Resumed harness state may still carry the between-turn sentinel; the
+      // next active turn uses the same sequence-derived identity as preamble.
+      const turnId =
+        event.data.turnId === "" ? `turn_${String(event.data.sequence)}` : event.data.turnId;
       return {
         event: "step.started",
         stepIndex: event.data.stepIndex,
-        turnId: event.data.turnId,
+        turnId,
       };
+    }
     default:
       return undefined;
   }

--- a/packages/eve/src/execution/node-step.ts
+++ b/packages/eve/src/execution/node-step.ts
@@ -84,6 +84,10 @@ export interface CreateExecutionNodeStepInput {
   readonly mode: RunMode;
   readonly modelResolutionScope: RuntimeModelResolutionScope;
   readonly node: ResolvedRuntimeAgentNode;
+  /** Rebuilds dynamic and runtime-contributed tools before approval handling. */
+  readonly resolveStepDynamicTools?: NonNullable<
+    Parameters<typeof createToolLoopHarness>[0]["resolveStepDynamicTools"]
+  >;
   /**
    * Effective `maxSubagents` cap configured by the experimental Workflow tool
    * definition and materialized on the session at creation.
@@ -125,6 +129,7 @@ export function createExecutionNodeStep(input: CreateExecutionNodeStepInput): St
       input.node.agent.config?.experimental?.subagentPersistentSessions === true,
     dispatchDynamicModelEvent: dispatchModelEvent,
     resolveModel,
+    resolveStepDynamicTools: input.resolveStepDynamicTools,
     runtimeIdentity: buildRuntimeIdentity(input.node),
     tools,
   });

--- a/packages/eve/src/execution/runtime-tool-lifecycle.ts
+++ b/packages/eve/src/execution/runtime-tool-lifecycle.ts
@@ -1,0 +1,74 @@
+import type { ModelMessage } from "ai";
+
+import type { AlsContext } from "#context/container.js";
+import {
+  dispatchDynamicToolEvent,
+  resolveStepDynamicTools,
+} from "#context/dynamic-tool-lifecycle.js";
+import {
+  dispatchRuntimeToolContributors,
+  refreshRuntimeToolContributionsForRuntimeRevision,
+  type RuntimeToolContributor,
+} from "#context/runtime-tool-contribution.js";
+import type { UnstampedMessageStreamEvent } from "#protocol/message.js";
+import type { ResolvedDynamicToolResolver } from "#runtime/types.js";
+
+interface RuntimeToolLifecycleInput {
+  readonly contributors: readonly RuntimeToolContributor[];
+  readonly ctx: AlsContext;
+  readonly resolvers: readonly ResolvedDynamicToolResolver[];
+  readonly runtimeRevision: string;
+}
+
+interface RuntimeToolEventInput {
+  readonly ctx: AlsContext;
+  readonly event: UnstampedMessageStreamEvent;
+  readonly messages: readonly ModelMessage[];
+}
+
+export function createRuntimeToolLifecycle(input: RuntimeToolLifecycleInput) {
+  const resolveStep = async (eventInput: RuntimeToolEventInput): Promise<void> => {
+    await resolveStepDynamicTools({
+      ctx: eventInput.ctx,
+      event: eventInput.event,
+      messages: eventInput.messages,
+      resolvers: input.resolvers,
+    });
+    await dispatchRuntimeToolContributors({
+      contributors: input.contributors,
+      ctx: eventInput.ctx,
+      event: eventInput.event,
+      messages: eventInput.messages,
+      runtimeRevision: input.runtimeRevision,
+    });
+  };
+
+  return {
+    async dispatch(eventInput: RuntimeToolEventInput): Promise<void> {
+      if (eventInput.event.type === "step.started") {
+        await resolveStep(eventInput);
+        return;
+      }
+      await dispatchDynamicToolEvent({
+        ctx: eventInput.ctx,
+        event: eventInput.event,
+        messages: eventInput.messages,
+        resolvers: input.resolvers,
+      });
+      await dispatchRuntimeToolContributors({
+        contributors: input.contributors,
+        ctx: eventInput.ctx,
+        event: eventInput.event,
+        messages: eventInput.messages,
+        runtimeRevision: input.runtimeRevision,
+      });
+    },
+    refresh: () =>
+      refreshRuntimeToolContributionsForRuntimeRevision({
+        contributors: input.contributors,
+        ctx: input.ctx,
+        runtimeRevision: input.runtimeRevision,
+      }),
+    resolveStep,
+  };
+}

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -15,10 +15,7 @@ import {
   dispatchDynamicSubagentEvent,
   refreshDynamicSessionSubagentsForRuntimeRevision,
 } from "#context/dynamic-subagent-lifecycle.js";
-import {
-  dispatchDynamicToolEvent,
-  refreshDynamicSessionToolsForRuntimeRevision,
-} from "#context/dynamic-tool-lifecycle.js";
+import { refreshDynamicSessionToolsForRuntimeRevision } from "#context/dynamic-tool-lifecycle.js";
 import {
   AuthKey,
   CapabilitiesKey,
@@ -30,6 +27,7 @@ import {
   TurnTaskDeliveryKey,
 } from "#context/keys.js";
 import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
+import { getFrameworkRuntimeToolContributors } from "#runtime/framework-tools/index.js";
 import { deserializeContext, serializeContext } from "#context/serialize.js";
 import {
   emitTurnPreamble,
@@ -94,6 +92,7 @@ import {
 } from "#execution/tasks/child/instructions.js";
 import { prepareWorkflowPreambleTrace } from "#execution/workflow-trace-context.js";
 import { resolveEffectiveAgentRuntime } from "#execution/effective-agent-config.js";
+import { createRuntimeToolLifecycle } from "#execution/runtime-tool-lifecycle.js";
 import { recordSubagentUsageSpans } from "#execution/subagent-usage-span.js";
 import { reconcileSessionContinuationToken } from "#execution/reconcile-session-continuation-token.js";
 import { hydrateDurableSession, refreshSessionFromTurnAgent } from "#execution/session.js";
@@ -308,17 +307,26 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
   const persistentSubagentSessions =
     tasksEnabled || bundle.resolvedAgent.config?.experimental?.subagentPersistentSessions === true;
   const dynamicToolResolvers = bundle.resolvedAgent.dynamicToolResolvers ?? [];
+  const runtimeToolContributors = getFrameworkRuntimeToolContributors();
   const effectiveNode = {
     ...bundle.graph.root,
     turnAgent: effectiveAgent.turnAgent,
   };
   const runtimeIdentity = buildRuntimeIdentity(effectiveNode);
+  let runtimeToolLifecycle: ReturnType<typeof createRuntimeToolLifecycle>;
   try {
     const deploymentId = process.env.VERCEL_DEPLOYMENT_ID?.trim();
     const dynamicRuntimeRevision = deploymentId
       ? `deployment:${deploymentId}`
       : await resolveRuntimeCompiledArtifactsVersionedCacheKey(bundle.compiledArtifactsSource);
     const sessionStarted = initialEmissionState.sessionStarted;
+    runtimeToolLifecycle = createRuntimeToolLifecycle({
+      contributors: runtimeToolContributors,
+      ctx,
+      resolvers: dynamicToolResolvers,
+      runtimeRevision: dynamicRuntimeRevision,
+    });
+    await runtimeToolLifecycle.refresh();
 
     if (!sessionStarted) {
       ctx.set(SessionDynamicSubagentRuntimeRevisionKey, dynamicRuntimeRevision);
@@ -388,12 +396,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
       messages: messages ?? [],
       persistentSessions: persistentSubagentSessions,
     });
-    await dispatchDynamicToolEvent({
-      ctx,
-      resolvers: dynamicToolResolvers,
-      event: emitted,
-      messages: messages ?? [],
-    });
+    await runtimeToolLifecycle.dispatch({ ctx, event: emitted, messages: messages ?? [] });
     await dispatchDynamicSkillEvent({
       ctx,
       resolvers: dynamicSkillResolvers,
@@ -504,6 +507,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
             nodeId: bundle.nodeId,
           },
           node: effectiveNode,
+          resolveStepDynamicTools: runtimeToolLifecycle.resolveStep,
           workflowMaxSubagents: refreshedSession.workflowMaxSubagents,
         });
         return step(modelSession, stepInput);

--- a/packages/eve/src/internal/nitro/routes/agent-info/build-agent-info-response-from-manifest.ts
+++ b/packages/eve/src/internal/nitro/routes/agent-info/build-agent-info-response-from-manifest.ts
@@ -1,6 +1,6 @@
 import {
   getAllFrameworkToolNames,
-  getFrameworkDynamicToolResolvers,
+  getFrameworkRuntimeToolContributors,
 } from "#runtime/framework-tools/index.js";
 import {
   getAllFrameworkChannelNames,
@@ -222,7 +222,7 @@ export function buildAgentInfoResponseFromManifest(
       authored: authoredTools,
       disabledFramework: [...manifest.disabledFrameworkTools],
       dynamic: [
-        ...getFrameworkDynamicToolResolvers().map((resolver) =>
+        ...getFrameworkRuntimeToolContributors().map((resolver) =>
           renderDynamicResolver(resolver, { origin: "framework" }),
         ),
         ...manifest.dynamicTools.map((resolver) =>

--- a/packages/eve/src/internal/nitro/routes/agent-info/build-agent-info-response.ts
+++ b/packages/eve/src/internal/nitro/routes/agent-info/build-agent-info-response.ts
@@ -2,7 +2,7 @@ import { ROOT_COMPILED_AGENT_NODE_ID } from "#compiler/manifest.js";
 import {
   getAllFrameworkToolDefinitions,
   getAllFrameworkToolNames,
-  getFrameworkDynamicToolResolvers,
+  getFrameworkRuntimeToolContributors,
   getOptInFrameworkToolNames,
 } from "#runtime/framework-tools/index.js";
 import {
@@ -388,7 +388,7 @@ function buildToolInfo(
   const authoredToolNames = new Set(agent.tools.map((tool) => tool.name));
   const disabledFrameworkTools = new Set(agent.disabledFrameworkTools);
   const allFrameworkToolNames = getAllFrameworkToolNames();
-  const dynamicFrameworkResolvers = getFrameworkDynamicToolResolvers();
+  const dynamicFrameworkResolvers = getFrameworkRuntimeToolContributors();
   const authored = agent.tools.map((tool) =>
     renderTool(tool, {
       origin: "authored",

--- a/packages/eve/src/runtime/framework-tools/connection-search-dynamic.test.ts
+++ b/packages/eve/src/runtime/framework-tools/connection-search-dynamic.test.ts
@@ -11,14 +11,12 @@ import {
 import { ConnectionAuthorizationRequiredError } from "#public/connections/errors.js";
 import type { ToolContext } from "#public/definitions/tool.js";
 import type { ConnectionRegistry, ConnectionToolMetadata } from "#runtime/connections/types.js";
-import { extractDiscoveredTools } from "#runtime/framework-tools/connection-search-dynamic.js";
-import { getFrameworkDynamicToolResolvers } from "#runtime/framework-tools/index.js";
-import type { ResolvedConnectionDefinition } from "#runtime/types.js";
 import {
-  isBrandedToolEntry,
-  type DynamicResolveContext,
-  type DynamicToolSet,
-} from "#shared/dynamic-tool-definition.js";
+  CONNECTION_SEARCH_RUNTIME_TOOL_CONTRIBUTOR,
+  extractDiscoveredTools,
+} from "#runtime/framework-tools/connection-search-dynamic.js";
+import type { ResolvedConnectionDefinition } from "#runtime/types.js";
+import { isBrandedToolEntry, type DynamicToolSet } from "#shared/dynamic-tool-definition.js";
 import { readDurableDynamicToolCallbacks } from "#shared/durable-dynamic-tool-callbacks.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -46,19 +44,21 @@ async function executeConnectionSearch(
   setupContext?.(ctx);
 
   return contextStorage.run(ctx, async () => {
-    const resolve = getConnectionSearchResolver().events["step.started"]!;
-    const resolved = (await resolve({}, {
-      channel: {},
-      messages: [],
-      session: { auth: { current: null, initiator: null }, id: "test-session" },
-    } satisfies DynamicResolveContext)) as DynamicToolSet;
+    const resolved = await resolveConnectionSearchTools(ctx);
 
-    return resolved["connection_search"]!.execute(input, {} as ToolContext);
+    return resolved!["connection_search"]!.execute(input, {} as ToolContext);
   });
 }
 
-function getConnectionSearchResolver() {
-  return getFrameworkDynamicToolResolvers()[0]!;
+async function resolveConnectionSearchTools(
+  ctx: ContextContainer,
+  messages: readonly Msg[] = [],
+): Promise<DynamicToolSet | null | undefined> {
+  return await CONNECTION_SEARCH_RUNTIME_TOOL_CONTRIBUTOR.resolve({
+    coordinate: { event: "step.started", stepIndex: 0, turnId: "turn-0" },
+    ctx,
+    messages,
+  });
 }
 
 function registry(input: {
@@ -90,18 +90,7 @@ describe("connection dynamic tools", () => {
         loadTools: {},
       }),
     );
-    const resolve = getConnectionSearchResolver().events["step.started"]!;
-
-    const tools = await contextStorage.run(ctx, () =>
-      resolve(
-        {},
-        {
-          channel: {},
-          messages: [],
-          session: { auth: { current: null, initiator: null }, id: "test-session" },
-        },
-      ),
-    );
+    const tools = await contextStorage.run(ctx, () => resolveConnectionSearchTools(ctx));
 
     expect(tools).toBeNull();
   });
@@ -135,21 +124,11 @@ describe("connection dynamic tools", () => {
     ];
     const ctx = new ContextContainer();
     ctx.set(ConnectionRegistryKey, connectionRegistry);
-    const resolver = getConnectionSearchResolver();
-    const resolve = resolver.events["step.started"]!;
+    const tools = (await contextStorage.run(ctx, () =>
+      resolveConnectionSearchTools(ctx, messages),
+    )) as DynamicToolSet;
 
-    const tools = await contextStorage.run(ctx, async () => {
-      return (await resolve(
-        {},
-        {
-          channel: {},
-          messages,
-          session: { auth: { current: null, initiator: null }, id: "test-session" },
-        },
-      )) as DynamicToolSet;
-    });
-
-    expect(resolver.eventNames).toEqual(["step.started"]);
+    expect(CONNECTION_SEARCH_RUNTIME_TOOL_CONTRIBUTOR.eventNames).toEqual(["step.started"]);
     expect(Object.keys(tools)).toEqual(["connection_search", "linear__list_issues"]);
     expect(Object.values(tools).every(isBrandedToolEntry)).toBe(true);
   });
@@ -429,12 +408,7 @@ describe("connection_search", () => {
     });
 
     const result = await contextStorage.run(ctx, async () => {
-      const resolve = getConnectionSearchResolver().events["step.started"]!;
-      const tools = (await resolve({}, {
-        channel: {},
-        messages: [],
-        session: { auth: { current: null, initiator: null }, id: "session-auth-replay" },
-      } satisfies DynamicResolveContext)) as DynamicToolSet;
+      const tools = (await resolveConnectionSearchTools(ctx)) as DynamicToolSet;
       const reference = readDurableDynamicToolCallbacks(tools["connection_search"]!)!.execute!;
 
       return await reference.callback(reference.closure, {

--- a/packages/eve/src/runtime/framework-tools/connection-search-dynamic.ts
+++ b/packages/eve/src/runtime/framework-tools/connection-search-dynamic.ts
@@ -14,7 +14,7 @@ import {
   isConnectionAuthorizationFailedError,
   isConnectionAuthorizationRequiredError,
 } from "#public/connections/errors.js";
-import { defineDynamic, defineTool } from "#public/definitions/tool.js";
+import { defineTool } from "#public/definitions/tool.js";
 import type { ToolContext } from "#public/definitions/tool.js";
 import {
   resolveApprovalPolicy,
@@ -23,6 +23,7 @@ import {
 } from "#public/definitions/approval.js";
 import type { JsonValue } from "#public/types/json.js";
 import type { JsonObject } from "#shared/json.js";
+import type { DynamicToolSet } from "#shared/dynamic-tool-definition.js";
 import { stampDurableDynamicToolCallbacks } from "#shared/durable-dynamic-tool-callbacks.js";
 import { writeCachedToken } from "#runtime/connections/authorization-tokens.js";
 import { principalKey, resolveConnectionPrincipal } from "#runtime/connections/principal.js";
@@ -43,6 +44,7 @@ import { toError } from "#shared/errors.js";
 import type { ModelMessage } from "ai";
 
 import { ConnectionRegistryKey } from "#context/providers/connection-key.js";
+import type { RuntimeToolContributor } from "#context/runtime-tool-contribution.js";
 
 const logger = createLogger("framework.connection-search-dynamic");
 
@@ -511,93 +513,87 @@ async function authorizeDiscoveredConnectionToolApproval(
     : await response(context);
 }
 
-// The step-scoped definition re-derives its tools from conversation history.
-// After compaction removes old search results, those tools naturally disappear.
-const connectionSearchDynamicDefinition = defineDynamic({
-  events: {
-    "step.started": async (_event, ctx) => {
-      const registry = loadContext().get(ConnectionRegistryKey);
-      if (!registry || registry.getConnections().length === 0) return null;
+function resolveConnectionSearchTools(messages: readonly ModelMessage[]): DynamicToolSet | null {
+  const registry = loadContext().get(ConnectionRegistryKey);
+  if (!registry || registry.getConnections().length === 0) return null;
 
-      const connections = registry.getConnections();
-      const connectionNames = connections.map((c) => c.connectionName);
-      const fromMessages = extractDiscoveredTools(ctx.messages);
-      const fromContext = loadContext().get(ConnectionSearchResultsKey) ?? [];
-      const mergedMap = new Map<string, ConnectionSearchResultItem>();
-      for (const r of fromContext) {
-        if (r.qualifiedName) mergedMap.set(r.qualifiedName, r);
-      }
-      for (const r of fromMessages) {
-        if (r.qualifiedName) mergedMap.set(r.qualifiedName, r);
-      }
-      const discovered = [...mergedMap.values()];
+  const connections = registry.getConnections();
+  const connectionNames = connections.map((connection) => connection.connectionName);
+  const fromMessages = extractDiscoveredTools(messages);
+  const fromContext = loadContext().get(ConnectionSearchResultsKey) ?? [];
+  const mergedMap = new Map<string, ConnectionSearchResultItem>();
+  for (const result of fromContext) {
+    if (result.qualifiedName) mergedMap.set(result.qualifiedName, result);
+  }
+  for (const result of fromMessages) {
+    if (result.qualifiedName) mergedMap.set(result.qualifiedName, result);
+  }
 
-      const tools: Record<string, object> = {};
-
-      const connectionSearchTool = defineTool({
-        description:
-          "Search for tools across your connections. " +
-          "Discovered tools become directly callable by their qualified name " +
-          "(e.g. `linear__list_issues`) in your next response. " +
-          `Available connections: ${connectionNames.join(", ")}.`,
-        inputSchema: CONNECTION_SEARCH_INPUT_SCHEMA,
-        async execute(input: ConnectionSearchInput) {
-          return executeConnectionSearch(input);
-        },
-        outputSchema: CONNECTION_SEARCH_OUTPUT_SCHEMA,
-      });
-      stampDurableDynamicToolCallbacks(connectionSearchTool, {
-        execute: {
-          callback: (_closure, input) => executeConnectionSearch(input as ConnectionSearchInput),
-          closure: {},
-        },
-      });
-      tools["connection_search"] = connectionSearchTool;
-
-      for (const result of discovered) {
-        const connectionName = result.connection;
-        const toolName = result.tool!;
-        const approval = registry.getConnectionApproval(connectionName);
-
-        const closure = { connectionName, toolName };
-        const discoveredTool = defineTool({
-          description: result.description,
-          inputSchema: (result.inputSchema ?? {
-            type: "object",
-          }) as JsonObject,
-          approval,
-          outputSchema: result.outputSchema as JsonObject | undefined,
-          async execute(input: Record<string, unknown>, executeCtx) {
-            return await executeDiscoveredConnectionTool(closure, input, executeCtx);
-          },
-        });
-        stampDurableDynamicToolCallbacks(discoveredTool, {
-          execute: { callback: executeDiscoveredConnectionTool, closure },
-          ...(approval === undefined
-            ? {}
-            : {
-                approvalRequest: {
-                  callback: requestDiscoveredConnectionToolApproval,
-                  closure,
-                },
-              }),
-          ...(approval === undefined ||
-          typeof approval === "function" ||
-          approval.response === undefined
-            ? {}
-            : {
-                approvalResponse: {
-                  callback: authorizeDiscoveredConnectionToolApproval,
-                  closure,
-                },
-              }),
-        });
-        tools[qualifiedConnectionToolName(connectionName, toolName)] = discoveredTool;
-      }
-
-      return tools;
+  const tools: Record<string, object> = {};
+  const connectionSearchTool = defineTool({
+    description:
+      "Search for tools across your connections. " +
+      "Discovered tools become directly callable by their qualified name " +
+      "(e.g. `linear__list_issues`) in your next response. " +
+      `Available connections: ${connectionNames.join(", ")}.`,
+    inputSchema: CONNECTION_SEARCH_INPUT_SCHEMA,
+    async execute(input: ConnectionSearchInput) {
+      return executeConnectionSearch(input);
     },
-  },
-});
+    outputSchema: CONNECTION_SEARCH_OUTPUT_SCHEMA,
+  });
+  stampDurableDynamicToolCallbacks(connectionSearchTool, {
+    execute: {
+      callback: (_closure, input) => executeConnectionSearch(input as ConnectionSearchInput),
+      closure: {},
+    },
+  });
+  tools["connection_search"] = connectionSearchTool;
 
-export default connectionSearchDynamicDefinition;
+  for (const result of mergedMap.values()) {
+    const connectionName = result.connection;
+    const toolName = result.tool!;
+    const approval = registry.getConnectionApproval(connectionName);
+    const closure = { connectionName, toolName };
+    const discoveredTool = defineTool({
+      description: result.description,
+      inputSchema: (result.inputSchema ?? { type: "object" }) as JsonObject,
+      approval,
+      outputSchema: result.outputSchema as JsonObject | undefined,
+      async execute(input: Record<string, unknown>, executeCtx) {
+        return await executeDiscoveredConnectionTool(closure, input, executeCtx);
+      },
+    });
+    stampDurableDynamicToolCallbacks(discoveredTool, {
+      execute: { callback: executeDiscoveredConnectionTool, closure },
+      ...(approval === undefined
+        ? {}
+        : {
+            approvalRequest: {
+              callback: requestDiscoveredConnectionToolApproval,
+              closure,
+            },
+          }),
+      ...(approval === undefined ||
+      typeof approval === "function" ||
+      approval.response === undefined
+        ? {}
+        : {
+            approvalResponse: {
+              callback: authorizeDiscoveredConnectionToolApproval,
+              closure,
+            },
+          }),
+    });
+    tools[qualifiedConnectionToolName(connectionName, toolName)] = discoveredTool;
+  }
+
+  return tools as DynamicToolSet;
+}
+
+export const CONNECTION_SEARCH_RUNTIME_TOOL_CONTRIBUTOR: RuntimeToolContributor = {
+  eventNames: ["step.started"],
+  ownerId: "eve:framework/connection-search",
+  resolve: ({ messages }) => resolveConnectionSearchTools(messages),
+  sourceId: "eve:connection-search-dynamic",
+};

--- a/packages/eve/src/runtime/framework-tools/index.test.ts
+++ b/packages/eve/src/runtime/framework-tools/index.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   getAllFrameworkToolDefinitions,
   getAllFrameworkToolNames,
-  getFrameworkDynamicToolResolvers,
+  getFrameworkRuntimeToolContributors,
   getFrameworkToolDefinitions,
   getOptInFrameworkToolNames,
 } from "#runtime/framework-tools/index.js";
@@ -26,7 +26,7 @@ describe("framework-tools/index", () => {
     expect(names.has("task_update")).toBe(true);
     expect(names.has("task_sleep")).toBe(false);
     expect(names.has("task_send")).toBe(false);
-    // connection_search is now a dynamic tool resolver, not a framework tool
+    // connection_search is runtime-contributed, not statically registered.
     expect(names.has("connection_search")).toBe(false);
   });
 
@@ -79,11 +79,12 @@ describe("framework-tools/index", () => {
     }
   });
 
-  it("registers connection search through the framework dynamic tool registry", () => {
-    expect(getFrameworkDynamicToolResolvers()).toMatchObject([
+  it("registers connection search through the runtime contribution registry", () => {
+    expect(getFrameworkRuntimeToolContributors()).toMatchObject([
       {
         eventNames: ["step.started"],
         logicalPath: "eve:framework/connection-search-dynamic",
+        ownerId: "eve:framework/connection-search",
         slug: "connection",
         sourceId: "eve:connection-search-dynamic",
       },

--- a/packages/eve/src/runtime/framework-tools/index.ts
+++ b/packages/eve/src/runtime/framework-tools/index.ts
@@ -13,8 +13,7 @@ import { TODO_TOOL_DEFINITION } from "#runtime/framework-tools/todo.js";
 import { WEB_FETCH_TOOL_DEFINITION } from "#runtime/framework-tools/web-fetch.js";
 import { WEB_SEARCH_TOOL_DEFINITION } from "#runtime/framework-tools/web-search.js";
 import { WRITE_FILE_TOOL_DEFINITION } from "#runtime/framework-tools/write-file.js";
-import connectionSearchDynamicDefinition from "#runtime/framework-tools/connection-search-dynamic.js";
-import { resolveLoadedDynamicToolDefinition } from "#runtime/resolve-dynamic-tool.js";
+import { CONNECTION_SEARCH_RUNTIME_TOOL_CONTRIBUTOR } from "#runtime/framework-tools/connection-search-dynamic.js";
 
 export { ConnectionRegistryKey } from "#context/providers/connection-key.js";
 export type { ReadFileStamp, ReadFileState } from "#runtime/framework-tools/file-state.js";
@@ -22,26 +21,21 @@ export { ReadFileStateKey } from "#runtime/framework-tools/file-state.js";
 export type { TodoItem, TodoState } from "#runtime/framework-tools/todo.js";
 export { TodoStateKey } from "#runtime/framework-tools/todo.js";
 
-import type {
-  ResolvedDynamicToolResolver,
-  ResolvedSkillDefinition,
-  ResolvedToolDefinition,
-} from "#runtime/types.js";
-import type { DynamicSentinel } from "#shared/dynamic-tool-definition.js";
+import type { ResolvedSkillDefinition, ResolvedToolDefinition } from "#runtime/types.js";
+import type { RuntimeToolContributor } from "#context/runtime-tool-contribution.js";
 
-interface FrameworkDynamicToolDefinition {
-  readonly definition: DynamicSentinel;
+interface FrameworkRuntimeToolContributor extends RuntimeToolContributor {
   readonly logicalPath: string;
   readonly slug: string;
-  readonly sourceId: string;
+  readonly sourceKind: "module";
 }
 
-const REGISTERED_FRAMEWORK_DYNAMIC_TOOLS: readonly FrameworkDynamicToolDefinition[] = [
+const REGISTERED_FRAMEWORK_RUNTIME_TOOL_CONTRIBUTORS: readonly FrameworkRuntimeToolContributor[] = [
   {
-    definition: connectionSearchDynamicDefinition,
+    ...CONNECTION_SEARCH_RUNTIME_TOOL_CONTRIBUTOR,
     logicalPath: "eve:framework/connection-search-dynamic",
     slug: "connection",
-    sourceId: "eve:connection-search-dynamic",
+    sourceKind: "module",
   },
 ];
 
@@ -72,8 +66,8 @@ const ALL_FRAMEWORK_TOOLS: readonly ResolvedToolDefinition[] = [
  * Returns framework-owned tool definitions registered in the tool registry
  * alongside authored tools during graph resolution.
  *
- * `connection_search` is no longer in this list. The graph resolution path
- * registers it as a framework dynamic tool resolver.
+ * `connection_search` is no longer in this list. The execution lifecycle
+ * supplies it through the runtime-tool contribution seam.
  */
 export function getFrameworkToolDefinitions(config?: {
   readonly authoredSkills?: readonly ResolvedSkillDefinition[];
@@ -89,19 +83,10 @@ export function getFrameworkToolDefinitions(config?: {
 }
 
 /**
- * Returns framework-owned dynamic tool resolvers.
- * Framework definitions use the public `defineDynamic()` contract and enter
- * the same loaded-definition resolver path as authored dynamic tools.
+ * Returns framework-owned runtime-tool contributors used by execution.
  */
-export function getFrameworkDynamicToolResolvers(): readonly ResolvedDynamicToolResolver[] {
-  return REGISTERED_FRAMEWORK_DYNAMIC_TOOLS.map((entry) =>
-    resolveLoadedDynamicToolDefinition(entry.definition, {
-      logicalPath: entry.logicalPath,
-      slug: entry.slug,
-      sourceId: entry.sourceId,
-      sourceKind: "module",
-    }),
-  );
+export function getFrameworkRuntimeToolContributors(): readonly FrameworkRuntimeToolContributor[] {
+  return REGISTERED_FRAMEWORK_RUNTIME_TOOL_CONTRIBUTORS;
 }
 
 /**

--- a/packages/eve/src/runtime/resolve-agent-graph.ts
+++ b/packages/eve/src/runtime/resolve-agent-graph.ts
@@ -16,7 +16,6 @@ import {
 } from "#runtime/framework-channels/index.js";
 import {
   getAllFrameworkToolNames,
-  getFrameworkDynamicToolResolvers,
   getFrameworkToolDefinitions,
 } from "#runtime/framework-tools/index.js";
 import { type ResolvedAgentGraphBundle, ROOT_RUNTIME_AGENT_NODE_ID } from "#runtime/graph.js";
@@ -238,10 +237,7 @@ async function resolveRuntimeAgentNode(
       subagentNodesById: input.subagentNodesById,
     }),
   });
-  const resolvedAgent = {
-    ...agent,
-    dynamicToolResolvers: [...agent.dynamicToolResolvers, ...getFrameworkDynamicToolResolvers()],
-  };
+  const resolvedAgent = agent;
 
   const node: ResolvedAgentGraphBundle["root"] = {
     agent: resolvedAgent,

--- a/packages/eve/test/scenarios/runtime-tool-contribution.scenario.test.ts
+++ b/packages/eve/test/scenarios/runtime-tool-contribution.scenario.test.ts
@@ -1,0 +1,129 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { Client } from "../../src/client/index.js";
+import {
+  type ScenarioAppDescriptor,
+  useScenarioApp,
+} from "../../src/internal/testing/scenario-app.js";
+import { startMcpStubServer } from "../tui-client/lib/mcp-stub-server.js";
+import {
+  DEV_SERVER_SCENARIO_TIMEOUT_MS,
+  TRANSACTIONAL_REBUILD_DESCRIPTOR,
+} from "./dev-server-descriptors.js";
+import { startEveDev, waitForCondition } from "./dev-server-harness.js";
+
+const scenarioApp = useScenarioApp();
+
+const RUNTIME_TOOL_CONTRIBUTION_DESCRIPTOR: ScenarioAppDescriptor = {
+  ...TRANSACTIONAL_REBUILD_DESCRIPTOR,
+  name: "runtime-tool-contribution",
+  files: {
+    ...Object.fromEntries(
+      Object.entries(TRANSACTIONAL_REBUILD_DESCRIPTOR.files).filter(
+        ([path]) => path !== "agent/tools/get_weather.ts" && !path.startsWith("agent/skills/"),
+      ),
+    ),
+    "agent/connections/stub.ts": [
+      'import { defineMcpClientConnection } from "eve/connections";',
+      'import { always } from "eve/tools/approval";',
+      "",
+      "export default defineMcpClientConnection({",
+      '  description: "Scenario MCP connection.",',
+      "  approval: always(),",
+      '  url: process.env.RUNTIME_TOOL_MCP_URL ?? "http://127.0.0.1:0/mcp",',
+      "});",
+      "",
+    ].join("\n"),
+  },
+};
+
+describe("runtime tool contributions", () => {
+  it(
+    "resumes a contributed connection tool approval in a fresh process",
+    async () => {
+      const marker = `runtime-contribution-${Date.now()}`;
+      const mcp = await startMcpStubServer({ marker });
+      const app = await scenarioApp(RUNTIME_TOOL_CONTRIBUTION_DESCRIPTOR);
+      const pinnedEnv = {
+        RUNTIME_TOOL_MCP_URL: mcp.url,
+        VERCEL_DEPLOYMENT_ID: "runtime-tool-contribution",
+        WORKFLOW_INLINE_OWNERSHIP_LEASE_SECONDS: "1",
+      };
+      let server = await startEveDev(app.appRoot, { env: pinnedEnv });
+
+      try {
+        const client = new Client({ host: server.url });
+        const created = await client.sessions.create({ message: "Hello." });
+        await expect(created.response.result()).resolves.toMatchObject({ status: "waiting" });
+
+        const searched = await (
+          await created.session.send(
+            'Use connection_search with keywords "echo marker" to discover the stub tool.',
+          )
+        ).result();
+        expect(searched.status).toBe("waiting");
+        expect(
+          searched.events.some(
+            (event) =>
+              event.type === "action.result" &&
+              event.data.result.kind === "tool-result" &&
+              event.data.result.toolName === "connection_search" &&
+              event.data.status === "completed",
+          ),
+        ).toBe(true);
+
+        const waiting = await (
+          await created.session.send('Use stub__echo_marker with note "cold replay".')
+        ).result();
+        expect(waiting.status).toBe("waiting");
+        expect(waiting.inputRequests).toHaveLength(1);
+
+        const sessionState = created.session.state;
+        await server.crash();
+        await waitForCondition(async () => {
+          try {
+            await readFile(join(app.appRoot, ".eve", "dev-server-state.v1.json"));
+            return false;
+          } catch (error) {
+            return error instanceof Error && "code" in error && error.code === "ENOENT";
+          }
+        }, "The crashed development server did not release its state record.");
+        server = await startEveDev(app.appRoot, { env: pinnedEnv });
+
+        const resumedSession = new Client({ host: server.url }).sessions.attach(
+          sessionState.sessionId,
+          { streamIndex: sessionState.streamIndex },
+        );
+        const resumed = await (
+          await resumedSession.respond([
+            {
+              optionId: "approve",
+              requestId: waiting.inputRequests[0]!.requestId,
+            },
+          ])
+        ).result();
+        expect(resumed.status).toBe("waiting");
+
+        const toolResult = resumed.events.find(
+          (event) =>
+            event.type === "action.result" &&
+            event.data.result.kind === "tool-result" &&
+            event.data.result.toolName === "stub__echo_marker" &&
+            event.data.status === "completed",
+        );
+        expect(toolResult).toBeDefined();
+        if (toolResult?.type !== "action.result" || toolResult.data.result.kind !== "tool-result") {
+          throw new Error("Expected the contributed connection tool result.");
+        }
+        expect(JSON.stringify(toolResult.data.result.output)).toContain(marker);
+      } finally {
+        await server.stop();
+        await mcp.stop();
+      }
+    },
+    DEV_SERVER_SCENARIO_TIMEOUT_MS,
+  );
+});


### PR DESCRIPTION
### Summary

Closes #2347. Framework-owned runtime features had no generic path to contribute tools after ordinary preamble resolution, so `connection_search` registered a synthetic `defineDynamic` resolver and future contributors would have needed to repeat validation, callback capture, replacement, and collision handling. This adds one internal, owner-scoped contribution seam that validates and captures an entire keyed tool set before publishing it, qualifies names once, stores source and runtime-revision provenance, and replaces or removes only that owner's active set through the existing dynamic-tool merge and replay path. `connection_search` now uses the seam, and persisted contributed tools rebind their approval, authorization, execution, and output callbacks after a cold start or runtime revision change. Resumed step events normalize the harness's empty turn sentinel to its canonical sequence-derived identity before durable validation.

No public authoring API changes, and the implementation contains no memory-specific behavior.

### Validation

Focused unit coverage passed with 81 tests, the tool-authorization integration suite passed with 23 tests, the cold-process scenario passed, and the subagent HITL TUI smoke passed. The complete workspace unit suite passed with 7,028 tests, and the workspace build passed. The full integration suite reached 660 passing tests; three sandbox-dependent cancellation cases failed before exercising F3 because the local microsandbox database is missing previously applied migration files, matching the pre-existing environment failure recorded in the implementation plan.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Patch changeset describing the observable durability and lifecycle guarantee.

**Implementation** — 12 files · `+764 / -169`

The generic contribution transaction and execution lifecycle own most of this category. The remaining changes migrate `connection_search` off its synthetic resolver and wire contributed metadata into the existing dynamic-tool replay, agent-info, and graph-resolution paths.

**Tests** — 4 files · `+578 / -53`

Focused unit coverage exercises atomic capture, qualification, owner replacement and removal, collisions, scope precedence, revision cleanup, packaged callback rehydration, and resumed-turn coordinate normalization. The cold-process scenario proves that a parked contributed tool resumes through the original callbacks after restart.
