### PR TITLE
fix(eve): derive Linq and Photon user auth

### DIFF
--- a/.changeset/linq-default-user-auth.md
+++ b/.changeset/linq-default-user-auth.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Linq inbound messages now derive user auth from their message authors, allowing user-scoped connections to request authorization by default.

--- a/.changeset/linq-default-user-auth.md
+++ b/.changeset/linq-default-user-auth.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Linq inbound messages now derive user auth from their message authors, allowing user-scoped connections to request authorization by default.
+Linq and Photon inbound messages now derive user auth from their message authors, allowing user-scoped connections to request authorization by default.

--- a/docs/channels/linq.mdx
+++ b/docs/channels/linq.mdx
@@ -16,7 +16,7 @@ export default linqChannel({
 });
 ```
 
-The default webhook route is `/eve/v1/linq`. The channel verifies forwarded webhooks with same-project Vercel OIDC by default, marks accepted messages as read, and continues the same eve session for every message in a Linq conversation. A new accepted message cooperatively cancels an active turn and steers its replacement turn.
+The default webhook route is `/eve/v1/linq`. The channel verifies forwarded webhooks with same-project Vercel OIDC by default, derives user auth from each message author, marks accepted messages as read, and continues the same eve session for every message in a Linq conversation. A new accepted message cooperatively cancels an active turn and steers its replacement turn.
 
 Set `turnPolicy: "queue"` when every response should finish before Linq starts the next message.
 

--- a/docs/channels/photon.mdx
+++ b/docs/channels/photon.mdx
@@ -22,10 +22,10 @@ export default photonIMessageChannel({
 ```
 
 The default webhook route is `/eve/v1/photon`. The channel verifies forwarded
-webhooks with same-project Vercel OIDC by default, marks accepted messages as
-read, and continues the same eve session for every message in an iMessage
-conversation. A new accepted message cooperatively cancels an active turn and
-steers its replacement turn.
+webhooks with same-project Vercel OIDC by default, derives user auth from each
+message author, marks accepted messages as read, and continues the same eve
+session for every message in an iMessage conversation. A new accepted message
+cooperatively cancels an active turn and steers its replacement turn.
 
 Set `turnPolicy: "queue"` when every response should finish before Photon starts the next message.
 

--- a/packages/eve/src/public/channels/linq/index.ts
+++ b/packages/eve/src/public/channels/linq/index.ts
@@ -1,4 +1,5 @@
 export {
+  defaultLinqAuth,
   linqChannel,
   type LinqChannel,
   type LinqChannelConfig,

--- a/packages/eve/src/public/channels/linq/linqChannel.test.ts
+++ b/packages/eve/src/public/channels/linq/linqChannel.test.ts
@@ -58,7 +58,18 @@ describe("linqChannel", () => {
     expect(markRead).toHaveBeenCalledWith(thread.id, message.id);
     expect(send).toHaveBeenCalledWith(
       { context: [], message: "Hello Linq" },
-      { auth: null, thread, title: undefined },
+      {
+        auth: {
+          attributes: { user_name: "user" },
+          authenticator: "linq-message",
+          issuer: "linq",
+          principalId: "linq:user",
+          principalType: "user",
+          subject: "user",
+        },
+        thread,
+        title: undefined,
+      },
     );
   });
 

--- a/packages/eve/src/public/channels/linq/linqChannel.ts
+++ b/packages/eve/src/public/channels/linq/linqChannel.ts
@@ -58,7 +58,7 @@ export interface LinqChannelConfig {
   readonly credentials?: LinqChannelCredentials;
   /** Per-event overrides for the underlying Chat SDK channel. */
   readonly events?: ChatSdkChannelEvents<{ linq: ReturnType<typeof createLinqAdapter> }>;
-  /** Inbound message policy. Defaults to dispatching every message with no user auth. */
+  /** Inbound message policy. Defaults to dispatching with the Linq message author's user auth. */
   readonly onMessage?: (
     ctx: LinqInboundMessageContext,
     message: Message,
@@ -150,8 +150,25 @@ async function resolveCredentialValue(value: LinqCredentialValue): Promise<strin
   return typeof value === "function" ? await value() : value;
 }
 
-async function defaultOnMessage(): Promise<LinqInboundResult> {
-  return { auth: null };
+/** Default Linq auth projection for inbound Chat SDK message authors. */
+export function defaultLinqAuth(message: Message): SessionAuthContext {
+  const attributes: Record<string, string> = {};
+  if (message.author.userName !== undefined) attributes.user_name = message.author.userName;
+  return {
+    attributes,
+    authenticator: "linq-message",
+    issuer: "linq",
+    principalId: `linq:${message.author.userId}`,
+    principalType: message.author.isBot ? "service" : "user",
+    subject: message.author.userId,
+  };
+}
+
+async function defaultOnMessage(
+  _ctx: LinqInboundMessageContext,
+  message: Message,
+): Promise<LinqInboundResult> {
+  return { auth: defaultLinqAuth(message) };
 }
 
 async function dispatchMessage(

--- a/packages/eve/src/public/channels/photon/index.ts
+++ b/packages/eve/src/public/channels/photon/index.ts
@@ -1,4 +1,5 @@
 export {
+  defaultPhotonAuth,
   photonIMessageChannel,
   type PhotonIMessageChannel,
   type PhotonIMessageChannelConfig,

--- a/packages/eve/src/public/channels/photon/photonIMessageChannel.test.ts
+++ b/packages/eve/src/public/channels/photon/photonIMessageChannel.test.ts
@@ -58,6 +58,40 @@ describe("photonIMessageChannel", () => {
     );
   });
 
+  it("derives user auth for default direct-message dispatch", async () => {
+    photonIMessageChannel({
+      credentials: async () => ({ projectId: "project-id", projectSecret: "project-secret" }),
+    });
+    const handler = directMessage.mock.calls[0]?.[0];
+    if (handler === undefined) throw new Error("Expected an inbound direct-message handler.");
+    const thread = { id: "thread-id" };
+    const message = new Message({
+      author: { isBot: false, isMe: false, userId: "user", userName: "user" },
+      id: "message-id",
+      raw: {},
+      text: "Hello Photon",
+      threadId: thread.id,
+    });
+
+    await handler(thread, message);
+
+    expect(send).toHaveBeenCalledWith(
+      { context: [], message: "Hello Photon" },
+      {
+        auth: {
+          attributes: { user_name: "user" },
+          authenticator: "photon-imessage",
+          issuer: "photon",
+          principalId: "photon:user",
+          principalType: "user",
+          subject: "user",
+        },
+        thread,
+        title: undefined,
+      },
+    );
+  });
+
   it("drops blank inbound messages without cancelling or sending", async () => {
     photonIMessageChannel({
       credentials: async () => ({ projectId: "project-id", projectSecret: "project-secret" }),
@@ -100,7 +134,18 @@ describe("photonIMessageChannel", () => {
 
     expect(send).toHaveBeenCalledWith(
       { context: [], message: "Hello group" },
-      { auth: null, thread, title: undefined },
+      {
+        auth: {
+          attributes: { user_name: "user" },
+          authenticator: "photon-imessage",
+          issuer: "photon",
+          principalId: "photon:user",
+          principalType: "user",
+          subject: "user",
+        },
+        thread,
+        title: undefined,
+      },
     );
   });
 });

--- a/packages/eve/src/public/channels/photon/photonIMessageChannel.ts
+++ b/packages/eve/src/public/channels/photon/photonIMessageChannel.ts
@@ -42,7 +42,7 @@ export interface PhotonIMessageChannelConfig {
   readonly credentials: PhotonIMessageChannelCredentials;
   /** Per-event overrides for the underlying Chat SDK channel. */
   readonly events?: ChatSdkChannelEvents<{ imessage: iMessageAdapter }>;
-  /** Inbound message policy. Defaults to dispatching every message with no user auth. */
+  /** Inbound message policy. Defaults to dispatching with the Photon message author's user auth. */
   readonly onMessage?: (
     ctx: PhotonInboundMessageContext,
     message: Message,
@@ -107,8 +107,25 @@ export function photonIMessageChannel(config: PhotonIMessageChannelConfig): Phot
   return bridge.channel;
 }
 
-async function defaultOnMessage(): Promise<PhotonInboundResult> {
-  return { auth: null };
+/** Default Photon auth projection for inbound Chat SDK message authors. */
+export function defaultPhotonAuth(message: Message): SessionAuthContext {
+  const attributes: Record<string, string> = {};
+  if (message.author.userName !== undefined) attributes.user_name = message.author.userName;
+  return {
+    attributes,
+    authenticator: "photon-imessage",
+    issuer: "photon",
+    principalId: `photon:${message.author.userId}`,
+    principalType: message.author.isBot ? "service" : "user",
+    subject: message.author.userId,
+  };
+}
+
+async function defaultOnMessage(
+  _ctx: PhotonInboundMessageContext,
+  message: Message,
+): Promise<PhotonInboundResult> {
+  return { auth: defaultPhotonAuth(message) };
 }
 
 async function dispatchMessage(


### PR DESCRIPTION
### Summary

Linq and Photon now derive a user principal from each inbound message author by default. User-scoped connections can therefore reach the authorization flow without requiring every app to provide a custom `onMessage` handler.

### Validation

Updates Linq and Photon channel unit coverage for the default inbound auth projection.

### Diff size

**Docs** — 3 files · `+10 / -5`

Documents the default for both first-party iMessage channels and release note.

**Implementation** — 4 files · `+42 / -6`

Adds the default author-to-principal projection and exports it for custom dispatch hooks.

**Tests** — 2 files · `+58 / -2`

Covers the default dispatch auth payload for Linq and Photon.
