### PR TITLE
feat(web): render streamed chat markdown via `streamdown`

### DIFF
--- a/apps/frameworks/next/app/_chat/App.tsx
+++ b/apps/frameworks/next/app/_chat/App.tsx
@@ -2,15 +2,29 @@
 
 import { useEveAgent } from "eve/react";
 import { type FormEvent, type JSX, useEffect, useMemo, useRef, useState } from "react";
+import { type Components, Streamdown } from "streamdown";
 
 import { traceReducer } from "./trace-reducer";
-import { resolveTurnFailureMessage, shouldRenderAssistantTurn } from "./turn-content";
+import {
+  resolveTurnAssistantMessage,
+  resolveTurnFailureMessage,
+  shouldRenderAssistantTurn,
+} from "./turn-content";
 import type { TraceTurn } from "./types";
+
+const streamdownComponents = {
+  img: () => null,
+} satisfies Components;
 
 function ConversationSection(props: {
   readonly isSending: boolean;
   readonly turns: readonly TraceTurn[];
 }) {
+  const activeTurnId = props.isSending ? props.turns.at(-1)?.turnId : undefined;
+  const hasStreamingAssistantText = props.turns.some(
+    (turn) => turn.turnId === activeTurnId && resolveTurnAssistantMessage(turn) !== undefined,
+  );
+
   return (
     <ul className="chat-feed">
       {props.turns.flatMap((turn) => {
@@ -30,21 +44,37 @@ function ConversationSection(props: {
           return rendered;
         }
 
-        const assistantText = turn.assistantMessage ?? resolveTurnFailureMessage(turn) ?? "";
+        const assistantText =
+          resolveTurnAssistantMessage(turn) ?? resolveTurnFailureMessage(turn) ?? "";
+        const isStreaming = turn.turnId === activeTurnId;
         rendered.push(
           <li
             className={`chat-row role-assistant${turn.status === "failed" ? " variant-error" : ""}`}
             key={`${turn.turnId}:assistant`}
           >
             <div className="chat-bubble-stack">
-              <div className="chat-bubble">{assistantText}</div>
+              <div className="chat-bubble">
+                {turn.status === "failed" ? (
+                  assistantText
+                ) : (
+                  <Streamdown
+                    animated
+                    components={streamdownComponents}
+                    isAnimating={isStreaming}
+                    mode={isStreaming ? "streaming" : "static"}
+                    skipHtml
+                  >
+                    {assistantText}
+                  </Streamdown>
+                )}
+              </div>
             </div>
           </li>,
         );
 
         return rendered;
       })}
-      {props.isSending ? (
+      {props.isSending && !hasStreamingAssistantText ? (
         <li className="chat-row role-assistant pending">
           <div className="chat-bubble">Thinking…</div>
         </li>

--- a/apps/frameworks/next/app/_chat/turn-content.ts
+++ b/apps/frameworks/next/app/_chat/turn-content.ts
@@ -73,6 +73,25 @@ function readMessageFromCompletedEvent(event: { readonly data?: unknown }): stri
 }
 
 /**
+ * Resolves the latest assistant text, including a response that is still
+ * streaming and has not emitted `message.completed` yet.
+ */
+export function resolveTurnAssistantMessage(turn: TraceTurn): string | undefined {
+  if (typeof turn.assistantMessage === "string" && turn.assistantMessage.length > 0) {
+    return turn.assistantMessage;
+  }
+
+  for (let index = turn.steps.length - 1; index >= 0; index -= 1) {
+    const responseText = turn.steps[index]?.responseText;
+    if (typeof responseText === "string" && responseText.length > 0) {
+      return responseText;
+    }
+  }
+
+  return undefined;
+}
+
+/**
  * Resolves the most useful assistant-facing failure text for a turn when no
  * normal assistant message was completed.
  */
@@ -102,7 +121,7 @@ export function resolveTurnFailureMessage(turn: TraceTurn): string | undefined {
  * for the provided turn.
  */
 export function shouldRenderAssistantTurn(turn: TraceTurn): boolean {
-  if (typeof turn.assistantMessage === "string" && turn.assistantMessage.length > 0) {
+  if (resolveTurnAssistantMessage(turn) !== undefined) {
     return true;
   }
 

--- a/apps/frameworks/next/app/globals.css
+++ b/apps/frameworks/next/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@source "../node_modules/streamdown/dist/*.js";
 
 :root {
   --background: #ffffff;
@@ -7,7 +8,13 @@
 
 @theme inline {
   --color-background: var(--background);
+  --color-border: var(--border);
   --color-foreground: var(--foreground);
+  --color-muted: var(--bg-hover);
+  --color-muted-foreground: var(--fg-muted);
+  --color-primary: var(--fg);
+  --color-primary-foreground: var(--fg-on-inverted);
+  --color-sidebar: var(--bg-subtle);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }

--- a/apps/frameworks/next/app/layout.tsx
+++ b/apps/frameworks/next/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import "streamdown/styles.css";
 import "./globals.css";
 
 const geistSans = Geist({

--- a/apps/frameworks/next/package.json
+++ b/apps/frameworks/next/package.json
@@ -19,6 +19,7 @@
     "next": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
+    "streamdown": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -441,6 +441,9 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 19.2.6(react@19.2.6)
+      streamdown:
+        specifier: 'catalog:'
+        version: 2.5.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@10.2.2)
       zod:
         specifier: 'catalog:'
         version: 4.4.3


### PR DESCRIPTION
### Summary

The Next.js eve web chat currently displays assistant output as plain text and waits for the completed message before showing it. This adopts Streamdown so partial responses render as safe, animated Markdown while they stream, then settle into static rendering without reanimating older turns on follow-up messages.

Raw HTML and Markdown images remain disabled for model output, while Streamdown's default link confirmation remains enabled.

**Before**

https://github.com/user-attachments/assets/6f6e7612-a699-4ca3-9885-c20c63cc527d

**After**

https://github.com/user-attachments/assets/6fd940fe-eeed-47a7-bc5b-99011e12013c

### Validation

Validated with the framework app's TypeScript check and a successful production Next.js build. No automated test was added because this demo app does not currently have a component-test setup.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [ ] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

Tests, documentation, and a changeset are not applicable to this private framework demo change.

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 6 files · `+66 / -5`

Adds Streamdown rendering, streaming-state handling, security and theme configuration, and the workspace dependency lock entry.

**Tests** — 0 files · `+0 / -0`

Not applicable; the framework demo has no existing component-test setup.
