### PR TITLE
fix(eve): park parents after task admission

### DIFF
--- a/.changeset/park-task-admission.md
+++ b/.changeset/park-task-admission.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Park receipt-only parent turns as soon as their background tasks are admitted, then let task notifications resume the parent without requiring a user-visible channel message. Mixed steps with synchronous results or dispatch failures still continue immediately.

--- a/e2e/fixtures/fixture-tasks/agent/agent.ts
+++ b/e2e/fixtures/fixture-tasks/agent/agent.ts
@@ -94,6 +94,7 @@ function respond(request: MockModelRequest): MockModelResponse | string {
   if (message === "TASK-FANOUT-PARENT-UPDATES") return fanoutTasks(request, 10);
   if (message === "TASK-PARENT-WAKE-UPDATES") return fanoutTasks(request, 3);
   if (message === REDUNDANT_REVIEW_SCENARIO) return startRedundantReviewers(request);
+  if (message === "TASK-DISPATCH-PARKS-PARENT") return startParentParkWorker(request);
   if (message === "TASK-FAN-IN") return fanInTasks(request);
   if (message === "TASK-UPDATE-SETUP") return startTaskUpdateChild(request);
   if (message === "TASK-CANCEL-SETUP") return setupCancelWorker(request);
@@ -238,6 +239,21 @@ function latestTaskState(messages: readonly string[]): TaskState | undefined {
     throw new Error("Invalid task state supplied to the model.");
   }
   return parsed as TaskState;
+}
+
+function startParentParkWorker(request: MockModelRequest): MockModelResponse | string {
+  if (resultById(request, "task-parent-park-worker") === undefined) {
+    return {
+      toolCalls: [
+        {
+          id: "task-parent-park-worker",
+          input: { message: "BUSY-WORKER-A TASK-DISPATCH-PARKS-CHILD" },
+          name: "busy-worker",
+        },
+      ],
+    };
+  }
+  return "TASK-DISPATCH-PARENT-RAN-AFTER-RECEIPT";
 }
 
 function sendTaskUpdate(request: MockModelRequest): MockModelResponse | string {

--- a/e2e/fixtures/fixture-tasks/evals/task-transition.ts
+++ b/e2e/fixtures/fixture-tasks/evals/task-transition.ts
@@ -266,7 +266,12 @@ export const TASK_TRANSITIONS = {
     guards: ["child-acknowledges-private-address"],
     expected: {
       outcome: "accepted",
-      postState: { lifecycle: "working", dispatch: "acknowledged", ownership: "owned" },
+      postState: {
+        lifecycle: "working",
+        dispatch: "acknowledged",
+        ownership: "owned",
+        parent: "parked",
+      },
       events: { emitted: ["background-receipt"] },
       sideEffects: { executed: ["child-dispatch", "task-index-write"] },
     },

--- a/e2e/fixtures/fixture-tasks/evals/task.agent.continue.rejected-agent-busy.eval.ts
+++ b/e2e/fixtures/fixture-tasks/evals/task.agent.continue.rejected-agent-busy.eval.ts
@@ -22,7 +22,6 @@ export default defineTaskEval({
   async test(t) {
     const setup = await t.send("CHILD-TASK-EXCLUSIVITY-SETUP");
     setup.expectOk();
-    setup.messageIncludes("CHILD-TASK-EXCLUSIVITY-READY");
     const initialTaskId = requireBackgroundTaskId(setup);
     const initial = await waitForCompletedTask(
       t,

--- a/e2e/fixtures/fixture-tasks/evals/task.authorization.callback.accepted-current-attempt.eval.ts
+++ b/e2e/fixtures/fixture-tasks/evals/task.authorization.callback.accepted-current-attempt.eval.ts
@@ -29,7 +29,6 @@ export default defineTaskEval({
   async test(t) {
     const started = await t.send("TASK-C7-AUTHORIZATION");
     started.expectOk();
-    started.messageIncludes("TASK-C7-STARTED");
     started.event("subagent.completed", {
       count: 1,
       data: { backgroundTask: { status: "working" }, subagentName: "approval-worker" },

--- a/e2e/fixtures/fixture-tasks/evals/task.dispatch.start.accepted-acknowledged.parent-parked.eval.ts
+++ b/e2e/fixtures/fixture-tasks/evals/task.dispatch.start.accepted-acknowledged.parent-parked.eval.ts
@@ -1,0 +1,48 @@
+import { satisfies } from "eve/evals/expect";
+
+import { defineTaskEval } from "./task-transition.js";
+import { requireBackgroundTaskId, requireSessionStreamIndex } from "./shared.js";
+
+/** An admitted background task yields its conversation parent until a task notification arrives. */
+export default defineTaskEval({
+  description:
+    "A background task receipt is persisted before the parent parks, without a receipt-follow-up model call.",
+  transition: {
+    primary: "task.dispatch.start.accepted-acknowledged",
+    dimensions: { transport: "local", parentPhase: "parked" },
+  },
+  async test(t) {
+    const dispatched = await t.send("TASK-DISPATCH-PARKS-PARENT");
+    dispatched.expectOk();
+    dispatched.event("step.started", { count: 1 });
+    dispatched.event("session.waiting", { count: 1 });
+    dispatched.notEvent("message.completed", {
+      data: (data) => data.finishReason !== "tool-calls",
+    });
+    await t.require(
+      dispatched.message,
+      satisfies(
+        (message) => message === undefined,
+        "task admission parks without a receipt-follow-up model message",
+      ),
+    );
+
+    const taskId = requireBackgroundTaskId(dispatched);
+    const sessionId = dispatched.sessionId;
+    const live = t.target.watchTurn(sessionId, {
+      startIndex: requireSessionStreamIndex(t, "Task completion wake"),
+    });
+    const wake = await live.result();
+
+    wake.expectOk();
+    wake.event("step.started", { count: 1 });
+    wake.eventsSatisfy("the next model call is caused by the task notification", (events) =>
+      events.some(
+        (event) =>
+          event.type === "message.received" &&
+          event.data.message.includes(`Background task ${taskId}`),
+      ),
+    );
+    t.noFailedActions();
+  },
+});

--- a/e2e/fixtures/fixture-tasks/evals/task.input.answer.accepted-complete.remote.eval.ts
+++ b/e2e/fixtures/fixture-tasks/evals/task.input.answer.accepted-complete.remote.eval.ts
@@ -21,7 +21,6 @@ export default defineTaskEval({
   async test(t) {
     const started = await t.send("TASK-C8-REMOTE-HITL");
     started.expectOk();
-    started.messageIncludes("TASK-C8-STARTED");
     started.event("subagent.completed", {
       count: 1,
       data: {

--- a/e2e/fixtures/fixture-tasks/evals/task.join.evaluate.observed-all-terminal.eval.ts
+++ b/e2e/fixtures/fixture-tasks/evals/task.join.evaluate.observed-all-terminal.eval.ts
@@ -30,7 +30,6 @@ export default defineTaskEval({
   async test(t) {
     const started = await t.send("TASK-FAN-IN");
     started.expectOk();
-    started.messageIncludes("TASK-FAN-IN-STARTED");
     started.calledSubagent("fanout-worker", { count: FAN_IN_SIZE });
 
     const tasksByMarker = backgroundTasksByMarker(started);

--- a/e2e/fixtures/fixture-tasks/evals/task.join.evaluate.observed-partial.eval.ts
+++ b/e2e/fixtures/fixture-tasks/evals/task.join.evaluate.observed-partial.eval.ts
@@ -31,7 +31,6 @@ export default defineTaskEval({
   async test(t) {
     const started = await t.send("TASK-FAN-IN");
     started.expectOk();
-    started.messageIncludes("TASK-FAN-IN-STARTED");
     started.calledSubagent("fanout-worker", { count: FAN_IN_SIZE });
 
     const tasksByMarker = backgroundTasksByMarker(started);

--- a/e2e/fixtures/fixture-tasks/evals/task.lifecycle.cancel.accepted-nonterminal.eval.ts
+++ b/e2e/fixtures/fixture-tasks/evals/task.lifecycle.cancel.accepted-nonterminal.eval.ts
@@ -20,7 +20,6 @@ export default defineTaskEval({
   async test(t) {
     const started = await t.send("TASK-CANCEL-SETUP");
     started.expectOk();
-    started.messageIncludes("TASK-CANCEL-READY");
     started.event("subagent.completed", {
       count: 1,
       data: { backgroundTask: { status: "working" }, subagentName: "fanout-worker" },

--- a/e2e/fixtures/fixture-tasks/evals/task.lifecycle.cancel.noop-already-cancelled.eval.ts
+++ b/e2e/fixtures/fixture-tasks/evals/task.lifecycle.cancel.noop-already-cancelled.eval.ts
@@ -24,7 +24,6 @@ export default defineTaskEval({
   async test(t) {
     const started = await t.send("TASK-CANCEL-SETUP");
     started.expectOk();
-    started.messageIncludes("TASK-CANCEL-READY");
     started.event("subagent.completed", {
       count: 1,
       data: { backgroundTask: { status: "working" }, subagentName: "fanout-worker" },

--- a/e2e/fixtures/fixture-tasks/evals/task.lifecycle.fail.accepted-nonterminal.eval.ts
+++ b/e2e/fixtures/fixture-tasks/evals/task.lifecycle.fail.accepted-nonterminal.eval.ts
@@ -17,7 +17,6 @@ export default defineTaskEval({
   async test(t) {
     const started = await t.send("TASK-A2-CHILD-FAILURE");
     started.expectOk();
-    started.messageIncludes("TASK-A2-CHILD-FAILURE-STARTED");
     started.event("subagent.completed", {
       count: 1,
       data: {

--- a/e2e/fixtures/fixture-tasks/evals/task.parent-interaction.send.accepted-live-children.eval.ts
+++ b/e2e/fixtures/fixture-tasks/evals/task.parent-interaction.send.accepted-live-children.eval.ts
@@ -21,7 +21,6 @@ export default defineTaskEval({
   async test(t) {
     const started = await t.send("TASK-FANOUT-PARENT-UPDATES");
     started.expectOk();
-    started.messageIncludes("TASK-FANOUT-STARTED");
     started.calledSubagent("fanout-worker", { count: FANOUT_SIZE });
 
     const taskIds = backgroundTaskIds(started);

--- a/e2e/fixtures/fixture-tasks/evals/task.parent.wake.emitted-ready.eval.ts
+++ b/e2e/fixtures/fixture-tasks/evals/task.parent.wake.emitted-ready.eval.ts
@@ -19,12 +19,11 @@ export default defineTaskEval({
       "task.input.answer.accepted-complete",
       "task.lifecycle.complete.accepted-nonterminal",
     ],
-    dimensions: { transport: "local", parentPhase: "active" },
+    dimensions: { transport: "local", parentPhase: "parked" },
   },
   async test(t) {
     const started = await t.send("TASK-PARENT-WAKE-UPDATES");
     started.expectOk();
-    started.messageIncludes("TASK-FANOUT-STARTED");
     started.calledSubagent("fanout-worker", { count: FANOUT_SIZE });
 
     const taskIds = backgroundTaskIds(started);

--- a/e2e/fixtures/fixture-tasks/evals/task.update.emitted-working.eval.ts
+++ b/e2e/fixtures/fixture-tasks/evals/task.update.emitted-working.eval.ts
@@ -15,7 +15,6 @@ export default defineTaskEval({
   async test(t) {
     const started = await t.send("TASK-UPDATE-SETUP");
     started.expectOk();
-    started.messageIncludes("TASK-UPDATE-STARTED");
     const taskId = requireBackgroundTaskId(started);
 
     const sessionId = t.sessionId;

--- a/packages/eve/src/harness/runtime-actions.test.ts
+++ b/packages/eve/src/harness/runtime-actions.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import {
   createRuntimeActionRequestFromToolCall,
   getPendingRuntimeActionBatch,
+  type PendingRuntimeActionBatch,
   resolvePendingRuntimeActions,
   resolveToolCallInputObject,
   setPendingRuntimeActionBatch,
@@ -23,9 +24,11 @@ import { getProxyInputRequests, upsertProxyInputRequests } from "#harness/proxy-
 import { getSessionTokenUsage, setTurnUsageState } from "#harness/turn-tag-state.js";
 import type { HarnessSession } from "#harness/types.js";
 import type { UnstampedMessageStreamEvent } from "#protocol/message.js";
+import type { RuntimeActionResult } from "#runtime/actions/types.js";
 
 const CHILD_SESSION_ID = "local-child-123456789012";
 const CHILD_CONTINUATION_TOKEN = "subagent:private-token";
+const TASK_ID = "task_0123456789abcdef";
 const ZERO_USAGE = {
   cacheReadTokens: 0,
   cacheWriteTokens: 0,
@@ -37,6 +40,29 @@ const OPERATION_ID = deriveAgentOperationId({
   parentSessionId: "test-session",
   parentTurnId: "turn_0",
 });
+
+function createBackgroundTaskReceipt(): Extract<
+  RuntimeActionResult,
+  { kind: "subagent-result"; origin: "child" }
+> {
+  return {
+    backgroundTask: { status: "working", taskId: TASK_ID },
+    callId: "call-1",
+    kind: "subagent-result",
+    origin: "child",
+    outcome: {
+      kind: "parked",
+      result: { kind: "succeeded", output: "delegated" },
+      usageDelta: ZERO_USAGE,
+    },
+    output: {
+      agentId: deriveAgentId("researcher", OPERATION_ID),
+      status: "working",
+      taskId: TASK_ID,
+    },
+    subagentName: "researcher",
+  };
+}
 
 describe("createRuntimeActionRequestFromToolCall", () => {
   const loadSkillCall = {
@@ -84,7 +110,10 @@ describe("createRuntimeActionRequestFromToolCall", () => {
   });
 });
 
-function createParkedSession(): HarnessSession {
+function createParkedSession(input?: {
+  readonly actions?: PendingRuntimeActionBatch["actions"];
+  readonly responseMessages?: readonly HarnessSession["history"][number][];
+}): HarnessSession {
   const base: HarnessSession = {
     agent: { modelReference: { id: "test-model" }, system: "", tools: [] },
     compaction: { recentWindowSize: 10, threshold: 100_000 },
@@ -108,7 +137,7 @@ function createParkedSession(): HarnessSession {
   });
 
   return setPendingRuntimeActionBatch({
-    actions: [
+    actions: input?.actions ?? [
       {
         callId: "call-1",
         description: "research subagent",
@@ -120,7 +149,7 @@ function createParkedSession(): HarnessSession {
       },
     ],
     event: { sequence: 0, stepIndex: 0, turnId: "turn_0" },
-    responseMessages: [],
+    responseMessages: input?.responseMessages ?? [],
     session: withUsage,
   });
 }
@@ -174,8 +203,11 @@ function createSessionWithRunningChild(): HarnessSession {
   });
 }
 
-function createSessionWithTaskAddress(): HarnessSession {
-  const prepared = prepareAgentStart(createParkedSession(), {
+function createSessionWithTaskAddress(input?: {
+  readonly actions?: PendingRuntimeActionBatch["actions"];
+  readonly responseMessages?: readonly HarnessSession["history"][number][];
+}): HarnessSession {
+  const prepared = prepareAgentStart(createParkedSession(input), {
     identity: {
       id: deriveAgentId("researcher", OPERATION_ID),
       name: "researcher",
@@ -202,7 +234,6 @@ function createSessionWithTaskAddress(): HarnessSession {
 describe("resolvePendingRuntimeActions", () => {
   it("marks a working task receipt as backgrounded on subagent.completed", async () => {
     const events: UnstampedMessageStreamEvent[] = [];
-    const taskId = "task_0123456789abcdef";
 
     const resolved = await resolvePendingRuntimeActions({
       emit: async (event) => {
@@ -210,34 +241,84 @@ describe("resolvePendingRuntimeActions", () => {
       },
       session: createSessionWithTaskAddress(),
       stepInput: {
-        runtimeActionResults: [
+        runtimeActionResults: [createBackgroundTaskReceipt()],
+      },
+    });
+
+    expect(events.find((event) => event.type === "subagent.completed")).toMatchObject({
+      data: { backgroundTask: { status: "working", taskId: TASK_ID } },
+    });
+    expect(resolved.backgroundTaskAdmissionOnly).toBe(true);
+    expect(getAgentHandleStore(resolved.session.state)?.handles).toEqual([
+      expect.objectContaining({ phase: "addressed" }),
+    ]);
+  });
+
+  it("does not classify a task receipt plus an executed tool result as admission-only", async () => {
+    const resolved = await resolvePendingRuntimeActions({
+      session: createSessionWithTaskAddress({
+        responseMessages: [
           {
-            backgroundTask: { status: "working", taskId },
+            content: [
+              {
+                output: { type: "text", value: "42" },
+                toolCallId: "add-1",
+                toolName: "add",
+                type: "tool-result",
+              },
+            ],
+            role: "tool",
+          },
+        ],
+      }),
+      stepInput: {
+        runtimeActionResults: [createBackgroundTaskReceipt()],
+      },
+    });
+
+    expect(resolved.backgroundTaskAdmissionOnly).toBe(false);
+  });
+
+  it("does not classify partial task admission as admission-only", async () => {
+    const resolved = await resolvePendingRuntimeActions({
+      session: createSessionWithTaskAddress({
+        actions: [
+          {
             callId: "call-1",
-            kind: "subagent-result",
-            origin: "child",
-            outcome: {
-              kind: "parked",
-              result: { kind: "succeeded", output: "delegated" },
-              usageDelta: ZERO_USAGE,
-            },
-            output: {
-              agentId: deriveAgentId("researcher", OPERATION_ID),
-              status: "working",
-              taskId,
-            },
+            description: "research subagent",
+            input: { message: "go" },
+            kind: "subagent-call",
+            name: "researcher",
+            nodeId: "subagents/researcher",
             subagentName: "researcher",
+          },
+          {
+            callId: "call-2",
+            description: "unavailable subagent",
+            input: { message: "go" },
+            kind: "subagent-call",
+            name: "unavailable",
+            nodeId: "subagents/unavailable",
+            subagentName: "unavailable",
+          },
+        ],
+      }),
+      stepInput: {
+        runtimeActionResults: [
+          createBackgroundTaskReceipt(),
+          {
+            callId: "call-2",
+            isError: true,
+            kind: "subagent-result",
+            origin: "dispatch",
+            output: { code: "SUBAGENT_UNAVAILABLE", message: "unavailable" },
+            subagentName: "unavailable",
           },
         ],
       },
     });
 
-    expect(events.find((event) => event.type === "subagent.completed")).toMatchObject({
-      data: { backgroundTask: { status: "working", taskId } },
-    });
-    expect(getAgentHandleStore(resolved.session.state)?.handles).toEqual([
-      expect.objectContaining({ phase: "addressed" }),
-    ]);
+    expect(resolved.backgroundTaskAdmissionOnly).toBe(false);
   });
 
   it("settles the running handle terminally and deletes it with the batch", async () => {

--- a/packages/eve/src/harness/runtime-actions.ts
+++ b/packages/eve/src/harness/runtime-actions.ts
@@ -66,6 +66,8 @@ export interface PendingRuntimeActionBatch {
  * Outcome of resolving a pending runtime-action batch.
  */
 interface ResolvePendingRuntimeActionsResult {
+  /** True when this model step produced task receipts and no synchronous tool outcome. */
+  readonly backgroundTaskAdmissionOnly: boolean;
   readonly messages: ModelMessage[];
   readonly outcome: "continue" | "resolved" | "unresolved";
   readonly session: HarnessSession;
@@ -192,6 +194,7 @@ export async function resolvePendingRuntimeActions(input: {
 
   if (batch === undefined) {
     return {
+      backgroundTaskAdmissionOnly: false,
       messages: [...input.session.history],
       outcome: "continue",
       session: input.session,
@@ -205,6 +208,7 @@ export async function resolvePendingRuntimeActions(input: {
 
   if (readyResults === undefined) {
     return {
+      backgroundTaskAdmissionOnly: false,
       messages: [...input.session.history],
       outcome: "unresolved",
       session: input.session,
@@ -343,10 +347,27 @@ export async function resolvePendingRuntimeActions(input: {
     });
   }
   return {
+    backgroundTaskAdmissionOnly:
+      readyResults.length > 0 &&
+      readyResults.every(
+        (result) =>
+          result.kind === "subagent-result" && readBackgroundTaskReceipt(result) !== undefined,
+      ) &&
+      !containsToolResult(batch.responseMessages),
     messages,
     outcome: "resolved",
     session: nextSession,
   };
+}
+
+function containsToolResult(messages: readonly ModelMessage[]): boolean {
+  // The model step may already contain local or provider-executed sibling
+  // results that are not part of the runtime-action batch. Those results need
+  // another model call even when every deferred subagent was admitted.
+  return messages.some(
+    (message) =>
+      Array.isArray(message.content) && message.content.some((part) => part.type === "tool-result"),
+  );
 }
 
 function readBackgroundTaskReceipt(

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -1580,6 +1580,90 @@ describe("createToolLoopHarness", () => {
     ]);
   });
 
+  it("parks a conversation parent immediately after background task admission", async () => {
+    const delegateToolCall = {
+      input: { message: "investigate" },
+      toolCallId: "delegate-1",
+      toolName: "delegate",
+      type: "tool-call" as const,
+    };
+    setupMockAgent({
+      finishReason: "tool-calls",
+      response: { messages: [{ content: [delegateToolCall], role: "assistant" }] },
+      text: "",
+      toolCalls: [delegateToolCall],
+      toolResults: [],
+    });
+
+    const { emit, events } = createEventCollector();
+    const runStep = createToolLoopHarness(
+      createTestConfig("conversation", emit, { tools: createDelegationToolMap() }),
+    );
+    const dispatched = await runStep(createTestSession(), { message: "Delegate this." });
+    const taskId = "task_0123456789abcdef";
+    const admitted = {
+      ...dispatched.session,
+      state: {
+        ...dispatched.session.state,
+        [AGENT_HANDLES_STATE_KEY]: {
+          handles: [
+            {
+              address: {
+                continuationToken: "delegate-token",
+                kind: "agent/local",
+                sessionId: "delegate-session",
+              },
+              identity: {
+                id: "ag_worker:delegate",
+                name: "worker",
+                nodeId: "workers",
+              },
+              operation: {
+                callId: "delegate-1",
+                id: "delegate-operation",
+                kind: "start",
+                parentTurnId: "turn_0",
+              },
+              phase: "running",
+            },
+          ],
+        },
+      },
+    } satisfies HarnessSession;
+
+    const parked = await runStep(admitted, {
+      runtimeActionResults: [
+        {
+          backgroundTask: { status: "working", taskId },
+          callId: "delegate-1",
+          kind: "subagent-result",
+          origin: "child",
+          outcome: {
+            kind: "parked",
+            result: { kind: "succeeded", output: "delegated" },
+            usageDelta: {
+              cacheReadTokens: 0,
+              cacheWriteTokens: 0,
+              inputTokens: 0,
+              outputTokens: 0,
+            },
+          },
+          output: { agentId: "ag_worker:delegate", status: "working", taskId },
+          subagentName: "worker",
+        },
+      ],
+    });
+
+    expect(ToolLoopAgent).toHaveBeenCalledTimes(1);
+    expect(parked.next).toBeNull();
+    expect(parked.settledTurn).toBeUndefined();
+    expect(getPendingRuntimeActionBatch(parked.session.state)).toBeUndefined();
+    expect(JSON.stringify(parked.session.history)).toContain(taskId);
+    expect(events.filter((event) => event.type === "step.started")).toHaveLength(1);
+    expect(events.at(-2)?.type).toBe("turn.completed");
+    expect(events.at(-1)?.type).toBe("session.waiting");
+  });
+
   it("parks on both batches when one step carries a runtime action and an approval", async () => {
     const gateToolCall = {
       input: { action: "run" },

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -834,6 +834,21 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     }
     session = resolvedRuntimeActions.session;
 
+    if (config.mode === "conversation" && resolvedRuntimeActions.backgroundTaskAdmissionOnly) {
+      // A receipt-only task admission yields the conversation turn. Persist
+      // the receipts for provider-valid history, but do not spend another model
+      // call presenting framework-owned admission state back to its creator.
+      let parkedSession = {
+        ...session,
+        history: [...resolvedRuntimeActions.messages],
+      };
+      if (emit) {
+        emissionState = await emitTurnEpilogue(emit, emissionState, config.mode);
+        parkedSession = setHarnessEmissionState(parkedSession, emissionState);
+      }
+      return { next: null, session: parkedSession };
+    }
+
     // Stale-response handling is two passes: drop what must never reach the
     // model (session-limit continuation answers), then convert what should
     // reach it as plain text.

--- a/packages/eve/src/runtime/prompt/compose.test.ts
+++ b/packages/eve/src/runtime/prompt/compose.test.ts
@@ -22,7 +22,7 @@ describe("composeRuntimeBasePrompt", () => {
     expect(prompt).not.toContainEqual(expect.stringContaining("<agents>"));
   });
 
-  it("instructs task-mode parents to rely on notifications instead of polling", () => {
+  it("describes task-mode background work and notifications", () => {
     const prompt = composeRuntimeBasePrompt({
       persistentSubagentSessions: true,
       subagentsAvailable: true,
@@ -30,14 +30,13 @@ describe("composeRuntimeBasePrompt", () => {
     });
 
     expect(prompt).toContainEqual(
-      expect.stringContaining("return immediately with a task receipt"),
+      expect.stringContaining(
+        "Subagent calls start durable background tasks and proceed independently.\nEach task will notify you",
+      ),
     );
-    expect(prompt).toContainEqual(
-      expect.stringContaining("notifications include the task's result"),
-    );
+    expect(prompt).toContainEqual(expect.stringContaining("task's result"));
     expect(prompt).not.toContainEqual(expect.stringContaining("task_peek"));
     expect(prompt).not.toContainEqual(expect.stringContaining("task_sleep"));
-    expect(prompt).toContainEqual(expect.stringContaining("notify you"));
   });
 
   it("omits agent messaging instructions when subagents are unavailable", () => {

--- a/packages/eve/src/runtime/prompt/compose.ts
+++ b/packages/eve/src/runtime/prompt/compose.ts
@@ -14,8 +14,15 @@ const PARALLEL_ACTION_INSTRUCTION =
 const AGENT_MESSAGING_INSTRUCTION =
   "Agent messaging\nAgents you have already delegated to stay available after they answer. eve injects the current `<agents>` list into the conversation as a note labeled `[Agents]`; it is added automatically by the framework, not written by the user, and never requires a reply. The list is only a record of those existing agents — their `agentId`, name, and latest status. It does not limit which subagent tools you can call: your tool list is the source of truth, and any subagent tool can always be called without `agentId` to start a new agent, including when the `<agents>` list is empty or absent. Pass `agentId` to the same subagent tool only to continue one of those existing agents' sessions.";
 
-const TASK_AGENT_MESSAGING_INSTRUCTION =
-  "Agent messaging\nSubagent calls start durable background tasks and return immediately with a task receipt. After delegating, continue helping the user or end your turn. The task will notify you when it completes, fails, needs input, or sends an update; completion and failure notifications include the task's result. Agents you have already delegated to remain visible in the framework-authored `<agents>` conversation note. `availability=busy` means the listed task still owns that agent session: wait for its notification or use task_cancel with its taskId instead of starting a continuation. `availability=available` means no nonterminal task owns the session, so you may pass agentId to the original subagent tool to continue it. Calling a subagent without agentId always starts a new agent session.";
+const TASK_AGENT_MESSAGING_INSTRUCTION = [
+  "Agent messaging",
+  "Subagent calls start durable background tasks and proceed independently.",
+  "Each task will notify you when it completes, fails, needs input, or sends an update. Completion and failure notifications include the task's result.",
+  "Agents you have already delegated to remain visible in the framework-authored `<agents>` conversation note.",
+  "`availability=busy` means the listed task still owns that agent session: wait for its notification or use task_cancel with its taskId instead of starting a continuation.",
+  "`availability=available` means no nonterminal task owns the session, so you may pass agentId to the original subagent tool to continue it.",
+  "Calling a subagent without agentId always starts a new agent session.",
+].join("\n");
 
 /**
  * Input for composing the base authored instructions prompt for one

--- a/research/tools-as-tasks.md
+++ b/research/tools-as-tasks.md
@@ -9,11 +9,12 @@ last_updated: "2026-08-20"
 ## Summary
 
 Under an opt-in `experimental.tasks` mode, eve should represent long-running work as durable,
-addressable tasks. This plan applies that model only to local and remote subagents. A subagent call
-returns a task receipt after dispatch instead of keeping the parent turn blocked until the child
-finishes. The parent receives result-bearing lifecycle notifications and can cancel the task with
-a framework-owned tool. The child can intentionally report progress to its parent with one
-framework-owned tool.
+addressable tasks. This plan applies that model only to local and remote subagents. A receipt-only
+subagent step records its task receipts after dispatch and parks the parent turn instead of keeping
+it blocked until the children finish. A mixed step continues so the model can handle synchronous
+results or dispatch failures. The parent receives result-bearing lifecycle notifications and can
+cancel the task with a framework-owned tool. The child can intentionally report progress to its
+parent with one framework-owned tool.
 
 Without the flag, current subagent behavior must remain unchanged. The implementation uses a
 generic background `defineTool` execution contract so the harness does not classify subagents.
@@ -53,8 +54,9 @@ cancel paths.
 
 ## Goals
 
-- Let a parent continue its turn while delegated work runs.
-- Wake the parent through lifecycle notifications instead of model-paced task checks.
+- Yield the parent turn after delegated work starts while the task proceeds independently.
+- Wake the parent through result-bearing lifecycle notifications instead of model-paced task
+  checks.
 - Let a child intentionally report progress to its parent instead of leaving progress to
   channel-layer guesswork.
 - Carry progress, input requests, authorization events, results, failures, and cancellation over
@@ -264,7 +266,9 @@ the AI SDK executes subagent definitions through the generic background-tool pat
 1. The harness creates a durable `working` task for the subagent call.
 2. It dispatches the child with the task binding.
 3. The child acknowledges its private address, which is persisted on the agent record immediately.
-4. The originating call receives its receipt and the turn continues.
+4. Each originating call receives its receipt in durable history. The parent parks when the step
+   contains only admitted task receipts; synchronous sibling results or dispatch failures continue
+   the model loop.
 
 Everything after acknowledgement — progress, input requests, authorization, terminal outcome —
 arrives over the task wire instead of resolving the dispatch. Task creation, parent indexing, the
@@ -340,8 +344,8 @@ sequenceDiagram
     H->>T: create working task
     H->>C: dispatch with TaskBinding
     C-->>H: acknowledge private child address
-    H-->>M: task receipt
-    M->>H: continue turn
+    H->>H: persist task receipt
+    H->>H: park parent turn
 
     C->>T: task.update or authorization
     T->>H: full task snapshot
@@ -409,8 +413,9 @@ than MCP compatibility.
 
 - With `experimental.tasks` absent or false, existing tool results, events, cancellation, and
   subagent blocking behavior do not change.
-- With it enabled, a slow subagent returns a task receipt and the parent can take another model
-  step before the child completes.
+- With it enabled, a receipt-only slow-subagent step records its task receipts and the parent parks
+  before the children complete. A later session delivery starts the next parent model step. Mixed
+  steps continue immediately so the model can handle synchronous results and dispatch failures.
 - With it enabled, the workflow tool is not advertised to the root session until graduation adds
   background-tool execution to the workflow host.
 - The original tool call has exactly one result in durable history. Later task output cannot be


### PR DESCRIPTION
### Summary

Related to #635. When a conversation step resolves only to admitted background-task receipts, feeding those receipts back into the model creates a second call whose only job is to acknowledge framework-owned state.

Before → after: receipt-only steps persisted their receipts and continued the model loop; they now persist the receipts and park the parent. The next task notification starts the next parent turn. Mixed steps still continue immediately when a sibling tool returns synchronously or a dispatch fails, and task-mode children keep their existing turn contract.

The task prompt now says only that background tasks proceed independently and notify the parent. It does not prescribe polling, waiting, continued work, or ending the turn.

### Validation

Focused prompt, runtime-action, and tool-loop coverage passed 227 unit tests; runtime-action dispatch integration passed 27 tests; the `eve` typecheck and `fixture-tasks` typecheck/build passed, including all 18 task transition declarations. The full `eve` unit run reached 7,091 passing tests and one skipped test, but two unrelated interactive-TUI tests failed in the parallel run; the complete three-test block passed immediately when rerun in isolation. The deterministic fixture eval remains CI-only.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+22 / -12`

Updates the task lifecycle contract and adds the release note for receipt-only parent parking.

**Implementation** — 3 files · `+45 / -2`

Classifies receipt-only resolution at the runtime-action boundary, parks only conversation parents, and keeps the model prompt policy-light.

**Tests** — 17 files · `+267 / -45`

Adds unit coverage for receipt-only and mixed-result boundaries, adds a deterministic fixture eval for the park-and-wake flow, and removes eleven obsolete receipt-acknowledgment assertions from existing task evals.
