### PR TITLE
chore(eve): e2e - remove ZAI GLM from model matrix

### DIFF
--- a/e2e/matrix.json
+++ b/e2e/matrix.json
@@ -2,8 +2,7 @@
   "$comment": "Registry for the e2e CI matrices. `models` drives the model suite (e2e-local): the first entry is the default every fixture runs on; fixtures with `\"e2e\": { \"modelMatrix\": \"full\" }` in package.json run on all of them. The short model name is the stable Actions check identifier, so updating a model version does not rename required checks. `worlds` drives the world suites: each entry backs one `world_matrix_<name>` output consumed by the matching `e2e-<name>.yml`, and `package` (when set) is exported to the job as EVE_E2E_WORKFLOW_WORLD. See e2e/README.md.",
   "models": [
     { "name": "openai-sol", "id": "openai/gpt-5.6-sol" },
-    { "name": "anthropic-opus", "id": "anthropic/claude-opus-5" },
-    { "name": "zai-glm", "id": "zai/glm-5.2" }
+    { "name": "anthropic-opus", "id": "anthropic/claude-opus-5" }
   ],
   "worlds": [{ "name": "vercel" }, { "name": "postgres", "package": "@workflow/world-postgres" }]
 }


### PR DESCRIPTION
### Summary

ZAI GLM has been repeatedly failing in the real-model e2e suite, making the aggregate check unreliable. This removes `zai-glm` from the central model registry; full-matrix fixtures continue to run against OpenAI and Anthropic, while world suites remain unchanged on deterministic mock models.

### Validation

Ran the e2e fixture discovery script and confirmed that 24 fixtures produce 31 model-suite jobs across only `openai-sol` and `anthropic-opus`. The real-model e2e suite itself runs only in CI.

No documentation, additional test code, or changeset is applicable for this CI-only registry change.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 0 files · `+0 / -0`

Not applicable.

**Tests** — 1 file · `+1 / -2`

The focused registry edit removes only the failing model entry and the now-unneeded trailing comma.
