### PR TITLE
research: extract eve registry service

### DIFF
--- a/research/registry-service-extraction.md
+++ b/research/registry-service-extraction.md
@@ -1,0 +1,205 @@
+---
+issue: TBD
+status: proposed
+last_updated: "2026-08-21"
+---
+
+# Registry service extraction
+
+## Goal
+
+Give registry discovery one eve-owned implementation that can be reused by:
+
+- `eve registry list/search/view`;
+- `eve add`;
+- the dev TUI's `/add` flow; and
+- `@eve/self-modification` discovery.
+
+The immediate public need is read-only discovery. `@eve/self-modification` is a
+separately published package, so it needs a narrow `eve/registry` entrypoint
+rather than a private CLI import or its own parser for the official index.
+
+Installation remains an internal eve capability in this phase. The CLI, TUI,
+and a development-mode agent action can share it without publishing a general
+project-mutation API. A production self-modification executor may create a need
+for a public mutation API later, but that API should be designed with the
+production executor rather than anticipated here.
+
+This extraction is not required for the initial guided self-modification
+handoff. Until it lands, self-modification can search the official index and ask
+the developer to type `/add <address>` manually. See
+[`selfmod-development-setup-actions.md`](./selfmod-development-setup-actions.md).
+
+## Current architecture
+
+Most registry behavior lives in
+`packages/eve/src/cli/commands/registry.ts`. Despite exporting TypeScript
+functions within the repository, that module is private because no `eve`
+package export reaches it.
+
+The module currently combines:
+
+1. address and source resolution for the official registry, configured
+   namespaces, direct URLs, the built-in skills registry, and the development
+   official-registry override;
+2. multi-registry search, partial errors, metadata enrichment, sorting, and
+   limits;
+3. manifest interpretation, component selection, eve version requirements, and
+   setup metadata;
+4. project mutation through the vendored shadcn registry client; and
+5. CLI-specific prompting, logging, NDJSON, terminal detection, and exit state.
+
+The setup flow and package helpers add TUI rendering, confirmation, setup fact
+aggregation, project preparation, and deployment follow-up.
+
+The vendored registry client currently exposes address-oriented operations:
+
+```ts
+searchRegistries(sources, options);
+getRegistryItems(addresses, options);
+addRegistryItems(addresses, options);
+```
+
+These are internal implementation details and must not be re-exported from
+`eve/registry`. In particular, `addRegistryItems` means “install these addressed
+items into a project”; it does not publish an item to a registry.
+
+## Proposed boundary
+
+### Public `eve/registry` API
+
+The initial public API is read-only and serves the concrete cross-package use
+case:
+
+```ts
+import { searchRegistryItems } from "eve/registry";
+
+const result = await searchRegistryItems({
+  appRoot,
+  query: "browser",
+  category: "extension",
+  limit: 10,
+  signal,
+});
+```
+
+The exact names can be finalized during implementation, but the entrypoint
+should expose an eve-owned result containing only the fields discovery needs:
+canonical address, title, description, category, and package component
+summaries. It must not expose vendored shadcn types, raw manifests, configured
+headers or parameters, CLI logging, terminal state, or mutable process state.
+
+The self-modification caller searches the official registry only. Internally,
+the same search implementation also supports the configured and URL sources
+needed by existing CLI and TUI behavior. Public support for selecting arbitrary
+sources should be added only when an external caller needs it.
+
+Search remains bounded, preserves partial results when one source fails, and
+validates malformed catalog entries at the boundary. Category matching includes
+package components so that a package can match a channel or extension search.
+
+### Internal registry operations
+
+Internal modules own the shared behavior needed to:
+
+- read registry configuration and compose built-in sources;
+- resolve canonical addresses without confusing configured or URL sources with
+  eve's official source;
+- search catalogs and normalize partial failures;
+- load and validate manifests and package components;
+- inspect the files, dependencies, environment variable names, and setup
+  declared by an item; and
+- install an inspected item and run eligible setup through an explicit caller
+  policy.
+
+Callers continue to own interaction and authorization concerns:
+
+- the CLI owns flags, prompts, logging, NDJSON, and exit codes;
+- `/add` owns browsing, confirmation, exclusive terminal use, host refresh,
+  add-more behavior, and deployment follow-up;
+- the development agent-action executor owns capability checks, request
+  correlation, HITL approval, project-mutation locking, and model resumption;
+- all callers choose the application root and authorize mutation before
+  installation.
+
+The shared implementation may use an internal inspect/apply split because a UI
+must show an item before installing it. That split is not a public API
+commitment.
+
+## Source and trust rules
+
+Source identity is an internal security and presentation concern, not a claim
+about who authored an integration's npm package. Items in eve's catalog may
+integrate third-party products while still being official-source items.
+
+Preserve these existing rules:
+
+- relative official addresses resolve through eve's trusted official source;
+- configured namespaces resolve through project registry configuration;
+- direct URLs remain visibly non-official;
+- configured headers and URL parameters never appear in results, model context,
+  errors, or durable events; and
+- only manifests resolved from eve's trusted official source may declare
+  executable eve setup behavior or registry packages.
+
+CLI and TUI presentation still needs a safe source label so developers can see
+what they are about to install. The initial public self-modification search does
+not need a general `RegistrySourceSummary` union because it is official-only.
+
+## Development agent-initiated add
+
+The first mutation use case outside the existing commands is development mode,
+where an agent asks the connected eve host to add a known registry address. The
+agent must not receive a filesystem mutation API or call the vendored installer
+directly.
+
+The intended flow is:
+
+1. The model invokes a framework-owned add action with a registry address.
+2. The harness accepts it only when the session advertises a local registry-add
+   capability and records a correlated pending request.
+3. The TUI resolves and inspects the item through the internal registry
+   implementation.
+4. The TUI shows the source and expected effects and obtains confirmation that
+   the model cannot answer. Initial releases should require approval for every
+   item.
+5. On approval, the TUI acquires the existing project-mutation boundary,
+   installs through the same internal primitive as `/add`, runs any eligible
+   interactive setup, refreshes the development host, and settles the pending
+   tool call.
+6. On rejection or cancellation, no installation begins and the tool call is
+   settled with that outcome.
+
+Clients without this capability retain the guided handoff: self-modification
+returns an exact `/add <address>` command for the local TUI or an
+`eve add <address>` command for the project terminal.
+
+The inspected item and the installed item should be the same content. The
+current vendored `addRegistryItems` operation resolves an address again, so it
+cannot by itself guarantee this. Before enabling direct agent-initiated
+installation, perform a focused spike to determine whether the vendored
+boundary can apply already-resolved content. If not, keep the guided `/add`
+handoff until eve owns the minimal installer seam required to preserve the
+approval boundary. The serialization format, hashing scheme, closure limits,
+and public plan shape are deliberately deferred.
+
+Installation remains non-transactional, as `eve add` is today. Development
+callers should report partial failure clearly and refresh or restart the host
+from known state. Transactional installation is not part of this extraction.
+
+## Completion criteria
+
+This extraction is complete when:
+
+- registry search and manifest semantics have one implementation;
+- `eve registry`, `eve add`, and `/add` are adapters over shared internal
+  operations;
+- `@eve/self-modification` uses the public read-only entrypoint instead of
+  parsing the official catalog itself;
+- source credentials and vendored registry types cannot cross the public or
+  model-facing boundary;
+- setup remains restricted to trusted official-source items;
+- the development action either installs the exact inspected content after HITL
+  approval or remains on the guided `/add` fallback; and
+- no public project-mutation API is introduced without a concrete external
+  executor.

--- a/research/registry-service-extraction.md
+++ b/research/registry-service-extraction.md
@@ -8,36 +8,38 @@ last_updated: "2026-08-21"
 
 ## Goal
 
-Give registry discovery one eve-owned implementation that can be reused by:
+Make the existing registry commands equally useful to humans and agents while
+removing duplicated registry behavior from the CLI, dev TUI, and
+`@eve/self-modification`.
 
-- `eve registry list/search/view`;
-- `eve add`;
-- the dev TUI's `/add` flow; and
-- `@eve/self-modification` discovery.
+The supported public interface remains the command surface:
 
-The immediate public need is read-only discovery. `@eve/self-modification` is a
-separately published package, so it needs a narrow `eve/registry` entrypoint
-rather than a private CLI import or its own parser for the official index.
+```sh
+eve registry list --json
+eve registry search <query> --json
+eve registry view <item> --json
+eve add <item> --non-interactive
+```
 
-Installation remains an internal eve capability in this phase. The CLI, TUI,
-and a development-mode agent action can share it without publishing a general
-project-mutation API. A production self-modification executor may create a need
-for a public mutation API later, but that API should be designed with the
-production executor rather than anticipated here.
+An agent with project command access should invoke these commands just as a
+human does. A constrained agent without host command access can request the same
+operation through a host capability, but that capability should adapt the
+existing command behavior rather than introduce a second registry API.
 
-This extraction is not required for the initial guided self-modification
-handoff. Until it lands, self-modification can search the official index and ask
-the developer to type `/add <address>` manually. See
+The extraction in this proposal is therefore internal. It does not add an
+`eve/registry` package export or a public TypeScript mutation API. A future
+production executor may reveal a need for one, but the command interface should
+be tried first and any new API should be designed with that concrete executor.
+
+The initial self-modification flow does not depend on this extraction. It can
+search the official index and ask the developer to run `/add <address>` or
+`eve add <address>` manually. See
 [`selfmod-development-setup-actions.md`](./selfmod-development-setup-actions.md).
 
 ## Current architecture
 
 Most registry behavior lives in
-`packages/eve/src/cli/commands/registry.ts`. Despite exporting TypeScript
-functions within the repository, that module is private because no `eve`
-package export reaches it.
-
-The module currently combines:
+`packages/eve/src/cli/commands/registry.ts`. It combines:
 
 1. address and source resolution for the official registry, configured
    namespaces, direct URLs, the built-in skills registry, and the development
@@ -50,9 +52,14 @@ The module currently combines:
 5. CLI-specific prompting, logging, NDJSON, terminal detection, and exit state.
 
 The setup flow and package helpers add TUI rendering, confirmation, setup fact
-aggregation, project preparation, and deployment follow-up.
+aggregation, project preparation, and deployment follow-up. A separate
+self-modification catalog parser would duplicate the first three
+responsibilities.
 
-The vendored registry client currently exposes address-oriented operations:
+## Thin wrapper over shadcn registries
+
+eve uses the shadcn registry protocol and vendored client. The client already
+provides the core address-oriented operations:
 
 ```ts
 searchRegistries(sources, options);
@@ -60,71 +67,77 @@ getRegistryItems(addresses, options);
 addRegistryItems(addresses, options);
 ```
 
-These are internal implementation details and must not be re-exported from
-`eve/registry`. In particular, `addRegistryItems` means “install these addressed
-items into a project”; it does not publish an item to a registry.
+The extracted code should remain a thin eve-specific wrapper around those
+operations. eve needs to add only the behavior the generic client cannot know:
 
-## Proposed boundary
+- built-in and project registry configuration;
+- official-source classification;
+- eve metadata, version requirements, and package components;
+- official-only setup eligibility;
+- project preparation required by eve items; and
+- adaptation to CLI, TUI, and agent interaction.
 
-### Public `eve/registry` API
+Do not introduce a generic registry provider interface, a parallel manifest
+model, a serializable installation plan, a transaction layer, or an eve-owned
+installer without a demonstrated requirement. Vendored shadcn types remain
+behind the internal boundary, but eve-owned internal types should normalize
+only the fields its callers actually use.
 
-The initial public API is read-only and serves the concrete cross-package use
-case:
+`addRegistryItems` means “install these addressed items into a project”; it does
+not publish an item to a registry and is not a proposed public eve API.
 
-```ts
-import { searchRegistryItems } from "eve/registry";
+## Shared internal boundary
 
-const result = await searchRegistryItems({
-  appRoot,
-  query: "browser",
-  category: "extension",
-  limit: 10,
-  signal,
-});
+Extract the smallest helpers needed to give every adapter the same behavior:
+
+- resolve official, configured, skills, and direct-URL addresses;
+- search registries and normalize partial source failures;
+- load manifests and interpret eve-specific metadata;
+- select and expand package components;
+- enforce eve version and setup trust rules; and
+- install through the vendored client.
+
+Keep interaction at the edges:
+
+- `eve registry` owns command arguments and human or JSON presentation;
+- `eve add` owns flags, prompts, NDJSON, and exit codes;
+- `/add` owns browsing, confirmation, exclusive terminal use, host refresh,
+  add-more behavior, and deployment follow-up; and
+- a development agent executor owns capability checks, request correlation,
+  mandatory approval, mutation locking, and model resumption.
+
+Internal extraction is justified only where two adapters otherwise implement
+the same registry semantics. Do not reshape working CLI code merely to produce
+a service-shaped layer.
+
+## Human and agent command parity
+
+The registry CLI is the machine interface as well as the human interface.
+Machine-readable modes must cover the same useful operations:
+
+- list and search return bounded structured results and per-source failures;
+- view returns the resolved item needed to make an installation decision;
+- add runs without interactive prompts under `--non-interactive` and reports a
+  stable terminal outcome, including missing answers or prerequisites; and
+- exit codes distinguish success, failure, and required input.
+
+The agent documentation should teach this sequence rather than a package API:
+
+```sh
+eve registry search browser --json
+eve registry view extension/agent-browser --json
+eve add extension/agent-browser --non-interactive
 ```
 
-The exact names can be finalized during implementation, but the entrypoint
-should expose an eve-owned result containing only the fields discovery needs:
-canonical address, title, description, category, and package component
-summaries. It must not expose vendored shadcn types, raw manifests, configured
-headers or parameters, CLI logging, terminal state, or mutable process state.
+This keeps discovery and installation coverage aligned: improvements to the
+commands benefit both humans and agents, and agents do not need a private parser
+or a separately maintained set of registry tools.
 
-The self-modification caller searches the official registry only. Internally,
-the same search implementation also supports the configured and URL sources
-needed by existing CLI and TUI behavior. Public support for selecting arbitrary
-sources should be added only when an external caller needs it.
-
-Search remains bounded, preserves partial results when one source fails, and
-validates malformed catalog entries at the boundary. Category matching includes
-package components so that a package can match a channel or extension search.
-
-### Internal registry operations
-
-Internal modules own the shared behavior needed to:
-
-- read registry configuration and compose built-in sources;
-- resolve canonical addresses without confusing configured or URL sources with
-  eve's official source;
-- search catalogs and normalize partial failures;
-- load and validate manifests and package components;
-- inspect the files, dependencies, environment variable names, and setup
-  declared by an item; and
-- install an inspected item and run eligible setup through an explicit caller
-  policy.
-
-Callers continue to own interaction and authorization concerns:
-
-- the CLI owns flags, prompts, logging, NDJSON, and exit codes;
-- `/add` owns browsing, confirmation, exclusive terminal use, host refresh,
-  add-more behavior, and deployment follow-up;
-- the development agent-action executor owns capability checks, request
-  correlation, HITL approval, project-mutation locking, and model resumption;
-- all callers choose the application root and authorize mutation before
-  installation.
-
-The shared implementation may use an internal inspect/apply split because a UI
-must show an item before installing it. That split is not a public API
-commitment.
+`@eve/self-modification` runs in a deliberately constrained sandbox, so it may
+not always have permission to execute the project CLI. In that environment it
+either returns the exact command for the developer or submits a constrained
+host request representing the same registry operation. The package does not
+need to import private CLI modules or a new `eve/registry` export.
 
 ## Source and trust rules
 
@@ -132,74 +145,89 @@ Source identity is an internal security and presentation concern, not a claim
 about who authored an integration's npm package. Items in eve's catalog may
 integrate third-party products while still being official-source items.
 
-Preserve these existing rules:
+Preserve the current rules:
 
 - relative official addresses resolve through eve's trusted official source;
 - configured namespaces resolve through project registry configuration;
 - direct URLs remain visibly non-official;
-- configured headers and URL parameters never appear in results, model context,
+- configured headers and URL parameters never appear in output, model context,
   errors, or durable events; and
 - only manifests resolved from eve's trusted official source may declare
   executable eve setup behavior or registry packages.
 
-CLI and TUI presentation still needs a safe source label so developers can see
-what they are about to install. The initial public self-modification search does
-not need a general `RegistrySourceSummary` union because it is official-only.
+Human and JSON output need only enough safe source information to explain where
+an item came from. This proposal does not introduce a public source identity
+type.
 
 ## Development agent-initiated add
 
-The first mutation use case outside the existing commands is development mode,
-where an agent asks the connected eve host to add a known registry address. The
-agent must not receive a filesystem mutation API or call the vendored installer
-directly.
+An agent with ordinary project shell authority can run
+`eve add <item> --non-interactive` directly. The special development flow is for
+a constrained agent that can request an add but cannot mutate the host project
+or approve its own request.
 
 The intended flow is:
 
-1. The model invokes a framework-owned add action with a registry address.
-2. The harness accepts it only when the session advertises a local registry-add
-   capability and records a correlated pending request.
-3. The TUI resolves and inspects the item through the internal registry
-   implementation.
-4. The TUI shows the source and expected effects and obtains confirmation that
-   the model cannot answer. Initial releases should require approval for every
-   item.
-5. On approval, the TUI acquires the existing project-mutation boundary,
-   installs through the same internal primitive as `/add`, runs any eligible
-   interactive setup, refreshes the development host, and settles the pending
-   tool call.
-6. On rejection or cancellation, no installation begins and the tool call is
-   settled with that outcome.
+1. The model requests the semantic equivalent of `eve add <address>` through a
+   local capability.
+2. The harness accepts it only for a connected development session and records
+   a correlated pending request.
+3. The TUI resolves and displays the item through the same internal operations
+   used by `eve registry view` and `/add`.
+4. The TUI obtains approval that the model cannot answer. Initial releases
+   require approval for every item.
+5. On approval, the TUI acquires the existing project-mutation boundary and
+   executes the same installation and setup behavior as `eve add`/`/add`, then
+   refreshes the development host and settles the tool call.
+6. Rejection or cancellation settles the request without beginning
+   installation.
 
-Clients without this capability retain the guided handoff: self-modification
-returns an exact `/add <address>` command for the local TUI or an
-`eve add <address>` command for the project terminal.
+This capability is a transport and approval adapter for the command operation,
+not a new general registry tool. It must not accept arbitrary commands, host
+paths, or package-manager arguments. Clients without the capability retain the
+manual `/add <address>` or `eve add <address>` handoff.
 
-The inspected item and the installed item should be the same content. The
-current vendored `addRegistryItems` operation resolves an address again, so it
-cannot by itself guarantee this. Before enabling direct agent-initiated
-installation, perform a focused spike to determine whether the vendored
-boundary can apply already-resolved content. If not, keep the guided `/add`
-handoff until eve owns the minimal installer seam required to preserve the
-approval boundary. The serialization format, hashing scheme, closure limits,
-and public plan shape are deliberately deferred.
+The development flow should preserve the same installation semantics and
+limitations as an equivalent human invocation, including non-transactional
+partial failure. Stronger content-integrity, rollback, or sandbox policy should
+not be added solely as part of this extraction.
 
-Installation remains non-transactional, as `eve add` is today. Development
-callers should report partial failure clearly and refresh or restart the host
-from known state. Transactional installation is not part of this extraction.
+## Future production flow
+
+A production executor would run against an isolated proposal checkout without a
+connected TUI. Start by evaluating whether the existing machine-oriented
+commands can provide the required behavior: structured discovery,
+noninteractive installation with setup skipped, useful exit outcomes, and a
+diff that the executor validates independently.
+
+Only add a public `eve/registry` TypeScript API if the production design exposes
+a concrete requirement that the CLI cannot satisfy, such as retaining resolved
+content across a durable approval boundary. Production authorization,
+sandboxing, egress, integrity, lifecycle-script policy, rollback, and pull
+request publication belong to that future design.
+
+## Validation
+
+- Characterize official, configured, skills, and direct-URL behavior before
+  moving shared helpers.
+- Cover JSON list, search, and view output as agent-facing command contracts.
+- Cover noninteractive add success, required input, continuation, cancellation,
+  and failure outcomes.
+- Preserve package component, eve version, official-only setup, and TUI
+  confirmation behavior.
+- Add development action coverage proving that the model cannot approve its own
+  request and that approval reaches the same add implementation.
 
 ## Completion criteria
 
 This extraction is complete when:
 
-- registry search and manifest semantics have one implementation;
-- `eve registry`, `eve add`, and `/add` are adapters over shared internal
-  operations;
-- `@eve/self-modification` uses the public read-only entrypoint instead of
-  parsing the official catalog itself;
-- source credentials and vendored registry types cannot cross the public or
-  model-facing boundary;
-- setup remains restricted to trusted official-source items;
-- the development action either installs the exact inspected content after HITL
-  approval or remains on the guided `/add` fallback; and
-- no public project-mutation API is introduced without a concrete external
-  executor.
+- humans and agents use the same documented registry command surface;
+- registry source, search, manifest, and installation semantics are not
+  reimplemented by each adapter;
+- `eve registry`, `eve add`, and `/add` preserve their existing behavior;
+- constrained self-modification uses a command handoff or host adapter instead
+  of a private catalog parser;
+- the internal layer remains a thin wrapper over the vendored shadcn client; and
+- no public TypeScript registry API or additional installation abstraction is
+  introduced without a concrete caller.


### PR DESCRIPTION
### Summary

This proposes making `eve registry` and `eve add` the shared public interface for humans and agents, with machine-readable modes covering discovery and noninteractive installation. Constrained agents without host command access use a capability adapter for the same operation, including development-mode HITL approval, rather than a separate registry API. The internal extraction remains a thin eve-specific wrapper over the vendored shadcn registry client, while a public TypeScript API and production-specific guarantees are deferred until a concrete executor requires them.

Review should focus on whether the command surface provides sufficient agent coverage and whether the proposed internal boundary adds only eve-specific behavior.

### Validation

No tests were run because this is a research-only change; the branch diff passes whitespace validation.

### Checklist

- [x] This change was requested or approved by a maintainer
- [ ] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+233 / -0`

Adds the focused research proposal covering command parity, shared internal registry behavior, development approval, and deferred production concerns.

**Implementation** — 0 files · `+0 / -0`

Not applicable.

**Tests** — 0 files · `+0 / -0`

Not applicable for a research-only proposal.
