### PR TITLE
feat(eve): channels - compile framework routes as agent sources

### DIFF
--- a/.changeset/true-framework-channels.md
+++ b/.changeset/true-framework-channels.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Compile the default eve channel and six runtime callback routes from root-only canonical channel sources. Application channel definitions and disable sentinels can now replace each framework route through ordinary path-based composition.

--- a/packages/eve/src/compiler/compose-framework-sources.test.ts
+++ b/packages/eve/src/compiler/compose-framework-sources.test.ts
@@ -5,13 +5,14 @@ import { createAgentSourceManifest, createModuleSourceRef } from "#discover/mani
 import { frameworkAgentSourceRegistry } from "#framework-sources/registry.js";
 
 describe("composeFrameworkSources", () => {
-  it("uses application tools and sandbox modules for matching canonical slots", () => {
+  it("uses application channels, tools, and sandbox modules for matching canonical slots", () => {
     const result = composeFrameworkSources({
       isRoot: true,
       manifest: createAgentSourceManifest({
         agentId: "root",
         agentRoot: "/app/agent",
         appRoot: "/app",
+        channels: [createModuleSourceRef({ logicalPath: "channels/eve.ts" })],
         sandbox: createModuleSourceRef({ logicalPath: "sandbox/sandbox.ts" }),
         tools: [createModuleSourceRef({ logicalPath: "tools/bash.ts" })],
       }),
@@ -23,6 +24,11 @@ describe("composeFrameworkSources", () => {
       result.manifest.tools.find((tool) => tool.logicalPath === "tools/bash.ts")?.sourceId,
     ).toBe("tools/bash.ts");
     expect(result.manifest.sandbox?.sourceId).toBe("sandbox/sandbox.ts");
+    expect(
+      result.manifest.channels.find((channel) => channel.logicalPath === "channels/eve.ts")
+        ?.sourceId,
+    ).toBe("channels/eve.ts");
+    expect(result.bindings["eve.framework-root:channels/eve.ts"]).toBeUndefined();
     expect(result.bindings["eve.framework-defaults:tools/bash.ts"]).toBeUndefined();
     expect(result.bindings["eve.framework-defaults:sandbox.ts"]).toBeUndefined();
   });
@@ -49,6 +55,7 @@ describe("composeFrameworkSources", () => {
       "tools/web_search.ts",
       "tools/write_file.ts",
     ]);
+    expect(result.manifest.channels).toEqual([]);
     expect(result.manifest.sandbox?.logicalPath).toBe("sandbox.ts");
     expect(result.bindings["eve.framework-defaults:tools/bash.ts"]).toEqual({
       backing: {

--- a/packages/eve/src/compiler/compose-framework-sources.ts
+++ b/packages/eve/src/compiler/compose-framework-sources.ts
@@ -5,7 +5,7 @@ import type { AgentSourceRegistry } from "#compiler/agent-source-registry.js";
 import { composeAgentModuleCandidates } from "#compiler/compose-agent-module-candidates.js";
 import type { CompiledModuleBinding } from "#compiler/module-binding.js";
 import { createProgrammaticModuleCandidates } from "#compiler/programmatic-module-candidates.js";
-import type { AgentSourceManifest, ToolSourceRef } from "#discover/manifest.js";
+import type { AgentSourceManifest, ChannelSourceRef, ToolSourceRef } from "#discover/manifest.js";
 import type { ModuleSourceRef } from "#shared/source-ref.js";
 
 export interface ComposedFrameworkSources {
@@ -20,6 +20,7 @@ export function composeFrameworkSources(input: {
   readonly registry: AgentSourceRegistry;
 }): ComposedFrameworkSources {
   const applicationRefs = [
+    ...input.manifest.channels,
     ...input.manifest.tools,
     ...(input.manifest.sandbox === null ? [] : [input.manifest.sandbox]),
   ];
@@ -32,7 +33,9 @@ export function composeFrameworkSources(input: {
     registry: input.registry,
   }).filter(
     (candidate) =>
-      candidate.logicalPath === "sandbox.ts" || candidate.logicalPath.startsWith("tools/"),
+      candidate.logicalPath.startsWith("channels/") ||
+      candidate.logicalPath === "sandbox.ts" ||
+      candidate.logicalPath.startsWith("tools/"),
   );
   const composition = composeAgentModuleCandidates([
     ...frameworkCandidates,
@@ -40,6 +43,7 @@ export function composeFrameworkSources(input: {
   ]);
   const refsBySourceId = new Map(applicationRefs.map((source) => [source.sourceId, source]));
   const bindings: Record<string, CompiledModuleBinding> = {};
+  const channels: ChannelSourceRef[] = [];
   const tools: ToolSourceRef[] = [];
   let sandbox: ModuleSourceRef | null = null;
 
@@ -53,6 +57,7 @@ export function composeFrameworkSources(input: {
         owner: winner.owner,
       };
     }
+    if (winner.logicalPath.startsWith("channels/")) channels.push(source);
     if (winner.logicalPath.startsWith("tools/")) tools.push(source);
     if (winner.logicalPath === "sandbox.ts" || winner.logicalPath.startsWith("sandbox/")) {
       sandbox = source;
@@ -61,7 +66,7 @@ export function composeFrameworkSources(input: {
 
   return {
     bindings,
-    manifest: { ...input.manifest, sandbox, tools },
+    manifest: { ...input.manifest, channels, sandbox, tools },
   };
 }
 

--- a/packages/eve/src/compiler/module-map.test.ts
+++ b/packages/eve/src/compiler/module-map.test.ts
@@ -143,6 +143,45 @@ describe("createCompiledModuleMapSource", () => {
     );
   });
 
+  it("imports root-only framework sources from the framework registry", () => {
+    const manifest = createManifestWithTool("/consumer/agent");
+    const sourceId = "eve.framework-root:channels/eve.ts";
+    const source = createCompiledModuleMapSource({
+      manifest: {
+        ...manifest,
+        bindings: {
+          [sourceId]: {
+            backing: {
+              kind: "programmatic",
+              moduleId: "channels/eve.ts",
+              registryId: "eve.framework-root",
+            },
+            logicalPath: "channels/eve.ts",
+            owner: { feature: "eve.framework-root", kind: "framework" },
+          },
+        },
+        channels: [
+          {
+            kind: "channel",
+            logicalPath: "channels/eve.ts",
+            method: "POST",
+            name: "eve",
+            sourceId,
+            sourceKind: "module",
+            urlPath: "/eve/v1/session",
+          },
+        ],
+        tools: [],
+      },
+      moduleMapPath: "/consumer/.eve/compile/module-map.mjs",
+    });
+
+    expect(source).toContain("frameworkAgentSourceRegistry as module_0");
+    expect(source).toContain(
+      'module_0.getModule({"kind":"programmatic","moduleId":"channels/eve.ts","registryId":"eve.framework-root"}).namespace',
+    );
+  });
+
   it("imports the physical binding instead of reconstructing it from logical identity", () => {
     const manifest = createManifestWithTool("/consumer/agent");
     const source = createCompiledModuleMapSource({

--- a/packages/eve/src/compiler/module-map.ts
+++ b/packages/eve/src/compiler/module-map.ts
@@ -11,7 +11,10 @@ import { assertTotalModuleBindings } from "#compiler/module-binding.js";
 import { collectModuleRefsForManifest } from "#compiler/module-references.js";
 import type { ModuleSourceRef } from "#shared/source-ref.js";
 import { normalizeEsmImportSpecifier } from "#internal/application/import-specifier.js";
-import { FRAMEWORK_AGENT_SOURCE_ID } from "#framework-sources/constants.js";
+import {
+  FRAMEWORK_AGENT_SOURCE_ID,
+  FRAMEWORK_ROOT_AGENT_SOURCE_ID,
+} from "#framework-sources/constants.js";
 
 /**
  * Compiled module ownership for one runtime graph node.
@@ -76,6 +79,12 @@ export function createCompiledModuleMapSource(input: CreateCompiledModuleMapSour
   const importSpecifierStyle = input.importSpecifierStyle ?? "relative";
   const programmaticRegistryImports = {
     [FRAMEWORK_AGENT_SOURCE_ID]: {
+      exportName: "frameworkAgentSourceRegistry",
+      importSpecifier: normalizeEsmImportSpecifier(
+        fileURLToPath(new URL("../framework-sources/registry.js", import.meta.url)),
+      ),
+    },
+    [FRAMEWORK_ROOT_AGENT_SOURCE_ID]: {
       exportName: "frameworkAgentSourceRegistry",
       importSpecifier: normalizeEsmImportSpecifier(
         fileURLToPath(new URL("../framework-sources/registry.js", import.meta.url)),

--- a/packages/eve/src/compiler/normalize-manifest.test.ts
+++ b/packages/eve/src/compiler/normalize-manifest.test.ts
@@ -40,7 +40,8 @@ describe("compileAgentManifest", () => {
         return await mocks.applicationDefinition(input);
       }
       const namespace = await input.moduleLoader.load(input.binding.backing);
-      return namespace[input.source.exportName ?? "default"];
+      const value = namespace[input.source.exportName ?? "default"];
+      return typeof value === "function" ? await value() : value;
     });
   });
 
@@ -376,6 +377,30 @@ describe("compileAgentManifest", () => {
       "write_file",
     ]);
     expect(compiled.webSearchProvider).toBe("exa");
+    expect(compiled.channels).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          adapterKind: "http",
+          logicalPath: "channels/eve.ts",
+          name: "eve",
+          sourceId: "eve.framework-root:channels/eve.ts",
+        }),
+        expect.objectContaining({
+          adapterKind: "http",
+          logicalPath: "channels/eve/v1/connections/callback/get.ts",
+          method: "GET",
+          name: "eve/v1/connections/callback/get",
+          sourceId: "eve.framework-root:channels/eve/v1/connections/callback/get.ts",
+        }),
+        expect.objectContaining({
+          adapterKind: "http",
+          logicalPath: "channels/eve/v1/task-input/post.ts",
+          method: "POST",
+          name: "eve/v1/task-input/post",
+          sourceId: "eve.framework-root:channels/eve/v1/task-input/post.ts",
+        }),
+      ]),
+    );
     expect(compiled.sandbox).toMatchObject({
       logicalPath: "sandbox.ts",
       sourceId: "eve.framework-defaults:sandbox.ts",

--- a/packages/eve/src/framework-sources/channels/eve.ts
+++ b/packages/eve/src/framework-sources/channels/eve.ts
@@ -1,0 +1,7 @@
+import { localDev, placeholderAuth, vercelOidc } from "#public/channels/auth.js";
+import { eveChannel } from "#public/channels/eve.js";
+
+export default () =>
+  eveChannel({
+    auth: [vercelOidc(), localDev(), placeholderAuth()],
+  });

--- a/packages/eve/src/framework-sources/channels/eve/v1/callback/post.ts
+++ b/packages/eve/src/framework-sources/channels/eve/v1/callback/post.ts
@@ -1,0 +1,8 @@
+import { EVE_CALLBACK_ROUTE_PATTERN } from "#protocol/routes.js";
+import { defineChannel, POST } from "#public/definitions/channel.js";
+import { handleSessionCallbackRequest } from "#runtime/session-callback-route.js";
+
+export default () =>
+  defineChannel({
+    routes: [POST(EVE_CALLBACK_ROUTE_PATTERN, handleSessionCallbackRequest)],
+  });

--- a/packages/eve/src/framework-sources/channels/eve/v1/connections/callback/get.ts
+++ b/packages/eve/src/framework-sources/channels/eve/v1/connections/callback/get.ts
@@ -1,0 +1,8 @@
+import { EVE_CONNECTION_CALLBACK_ROUTE_PATTERN } from "#protocol/routes.js";
+import { defineChannel, GET } from "#public/definitions/channel.js";
+import { handleConnectionCallbackRequest } from "#runtime/connections/callback-route.js";
+
+export default () =>
+  defineChannel({
+    routes: [GET(EVE_CONNECTION_CALLBACK_ROUTE_PATTERN, handleConnectionCallbackRequest)],
+  });

--- a/packages/eve/src/framework-sources/channels/eve/v1/connections/callback/legacy/get.ts
+++ b/packages/eve/src/framework-sources/channels/eve/v1/connections/callback/legacy/get.ts
@@ -1,0 +1,10 @@
+import { EVE_LEGACY_CONNECTION_CALLBACK_ROUTE_PATTERN } from "#protocol/routes.js";
+import { defineChannel, GET } from "#public/definitions/channel.js";
+import { handleLegacyConnectionCallbackRequest } from "#runtime/connections/callback-route.js";
+
+export default () =>
+  defineChannel({
+    routes: [
+      GET(EVE_LEGACY_CONNECTION_CALLBACK_ROUTE_PATTERN, handleLegacyConnectionCallbackRequest),
+    ],
+  });

--- a/packages/eve/src/framework-sources/channels/eve/v1/connections/callback/legacy/post.ts
+++ b/packages/eve/src/framework-sources/channels/eve/v1/connections/callback/legacy/post.ts
@@ -1,0 +1,10 @@
+import { EVE_LEGACY_CONNECTION_CALLBACK_ROUTE_PATTERN } from "#protocol/routes.js";
+import { defineChannel, POST } from "#public/definitions/channel.js";
+import { handleLegacyConnectionCallbackRequest } from "#runtime/connections/callback-route.js";
+
+export default () =>
+  defineChannel({
+    routes: [
+      POST(EVE_LEGACY_CONNECTION_CALLBACK_ROUTE_PATTERN, handleLegacyConnectionCallbackRequest),
+    ],
+  });

--- a/packages/eve/src/framework-sources/channels/eve/v1/connections/callback/post.ts
+++ b/packages/eve/src/framework-sources/channels/eve/v1/connections/callback/post.ts
@@ -1,0 +1,8 @@
+import { EVE_CONNECTION_CALLBACK_ROUTE_PATTERN } from "#protocol/routes.js";
+import { defineChannel, POST } from "#public/definitions/channel.js";
+import { handleConnectionCallbackRequest } from "#runtime/connections/callback-route.js";
+
+export default () =>
+  defineChannel({
+    routes: [POST(EVE_CONNECTION_CALLBACK_ROUTE_PATTERN, handleConnectionCallbackRequest)],
+  });

--- a/packages/eve/src/framework-sources/channels/eve/v1/task-input/post.ts
+++ b/packages/eve/src/framework-sources/channels/eve/v1/task-input/post.ts
@@ -1,0 +1,8 @@
+import { EVE_TASK_INPUT_ROUTE_PATTERN } from "#protocol/routes.js";
+import { defineChannel, POST } from "#public/definitions/channel.js";
+import { handleTaskInputResponseRequest } from "#runtime/task-input-response-route.js";
+
+export default () =>
+  defineChannel({
+    routes: [POST(EVE_TASK_INPUT_ROUTE_PATTERN, handleTaskInputResponseRequest)],
+  });

--- a/packages/eve/src/framework-sources/constants.ts
+++ b/packages/eve/src/framework-sources/constants.ts
@@ -1,1 +1,2 @@
 export const FRAMEWORK_AGENT_SOURCE_ID = "eve.framework-defaults";
+export const FRAMEWORK_ROOT_AGENT_SOURCE_ID = "eve.framework-root";

--- a/packages/eve/src/framework-sources/registry.ts
+++ b/packages/eve/src/framework-sources/registry.ts
@@ -9,7 +9,7 @@ import * as webSearch from "./tools/web_search.js";
 import * as writeFile from "./tools/write_file.js";
 import { createAgentSourceRegistry } from "#compiler/agent-source-registry.js";
 import { defineProgrammaticAgentSource } from "#compiler/programmatic-agent-source.js";
-import { FRAMEWORK_AGENT_SOURCE_ID } from "./constants.js";
+import { FRAMEWORK_AGENT_SOURCE_ID, FRAMEWORK_ROOT_AGENT_SOURCE_ID } from "./constants.js";
 
 const frameworkAgentSource = defineProgrammaticAgentSource({
   id: FRAMEWORK_AGENT_SOURCE_ID,
@@ -26,6 +26,39 @@ const frameworkAgentSource = defineProgrammaticAgentSource({
   ],
 });
 
+const frameworkRootAgentSource = defineProgrammaticAgentSource({
+  id: FRAMEWORK_ROOT_AGENT_SOURCE_ID,
+  modules: [
+    { logicalPath: "channels/eve.ts", namespace: eveChannel },
+    { logicalPath: "channels/eve/v1/callback/post.ts", namespace: sessionCallbackPost },
+    {
+      logicalPath: "channels/eve/v1/connections/callback/get.ts",
+      namespace: connectionCallbackGet,
+    },
+    {
+      logicalPath: "channels/eve/v1/connections/callback/legacy/get.ts",
+      namespace: legacyConnectionCallbackGet,
+    },
+    {
+      logicalPath: "channels/eve/v1/connections/callback/legacy/post.ts",
+      namespace: legacyConnectionCallbackPost,
+    },
+    {
+      logicalPath: "channels/eve/v1/connections/callback/post.ts",
+      namespace: connectionCallbackPost,
+    },
+    { logicalPath: "channels/eve/v1/task-input/post.ts", namespace: taskInputPost },
+  ],
+});
+
 export const frameworkAgentSourceRegistry = createAgentSourceRegistry([
   { applyTo: "all-local-nodes", source: frameworkAgentSource },
+  { applyTo: "root", source: frameworkRootAgentSource },
 ]);
+import * as eveChannel from "./channels/eve.js";
+import * as sessionCallbackPost from "./channels/eve/v1/callback/post.js";
+import * as connectionCallbackGet from "./channels/eve/v1/connections/callback/get.js";
+import * as legacyConnectionCallbackGet from "./channels/eve/v1/connections/callback/legacy/get.js";
+import * as legacyConnectionCallbackPost from "./channels/eve/v1/connections/callback/legacy/post.js";
+import * as connectionCallbackPost from "./channels/eve/v1/connections/callback/post.js";
+import * as taskInputPost from "./channels/eve/v1/task-input/post.js";

--- a/packages/eve/src/runtime/connections/callback-route.ts
+++ b/packages/eve/src/runtime/connections/callback-route.ts
@@ -115,7 +115,7 @@ export async function handleConnectionCallbackRequest(
   return handleCallbackRequest(request, ctx, false);
 }
 
-async function handleLegacyConnectionCallbackRequest(
+export async function handleLegacyConnectionCallbackRequest(
   request: Request,
   ctx: RouteContext,
 ): Promise<Response> {


### PR DESCRIPTION
### Summary

Related to #2347. This is the eighth PR in the programmatic-agent-sources stack and depends on #2413.

Framework HTTP surfaces were still created as resolved runtime objects outside compilation. That gave channels a second ownership path and meant application replacement and disable behavior was implemented after normalization.

Register the default eve channel plus the six connection, session, and task callback handlers as root-only programmatic channel modules. The callback modules are ordinary one-route `defineChannel()` factories with HTTP adapter metadata. The composer now includes application and framework channel candidates, selects by canonical logical path, and sends only winners through ordinary channel normalization.

### Behavior

- Preserves every existing URL, method, authorization rule, legacy connection callback, status code, and response body.
- An application channel or `disableRoute()` at any of the seven canonical identities replaces that complete framework module before route expansion.
- Subagents do not receive root-only channel sources.

### Scope

- The temporary runtime/Nitro framework-channel merge remains for legacy in-memory graphs and is removed by the following stack layer.
- Does not implement the memory lifecycle proof; that remains an explicit research-plan follow-up.

### Validation

- `pnpm fmt`
- `pnpm lint` (passes; retains the pre-existing Teams optional-chaining warning)
- `pnpm typecheck`
- `pnpm guard:invariants`
- `pnpm test:unit` (671 files; 7,046 passed, 1 skipped)

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
