### PR TITLE
chore(eve): testing - compile memory fixtures through source graph

### DIFF
--- a/packages/eve/src/compiler/compile-from-memory.test.ts
+++ b/packages/eve/src/compiler/compile-from-memory.test.ts
@@ -9,21 +9,24 @@ import {
 import { compileFromMemory } from "#compiler/compile-from-memory.js";
 
 describe("compileFromMemory", () => {
-  it("produces a manifest and module map with minimal input", () => {
-    const { manifest, moduleMap } = compileFromMemory({ model: "openai/gpt-5.4" });
+  it("produces a manifest and module map with minimal input", async () => {
+    const { manifest, moduleMap } = await compileFromMemory({ model: "openai/gpt-5.4" });
 
     expect(manifest.kind).toBe(COMPILED_AGENT_MANIFEST_KIND);
     expect(manifest.version).toBe(COMPILED_AGENT_MANIFEST_VERSION);
     expect(manifest.config.name).toBe("memory-agent");
     expect(manifest.config.model?.id).toBe("openai/gpt-5.4");
-    expect(manifest.tools).toEqual([]);
+    expect(manifest.tools.filter((tool) => tool.sourceId.startsWith("memory:"))).toEqual([]);
+    expect(manifest.tools.length).toBeGreaterThan(0);
     expect(manifest.skills).toEqual([]);
     expect(manifest.subagents).toEqual([]);
-    expect(moduleMap.nodes[ROOT_COMPILED_AGENT_NODE_ID]?.modules).toEqual({});
+    expect(
+      Object.keys(moduleMap.nodes[ROOT_COMPILED_AGENT_NODE_ID]?.modules ?? {}).length,
+    ).toBeGreaterThan(0);
   });
 
-  it("honours descriptor overrides for name, model, and roots", () => {
-    const { manifest } = compileFromMemory({
+  it("honours descriptor overrides for name, model, and roots", async () => {
+    const { manifest } = await compileFromMemory({
       name: "custom-agent",
       model: "mock/custom",
       appRoot: "/app",
@@ -36,31 +39,57 @@ describe("compileFromMemory", () => {
     expect(manifest.agentRoot).toBe("/app/agent");
   });
 
-  it("projects authored tools into the manifest and module map", () => {
-    const { manifest, moduleMap } = compileFromMemory({
+  it("projects authored tools into the manifest and module map", async () => {
+    const executeWeather = async () => ({ temperature: 72 });
+    const { manifest, moduleMap } = await compileFromMemory({
       model: "openai/gpt-5.4",
       tools: [
-        { name: "weather", description: "Gets the weather.", inputSchema: { kind: "object" } },
+        {
+          name: "weather",
+          description: "Gets the weather.",
+          execute: executeWeather,
+          inputSchema: { kind: "object" },
+        },
         { name: "echo", outputSchema: { type: "string" } },
       ],
     });
 
-    expect(manifest.tools).toHaveLength(2);
-    const [weather, echo] = manifest.tools;
-    expect(weather?.name).toBe("weather");
-    expect(weather?.description).toBe("Gets the weather.");
-    expect(weather?.inputSchema).toEqual({ kind: "object" });
-    expect(weather?.logicalPath).toBe("tools/weather.ts");
-    expect(echo?.description).toBe("echo test tool.");
-    expect(echo?.outputSchema).toEqual({ type: "string" });
+    const authoredTools = manifest.tools.filter((tool) => tool.sourceId.startsWith("memory:"));
+    expect(authoredTools).toHaveLength(2);
+    const weather = authoredTools.find((tool) => tool.name === "weather");
+    const echo = authoredTools.find((tool) => tool.name === "echo");
+    if (weather === undefined || echo === undefined)
+      throw new Error("Missing authored test tools.");
+    expect(weather.name).toBe("weather");
+    expect(weather.description).toBe("Gets the weather.");
+    expect(weather.inputSchema).toEqual({ kind: "object" });
+    expect(weather.logicalPath).toBe("tools/weather.ts");
+    expect(echo.description).toBe("echo test tool.");
+    expect(echo.outputSchema).toEqual({ type: "string" });
 
     const rootModules = moduleMap.nodes[ROOT_COMPILED_AGENT_NODE_ID]?.modules ?? {};
-    expect(Object.keys(rootModules)).toHaveLength(2);
-    expect(rootModules[weather?.sourceId ?? ""]).toBeDefined();
+    expect(
+      Object.keys(rootModules).filter((sourceId) => sourceId.startsWith("memory:")),
+    ).toHaveLength(2);
+    const weatherNamespace = rootModules[weather.sourceId];
+    if (weatherNamespace === undefined) throw new Error("Missing weather module namespace.");
+    expect(weatherNamespace.default).toMatchObject({
+      description: "Gets the weather.",
+    });
+    expect((weatherNamespace.default as { execute?: unknown }).execute).toBe(executeWeather);
+    expect(manifest.bindings[weather.sourceId]).toMatchObject({
+      backing: {
+        kind: "programmatic",
+        moduleId: "tools/weather.ts",
+        registryId: "eve-memory-application",
+      },
+      owner: { kind: "application" },
+    });
+    expect(rootModules["agent.ts"]?.default).toMatchObject({ model: "openai/gpt-5.4" });
   });
 
-  it("projects markdown skills into the manifest", () => {
-    const { manifest } = compileFromMemory({
+  it("projects ordinary skill modules into the manifest", async () => {
+    const { manifest } = await compileFromMemory({
       model: "openai/gpt-5.4",
       skills: [{ name: "greetings", description: "Say hi", markdown: "# greet\n" }],
     });
@@ -70,18 +99,18 @@ describe("compileFromMemory", () => {
     expect(skill?.name).toBe("greetings");
     expect(skill?.description).toBe("Say hi");
     expect(skill?.markdown).toBe("# greet\n");
-    expect(skill?.sourceKind).toBe("markdown");
-    expect(skill?.logicalPath).toBe("skills/greetings.md");
+    expect(skill?.sourceKind).toBe("module");
+    expect(skill?.logicalPath).toBe("skills/greetings.ts");
   });
 
-  it("produces a manifest that passes the versioned schema validation", () => {
-    const { manifest } = compileFromMemory({
+  it("produces a manifest that passes the versioned schema validation", async () => {
+    const { manifest } = await compileFromMemory({
       model: "openai/gpt-5.4",
       tools: [{ name: "ping" }],
       skills: [{ name: "hello", description: "Greet" }],
     });
 
     const parsed = compiledAgentManifestSchema.safeParse(manifest);
-    expect(parsed.success).toBe(true);
+    expect(parsed.success, parsed.error?.message).toBe(true);
   });
 });

--- a/packages/eve/src/compiler/compile-from-memory.ts
+++ b/packages/eve/src/compiler/compile-from-memory.ts
@@ -1,170 +1,193 @@
 import type { JsonObject } from "#shared/json.js";
-import { classifyModelRouting } from "#internal/classify-model-routing.js";
+import type { SkillFileContent } from "#public/definitions/skill.js";
+import type { ResolvedToolDefinition } from "#runtime/types.js";
+import { createAgentSourceManifest, createModuleSourceRef } from "#discover/manifest.js";
 import {
-  type CompiledAgentDefinition,
-  type CompiledAgentManifest,
-  type CompiledSkillDefinition,
-  type CompiledToolDefinition,
-  createCompiledAgentManifest,
-  ROOT_COMPILED_AGENT_NODE_ID,
-} from "#compiler/manifest.js";
-import type { CompiledModuleMap } from "#compiler/module-map.js";
-import { prepareKernelCapabilities } from "#compiler/prepare-kernel-capabilities.js";
+  createAgentSourceRegistry,
+  type AgentSourceRegistry,
+} from "#compiler/agent-source-registry.js";
+import { defineProgrammaticAgentSource } from "#compiler/programmatic-agent-source.js";
+import { frameworkAgentSourceRegistry } from "#framework-sources/registry.js";
+import { compileAgentManifest } from "#compiler/normalize-manifest.js";
+import type { CompiledAgentManifest } from "#compiler/manifest.js";
+import {
+  createProgrammaticCompiledModuleMap,
+  type CompiledModuleMap,
+} from "#compiler/module-map.js";
+import type { CompiledRuntimeModelCatalogLoader } from "#compiler/model-catalog.js";
 
-/**
- * Declarative description of an in-memory authored agent used by the test
- * harness.
- */
+const MEMORY_APPLICATION_SOURCE_ID = "eve-memory-application";
+const MEMORY_MODEL_LIMITS = {
+  contextWindowTokens: 128_000,
+  maxOutputTokens: 32_000,
+} as const;
+
+/** Declarative description of an in-memory authored agent used by tests. */
 export interface CompileFromMemoryInput {
   /** Identifies this synthetic agent in manifest metadata and error output. */
   readonly name?: string;
-  /**
-   * Virtual app root used in manifest paths. The directory does not need to
-   * exist on disk; discovery never runs against it.
-   */
+  /** Virtual app root. No files need to exist beneath it. */
   readonly appRoot?: string;
-  /**
-   * Virtual agent root. Defaults to `<appRoot>/agent`.
-   */
+  /** Virtual agent root. Defaults to `<appRoot>/agent`. */
   readonly agentRoot?: string;
-  /** Model id assigned to the synthetic agent config. */
+  /** Model id authored by the synthetic `agent.ts`. */
   readonly model: string;
-  /** Session token limits assigned to the synthetic agent config. */
   readonly limits?: {
     readonly maxInputTokensPerSession?: number | false;
     readonly maxOutputTokensPerSession?: number | false;
     readonly sessionTimeoutMs?: number | false;
   };
   readonly outputSchema?: JsonObject;
-  /**
-   * Authored tools to project into the compiled manifest and module map.
-   *
-   * Each entry corresponds to a single module-backed tool. The harness does
-   * not load the tool module from disk — its runtime behaviour is injected
-   * separately via the AppHarness `mockTool` API.
-   */
   readonly tools?: readonly CompileFromMemoryToolInput[];
-  /**
-   * Authored markdown skills to include in the manifest.
-   */
   readonly skills?: readonly CompileFromMemorySkillInput[];
 }
 
-/**
- * Per-tool descriptor entry consumed by {@link compileFromMemory}.
- */
+/** One ordinary `tools/<name>.ts` module in the in-memory application source. */
 export interface CompileFromMemoryToolInput {
-  /** Model-facing tool name; must match the slot name in the module map. */
   readonly name: string;
-  /** Human-readable description propagated to the compiled manifest. */
   readonly description?: string;
-  /**
-   * JSON-schema-like object describing the tool input. Passed through as-is
-   * (lowered to `null` when omitted).
-   */
   readonly inputSchema?: JsonObject | null;
-  /** JSON-schema-like object describing the tool output. */
   readonly outputSchema?: JsonObject;
+  readonly execute?: ResolvedToolDefinition["execute"];
+  readonly execution?: ResolvedToolDefinition["execution"];
+  readonly approval?: ResolvedToolDefinition["approval"];
+  readonly toModelOutput?: ResolvedToolDefinition["toModelOutput"];
 }
 
-/**
- * Per-skill descriptor entry consumed by {@link compileFromMemory}.
- */
+/** One ordinary `skills/<name>.ts` module in the in-memory application source. */
 export interface CompileFromMemorySkillInput {
   readonly name: string;
   readonly description: string;
   readonly markdown?: string;
+  readonly files?: Readonly<Record<string, SkillFileContent>>;
+  readonly license?: string;
+  readonly metadata?: Readonly<Record<string, string>>;
 }
 
-/**
- * Result produced by {@link compileFromMemory}. Shaped to match the subset
- * of `CompileAgentResult` that the runtime and harness need.
- */
 export interface CompileFromMemoryResult {
   readonly manifest: CompiledAgentManifest;
   readonly moduleMap: CompiledModuleMap;
 }
 
 /**
- * Builds a compiled manifest and matching module map directly from an
- * in-memory descriptor, bypassing discovery and bundling entirely.
- *
- * Intended for integration tests that want to exercise runtime behaviour
- * without the cost of real compilation. Production code must continue to
- * use {@link compileAgent}.
+ * Compiles an in-process authored source through the same source composition,
+ * primitive normalizers, binding validation, and kernel preparation used by a
+ * filesystem-authored agent. Only module loading differs: namespaces come from
+ * a scoped programmatic registry instead of JavaScript files on disk.
  */
-export function compileFromMemory(input: CompileFromMemoryInput): CompileFromMemoryResult {
+export async function compileFromMemory(
+  input: CompileFromMemoryInput,
+): Promise<CompileFromMemoryResult> {
   const appRoot = input.appRoot ?? "/virtual/eve-memory-app";
   const agentRoot = input.agentRoot ?? `${appRoot}/agent`;
   const agentName = input.name ?? "memory-agent";
-
-  const config: CompiledAgentDefinition = {
-    model: { id: input.model, routing: classifyModelRouting(input.model) },
-    name: agentName,
-  };
-  if (input.limits !== undefined) {
-    config.limits = input.limits;
-  }
-  if (input.outputSchema !== undefined) {
-    config.outputSchema = input.outputSchema;
-  }
-
-  const tools: CompiledToolDefinition[] = (input.tools ?? []).map((toolInput) => ({
-    description: toolInput.description ?? `${toolInput.name} test tool.`,
-    inputSchema: toolInput.inputSchema ?? null,
-    logicalPath: `tools/${toolInput.name}.ts`,
-    name: toolInput.name,
-    outputSchema: toolInput.outputSchema,
-    sourceId: createMemorySourceId(`tools/${toolInput.name}.ts`),
-    sourceKind: "module",
-  }));
-
-  const skills: CompiledSkillDefinition[] = (input.skills ?? []).map((skillInput) => ({
-    description: skillInput.description,
-    logicalPath: `skills/${skillInput.name}.md`,
-    markdown: skillInput.markdown ?? `# ${skillInput.name}\n`,
-    name: skillInput.name,
-    sourceId: createMemorySourceId(`skills/${skillInput.name}.md`),
-    sourceKind: "markdown",
-  }));
-
-  const manifest = createCompiledAgentManifest({
-    agentRoot,
-    appRoot,
-    config,
-    kernelCapabilities: prepareKernelCapabilities({
-      disabled: new Set(),
-      frameworkLoadSkill: true,
-      hasSkills: skills.length > 0,
-      isRoot: true,
-      tasksEnabled: true,
-      toolNames: new Set(tools.map((tool) => tool.name)),
-      webSearch: false,
-      workflow: false,
-    }),
-    skills,
-    tools,
+  const toolModules = (input.tools ?? []).map((tool) => {
+    const logicalPath = `tools/${tool.name}.ts`;
+    return {
+      logicalPath,
+      namespace: { default: createAuthoredToolDefinition(tool) },
+    };
   });
-
-  const moduleMap: CompiledModuleMap = {
-    nodes: {
-      [ROOT_COMPILED_AGENT_NODE_ID]: {
-        modules: Object.fromEntries(
-          tools.map((tool) => [tool.sourceId, Object.freeze({}) as Record<string, unknown>]),
-        ),
+  const skillModules = (input.skills ?? []).map((skill) => {
+    const logicalPath = `skills/${skill.name}.ts`;
+    return {
+      logicalPath,
+      namespace: { default: createAuthoredSkillDefinition(skill) },
+    };
+  });
+  const applicationSource = defineProgrammaticAgentSource({
+    id: MEMORY_APPLICATION_SOURCE_ID,
+    modules: [
+      {
+        logicalPath: "agent.ts",
+        namespace: { default: createAuthoredAgentDefinition(input) },
       },
+      ...toolModules,
+      ...skillModules,
+    ],
+  });
+  const registry = createMemoryRegistry(applicationSource);
+  const manifest = await compileAgentManifest(
+    createAgentSourceManifest({
+      agentId: agentName,
+      agentRoot,
+      appRoot,
+      configModule: createModuleSourceRef({ logicalPath: "agent.ts" }),
+      skills: skillModules.map(({ logicalPath }) =>
+        createModuleSourceRef({ logicalPath, sourceId: createMemorySourceId(logicalPath) }),
+      ),
+      tools: toolModules.map(({ logicalPath }) =>
+        createModuleSourceRef({ logicalPath, sourceId: createMemorySourceId(logicalPath) }),
+      ),
+    }),
+    {
+      applicationSourceOrigin: {
+        backing: { kind: "programmatic", registryId: applicationSource.id },
+        layer: "application",
+        owner: { kind: "application" },
+      },
+      modelCatalog: memoryModelCatalog,
+      moduleRegistry: registry,
     },
-  };
+  );
 
   return {
     manifest,
-    moduleMap,
+    moduleMap: createProgrammaticCompiledModuleMap({ manifest, registry }),
   };
 }
 
+function createMemoryRegistry(
+  applicationSource: ReturnType<typeof defineProgrammaticAgentSource>,
+): AgentSourceRegistry {
+  return createAgentSourceRegistry([
+    ...frameworkAgentSourceRegistry.registrations,
+    { applyTo: "root", source: applicationSource },
+  ]);
+}
+
+function createAuthoredAgentDefinition(input: CompileFromMemoryInput): Record<string, unknown> {
+  const definition: Record<string, unknown> = { model: input.model };
+  if (input.limits !== undefined) definition.limits = input.limits;
+  if (input.outputSchema !== undefined) definition.outputSchema = input.outputSchema;
+  return definition;
+}
+
+function createAuthoredToolDefinition(tool: CompileFromMemoryToolInput): Record<string, unknown> {
+  const definition: Record<string, unknown> = {
+    description: tool.description ?? `${tool.name} test tool.`,
+    execute: tool.execute ?? (async () => null),
+  };
+  if (tool.approval !== undefined) definition.approval = tool.approval;
+  if (tool.execution !== undefined) definition.execution = tool.execution;
+  if (tool.inputSchema !== undefined) definition.inputSchema = tool.inputSchema;
+  if (tool.outputSchema !== undefined) definition.outputSchema = tool.outputSchema;
+  if (tool.toModelOutput !== undefined) definition.toModelOutput = tool.toModelOutput;
+  return definition;
+}
+
+function createAuthoredSkillDefinition(
+  skill: CompileFromMemorySkillInput,
+): Record<string, unknown> {
+  const definition: Record<string, unknown> = {
+    description: skill.description,
+    markdown: skill.markdown ?? `# ${skill.name}\n`,
+  };
+  if (skill.files !== undefined) definition.files = skill.files;
+  if (skill.license !== undefined) definition.license = skill.license;
+  if (skill.metadata !== undefined) definition.metadata = skill.metadata;
+  return definition;
+}
+
+const memoryModelCatalog: CompiledRuntimeModelCatalogLoader = {
+  async getByProviderModelId() {
+    return null;
+  },
+  async getModelLimits() {
+    return MEMORY_MODEL_LIMITS;
+  },
+};
+
 function createMemorySourceId(logicalPath: string): string {
-  // A deterministic, stable id per logical path. The runtime only requires
-  // these to be unique within the module map, so a prefix + the path is
-  // sufficient — no hashing needed.
-  return `memory::${logicalPath}`;
+  return `memory:${logicalPath}`;
 }

--- a/packages/eve/src/compiler/compose-agent-sources.ts
+++ b/packages/eve/src/compiler/compose-agent-sources.ts
@@ -43,7 +43,9 @@ type ComposableSlot =
   | "tools";
 
 export interface AgentSourceOrigin {
-  readonly backing: Omit<Extract<CompiledModuleBacking, { kind: "filesystem" }>, "sourcePath">;
+  readonly backing:
+    | Omit<Extract<CompiledModuleBacking, { kind: "filesystem" }>, "sourcePath">
+    | Omit<Extract<CompiledModuleBacking, { kind: "programmatic" }>, "moduleId">;
   readonly extensionNamespace?: string;
   readonly layer: Exclude<AgentSourceLayer, "framework-default">;
   readonly owner: AgentSourceOwner;
@@ -115,7 +117,10 @@ export function composeAgentSources(input: {
       throw new Error(`Missing source metadata for candidate "${winner.sourceId}".`);
     }
     selected[entry.slot].push(entry.source as never);
-    if (entry.source.sourceKind === "module" && winner.layer !== "application") {
+    if (
+      entry.source.sourceKind === "module" &&
+      (winner.layer !== "application" || winner.backing.kind === "programmatic")
+    ) {
       bindings[winner.sourceId] = {
         backing: winner.backing,
         logicalPath: winner.logicalPath,
@@ -247,7 +252,11 @@ function createManifestCandidates(input: {
     const sourcePath = physicalSourcePath(input.manifest, original);
     return {
       candidate: {
-        backing: { ...input.origin.backing, sourcePath },
+        backing: createOriginModuleBacking({
+          logicalPath: original.logicalPath,
+          origin: input.origin,
+          sourcePath,
+        }),
         ...(input.origin.extensionNamespace === undefined
           ? {}
           : { extensionNamespace: input.origin.extensionNamespace }),
@@ -271,6 +280,15 @@ function composeSubagentSources(
   readonly bindings: Readonly<Record<string, CompiledModuleBinding>>;
   readonly sources: LocalSubagentSourceRef[];
 } {
+  if (applicationOrigin.backing.kind === "programmatic" && manifest.subagents.length > 0) {
+    throw new Error(
+      `Programmatic application source "${applicationOrigin.backing.registryId}" cannot introduce subagents.`,
+    );
+  }
+  const applicationExternalDependencies =
+    applicationOrigin.backing.kind === "filesystem"
+      ? applicationOrigin.backing.externalDependencies
+      : [];
   const candidates: Array<{
     readonly candidate: AgentModuleCandidate;
     readonly source: LocalSubagentSourceRef;
@@ -286,10 +304,7 @@ function composeSubagentSources(
 
   for (const mount of manifest.resolvedExtensions) {
     const externalDependencies = [
-      ...new Set([
-        ...applicationOrigin.backing.externalDependencies,
-        ...mount.externalDependencies,
-      ]),
+      ...new Set([...applicationExternalDependencies, ...mount.externalDependencies]),
     ];
     const packageOrigin: AgentSourceOrigin = {
       backing: {
@@ -364,6 +379,11 @@ function createSubagentCandidate(
   source: LocalSubagentSourceRef,
   origin: AgentSourceOrigin,
 ): AgentModuleCandidate {
+  if (origin.backing.kind === "programmatic") {
+    throw new Error(
+      `Programmatic application source "${origin.backing.registryId}" cannot introduce subagents.`,
+    );
+  }
   return {
     backing: { ...origin.backing, sourcePath: source.entryPath },
     layer: origin.layer,
@@ -372,6 +392,22 @@ function createSubagentCandidate(
     owner: origin.owner,
     sourceId: source.sourceId,
   };
+}
+
+export function createOriginModuleBacking(input: {
+  readonly logicalPath: string;
+  readonly origin: AgentSourceOrigin;
+  readonly sourcePath: string;
+}): CompiledModuleBacking {
+  if (input.origin.backing.kind === "programmatic") {
+    return {
+      kind: "programmatic",
+      moduleId: input.logicalPath,
+      registryId: input.origin.backing.registryId,
+    };
+  }
+
+  return { ...input.origin.backing, sourcePath: input.sourcePath };
 }
 
 function projectRootExtensionSubagent(

--- a/packages/eve/src/compiler/module-map.ts
+++ b/packages/eve/src/compiler/module-map.ts
@@ -7,8 +7,12 @@ import type {
   CompiledAgentResources,
 } from "#compiler/manifest.js";
 import { ROOT_COMPILED_AGENT_NODE_ID } from "#compiler/manifest.js";
-import { assertTotalModuleBindings } from "#compiler/module-binding.js";
+import { assertTotalModuleBindings, type CompiledModuleBinding } from "#compiler/module-binding.js";
 import { collectModuleRefsForManifest } from "#compiler/module-references.js";
+import {
+  getProgrammaticModuleNamespace,
+  type AgentSourceRegistry,
+} from "#compiler/agent-source-registry.js";
 import type { ModuleSourceRef } from "#shared/source-ref.js";
 import { normalizeEsmImportSpecifier } from "#internal/application/import-specifier.js";
 import {
@@ -42,6 +46,37 @@ export const compiledModuleMapSchema = z
   .strict();
 
 /**
+ * Materializes a module map when every compiled binding is backed by one
+ * programmatic source registry. This is the in-process counterpart to the
+ * generated module-map artifact: both consume the compiled manifest's total
+ * binding table instead of reconstructing modules from authored inputs.
+ */
+export function createProgrammaticCompiledModuleMap(input: {
+  readonly manifest: CompiledAgentManifest;
+  readonly registry: AgentSourceRegistry;
+}): CompiledModuleMap {
+  return {
+    nodes: Object.fromEntries(
+      collectBoundModuleNodeScopes(input.manifest).map((node) => [
+        node.nodeId,
+        {
+          modules: Object.fromEntries(
+            node.modules.map(({ binding, sourceId }) => {
+              if (binding.backing.kind !== "programmatic") {
+                throw new Error(
+                  `Cannot materialize filesystem binding "${sourceId}" on compiled node "${node.nodeId}" without generating a module-map artifact.`,
+                );
+              }
+              return [sourceId, getProgrammaticModuleNamespace(input.registry, binding.backing)];
+            }),
+          ),
+        },
+      ]),
+    ),
+  };
+}
+
+/**
  * Input for generating the compiled authored module map artifact.
  */
 export interface CreateCompiledModuleMapSourceInput {
@@ -70,6 +105,60 @@ interface CollectedModuleNodeScope {
   readonly nodeId: string;
 }
 
+interface CollectedBoundModuleNodeScope {
+  readonly modules: ReadonlyArray<{
+    readonly binding: CompiledModuleBinding;
+    readonly sourceId: string;
+  }>;
+  readonly nodeId: string;
+}
+
+function collectBoundModuleNodeScopes(
+  manifest: CompiledAgentManifest,
+): CollectedBoundModuleNodeScope[] {
+  return [
+    collectBoundModuleNodeScope({
+      manifest,
+      nodeId: ROOT_COMPILED_AGENT_NODE_ID,
+    }),
+    ...[...manifest.subagents]
+      .sort((left, right) => left.nodeId.localeCompare(right.nodeId))
+      .map((subagent) =>
+        collectBoundModuleNodeScope({
+          additionalModuleRef: subagent.configResolver,
+          manifest: subagent.agent,
+          nodeId: subagent.nodeId,
+        }),
+      ),
+  ];
+}
+
+function collectBoundModuleNodeScope(input: {
+  readonly additionalModuleRef?: ModuleSourceRef;
+  readonly manifest: CompiledAgentNodeManifest | CompiledAgentResources;
+  readonly nodeId: string;
+}): CollectedBoundModuleNodeScope {
+  assertTotalModuleBindings({
+    additionalRefs: input.additionalModuleRef === undefined ? [] : [input.additionalModuleRef],
+    bindings: input.manifest.bindings,
+    manifest: input.manifest,
+    nodeId: input.nodeId,
+  });
+
+  return {
+    modules: [
+      ...collectModuleRefsForManifest(input.manifest),
+      ...(input.additionalModuleRef === undefined ? [] : [input.additionalModuleRef]),
+    ]
+      .sort((left, right) => left.sourceId.localeCompare(right.sourceId))
+      .map((source) => ({
+        binding: input.manifest.bindings[source.sourceId]!,
+        sourceId: source.sourceId,
+      })),
+    nodeId: input.nodeId,
+  };
+}
+
 /**
  * Generates the compiler-owned module map artifact that statically imports
  * every module-backed authored source.
@@ -93,33 +182,22 @@ export function createCompiledModuleMapSource(input: CreateCompiledModuleMapSour
     ...input.programmaticRegistryImports,
   };
   let nextBindingIndex = 0;
-  const collectedScopes: CollectedModuleNodeScope[] = [
-    collectModuleNodeScope({
-      importSpecifierStyle,
-      manifest: input.manifest,
-      moduleMapDirectory,
-      nextBindingName() {
-        return `module_${nextBindingIndex++}`;
-      },
-      nodeId: ROOT_COMPILED_AGENT_NODE_ID,
-      programmaticRegistryImports,
-    }),
-    ...[...input.manifest.subagents]
-      .sort((left, right) => left.nodeId.localeCompare(right.nodeId))
-      .map((subagent) =>
-        collectModuleNodeScope({
-          importSpecifierStyle,
-          manifest: subagent.agent,
-          additionalModuleRef: subagent.configResolver,
-          moduleMapDirectory,
-          nextBindingName() {
-            return `module_${nextBindingIndex++}`;
-          },
-          nodeId: subagent.nodeId,
-          programmaticRegistryImports,
-        }),
-      ),
-  ];
+  const collectedScopes: CollectedModuleNodeScope[] = collectBoundModuleNodeScopes(
+    input.manifest,
+  ).map((scope) => ({
+    modules: scope.modules.map(({ binding, sourceId }) =>
+      collectModuleImport({
+        binding,
+        bindingName: `module_${nextBindingIndex++}`,
+        importSpecifierStyle,
+        moduleMapDirectory,
+        nodeId: scope.nodeId,
+        programmaticRegistryImports,
+        sourceId,
+      }),
+    ),
+    nodeId: scope.nodeId,
+  }));
   const allModules = collectedScopes.flatMap((scope) => scope.modules);
 
   const staticImports = allModules.map((moduleImport) => moduleImport.importStatement);
@@ -134,43 +212,6 @@ export function createCompiledModuleMapSource(input: CreateCompiledModuleMapSour
     "export default moduleMap;",
     "",
   ].join("\n");
-}
-
-function collectModuleNodeScope(input: {
-  readonly additionalModuleRef?: ModuleSourceRef;
-  readonly importSpecifierStyle: "absolute" | "relative";
-  readonly manifest: CompiledAgentNodeManifest | CompiledAgentResources;
-  readonly moduleMapDirectory: string;
-  readonly nextBindingName: () => string;
-  readonly nodeId: string;
-  readonly programmaticRegistryImports?: CreateCompiledModuleMapSourceInput["programmaticRegistryImports"];
-}): CollectedModuleNodeScope {
-  assertTotalModuleBindings({
-    additionalRefs: input.additionalModuleRef === undefined ? [] : [input.additionalModuleRef],
-    bindings: input.manifest.bindings,
-    manifest: input.manifest,
-    nodeId: input.nodeId,
-  });
-
-  return {
-    modules: [
-      ...collectModuleRefsForManifest(input.manifest),
-      ...(input.additionalModuleRef === undefined ? [] : [input.additionalModuleRef]),
-    ]
-      .sort((left, right) => left.sourceId.localeCompare(right.sourceId))
-      .map((moduleSourceRef) =>
-        collectModuleImport({
-          binding: input.manifest.bindings[moduleSourceRef.sourceId]!,
-          bindingName: input.nextBindingName(),
-          importSpecifierStyle: input.importSpecifierStyle,
-          moduleMapDirectory: input.moduleMapDirectory,
-          nodeId: input.nodeId,
-          programmaticRegistryImports: input.programmaticRegistryImports,
-          sourceId: moduleSourceRef.sourceId,
-        }),
-      ),
-    nodeId: input.nodeId,
-  };
 }
 
 export { collectModuleRefsForManifest } from "#compiler/module-references.js";

--- a/packages/eve/src/compiler/normalize-agent-config.ts
+++ b/packages/eve/src/compiler/normalize-agent-config.ts
@@ -17,6 +17,7 @@ import {
 } from "#shared/agent-definition.js";
 import type { DynamicToolEventName } from "#shared/dynamic-tool-definition.js";
 import type { CompiledAgentDefinition, CompiledRuntimeModelReference } from "#compiler/manifest.js";
+import type { CompiledModuleBinding } from "#compiler/module-binding.js";
 import type { CompiledRuntimeModelLimits } from "#compiler/model-catalog.js";
 import {
   loadModuleBackedDefinition,
@@ -33,6 +34,7 @@ export async function compileAgentConfig(
   manifest: AgentSourceManifest,
   context: ManifestCompileContext,
   options: {
+    readonly binding?: CompiledModuleBinding;
     readonly definition?: unknown;
   } = {},
 ): Promise<CompiledAgentDefinition> {
@@ -47,6 +49,7 @@ export async function compileAgentConfig(
         ? { model: DEFAULT_AGENT_MODEL_ID }
         : await loadModuleBackedDefinition({
             agentRoot: manifest.agentRoot,
+            binding: options.binding,
             displayPath: configModulePath!,
             kind: "agent config",
             moduleLoader: context.moduleLoader,

--- a/packages/eve/src/compiler/normalize-manifest.ts
+++ b/packages/eve/src/compiler/normalize-manifest.ts
@@ -41,8 +41,10 @@ import {
   type CompiledModuleBinding,
 } from "#compiler/module-binding.js";
 import type { AgentSourceLayer } from "#compiler/agent-module-candidate.js";
+import type { AgentSourceRegistry } from "#compiler/agent-source-registry.js";
 import {
   composeAgentSources,
+  createOriginModuleBacking,
   type AgentSourceOrigin,
   type ComposedAgentSources,
 } from "#compiler/compose-agent-sources.js";
@@ -59,18 +61,28 @@ import {
 /**
  * Compiles one discovery manifest into the normalized manifest loaded by the runtime.
  */
+export interface CompileAgentManifestOptions {
+  readonly applicationSourceOrigin?: AgentSourceOrigin;
+  readonly modelCatalog?: ManifestCompileContext["modelCatalog"];
+  readonly moduleRegistry?: AgentSourceRegistry;
+}
+
 export async function compileAgentManifest(
   manifest: AgentSourceManifest,
+  options: CompileAgentManifestOptions = {},
 ): Promise<CompiledAgentManifest> {
   const context: ManifestCompileContext = {
     bindingsByNodeId: new Map(),
     compositionsByNodeId: new Map(),
     manifestsByNodeId: new Map(),
-    modelCatalog: createCompiledRuntimeModelCatalogLoader(manifest.appRoot),
-    moduleLoader: createAgentModuleNamespaceLoader({ registry: frameworkAgentSourceRegistry }),
+    modelCatalog: options.modelCatalog ?? createCompiledRuntimeModelCatalogLoader(manifest.appRoot),
+    moduleLoader: createAgentModuleNamespaceLoader({
+      registry: options.moduleRegistry ?? frameworkAgentSourceRegistry,
+    }),
   };
   const compiledNode = await compileAgentNodeManifest(manifest, context, {
     nodeId: ROOT_COMPILED_AGENT_NODE_ID,
+    sourceOrigin: options.applicationSourceOrigin,
   });
   const rootSources = context.manifestsByNodeId.get(ROOT_COMPILED_AGENT_NODE_ID) ?? manifest;
   const subagentGraph = await compileSubagentGraph({
@@ -124,11 +136,23 @@ async function compileAgentNodeManifest(
   } = {},
 ): Promise<CompiledAgentNodeManifest> {
   const nodeId = options.nodeId ?? manifest.agentId;
+  const configBinding =
+    options.sourceOrigin === undefined || manifest.configModule === undefined
+      ? undefined
+      : {
+          backing: createOriginModuleBacking({
+            logicalPath: manifest.configModule.logicalPath,
+            origin: options.sourceOrigin,
+            sourcePath: resolve(manifest.agentRoot, manifest.configModule.logicalPath),
+          }),
+          logicalPath: manifest.configModule.logicalPath,
+          owner: options.sourceOrigin.owner,
+        };
   const rawConfig = Object.hasOwn(options, "agentConfigDefinition")
     ? await compileAgentConfig(manifest, context, {
         definition: options.agentConfigDefinition,
       })
-    : await compileAgentConfig(manifest, context);
+    : await compileAgentConfig(manifest, context, { binding: configBinding });
   if (options.allowRootOnlyConfig === false && rawConfig.experimental?.workflow !== undefined) {
     throw new Error(
       `Workflow runtime configuration is only supported on the root agent config. Remove "experimental.workflow" from "${manifest.agentId}".`,
@@ -558,10 +582,11 @@ function bindOriginConfigModule(
   return {
     ...bindings,
     [source.sourceId]: {
-      backing: {
-        ...origin.backing,
+      backing: createOriginModuleBacking({
+        logicalPath: source.logicalPath,
+        origin,
         sourcePath: resolve(manifest.agentRoot, source.logicalPath),
-      },
+      }),
       logicalPath: source.logicalPath,
       owner: origin.owner,
     },

--- a/packages/eve/src/compiler/normalize-skill.ts
+++ b/packages/eve/src/compiler/normalize-skill.ts
@@ -2,6 +2,7 @@ import { stripLogicalPathExtension } from "#discover/filesystem.js";
 import type { SkillSourceRef } from "#discover/manifest.js";
 import type { SkillPackageSourceRef } from "#shared/source-ref.js";
 import type { NamedSkillDefinition } from "#shared/skill-definition.js";
+import type { SkillDefinition } from "#public/definitions/skill.js";
 import { normalizeSkillDefinition } from "#internal/authored-definition/core.js";
 import type {
   CompiledDynamicSkillDefinition,
@@ -48,22 +49,7 @@ export async function compileSkillSource(
     );
     return {
       kind: "skill",
-      definition: {
-        description: definition.description,
-        files: definition.files,
-        license: definition.license,
-        logicalPath: source.logicalPath,
-        markdown: definition.markdown,
-        metadata:
-          definition.metadata === undefined
-            ? undefined
-            : {
-                ...definition.metadata,
-              },
-        name: stripLogicalPathExtension(source.logicalPath).replace(/^skills\//, ""),
-        sourceId: source.sourceId,
-        sourceKind: source.sourceKind,
-      },
+      definition: createCompiledSkillDefinition(source, definition),
     };
   }
 
@@ -100,26 +86,38 @@ export async function compileSkillSource(
     exportValue,
     `Expected the skill export "${source.exportName ?? "default"}" from "${source.logicalPath}" to match the public eve shape.`,
   );
-
   return {
     kind: "skill",
-    definition: {
-      description: definition.description,
-      files: definition.files,
-      license: definition.license,
-      logicalPath: source.logicalPath,
-      markdown: definition.markdown,
-      metadata:
-        definition.metadata === undefined
-          ? undefined
-          : {
-              ...definition.metadata,
-            },
-      name: stripLogicalPathExtension(source.logicalPath).replace(/^skills\//, ""),
-      sourceId: source.sourceId,
-      sourceKind: source.sourceKind,
-    },
+    definition: createCompiledSkillDefinition(source, definition),
   };
+}
+
+function createCompiledSkillDefinition(
+  source: Extract<SkillSourceRef, { sourceKind: "markdown" | "module" }>,
+  definition: SkillDefinition,
+): CompiledSkillDefinition {
+  const shared = {
+    description: definition.description,
+    license: definition.license,
+    logicalPath: source.logicalPath,
+    markdown: definition.markdown,
+    metadata:
+      definition.metadata === undefined
+        ? undefined
+        : {
+            ...definition.metadata,
+          },
+    name: stripLogicalPathExtension(source.logicalPath).replace(/^skills\//, ""),
+    sourceId: source.sourceId,
+  };
+  const compiled: CompiledSkillDefinition =
+    source.sourceKind === "markdown"
+      ? { ...shared, sourceKind: "markdown" }
+      : { ...shared, exportName: source.exportName, sourceKind: "module" };
+  if (definition.files !== undefined) {
+    Object.assign(compiled, { files: definition.files });
+  }
+  return compiled;
 }
 
 function compileSkillPackageSource(

--- a/packages/eve/src/compiler/normalize-subagent.ts
+++ b/packages/eve/src/compiler/normalize-subagent.ts
@@ -10,6 +10,7 @@ import {
   createCompiledSubagentNodeId,
 } from "#compiler/manifest.js";
 import {
+  createOriginModuleBacking,
   getSubagentSourceOrigin,
   type AgentSourceOrigin,
 } from "#compiler/compose-agent-sources.js";
@@ -166,10 +167,11 @@ async function compileSubagentDefinition(input: {
       sourceOrigin === undefined
         ? undefined
         : {
-            backing: {
-              ...sourceOrigin.backing,
+            backing: createOriginModuleBacking({
+              logicalPath: configModule.logicalPath,
+              origin: sourceOrigin,
               sourcePath: join(input.source.manifest.agentRoot, configModule.logicalPath),
-            },
+            }),
             logicalPath: configModule.logicalPath,
             owner: sourceOrigin.owner,
           },

--- a/packages/eve/src/context/accessors.integration.test.ts
+++ b/packages/eve/src/context/accessors.integration.test.ts
@@ -22,7 +22,7 @@ describe("buildCallbackContext – session", () => {
   });
 
   it("returns the active session identity across async boundaries", async () => {
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
 
     const session = await runtime.runAsSession(
       {
@@ -50,7 +50,7 @@ describe("buildCallbackContext – session", () => {
   });
 
   it("preserves parent lineage on the public session", async () => {
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
 
     const session = await runtime.runAsSession(
       {
@@ -88,7 +88,7 @@ describe("buildCallbackContext – getSandbox", () => {
         "echo ready": { exitCode: 0, stderr: "", stdout: "ready" },
       },
     });
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
 
     const live = (await runtime.runAsSession({ sandbox }, async () => {
       await Promise.resolve();
@@ -106,7 +106,7 @@ describe("buildCallbackContext – getSandbox", () => {
       id: "sbx_public_sandbox_file",
       initialFiles: { "note.txt": "file content" },
     });
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
 
     const live = (await runtime.runAsSession(
       { sandbox },
@@ -130,7 +130,7 @@ describe("buildCallbackContext – getSandbox", () => {
         stops += 1;
       },
     });
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
 
     await runtime.runAsSession({ sandbox }, async () => {
       const live: RuntimeSandboxSession = await buildCallbackContext().getSandbox();
@@ -147,7 +147,7 @@ describe("buildCallbackContext – getSkill", () => {
   });
 
   it("throws when authored runtime execution does not include skill access", async () => {
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
 
     await expect(
       runtime.runAsSession({}, () => buildCallbackContext().getSkill("semantic-model")),
@@ -168,7 +168,7 @@ describe("buildCallbackContext – getSkill", () => {
         "/workspace/skills/semantic-model/references/catalog.yml": "entities: []\n",
       },
     });
-    const runtime = createTestRuntime({ skills: [skill.source] });
+    const runtime = await createTestRuntime({ skills: [skill.source] });
 
     const result = await runtime.runAsSession({ sandbox }, async () => {
       await Promise.resolve();

--- a/packages/eve/src/context/build-base-tool-context.integration.test.ts
+++ b/packages/eve/src/context/build-base-tool-context.integration.test.ts
@@ -13,7 +13,7 @@ describe("buildBaseToolContext – getSandbox abort binding", () => {
         return { exitCode: 0, stderr: "", stdout: "" };
       },
     });
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
     const controller = new AbortController();
 
     await runtime.runAsSession({ sandbox }, async () => {
@@ -41,7 +41,7 @@ describe("buildBaseToolContext – getSandbox abort binding", () => {
         return { exitCode: 0, stderr: "", stdout: "" };
       },
     });
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
 
     await runtime.runAsSession({ sandbox }, async () => {
       const ctx = buildBaseToolContext({

--- a/packages/eve/src/execution/durable-session-store.integration.test.ts
+++ b/packages/eve/src/execution/durable-session-store.integration.test.ts
@@ -13,7 +13,7 @@ import {
  */
 describe("durableSessionStore integration", () => {
   it("each step's readDurableSession returns the immediately-preceding write", async () => {
-    const runtime = createTestRuntime({ agent: { name: "durable-session-store-fixture" } });
+    const runtime = await createTestRuntime({ agent: { name: "durable-session-store-fixture" } });
 
     await runtime.run(async () => {
       const run = await start(durableSessionStoreFixtureWorkflow, [
@@ -37,7 +37,9 @@ describe("durableSessionStore integration", () => {
   });
 
   it("a standalone read step after several writes returns the latest returned state", async () => {
-    const runtime = createTestRuntime({ agent: { name: "durable-session-store-fixture-tail" } });
+    const runtime = await createTestRuntime({
+      agent: { name: "durable-session-store-fixture-tail" },
+    });
 
     await runtime.run(async () => {
       const run = await start(durableSessionStoreFixtureWorkflow, [
@@ -65,7 +67,9 @@ describe("durableSessionStore integration", () => {
   });
 
   it("a write-step retry's returned state is what the subsequent read returns", async () => {
-    const runtime = createTestRuntime({ agent: { name: "durable-session-store-fixture-retry" } });
+    const runtime = await createTestRuntime({
+      agent: { name: "durable-session-store-fixture-retry" },
+    });
 
     await runtime.run(async () => {
       const run = await start(durableSessionRetryFixtureWorkflow, []);

--- a/packages/eve/src/execution/harness-tool-execution.integration.test.ts
+++ b/packages/eve/src/execution/harness-tool-execution.integration.test.ts
@@ -41,7 +41,7 @@ describe("authored tool execution", () => {
         };
       },
     });
-    const runtime = createTestRuntime({ tools: [weatherTool] });
+    const runtime = await createTestRuntime({ tools: [weatherTool] });
 
     const result = await runtime.runAsSession(undefined, async () => {
       return await runtime.executeTool(weatherTool, { city: "Brooklyn" });
@@ -62,7 +62,7 @@ describe("authored tool execution", () => {
         throw new Error("weather upstream unavailable");
       },
     });
-    const runtime = createTestRuntime({ tools: [weatherTool] });
+    const runtime = await createTestRuntime({ tools: [weatherTool] });
 
     await expect(
       runtime.runAsSession(undefined, async () => {
@@ -79,7 +79,7 @@ describe("authored tool execution", () => {
         return ctx.session;
       },
     });
-    const runtime = createTestRuntime({ tools: [sessionProbe] });
+    const runtime = await createTestRuntime({ tools: [sessionProbe] });
 
     const result = await runtime.runAsSession(
       {
@@ -109,7 +109,7 @@ describe("authored tool execution", () => {
         return ctx.session;
       },
     });
-    const runtime = createTestRuntime({ tools: [sessionProbe] });
+    const runtime = await createTestRuntime({ tools: [sessionProbe] });
 
     const result = await runtime.runAsSession(
       {
@@ -157,7 +157,7 @@ describe("authored tool execution", () => {
         return await ctx.getSkill("semantic-model").file("references/catalog.yml").text();
       },
     });
-    const runtime = createTestRuntime({
+    const runtime = await createTestRuntime({
       tools: [skillReader],
       skills: [semanticModel.source],
     });
@@ -187,7 +187,7 @@ describe("authored tool execution", () => {
         return { content, id: live.id };
       },
     });
-    const runtime = createTestRuntime({ tools: [sandboxTool] });
+    const runtime = await createTestRuntime({ tools: [sandboxTool] });
 
     const result = (await runtime.runAsSession({ sandbox }, async () =>
       runtime.executeTool(sandboxTool, {}),
@@ -222,7 +222,7 @@ describe("authored tool execution", () => {
         return { reportPath, stdout: result.stdout.trim() };
       },
     });
-    const runtime = createTestRuntime({ tools: [resolveTool] });
+    const runtime = await createTestRuntime({ tools: [resolveTool] });
 
     const result = await runtime.runAsSession({ sandbox }, async () =>
       runtime.executeTool(resolveTool, {}),

--- a/packages/eve/src/execution/session-limit-cancellation.integration.test.ts
+++ b/packages/eve/src/execution/session-limit-cancellation.integration.test.ts
@@ -77,7 +77,7 @@ function requestIdFromPromptTurn(events: readonly UnstampedMessageStreamEvent[])
 
 describe("session-limit continuation decline integration", () => {
   it("cancels the turn and keeps the session resumable when the user declines", async () => {
-    const runtime = createTestRuntime({
+    const runtime = await createTestRuntime({
       agent: { limits: { maxInputTokensPerSession: 1 }, name: "limit-decline-root" },
     });
     const continuationToken = "http:limit-decline-root";
@@ -143,7 +143,7 @@ describe("session-limit continuation decline integration", () => {
   }, 60_000);
 
   it("fails a zero-quota delegation fast and declines the root's own prompt", async () => {
-    const runtime = createTestRuntime({
+    const runtime = await createTestRuntime({
       agent: { limits: { maxInputTokensPerSession: 1 }, name: "limit-decline-child" },
     });
     const continuationToken = "http:limit-decline-child";

--- a/packages/eve/src/execution/settle-cancelled-turn-step.integration.test.ts
+++ b/packages/eve/src/execution/settle-cancelled-turn-step.integration.test.ts
@@ -99,7 +99,7 @@ function buildSerializedContext(): Record<string, unknown> {
 
 describe("settleCancelledTurnStep handle store", () => {
   it("parks abandoned running handles as cancelled and keeps parked ones", async () => {
-    const runtime = createTestRuntime({ agent: { name: "settle-cancel-handles" } });
+    const runtime = await createTestRuntime({ agent: { name: "settle-cancel-handles" } });
 
     await runtime.run(async () => {
       const result = await settleCancelledTurnStep({

--- a/packages/eve/src/execution/task-model-retry.integration.test.ts
+++ b/packages/eve/src/execution/task-model-retry.integration.test.ts
@@ -7,7 +7,7 @@ import { taskModelRetryFixtureWorkflow } from "#internal/testing/task-model-retr
 
 describe("task model retry integration", () => {
   it("retries a recoverable task error from the committed session snapshot", async () => {
-    const runtime = createTestRuntime({ agent: { name: "task-model-retry-fixture" } });
+    const runtime = await createTestRuntime({ agent: { name: "task-model-retry-fixture" } });
 
     await runtime.run(async () => {
       const run = await start(taskModelRetryFixtureWorkflow, [{ failThroughAttempt: 1 }]);
@@ -32,7 +32,9 @@ describe("task model retry integration", () => {
   });
 
   it("notifies the parent once after Workflow exhausts persistent failures", async () => {
-    const runtime = createTestRuntime({ agent: { name: "task-model-retry-exhaustion-fixture" } });
+    const runtime = await createTestRuntime({
+      agent: { name: "task-model-retry-exhaustion-fixture" },
+    });
 
     await runtime.run(async () => {
       const run = await start(taskModelRetryFixtureWorkflow, [

--- a/packages/eve/src/execution/tasks/parent/tool-execution.integration.test.ts
+++ b/packages/eve/src/execution/tasks/parent/tool-execution.integration.test.ts
@@ -45,7 +45,7 @@ describe("background subagent tool execution", () => {
   });
 
   it("runs concurrent local and remote defineTool calls as independent durable tasks", async () => {
-    const runtime = createTestRuntime({ agent: { name: "background-subagent" } });
+    const runtime = await createTestRuntime({ agent: { name: "background-subagent" } });
 
     await runtime.run(async () => {
       const remoteNode = {

--- a/packages/eve/src/execution/tool-auth.integration.test.ts
+++ b/packages/eve/src/execution/tool-auth.integration.test.ts
@@ -93,7 +93,7 @@ describe("approval response authorization", () => {
         return { token: "linear-token" };
       },
     };
-    const runtime = createTestRuntime({ tools: [] });
+    const runtime = await createTestRuntime({ tools: [] });
 
     const tokens = await runtime.runAsSession(undefined, async () => {
       const auth = buildApprovalResponseAuth({
@@ -123,7 +123,7 @@ describe("approval response authorization", () => {
         return { token: "bound-responder-token" };
       },
     };
-    const runtime = createTestRuntime({ tools: [] });
+    const runtime = await createTestRuntime({ tools: [] });
 
     await runtime.runAsSession(undefined, async () => {
       loadContext().set(AuthKey, {
@@ -172,7 +172,7 @@ describe("tool-hosted authorization", () => {
         return { first: first.token, second: second.token };
       },
     });
-    const runtime = createTestRuntime({ tools: [tool] });
+    const runtime = await createTestRuntime({ tools: [tool] });
 
     const result = await runtime.runAsSession(undefined, async () => runtime.executeTool(tool, {}));
 
@@ -188,7 +188,7 @@ describe("tool-hosted authorization", () => {
         return { callId: ctx.callId, toolName: ctx.toolName };
       },
     });
-    const runtime = createTestRuntime({ tools: [tool] });
+    const runtime = await createTestRuntime({ tools: [tool] });
 
     const result = await runtime.runAsSession(undefined, async () => runtime.executeTool(tool, {}));
 
@@ -213,7 +213,7 @@ describe("tool-hosted authorization", () => {
         return { first: first.token, second: second.token };
       },
     });
-    const runtime = createTestRuntime({ tools: [tool] });
+    const runtime = await createTestRuntime({ tools: [tool] });
 
     const result = await runtime.runAsSession(undefined, async () => runtime.executeTool(tool, {}));
 
@@ -242,7 +242,7 @@ describe("tool-hosted authorization", () => {
         return { github: github.token, linear: linear.token };
       },
     });
-    const runtime = createTestRuntime({ tools: [tool] });
+    const runtime = await createTestRuntime({ tools: [tool] });
 
     const result = await runtime.runAsSession(undefined, async () => runtime.executeTool(tool, {}));
 
@@ -269,7 +269,7 @@ describe("tool-hosted authorization", () => {
         await ctx.getToken(linearAuth);
       },
     });
-    const runtime = createTestRuntime({ tools: [tool] });
+    const runtime = await createTestRuntime({ tools: [tool] });
 
     await expect(
       runtime.runAsSession(undefined, async () => runtime.executeTool(tool, {})),
@@ -283,7 +283,7 @@ describe("tool-hosted authorization", () => {
         return await (ctx.getToken as () => Promise<TokenResult>)();
       },
     });
-    const runtime = createTestRuntime({ tools: [tool] });
+    const runtime = await createTestRuntime({ tools: [tool] });
 
     await expect(
       runtime.runAsSession(undefined, async () => runtime.executeTool(tool, {})),
@@ -310,7 +310,7 @@ describe("tool-hosted authorization", () => {
         return await ctx.getToken(inlineAuth, { displayName: "Linear" });
       },
     });
-    const runtime = createTestRuntime({ tools: [tool] });
+    const runtime = await createTestRuntime({ tools: [tool] });
 
     const result = await runtime.runAsSession(
       { sessionId: "session_inline_auth_park" },
@@ -352,7 +352,7 @@ describe("tool-hosted authorization", () => {
         return await ctx.getToken(inlineAuth);
       },
     });
-    const runtime = createTestRuntime({ tools: [tool] });
+    const runtime = await createTestRuntime({ tools: [tool] });
 
     const result = await runtime.runAsSession(
       { sessionId: "session_connect_callback" },
@@ -390,7 +390,7 @@ describe("tool-hosted authorization", () => {
         return await ctx.getToken(auth);
       },
     });
-    const runtime = createTestRuntime({ tools: [tool] });
+    const runtime = await createTestRuntime({ tools: [tool] });
 
     const result = await runtime.runAsSession({ sessionId: "session_auth_park" }, async () => {
       seedUserPrincipal();
@@ -429,7 +429,7 @@ describe("tool-hosted authorization", () => {
         return await ctx.getToken(auth);
       },
     });
-    const runtime = createTestRuntime({ tools: [tool] });
+    const runtime = await createTestRuntime({ tools: [tool] });
 
     const result = await runtime.runAsSession({ sessionId: "session_display_name" }, async () => {
       seedUserPrincipal();
@@ -465,7 +465,7 @@ describe("tool-hosted authorization", () => {
         return await ctx.getToken(auth);
       },
     });
-    const runtime = createTestRuntime({ tools: [tool] });
+    const runtime = await createTestRuntime({ tools: [tool] });
 
     const result = await runtime.runAsSession(
       { sessionId: "session_display_name_strategy" },
@@ -500,7 +500,7 @@ describe("tool-hosted authorization", () => {
         ctx.requireAuth(auth);
       },
     });
-    const runtime = createTestRuntime({ tools: [tool] });
+    const runtime = await createTestRuntime({ tools: [tool] });
 
     const result = await runtime.runAsSession({ sessionId: "session_require_auth" }, async () => {
       seedUserPrincipal();
@@ -535,7 +535,7 @@ describe("tool-hosted authorization", () => {
         return await ctx.getToken(auth);
       },
     });
-    const runtime = createTestRuntime({ tools: [tool] });
+    const runtime = await createTestRuntime({ tools: [tool] });
 
     const result = await runtime.runAsSession({ sessionId: "session_resume" }, async () => {
       seedUserPrincipal();
@@ -581,7 +581,7 @@ describe("tool-hosted authorization", () => {
         return await ctx.getToken(inlineAuth);
       },
     });
-    const runtime = createTestRuntime({ tools: [tool] });
+    const runtime = await createTestRuntime({ tools: [tool] });
 
     const result = await runtime.runAsSession({ sessionId: "session_inline_resume" }, async () => {
       seedUserPrincipal();
@@ -630,7 +630,7 @@ describe("tool-hosted authorization", () => {
         ctx.requireAuth(inlineAuth);
       },
     });
-    const runtime = createTestRuntime({ tools: [tool] });
+    const runtime = await createTestRuntime({ tools: [tool] });
 
     const result = await runtime.runAsSession({ sessionId: "session_inline_require" }, async () => {
       seedUserPrincipal();
@@ -670,7 +670,7 @@ describe("tool-hosted authorization", () => {
         ctx.requireAuth(auth);
       },
     });
-    const runtime = createTestRuntime({ tools: [tool] });
+    const runtime = await createTestRuntime({ tools: [tool] });
 
     const error = await runtime
       .runAsSession({ sessionId: "session_loop_guard" }, async () => {
@@ -719,7 +719,7 @@ describe("tool-hosted authorization", () => {
         ctx.requireAuth(inlineAuth);
       },
     });
-    const runtime = createTestRuntime({ tools: [tool] });
+    const runtime = await createTestRuntime({ tools: [tool] });
 
     const error = await runtime
       .runAsSession({ sessionId: "session_inline_loop_guard" }, async () => {
@@ -757,7 +757,7 @@ describe("tool-hosted authorization", () => {
       },
     };
     const scoped = { authorization: auth, connection: { url: "" }, scope: "list_groups" };
-    const runtime = createTestRuntime({ tools: [] });
+    const runtime = await createTestRuntime({ tools: [] });
 
     const tokens = await runtime.runAsSession({ sessionId: "session_evict" }, async () => {
       seedUserPrincipal();
@@ -788,7 +788,7 @@ describe("tool-hosted authorization", () => {
       },
     };
     const scoped = { authorization: auth, connection: { url: "" }, scope: "list_groups" };
-    const runtime = createTestRuntime({ tools: [] });
+    const runtime = await createTestRuntime({ tools: [] });
 
     await runtime.runAsSession({ sessionId: "session_evict_cascade" }, async () => {
       seedUserPrincipal();
@@ -819,7 +819,7 @@ describe("tool-hosted authorization", () => {
         return await ctx.getToken(auth);
       },
     });
-    const runtime = createTestRuntime({ tools: [tool] });
+    const runtime = await createTestRuntime({ tools: [tool] });
 
     // No CallbackBaseUrlKey set → getHookUrl returns undefined → no park
     // signal. The interactive path must NOT leak the raw Required into the
@@ -851,7 +851,7 @@ describe("tool-hosted authorization", () => {
         return await ctx.getToken(auth);
       },
     });
-    const runtime = createTestRuntime({ tools: [tool] });
+    const runtime = await createTestRuntime({ tools: [tool] });
 
     // Non-interactive strategies have no consent flow to park on, so the
     // model should see the original failure.

--- a/packages/eve/src/execution/turn-cancellation.integration.test.ts
+++ b/packages/eve/src/execution/turn-cancellation.integration.test.ts
@@ -9,7 +9,6 @@ import {
   filterEventsByType,
 } from "#internal/testing/events.js";
 import { waitForHook } from "#internal/testing/workflow-test-helpers.js";
-import { ROOT_COMPILED_AGENT_NODE_ID } from "#compiler/manifest.js";
 import { createBundledRuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
 import { sessionCommandHookToken } from "#execution/session-command-token.js";
 import { turnCancellationHookToken } from "#execution/turn-cancellation-token.js";
@@ -89,7 +88,7 @@ interface WaitToolFixture {
   toolStarts(): number;
 }
 
-function createWaitToolRuntime(agentName: string): WaitToolFixture {
+async function createWaitToolRuntime(agentName: string): Promise<WaitToolFixture> {
   let aborts = 0;
   let starts = 0;
   let resolveStarted: (() => void) | undefined;
@@ -105,14 +104,7 @@ function createWaitToolRuntime(agentName: string): WaitToolFixture {
       aborts += 1;
     },
   );
-  const runtime = createTestRuntime({ agent: { name: agentName }, tools: [waitTool] });
-  const manifestTool = runtime.manifest.tools.find((tool) => tool.name === WAIT_TOOL_NAME);
-  if (manifestTool === undefined) {
-    throw new Error(`Expected ${WAIT_TOOL_NAME} to be present in the test manifest.`);
-  }
-  runtime.moduleMap.nodes[ROOT_COMPILED_AGENT_NODE_ID]!.modules[manifestTool.sourceId] = {
-    default: { execute: waitTool.execute },
-  };
+  const runtime = await createTestRuntime({ agent: { name: agentName }, tools: [waitTool] });
   return { runtime, toolStarted, toolAborts: () => aborts, toolStarts: () => starts };
 }
 
@@ -266,7 +258,7 @@ async function expectCancelResponse(
 
 describe("turn cancellation integration", () => {
   it("buffers a default steering message before replacing the active turn", async () => {
-    const fixture = createWaitToolRuntime("turn-steer-message");
+    const fixture = await createWaitToolRuntime("turn-steer-message");
     const rawToken = "turn-steer-message";
     const continuationToken = `http:${rawToken}`;
     const workflowRuntime = createWorkflowRuntime({
@@ -330,7 +322,7 @@ describe("turn cancellation integration", () => {
   }, 60_000);
 
   it("cancels a turn mid-tool and accepts the next message normally", async () => {
-    const fixture = createWaitToolRuntime("turn-cancel-tool");
+    const fixture = await createWaitToolRuntime("turn-cancel-tool");
     const continuationToken = "http:turn-cancel-tool";
 
     await fixture.runtime.run(async () => {
@@ -407,7 +399,7 @@ describe("turn cancellation integration", () => {
   });
 
   it("cancels a turn through the eve channel cancel route", async () => {
-    const fixture = createWaitToolRuntime("turn-cancel-route");
+    const fixture = await createWaitToolRuntime("turn-cancel-route");
     const continuationToken = "http:turn-cancel-route";
     const cancelViaRoute = createCancelRouteCaller();
 
@@ -483,7 +475,7 @@ describe("turn cancellation integration", () => {
   }, 60_000);
 
   it("cancels a turn from a channel route helper addressed by continuation token", async () => {
-    const fixture = createWaitToolRuntime("turn-cancel-helper");
+    const fixture = await createWaitToolRuntime("turn-cancel-helper");
     const rawToken = "turn-cancel-helper";
     const continuationToken = `http:${rawToken}`;
     const workflowRuntime = createWorkflowRuntime({
@@ -573,7 +565,7 @@ describe("turn cancellation integration", () => {
   }, 60_000);
 
   it("cascades cancellation to an in-flight subagent and does not re-dispatch it", async () => {
-    const fixture = createWaitToolRuntime("turn-cancel-subagent");
+    const fixture = await createWaitToolRuntime("turn-cancel-subagent");
     const continuationToken = "http:turn-cancel-subagent";
 
     await fixture.runtime.run(async () => {
@@ -639,7 +631,7 @@ describe("turn cancellation integration", () => {
   }, 60_000);
 
   it("cancels a turn parked on a child HITL request without corrupting the stream", async () => {
-    const runtime = createTestRuntime({ agent: { name: "turn-cancel-hitl" } });
+    const runtime = await createTestRuntime({ agent: { name: "turn-cancel-hitl" } });
     const continuationToken = "http:turn-cancel-hitl";
 
     await runtime.run(async () => {
@@ -730,7 +722,7 @@ describe("turn cancellation integration", () => {
   }, 60_000);
 
   it("consumes a cancel with a stale turn guard as a no-op and keeps the turn running", async () => {
-    const fixture = createWaitToolRuntime("turn-cancel-stale-guard");
+    const fixture = await createWaitToolRuntime("turn-cancel-stale-guard");
     const continuationToken = "http:turn-cancel-stale-guard";
 
     await fixture.runtime.run(async () => {
@@ -777,7 +769,7 @@ describe("turn cancellation integration", () => {
   }, 60_000);
 
   it("treats a cancel after the turn settled as a benign no-op", async () => {
-    const runtime = createTestRuntime({ agent: { name: "turn-cancel-late" } });
+    const runtime = await createTestRuntime({ agent: { name: "turn-cancel-late" } });
     const continuationToken = "http:turn-cancel-late";
 
     await runtime.run(async () => {
@@ -827,7 +819,7 @@ describe("turn cancellation integration", () => {
   });
 
   it("completes settled turn runs so the world sweeps their hooks", async () => {
-    const runtime = createTestRuntime({ agent: { name: "turn-cancel-sweep" } });
+    const runtime = await createTestRuntime({ agent: { name: "turn-cancel-sweep" } });
     const continuationToken = "http:turn-cancel-sweep";
 
     await runtime.run(async () => {

--- a/packages/eve/src/execution/workflow-entry.integration.test.ts
+++ b/packages/eve/src/execution/workflow-entry.integration.test.ts
@@ -4,7 +4,7 @@ import { hydrateWorkflowArguments } from "@workflow/core/serialization";
 
 import { createChannelAddress } from "#channel/channel-address.js";
 import { captureTurnEvents, filterEventsByType } from "#internal/testing/events.js";
-import { createTestRuntime } from "#internal/testing/app-harness.js";
+import { createTestRuntime, type TestRuntime } from "#internal/testing/app-harness.js";
 import { waitForHook } from "#internal/testing/workflow-test-helpers.js";
 import { createBundledRuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
 import { workflowEntry } from "#execution/workflow-entry.js";
@@ -15,7 +15,6 @@ import {
 import { createToolExecuteWithAuth } from "#execution/tool-auth.js";
 import { createWorkflowRuntime } from "#execution/workflow-runtime.js";
 import { normalizeEveAttributes } from "#runtime/attributes/normalize.js";
-import { ROOT_COMPILED_AGENT_NODE_ID } from "#compiler/manifest.js";
 import { ConnectionAuthorizationRequiredError } from "#public/connections/errors.js";
 import type { MessageStreamEvent } from "#protocol/message.js";
 import { isEventId } from "#protocol/event-id.js";
@@ -70,7 +69,7 @@ function buildSerializedContext(overrides: {
 interface WeatherAuthRuntime {
   completeCalls(): number;
   completedPrincipals(): readonly ConnectionPrincipal[];
-  runtime: ReturnType<typeof createTestRuntime>;
+  runtime: TestRuntime;
 }
 
 /**
@@ -79,7 +78,7 @@ interface WeatherAuthRuntime {
  * `oauth-code` callback. Shared by the callback-resume and
  * challenge-stays-open driver tests.
  */
-function createWeatherAuthRuntime(agentName: string): WeatherAuthRuntime {
+async function createWeatherAuthRuntime(agentName: string): Promise<WeatherAuthRuntime> {
   let completeCalls = 0;
   const completedPrincipals: ConnectionPrincipal[] = [];
   const weatherAuth: AuthorizationDefinition<{ nonce: string }> = {
@@ -142,19 +141,10 @@ function createWeatherAuthRuntime(agentName: string): WeatherAuthRuntime {
     sourceId: "tools/get_weather.ts",
     sourceKind: "module",
   };
-  const runtime = createTestRuntime({
+  const runtime = await createTestRuntime({
     agent: { name: agentName },
     tools: [getWeatherTool],
   });
-  const manifestTool = runtime.manifest.tools.find((tool) => tool.name === getWeatherTool.name);
-  if (manifestTool === undefined) {
-    throw new Error("Expected get_weather to be present in the test manifest.");
-  }
-  runtime.moduleMap.nodes[ROOT_COMPILED_AGENT_NODE_ID]!.modules[manifestTool.sourceId] = {
-    default: {
-      execute: getWeatherTool.execute,
-    },
-  };
   return {
     completeCalls: () => completeCalls,
     completedPrincipals: () => completedPrincipals,
@@ -188,7 +178,9 @@ function expectSingleTurn(events: readonly MessageStreamEvent[], turnId: string)
 
 describe("workflowEntry integration", () => {
   it("resumes normal follow-ups after an interactive authorization callback", async () => {
-    const { completeCalls, runtime } = createWeatherAuthRuntime("workflow-entry-auth-followup");
+    const { completeCalls, runtime } = await createWeatherAuthRuntime(
+      "workflow-entry-auth-followup",
+    );
     const continuationToken = "http:workflow-entry-auth-followup";
 
     await runtime.run(async () => {
@@ -304,7 +296,7 @@ describe("workflowEntry integration", () => {
   });
 
   it("runs ordinary deliveries while an authorization challenge stays open", async () => {
-    const { completeCalls, completedPrincipals, runtime } = createWeatherAuthRuntime(
+    const { completeCalls, completedPrincipals, runtime } = await createWeatherAuthRuntime(
       "workflow-entry-auth-open",
     );
     const continuationToken = "http:workflow-entry-auth-open";
@@ -440,7 +432,9 @@ describe("workflowEntry integration", () => {
   });
 
   it("defers ordinary deliveries while a task waits for authorization", async () => {
-    const { completeCalls, runtime } = createWeatherAuthRuntime("workflow-entry-task-auth-open");
+    const { completeCalls, runtime } = await createWeatherAuthRuntime(
+      "workflow-entry-task-auth-open",
+    );
     const continuationToken = "http:workflow-entry-task-auth-open";
 
     await runtime.run(async () => {
@@ -505,7 +499,9 @@ describe("workflowEntry integration", () => {
   });
 
   it("ignores stale and duplicate callbacks after a challenge is replaced", async () => {
-    const { completeCalls, runtime } = createWeatherAuthRuntime("workflow-entry-auth-replaced");
+    const { completeCalls, runtime } = await createWeatherAuthRuntime(
+      "workflow-entry-auth-replaced",
+    );
     const continuationToken = "http:workflow-entry-auth-replaced";
 
     await runtime.run(async () => {
@@ -592,7 +588,7 @@ describe("workflowEntry integration", () => {
   });
 
   it("completes the challenge after a no-op cancel consumed the parked wait", async () => {
-    const { completeCalls, runtime } = createWeatherAuthRuntime("workflow-entry-auth-cancel");
+    const { completeCalls, runtime } = await createWeatherAuthRuntime("workflow-entry-auth-cancel");
     const continuationToken = "http:workflow-entry-auth-cancel";
 
     await runtime.run(async () => {
@@ -675,7 +671,7 @@ describe("workflowEntry integration", () => {
   });
 
   it("parks in conversation mode and resumes via runtime delivery", async () => {
-    const runtime = createTestRuntime({ agent: { name: "workflow-entry-conversation" } });
+    const runtime = await createTestRuntime({ agent: { name: "workflow-entry-conversation" } });
     const continuationToken = "http:workflow-entry-conversation";
 
     await runtime.run(async () => {
@@ -744,7 +740,7 @@ describe("workflowEntry integration", () => {
   });
 
   it("publishes the session ID as the waiting address for an ID-only session", async () => {
-    const runtime = createTestRuntime({ agent: { name: "workflow-entry-id-only" } });
+    const runtime = await createTestRuntime({ agent: { name: "workflow-entry-id-only" } });
 
     await runtime.run(async () => {
       const run = await start(workflowEntry, [
@@ -771,7 +767,7 @@ describe("workflowEntry integration", () => {
   });
 
   it("stamps every stream event with an id that survives a rewind", async () => {
-    const runtime = createTestRuntime({ agent: { name: "workflow-entry-event-ids" } });
+    const runtime = await createTestRuntime({ agent: { name: "workflow-entry-event-ids" } });
     const continuationToken = "http:workflow-entry-event-ids";
 
     await runtime.run(async () => {
@@ -834,7 +830,7 @@ describe("workflowEntry integration", () => {
   });
 
   it("completes an expired conversation and lets its channel start a fresh session", async () => {
-    const runtime = createTestRuntime({ agent: { name: "workflow-entry-timeout" } });
+    const runtime = await createTestRuntime({ agent: { name: "workflow-entry-timeout" } });
     const continuationToken = "http:workflow-entry-timeout";
     const workflowRuntime = createWorkflowRuntime({
       compiledArtifactsSource: createBundledRuntimeCompiledArtifactsSource(),
@@ -897,7 +893,9 @@ describe("workflowEntry integration", () => {
   });
 
   it("notifies each delegated conversation turn and remains available via agentId", async () => {
-    const runtime = createTestRuntime({ agent: { name: "workflow-entry-delegated-conversation" } });
+    const runtime = await createTestRuntime({
+      agent: { name: "workflow-entry-delegated-conversation" },
+    });
     const workflowRuntime = createWorkflowRuntime({
       compiledArtifactsSource: createBundledRuntimeCompiledArtifactsSource(),
     });
@@ -976,7 +974,7 @@ describe("workflowEntry integration", () => {
   });
 
   it("exits a competing continuation owner before its first turn", async () => {
-    const runtime = createTestRuntime({ agent: { name: "workflow-entry-hook-owner" } });
+    const runtime = await createTestRuntime({ agent: { name: "workflow-entry-hook-owner" } });
     const continuationToken = "http:workflow-entry-hook-owner";
 
     await runtime.run(async () => {
@@ -1031,7 +1029,7 @@ describe("workflowEntry integration", () => {
   });
 
   it("emits completed structured results for a conversation turn outputSchema", async () => {
-    const runtime = createTestRuntime({ agent: { name: "workflow-entry-output-schema" } });
+    const runtime = await createTestRuntime({ agent: { name: "workflow-entry-output-schema" } });
     const continuationToken = "http:workflow-entry-output-schema";
     const outputSchema = {
       properties: {
@@ -1090,7 +1088,7 @@ describe("workflowEntry integration", () => {
   });
 
   it("completes immediately in task mode", async () => {
-    const runtime = createTestRuntime({ agent: { name: "workflow-entry-task" } });
+    const runtime = await createTestRuntime({ agent: { name: "workflow-entry-task" } });
 
     await runtime.run(async () => {
       const run = await start(workflowEntry, [
@@ -1119,7 +1117,7 @@ describe("workflowEntry integration", () => {
       required: ["summary"],
       type: "object",
     } as const;
-    const runtime = createTestRuntime({
+    const runtime = await createTestRuntime({
       agent: { name: "workflow-entry-task-output-schema", outputSchema },
     });
 
@@ -1143,7 +1141,7 @@ describe("workflowEntry integration", () => {
   });
 
   it("emits `$eve.*` session attributes onto the parent workflow run", async () => {
-    const runtime = createTestRuntime({ agent: { name: "workflow-entry-tags" } });
+    const runtime = await createTestRuntime({ agent: { name: "workflow-entry-tags" } });
     const continuationToken = "http:workflow-entry-tags";
 
     await runtime.run(async () => {
@@ -1195,7 +1193,7 @@ describe("workflowEntry integration", () => {
   });
 
   it("emits parent lineage onto a subagent workflow run", async () => {
-    const runtime = createTestRuntime({ agent: { name: "workflow-entry-subagent-tags" } });
+    const runtime = await createTestRuntime({ agent: { name: "workflow-entry-subagent-tags" } });
 
     await runtime.run(async () => {
       const serializedContext = buildSerializedContext({

--- a/packages/eve/src/harness/attachment-staging.integration.test.ts
+++ b/packages/eve/src/harness/attachment-staging.integration.test.ts
@@ -29,7 +29,7 @@ import {
 describe("stageAttachmentsToSandbox (integration)", () => {
   it("writes FilePart bytes into the active sandbox and rewrites data to an eve-sandbox: ref", async () => {
     const sandbox = mockSandbox({ id: "sbx_integration" });
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
     const csvBytes = Buffer.from("id,name\n1,alpha\n", "utf8");
 
     const content: UserContent = [
@@ -75,7 +75,7 @@ describe("stageAttachmentsToSandbox (integration)", () => {
         return await live.readTextFile({ path: filePath });
       },
     });
-    const runtime = createTestRuntime({ tools: [readTool] });
+    const runtime = await createTestRuntime({ tools: [readTool] });
     const payload = "id,name\n1,alpha\n";
     const bytes = Buffer.from(payload, "utf8");
 
@@ -98,7 +98,7 @@ describe("stageAttachmentsToSandbox (integration)", () => {
 
   it("passes text-only messages through without touching the sandbox", async () => {
     const sandbox = mockSandbox({ id: "sbx_text" });
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
 
     const result = await runtime.runAsSession({ sandbox }, async () =>
       stageAttachmentsToSandbox("hello"),
@@ -110,7 +110,7 @@ describe("stageAttachmentsToSandbox (integration)", () => {
 
   it("passes UserContent arrays with no FileParts through untouched", async () => {
     const sandbox = mockSandbox({ id: "sbx_no_files" });
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
     const content: UserContent = [{ type: "text", text: "just text" }];
 
     const staged = await runtime.runAsSession({ sandbox }, async () =>
@@ -122,7 +122,7 @@ describe("stageAttachmentsToSandbox (integration)", () => {
   });
 
   it("returns the message unchanged when no SandboxKey is bound on the context", async () => {
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
     const payload = Buffer.from("bytes", "utf8");
     const content: UserContent = [
       { data: payload, filename: "orphan.txt", mediaType: "text/plain", type: "file" },
@@ -138,7 +138,7 @@ describe("stageAttachmentsToSandbox (integration)", () => {
 
   it("dedupes repeated uploads of the same payload within one session", async () => {
     const sandbox = mockSandbox({ id: "sbx_dedupe" });
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
     const payload = Buffer.from("shared-payload", "utf8");
 
     const firstStaged = await runtime.runAsSession({ sandbox }, async () => {
@@ -180,7 +180,7 @@ describe("stageAttachmentsToSandbox (integration)", () => {
     };
 
     const sandbox = mockSandbox({ id: "sbx_ref" });
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
     const content: UserContent = [
       { type: "text", text: "what do you see?" },
       {
@@ -229,7 +229,7 @@ describe("stageAttachmentsToSandbox (integration)", () => {
       state: {},
     };
     const sandbox = mockSandbox({ id: "sbx_refine" });
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
     const content: UserContent = [
       {
         data: new URL("https://example.com/image"),
@@ -258,7 +258,7 @@ describe("stageAttachmentsToSandbox (integration)", () => {
       state: {},
     };
     const sandbox = mockSandbox({ id: "sbx_preserve" });
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
     const content: UserContent = [
       {
         data: new URL("https://example.com/report.csv"),
@@ -280,7 +280,7 @@ describe("stageAttachmentsToSandbox (integration)", () => {
     const adapter: ChannelAdapter<any> = { kind: "custom-channel", state: {} };
     const fileUrl = new URL("https://example.com/a.bin");
     const sandbox = mockSandbox({ id: "sbx_no_resolver" });
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
     const content: UserContent = [
       { data: fileUrl, filename: "a.bin", mediaType: "application/octet-stream", type: "file" },
     ];
@@ -307,7 +307,7 @@ describe("stageAttachmentsToSandbox (integration)", () => {
       state: {},
     };
     const sandbox = mockSandbox({ id: "sbx_threw" });
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
     const content: UserContent = [
       {
         data: new URL("https://example.com/a.bin"),
@@ -338,7 +338,7 @@ describe("stageAttachmentsToSandbox (integration)", () => {
       state: {},
     };
     const sandbox = mockSandbox({ id: "sbx_propagate" });
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
     const content: UserContent = [
       {
         data: new URL("https://example.com/a.bin"),
@@ -357,7 +357,7 @@ describe("stageAttachmentsToSandbox (integration)", () => {
 
   it("works alongside non-file parts in the same user message", async () => {
     const sandbox = mockSandbox({ id: "sbx_mixed" });
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
     const imageBytes = new Uint8Array([137, 80, 78, 71]);
     const fileBytes = Buffer.from("text", "utf8");
 
@@ -391,7 +391,7 @@ describe("hydrateSandboxAttachments (integration)", () => {
 
   it("hydrates small images inline as bytes — provider consumes them multimodally", async () => {
     const sandbox = mockSandbox({ id: "sbx_hydrate_image" });
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
 
     const stagedContent = (await runtime.runAsSession({ sandbox }, async () =>
       stageAttachmentsToSandbox([
@@ -429,7 +429,7 @@ describe("hydrateSandboxAttachments (integration)", () => {
 
   it("hydrates small PDFs inline as bytes — provider handles them natively", async () => {
     const sandbox = mockSandbox({ id: "sbx_hydrate_pdf" });
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
 
     const stagedContent = (await runtime.runAsSession({ sandbox }, async () =>
       stageAttachmentsToSandbox([
@@ -454,7 +454,7 @@ describe("hydrateSandboxAttachments (integration)", () => {
 
   it("substitutes non-inlinable FileParts with a text reference pointing at the sandbox path", async () => {
     const sandbox = mockSandbox({ id: "sbx_hydrate_text_ref" });
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
     const csvBytes = Buffer.from("id,name\n1,alpha\n", "utf8");
 
     const stagedContent = (await runtime.runAsSession({ sandbox }, async () =>
@@ -490,7 +490,7 @@ describe("hydrateSandboxAttachments (integration)", () => {
 
   it("treats oversized images (>3 MiB) as non-inlinable — renders a text reference instead of bytes", async () => {
     const sandbox = mockSandbox({ id: "sbx_hydrate_big_image" });
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
     // One byte over the 3 MiB cap so the ref size fails the inline
     // check without allocating two massive buffers in the test.
     const oversizedImage = Buffer.alloc(3 * 1024 * 1024 + 1, 0x89);
@@ -518,7 +518,7 @@ describe("hydrateSandboxAttachments (integration)", () => {
 
   it("treats oversized PDFs (>20 MiB) as non-inlinable — renders a text reference instead of bytes", async () => {
     const sandbox = mockSandbox({ id: "sbx_hydrate_big_pdf" });
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
     const oversizedPdf = Buffer.alloc(20 * 1024 * 1024 + 1, 0x25);
 
     const stagedContent = (await runtime.runAsSession({ sandbox }, async () =>
@@ -549,7 +549,7 @@ describe("hydrateSandboxAttachments (integration)", () => {
 
   it("treats unknown binary media types as non-inlinable — renders a text reference", async () => {
     const sandbox = mockSandbox({ id: "sbx_hydrate_binary" });
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
     const binary = Buffer.from([0x00, 0x01, 0x02, 0x03]);
 
     const stagedContent = (await runtime.runAsSession({ sandbox }, async () =>
@@ -580,7 +580,7 @@ describe("hydrateSandboxAttachments (integration)", () => {
 
   it("returns the input array unchanged (no allocation) when no messages contain sandbox refs", async () => {
     const sandbox = mockSandbox({ id: "sbx_noop" });
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
 
     const messages = [{ content: "plain text", role: "user" as const }];
     const hydrated = await runtime.runAsSession({ sandbox }, async () =>
@@ -592,7 +592,7 @@ describe("hydrateSandboxAttachments (integration)", () => {
 
   it("is idempotent on inline Buffer FileParts", async () => {
     const sandbox = mockSandbox({ id: "sbx_idempotent" });
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
     const bytes = Buffer.from("hi", "utf8");
     const messages = [
       {
@@ -617,7 +617,7 @@ describe("hydrateSandboxAttachments (integration)", () => {
     // Hydration must not fail the whole turn over it — it degrades to a
     // text part so the run survives (#276).
     const sandbox = mockSandbox({ id: "sbx_missing" });
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
 
     // Ref pointing at a path that was never written. Use an
     // inlinable media type so the byte-read path fires —
@@ -662,7 +662,7 @@ describe("hydrateSandboxAttachments (integration)", () => {
     // resuming a durable session whose ephemeral sandbox is gone. The
     // bytes are unreachable, but the turn must not fail.
     const stagingSandbox = mockSandbox({ id: "sbx_resume_stage" });
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
 
     const stagedContent = (await runtime.runAsSession({ sandbox: stagingSandbox }, async () =>
       stageAttachmentsToSandbox([
@@ -696,7 +696,7 @@ describe("hydrateSandboxAttachments (integration)", () => {
     // would still cost a full sandbox read per turn just to be
     // thrown away.
     const sandbox = mockSandbox({ id: "sbx_no_read" });
-    const runtime = createTestRuntime();
+    const runtime = await createTestRuntime();
     const csvBytes = Buffer.from("id,name\n1,alpha\n", "utf8");
 
     const stagedContent = (await runtime.runAsSession({ sandbox }, async () =>

--- a/packages/eve/src/internal/testing/app-harness.integration.test.ts
+++ b/packages/eve/src/internal/testing/app-harness.integration.test.ts
@@ -22,7 +22,7 @@ function buildSerializedContext(overrides: {
 
 describe("AppHarness pilot", () => {
   it("runs a task-mode turn end-to-end against an in-memory test runtime", async () => {
-    const runtime = createTestRuntime({ agent: { name: "pilot-agent" } });
+    const runtime = await createTestRuntime({ agent: { name: "pilot-agent" } });
 
     const output = await runtime.run(async () => {
       const run = await start(workflowEntry, [
@@ -45,7 +45,7 @@ describe("AppHarness pilot", () => {
   });
 
   it("keeps compiled artifacts scoped to the test runtime session", async () => {
-    const runtime = createTestRuntime({ agent: { name: "scope-probe" } });
+    const runtime = await createTestRuntime({ agent: { name: "scope-probe" } });
 
     // Before `run`, the session has no artifacts installed.
     expect(runtime.session.compiledArtifacts).toBeNull();
@@ -66,8 +66,8 @@ describe("AppHarness pilot", () => {
   });
 
   it("isolates two concurrent test runtimes without cache crosstalk", async () => {
-    const runtimeA = createTestRuntime({ agent: { name: "tenant-a" } });
-    const runtimeB = createTestRuntime({ agent: { name: "tenant-b" } });
+    const runtimeA = await createTestRuntime({ agent: { name: "tenant-a" } });
+    const runtimeB = await createTestRuntime({ agent: { name: "tenant-b" } });
 
     const outputs = await Promise.all([
       runtimeA.run(async () => {

--- a/packages/eve/src/internal/testing/app-harness.ts
+++ b/packages/eve/src/internal/testing/app-harness.ts
@@ -1,6 +1,6 @@
 import type { JsonObject } from "#shared/json.js";
 import type { ChannelAdapter } from "#channel/adapter.js";
-import { compileFromMemory } from "#compiler/compile-from-memory.js";
+import { compileFromMemory, type CompileFromMemoryInput } from "#compiler/compile-from-memory.js";
 import type { CompiledAgentManifest, CompiledSkillDefinition } from "#compiler/manifest.js";
 import type { CompiledModuleMap } from "#compiler/module-map.js";
 import type { SessionParent, SessionTurn } from "#context/keys.js";
@@ -13,7 +13,7 @@ import {
 } from "#runtime/sessions/runtime-session.js";
 import { createRuntimeToolRegistry } from "#runtime/tools/registry.js";
 import type { ResolvedToolDefinition } from "#runtime/types.js";
-import { serializeInputSchema } from "#shared/tool-schema.js";
+import { serializeInputSchema, serializeOutputSchema } from "#shared/tool-schema.js";
 import {
   buildActiveSessionContext,
   type ActiveSessionInit,
@@ -126,64 +126,40 @@ const DEFAULT_AGENT_NAME = "test-agent";
 /**
  * Builds an in-memory {@link TestRuntime} for the given descriptor.
  *
- * The returned runtime already has its synthetic compiled artifacts
+ * The resolved runtime already has its synthetic compiled artifacts
  * installed on its scoped session. Callers invoke `runtime.run(fn)` or
  * `runtime.runAsSession(init, fn)` to execute code under the active
  * session (and, in the latter case, under a seeded authored context).
  */
 export const TEST_DEFAULT_MODEL_ID = "openai/gpt-5.4";
 
-export function createTestRuntime(descriptor: TestAppDescriptor = {}): TestRuntime {
-  const compileInput: {
-    name: string;
-    model: string;
-    limits?: {
-      readonly maxInputTokensPerSession?: number | false;
-      readonly maxOutputTokensPerSession?: number | false;
-      readonly sessionTimeoutMs?: number | false;
-    };
-    outputSchema?: JsonObject;
-    tools?: readonly {
-      readonly name: string;
-      readonly description?: string;
-      readonly inputSchema?: JsonObject | null;
-    }[];
-    skills?: readonly {
-      readonly name: string;
-      readonly description: string;
-      readonly markdown?: string;
-    }[];
-  } = {
+export async function createTestRuntime(descriptor: TestAppDescriptor = {}): Promise<TestRuntime> {
+  const compileInput: CompileFromMemoryInput = {
     name: descriptor.agent?.name ?? DEFAULT_AGENT_NAME,
     model: descriptor.agent?.model ?? TEST_DEFAULT_MODEL_ID,
     limits: descriptor.agent?.limits,
     outputSchema: descriptor.agent?.outputSchema,
+    tools: descriptor.tools?.map((tool) => ({
+      approval: tool.approval,
+      description: tool.description,
+      execute: tool.execute,
+      execution: tool.execution,
+      inputSchema: serializeInputSchema(tool.inputSchema),
+      name: tool.name,
+      outputSchema: serializeOutputSchema(tool.outputSchema),
+      toModelOutput: tool.toModelOutput,
+    })),
+    skills: descriptor.skills?.map((skill) => ({
+      name: skill.name,
+      description: skill.description,
+      files: skill.files,
+      license: skill.license,
+      markdown: skill.markdown,
+      metadata: skill.metadata,
+    })),
   };
 
-  if (descriptor.tools !== undefined && descriptor.tools.length > 0) {
-    compileInput.tools = descriptor.tools.map((tool) => ({
-      name: tool.name,
-      description: tool.description,
-      inputSchema: serializeInputSchema(tool.inputSchema),
-    }));
-  }
-
-  if (descriptor.skills !== undefined && descriptor.skills.length > 0) {
-    compileInput.skills = descriptor.skills.map((skill) => {
-      const entry: { name: string; description: string; markdown?: string } = {
-        name: skill.name,
-        description: skill.description,
-      };
-
-      if (skill.markdown !== undefined) {
-        entry.markdown = skill.markdown;
-      }
-
-      return entry;
-    });
-  }
-
-  const { manifest, moduleMap } = compileFromMemory(compileInput);
+  const { manifest, moduleMap } = await compileFromMemory(compileInput);
   const session = createRuntimeSession(descriptor.agent?.name ?? DEFAULT_AGENT_NAME);
   const tools = descriptor.tools ?? [];
   const skills = descriptor.skills ?? [];


### PR DESCRIPTION
### Summary

Related to #2347. This layer of stack #2420 is stacked on #2417.

Replace the integration harness's direct manifest fabrication with an ordinary programmatic application source. Synthetic `agent.ts`, tool, and skill modules now occupy their canonical logical paths and pass through the same source composition, primitive normalization, framework-default, binding-validation, and kernel-preparation pipeline as filesystem-authored agents. The in-process module map consumes the same complete binding collection as generated artifacts and preserves real namespaces and callbacks.

This PR also removes the narrow capability adapter retained in #2410 so that the earlier core PR can land independently. Programmatic application origins remain source-neutral and cannot recursively introduce subagents. The harness API becomes asynchronous because it now executes the real normalizers.

Scope boundary: the memory-vs-disk lifecycle-equivalence proof remains a required follow-up in the research plan and is intentionally not claimed here. Stack-level docs, deterministic e2e coverage, and the minor changeset follow in #2419.

### Validation

The exact final stack tree passed the full eve unit suite with 7,051 tests and 1 skip, plus 26 focused compiler and agent-info scenarios. Formatting, workspace typecheck, lint, invariant checks, and docs validation are green. Local integration coverage reaches the canonical compiler path; three cancellation cases remain blocked locally by a microsandbox database containing migrations unavailable in this checkout. The full unit, Linux and Windows integration, scenario, TUI, typecheck, lint, invariant, and docs gates are independently green in [exact-head CI](https://github.com/vercel/eve/actions/runs/32582752568).

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package (the stack-level minor changeset follows in #2419)
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

Documentation and release metadata intentionally follow in #2419.

**Implementation** — 8 files · `+381 / -277`

The canonical compiler path replaces the direct manifest shortcut and extends the shared programmatic binding machinery needed by in-memory sources.

**Tests** — 14 files · `+176 / -151`

Harness and execution tests migrate from patched empty namespaces to real authored module definitions and callbacks.
