### PR TITLE
feat(eve): connect workflow runs to agent traces

### DIFF
--- a/.changeset/eve-trace-id-attribute.md
+++ b/.changeset/eve-trace-id-attribute.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Workflow runs for session, subagent, and turn rows now carry a `$eve.trace_id` attribute pointing at the `agent.session` span's trace id, letting dashboards correlate a run with its OTEL trace. The trace id is read from the pre-allocated trace seed in the serialized context at run creation time. Attribute absence means no exported OTEL trace exists.
+Workflow session, subagent, and turn rows now include `$eve.trace_id` when a sampled agent trace is available, allowing workflow views to open the corresponding OpenTelemetry trace directly. Rows without an exported agent trace omit the attribute.

--- a/.changeset/eve-trace-id-attribute.md
+++ b/.changeset/eve-trace-id-attribute.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Workflow runs for session, subagent, and turn rows now carry a `$eve.trace_id` attribute pointing at the `agent.session` span's trace id, letting dashboards correlate a run with its OTEL trace. The trace id is read from the pre-allocated trace seed in the serialized context at run creation time. Attribute absence means no exported OTEL trace exists.

--- a/docs/guides/instrumentation.md
+++ b/docs/guides/instrumentation.md
@@ -164,7 +164,7 @@ Structural tags describe each run's place in the tree:
 - `$eve.subagent`: compiled graph node id (subagent runs only)
 - `$eve.trigger`: the channel kind that started the run
 - `$eve.title`: truncated title derived from the first user message
-- `$eve.trace_id`: trace id of the run's `agent.session` span, written on session, subagent, and turn rows so a dashboard run can be joined to its OpenTelemetry trace. Present only when the trace is sampled; absence means no exported OTEL trace exists.
+- `$eve.trace_id`: trace id of the sampled agent trace containing the run, written on session, subagent, and turn rows so a dashboard run can be joined to its OpenTelemetry trace. Present only when the trace is sampled; absence means no exported OTEL trace exists.
 
 Per-turn usage tags are written on each step of a turn, accumulating cumulative totals (last write wins):
 

--- a/docs/guides/instrumentation.md
+++ b/docs/guides/instrumentation.md
@@ -164,6 +164,7 @@ Structural tags describe each run's place in the tree:
 - `$eve.subagent`: compiled graph node id (subagent runs only)
 - `$eve.trigger`: the channel kind that started the run
 - `$eve.title`: truncated title derived from the first user message
+- `$eve.trace_id`: trace id of the run's `agent.session` span, written on session, subagent, and turn rows so a dashboard run can be joined to its OpenTelemetry trace. Present only when the trace is sampled; absence means no exported OTEL trace exists.
 
 Per-turn usage tags are written on each step of a turn, accumulating cumulative totals (last write wins):
 

--- a/packages/eve/src/execution/eve-workflow-attributes.test.ts
+++ b/packages/eve/src/execution/eve-workflow-attributes.test.ts
@@ -11,6 +11,7 @@ import {
   readParentLineage,
   readParentSessionId,
   readRootSessionId,
+  readSessionTraceId,
 } from "#execution/eve-workflow-attributes.js";
 import { ChannelRequestIdKey } from "#context/keys.js";
 
@@ -151,6 +152,7 @@ describe("buildSessionAttributes", () => {
     expect(attrs).toEqual({
       "$eve.channel_request_id": undefined,
       "$eve.is_trace_content_visible": true,
+      "$eve.trace_id": undefined,
       "$eve.type": "session",
       "$eve.trigger": "slack",
       "$eve.title": "ship the thing please",
@@ -191,6 +193,30 @@ describe("buildSessionAttributes", () => {
 
     expect(attrs["$eve.channel_request_id"]).toBe("req_session");
   });
+
+  it("emits $eve.trace_id from a sampled trace seed", () => {
+    const attrs = buildSessionAttributes({
+      inputMessage: "hi",
+      serializedContext: {
+        ...slackChannelCtx,
+        "eve.sessionTraceSeed": { spanId: "a".repeat(16), traceFlags: 1, traceId: "b".repeat(32) },
+      },
+    });
+
+    expect(attrs["$eve.trace_id"]).toBe("b".repeat(32));
+  });
+
+  it("withholds $eve.trace_id from an unsampled trace seed", () => {
+    const attrs = buildSessionAttributes({
+      inputMessage: "hi",
+      serializedContext: {
+        ...slackChannelCtx,
+        "eve.sessionTraceSeed": { spanId: "a".repeat(16), traceFlags: 0, traceId: "b".repeat(32) },
+      },
+    });
+
+    expect(attrs["$eve.trace_id"]).toBeUndefined();
+  });
 });
 
 describe("buildSubagentRootAttributes", () => {
@@ -207,6 +233,7 @@ describe("buildSubagentRootAttributes", () => {
     expect(attrs).toEqual({
       "$eve.channel_request_id": undefined,
       "$eve.is_trace_content_visible": true,
+      "$eve.trace_id": undefined,
       "$eve.type": "subagent",
       "$eve.parent": "wrun_parent_subagent",
       "$eve.parent_call": "call_subagent_0",
@@ -230,6 +257,22 @@ describe("buildSubagentRootAttributes", () => {
 
     expect(attrs["$eve.channel_request_id"]).toBe("req_subagent");
   });
+
+  it("emits $eve.trace_id from a sampled trace seed", () => {
+    const attrs = buildSubagentRootAttributes({
+      identity: { nodeId: "subagents/linear" },
+      parentCallId: "call_subagent_0",
+      parentSessionId: "wrun_parent_subagent",
+      parentTurnId: "turn_0",
+      rootSessionId: "wrun_top_level_session",
+      serializedContext: {
+        ...subagentChainCtx,
+        "eve.sessionTraceSeed": { spanId: "e".repeat(16), traceFlags: 1, traceId: "f".repeat(32) },
+      },
+    });
+
+    expect(attrs["$eve.trace_id"]).toBe("f".repeat(32));
+  });
 });
 
 describe("buildTurnAttributes", () => {
@@ -243,6 +286,7 @@ describe("buildTurnAttributes", () => {
     expect(attrs).toEqual({
       "$eve.channel_request_id": undefined,
       "$eve.is_trace_content_visible": true,
+      "$eve.trace_id": undefined,
       "$eve.type": "turn",
       "$eve.parent": "wrun_session_123",
       "$eve.root": "wrun_session_123",
@@ -258,5 +302,40 @@ describe("buildTurnAttributes", () => {
     });
 
     expect(attrs["$eve.channel_request_id"]).toBe("req_turn");
+  });
+
+  it("emits $eve.trace_id from a sampled trace seed", () => {
+    const attrs = buildTurnAttributes({
+      parentSessionId: "wrun_session_123",
+      rootSessionId: "wrun_session_123",
+      serializedContext: {
+        ...slackChannelCtx,
+        "eve.sessionTraceSeed": { spanId: "c".repeat(16), traceFlags: 1, traceId: "d".repeat(32) },
+      },
+    });
+
+    expect(attrs["$eve.trace_id"]).toBe("d".repeat(32));
+  });
+});
+
+describe("readSessionTraceId", () => {
+  it("returns the trace id from a sampled seed", () => {
+    expect(
+      readSessionTraceId({
+        "eve.sessionTraceSeed": { spanId: "a".repeat(16), traceFlags: 1, traceId: "b".repeat(32) },
+      }),
+    ).toBe("b".repeat(32));
+  });
+
+  it("returns undefined for an unsampled seed", () => {
+    expect(
+      readSessionTraceId({
+        "eve.sessionTraceSeed": { spanId: "a".repeat(16), traceFlags: 0, traceId: "b".repeat(32) },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when no seed is present", () => {
+    expect(readSessionTraceId({})).toBeUndefined();
   });
 });

--- a/packages/eve/src/execution/eve-workflow-attributes.ts
+++ b/packages/eve/src/execution/eve-workflow-attributes.ts
@@ -26,10 +26,14 @@
  * - `$eve.invocation_token` — channel-local continuation token for an external invocation
  * - `$eve.invocation_owner` — SHA-256 fingerprint of the invocation's initiating principal
  * - `$eve.is_trace_content_visible` — whether observability may read content-bearing workflow data
+ * - `$eve.trace_id` — trace id of the `agent.session` span, read from the pre-allocated
+ *   trace seed in the serialized context. Present only when the trace is sampled;
+ *   absence means no exported OTEL trace exists.
  */
 
-import { ChannelRequestIdKey } from "#context/keys.js";
+import { ChannelRequestIdKey, type SessionTraceSeed } from "#context/keys.js";
 import { shouldCaptureInstrumentationContent } from "#harness/instrumentation/content-policy.js";
+import { isSampledTrace } from "#tracing/sampled-trace.js";
 import type { EveAttributeValue } from "#runtime/attributes/normalize.js";
 import { normalizeChannelAudience } from "#shared/channel-audience.js";
 import { isNonEmptyString } from "#shared/guards.js";
@@ -86,6 +90,12 @@ export function readChannelKind(serializedContext: Record<string, unknown>): str
 export function isWorkflowTraceContentVisible(serializedContext: Record<string, unknown>): boolean {
   const channel = serializedContext["eve.channel"] as SerializedChannelAdapter | undefined;
   return shouldCaptureInstrumentationContent(normalizeChannelAudience(channel?.audience));
+}
+
+export function readSessionTraceId(serializedContext: Record<string, unknown>): string | undefined {
+  const seed = serializedContext["eve.sessionTraceSeed"] as SessionTraceSeed | undefined;
+  if (seed === undefined || !isSampledTrace(seed)) return undefined;
+  return isNonEmptyString(seed.traceId) ? seed.traceId : undefined;
 }
 
 /**
@@ -222,6 +232,7 @@ export function buildSessionAttributes(input: {
   return {
     "$eve.channel_request_id": readChannelRequestId(input.serializedContext),
     "$eve.is_trace_content_visible": isTraceContentVisible,
+    "$eve.trace_id": readSessionTraceId(input.serializedContext),
     "$eve.type": "session",
     "$eve.trigger": readChannelKind(input.serializedContext),
     "$eve.title": isTraceContentVisible ? deriveSessionTitle(input.inputMessage) : undefined,
@@ -248,6 +259,7 @@ export function buildSubagentRootAttributes(input: {
   return {
     "$eve.channel_request_id": readChannelRequestId(input.serializedContext),
     "$eve.is_trace_content_visible": isWorkflowTraceContentVisible(input.serializedContext),
+    "$eve.trace_id": readSessionTraceId(input.serializedContext),
     "$eve.type": "subagent",
     "$eve.parent": input.parentSessionId,
     "$eve.parent_call": input.parentCallId,
@@ -277,6 +289,7 @@ export function buildTurnAttributes(input: {
   return {
     "$eve.channel_request_id": input.requestId,
     "$eve.is_trace_content_visible": isWorkflowTraceContentVisible(input.serializedContext),
+    "$eve.trace_id": readSessionTraceId(input.serializedContext),
     "$eve.type": "turn",
     "$eve.parent": input.parentSessionId,
     "$eve.root": input.rootSessionId,

--- a/packages/eve/src/tracing/sampled-trace.ts
+++ b/packages/eve/src/tracing/sampled-trace.ts
@@ -1,9 +1,12 @@
-import { TraceFlags, type SpanContext } from "#compiled/@opentelemetry/api/index.js";
 import type { ChannelAudience } from "#shared/channel-audience.js";
 import type { TraceCapturePolicy } from "#tracing/otel-declaration.js";
 
-export function isSampledTrace(context: Pick<SpanContext, "traceFlags">): boolean {
-  return (context.traceFlags & TraceFlags.SAMPLED) === TraceFlags.SAMPLED;
+// W3C sampled flag; written as a literal so this module stays out of the
+// vendored OTel chunk, which the workflow driver bundle cannot include.
+const TRACE_FLAGS_SAMPLED = 0x01;
+
+export function isSampledTrace(context: { readonly traceFlags: number }): boolean {
+  return (context.traceFlags & TRACE_FLAGS_SAMPLED) === TRACE_FLAGS_SAMPLED;
 }
 
 export function evaluateTracePolicy(


### PR DESCRIPTION
### Summary

Workflow views need a direct way to open the corresponding OpenTelemetry agent trace. This adds `$eve.trace_id` to session, subagent, and turn workflow rows whenever a sampled agent trace is available.

Consumers can use the attribute to select the OpenTelemetry trace directly. When it is absent, they can continue using the workflow-based trace. Audience-based content visibility is unchanged.

### Validation

Regression coverage verifies `$eve.trace_id` on session, subagent, and turn rows, and verifies that the attribute is withheld when the trace is unsampled or unavailable. Typecheck, lint, formatting, invariant checks, documentation checks, and 7,055 unit tests passed.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+6 / -0`

Documents the workflow-to-trace correlation attribute and records it for release notes.

**Implementation** — 1 file · `+14 / -1`

Adds `$eve.trace_id` to the workflow attributes used by session, subagent, and turn rows.

**Tests** — 1 file · `+79 / -0`

Covers sampled, unsampled, and unavailable trace contexts across workflow row types.
