### PR TITLE
chore(eve): dynamic tools - centralize runtime contributions

### DIFF
--- a/.changeset/runtime-tool-contributions.md
+++ b/.changeset/runtime-tool-contributions.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Dynamic tools contributed by framework runtime code (starting with `connection_search`) now flow through one owner-scoped contribution path that validates entries, captures callbacks durably, replaces each contributor's tool set atomically per lifecycle boundary, and cleans up contributors removed by a redeploy — instead of each feature re-implementing dynamic resolution.

--- a/packages/eve/src/context/durable-dynamic-tool-metadata.ts
+++ b/packages/eve/src/context/durable-dynamic-tool-metadata.ts
@@ -1,0 +1,154 @@
+import type {
+  DurableDynamicToolMetadata,
+  RuntimeToolContributionProvenance,
+} from "#context/keys.js";
+import type { DynamicToolEntry } from "#shared/dynamic-tool-definition.js";
+import {
+  registerDurableDynamicCallback,
+  readDurableDynamicToolCallbacks,
+  type DurableDynamicCallbackPhase,
+  type DurableDynamicCallbackReference,
+  type DurableDynamicToolCallbacks,
+  type StampedDurableDynamicCallback,
+} from "#shared/durable-dynamic-tool-callbacks.js";
+import { toErrorMessage } from "#shared/errors.js";
+import { parseJsonObject } from "#shared/json.js";
+import { serializeInputSchema, serializeOutputSchema } from "#shared/tool-schema.js";
+
+/**
+ * Shared construction/validation for durable dynamic tool metadata. Kept
+ * separate from the authored-resolver lifecycle so runtime tool
+ * contributions can build identical metadata without importing the
+ * lifecycle module.
+ */
+
+function validateReference(input: {
+  readonly name: string;
+  readonly phase: DurableDynamicCallbackPhase;
+  readonly stamped: StampedDurableDynamicCallback | undefined;
+  readonly required: boolean;
+}): DurableDynamicCallbackReference | undefined {
+  if (input.stamped === undefined) {
+    if (input.required) {
+      throw new Error(
+        `Dynamic tool "${input.name}" callback "${input.phase}" does not have a durable descriptor. ` +
+          "Author the callback inline in transformed source or use an eve durable callback helper.",
+      );
+    }
+    return undefined;
+  }
+  const unknownKeys = Object.keys(input.stamped).filter(
+    (key) => key !== "closure" && key !== "callback",
+  );
+  if (unknownKeys.includes("stepId")) {
+    throw new Error(
+      `Dynamic tool "${input.name}" callback "${input.phase}" was persisted by a pre-release eve ` +
+        "version that identified callbacks by build offset. Start a new session to re-resolve it.",
+    );
+  }
+  if (unknownKeys.length > 0) {
+    throw new Error(
+      `Dynamic tool "${input.name}" has invalid ${input.phase} callback metadata: unknown key(s) ${unknownKeys.join(", ")}.`,
+    );
+  }
+  if (typeof input.stamped.callback !== "function") {
+    throw new Error(
+      `Dynamic tool "${input.name}" callback "${input.phase}" does not have a durable descriptor. ` +
+        "Author the callback inline in transformed source or use an eve durable callback helper.",
+    );
+  }
+  let closure: DurableDynamicCallbackReference["closure"];
+  try {
+    closure = parseJsonObject(input.stamped.closure);
+  } catch (error) {
+    throw new Error(
+      `Dynamic tool "${input.name}" callback "${input.phase}" has a non-serializable capture. ${toErrorMessage(error)}`,
+    );
+  }
+  registerDurableDynamicCallback({
+    callback: input.stamped.callback,
+    phase: input.phase,
+    toolName: input.name,
+  });
+  return { closure };
+}
+
+export function validateDurableDynamicToolCallbacks(
+  name: string,
+  entry: DynamicToolEntry,
+): DurableDynamicToolCallbacks {
+  const raw = readDurableDynamicToolCallbacks(entry) ?? {};
+  const unknownPhases = Object.keys(raw).filter(
+    (key) =>
+      key !== "execute" &&
+      key !== "approvalRequest" &&
+      key !== "approvalResponse" &&
+      key !== "toModelOutput",
+  );
+  if (unknownPhases.length > 0) {
+    throw new Error(
+      `Dynamic tool "${name}" has unknown durable callback phase(s): ${unknownPhases.join(", ")}.`,
+    );
+  }
+
+  const hasApproval = entry.approval !== undefined;
+  const hasApprovalResponse =
+    entry.approval !== undefined &&
+    typeof entry.approval !== "function" &&
+    entry.approval.response !== undefined;
+  const execute = validateReference({
+    name,
+    phase: "execute",
+    stamped: raw.execute,
+    required: true,
+  })!;
+  const approvalRequest = validateReference({
+    name,
+    phase: "approvalRequest",
+    stamped: raw.approvalRequest,
+    required: hasApproval,
+  });
+  const approvalResponse = validateReference({
+    name,
+    phase: "approvalResponse",
+    stamped: raw.approvalResponse,
+    required: hasApprovalResponse,
+  });
+  const toModelOutput = validateReference({
+    name,
+    phase: "toModelOutput",
+    stamped: raw.toModelOutput,
+    required: entry.toModelOutput !== undefined,
+  });
+
+  const callbacks: {
+    execute: DurableDynamicCallbackReference;
+    approvalRequest?: DurableDynamicCallbackReference;
+    approvalResponse?: DurableDynamicCallbackReference;
+    toModelOutput?: DurableDynamicCallbackReference;
+  } = { execute };
+  if (approvalRequest !== undefined) callbacks.approvalRequest = approvalRequest;
+  if (approvalResponse !== undefined) callbacks.approvalResponse = approvalResponse;
+  if (toModelOutput !== undefined) callbacks.toModelOutput = toModelOutput;
+  return callbacks;
+}
+
+export function createDurableDynamicToolMetadata(input: {
+  readonly entry: DynamicToolEntry;
+  readonly entryKey: string;
+  readonly name: string;
+  readonly resolverSlug: string;
+  readonly provenance?: RuntimeToolContributionProvenance;
+}): DurableDynamicToolMetadata {
+  const metadata = {
+    callbacks: validateDurableDynamicToolCallbacks(input.name, input.entry),
+    description: input.entry.description,
+    entryKey: input.entryKey,
+    inputSchema: serializeInputSchema(input.entry.inputSchema),
+    name: input.name,
+    outputSchema: serializeOutputSchema(input.entry.outputSchema),
+    resolverSlug: input.resolverSlug,
+  };
+  if (input.provenance === undefined) return metadata;
+  return { ...metadata, contribution: input.provenance };
+}

--- a/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
@@ -19,8 +19,9 @@ const {
   replayDynamicSessionTools,
   dispatchDynamicToolEvent,
   refreshDynamicSessionToolsForRuntimeRevision,
-  validateDurableDynamicToolCallbacks,
 } = await import("#context/dynamic-tool-lifecycle.js");
+const { validateDurableDynamicToolCallbacks } =
+  await import("#context/durable-dynamic-tool-metadata.js");
 const { buildDynamicTools, buildResponseAuthorizationTools } =
   await import("#context/build-dynamic-tools.js");
 

--- a/packages/eve/src/context/dynamic-tool-lifecycle.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.ts
@@ -1,13 +1,16 @@
 import type { ModelMessage } from "ai";
 
+import {
+  applyRuntimeToolContributions,
+  durableKeyForEvent,
+} from "#context/runtime-tool-contribution.js";
+import { createDurableDynamicToolMetadata } from "#context/durable-dynamic-tool-metadata.js";
 import { replayDynamicTools } from "#context/build-dynamic-tools.js";
 import type { ContextContainer } from "#context/container.js";
-import type { ContextKey } from "#context/key.js";
 import {
   SessionDynamicToolMetadataKey,
   SessionDynamicToolRuntimeRevisionKey,
   StepDynamicToolMetadataKey,
-  TurnDynamicToolMetadataKey,
   type DurableDynamicToolMetadata,
 } from "#context/keys.js";
 import { buildResolveContext } from "#context/dynamic-resolve-context.js";
@@ -19,18 +22,8 @@ import {
   ALLOWED_DYNAMIC_TOOL_EVENTS,
   isBrandedToolEntry,
 } from "#shared/dynamic-tool-definition.js";
-import {
-  hasUnregisteredDurableDynamicCallbacks,
-  type DurableDynamicCallbackPhase,
-  type DurableDynamicCallbackReference,
-  type DurableDynamicToolCallbacks,
-  type StampedDurableDynamicCallback,
-  readDurableDynamicToolCallbacks,
-  registerDurableDynamicCallback,
-} from "#shared/durable-dynamic-tool-callbacks.js";
+import { hasUnregisteredDurableDynamicCallbacks } from "#shared/durable-dynamic-tool-callbacks.js";
 import { toErrorMessage } from "#shared/errors.js";
-import { parseJsonObject } from "#shared/json.js";
-import { serializeInputSchema, serializeOutputSchema } from "#shared/tool-schema.js";
 import type { ResolvedDynamicToolResolver } from "#runtime/types.js";
 
 const log = createLogger("dynamic-tools");
@@ -64,21 +57,6 @@ export function replayDynamicSessionTools(
   return replayDynamicTools(metadata);
 }
 
-function durableKeyForEvent(
-  eventType: string,
-): ContextKey<readonly DurableDynamicToolMetadata[]> | undefined {
-  switch (eventType) {
-    case "session.started":
-      return SessionDynamicToolMetadataKey;
-    case "turn.started":
-      return TurnDynamicToolMetadataKey;
-    case "step.started":
-      return StepDynamicToolMetadataKey;
-    default:
-      return undefined;
-  }
-}
-
 function readDynamicToolResult(
   resolver: ResolvedDynamicToolResolver,
   value: unknown,
@@ -104,134 +82,6 @@ function readDynamicToolResult(
   return { entries, isSingle: false };
 }
 
-function validateReference(input: {
-  readonly name: string;
-  readonly phase: DurableDynamicCallbackPhase;
-  readonly stamped: StampedDurableDynamicCallback | undefined;
-  readonly required: boolean;
-}): DurableDynamicCallbackReference | undefined {
-  if (input.stamped === undefined) {
-    if (input.required) {
-      throw new Error(
-        `Dynamic tool "${input.name}" callback "${input.phase}" does not have a durable descriptor. ` +
-          "Author the callback inline in transformed source or use an eve durable callback helper.",
-      );
-    }
-    return undefined;
-  }
-  const unknownKeys = Object.keys(input.stamped).filter(
-    (key) => key !== "closure" && key !== "callback",
-  );
-  if (unknownKeys.includes("stepId")) {
-    throw new Error(
-      `Dynamic tool "${input.name}" callback "${input.phase}" was persisted by a pre-release eve ` +
-        "version that identified callbacks by build offset. Start a new session to re-resolve it.",
-    );
-  }
-  if (unknownKeys.length > 0) {
-    throw new Error(
-      `Dynamic tool "${input.name}" has invalid ${input.phase} callback metadata: unknown key(s) ${unknownKeys.join(", ")}.`,
-    );
-  }
-  if (typeof input.stamped.callback !== "function") {
-    throw new Error(
-      `Dynamic tool "${input.name}" callback "${input.phase}" does not have a durable descriptor. ` +
-        "Author the callback inline in transformed source or use an eve durable callback helper.",
-    );
-  }
-  let closure: DurableDynamicCallbackReference["closure"];
-  try {
-    closure = parseJsonObject(input.stamped.closure);
-  } catch (error) {
-    throw new Error(
-      `Dynamic tool "${input.name}" callback "${input.phase}" has a non-serializable capture. ${toErrorMessage(error)}`,
-    );
-  }
-  registerDurableDynamicCallback({
-    callback: input.stamped.callback,
-    phase: input.phase,
-    toolName: input.name,
-  });
-  return { closure };
-}
-
-export function validateDurableDynamicToolCallbacks(
-  name: string,
-  entry: DynamicToolEntry,
-): DurableDynamicToolCallbacks {
-  const raw = readDurableDynamicToolCallbacks(entry) ?? {};
-  const unknownPhases = Object.keys(raw).filter(
-    (key) =>
-      key !== "execute" &&
-      key !== "approvalRequest" &&
-      key !== "approvalResponse" &&
-      key !== "toModelOutput",
-  );
-  if (unknownPhases.length > 0) {
-    throw new Error(
-      `Dynamic tool "${name}" has unknown durable callback phase(s): ${unknownPhases.join(", ")}.`,
-    );
-  }
-
-  const hasApproval = entry.approval !== undefined;
-  const hasApprovalResponse =
-    entry.approval !== undefined &&
-    typeof entry.approval !== "function" &&
-    entry.approval.response !== undefined;
-  const execute = validateReference({
-    name,
-    phase: "execute",
-    stamped: raw.execute,
-    required: true,
-  })!;
-  const approvalRequest = validateReference({
-    name,
-    phase: "approvalRequest",
-    stamped: raw.approvalRequest,
-    required: hasApproval,
-  });
-  const approvalResponse = validateReference({
-    name,
-    phase: "approvalResponse",
-    stamped: raw.approvalResponse,
-    required: hasApprovalResponse,
-  });
-  const toModelOutput = validateReference({
-    name,
-    phase: "toModelOutput",
-    stamped: raw.toModelOutput,
-    required: entry.toModelOutput !== undefined,
-  });
-
-  const callbacks: {
-    execute: DurableDynamicCallbackReference;
-    approvalRequest?: DurableDynamicCallbackReference;
-    approvalResponse?: DurableDynamicCallbackReference;
-    toModelOutput?: DurableDynamicCallbackReference;
-  } = { execute };
-  if (approvalRequest !== undefined) callbacks.approvalRequest = approvalRequest;
-  if (approvalResponse !== undefined) callbacks.approvalResponse = approvalResponse;
-  if (toModelOutput !== undefined) callbacks.toModelOutput = toModelOutput;
-  return callbacks;
-}
-
-function createMetadata(input: {
-  readonly entry: DynamicToolEntry;
-  readonly entryKey: string;
-  readonly name: string;
-  readonly resolver: ResolvedDynamicToolResolver;
-}): DurableDynamicToolMetadata {
-  return {
-    callbacks: validateDurableDynamicToolCallbacks(input.name, input.entry),
-    description: input.entry.description,
-    entryKey: input.entryKey,
-    inputSchema: serializeInputSchema(input.entry.inputSchema),
-    name: input.name,
-    outputSchema: serializeOutputSchema(input.entry.outputSchema),
-    resolverSlug: input.resolver.slug,
-  };
-}
-
 interface ResolvedDynamicToolEvent {
   readonly metadata: readonly DurableDynamicToolMetadata[];
 }
@@ -252,7 +102,12 @@ async function resolveToolsFromEvent(
       const named = qualifyDynamicToolNames(resolver, isSingle, entries);
       return {
         metadata: named.map(({ name, entryKey, entry }) =>
-          createMetadata({ entry, entryKey, name, resolver }),
+          createDurableDynamicToolMetadata({
+            entry,
+            entryKey,
+            name,
+            resolverSlug: resolver.slug,
+          }),
         ),
         resolver,
       };
@@ -316,8 +171,17 @@ export async function resolveStepDynamicTools(input: {
     matching.length === 0
       ? { metadata: [] }
       : await resolveToolsFromEvent(input.ctx, matching, input.event, input.messages);
-  input.ctx.set(StepDynamicToolMetadataKey, metadata);
-  if (coordinate !== undefined) resolvedStepTools.set(input.ctx, { coordinate, metadata });
+  const finalMetadata = await applyRuntimeToolContributions({
+    ctx: input.ctx,
+    event: input.event,
+    messages: input.messages,
+    resolverMetadata: metadata,
+    replacesResolverEntries: "all",
+    runtimeRevision: input.ctx.get(SessionDynamicToolRuntimeRevisionKey) ?? "",
+  });
+  input.ctx.set(StepDynamicToolMetadataKey, finalMetadata);
+  if (coordinate !== undefined)
+    resolvedStepTools.set(input.ctx, { coordinate, metadata: finalMetadata });
 }
 
 export async function dispatchDynamicToolEvent(input: {
@@ -344,12 +208,30 @@ export async function dispatchDynamicToolEvent(input: {
   if (durableKey === undefined) return;
 
   if (input.event.type === "session.started") {
-    input.ctx.set(SessionDynamicToolMetadataKey, metadata);
+    input.ctx.set(
+      SessionDynamicToolMetadataKey,
+      await applyRuntimeToolContributions({
+        ctx: input.ctx,
+        event: input.event,
+        messages: input.messages,
+        resolverMetadata: metadata,
+        replacesResolverEntries: "all",
+        runtimeRevision: input.ctx.get(SessionDynamicToolRuntimeRevisionKey) ?? "",
+      }),
+    );
     return;
   }
-  const slugs = new Set(matching.map((resolver) => resolver.slug));
-  const kept = (input.ctx.get(durableKey) ?? []).filter((entry) => !slugs.has(entry.resolverSlug));
-  input.ctx.set(durableKey, [...kept, ...metadata]);
+  input.ctx.set(
+    durableKey,
+    await applyRuntimeToolContributions({
+      ctx: input.ctx,
+      event: input.event,
+      messages: input.messages,
+      resolverMetadata: metadata,
+      replacesResolverEntries: new Set(matching.map((resolver) => resolver.slug)),
+      runtimeRevision: input.ctx.get(SessionDynamicToolRuntimeRevisionKey) ?? "",
+    }),
+  );
 }
 
 /**
@@ -377,6 +259,18 @@ export async function refreshDynamicSessionToolsForRuntimeRevision(input: {
     matching.length === 0
       ? { metadata: [] }
       : await resolveToolsFromEvent(input.ctx, matching, input.event, input.messages);
-  input.ctx.set(SessionDynamicToolMetadataKey, metadata);
+  // Re-running the contribution pass re-registers persisted contributed
+  // callbacks in this process and drops contributors the revision removed.
+  input.ctx.set(
+    SessionDynamicToolMetadataKey,
+    await applyRuntimeToolContributions({
+      ctx: input.ctx,
+      event: input.event,
+      messages: input.messages,
+      resolverMetadata: metadata,
+      replacesResolverEntries: "all",
+      runtimeRevision: input.runtimeRevision,
+    }),
+  );
   input.ctx.set(SessionDynamicToolRuntimeRevisionKey, input.runtimeRevision);
 }

--- a/packages/eve/src/context/keys.ts
+++ b/packages/eve/src/context/keys.ts
@@ -162,8 +162,22 @@ export interface DurableDynamicToolMetadata {
   readonly description: string;
   readonly inputSchema: JsonObject;
   readonly outputSchema?: JsonObject;
+  /**
+   * Owner identity used for replacement and collision detection. Authored
+   * dynamic tools carry their resolver slug; runtime-contributed tools carry
+   * their contribution owner id.
+   */
   readonly resolverSlug: string;
   readonly entryKey: string;
+  /** Present only when the entry was contributed by runtime code rather than an authored dynamic resolver. */
+  readonly contribution?: RuntimeToolContributionProvenance;
+}
+
+/** Provenance recorded for tools contributed through the runtime contribution seam. */
+export interface RuntimeToolContributionProvenance {
+  readonly ownerId: string;
+  readonly runtimeRevision: string;
+  readonly sourceId: string;
 }
 
 /**

--- a/packages/eve/src/context/runtime-tool-contribution.test.ts
+++ b/packages/eve/src/context/runtime-tool-contribution.test.ts
@@ -1,0 +1,568 @@
+import { jsonSchema } from "ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("#context/build-callback-context.js", () => ({
+  buildCallbackContext: () => ({
+    session: { id: "test", auth: { current: null, initiator: null }, turn: {} },
+  }),
+}));
+
+// Import after mock so the module picks up the mock
+const { contributeRuntimeTools, registerRuntimeToolContributor } =
+  await import("#context/runtime-tool-contribution.js");
+const { dispatchDynamicToolEvent, refreshDynamicSessionToolsForRuntimeRevision } =
+  await import("#context/dynamic-tool-lifecycle.js");
+const { buildDynamicTools, buildResponseAuthorizationTools } =
+  await import("#context/build-dynamic-tools.js");
+
+import { ContextContainer } from "#context/container.js";
+import type { HarnessToolDefinition } from "#harness/execute-tool.js";
+import type { DurableDynamicToolMetadata } from "#context/keys.js";
+import {
+  SessionDynamicToolMetadataKey,
+  SessionDynamicToolRuntimeRevisionKey,
+  TurnDynamicToolMetadataKey,
+} from "#context/keys.js";
+import { defineTool } from "#public/definitions/tool.js";
+import type { DynamicToolEntry, DynamicToolSet } from "#shared/dynamic-tool-definition.js";
+import { stampDurableDynamicToolCallbacks } from "#shared/durable-dynamic-tool-callbacks.js";
+import { createSessionStartedEvent, type UnstampedMessageStreamEvent } from "#protocol/message.js";
+
+import { SessionIdKey } from "#context/keys.js";
+
+const CONTRIBUTOR_REGISTRY = Symbol.for("eve:runtime-tool-contributors");
+
+function resetContributors(): void {
+  (globalThis as Record<symbol, unknown[]>)[CONTRIBUTOR_REGISTRY] = [];
+}
+
+let contextCounter = 0;
+function createCtx(sessionId = `test-session-${++contextCounter}`): ContextContainer {
+  const ctx = new ContextContainer();
+  ctx.set(SessionIdKey, sessionId);
+  ctx.set(SessionDynamicToolRuntimeRevisionKey, "deployment:test");
+  return ctx;
+}
+
+function makeEvent(type: string): UnstampedMessageStreamEvent {
+  return { type, data: {} } as UnstampedMessageStreamEvent;
+}
+
+const executeOptions = { messages: [], toolCallId: "call_1" };
+
+function createReplayableTool(
+  description = "stub",
+  executeFn: (input: Record<string, unknown>) => unknown = () => ({ ok: true }),
+): DynamicToolEntry {
+  const entry = defineTool({
+    description,
+    inputSchema: { type: "object" },
+    execute: async (input: Record<string, unknown>): Promise<unknown> => executeFn(input),
+  });
+  stampDurableDynamicToolCallbacks(entry, {
+    execute: {
+      callback: (_closure, input) => executeFn(input as Record<string, unknown>),
+      closure: {},
+    },
+  });
+  return entry;
+}
+
+interface TestContributorOptions {
+  readonly ownerId: string;
+  readonly eventNames?: readonly ("session.started" | "turn.started" | "step.started")[];
+  readonly prefix?: string;
+  readonly tools:
+    | DynamicToolSet
+    | null
+    | (() => DynamicToolSet | null | Promise<DynamicToolSet | null>);
+}
+
+function registerTestContributor(options: TestContributorOptions): void {
+  const compute = options.tools;
+  registerRuntimeToolContributor({
+    ownerId: options.ownerId,
+    slug: options.ownerId,
+    logicalPath: `eve:${options.ownerId}`,
+    sourceId: `eve:${options.ownerId}`,
+    sourceKind: "module",
+    eventNames: options.eventNames ?? ["turn.started"],
+    contribute: () => (typeof compute === "function" ? compute() : compute),
+  });
+}
+
+afterEach(() => {
+  resetContributors();
+});
+
+describe("contributeRuntimeTools", () => {
+  it("publishes a keyed branded tool through the same durable capture as authored dynamic tools", async () => {
+    const ctx = createCtx();
+    contributeRuntimeTools({
+      coordinate: { event: "turn.started" },
+      ctx,
+      ownerId: "eve.test",
+      runtimeRevision: "deployment:r1",
+      sourceId: "eve:test",
+      tools: { greet: createReplayableTool("hello tool") },
+    });
+
+    const metadata = ctx.get(TurnDynamicToolMetadataKey) ?? [];
+    expect(metadata).toHaveLength(1);
+    expect(metadata[0]).toMatchObject({
+      contribution: {
+        ownerId: "eve.test",
+        runtimeRevision: "deployment:r1",
+        sourceId: "eve:test",
+      },
+      name: "greet",
+      resolverSlug: "eve.test",
+    });
+    const [tool] = buildDynamicTools(ctx);
+    expect(tool!.name).toBe("greet");
+    await expect(tool!.execute!({}, executeOptions)).resolves.toEqual({ ok: true });
+  });
+
+  it("qualifies names exactly once through the qualification prefix", () => {
+    const ctx = createCtx();
+    contributeRuntimeTools({
+      coordinate: { event: "turn.started" },
+      ctx,
+      ownerId: "eve.memory",
+      qualificationPrefix: "notes",
+      runtimeRevision: "deployment:r1",
+      sourceId: "eve:memory",
+      tools: { save_memory: createReplayableTool(), remove_memory: createReplayableTool() },
+    });
+
+    expect((ctx.get(TurnDynamicToolMetadataKey) ?? []).map((entry) => entry.name)).toEqual([
+      "notes__save_memory",
+      "notes__remove_memory",
+    ]);
+  });
+
+  it("lets two owners qualify the same local name without collision", () => {
+    const ctx = createCtx();
+    for (const ownerId of ["eve.one", "eve.two"]) {
+      contributeRuntimeTools({
+        coordinate: { event: "turn.started" },
+        ctx,
+        ownerId,
+        qualificationPrefix: ownerId.replace("eve.", ""),
+        runtimeRevision: "deployment:r1",
+        sourceId: `eve:${ownerId}`,
+        tools: { save: createReplayableTool() },
+      });
+    }
+
+    expect((ctx.get(TurnDynamicToolMetadataKey) ?? []).map((entry) => entry.name)).toEqual([
+      "one__save",
+      "two__save",
+    ]);
+  });
+
+  it("replaces an owner's active set while other owners remain", () => {
+    const ctx = createCtx();
+    contributeRuntimeTools({
+      coordinate: { event: "turn.started" },
+      ctx,
+      ownerId: "a",
+      runtimeRevision: "r",
+      sourceId: "a",
+      tools: { old_tool: createReplayableTool("v1") },
+    });
+    contributeRuntimeTools({
+      coordinate: { event: "turn.started" },
+      ctx,
+      ownerId: "b",
+      runtimeRevision: "r",
+      sourceId: "b",
+      tools: { b_tool: createReplayableTool("b") },
+    });
+
+    contributeRuntimeTools({
+      coordinate: { event: "turn.started" },
+      ctx,
+      ownerId: "a",
+      runtimeRevision: "r2",
+      sourceId: "a",
+      tools: { new_tool_a: createReplayableTool("v2"), new_tool_b: createReplayableTool("v3") },
+    });
+
+    expect((ctx.get(TurnDynamicToolMetadataKey) ?? []).map((entry) => entry.name)).toEqual([
+      "b_tool",
+      "new_tool_a",
+      "new_tool_b",
+    ]);
+  });
+
+  it("removes only the owner's prior contribution for null and for an empty map", () => {
+    const ctx = createCtx();
+    const base = {
+      coordinate: { event: "turn.started" } as const,
+      ctx,
+      runtimeRevision: "r",
+    };
+    contributeRuntimeTools({
+      ...base,
+      ownerId: "a",
+      sourceId: "a",
+      tools: { a: createReplayableTool() },
+    });
+    contributeRuntimeTools({
+      ...base,
+      ownerId: "b",
+      sourceId: "b",
+      tools: { b: createReplayableTool() },
+    });
+
+    contributeRuntimeTools({ ...base, ownerId: "a", sourceId: "a", tools: null });
+    expect((ctx.get(TurnDynamicToolMetadataKey) ?? []).map((entry) => entry.name)).toEqual(["b"]);
+
+    contributeRuntimeTools({ ...base, ownerId: "b", sourceId: "b", tools: {} });
+    expect(ctx.get(TurnDynamicToolMetadataKey)).toEqual([]);
+  });
+
+  it("rejects a lone branded tool, unbranded values, and invalid inputs without publishing", () => {
+    const ctx = createCtx();
+    const base = {
+      coordinate: { event: "turn.started" } as const,
+      ctx,
+      ownerId: "a",
+      runtimeRevision: "r",
+      sourceId: "a",
+    };
+
+    // A lone branded tool passed instead of a keyed map.
+    const loneBranded = createReplayableTool() as never;
+    expect(() => contributeRuntimeTools({ ...base, tools: loneBranded })).toThrow(/keyed map/);
+    expect(() =>
+      contributeRuntimeTools({
+        ...base,
+        tools: {
+          bad: {
+            description: "no brand",
+            inputSchema: { type: "object" },
+            execute: () => null,
+          } as DynamicToolEntry,
+        },
+      }),
+    ).toThrow(/defineTool/);
+    expect(() => contributeRuntimeTools({ ...base, ownerId: "", tools: null })).toThrow(/ownerId/);
+    expect(ctx.get(TurnDynamicToolMetadataKey)).toBeUndefined();
+  });
+});
+
+describe("dispatched runtime contributions", () => {
+  it("runs registered contributors at their declared events and publishes their tools", async () => {
+    const ctx = createCtx();
+    registerTestContributor({
+      ownerId: "eve.search",
+      tools: { connection_search: createReplayableTool("search") },
+    });
+
+    await dispatchDynamicToolEvent({
+      ctx,
+      event: makeEvent("turn.started"),
+      messages: [],
+      resolvers: [],
+    });
+
+    const built = buildDynamicTools(ctx);
+    expect(built.map((tool) => tool.name)).toEqual(["connection_search"]);
+    await expect(built[0]!.execute!({}, executeOptions)).resolves.toEqual({ ok: true });
+  });
+
+  it("captures every valid entry when another owner fails validation", async () => {
+    const ctx = createCtx();
+    registerTestContributor({
+      ownerId: "a",
+      tools: () => ({
+        good: createReplayableTool("good"),
+        bad: {
+          description: "unbranded",
+          inputSchema: { type: "object" },
+          execute: () => null,
+        } as DynamicToolEntry,
+      }),
+    });
+    registerTestContributor({ ownerId: "b", tools: { b_tool: createReplayableTool("b") } });
+
+    await dispatchDynamicToolEvent({
+      ctx,
+      event: makeEvent("turn.started"),
+      messages: [],
+      resolvers: [],
+    });
+
+    // Owner A failed wholesale: no partial A set becomes callable.
+    expect(buildDynamicTools(ctx).map((tool) => tool.name)).toEqual(["b_tool"]);
+  });
+
+  it("fails the operation when two owners collide on one qualified name", async () => {
+    const ctx = createCtx();
+    registerTestContributor({
+      ownerId: "a",
+      prefix: "same",
+      tools: { x: createReplayableTool() },
+    });
+    registerTestContributor({
+      ownerId: "b",
+      prefix: "same",
+      tools: { x: createReplayableTool() },
+    });
+
+    await expect(
+      dispatchDynamicToolEvent({
+        ctx,
+        event: makeEvent("turn.started"),
+        messages: [],
+        resolvers: [],
+      }),
+    ).rejects.toThrow(/collides/);
+  });
+
+  it("keeps narrower scopes ahead of wider ones for same-name tools", async () => {
+    const ctx = createCtx();
+    registerRuntimeToolContributor({
+      ownerId: "session-owner",
+      slug: "session-owner",
+      logicalPath: "eve:session-owner",
+      sourceId: "session-owner",
+      sourceKind: "module",
+      eventNames: ["session.started"],
+      contribute: () => ({ shared: createReplayableTool("session") }),
+    });
+    registerRuntimeToolContributor({
+      ownerId: "step-owner",
+      slug: "step-owner",
+      logicalPath: "eve:step-owner",
+      sourceId: "step-owner",
+      sourceKind: "module",
+      eventNames: ["step.started"],
+      contribute: () => ({ shared: createReplayableTool("step") }),
+    });
+
+    await dispatchDynamicToolEvent({
+      ctx,
+      event: makeEvent("session.started"),
+      messages: [],
+      resolvers: [],
+    });
+    await dispatchDynamicToolEvent({
+      ctx,
+      event: makeEvent("step.started"),
+      messages: [],
+      resolvers: [],
+    });
+
+    const built = buildDynamicTools(ctx);
+    const stepIndex = built.findIndex((tool) => tool.description === "step");
+    const sessionIndex = built.findIndex((tool) => tool.description === "session");
+    expect(stepIndex).toBeGreaterThanOrEqual(0);
+    expect(sessionIndex).toBeGreaterThan(stepIndex);
+    expect(built.filter((tool) => tool.name === "shared")).toHaveLength(2);
+  });
+
+  it("replaces authored static tools on name collision, following the established precedence", async () => {
+    const ctx = createCtx();
+    registerTestContributor({
+      ownerId: "a",
+      tools: () => ({ authored_name: createReplayableTool("dynamic winner") }),
+    });
+    await dispatchDynamicToolEvent({
+      ctx,
+      event: makeEvent("turn.started"),
+      messages: [],
+      resolvers: [],
+    });
+
+    const authoredTools = new Map([
+      [
+        "authored_name",
+        {
+          description: "authored loser",
+          inputSchema: jsonSchema({ type: "object" }),
+          name: "authored_name",
+        } as HarnessToolDefinition,
+      ],
+    ]);
+    const merged = buildResponseAuthorizationTools({ authoredTools, context: ctx });
+    expect(merged.get("authored_name")!.description).toBe("dynamic winner");
+  });
+
+  it("retains contributed tools in cached step resolution across repeated coordinates", async () => {
+    const ctx = createCtx();
+    let calls = 0;
+    registerRuntimeToolContributor({
+      ownerId: "stepper",
+      slug: "stepper",
+      logicalPath: "eve:stepper",
+      sourceId: "stepper",
+      sourceKind: "module",
+      eventNames: ["step.started"],
+      contribute: () => {
+        calls += 1;
+        return { stepped: createReplayableTool("stepped") };
+      },
+    });
+
+    const event = {
+      data: { stepIndex: 0, turnId: "turn-1" },
+      type: "step.started",
+    } as UnstampedMessageStreamEvent;
+    await dispatchDynamicToolEvent({ ctx, event, messages: [], resolvers: [] });
+    await dispatchDynamicToolEvent({ ctx, event, messages: [], resolvers: [] });
+
+    // The second dispatch replays the cached coordinate without re-running contributors.
+    expect(calls).toBe(1);
+    expect(buildDynamicTools(ctx).map((tool) => tool.name)).toEqual(["stepped"]);
+  });
+
+  it("rebinds contributed callbacks after a simulated cold start", async () => {
+    const ctx = createCtx();
+    registerTestContributor({ ownerId: "a", tools: { cold: createReplayableTool("cold") } });
+    await dispatchDynamicToolEvent({
+      ctx,
+      event: makeEvent("turn.started"),
+      messages: [],
+      resolvers: [],
+    });
+
+    const registryGlobal = globalThis as Record<
+      symbol,
+      Map<string, Map<string, unknown>> | undefined
+    >;
+    const callbackRegistry = registryGlobal[Symbol.for("eve:dynamic-tool-callbacks")]!;
+    callbackRegistry.delete("cold");
+
+    // Replay fails closed while the binding is missing…
+    const [missing] = buildDynamicTools(ctx);
+    await expect(missing!.execute!({}, executeOptions)).rejects.toThrow(/cannot replay/);
+
+    // …and the next boundary re-runs the contributor, restoring the binding.
+    await dispatchDynamicToolEvent({
+      ctx,
+      event: makeEvent("turn.started"),
+      messages: [],
+      resolvers: [],
+    });
+    const [restored] = buildDynamicTools(ctx);
+    await expect(restored!.execute!({}, executeOptions)).resolves.toEqual({ ok: true });
+  });
+
+  it("round-trips contribution provenance through context serialization", async () => {
+    const ctx = createCtx();
+    registerTestContributor({
+      ownerId: "eve.search",
+      tools: { persisted_tool: createReplayableTool("persisted") },
+    });
+    await dispatchDynamicToolEvent({
+      ctx,
+      event: makeEvent("turn.started"),
+      messages: [],
+      resolvers: [],
+    });
+
+    const { deserializeContext, serializeContext } = await import("#context/serialize.js");
+    const restored = await deserializeContext(serializeContext(ctx));
+
+    const metadata = restored.get(TurnDynamicToolMetadataKey) ?? [];
+    expect(metadata).toHaveLength(1);
+    expect(metadata[0]).toMatchObject({
+      contribution: {
+        ownerId: "eve.search",
+        runtimeRevision: "deployment:test",
+        sourceId: "eve:eve.search",
+      },
+      name: "persisted_tool",
+    });
+  });
+
+  it("cleans a contributor removed by a runtime revision during session refresh", async () => {
+    const ctx = createCtx();
+    registerRuntimeToolContributor({
+      ownerId: "staying-owner",
+      slug: "staying-owner",
+      logicalPath: "eve:staying-owner",
+      sourceId: "staying-owner",
+      sourceKind: "module",
+      eventNames: ["session.started"],
+      contribute: () => ({ staying: createReplayableTool("staying") }),
+    });
+    registerRuntimeToolContributor({
+      ownerId: "leaving-owner",
+      slug: "leaving-owner",
+      logicalPath: "eve:leaving-owner",
+      sourceId: "leaving-owner",
+      sourceKind: "module",
+      eventNames: ["session.started"],
+      contribute: () => ({ leaving: createReplayableTool("leaving") }),
+    });
+    ctx.set(SessionDynamicToolRuntimeRevisionKey, "deployment:dpl_1");
+    await dispatchDynamicToolEvent({
+      ctx,
+      event: makeEvent("session.started"),
+      messages: [],
+      resolvers: [],
+    });
+    expect(
+      buildDynamicTools(ctx)
+        .map((tool) => tool.name)
+        .sort(),
+    ).toEqual(["leaving", "staying"]);
+
+    resetContributors();
+    registerRuntimeToolContributor({
+      ownerId: "staying-owner",
+      slug: "staying-owner",
+      logicalPath: "eve:staying-owner",
+      sourceId: "staying-owner",
+      sourceKind: "module",
+      eventNames: ["session.started"],
+      contribute: () => ({ staying: createReplayableTool("staying-v2") }),
+    });
+
+    await refreshDynamicSessionToolsForRuntimeRevision({
+      ctx,
+      event: createSessionStartedEvent(),
+      messages: [],
+      resolvers: [],
+      runtimeRevision: "deployment:dpl_2",
+    });
+
+    expect(buildDynamicTools(ctx).map((tool) => tool.name)).toEqual(["staying"]);
+    expect(ctx.get(SessionDynamicToolRuntimeRevisionKey)).toBe("deployment:dpl_2");
+  });
+
+  it("keeps session contributions out of the resolver-replaced set only until republished", async () => {
+    const ctx = createCtx();
+    const resolver = {
+      slug: "authored",
+      eventNames: ["session.started"] as const,
+      events: {
+        "session.started": () => ({ from_resolver: createReplayableTool("resolver") }),
+      },
+      sourceId: "test:authored",
+      sourceKind: "module" as const,
+      logicalPath: "agent/tools/authored.ts",
+    };
+    registerTestContributor({
+      eventNames: ["session.started"],
+      ownerId: "contributor",
+      tools: { from_contributor: createReplayableTool("contributor") },
+    });
+
+    await dispatchDynamicToolEvent({
+      ctx,
+      event: makeEvent("session.started"),
+      messages: [],
+      resolvers: [resolver],
+    });
+
+    const names = (ctx.get(SessionDynamicToolMetadataKey) ?? []).map(
+      (entry: DurableDynamicToolMetadata) => entry.name,
+    );
+    expect(names).toEqual(["from_resolver", "from_contributor"]);
+  });
+});

--- a/packages/eve/src/context/runtime-tool-contribution.ts
+++ b/packages/eve/src/context/runtime-tool-contribution.ts
@@ -1,0 +1,309 @@
+import type { ModelMessage } from "ai";
+
+import { createDurableDynamicToolMetadata } from "#context/durable-dynamic-tool-metadata.js";
+import type { ContextContainer } from "#context/container.js";
+import type { ContextKey } from "#context/key.js";
+import {
+  SessionDynamicToolMetadataKey,
+  StepDynamicToolMetadataKey,
+  TurnDynamicToolMetadataKey,
+  type DurableDynamicToolMetadata,
+  type RuntimeToolContributionProvenance,
+} from "#context/keys.js";
+import { createLogger } from "#internal/logging.js";
+import type { DynamicToolEntry, DynamicToolEventName } from "#shared/dynamic-tool-definition.js";
+import { isBrandedToolEntry } from "#shared/dynamic-tool-definition.js";
+import { toErrorMessage } from "#shared/errors.js";
+import type { UnstampedMessageStreamEvent } from "#protocol/message.js";
+
+const log = createLogger("dynamic-tools");
+
+/**
+ * Internal seam for framework runtime features that contribute branded
+ * dynamic tools outside the authored `defineDynamic` resolver path
+ * (`connection_search` today; scoped provider tooling later). Contributions
+ * flow through the same validation, durable callback capture, tier storage,
+ * and replay machinery as authored dynamic tools — this module owns only the
+ * owner-scoped transaction around them.
+ */
+
+export interface RuntimeToolContributorContributeInput {
+  readonly event: UnstampedMessageStreamEvent;
+  readonly messages: readonly ModelMessage[];
+}
+
+/** A runtime feature that produces a qualified map of dynamic tools at lifecycle boundaries. */
+export interface RuntimeToolContributor {
+  /** Identity whose active set is replaced atomically on each contribution. */
+  readonly ownerId: string;
+  /** Advertisement identity for introspection surfaces. */
+  readonly slug: string;
+  readonly logicalPath: string;
+  readonly sourceId: string;
+  readonly sourceKind: string;
+  readonly eventNames: readonly DynamicToolEventName[];
+  /**
+   * Builds the current tool set. Return `null` to contribute nothing and
+   * remove any prior contribution at this boundary's scope. Throwing fails
+   * this owner's whole result: nothing partial becomes callable.
+   */
+  contribute(
+    input: RuntimeToolContributorContributeInput,
+  ):
+    | Readonly<Record<string, DynamicToolEntry>>
+    | null
+    | Promise<Readonly<Record<string, DynamicToolEntry>> | null>;
+}
+
+const CONTRIBUTOR_REGISTRY = Symbol.for("eve:runtime-tool-contributors");
+
+function getContributorRegistry(): RuntimeToolContributor[] {
+  const global = globalThis as Record<symbol, RuntimeToolContributor[] | undefined>;
+  const existing = global[CONTRIBUTOR_REGISTRY];
+  if (existing !== undefined) return existing;
+  const registry: RuntimeToolContributor[] = [];
+  global[CONTRIBUTOR_REGISTRY] = registry;
+  return registry;
+}
+
+/** Registers one runtime contributor, replacing any prior registration with the same owner id. */
+export function registerRuntimeToolContributor(contributor: RuntimeToolContributor): void {
+  const registry = getContributorRegistry();
+  const index = registry.findIndex((entry) => entry.ownerId === contributor.ownerId);
+  if (index >= 0) {
+    registry[index] = contributor;
+    return;
+  }
+  registry.push(contributor);
+}
+
+export function getRuntimeToolContributors(): readonly RuntimeToolContributor[] {
+  return [...getContributorRegistry()];
+}
+
+export interface RuntimeToolContributionInput {
+  readonly ctx: ContextContainer;
+  /** Lifecycle coordinate of the contribution; selects the durable metadata tier. */
+  readonly coordinate: {
+    readonly event: DynamicToolEventName;
+    readonly stepIndex?: number;
+    readonly turnId?: string;
+  };
+  readonly ownerId: string;
+  /** Optional namespace applied exactly once as `${prefix}__${key}` to every entry key. */
+  readonly qualificationPrefix?: string;
+  readonly runtimeRevision: string;
+  readonly sourceId: string;
+  /** Keyed map of branded tools, or `null`/empty to remove this owner's prior contribution. */
+  readonly tools: Readonly<Record<string, DynamicToolEntry>> | null;
+}
+
+export function durableKeyForEvent(
+  eventType: string,
+): ContextKey<readonly DurableDynamicToolMetadata[]> | undefined {
+  switch (eventType) {
+    case "session.started":
+      return SessionDynamicToolMetadataKey;
+    case "turn.started":
+      return TurnDynamicToolMetadataKey;
+    case "step.started":
+      return StepDynamicToolMetadataKey;
+    default:
+      return undefined;
+  }
+}
+
+interface PreparedContribution {
+  readonly ownerId: string;
+  readonly metadata: readonly DurableDynamicToolMetadata[];
+}
+
+/** Validates and captures one owner's tool set without publishing anything. */
+function prepareContribution(input: {
+  readonly ownerId: string;
+  readonly qualificationPrefix?: string;
+  readonly runtimeRevision: string;
+  readonly sourceId: string;
+  readonly tools: Readonly<Record<string, DynamicToolEntry>> | null;
+}): PreparedContribution {
+  if (typeof input.ownerId !== "string" || input.ownerId === "") {
+    throw new Error(`Runtime tool contribution requires a non-empty ownerId.`);
+  }
+  if (
+    input.qualificationPrefix !== undefined &&
+    (typeof input.qualificationPrefix !== "string" || input.qualificationPrefix === "")
+  ) {
+    throw new Error(
+      `Runtime tool contribution "${input.ownerId}" requires a non-empty qualificationPrefix.`,
+    );
+  }
+  if (typeof input.sourceId !== "string" || input.sourceId === "") {
+    throw new Error(`Runtime tool contribution "${input.ownerId}" requires a non-empty sourceId.`);
+  }
+
+  const tools = input.tools;
+  if (tools === null) return { ownerId: input.ownerId, metadata: [] };
+  if (typeof tools !== "object" || Array.isArray(tools)) {
+    throw new Error(
+      `Runtime tool contribution "${input.ownerId}" must be a keyed map of defineTool() values or null.`,
+    );
+  }
+  if (isBrandedToolEntry(tools)) {
+    throw new Error(
+      `Runtime tool contribution "${input.ownerId}" must be a keyed map of defineTool() values, not a lone tool. Wrap every entry in a record keyed by its local name.`,
+    );
+  }
+
+  const prefix = input.qualificationPrefix === undefined ? "" : `${input.qualificationPrefix}__`;
+  const provenance: RuntimeToolContributionProvenance = {
+    ownerId: input.ownerId,
+    runtimeRevision: input.runtimeRevision,
+    sourceId: input.sourceId,
+  };
+  const seen = new Set<string>();
+  const metadata = Object.entries(tools).map(([key, entry]) => {
+    if (!isBrandedToolEntry(entry)) {
+      throw new Error(
+        `Runtime tool contribution "${key}" from owner "${input.ownerId}" is not wrapped in defineTool(). Wrap every contributed tool entry in defineTool().`,
+      );
+    }
+    const name = `${prefix}${key}`;
+    if (seen.has(name)) {
+      throw new Error(
+        `Runtime tool contribution "${input.ownerId}" produced duplicate qualified name "${name}".`,
+      );
+    }
+    seen.add(name);
+    return createDurableDynamicToolMetadata({
+      entry: entry as DynamicToolEntry,
+      entryKey: key,
+      name,
+      provenance,
+      resolverSlug: input.ownerId,
+    });
+  });
+  return { ownerId: input.ownerId, metadata };
+}
+
+function findCollision(
+  batches: readonly PreparedContribution[],
+): { readonly incomingOwnerId: string; readonly name: string; readonly owner: string } | undefined {
+  const ownersByName = new Map<string, string>();
+  for (const batch of batches) {
+    for (const entry of batch.metadata) {
+      const previousOwner = ownersByName.get(entry.name);
+      if (previousOwner !== undefined && previousOwner !== batch.ownerId) {
+        return { incomingOwnerId: batch.ownerId, name: entry.name, owner: previousOwner };
+      }
+      ownersByName.set(entry.name, batch.ownerId);
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Contributes runtime tools through the same validation and durable callback
+ * capture path as authored dynamic tools, replacing this owner's active set
+ * at the coordinate's scope atomically. A `null` or empty map removes only
+ * this owner's prior contribution.
+ */
+export function contributeRuntimeTools(
+  input: RuntimeToolContributionInput,
+): readonly DurableDynamicToolMetadata[] {
+  const key = durableKeyForEvent(input.coordinate.event);
+  if (key === undefined) {
+    throw new Error(
+      `Runtime tool contribution "${input.ownerId}" uses unsupported event "${String(input.coordinate.event)}".`,
+    );
+  }
+  const prepared = prepareContribution(input);
+  const prior = input.ctx.get(key) ?? [];
+
+  const otherOwners = prior
+    .filter((entry) => entry.contribution !== undefined && entry.resolverSlug !== prepared.ownerId)
+    .map((entry): PreparedContribution => ({
+      metadata: [entry],
+      ownerId: entry.resolverSlug,
+    }));
+  const collision = findCollision([...otherOwners, prepared]);
+  if (collision !== undefined) {
+    throw new Error(
+      `Dynamic tool "${collision.name}" contributed by runtime owner "${prepared.ownerId}" collides with owner "${collision.owner}". Namespace the map key manually.`,
+    );
+  }
+
+  const kept = prior.filter((entry) => entry.contribution?.ownerId !== prepared.ownerId);
+  const next = [...kept, ...prepared.metadata];
+  input.ctx.set(key, next);
+  return prepared.metadata;
+}
+
+/**
+ * Runs every registered contributor matching the event and publishes their
+ * combined result as one tier update. A contributor failure publishes
+ * nothing from that owner and drops its prior entries at this scope; a
+ * cross-owner collision fails the enclosing operation before anything is
+ * published. Returns the full metadata array to persist for the tier —
+ * resolver-produced entries first, then contributions.
+ */
+export async function applyRuntimeToolContributions(input: {
+  readonly ctx: ContextContainer;
+  readonly event: UnstampedMessageStreamEvent;
+  readonly messages: readonly ModelMessage[];
+  /** Resolver-produced metadata for this boundary, composed ahead of contributions. */
+  readonly resolverMetadata: readonly DurableDynamicToolMetadata[];
+  /**
+   * Which persisted resolver-owned entries this boundary replaces: `"all"`
+   * for full-replace tiers (`session.started`, `step.started`), or the set of
+   * resolver slugs owned by this boundary for merge tiers (`turn.started`).
+   */
+  readonly replacesResolverEntries: ReadonlySet<string> | "all";
+  readonly runtimeRevision: string;
+}): Promise<readonly DurableDynamicToolMetadata[]> {
+  const key = durableKeyForEvent(input.event.type);
+  if (key === undefined) return input.resolverMetadata;
+
+  const batches: PreparedContribution[] = [];
+  for (const contributor of getRuntimeToolContributors()) {
+    if (!contributor.eventNames.includes(input.event.type as DynamicToolEventName)) continue;
+    try {
+      const tools = await contributor.contribute({
+        event: input.event,
+        messages: input.messages,
+      });
+      batches.push(
+        prepareContribution({
+          ownerId: contributor.ownerId,
+          runtimeRevision: input.runtimeRevision,
+          sourceId: contributor.sourceId,
+          tools: tools as Readonly<Record<string, DynamicToolEntry>> | null,
+        }),
+      );
+    } catch (error) {
+      log.error(
+        `Runtime tool contributor (${input.event.type}) failed — publishing nothing from it.`,
+        {
+          ownerId: contributor.ownerId,
+          error: toErrorMessage(error),
+        },
+      );
+      batches.push({ ownerId: contributor.ownerId, metadata: [] });
+    }
+  }
+
+  const collision = findCollision(batches);
+  if (collision !== undefined) {
+    throw new Error(
+      `Dynamic tool "${collision.name}" contributed by runtime owner "${collision.incomingOwnerId}" collides with owner "${collision.owner}". Namespace the map key manually.`,
+    );
+  }
+
+  const slugs = input.replacesResolverEntries;
+  const kept = (input.ctx.get(key) ?? []).filter((entry) => {
+    if (entry.contribution !== undefined) return false;
+    return slugs !== "all" && !slugs.has(entry.resolverSlug);
+  });
+  const next = [...kept, ...input.resolverMetadata, ...batches.flatMap((batch) => batch.metadata)];
+  input.ctx.set(key, next);
+  return next;
+}

--- a/packages/eve/src/internal/nitro/routes/agent-info/build-agent-info-response-from-manifest.ts
+++ b/packages/eve/src/internal/nitro/routes/agent-info/build-agent-info-response-from-manifest.ts
@@ -1,6 +1,6 @@
 import {
   getAllFrameworkToolNames,
-  getFrameworkDynamicToolResolvers,
+  getFrameworkRuntimeToolContributors,
 } from "#runtime/framework-tools/index.js";
 import {
   getAllFrameworkChannelNames,
@@ -222,8 +222,8 @@ export function buildAgentInfoResponseFromManifest(
       authored: authoredTools,
       disabledFramework: [...manifest.disabledFrameworkTools],
       dynamic: [
-        ...getFrameworkDynamicToolResolvers().map((resolver) =>
-          renderDynamicResolver(resolver, { origin: "framework" }),
+        ...getFrameworkRuntimeToolContributors().map((contributor) =>
+          renderDynamicResolver(contributor, { origin: "framework" }),
         ),
         ...manifest.dynamicTools.map((resolver) =>
           renderDynamicResolver(resolver, { origin: "authored" }),

--- a/packages/eve/src/internal/nitro/routes/agent-info/build-agent-info-response.ts
+++ b/packages/eve/src/internal/nitro/routes/agent-info/build-agent-info-response.ts
@@ -2,7 +2,7 @@ import { ROOT_COMPILED_AGENT_NODE_ID } from "#compiler/manifest.js";
 import {
   getAllFrameworkToolDefinitions,
   getAllFrameworkToolNames,
-  getFrameworkDynamicToolResolvers,
+  getFrameworkRuntimeToolContributors,
   getOptInFrameworkToolNames,
 } from "#runtime/framework-tools/index.js";
 import {
@@ -388,7 +388,6 @@ function buildToolInfo(
   const authoredToolNames = new Set(agent.tools.map((tool) => tool.name));
   const disabledFrameworkTools = new Set(agent.disabledFrameworkTools);
   const allFrameworkToolNames = getAllFrameworkToolNames();
-  const dynamicFrameworkResolvers = getFrameworkDynamicToolResolvers();
   const authored = agent.tools.map((tool) =>
     renderTool(tool, {
       origin: "authored",
@@ -406,8 +405,8 @@ function buildToolInfo(
     authored,
     disabledFramework: [...agent.disabledFrameworkTools],
     dynamic: [
-      ...dynamicFrameworkResolvers.map((resolver) =>
-        renderDynamicResolver(resolver, { origin: "framework" }),
+      ...getFrameworkRuntimeToolContributors().map((contributor) =>
+        renderDynamicResolver(contributor, { origin: "framework" }),
       ),
       ...agent.dynamicToolResolvers.map((resolver) =>
         renderDynamicResolver(resolver, { origin: "authored" }),

--- a/packages/eve/src/runtime/framework-tools/connection-search-dynamic.test.ts
+++ b/packages/eve/src/runtime/framework-tools/connection-search-dynamic.test.ts
@@ -11,14 +11,12 @@ import {
 import { ConnectionAuthorizationRequiredError } from "#public/connections/errors.js";
 import type { ToolContext } from "#public/definitions/tool.js";
 import type { ConnectionRegistry, ConnectionToolMetadata } from "#runtime/connections/types.js";
-import { extractDiscoveredTools } from "#runtime/framework-tools/connection-search-dynamic.js";
-import { getFrameworkDynamicToolResolvers } from "#runtime/framework-tools/index.js";
-import type { ResolvedConnectionDefinition } from "#runtime/types.js";
 import {
-  isBrandedToolEntry,
-  type DynamicResolveContext,
-  type DynamicToolSet,
-} from "#shared/dynamic-tool-definition.js";
+  connectionSearchRuntimeToolContributor,
+  extractDiscoveredTools,
+} from "#runtime/framework-tools/connection-search-dynamic.js";
+import type { ResolvedConnectionDefinition } from "#runtime/types.js";
+import { isBrandedToolEntry, type DynamicToolSet } from "#shared/dynamic-tool-definition.js";
 import { readDurableDynamicToolCallbacks } from "#shared/durable-dynamic-tool-callbacks.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -36,6 +34,20 @@ function connection(name: string): ResolvedConnectionDefinition {
   };
 }
 
+async function contributeConnectionSearchTools(
+  ctx: ContextContainer,
+  messages: readonly unknown[] = [],
+): Promise<DynamicToolSet | null> {
+  return contextStorage.run(ctx, () =>
+    connectionSearchRuntimeToolContributor.contribute({
+      event: { type: "step.started", data: {} } as never,
+      messages: messages as Parameters<
+        typeof connectionSearchRuntimeToolContributor.contribute
+      >[0]["messages"],
+    }),
+  ) as Promise<DynamicToolSet | null>;
+}
+
 async function executeConnectionSearch(
   registry: ConnectionRegistry,
   input: { readonly connection?: string; readonly keywords: string; readonly limit?: number },
@@ -46,19 +58,9 @@ async function executeConnectionSearch(
   setupContext?.(ctx);
 
   return contextStorage.run(ctx, async () => {
-    const resolve = getConnectionSearchResolver().events["step.started"]!;
-    const resolved = (await resolve({}, {
-      channel: {},
-      messages: [],
-      session: { auth: { current: null, initiator: null }, id: "test-session" },
-    } satisfies DynamicResolveContext)) as DynamicToolSet;
-
+    const resolved = (await contributeConnectionSearchTools(ctx))!;
     return resolved["connection_search"]!.execute(input, {} as ToolContext);
   });
-}
-
-function getConnectionSearchResolver() {
-  return getFrameworkDynamicToolResolvers()[0]!;
 }
 
 function registry(input: {
@@ -90,18 +92,7 @@ describe("connection dynamic tools", () => {
         loadTools: {},
       }),
     );
-    const resolve = getConnectionSearchResolver().events["step.started"]!;
-
-    const tools = await contextStorage.run(ctx, () =>
-      resolve(
-        {},
-        {
-          channel: {},
-          messages: [],
-          session: { auth: { current: null, initiator: null }, id: "test-session" },
-        },
-      ),
-    );
+    const tools = await contributeConnectionSearchTools(ctx);
 
     expect(tools).toBeNull();
   });
@@ -135,21 +126,10 @@ describe("connection dynamic tools", () => {
     ];
     const ctx = new ContextContainer();
     ctx.set(ConnectionRegistryKey, connectionRegistry);
-    const resolver = getConnectionSearchResolver();
-    const resolve = resolver.events["step.started"]!;
 
-    const tools = await contextStorage.run(ctx, async () => {
-      return (await resolve(
-        {},
-        {
-          channel: {},
-          messages,
-          session: { auth: { current: null, initiator: null }, id: "test-session" },
-        },
-      )) as DynamicToolSet;
-    });
+    const tools = (await contributeConnectionSearchTools(ctx, messages))!;
 
-    expect(resolver.eventNames).toEqual(["step.started"]);
+    expect(connectionSearchRuntimeToolContributor.eventNames).toEqual(["step.started"]);
     expect(Object.keys(tools)).toEqual(["connection_search", "linear__list_issues"]);
     expect(Object.values(tools).every(isBrandedToolEntry)).toBe(true);
   });
@@ -429,12 +409,7 @@ describe("connection_search", () => {
     });
 
     const result = await contextStorage.run(ctx, async () => {
-      const resolve = getConnectionSearchResolver().events["step.started"]!;
-      const tools = (await resolve({}, {
-        channel: {},
-        messages: [],
-        session: { auth: { current: null, initiator: null }, id: "session-auth-replay" },
-      } satisfies DynamicResolveContext)) as DynamicToolSet;
+      const tools = (await contributeConnectionSearchTools(ctx))!;
       const reference = readDurableDynamicToolCallbacks(tools["connection_search"]!)!.execute!;
 
       return await reference.callback(reference.closure, {

--- a/packages/eve/src/runtime/framework-tools/connection-search-dynamic.ts
+++ b/packages/eve/src/runtime/framework-tools/connection-search-dynamic.ts
@@ -14,8 +14,10 @@ import {
   isConnectionAuthorizationFailedError,
   isConnectionAuthorizationRequiredError,
 } from "#public/connections/errors.js";
-import { defineDynamic, defineTool } from "#public/definitions/tool.js";
+import { defineTool } from "#public/definitions/tool.js";
 import type { ToolContext } from "#public/definitions/tool.js";
+import type { RuntimeToolContributor } from "#context/runtime-tool-contribution.js";
+import type { DynamicToolEntry } from "#shared/dynamic-tool-definition.js";
 import {
   resolveApprovalPolicy,
   type ApprovalContext,
@@ -511,93 +513,98 @@ async function authorizeDiscoveredConnectionToolApproval(
     : await response(context);
 }
 
-// The step-scoped definition re-derives its tools from conversation history.
+// The step-scoped contribution re-derives its tools from conversation history.
 // After compaction removes old search results, those tools naturally disappear.
-const connectionSearchDynamicDefinition = defineDynamic({
-  events: {
-    "step.started": async (_event, ctx) => {
-      const registry = loadContext().get(ConnectionRegistryKey);
-      if (!registry || registry.getConnections().length === 0) return null;
+export const connectionSearchRuntimeToolContributor: RuntimeToolContributor = {
+  ownerId: "eve.connection-search",
+  slug: "connection",
+  logicalPath: "eve:framework/connection-search-dynamic",
+  sourceId: "eve:connection-search-dynamic",
+  sourceKind: "module",
+  eventNames: ["step.started"],
+  async contribute({ messages }) {
+    const registry = loadContext().get(ConnectionRegistryKey);
+    if (!registry || registry.getConnections().length === 0) return null;
 
-      const connections = registry.getConnections();
-      const connectionNames = connections.map((c) => c.connectionName);
-      const fromMessages = extractDiscoveredTools(ctx.messages);
-      const fromContext = loadContext().get(ConnectionSearchResultsKey) ?? [];
-      const mergedMap = new Map<string, ConnectionSearchResultItem>();
-      for (const r of fromContext) {
-        if (r.qualifiedName) mergedMap.set(r.qualifiedName, r);
-      }
-      for (const r of fromMessages) {
-        if (r.qualifiedName) mergedMap.set(r.qualifiedName, r);
-      }
-      const discovered = [...mergedMap.values()];
+    const connections = registry.getConnections();
+    const connectionNames = connections.map((c) => c.connectionName);
+    const fromMessages = extractDiscoveredTools(messages);
+    const fromContext = loadContext().get(ConnectionSearchResultsKey) ?? [];
+    const mergedMap = new Map<string, ConnectionSearchResultItem>();
+    for (const r of fromContext) {
+      if (r.qualifiedName) mergedMap.set(r.qualifiedName, r);
+    }
+    for (const r of fromMessages) {
+      if (r.qualifiedName) mergedMap.set(r.qualifiedName, r);
+    }
+    const discovered = [...mergedMap.values()];
 
-      const tools: Record<string, object> = {};
+    const tools: Record<string, DynamicToolEntry> = {};
+    const addTool = (name: string, definition: unknown): void => {
+      tools[name] = definition as DynamicToolEntry;
+    };
 
-      const connectionSearchTool = defineTool({
-        description:
-          "Search for tools across your connections. " +
-          "Discovered tools become directly callable by their qualified name " +
-          "(e.g. `linear__list_issues`) in your next response. " +
-          `Available connections: ${connectionNames.join(", ")}.`,
-        inputSchema: CONNECTION_SEARCH_INPUT_SCHEMA,
-        async execute(input: ConnectionSearchInput) {
-          return executeConnectionSearch(input);
+    const connectionSearchTool = defineTool({
+      description:
+        "Search for tools across your connections. " +
+        "Discovered tools become directly callable by their qualified name " +
+        "(e.g. `linear__list_issues`) in your next response. " +
+        `Available connections: ${connectionNames.join(", ")}.`,
+      inputSchema: CONNECTION_SEARCH_INPUT_SCHEMA,
+      async execute(input: ConnectionSearchInput) {
+        return executeConnectionSearch(input);
+      },
+      outputSchema: CONNECTION_SEARCH_OUTPUT_SCHEMA,
+    });
+    stampDurableDynamicToolCallbacks(connectionSearchTool, {
+      execute: {
+        callback: (_closure, input) => executeConnectionSearch(input as ConnectionSearchInput),
+        closure: {},
+      },
+    });
+    addTool("connection_search", connectionSearchTool);
+
+    for (const result of discovered) {
+      const connectionName = result.connection;
+      const toolName = result.tool!;
+      const approval = registry.getConnectionApproval(connectionName);
+
+      const closure = { connectionName, toolName };
+      const discoveredTool = defineTool({
+        description: result.description,
+        inputSchema: (result.inputSchema ?? {
+          type: "object",
+        }) as JsonObject,
+        approval,
+        outputSchema: result.outputSchema as JsonObject | undefined,
+        async execute(input: Record<string, unknown>, executeCtx) {
+          return await executeDiscoveredConnectionTool(closure, input, executeCtx);
         },
-        outputSchema: CONNECTION_SEARCH_OUTPUT_SCHEMA,
       });
-      stampDurableDynamicToolCallbacks(connectionSearchTool, {
-        execute: {
-          callback: (_closure, input) => executeConnectionSearch(input as ConnectionSearchInput),
-          closure: {},
-        },
+      stampDurableDynamicToolCallbacks(discoveredTool, {
+        execute: { callback: executeDiscoveredConnectionTool, closure },
+        ...(approval === undefined
+          ? {}
+          : {
+              approvalRequest: {
+                callback: requestDiscoveredConnectionToolApproval,
+                closure,
+              },
+            }),
+        ...(approval === undefined ||
+        typeof approval === "function" ||
+        approval.response === undefined
+          ? {}
+          : {
+              approvalResponse: {
+                callback: authorizeDiscoveredConnectionToolApproval,
+                closure,
+              },
+            }),
       });
-      tools["connection_search"] = connectionSearchTool;
+      addTool(qualifiedConnectionToolName(connectionName, toolName), discoveredTool);
+    }
 
-      for (const result of discovered) {
-        const connectionName = result.connection;
-        const toolName = result.tool!;
-        const approval = registry.getConnectionApproval(connectionName);
-
-        const closure = { connectionName, toolName };
-        const discoveredTool = defineTool({
-          description: result.description,
-          inputSchema: (result.inputSchema ?? {
-            type: "object",
-          }) as JsonObject,
-          approval,
-          outputSchema: result.outputSchema as JsonObject | undefined,
-          async execute(input: Record<string, unknown>, executeCtx) {
-            return await executeDiscoveredConnectionTool(closure, input, executeCtx);
-          },
-        });
-        stampDurableDynamicToolCallbacks(discoveredTool, {
-          execute: { callback: executeDiscoveredConnectionTool, closure },
-          ...(approval === undefined
-            ? {}
-            : {
-                approvalRequest: {
-                  callback: requestDiscoveredConnectionToolApproval,
-                  closure,
-                },
-              }),
-          ...(approval === undefined ||
-          typeof approval === "function" ||
-          approval.response === undefined
-            ? {}
-            : {
-                approvalResponse: {
-                  callback: authorizeDiscoveredConnectionToolApproval,
-                  closure,
-                },
-              }),
-        });
-        tools[qualifiedConnectionToolName(connectionName, toolName)] = discoveredTool;
-      }
-
-      return tools;
-    },
+    return tools;
   },
-});
-
-export default connectionSearchDynamicDefinition;
+};

--- a/packages/eve/src/runtime/framework-tools/index.test.ts
+++ b/packages/eve/src/runtime/framework-tools/index.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   getAllFrameworkToolDefinitions,
   getAllFrameworkToolNames,
-  getFrameworkDynamicToolResolvers,
+  getFrameworkRuntimeToolContributors,
   getFrameworkToolDefinitions,
   getOptInFrameworkToolNames,
 } from "#runtime/framework-tools/index.js";
@@ -79,11 +79,12 @@ describe("framework-tools/index", () => {
     }
   });
 
-  it("registers connection search through the framework dynamic tool registry", () => {
-    expect(getFrameworkDynamicToolResolvers()).toMatchObject([
+  it("registers connection search as a framework runtime tool contributor", () => {
+    expect(getFrameworkRuntimeToolContributors()).toMatchObject([
       {
         eventNames: ["step.started"],
         logicalPath: "eve:framework/connection-search-dynamic",
+        ownerId: "eve.connection-search",
         slug: "connection",
         sourceId: "eve:connection-search-dynamic",
       },

--- a/packages/eve/src/runtime/framework-tools/index.ts
+++ b/packages/eve/src/runtime/framework-tools/index.ts
@@ -13,8 +13,8 @@ import { TODO_TOOL_DEFINITION } from "#runtime/framework-tools/todo.js";
 import { WEB_FETCH_TOOL_DEFINITION } from "#runtime/framework-tools/web-fetch.js";
 import { WEB_SEARCH_TOOL_DEFINITION } from "#runtime/framework-tools/web-search.js";
 import { WRITE_FILE_TOOL_DEFINITION } from "#runtime/framework-tools/write-file.js";
-import connectionSearchDynamicDefinition from "#runtime/framework-tools/connection-search-dynamic.js";
-import { resolveLoadedDynamicToolDefinition } from "#runtime/resolve-dynamic-tool.js";
+import { registerRuntimeToolContributor } from "#context/runtime-tool-contribution.js";
+import { connectionSearchRuntimeToolContributor } from "#runtime/framework-tools/connection-search-dynamic.js";
 
 export { ConnectionRegistryKey } from "#context/providers/connection-key.js";
 export type { ReadFileStamp, ReadFileState } from "#runtime/framework-tools/file-state.js";
@@ -22,28 +22,21 @@ export { ReadFileStateKey } from "#runtime/framework-tools/file-state.js";
 export type { TodoItem, TodoState } from "#runtime/framework-tools/todo.js";
 export { TodoStateKey } from "#runtime/framework-tools/todo.js";
 
-import type {
-  ResolvedDynamicToolResolver,
-  ResolvedSkillDefinition,
-  ResolvedToolDefinition,
-} from "#runtime/types.js";
-import type { DynamicSentinel } from "#shared/dynamic-tool-definition.js";
+import type { ResolvedSkillDefinition, ResolvedToolDefinition } from "#runtime/types.js";
 
-interface FrameworkDynamicToolDefinition {
-  readonly definition: DynamicSentinel;
-  readonly logicalPath: string;
-  readonly slug: string;
-  readonly sourceId: string;
+// Framework runtime contributors register at module evaluation. This module is
+// imported by graph resolution, so every process that resolves an agent has
+// its framework contributors registered before the first dynamic-tool dispatch.
+registerRuntimeToolContributor(connectionSearchRuntimeToolContributor);
+
+/**
+ * Returns framework-owned runtime tool contributors for introspection
+ * surfaces. Their tools are contributed through the runtime contribution
+ * seam rather than authored `defineDynamic` resolvers.
+ */
+export function getFrameworkRuntimeToolContributors() {
+  return [connectionSearchRuntimeToolContributor];
 }
-
-const REGISTERED_FRAMEWORK_DYNAMIC_TOOLS: readonly FrameworkDynamicToolDefinition[] = [
-  {
-    definition: connectionSearchDynamicDefinition,
-    logicalPath: "eve:framework/connection-search-dynamic",
-    slug: "connection",
-    sourceId: "eve:connection-search-dynamic",
-  },
-];
 
 const REGISTERED_FRAMEWORK_TOOLS: readonly ResolvedToolDefinition[] = [
   ASK_QUESTION_TOOL_DEFINITION,
@@ -85,22 +78,6 @@ export function getFrameworkToolDefinitions(config?: {
     definition.name === SKILL_TOOL_DEFINITION.name
       ? createSkillToolDefinition(authoredSkills)
       : definition,
-  );
-}
-
-/**
- * Returns framework-owned dynamic tool resolvers.
- * Framework definitions use the public `defineDynamic()` contract and enter
- * the same loaded-definition resolver path as authored dynamic tools.
- */
-export function getFrameworkDynamicToolResolvers(): readonly ResolvedDynamicToolResolver[] {
-  return REGISTERED_FRAMEWORK_DYNAMIC_TOOLS.map((entry) =>
-    resolveLoadedDynamicToolDefinition(entry.definition, {
-      logicalPath: entry.logicalPath,
-      slug: entry.slug,
-      sourceId: entry.sourceId,
-      sourceKind: "module",
-    }),
   );
 }
 

--- a/packages/eve/src/runtime/resolve-agent-graph.ts
+++ b/packages/eve/src/runtime/resolve-agent-graph.ts
@@ -16,7 +16,6 @@ import {
 } from "#runtime/framework-channels/index.js";
 import {
   getAllFrameworkToolNames,
-  getFrameworkDynamicToolResolvers,
   getFrameworkToolDefinitions,
 } from "#runtime/framework-tools/index.js";
 import { type ResolvedAgentGraphBundle, ROOT_RUNTIME_AGENT_NODE_ID } from "#runtime/graph.js";
@@ -240,7 +239,7 @@ async function resolveRuntimeAgentNode(
   });
   const resolvedAgent = {
     ...agent,
-    dynamicToolResolvers: [...agent.dynamicToolResolvers, ...getFrameworkDynamicToolResolvers()],
+    dynamicToolResolvers: agent.dynamicToolResolvers,
   };
 
   const node: ResolvedAgentGraphBundle["root"] = {


### PR DESCRIPTION
### Summary

Related to #2347 (F3) and #1510. Framework runtime features sometimes need to contribute a set of branded dynamic tools from runtime state — `connection_search` does this today, and planned scoped provider tooling will next. Until now the only contribution path was an authored `defineDynamic` resolver, so framework code either contorted itself into a synthetic resolver or would have to re-implement validation, durable callback capture, replacement, and cleanup.

This PR adds one internal, feature-independent seam:

- `contributeRuntimeTools` — an owner-scoped transaction that validates a keyed map of branded tools, qualifies names exactly once via an optional prefix, captures callbacks through the same durable-descriptor path as authored dynamic tools, replaces that owner's active set atomically at one lifecycle tier, and treats `null`/empty as removal of only that owner's entries.
- A small registered-contributor dispatch that runs alongside authored dynamic resolution at `session.started`/`turn.started`/`step.started`, publishing all contributors for a boundary in one tier update; a contributor failure publishes nothing partial, and a cross-owner name collision fails the operation with the established error semantics.

`connection_search` migrates as the first consumer: its step-scoped tool derivation now feeds the seam instead of a framework `defineDynamic` resolver registered at graph resolution. Public behavior is unchanged — same tool names, same durable replay identity, same authorization continuation, same introspection output shape.

Deliberate scope boundaries: no memory types or terminology anywhere; no new approval or origin machinery (contributed calls reuse the existing dynamic-tool engine end to end); contributed provenance (`ownerId`, source, runtime revision) rides on the existing durable metadata rather than a parallel store.

### Validation

Focused unit coverage drives the new seam directly and through `dispatchDynamicToolEvent`: validation failures publish nothing, owner replacement/removal is isolated per owner, cross-owner collisions fail closed, tier precedence matches the existing first-wins rules, step-resolution caching retains contributions, simulated cold-start rebinding recovers through contributor re-run, and contribution provenance survives context serialization round-trip. The migrated `connection_search` unit suite exercises the contributor directly, including its authorization-signal path. Full unit and integration suites pass; the three integration failures in sandbox-provisioning tests reproduce identically on `main` (stale local microsandbox state). Compile-agent, agent-info-route, and dynamic-tool-cold-replay scenarios pass against a fresh build. CI e2e will cover the migrated `connection_search` path end to end via the existing petstore evals, including approval park/resume.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests where relevant
- [x] I added a changeset if this touches the published `eve` package
- [ ] Documentation updated

Documentation was reviewed and needs no change: published docs describe `connection_search` behaviorally and make no claims about its resolution mechanism.

- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Changeset only; published docs required no change.

**Implementation** — 9 files · `+592 / -300`

The seam is a new focused module; most of the remaining implementation diff is mechanical migration of `connection_search` off the synthetic resolver registration and extraction of shared metadata construction so the lifecycle and the seam can share it without an import cycle.

**Tests** — 4 files · `+656 / -50`

New unit suite for the seam's transaction, dispatch, failure-isolation, precedence, cold-rebind, and persistence semantics; the connection-search suite now drives the contributor instead of the removed resolver wrapper.

