### PR TITLE
Revert "feat(eve): emit vercel.session_id on agent spans when running on Vercel (#2400)"

### DIFF
--- a/.changeset/vercel-session-id-attribute.md
+++ b/.changeset/vercel-session-id-attribute.md
@@ -1,5 +1,0 @@
----
-"eve": patch
----
-
-Agent spans now carry `vercel.session_id` (set to the root session id) when running on Vercel, so traces can be equality-looked-up across all session windows via an indexed column. The attribute is omitted in local `eve dev`.

--- a/packages/eve/src/tracing/agent-action-instrumentation.ts
+++ b/packages/eve/src/tracing/agent-action-instrumentation.ts
@@ -45,7 +45,6 @@ export interface AgentActionContext {
 
 /** Builds durable `agent.action` spans around eve's runtime dispatch boundary. */
 export function createAgentActionInstrumentation(input: {
-  readonly emitVercelSessionId?: boolean;
   readonly frameworkVersion: string;
   readonly idGenerator: AgentSpanIdGenerator;
   readonly recordInputs: boolean;
@@ -56,7 +55,6 @@ export function createAgentActionInstrumentation(input: {
   readonly stateStore: AgentTraceStateStore;
   readonly tracer: Tracer;
 }): AgentActionInstrumentation {
-  const emitVercelSessionId = input.emitVercelSessionId ?? false;
   const byAttempt = new Map<string, Set<string>>();
 
   const onStarted = async (event: InstrumentationActionStartedEvent): Promise<void> => {
@@ -133,9 +131,6 @@ export function createAgentActionInstrumentation(input: {
             "agent.step.attempt": state.attemptIndex,
             "agent.step.index": state.stepIndex,
             "agent.turn.id": state.turnId,
-            ...(emitVercelSessionId
-              ? { "vercel.session_id": state.rootSessionId }
-              : {}),
           },
           startTime: state.startTimeMs,
         },

--- a/packages/eve/src/tracing/agent-approval-instrumentation.ts
+++ b/packages/eve/src/tracing/agent-approval-instrumentation.ts
@@ -41,7 +41,6 @@ export function createAgentApprovalInstrumentation(input: {
     turnId: string,
     callId: string,
   ) => Promise<AgentActionContext | undefined>;
-  readonly emitVercelSessionId?: boolean;
   readonly frameworkVersion: string;
   readonly idGenerator: AgentSpanIdGenerator;
   readonly recordInputs: boolean;
@@ -51,7 +50,6 @@ export function createAgentApprovalInstrumentation(input: {
   NonNullable<InstrumentationProviderDefinition["events"]>,
   "input.requested" | "input.resolved"
 > {
-  const emitVercelSessionId = input.emitVercelSessionId ?? false;
   const onRequested = async (
     event: InstrumentationInputRequestedEvent,
     ctx: InstrumentationHandlerContext,
@@ -112,9 +110,6 @@ export function createAgentApprovalInstrumentation(input: {
               "agent.step.attempt": state.attemptIndex,
               "agent.step.index": state.stepIndex,
               "agent.turn.id": state.turnId,
-              ...(emitVercelSessionId
-                ? { "vercel.session_id": state.rootSessionId }
-                : {}),
             },
             startTime: state.startTimeMs,
           },

--- a/packages/eve/src/tracing/agent-channel-delivery-instrumentation.ts
+++ b/packages/eve/src/tracing/agent-channel-delivery-instrumentation.ts
@@ -35,7 +35,6 @@ interface ChannelDeliverySpanState {
 
 /** Builds durable channel delivery spans around the turn that consumes each request. */
 export function createAgentChannelDeliveryInstrumentation(input: {
-  readonly emitVercelSessionId?: boolean;
   readonly ensureSessionContext: (
     event: InstrumentationSessionStartedEvent,
   ) => Promise<AgentSessionTraceState>;
@@ -51,7 +50,6 @@ export function createAgentChannelDeliveryInstrumentation(input: {
   | "channel.delivery.failed"
   | "channel.delivery.started"
 > {
-  const emitVercelSessionId = input.emitVercelSessionId ?? false;
   const onStarted = async (
     event: InstrumentationChannelDeliveryStartedEvent,
     ctx: InstrumentationHandlerContext,
@@ -132,9 +130,6 @@ export function createAgentChannelDeliveryInstrumentation(input: {
             "agent.session.window": session?.window ?? state.window,
             "agent.turn.id": event.turnId,
             "agent.turn.sequence": event.sequence,
-            ...(emitVercelSessionId
-              ? { "vercel.session_id": event.rootSessionId }
-              : {}),
           },
           kind: SpanKind.CONSUMER,
           links:

--- a/packages/eve/src/tracing/agent-otel-provider.test.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.test.ts
@@ -62,7 +62,6 @@ interface TestRuntime {
 function createRuntime(
   stateStore: AgentTraceStateStore = new InMemoryAgentTraceStateStore(),
   tracePolicy: TraceCapturePolicy | null = () => true,
-  options: { readonly emitVercelSessionId?: boolean } = {},
 ): TestRuntime {
   const exporter = new InMemorySpanExporter();
   const idGenerator = new AgentSpanIdGenerator();
@@ -74,7 +73,6 @@ function createRuntime(
   const agentOtelInput: Omit<AgentOtelInstrumentationInput, "tracePolicy"> & {
     tracePolicy?: TraceCapturePolicy;
   } = {
-    emitVercelSessionId: options.emitVercelSessionId,
     frameworkVersion: "test",
     idGenerator,
     recordInputs: true,
@@ -1848,47 +1846,5 @@ describe("createAgentOtelInstrumentation", () => {
       "error.type": "TOOL_CALL_FAILED",
     });
     expect(byName(spans, "agent.turn")[0]!.status.code).toBe(SpanStatusCode.UNSET);
-  });
-
-  describe("emitVercelSessionId", () => {
-    it("emits vercel.session_id on session, turn, step, and action spans when enabled", async () => {
-      const runtime = createRuntime(undefined, undefined, { emitVercelSessionId: true });
-      await emitAttempt({
-        hooks: runtime.hooks,
-        runInContext: runtime.runInContext,
-        sessionId: "session-1",
-        turnId: "turn-1",
-        turnSequence: 0,
-      });
-      await runtime.provider.forceFlush();
-
-      const spans = runtime.exporter.getFinishedSpans();
-      const session = byName(spans, "agent.session")[0]!;
-      const turn = byName(spans, "agent.turn")[0]!;
-      const step = byName(spans, "agent.step")[0]!;
-      const action = byName(spans, "agent.action")[0]!;
-
-      expect(session.attributes["vercel.session_id"]).toBe("session-1");
-      expect(turn.attributes["vercel.session_id"]).toBe("session-1");
-      expect(step.attributes["vercel.session_id"]).toBe("session-1");
-      expect(action.attributes["vercel.session_id"]).toBe("session-1");
-    });
-
-    it("does not emit vercel.session_id by default", async () => {
-      const runtime = createRuntime();
-      await emitAttempt({
-        hooks: runtime.hooks,
-        runInContext: runtime.runInContext,
-        sessionId: "session-1",
-        turnId: "turn-1",
-        turnSequence: 0,
-      });
-      await runtime.provider.forceFlush();
-
-      const spans = runtime.exporter.getFinishedSpans();
-      for (const span of spans) {
-        expect(span.attributes["vercel.session_id"]).toBeUndefined();
-      }
-    });
   });
 });

--- a/packages/eve/src/tracing/agent-otel-provider.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.ts
@@ -73,14 +73,6 @@ export interface AgentOtelInstrumentationInput {
   readonly stateStore: AgentTraceStateStore;
   readonly tracer: Tracer;
   readonly tracePolicy?: TraceCapturePolicy;
-  /**
-   * When true, every agent span also carries `vercel.session_id` set to the
-   * root session id. The VDP trace ingestion materialized view extracts this
-   * into the indexed `sessionId` column so Agent Runs can equality-lookup a
-   * session across all trace windows without scanning the attribute map.
-   * Emitted only on Vercel (not local `eve dev`).
-   */
-  readonly emitVercelSessionId?: boolean;
 }
 
 /** OTel event definition and its trusted framework context runner. */
@@ -101,7 +93,6 @@ export function createAgentOtelInstrumentation(
 ): AgentOtelInstrumentation {
   const recordInputs = input.recordInputs ?? false;
   const recordOutputs = input.recordOutputs ?? false;
-  const emitVercelSessionId = input.emitVercelSessionId ?? false;
   const executionContexts = new WeakMap<InstrumentationAttemptScope, Map<string, Context>>();
   const attemptScopes = new Map<string, InstrumentationAttemptScope>();
   // A serverless turn runs inside one `turnStep` "use step" invocation. If
@@ -110,7 +101,6 @@ export function createAgentOtelInstrumentation(
   const steps = new WeakMap<InstrumentationAttemptScope, AttemptSpanState>();
   const modelSpans = new WeakMap<InstrumentationAttemptScope, Map<string, SpanState>>();
   const actions = createAgentActionInstrumentation({
-    emitVercelSessionId,
     frameworkVersion: input.frameworkVersion,
     idGenerator: input.idGenerator,
     recordInputs,
@@ -124,7 +114,6 @@ export function createAgentOtelInstrumentation(
   });
   const approvals = createAgentApprovalInstrumentation({
     actionContextFor: actions.contextFor,
-    emitVercelSessionId,
     frameworkVersion: input.frameworkVersion,
     idGenerator: input.idGenerator,
     recordInputs,
@@ -179,9 +168,6 @@ export function createAgentOtelInstrumentation(
               "agent.step.index": event.scope.stepIndex,
               "agent.turn.id": event.scope.turnId,
               "agent.name": event.scope.functionId,
-              ...(emitVercelSessionId
-                ? { "vercel.session_id": event.scope.rootSessionId ?? event.scope.sessionId }
-                : {}),
               ...runtimeContextAttributes(event.runtimeContext),
             },
             links:
@@ -288,9 +274,6 @@ export function createAgentOtelInstrumentation(
                   "agent.session.window": session?.window,
                   "agent.turn.id": event.turnId,
                   "agent.turn.sequence": turn.sequence,
-                  ...(emitVercelSessionId
-                    ? { "vercel.session_id": turn.rootSessionId }
-                    : {}),
                 },
                 startTime: turn.startTimeMs,
               },
@@ -428,7 +411,6 @@ export function createAgentOtelInstrumentation(
   };
 
   const channelDeliveries = createAgentChannelDeliveryInstrumentation({
-    emitVercelSessionId,
     ensureSessionContext,
     frameworkVersion: input.frameworkVersion,
     idGenerator: input.idGenerator,

--- a/packages/eve/src/tracing/agent-otel-session-context.ts
+++ b/packages/eve/src/tracing/agent-otel-session-context.ts
@@ -17,7 +17,6 @@ import {
 } from "#tracing/agent-trace-state.js";
 
 interface AgentOtelSessionContextInput {
-  readonly emitVercelSessionId?: boolean;
   readonly frameworkVersion: string;
   readonly idGenerator: AgentSpanIdGenerator;
   readonly stateStore: AgentTraceStateStore;
@@ -40,7 +39,6 @@ interface AgentOtelSessionContext {
 export function createAgentOtelSessionContext(
   input: AgentOtelSessionContextInput,
 ): AgentOtelSessionContext {
-  const emitVercelSessionId = input.emitVercelSessionId ?? false;
   const openSessionWindow = (window: {
     readonly agentName?: string;
     readonly channelAudience: ChannelAudience;
@@ -67,9 +65,6 @@ export function createAgentOtelSessionContext(
         "agent.session.id": window.sessionId,
         "agent.session.window": window.index,
         "agent.trace.schema.version": 1,
-        ...(emitVercelSessionId
-          ? { "vercel.session_id": window.rootSessionId }
-          : {}),
         ...(window.previousTraceId === undefined
           ? {}
           : { "agent.session.window.previous.trace.id": window.previousTraceId }),

--- a/packages/eve/src/tracing/install-instrumentation-runtime.ts
+++ b/packages/eve/src/tracing/install-instrumentation-runtime.ts
@@ -10,7 +10,6 @@ import {
   type InstrumentationRuntime,
 } from "#harness/instrumentation/runtime.js";
 import { createLogger, formatError } from "#internal/logging.js";
-import { isEveDevEnvironment } from "#internal/application/dev-environment.js";
 import { ContextAgentTraceStateStore } from "#tracing/agent-trace-context-store.js";
 import { createAgentOtelInstrumentation } from "#tracing/agent-otel-provider.js";
 import { hasSessionRelease, type LocalTracesProcessor } from "#tracing/local-traces.js";
@@ -49,7 +48,6 @@ export function installInstrumentationRuntime(input: {
       serviceName: input.serviceName,
     });
     const agentOtel = createAgentOtelInstrumentation({
-      emitVercelSessionId: process.env.VERCEL_ENV !== undefined && !isEveDevEnvironment(),
       frameworkVersion: input.frameworkVersion,
       idGenerator: otelRuntime.idGenerator,
       recordInputs: input.collected.settings.recordInputs,


### PR DESCRIPTION
### Summary

Reverts #2400. This removes the conditional `vercel.session_id` attribute from agent spans and restores the previous tracing behavior. It also removes the unreleased changeset and tests specific to that behavior.

### Validation

The focused tracing suite passes all 39 remaining tests with `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/tracing/agent-otel-provider.test.ts`.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [ ] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+0 / -5`

Removes the unreleased release note for the reverted behavior.

**Implementation** — 6 files · `+0 / -40`

Restores tracing instrumentation to its state before #2400.

**Tests** — 1 file · `+0 / -44`

Removes the coverage for the reverted instrumentation option and span attribute.
