### PR TITLE
fix(site): prevent redirects in benchmark social image cards

### DIFF
--- a/apps/docs/app/[lang]/benchmarks/page.tsx
+++ b/apps/docs/app/[lang]/benchmarks/page.tsx
@@ -13,10 +13,14 @@ export const metadata: Metadata = {
   ...titleMetadata,
   description,
   alternates: canonicalAlternates(canonicalRoutes.benchmarks),
-  openGraph: titleMetadata.openGraph,
+  openGraph: {
+    ...titleMetadata.openGraph,
+    images: ["/benchmarks/opengraph-image"],
+  },
   twitter: {
     ...titleMetadata.twitter,
     card: "summary_large_image",
+    images: ["/benchmarks/twitter-image"],
   },
 };
 


### PR DESCRIPTION
### Summary

The benchmarks page advertised locale-prefixed social image URLs that redirect before serving the image, causing X to render a placeholder instead of the card image. It now advertises the canonical, non-redirecting Open Graph and X image URLs while preserving the existing generated images.

### Validation

Built the docs site and confirmed the generated benchmarks HTML points `og:image` and `twitter:image` directly to `https://eve.dev/benchmarks/...`; focused formatting, linting, and TypeScript checks also pass.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 1 file · `+5 / -1`

Keeps the fix local to the benchmarks page metadata.

**Tests** — 0 files · `+0 / -0`

The generated production HTML was inspected directly because this is framework-rendered metadata.
