### PR TITLE
docs: remove evals construction banner

### DIFF
--- a/apps/docs/app/[lang]/evals/page.tsx
+++ b/apps/docs/app/[lang]/evals/page.tsx
@@ -27,12 +27,6 @@ const EvalsPage = () => {
 
   return (
     <main className="mx-auto w-full min-w-0 max-w-[1080px] px-4 pb-32 sm:px-6">
-      <div className="mt-8 rounded-xl border border-gray-400 bg-gray-100 px-4 py-3 text-gray-900 text-sm leading-6">
-        <span className="font-medium text-gray-1000">Under construction.</span> This evaluation
-        suite is actively under development. Its results, methodology, and presentation are subject
-        to change.
-      </div>
-
       <section className="flex min-w-0 flex-col items-center px-0 pt-16 pb-12 text-center sm:px-4">
         <h1 className="text-gray-1000 text-heading-48 sm:text-heading-64">Agent Evaluations</h1>
         <p className="mt-5 max-w-3xl text-gray-900 text-lg">


### PR DESCRIPTION
### Summary

The published evaluations page still labels the suite as under construction. This removes that banner so the page leads directly into the current benchmark results.

### Validation

No tests were run; this is a copy-only removal with no behavior change.

### Checklist

- [x] This change was requested or approved by a maintainer
- [ ] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+0 / -6`

Removes the obsolete notice from the evaluations page.

**Implementation** — 0 files · `+0 / -0`

Not applicable.

**Tests** — 0 files · `+0 / -0`

Not applicable.
