### PR TITLE
docs(eve): research production self-modification and registry installation

### DIFF
--- a/research/production-self-modification.md
+++ b/research/production-self-modification.md
@@ -1,31 +1,41 @@
 ---
 issue: TBD
 status: proposed
-last_updated: "2026-08-24"
+last_updated: "2026-08-28"
 ---
 
 # Self-modification pull requests
 
 ## Summary
 
-Self-modification has two capabilities:
+Self-modification has two execution modes:
 
-- **Local editing:** while `eve dev` runs, a subagent edits the authored source tree directly.
-- **Draft pull requests:** in a deployed application, a subagent edits an isolated checkout and may create a draft pull request for review.
+- **Local editing:** while `eve dev` runs, a subagent edits the authored source
+  tree directly.
+- **Draft pull requests:** in a deployed application, a subagent edits an
+  isolated checkout, may install official eve registry items, and may create a
+  draft pull request for review.
 
-A draft pull request never changes the running application, pushes to the base branch, merges, or deploys a change. Review, merge, and redeployment remain separate boundaries.
+A successful production change means "changed in the proposal." It never
+changes the running application, pushes to the target branch, merges, deploys,
+configures secrets, or completes deferred activation work. Those remain
+separate review and operations boundaries.
 
 ```text
 accepted deployed session
           │
           ▼
-self-modification child session ◄── trusted repository + deployed revision
+self-modification child session ◄── trusted repository configuration
           │
           ▼
-isolated checkout ── edit ── validated proposal
+isolated target-branch checkout
+    ├── edit application/agent/
+    ├── search the official registry
+    ├── run fixed eve add operations
+    └── collect supported setup answers without a model turn
           │
           ▼
-trusted publisher ── namespaced branch ── draft pull request
+validated proposal ── trusted publisher ── draft pull request
                                               │
                                               ▼
                                   review, merge, and redeploy
@@ -33,7 +43,10 @@ trusted publisher ── namespaced branch ── draft pull request
 
 ## Authoring API
 
-The scaffold keeps the agent, sandbox, and extension as separate product boundaries, but they share one typed configuration module. The agent owns delegation, the sandbox owns source access and checkout, and the extension owns instructions and publishing.
+The scaffold keeps the agent, sandbox, and extension as separate product
+boundaries, but they share one typed configuration module. The agent owns
+delegation, the sandbox owns source access and checkout, and the extension owns
+instructions, registry coordination, and publication.
 
 ```ts
 import { defineSelfModificationConfig } from "@eve/self-modification/config";
@@ -44,80 +57,224 @@ export default defineSelfModificationConfig({
   },
   source: {
     git: {
-      repository: "github.com/acme/support-agent",
+      repository: "github.com/acme/agents",
+      directory: "apps/support-agent",
     },
   },
-  change: {
-    behavior: "review",
+  target: {
     branch: "main",
   },
 });
 ```
 
-`development.enabled` controls direct source edits under `eve dev` and defaults to `true`. Omitting either `source` or `change` disables self-modification outside local development. `source.git.repository` is the only GitHub repository the flow may access, and `change.branch` is the pull request target.
+`development.enabled` controls direct source edits under `eve dev` and defaults
+to `true`. `source.git.repository` is the only GitHub repository the production
+flow may access. `source.git.directory` is the repository-relative application
+root containing `agent/`; `"."` represents the repository root.
+`target.branch` is both the checkout base and the draft pull request base.
+Omitting either `source` or `target` disables production self-modification.
 
-The same config is passed to the agent and sandbox definitions and mounted as the extension config. The model belongs to the agent definition; a custom process-capable sandbox backend belongs to the sandbox definition. The PAT is operational configuration, never authored configuration.
-
-A deployed application becomes eligible for draft pull requests only when it includes both `source` and `change`; trusted deployment source metadata must also be available. The GitHub credential is required when the sandbox prepares or publishes a proposal.
+The same config is passed to the agent and sandbox definitions and mounted as
+the extension config. The model belongs to the agent definition; a custom
+process-capable sandbox backend belongs to the sandbox definition. GitHub
+credentials are operational configuration and never authored configuration.
 
 ## One authoring surface, two execution modes
 
-Local editing and draft pull requests use the same dynamic self-modification subagent and typed configuration module, but they have different effect boundaries:
+Local editing and draft pull requests use the same dynamic self-modification
+subagent and typed configuration, but have different effect boundaries:
 
-| Shared boundary   | Local development                                                                 | Deployed pull request                                                                                  |
-| ----------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| Purpose           | Makes persistent authored-source changes; changes do not affect the current turn. | Makes persistent authored-source changes; changes do not affect the current turn.                      |
-| Source workspace  | Directly edits the authored `agent/` directory mounted at `/source`.              | Edits an isolated checkout of the configured target branch.                                            |
-| Result            | The change is available on a subsequent local turn.                               | The change becomes effective only after review, merge, and redeployment.                               |
-| Activation        | Selected when `EVE_DEV=1`; `development.enabled` defaults to `true`.              | Selected outside development when `source` and `change` are configured and trusted prerequisites pass. |
-| Sandbox boundary  | Uses the constrained `just-bash` filesystem.                                      | Uses a per-session VM or container, trusted deployment source, and proposal capture.                   |
-| GitHub capability | Has no GitHub credential or publication capability.                               | Trusted checkout and publication boundaries resolve the credential separately from the model sandbox.  |
+| Shared boundary       | Local development                                                                 | Deployed pull request                                                                                      |
+| --------------------- | --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Purpose               | Makes persistent authored-source changes; changes do not affect the current turn. | Prepares persistent authored-source and official registry changes; changes do not affect the current turn. |
+| Source workspace      | Directly edits the authored `agent/` directory mounted at `/source`.              | Edits an isolated checkout of the configured target branch.                                                |
+| Registry installation | Keeps the existing development flow.                                              | Runs a constrained, trusted `eve add` operation in the configured application root.                        |
+| Result                | The change is available on a subsequent local turn.                               | The change becomes effective only after review, merge, and redeployment.                                   |
+| Activation            | Selected when `EVE_DEV=1`; `development.enabled` defaults to `true`.              | Selected outside development when `source` and `target` are configured and trusted prerequisites pass.     |
+| GitHub capability     | Has no GitHub credential or publication capability.                               | Trusted checkout and publication code resolve separate credentials outside the model sandbox.              |
 
-The modes are mutually exclusive. Even when `source` and `change` are configured, `eve dev` selects local editing unless `development.enabled` is `false`; it never uses the deployed pull request workflow.
+The modes are mutually exclusive. Even when production is configured,
+`eve dev` selects local editing unless `development.enabled` is `false`; it
+never uses the deployed pull request workflow.
 
-## Vercel deployments
+## Production source and workspace
 
-When the deployment runs on Vercel, the self-modification sandbox selects Vercel Sandbox automatically. A self-hosted deployment instead needs the process-capable backend supplied by its sandbox definition.
+A production child fetches the configured target branch tip and owns one
+isolated checkout for its lifetime:
 
-Vercel Git metadata supplies the deployment source when no explicit `EVE_SOURCE_*` source metadata is set. The metadata identifies the GitHub owner and repository, deployed commit SHA and ref, plus the Vercel deployment ID and creation time. The deployed revision remains the inspection baseline; self-modification still edits the configured target branch. Explicit source metadata takes precedence over the Vercel metadata.
-
-## Trusted deployment source
-
-A proposal starts from the immutable source identity captured when eve builds the deployment: repository host and path, full revision, and repository-relative application root. Runtime Git state, package metadata, a user request, and model output are not provenance authorities.
-
-### Why use the deployment source instead of checking out the default branch
-
-A checkout of the repository's current default branch alone cannot establish what the running agent represents. That branch can advance after deployment, be renamed, or contain commits that were never deployed. Starting there would let self-modification investigate and propose against arbitrary repository state rather than the source the requester is using.
-
-The captured deployment revision gives the sandbox an immutable investigation baseline, while the configured target branch remains the intentional target for a mergeable pull request. Fetching both and requiring the deployed revision to be an ancestor of that branch answers two separate questions: which source produced this deployment, and whether the proposal can safely target the current review branch. The repository-relative application root also prevents a monorepo checkout from treating an unrelated application as the deployed agent. Deployment source is the provenance boundary; the target checkout is only the editing target.
-
-Before checkout, self-modification verifies that deployment source metadata exists, was not derived from a local build, and identifies `github.com/<configured repository>`. The checkout fetches both the deployed revision and the latest configured target branch. The deployed tree supports investigation; edits apply only to the target checkout. The deployed revision must be an ancestor of that branch.
-
-## Proposal API
-
-A proposal is captured from the prepared sandbox workspace, not supplied by the model. It records the immutable base revision and tree, the proposed tree, the total changed bytes, and one record for every changed path:
-
-```ts
-interface SelfModificationProposal {
-  readonly baseSha: string;
-  readonly baseTreeSha: string;
-  readonly proposedTreeSha: string;
-  readonly changedBytes: number;
-  readonly changes: readonly {
-    readonly path: string;
-    readonly kind: "add" | "delete" | "modify";
-    readonly mode: "100644" | "100755" | null;
-    readonly objectId: string | null;
-    readonly bytes: number;
-  }[];
-}
+```text
+/workspace/                         repository checkout, readable for discovery
+/workspace/apps/support-agent/      configured application root
+/source/                            writable view of application/agent/
+/eve-docs/                          read-only version-matched eve docs
 ```
 
-The publisher captures this value after editing, validates its paths, file kinds, size, and Git object IDs, then reconstructs the Git tree from the captured blobs. The model cannot choose the base revision, repository, branch, changed paths, or blob identities. This separates the model-written pull request description from the source change that publication verifies.
+The configured repository, application directory, and target branch are the
+source authority. This MVP does not capture or reproduce the revision currently
+deployed. If the target branch moves after checkout, publication fails and asks
+the user to retry rather than silently rebasing.
+
+The full checkout is readable because registry installation may need a root
+manifest, workspace configuration, and lockfile. Ordinary model mutation tools
+remain rooted at `/source`. Production must replace or wrap generic file and
+shell tools if they cannot enforce that boundary.
+
+The trusted registry coordinator is the only broader writer. It may run a fixed
+`eve add` operation in the application root and retain only the package,
+lockfile, and generated source changes attributable to that operation. It
+accepts no model-supplied command, executable, flags, URL, or environment.
+
+One child-session lock serializes model edits, registry installs, rollback, and
+final capture. A failed or cancelled install restores its starting tree without
+discarding earlier model edits or completed installs.
+
+## Proposal integrity
+
+A proposal is captured from the prepared workspace, not supplied by the model.
+It records the immutable target-branch base, proposed tree, total changed bytes,
+and each changed path and Git object. Publication enforces two mutation rules:
+
+1. paths below the configured application's `agent/` directory may contain the
+   final model-authored contents;
+2. every other changed path must exactly match the recorded after-state of a
+   completed registry operation.
+
+Each successful registry operation records its starting and resulting trees,
+changed paths, object IDs, modes, installed items, required environment variable
+names, and whether activation remains. A later operation may supersede the
+record for a shared manifest or lockfile. Publication rejects an outside-
+`agent/` file changed after the final applicable registry operation.
+
+Proposal capture also rejects malformed paths, path escapes, symlinks, unsafe
+file modes, `.git`, `.env*`, self-modification policy or config, dependencies,
+build output, and changes over the file or byte limits. Repository-specific
+typechecking, tests, dependency installation, and preview builds remain pull
+request CI responsibilities.
+
+Mutation state belongs to `@eve/self-modification`; it is not a generic
+framework session-mutation journal. An active mutation identifies its rollback
+boundary and associated setup operation. A completed private receipt authorizes
+exact Git objects outside `agent/`, but contains no setup answers, secrets, or
+provider continuation state.
+
+## Registry tool API
+
+Production adds `selfmod__registry_add` beside registry search. Its only
+model-authored input is an exact official registry address such as
+`channel/slack`. Trusted code runs the checkout's own CLI with fixed arguments:
+
+```text
+eve add <address>
+  --non-interactive
+  --silent
+  [--skip-install]
+  [--answer <key>=<JSON> ...]
+```
+
+The MVP excludes third-party registries, URLs, `@skills` addresses, arbitrary
+shell arguments, and environment overrides.
+
+The checkout may not have dependencies. The first install lazily finds the
+package-manager root, performs a frozen install with lifecycle scripts disabled,
+and resolves the checkout's locked eve binary. It never uses `PATH`, `npx`, or
+the running deployment's eve binary. Installed dependencies remain untracked.
+Initial support may be limited to package managers for which these guarantees
+can be enforced.
+
+The process receives no application secrets, user-supplied provider secrets, or
+GitHub token. Source installation network access is limited to the official eve
+registry and the package registry required by the locked install. Built-in
+setup adapters may separately receive a narrowly scoped workload credential and
+fixed provider-host allowlist; a setup answer cannot broaden egress.
+
+The model receives only a concise terminal result:
+
+```ts
+type ProductionRegistryAddResult =
+  | {
+      status: "installed-in-proposal";
+      address: string;
+      changedPaths: readonly string[];
+      envVars: readonly string[];
+      setup: "complete" | "activation-required";
+    }
+  | { status: "unsupported"; address: string; reason: string };
+```
+
+Answers, secrets, pending request IDs, provider continuation state, and
+publication records never appear in model-facing output.
+
+## Model-bypassing setup coordination
+
+A deployed agent has no setup TUI. Supported registry questions and durable
+browser or device authorization therefore use a framework-owned, channel-neutral
+`tool-input` request. They never ask either the parent or child model to relay
+setup.
+
+When headless setup returns `input_required`, trusted coordination code parks
+the registry tool call and sends a plain-text prompt through the session's
+normal reply route. The operation ID, accumulated answers, and immutable request
+ID are private durable runtime state—not `session.state`, model messages, or
+model-facing output. A valid reply is journaled, the same tool execution
+resumes, and the CLI reruns with all accumulated answers.
+
+The harness addition remains narrow: it parks, routes, authorizes, cancels, and
+replays trusted tool input, including child-to-parent pending-input proxying. It
+does not gain a public `ToolContext.requestInput()`, generic durable operation
+store, or workflow API. A request cannot park beside a sibling effectful tool
+call that cannot be replayed safely.
+
+Only the initiating session's attributed and authorized responder may answer;
+there is no anonymous fallback. Stale, malformed, cross-session, and
+unauthorized replies do not resume setup. Channels need only a stable session or
+reply route, attributed inbound text, and ordinary outbound text. Outbound-only
+or uncorrelated transports report setup as unsupported before parking.
+
+Questions are rendered as numbered plain text. Multi-select uses comma-separated
+numbers, and editable select uses an explicit `custom: <value>` form. Invalid
+input creates a replacement prompt and does not reach a model. Prompts explain
+that the next correlated reply is setup input and always provide an explicit
+cancel response.
+
+### Durable external authorization
+
+A live subprocess cannot be the continuation for browser or device setup: a
+parked action may resume on another worker. Supported setup adapters therefore
+turn an external action into private durable data with idempotent `inspect`,
+`complete`, and `cancel` operations. Only safe presentation data—message, URL,
+user code, and expiration—is sent to the user.
+
+On `continue`, trusted code inspects the stored provider operation. Completion
+finalizes it idempotently; a pending action creates a new immutable input
+attempt; expiration, failure, or cancellation performs cleanup and returns an
+actionable result. Worker replacement restores the private continuation rather
+than a subprocess. Slack, managed Linq, and Photon are the initial adapters.
+Automatic callback-driven resume is not required; an explicit `continue` reply
+is the MVP wake-up mechanism.
+
+Private setup state belongs to `eve/setup`, whose built-in integrations already
+own provider setup. `@eve/self-modification` stores only a setup operation ID and
+terminal result; it never interprets answers or provider continuation data. The
+harness treats setup state and mutation receipts as opaque.
+
+### Unsupported interactions
+
+Tool input never collects passwords, API keys, environment variable values, or
+other secrets. It also rejects file uploads, device-local choices, and external
+effects that cannot be inspected, completed, and cancelled idempotently.
+
+If deterministic source installation completes before an unsupported
+prerequisite, the proposal keeps it and reports
+`setup: "activation-required"`, including required environment variable names
+and actionable post-deployment guidance. If useful installation cannot be
+separated safely from the prerequisite, the operation rolls back and returns
+`unsupported`. Non-blocking activation URLs remain proposal follow-up work.
 
 ## Publish tool API
 
-The publish tool is available only in a delegated session when `source` and `change` are configured and trusted deployment source checks pass. Its model-facing input is deliberately limited to pull request presentation:
+The publish tool is available only in a delegated production session after
+configuration, workspace, and credential checks pass. Its model-facing input is
+limited to pull request presentation:
 
 ```ts
 {
@@ -126,48 +283,139 @@ The publish tool is available only in a delegated session when `source` and `cha
 }
 ```
 
-The tool derives the repository, target branch, deployed revision, prepared workspace, and replay-safe operation identifier from trusted configuration and session context. It does not accept a branch name, repository, base revision, file list, Git object ID, credential, or operation ID from the model.
+The tool derives the repository, target branch, base revision, workspace,
+registry receipts, and replay-safe operation identifier from trusted context.
+It does not accept a branch, repository, base revision, changed path, Git object,
+credential, or operation ID from the model.
 
-On success it returns the configured target branch, generated namespaced branch, changed paths, commit SHA, deployed SHA, draft flag, pull request state, and pull request URL. The result describes a draft pull request only; the tool cannot merge, approve, close, retarget, or update the target branch.
+Publication captures and validates the complete proposal before resolving a
+write credential. It may create Git objects, a branch under
+`eve-self-modification/`, and a draft pull request against the configured target
+branch. It cannot update that branch, merge, approve, close, or retarget a pull
+request. Retrying finds or updates the same draft; target-branch movement causes
+publication to fail.
 
-## Isolated editing and publication
+The result and final review identify the repository and target branch, generated
+branch, commit, every changed path, installed registry addresses, package and
+lockfile changes, required environment variable names, deferred activation, and
+draft pull request URL. They state that merge and deployment have not occurred.
 
-The model edits a per-session sandbox checkout. Checkout briefly enables a GitHub network policy that injects the PAT without putting it in a command or environment variable. The policy returns to deny-all before model editing begins. Publication resolves the PAT in the trusted application runtime; it never returns the token to the sandbox.
+## GitHub credentials
 
-Proposal capture treats the sandbox as untrusted. It limits edits to the deployed application’s `agent/` directory, excludes generated configuration and build artifacts, rejects unsafe file kinds and malformed paths, and enforces file and byte limits. Repository-specific typechecking, tests, dependency installation, and preview builds belong in pull request CI.
+GitHub credentials remain in trusted checkout and publication code. They never
+enter prompts, model sandboxes, durable setup state, Git remotes, or registry CLI
+environments. One internal provider boundary resolves separate just-in-time
+checkout and publication tokens.
 
-Publication receives a trusted request containing the configured destination, deployed revision, workspace, and replay-safe operation identifier; the model provides only pull request presentation. The initial GitHub publisher captures and validates the complete proposal before resolving the PAT. It may create Git objects, a branch under `eve-self-modification/`, and a draft pull request against the configured target branch. It cannot update that branch, merge, approve, close, or retarget a pull request. A stable operation identifier makes retrying publication replay-safe.
+### Vercel production
+
+A production deployment on Vercel uses the ordinary Vercel GitHub App linked to
+its project:
+
+1. eve obtains workload identity for the running Vercel project;
+2. a workload-authenticated broker verifies that the exact project Git link
+   matches `source.git.repository`;
+3. the broker resolves the ordinary Vercel GitHub App installation; and
+4. it mints a repository- and permission-scoped installation token.
+
+Checkout receives Contents read. Publication receives Contents write and Pull
+requests write. Scoped requests bypass any installation-wide token cache. The
+broker rejects previews initially, owner fallback, unrelated repositories,
+OAuth-user credentials, missing or suspended installations, and
+caller-selected permissions. Audit records identify the project, deployment,
+repository, installation, and capability, never the token.
+
+This is trusted workload authentication, not deployment-source tracking. A
+broker failure never falls back to a PAT.
+
+### PAT alternative
+
+CI, self-hosted, and other supported GitHub deployments use
+`EVE_SELF_MODIFICATION_GITHUB_TOKEN`. The recommended fine-grained PAT is
+restricted to the configured repository with Contents and Pull requests
+read/write. It uses the same trusted provider boundary.
 
 ## Setup and scaffolding
 
-`eve add experimental/self-modification` generates `config.ts`. The scaffold makes draft-pull-request configuration an explicit, reviewable authoring decision instead of a collection of environment variables whose repository and branch settings can drift apart. Non-interactive installation leaves the default local-editing configuration intact.
+`eve add experimental/self-modification` generates `config.ts`. Non-interactive
+installation leaves the default local-editing configuration intact.
 
-Interactive setup detects and confirms the GitHub repository and base branch, writes `source` and `change`, and instructs the operator to set `EVE_SELF_MODIFICATION_GITHUB_TOKEN` in the deployment’s secret configuration. The shared configuration is then passed to the agent, sandbox, and extension, so they use the same repository and pull request target. Re-running setup may fill in missing generated configuration, but must not silently broaden an existing repository or branch selection.
+Interactive setup detects and displays the GitHub repository,
+repository-relative application directory, and default branch before writing
+`source` and `target`. It does not silently overwrite or broaden existing
+authored configuration. The generated agent, sandbox, and extension entrypoints
+consume the same value.
 
-The recommended credential is a fine-grained PAT restricted to the configured repository with Contents read and write, Pull requests read and write, and Metadata read. Setup never writes the PAT into source.
+For a Git-connected Vercel production project, setup explains that the linked
+Vercel GitHub App supplies credentials and does not request a PAT. Manual and
+self-hosted deployment setup instructs the operator to configure the PAT as a
+secret. Setup never writes credentials into source.
+
+## Ownership and validation
+
+Changes under `packages/eve` are limited to two framework-owned surfaces:
+
+- the harness owns the narrow `tool-input` pending-input kind, trusted
+  interruption, response routing, child proxying, replay, authorization, and
+  cancellation;
+- `eve/setup` owns setup answer accumulation, private continuation storage,
+  external-action outcomes, and the Slack, Linq, and Photon adapters.
+
+`packages/eve-self-modification` owns production configuration and mode
+selection, checkout and constrained workspaces, registry invocation, mutation
+serialization and rollback, proposal validation, and draft publication. The
+packages share only stable operation IDs and terminal setup results.
+
+Focused tests must cover configuration and path validation, nested workspaces
+and lockfiles, exact registry after-state enforcement, rollback boundaries,
+model-bypassing answer replay, worker replacement during external setup,
+idempotent completion and cancellation, responder authorization, absence of
+private state from model and terminal output, credential downscoping, target
+branch movement, and replay-safe publication.
+
+A fixture-owned E2E eval is the official proof that a deployed parent delegates
+once, setup replies bypass both models, the child continues editing, and one
+draft pull request contains ordinary edits plus registry source, manifest, and
+lockfile changes.
 
 ## Scope and limitations
 
-The initial flow supports one GitHub repository and one target branch per definition. It does not support GitLab, Bitbucket, forks, coordinated multi-repository proposals, private package registry credentials, Git LFS content, networked pre-publication validation, deployment actions, or amending an existing proposal.
+The initial flow supports one GitHub repository and target branch per
+definition, official registry items, and package managers whose locked bootstrap
+can be enforced. It does not support GitLab, Bitbucket, forks, coordinated
+multi-repository proposals, third-party registries, private package registry
+credentials, Git LFS, arbitrary networked validation, deployment actions, or
+merging a proposal.
 
-There is no self-modification-specific principal policy or in-session approval prompt. Every session accepted by an application with deployed source changes configured can request a draft pull request. Applications must protect inbound routes and channels before enabling it.
+There is no self-modification-specific principal policy or in-session approval
+prompt. Every session accepted by an application with production
+self-modification configured can request a draft pull request. Applications must
+protect inbound routes and channels before enabling it.
 
 ## Future work
 
-### GitHub App installation tokens
-
-Replace the PAT with credentials from an existing GitHub App installation. An eve-owned adapter should discover the configured installation and mint repository-scoped installation tokens: a read-only token for checkout and a separately scoped write token for publication. This removes the PAT's unavoidable read/write overlap, so compromise of the checkout boundary cannot obtain write capability. Installation discovery, caching, refresh, and private-key handling must remain behind the adapter.
-
-### Principal access policies
-
-Add explicit allow policies over verified session principals. The policy must be checked when self-modification is exposed, before a sandbox is prepared, and again immediately before publication; a route-level authentication check alone is insufficient for a capability that opens pull requests. When a policy is configured, unmatched or absent principals must be denied. Setup can later help map channel-specific identities to those rules without making a model request an authority.
-
-### Basic validation
-
-Add an optional, bounded validation stage for the captured proposal before publication. The initial integrity checks remain mandatory and are not a substitute for application validation. A later scaffolded policy can allow a small, explicit set of safe checks—such as formatting, typechecking, or focused tests—and report their results on the draft pull request. Validation must run without publication credentials, have resource limits, and remain advisory rather than a reason to grant the sandbox more filesystem or network access. Full repository validation continues to belong in CI.
+- Compare proposals with the deployed revision and verify deployment after
+  merge.
+- Replace plain-text setup presentation with optional native channel widgets
+  over the same answer contract.
+- Add callback-driven wake-up for supported external authorization.
+- Broker secrets and additional reconcilable external setup effects.
+- Support more package managers and third-party registries with equivalent
+  integrity guarantees.
+- Add explicit policies over verified session principals, checked before
+  sandbox preparation and again before publication.
+- Add optional bounded formatting, typechecking, or focused tests without
+  publication credentials; full validation remains pull request CI.
 
 ## Future exploration, not planned
 
-The flow in this document is conversation-driven: the root agent delegates when a user asks for a persistent source change. It may infer that a request should persist, but it does not initiate self-modification without a conversational request.
+The flow is conversation-driven: the root agent delegates when a user asks for
+a persistent source change or registry installation. It may infer that a request
+should persist, but it does not initiate self-modification without a
+conversational request.
 
-Triggers and trigger prompts are a separate future area, not part of this plan. Possible signals include schedules, evaluations, CI failures, operational telemetry, or a detected source condition. Each would need an explicit triggering policy, a bounded prompt and input provenance, deduplication and rate limits, and an authorization model that establishes who or what may create a proposal. They must not turn an untrusted event payload or model observation into authority to modify source or publish a pull request.
+Schedules, evaluations, CI failures, telemetry, and source conditions are a
+separate future area. Each would need explicit trigger policy, bounded input
+provenance, deduplication, rate limits, and authorization. An untrusted event or
+model observation must never become authority to modify source or publish a pull
+request.

--- a/research/production-self-modification.md
+++ b/research/production-self-modification.md
@@ -1,0 +1,170 @@
+---
+issue: TBD
+status: proposed
+last_updated: "2026-08-24"
+---
+
+# Self-modification pull requests
+
+## Summary
+
+Self-modification has two capabilities:
+
+- **Local editing:** while `eve dev` runs, a subagent edits the authored source tree directly.
+- **Draft pull requests:** in a deployed application, a subagent edits an isolated checkout and may create a draft pull request for review.
+
+A draft pull request never changes the running application, pushes to the base branch, merges, or deploys a change. Review, merge, and redeployment remain separate boundaries.
+
+```text
+accepted deployed session
+          │
+          ▼
+self-modification child session ◄── trusted repository + deployed revision
+          │
+          ▼
+isolated checkout ── edit ── validated proposal
+          │
+          ▼
+trusted publisher ── namespaced branch ── draft pull request
+                                              │
+                                              ▼
+                                  review, merge, and redeploy
+```
+
+## Authoring API
+
+The scaffold keeps the agent, sandbox, and extension as separate product boundaries, but they share one typed configuration module. The agent owns delegation, the sandbox owns source access and checkout, and the extension owns instructions and publishing.
+
+```ts
+import { defineSelfModificationConfig } from "@eve/self-modification/config";
+
+export default defineSelfModificationConfig({
+  development: {
+    enabled: false,
+  },
+  pullRequests: {
+    git: {
+      repository: "acme/support-agent",
+      baseBranch: "main",
+    },
+  },
+});
+```
+
+`development.enabled` controls direct source edits under `eve dev` and defaults to `true`. Omitting `pullRequests` disables self-modification outside local development. `pullRequests.git` makes both the Git boundary and the result explicit: `repository` is the only GitHub repository the flow may access, and `baseBranch` is the pull request target.
+
+The same config is passed to the agent and sandbox definitions and mounted as the extension config. The model belongs to the agent definition; a custom process-capable sandbox backend belongs to the sandbox definition. The PAT is operational configuration, never authored configuration.
+
+Any deployed application that includes `pullRequests` enables the draft-pull-request capability.
+
+## One authoring surface, two execution modes
+
+Local editing and draft pull requests use the same dynamic self-modification subagent and typed configuration module, but they have different effect boundaries:
+
+| Shared boundary   | Local development                                                                 | Deployed pull request                                                                                 |
+| ----------------- | --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Purpose           | Makes persistent authored-source changes; changes do not affect the current turn. | Makes persistent authored-source changes; changes do not affect the current turn.                     |
+| Source workspace  | Directly edits the authored `agent/` directory mounted at `/source`.              | Edits an isolated checkout of the configured pull request base.                                       |
+| Result            | The change is available on a subsequent local turn.                               | The change becomes effective only after review, merge, and redeployment.                              |
+| Activation        | Selected when `EVE_DEV=1`; `development.enabled` defaults to `true`.              | Selected outside development when `pullRequests` is configured.                                       |
+| Sandbox boundary  | Uses the constrained `just-bash` filesystem.                                      | Uses a per-session VM or container, trusted deployment source, and proposal capture.                  |
+| GitHub capability | Has no GitHub credential or publication capability.                               | Trusted checkout and publication boundaries resolve the credential separately from the model sandbox. |
+
+The modes are mutually exclusive. Even when `pullRequests` is configured, `eve dev` selects local editing unless `development.enabled` is `false`; it never uses the deployed pull request workflow.
+
+## Vercel deployments
+
+When the deployment runs on Vercel, the self-modification sandbox selects Vercel Sandbox automatically. A self-hosted deployment instead needs the process-capable backend supplied by its sandbox definition.
+
+Vercel Git metadata supplies the deployment source when no explicit `EVE_SOURCE_*` source metadata is set. The metadata identifies the GitHub owner and repository, deployed commit SHA and ref, plus the Vercel deployment ID and creation time. The deployed revision remains the inspection baseline; self-modification still edits the configured pull request base. Explicit source metadata takes precedence over the Vercel metadata.
+
+## Trusted deployment source
+
+A proposal starts from the immutable source identity captured when eve builds the deployment: repository host and path, full revision, and repository-relative application root. Runtime Git state, package metadata, a user request, and model output are not provenance authorities.
+
+### Why use the deployment source instead of checking out the default branch
+
+A checkout of the repository's current default branch alone cannot establish what the running agent represents. That branch can advance after deployment, be renamed, or contain commits that were never deployed. Starting there would let self-modification investigate and propose against arbitrary repository state rather than the source the requester is using.
+
+The captured deployment revision gives the sandbox an immutable investigation baseline, while the configured base branch remains the intentional target for a mergeable pull request. Fetching both and requiring the deployed revision to be an ancestor of the base answers two separate questions: which source produced this deployment, and whether the proposal can safely target the current review branch. The repository-relative application root also prevents a monorepo checkout from treating an unrelated application as the deployed agent. Deployment source is the provenance boundary; the base checkout is only the editing target.
+
+Before checkout, self-modification verifies that deployment source metadata exists, was not derived from a local build, and identifies `github.com/<configured repository>`. The checkout fetches both the deployed revision and the latest configured base branch. The deployed tree supports investigation; edits apply only to the base checkout. The deployed revision must be an ancestor of the base.
+
+## Proposal API
+
+A proposal is captured from the prepared sandbox workspace, not supplied by the model. It records the immutable base revision and tree, the proposed tree, the total changed bytes, and one record for every changed path:
+
+```ts
+interface SelfModificationProposal {
+  readonly baseSha: string;
+  readonly baseTreeSha: string;
+  readonly proposedTreeSha: string;
+  readonly changedBytes: number;
+  readonly changes: readonly {
+    readonly path: string;
+    readonly kind: "add" | "delete" | "modify";
+    readonly mode: "100644" | "100755" | null;
+    readonly objectId: string | null;
+    readonly bytes: number;
+  }[];
+}
+```
+
+The publisher captures this value after editing, validates its paths, file kinds, size, and Git object IDs, then reconstructs the Git tree from the captured blobs. The model cannot choose the base revision, repository, branch, changed paths, or blob identities. This separates the model-written pull request description from the source change that publication verifies.
+
+## Publish tool API
+
+The publish tool is available only in a delegated session when `pullRequests` is configured and trusted deployment source checks pass. Its model-facing input is deliberately limited to pull request presentation:
+
+```ts
+{
+  title: string; // 1–256 characters
+  summary: string; // 1–10,000 characters
+}
+```
+
+The tool derives the repository, base branch, deployed revision, prepared workspace, and replay-safe operation identifier from trusted configuration and session context. It does not accept a branch name, repository, base revision, file list, Git object ID, credential, or operation ID from the model.
+
+On success it returns the configured base branch, generated namespaced branch, changed paths, commit SHA, deployed SHA, draft flag, pull request state, and pull request URL. The result describes a draft pull request only; the tool cannot merge, approve, close, retarget, or update the base branch.
+
+## Isolated editing and publication
+
+The model edits a per-session sandbox checkout. Checkout briefly enables a GitHub network policy that injects the PAT without putting it in a command or environment variable. The policy returns to deny-all before model editing begins. Publication resolves the PAT in the trusted application runtime; it never returns the token to the sandbox.
+
+Proposal capture treats the sandbox as untrusted. It limits edits to the deployed application’s `agent/` directory, excludes generated configuration and build artifacts, rejects unsafe file kinds and malformed paths, and enforces file and byte limits. Repository-specific typechecking, tests, dependency installation, and preview builds belong in pull request CI.
+
+The trusted publisher captures and validates the complete proposal before resolving the PAT. It may create Git objects, a branch under `eve-self-modification/`, and a draft pull request against the configured base. It cannot update the base branch, merge, approve, close, or retarget a pull request. A stable operation identifier makes retrying publication replay-safe.
+
+## Setup and scaffolding
+
+`eve add experimental/self-modification` generates `config.ts`. The scaffold makes draft-pull-request configuration an explicit, reviewable authoring decision instead of a collection of environment variables whose repository and branch settings can drift apart. Non-interactive installation leaves the default local-editing configuration intact.
+
+Interactive setup detects and confirms the GitHub repository and base branch, writes `pullRequests.git`, and instructs the operator to set `EVE_SELF_MODIFICATION_GITHUB_TOKEN` in the deployment’s secret configuration. The shared configuration is then passed to the agent, sandbox, and extension, so they use the same repository and pull request target. Re-running setup may fill in missing generated configuration, but must not silently broaden an existing repository or branch selection.
+
+The recommended credential is a fine-grained PAT restricted to the configured repository with Contents read and write, Pull requests read and write, and Metadata read. Setup never writes the PAT into source.
+
+## Scope and limitations
+
+The initial flow supports one GitHub repository and one base branch per definition. It does not support GitLab, Bitbucket, forks, coordinated multi-repository proposals, private package registry credentials, Git LFS content, networked pre-publication validation, deployment actions, or amending an existing proposal.
+
+There is no self-modification-specific principal policy or in-session approval prompt. Every session accepted by an application with `pullRequests` configured can request a draft pull request. Applications must protect inbound routes and channels before enabling it.
+
+## Future work
+
+### GitHub App installation tokens
+
+Replace the PAT with credentials from an existing GitHub App installation. An eve-owned adapter should discover the configured installation and mint repository-scoped installation tokens: a read-only token for checkout and a separately scoped write token for publication. This removes the PAT's unavoidable read/write overlap, so compromise of the checkout boundary cannot obtain write capability. Installation discovery, caching, refresh, and private-key handling must remain behind the adapter.
+
+### Principal access policies
+
+Add explicit allow policies over verified session principals. The policy must be checked when self-modification is exposed, before a sandbox is prepared, and again immediately before publication; a route-level authentication check alone is insufficient for a capability that opens pull requests. When a policy is configured, unmatched or absent principals must be denied. Setup can later help map channel-specific identities to those rules without making a model request an authority.
+
+### Basic validation
+
+Add an optional, bounded validation stage for the captured proposal before publication. The initial integrity checks remain mandatory and are not a substitute for application validation. A later scaffolded policy can allow a small, explicit set of safe checks—such as formatting, typechecking, or focused tests—and report their results on the draft pull request. Validation must run without publication credentials, have resource limits, and remain advisory rather than a reason to grant the sandbox more filesystem or network access. Full repository validation continues to belong in CI.
+
+## Future exploration, not planned
+
+The flow in this document is conversation-driven: the root agent delegates when a user asks for a persistent source change. It may infer that a request should persist, but it does not initiate self-modification without a conversational request.
+
+Triggers and trigger prompts are a separate future area, not part of this plan. Possible signals include schedules, evaluations, CI failures, operational telemetry, or a detected source condition. Each would need an explicit triggering policy, a bounded prompt and input provenance, deduplication and rate limits, and an authorization model that establishes who or what may create a proposal. They must not turn an untrusted event payload or model observation into authority to modify source or publish a pull request.

--- a/research/production-self-modification.md
+++ b/research/production-self-modification.md
@@ -42,41 +42,44 @@ export default defineSelfModificationConfig({
   development: {
     enabled: false,
   },
-  pullRequests: {
+  source: {
     git: {
-      repository: "acme/support-agent",
-      baseBranch: "main",
+      repository: "github.com/acme/support-agent",
     },
+  },
+  change: {
+    behavior: "review",
+    branch: "main",
   },
 });
 ```
 
-`development.enabled` controls direct source edits under `eve dev` and defaults to `true`. Omitting `pullRequests` disables self-modification outside local development. `pullRequests.git` makes both the Git boundary and the result explicit: `repository` is the only GitHub repository the flow may access, and `baseBranch` is the pull request target.
+`development.enabled` controls direct source edits under `eve dev` and defaults to `true`. Omitting either `source` or `change` disables self-modification outside local development. `source.git.repository` is the only GitHub repository the flow may access, and `change.branch` is the pull request target.
 
 The same config is passed to the agent and sandbox definitions and mounted as the extension config. The model belongs to the agent definition; a custom process-capable sandbox backend belongs to the sandbox definition. The PAT is operational configuration, never authored configuration.
 
-Any deployed application that includes `pullRequests` enables the draft-pull-request capability.
+A deployed application becomes eligible for draft pull requests only when it includes both `source` and `change`; trusted deployment source metadata must also be available. The GitHub credential is required when the sandbox prepares or publishes a proposal.
 
 ## One authoring surface, two execution modes
 
 Local editing and draft pull requests use the same dynamic self-modification subagent and typed configuration module, but they have different effect boundaries:
 
-| Shared boundary   | Local development                                                                 | Deployed pull request                                                                                 |
-| ----------------- | --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| Purpose           | Makes persistent authored-source changes; changes do not affect the current turn. | Makes persistent authored-source changes; changes do not affect the current turn.                     |
-| Source workspace  | Directly edits the authored `agent/` directory mounted at `/source`.              | Edits an isolated checkout of the configured pull request base.                                       |
-| Result            | The change is available on a subsequent local turn.                               | The change becomes effective only after review, merge, and redeployment.                              |
-| Activation        | Selected when `EVE_DEV=1`; `development.enabled` defaults to `true`.              | Selected outside development when `pullRequests` is configured.                                       |
-| Sandbox boundary  | Uses the constrained `just-bash` filesystem.                                      | Uses a per-session VM or container, trusted deployment source, and proposal capture.                  |
-| GitHub capability | Has no GitHub credential or publication capability.                               | Trusted checkout and publication boundaries resolve the credential separately from the model sandbox. |
+| Shared boundary   | Local development                                                                 | Deployed pull request                                                                                  |
+| ----------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Purpose           | Makes persistent authored-source changes; changes do not affect the current turn. | Makes persistent authored-source changes; changes do not affect the current turn.                      |
+| Source workspace  | Directly edits the authored `agent/` directory mounted at `/source`.              | Edits an isolated checkout of the configured target branch.                                            |
+| Result            | The change is available on a subsequent local turn.                               | The change becomes effective only after review, merge, and redeployment.                               |
+| Activation        | Selected when `EVE_DEV=1`; `development.enabled` defaults to `true`.              | Selected outside development when `source` and `change` are configured and trusted prerequisites pass. |
+| Sandbox boundary  | Uses the constrained `just-bash` filesystem.                                      | Uses a per-session VM or container, trusted deployment source, and proposal capture.                   |
+| GitHub capability | Has no GitHub credential or publication capability.                               | Trusted checkout and publication boundaries resolve the credential separately from the model sandbox.  |
 
-The modes are mutually exclusive. Even when `pullRequests` is configured, `eve dev` selects local editing unless `development.enabled` is `false`; it never uses the deployed pull request workflow.
+The modes are mutually exclusive. Even when `source` and `change` are configured, `eve dev` selects local editing unless `development.enabled` is `false`; it never uses the deployed pull request workflow.
 
 ## Vercel deployments
 
 When the deployment runs on Vercel, the self-modification sandbox selects Vercel Sandbox automatically. A self-hosted deployment instead needs the process-capable backend supplied by its sandbox definition.
 
-Vercel Git metadata supplies the deployment source when no explicit `EVE_SOURCE_*` source metadata is set. The metadata identifies the GitHub owner and repository, deployed commit SHA and ref, plus the Vercel deployment ID and creation time. The deployed revision remains the inspection baseline; self-modification still edits the configured pull request base. Explicit source metadata takes precedence over the Vercel metadata.
+Vercel Git metadata supplies the deployment source when no explicit `EVE_SOURCE_*` source metadata is set. The metadata identifies the GitHub owner and repository, deployed commit SHA and ref, plus the Vercel deployment ID and creation time. The deployed revision remains the inspection baseline; self-modification still edits the configured target branch. Explicit source metadata takes precedence over the Vercel metadata.
 
 ## Trusted deployment source
 
@@ -86,9 +89,9 @@ A proposal starts from the immutable source identity captured when eve builds th
 
 A checkout of the repository's current default branch alone cannot establish what the running agent represents. That branch can advance after deployment, be renamed, or contain commits that were never deployed. Starting there would let self-modification investigate and propose against arbitrary repository state rather than the source the requester is using.
 
-The captured deployment revision gives the sandbox an immutable investigation baseline, while the configured base branch remains the intentional target for a mergeable pull request. Fetching both and requiring the deployed revision to be an ancestor of the base answers two separate questions: which source produced this deployment, and whether the proposal can safely target the current review branch. The repository-relative application root also prevents a monorepo checkout from treating an unrelated application as the deployed agent. Deployment source is the provenance boundary; the base checkout is only the editing target.
+The captured deployment revision gives the sandbox an immutable investigation baseline, while the configured target branch remains the intentional target for a mergeable pull request. Fetching both and requiring the deployed revision to be an ancestor of that branch answers two separate questions: which source produced this deployment, and whether the proposal can safely target the current review branch. The repository-relative application root also prevents a monorepo checkout from treating an unrelated application as the deployed agent. Deployment source is the provenance boundary; the target checkout is only the editing target.
 
-Before checkout, self-modification verifies that deployment source metadata exists, was not derived from a local build, and identifies `github.com/<configured repository>`. The checkout fetches both the deployed revision and the latest configured base branch. The deployed tree supports investigation; edits apply only to the base checkout. The deployed revision must be an ancestor of the base.
+Before checkout, self-modification verifies that deployment source metadata exists, was not derived from a local build, and identifies `github.com/<configured repository>`. The checkout fetches both the deployed revision and the latest configured target branch. The deployed tree supports investigation; edits apply only to the target checkout. The deployed revision must be an ancestor of that branch.
 
 ## Proposal API
 
@@ -114,7 +117,7 @@ The publisher captures this value after editing, validates its paths, file kinds
 
 ## Publish tool API
 
-The publish tool is available only in a delegated session when `pullRequests` is configured and trusted deployment source checks pass. Its model-facing input is deliberately limited to pull request presentation:
+The publish tool is available only in a delegated session when `source` and `change` are configured and trusted deployment source checks pass. Its model-facing input is deliberately limited to pull request presentation:
 
 ```ts
 {
@@ -123,9 +126,9 @@ The publish tool is available only in a delegated session when `pullRequests` is
 }
 ```
 
-The tool derives the repository, base branch, deployed revision, prepared workspace, and replay-safe operation identifier from trusted configuration and session context. It does not accept a branch name, repository, base revision, file list, Git object ID, credential, or operation ID from the model.
+The tool derives the repository, target branch, deployed revision, prepared workspace, and replay-safe operation identifier from trusted configuration and session context. It does not accept a branch name, repository, base revision, file list, Git object ID, credential, or operation ID from the model.
 
-On success it returns the configured base branch, generated namespaced branch, changed paths, commit SHA, deployed SHA, draft flag, pull request state, and pull request URL. The result describes a draft pull request only; the tool cannot merge, approve, close, retarget, or update the base branch.
+On success it returns the configured target branch, generated namespaced branch, changed paths, commit SHA, deployed SHA, draft flag, pull request state, and pull request URL. The result describes a draft pull request only; the tool cannot merge, approve, close, retarget, or update the target branch.
 
 ## Isolated editing and publication
 
@@ -133,21 +136,21 @@ The model edits a per-session sandbox checkout. Checkout briefly enables a GitHu
 
 Proposal capture treats the sandbox as untrusted. It limits edits to the deployed application’s `agent/` directory, excludes generated configuration and build artifacts, rejects unsafe file kinds and malformed paths, and enforces file and byte limits. Repository-specific typechecking, tests, dependency installation, and preview builds belong in pull request CI.
 
-The trusted publisher captures and validates the complete proposal before resolving the PAT. It may create Git objects, a branch under `eve-self-modification/`, and a draft pull request against the configured base. It cannot update the base branch, merge, approve, close, or retarget a pull request. A stable operation identifier makes retrying publication replay-safe.
+Publication receives a trusted request containing the configured destination, deployed revision, workspace, and replay-safe operation identifier; the model provides only pull request presentation. The initial GitHub publisher captures and validates the complete proposal before resolving the PAT. It may create Git objects, a branch under `eve-self-modification/`, and a draft pull request against the configured target branch. It cannot update that branch, merge, approve, close, or retarget a pull request. A stable operation identifier makes retrying publication replay-safe.
 
 ## Setup and scaffolding
 
 `eve add experimental/self-modification` generates `config.ts`. The scaffold makes draft-pull-request configuration an explicit, reviewable authoring decision instead of a collection of environment variables whose repository and branch settings can drift apart. Non-interactive installation leaves the default local-editing configuration intact.
 
-Interactive setup detects and confirms the GitHub repository and base branch, writes `pullRequests.git`, and instructs the operator to set `EVE_SELF_MODIFICATION_GITHUB_TOKEN` in the deployment’s secret configuration. The shared configuration is then passed to the agent, sandbox, and extension, so they use the same repository and pull request target. Re-running setup may fill in missing generated configuration, but must not silently broaden an existing repository or branch selection.
+Interactive setup detects and confirms the GitHub repository and base branch, writes `source` and `change`, and instructs the operator to set `EVE_SELF_MODIFICATION_GITHUB_TOKEN` in the deployment’s secret configuration. The shared configuration is then passed to the agent, sandbox, and extension, so they use the same repository and pull request target. Re-running setup may fill in missing generated configuration, but must not silently broaden an existing repository or branch selection.
 
 The recommended credential is a fine-grained PAT restricted to the configured repository with Contents read and write, Pull requests read and write, and Metadata read. Setup never writes the PAT into source.
 
 ## Scope and limitations
 
-The initial flow supports one GitHub repository and one base branch per definition. It does not support GitLab, Bitbucket, forks, coordinated multi-repository proposals, private package registry credentials, Git LFS content, networked pre-publication validation, deployment actions, or amending an existing proposal.
+The initial flow supports one GitHub repository and one target branch per definition. It does not support GitLab, Bitbucket, forks, coordinated multi-repository proposals, private package registry credentials, Git LFS content, networked pre-publication validation, deployment actions, or amending an existing proposal.
 
-There is no self-modification-specific principal policy or in-session approval prompt. Every session accepted by an application with `pullRequests` configured can request a draft pull request. Applications must protect inbound routes and channels before enabling it.
+There is no self-modification-specific principal policy or in-session approval prompt. Every session accepted by an application with deployed source changes configured can request a draft pull request. Applications must protect inbound routes and channels before enabling it.
 
 ## Future work
 

--- a/research/production-self-modification.md
+++ b/research/production-self-modification.md
@@ -52,27 +52,31 @@ instructions, registry coordination, and publication.
 import { defineSelfModificationConfig } from "@eve/self-modification/config";
 
 export default defineSelfModificationConfig({
-  development: {
+  local: {
     enabled: false,
   },
-  source: {
-    git: {
-      repository: "github.com/acme/agents",
-      directory: "apps/support-agent",
+  deployed: {
+    source: {
+      git: {
+        repository: "github.com/acme/agents",
+        directory: "apps/support-agent",
+      },
     },
-  },
-  target: {
-    branch: "main",
+    target: {
+      branch: "main",
+    },
   },
 });
 ```
 
-`development.enabled` controls direct source edits under `eve dev` and defaults
-to `true`. `source.git.repository` is the only GitHub repository the production
-flow may access. `source.git.directory` is the repository-relative application
-root containing `agent/`; `"."` represents the repository root.
-`target.branch` is both the checkout base and the draft pull request base.
-Omitting either `source` or `target` disables production self-modification.
+`local.enabled` controls live direct source edits under `eve dev` and defaults
+to `true`; the development source watcher reloads those edits for subsequent
+turns. `deployed.source.git.repository` is the only GitHub repository the
+deployed flow may access. `deployed.source.git.directory` is the
+repository-relative application root containing `agent/`; `"."` represents the
+repository root. `deployed.target.branch` is both the checkout base and the
+draft pull request base. Omitting either `deployed.source` or
+`deployed.target` disables deployed self-modification.
 
 The same config is passed to the agent and sandbox definitions and mounted as
 the extension config. The model belongs to the agent definition; a custom
@@ -84,18 +88,18 @@ credentials are operational configuration and never authored configuration.
 Local editing and draft pull requests use the same dynamic self-modification
 subagent and typed configuration, but have different effect boundaries:
 
-| Shared boundary       | Local development                                                                 | Deployed pull request                                                                                      |
-| --------------------- | --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| Purpose               | Makes persistent authored-source changes; changes do not affect the current turn. | Prepares persistent authored-source and official registry changes; changes do not affect the current turn. |
-| Source workspace      | Directly edits the authored `agent/` directory mounted at `/source`.              | Edits an isolated checkout of the configured target branch.                                                |
-| Registry installation | Keeps the existing development flow.                                              | Runs a constrained, trusted `eve add` operation in the configured application root.                        |
-| Result                | The change is available on a subsequent local turn.                               | The change becomes effective only after review, merge, and redeployment.                                   |
-| Activation            | Selected when `EVE_DEV=1`; `development.enabled` defaults to `true`.              | Selected outside development when `source` and `target` are configured and trusted prerequisites pass.     |
-| GitHub capability     | Has no GitHub credential or publication capability.                               | Trusted checkout and publication code resolve separate credentials outside the model sandbox.              |
+| Shared boundary       | Local live editing                                                                | Deployed pull request                                                                                                          |
+| --------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Purpose               | Makes persistent authored-source changes; changes do not affect the current turn. | Prepares persistent authored-source and official registry changes; changes do not affect the current turn.                     |
+| Source workspace      | Directly edits the authored `agent/` directory mounted at `/source`.              | Edits an isolated checkout of the configured target branch.                                                                    |
+| Registry installation | Keeps the existing local flow.                                                    | Runs a constrained, trusted `eve add` operation in the configured application root.                                            |
+| Result                | The source watcher reloads the change for a subsequent local turn.                | The change becomes effective only after review, merge, and redeployment.                                                       |
+| Activation            | Selected when `EVE_DEV=1`; `local.enabled` defaults to `true`.                    | Selected outside local development when `deployed.source` and `deployed.target` are configured and trusted prerequisites pass. |
+| GitHub capability     | Has no GitHub credential or publication capability.                               | Trusted checkout and publication code resolve separate credentials outside the model sandbox.                                  |
 
-The modes are mutually exclusive. Even when production is configured,
-`eve dev` selects local editing unless `development.enabled` is `false`; it
-never uses the deployed pull request workflow.
+The modes are mutually exclusive. Even when deployed self-modification is
+configured, `eve dev` selects local live editing unless `local.enabled` is
+`false`; it never uses the deployed pull request workflow.
 
 ## Production source and workspace
 
@@ -314,7 +318,7 @@ its project:
 
 1. eve obtains workload identity for the running Vercel project;
 2. a workload-authenticated broker verifies that the exact project Git link
-   matches `source.git.repository`;
+   matches `deployed.source.git.repository`;
 3. the broker resolves the ordinary Vercel GitHub App installation; and
 4. it mints a repository- and permission-scoped installation token.
 
@@ -342,7 +346,7 @@ installation leaves the default local-editing configuration intact.
 
 Interactive setup detects and displays the GitHub repository,
 repository-relative application directory, and default branch before writing
-`source` and `target`. It does not silently overwrite or broaden existing
+`deployed.source` and `deployed.target`. It does not silently overwrite or broaden existing
 authored configuration. The generated agent, sandbox, and extension entrypoints
 consume the same value.
 


### PR DESCRIPTION
### Summary

Proposes a unified design for local self-editing and production draft pull requests, including official eve registry installation in the same isolated proposal workspace. The plan defines target-branch checkout, constrained model and installer mutation boundaries, model-bypassing setup input, replay-safe publication, and separate trusted GitHub credentials. It deliberately leaves merge, deployment, secret configuration, deployed-revision comparison, and unsupported activation work outside self-modification.

Review should focus on the target branch as the source authority, exact registry after-state enforcement outside `agent/`, and the narrow `tool-input` framework boundary.

### Validation

Documentation-only change; reviewed the consolidated proposal for internal consistency and confirmed the branch contains only the intended research document. Runtime tests are not applicable.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+421 / -0`

The consolidated research plan covers the authoring API, production trust boundaries, registry setup lifecycle, credential handling, publication semantics, validation expectations, and explicit non-goals.

**Implementation** — 0 files · `+0 / -0`

Not applicable.

**Tests** — 0 files · `+0 / -0`

Not applicable for this research-only proposal.
