### PR TITLE
Update New York eve event date

### DIFF
--- a/apps/docs/app/(nights)/nights/page.tsx
+++ b/apps/docs/app/(nights)/nights/page.tsx
@@ -42,7 +42,7 @@ const events = [
   },
   {
     city: "New York",
-    date: "Tuesday, September 8, 5:30 PM EDT",
+    date: "Thursday, September 10, 5:30 PM EDT",
     href: "https://luma.com/eveNY",
   },
   {


### PR DESCRIPTION
### Summary

Updates the New York eve event from Tuesday, September 8 to Thursday, September 10. The start time, timezone, and RSVP link are unchanged.

### Validation

Confirmed September 10, 2026 falls on a Thursday and that the remaining event details are preserved. Automated tests are not applicable to this content-only correction.

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 1 file · `+1 / -1`

Updates the date string in the existing event data without changing the event structure or link.

**Tests** — 0 files · `+0 / -0`

Not applicable for this content-only correction.
