### PR TITLE
docs(eve): agent sources - document canonical composition

### DIFF
--- a/.changeset/brave-agent-sources.md
+++ b/.changeset/brave-agent-sources.md
@@ -1,0 +1,5 @@
+---
+"eve": minor
+---
+
+Compile application, extension, and framework primitives through one path-derived source graph, removing framework-specific merge and fallback paths. Agent inspection now reports authoritative source ownership, composition diagnostics, ordered channel routes, and native kernel capability state through schema version 3.

--- a/docs/channels/eve.mdx
+++ b/docs/channels/eve.mdx
@@ -34,6 +34,26 @@ The application exposes a health route plus eve channel routes that inspect the 
 
 The session routes use only durable session IDs. Create a session explicitly, then put its returned ID in every follow-up, control, and stream path.
 
+### Inspect the compiled agent
+
+`GET /eve/v1/info` returns the version 3 inspection snapshot used by the CLI,
+development UI, and typed client. The response projects one effective compiled
+agent rather than rebuilding framework state at request time:
+
+- static definitions include their logical path, source ID, and owner;
+- dynamic tool, skill, and instruction resolvers are listed separately from
+  their session-specific outputs;
+- `kernel.prepared` reports native capabilities the compiled node can prepare,
+  while `kernel.reserved` reports names the kernel never exposes as authored
+  definitions;
+- `channels` is the effective ordered route list used for dispatch; and
+- `composition` records framework or extension candidates that application
+  sources shadowed or disabled.
+
+The snapshot does not claim which conditional capabilities a particular model
+call received. Use `Client.info()` from `eve/client` when you want the response
+validated against the current schema.
+
 ### Start and continue a session
 
 Start a session with an initial message, then use the returned `sessionId` for every follow-up and control operation:

--- a/docs/concepts/built-in-tools.md
+++ b/docs/concepts/built-in-tools.md
@@ -7,7 +7,7 @@ eve provides a default tool set for every agent and additional framework tools y
 
 ## Default tools
 
-Default tools require no imports. The exact set depends on the agent and session. `agent` is available only in the root session; `load_skill` and `connection_search` appear only when the agent declares the corresponding resources; `ask_question` requires a session that can request user input; and `web_search` requires a supported model provider. The harness advertises only the tools available to the current session.
+Default tools require no imports. Most defaults compile from the same path-derived slots as authored tools, so a file such as `agent/tools/bash.ts` replaces or disables the default before the agent starts. Session-dependent capabilities are prepared separately: `agent` is available only in the root session; `load_skill` and `connection_search` appear only when the agent declares the corresponding resources; `ask_question` requires a session that can request user input; and `web_search` requires a supported model provider. The harness advertises only the tools available to the current session.
 
 The default shell and file tools (`bash`, `read_file`, and `write_file`) run in the app and proxy their work into the agent's [sandbox](../sandbox). The table shows where each tool's effect lands.
 

--- a/docs/concepts/sessions-runs-and-streaming.md
+++ b/docs/concepts/sessions-runs-and-streaming.md
@@ -244,13 +244,25 @@ Start with the [Client SDK](../guides/client/overview) guide. It covers basic us
 
 ## Inspect the agent over HTTP
 
-`GET /eve/v1/info` returns a JSON inspection snapshot for the running agent: model, static instructions, authored and framework tools, skills, channels, schedules, subagents, sandbox, connections, hooks, workflow, and workspace metadata. Static instructions are an ordered array whose entries expose `content` and `role`; dynamic resolver output is runtime context and is not included. The route uses the resolved `eveChannel()` auth when `agent/channels/eve.ts` authors one; otherwise it falls back to the framework default of Vercel OIDC plus local development access.
+`GET /eve/v1/info` returns the version 3 inspection snapshot for the effective
+compiled agent. Static resources carry their source owner, dynamic resolvers
+are separate from their session-specific outputs, native kernel capabilities
+are separate from compiled tools, and channel routes appear once in dispatch
+order. Composition diagnostics explain which lower-precedence sources were
+shadowed or disabled. See [Inspect the compiled
+agent](../channels/eve#inspect-the-compiled-agent) for the field groups and
+their boundaries.
 
 ```bash
 curl http://127.0.0.1:2000/eve/v1/info
 ```
 
-With the default auth chain (`[vercelOidc(), localDev(), placeholderAuth()]`), a Vercel OIDC bearer takes precedence, an `eve dev` or `vercel dev` server authenticates local requests, and everything else is rejected. A deployed Vercel target requires a valid OIDC bearer, with a same-project bypass for in-deployment callers. See [auth & route protection](../guides/auth-and-route-protection).
+The route uses the selected `eveChannel()` auth. With the default auth chain
+(`[vercelOidc(), localDev(), placeholderAuth()]`), a Vercel OIDC bearer takes
+precedence, an `eve dev` or `vercel dev` server authenticates local requests,
+and everything else is rejected. A deployed Vercel target requires a valid
+OIDC bearer, with a same-project bypass for in-deployment callers. See [auth &
+route protection](../guides/auth-and-route-protection).
 
 ## Dispatch order
 

--- a/docs/guides/client/overview.mdx
+++ b/docs/guides/client/overview.mdx
@@ -34,12 +34,19 @@ Non-2xx responses throw `ClientError`, which carries the HTTP `status` and respo
 
 ## Inspect an agent
 
-Use `info()` to inspect a development agent. The client parses and validates the complete response before returning it:
+Use `info()` to inspect a running agent. The client parses and validates the complete response before returning it:
 
 ```ts
 const info = await client.info();
 console.log(info.agent.name, info.agent.model.id);
 ```
+
+The version 3 result distinguishes compiled resources from native runtime
+capabilities. Read `tools.static` and the other static lists for effective
+definitions and their source owners, `tools.dynamic` for resolver definitions,
+`kernel` for prepared or reserved native capabilities, `channels` for the
+ordered dispatch routes, and `composition` for shadowed or disabled sources.
+Dynamic resolver output is session-specific and is not part of this snapshot.
 
 ## Authentication
 

--- a/docs/guides/dynamic-capabilities.md
+++ b/docs/guides/dynamic-capabilities.md
@@ -123,8 +123,7 @@ returns `null`. If a resolver throws or returns an invalid definition, eve logs 
 failure and omits the subagent.
 
 The resolved set applies to local and remote direct delegation and the
-`Workflow` tool. eve
-also checks availability again before starting the child, so a stale or
+`Workflow` tool. eve also checks availability again before starting the child, so a stale or
 manually constructed call fails with `SUBAGENT_UNAVAILABLE`. Treat conditional
 availability as capability composition, not as the only authorization
 boundary: sensitive child tools still need their own authorization and
@@ -187,7 +186,14 @@ A single return produces one tool named after the file slug, identical to a stat
 
 ### Conflicts
 
-A dynamic tool or skill whose name matches an **authored** one **overrides** it — a per-caller resolver can replace a built-in by name. Two **dynamic** resolvers emitting the same name is a genuine ambiguity and throws; namespace one of the keys manually to resolve it.
+A dynamic tool or skill whose name matches an **authored** one **overrides** it — a per-caller resolver can replace a built-in by name. Two **dynamic** resolvers emitting the same name create a genuine ambiguity and throw; namespace one of the keys manually to resolve it.
+
+### Inspection
+
+`GET /eve/v1/info` reports each compiled dynamic resolver with its source and
+subscribed event names. It does not execute resolvers or include their
+session-specific outputs. Those outputs materialize only inside the matching
+session lifecycle.
 
 ### Events
 
@@ -260,7 +266,7 @@ export default defineDynamic({
 
 The caller's team gets its own playbook advertised as a loadable skill; everyone else gets nothing.
 
-Skills follow the same naming rule as tools: a single `defineSkill(...)` is named after the file slug, while a map names each entry by its bare key (namespace the key yourself if it might collide). A dynamic skill overrides a same-named authored one; two dynamic resolvers emitting the same name throws.
+Skills follow the same naming rule as tools: a single `defineSkill(...)` is named after the file slug, while a map names each entry by its bare key (namespace the key yourself if it might collide). A dynamic skill overrides a same-named authored one; two dynamic resolvers emitting the same name throw.
 
 ## Dynamic instructions
 

--- a/docs/sandbox.mdx
+++ b/docs/sandbox.mdx
@@ -5,7 +5,7 @@ description: "The agent's isolated bash environment, including built-in file too
 
 The sandbox is the agent's isolated bash environment: a filesystem rooted at `/workspace` where it can run shell commands, execute scripts, and read or write files without ever touching your app runtime. Every eve agent has exactly one. The default `bash`, `read_file`, and `write_file` tools target it; you can also add the framework's `glob` and `grep` tools or access it from authored code.
 
-A working sandbox exists by default, with nothing to author. Override it only to add setup, seed files, pick a backend, or lock down the network.
+A working sandbox definition exists by default at the logical `agent/sandbox.ts` slot, with nothing to author. An authored sandbox at that slot replaces the default during compilation. Override it only to add setup, seed files, pick a backend, or lock down the network.
 
 The default sandbox is not a substitute for configuring network policy, credentials, retention, deletion, or other controls your application requires.
 

--- a/e2e/fixtures/agent-tools/evals/inspection/canonical-source-graph.eval.ts
+++ b/e2e/fixtures/agent-tools/evals/inspection/canonical-source-graph.eval.ts
@@ -1,0 +1,47 @@
+import type { AgentInfoResult } from "eve/client";
+import { defineEval } from "eve/evals";
+import { equals, satisfies } from "eve/evals/expect";
+
+export default defineEval({
+  description: "Inspection projects the canonical source graph without duplicate runtime state.",
+  async test(t) {
+    const response = await t.target.fetch("/eve/v1/info");
+    if (!response.ok) {
+      throw new Error(`GET /eve/v1/info failed (${response.status}): ${await response.text()}`);
+    }
+
+    const info = (await response.json()) as AgentInfoResult;
+    t.check(info.version, equals(3));
+    t.check(
+      info,
+      satisfies<AgentInfoResult>((value) => {
+        const staticTool = (name: string) => value.tools.static.find((tool) => tool.name === name);
+        const dynamicTool = (slug: string) =>
+          value.tools.dynamic.find((tool) => tool.slug === slug);
+        const infoRoute = value.channels.find(
+          (channel) => channel.method === "GET" && channel.urlPath === "/eve/v1/info",
+        );
+        const webSearchComposition = value.composition.shadowed.find(
+          (entry) => entry.slot === "tools/web_search",
+        );
+
+        return (
+          staticTool("bash")?.owner.kind === "framework" &&
+          staticTool("override-target")?.owner.kind === "application" &&
+          dynamicTool("connection_search")?.owner.kind === "framework" &&
+          dynamicTool("override-provider")?.owner.kind === "application" &&
+          value.sandbox?.owner.kind === "framework" &&
+          infoRoute?.owner.kind === "framework" &&
+          value.kernel.prepared.some((capability) => capability.name === "agent") &&
+          value.kernel.prepared.some((capability) => capability.name === "web_search") &&
+          value.kernel.reserved.some((capability) => capability.name === "final_output") &&
+          webSearchComposition?.source.owner.kind === "framework" &&
+          webSearchComposition.by.owner.kind === "application"
+        );
+      }, "canonical source ownership, composition, routes, and kernel projection"),
+    );
+
+    await t.send("Complete one ordinary turn without calling tools.");
+    t.succeeded();
+  },
+});

--- a/research/programmatic-agent-sources.md
+++ b/research/programmatic-agent-sources.md
@@ -1,7 +1,7 @@
 ---
 issue: https://github.com/vercel/eve/issues/2347
-status: proposed
-last_updated: "2026-08-21"
+status: in-progress
+last_updated: "2026-08-22"
 ---
 
 # Programmatic agent sources
@@ -482,30 +482,32 @@ implementation acceptance item, not work performed by the research PR.
 
 ## Delivery
 
-1. **Source-neutral compilation.** Introduce candidates, the namespace-loader
-   boundary, required per-node bindings, hashing, and cold-start loading. Route
-   existing filesystem and in-memory compilation through it with no behavior
-   change.
-2. **Canonical composition.** Project extensions into final logical paths and
-   compose framework, extension, override, and application candidates before
-   normalization. Delete the per-primitive extension composition path as each
-   primitive moves.
-3. **Ordinary framework sources.** Migrate public default tools,
-   `connection_search`, the default sandbox, the default channel, and all six
-   callback modules. Make the effective manifest drive graph and Nitro routes.
-4. **Kernel and inspection.** Install the closed native capability and adapter
-   inventories, move `load_skill` to an ordinary definition if its context
-   provider proof succeeds, and replace agent-info v2 with the single v3
-   projector.
-5. **Memory proof and cleanup gate.** Complete the explicit memory lifecycle
-   proof, run end-to-end cold-start coverage, and verify every superseded path
-   below is gone before declaring the architecture ready for memory.
+This implementation is a serial stack with one deliberately large core
+migration. Source-neutral bindings and composition can land independently, as
+can inspection, the test-only in-memory compiler, and documentation. Moving
+framework capabilities cannot be split by primitive: generated binding
+reachability, framework and extension precedence, legacy-path deletion, and
+the closed kernel inventory must change together or an intermediate manifest
+can contain bindings with no executable owner.
 
-Each stage must stay buildable and delete the path it supersedes. Transitional
-adapters may exist within a branch while a stage is being implemented, but do
-not land a permanent compatibility layer. The final implementation includes a
-minor changeset and updates tool, dynamic capability, channel, sandbox, and
-agent-info documentation.
+The landing order is:
+
+1. establish source-neutral module bindings;
+2. establish the canonical source composer;
+3. atomically move the default sandbox, ordinary framework tools,
+   `connection_search`, `load_skill`, `web_search`, the eve channel, and
+   callback routes onto that composer; project extension packages and
+   overrides into the same slots; install the closed kernel inventory; and
+   delete the superseded compiler and runtime machinery;
+4. replace agent-info v2 with the single v3 projector;
+5. route the test-only in-memory compiler through the same source graph; and
+6. finish with documentation, deterministic fixture inspection, and one minor
+   changeset for the breaking inspection contract.
+
+The memory lifecycle proof is intentionally not part of this stack. It remains
+a required follow-up before memory may adopt programmatic sources, as specified
+in [Memory lifecycle proof still required](#memory-lifecycle-proof-still-required).
+It must not introduce a compatibility layer or a memory-only contributor seam.
 
 ## Required deletions
 


### PR DESCRIPTION
### Summary

Related to #2347. This is the final layer of stack #2420 and is stacked on #2418.

Document the canonical agent-source architecture as a serial stack with one deliberately atomic core migration. The docs explain source ownership and precedence, the agent-info v3 inspection contract, and why memory adoption still requires a lifecycle-equivalence proof without a memory-only registry or contributor seam.

Add a deterministic `agent-tools` eval that reads the live `/eve/v1/info` response and verifies framework/application ownership, static and dynamic definitions, web-search shadowing, the effective info route, prepared and reserved kernel capabilities, and a completed durable turn. A minor changeset records the breaking inspection contract.

### Validation

The exact final stack tree passed docs validation across 82 pages and 262 eve import paths, plus the full unit suite with 7,051 tests and 1 skip. [Exact-head CI](https://github.com/vercel/eve/actions/runs/32582753010), the [Postgres matrix](https://github.com/vercel/eve/actions/runs/32582753111), and the [Vercel matrix](https://github.com/vercel/eve/actions/runs/32582753012) are fully green and exercise the live inspection eval, complete application boot path, 50-session concurrent workflow stress, and 100 sequential durable turns. The [local model matrix](https://github.com/vercel/eve/actions/runs/32582753013) passed 33/38 model jobs; the remaining failures were provider-output or loopback-transport variance in prompt-cache, subagent, task-reporting, and agent-tools evals.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 8 files · `+87 / -35`

The research plan, public architecture and behavior docs, and breaking-change metadata are updated together so the final contract is reviewable in one place.

**Implementation** — 0 files · `+0 / -0`

Not applicable; implementation lands in the preceding stack layers.

**Tests** — 1 file · `+47 / -0`

One deterministic eval covers the complete live inspection contract without adding fixture-only support code.
