### PR TITLE
fix(eve): clean up abandoned web chat streams

### DIFF
--- a/.changeset/clean-up-web-chat-streams.md
+++ b/.changeset/clean-up-web-chat-streams.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Generated Web Chat apps now include their new-session and resumable-session routes. Abandoned browser session streams also release their local workflow listeners instead of accumulating them across navigation.

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -1492,6 +1492,16 @@
           "target": "app/page.tsx"
         },
         {
+          "path": "registry/channel/web/app/s/[sessionId]/page.tsx",
+          "type": "registry:file",
+          "target": "app/s/[sessionId]/page.tsx"
+        },
+        {
+          "path": "registry/channel/web/app/s/page.tsx",
+          "type": "registry:file",
+          "target": "app/s/page.tsx"
+        },
+        {
           "path": "registry/channel/web/components.json",
           "type": "registry:file",
           "target": "components.json"

--- a/packages/eve/src/public/channels/eve.test.ts
+++ b/packages/eve/src/public/channels/eve.test.ts
@@ -344,13 +344,13 @@ function createEveStreamHandler(input: EveChannelInput) {
   return {
     getEventStream,
     getStreamTailIndex,
-    async fetch(url: string) {
+    async fetch(url: string, init?: RequestInit) {
       const args: RouteHandlerArgs = {
         ...createRouteArgs(),
         attachSession: () => session,
         params: { sessionId: "test-session-id" },
       };
-      return (streamRoute as any).handler(new Request(url), args);
+      return (streamRoute as any).handler(new Request(url, init), args);
     },
   };
 }
@@ -531,6 +531,26 @@ describe("eveChannel — stream cursor", () => {
     await reader.cancel();
 
     expect(new TextDecoder().decode(firstChunk.value)).toBe("\n");
+  });
+
+  it("cancels the durable stream when the request aborts", async () => {
+    const handler = createEveStreamHandler({ auth: none() });
+    const cancelled = vi.fn();
+    handler.getEventStream.mockResolvedValueOnce(
+      new ReadableStream({
+        cancel: cancelled,
+      }),
+    );
+    const abort = new AbortController();
+
+    const response = await handler.fetch("https://eve.test/eve/v1/session/test-session-id/stream", {
+      signal: abort.signal,
+    });
+    const reader = response.body!.getReader();
+    await reader.read();
+    abort.abort();
+
+    await vi.waitFor(() => expect(cancelled).toHaveBeenCalledOnce());
   });
 
   it("forwards negative tail-relative start indices", async () => {

--- a/packages/eve/src/public/channels/eve.ts
+++ b/packages/eve/src/public/channels/eve.ts
@@ -1068,7 +1068,7 @@ async function createSessionStreamResponse(request: Request, session: Session): 
     if (tailIndex !== undefined) {
       headers.set(EVE_STREAM_TAIL_INDEX_HEADER, String(tailIndex));
     }
-    return new Response(serializeAsNdjson(events), {
+    return new Response(serializeAsNdjson(events, request.signal), {
       headers,
     });
   } catch {
@@ -1352,16 +1352,19 @@ function parseStartIndex(request: Request): number | undefined | Response {
   return parsed;
 }
 
-function serializeAsNdjson(events: ReadableStream<unknown>): ReadableStream<Uint8Array> {
+function serializeAsNdjson(
+  events: ReadableStream<unknown>,
+  signal: AbortSignal,
+): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder();
-  return events.pipeThrough(
-    new TransformStream<unknown, Uint8Array>({
-      start(controller) {
-        controller.enqueue(encoder.encode("\n"));
-      },
-      transform(event, controller) {
-        controller.enqueue(encoder.encode(`${JSON.stringify(event)}\n`));
-      },
-    }),
-  );
+  const transform = new TransformStream<unknown, Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode("\n"));
+    },
+    transform(event, controller) {
+      controller.enqueue(encoder.encode(`${JSON.stringify(event)}\n`));
+    },
+  });
+  void events.pipeTo(transform.writable, { signal }).catch(() => {});
+  return transform.readable;
 }

--- a/packages/eve/src/setup/scaffold/index.integration.test.ts
+++ b/packages/eve/src/setup/scaffold/index.integration.test.ts
@@ -228,6 +228,12 @@ describe("ensureChannel", () => {
     await expect(readFile(join(projectRoot, "app/page.tsx"), "utf8")).resolves.toContain(
       "AgentChat",
     );
+    await expect(readFile(join(projectRoot, "app/s/page.tsx"), "utf8")).resolves.toContain(
+      "<AgentChat sessionless />",
+    );
+    await expect(
+      readFile(join(projectRoot, "app/s/[sessionId]/page.tsx"), "utf8"),
+    ).resolves.toContain("<AgentChat sessionId={sessionId} />");
     await expect(
       readFile(join(projectRoot, "agent/tools/randomize.ts"), "utf8"),
     ).rejects.toMatchObject({


### PR DESCRIPTION
### Summary

Generated Web Chat apps rewrite active conversations to `/s/<sessionId>` and link new chats to `/s`, but the public `channel/web` registry item omitted both pages. This adds the existing resumable-session and sessionless new-chat pages to `eve add channel/web`. It also propagates an aborted HTTP request into the underlying durable event stream so browser navigation releases local Workflow World listeners instead of accumulating `MaxListenersExceededWarning` warnings.

### Validation

Reproduced the missing routes with a newly initialized Web Chat app, confirmed both routes are included by focused scaffold coverage, and verified request cancellation reaches the underlying durable stream with the complete eve channel unit suite. The full Web Chat scaffold integration suite and registry validation also pass.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

A concise changeset records the user-visible scaffold and stream-cleanup fixes.

**Implementation** — 2 files · `+25 / -12`

The registry exposes the two already-authored session pages, while the HTTP stream adapter now binds durable-stream lifetime to request lifetime.

**Tests** — 2 files · `+28 / -2`

Regression coverage verifies both generated routes and cancellation of an abandoned durable stream.
