### PR TITLE
feat(eve): connections - compile search as an agent source

### DIFF
--- a/.changeset/fresh-connection-search.md
+++ b/.changeset/fresh-connection-search.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Compile `connection_search` as an ordinary dynamic tool source and keep discovered connection tools exclusively in durable context. Existing sessions without that context search again instead of reconstructing tools from message history.

--- a/packages/eve/src/cli/dev/tui/tool-presentation.test.ts
+++ b/packages/eve/src/cli/dev/tui/tool-presentation.test.ts
@@ -174,6 +174,7 @@ describe("presentTool", () => {
       agent: { message: "audit the auth flow" },
       ask_question: { prompt: "Which environment?" },
       bash: { command: "ls" },
+      connection_search: { keywords: "linear issues" },
       glob: { pattern: "**/*.ts" },
       grep: { pattern: "useEve" },
       load_skill: { skill: "commit" },

--- a/packages/eve/src/compiler/compose-framework-sources.test.ts
+++ b/packages/eve/src/compiler/compose-framework-sources.test.ts
@@ -41,6 +41,7 @@ describe("composeFrameworkSources", () => {
 
     expect(result.manifest.tools.map((tool) => tool.logicalPath)).toEqual([
       "tools/bash.ts",
+      "tools/connection_search.ts",
       "tools/read_file.ts",
       "tools/todo.ts",
       "tools/web_fetch.ts",

--- a/packages/eve/src/compiler/normalize-manifest.test.ts
+++ b/packages/eve/src/compiler/normalize-manifest.test.ts
@@ -316,6 +316,13 @@ describe("compileAgentManifest", () => {
       "web_fetch",
       "write_file",
     ]);
+    expect(compiled.dynamicTools).toContainEqual(
+      expect.objectContaining({
+        logicalPath: "tools/connection_search.ts",
+        slug: "connection_search",
+        sourceId: "eve.framework-defaults:tools/connection_search.ts",
+      }),
+    );
   });
 
   it("compiles framework defaults through ordinary module bindings", async () => {
@@ -377,6 +384,37 @@ describe("compileAgentManifest", () => {
     );
     expect(compiled.bindings["tools/bash.ts"]?.backing.kind).toBe("filesystem");
     expect(compiled.bindings["eve.framework-defaults:tools/bash.ts"]).toBeUndefined();
+  });
+
+  it("lets an application tool replace the framework connection search resolver", async () => {
+    mocks.compileAgentConfig.mockResolvedValue(createConfig({ name: "root" }));
+    mocks.applicationDefinition.mockResolvedValue(
+      defineTool({
+        description: "Search a fixed connection index",
+        inputSchema: z.object({}),
+        execute: () => [],
+      }),
+    );
+
+    const compiled = await compileAgentManifest(
+      createAgentSourceManifest({
+        agentId: "root",
+        agentRoot: "/app/agent",
+        appRoot: "/app",
+        tools: [createModuleSourceRef({ logicalPath: "tools/connection_search.ts" })],
+      }),
+    );
+
+    expect(compiled.tools).toContainEqual(
+      expect.objectContaining({
+        name: "connection_search",
+        sourceId: "tools/connection_search.ts",
+      }),
+    );
+    expect(compiled.dynamicTools).not.toContainEqual(
+      expect.objectContaining({ slug: "connection_search" }),
+    );
+    expect(compiled.bindings["eve.framework-defaults:tools/connection_search.ts"]).toBeUndefined();
   });
 
   it("preserves ordered static instruction content, roles, and legacy definitions", async () => {

--- a/packages/eve/src/framework-sources/registry.ts
+++ b/packages/eve/src/framework-sources/registry.ts
@@ -1,4 +1,5 @@
 import * as bash from "./tools/bash.js";
+import * as connectionSearch from "./tools/connection_search.js";
 import * as readFile from "./tools/read_file.js";
 import * as sandbox from "./sandbox.js";
 import * as todo from "./tools/todo.js";
@@ -13,6 +14,7 @@ const frameworkAgentSource = defineProgrammaticAgentSource({
   modules: [
     { logicalPath: "sandbox.ts", namespace: sandbox },
     { logicalPath: "tools/bash.ts", namespace: bash },
+    { logicalPath: "tools/connection_search.ts", namespace: connectionSearch },
     { logicalPath: "tools/read_file.ts", namespace: readFile },
     { logicalPath: "tools/todo.ts", namespace: todo },
     { logicalPath: "tools/web_fetch.ts", namespace: webFetch },

--- a/packages/eve/src/framework-sources/tools/connection_search.ts
+++ b/packages/eve/src/framework-sources/tools/connection_search.ts
@@ -1,0 +1,1 @@
+export { default } from "#runtime/framework-tools/connection-search-dynamic.js";

--- a/packages/eve/src/internal/nitro/routes/agent-info/build-agent-info-response-from-manifest.ts
+++ b/packages/eve/src/internal/nitro/routes/agent-info/build-agent-info-response-from-manifest.ts
@@ -1,7 +1,4 @@
-import {
-  getAllFrameworkToolNames,
-  getFrameworkDynamicToolResolvers,
-} from "#runtime/framework-tools/index.js";
+import { getAllFrameworkToolNames } from "#runtime/framework-tools/index.js";
 import {
   getAllFrameworkChannelNames,
   getFrameworkChannelDefinitions,
@@ -221,14 +218,14 @@ export function buildAgentInfoResponseFromManifest(
       available: [...frameworkToolInfo.available, ...authoredTools],
       authored: authoredTools,
       disabledFramework: [...manifest.disabledFrameworkTools],
-      dynamic: [
-        ...getFrameworkDynamicToolResolvers().map((resolver) =>
-          renderDynamicResolver(resolver, { origin: "framework" }),
-        ),
-        ...manifest.dynamicTools.map((resolver) =>
-          renderDynamicResolver(resolver, { origin: "authored" }),
-        ),
-      ],
+      dynamic: manifest.dynamicTools.map((resolver) =>
+        renderDynamicResolver(resolver, {
+          origin:
+            manifest.bindings[resolver.sourceId]?.owner.kind === "framework"
+              ? "framework"
+              : "authored",
+        }),
+      ),
       framework: frameworkToolInfo.framework,
       reserved: [WORKFLOW_TOOL_NAME, LOAD_SKILL_TOOL_NAME],
     },

--- a/packages/eve/src/internal/nitro/routes/agent-info/build-agent-info-response.ts
+++ b/packages/eve/src/internal/nitro/routes/agent-info/build-agent-info-response.ts
@@ -2,7 +2,6 @@ import { ROOT_COMPILED_AGENT_NODE_ID } from "#compiler/manifest.js";
 import {
   getAllFrameworkToolDefinitions,
   getAllFrameworkToolNames,
-  getFrameworkDynamicToolResolvers,
   getOptInFrameworkToolNames,
 } from "#runtime/framework-tools/index.js";
 import {
@@ -239,7 +238,7 @@ export function buildAgentInfoResponse(
   if (config === undefined) {
     throw new Error("Cannot inspect unresolved dynamic subagent resources as a root agent.");
   }
-  const tools = buildToolInfo(agent, getRootDelegationToolNames(data.manifest));
+  const tools = buildToolInfo(agent, getRootDelegationToolNames(data.manifest), data.manifest);
 
   return {
     agent: {
@@ -384,11 +383,11 @@ function buildChannelInfo(agent: ResolvedAgent): AgentInfoChannels {
 function buildToolInfo(
   agent: ResolvedAgent,
   delegationToolNames: ReadonlySet<string>,
+  manifest: CompiledAgentManifest,
 ): AgentInfoTools {
   const authoredToolNames = new Set(agent.tools.map((tool) => tool.name));
   const disabledFrameworkTools = new Set(agent.disabledFrameworkTools);
   const allFrameworkToolNames = getAllFrameworkToolNames();
-  const dynamicFrameworkResolvers = getFrameworkDynamicToolResolvers();
   const authored = agent.tools.map((tool) =>
     renderTool(tool, {
       origin: "authored",
@@ -405,14 +404,14 @@ function buildToolInfo(
     available: [...frameworkInfo.available, ...authored],
     authored,
     disabledFramework: [...agent.disabledFrameworkTools],
-    dynamic: [
-      ...dynamicFrameworkResolvers.map((resolver) =>
-        renderDynamicResolver(resolver, { origin: "framework" }),
-      ),
-      ...agent.dynamicToolResolvers.map((resolver) =>
-        renderDynamicResolver(resolver, { origin: "authored" }),
-      ),
-    ],
+    dynamic: agent.dynamicToolResolvers.map((resolver) =>
+      renderDynamicResolver(resolver, {
+        origin:
+          manifest.bindings[resolver.sourceId]?.owner.kind === "framework"
+            ? "framework"
+            : "authored",
+      }),
+    ),
     framework: frameworkInfo.framework,
     reserved: [WORKFLOW_TOOL_NAME, LOAD_SKILL_TOOL_NAME],
   };

--- a/packages/eve/src/runtime/framework-tools/connection-search-dynamic.test.ts
+++ b/packages/eve/src/runtime/framework-tools/connection-search-dynamic.test.ts
@@ -11,8 +11,10 @@ import {
 import { ConnectionAuthorizationRequiredError } from "#public/connections/errors.js";
 import type { ToolContext } from "#public/definitions/tool.js";
 import type { ConnectionRegistry, ConnectionToolMetadata } from "#runtime/connections/types.js";
-import { extractDiscoveredTools } from "#runtime/framework-tools/connection-search-dynamic.js";
-import { getFrameworkDynamicToolResolvers } from "#runtime/framework-tools/index.js";
+import connectionSearchDynamicDefinition, {
+  ConnectionSearchResultsKey,
+} from "#runtime/framework-tools/connection-search-dynamic.js";
+import { resolveLoadedDynamicToolDefinition } from "#runtime/resolve-dynamic-tool.js";
 import type { ResolvedConnectionDefinition } from "#runtime/types.js";
 import {
   isBrandedToolEntry,
@@ -20,9 +22,6 @@ import {
   type DynamicToolSet,
 } from "#shared/dynamic-tool-definition.js";
 import { readDurableDynamicToolCallbacks } from "#shared/durable-dynamic-tool-callbacks.js";
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Msg = any;
 
 function connection(name: string): ResolvedConnectionDefinition {
   return {
@@ -58,7 +57,12 @@ async function executeConnectionSearch(
 }
 
 function getConnectionSearchResolver() {
-  return getFrameworkDynamicToolResolvers()[0]!;
+  return resolveLoadedDynamicToolDefinition(connectionSearchDynamicDefinition, {
+    logicalPath: "tools/connection_search.ts",
+    slug: "connection_search",
+    sourceId: "eve.framework-defaults:tools/connection_search.ts",
+    sourceKind: "module",
+  });
 }
 
 function registry(input: {
@@ -112,29 +116,17 @@ describe("connection dynamic tools", () => {
       connections: [linear],
       loadTools: { linear: async () => [] },
     });
-    const messages: Msg[] = [
-      {
-        role: "tool",
-        content: [
-          {
-            type: "tool-result",
-            toolCallId: "call-1",
-            toolName: "connection_search",
-            output: [
-              {
-                connection: "linear",
-                description: "List issues",
-                inputSchema: { type: "object" },
-                qualifiedName: "linear__list_issues",
-                tool: "list_issues",
-              },
-            ],
-          },
-        ],
-      },
-    ];
     const ctx = new ContextContainer();
     ctx.set(ConnectionRegistryKey, connectionRegistry);
+    ctx.set(ConnectionSearchResultsKey, [
+      {
+        connection: "linear",
+        description: "List issues",
+        inputSchema: { type: "object" },
+        qualifiedName: "linear__list_issues",
+        tool: "list_issues",
+      },
+    ]);
     const resolver = getConnectionSearchResolver();
     const resolve = resolver.events["step.started"]!;
 
@@ -143,7 +135,7 @@ describe("connection dynamic tools", () => {
         {},
         {
           channel: {},
-          messages,
+          messages: [],
           session: { auth: { current: null, initiator: null }, id: "test-session" },
         },
       )) as DynamicToolSet;
@@ -152,6 +144,47 @@ describe("connection dynamic tools", () => {
     expect(resolver.eventNames).toEqual(["step.started"]);
     expect(Object.keys(tools)).toEqual(["connection_search", "linear__list_issues"]);
     expect(Object.values(tools).every(isBrandedToolEntry)).toBe(true);
+  });
+
+  it("does not reconstruct discovered tools from message history", async () => {
+    const linear = connection("linear");
+    const ctx = new ContextContainer();
+    ctx.set(
+      ConnectionRegistryKey,
+      registry({ connections: [linear], loadTools: { linear: async () => [] } }),
+    );
+
+    const tools = await contextStorage.run(ctx, async () =>
+      getConnectionSearchResolver().events["step.started"]!(
+        {},
+        {
+          channel: {},
+          messages: [
+            {
+              content: [
+                {
+                  output: [
+                    {
+                      connection: "linear",
+                      description: "List issues",
+                      qualifiedName: "linear__list_issues",
+                      tool: "list_issues",
+                    },
+                  ],
+                  toolCallId: "call-1",
+                  toolName: "connection_search",
+                  type: "tool-result",
+                },
+              ],
+              role: "tool",
+            },
+          ],
+          session: { auth: { current: null, initiator: null }, id: "test-session" },
+        },
+      ),
+    );
+
+    expect(Object.keys(tools as DynamicToolSet)).toEqual(["connection_search"]);
   });
 });
 
@@ -444,152 +477,5 @@ describe("connection_search", () => {
     });
 
     expect(isAuthorizationSignal(result)).toBe(true);
-  });
-});
-
-describe("extractDiscoveredTools", () => {
-  it("extracts tools from raw array output", () => {
-    const messages: Msg[] = [
-      { role: "user", content: [{ type: "text", text: "search" }] },
-      {
-        role: "tool",
-        content: [
-          {
-            type: "tool-result",
-            toolCallId: "call-1",
-            toolName: "connection_search",
-            output: [
-              {
-                connection: "linear",
-                tool: "list_issues",
-                qualifiedName: "linear__list_issues",
-                description: "List issues",
-                inputSchema: { type: "object" },
-                outputSchema: { type: "object" },
-              },
-            ],
-          },
-        ],
-      },
-    ];
-
-    const result = extractDiscoveredTools(messages);
-    expect(result).toHaveLength(1);
-    expect(result[0]!.qualifiedName).toBe("linear__list_issues");
-    expect(result[0]!.connection).toBe("linear");
-    expect(result[0]!.tool).toBe("list_issues");
-    expect(result[0]!.outputSchema).toEqual({ type: "object" });
-  });
-
-  it("extracts tools from ToolResultOutput json wrapper", () => {
-    const messages: Msg[] = [
-      {
-        role: "tool",
-        content: [
-          {
-            type: "tool-result",
-            toolCallId: "call-1",
-            toolName: "connection_search",
-            output: {
-              type: "json",
-              value: [
-                {
-                  connection: "linear",
-                  tool: "list_issues",
-                  qualifiedName: "linear__list_issues",
-                  description: "List issues",
-                  inputSchema: { type: "object" },
-                },
-              ],
-            },
-          },
-        ],
-      },
-    ];
-
-    const result = extractDiscoveredTools(messages);
-    expect(result).toHaveLength(1);
-    expect(result[0]!.qualifiedName).toBe("linear__list_issues");
-  });
-
-  it("returns empty for no tool results", () => {
-    const messages: Msg[] = [{ role: "user", content: [{ type: "text", text: "hello" }] }];
-    expect(extractDiscoveredTools(messages)).toHaveLength(0);
-  });
-
-  it("deduplicates by qualifiedName (latest wins)", () => {
-    const messages: Msg[] = [
-      {
-        role: "tool",
-        content: [
-          {
-            type: "tool-result",
-            toolCallId: "call-1",
-            toolName: "connection_search",
-            output: [
-              {
-                connection: "linear",
-                tool: "list_issues",
-                qualifiedName: "linear__list_issues",
-                description: "Old description",
-              },
-            ],
-          },
-        ],
-      },
-      {
-        role: "tool",
-        content: [
-          {
-            type: "tool-result",
-            toolCallId: "call-2",
-            toolName: "connection_search",
-            output: [
-              {
-                connection: "linear",
-                tool: "list_issues",
-                qualifiedName: "linear__list_issues",
-                description: "New description",
-              },
-            ],
-          },
-        ],
-      },
-    ];
-
-    const result = extractDiscoveredTools(messages);
-    expect(result).toHaveLength(1);
-    expect(result[0]!.description).toBe("New description");
-  });
-
-  it("skips items without tool or qualifiedName", () => {
-    const messages: Msg[] = [
-      {
-        role: "tool",
-        content: [
-          {
-            type: "tool-result",
-            toolCallId: "call-1",
-            toolName: "connection_search",
-            output: [
-              {
-                connection: "linear",
-                description: "No tool or qualifiedName",
-              },
-              {
-                connection: "linear",
-                tool: "list_issues",
-                qualifiedName: "linear__list_issues",
-                description: "Valid",
-              },
-            ],
-          },
-        ],
-      },
-    ];
-
-    const result = extractDiscoveredTools(messages);
-    expect(result).toHaveLength(1);
-    expect(result[0]!.description).toBe("Valid");
   });
 });

--- a/packages/eve/src/runtime/framework-tools/connection-search-dynamic.ts
+++ b/packages/eve/src/runtime/framework-tools/connection-search-dynamic.ts
@@ -40,8 +40,6 @@ import {
 import type { ResolvedConnectionDefinition } from "#runtime/types.js";
 import { createLogger } from "#internal/logging.js";
 import { toError } from "#shared/errors.js";
-import type { ModelMessage } from "ai";
-
 import { ConnectionRegistryKey } from "#context/providers/connection-key.js";
 
 const logger = createLogger("framework.connection-search-dynamic");
@@ -78,7 +76,7 @@ const CONNECTION_SEARCH_OUTPUT_SCHEMA = z.array(CONNECTION_SEARCH_RESULT_ITEM_SC
  * `executeConnectionSearch` so the resolver can find discovered tools without
  * relying on model-facing tool result history.
  */
-const ConnectionSearchResultsKey = new ContextKey<readonly ConnectionSearchResultItem[]>(
+export const ConnectionSearchResultsKey = new ContextKey<readonly ConnectionSearchResultItem[]>(
   "eve.connectionSearchResults",
 );
 
@@ -363,44 +361,6 @@ async function executeConnectionSearch(
   return summaries;
 }
 
-/**
- * Extracts connection search results from conversation history.
- * Scans tool-result messages for `connection_search` results and
- * returns deduplicated tool metadata (latest result wins per qualifiedName).
- */
-export function extractDiscoveredTools(
-  messages: readonly ModelMessage[],
-): ConnectionSearchResultItem[] {
-  const byQualifiedName = new Map<string, ConnectionSearchResultItem>();
-
-  for (const msg of messages) {
-    if (msg.role !== "tool") continue;
-    const parts = msg.content as Array<{
-      type: string;
-      toolName?: string;
-      output?: unknown;
-    }>;
-    for (const part of parts) {
-      if (part.type !== "tool-result" || part.toolName !== "connection_search") continue;
-      const output = part.output;
-      if (output === undefined || output === null) continue;
-      const items = (
-        typeof output === "object" && "type" in output && "value" in output
-          ? (output as { value: unknown }).value
-          : output
-      ) as unknown;
-      if (!Array.isArray(items)) continue;
-      for (const item of items as ConnectionSearchResultItem[]) {
-        if (item.tool && item.qualifiedName) {
-          byQualifiedName.set(item.qualifiedName, item);
-        }
-      }
-    }
-  }
-
-  return [...byQualifiedName.values()];
-}
-
 function readDiscoveredToolClosure(closure: JsonObject): {
   readonly connectionName: string;
   readonly toolName: string;
@@ -511,26 +471,15 @@ async function authorizeDiscoveredConnectionToolApproval(
     : await response(context);
 }
 
-// The step-scoped definition re-derives its tools from conversation history.
-// After compaction removes old search results, those tools naturally disappear.
 const connectionSearchDynamicDefinition = defineDynamic({
   events: {
-    "step.started": async (_event, ctx) => {
+    "step.started": async () => {
       const registry = loadContext().get(ConnectionRegistryKey);
       if (!registry || registry.getConnections().length === 0) return null;
 
       const connections = registry.getConnections();
       const connectionNames = connections.map((c) => c.connectionName);
-      const fromMessages = extractDiscoveredTools(ctx.messages);
-      const fromContext = loadContext().get(ConnectionSearchResultsKey) ?? [];
-      const mergedMap = new Map<string, ConnectionSearchResultItem>();
-      for (const r of fromContext) {
-        if (r.qualifiedName) mergedMap.set(r.qualifiedName, r);
-      }
-      for (const r of fromMessages) {
-        if (r.qualifiedName) mergedMap.set(r.qualifiedName, r);
-      }
-      const discovered = [...mergedMap.values()];
+      const discovered = loadContext().get(ConnectionSearchResultsKey) ?? [];
 
       const tools: Record<string, object> = {};
 

--- a/packages/eve/src/runtime/framework-tools/index.test.ts
+++ b/packages/eve/src/runtime/framework-tools/index.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import {
   getAllFrameworkToolDefinitions,
   getAllFrameworkToolNames,
-  getFrameworkDynamicToolResolvers,
   getFrameworkToolDefinitions,
   getOptInFrameworkToolNames,
 } from "#runtime/framework-tools/index.js";
@@ -26,8 +25,7 @@ describe("framework-tools/index", () => {
     expect(names.has("task_update")).toBe(true);
     expect(names.has("task_sleep")).toBe(false);
     expect(names.has("task_send")).toBe(false);
-    // connection_search is now a dynamic tool resolver, not a framework tool
-    expect(names.has("connection_search")).toBe(false);
+    expect(names.has("connection_search")).toBe(true);
   });
 
   it("contains every framework tool exactly once", () => {
@@ -77,16 +75,5 @@ describe("framework-tools/index", () => {
 
       expect(tool.outputSchema, `${tool.name} has outputSchema`).toBeDefined();
     }
-  });
-
-  it("registers connection search through the framework dynamic tool registry", () => {
-    expect(getFrameworkDynamicToolResolvers()).toMatchObject([
-      {
-        eventNames: ["step.started"],
-        logicalPath: "eve:framework/connection-search-dynamic",
-        slug: "connection",
-        sourceId: "eve:connection-search-dynamic",
-      },
-    ]);
   });
 });

--- a/packages/eve/src/runtime/framework-tools/index.ts
+++ b/packages/eve/src/runtime/framework-tools/index.ts
@@ -13,8 +13,6 @@ import { TODO_TOOL_DEFINITION } from "#runtime/framework-tools/todo.js";
 import { WEB_FETCH_TOOL_DEFINITION } from "#runtime/framework-tools/web-fetch.js";
 import { WEB_SEARCH_TOOL_DEFINITION } from "#runtime/framework-tools/web-search.js";
 import { WRITE_FILE_TOOL_DEFINITION } from "#runtime/framework-tools/write-file.js";
-import connectionSearchDynamicDefinition from "#runtime/framework-tools/connection-search-dynamic.js";
-import { resolveLoadedDynamicToolDefinition } from "#runtime/resolve-dynamic-tool.js";
 
 export { ConnectionRegistryKey } from "#context/providers/connection-key.js";
 export type { ReadFileStamp, ReadFileState } from "#runtime/framework-tools/file-state.js";
@@ -22,28 +20,7 @@ export { ReadFileStateKey } from "#runtime/framework-tools/file-state.js";
 export type { TodoItem, TodoState } from "#runtime/framework-tools/todo.js";
 export { TodoStateKey } from "#runtime/framework-tools/todo.js";
 
-import type {
-  ResolvedDynamicToolResolver,
-  ResolvedSkillDefinition,
-  ResolvedToolDefinition,
-} from "#runtime/types.js";
-import type { DynamicSentinel } from "#shared/dynamic-tool-definition.js";
-
-interface FrameworkDynamicToolDefinition {
-  readonly definition: DynamicSentinel;
-  readonly logicalPath: string;
-  readonly slug: string;
-  readonly sourceId: string;
-}
-
-const REGISTERED_FRAMEWORK_DYNAMIC_TOOLS: readonly FrameworkDynamicToolDefinition[] = [
-  {
-    definition: connectionSearchDynamicDefinition,
-    logicalPath: "eve:framework/connection-search-dynamic",
-    slug: "connection",
-    sourceId: "eve:connection-search-dynamic",
-  },
-];
+import type { ResolvedSkillDefinition, ResolvedToolDefinition } from "#runtime/types.js";
 
 const REGISTERED_FRAMEWORK_TOOLS: readonly ResolvedToolDefinition[] = [
   ASK_QUESTION_TOOL_DEFINITION,
@@ -72,8 +49,7 @@ const ALL_FRAMEWORK_TOOLS: readonly ResolvedToolDefinition[] = [
  * Returns framework-owned tool definitions registered in the tool registry
  * alongside authored tools during graph resolution.
  *
- * `connection_search` is no longer in this list. The graph resolution path
- * registers it as a framework dynamic tool resolver.
+ * Source-composed dynamic tools are not represented in this legacy catalog.
  */
 export function getFrameworkToolDefinitions(config?: {
   readonly authoredSkills?: readonly ResolvedSkillDefinition[];
@@ -85,22 +61,6 @@ export function getFrameworkToolDefinitions(config?: {
     definition.name === SKILL_TOOL_DEFINITION.name
       ? createSkillToolDefinition(authoredSkills)
       : definition,
-  );
-}
-
-/**
- * Returns framework-owned dynamic tool resolvers.
- * Framework definitions use the public `defineDynamic()` contract and enter
- * the same loaded-definition resolver path as authored dynamic tools.
- */
-export function getFrameworkDynamicToolResolvers(): readonly ResolvedDynamicToolResolver[] {
-  return REGISTERED_FRAMEWORK_DYNAMIC_TOOLS.map((entry) =>
-    resolveLoadedDynamicToolDefinition(entry.definition, {
-      logicalPath: entry.logicalPath,
-      slug: entry.slug,
-      sourceId: entry.sourceId,
-      sourceKind: "module",
-    }),
   );
 }
 
@@ -127,5 +87,8 @@ export function getOptInFrameworkToolNames(): ReadonlySet<string> {
  * as an authoring error rather than silently dropping the request.
  */
 export function getAllFrameworkToolNames(): ReadonlySet<string> {
-  return new Set(ALL_FRAMEWORK_TOOLS.map((definition) => definition.name));
+  return new Set([
+    ...ALL_FRAMEWORK_TOOLS.map((definition) => definition.name),
+    "connection_search",
+  ]);
 }

--- a/packages/eve/src/runtime/resolve-agent-graph.ts
+++ b/packages/eve/src/runtime/resolve-agent-graph.ts
@@ -16,7 +16,6 @@ import {
 } from "#runtime/framework-channels/index.js";
 import {
   getAllFrameworkToolNames,
-  getFrameworkDynamicToolResolvers,
   getFrameworkToolDefinitions,
 } from "#runtime/framework-tools/index.js";
 import { type ResolvedAgentGraphBundle, ROOT_RUNTIME_AGENT_NODE_ID } from "#runtime/graph.js";
@@ -238,10 +237,7 @@ async function resolveRuntimeAgentNode(
       subagentNodesById: input.subagentNodesById,
     }),
   });
-  const resolvedAgent = {
-    ...agent,
-    dynamicToolResolvers: [...agent.dynamicToolResolvers, ...getFrameworkDynamicToolResolvers()],
-  };
+  const resolvedAgent = agent;
 
   const node: ResolvedAgentGraphBundle["root"] = {
     agent: resolvedAgent,


### PR DESCRIPTION
### Summary

Related to #2347. This is the fifth PR in the programmatic-agent-sources stack and depends on #2410.

`connection_search` still entered the runtime through a framework-only dynamic-tool registry after framework defaults moved into the compiler. That left two ownership paths for dynamic tools and forced agent inspection to merge two inventories.

Compile `connection_search` from `tools/connection_search.ts` through the same source composer and dynamic-definition resolver as authored tools. Framework provenance now comes from the winning source binding, and runtime graph resolution and agent inspection consume the manifest's single dynamic-tool inventory.

Discovered connection tools are now read only from durable execution context. The previous compatibility scanner reconstructed capability from model-facing tool-result history, coupling runtime state to transcript shape. Existing sessions without durable search state simply run `connection_search` again.

### Scope

- Preserves the public `connection_search` API and connection-tool authorization behavior.
- Removes the separate framework dynamic-tool registry and transcript-history scanner.
- Does not implement the memory lifecycle proof; that remains an explicit follow-up in the research plan.

### Validation

- `pnpm fmt`
- `pnpm lint` (passes; retains the pre-existing Teams optional-chaining warning)
- `pnpm typecheck`
- `pnpm guard:invariants`
- `pnpm test:unit` (671 files; 7,043 passed, 1 skipped)

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
