### PR TITLE
fix(eve): auth - accept global Vercel OIDC issuer

### DIFF
--- a/.changeset/tidy-plums-travel.md
+++ b/.changeset/tidy-plums-travel.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Accept Vercel OIDC tokens issued from the global issuer in `vercelOidc()` and `verifyVercelOidc()`.

--- a/packages/eve/src/channel/auth/oidc.ts
+++ b/packages/eve/src/channel/auth/oidc.ts
@@ -6,6 +6,7 @@ import {
   areTokenClaimMatchersSatisfied,
   createJwtAuthenticatedCallerPrincipal,
 } from "#channel/auth/token-claims.js";
+import { isVercelOidcIssuer } from "#shared/vercel-project.js";
 import type {
   ResolvedOidcAuthStrategy,
   RouteStrategyAuthenticationResult,
@@ -50,7 +51,7 @@ export async function authenticateOidcStrategy(input: {
 
     const hasExternalSubject =
       input.strategy.acceptCurrentVercelProject &&
-      input.strategy.issuer.startsWith("https://oidc.vercel.com/") &&
+      isVercelOidcIssuer(input.strategy.issuer) &&
       verified.payload.external_sub !== undefined;
     if (hasExternalSubject) {
       if (
@@ -78,7 +79,7 @@ export async function authenticateOidcStrategy(input: {
 
     const hasDevelopmentUserSubject =
       input.strategy.acceptCurrentVercelProject &&
-      input.strategy.issuer.startsWith("https://oidc.vercel.com/") &&
+      isVercelOidcIssuer(input.strategy.issuer) &&
       verified.payload.user_id !== undefined;
     if (hasDevelopmentUserSubject) {
       if (
@@ -212,7 +213,7 @@ function isCurrentVercelProjectToken(input: {
   readonly payload: JWTPayload;
   readonly strategy: ResolvedOidcAuthStrategy;
 }): boolean {
-  if (!input.issuer.startsWith("https://oidc.vercel.com")) {
+  if (!isVercelOidcIssuer(input.issuer)) {
     return false;
   }
 

--- a/packages/eve/src/public/channels/auth.test.ts
+++ b/packages/eve/src/public/channels/auth.test.ts
@@ -873,6 +873,19 @@ describe("verifyVercelOidc", () => {
     }
   });
 
+  it("authenticates a current-project token from the global Vercel issuer", async () => {
+    const issuer = await installMockedVercelIssuer("global-issuer", "global");
+    try {
+      const token = await issuer.signToken({ project_id: "prj_current" });
+
+      await expect(
+        verifyVercelOidc(token, { currentVercelProject: { projectId: "prj_current" } }),
+      ).resolves.toMatchObject({ ok: true });
+    } finally {
+      issuer.restore();
+    }
+  });
+
   it("authenticates a development Vercel user token as a user principal", async () => {
     vi.stubEnv("VERCEL_PROJECT_ID", "prj_current");
     vi.stubEnv("VERCEL_TARGET_ENV", "development");
@@ -1300,7 +1313,10 @@ describe("verifyVercelOidc", () => {
  * jose's module-level JWKS cache (keyed on the JWKS URL) does not bleed
  * keys across tests when several cases run in the same file.
  */
-async function installMockedVercelIssuer(slug: string): Promise<{
+async function installMockedVercelIssuer(
+  slug: string,
+  issuerMode: "global" | "team" = "team",
+): Promise<{
   readonly issuer: string;
   readonly signToken: (
     claims: Record<string, unknown>,
@@ -1309,7 +1325,8 @@ async function installMockedVercelIssuer(slug: string): Promise<{
   readonly restore: () => void;
 }> {
   const teamSlug = `${slug}-${crypto.randomUUID()}`;
-  const issuer = `https://oidc.vercel.com/${teamSlug}`;
+  const issuer =
+    issuerMode === "global" ? "https://oidc.vercel.com" : `https://oidc.vercel.com/${teamSlug}`;
   const audience = `https://vercel.com/${teamSlug}`;
   const jwksUrl = `${issuer}/.well-known/jwks.json`;
   const discoveryUrl = `${issuer}/.well-known/openid-configuration`;

--- a/packages/eve/src/public/channels/auth.ts
+++ b/packages/eve/src/public/channels/auth.ts
@@ -22,6 +22,7 @@ import {
   type ResolvedOidcAuthStrategy,
   type RouteStrategyAuthenticationResult,
 } from "#channel/auth/types.js";
+import { isVercelOidcIssuer } from "#shared/vercel-project.js";
 
 const vercelOidcLog = createLogger("auth.vercel-oidc");
 import {
@@ -847,8 +848,6 @@ const LOCAL_DEV_SESSION_AUTH_CONTEXT: SessionAuthContext = {
   principalType: "local-dev",
 };
 
-const VERCEL_OIDC_ISSUER_PREFIX = "https://oidc.vercel.com/";
-
 /**
  * Expected prefix for the `aud` claim of a Vercel-minted OIDC token
  * (`https://vercel.com/<owner-slug>`). Requiring it gives a real audience
@@ -923,7 +922,7 @@ export async function verifyVercelOidc(
     return { ok: false };
   }
 
-  if (!claims.issuer.startsWith(VERCEL_OIDC_ISSUER_PREFIX)) {
+  if (!isVercelOidcIssuer(claims.issuer)) {
     vercelOidcLog.debug("Rejected token whose issuer is not a Vercel OIDC issuer.", {
       issuer: claims.issuer,
     });

--- a/packages/eve/src/runtime/connections/principal.ts
+++ b/packages/eve/src/runtime/connections/principal.ts
@@ -14,6 +14,7 @@ import { type AlsContext, contextStorage } from "#context/container.js";
 import { AuthKey, type SessionAuthContext } from "#context/keys.js";
 import { ConnectionAuthorizationFailedError } from "#public/connections/errors.js";
 import type { AuthorizationDefinition, ConnectionPrincipal } from "#shared/connection-types.js";
+import { isVercelOidcIssuer } from "#shared/vercel-project.js";
 
 /**
  * Stable string key identifying one principal within a connection's
@@ -124,7 +125,7 @@ export function resolveConnectionPrincipalFromAuth(
 function isVercelDevelopmentUser(current: SessionAuthContext): boolean {
   return (
     current.authenticator === "oidc" &&
-    current.issuer?.startsWith("https://oidc.vercel.com/") === true &&
+    isVercelOidcIssuer(current.issuer) &&
     current.attributes.environment === "development" &&
     current.subject === current.attributes.user_id
   );

--- a/packages/eve/src/shared/vercel-project.ts
+++ b/packages/eve/src/shared/vercel-project.ts
@@ -11,6 +11,11 @@ export interface VercelOidcTokenClaims {
 }
 
 const EMPTY_CLAIMS: VercelOidcTokenClaims = { ownerId: undefined, projectId: undefined };
+const VERCEL_OIDC_ISSUER = "https://oidc.vercel.com";
+
+export function isVercelOidcIssuer(issuer: string | undefined): boolean {
+  return issuer === VERCEL_OIDC_ISSUER || issuer?.startsWith(`${VERCEL_OIDC_ISSUER}/`) === true;
+}
 
 /**
  * Decodes the payload claims of a Vercel OIDC token. Values that are not


### PR DESCRIPTION
### Summary

Vercel's global OIDC issuer uses the bare `https://oidc.vercel.com` origin, but eve only recognized team-scoped issuers with a trailing path and rejected global tokens before signature verification. This change uses one exact-or-slash issuer predicate across verification, user classification, and Vercel Connect principal projection. Team-scoped issuer behavior and opaque auth failures remain unchanged.

### Validation

Confirmed with a focused signed-JWT regression using mocked global discovery and JWKS; the adjacent auth, connection-principal, and Vercel-project unit suites pass with 114 tests.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

The patch changeset records the corrected issuer behavior for the next release.

**Implementation** — 4 files · `+13 / -7`

A shared issuer predicate replaces the existing divergent checks without changing the public API.

**Tests** — 1 file · `+19 / -2`

One signed-token regression covers the global issuer through `verifyVercelOidc` with a minimal extension to the existing issuer helper.
