### PR TITLE
refactor(eve): migrate legacy sessions into frozen plans

### DIFF
--- a/packages/eve/src/execution/settle-cancelled-turn-step.ts
+++ b/packages/eve/src/execution/settle-cancelled-turn-step.ts
@@ -29,7 +29,7 @@ import { clearPendingRuntimeActionBatch } from "#harness/runtime-actions.js";
 import { createInstrumentationHandleEvent } from "#harness/instrumentation/native-events.js";
 import { getInstrumentationRuntime } from "#instrumentation/runtime.js";
 import { bindSessionInstrumentation } from "#instrumentation/bind-session.js";
-import { SessionInstrumentationPlanKey } from "#instrumentation/session-plan.js";
+import { ensureSessionInstrumentationPlan } from "#instrumentation/migration.js";
 import { getTurnUsageState, toUsage } from "#harness/turn-tag-state.js";
 import { clearPendingWorkflowInterrupt } from "#harness/workflow-interrupt-state.js";
 import {
@@ -73,10 +73,17 @@ export async function settleCancelledTurnStep(input: {
     durable: durableSession,
     turnAgent: effectiveAgent.turnAgent,
   });
-  const instrumentation = bindSessionInstrumentation({
-    plan: ctx.get(SessionInstrumentationPlanKey),
+  const instrumentationRuntime = getInstrumentationRuntime();
+  const instrumentationPlan = ensureSessionInstrumentationPlan({
+    agentName: effectiveAgent.turnAgent.id,
+    ctx,
     rootSessionId: session.rootSessionId ?? session.sessionId,
-    runtime: getInstrumentationRuntime(),
+    runtime: instrumentationRuntime,
+  });
+  const instrumentation = bindSessionInstrumentation({
+    plan: instrumentationPlan,
+    rootSessionId: session.rootSessionId ?? session.sessionId,
+    runtime: instrumentationRuntime,
     sessionId: session.sessionId,
   });
 

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -44,7 +44,7 @@ import {
 } from "#harness/channel-delivery-instrumentation.js";
 import { getInstrumentationRuntime } from "#instrumentation/runtime.js";
 import { bindSessionInstrumentation } from "#instrumentation/bind-session.js";
-import { SessionInstrumentationPlanKey } from "#instrumentation/session-plan.js";
+import { ensureSessionInstrumentationPlan } from "#instrumentation/migration.js";
 import { preserveSerializedSessionInstrumentation } from "#instrumentation/preservation.js";
 import { RuntimeActionSettlementTimesKey } from "#harness/runtime-action-settlement-state.js";
 import { matchAuthorizationCallbacks } from "#execution/authorization-callback-match.js";
@@ -194,10 +194,17 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
     turnAgent: effectiveAgent.turnAgent,
   });
   const history = createExecutionHistoryView(initialSession);
-  const instrumentation = bindSessionInstrumentation({
-    plan: ctx.get(SessionInstrumentationPlanKey),
+  const instrumentationRuntime = getInstrumentationRuntime();
+  const instrumentationPlan = ensureSessionInstrumentationPlan({
+    agentName: effectiveAgent.turnAgent.id,
+    ctx,
     rootSessionId: initialSession.rootSessionId ?? initialSession.sessionId,
-    runtime: getInstrumentationRuntime(),
+    runtime: instrumentationRuntime,
+  });
+  const instrumentation = bindSessionInstrumentation({
+    plan: instrumentationPlan,
+    rootSessionId: initialSession.rootSessionId ?? initialSession.sessionId,
+    runtime: instrumentationRuntime,
     sessionId: initialSession.sessionId,
   });
   const initialEmissionState = getHarnessEmissionState(initialSession.state);

--- a/packages/eve/src/instrumentation/migration.test.ts
+++ b/packages/eve/src/instrumentation/migration.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ContextContainer } from "#context/container.js";
+import { ChannelInstrumentationKey, SessionTraceSeedKey } from "#context/keys.js";
+import { createInstrumentationHooks } from "#instrumentation/lifecycle.js";
+import { ensureSessionInstrumentationPlan } from "#instrumentation/migration.js";
+import type { InstrumentationRuntime } from "#instrumentation/runtime.js";
+import { parseSessionInstrumentationPlan } from "#instrumentation/session-plan.js";
+import { AgentSpanIdGenerator } from "#tracing/agent-span-id-generator.js";
+
+function runtime(tracePolicy: () => boolean): InstrumentationRuntime {
+  return {
+    forceFlush: async () => undefined,
+    hooks: createInstrumentationHooks([]),
+    idGenerator: new AgentSpanIdGenerator(),
+    otelSettings: {
+      recordInputs: false,
+      recordOutputs: false,
+      traceChannelRequests: false,
+      tracePolicy,
+    },
+    prepareSessionTrace: async () => ({ spanId: "", traceFlags: 0, traceId: "" }),
+    runInContext: (_operation, execute) => execute(),
+    shutdown: async () => undefined,
+  };
+}
+
+describe("ensureSessionInstrumentationPlan", () => {
+  it("preserves an existing seed exactly without evaluating policy", () => {
+    const tracePolicy = vi.fn(() => false);
+    const ctx = new ContextContainer();
+    const seed = {
+      spanId: "1111111111111111",
+      traceFlags: 1,
+      traceId: "22222222222222222222222222222222",
+    };
+    ctx.set(SessionTraceSeedKey, seed);
+    ctx.set(ChannelInstrumentationKey, {
+      channelType: "web",
+      kind: "channel:web",
+      metadata: { audience: "private" },
+    });
+
+    const plan = ensureSessionInstrumentationPlan({
+      agentName: "test-agent",
+      ctx,
+      rootSessionId: "session-1",
+      runtime: runtime(tracePolicy),
+    });
+
+    expect(parseSessionInstrumentationPlan(plan)).toMatchObject(seed);
+    expect(tracePolicy).not.toHaveBeenCalled();
+  });
+
+  it("evaluates policy once when no seed exists and freezes classification", () => {
+    const tracePolicy = vi.fn(() => true);
+    const ctx = new ContextContainer();
+    ctx.set(ChannelInstrumentationKey, {
+      channelType: "web",
+      kind: "channel:web",
+      metadata: { audience: "public" },
+    });
+    const installedRuntime = runtime(tracePolicy);
+
+    const first = ensureSessionInstrumentationPlan({
+      agentName: "test-agent",
+      ctx,
+      rootSessionId: "session-1",
+      runtime: installedRuntime,
+    });
+    ctx.set(ChannelInstrumentationKey, {
+      channelType: "schedule",
+      kind: "schedule",
+      metadata: { audience: "private" },
+    });
+    const second = ensureSessionInstrumentationPlan({
+      agentName: "test-agent",
+      ctx,
+      rootSessionId: "session-1",
+      runtime: installedRuntime,
+    });
+
+    expect(second).toBe(first);
+    expect(tracePolicy).toHaveBeenCalledTimes(1);
+    expect(parseSessionInstrumentationPlan(second)).toMatchObject({
+      audience: "public",
+      channelKind: "channel:web",
+      channelType: "web",
+    });
+  });
+});

--- a/packages/eve/src/instrumentation/migration.ts
+++ b/packages/eve/src/instrumentation/migration.ts
@@ -1,0 +1,41 @@
+import type { ContextContainer } from "#context/container.js";
+import {
+  ChannelInstrumentationKey,
+  ParentTraceContextKey,
+  SessionTraceSeedKey,
+} from "#context/keys.js";
+import type { InstrumentationRuntime } from "#instrumentation/runtime.js";
+import {
+  migrateSessionInstrumentation,
+  planSessionInstrumentation,
+  readPlanTraceContext,
+  SessionInstrumentationPlanKey,
+  type SerializedSessionInstrumentation,
+} from "#instrumentation/session-plan.js";
+
+/** Installs a plan once for a workflow context created before plans existed. */
+export function ensureSessionInstrumentationPlan(input: {
+  readonly agentName?: string;
+  readonly ctx: ContextContainer;
+  readonly rootSessionId: string;
+  readonly runtime: InstrumentationRuntime | undefined;
+}): SerializedSessionInstrumentation {
+  const existing = input.ctx.get(SessionInstrumentationPlanKey);
+  if (existing !== undefined) return existing;
+
+  const session = {
+    agentName: input.agentName,
+    channel: input.ctx.get(ChannelInstrumentationKey),
+    parentTraceContext: input.ctx.get(ParentTraceContextKey),
+    rootSessionId: input.rootSessionId,
+  };
+  const seed = input.ctx.get(SessionTraceSeedKey);
+  const plan =
+    seed === undefined
+      ? planSessionInstrumentation({ runtime: input.runtime, session })
+      : migrateSessionInstrumentation({ runtime: input.runtime, seed, session });
+  input.ctx.set(SessionInstrumentationPlanKey, plan);
+  const traceContext = readPlanTraceContext(plan);
+  if (traceContext !== undefined) input.ctx.set(SessionTraceSeedKey, traceContext);
+  return plan;
+}

--- a/packages/eve/src/instrumentation/preservation.ts
+++ b/packages/eve/src/instrumentation/preservation.ts
@@ -6,8 +6,10 @@ export function preserveSerializedSessionInstrumentation(
   original: Record<string, unknown>,
   interrupted: Record<string, unknown>,
 ): Record<string, unknown> {
-  return preserveSerializedInstrumentationState(
+  const preserved = preserveSerializedInstrumentationState(
     preserveSerializedAgentTraceState(original, interrupted),
     interrupted,
   );
+  const plan = interrupted["eve.sessionInstrumentationPlan"];
+  return plan === undefined ? preserved : { ...preserved, "eve.sessionInstrumentationPlan": plan };
 }

--- a/packages/eve/src/instrumentation/session-plan.ts
+++ b/packages/eve/src/instrumentation/session-plan.ts
@@ -285,6 +285,34 @@ export function planSessionInstrumentation(input: {
   return { schemaVersion: SCHEMA_VERSION, data: toJsonObject(data) };
 }
 
+/** Builds a one-time migration plan while preserving an existing seed exactly. */
+export function migrateSessionInstrumentation(input: {
+  readonly runtime?: InstrumentationPlanningRuntime;
+  readonly seed: InstrumentationTraceContext;
+  readonly session: SessionInstrumentationPlanningInput;
+}): SerializedSessionInstrumentation {
+  const audience = normalizeChannelAudience(input.session.channel?.metadata.audience);
+  const sampled = (input.seed.traceFlags & 0x01) === 0x01;
+  const data: SessionInstrumentationPlanData = {
+    agentName: input.session.agentName,
+    audience,
+    captureLevel: resolveCaptureLevel(input.runtime, sampled),
+    channelKind: input.session.channel?.kind,
+    channelMetadata: snapshotChannelMetadata(input.session.channel?.metadata),
+    channelType: input.session.channel?.channelType,
+    functionId: input.runtime?.otelSettings?.functionId,
+    isTraceContentVisible: shouldCaptureContent(audience),
+    recordInputs: input.runtime?.otelSettings?.recordInputs,
+    recordOutputs: input.runtime?.otelSettings?.recordOutputs,
+    rootSessionId: input.session.rootSessionId,
+    sampled,
+    spanId: input.seed.spanId,
+    traceFlags: input.seed.traceFlags,
+    traceId: input.seed.traceId,
+  };
+  return { schemaVersion: SCHEMA_VERSION, data: toJsonObject(data) };
+}
+
 function snapshotChannelMetadata(value: unknown): JsonObject {
   try {
     return parseJsonObject(value ?? {});

--- a/packages/eve/src/tracing/agent-otel-provider.test.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.test.ts
@@ -112,6 +112,7 @@ async function emitAttempt(input: {
   readonly turnAlreadyStarted?: boolean;
   readonly turnId: string;
   readonly turnSequence: number;
+  readonly traceSeed?: InstrumentationTraceContext;
 }): Promise<void> {
   const scope: InstrumentationAttemptScope = {
     attemptId: `${input.sessionId}:${input.turnId}:0:${input.attemptIndex ?? 0}`,
@@ -292,6 +293,7 @@ async function publishTurnStarted(input: {
   readonly parentTraceContext?: InstrumentationTraceContext;
   readonly rootSessionId?: string;
   readonly sessionId: string;
+  readonly traceSeed?: InstrumentationTraceContext;
   readonly turnId: string;
   readonly turnSequence: number;
 }): Promise<void> {
@@ -304,6 +306,15 @@ async function publishTurnStarted(input: {
     parentTraceContext: input.parentTraceContext,
     rootSessionId,
     sessionId: input.sessionId,
+    traceSeed:
+      input.traceSeed ??
+      (input.parentTraceContext === undefined
+        ? {
+            spanId: "1111111111111111",
+            traceFlags: 1,
+            traceId: "22222222222222222222222222222222",
+          }
+        : undefined),
     type: "session.started",
   });
   await input.hooks.publish({
@@ -354,6 +365,11 @@ describe("createAgentOtelInstrumentation", () => {
       idempotencyKey: sessionIdempotencyKey("session-1"),
       rootSessionId: "session-1",
       sessionId: "session-1",
+      traceSeed: {
+        spanId: "1111111111111111",
+        traceFlags: 1,
+        traceId: "22222222222222222222222222222222",
+      },
       type: "session.started" as const,
     };
     const turnEvent = {
@@ -409,7 +425,7 @@ describe("createAgentOtelInstrumentation", () => {
     expect(session.spanContext().spanId).toBe(seed.spanId);
   });
 
-  it("falls back to fresh ids when no trace seed is present", async () => {
+  it("fails closed when migration did not provide a trace seed", async () => {
     const runtime = createRuntime();
     const sessionEvent = {
       agentName: "weather",
@@ -423,14 +439,11 @@ describe("createAgentOtelInstrumentation", () => {
     await runtime.hooks.publish(sessionEvent);
     await runtime.provider.forceFlush();
 
-    const spans = runtime.exporter.getFinishedSpans();
-    const session = byName(spans, "agent.session")[0]!;
-    expect(session.spanContext().traceId).toBe(trace.traceId);
-    // Fresh span id is random, not derived — just verify it matches the returned context.
-    expect(session.spanContext().spanId).toBe(trace.spanId);
+    expect(trace.traceFlags).toBe(0);
+    expect(byName(runtime.exporter.getFinishedSpans(), "agent.session")).toHaveLength(0);
   });
 
-  it("passes channelType to the policy on the seedless fallback path", async () => {
+  it("does not evaluate policy on a seedless provider fallback", async () => {
     let captured: { channelType?: string } | undefined;
     const runtime = createRuntime(undefined, (trace) => {
       captured = trace;
@@ -447,7 +460,7 @@ describe("createAgentOtelInstrumentation", () => {
 
     await runtime.prepareSessionTrace(sessionEvent);
 
-    expect(captured?.channelType).toBe("slack");
+    expect(captured).toBeUndefined();
   });
 
   it("inherits parent trace context for delegated agents", async () => {
@@ -540,6 +553,11 @@ describe("createAgentOtelInstrumentation", () => {
         idempotencyKey,
         rootSessionId: "session-1",
         sessionId: "session-1",
+        traceSeed: {
+          spanId: "1111111111111111",
+          traceFlags: 1,
+          traceId: "22222222222222222222222222222222",
+        },
         type: "channel.delivery.started",
       });
       await runtime.hooks.publish({
@@ -605,6 +623,11 @@ describe("createAgentOtelInstrumentation", () => {
         idempotencyKey: sessionIdempotencyKey("session-1"),
         rootSessionId: "session-1",
         sessionId: "session-1",
+        traceSeed: {
+          spanId: "1111111111111111",
+          traceFlags: 1,
+          traceId: "22222222222222222222222222222222",
+        },
         type: "session.started",
       });
       await runtime.hooks.publish(started);
@@ -800,7 +823,7 @@ describe("createAgentOtelInstrumentation", () => {
   });
 
   it.each(["private", "unknown"] as const)(
-    "does not record %s conversation traces by default",
+    "does not record %s conversation traces when the frozen plan is unsampled",
     async (audience) => {
       const runtime = createRuntime(new InMemoryAgentTraceStateStore(), null);
 
@@ -809,6 +832,11 @@ describe("createAgentOtelInstrumentation", () => {
         hooks: runtime.hooks,
         runInContext: runtime.runInContext,
         sessionId: `session-${audience}`,
+        traceSeed: {
+          spanId: "1111111111111111",
+          traceFlags: 0,
+          traceId: "22222222222222222222222222222222",
+        },
         turnId: `turn-${audience}`,
         turnSequence: 0,
       });
@@ -1395,6 +1423,11 @@ describe("createAgentOtelInstrumentation", () => {
       idempotencyKey: sessionIdempotencyKey("session-1"),
       rootSessionId: "session-1",
       sessionId: "session-1",
+      traceSeed: {
+        spanId: "1111111111111111",
+        traceFlags: 1,
+        traceId: "22222222222222222222222222222222",
+      },
       type: "session.started",
     });
     await runtime.hooks.publish({
@@ -1682,9 +1715,8 @@ describe("createAgentOtelInstrumentation", () => {
     const firstTurn = byName(firstRuntime.exporter.getFinishedSpans(), "agent.turn")[0]!;
     const replayTurn = byName(replayRuntime.exporter.getFinishedSpans(), "agent.turn")[0]!;
     // The abandoned attempt keeps its own trace rather than interleaving with
-    // the retry. Both carry `agent.session.id`, so the session view still
-    // resolves to every trace the session produced.
-    expect(replayTurn.spanContext().traceId).not.toBe(firstTurn.spanContext().traceId);
+    // Migration preserves one frozen trace identity across replay.
+    expect(replayTurn.spanContext().traceId).toBe(firstTurn.spanContext().traceId);
     expect(replayTurn.attributes["agent.session.id"]).toBe(
       firstTurn.attributes["agent.session.id"],
     );

--- a/packages/eve/src/tracing/agent-otel-session-context.ts
+++ b/packages/eve/src/tracing/agent-otel-session-context.ts
@@ -9,8 +9,7 @@ import {
 import type { AgentSpanIdGenerator } from "#tracing/agent-span-id-generator.js";
 import { normalizeChannelAudience } from "#shared/channel-audience.js";
 import type { ChannelAudience } from "#shared/channel-audience.js";
-import type { TraceCapturePolicy } from "#tracing/otel-declaration.js";
-import { evaluateTracePolicy, isSampledTrace } from "#tracing/sampled-trace.js";
+import { isSampledTrace } from "#tracing/sampled-trace.js";
 import type { AgentSessionTraceState, AgentTraceStateStore } from "#tracing/agent-trace-state.js";
 import { withNativeSamplingDecision } from "#tracing/native-sampling.js";
 
@@ -19,7 +18,6 @@ interface AgentOtelSessionContextInput {
   readonly idGenerator: AgentSpanIdGenerator;
   readonly stateStore: AgentTraceStateStore;
   readonly tracer: Tracer;
-  readonly tracePolicy?: TraceCapturePolicy;
 }
 
 interface AgentOtelSessionContext {
@@ -77,35 +75,14 @@ export function createAgentOtelSessionContext(
       span.end();
       return span.spanContext();
     }
-    // Fallback for already-running workflows that predate the seed.
-    if (
-      !evaluateTracePolicy(input.tracePolicy, {
-        agentName: session.agentName,
-        audience: session.channelAudience,
-        channelType: session.channelType,
-      })
-    ) {
-      return {
-        isRemote: false,
-        spanId: input.idGenerator.deriveSpanId(`session:${session.sessionId}`),
-        traceFlags: 0,
-        traceId: input.idGenerator.generateTraceId(),
-      };
-    }
-    const span = input.tracer.startSpan("agent.session", {
-      attributes: {
-        "agent.framework.name": "eve",
-        "agent.framework.version": input.frameworkVersion,
-        "agent.channel.audience": session.channelAudience,
-        "agent.name": session.agentName,
-        "agent.session.id": session.sessionId,
-        "agent.trace.schema.version": 2,
-      },
-      root: true,
-    });
-    span.addEvent("session.started");
-    span.end();
-    return span.spanContext();
+    // Missing seeds are invalid after workflow-context migration. Fail closed
+    // without re-evaluating policy or creating an exported native root.
+    return {
+      isRemote: false,
+      spanId: input.idGenerator.deriveSpanId(`session:${session.sessionId}`),
+      traceFlags: 0,
+      traceId: input.idGenerator.generateTraceId(),
+    };
   };
 
   const ensureSessionContext = async (


### PR DESCRIPTION
### Summary

Stack 8/10. Adds one-time migration for workflow contexts created before serialized plans existed. Existing trace IDs, span IDs, and sampled flags are preserved exactly; sessions without a seed evaluate current policy once, store the resulting plan, and retain it across cancellation. The OTel provider no longer evaluates policy on a seedless fallback.

### Validation

Validated with migration, cancellation, workflow-step, replay, and agent OTel suites plus the full integration run.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package (included in stack PR #2556)
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 6 files · `+101 / -39`

Adds context migration and generic preservation while removing provider-side seedless admission logic.

**Tests** — 2 files · `+135 / -12`

Covers exact seed preservation, one-time evaluation, frozen classification, and replay identity.
