### PR TITLE
[eve]: skip init release-age scenario on Version Packages PRs

### DIFF
--- a/packages/eve/test/scenarios/eve-init.scenario.test.ts
+++ b/packages/eve/test/scenarios/eve-init.scenario.test.ts
@@ -14,6 +14,10 @@ import { useTemporaryDirectories } from "../../src/internal/testing/use-temporar
 const EVE_BIN_PATH = fileURLToPath(new URL("../../bin/eve.js", import.meta.url));
 const runFile = promisify(execFile);
 const RELEASE_AGE_MINUTES = "2880";
+// Changesets opens Version Packages PRs on `changeset-release/<base>`. Those
+// PRs bump package.json before npm has that version, so a real registry
+// install of the scaffolded eve range cannot succeed yet.
+const isChangesetReleasePr = process.env.GITHUB_HEAD_REF?.startsWith("changeset-release/") === true;
 
 const createScratchDirectory = useTemporaryDirectories();
 
@@ -156,35 +160,38 @@ async function createFakeNpmEnvironment(scratch: string): Promise<{
 }
 
 describe("eve init smoke", () => {
-  it("resolves a standalone pnpm scaffold under the release-age policy", async () => {
-    const scratch = await createScratchDirectory("eve-init-release-age-");
-    const env = {
-      ...withoutCodingAgentMarkers(process.env),
-      // The agent path skips the interactive dev handoff, which cannot run
-      // against the real pnpm install this scenario performs.
-      AI_AGENT: "claude",
-      CI: "true",
-      PNPM_CONFIG_MINIMUM_RELEASE_AGE: RELEASE_AGE_MINUTES,
-      // A fresh eve release is younger than the policy window, so resolution
-      // would rightly fail. Internal testing opts the framework package out
-      // through the environment instead of any scaffold-owned bypass.
-      PNPM_CONFIG_MINIMUM_RELEASE_AGE_EXCLUDE: '["eve"]',
-    };
+  it.skipIf(isChangesetReleasePr)(
+    "resolves a standalone pnpm scaffold under the release-age policy",
+    async () => {
+      const scratch = await createScratchDirectory("eve-init-release-age-");
+      const env = {
+        ...withoutCodingAgentMarkers(process.env),
+        // The agent path skips the interactive dev handoff, which cannot run
+        // against the real pnpm install this scenario performs.
+        AI_AGENT: "claude",
+        CI: "true",
+        PNPM_CONFIG_MINIMUM_RELEASE_AGE: RELEASE_AGE_MINUTES,
+        // A fresh eve release is younger than the policy window, so resolution
+        // would rightly fail. Internal testing opts the framework package out
+        // through the environment instead of any scaffold-owned bypass.
+        PNPM_CONFIG_MINIMUM_RELEASE_AGE_EXCLUDE: '["eve"]',
+      };
 
-    const result = await runEveBin(scratch, ["init", "policy-agent"], env);
+      const result = await runEveBin(scratch, ["init", "policy-agent"], env);
 
-    expect(result.exitCode, result.stderr).toBe(0);
-    const projectDir = join(scratch, "policy-agent");
-    await expect(readFile(join(projectDir, "pnpm-workspace.yaml"), "utf8")).resolves.not.toContain(
-      "minimumReleaseAgeExclude:",
-    );
-    await expect(
-      runFile("pnpm", ["add", "--ignore-scripts", "--lockfile-only", "is-number@7.0.0"], {
-        cwd: projectDir,
-        env,
-      }),
-    ).resolves.toMatchObject({ stderr: expect.any(String) });
-  });
+      expect(result.exitCode, result.stderr).toBe(0);
+      const projectDir = join(scratch, "policy-agent");
+      await expect(
+        readFile(join(projectDir, "pnpm-workspace.yaml"), "utf8"),
+      ).resolves.not.toContain("minimumReleaseAgeExclude:");
+      await expect(
+        runFile("pnpm", ["add", "--ignore-scripts", "--lockfile-only", "is-number@7.0.0"], {
+          cwd: projectDir,
+          env,
+        }),
+      ).resolves.toMatchObject({ stderr: expect.any(String) });
+    },
+  );
 
   it("creates the base template with the default model and no Vercel state", async () => {
     const scratch = await createScratchDirectory("eve-init-");


### PR DESCRIPTION
### Summary

Related to #2451. The init release-age scenario installs published `eve` from the registry. Changesets Version Packages PRs bump `package.json` before that version exists on npm, so the scenario fails with `ERR_PNPM_NO_MATCHING_VERSION`. Skip it when `GITHUB_HEAD_REF` starts with `changeset-release/` (the Changesets branch for those PRs). Normal PRs still run the full registry coverage.

### Validation

Confirmed the scenario passes without `GITHUB_HEAD_REF`, and is skipped when `GITHUB_HEAD_REF=changeset-release/main`.

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

No changeset: test-only change.

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 0 files · `+0 / -0`

Not applicable.

**Tests** — 1 file · `+36 / -29`

Adds a Changesets-branch skip around the existing release-age scenario; no product behavior change.