### PR TITLE
feat(docs): add SRE agent template

### DIFF
--- a/apps/docs/app/[lang]/templates/integration-icons.tsx
+++ b/apps/docs/app/[lang]/templates/integration-icons.tsx
@@ -1,6 +1,7 @@
 import { BracesIcon } from "lucide-react";
 import type { ComponentType, SVGProps } from "react";
 import {
+  datadogLogo,
   githubLogo,
   linearLogo,
   notionLogo,
@@ -9,6 +10,7 @@ import {
   sentryLogo,
   slackLogo,
   typefullyLogo,
+  vercelLogo,
   webLogo,
 } from "@/lib/integrations/logos";
 import type { TemplateIntegration } from "@/lib/templates/data";
@@ -16,6 +18,7 @@ import type { TemplateIntegration } from "@/lib/templates/data";
 type IconComponent = ComponentType<SVGProps<SVGSVGElement>>;
 
 export const integrationIcons: Record<TemplateIntegration, IconComponent> = {
+  Datadog: datadogLogo,
   GitHub: githubLogo,
   "HTTP API": BracesIcon,
   Linear: linearLogo,
@@ -25,5 +28,6 @@ export const integrationIcons: Record<TemplateIntegration, IconComponent> = {
   Sentry: sentryLogo,
   Slack: slackLogo,
   Typefully: typefullyLogo,
+  Vercel: vercelLogo,
   "Web chat": webLogo,
 };

--- a/apps/docs/lib/templates/manifest.ts
+++ b/apps/docs/lib/templates/manifest.ts
@@ -4,6 +4,7 @@
 export type TemplateCategory = "Chat" | "Collaboration" | "Example" | "Marketing";
 
 export type TemplateIntegration =
+  | "Datadog"
   | "GitHub"
   | "HTTP API"
   | "Linear"
@@ -13,6 +14,7 @@ export type TemplateIntegration =
   | "Sentry"
   | "Slack"
   | "Typefully"
+  | "Vercel"
   | "Web chat";
 
 export type TemplateSource = "GitHub" | "Vercel Templates";
@@ -207,6 +209,34 @@ export const templateManifest: TemplateManifestEntry[] = [
       "agent/subagents/implementer/agent.ts",
       "agent/subagents/implementer/tools/push_branch.ts",
       "agent/subagents/reviewer/agent.ts",
+    ],
+  },
+  {
+    slug: "eve-sre-agent-template",
+    title: "Incident response",
+    setupPrompt:
+      "I want to set up sre, an incident response agent built with the eve framework. Read the setup instructions at https://github.com/vercel-labs/eve-sre-agent-template/blob/main/docs/setup-for-agents.md and follow them. They cover creating and linking the Vercel project, connecting Slack, GitHub, Datadog, and Vercel, deploying the agent, and verifying it in Slack.",
+    description:
+      "sre, an incident response agent that investigates alerts from Slack or webhooks using live Datadog, GitHub, and Vercel evidence, with read-only access by default.",
+    sourceHref: "https://github.com/vercel-labs/eve-sre-agent-template/tree/main",
+    category: "Collaboration",
+    model: "openai/gpt-5.6-terra",
+    integrations: ["Slack", "Datadog", "GitHub", "Vercel", "HTTP API"],
+    source: "Vercel Templates",
+    github: { owner: "vercel-labs", repo: "eve-sre-agent-template", ref: "main" },
+    files: [
+      "agent/agent.ts",
+      "agent/channels/slack.ts",
+      "agent/channels/webhook.ts",
+      "agent/connections/datadog.ts",
+      "agent/connections/vercel.ts",
+      "agent/extensions/github.ts",
+      "agent/instructions/instructions.md",
+      "agent/lib/webhook/route.ts",
+      "agent/skills/deep-investigation/SKILL.md",
+      "agent/skills/hypothesis-validation/SKILL.md",
+      "agent/tools/evidence_record.ts",
+      "agent/tools/watch_slack_channel.ts",
     ],
   },
   {


### PR DESCRIPTION
### Summary

Adds the sre incident response agent to the templates gallery with a coding-agent setup prompt modeled on Foreman. The gallery entry highlights its Slack, webhook, Datadog, GitHub, and Vercel surfaces and embeds representative agent files. Datadog and Vercel are also available as gallery integration filters.

### Validation

The focused template unit tests pass (13 tests), and the changed files pass TypeScript, oxlint, and formatting checks. `templates:sync` currently cannot complete because `vercel-labs/eve-sre-agent-template` is internal and the sync fetches file contents anonymously from `raw.githubusercontent.com`; the repository must be public before this can merge and build successfully.

### Checklist

- [x] This change was requested or approved by a maintainer
- [ ] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+30 / -0`

Adds the curated template metadata, coding-agent setup prompt, and representative file selection.

**Implementation** — 1 file · `+4 / -0`

Maps the two newly exposed integration filters to existing Datadog and Vercel logos.

**Tests** — 0 files · `+0 / -0`

Existing template composition and sync helpers cover this data-driven addition.
