### PR TITLE
refactor(eve): bind session instrumentation once per worker

### DIFF
--- a/packages/eve/src/execution/node-step.ts
+++ b/packages/eve/src/execution/node-step.ts
@@ -11,7 +11,8 @@ import { LOAD_SKILL_TOOL_NAME } from "#runtime/skills/fragment-context.js";
 import { createToolLoopHarness } from "#harness/tool-loop.js";
 import type { HandleEventFn, HarnessToolMap, StepFn } from "#harness/types.js";
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
-import { getInstrumentationRuntime } from "#instrumentation/runtime.js";
+import type { SessionInstrumentation } from "#instrumentation/session-plan.js";
+import { bindSessionInstrumentation } from "#instrumentation/bind-session.js";
 import { createLogger } from "#internal/logging.js";
 import type { RuntimeIdentity } from "#protocol/message.js";
 import { UNSPECIFIED_INPUT_SCHEMA } from "#tools/schema.js";
@@ -74,6 +75,7 @@ export interface CreateExecutionNodeStepInput {
   readonly handleEvent?: HandleEventFn;
   readonly historyProjector?: HistoryViewProjector;
   readonly historyView?: PreparedHistoryView;
+  readonly instrumentation?: SessionInstrumentation;
   readonly mode: RunMode;
   readonly modelResolutionScope: RuntimeModelResolutionScope;
   readonly node: ResolvedRuntimeAgentNode;
@@ -89,6 +91,14 @@ export interface CreateExecutionNodeStepInput {
  * tool, sandbox, and subagent wiring.
  */
 export function createExecutionNodeStep(input: CreateExecutionNodeStepInput): StepFn {
+  const instrumentation =
+    input.instrumentation ??
+    bindSessionInstrumentation({
+      plan: undefined,
+      rootSessionId: "",
+      runtime: undefined,
+      sessionId: "",
+    });
   const resolveModel = createRuntimeModelResolver(input.modelResolutionScope);
   const dispatchModelEvent =
     input.node.turnAgent.dynamicModel === undefined
@@ -98,7 +108,6 @@ export function createExecutionNodeStep(input: CreateExecutionNodeStepInput): St
           input.node.turnAgent.dynamicModel,
         );
   const tools = createNodeHarnessTools({ node: input.node });
-  const instrumentation = getInstrumentationRuntime();
   const step = createToolLoopHarness({
     abortSignal: input.abortSignal,
     capabilities: input.capabilities,
@@ -118,7 +127,6 @@ export function createExecutionNodeStep(input: CreateExecutionNodeStepInput): St
     runtimeIdentity: buildRuntimeIdentity(input.node),
     tools,
   });
-  if (instrumentation === undefined) return step;
   return async (session, stepInput) => {
     try {
       return await step(session, stepInput);

--- a/packages/eve/src/execution/settle-cancelled-turn-step.ts
+++ b/packages/eve/src/execution/settle-cancelled-turn-step.ts
@@ -29,6 +29,8 @@ import { abandonRunningAgentTurns } from "#harness/handles/transitions.js";
 import { clearPendingRuntimeActionBatch } from "#harness/runtime-actions.js";
 import { createInstrumentationHandleEvent } from "#harness/instrumentation/native-events.js";
 import { getInstrumentationRuntime } from "#instrumentation/runtime.js";
+import { bindSessionInstrumentation } from "#instrumentation/bind-session.js";
+import { SessionInstrumentationPlanKey } from "#instrumentation/session-plan.js";
 import { getTurnUsageState, toUsage } from "#harness/turn-tag-state.js";
 import { clearPendingWorkflowInterrupt } from "#harness/workflow-interrupt-state.js";
 import {
@@ -65,14 +67,18 @@ export async function settleCancelledTurnStep(input: {
   const adapterCtx = buildAdapterContext(adapter, ctx);
   const bundle = ctx.require(BundleKey);
   const effectiveAgent = resolveEffectiveAgentRuntime(bundle, ctx);
-  const instrumentation = getInstrumentationRuntime();
-
   let session = hydrateDurableSession({
     compactionOverrides: {
       thresholdPercent: effectiveAgent.thresholdPercent,
     },
     durable: durableSession,
     turnAgent: effectiveAgent.turnAgent,
+  });
+  const instrumentation = bindSessionInstrumentation({
+    plan: ctx.get(SessionInstrumentationPlanKey),
+    rootSessionId: session.rootSessionId ?? session.sessionId,
+    runtime: getInstrumentationRuntime(),
+    sessionId: session.sessionId,
   });
 
   let emissionState = getHarnessEmissionState(durableSession.state);
@@ -109,7 +115,7 @@ export async function settleCancelledTurnStep(input: {
             agentName: bundle.turnAgent.id,
             channelKind: ctx.get(ChannelInstrumentationKey)?.kind,
             handleEvent: baseEmit,
-            hooks: instrumentation?.hooks,
+            hooks: instrumentation.hooks,
             sessionId: session.sessionId,
             turnId: activeTurnId(emissionState),
           }) ?? baseEmit;
@@ -121,7 +127,7 @@ export async function settleCancelledTurnStep(input: {
       emissionState = scoped.result;
       session = scoped.session;
     } finally {
-      await instrumentation?.forceFlush();
+      await instrumentation.forceFlush();
       writer.releaseLock();
     }
   }

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -43,6 +43,8 @@ import {
   instrumentChannelDelivery,
 } from "#harness/channel-delivery-instrumentation.js";
 import { getInstrumentationRuntime } from "#instrumentation/runtime.js";
+import { bindSessionInstrumentation } from "#instrumentation/bind-session.js";
+import { SessionInstrumentationPlanKey } from "#instrumentation/session-plan.js";
 import { preserveSerializedInstrumentationState } from "#instrumentation/state.js";
 import { RuntimeActionSettlementTimesKey } from "#harness/runtime-action-settlement-state.js";
 import { preserveSerializedAgentTraceState } from "#tracing/agent-trace-context-store.js";
@@ -193,7 +195,12 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
     turnAgent: effectiveAgent.turnAgent,
   });
   const history = createExecutionHistoryView(initialSession);
-  const instrumentation = getInstrumentationRuntime();
+  const instrumentation = bindSessionInstrumentation({
+    plan: ctx.get(SessionInstrumentationPlanKey),
+    rootSessionId: initialSession.rootSessionId ?? initialSession.sessionId,
+    runtime: getInstrumentationRuntime(),
+    sessionId: initialSession.sessionId,
+  });
   const initialEmissionState = getHarnessEmissionState(initialSession.state);
 
   if (rawInput.input?.kind === "deliver") {
@@ -202,7 +209,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
         agentName: bundle.turnAgent.id,
         ctx,
         delivery: rawInput.input as DeliverHookPayload,
-        hooks: instrumentation?.hooks,
+        instrumentation,
         rootSessionId: initialSession.rootSessionId ?? initialSession.sessionId,
         sequence: initialEmissionState.sequence,
         sessionId: initialSession.sessionId,
@@ -217,7 +224,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
         ctx,
         error,
         errorCode: channelDeliveryErrorCode(error),
-        hooks: instrumentation?.hooks,
+        instrumentation,
         includeTurn: false,
         outcome: "failed",
       }),
@@ -294,7 +301,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
     await contextStorage.run(ctx, () =>
       instrumentChannelDelivery({
         ctx,
-        hooks: instrumentation?.hooks,
+        instrumentation,
         includeTurn: false,
         outcome: "completed",
       }),
@@ -441,9 +448,8 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
           prepareDynamicInstructionPreamble(ctx, history.messages(schemaSession));
           let instructionMessages: readonly import("ai").ModelMessage[] = [];
           const traceContext = await prepareWorkflowPreambleTrace({
-            ctx,
             emissionState,
-            runtimeIdentity,
+            instrumentation,
             session: schemaSession,
           });
           try {
@@ -509,6 +515,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
           handleEvent,
           historyProjector: history.projector,
           historyView: history.prepare(modelSession),
+          instrumentation,
           mode,
           modelResolutionScope: {
             moduleMap: bundle.moduleMap,

--- a/packages/eve/src/execution/workflow-trace-context.ts
+++ b/packages/eve/src/execution/workflow-trace-context.ts
@@ -1,40 +1,18 @@
-import type { ContextContainer } from "#context/container.js";
-import {
-  ChannelInstrumentationKey,
-  ParentSessionKey,
-  ParentTraceContextKey,
-  SessionTraceSeedKey,
-} from "#context/keys.js";
 import type { HarnessEmissionState } from "#harness/emission.js";
-import { getInstrumentationRuntime } from "#instrumentation/runtime.js";
-import { resolveParentLineage } from "#harness/parent-lineage.js";
-import { prepareTurnTraceContext } from "#harness/prepare-trace-context.js";
 import type { HarnessSession } from "#harness/types.js";
-import type { RuntimeIdentity, RuntimeTraceContext } from "#protocol/message.js";
-import { ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
-import { normalizeChannelAudience } from "#shared/channel-audience.js";
+import type { SessionInstrumentation } from "#instrumentation/session-plan.js";
+import type { RuntimeTraceContext } from "#protocol/message.js";
 
 /** Prepares native tracing for workflow-owned preambles emitted outside the tool loop. */
 export async function prepareWorkflowPreambleTrace(input: {
-  readonly ctx: ContextContainer;
   readonly emissionState: HarnessEmissionState;
-  readonly runtimeIdentity: RuntimeIdentity;
+  readonly instrumentation: SessionInstrumentation;
   readonly session: HarnessSession;
 }): Promise<RuntimeTraceContext | undefined> {
-  const parent = input.ctx.get(ParentSessionKey);
-  const channel = input.ctx.get(ChannelInstrumentationKey);
-  return await prepareTurnTraceContext({
-    agentName: input.runtimeIdentity.agentName,
-    channelAudience: normalizeChannelAudience(channel?.metadata.audience),
-    channelType: channel?.channelType,
-    instrumentation: getInstrumentationRuntime(),
-    parentLineage: resolveParentLineage(parent, input.ctx.get(ChannelKey)),
-    parentTraceContext: input.ctx.get(ParentTraceContextKey),
-    rootSessionId: parent?.rootSessionId ?? input.session.rootSessionId ?? input.session.sessionId,
+  return await input.instrumentation.preparePreamble({
     sequence: input.emissionState.sequence,
     sessionId: input.session.sessionId,
     sessionStarted: input.emissionState.sessionStarted,
-    traceSeed: input.ctx.get(SessionTraceSeedKey),
     turnId: `turn_${input.emissionState.sequence}`,
   });
 }

--- a/packages/eve/src/harness/channel-delivery-instrumentation.test.ts
+++ b/packages/eve/src/harness/channel-delivery-instrumentation.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from "vitest";
 
 import { ContextContainer, contextStorage } from "#context/container.js";
-import { ChannelInstrumentationKey, ParentTraceContextKey } from "#context/keys.js";
 import { instrumentChannelDelivery } from "#harness/channel-delivery-instrumentation.js";
+import { bindSessionInstrumentation } from "#instrumentation/bind-session.js";
 import {
   createInstrumentationHooks,
   type InstrumentationEvent,
 } from "#instrumentation/lifecycle.js";
+import type { InstrumentationRuntime } from "#instrumentation/runtime.js";
+import { planSessionInstrumentation } from "#instrumentation/session-plan.js";
 
 describe("channel delivery instrumentation", () => {
   it("projects only known content and redacts it from metadata providers", async () => {
@@ -38,11 +40,31 @@ describe("channel delivery instrumentation", () => {
       traceFlags: 1,
       traceId: "11111111111111111111111111111111",
     };
-    ctx.set(ChannelInstrumentationKey, {
-      kind: "channel:slack",
-      metadata: { audience: "public" },
+    const runtime: InstrumentationRuntime = {
+      forceFlush: async () => undefined,
+      hooks,
+      otelSettings: undefined,
+      runInContext: (_operation, execute) => execute(),
+      shutdown: async () => undefined,
+    };
+    const plan = planSessionInstrumentation({
+      runtime,
+      session: {
+        agentName: "test-agent",
+        channel: {
+          kind: "channel:slack",
+          metadata: { audience: "public" },
+        },
+        parentTraceContext,
+        rootSessionId: "session-1",
+      },
     });
-    ctx.set(ParentTraceContextKey, parentTraceContext);
+    const instrumentation = bindSessionInstrumentation({
+      plan,
+      rootSessionId: "session-1",
+      runtime,
+      sessionId: "session-1",
+    });
 
     await contextStorage.run(ctx, async () => {
       await instrumentChannelDelivery({
@@ -59,7 +81,7 @@ describe("channel delivery instrumentation", () => {
           kind: "deliver",
           payloads: [{ interaction: { secret: true }, message: "hello" }],
         },
-        hooks,
+        instrumentation,
         rootSessionId: "session-1",
         sequence: 0,
         sessionId: "session-1",
@@ -67,7 +89,7 @@ describe("channel delivery instrumentation", () => {
       });
       await instrumentChannelDelivery({
         ctx,
-        hooks,
+        instrumentation,
         includeTurn: true,
         outcome: "completed",
       });

--- a/packages/eve/src/harness/channel-delivery-instrumentation.ts
+++ b/packages/eve/src/harness/channel-delivery-instrumentation.ts
@@ -1,26 +1,20 @@
 import type { DeliverHookPayload, DeliverPayload } from "#channel/types.js";
 import type { AlsContext } from "#context/container.js";
-import {
-  ActiveChannelDeliveriesKey,
-  ChannelInstrumentationKey,
-  ParentTraceContextKey,
-  SessionTraceSeedKey,
-  type ActiveChannelDelivery,
-} from "#context/keys.js";
+import { ActiveChannelDeliveriesKey, type ActiveChannelDelivery } from "#context/keys.js";
 import type {
   InstrumentationChannelDeliveryOutcome,
   InstrumentationChannelDeliveryTerminalEvent,
   InstrumentationHooks,
 } from "#instrumentation/lifecycle.js";
 import { channelDeliveryIdempotencyKey } from "#instrumentation/lifecycle.js";
-import { instrumentationHooksForAudience } from "#harness/instrumentation/content-policy.js";
-import { normalizeChannelAudience } from "#shared/channel-audience.js";
+import type { SessionInstrumentation } from "#instrumentation/session-plan.js";
 
 interface ChannelDeliveryStartInstrumentation {
   readonly agentName?: string;
   readonly ctx: AlsContext;
   readonly delivery: DeliverHookPayload;
-  readonly hooks: InstrumentationHooks | undefined;
+  readonly hooks?: InstrumentationHooks;
+  readonly instrumentation?: SessionInstrumentation;
   readonly rootSessionId: string;
   readonly sequence: number;
   readonly sessionId: string;
@@ -31,7 +25,8 @@ interface ChannelDeliveryTerminalInstrumentation {
   readonly ctx: AlsContext;
   readonly error?: unknown;
   readonly errorCode?: string;
-  readonly hooks: InstrumentationHooks | undefined;
+  readonly hooks?: InstrumentationHooks;
+  readonly instrumentation?: SessionInstrumentation;
   readonly includeTurn: boolean;
   readonly outcome: InstrumentationChannelDeliveryOutcome;
 }
@@ -45,17 +40,15 @@ export function instrumentChannelDelivery(
 export async function instrumentChannelDelivery(
   input: ChannelDeliveryStartInstrumentation | ChannelDeliveryTerminalInstrumentation,
 ): Promise<void> {
+  const instrumentation = resolveInstrumentation(input);
+  if (instrumentation === undefined) return;
   if (!("delivery" in input)) {
     const active = input.ctx.get(ActiveChannelDeliveriesKey);
-    if (active === undefined || input.hooks === undefined) return;
+    if (active === undefined) return;
     const type =
       `channel.delivery.${input.outcome}` as InstrumentationChannelDeliveryTerminalEvent["type"];
     for (const item of active) {
-      const hooks = instrumentationHooksForAudience(
-        input.hooks,
-        normalizeChannelAudience(item.delivery.channelAudience),
-      );
-      await hooks?.publish({
+      await instrumentation.publish({
         agentName: item.agentName,
         delivery: item.delivery,
         error: input.error,
@@ -73,17 +66,12 @@ export async function instrumentChannelDelivery(
     return;
   }
 
-  if (input.hooks === undefined || input.delivery.deliveryMetadata === undefined) return;
+  if (input.delivery.deliveryMetadata === undefined) return;
 
   const active: ActiveChannelDelivery[] = [];
-  const channelAudience = normalizeChannelAudience(
-    input.ctx.get(ChannelInstrumentationKey)?.metadata.audience,
-  );
-  const hooks = instrumentationHooksForAudience(input.hooks, channelAudience);
   for (const metadata of input.delivery.deliveryMetadata) {
     const payload = input.delivery.payloads[metadata.payloadIndex];
     const delivery = {
-      channelAudience,
       channelKind: metadata.channelKind,
       channelName: metadata.channelName,
       deliveryId: metadata.deliveryId,
@@ -91,7 +79,9 @@ export async function instrumentChannelDelivery(
       requestTraceContext: metadata.requestTraceContext,
     };
     const deliveryInput =
-      !hooks?.capturesContent || payload === undefined ? undefined : projectDeliveryInput(payload);
+      !instrumentation.hooks.capturesContent || payload === undefined
+        ? undefined
+        : projectDeliveryInput(payload);
     const item: ActiveChannelDelivery = {
       agentName: input.agentName,
       delivery,
@@ -101,19 +91,25 @@ export async function instrumentChannelDelivery(
       turnId: input.turnId,
     };
     active.push(item);
-    await hooks?.publish({
+    await instrumentation.publish({
       agentName: item.agentName,
       delivery,
       idempotencyKey: channelDeliveryIdempotencyKey(input.sessionId, delivery.deliveryId),
       input: deliveryInput,
-      parentTraceContext: input.ctx.get(ParentTraceContextKey),
       rootSessionId: input.rootSessionId,
       sessionId: input.sessionId,
-      traceSeed: input.ctx.get(SessionTraceSeedKey),
       type: "channel.delivery.started",
     });
   }
   if (active.length > 0) input.ctx.set(ActiveChannelDeliveriesKey, active);
+}
+
+function resolveInstrumentation(
+  input: ChannelDeliveryStartInstrumentation | ChannelDeliveryTerminalInstrumentation,
+): Pick<SessionInstrumentation, "hooks" | "publish"> | undefined {
+  if (input.instrumentation !== undefined) return input.instrumentation;
+  if (input.hooks === undefined) return undefined;
+  return { hooks: input.hooks, publish: (event) => input.hooks!.publish(event) };
 }
 
 function projectDeliveryInput(payload: DeliverPayload) {

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -37,7 +37,6 @@ import {
   ParentSessionKey,
   ParentTraceContextKey,
   SessionCallbackKey,
-  SessionTraceSeedKey,
   TurnTaskDeliveryKey,
   TurnTaskStateKey,
 } from "#context/keys.js";
@@ -156,7 +155,6 @@ import {
 import type { InstrumentationAttemptScope } from "#instrumentation/lifecycle.js";
 import { attemptIdempotencyKey } from "#instrumentation/lifecycle.js";
 import { resolveParentLineage } from "#harness/parent-lineage.js";
-import { prepareTurnTraceContext } from "#harness/prepare-trace-context.js";
 import { ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
 import { TASK_UPDATE_TOOL_NAME } from "#tools/framework/task-contract.js";
 import { readTaskIdFromInboxToken } from "#tasks/task-inbox-token.js";
@@ -672,7 +670,6 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     const taskUpdatesEnabled = taskOwned && config.tools.has(TASK_UPDATE_TOOL_NAME);
     const parentLineage = resolveParentLineage(parent, channel);
     const parentTraceContext = store?.get(ParentTraceContextKey);
-    const traceSeed = store?.get(SessionTraceSeedKey);
     let activeAttemptScope: InstrumentationAttemptScope | undefined;
     const emit = createInstrumentationHandleEvent({
       agentName: config.runtimeIdentity?.agentName,
@@ -732,20 +729,13 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
               traceId: spanContext.traceId,
             }
           : undefined;
-      return await prepareTurnTraceContext({
-        agentName: config.runtimeIdentity?.agentName,
-        channelAudience,
-        channelType: channelInstrumentation?.channelType,
-        instrumentation: config.instrumentation,
-        parentLineage,
-        parentTraceContext,
-        rootSessionId: parent?.rootSessionId ?? session.rootSessionId ?? session.sessionId,
+      if (config.instrumentation?.preparePreamble === undefined) return authoredTraceContext;
+      return await config.instrumentation.preparePreamble({
         sequence: emissionState.sequence,
         sessionId: session.sessionId,
         sessionStarted: emissionState.sessionStarted,
-        traceContext: authoredTraceContext,
-        traceSeed,
         turnId: `turn_${emissionState.sequence}`,
+        traceContext: authoredTraceContext,
       });
     };
 

--- a/packages/eve/src/harness/types.ts
+++ b/packages/eve/src/harness/types.ts
@@ -14,7 +14,7 @@ import type { InternalToolDefinition } from "#tools/definition.js";
 import type { WebSearchProvider } from "#shared/web-search.js";
 import type { AgentReasoningDefinition } from "#shared/agent-definition.js";
 import type { HarnessToolDefinition } from "#harness/execute-tool.js";
-import type { HarnessInstrumentation } from "#instrumentation/runtime.js";
+import type { SessionInstrumentation } from "#instrumentation/session-plan.js";
 import type { HistoryViewProjector, PreparedHistoryView } from "#shared/history-view.js";
 
 /**
@@ -24,6 +24,21 @@ import type { HistoryViewProjector, PreparedHistoryView } from "#shared/history-
  * across workflow step boundaries.
  */
 export type SessionToolDefinition = Readonly<InternalToolDefinition>;
+
+type ToolLoopInstrumentation = Pick<SessionInstrumentation, "hooks" | "runInContext"> &
+  Partial<
+    Pick<
+      SessionInstrumentation,
+      | "forceFlush"
+      | "preparePreamble"
+      | "prepareSessionTrace"
+      | "prepareTurnTrace"
+      | "propagationFor"
+      | "publish"
+      | "runStep"
+      | "telemetryForAttempt"
+    >
+  >;
 
 /** Authored-key → opaque-value map stored on `session.state`. */
 export type SessionStateMap = Readonly<Record<string, unknown>>;
@@ -310,7 +325,7 @@ export interface ToolLoopHarnessConfig {
    * Internal lifecycle hooks injected into each actual model attempt.
    * Omitted in production until an instrumentation runtime opts in.
    */
-  readonly instrumentation?: HarnessInstrumentation;
+  readonly instrumentation?: ToolLoopInstrumentation;
   /**
    * Execution mode for the current harness.
    *

--- a/packages/eve/src/instrumentation/bind-session.test.ts
+++ b/packages/eve/src/instrumentation/bind-session.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+
+import { bindSessionInstrumentation } from "#instrumentation/bind-session.js";
+import {
+  createInstrumentationHooks,
+  type InstrumentationEvent,
+  type InstrumentationHooks,
+} from "#instrumentation/lifecycle.js";
+import type { InstrumentationRuntime } from "#instrumentation/runtime.js";
+import { planSessionInstrumentation } from "#instrumentation/session-plan.js";
+import { AgentSpanIdGenerator } from "#tracing/agent-span-id-generator.js";
+
+function runtime(input: {
+  readonly hooks: InstrumentationHooks;
+  readonly sampled?: boolean;
+}): InstrumentationRuntime {
+  return {
+    forceFlush: async () => undefined,
+    hooks: input.hooks,
+    idGenerator: new AgentSpanIdGenerator(),
+    otelSettings: {
+      recordInputs: false,
+      recordOutputs: false,
+      traceChannelRequests: false,
+      tracePolicy: () => input.sampled ?? false,
+    },
+    prepareSessionTrace: async () => ({
+      spanId: "1111111111111111",
+      traceFlags: input.sampled ? 1 : 0,
+      traceId: "44444444444444444444444444444444",
+    }),
+    runInContext: (_operation, execute) => execute(),
+    shutdown: async () => undefined,
+  };
+}
+
+function plan(input: {
+  readonly audience?: "private" | "public";
+  readonly hooks: InstrumentationHooks;
+  readonly sampled?: boolean;
+}) {
+  return planSessionInstrumentation({
+    runtime: runtime(input),
+    session: {
+      agentName: "test-agent",
+      channel: {
+        channelType: "web",
+        kind: "channel:web",
+        metadata: { audience: input.audience ?? "public" },
+      },
+      rootSessionId: "session-1",
+    },
+  });
+}
+
+function modelStartedEvent(): InstrumentationEvent {
+  return {
+    idempotencyKey: "model-1",
+    input: { instructions: "secret", messages: [{ role: "user", content: "hello" }] },
+    model: { modelId: "test", provider: "test" },
+    scope: {
+      attemptId: "attempt-1",
+      attemptIndex: 0,
+      sessionId: "session-1",
+      stepIndex: 0,
+      turnId: "turn_0",
+    },
+    type: "model.call.started",
+  };
+}
+
+describe("bindSessionInstrumentation", () => {
+  it("binds current provider implementations without increasing frozen capture", async () => {
+    const planningHooks = createInstrumentationHooks([]);
+    const frozenPlan = plan({ hooks: planningHooks, sampled: false });
+    const received: InstrumentationEvent[] = [];
+    const currentHooks = createInstrumentationHooks([
+      {
+        capture: "content",
+        events: {
+          "model.call.started": (event) => {
+            received.push(event);
+          },
+        },
+        name: "current",
+      },
+    ]);
+    const controls = bindSessionInstrumentation({
+      plan: frozenPlan,
+      rootSessionId: "session-1",
+      runtime: runtime({ hooks: currentHooks, sampled: false }),
+      sessionId: "session-1",
+    });
+
+    await controls.publish(modelStartedEvent());
+
+    expect(controls.hooks.capturesContent).toBe(false);
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({ input: undefined });
+  });
+
+  it("does not let rejected OTel admission suppress authored content capture", async () => {
+    const received: InstrumentationEvent[] = [];
+    const hooks = createInstrumentationHooks([
+      {
+        capture: "content",
+        events: {
+          "model.call.started": (event) => {
+            received.push(event);
+          },
+        },
+        name: "authored",
+      },
+    ]);
+    const frozenPlan = plan({ hooks, sampled: false });
+    const controls = bindSessionInstrumentation({
+      plan: frozenPlan,
+      rootSessionId: "session-1",
+      runtime: runtime({ hooks, sampled: false }),
+      sessionId: "session-1",
+    });
+
+    await controls.publish(modelStartedEvent());
+
+    expect(received[0]).toMatchObject({
+      input: { instructions: "secret", messages: [{ role: "user", content: "hello" }] },
+    });
+  });
+
+  it("keeps admitted private trace content for destination-local redaction", async () => {
+    const received: InstrumentationEvent[] = [];
+    const hooks = createInstrumentationHooks([
+      {
+        capture: "content",
+        events: {
+          "model.call.started": (event) => {
+            received.push(event);
+          },
+        },
+        name: "otel",
+      },
+    ]);
+    const frozenPlan = plan({ audience: "private", hooks, sampled: true });
+    const controls = bindSessionInstrumentation({
+      plan: frozenPlan,
+      rootSessionId: "session-1",
+      runtime: runtime({ hooks, sampled: true }),
+      sessionId: "session-1",
+    });
+
+    await controls.publish(modelStartedEvent());
+
+    expect(received[0]).toMatchObject({
+      input: { instructions: "secret", messages: [{ role: "user", content: "hello" }] },
+    });
+  });
+});

--- a/packages/eve/src/instrumentation/bind-session.ts
+++ b/packages/eve/src/instrumentation/bind-session.ts
@@ -1,0 +1,146 @@
+import { withoutInstrumentationContent } from "#instrumentation/content.js";
+import {
+  sessionIdempotencyKey,
+  turnIdempotencyKey,
+  type InstrumentationEvent,
+  type InstrumentationHooks,
+} from "#instrumentation/lifecycle.js";
+import type { InstrumentationRuntime } from "#instrumentation/runtime.js";
+import {
+  parseSessionInstrumentationPlan,
+  readPlanTraceContext,
+  type SerializedSessionInstrumentation,
+  type SessionInstrumentation,
+} from "#instrumentation/session-plan.js";
+
+const inertHooks: InstrumentationHooks = {
+  capturesContent: false,
+  publish: async () => undefined,
+};
+
+export function bindSessionInstrumentation(input: {
+  readonly plan: SerializedSessionInstrumentation | undefined;
+  readonly rootSessionId: string;
+  readonly runtime: InstrumentationRuntime | undefined;
+  readonly sessionId: string;
+}): SessionInstrumentation {
+  if (input.plan !== undefined && input.runtime?.bindSession !== undefined) {
+    return input.runtime.bindSession({
+      plan: input.plan,
+      rootSessionId: input.rootSessionId,
+      sessionId: input.sessionId,
+    });
+  }
+
+  const plan = input.plan === undefined ? undefined : parseSessionInstrumentationPlan(input.plan);
+  const hooks = frozenHooks(input.runtime?.hooks, plan?.captureLevel === "content");
+  const runInContext = input.runtime?.runInContext ?? ((_operation, execute) => execute());
+
+  return {
+    forceFlush: input.runtime?.forceFlush ?? (async () => undefined),
+    hooks,
+    preparePreamble: async (preamble) => {
+      let prepared = preamble.traceContext;
+      if (!preamble.sessionStarted && input.runtime?.prepareSessionTrace !== undefined) {
+        prepared = await input.runtime.prepareSessionTrace({
+          agentName: plan?.agentName,
+          channelAudience: plan?.audience,
+          channelKind: plan?.channelKind,
+          channelType: plan?.channelType,
+          idempotencyKey: sessionIdempotencyKey(input.sessionId),
+          parentTraceContext: plan?.parentTraceContext,
+          rootSessionId: input.rootSessionId,
+          sessionId: input.sessionId,
+          traceSeed: readPlanTraceContext(input.plan),
+          type: "session.started",
+        });
+      }
+      if (input.runtime?.prepareTurnTrace !== undefined) {
+        prepared = await input.runtime.prepareTurnTrace({
+          idempotencyKey: turnIdempotencyKey(input.sessionId, preamble.turnId),
+          parentLineage: plan?.parentLineage,
+          parentTraceContext: plan?.parentTraceContext,
+          rootSessionId: input.rootSessionId,
+          sequence: preamble.sequence,
+          sessionId: input.sessionId,
+          turnId: preamble.turnId,
+          type: "turn.started",
+        });
+      }
+      return preamble.traceContext ?? prepared;
+    },
+    prepareSessionTrace: input.runtime?.prepareSessionTrace,
+    prepareTurnTrace: input.runtime?.prepareTurnTrace,
+    propagationFor: ({ callId, sessionId, turnId }) => {
+      const traceContext = readPlanTraceContext(input.plan);
+      if (traceContext === undefined) return undefined;
+      return {
+        parentLineage: { callId, sessionId, turnId },
+        traceContext,
+      };
+    },
+    publish: async (event) => hooks.publish(enrichEvent(event, plan)),
+    runInContext,
+    runStep: async (_step, execute) => execute(),
+    telemetryForAttempt: () => undefined,
+  };
+}
+
+function frozenHooks(
+  hooks: InstrumentationHooks | undefined,
+  capturesContent: boolean,
+): InstrumentationHooks {
+  if (hooks === undefined) return inertHooks;
+  if (capturesContent || !hooks.capturesContent) return hooks;
+  return {
+    capturesContent: false,
+    publish: (event) => hooks.publish(withoutInstrumentationContent(event)),
+  };
+}
+
+function enrichEvent(
+  event: InstrumentationEvent,
+  plan: ReturnType<typeof parseSessionInstrumentationPlan>,
+): InstrumentationEvent {
+  if (plan === undefined) return event;
+  if (event.type === "session.started") {
+    return {
+      ...event,
+      agentName: plan.agentName,
+      channelAudience: plan.audience,
+      channelKind: plan.channelKind,
+      channelType: plan.channelType,
+      parentTraceContext: plan.parentTraceContext,
+      rootSessionId: plan.rootSessionId || event.rootSessionId,
+      traceSeed: {
+        spanId: plan.spanId,
+        traceFlags: plan.traceFlags,
+        traceId: plan.traceId,
+      },
+    };
+  }
+  if (
+    event.type === "channel.delivery.started" ||
+    event.type === "channel.delivery.cancelled" ||
+    event.type === "channel.delivery.completed" ||
+    event.type === "channel.delivery.failed"
+  ) {
+    return {
+      ...event,
+      agentName: plan.agentName,
+      delivery: { ...event.delivery, channelAudience: plan.audience },
+      ...(event.type === "channel.delivery.started"
+        ? {
+            parentTraceContext: plan.parentTraceContext,
+            traceSeed: {
+              spanId: plan.spanId,
+              traceFlags: plan.traceFlags,
+              traceId: plan.traceId,
+            },
+          }
+        : {}),
+      rootSessionId: plan.rootSessionId || event.rootSessionId,
+    };
+  }
+  return event;
+}

--- a/packages/eve/src/instrumentation/session-plan.ts
+++ b/packages/eve/src/instrumentation/session-plan.ts
@@ -6,8 +6,13 @@ import { normalizeChannelAudience } from "#shared/channel-audience.js";
 import { isEveDevEnvironment } from "#internal/application/dev-environment.js";
 import type { InstrumentationCapture } from "#instrumentation/lifecycle.js";
 import type {
+  InstrumentationContextRunner,
+  InstrumentationEvent,
+  InstrumentationHooks,
   InstrumentationParentLineage,
+  InstrumentationSessionStartedEvent,
   InstrumentationTraceContext,
+  InstrumentationTurnStartedEvent,
 } from "#instrumentation/lifecycle.js";
 import type { RuntimeTraceContext } from "#protocol/message.js";
 import type { JsonObject, JsonValue } from "#shared/json.js";
@@ -348,26 +353,7 @@ export interface SessionTelemetryOptions {
 }
 
 /** Structural event input published by the harness. */
-export type InstrumentationEventInput =
-  | { readonly type: "session.started"; readonly sessionId: string }
-  | {
-      readonly type: "session.completed" | "session.waiting" | "session.failed";
-      readonly sessionId: string;
-      readonly turnId?: string;
-      readonly error?: unknown;
-    }
-  | {
-      readonly type: "turn.started";
-      readonly sessionId: string;
-      readonly turnId: string;
-      readonly sequence: number;
-    }
-  | {
-      readonly type: "turn.completed" | "turn.cancelled" | "turn.failed";
-      readonly sessionId: string;
-      readonly turnId: string;
-      readonly error?: unknown;
-    };
+export type InstrumentationEventInput = InstrumentationEvent;
 
 /** Input to {@link SessionInstrumentation.preparePreamble}. */
 export interface PreambleInput {
@@ -375,6 +361,7 @@ export interface PreambleInput {
   readonly turnId: string;
   readonly sequence: number;
   readonly sessionStarted: boolean;
+  readonly traceContext?: RuntimeTraceContext;
 }
 
 /** Input to {@link SessionInstrumentation.telemetryForAttempt}. */
@@ -412,6 +399,18 @@ export interface InstrumentationPropagation {
  * policy, re-read channel metadata, or change the producer capture level.
  */
 export interface SessionInstrumentation {
+  /** @internal Transitional AI SDK bridge surface. */
+  readonly hooks: InstrumentationHooks;
+  /** @internal Transitional AI SDK bridge surface. */
+  readonly prepareSessionTrace?: (
+    event: InstrumentationSessionStartedEvent,
+  ) => Promise<InstrumentationTraceContext>;
+  /** @internal Transitional AI SDK bridge surface. */
+  readonly prepareTurnTrace?: (
+    event: InstrumentationTurnStartedEvent,
+  ) => Promise<InstrumentationTraceContext>;
+  /** @internal Transitional AI SDK bridge surface. */
+  readonly runInContext: InstrumentationContextRunner;
   publish(event: InstrumentationEventInput): Promise<void>;
   preparePreamble(input: PreambleInput): Promise<RuntimeTraceContext | undefined>;
   telemetryForAttempt(input: AttemptInstrumentationInput): SessionTelemetryOptions | undefined;


### PR DESCRIPTION
### Summary

Stack 4/10. Binds one `SessionInstrumentation` control instance after worker context hydration and passes it through channel delivery, workflow preambles, node execution, cancellation settlement, and the tool loop. Provider implementations can update between workers, but the session's frozen producer capture level cannot increase.

### Validation

Validated with bound-control, channel-delivery, workflow-step, node-step, and tool-loop coverage plus the full stack suites.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package (included in stack PR #2556)
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 9 files · `+246 / -101`

Introduces the binding adapter and threads the resulting controls through every worker-owned instrumentation boundary.

**Tests** — 2 files · `+186 / -7`

Covers frozen capture, current-provider binding, private admitted content, and channel delivery enrichment.
