### PR TITLE
Clarify X Chat SDK setup

### DIFF
--- a/.changeset/quiet-cobras-smile.md
+++ b/.changeset/quiet-cobras-smile.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Show registry item documentation links after adding an integration from the dev TUI, including the focused X Chat SDK setup guide.

--- a/.changeset/quiet-cobras-smile.md
+++ b/.changeset/quiet-cobras-smile.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Show registry item documentation links after adding an integration from the dev TUI, including the focused X Chat SDK setup guide.
+Show declared environment variables and an eve setup link after adding a registry integration from the dev TUI. Chat SDK adapter links open the integration page's Configure section.

--- a/apps/docs/app/[lang]/integrations/[slug]/page.tsx
+++ b/apps/docs/app/[lang]/integrations/[slug]/page.tsx
@@ -156,7 +156,7 @@ const IntegrationDetailPage = async ({ params }: PageProps<"/[lang]/integrations
             </Markdown>
           )}
         </Section>
-        <Section id="setup" title="Configure">
+        <Section id="configure" title="Configure">
           {setup ? (
             <Suspense
               fallback={

--- a/apps/docs/app/[lang]/integrations/[slug]/page.tsx
+++ b/apps/docs/app/[lang]/integrations/[slug]/page.tsx
@@ -54,8 +54,16 @@ export const generateMetadata = async ({
   };
 };
 
-const Section = ({ title, children }: { title: string; children: React.ReactNode }) => (
-  <section className="flex flex-col gap-2 border-t py-8 first:border-t-0 first:pt-0">
+const Section = ({
+  id,
+  title,
+  children,
+}: {
+  id?: string;
+  title: string;
+  children: React.ReactNode;
+}) => (
+  <section className="flex flex-col gap-2 border-t py-8 first:border-t-0 first:pt-0" id={id}>
     <h2 className="text-gray-1000 text-heading-20">{title}</h2>
     {children}
   </section>
@@ -148,7 +156,7 @@ const IntegrationDetailPage = async ({ params }: PageProps<"/[lang]/integrations
             </Markdown>
           )}
         </Section>
-        <Section title="Configure">
+        <Section id="setup" title="Configure">
           {setup ? (
             <Suspense
               fallback={

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -515,20 +515,22 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 export default channel;
 \`\`\`
 
-Set up X before you deploy:
+For a DM-only agent, keep \`bot.onDirectMessage\` and remove the \`bot.onNewMention\` and \`bot.onSubscribedMessage\` handlers.
+
+### Set up X authentication
 
 1. In the [X developer portal](https://developer.x.com), create a Project and App.
 2. Under **Keys and tokens**, copy the app's **API Key Secret** into \`X_CONSUMER_SECRET\`.
-3. Enable OAuth 2.0 user authentication with \`tweet.read\`, \`tweet.write\`, \`users.read\`, \`dm.read\`, \`dm.write\`, \`like.write\`, and \`offline.access\` scopes.
+3. Enable OAuth 2.0 user authentication with \`dm.read\` and \`dm.write\`. Also add \`users.read\`, or set \`X_USER_ID\` explicitly so the adapter can identify the bot account. Add \`tweet.read\` and \`tweet.write\` for public mentions and replies, \`like.write\` for likes, and \`media.write\` for image uploads. Add \`offline.access\` only when the adapter manages token refresh.
 4. Authorize the app as the bot account. Set \`X_CLIENT_ID\` and \`X_REFRESH_TOKEN\` so the adapter can refresh the short-lived OAuth 2.0 access token. In production, use a durable state adapter and set \`X_ENCRYPTION_KEY\` to a base64-encoded 32-byte key to encrypt persisted tokens. Alternatively, set a static OAuth 2.0 user token as \`X_USER_ACCESS_TOKEN\`.
 5. Deploy the agent. For a production deployment at \`https://your-domain.com\`, its X webhook URL is \`https://your-domain.com/eve/v1/x\`.
 
 See the [X adapter docs](https://chat-sdk.dev/adapters/official/x) for the adapter's complete credential reference.`,
-    configure: `After deployment:
+    configure: `### Set up the webhook
 
 1. In the [X developer console](https://console.x.com), register \`https://your-domain.com/eve/v1/x\` as the Activity API webhook URL, replacing the domain with your production deployment. The URL must be publicly accessible HTTPS without a port.
-2. Allow X to complete its CRC \`GET\` challenge. eve answers that challenge automatically, including X's hourly re-validation. Signed event deliveries arrive as \`POST\` requests on the same URL.
-3. Create subscriptions for \`post.mention.create\`, \`dm.received\`, and \`dm.sent\`. The DM events are private, so authorize the app as the bot account before creating those subscriptions.
+2. Allow X to complete its CRC \`GET\` challenge. The adapter answers it automatically, including later revalidation requests. Signed event deliveries arrive as \`POST\` requests on the same URL.
+3. Create a \`dm.received\` subscription for a DM-only agent. Add \`post.mention.create\` to receive public mentions. \`dm.sent\` is optional; subscribe to it only when your app needs events for outgoing DMs. These are private events, so authorize the app as the bot account before creating the subscriptions.
 
 The adapter owns X authentication, CRC handling, signature verification, and delivery; eve owns session dispatch and replies. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for routes and state options.`,
   },

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -427,8 +427,10 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 });
 
 export default channel;
-\`\`\``,
-    configure: `Follow the [Google Chat adapter documentation](https://chat-sdk.dev/adapters/official/gchat) to authenticate and configure the app. Set its HTTP endpoint to \`/eve/v1/gchat\`. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
+\`\`\`
+
+Credentials come from the \`createGoogleChatAdapter\` config or the adapter's environment variables; see the [Google Chat adapter docs](https://chat-sdk.dev/adapters/official/gchat).`,
+    configure: `The adapter mounts its webhook at \`/eve/v1/gchat\`. Point your Google Chat app's HTTP endpoint at it. The adapter owns provider auth, verification, and delivery, while eve owns session dispatch, streaming, typing, and human-in-the-loop. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for routes, streaming, and state options.`,
   },
   "chat-sdk-whatsapp": {
     logo: "whatsapp",
@@ -465,8 +467,10 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 });
 
 export default channel;
-\`\`\``,
-    configure: `Follow the [WhatsApp adapter documentation](https://chat-sdk.dev/adapters/official/whatsapp) to authenticate and configure the app. Set its webhook URL to \`/eve/v1/whatsapp\`. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
+\`\`\`
+
+Credentials come from the \`createWhatsAppAdapter\` config or the adapter's environment variables; see the [WhatsApp adapter docs](https://chat-sdk.dev/adapters/official/whatsapp).`,
+    configure: `The adapter mounts its webhook at \`/eve/v1/whatsapp\`. Point your WhatsApp Business Cloud webhook at it. The adapter owns provider auth, verification, and delivery, while eve owns session dispatch, streaming, typing, and human-in-the-loop. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for routes, streaming, and state options.`,
   },
   "chat-sdk-x": {
     logo: "x",
@@ -512,7 +516,7 @@ export default channel;
 \`\`\`
 
 For a DM-only agent, keep \`bot.onDirectMessage\` and remove the \`bot.onNewMention\` and \`bot.onSubscribedMessage\` handlers. Configure the app's credentials and webhook before deploying.`,
-    configure: `Follow the [X adapter authentication guide](https://chat-sdk.dev/adapters/official/x#authentication) and [webhook setup](https://chat-sdk.dev/adapters/official/x#2-register-a-webhook-and-subscriptions). Register the deployed agent's \`/eve/v1/x\` route as the Activity API webhook URL. The adapter handles X's CRC \`GET\` challenge and signed \`POST\` event deliveries. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
+    configure: `Follow the [X adapter documentation](https://chat-sdk.dev/adapters/official/x) to configure authentication, webhook verification, and Activity API subscriptions. Register the deployed agent's \`/eve/v1/x\` route as the X webhook URL. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
   },
   "chat-sdk-messenger": {
     logo: "messenger",
@@ -549,8 +553,10 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 });
 
 export default channel;
-\`\`\``,
-    configure: `Follow the [Messenger adapter documentation](https://chat-sdk.dev/adapters/official/messenger) to authenticate and configure the app. Set its webhook URL to \`/eve/v1/messenger\`. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
+\`\`\`
+
+Credentials come from the \`createMessengerAdapter\` config or the adapter's environment variables; see the [Messenger adapter docs](https://chat-sdk.dev/adapters/official/messenger).`,
+    configure: `The adapter mounts its webhook at \`/eve/v1/messenger\`. Point your Messenger webhook at it. The adapter owns provider auth, verification, and delivery, while eve owns session dispatch, streaming, typing, and human-in-the-loop. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for routes, streaming, and state options.`,
   },
   "chat-sdk-zernio": {
     logo: "zernio",
@@ -600,8 +606,10 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 });
 
 export default channel;
-\`\`\``,
-    configure: `Follow the [Zernio adapter documentation](https://chat-sdk.dev/adapters/vendor-official/zernio) to authenticate and configure webhooks. Point Zernio webhooks at \`/eve/v1/zernio\`. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
+\`\`\`
+
+See the [Zernio adapter documentation](https://chat-sdk.dev/adapters/vendor-official/zernio) for supported events, capabilities, and credentials.`,
+    configure: `Set \`ZERNIO_API_KEY\` and \`ZERNIO_WEBHOOK_SECRET\`, then point Zernio webhooks at \`/eve/v1/zernio\`. Zernio provides one adapter for Instagram, Facebook, X, Telegram, WhatsApp, Bluesky, and Reddit. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
   },
   "chat-sdk-velt": {
     logo: "velt",
@@ -654,8 +662,10 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 });
 
 export default channel;
-\`\`\``,
-    configure: `Follow the [Velt adapter documentation](https://chat-sdk.dev/adapters/vendor-official/velt) to create a bot user and configure its webhook. Send comment events to \`/eve/v1/velt\`. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
+\`\`\`
+
+See the [Velt adapter documentation](https://chat-sdk.dev/adapters/vendor-official/velt) for supported events, capabilities, and credentials.`,
+    configure: `Create a Velt bot user and webhook, set \`VELT_API_KEY\` and \`VELT_WEBHOOK_SECRET\`, then send comment events to \`/eve/v1/velt\`. The adapter maps documents to channels, annotations to threads, and comments to messages. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
   },
   "chat-sdk-sendblue": {
     logo: "sendblue",
@@ -695,8 +705,10 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 });
 
 export default channel;
-\`\`\``,
-    configure: `Follow the [Sendblue adapter documentation](https://chat-sdk.dev/adapters/vendor-official/sendblue) to authenticate and configure webhooks. Point Sendblue webhooks at \`/eve/v1/sendblue\`. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
+\`\`\`
+
+See the [Sendblue adapter documentation](https://chat-sdk.dev/adapters/vendor-official/sendblue) for supported events, capabilities, and credentials.`,
+    configure: `Set \`SENDBLUE_API_KEY\`, \`SENDBLUE_API_SECRET\`, and \`SENDBLUE_FROM_NUMBER\`, then point Sendblue webhooks at \`/eve/v1/sendblue\`. The adapter also supports tapbacks, typing indicators, delivery callbacks, and number lookup. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
   },
   "chat-sdk-novu": {
     logo: "novu",
@@ -744,8 +756,10 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 });
 
 export default channel;
-\`\`\``,
-    configure: `Follow the [Novu adapter documentation](https://chat-sdk.dev/adapters/vendor-official/novu) to authenticate, choose a channel, and configure provider delivery. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
+\`\`\`
+
+See the [Novu adapter documentation](https://chat-sdk.dev/adapters/vendor-official/novu) for supported events, capabilities, and credentials.`,
+    configure: `Run \`npx novu connect --runtime chat-sdk\` to authenticate Novu, choose a channel, and create the required environment variables. Novu manages provider credentials, identity, delivery, and conversation history across its supported channels. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
   },
   "chat-sdk-liveblocks": {
     logo: "liveblocks",
@@ -797,8 +811,10 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 });
 
 export default channel;
-\`\`\``,
-    configure: `Follow the [Liveblocks adapter documentation](https://chat-sdk.dev/adapters/vendor-official/liveblocks) to authenticate and configure its webhook. Send comment events to \`/eve/v1/liveblocks\`. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
+\`\`\`
+
+See the [Liveblocks adapter documentation](https://chat-sdk.dev/adapters/vendor-official/liveblocks) for supported events, capabilities, and credentials.`,
+    configure: `Create a Liveblocks webhook, set \`LIVEBLOCKS_SECRET_KEY\` and \`LIVEBLOCKS_WEBHOOK_SECRET\`, and send comment events to \`/eve/v1/liveblocks\`. The adapter maps rooms to channels, comment threads to threads, and comments to messages. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
   },
   linq: {
     logo: "linq",
@@ -863,8 +879,10 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 });
 
 export default channel;
-\`\`\``,
-    configure: `Follow the [Kapso adapter documentation](https://chat-sdk.dev/adapters/vendor-official/kapso) to connect a WhatsApp number and configure its webhook. Point the Kapso webhook at \`/eve/v1/kapso\`. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
+\`\`\`
+
+See the [Kapso adapter documentation](https://chat-sdk.dev/adapters/vendor-official/kapso) for supported events, capabilities, and credentials.`,
+    configure: `Connect a WhatsApp number in Kapso, set \`KAPSO_API_KEY\`, \`KAPSO_PHONE_NUMBER_ID\`, and \`KAPSO_WEBHOOK_SECRET\`, then point the Kapso webhook at \`/eve/v1/kapso\`. Use this provider-managed option when you do not want to integrate directly with the WhatsApp Cloud API. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
   },
   photon: {
     logo: "photon",
@@ -930,8 +948,10 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 });
 
 export default channel;
-\`\`\``,
-    configure: `Follow the [Dial adapter documentation](https://chat-sdk.dev/adapters/vendor-official/dial) to authenticate, provision a number, and configure its webhook. Point the webhook at \`/eve/v1/dial\`. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
+\`\`\`
+
+See the [Dial adapter documentation](https://chat-sdk.dev/adapters/vendor-official/dial) for supported events, capabilities, and credentials.`,
+    configure: `Create a Dial number, set \`DIAL_API_KEY\`, \`DIAL_FROM_NUMBER_ID\`, and \`DIAL_WEBHOOK_SECRET\`, then point its webhook at \`/eve/v1/dial\`. Dial maps each phone-number pair to a thread and delivers SMS, MMS, iMessage, and voice transcripts. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
   },
   "chat-sdk-agentphone": {
     logo: "agentphone",
@@ -974,8 +994,10 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 });
 
 export default channel;
-\`\`\``,
-    configure: `Follow the [AgentPhone adapter documentation](https://chat-sdk.dev/adapters/vendor-official/agentphone) to create an agent and configure its webhook. Point the webhook at \`/eve/v1/agentphone\`. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
+\`\`\`
+
+See the [AgentPhone adapter documentation](https://chat-sdk.dev/adapters/vendor-official/agentphone) for supported events, capabilities, and credentials.`,
+    configure: `Create an AgentPhone agent, set \`AGENTPHONE_API_KEY\`, \`AGENTPHONE_AGENT_ID\`, and \`AGENTPHONE_WEBHOOK_SECRET\`, then point its webhook at \`/eve/v1/agentphone\`. The adapter handles SMS, MMS, iMessage, and completed voice-call transcripts. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
   },
   "chat-sdk-lark": {
     logo: "lark",
@@ -1016,8 +1038,10 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 await bot.initialize();
 
 export default channel;
-\`\`\``,
-    configure: `Follow the [Lark / Feishu adapter documentation](https://chat-sdk.dev/adapters/vendor-official/lark) to create and authenticate the app. It uses a WebSocket long connection rather than an HTTP webhook, so call \`bot.initialize()\` and run eve in a long-lived Node.js process. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
+\`\`\`
+
+See the [Lark / Feishu adapter documentation](https://chat-sdk.dev/adapters/vendor-official/lark) for all supported events and credentials.`,
+    configure: `Create a Lark or Feishu app and set \`LARK_APP_ID\` and \`LARK_APP_SECRET\`. The adapter uses Lark’s WebSocket long connection rather than an HTTP webhook, so call \`bot.initialize()\` and run eve in a long-lived Node.js process. This is a vendor-official Chat SDK adapter built on the official Lark Node SDK. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
   },
   "chat-sdk-beeper": {
     logo: "beeper",
@@ -1058,8 +1082,10 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 await bot.initialize();
 
 export default channel;
-\`\`\``,
-    configure: `Follow the [Beeper Matrix adapter documentation](https://chat-sdk.dev/adapters/vendor-official/matrix) to configure credentials and Matrix sync. It uses Matrix sync rather than webhooks, so call \`bot.initialize()\` and run eve in a long-lived Node.js process. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
+\`\`\`
+
+See the [Beeper Matrix adapter documentation](https://chat-sdk.dev/adapters/vendor-official/matrix) for all supported events and credentials.`,
+    configure: `Set the Matrix homeserver, access token, and bot identity environment variables documented by Beeper. This adapter consumes Matrix sync rather than webhooks, so call \`bot.initialize()\` and run eve in a long-lived Node.js process. It requires Node.js 22 or newer and a durable state adapter in production. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
   },
   "chat-sdk-resend": {
     logo: "resend",
@@ -1108,8 +1134,10 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 });
 
 export default channel;
-\`\`\``,
-    configure: `Follow the [Email (Resend) adapter documentation](https://chat-sdk.dev/adapters/vendor-official/resend) to authenticate, verify a sending domain, and configure inbound email. Point the inbound webhook at \`/eve/v1/resend\`. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
+\`\`\`
+
+See the [Email (Resend) adapter documentation](https://chat-sdk.dev/adapters/vendor-official/resend) for all supported events and credentials.`,
+    configure: `Verify a sending domain in Resend, set \`RESEND_API_KEY\`, \`RESEND_WEBHOOK_SECRET\`, and \`RESEND_FROM_ADDRESS\`, then point the Resend inbound webhook at \`/eve/v1/resend\`. This is a vendor-official Chat SDK adapter. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
   },
 };
 const extensionPresentations: Record<string, ExtensionPresentation> = {

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -495,10 +495,16 @@ export const { bot, channel, send } = chatSdkChannel({
   userName: "My Agent",
   adapters: { x: createXAdapter() },
   state: createMemoryState(),
+  // X buffers replies and posts once rather than editing a streamed message.
+  streaming: false,
 });
 
 bot.onNewMention(async (thread: Thread, message: Message) => {
   await thread.subscribe();
+  await send(message.text, { thread });
+});
+
+bot.onDirectMessage(async (thread: Thread, message: Message) => {
   await send(message.text, { thread });
 });
 
@@ -509,8 +515,22 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 export default channel;
 \`\`\`
 
-Credentials come from the \`createXAdapter\` config or the adapter's environment variables; see the [X adapter docs](https://chat-sdk.dev/adapters/official/x).`,
-    configure: `The adapter mounts its webhook at \`/eve/v1/x\`. Point your X account activity webhook at it. The adapter owns provider auth, verification, and delivery, while eve owns session dispatch, streaming, typing, and human-in-the-loop. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for routes, streaming, and state options.`,
+Set up X before you deploy:
+
+1. In the [X developer portal](https://developer.x.com), create a Project and App.
+2. Under **Keys and tokens**, copy the app's **API Key Secret** into \`X_CONSUMER_SECRET\`.
+3. Enable OAuth 2.0 user authentication with \`tweet.read\`, \`tweet.write\`, \`users.read\`, \`dm.read\`, \`dm.write\`, \`like.write\`, and \`offline.access\` scopes.
+4. Authorize the app as the bot account. Set \`X_CLIENT_ID\` and \`X_REFRESH_TOKEN\` so the adapter can refresh the short-lived OAuth 2.0 access token. In production, use a durable state adapter and set \`X_ENCRYPTION_KEY\` to a base64-encoded 32-byte key to encrypt persisted tokens. Alternatively, set a static OAuth 2.0 user token as \`X_USER_ACCESS_TOKEN\`.
+5. Deploy the agent. For a production deployment at \`https://your-domain.com\`, its X webhook URL is \`https://your-domain.com/eve/v1/x\`.
+
+See the [X adapter docs](https://chat-sdk.dev/adapters/official/x) for the adapter's complete credential reference.`,
+    configure: `After deployment:
+
+1. In the [X developer console](https://console.x.com), register \`https://your-domain.com/eve/v1/x\` as the Activity API webhook URL, replacing the domain with your production deployment. The URL must be publicly accessible HTTPS without a port.
+2. Allow X to complete its CRC \`GET\` challenge. eve answers that challenge automatically, including X's hourly re-validation. Signed event deliveries arrive as \`POST\` requests on the same URL.
+3. Create subscriptions for \`post.mention.create\`, \`dm.received\`, and \`dm.sent\`. The DM events are private, so authorize the app as the bot account before creating those subscriptions.
+
+The adapter owns X authentication, CRC handling, signature verification, and delivery; eve owns session dispatch and replies. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for routes and state options.`,
   },
   "chat-sdk-messenger": {
     logo: "messenger",

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -427,10 +427,8 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 });
 
 export default channel;
-\`\`\`
-
-Credentials come from the \`createGoogleChatAdapter\` config or the adapter's environment variables; see the [Google Chat adapter docs](https://chat-sdk.dev/adapters/official/gchat).`,
-    configure: `The adapter mounts its webhook at \`/eve/v1/gchat\`. Point your Google Chat app's HTTP endpoint at it. The adapter owns provider auth, verification, and delivery, while eve owns session dispatch, streaming, typing, and human-in-the-loop. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for routes, streaming, and state options.`,
+\`\`\``,
+    configure: `Follow the [Google Chat adapter documentation](https://chat-sdk.dev/adapters/official/gchat) to authenticate and configure the app. Set its HTTP endpoint to \`/eve/v1/gchat\`. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
   },
   "chat-sdk-whatsapp": {
     logo: "whatsapp",
@@ -467,10 +465,8 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 });
 
 export default channel;
-\`\`\`
-
-Credentials come from the \`createWhatsAppAdapter\` config or the adapter's environment variables; see the [WhatsApp adapter docs](https://chat-sdk.dev/adapters/official/whatsapp).`,
-    configure: `The adapter mounts its webhook at \`/eve/v1/whatsapp\`. Point your WhatsApp Business Cloud webhook at it. The adapter owns provider auth, verification, and delivery, while eve owns session dispatch, streaming, typing, and human-in-the-loop. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for routes, streaming, and state options.`,
+\`\`\``,
+    configure: `Follow the [WhatsApp adapter documentation](https://chat-sdk.dev/adapters/official/whatsapp) to authenticate and configure the app. Set its webhook URL to \`/eve/v1/whatsapp\`. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
   },
   "chat-sdk-x": {
     logo: "x",
@@ -516,21 +512,7 @@ export default channel;
 \`\`\`
 
 For a DM-only agent, keep \`bot.onDirectMessage\` and remove the \`bot.onNewMention\` and \`bot.onSubscribedMessage\` handlers. Configure the app's credentials and webhook before deploying.`,
-    configure: `### Authenticate with X
-
-1. In the [X developer portal](https://developer.x.com), create a Project and App.
-2. Under **Keys and tokens**, copy the app's **API Key Secret** into \`X_CONSUMER_SECRET\`.
-3. Enable OAuth 2.0 user authentication with \`dm.read\` and \`dm.write\`. Also add \`users.read\`, or set \`X_USER_ID\` explicitly so the adapter can identify the bot account. Add \`tweet.read\` and \`tweet.write\` for public mentions and replies, \`like.write\` for likes, and \`media.write\` for image uploads. Add \`offline.access\` only when the adapter manages token refresh.
-4. Authorize the app as the bot account. Set \`X_CLIENT_ID\` and \`X_REFRESH_TOKEN\` so the adapter can refresh the short-lived OAuth 2.0 access token. In production, use a durable state adapter and set \`X_ENCRYPTION_KEY\` to a base64-encoded 32-byte key to encrypt persisted tokens. Alternatively, set a static OAuth 2.0 user token as \`X_USER_ACCESS_TOKEN\`.
-
-### Set up the webhook
-
-1. Deploy the agent. For a production deployment at \`https://your-domain.com\`, its X webhook URL is \`https://your-domain.com/eve/v1/x\`.
-2. In the [X developer console](https://console.x.com), register that URL as the Activity API webhook URL. The URL must be publicly accessible HTTPS without a port.
-3. Allow X to complete its CRC \`GET\` challenge. The adapter answers it automatically, including later revalidation requests. Signed event deliveries arrive as \`POST\` requests on the same URL.
-4. Create a \`dm.received\` subscription for a DM-only agent. Add \`post.mention.create\` to receive public mentions. \`dm.sent\` is optional; subscribe to it only when your app needs events for outgoing DMs. These are private events, so authorize the app as the bot account before creating the subscriptions.
-
-The adapter owns X authentication, CRC handling, signature verification, and delivery; eve owns session dispatch and replies. See the [X adapter docs](https://chat-sdk.dev/adapters/official/x) for the complete credential reference and the [Chat SDK channel docs](/docs/channels/chat-sdk) for route and state options.`,
+    configure: `Follow the [X adapter authentication guide](https://chat-sdk.dev/adapters/official/x#authentication) and [webhook setup](https://chat-sdk.dev/adapters/official/x#2-register-a-webhook-and-subscriptions). Register the deployed agent's \`/eve/v1/x\` route as the Activity API webhook URL. The adapter handles X's CRC \`GET\` challenge and signed \`POST\` event deliveries. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
   },
   "chat-sdk-messenger": {
     logo: "messenger",
@@ -567,10 +549,8 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 });
 
 export default channel;
-\`\`\`
-
-Credentials come from the \`createMessengerAdapter\` config or the adapter's environment variables; see the [Messenger adapter docs](https://chat-sdk.dev/adapters/official/messenger).`,
-    configure: `The adapter mounts its webhook at \`/eve/v1/messenger\`. Point your Messenger webhook at it. The adapter owns provider auth, verification, and delivery, while eve owns session dispatch, streaming, typing, and human-in-the-loop. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for routes, streaming, and state options.`,
+\`\`\``,
+    configure: `Follow the [Messenger adapter documentation](https://chat-sdk.dev/adapters/official/messenger) to authenticate and configure the app. Set its webhook URL to \`/eve/v1/messenger\`. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
   },
   "chat-sdk-zernio": {
     logo: "zernio",
@@ -620,10 +600,8 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 });
 
 export default channel;
-\`\`\`
-
-See the [Zernio adapter documentation](https://chat-sdk.dev/adapters/vendor-official/zernio) for supported events, capabilities, and credentials.`,
-    configure: `Set \`ZERNIO_API_KEY\` and \`ZERNIO_WEBHOOK_SECRET\`, then point Zernio webhooks at \`/eve/v1/zernio\`. Zernio provides one adapter for Instagram, Facebook, X, Telegram, WhatsApp, Bluesky, and Reddit. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
+\`\`\``,
+    configure: `Follow the [Zernio adapter documentation](https://chat-sdk.dev/adapters/vendor-official/zernio) to authenticate and configure webhooks. Point Zernio webhooks at \`/eve/v1/zernio\`. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
   },
   "chat-sdk-velt": {
     logo: "velt",
@@ -676,10 +654,8 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 });
 
 export default channel;
-\`\`\`
-
-See the [Velt adapter documentation](https://chat-sdk.dev/adapters/vendor-official/velt) for supported events, capabilities, and credentials.`,
-    configure: `Create a Velt bot user and webhook, set \`VELT_API_KEY\` and \`VELT_WEBHOOK_SECRET\`, then send comment events to \`/eve/v1/velt\`. The adapter maps documents to channels, annotations to threads, and comments to messages. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
+\`\`\``,
+    configure: `Follow the [Velt adapter documentation](https://chat-sdk.dev/adapters/vendor-official/velt) to create a bot user and configure its webhook. Send comment events to \`/eve/v1/velt\`. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
   },
   "chat-sdk-sendblue": {
     logo: "sendblue",
@@ -719,10 +695,8 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 });
 
 export default channel;
-\`\`\`
-
-See the [Sendblue adapter documentation](https://chat-sdk.dev/adapters/vendor-official/sendblue) for supported events, capabilities, and credentials.`,
-    configure: `Set \`SENDBLUE_API_KEY\`, \`SENDBLUE_API_SECRET\`, and \`SENDBLUE_FROM_NUMBER\`, then point Sendblue webhooks at \`/eve/v1/sendblue\`. The adapter also supports tapbacks, typing indicators, delivery callbacks, and number lookup. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
+\`\`\``,
+    configure: `Follow the [Sendblue adapter documentation](https://chat-sdk.dev/adapters/vendor-official/sendblue) to authenticate and configure webhooks. Point Sendblue webhooks at \`/eve/v1/sendblue\`. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
   },
   "chat-sdk-novu": {
     logo: "novu",
@@ -770,10 +744,8 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 });
 
 export default channel;
-\`\`\`
-
-See the [Novu adapter documentation](https://chat-sdk.dev/adapters/vendor-official/novu) for supported events, capabilities, and credentials.`,
-    configure: `Run \`npx novu connect --runtime chat-sdk\` to authenticate Novu, choose a channel, and create the required environment variables. Novu manages provider credentials, identity, delivery, and conversation history across its supported channels. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
+\`\`\``,
+    configure: `Follow the [Novu adapter documentation](https://chat-sdk.dev/adapters/vendor-official/novu) to authenticate, choose a channel, and configure provider delivery. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
   },
   "chat-sdk-liveblocks": {
     logo: "liveblocks",
@@ -825,10 +797,8 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 });
 
 export default channel;
-\`\`\`
-
-See the [Liveblocks adapter documentation](https://chat-sdk.dev/adapters/vendor-official/liveblocks) for supported events, capabilities, and credentials.`,
-    configure: `Create a Liveblocks webhook, set \`LIVEBLOCKS_SECRET_KEY\` and \`LIVEBLOCKS_WEBHOOK_SECRET\`, and send comment events to \`/eve/v1/liveblocks\`. The adapter maps rooms to channels, comment threads to threads, and comments to messages. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
+\`\`\``,
+    configure: `Follow the [Liveblocks adapter documentation](https://chat-sdk.dev/adapters/vendor-official/liveblocks) to authenticate and configure its webhook. Send comment events to \`/eve/v1/liveblocks\`. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
   },
   linq: {
     logo: "linq",
@@ -893,10 +863,8 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 });
 
 export default channel;
-\`\`\`
-
-See the [Kapso adapter documentation](https://chat-sdk.dev/adapters/vendor-official/kapso) for supported events, capabilities, and credentials.`,
-    configure: `Connect a WhatsApp number in Kapso, set \`KAPSO_API_KEY\`, \`KAPSO_PHONE_NUMBER_ID\`, and \`KAPSO_WEBHOOK_SECRET\`, then point the Kapso webhook at \`/eve/v1/kapso\`. Use this provider-managed option when you do not want to integrate directly with the WhatsApp Cloud API. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
+\`\`\``,
+    configure: `Follow the [Kapso adapter documentation](https://chat-sdk.dev/adapters/vendor-official/kapso) to connect a WhatsApp number and configure its webhook. Point the Kapso webhook at \`/eve/v1/kapso\`. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
   },
   photon: {
     logo: "photon",
@@ -962,10 +930,8 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 });
 
 export default channel;
-\`\`\`
-
-See the [Dial adapter documentation](https://chat-sdk.dev/adapters/vendor-official/dial) for supported events, capabilities, and credentials.`,
-    configure: `Create a Dial number, set \`DIAL_API_KEY\`, \`DIAL_FROM_NUMBER_ID\`, and \`DIAL_WEBHOOK_SECRET\`, then point its webhook at \`/eve/v1/dial\`. Dial maps each phone-number pair to a thread and delivers SMS, MMS, iMessage, and voice transcripts. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
+\`\`\``,
+    configure: `Follow the [Dial adapter documentation](https://chat-sdk.dev/adapters/vendor-official/dial) to authenticate, provision a number, and configure its webhook. Point the webhook at \`/eve/v1/dial\`. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
   },
   "chat-sdk-agentphone": {
     logo: "agentphone",
@@ -1008,10 +974,8 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 });
 
 export default channel;
-\`\`\`
-
-See the [AgentPhone adapter documentation](https://chat-sdk.dev/adapters/vendor-official/agentphone) for supported events, capabilities, and credentials.`,
-    configure: `Create an AgentPhone agent, set \`AGENTPHONE_API_KEY\`, \`AGENTPHONE_AGENT_ID\`, and \`AGENTPHONE_WEBHOOK_SECRET\`, then point its webhook at \`/eve/v1/agentphone\`. The adapter handles SMS, MMS, iMessage, and completed voice-call transcripts. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
+\`\`\``,
+    configure: `Follow the [AgentPhone adapter documentation](https://chat-sdk.dev/adapters/vendor-official/agentphone) to create an agent and configure its webhook. Point the webhook at \`/eve/v1/agentphone\`. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
   },
   "chat-sdk-lark": {
     logo: "lark",
@@ -1052,10 +1016,8 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 await bot.initialize();
 
 export default channel;
-\`\`\`
-
-See the [Lark / Feishu adapter documentation](https://chat-sdk.dev/adapters/vendor-official/lark) for all supported events and credentials.`,
-    configure: `Create a Lark or Feishu app and set \`LARK_APP_ID\` and \`LARK_APP_SECRET\`. The adapter uses Lark’s WebSocket long connection rather than an HTTP webhook, so call \`bot.initialize()\` and run eve in a long-lived Node.js process. This is a vendor-official Chat SDK adapter built on the official Lark Node SDK. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
+\`\`\``,
+    configure: `Follow the [Lark / Feishu adapter documentation](https://chat-sdk.dev/adapters/vendor-official/lark) to create and authenticate the app. It uses a WebSocket long connection rather than an HTTP webhook, so call \`bot.initialize()\` and run eve in a long-lived Node.js process. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
   },
   "chat-sdk-beeper": {
     logo: "beeper",
@@ -1096,10 +1058,8 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 await bot.initialize();
 
 export default channel;
-\`\`\`
-
-See the [Beeper Matrix adapter documentation](https://chat-sdk.dev/adapters/vendor-official/matrix) for all supported events and credentials.`,
-    configure: `Set the Matrix homeserver, access token, and bot identity environment variables documented by Beeper. This adapter consumes Matrix sync rather than webhooks, so call \`bot.initialize()\` and run eve in a long-lived Node.js process. It requires Node.js 22 or newer and a durable state adapter in production. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
+\`\`\``,
+    configure: `Follow the [Beeper Matrix adapter documentation](https://chat-sdk.dev/adapters/vendor-official/matrix) to configure credentials and Matrix sync. It uses Matrix sync rather than webhooks, so call \`bot.initialize()\` and run eve in a long-lived Node.js process. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
   },
   "chat-sdk-resend": {
     logo: "resend",
@@ -1148,10 +1108,8 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 });
 
 export default channel;
-\`\`\`
-
-See the [Email (Resend) adapter documentation](https://chat-sdk.dev/adapters/vendor-official/resend) for all supported events and credentials.`,
-    configure: `Verify a sending domain in Resend, set \`RESEND_API_KEY\`, \`RESEND_WEBHOOK_SECRET\`, and \`RESEND_FROM_ADDRESS\`, then point the Resend inbound webhook at \`/eve/v1/resend\`. This is a vendor-official Chat SDK adapter. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
+\`\`\``,
+    configure: `Follow the [Email (Resend) adapter documentation](https://chat-sdk.dev/adapters/vendor-official/resend) to authenticate, verify a sending domain, and configure inbound email. Point the inbound webhook at \`/eve/v1/resend\`. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve route and state options.`,
   },
 };
 const extensionPresentations: Record<string, ExtensionPresentation> = {

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -515,24 +515,22 @@ bot.onSubscribedMessage(async (thread: Thread, message: Message) => {
 export default channel;
 \`\`\`
 
-For a DM-only agent, keep \`bot.onDirectMessage\` and remove the \`bot.onNewMention\` and \`bot.onSubscribedMessage\` handlers.
-
-### Set up X authentication
+For a DM-only agent, keep \`bot.onDirectMessage\` and remove the \`bot.onNewMention\` and \`bot.onSubscribedMessage\` handlers. Configure the app's credentials and webhook before deploying.`,
+    configure: `### Authenticate with X
 
 1. In the [X developer portal](https://developer.x.com), create a Project and App.
 2. Under **Keys and tokens**, copy the app's **API Key Secret** into \`X_CONSUMER_SECRET\`.
 3. Enable OAuth 2.0 user authentication with \`dm.read\` and \`dm.write\`. Also add \`users.read\`, or set \`X_USER_ID\` explicitly so the adapter can identify the bot account. Add \`tweet.read\` and \`tweet.write\` for public mentions and replies, \`like.write\` for likes, and \`media.write\` for image uploads. Add \`offline.access\` only when the adapter manages token refresh.
 4. Authorize the app as the bot account. Set \`X_CLIENT_ID\` and \`X_REFRESH_TOKEN\` so the adapter can refresh the short-lived OAuth 2.0 access token. In production, use a durable state adapter and set \`X_ENCRYPTION_KEY\` to a base64-encoded 32-byte key to encrypt persisted tokens. Alternatively, set a static OAuth 2.0 user token as \`X_USER_ACCESS_TOKEN\`.
-5. Deploy the agent. For a production deployment at \`https://your-domain.com\`, its X webhook URL is \`https://your-domain.com/eve/v1/x\`.
 
-See the [X adapter docs](https://chat-sdk.dev/adapters/official/x) for the adapter's complete credential reference.`,
-    configure: `### Set up the webhook
+### Set up the webhook
 
-1. In the [X developer console](https://console.x.com), register \`https://your-domain.com/eve/v1/x\` as the Activity API webhook URL, replacing the domain with your production deployment. The URL must be publicly accessible HTTPS without a port.
-2. Allow X to complete its CRC \`GET\` challenge. The adapter answers it automatically, including later revalidation requests. Signed event deliveries arrive as \`POST\` requests on the same URL.
-3. Create a \`dm.received\` subscription for a DM-only agent. Add \`post.mention.create\` to receive public mentions. \`dm.sent\` is optional; subscribe to it only when your app needs events for outgoing DMs. These are private events, so authorize the app as the bot account before creating the subscriptions.
+1. Deploy the agent. For a production deployment at \`https://your-domain.com\`, its X webhook URL is \`https://your-domain.com/eve/v1/x\`.
+2. In the [X developer console](https://console.x.com), register that URL as the Activity API webhook URL. The URL must be publicly accessible HTTPS without a port.
+3. Allow X to complete its CRC \`GET\` challenge. The adapter answers it automatically, including later revalidation requests. Signed event deliveries arrive as \`POST\` requests on the same URL.
+4. Create a \`dm.received\` subscription for a DM-only agent. Add \`post.mention.create\` to receive public mentions. \`dm.sent\` is optional; subscribe to it only when your app needs events for outgoing DMs. These are private events, so authorize the app as the bot account before creating the subscriptions.
 
-The adapter owns X authentication, CRC handling, signature verification, and delivery; eve owns session dispatch and replies. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for routes and state options.`,
+The adapter owns X authentication, CRC handling, signature verification, and delivery; eve owns session dispatch and replies. See the [X adapter docs](https://chat-sdk.dev/adapters/official/x) for the complete credential reference and the [Chat SDK channel docs](/docs/channels/chat-sdk) for route and state options.`,
   },
   "chat-sdk-messenger": {
     logo: "messenger",

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -1671,7 +1671,7 @@
       },
       "meta": {
         "eve": {
-          "docs": "https://chat-sdk.dev/adapters/official/gchat",
+          "docs": "/integrations/chat-sdk-gchat#setup",
           "implementation": "chat-sdk"
         }
       }
@@ -1697,7 +1697,7 @@
       },
       "meta": {
         "eve": {
-          "docs": "https://chat-sdk.dev/adapters/official/whatsapp",
+          "docs": "/integrations/chat-sdk-whatsapp#setup",
           "implementation": "chat-sdk"
         }
       }
@@ -1721,7 +1721,7 @@
       },
       "meta": {
         "eve": {
-          "docs": "https://chat-sdk.dev/adapters/official/x",
+          "docs": "/integrations/chat-sdk-x#setup",
           "implementation": "chat-sdk"
         }
       }
@@ -1746,7 +1746,7 @@
       },
       "meta": {
         "eve": {
-          "docs": "https://chat-sdk.dev/adapters/official/messenger",
+          "docs": "/integrations/chat-sdk-messenger#setup",
           "implementation": "chat-sdk"
         }
       }
@@ -1770,7 +1770,7 @@
       ],
       "meta": {
         "eve": {
-          "docs": "https://chat-sdk.dev/adapters/vendor-official/zernio",
+          "docs": "/integrations/chat-sdk-zernio#setup",
           "implementation": "chat-sdk"
         }
       }
@@ -1794,7 +1794,7 @@
       ],
       "meta": {
         "eve": {
-          "docs": "https://chat-sdk.dev/adapters/vendor-official/velt",
+          "docs": "/integrations/chat-sdk-velt#setup",
           "implementation": "chat-sdk"
         }
       }
@@ -1819,7 +1819,7 @@
       ],
       "meta": {
         "eve": {
-          "docs": "https://chat-sdk.dev/adapters/vendor-official/sendblue",
+          "docs": "/integrations/chat-sdk-sendblue#setup",
           "implementation": "chat-sdk"
         }
       }
@@ -1843,7 +1843,7 @@
       },
       "meta": {
         "eve": {
-          "docs": "https://chat-sdk.dev/adapters/vendor-official/novu",
+          "docs": "/integrations/chat-sdk-novu#setup",
           "implementation": "chat-sdk"
         }
       }
@@ -1867,7 +1867,7 @@
       ],
       "meta": {
         "eve": {
-          "docs": "https://chat-sdk.dev/adapters/vendor-official/liveblocks",
+          "docs": "/integrations/chat-sdk-liveblocks#setup",
           "implementation": "chat-sdk"
         }
       }
@@ -1912,7 +1912,7 @@
       ],
       "meta": {
         "eve": {
-          "docs": "https://chat-sdk.dev/adapters/vendor-official/kapso",
+          "docs": "/integrations/chat-sdk-kapso#setup",
           "implementation": "chat-sdk"
         }
       }
@@ -1957,7 +1957,7 @@
       ],
       "meta": {
         "eve": {
-          "docs": "https://chat-sdk.dev/adapters/vendor-official/dial",
+          "docs": "/integrations/chat-sdk-dial#setup",
           "implementation": "chat-sdk"
         }
       }
@@ -1982,7 +1982,7 @@
       ],
       "meta": {
         "eve": {
-          "docs": "https://chat-sdk.dev/adapters/vendor-official/agentphone",
+          "docs": "/integrations/chat-sdk-agentphone#setup",
           "implementation": "chat-sdk"
         }
       }
@@ -2006,7 +2006,7 @@
       ],
       "meta": {
         "eve": {
-          "docs": "https://chat-sdk.dev/adapters/vendor-official/lark",
+          "docs": "/integrations/chat-sdk-lark#setup",
           "implementation": "chat-sdk"
         }
       }
@@ -2030,7 +2030,7 @@
       },
       "meta": {
         "eve": {
-          "docs": "https://chat-sdk.dev/adapters/vendor-official/matrix",
+          "docs": "/integrations/chat-sdk-beeper#setup",
           "implementation": "chat-sdk"
         }
       }
@@ -2055,7 +2055,7 @@
       ],
       "meta": {
         "eve": {
-          "docs": "https://chat-sdk.dev/adapters/vendor-official/resend",
+          "docs": "/integrations/chat-sdk-resend#setup",
           "implementation": "chat-sdk"
         }
       }

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -1717,13 +1717,7 @@
       ],
       "envVars": {
         "X_CONSUMER_SECRET": "",
-        "X_USER_ACCESS_TOKEN": "",
-        "X_CLIENT_ID": "",
-        "X_REFRESH_TOKEN": "",
-        "X_CLIENT_SECRET": "",
-        "X_ENCRYPTION_KEY": "",
-        "X_USER_ID": "",
-        "X_USERNAME": ""
+        "X_USER_ACCESS_TOKEN": ""
       },
       "meta": {
         "eve": {

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -1671,7 +1671,7 @@
       },
       "meta": {
         "eve": {
-          "docs": "/integrations/chat-sdk-gchat#setup",
+          "docs": "/integrations/chat-sdk-gchat#configure",
           "implementation": "chat-sdk"
         }
       }
@@ -1697,7 +1697,7 @@
       },
       "meta": {
         "eve": {
-          "docs": "/integrations/chat-sdk-whatsapp#setup",
+          "docs": "/integrations/chat-sdk-whatsapp#configure",
           "implementation": "chat-sdk"
         }
       }
@@ -1721,7 +1721,7 @@
       },
       "meta": {
         "eve": {
-          "docs": "/integrations/chat-sdk-x#setup",
+          "docs": "/integrations/chat-sdk-x#configure",
           "implementation": "chat-sdk"
         }
       }
@@ -1746,7 +1746,7 @@
       },
       "meta": {
         "eve": {
-          "docs": "/integrations/chat-sdk-messenger#setup",
+          "docs": "/integrations/chat-sdk-messenger#configure",
           "implementation": "chat-sdk"
         }
       }
@@ -1770,7 +1770,7 @@
       ],
       "meta": {
         "eve": {
-          "docs": "/integrations/chat-sdk-zernio#setup",
+          "docs": "/integrations/chat-sdk-zernio#configure",
           "implementation": "chat-sdk"
         }
       }
@@ -1794,7 +1794,7 @@
       ],
       "meta": {
         "eve": {
-          "docs": "/integrations/chat-sdk-velt#setup",
+          "docs": "/integrations/chat-sdk-velt#configure",
           "implementation": "chat-sdk"
         }
       }
@@ -1819,7 +1819,7 @@
       ],
       "meta": {
         "eve": {
-          "docs": "/integrations/chat-sdk-sendblue#setup",
+          "docs": "/integrations/chat-sdk-sendblue#configure",
           "implementation": "chat-sdk"
         }
       }
@@ -1843,7 +1843,7 @@
       },
       "meta": {
         "eve": {
-          "docs": "/integrations/chat-sdk-novu#setup",
+          "docs": "/integrations/chat-sdk-novu#configure",
           "implementation": "chat-sdk"
         }
       }
@@ -1867,7 +1867,7 @@
       ],
       "meta": {
         "eve": {
-          "docs": "/integrations/chat-sdk-liveblocks#setup",
+          "docs": "/integrations/chat-sdk-liveblocks#configure",
           "implementation": "chat-sdk"
         }
       }
@@ -1912,7 +1912,7 @@
       ],
       "meta": {
         "eve": {
-          "docs": "/integrations/chat-sdk-kapso#setup",
+          "docs": "/integrations/chat-sdk-kapso#configure",
           "implementation": "chat-sdk"
         }
       }
@@ -1957,7 +1957,7 @@
       ],
       "meta": {
         "eve": {
-          "docs": "/integrations/chat-sdk-dial#setup",
+          "docs": "/integrations/chat-sdk-dial#configure",
           "implementation": "chat-sdk"
         }
       }
@@ -1982,7 +1982,7 @@
       ],
       "meta": {
         "eve": {
-          "docs": "/integrations/chat-sdk-agentphone#setup",
+          "docs": "/integrations/chat-sdk-agentphone#configure",
           "implementation": "chat-sdk"
         }
       }
@@ -2006,7 +2006,7 @@
       ],
       "meta": {
         "eve": {
-          "docs": "/integrations/chat-sdk-lark#setup",
+          "docs": "/integrations/chat-sdk-lark#configure",
           "implementation": "chat-sdk"
         }
       }
@@ -2030,7 +2030,7 @@
       },
       "meta": {
         "eve": {
-          "docs": "/integrations/chat-sdk-beeper#setup",
+          "docs": "/integrations/chat-sdk-beeper#configure",
           "implementation": "chat-sdk"
         }
       }
@@ -2055,7 +2055,7 @@
       ],
       "meta": {
         "eve": {
-          "docs": "/integrations/chat-sdk-resend#setup",
+          "docs": "/integrations/chat-sdk-resend#configure",
           "implementation": "chat-sdk"
         }
       }

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -1671,7 +1671,7 @@
       },
       "meta": {
         "eve": {
-          "docs": "/docs/channels/chat-sdk",
+          "docs": "https://chat-sdk.dev/adapters/official/gchat",
           "implementation": "chat-sdk"
         }
       }
@@ -1697,7 +1697,7 @@
       },
       "meta": {
         "eve": {
-          "docs": "/docs/channels/chat-sdk",
+          "docs": "https://chat-sdk.dev/adapters/official/whatsapp",
           "implementation": "chat-sdk"
         }
       }
@@ -1717,14 +1717,17 @@
       ],
       "envVars": {
         "X_CONSUMER_SECRET": "",
+        "X_USER_ACCESS_TOKEN": "",
         "X_CLIENT_ID": "",
         "X_REFRESH_TOKEN": "",
+        "X_CLIENT_SECRET": "",
         "X_ENCRYPTION_KEY": "",
-        "X_USER_ACCESS_TOKEN": ""
+        "X_USER_ID": "",
+        "X_USERNAME": ""
       },
       "meta": {
         "eve": {
-          "docs": "/integrations/chat-sdk-x",
+          "docs": "https://chat-sdk.dev/adapters/official/x",
           "implementation": "chat-sdk"
         }
       }
@@ -1749,7 +1752,7 @@
       },
       "meta": {
         "eve": {
-          "docs": "/docs/channels/chat-sdk",
+          "docs": "https://chat-sdk.dev/adapters/official/messenger",
           "implementation": "chat-sdk"
         }
       }
@@ -1773,7 +1776,7 @@
       ],
       "meta": {
         "eve": {
-          "docs": "/docs/channels/chat-sdk",
+          "docs": "https://chat-sdk.dev/adapters/vendor-official/zernio",
           "implementation": "chat-sdk"
         }
       }
@@ -1797,7 +1800,7 @@
       ],
       "meta": {
         "eve": {
-          "docs": "/docs/channels/chat-sdk",
+          "docs": "https://chat-sdk.dev/adapters/vendor-official/velt",
           "implementation": "chat-sdk"
         }
       }
@@ -1822,7 +1825,7 @@
       ],
       "meta": {
         "eve": {
-          "docs": "/docs/channels/chat-sdk",
+          "docs": "https://chat-sdk.dev/adapters/vendor-official/sendblue",
           "implementation": "chat-sdk"
         }
       }
@@ -1846,7 +1849,7 @@
       },
       "meta": {
         "eve": {
-          "docs": "/docs/channels/chat-sdk",
+          "docs": "https://chat-sdk.dev/adapters/vendor-official/novu",
           "implementation": "chat-sdk"
         }
       }
@@ -1870,7 +1873,7 @@
       ],
       "meta": {
         "eve": {
-          "docs": "/docs/channels/chat-sdk",
+          "docs": "https://chat-sdk.dev/adapters/vendor-official/liveblocks",
           "implementation": "chat-sdk"
         }
       }
@@ -1915,7 +1918,7 @@
       ],
       "meta": {
         "eve": {
-          "docs": "/docs/channels/chat-sdk",
+          "docs": "https://chat-sdk.dev/adapters/vendor-official/kapso",
           "implementation": "chat-sdk"
         }
       }
@@ -1960,7 +1963,7 @@
       ],
       "meta": {
         "eve": {
-          "docs": "/docs/channels/chat-sdk",
+          "docs": "https://chat-sdk.dev/adapters/vendor-official/dial",
           "implementation": "chat-sdk"
         }
       }
@@ -1985,7 +1988,7 @@
       ],
       "meta": {
         "eve": {
-          "docs": "/docs/channels/chat-sdk",
+          "docs": "https://chat-sdk.dev/adapters/vendor-official/agentphone",
           "implementation": "chat-sdk"
         }
       }
@@ -2009,7 +2012,7 @@
       ],
       "meta": {
         "eve": {
-          "docs": "/docs/channels/chat-sdk",
+          "docs": "https://chat-sdk.dev/adapters/vendor-official/lark",
           "implementation": "chat-sdk"
         }
       }
@@ -2033,7 +2036,7 @@
       },
       "meta": {
         "eve": {
-          "docs": "/docs/channels/chat-sdk",
+          "docs": "https://chat-sdk.dev/adapters/vendor-official/matrix",
           "implementation": "chat-sdk"
         }
       }
@@ -2058,7 +2061,7 @@
       ],
       "meta": {
         "eve": {
-          "docs": "/docs/channels/chat-sdk",
+          "docs": "https://chat-sdk.dev/adapters/vendor-official/resend",
           "implementation": "chat-sdk"
         }
       }

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -1717,11 +1717,14 @@
       ],
       "envVars": {
         "X_CONSUMER_SECRET": "",
+        "X_CLIENT_ID": "",
+        "X_REFRESH_TOKEN": "",
+        "X_ENCRYPTION_KEY": "",
         "X_USER_ACCESS_TOKEN": ""
       },
       "meta": {
         "eve": {
-          "docs": "/docs/channels/chat-sdk",
+          "docs": "/integrations/x",
           "implementation": "chat-sdk"
         }
       }

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -1724,7 +1724,7 @@
       },
       "meta": {
         "eve": {
-          "docs": "/integrations/x",
+          "docs": "/integrations/chat-sdk-x",
           "implementation": "chat-sdk"
         }
       }

--- a/apps/docs/registry/channels/chat-sdk-x.ts
+++ b/apps/docs/registry/channels/chat-sdk-x.ts
@@ -7,10 +7,16 @@ export const { bot, channel, send } = chatSdkChannel({
   userName: "My Agent",
   adapters: { x: createXAdapter() },
   state: createMemoryState(),
+  // X buffers replies and posts once rather than editing a streamed message.
+  streaming: false,
 });
 
 bot.onNewMention(async (thread: Thread, message: Message) => {
   await thread.subscribe();
+  await send(message.text, { thread });
+});
+
+bot.onDirectMessage(async (thread: Thread, message: Message) => {
   await send(message.text, { thread });
 });
 

--- a/docs/channels/chat-sdk.mdx
+++ b/docs/channels/chat-sdk.mdx
@@ -63,7 +63,7 @@ eve deploy
 
 ## Configure the webhook route
 
-Each adapter mounts `GET` and `POST` routes at `/eve/v1/{adapterName}`, so the `resend` adapter above is served at `/eve/v1/resend`. Point your provider's webhook (the Resend inbound address, the Slack Event Subscriptions URL, etc.) at that path. The adapter decides how to handle each method; providers such as X use `GET` for a webhook-verification challenge and `POST` for event delivery.
+Each adapter registers `GET` and `POST` handlers at `/eve/v1/{adapterName}`, so the `resend` adapter above is served at `/eve/v1/resend`. Point your provider's webhook (the Resend inbound address, the Slack Event Subscriptions URL, etc.) at that path. The adapter handles the incoming method. For example, X sends its webhook-verification challenge with `GET` and delivers events with `POST`.
 
 Override the base path for every adapter with `route`, or pin an individual adapter's path with `routes`:
 

--- a/docs/channels/chat-sdk.mdx
+++ b/docs/channels/chat-sdk.mdx
@@ -63,7 +63,7 @@ eve deploy
 
 ## Configure the webhook route
 
-Each adapter mounts one `POST` route at `/eve/v1/{adapterName}`, so the `resend` adapter above is served at `/eve/v1/resend`. Point your provider's webhook (the Resend inbound address, the Slack Event Subscriptions URL, etc.) at that path.
+Each adapter mounts `GET` and `POST` routes at `/eve/v1/{adapterName}`, so the `resend` adapter above is served at `/eve/v1/resend`. Point your provider's webhook (the Resend inbound address, the Slack Event Subscriptions URL, etc.) at that path. The adapter decides how to handle each method; providers such as X use `GET` for a webhook-verification challenge and `POST` for event delivery.
 
 Override the base path for every adapter with `route`, or pin an individual adapter's path with `routes`:
 

--- a/packages/eve/src/setup/flows/registry.test.ts
+++ b/packages/eve/src/setup/flows/registry.test.ts
@@ -146,7 +146,7 @@ describe("runRegistryFlow", () => {
         {
           output: [
             "Environment: BROWSER_TOKEN, BROWSER_URL",
-            "Documentation: https://eve.dev/integrations/browser",
+            "Setup: https://eve.dev/integrations/browser",
           ],
         },
       ],

--- a/packages/eve/src/setup/flows/registry.test.ts
+++ b/packages/eve/src/setup/flows/registry.test.ts
@@ -124,6 +124,31 @@ describe("runRegistryFlow", () => {
     });
   });
 
+  it("links to an installed registry item's documentation", async () => {
+    const answers = ["category:extension", "item:0", "add"];
+    const fake = createFakePrompter({ single: () => answers.shift()! });
+
+    await expect(
+      runRegistryFlow({
+        appRoot: APP_ROOT,
+        prompter: fake.prompter,
+        deps: deps({
+          getRegistryItemManifest: vi.fn(async () => ({
+            description: "Browser automation",
+            meta: { eve: { docs: "/integrations/browser" } },
+            name: "extension/agent-browser",
+          })),
+        }),
+      }),
+    ).resolves.toMatchObject({
+      items: [
+        {
+          output: ["Documentation: https://eve.dev/integrations/browser"],
+        },
+      ],
+    });
+  });
+
   it("uses the registry title when labeling an item", async () => {
     const answers = ["category:channel", "action:back", "action:done"];
     const prompts: unknown[] = [];

--- a/packages/eve/src/setup/flows/registry.test.ts
+++ b/packages/eve/src/setup/flows/registry.test.ts
@@ -59,11 +59,11 @@ describe("runRegistryFlow", () => {
           address: "extension/agent-browser",
           title: "Agent Browser",
           facts: [],
-          output: [],
+          output: ["Environment: AGENT_BROWSER_TOKEN"],
         },
       ],
       facts: [],
-      output: [],
+      output: ["Environment: AGENT_BROWSER_TOKEN"],
     });
     expect(flowDeps.installRegistryItem).toHaveBeenCalledWith(
       APP_ROOT,
@@ -124,7 +124,7 @@ describe("runRegistryFlow", () => {
     });
   });
 
-  it("links to an installed registry item's documentation", async () => {
+  it("prints an installed registry item's environment and documentation", async () => {
     const answers = ["category:extension", "item:0", "add"];
     const fake = createFakePrompter({ single: () => answers.shift()! });
 
@@ -135,6 +135,7 @@ describe("runRegistryFlow", () => {
         deps: deps({
           getRegistryItemManifest: vi.fn(async () => ({
             description: "Browser automation",
+            envVars: { BROWSER_TOKEN: "", BROWSER_URL: "" },
             meta: { eve: { docs: "/integrations/browser" } },
             name: "extension/agent-browser",
           })),
@@ -143,7 +144,10 @@ describe("runRegistryFlow", () => {
     ).resolves.toMatchObject({
       items: [
         {
-          output: ["Documentation: https://eve.dev/integrations/browser"],
+          output: [
+            "Environment: BROWSER_TOKEN, BROWSER_URL",
+            "Documentation: https://eve.dev/integrations/browser",
+          ],
         },
       ],
     });

--- a/packages/eve/src/setup/flows/registry.ts
+++ b/packages/eve/src/setup/flows/registry.ts
@@ -183,6 +183,13 @@ function summarizeDetails(values: readonly string[], limit = 3): string {
   return remaining > 0 ? `${visible.join(", ")} … (+${remaining} more)` : visible.join(", ");
 }
 
+function environmentVariables(manifest: Record<string, unknown>): string[] {
+  const envVars = manifest.envVars;
+  return typeof envVars === "object" && envVars !== null && !Array.isArray(envVars)
+    ? Object.keys(envVars)
+    : [];
+}
+
 function itemDetails(
   item: RegistryCatalogItem,
   manifest: Record<string, unknown>,
@@ -195,10 +202,9 @@ function itemDetails(
   ];
   if (dependencies.length > 0)
     details.push({ label: "Packages", value: summarizeDetails(dependencies) });
-  const envVars = manifest.envVars;
-  if (typeof envVars === "object" && envVars !== null && !Array.isArray(envVars)) {
-    const names = Object.keys(envVars);
-    if (names.length > 0) details.push({ label: "Environment", value: summarizeDetails(names) });
+  const environment = environmentVariables(manifest);
+  if (environment.length > 0) {
+    details.push({ label: "Environment", value: summarizeDetails(environment) });
   }
   const files = Array.isArray(manifest.files) ? manifest.files : [];
   const targets = files.flatMap((file) => {
@@ -222,6 +228,7 @@ async function inspectItem(
       kind: "added";
       output: readonly string[];
       documentation?: string;
+      environment?: readonly string[];
       setup?: Awaited<ReturnType<RegistryFlowDeps["installRegistryItem"]>>["setup"];
     }
   | { kind: "back" }
@@ -257,7 +264,12 @@ async function inspectItem(
           signal,
         });
       const result = await (prompter.withExclusiveTerminal?.(install) ?? install());
-      return { kind: "added", documentation: documentationLink(manifest), ...result };
+      return {
+        kind: "added",
+        documentation: documentationLink(manifest),
+        environment: environmentVariables(manifest),
+        ...result,
+      };
     } finally {
       spinner?.stop();
     }
@@ -304,7 +316,14 @@ async function offerItem(
     input.signal,
   );
   if (inspected.kind !== "added") return undefined;
-  session.add(item.address, itemLabel(item), inspected.output, inspected.setup);
+  const output = [...inspected.output];
+  if (inspected.environment !== undefined && inspected.environment.length > 0) {
+    output.push(`Environment: ${inspected.environment.join(", ")}`);
+  }
+  if (inspected.documentation !== undefined) {
+    output.push(`Setup: ${inspected.documentation}`);
+  }
+  session.add(item.address, itemLabel(item), output, inspected.setup);
   const next = await session.continueAfterInstall({
     appRoot: input.appRoot,
     prompter: input.prompter,

--- a/packages/eve/src/setup/flows/registry.ts
+++ b/packages/eve/src/setup/flows/registry.ts
@@ -1,3 +1,4 @@
+import { z } from "#compiled/zod/index.js";
 import type { RegistryCatalogItem } from "#cli/commands/registry.js";
 import type {
   Prompter,
@@ -162,6 +163,20 @@ function manifestRecord(manifest: unknown): Record<string, unknown> {
     : {};
 }
 
+const RegistryDocumentationSchema = z.object({
+  meta: z
+    .object({
+      eve: z.object({ docs: z.string().min(1).optional() }).optional(),
+    })
+    .optional(),
+});
+
+function documentationLink(manifest: Record<string, unknown>): string | undefined {
+  const docs = RegistryDocumentationSchema.safeParse(manifest).data?.meta?.eve?.docs;
+  if (docs === undefined) return undefined;
+  return docs.startsWith("/") ? `https://eve.dev${docs}` : docs;
+}
+
 function summarizeDetails(values: readonly string[], limit = 3): string {
   const visible = values.slice(0, limit);
   const remaining = values.length - visible.length;
@@ -206,6 +221,7 @@ async function inspectItem(
   | {
       kind: "added";
       output: readonly string[];
+      documentation?: string;
       setup?: Awaited<ReturnType<RegistryFlowDeps["installRegistryItem"]>>["setup"];
     }
   | { kind: "back" }
@@ -241,7 +257,7 @@ async function inspectItem(
           signal,
         });
       const result = await (prompter.withExclusiveTerminal?.(install) ?? install());
-      return { kind: "added", ...result };
+      return { kind: "added", documentation: documentationLink(manifest), ...result };
     } finally {
       spinner?.stop();
     }


### PR DESCRIPTION
### Summary

`/add` now prints every environment variable declared by an installed registry item, followed by an eve-specific setup link. Every Chat SDK registry item links to its integration page’s **Configure** section; the X setup page links to the Chat SDK X adapter documentation for provider-owned authentication, webhook verification, and subscriptions. The X registry item declares the default static-token credentials (`X_CONSUMER_SECRET` and `X_USER_ACCESS_TOKEN`); the linked setup docs cover managed refresh and optional settings.

### Validation

`pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/setup/flows/registry.test.ts`, `pnpm docs:check`, and `pnpm --filter eve-docs registry:check` passed after rebasing onto `main`.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 6 files · `+46 / -21`

Adds X channel metadata, places each Chat SDK registry link at its eve Configure section, and replaces the duplicated X provider walkthrough with the maintained Chat SDK reference.

**Implementation** — 1 file · `+41 / -6`

Extends the shared registry-install completion path to print declared environment variables and an eve setup link for both browser and direct-address `/add` flows.

**Tests** — 1 file · `+31 / -2`

Covers the post-install environment and setup-link output.
