### PR TITLE
feat(eve): add j/k TUI navigation

### DIFF
--- a/.changeset/tidy-jaguars-navigate.md
+++ b/.changeset/tidy-jaguars-navigate.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add `j` and `k` as down and up shortcuts in non-editing TUI menus and the trace viewer while preserving normal text input in prompts, search fields, and editors.

--- a/packages/eve/src/cli/dev/tui/setup-selection-input.test.ts
+++ b/packages/eve/src/cli/dev/tui/setup-selection-input.test.ts
@@ -12,6 +12,18 @@ describe("setupSelectionIntent", () => {
     expect(setupSelectionIntent({ type: "down" })).toEqual({ kind: "move", direction: "down" });
     expect(setupSelectionIntent({ type: "ctrl-p" })).toEqual({ kind: "move", direction: "up" });
     expect(setupSelectionIntent({ type: "ctrl-n" })).toEqual({ kind: "move", direction: "down" });
+    expect(
+      setupSelectionIntent(
+        { type: "text", value: "k", framing: "unframed" },
+        { textNavigation: true },
+      ),
+    ).toEqual({ kind: "move", direction: "up" });
+    expect(
+      setupSelectionIntent(
+        { type: "text", value: "j", framing: "unframed" },
+        { textNavigation: true },
+      ),
+    ).toEqual({ kind: "move", direction: "down" });
     expect(setupSelectionIntent({ type: "ctrl-r" })).toEqual({ kind: "repaint" });
     expect(setupSelectionIntent({ type: "enter" })).toEqual({ kind: "submit" });
   });
@@ -58,6 +70,39 @@ describe("setupSelectionIntent", () => {
         required: true,
       }),
     ).toEqual({ kind: "error", message: "Select at least one option, then submit." });
+  });
+
+  it("uses j/k navigation only for non-searchable selections", () => {
+    const options = [
+      { value: "first", label: "First" },
+      { value: "second", label: "Second" },
+    ];
+    const initial = initialSelectState({ options });
+    const moved = reduceSetupSelectInput({
+      key: { type: "text", value: "j", framing: "unframed" },
+      kind: "single",
+      options,
+      select: initial,
+    });
+    expect(moved).toMatchObject({ kind: "update", select: { cursor: 1 } });
+    if (moved.kind !== "update") return;
+    expect(
+      reduceSetupSelectInput({
+        key: { type: "text", value: "k", framing: "unframed" },
+        kind: "single",
+        options,
+        select: moved.select,
+      }),
+    ).toMatchObject({ kind: "update", select: { cursor: 0 } });
+
+    expect(
+      reduceSetupSelectInput({
+        key: { type: "text", value: "j", framing: "unframed" },
+        kind: "search",
+        options,
+        select: initial,
+      }),
+    ).toMatchObject({ kind: "update", select: { filter: "j" } });
   });
 
   it("applies filter text and submits the visible match", () => {
@@ -125,6 +170,22 @@ describe("setupSelectionIntent", () => {
     expect(result.kind).toBe("update");
     if (result.kind !== "update") return;
     expect(result.select.filter).toBe("Boston");
+  });
+
+  it("does not turn pasted j/k into navigation", () => {
+    const options = [
+      { value: "first", label: "First" },
+      { value: "second", label: "Second" },
+    ];
+
+    expect(
+      reduceSetupSelectInput({
+        key: { type: "text", value: "j", framing: "bracketed-paste" },
+        kind: "single",
+        options,
+        select: initialSelectState({ options }),
+      }),
+    ).toEqual({ kind: "ignore" });
   });
 
   it("does not turn a pasted space into a multi-select toggle", () => {

--- a/packages/eve/src/cli/dev/tui/setup-selection-input.ts
+++ b/packages/eve/src/cli/dev/tui/setup-selection-input.ts
@@ -19,7 +19,15 @@ export type SetupSelectionIntent =
   | { kind: "submit" };
 
 /** Maps terminal keys to the intents every setup selection surface shares. */
-export function setupSelectionIntent(key: TerminalKey): SetupSelectionIntent | undefined {
+export function setupSelectionIntent(
+  key: TerminalKey,
+  options: { textNavigation?: boolean } = {},
+): SetupSelectionIntent | undefined {
+  if (options.textNavigation && key.type === "text" && key.framing === "unframed") {
+    if (key.value === "k") return { kind: "move", direction: "up" };
+    if (key.value === "j") return { kind: "move", direction: "down" };
+  }
+
   switch (key.type) {
     case "ctrl-c":
     case "escape":
@@ -142,7 +150,7 @@ function editSetupSelect(input: SetupSelectInputState): SetupSelectInputResult {
 
 /** Pure key transition for a setup select; rendering and lifecycle stay outside. */
 export function reduceSetupSelectInput(input: SetupSelectInputState): SetupSelectInputResult {
-  const intent = setupSelectionIntent(input.key);
+  const intent = setupSelectionIntent(input.key, { textNavigation: !isSearchableSelect(input) });
   switch (intent?.kind) {
     case "cancel":
       if (

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
@@ -2439,14 +2439,14 @@ describe("TerminalRenderer (inline scrollback)", () => {
     expect(snapshot).not.toContain("Enter to select");
     expect(countOccurrences(snapshot, "Esc to")).toBe(1);
 
-    input.down();
+    input.send("j");
     const unselected = screen
       .snapshot()
       .split("\n")
       .find((line) => line.includes("AI Gateway"));
     expect(unselected).toContain("1. AI Gateway");
     expect(unselected).not.toContain("▶");
-    input.up();
+    input.send("k");
 
     input.enter();
     await expect(answer).resolves.toEqual({ optionId: "gateway" });

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.ts
@@ -1245,6 +1245,14 @@ export class TerminalRenderer implements AgentTUIRenderer {
         }
 
         if (mode === "overlay") {
+          const textNavigation = setupSelectionIntent(key, {
+            textNavigation: !isOnFreeformRow(),
+          });
+          if (textNavigation?.kind === "move") {
+            moveCursor(textNavigation.direction === "up" ? -1 : 1);
+            return;
+          }
+
           switch (key.type) {
             case "up":
             case "ctrl-p":
@@ -1993,7 +2001,7 @@ export class TerminalRenderer implements AgentTUIRenderer {
 
     const question = this.#captureSetupQuestion<string | undefined>(
       (key, settle) => {
-        const intent = setupSelectionIntent(key);
+        const intent = setupSelectionIntent(key, { textNavigation: true });
         switch (intent?.kind) {
           case "cancel":
             settle(undefined);
@@ -2111,7 +2119,7 @@ export class TerminalRenderer implements AgentTUIRenderer {
           );
         };
 
-        const intent = setupSelectionIntent(key);
+        const intent = setupSelectionIntent(key, { textNavigation: !onEditableRow() });
         switch (intent?.kind) {
           case "cancel":
             settle(undefined);
@@ -2239,7 +2247,9 @@ export class TerminalRenderer implements AgentTUIRenderer {
           }
         };
 
-        const intent = setupSelectionIntent(key);
+        const intent = setupSelectionIntent(key, {
+          textNavigation: interaction.phase.kind === "inactive",
+        });
         switch (intent?.kind) {
           case "cancel":
             dispatch({ type: "cancel" });

--- a/packages/eve/src/cli/dev/tui/traces/trace-viewer-state.test.ts
+++ b/packages/eve/src/cli/dev/tui/traces/trace-viewer-state.test.ts
@@ -106,6 +106,31 @@ describe("reduceTraceViewerKey", () => {
     expect(state.selectedRow).toBe(count - 2);
   });
 
+  it("moves and scrolls with j/k", () => {
+    let state = applyLoadedTrace(createTraceViewerState(), conversationTrace());
+    state = reduceTraceViewerKey(state, key("text", "j"), ENV).state;
+    expect(state.selectedRow).toBe(1);
+    state = reduceTraceViewerKey(state, key("text", "k"), ENV).state;
+    expect(state.selectedRow).toBe(0);
+
+    state = reduceTraceViewerKey(state, key("enter"), ENV).state;
+    state = reduceTraceViewerKey(state, key("tab"), ENV).state;
+    state = reduceTraceViewerKey(state, key("text", "j"), ENV).state;
+    expect(state.panelScroll).toBe(1);
+    state = reduceTraceViewerKey(state, key("text", "k"), ENV).state;
+    expect(state.panelScroll).toBe(0);
+  });
+
+  it("ignores pasted j/k navigation", () => {
+    const state = applyLoadedTrace(createTraceViewerState(), conversationTrace());
+    const result = reduceTraceViewerKey(
+      state,
+      { type: "text", value: "j", framing: "bracketed-paste" },
+      ENV,
+    );
+    expect(result.state.selectedRow).toBe(0);
+  });
+
   it("jumps home and end", () => {
     let state = applyLoadedTrace(createTraceViewerState(), conversationTrace());
     state = reduceTraceViewerKey(state, key("end"), ENV).state;

--- a/packages/eve/src/cli/dev/tui/traces/trace-viewer-state.ts
+++ b/packages/eve/src/cli/dev/tui/traces/trace-viewer-state.ts
@@ -380,6 +380,20 @@ export function reduceTraceViewerKey(
     }
     case "text": {
       if (key.framing === "bracketed-paste") return { state: base };
+      if (key.value === "k") {
+        if (base.panelFocus) {
+          return { state: { ...base, panelScroll: Math.max(0, base.panelScroll - 1) } };
+        }
+        return { state: moveSelection(base, -1, environment) };
+      }
+      if (key.value === "j") {
+        if (base.panelFocus) {
+          return {
+            state: { ...base, panelScroll: Math.min(panelMaxScroll, base.panelScroll + 1) },
+          };
+        }
+        return { state: moveSelection(base, 1, environment) };
+      }
       if (key.value === "q") return { state: base, effect: "close" };
       if (key.value === "[" || key.value === "]") {
         const delta = key.value === "[" ? 1 : -1;


### PR DESCRIPTION
### Summary

The TUI currently requires arrow keys or Ctrl+N/Ctrl+P to navigate menus. This adds familiar `j`/`k` down/up shortcuts to non-editing selection surfaces and the trace viewer while preserving ordinary text entry in prompts, search fields, inline editors, freeform inputs, and bracketed paste.

### Validation

Focused TUI unit coverage passed all 219 tests, including menu navigation, question overlays, trace selection and panel scrolling, searchable inputs, active editors, and pasted text.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

A patch changeset records the new navigation shortcuts for the published package.

**Implementation** — 3 files · `+37 / -5`

The shortcut mapping stays scoped to existing selection reducers and navigation-only renderer states so text-entry behavior remains unchanged.

**Tests** — 3 files · `+88 / -2`

Focused coverage exercises non-searchable menus, editable and searchable boundaries, selection overlays, trace navigation, panel scrolling, and bracketed paste.
