### PR TITLE
feat(eve): tools - compose the default web search source

### DIFF
--- a/.changeset/light-web-search.md
+++ b/.changeset/light-web-search.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Compose the default Exa-backed `web_search` configuration from the canonical `tools/web_search.ts` source slot, so application provider configuration and custom tool replacements override it through the ordinary source graph.

--- a/packages/eve/src/compiler/compose-framework-sources.test.ts
+++ b/packages/eve/src/compiler/compose-framework-sources.test.ts
@@ -46,6 +46,7 @@ describe("composeFrameworkSources", () => {
       "tools/read_file.ts",
       "tools/todo.ts",
       "tools/web_fetch.ts",
+      "tools/web_search.ts",
       "tools/write_file.ts",
     ]);
     expect(result.manifest.sandbox?.logicalPath).toBe("sandbox.ts");

--- a/packages/eve/src/compiler/normalize-manifest.test.ts
+++ b/packages/eve/src/compiler/normalize-manifest.test.ts
@@ -304,11 +304,11 @@ describe("compileAgentManifest", () => {
       tools: [createModuleSourceRef({ logicalPath: "tools/web_search.ts" })],
     });
     mocks.compileAgentConfig.mockResolvedValue(createConfig({ name: "root" }));
-    mocks.applicationDefinition.mockResolvedValue(webSearch({ provider: "exa" }));
+    mocks.applicationDefinition.mockResolvedValue(webSearch({ provider: "parallel" }));
 
     const compiled = await compileAgentManifest(manifest);
 
-    expect(compiled.webSearchProvider).toBe("exa");
+    expect(compiled.webSearchProvider).toBe("parallel");
     expect(compiled.tools.map((tool) => tool.name)).toEqual([
       "bash",
       "load_skill",
@@ -324,6 +324,36 @@ describe("compileAgentManifest", () => {
         sourceId: "eve.framework-defaults:tools/connection_search.ts",
       }),
     );
+  });
+
+  it("lets an application tool replace the default web search sentinel", async () => {
+    mocks.compileAgentConfig.mockResolvedValue(createConfig({ name: "root" }));
+    mocks.applicationDefinition.mockResolvedValue(
+      defineTool({
+        description: "Search an application index",
+        inputSchema: z.object({ query: z.string() }),
+        execute: () => [],
+      }),
+    );
+
+    const compiled = await compileAgentManifest(
+      createAgentSourceManifest({
+        agentId: "root",
+        agentRoot: "/app/agent",
+        appRoot: "/app",
+        tools: [createModuleSourceRef({ logicalPath: "tools/web_search.ts" })],
+      }),
+    );
+
+    expect(compiled.webSearchProvider).toBeUndefined();
+    expect(compiled.tools).toContainEqual(
+      expect.objectContaining({
+        description: "Search an application index",
+        name: "web_search",
+        sourceId: "tools/web_search.ts",
+      }),
+    );
+    expect(compiled.bindings["eve.framework-defaults:tools/web_search.ts"]).toBeUndefined();
   });
 
   it("compiles framework defaults through ordinary module bindings", async () => {
@@ -345,6 +375,7 @@ describe("compileAgentManifest", () => {
       "web_fetch",
       "write_file",
     ]);
+    expect(compiled.webSearchProvider).toBe("exa");
     expect(compiled.sandbox).toMatchObject({
       logicalPath: "sandbox.ts",
       sourceId: "eve.framework-defaults:sandbox.ts",

--- a/packages/eve/src/framework-sources/registry.ts
+++ b/packages/eve/src/framework-sources/registry.ts
@@ -5,6 +5,7 @@ import * as readFile from "./tools/read_file.js";
 import * as sandbox from "./sandbox.js";
 import * as todo from "./tools/todo.js";
 import * as webFetch from "./tools/web_fetch.js";
+import * as webSearch from "./tools/web_search.js";
 import * as writeFile from "./tools/write_file.js";
 import { createAgentSourceRegistry } from "#compiler/agent-source-registry.js";
 import { defineProgrammaticAgentSource } from "#compiler/programmatic-agent-source.js";
@@ -20,6 +21,7 @@ const frameworkAgentSource = defineProgrammaticAgentSource({
     { logicalPath: "tools/read_file.ts", namespace: readFile },
     { logicalPath: "tools/todo.ts", namespace: todo },
     { logicalPath: "tools/web_fetch.ts", namespace: webFetch },
+    { logicalPath: "tools/web_search.ts", namespace: webSearch },
     { logicalPath: "tools/write_file.ts", namespace: writeFile },
   ],
 });

--- a/packages/eve/src/framework-sources/tools/web_search.ts
+++ b/packages/eve/src/framework-sources/tools/web_search.ts
@@ -1,0 +1,3 @@
+import { webSearch } from "#public/tools/web-search.js";
+
+export default webSearch({ provider: "exa" });


### PR DESCRIPTION
### Summary

Related to #2347. This is the seventh PR in the programmatic-agent-sources stack and depends on #2412.

The default web-search provider was still an implicit runtime fallback. An application could configure or replace `web_search`, but there was no framework source occupying the same canonical slot for the source composer to arbitrate.

Register the default `webSearch({ provider: "exa" })` sentinel as `tools/web_search.ts`. Application provider configuration and a fully custom `defineTool()` export now replace that default through the same path-based winner selection as other tools.

### Behavior

- Preserves Exa as the AI Gateway default and preserves direct-provider native search selection.
- An application `webSearch({ provider: "parallel" })` selects Parallel.
- An application tool at `tools/web_search.ts` removes provider configuration and executes as the custom tool.

### Scope

- Provider-tool materialization remains execution-kernel behavior and is removed from the legacy catalog in a later stack layer.
- Does not implement the memory lifecycle proof; that remains an explicit research-plan follow-up.

### Validation

- `pnpm fmt`
- `pnpm lint` (passes; retains the pre-existing Teams optional-chaining warning)
- `pnpm typecheck`
- `pnpm guard:invariants`
- `pnpm test:unit` (671 files; 7,046 passed, 1 skipped)

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
