### PR TITLE
refactor(eve): plan instrumentation before workflow start

### DIFF
--- a/packages/eve/src/execution/eve-workflow-attributes.ts
+++ b/packages/eve/src/execution/eve-workflow-attributes.ts
@@ -38,6 +38,12 @@ import { isSampledTrace } from "#tracing/sampled-trace.js";
 import type { EveAttributeValue } from "#runtime/attributes/normalize.js";
 import { normalizeChannelAudience } from "#shared/channel-audience.js";
 import { isNonEmptyString } from "#shared/guards.js";
+import {
+  readPlanTraceId,
+  readPlanIsTraceContentVisible,
+  readPlanChannelKind,
+  type SerializedSessionInstrumentation,
+} from "#instrumentation/session-plan.js";
 
 /**
  * Active compiled graph node id for the session's agent. Returned by
@@ -67,6 +73,17 @@ interface SerializedSessionParent {
   };
 }
 
+function readPlanFromContext(
+  serializedContext: Record<string, unknown>,
+): SerializedSessionInstrumentation | undefined {
+  const raw = serializedContext["eve.sessionInstrumentationPlan"];
+  if (raw === undefined || typeof raw !== "object" || raw === null) return undefined;
+  const record = raw as Record<string, unknown>;
+  if (record["schemaVersion"] !== 1) return undefined;
+  if (typeof record["data"] !== "object" || record["data"] === null) return undefined;
+  return raw as SerializedSessionInstrumentation;
+}
+
 /**
  * Parent session lineage decoded from the serialized run context.
  */
@@ -83,6 +100,8 @@ export interface SessionParentLineage {
  * tag emission silently drops undefined values.
  */
 export function readChannelKind(serializedContext: Record<string, unknown>): string | undefined {
+  const plan = readPlanFromContext(serializedContext);
+  if (plan !== undefined) return readPlanChannelKind(plan);
   const channel = serializedContext[CHANNEL_CONTEXT_KEY_NAME] as
     | SerializedChannelAdapter
     | undefined;
@@ -91,6 +110,8 @@ export function readChannelKind(serializedContext: Record<string, unknown>): str
 }
 
 export function isWorkflowTraceContentVisible(serializedContext: Record<string, unknown>): boolean {
+  const plan = readPlanFromContext(serializedContext);
+  if (plan !== undefined) return readPlanIsTraceContentVisible(plan);
   const channel = serializedContext[CHANNEL_CONTEXT_KEY_NAME] as
     | SerializedChannelAdapter
     | undefined;
@@ -98,6 +119,8 @@ export function isWorkflowTraceContentVisible(serializedContext: Record<string, 
 }
 
 export function readSessionTraceId(serializedContext: Record<string, unknown>): string | undefined {
+  const plan = readPlanFromContext(serializedContext);
+  if (plan !== undefined) return readPlanTraceId(plan);
   const seed = serializedContext["eve.sessionTraceSeed"] as SessionTraceSeed | undefined;
   if (seed === undefined || !isSampledTrace(seed)) return undefined;
   return isNonEmptyString(seed.traceId) ? seed.traceId : undefined;

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -18,11 +18,7 @@ import type {
   SessionCommandResult,
 } from "#channel/types.js";
 import { serializeContext } from "#context/serialize.js";
-import {
-  ChannelInstrumentationKey,
-  SessionTraceSeedKey,
-  type SessionTraceSeed,
-} from "#context/keys.js";
+import { ChannelInstrumentationKey, ParentSessionKey, SessionTraceSeedKey } from "#context/keys.js";
 import {
   buildSessionAttributes,
   buildSubagentRootAttributes,
@@ -56,8 +52,14 @@ import { sessionCommandHookToken } from "#execution/session-command-token.js";
 import { resumeSessionInbox } from "#execution/wire/session-inbox-resume.js";
 import type { DynamicSubagentAgentConfig } from "#runtime/subagents/dynamic-agent-config.js";
 import { getInstrumentationRuntime } from "#instrumentation/runtime.js";
-import { evaluateTracePolicy } from "#tracing/sampled-trace.js";
-import { normalizeChannelAudience } from "#shared/channel-audience.js";
+import { resolveParentLineage } from "#harness/parent-lineage.js";
+import {
+  planSessionInstrumentation,
+  readPlanTraceContext,
+  SessionInstrumentationPlanKey,
+  type SessionInstrumentationPlanningInput,
+} from "#instrumentation/session-plan.js";
+import { ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
 
 const WORKFLOW_ENTRY_NAME = "workflowEntry";
 const TURN_WORKFLOW_NAME = "turnWorkflow";
@@ -147,12 +149,22 @@ export function createWorkflowRuntime(config: {
       });
       const effectiveAgent = resolveEffectiveAgentRuntime(bundle, ctx);
       const channelInstrumentation = ctx.get(ChannelInstrumentationKey);
-      const traceSeed = allocateSessionTraceSeed({
+      const parent = ctx.get(ParentSessionKey);
+      const instrumentationParentLineage = resolveParentLineage(parent, ctx.get(ChannelKey));
+      const rootSessionId = parent?.rootSessionId ?? "";
+      const planInput: SessionInstrumentationPlanningInput = {
         agentName: effectiveAgent.turnAgent.id,
-        audience: normalizeChannelAudience(channelInstrumentation?.metadata.audience),
-        channelType: channelInstrumentation?.channelType,
+        channel: channelInstrumentation,
         parentTraceContext: input.parentTraceContext,
+        parentLineage: instrumentationParentLineage,
+        rootSessionId,
+      };
+      const plan = planSessionInstrumentation({
+        runtime: getInstrumentationRuntime(),
+        session: planInput,
       });
+      ctx.set(SessionInstrumentationPlanKey, plan);
+      const traceSeed = readPlanTraceContext(plan);
       if (traceSeed !== undefined) {
         ctx.set(SessionTraceSeedKey, traceSeed);
       }
@@ -449,37 +461,5 @@ function normalizeWorkflowHook(value: unknown): WorkflowHookRecord {
 
   return {
     runId,
-  };
-}
-
-function allocateSessionTraceSeed(input: {
-  readonly agentName?: string;
-  readonly audience: ReturnType<typeof normalizeChannelAudience>;
-  readonly channelType?: string;
-  readonly parentTraceContext?: {
-    readonly traceId: string;
-    readonly spanId: string;
-    readonly traceFlags: number;
-  };
-}): SessionTraceSeed | undefined {
-  if (input.parentTraceContext !== undefined) {
-    return {
-      spanId: input.parentTraceContext.spanId,
-      traceFlags: input.parentTraceContext.traceFlags,
-      traceId: input.parentTraceContext.traceId,
-    };
-  }
-  const instrumentation = getInstrumentationRuntime();
-  if (instrumentation?.prepareSessionTrace === undefined) return undefined;
-  if (instrumentation.idGenerator === undefined) return undefined;
-  const sampled = evaluateTracePolicy(instrumentation.otelSettings?.tracePolicy, {
-    agentName: input.agentName,
-    audience: input.audience,
-    channelType: input.channelType,
-  });
-  return {
-    spanId: instrumentation.idGenerator.allocateSpanId(),
-    traceFlags: sampled ? 1 : 0,
-    traceId: instrumentation.idGenerator.generateTraceId(),
   };
 }

--- a/packages/eve/src/instrumentation/session-plan.test.ts
+++ b/packages/eve/src/instrumentation/session-plan.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { ChannelInstrumentationProjection } from "#channel/instrumentation.js";
 import {
   planSessionInstrumentation,
   parseSessionInstrumentationPlan,
@@ -9,6 +10,7 @@ import {
   type InstrumentationPlanningRuntime,
   type SessionInstrumentationPlanningInput,
 } from "#instrumentation/session-plan.js";
+import type { ChannelAudience } from "#shared/channel-audience.js";
 
 function makeRuntime(
   overrides: Partial<InstrumentationPlanningRuntime> = {},
@@ -24,6 +26,7 @@ function makeRuntime(
       recordOutputs: false,
     },
     hooks: { capturesContent: false },
+    prepareSessionTrace: () => undefined,
     ...overrides,
   };
 }
@@ -39,7 +42,6 @@ function makeSession(
       metadata: { audience: "public" },
     },
     rootSessionId: "session-1",
-    sessionId: "session-1",
     ...overrides,
   };
 }
@@ -119,7 +121,6 @@ describe("planSessionInstrumentation", () => {
           parentTraceContext,
           parentLineage: { callId: "call-1", sessionId: "parent-1", turnId: "turn_1" },
           rootSessionId: "parent-1",
-          sessionId: "child-1",
         }),
       });
       const data = parseSessionInstrumentationPlan(plan);
@@ -294,17 +295,15 @@ describe("planSessionInstrumentation", () => {
 
   describe("frozen classification", () => {
     it("snapshots audience at planning time", () => {
-      const metadata: { audience: string } = { audience: "public" };
-      const channel = { channelType: "web", kind: "web", metadata } as unknown as {
-        channelType: string;
-        kind: string;
-        metadata: { audience: string };
+      const metadata: { audience: ChannelAudience } = { audience: "public" };
+      const channel: ChannelInstrumentationProjection = {
+        channelType: "web",
+        kind: "web",
+        metadata,
       };
       const plan = planSessionInstrumentation({
         runtime: makeRuntime(),
-        session: makeSession({
-          channel: channel as unknown as SessionInstrumentationPlanningInput["channel"],
-        }),
+        session: makeSession({ channel }),
       });
       const data = parseSessionInstrumentationPlan(plan);
       expect(data?.audience).toBe("public");

--- a/packages/eve/src/instrumentation/session-plan.ts
+++ b/packages/eve/src/instrumentation/session-plan.ts
@@ -10,7 +10,7 @@ import type {
   InstrumentationTraceContext,
 } from "#instrumentation/lifecycle.js";
 import type { RuntimeTraceContext } from "#protocol/message.js";
-import type { JsonObject } from "#shared/json.js";
+import type { JsonObject, JsonValue } from "#shared/json.js";
 
 /**
  * Opaque serialized session instrumentation plan.
@@ -34,7 +34,6 @@ export interface SessionInstrumentationPlanningInput {
   readonly parentTraceContext?: InstrumentationTraceContext;
   readonly parentLineage?: InstrumentationParentLineage;
   readonly rootSessionId: string;
-  readonly sessionId: string;
 }
 
 /** Frozen session instrumentation facts, private to `src/instrumentation/`. */
@@ -57,6 +56,16 @@ export interface SessionInstrumentationPlanData {
 }
 
 const SCHEMA_VERSION = 1 as const;
+
+function toJsonObject(data: SessionInstrumentationPlanData): JsonObject {
+  const result: Record<string, JsonValue> = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (value !== undefined) {
+      result[key] = value as JsonValue;
+    }
+  }
+  return result;
+}
 
 function isInstrumentationCaptureLevel(value: unknown): value is InstrumentationCapture {
   return value === "content" || value === "metadata";
@@ -177,10 +186,14 @@ export function planSessionInstrumentation(input: {
       parentLineage,
       rootSessionId,
     };
-    return { schemaVersion: SCHEMA_VERSION, data: data as unknown as JsonObject };
+    return { schemaVersion: SCHEMA_VERSION, data: toJsonObject(data) };
   }
 
-  if (runtime?.idGenerator === undefined || runtime.otelSettings === undefined) {
+  if (
+    runtime?.idGenerator === undefined ||
+    runtime.otelSettings === undefined ||
+    runtime.prepareSessionTrace === undefined
+  ) {
     const data: SessionInstrumentationPlanData = {
       agentName,
       audience,
@@ -194,7 +207,7 @@ export function planSessionInstrumentation(input: {
       isTraceContentVisible: shouldCaptureContent(audience),
       rootSessionId,
     };
-    return { schemaVersion: SCHEMA_VERSION, data: data as unknown as JsonObject };
+    return { schemaVersion: SCHEMA_VERSION, data: toJsonObject(data) };
   }
 
   const sampled = evaluateTracePolicySafe(runtime.otelSettings.tracePolicy, {
@@ -218,7 +231,7 @@ export function planSessionInstrumentation(input: {
     recordOutputs: runtime.otelSettings.recordOutputs,
     rootSessionId,
   };
-  return { schemaVersion: SCHEMA_VERSION, data: data as unknown as JsonObject };
+  return { schemaVersion: SCHEMA_VERSION, data: toJsonObject(data) };
 }
 
 function resolveCaptureLevel(
@@ -270,6 +283,7 @@ export interface InstrumentationPlanningRuntime {
     readonly recordOutputs?: boolean;
   };
   readonly hooks?: { readonly capturesContent: boolean };
+  readonly prepareSessionTrace?: unknown;
 }
 
 // ---------- Workflow attribute helpers ----------


### PR DESCRIPTION
### Summary

Stack 3/10. Replaces trace-policy and ID allocation in `createWorkflowRuntime().createSession()` with one instrumentation planning call, stores the plan before workflow serialization, and derives `$eve.trace_id`, `$eve.trigger`, and `$eve.is_trace_content_visible` from it. Legacy context reads remain migration-only fallbacks until stack PR #2554.

### Validation

Validated with focused workflow-runtime and workflow-attribute tests plus the complete stack suites.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package (included in stack PR #2556)
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 3 files · `+65 / -48`

Moves create-time policy decisions behind the plan and switches workflow attribute projection to the frozen source.

**Tests** — 1 file · `+9 / -10`

Updates plan fixtures while preserving the existing workflow-runtime coverage.
