### PR TITLE
fix(eve): publish sandbox image to public VCR repository

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -24,9 +24,9 @@ env:
   GHCR_REGISTRY: ghcr.io
   GHCR_IMAGE_NAME: vercel/eve
   VCR_REGISTRY: vcr.vercel.com
-  VCR_PROJECT_SLUG: eve-e2e
-  VCR_REPOSITORY: eve
-  VCR_TEAM_SLUG: curated-tests
+  VCR_PROJECT_SLUG: eve
+  VCR_REPOSITORY: base
+  VCR_TEAM_SLUG: vercel
 
 jobs:
   build:
@@ -97,10 +97,10 @@ jobs:
       - name: Validate VCR configuration
         if: github.event_name != 'pull_request'
         env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          EVE_VERCEL_IMAGE_TOKEN: ${{ secrets.EVE_VERCEL_IMAGE_TOKEN }}
         run: |
           missing=0
-          for name in VERCEL_TOKEN; do
+          for name in EVE_VERCEL_IMAGE_TOKEN; do
             if [ -z "${!name}" ]; then
               echo "::error::${name} must be configured to publish to VCR."
               missing=1
@@ -111,12 +111,12 @@ jobs:
       - name: Link Vercel project and pull OIDC token
         if: github.event_name != 'pull_request'
         env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          EVE_VERCEL_IMAGE_TOKEN: ${{ secrets.EVE_VERCEL_IMAGE_TOKEN }}
         run: |
           set -euo pipefail
 
-          pnpm dlx vercel@58.4.4 link --yes --project "$VCR_PROJECT_SLUG" --team "$VCR_TEAM_SLUG" --token "$VERCEL_TOKEN"
-          pnpm dlx vercel@58.4.4 env pull --yes --environment=preview --token "$VERCEL_TOKEN"
+          pnpm dlx vercel@58.4.4 link --yes --project "$VCR_PROJECT_SLUG" --team "$VCR_TEAM_SLUG" --token "$EVE_VERCEL_IMAGE_TOKEN"
+          pnpm dlx vercel@58.4.4 env pull --yes --environment=preview --token "$EVE_VERCEL_IMAGE_TOKEN"
 
           oidc_token="$(node -e '
             const fs = require("node:fs");


### PR DESCRIPTION
### Summary

Updates eve's VCR publishing target to the public `vercel/eve/base` repository and uses `EVE_VERCEL_IMAGE_TOKEN` while preserving the existing OIDC login flow. The Vercel sandbox backend continues using its current image until the new image is published and verified.

### Validation

No runtime tests are required because this change is limited to image-publishing configuration.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 1 file · `+8 / -8`

Retargets the existing VCR workflow and its authentication secret.

**Tests** — 0 files · `+0 / -0`

Not applicable; runtime behavior is unchanged.
