### PR TITLE
feat(sandbox): support just-bash custom commands

### DIFF
--- a/.changeset/bright-bash-commands.md
+++ b/.changeset/bright-bash-commands.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Allow `justbash({ customCommands })` to register trusted host application commands in live just-bash sandbox sessions.

--- a/docs/sandbox.mdx
+++ b/docs/sandbox.mdx
@@ -182,6 +182,26 @@ export default defineSandbox({
 
 `justbash()` needs no daemon or VM, but commands run in a simulated bash with a virtual filesystem under `.eve/sandbox-cache/`, with no real binaries (`git`, `node`, package managers) and no network isolation. The `just-bash` package is an optional peer dependency, so `eve dev` installs it into your application automatically when missing (disable with `autoInstall: false`); production processes fail with an actionable install error instead.
 
+Pass `customCommands` to expose a `just-bash` `CustomCommand` inside each live sandbox session. The command participates in shell pipelines, redirections, and exit-code handling like a built-in command:
+
+```ts title="agent/sandbox.ts"
+import { defineSandbox } from "eve/sandbox";
+import { justbash } from "eve/sandbox/just-bash";
+import { decodeBytesToUtf8, defineCommand } from "just-bash";
+
+const uppercase = defineCommand("uppercase", async (_args, context) => ({
+  stdout: decodeBytesToUtf8(context.stdin).toUpperCase(),
+  stderr: "",
+  exitCode: 0,
+}));
+
+export default defineSandbox({
+  backend: justbash({ customCommands: [uppercase] }),
+});
+```
+
+Custom commands are registered on live and reopened sessions, not during template prewarming. They run trusted host application code and create an explicit bridge from the sandbox to that code. Adapters can use this extension point to expose application APIs such as a Capable App's CLI; the outer eve `bash` tool does not automatically provide per-command Capable approvals.
+
 You can also write your own backend. A `SandboxBackend` is an adapter object with a `name`, a `create`, and an optional `prewarm`. It can point at your own container runner, VM pool, internal sandbox service, or another isolation layer, as long as it returns the `SandboxSession` operations eve needs. Handles returned by `create` implement `shutdown()`, which stops the underlying compute at server shutdown. See the `SandboxBackend*` types on `eve/sandbox`.
 
 ## Lifecycle

--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -401,7 +401,7 @@
     "@opentelemetry/api": "^1.0.0",
     "ai": "catalog:",
     "braintrust": "^3.0.0",
-    "just-bash": "^3.0.0",
+    "just-bash": "^3.1.0",
     "microsandbox": "^0.5.0"
   },
   "peerDependenciesMeta": {

--- a/packages/eve/src/execution/sandbox/bindings/just-bash-runtime.ts
+++ b/packages/eve/src/execution/sandbox/bindings/just-bash-runtime.ts
@@ -75,6 +75,7 @@ async function loadJustBashModule(input: {
 export async function createBashSandbox(input: {
   readonly appRoot: string;
   readonly autoInstall: boolean;
+  readonly customCommands?: JustBashSandboxCreateOptions["customCommands"];
   readonly filesystem?: JustBashSandboxCreateOptions["filesystem"];
   readonly rootPath: string;
   readonly sessionKey: string;
@@ -112,6 +113,7 @@ export async function createBashSandbox(input: {
 
   const sandbox = await Sandbox.create({
     cwd: WORKSPACE_ROOT,
+    customCommands: input.customCommands === undefined ? undefined : [...input.customCommands],
     env: metadata?.env as Record<string, string> | undefined,
     fs: filesystem,
     network: {

--- a/packages/eve/src/execution/sandbox/bindings/just-bash.scenario.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/just-bash.scenario.test.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { mkdir, readdir, readFile, stat, utimes, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
-import { MountableFs, ReadWriteFs } from "just-bash";
+import { decodeBytesToUtf8, defineCommand, MountableFs, ReadWriteFs } from "just-bash";
 import { describe, expect, it } from "vitest";
 
 import { useTemporaryDirectories } from "#internal/testing/use-temporary-app-roots.js";
@@ -401,6 +401,43 @@ describe("just-bash sandbox file API", () => {
     const result = await handle.session.run({ command: "wc -c < assets/fixture.bin" });
     expect(result.exitCode).toBe(0);
     expect(Number(result.stdout.trim())).toBe(bytes.length);
+  });
+});
+
+describe("just-bash custom commands", () => {
+  it("forwards custom commands to live sessions", async () => {
+    const appRoot = await createTemporaryCacheDirectory("custom-command");
+    const backend = justbash({
+      customCommands: [
+        defineCommand("cap", async (args, context) => {
+          if (args[0] === "fail") {
+            return { exitCode: 23, stderr: "cap failed\n", stdout: "" };
+          }
+          return {
+            exitCode: 0,
+            stderr: "",
+            stdout: decodeBytesToUtf8(context.stdin).toUpperCase(),
+          };
+        }),
+      ],
+    });
+    const handle = await backend.create({
+      runtimeContext: { appRoot },
+      sessionKey: "session-custom-command",
+      templateKey: null,
+    });
+    await expect(
+      handle.session.run({ command: "printf 'hello' | cap > result.txt" }),
+    ).resolves.toMatchObject({
+      exitCode: 0,
+      stdout: "",
+    });
+    await expect(handle.session.readTextFile({ path: "result.txt" })).resolves.toBe("HELLO");
+    await expect(handle.session.run({ command: "cap fail" })).resolves.toMatchObject({
+      exitCode: 23,
+      stderr: "cap failed\n",
+    });
+    await handle.shutdown();
   });
 });
 

--- a/packages/eve/src/execution/sandbox/bindings/just-bash.ts
+++ b/packages/eve/src/execution/sandbox/bindings/just-bash.ts
@@ -64,6 +64,7 @@ export function createJustBashSandboxBackend(
   input: CreateJustBashSandboxBackendInput = {},
 ): SandboxBackend {
   const autoInstall = input.createOptions?.autoInstall ?? true;
+  const customCommands = input.createOptions?.customCommands;
   const filesystem = input.createOptions?.filesystem;
   return {
     name: JUST_BASH_BACKEND_NAME,
@@ -158,6 +159,7 @@ export function createJustBashSandboxBackend(
       const sandbox = await createBashSandbox({
         appRoot: createInput.runtimeContext.appRoot,
         autoInstall,
+        customCommands,
         filesystem,
         rootPath: sessionRootPath,
         sessionKey: createInput.sessionKey,

--- a/packages/eve/src/public/sandbox/just-bash-sandbox.ts
+++ b/packages/eve/src/public/sandbox/just-bash-sandbox.ts
@@ -1,4 +1,4 @@
-import type { IFileSystem } from "just-bash";
+import type { CustomCommand, IFileSystem } from "just-bash";
 
 /**
  * Context passed to a custom just-bash filesystem factory for each live handle.
@@ -28,6 +28,17 @@ export interface JustBashSandboxCreateOptions {
    * actionable install error instead. Defaults to `true`.
    */
   readonly autoInstall?: boolean;
+  /**
+   * Registers trusted host application code as commands in each live
+   * just-bash interpreter. Custom commands can participate in normal shell
+   * composition, including pipelines and redirections.
+   *
+   * Custom commands are not available during template prewarming. They run in
+   * eve's host process, outside the virtual filesystem security boundary, and
+   * are responsible for validating their own inputs and cleaning up host
+   * resources.
+   */
+  readonly customCommands?: ReadonlyArray<CustomCommand>;
   /**
    * Composes the filesystem used by each live sandbox handle. The factory is
    * called when a handle opens with eve's durable default filesystem; return a


### PR DESCRIPTION
### Summary

`just-bash` can register in-process custom commands, but eve's `justbash()` backend did not expose or forward them. This adds a typed `customCommands` option for live interpreters while leaving template prewarming unchanged. The `just-bash` optional peer floor moves to `^3.1.0`, where `Sandbox.create()` began accepting custom commands.

### Validation

A focused real just-bash scenario verifies pipeline and redirection composition plus custom exit codes; the full just-bash scenario file passes (23/23).

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+25 / -0`

Adds a compact usage example and the required patch changeset.

**Implementation** — 4 files · `+17 / -2`

Keeps the new public option and live-interpreter forwarding local to the existing just-bash backend.

**Tests** — 1 file · `+38 / -1`

One focused scenario covers the public behavior without duplicating just-bash's own option-forwarding tests.
