### PR TITLE
feat(eve): scaffold project readme

### DIFF
--- a/.changeset/bright-agents-read.md
+++ b/.changeset/bright-agents-read.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+New standalone projects created by `eve init` now include a `README.md` with templated project and development instructions.

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -75,6 +75,7 @@ A minimal agent needs `instructions.md`; `agent.ts` is optional when the default
 
 ```text
 my-agent/
+├── README.md
 ├── package.json
 ├── tsconfig.json
 ├── agent/

--- a/packages/eve/src/setup/scaffold/create/project.ts
+++ b/packages/eve/src/setup/scaffold/create/project.ts
@@ -226,6 +226,42 @@ You are a helpful assistant.
 `;
 
 const SHARED_TEMPLATE_FILES: Record<string, string> = {
+  "README.md": `# __EVE_INIT_APP_NAME__
+
+This is an [eve](https://eve.dev) agent bootstrapped with [\`eve init\`](https://eve.dev/docs/reference/cli#eve-init).
+
+## Getting started
+
+First, run the development server:
+
+\`\`\`bash
+eve dev
+\`\`\`
+
+The development TUI opens an interactive session where you can send messages to your agent.
+
+Start by editing \`agent/instructions.md\` to define the agent's identity, purpose, tone, and response guidelines. Configure its model and runtime behavior in \`agent/agent.ts\`.
+
+Add capabilities under \`agent/\`, including tools, connections, channels, skills, subagents, and schedules. eve reloads your changes as you work.
+
+## Learn more
+
+To learn more about eve, explore these resources:
+
+- [eve documentation](https://eve.dev/docs) — learn about eve's features and authoring APIs.
+- [Build an Agent tutorial](https://eve.dev/docs/tutorial/first-agent) — build and deploy an agent step by step.
+- [eve on GitHub](https://github.com/vercel/eve) — view the source and contribute.
+
+## Deploy on Vercel
+
+Deploy your agent to [Vercel](https://vercel.com) from the project root:
+
+\`\`\`bash
+eve deploy
+\`\`\`
+
+\`eve deploy\` links a Vercel project if needed and deploys the agent to production. See the [eve deployment documentation](https://eve.dev/docs/guides/deployment/vercel) for authentication, environment variables, and deployment options.
+`,
   "agent/channels/eve.ts": WEB_APP_TEMPLATE_FILES["agent/channels/eve.ts"],
   "agent/instructions.md": AGENT_INSTRUCTIONS_TEMPLATE,
   "tsconfig.json": `{

--- a/packages/eve/src/setup/scaffold/index.integration.test.ts
+++ b/packages/eve/src/setup/scaffold/index.integration.test.ts
@@ -1023,6 +1023,12 @@ describe("scaffoldBaseProject", () => {
     const agentSource = await readFile(join(projectRoot, "agent/agent.ts"), "utf8");
     expect(agentSource).toContain('model: "openai/gpt-5-mini"');
     expect(agentSource).not.toContain("modelOptions");
+    const readme = await readFile(join(projectRoot, "README.md"), "utf8");
+    expect(readme).toContain("# demo-agent");
+    expect(readme).toContain("## Getting started");
+    expect(readme).toContain("## Learn more");
+    expect(readme).toContain("## Deploy on Vercel");
+    expect(readme).not.toContain("__EVE_INIT_");
     const packageJson = await readFile(join(projectRoot, "package.json"), "utf8");
     expect(packageJson).toContain('"eve": "^0.25.0"');
     // Channels added later (`eve add channel/slack`, possibly next to a
@@ -1107,6 +1113,7 @@ describe("scaffoldBaseProject", () => {
       await expect(readFile(join(projectRoot, "package.json"), "utf8")).resolves.toContain(
         '"eve": "^0.25.0"',
       );
+      await expect(readFile(join(projectRoot, "README.md"), "utf8")).resolves.toContain("eve dev");
       await expect(pathExists(join(projectRoot, "pnpm-workspace.yaml"))).resolves.toBe(
         packageManager === "pnpm",
       );

--- a/packages/eve/test/scenarios/eve-init.scenario.test.ts
+++ b/packages/eve/test/scenarios/eve-init.scenario.test.ts
@@ -197,6 +197,13 @@ describe("eve init smoke", () => {
     const projectDir = join(scratch, "smoke-agent");
     const canonicalProjectDir = await realpath(projectDir);
     const agentSource = await readFile(join(projectDir, "agent/agent.ts"), "utf8");
+    const readme = await readFile(join(projectDir, "README.md"), "utf8");
+    expect(readme).toContain("# smoke-agent");
+    expect(readme).toContain("## Getting started");
+    expect(readme).toContain("eve dev");
+    expect(readme).toContain("## Learn more");
+    expect(readme).toContain("## Deploy on Vercel");
+    expect(readme).toContain("eve deploy");
     const packageJson = JSON.parse(await readFile(join(projectDir, "package.json"), "utf8")) as {
       engines?: { node?: string };
     };


### PR DESCRIPTION
### Summary

Standalone projects created by `eve init` currently lack an introduction to their generated structure and next steps. This adds a project-name-aware `README.md` organized around getting started, learning eve, and deploying to Vercel. Adding eve to an existing package remains unchanged and does not replace a host project's README.

### Validation

The focused scaffold integration suite passed all 64 tests, including generated README coverage across supported package managers. The existing `eve init` scenario now also asserts the README contract for CI coverage.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+6 / -0`

Updates the documented project layout and adds the required release note.

**Implementation** — 1 file · `+36 / -0`

Adds the complete generated README template to standalone project scaffolding.

**Tests** — 2 files · `+14 / -0`

Covers template rendering in the scaffold integration suite and the end-to-end init scenario.
