### PR TITLE
fix(eve): web_fetch - follow safe redirects

### DIFF
--- a/.changeset/safe-web-fetch-redirects.md
+++ b/.changeset/safe-web-fetch-redirects.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Follow up to ten `web_fetch` redirects while rechecking each destination for SSRF safety. Non-success HTTP responses now return a plain-text failure result with the response body when available instead of failing the tool call.

--- a/docs/concepts/built-in-tools.md
+++ b/docs/concepts/built-in-tools.md
@@ -32,6 +32,7 @@ Notes:
 - **`load_skill`** only pulls instructions into context. It adds no new execution surface, because behavior still comes from the tools the agent already has.
 - **`connection_search`** surfaces a connection's tools by their qualified name (e.g. `linear__list_issues`), which the model can then call directly. It's registered only when the agent has connections.
 - **`web_search`** has no local executor; the provider runs it. AI Gateway models use Exa by default. To use Parallel instead, export `webSearch({ provider: "parallel" })` from `agent/tools/web_search.ts`. Direct provider models continue to use their native search implementation. To supply your own implementation, override it with `defineTool()`.
+- **`web_fetch`** follows up to ten redirects, rechecking every destination for SSRF safety. Non-success HTTP responses return a plain-text failure result with the response body when available instead of failing the tool call.
 
 Review these default tools before production use. Disable, wrap, restrict, or require approval for any tool that can access the filesystem, network, shell, or sensitive data.
 

--- a/packages/eve/src/execution/web-fetch/request.test.ts
+++ b/packages/eve/src/execution/web-fetch/request.test.ts
@@ -204,14 +204,14 @@ describe("requestPublicUrl", () => {
     expect(fetchDispatcher).toBe(networkMocks.dispatcherInstances[0]);
   });
 
-  it("returns private redirect targets without requesting them", async () => {
+  it("rejects private redirect targets without requesting them", async () => {
     queueResponse({
       headers: { location: "https://169.254.169.254/latest/meta-data" },
       status: 302,
     });
 
     await expect(requestPublicUrl("https://example.com", REQUEST_OPTIONS)).rejects.toThrow(
-      "Request redirected to https://169.254.169.254/latest/meta-data. Call web_fetch again",
+      "URL must not target localhost, private, link-local, or reserved IP addresses",
     );
 
     expect(networkMocks.fetch).toHaveBeenCalledTimes(1);
@@ -234,19 +234,23 @@ describe("requestPublicUrl", () => {
     expect(networkMocks.lookup).toHaveBeenCalledTimes(1);
   });
 
-  it("returns an absolute HTTPS redirect target for agent follow-up", async () => {
-    queueResponse({
-      headers: { location: "/article" },
-      status: 301,
-    });
+  it("follows at most ten relative HTTPS redirects", async () => {
+    for (let index = 1; index <= 11; index++) {
+      queueResponse({
+        headers: { location: `/redirect-${index}` },
+        status: 301,
+      });
+    }
 
-    await expect(requestPublicUrl("https://example.com/start", REQUEST_OPTIONS)).rejects.toThrow(
-      "Request redirected to https://example.com/article. Call web_fetch again with that URL.",
+    const response = await requestPublicUrl("https://example.com/start", REQUEST_OPTIONS);
+
+    expect(response.status).toBe(301);
+    expect(networkMocks.fetch).toHaveBeenCalledTimes(11);
+    expect(networkMocks.agentClose).toHaveBeenCalledTimes(11);
+    expect(networkMocks.lookup).toHaveBeenCalledTimes(11);
+    expect(networkMocks.fetch.mock.calls[10]![0]).toEqual(
+      new URL("https://example.com/redirect-10"),
     );
-
-    expect(networkMocks.fetch).toHaveBeenCalledTimes(1);
-    expect(networkMocks.agentClose).toHaveBeenCalledTimes(1);
-    expect(networkMocks.lookup).toHaveBeenCalledTimes(1);
   });
 
   it("rejects declared and streamed bodies over the response limit", async () => {

--- a/packages/eve/src/execution/web-fetch/request.ts
+++ b/packages/eve/src/execution/web-fetch/request.ts
@@ -7,6 +7,7 @@ import type { Dispatcher1Wrapper } from "undici";
 import { isLoopbackHostname, isPrivateOrReservedIpAddress } from "#shared/network-address.js";
 
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const MAX_REDIRECTS = 10;
 const UNSAFE_DESTINATION_ERROR =
   "URL must not target localhost, private, link-local, or reserved IP addresses.";
 
@@ -32,23 +33,28 @@ export async function requestPublicUrl(
   urlText: string,
   options: PublicUrlRequestOptions,
 ): Promise<Response> {
-  const url = parseHttpsUrl(urlText);
-  const { dispatcher, response } = await requestOnce(url, options);
+  let url = parseHttpsUrl(urlText);
 
-  try {
-    const location = response.headers.get("location");
+  for (let redirectCount = 0; ; redirectCount++) {
+    const { dispatcher, response } = await requestOnce(url, options);
 
-    if (location !== null && REDIRECT_STATUSES.has(response.status)) {
-      await cancelResponseBody(response);
-      const redirectUrl = parseHttpsUrl(new URL(location, url).toString());
-      throw new Error(
-        `Request redirected to ${redirectUrl.toString()}. Call web_fetch again with that URL.`,
-      );
+    try {
+      const location = response.headers.get("location");
+
+      if (
+        location !== null &&
+        REDIRECT_STATUSES.has(response.status) &&
+        redirectCount < MAX_REDIRECTS
+      ) {
+        await cancelResponseBody(response);
+        url = parseHttpsUrl(new URL(location, url).toString());
+        continue;
+      }
+
+      return await consumeResponse(response, options.maxResponseSize);
+    } finally {
+      await dispatcher.close();
     }
-
-    return await consumeResponse(response, options.maxResponseSize);
-  } finally {
-    await dispatcher.close();
   }
 }
 

--- a/packages/eve/src/execution/web-fetch/tool.test.ts
+++ b/packages/eve/src/execution/web-fetch/tool.test.ts
@@ -190,12 +190,15 @@ describe("executeWebFetchTool", () => {
     expect(result.content).toBe(json);
   });
 
-  it("throws on non-ok responses", async () => {
+  it("returns non-ok responses as plain-text failures", async () => {
     requestPublicUrlMock.mockResolvedValueOnce(new Response("Not Found", { status: 404 }));
 
-    await expect(executeWebFetchTool({ url: "https://example.com/missing" })).rejects.toThrow(
-      "Request failed with status code: 404",
-    );
+    await expect(executeWebFetchTool({ url: "https://example.com/missing" })).resolves.toEqual({
+      content: "Request failed with status code: 404\n\nNot Found",
+      contentType: expect.stringContaining("text/plain"),
+      truncated: false,
+      url: "https://example.com/missing",
+    });
   });
 
   it("retries with honest user-agent on Cloudflare challenge", async () => {

--- a/packages/eve/src/execution/web-fetch/tool.ts
+++ b/packages/eve/src/execution/web-fetch/tool.ts
@@ -91,10 +91,6 @@ export async function executeWebFetchTool(
         })
       : initial;
 
-  if (!response.ok) {
-    throw new Error(`Request failed with status code: ${response.status}`);
-  }
-
   const buffer = await response.arrayBuffer();
 
   const contentType = response.headers.get("content-type") ?? "";
@@ -109,6 +105,11 @@ export async function executeWebFetchTool(
     rawContent = extractTextFromHtml(body);
   } else {
     rawContent = body;
+  }
+
+  if (!response.ok) {
+    const failure = `Request failed with status code: ${response.status}`;
+    rawContent = rawContent.length === 0 ? failure : `${failure}\n\n${rawContent}`;
   }
 
   const { output: content, truncated } = truncateHead(rawContent);


### PR DESCRIPTION
### Summary

`web_fetch` previously stopped on redirects and treated non-success HTTP responses as failed tool executions. It now follows up to ten redirects through eve's manual request path, rebuilding the guarded dispatcher and rerunning HTTPS, hostname, and DNS safety checks for every destination. A response at the redirect limit is not followed and, like other non-success responses, returns a plain-text failure result containing its bounded, formatted response body when available.

### Validation

Focused unit coverage confirms the ten-hop cap, SSRF rejection for redirect targets, and normal tool results containing response bodies for non-success responses (27 tests passed).

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+6 / -0`

Adds one built-in tool note and the required patch changeset.

**Implementation** — 2 files · `+26 / -19`

Keeps redirect handling inside the existing guarded request helper and reuses the normal bounded body formatting path for non-success responses.

**Tests** — 2 files · `+24 / -17`

Adjusts the existing redirect and HTTP failure coverage without adding new test cases.
