### PR TITLE
refactor(eve): encapsulate propagation and native sampling

### DIFF
--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -482,6 +482,8 @@ export interface RunInput {
    * because trace state is scoped to one session's context.
    */
   readonly parentTraceContext?: SessionTraceContext;
+  /** Whether parentTraceContext crossed a remote agent boundary. */
+  readonly parentTraceIsRemote?: boolean;
   /**
    * Runtime-supplied session limits. Delegated local subagents use this to
    * carry the parent's remaining quota and delegation caps with the same limit

--- a/packages/eve/src/eve-channel/index.ts
+++ b/packages/eve/src/eve-channel/index.ts
@@ -204,6 +204,7 @@ export function eveChannel(input: EveChannelInput): EveChannel {
             },
             mode: body.mode ?? "conversation",
             parentTraceContext,
+            parentTraceIsRemote: parentTraceContext !== undefined,
             title: messageResult.title,
           });
         } catch (error) {

--- a/packages/eve/src/execution/dispatch-runtime-actions-shared.ts
+++ b/packages/eve/src/execution/dispatch-runtime-actions-shared.ts
@@ -35,7 +35,10 @@ import {
   type RuntimeSession,
 } from "#execution/agent-handle-dispatch.js";
 import { getAgentHandleStore } from "#harness/handles/store.js";
-import { readActionTraceContext } from "#tracing/agent-trace-context-store.js";
+import {
+  readChildInstrumentationTraceContext,
+  readSessionInstrumentationTraceContext,
+} from "#instrumentation/propagation.js";
 import {
   assertUniqueRuntimeActionCallIds,
   getPendingRuntimeActionBatch,
@@ -65,7 +68,6 @@ import { hydrateDurableSession } from "#execution/session.js";
 import { buildSubagentRunInput, type SubagentInputSource } from "#execution/subagent-tool.js";
 import { workflowEntryReference } from "#execution/workflow-runtime.js";
 import { createLogger, logError } from "#internal/logging.js";
-import { readSessionTraceContext } from "#tracing/agent-trace-context-store.js";
 import { resolveSubagentDepth } from "#harness/subagent-depth.js";
 import { getDynamicSubagentSelection } from "#context/dynamic-subagent-lifecycle.js";
 import { resolveEffectiveAgentRuntime } from "#execution/effective-agent-config.js";
@@ -280,7 +282,10 @@ async function prepareActionDispatch(input: {
       input.fanoutSize ??
       plan.filter((entry) => entry.kind === "start" && entry.target.kind === "local").length,
     initiatorAuth: ctx.get(InitiatorAuthKey) ?? null,
-    parentTraceContext: readSessionTraceContext(input.serializedContext, session.sessionId),
+    parentTraceContext: readSessionInstrumentationTraceContext(
+      input.serializedContext,
+      session.sessionId,
+    ),
     plan,
     sandboxSessionId,
     serializedContext: input.serializedContext,
@@ -559,12 +564,12 @@ export async function startSubagent(input: {
   readonly target: DispatchStartTarget;
 }): Promise<DispatchOutcome> {
   const parentTraceContext =
-    readActionTraceContext(
-      input.serializedContext,
-      input.session.sessionId,
-      input.batchEvent.turnId,
-      input.target.action.callId,
-    ) ?? input.parentTraceContext;
+    readChildInstrumentationTraceContext({
+      callId: input.target.action.callId,
+      serializedContext: input.serializedContext,
+      sessionId: input.session.sessionId,
+      turnId: input.batchEvent.turnId,
+    }) ?? input.parentTraceContext;
 
   switch (input.target.kind) {
     case "local":

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -156,6 +156,7 @@ export function createWorkflowRuntime(config: {
         agentName: effectiveAgent.turnAgent.id,
         channel: channelInstrumentation,
         parentTraceContext: input.parentTraceContext,
+        parentTraceIsRemote: input.parentTraceIsRemote,
         parentLineage: instrumentationParentLineage,
         rootSessionId,
       };

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -45,9 +45,8 @@ import {
 import { getInstrumentationRuntime } from "#instrumentation/runtime.js";
 import { bindSessionInstrumentation } from "#instrumentation/bind-session.js";
 import { SessionInstrumentationPlanKey } from "#instrumentation/session-plan.js";
-import { preserveSerializedInstrumentationState } from "#instrumentation/state.js";
+import { preserveSerializedSessionInstrumentation } from "#instrumentation/preservation.js";
 import { RuntimeActionSettlementTimesKey } from "#harness/runtime-action-settlement-state.js";
-import { preserveSerializedAgentTraceState } from "#tracing/agent-trace-context-store.js";
 import { matchAuthorizationCallbacks } from "#execution/authorization-callback-match.js";
 import { readTurnSleepDurationMs } from "#harness/turn-sleep.js";
 import { isTurnCancellation, throwIfTurnAborted } from "#harness/turn-cancellation.js";
@@ -553,11 +552,8 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
             backgroundTaskState: createDurableSessionState({ session: cancelledSession }),
             backgroundTasks: retained.backgroundTasks,
           }),
-      serializedContext: preserveSerializedInstrumentationState(
-        preserveSerializedAgentTraceState(
-          preserveSerializedSessionDynamicModelSelection(input.serializedContext, interrupted),
-          interrupted,
-        ),
+      serializedContext: preserveSerializedSessionInstrumentation(
+        preserveSerializedSessionDynamicModelSelection(input.serializedContext, interrupted),
         interrupted,
       ),
       sessionState: createDurableSessionState({ session: cancelledSession }),

--- a/packages/eve/src/instrumentation/bind-session.ts
+++ b/packages/eve/src/instrumentation/bind-session.ts
@@ -17,6 +17,7 @@ import {
 } from "#instrumentation/session-plan.js";
 import { recordErrorOnSpan } from "#internal/logging.js";
 import { normalizeInstrumentationChannelKind } from "#internal/instrumentation.js";
+import { withNativeSamplingDecision } from "#tracing/native-sampling.js";
 
 interface InstrumentationTurnTraceState {
   readonly spanId: string;
@@ -107,17 +108,25 @@ export function bindSessionInstrumentation(input: {
     runStep: async (step, execute) => {
       if (!usesOtel) return execute();
       const tracer = trace.getTracer("eve");
+      const nativeContext = withNativeSamplingDecision(
+        otelContext.active(),
+        plan?.sampled === true,
+      );
       const turnSpan = step.hasInput
-        ? tracer.startSpan("ai.eve.turn", {
-            attributes: {
-              "ai.telemetry.functionId":
-                input.runtime?.otelSettings?.functionId ?? step.agentName ?? "",
-              "eve.environment": step.environment,
-              "eve.session.id": step.sessionId,
-              "eve.turn.id": step.turnId,
-              "eve.version": step.eveVersion,
+        ? tracer.startSpan(
+            "ai.eve.turn",
+            {
+              attributes: {
+                "ai.telemetry.functionId":
+                  input.runtime?.otelSettings?.functionId ?? step.agentName ?? "",
+                "eve.environment": step.environment,
+                "eve.session.id": step.sessionId,
+                "eve.turn.id": step.turnId,
+                "eve.version": step.eveVersion,
+              },
             },
-          })
+            nativeContext,
+          )
         : undefined;
       const store = contextStorage.getStore();
       if (turnSpan !== undefined) {
@@ -126,13 +135,10 @@ export function bindSessionInstrumentation(input: {
       const stored = store?.get(InstrumentationTurnTraceKey);
       const parentContext =
         turnSpan !== undefined
-          ? trace.setSpan(otelContext.active(), turnSpan)
+          ? trace.setSpan(nativeContext, turnSpan)
           : stored === undefined
             ? undefined
-            : trace.setSpan(
-                otelContext.active(),
-                trace.wrapSpanContext({ ...stored, isRemote: true }),
-              );
+            : trace.setSpan(nativeContext, trace.wrapSpanContext({ ...stored, isRemote: true }));
       try {
         return parentContext === undefined
           ? await execute()

--- a/packages/eve/src/instrumentation/preservation.ts
+++ b/packages/eve/src/instrumentation/preservation.ts
@@ -1,0 +1,13 @@
+import { preserveSerializedInstrumentationState } from "#instrumentation/state.js";
+import { preserveSerializedAgentTraceState } from "#tracing/agent-trace-context-store.js";
+
+/** Preserves every instrumentation-owned durable slot from an interrupted worker. */
+export function preserveSerializedSessionInstrumentation(
+  original: Record<string, unknown>,
+  interrupted: Record<string, unknown>,
+): Record<string, unknown> {
+  return preserveSerializedInstrumentationState(
+    preserveSerializedAgentTraceState(original, interrupted),
+    interrupted,
+  );
+}

--- a/packages/eve/src/instrumentation/propagation.ts
+++ b/packages/eve/src/instrumentation/propagation.ts
@@ -1,0 +1,65 @@
+import type { InstrumentationTraceContext } from "#instrumentation/lifecycle.js";
+import {
+  parseSessionInstrumentationPlan,
+  type SerializedSessionInstrumentation,
+} from "#instrumentation/session-plan.js";
+import {
+  readActionTraceContext,
+  readSessionTraceContext,
+} from "#tracing/agent-trace-context-store.js";
+
+/** Returns portable session propagation without exposing provider state to execution. */
+export function readSessionInstrumentationTraceContext(
+  serializedContext: Readonly<Record<string, unknown>>,
+  sessionId: string,
+): InstrumentationTraceContext | undefined {
+  const plan = readPlan(serializedContext);
+  if (plan !== undefined) {
+    const data = parseSessionInstrumentationPlan(plan);
+    if (data !== undefined && data.traceId.length > 0) {
+      return { spanId: data.spanId, traceFlags: data.traceFlags, traceId: data.traceId };
+    }
+  }
+  return portable(readSessionTraceContext(serializedContext, sessionId));
+}
+
+/** Returns action propagation, falling back to the frozen session context. */
+export function readChildInstrumentationTraceContext(input: {
+  readonly callId: string;
+  readonly serializedContext: Readonly<Record<string, unknown>>;
+  readonly sessionId: string;
+  readonly turnId: string;
+}): InstrumentationTraceContext | undefined {
+  return (
+    portable(
+      readActionTraceContext(input.serializedContext, input.sessionId, input.turnId, input.callId),
+    ) ?? readSessionInstrumentationTraceContext(input.serializedContext, input.sessionId)
+  );
+}
+
+function readPlan(
+  serializedContext: Readonly<Record<string, unknown>>,
+): SerializedSessionInstrumentation | undefined {
+  const value = serializedContext["eve.sessionInstrumentationPlan"];
+  if (typeof value !== "object" || value === null) return undefined;
+  const record = value as Record<string, unknown>;
+  if (record["schemaVersion"] !== 1 || typeof record["data"] !== "object") return undefined;
+  return value as SerializedSessionInstrumentation;
+}
+
+function portable(
+  context:
+    | {
+        readonly spanId: string;
+        readonly traceFlags: number;
+        readonly traceId: string;
+      }
+    | undefined,
+): InstrumentationTraceContext | undefined {
+  if (context === undefined) return undefined;
+  return {
+    spanId: context.spanId,
+    traceFlags: context.traceFlags,
+    traceId: context.traceId,
+  };
+}

--- a/packages/eve/src/instrumentation/session-plan.test.ts
+++ b/packages/eve/src/instrumentation/session-plan.test.ts
@@ -146,6 +146,60 @@ describe("planSessionInstrumentation", () => {
     });
   });
 
+  describe("remote admission veto", () => {
+    it("rejects a sampled remote parent when local policy rejects", () => {
+      const plan = planSessionInstrumentation({
+        runtime: makeRuntime({ otelSettings: { tracePolicy: () => false } }),
+        session: makeSession({
+          parentTraceContext: {
+            spanId: "parent-span-id",
+            traceFlags: 1,
+            traceId: "parent-trace-id",
+          },
+          parentTraceIsRemote: true,
+        }),
+      });
+
+      expect(parseSessionInstrumentationPlan(plan)).toMatchObject({
+        sampled: false,
+        traceFlags: 0,
+        traceId: "parent-trace-id",
+      });
+    });
+
+    it("keeps a sampled remote parent when local policy admits", () => {
+      const plan = planSessionInstrumentation({
+        runtime: makeRuntime({ otelSettings: { tracePolicy: () => true } }),
+        session: makeSession({
+          parentTraceContext: {
+            spanId: "parent-span-id",
+            traceFlags: 1,
+            traceId: "parent-trace-id",
+          },
+          parentTraceIsRemote: true,
+        }),
+      });
+
+      expect(parseSessionInstrumentationPlan(plan)?.sampled).toBe(true);
+    });
+
+    it("never promotes an unsampled remote parent", () => {
+      const plan = planSessionInstrumentation({
+        runtime: makeRuntime({ otelSettings: { tracePolicy: () => true } }),
+        session: makeSession({
+          parentTraceContext: {
+            spanId: "parent-span-id",
+            traceFlags: 0,
+            traceId: "parent-trace-id",
+          },
+          parentTraceIsRemote: true,
+        }),
+      });
+
+      expect(parseSessionInstrumentationPlan(plan)?.sampled).toBe(false);
+    });
+  });
+
   describe("no instrumentation runtime", () => {
     it("produces an inert plan", () => {
       const plan = planSessionInstrumentation({

--- a/packages/eve/src/instrumentation/session-plan.ts
+++ b/packages/eve/src/instrumentation/session-plan.ts
@@ -39,6 +39,7 @@ export interface SessionInstrumentationPlanningInput {
   readonly agentName?: string;
   readonly channel?: ChannelInstrumentationProjection;
   readonly parentTraceContext?: InstrumentationTraceContext;
+  readonly parentTraceIsRemote?: boolean;
   readonly parentLineage?: InstrumentationParentLineage;
   readonly rootSessionId: string;
 }
@@ -196,6 +197,21 @@ export function planSessionInstrumentation(input: {
   const runtime = input.runtime;
 
   if (parentTraceContext !== undefined) {
+    const incomingSampled = (parentTraceContext.traceFlags & 0x01) === 0x01;
+    const sampled = input.session.parentTraceIsRemote
+      ? incomingSampled &&
+        evaluateTracePolicySafe(runtime?.otelSettings?.tracePolicy, {
+          agentName,
+          audience,
+          channelType,
+        })
+      : incomingSampled;
+    const effectiveParentTraceContext = {
+      ...parentTraceContext,
+      traceFlags: sampled
+        ? parentTraceContext.traceFlags | 0x01
+        : parentTraceContext.traceFlags & ~0x01,
+    };
     const data: SessionInstrumentationPlanData = {
       agentName,
       audience,
@@ -204,17 +220,14 @@ export function planSessionInstrumentation(input: {
       channelMetadata,
       traceId: parentTraceContext.traceId,
       spanId: parentTraceContext.spanId,
-      traceFlags: parentTraceContext.traceFlags,
-      sampled: (parentTraceContext.traceFlags & 0x01) === 0x01,
-      captureLevel: resolveCaptureLevel(
-        runtime,
-        parentTraceContext.traceFlags & 0x01 ? true : false,
-      ),
+      traceFlags: effectiveParentTraceContext.traceFlags,
+      sampled,
+      captureLevel: resolveCaptureLevel(runtime, sampled),
       functionId: runtime?.otelSettings?.functionId,
       isTraceContentVisible: shouldCaptureContent(audience),
       recordInputs: runtime?.otelSettings?.recordInputs,
       recordOutputs: runtime?.otelSettings?.recordOutputs,
-      parentTraceContext,
+      parentTraceContext: effectiveParentTraceContext,
       parentLineage,
       rootSessionId,
     };

--- a/packages/eve/src/tracing/agent-otel-session-context.ts
+++ b/packages/eve/src/tracing/agent-otel-session-context.ts
@@ -1,4 +1,4 @@
-import type { SpanContext, Tracer } from "#compiled/@opentelemetry/api/index.js";
+import { ROOT_CONTEXT, type SpanContext, type Tracer } from "#compiled/@opentelemetry/api/index.js";
 
 import {
   sessionIdempotencyKey,
@@ -12,6 +12,7 @@ import type { ChannelAudience } from "#shared/channel-audience.js";
 import type { TraceCapturePolicy } from "#tracing/otel-declaration.js";
 import { evaluateTracePolicy, isSampledTrace } from "#tracing/sampled-trace.js";
 import type { AgentSessionTraceState, AgentTraceStateStore } from "#tracing/agent-trace-state.js";
+import { withNativeSamplingDecision } from "#tracing/native-sampling.js";
 
 interface AgentOtelSessionContextInput {
   readonly frameworkVersion: string;
@@ -54,17 +55,21 @@ export function createAgentOtelSessionContext(
         };
       }
       const startSpan = () =>
-        input.tracer.startSpan("agent.session", {
-          attributes: {
-            "agent.framework.name": "eve",
-            "agent.framework.version": input.frameworkVersion,
-            "agent.channel.audience": session.channelAudience,
-            "agent.name": session.agentName,
-            "agent.session.id": session.sessionId,
-            "agent.trace.schema.version": 2,
+        input.tracer.startSpan(
+          "agent.session",
+          {
+            attributes: {
+              "agent.framework.name": "eve",
+              "agent.framework.version": input.frameworkVersion,
+              "agent.channel.audience": session.channelAudience,
+              "agent.name": session.agentName,
+              "agent.session.id": session.sessionId,
+              "agent.trace.schema.version": 2,
+            },
+            root: true,
           },
-          root: true,
-        });
+          withNativeSamplingDecision(ROOT_CONTEXT, true),
+        );
       const span = input.idGenerator.withSpanId(session.traceSeed.spanId, () =>
         input.idGenerator.withTraceId(session.traceSeed!.traceId, startSpan),
       );

--- a/packages/eve/src/tracing/native-sampling.ts
+++ b/packages/eve/src/tracing/native-sampling.ts
@@ -1,0 +1,15 @@
+import { createContextKey, type Context } from "#compiled/@opentelemetry/api/index.js";
+
+const NATIVE_SAMPLING_DECISION_KEY = createContextKey("eve.native.sampling-decision");
+
+export function nativeSamplingDecision(context: unknown): boolean | undefined {
+  if (typeof context !== "object" || context === null) return undefined;
+  const getValue = Reflect.get(context, "getValue");
+  if (typeof getValue !== "function") return undefined;
+  const value = Reflect.apply(getValue, context, [NATIVE_SAMPLING_DECISION_KEY]);
+  return typeof value === "boolean" ? value : undefined;
+}
+
+export function withNativeSamplingDecision(context: Context, sampled: boolean): Context {
+  return context.setValue(NATIVE_SAMPLING_DECISION_KEY, sampled);
+}

--- a/packages/eve/src/tracing/otel-registration.test.ts
+++ b/packages/eve/src/tracing/otel-registration.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { ROOT_CONTEXT } from "#compiled/@opentelemetry/api/index.js";
+import { withNativeSamplingDecision } from "#tracing/native-sampling.js";
 import { registerOtelPipeline } from "#tracing/otel-registration.js";
 
 const { registerOTel } = vi.hoisted(() => ({ registerOTel: vi.fn() }));
@@ -29,9 +31,34 @@ describe("registerOtelPipeline", () => {
         instrumentations: [],
         propagators: expect.arrayContaining(["tracecontext", expect.any(Object)]),
         serviceName: "weather",
-        traceSampler: "always_on",
+        traceSampler: expect.any(Object),
       }),
     );
+  });
+
+  it("keeps native decisions authoritative while delegating unrelated roots", () => {
+    registerOTel.mockImplementation(() => undefined);
+    expect(() =>
+      registerOtelPipeline({
+        pipeline: { sampler: "always_off", spanProcessors: [] },
+        serviceName: "weather",
+      }),
+    ).toThrow();
+    const configuration = registerOTel.mock.calls.at(-1)?.[0] as {
+      traceSampler: {
+        shouldSample(...args: unknown[]): { readonly decision: number };
+      };
+    };
+    const sampler = configuration.traceSampler;
+
+    expect(
+      sampler.shouldSample(
+        withNativeSamplingDecision(ROOT_CONTEXT, true),
+        "1".repeat(32),
+        "agent.session",
+      ).decision,
+    ).toBe(2);
+    expect(sampler.shouldSample(ROOT_CONTEXT, "1".repeat(32), "authored.root").decision).toBe(0);
   });
 
   it("omits the sampler entirely rather than passing undefined", () => {

--- a/packages/eve/src/tracing/otel-registration.ts
+++ b/packages/eve/src/tracing/otel-registration.ts
@@ -6,10 +6,12 @@ import {
   type Configuration,
   type SpanProcessor,
   type SpanProcessorOrName,
+  type SamplerOrName,
 } from "#compiled/@vercel/otel/index.js";
 
 import { AgentSpanIdGenerator } from "#tracing/agent-span-id-generator.js";
 import type { OtelPipeline } from "#tracing/otel-declaration.js";
+import { nativeSamplingDecision } from "#tracing/native-sampling.js";
 
 const REGISTRATION_SPAN_NAME = "eve.otel.registration";
 const REPLAY_DEDUPLICATION_LIMIT = 100_000;
@@ -131,7 +133,7 @@ export function registerOtelPipeline(input: {
     // passing an explicit `undefined` sampler.
     pipeline.sampler === undefined
       ? configuration
-      : { ...configuration, traceSampler: pipeline.sampler },
+      : { ...configuration, traceSampler: new NativeDecisionSampler(pipeline.sampler) },
   );
 
   const ownsTracer = globalTracerUses(idGenerator);
@@ -160,6 +162,53 @@ export function registerOtelPipeline(input: {
     idGenerator,
     shutdown: () => provider.shutdown!(),
   };
+}
+
+class NativeDecisionSampler {
+  private readonly delegate: SamplerOrName;
+
+  constructor(delegate: SamplerOrName) {
+    this.delegate = delegate;
+  }
+
+  shouldSample(...args: never[]): unknown {
+    const decision = nativeSamplingDecision(args[0]);
+    if (decision !== undefined) return { decision: decision ? 2 : 0 };
+    if (typeof this.delegate === "object") {
+      return Reflect.apply(this.delegate.shouldSample, this.delegate, args);
+    }
+    return namedSamplingResult(this.delegate, args[0], args[1]);
+  }
+
+  toString(): string {
+    return `NativeDecisionSampler{${String(this.delegate)}}`;
+  }
+}
+
+function namedSamplingResult(
+  sampler: Exclude<SamplerOrName, object>,
+  parentContext: unknown,
+  traceId: unknown,
+): { readonly decision: number } {
+  if (sampler === "always_off") return { decision: 0 };
+  if (sampler === "always_on") return { decision: 2 };
+  if (sampler.startsWith("parentbased_")) {
+    const parent = trace.getSpan(parentContext as Context)?.spanContext();
+    if (parent !== undefined) return { decision: (parent.traceFlags & 0x01) === 0x01 ? 2 : 0 };
+  }
+  if (sampler === "traceidratio" || sampler === "parentbased_traceidratio") {
+    const ratio = Number(process.env.OTEL_TRACES_SAMPLER_ARG ?? "1");
+    return { decision: samplesTraceId(traceId, ratio) ? 2 : 0 };
+  }
+  return { decision: 2 };
+}
+
+function samplesTraceId(traceId: unknown, ratio: number): boolean {
+  if (typeof traceId !== "string" || !Number.isFinite(ratio)) return false;
+  if (ratio <= 0) return false;
+  if (ratio >= 1) return true;
+  const prefix = Number.parseInt(traceId.slice(0, 8), 16);
+  return prefix / 0xffffffff < ratio;
 }
 
 /** Lifecycle retained from the tracer provider that owns every destination. */


### PR DESCRIPTION
### Summary

Stack 6/10. Encapsulates cancellation preservation and child propagation behind instrumentation helpers, removing production `#tracing/*` imports from execution. Remote sessions apply `incoming sampled && local admission`, local children inherit, and a private OTel context marker makes native decisions authoritative while unrelated roots still delegate to the process sampler.

### Validation

Validated with remote-veto, durable propagation, native-sampler, agent OTel, workflow-runtime, and dispatch integration coverage.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package (included in stack PR #2556)
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 12 files · `+220 / -49`

Adds generic propagation/preservation helpers and the native sampler wrapper while removing trace-store knowledge from execution.

**Tests** — 2 files · `+82 / -1`

Covers remote veto, unsampled preservation, and native versus unrelated sampler decisions.
