### PR TITLE
feat(eve): expose channel type to trace policies

### DIFF
--- a/.changeset/trace-policy-channel-type.md
+++ b/.changeset/trace-policy-channel-type.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Trace capture policies now receive the originating channel's type, letting a policy sample by channel (for example retaining interactive traffic while dropping scheduled runs). Policies that ignore the field are unaffected.

--- a/packages/eve/src/channel/instrumentation.test.ts
+++ b/packages/eve/src/channel/instrumentation.test.ts
@@ -11,6 +11,7 @@ describe("channel instrumentation", () => {
     };
 
     expect(buildChannelInstrumentationProjection({ adapter, channelName: "support" })).toEqual({
+      channelType: "slack",
       kind: "channel:support",
       metadata: { audience: "unknown" },
     });
@@ -60,6 +61,7 @@ describe("channel instrumentation", () => {
     };
 
     expect(buildChannelInstrumentationProjection({ adapter, channelName: "support" })).toEqual({
+      channelType: "slack",
       kind: "channel:support",
       metadata: { audience: "unknown" },
     });

--- a/packages/eve/src/channel/instrumentation.ts
+++ b/packages/eve/src/channel/instrumentation.ts
@@ -10,6 +10,7 @@ import { normalizeChannelAudience } from "#shared/channel-audience.js";
 const log = createLogger("channel.instrumentation");
 
 export interface ChannelInstrumentationProjection {
+  readonly channelType?: string;
   readonly kind: string;
   readonly metadata: ChannelInstrumentationMetadata;
 }
@@ -22,6 +23,7 @@ export function buildChannelInstrumentationProjection(input: {
   const { adapter, channelName, existingKind } = input;
 
   return {
+    channelType: getAdapterKind(adapter),
     kind: resolveKind({ adapter, channelName, existingKind }),
     metadata: resolveMetadata(adapter),
   };

--- a/packages/eve/src/execution/runtime-context.ts
+++ b/packages/eve/src/execution/runtime-context.ts
@@ -37,6 +37,7 @@ export function buildRunContext(input: {
   if (run.channelMetadata !== undefined) {
     const existing = ctx.get(ChannelInstrumentationKey);
     ctx.set(ChannelInstrumentationKey, {
+      channelType: existing?.channelType ?? run.channelMetadata.channelType,
       kind: existing?.kind ?? run.channelMetadata.kind,
       metadata: run.channelMetadata.metadata,
     });

--- a/packages/eve/src/execution/workflow-runtime.test.ts
+++ b/packages/eve/src/execution/workflow-runtime.test.ts
@@ -712,6 +712,40 @@ describe("createWorkflowRuntime#createSession trace seed allocation", () => {
     expect(seed!.traceId).toMatch(/^[0-9a-f]{32}$/u);
   });
 
+  it("passes the channel adapter kind as channelType to the policy", async () => {
+    const idGenerator = new AgentSpanIdGenerator();
+    let captured: { channelType?: string } | undefined;
+    registerInstrumentationRuntime({
+      forceFlush: async () => undefined,
+      hooks: undefined as never,
+      idGenerator,
+      otelSettings: {
+        tracePolicy: (trace: { channelType?: string }) => {
+          captured = trace;
+          return true;
+        },
+        recordInputs: false,
+        recordOutputs: false,
+        traceChannelRequests: false,
+      },
+      prepareSessionTrace: vi.fn().mockResolvedValue(undefined),
+      runInContext: (_op: never, fn: () => unknown) => fn(),
+      shutdown: async () => undefined,
+    } as never);
+    mockBundleAndRun();
+    startMock.mockResolvedValue({ runId: "driver-run" });
+
+    await buildRuntime().createSession({
+      adapter: { kind: "slack" },
+      auth: null,
+      channelMetadata: { kind: "slack", metadata: { audience: "public" } },
+      input: { message: "hello" },
+      mode: "conversation",
+    });
+
+    expect(captured?.channelType).toBe("slack");
+  });
+
   it("allocates an unsampled trace seed when the policy is unsampled", async () => {
     installAgentOtelRuntime(new AgentSpanIdGenerator(), () => false);
     mockBundleAndRun();

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -146,9 +146,11 @@ export function createWorkflowRuntime(config: {
         run: input,
       });
       const effectiveAgent = resolveEffectiveAgentRuntime(bundle, ctx);
+      const channelInstrumentation = ctx.get(ChannelInstrumentationKey);
       const traceSeed = allocateSessionTraceSeed({
         agentName: effectiveAgent.turnAgent.id,
-        audience: normalizeChannelAudience(ctx.get(ChannelInstrumentationKey)?.metadata.audience),
+        audience: normalizeChannelAudience(channelInstrumentation?.metadata.audience),
+        channelType: channelInstrumentation?.channelType,
         parentTraceContext: input.parentTraceContext,
       });
       if (traceSeed !== undefined) {
@@ -453,6 +455,7 @@ function normalizeWorkflowHook(value: unknown): WorkflowHookRecord {
 function allocateSessionTraceSeed(input: {
   readonly agentName?: string;
   readonly audience: ReturnType<typeof normalizeChannelAudience>;
+  readonly channelType?: string;
   readonly parentTraceContext?: {
     readonly traceId: string;
     readonly spanId: string;
@@ -472,6 +475,7 @@ function allocateSessionTraceSeed(input: {
   const sampled = evaluateTracePolicy(instrumentation.otelSettings?.tracePolicy, {
     agentName: input.agentName,
     audience: input.audience,
+    channelType: input.channelType,
   });
   return {
     spanId: instrumentation.idGenerator.allocateSpanId(),

--- a/packages/eve/src/execution/workflow-trace-context.ts
+++ b/packages/eve/src/execution/workflow-trace-context.ts
@@ -26,6 +26,7 @@ export async function prepareWorkflowPreambleTrace(input: {
   return await prepareTurnTraceContext({
     agentName: input.runtimeIdentity.agentName,
     channelAudience: normalizeChannelAudience(channel?.metadata.audience),
+    channelType: channel?.channelType,
     instrumentation: getInstrumentationRuntime(),
     parentLineage: resolveParentLineage(parent, input.ctx.get(ChannelKey)),
     parentTraceContext: input.ctx.get(ParentTraceContextKey),

--- a/packages/eve/src/harness/instrumentation/lifecycle.ts
+++ b/packages/eve/src/harness/instrumentation/lifecycle.ts
@@ -287,6 +287,7 @@ export interface InstrumentationSessionStartedEvent {
   readonly type: "session.started";
   readonly agentName?: string;
   readonly channelKind?: string;
+  readonly channelType?: string;
   readonly channelAudience?: ChannelAudience;
   readonly idempotencyKey: string;
   readonly parentTraceContext?: InstrumentationTraceContext;

--- a/packages/eve/src/harness/prepare-trace-context.ts
+++ b/packages/eve/src/harness/prepare-trace-context.ts
@@ -15,6 +15,7 @@ const log = createLogger("harness.prepare-trace-context");
 export async function prepareTurnTraceContext(input: {
   readonly agentName?: string;
   readonly channelAudience?: ChannelAudience;
+  readonly channelType?: string;
   readonly instrumentation?: HarnessInstrumentation;
   readonly parentLineage?: InstrumentationParentLineage;
   readonly parentTraceContext?: InstrumentationTraceContext;
@@ -33,6 +34,7 @@ export async function prepareTurnTraceContext(input: {
       prepared = await input.instrumentation.prepareSessionTrace({
         agentName: input.agentName,
         channelAudience: input.channelAudience,
+        channelType: input.channelType,
         idempotencyKey: sessionIdempotencyKey(input.sessionId),
         parentTraceContext: input.parentTraceContext,
         rootSessionId: input.rootSessionId,

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -735,6 +735,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       return await prepareTurnTraceContext({
         agentName: config.runtimeIdentity?.agentName,
         channelAudience,
+        channelType: channelInstrumentation?.channelType,
         instrumentation: config.instrumentation,
         parentLineage,
         parentTraceContext,

--- a/packages/eve/src/tracing/agent-otel-provider.test.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.test.ts
@@ -430,6 +430,26 @@ describe("createAgentOtelInstrumentation", () => {
     expect(session.spanContext().spanId).toBe(trace.spanId);
   });
 
+  it("passes channelType to the policy on the seedless fallback path", async () => {
+    let captured: { channelType?: string } | undefined;
+    const runtime = createRuntime(undefined, (trace) => {
+      captured = trace;
+      return true;
+    });
+    const sessionEvent = {
+      agentName: "weather",
+      channelType: "slack",
+      idempotencyKey: sessionIdempotencyKey("session-noseed-kind"),
+      rootSessionId: "session-noseed-kind",
+      sessionId: "session-noseed-kind",
+      type: "session.started" as const,
+    };
+
+    await runtime.prepareSessionTrace(sessionEvent);
+
+    expect(captured?.channelType).toBe("slack");
+  });
+
   it("inherits parent trace context for delegated agents", async () => {
     const runtime = createRuntime();
     const parentTrace: InstrumentationTraceContext = {

--- a/packages/eve/src/tracing/agent-otel-session-context.ts
+++ b/packages/eve/src/tracing/agent-otel-session-context.ts
@@ -39,6 +39,7 @@ export function createAgentOtelSessionContext(
   const openSessionTrace = (session: {
     readonly agentName?: string;
     readonly channelAudience: ChannelAudience;
+    readonly channelType?: string;
     readonly rootSessionId: string;
     readonly sessionId: string;
     readonly traceSeed?: InstrumentationTraceContext;
@@ -76,6 +77,7 @@ export function createAgentOtelSessionContext(
       !evaluateTracePolicy(input.tracePolicy, {
         agentName: session.agentName,
         audience: session.channelAudience,
+        channelType: session.channelType,
       })
     ) {
       return {
@@ -115,6 +117,7 @@ export function createAgentOtelSessionContext(
             ? openSessionTrace({
                 agentName: event.agentName,
                 channelAudience: normalizeChannelAudience(event.channelAudience),
+                channelType: event.channelType,
                 rootSessionId: event.rootSessionId,
                 sessionId: event.sessionId,
                 traceSeed: event.traceSeed,

--- a/packages/eve/src/tracing/otel-declaration.ts
+++ b/packages/eve/src/tracing/otel-declaration.ts
@@ -107,6 +107,7 @@ export interface ContentOptions {
 export interface TraceCaptureContext {
   readonly agentName?: string;
   readonly audience: ChannelAudience;
+  readonly channelType?: string;
 }
 
 export type TraceCapturePolicy = (trace: TraceCaptureContext) => boolean;

--- a/packages/eve/src/tracing/sampled-trace.ts
+++ b/packages/eve/src/tracing/sampled-trace.ts
@@ -14,6 +14,7 @@ export function evaluateTracePolicy(
   trace: {
     readonly agentName?: string;
     readonly audience: ChannelAudience;
+    readonly channelType?: string;
   },
 ): boolean {
   try {
@@ -21,6 +22,7 @@ export function evaluateTracePolicy(
       policy?.({
         agentName: trace.agentName,
         audience: trace.audience,
+        channelType: trace.channelType,
       }) ?? trace.audience === "public"
     );
   } catch {


### PR DESCRIPTION
### Summary

A trace capture policy could distinguish channel audiences, but not the originating channel type. `TraceCaptureContext` now includes the channel adapter kind as `channelType`, allowing policies to sample Slack, HTTP, scheduled, and other traffic differently. The value is available during both initial trace allocation and fallback session trace setup, so the policy receives consistent context across both paths. Existing policies that ignore `channelType` are unaffected.

### Validation

Unit coverage confirms that policies receive the bare adapter kind during initial trace allocation and that the seedless fallback forwards the same value. The complete eve unit and integration suites pass.

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Changeset describing the new sampling dimension.

**Implementation** — 10 files · `+19 / -1`

Threads the channel type through existing channel, execution, harness, and tracing boundaries to both policy evaluation paths.

**Tests** — 3 files · `+56 / -0`

Covers the initial allocation path, the fallback path, and the distinction between channel type and route-scoped instrumentation kind.
