### PR TITLE
docs: upgrade Geistdocs to 1.23.0

### DIFF
--- a/apps/docs/app/[lang]/(home)/components/home-content.tsx
+++ b/apps/docs/app/[lang]/(home)/components/home-content.tsx
@@ -20,6 +20,7 @@ export const homeMetadata: Metadata = {
     ...titleMetadata.openGraph,
     description: tagline,
     images: [staticOgImage],
+    type: "website",
   },
   twitter: {
     ...titleMetadata.twitter,

--- a/apps/docs/lib/geistdocs/config.tsx
+++ b/apps/docs/lib/geistdocs/config.tsx
@@ -14,6 +14,7 @@ import {
   translations,
 } from "@/geistdocs";
 import { defaultLanguage } from "./languages";
+import { getSiteOrigin } from "./url";
 
 export const config = defineConfig({
   title,
@@ -26,6 +27,7 @@ export const config = defineConfig({
   navbarActiveProduct: "eve",
   basePath,
   siteId,
+  siteUrl: getSiteOrigin(),
   translations,
   // Built-in edit link hardcodes `/edit/` and a `content/docs/` prefix; we
   // render our own `/blob/` link instead (see EditOnGithubAction).

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -24,7 +24,7 @@
     "@icons-pack/react-simple-icons": "13.13.0",
     "@streamdown/code": "1.1.1",
     "@vercel/analytics": "2.0.1",
-    "@vercel/geistdocs": "1.22.0",
+    "@vercel/geistdocs": "1.23.0",
     "@vercel/speed-insights": "2.0.0",
     "@vgpu/core": "0.0.7",
     "@vgpu/render": "0.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,8 +179,8 @@ importers:
         specifier: 2.0.1
         version: 2.0.1(@sveltejs/kit@2.63.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(next@16.3.1(@babel/core@7.29.0(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nuxt@4.4.6(eddae254238b412d8a46133f9d7579b6))(react@19.2.6)(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vue@3.5.35(typescript@6.0.3))
       '@vercel/geistdocs':
-        specifier: 1.22.0
-        version: 1.22.0(af419ac2f77fc42ec3d0d44b87253972)
+        specifier: 1.23.0
+        version: 1.23.0(af419ac2f77fc42ec3d0d44b87253972)
       '@vercel/speed-insights':
         specifier: 2.0.0
         version: 2.0.0(@sveltejs/kit@2.63.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(next@16.3.1(@babel/core@7.29.0(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nuxt@4.4.6(eddae254238b412d8a46133f9d7579b6))(react@19.2.6)(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vue@3.5.35(typescript@6.0.3))
@@ -7873,8 +7873,8 @@ packages:
   '@vercel/gatsby-plugin-vercel-builder@2.2.35':
     resolution: {integrity: sha512-H1qNhnvyRIhek/esVnVK+RoFsxrSOLl4qiM4iyV2IcjDoqY4H0Ped65tc5ZgZEP/P2KGNYfEDSBEukdBZa+kCg==}
 
-  '@vercel/geistdocs@1.22.0':
-    resolution: {integrity: sha512-4tQ1vu9GK/SC04ROt64vI3RbI5aww59dW8nkuTQNrKALP91reHESQqcUR0u7Q7NO5ndRtfTAdSZ7T1bMiMecig==}
+  '@vercel/geistdocs@1.23.0':
+    resolution: {integrity: sha512-mmRwmb4UEZkGEfShafwnc6RTq4oxSATx06CRL0qcr6kU0kHYNW917J+r5H4ynQduq01EhXpWLHu3GwRvElDCYQ==}
     hasBin: true
     peerDependencies:
       next: ^16.3.0
@@ -22290,7 +22290,7 @@ snapshots:
       etag: 1.8.1
       fs-extra: 11.1.0
 
-  '@vercel/geistdocs@1.22.0(af419ac2f77fc42ec3d0d44b87253972)':
+  '@vercel/geistdocs@1.23.0(af419ac2f77fc42ec3d0d44b87253972)':
     dependencies:
       '@ai-sdk/react': 3.0.193(react@19.2.6)(zod@4.4.3)
       '@clack/prompts': 0.11.0


### PR DESCRIPTION
### Summary

Eve docs remained on Geistdocs 1.22.0, so the new homepage Markdown negotiation and product metadata were unavailable. This upgrades to 1.23.0, supplies Eve's canonical origin for generated canonicals and JSON-LD, adds `og:type=website`, and preserves Eve's custom sitemap and global 404.

### Validation

A frozen install and formatting check passed; `NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL=localhost:4321 pnpm --filter eve-docs build` generated 456 pages, and `pnpm --filter eve-docs test:unit` passed 161 tests. Local production probes confirmed root Markdown negotiation with `Vary: Accept`, “When to use eve,” SoftwareApplication JSON-LD, complete homepage metadata, smart docs 404s, and existing sitemap, robots, llms, and page-Markdown routes.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 4 files · `+9 / -6`

A focused package and lockfile update plus the two metadata/config adapters required to activate the release safely.

**Tests** — 0 files · `+0 / -0`

Existing docs build, unit coverage, and direct route probes cover the upgraded behavior.