### PR TITLE
chore(docs): update geistdocs to 1.24.0

### DIFF
--- a/apps/docs/lib/geistdocs/markdown-routes.test.ts
+++ b/apps/docs/lib/geistdocs/markdown-routes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { markdownRoutes } from "./markdown-routes";
+import { markdownNotFound, markdownRoutes } from "./markdown-routes";
 
 const integrationsRoute = markdownRoutes.find(({ from }) => from === "/integrations/*path");
 
@@ -22,5 +22,21 @@ describe("markdownRoutes", () => {
       from: "/docs/*path",
       to: "/[lang]/llms.mdx/*path",
     });
+  });
+});
+
+describe("markdownNotFound", () => {
+  it("returns a Markdown 404 for unmatched paths", () => {
+    expect(markdownNotFound({ language: "en", pathname: "/no-such-page" })).toBe(true);
+  });
+
+  it("lets HTML-only route families continue to the app", () => {
+    for (const pathname of ["/templates", "/templates/slack-agent", "/benchmarks", "/resources"]) {
+      expect(markdownNotFound({ language: "en", pathname })).toBe(false);
+    }
+  });
+
+  it("still covers unmapped paths under mapped families", () => {
+    expect(markdownNotFound({ language: "en", pathname: "/guides/removed-page" })).toBe(true);
   });
 });

--- a/apps/docs/lib/geistdocs/markdown-routes.ts
+++ b/apps/docs/lib/geistdocs/markdown-routes.ts
@@ -1,6 +1,20 @@
-import type { GeistdocsMarkdownRoute } from "@vercel/geistdocs/proxy";
+import type { CreateProxyOptions, GeistdocsMarkdownRoute } from "@vercel/geistdocs/proxy";
 
 export const markdownRoutes: GeistdocsMarkdownRoute[] = [
   { from: "/docs/*path", to: "/[lang]/llms.mdx/*path" },
   { from: "/integrations/*path", to: "/[lang]/llms.mdx/integrations/*path" },
 ];
+
+// Route families with valid HTML pages but no Markdown mapping. Agents and
+// Markdown requests to unmatched paths elsewhere get a recoverable Markdown
+// 404 (geistdocs `markdownNotFound`); these families continue to the app so
+// their consumer-owned HTML responses stay intact.
+const htmlOnlyRouteFamilies = ["/templates", "/benchmarks", "/resources"];
+
+type MarkdownNotFoundPredicate = Extract<
+  CreateProxyOptions["markdownNotFound"],
+  (context: never) => boolean
+>;
+
+export const markdownNotFound: MarkdownNotFoundPredicate = ({ pathname }) =>
+  !htmlOnlyRouteFamilies.some((family) => pathname === family || pathname.startsWith(`${family}/`));

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -24,7 +24,7 @@
     "@icons-pack/react-simple-icons": "13.13.0",
     "@streamdown/code": "1.1.1",
     "@vercel/analytics": "2.0.1",
-    "@vercel/geistdocs": "1.23.1",
+    "@vercel/geistdocs": "1.24.0",
     "@vercel/speed-insights": "2.0.0",
     "@vgpu/core": "0.0.7",
     "@vgpu/render": "0.0.7",

--- a/apps/docs/proxy.ts
+++ b/apps/docs/proxy.ts
@@ -2,12 +2,13 @@ import { createProxy } from "@vercel/geistdocs/proxy";
 import { NextResponse, type NextFetchEvent, type NextRequest } from "next/server";
 import { config as geistdocsConfig } from "@/lib/geistdocs/config";
 import { removeProxyMarkdownCanonical } from "@/lib/geistdocs/markdown-canonical";
-import { markdownRoutes } from "@/lib/geistdocs/markdown-routes";
+import { markdownNotFound, markdownRoutes } from "@/lib/geistdocs/markdown-routes";
 import { trackMdRequest } from "@/lib/geistdocs/md-tracking";
 
 const geistdocsProxy = createProxy({
   config: geistdocsConfig,
   markdownRoutes,
+  markdownNotFound,
   trackMarkdownRequest: trackMdRequest,
   before: ({ request }) => (request.nextUrl.pathname === "/nights" ? NextResponse.next() : null),
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,8 +179,8 @@ importers:
         specifier: 2.0.1
         version: 2.0.1(@sveltejs/kit@2.63.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(next@16.3.1(@babel/core@7.29.0(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nuxt@4.4.6(eddae254238b412d8a46133f9d7579b6))(react@19.2.6)(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vue@3.5.35(typescript@6.0.3))
       '@vercel/geistdocs':
-        specifier: 1.23.1
-        version: 1.23.1(af419ac2f77fc42ec3d0d44b87253972)
+        specifier: 1.24.0
+        version: 1.24.0(af419ac2f77fc42ec3d0d44b87253972)
       '@vercel/speed-insights':
         specifier: 2.0.0
         version: 2.0.0(@sveltejs/kit@2.63.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(next@16.3.1(@babel/core@7.29.0(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nuxt@4.4.6(eddae254238b412d8a46133f9d7579b6))(react@19.2.6)(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vue@3.5.35(typescript@6.0.3))
@@ -7902,8 +7902,8 @@ packages:
   '@vercel/gatsby-plugin-vercel-builder@2.2.35':
     resolution: {integrity: sha512-H1qNhnvyRIhek/esVnVK+RoFsxrSOLl4qiM4iyV2IcjDoqY4H0Ped65tc5ZgZEP/P2KGNYfEDSBEukdBZa+kCg==}
 
-  '@vercel/geistdocs@1.23.1':
-    resolution: {integrity: sha512-XjXfZe7a4NrB0+dFoUthH5wQTVApxtTscbh4QPbtAjAgly6MJtL6R4+vPs88m4/x0HsaX76R7qllCv53DnISvw==}
+  '@vercel/geistdocs@1.24.0':
+    resolution: {integrity: sha512-VSYT3ojk5m5RucEhFOlCN+iZuCb+qPIUsqMSG4HRwUIxeHUHHURi/FV1B97pFLGTOMkUfdcNZnzXi2Qq6vSQiA==}
     hasBin: true
     peerDependencies:
       next: ^16.3.0
@@ -22338,7 +22338,7 @@ snapshots:
       etag: 1.8.1
       fs-extra: 11.1.0
 
-  '@vercel/geistdocs@1.23.1(af419ac2f77fc42ec3d0d44b87253972)':
+  '@vercel/geistdocs@1.24.0(af419ac2f77fc42ec3d0d44b87253972)':
     dependencies:
       '@ai-sdk/react': 3.0.193(react@19.2.6)(zod@4.4.3)
       '@clack/prompts': 0.11.0


### PR DESCRIPTION
Bumps the docs site to `@vercel/geistdocs` 1.24.0 and opts into its new `markdownNotFound` proxy behavior: agent and `Accept: text/markdown` requests to unmatched paths now get a concise Markdown 404 with links to `/docs`, `/sitemap.md`, and `/llms.txt`, instead of the HTML not-found page. `/templates`, `/benchmarks`, and `/resources` stay HTML-only (they have no Markdown mapping), and browsers are unaffected everywhere.

1.24.0 also brings the "When to use eve" section (driven by the existing `agent.product` metadata) into the generated `/llms-full.txt`, and a package-internal navbar accessibility fix.

Verified with `test:unit` (165/165), `docs:check`, `check:deps`, oxlint/oxfmt, a production build, and `next start` smoke checks of the new 404 negotiation and the unchanged HTML families.

## Review notes

- One review candidate claimed the predicate would Markdown-404 `/` and `/integrations` for agents; refuted — both are matched by package/consumer Markdown routes before the `markdownNotFound` fallthrough runs, and runtime checks confirm they return 200 Markdown.
