### PR TITLE
fix(eve): follow active turns after session replay

### DIFF
--- a/.changeset/follow-existing-web-chat-streams.md
+++ b/.changeset/follow-existing-web-chat-streams.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Resume an existing Web Chat session's active response even when its durable history still ends at the previous turn boundary.

--- a/packages/eve/src/client/eve-agent-store.test.ts
+++ b/packages/eve/src/client/eve-agent-store.test.ts
@@ -239,11 +239,12 @@ describe("EveAgentStore session resume", () => {
     expect(store.snapshot.error?.message).toBe("Session failed.");
   });
 
-  it("replays a settled session without opening a live stream", async () => {
+  it("probes beyond a settled replay without reconnecting an idle stream", async () => {
     const events = turnEvents();
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(boundedStreamResponse(events));
+      .mockResolvedValueOnce(boundedStreamResponse(events))
+      .mockResolvedValueOnce(streamResponse([]));
     const store = new EveAgentStore({
       initialSession: { sessionId: "session_1", streamIndex: 0 },
       reducer: defaultMessageReducer(),
@@ -253,12 +254,75 @@ describe("EveAgentStore session resume", () => {
 
     await store.resume();
 
-    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(
+      new URL(fetchMock.mock.calls[1]![0].toString(), "http://localhost").searchParams.get(
+        "startIndex",
+      ),
+    ).toBe(String(events.length));
     expect(publishedEventCounts).not.toContain(1);
     expect(publishedEventCounts).not.toContain(2);
     expect(store.snapshot.status).toBe("ready");
     expect(store.snapshot.events).toEqual(events);
     expect(store.snapshot.session).toEqual({ sessionId: "session_1", streamIndex: events.length });
+  });
+
+  it("follows a turn accepted after the last settled event was persisted", async () => {
+    const events = stampTestEvents([
+      createMessageReceivedEvent({ message: "Hello", sequence: 0, turnId: "turn_1" }),
+      createMessageCompletedEvent({
+        finishReason: "stop",
+        message: "Hi there.",
+        sequence: 1,
+        stepIndex: 0,
+        turnId: "turn_1",
+      }),
+      createSessionWaitingEvent(),
+      createMessageReceivedEvent({ message: "Again", sequence: 0, turnId: "turn_2" }),
+      createTurnStartedEvent({ sequence: 1, turnId: "turn_2" }),
+      createMessageCompletedEvent({
+        finishReason: "stop",
+        message: "A second reply.",
+        sequence: 2,
+        stepIndex: 0,
+        turnId: "turn_2",
+      }),
+      createSessionWaitingEvent(),
+    ] as UnstampedMessageStreamEvent[]);
+    const settled = events.slice(0, 3);
+    const [received, started, completed, waiting] = events.slice(3);
+    const live = controlledStreamResponse();
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(boundedStreamResponse(settled))
+      .mockResolvedValueOnce(live.response);
+    const store = new EveAgentStore({
+      initialSession: { sessionId: "session_1", streamIndex: 0 },
+      reducer: defaultMessageReducer(),
+    });
+
+    const resuming = store.resume();
+    await vi.waitFor(() => expect(store.snapshot.events).toEqual(settled));
+
+    live.emit(received!);
+    live.emit(started!);
+    live.emit(completed!);
+    live.emit(waiting!);
+    live.close();
+    await resuming;
+
+    expect(store.snapshot.status).toBe("ready");
+    expect(store.snapshot.events.slice(settled.length).map((event) => event.type)).toEqual([
+      "message.received",
+      "turn.started",
+      "message.completed",
+      "session.waiting",
+    ]);
+    expect(store.snapshot.data.messages.at(-1)?.parts).toContainEqual({
+      state: "done",
+      stepIndex: 0,
+      text: "A second reply.",
+      type: "text",
+    });
   });
 
   it("replays history and follows an interrupted turn through its boundary", async () => {

--- a/packages/eve/src/client/eve-agent-store.ts
+++ b/packages/eve/src/client/eve-agent-store.ts
@@ -339,9 +339,13 @@ export class EveAgentStore<TData> {
 
       if (!this.#isActiveTurn(turn)) return;
       this.#publish();
-      if (!isSettledSessionTail(replayed)) {
+      const replaySettled = isSettledSessionTail(replayed);
+      if (!replaySettled || replayed.at(-1)?.type === "session.waiting") {
         const pendingAuthorizations = collectPendingAuthorizations(replayed);
-        for await (const event of session.stream({ signal: turn.abortController.signal })) {
+        for await (const event of session.stream({
+          signal: turn.abortController.signal,
+          streamReconnectPolicy: replaySettled ? { reconnect: false } : undefined,
+        })) {
           if (!this.#isActiveTurn(turn)) return;
           this.#acceptServerEvent(event);
           updatePendingAuthorizations(pendingAuthorizations, event);

--- a/packages/eve/src/react/use-eve-agent.test.ts
+++ b/packages/eve/src/react/use-eve-agent.test.ts
@@ -675,7 +675,8 @@ describe("useEveAgent", () => {
     ];
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(createBoundedStreamResponse(events));
+      .mockResolvedValueOnce(createBoundedStreamResponse(events))
+      .mockResolvedValueOnce(createEagerStreamResponse([]));
     let helpers: UseEveAgentHelpers<EveMessageData> | undefined;
     const statuses: string[] = [];
 
@@ -693,7 +694,7 @@ describe("useEveAgent", () => {
       await vi.waitFor(() => expect(helpers?.events).toHaveLength(events.length));
     });
 
-    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(statuses[0]).toBe("submitted");
     expect(helpers?.status).toBe("ready");
     expect(helpers?.data).toEqual(

--- a/packages/eve/src/svelte/use-eve-agent.test.ts
+++ b/packages/eve/src/svelte/use-eve-agent.test.ts
@@ -93,7 +93,10 @@ describe("useEveAgent (Svelte rune binding)", () => {
       createMessageReceivedEvent({ message: "Hello", sequence: 0, turnId: "turn_1" }),
       createSessionWaitingEvent(),
     ];
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(createBoundedStreamResponse(events));
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(createBoundedStreamResponse(events))
+      .mockResolvedValueOnce(createEagerStreamResponse([]));
     const seenEvents: UnstampedMessageStreamEvent[] = [];
 
     useEveAgent({
@@ -105,6 +108,7 @@ describe("useEveAgent (Svelte rune binding)", () => {
     });
 
     await vi.waitFor(() => expect(seenEvents).toEqual(stampTestEvents(events)));
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
   });
 
   it("sends messages and notifies lifecycle callbacks from the shared store", async () => {

--- a/packages/eve/src/vue/use-eve-agent.test.ts
+++ b/packages/eve/src/vue/use-eve-agent.test.ts
@@ -352,7 +352,9 @@ describe("useEveAgent (Vue composable wiring)", () => {
       }),
       createSessionWaitingEvent(),
     ];
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(createBoundedStreamResponse(events));
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(createBoundedStreamResponse(events))
+      .mockResolvedValueOnce(createEagerStreamResponse([]));
     const scope = effectScope();
     const agent = scope.run(() =>
       useEveAgent({


### PR DESCRIPTION
### Summary

When the same Web Chat session was open in two tabs, the second tab could replay through the previous `session.waiting` event and stop before observing a newly accepted turn. Session resume now performs one non-reconnecting probe beyond a settled waiting boundary, so it follows an active response without continuously polling an idle session. Terminal completed and failed sessions preserve their existing behavior.

### Validation

Reproduced the stale settled-tail race in focused store coverage and confirmed that React, Vue, and Svelte automatic resume complete after the probe; all 43 focused unit tests and the `eve` package typecheck pass.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

A compact changeset records the user-visible fix for the published `eve` package; standalone documentation is unchanged because this restores the documented resume behavior.

**Implementation** — 1 file · `+6 / -2`

Keeps the fix local to session resume by probing once after a settled waiting boundary while preserving normal follow behavior for interrupted turns.

**Tests** — 4 files · `+78 / -7`

Regression coverage models both an actually idle session and the cross-tab race where a new turn begins immediately after the replayed boundary. Framework binding tests also account for the intentional second stream request during automatic resume.
