### PR TITLE
docs(eve): document frozen session instrumentation

### DIFF
--- a/.changeset/frozen-session-instrumentation.md
+++ b/.changeset/frozen-session-instrumentation.md
@@ -1,0 +1,5 @@
+---
+"eve": minor
+---
+
+Freeze instrumentation policy when a session is created and route lifecycle events, AI SDK telemetry, propagation, and cancellation through one bound session control surface. Native `agent.*` traces now preserve `tracePolicy` decisions even when the process sampler would make a different choice; destination export policies remain independent.

--- a/docs/channels/custom.mdx
+++ b/docs/channels/custom.mdx
@@ -304,9 +304,11 @@ export default defineChannel({
 });
 ```
 
-The projection is re-evaluated whenever adapter state changes after channel event handlers run. Dynamic tool resolvers read it via `ctx.channel.metadata` and narrow it with `isChannel`. See [Dynamic capabilities](../guides/dynamic-capabilities) for the full consumption pattern.
+The projection is re-evaluated whenever adapter state changes after channel event handlers run. Dynamic tool resolvers read the live projection via `ctx.channel.metadata` and narrow it with `isChannel`. See [Dynamic capabilities](../guides/dynamic-capabilities) for the full consumption pattern.
 
 Metadata may include an `audience` classification: `public`, `private`, or `unknown`. Omit it when the channel cannot classify the conversation confidently; eve normalizes missing and invalid values to `unknown`. Consumers must treat `unknown` as non-public.
+
+Instrumentation snapshots the projection when `createSession` runs. A later `deliver` hook or channel event may change the live metadata seen by dynamic resolvers, but it cannot change trace admission, provider capture, `$eve.is_trace_content_visible`, or the metadata passed to instrumentation runtime-context resolvers for that session.
 
 When a parent agent dispatches a subagent, the framework forwards the parent's channel metadata projection to the child. The same `metadata(state)` projector also serves instrumentation metadata resolvers.
 

--- a/docs/concepts/sessions-runs-and-streaming.md
+++ b/docs/concepts/sessions-runs-and-streaming.md
@@ -74,7 +74,7 @@ The stream is newline-delimited JSON (NDJSON), one event per line:
 | `session.failed`          | The session failed.                                                                                              |
 | `session.completed`       | The session reached a terminal end.                                                                              |
 
-The optional `data.trace` on session and turn starts contains eve-owned W3C trace coordinates: `traceId`, `spanId`, and `traceFlags`. Use it to correlate stream consumers such as eval reporters with an observability backend. An uninstrumented target omits it.
+The optional `data.trace` on session and turn starts contains eve-owned W3C trace coordinates: `traceId`, `spanId`, and `traceFlags`. Use it to correlate stream consumers such as eval reporters with an observability backend. eve freezes this trace decision when the session is created. Local subagents inherit it; remote agents can veto an incoming sampled decision with their local trace policy, and an incoming unsampled decision remains unsampled. An uninstrumented target omits it.
 
 `reasoning.appended` and `message.appended` stream incremental output as it arrives. When the durable stream writer is busy, eve may coalesce adjacent deltas of the same type; the text remains in source order, and any other event forms an ordering barrier. Each append carries both the new delta and the cumulative text for the current block. The finalized block shows up on `message.completed` and `reasoning.completed`, which is the compatibility path for clients that don't render incremental streaming.
 
@@ -264,6 +264,8 @@ Every stream event runs four steps, in this order:
 4. **Dynamic resolvers**: [dynamic](../guides/dynamic-capabilities) tool, skill, and instruction resolvers fire, and `ctx.channel.metadata` already holds the freshly projected metadata from step 2.
 
 The order is structural, not incidental. By the time a resolver or hook reads channel metadata, the channel has already updated its state and the projection is current.
+
+Instrumentation is the exception to this live projection: trace admission, producer capture, workflow visibility, and instrumentation runtime-context channel metadata use the snapshot taken when the session was created.
 
 ## What to read next
 

--- a/docs/guides/instrumentation.md
+++ b/docs/guides/instrumentation.md
@@ -60,6 +60,19 @@ The third configurable surface, [runtime context events](#runtime-context), atta
 
 Built-in messaging channels classify their instrumentation metadata with an `audience`: `public`, `private`, or `unknown`. Slack public channels and Chat SDK workspace-visible threads are public; direct and private conversations are private; platform surfaces without enough visibility evidence remain unknown.
 
+## Four instrumentation decisions
+
+eve keeps four decisions separate so one observability destination cannot change another:
+
+1. **Session trace admission** decides whether eve creates a native `agent.*` trace. `tracePolicy` runs once when the session is created. Local subagents inherit the parent decision. A remote agent accepts a propagated sampled decision only when its own local policy also admits the session.
+2. **Provider producer capture** decides whether eve builds content-bearing lifecycle events and AI SDK telemetry. The session freezes the union of content requested by authored providers, an admitted native trace, and legacy `recordInputs` or `recordOutputs` settings. Rejecting an OTel trace does not disable an independent authored content provider.
+3. **Workflow content visibility** controls `$eve.is_trace_content_visible` and content-derived workflow attributes. It follows the existing audience rule and freezes when the session is created. This flag is separate from provider capture.
+4. **Per-destination span export policy** filters the admitted span immediately before one destination's processor chain. Each destination receives its own facade; filtering does not mutate the shared span or another destination's view.
+
+An admitted private or unknown trace captures complete source content before destination filtering. Add `redactSpanInputs()` and `redactSpanOutputs()` to every destination that must not receive that content.
+
+When you use the instrumentation provider layout, `otel({ tracePolicy, sampler })` applies these boundaries explicitly. `tracePolicy` is authoritative for native `agent.*` traces and their AI SDK descendants. `sampler` still controls unrelated authored, request, and auto-instrumented roots, but it cannot overturn a native session decision. The process sampler continues to preserve an incoming unsampled remote parent.
+
 ## Channel delivery traces
 
 Instrumentation providers receive `channel.delivery.started` followed by
@@ -110,7 +123,7 @@ export default defineInstrumentation({
 });
 ```
 
-The callback receives:
+The callback receives a session-frozen instrumentation channel snapshot:
 
 - `session`: the session id, current and initiator auth, and parent session lineage when this is a child run
 - `turn`: the stream turn id and sequence, for example `turn_0`
@@ -120,7 +133,7 @@ The callback receives:
 
 A channel exposes its identity through `kind`. For authored channels it is `channel:<name>`, where `<name>` is the channel's filename under `agent/channels/`, so `agent/channels/support.ts` is `channel:support`. Framework channels use `http`, `schedule`, or `subagent`, and an unrecognized or absent kind normalizes to `unknown`. The kind is also emitted as the `eve.channel.kind` span attribute. To access an authored channel's metadata with its precise type, import the channel definition and narrow with `isChannel(input.channel, supportChannel)`.
 
-Channel metadata is channel-owned. Built-in channels expose only the fields they choose to make observable; Slack, for example, projects `channelId`, `teamId`, `threadTs`, and `triggeringUserId` from its durable channel state. User-authored channels expose their own projection by returning `metadata(state)` from `defineChannel`. Runtime instrumentation never falls back to raw channel state.
+Channel metadata is channel-owned. Built-in channels expose only the fields they choose to make observable; Slack, for example, projects `channelId`, `teamId`, `threadTs`, and `triggeringUserId` from its durable channel state. User-authored channels expose their own projection by returning `metadata(state)` from `defineChannel`. eve snapshots this projection when the session is created, so later adapter state changes do not reclassify instrumentation. Runtime instrumentation never falls back to raw channel state.
 
 ## Authored trace hierarchy
 
@@ -165,6 +178,7 @@ Structural tags describe each run's place in the tree:
 - `$eve.trigger`: the channel kind that started the run
 - `$eve.title`: truncated title derived from the first user message
 - `$eve.trace_id`: trace id of the sampled agent trace containing the run, written on session, subagent, and turn rows so a dashboard run can be joined to its OpenTelemetry trace. Present only when the trace is sampled; absence means no exported OTEL trace exists.
+- `$eve.is_trace_content_visible`: audience-based workflow privacy decision frozen when the session is created. It does not indicate whether a provider captured content before destination filtering.
 
 Per-turn usage tags are written on each step of a turn, accumulating cumulative totals (last write wins):
 

--- a/docs/reference/typescript-api.md
+++ b/docs/reference/typescript-api.md
@@ -93,6 +93,7 @@ Tool-wide authoring helpers such as `defineTool`, `defineDynamic`, and `disableT
 | `eve/context`                                                               | `defineState`, session and state types                                    |
 | `eve/sandbox`                                                               | `defineSandbox`, backends                                                 |
 | `eve/instrumentation`                                                       | `defineInstrumentation`, `isChannel`                                      |
+| `eve/instrumentation/otel`                                                  | `otel`, `otelIntegration`, `agentRuns`, `localTraces`, span export policies |
 | `eve/models/openai`                                                         | `chatgpt`, deprecated `experimental_chatgpt`                              |
 | `eve/evals`                                                                 | `defineEval`, `defineEvalConfig`, `mockModel`, eval types                 |
 | `eve/evals/expect`                                                          | `includes`, `equals`, `matches`, `similarity`                             |
@@ -103,6 +104,8 @@ Tool-wide authoring helpers such as `defineTool`, `defineDynamic`, and `disableT
 | [`eve/client`](../guides/client/overview)                                   | `Client`, `ClientSession`, health and agent-info schemas, response errors |
 
 Exported types ship from the same entrypoint as the helper they describe (for example `ToolDefinition` and `ToolContext` from `eve/tools`). The `exports` field in `packages/eve/package.json` lists every public entrypoint.
+
+For instrumentation provider projects, `otel({ tracePolicy })` freezes native session admission at session creation. `OtelOptions.sampler` controls unrelated OpenTelemetry roots but cannot override an admitted or rejected native `agent.*` trace. Destination `exportPolicy` values run independently at each destination processor boundary. See [Observability](../guides/instrumentation#four-instrumentation-decisions).
 
 ## ChatGPT subscription models
 

--- a/e2e/fixtures/agent-tools/agent/channels/metadata-provider.ts
+++ b/e2e/fixtures/agent-tools/agent/channels/metadata-provider.ts
@@ -1,15 +1,31 @@
 import { defineChannel, POST } from "eve/channels";
 
 interface MetadataProviderState {
+  audience: "private" | "public" | "unknown";
   topic: string | null;
   contextMessages: string[];
+  mutateAudienceOnTurn: boolean;
+}
+
+declare global {
+  var __eveLiveChannelMetadata: unknown;
 }
 
 export default defineChannel({
-  state: { topic: null, contextMessages: [] } as MetadataProviderState,
+  state: {
+    audience: "unknown",
+    topic: null,
+    contextMessages: [],
+    mutateAudienceOnTurn: false,
+  } as MetadataProviderState,
+
+  context(state) {
+    return { state };
+  },
 
   metadata(state) {
     return {
+      audience: state.audience,
       topic: state.topic,
       contextMessages: state.contextMessages,
     };
@@ -19,8 +35,10 @@ export default defineChannel({
     POST<MetadataProviderState>("/metadata-provider/start", async (request, { from }) => {
       const body = (await request.json().catch(() => ({}))) as {
         message?: string;
+        audience?: MetadataProviderState["audience"];
         topic?: string;
         contextMessages?: string[];
+        mutateAudienceOnTurn?: boolean;
       };
 
       const session = await from(`mp:${crypto.randomUUID().slice(0, 8)}`).send(
@@ -28,8 +46,10 @@ export default defineChannel({
         {
           auth: null,
           state: {
+            audience: body.audience ?? "unknown",
             topic: body.topic ?? null,
             contextMessages: body.contextMessages ?? [],
+            mutateAudienceOnTurn: body.mutateAudienceOnTurn === true,
           },
         },
       );
@@ -37,4 +57,14 @@ export default defineChannel({
       return Response.json({ ok: true, sessionId: session.id });
     }),
   ],
+  events: {
+    "turn.started"(_event, channel) {
+      if (channel.state.mutateAudienceOnTurn) channel.state.audience = "private";
+      globalThis.__eveLiveChannelMetadata = {
+        audience: channel.state.audience,
+        contextMessages: channel.state.contextMessages,
+        topic: channel.state.topic,
+      };
+    },
+  },
 });

--- a/e2e/fixtures/agent-tools/agent/instrumentation.ts
+++ b/e2e/fixtures/agent-tools/agent/instrumentation.ts
@@ -1,0 +1,15 @@
+import { defineInstrumentation } from "eve/instrumentation";
+
+declare global {
+  var __eveInstrumentationSnapshot: unknown;
+}
+
+export default defineInstrumentation({
+  events: {
+    "step.started"(input) {
+      globalThis.__eveInstrumentationSnapshot = input.channel;
+      return undefined;
+    },
+  },
+  recordInputs: true,
+});

--- a/e2e/fixtures/agent-tools/agent/tools/instrumentation-snapshot.ts
+++ b/e2e/fixtures/agent-tools/agent/tools/instrumentation-snapshot.ts
@@ -1,0 +1,19 @@
+import { defineTool } from "eve/tools";
+import { z } from "zod";
+
+declare global {
+  var __eveInstrumentationSnapshot: unknown;
+  var __eveLiveChannelMetadata: unknown;
+}
+
+export default defineTool({
+  description:
+    "Return the frozen instrumentation channel snapshot and the current live channel metadata.",
+  inputSchema: z.object({}),
+  execute() {
+    return {
+      frozen: globalThis.__eveInstrumentationSnapshot,
+      live: globalThis.__eveLiveChannelMetadata,
+    };
+  },
+});

--- a/e2e/fixtures/agent-tools/evals/channel-metadata/instrumentation-freeze.eval.ts
+++ b/e2e/fixtures/agent-tools/evals/channel-metadata/instrumentation-freeze.eval.ts
@@ -1,0 +1,37 @@
+import { defineEval } from "eve/evals";
+
+import { startChannelSession } from "./shared";
+
+const TOOL_NAME = "instrumentation-snapshot";
+
+export default defineEval({
+  tags: ["real-model"],
+  description: "Legacy instrumentation freezes channel classification when the session is created.",
+  async test(t) {
+    const sessionId = await startChannelSession(t.target, "/metadata-provider/start", {
+      audience: "public",
+      message: `Call the ${TOOL_NAME} tool exactly once, then report its result.`,
+      mutateAudienceOnTurn: true,
+      topic: "instrumentation-freeze",
+    });
+    const session = await t.target.attachSession(sessionId);
+
+    session.succeeded();
+    session.calledTool(TOOL_NAME, {
+      count: 1,
+      output: (value: unknown) =>
+        isRecord(value) &&
+        isRecord(value.frozen) &&
+        value.frozen.kind === "channel:metadata-provider" &&
+        isRecord(value.frozen.metadata) &&
+        value.frozen.metadata.audience === "public" &&
+        isRecord(value.live) &&
+        value.live.audience === "private",
+    });
+    session.noFailedActions();
+  },
+});
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/packages/eve/src/execution/dispatch-runtime-actions-step.integration.test.ts
+++ b/packages/eve/src/execution/dispatch-runtime-actions-step.integration.test.ts
@@ -277,7 +277,7 @@ describe("dispatchRuntimeActionsStep child starts", () => {
     expect(mocks.createSession).toHaveBeenCalledTimes(1);
     expect(mocks.createSession).toHaveBeenCalledWith(
       expect.objectContaining({
-        parentTraceContext: { isRemote: false, spanId: actionSpanId, traceFlags: 1, traceId },
+        parentTraceContext: { spanId: actionSpanId, traceFlags: 1, traceId },
       }),
     );
     expect(getAgentHandleStore(readResultSessionState(result, session))).toEqual({
@@ -639,7 +639,7 @@ describe("dispatchRuntimeActionsStep child starts", () => {
     expect(result.results).toEqual([]);
     expect(mocks.startRemoteAgentSession).toHaveBeenCalledWith(
       expect.objectContaining({
-        parentTraceContext: { isRemote: false, spanId: actionSpanId, traceFlags: 1, traceId },
+        parentTraceContext: { spanId: actionSpanId, traceFlags: 1, traceId },
       }),
     );
     expect(getAgentHandleStore(readResultSessionState(result, session))).toEqual({

--- a/packages/eve/src/instrumentation/bind-session.ts
+++ b/packages/eve/src/instrumentation/bind-session.ts
@@ -108,10 +108,10 @@ export function bindSessionInstrumentation(input: {
     runStep: async (step, execute) => {
       if (!usesOtel) return execute();
       const tracer = trace.getTracer("eve");
-      const nativeContext = withNativeSamplingDecision(
-        otelContext.active(),
-        plan?.sampled === true,
-      );
+      const nativeContext =
+        plan !== undefined && plan.traceId.length > 0
+          ? withNativeSamplingDecision(otelContext.active(), plan.sampled)
+          : otelContext.active();
       const turnSpan = step.hasInput
         ? tracer.startSpan(
             "ai.eve.turn",

--- a/packages/eve/src/tracing/agent-otel-session-context.ts
+++ b/packages/eve/src/tracing/agent-otel-session-context.ts
@@ -64,7 +64,6 @@ export function createAgentOtelSessionContext(
               "agent.session.id": session.sessionId,
               "agent.trace.schema.version": 2,
             },
-            root: true,
           },
           withNativeSamplingDecision(ROOT_CONTEXT, true),
         );

--- a/packages/eve/src/tracing/content-span-processor.integration.test.ts
+++ b/packages/eve/src/tracing/content-span-processor.integration.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import type { SpanProcessor } from "#compiled/@vercel/otel/index.js";
+import { contentFilteringProcessor } from "#tracing/content-span-processor.js";
+import { redactSpanInputs, redactSpanOutputs } from "#tracing/span-export-policy.js";
+
+function destination(): SpanProcessor & { readonly ended: unknown[] } {
+  const ended: unknown[] = [];
+  return {
+    ended,
+    forceFlush: async () => undefined,
+    onEnd: (span) => {
+      ended.push(span);
+    },
+    onStart: () => undefined,
+    shutdown: async () => undefined,
+  };
+}
+
+describe("destination export policy isolation", () => {
+  it("delivers different views of the same admitted span without mutating it", () => {
+    const inputRedacted = destination();
+    const outputRedacted = destination();
+    const original = {
+      attributes: {
+        "agent.channel.audience": "private",
+        "ai.prompt.messages": "private input",
+        "ai.response.text": "private output",
+      },
+      spanContext: () => ({ spanId: "1".repeat(16), traceId: "2".repeat(32) }),
+    };
+
+    contentFilteringProcessor(inputRedacted, redactSpanInputs()).onEnd(original);
+    contentFilteringProcessor(outputRedacted, redactSpanOutputs()).onEnd(original);
+
+    expect((inputRedacted.ended[0] as { attributes: Record<string, unknown> }).attributes).toEqual({
+      "agent.channel.audience": "private",
+      "ai.response.text": "private output",
+    });
+    expect((outputRedacted.ended[0] as { attributes: Record<string, unknown> }).attributes).toEqual(
+      {
+        "agent.channel.audience": "private",
+        "ai.prompt.messages": "private input",
+      },
+    );
+    expect(original.attributes).toEqual({
+      "agent.channel.audience": "private",
+      "ai.prompt.messages": "private input",
+      "ai.response.text": "private output",
+    });
+  });
+});

--- a/packages/eve/src/tracing/otel-declaration.ts
+++ b/packages/eve/src/tracing/otel-declaration.ts
@@ -70,10 +70,11 @@ export interface OtelOptions {
    */
   readonly resource?: Readonly<Record<string, unknown>>;
   /**
-   * Head sampling, and it is global: it decides whether a span is created at
-   * all, so it thins eve's own sinks and the `traceparent` eve propagates
-   * along with your exporters. To thin one backend only, drop spans in a
-   * processor.
+   * Process-wide head sampling for unrelated authored, request, and
+   * auto-instrumented spans. Native `agent.*` traces and AI SDK descendants
+   * preserve the decision frozen by `tracePolicy`; this sampler cannot
+   * override that decision. To thin one backend only, drop spans in a
+   * destination processor.
    */
   readonly sampler?: SamplerOrName;
   /** Composed into one propagator. All inject; the first to extract wins. Defaults to `auto`. */

--- a/research/channel-audience-content-policy.md
+++ b/research/channel-audience-content-policy.md
@@ -1,7 +1,7 @@
 ---
 issue: https://github.com/vercel/eve/issues/2331
-status: proposed
-last_updated: "2026-08-20"
+status: implemented
+last_updated: "2026-08-25"
 ---
 
 # Audience-aware trace content policy
@@ -20,9 +20,11 @@ Channels may project one of three values from their existing synchronous `metada
 type ChannelAudience = "public" | "private" | "unknown";
 ```
 
-The field is optional for authored channels. Eve normalizes absent, malformed, and unsupported values to `unknown`. Built-in channel metadata interfaces require the field and classify only from platform evidence already captured during dispatch; ambiguous and proactive destinations remain `unknown` rather than performing observability-only network requests.
+The field is optional for authored channels. eve normalizes absent, malformed, and unsupported values to `unknown`. Built-in channel metadata interfaces require the field and classify only from platform evidence already captured during dispatch; ambiguous and proactive destinations remain `unknown` rather than performing observability-only network requests.
 
-The normalized audience is persisted with session trace state and exported as `agent.channel.audience` only on each `agent.session` window. Durable Eve state and an internal OpenTelemetry context key make the same value available to descendant export policies without duplicating a public attribute onto every span. Local subagents inherit the parent audience. Remote agents classify their receiving channel independently rather than trusting opaque metadata across deployment boundaries.
+The normalized audience is frozen in a serializable instrumentation plan when the session is created and exported as `agent.channel.audience` only on each `agent.session` window. Durable eve state and an internal OpenTelemetry context key make the same value available to descendant export policies without duplicating a public attribute onto every span. Adapter metadata changes during delivery do not reclassify instrumentation. Remote agents classify their receiving channel independently rather than trusting opaque metadata across deployment boundaries.
+
+The frozen plan also separates trace admission, producer capture, workflow content visibility, and destination export filtering. An admitted private or unknown trace captures complete source content; each destination redacts independently. Authored non-OTel providers remain independent from OTel admission.
 
 ## Public tracing API
 
@@ -148,7 +150,7 @@ This keeps unclassified local HTTP/TUI sessions observable while still rejecting
 The runtime order is:
 
 1. Derive and normalize the channel audience.
-2. Evaluate the process-wide `tracePolicy` before creating `agent.session`.
+2. Evaluate the process-wide `tracePolicy` once during session planning. Local children inherit; remote receivers may veto an incoming sampled decision.
 3. For accepted traces, capture complete Eve and AI SDK spans.
 4. Run each managed destination's composed export policies in declaration order. Custom integrations run their declared span processors.
 5. Hand the resulting facade to that destination's processors or exporter.

--- a/research/provider-neutral-local-observability.md
+++ b/research/provider-neutral-local-observability.md
@@ -1,7 +1,7 @@
 ---
 issue: TBD
-status: in-progress
-last_updated: "2026-07-30"
+status: implemented
+last_updated: "2026-08-25"
 ---
 
 # Provider-neutral local observability
@@ -94,16 +94,12 @@ attributes, or parent contexts.
 ### The session root is a real span
 
 `agent.session` is a real root span opened with OTel's `root` option, not a synthesized parent
-context. eve persists its span context — including the sampling decision it actually received — and
-later turns parent to that stored context.
+context. Session planning allocates its identity and freezes admission before workflow startup. eve
+persists that context, and later turns parent to the stored identity.
 
-This is what makes an authored sampler work. A synthesized parent asserting a sampled flag is a
-valid parent to `ParentBasedSampler`, which resolves through a parent branch and never consults the
-configured root rule. Asserting unsampled instead selects `localParentNotSampled`, which drops
-everything. A genuine root avoids both.
-
-Sampling is therefore per session trace. `agent.session.id` is a creation-time attribute, so an
-author can key a sampler on it.
+The native decision is authoritative for `agent.*` and AI SDK descendants. eve marks native OTel
+context so the process sampler preserves the frozen decision; unrelated authored, request, and
+auto-instrumented roots still delegate to the configured sampler unchanged.
 
 ### Marker spans
 
@@ -124,11 +120,11 @@ guaranteed close and could carry a real duration; that is tracked separately.
 
 ### Subagents
 
-A local subagent keeps its own session identity but adopts the parent action's `SpanContext`, so
-delegated work appears directly beneath the action that caused it. Remote dispatch sends the same
-context as `traceparent`; the receiver adopts it when available. A child with no propagated context
-opens its own root. `eve traces` resolves any session recorded in a trace, not only the one that
-opened it.
+A local subagent keeps its own session identity but inherits the parent action's instrumentation
+decision and context, so delegated work appears directly beneath the action that caused it. Remote
+dispatch sends `traceparent`; the receiver keeps an incoming unsampled decision and applies its local
+policy as a veto to an incoming sampled decision. A child with no propagated context opens its own
+root. `eve traces` resolves any session recorded in a trace, not only the one that opened it.
 
 ## Runtime integration
 
@@ -155,9 +151,8 @@ a supported customization surface. Braintrust's documented integration uses eve 
 
 ## Compatibility
 
-Production keeps its current `defineInstrumentation` and `@ai-sdk/otel` behavior until provider
-migration ships. Without lifecycle hooks no bridge is installed and production follows the existing
-authored path unchanged. Stream hooks and `step.started` semantics are unchanged.
+Legacy `defineInstrumentation()` and provider-directory layouts both adapt to the same serializable
+session plan and bound control surface. Stream hooks and `step.started` semantics are unchanged.
 
 ## Delivery phases
 
@@ -169,21 +164,20 @@ authored path unchanged. Stream hooks and `step.started` semantics are unchanged
 4. **Persistence.** — _landed._ OTLP/JSON segments, session context restored across dev worker
    restarts, retention bounds, capture policy.
 5. **Inspection.** — _landed._ `eve traces ls` and `eve traces [trace]`.
-6. **Session windows.** — _in review._ Real `agent.session` root with its recorded sampling
+6. **Session windows.** — _landed._ Real `agent.session` root with its recorded sampling
    decision, window rolling, subagent adoption, session-to-windows resolution in `eve traces`.
-7. **Public providers.** — _not started._ Promote the lifecycle contract into public hooks and
+7. **Public providers.** — _landed._ Promote the lifecycle contract into public hooks and
    migrate OTel, Vercel, Braintrust, and custom instrumentation onto it.
 
 ## Acceptance criteria
 
-- The lifecycle layer imports no OTel types. It does derive AI SDK callback payload shapes from
-  `Telemetry`, so `attempt`, `model.call`, and `tool.call` events currently expose AI SDK types to
-  providers — a known deviation from provider neutrality, to close in phase 7.
+- The lifecycle layer imports neither OTel nor AI SDK types. The harness-owned bridge maps AI SDK
+  callbacks into eve-owned event payloads before providers observe them.
 - Multiple providers observe one attempt while execution occurs exactly once.
 - No provider definition receives model or tool execution functions.
 - Documented authored instrumentation continues to observe eve calls.
 - Each provider builds its trace without inheriting Workflow or another provider's trace.
-- No eve span inherits a synthesized parent, so an authored sampler's root rule is consulted.
+- Native eve spans preserve the session decision; unrelated roots still use the authored sampler.
 - A session of ordinary length is exactly one trace; a session of any length has bounded traces.
 - `eve traces <session>` resolves every window of a session.
 - Parallel tool calls retain independent provider state.


### PR DESCRIPTION
### Summary

Stack 10/10. Documents the four independent instrumentation decisions: session trace admission, producer capture, workflow visibility, and destination export policy. It adds destination-isolation integration coverage, an E2E eval for create-time metadata freeze through legacy instrumentation, and the required minor changeset for native sampler semantics.

### Validation

The rebased stack passed 7,092 unit tests, 666 integration tests, focused provider/bootstrap scenario tests, typecheck, invariant guards, and docs checks. The new E2E eval is CI-only and was not run locally.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 7 files · `+56 / -34`

Explains the public behavior, updates the two implementation research plans, and records the minor release change.

**Implementation** — 3 files · `+9 / -9`

Includes the final sampler edge-case correction and W3C-only propagation expectation update.

**Tests** — 6 files · `+156 / -3`

Adds destination-isolation integration coverage and a fixture-owned E2E eval for create-time freeze and legacy parity.
