### PR TITLE
fix(eve): offer Vercel CLI upgrade for Linq setup

### DIFF
--- a/.changeset/bright-linq-vercel-cli.md
+++ b/.changeset/bright-linq-vercel-cli.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Linq setup now recognizes Vercel CLI versions that lack required trigger options and offers to upgrade the CLI from the `/add` flow instead of reporting a generic connector failure.

--- a/packages/eve/src/cli/dev/tui/setup-commands.test.ts
+++ b/packages/eve/src/cli/dev/tui/setup-commands.test.ts
@@ -302,6 +302,34 @@ describe("runTuiSetupCommand", () => {
     );
   });
 
+  it("prompts to upgrade when an installed registry item's setup needs a newer CLI", async () => {
+    const flows = fakeFlows({
+      runRegistryFlow: vi.fn<TuiSetupFlows["runRegistryFlow"]>(async () => {
+        throw new RegistryFlowFailedError(
+          new HumanActionRequiredError({
+            kind: "vercel-cli-upgrade",
+            command: "vercel upgrade",
+            reason: "The installed Vercel CLI does not support Linq trigger options.",
+          }),
+          {
+            kind: "done",
+            addedItems: ["channel/linq"],
+            items: [{ address: "channel/linq", title: "Linq", facts: [], output: [] }],
+            facts: [],
+          },
+        );
+      }),
+      runInstallVercelCliFlow: vi.fn<TuiSetupFlows["runInstallVercelCliFlow"]>(async () => ({
+        kind: "installed",
+      })),
+    });
+
+    await expect(run({ command: "add", flows, upgradeChoice: "upgrade" })).resolves.toEqual({
+      message: "Upgraded the Vercel CLI. Retry /add.",
+      preserveFlowDiagnostics: false,
+    });
+  });
+
   it("gives the manual upgrade command when the old-CLI prompt is declined", async () => {
     const flows = fakeFlows({
       runModelFlow: vi.fn<TuiSetupFlows["runModelFlow"]>(async () => {

--- a/packages/eve/src/cli/dev/tui/setup-commands.ts
+++ b/packages/eve/src/cli/dev/tui/setup-commands.ts
@@ -300,6 +300,13 @@ async function executeSetupCommand(
       }
     }
   } catch (error) {
+    const actionableError = error instanceof RegistryFlowFailedError ? error.cause : error;
+    const upgrade = await vercelCliUpgradeOutcome(actionableError, command, flows, {
+      appRoot,
+      prompter,
+      signal,
+    });
+    if (upgrade !== undefined) return upgrade;
     if (error instanceof RegistryFlowFailedError) {
       const completed = error.completed;
       return {
@@ -314,12 +321,6 @@ async function executeSetupCommand(
         preserveFlowDiagnostics: command !== "model",
       };
     }
-    const upgrade = await vercelCliUpgradeOutcome(error, command, flows, {
-      appRoot,
-      prompter,
-      signal,
-    });
-    if (upgrade !== undefined) return upgrade;
     // Provisioning steps (link, deploy, Slack) throw a Vercel human action when
     // `whoami` fails or a scope is denied. Route it to the in-TUI fix instead of
     // dumping the raw "Human action required" message.
@@ -352,7 +353,7 @@ async function vercelCliUpgradeOutcome(
   let choice: "upgrade" | "later";
   try {
     choice = await input.prompter.select({
-      message: "Your Vercel CLI needs an update to list your teams. Upgrade now?",
+      message: "Your Vercel CLI needs an update to continue setup. Upgrade now?",
       options: [
         {
           value: "upgrade",

--- a/packages/eve/src/setup/integrations/linq/connect.test.ts
+++ b/packages/eve/src/setup/integrations/linq/connect.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { ChannelSetupLog } from "#setup/cli/index.js";
+import { HumanActionRequiredError } from "#setup/human-action.js";
 
 import { parseCreatedLinqConnector, provisionLinqConnector } from "./connect.js";
 
@@ -28,6 +29,32 @@ describe("Linq Connect provisioning", () => {
         JSON.stringify({ ...createdConnector, data: { phoneNumbers: ["+14155550123"] } }),
       ),
     ).toEqual({ id: "scl_linq", uid: "linq/agent", phoneNumber: "+14155550123" });
+  });
+
+  it("requests a Vercel CLI upgrade when trigger options are unsupported", async () => {
+    const runVercelCaptureStdout = vi.fn(async () => ({
+      ok: false as const,
+      stdout: "",
+      stderr:
+        "Vercel CLI 56.4.1 (Node.js 24.18.0)\nError: unknown or unexpected option: --trigger-event",
+    }));
+
+    await expect(
+      provisionLinqConnector({
+        log: log(),
+        project: { orgId: "team_123", projectId: "prj_123" },
+        projectRoot: "/project",
+        slug: "agent",
+        deps: { runVercel: vi.fn(), runVercelCaptureStdout },
+      }),
+    ).rejects.toEqual(
+      new HumanActionRequiredError({
+        kind: "vercel-cli-upgrade",
+        command: "vercel upgrade",
+        reason:
+          "The installed Vercel CLI does not support the trigger options Linq setup needs. Upgrade it and retry.",
+      }),
+    );
   });
 
   it("creates a connector for an existing Linq account without exposing its token in argv", async () => {

--- a/packages/eve/src/setup/integrations/linq/connect.ts
+++ b/packages/eve/src/setup/integrations/linq/connect.ts
@@ -1,6 +1,7 @@
 import type { ChannelSetupLog } from "#setup/cli/index.js";
 import { createPromptCommandOutput, withPhase } from "#setup/cli/index.js";
 import type { ProcessOutputHandler } from "#setup/primitives/process-output.js";
+import { HumanActionRequiredError } from "#setup/human-action.js";
 import { replaceConnectTrigger } from "#setup/connect-provisioning.js";
 import type { VercelProjectReference } from "#setup/project-resolution.js";
 import {
@@ -53,6 +54,15 @@ export function parseCreatedLinqConnector(stdout: string): LinqConnectorRef | un
 
 function requireCreatedConnector(result: RunVercelCaptureResult): LinqConnectorRef {
   if (!result.ok) {
+    const output = `${result.stderr ?? ""}\n${result.stdout}`;
+    if (/(?:unknown|unexpected|invalid).*--trigger-event/iu.test(output)) {
+      throw new HumanActionRequiredError({
+        kind: "vercel-cli-upgrade",
+        command: "vercel upgrade",
+        reason:
+          "The installed Vercel CLI does not support the trigger options Linq setup needs. Upgrade it and retry.",
+      });
+    }
     const detail = [result.stderr, result.stdout].find(
       (value): value is string => value !== undefined && value.trim().length > 0,
     );


### PR DESCRIPTION
### Summary

Linq connector setup reported a generic creation failure when an older Vercel CLI did not recognize the required `--trigger-event` option. It now classifies that response as an upgrade action, and `/add` unwraps the action after installing a registry item so the existing interactive Vercel CLI upgrade flow can recover. Other connector failures retain their existing diagnostics.

### Validation

Reproduced the old-CLI response in focused Linq coverage and confirmed both direct classification and the wrapped `/add` upgrade prompt across 37 passing unit tests; the `eve` package typecheck also passed.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

A short patch changeset describes the user-visible recovery behavior.

**Implementation** — 2 files · `+18 / -7`

The change stays at the Linq failure classifier and existing TUI recovery boundary.

**Tests** — 2 files · `+55 / -0`

Regression coverage exercises the exact Vercel CLI error and its registry-flow wrapper.
