### PR TITLE
feat(eve): support Deployment Protection in vercelOidc

### DIFF
--- a/.changeset/fresh-vercel-agent-oidc.md
+++ b/.changeset/fresh-vercel-agent-oidc.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Send remote-agent Vercel OIDC credentials in both the bearer and trusted-OIDC headers so `vercelOidc()` can reach eve agents behind Vercel Deployment Protection.

--- a/docs/guides/remote-agents.md
+++ b/docs/guides/remote-agents.md
@@ -86,15 +86,32 @@ To require structured output, set an `outputSchema` on the agent definition for 
 
 ## Outbound auth
 
-`auth` is an `OutboundAuthFn` from `eve/agents/auth` that attaches request headers to the outbound dispatch:
+Use `vercelOidc()` from `eve/agents/auth` when one Vercel-deployed eve agent calls another, as shown in the first example on this page.
 
-| Helper                          | Header                                                                       |
-| ------------------------------- | ---------------------------------------------------------------------------- |
-| `vercelOidc(opts?)`             | `Authorization: Bearer <Vercel OIDC token>` (deployment-to-deployment trust) |
-| `bearer(token)`                 | `Authorization: Bearer <token>` (static or lazily resolved)                  |
-| `basic({ username, password })` | `Authorization: Basic …`                                                     |
+For calls between different Vercel projects, allow the calling project on the receiving agent's eve channel:
 
-If you are calling another Vercel-deployed eve agent, reach for `vercelOidc()`. The remote verifies the OIDC token to authorize the caller. See [Auth & route protection](./auth-and-route-protection) for the receiving side.
+```ts title="agent/channels/eve.ts"
+import { vercelOidc, vercelSubject } from "eve/channels/auth";
+import { eveChannel } from "eve/channels/eve";
+
+export default eveChannel({
+  auth: [
+    vercelOidc({
+      subjects: [
+        vercelSubject({
+          teamSlug: "acme",
+          projectName: "calling-agent",
+          environment: "production",
+        }),
+      ],
+    }),
+  ],
+});
+```
+
+Set `teamSlug`, `projectName`, and `environment` to the calling deployment's Vercel OIDC subject. See [subject patterns and `vercelSubject(...)`](./auth-and-route-protection#subjects-patterns-and-vercelsubject) for other environments and wildcard matching.
+
+If [Vercel Deployment Protection](https://vercel.com/docs/deployment-protection) is active on the receiving project, also configure [Trusted Sources](https://vercel.com/docs/deployment-protection/methods-to-bypass-deployment-protection/trusted-sources) to allow the calling project and environment. The eve subject allowlist and Trusted Sources are separate checks; cross-project calls need both.
 
 ## Forwarding the caller identity
 

--- a/packages/eve/src/public/agents/auth.test.ts
+++ b/packages/eve/src/public/agents/auth.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("#compiled/@vercel/oidc/index.js", () => ({
+  getVercelOidcToken: vi.fn(),
+}));
+
+import { getVercelOidcToken } from "#compiled/@vercel/oidc/index.js";
+import { VERCEL_TRUSTED_OIDC_IDP_TOKEN_HEADER } from "#client/types.js";
+import { vercelOidc } from "#public/agents/auth.js";
+
+describe("vercelOidc", () => {
+  afterEach(() => vi.resetAllMocks());
+
+  it("authenticates the eve route and Vercel Deployment Protection", async () => {
+    vi.mocked(getVercelOidcToken).mockResolvedValue("oidc-token");
+
+    const auth = vercelOidc({ project: "weather", team: "acme" });
+
+    await expect(auth()).resolves.toEqual({
+      headers: {
+        authorization: "Bearer oidc-token",
+        [VERCEL_TRUSTED_OIDC_IDP_TOKEN_HEADER]: "oidc-token",
+      },
+    });
+    expect(getVercelOidcToken).toHaveBeenCalledWith({ project: "weather", team: "acme" });
+  });
+
+  it("resolves a fresh token for each request", async () => {
+    vi.mocked(getVercelOidcToken)
+      .mockResolvedValueOnce("first-token")
+      .mockResolvedValueOnce("second-token");
+    const auth = vercelOidc();
+
+    await expect(auth()).resolves.toMatchObject({
+      headers: { authorization: "Bearer first-token" },
+    });
+    await expect(auth()).resolves.toMatchObject({
+      headers: { authorization: "Bearer second-token" },
+    });
+  });
+});

--- a/packages/eve/src/public/agents/auth.ts
+++ b/packages/eve/src/public/agents/auth.ts
@@ -1,6 +1,6 @@
 import { getVercelOidcToken } from "#compiled/@vercel/oidc/index.js";
 
-import type { TokenValue } from "#client/types.js";
+import { type TokenValue, VERCEL_TRUSTED_OIDC_IDP_TOKEN_HEADER } from "#client/types.js";
 
 /**
  * Outbound request auth hook for remote agent dispatch. Runs once per
@@ -26,18 +26,26 @@ export interface VercelOidcOptions {
 }
 
 /**
- * Returns an {@link OutboundAuthFn} that emits a `Bearer` Vercel OIDC token for
- * outbound remote-agent requests. Reads the token from the request context or
- * the `VERCEL_OIDC_TOKEN` environment variable (refreshed in development when
- * expired). Pass {@link VercelOidcOptions} to scope the refresh to a team or
- * project; defaults to `{}`.
+ * Returns an {@link OutboundAuthFn} that emits a Vercel OIDC token in both the
+ * bearer and trusted-identity-provider headers for outbound remote-agent
+ * requests. The bearer authenticates the eve route, while the trusted header
+ * passes Vercel Deployment Protection.
+ *
+ * Reads the token from the request context or the `VERCEL_OIDC_TOKEN`
+ * environment variable (refreshed in development when expired). Pass
+ * {@link VercelOidcOptions} to scope the refresh to a team or project; defaults
+ * to `{}`.
  */
 export function vercelOidc(options: VercelOidcOptions = {}): OutboundAuthFn {
-  return async () => ({
-    headers: {
-      authorization: `Bearer ${await getVercelOidcToken(options)}`,
-    },
-  });
+  return async () => {
+    const token = await getVercelOidcToken(options);
+    return {
+      headers: {
+        authorization: `Bearer ${token}`,
+        [VERCEL_TRUSTED_OIDC_IDP_TOKEN_HEADER]: token,
+      },
+    };
+  };
 }
 
 /**

--- a/packages/eve/src/public/channels/telegram/telegramChannel.ts
+++ b/packages/eve/src/public/channels/telegram/telegramChannel.ts
@@ -311,7 +311,7 @@ export function telegramChannel(config: TelegramChannelConfig = {}): TelegramCha
         typeof receiveTarget.messageThreadId === "number"
           ? receiveTarget.messageThreadId
           : undefined;
-      const requestedConversationId = readOptionalString(receiveTarget.conversationId);
+      const requestedConversationId = readChatId(receiveTarget.conversationId);
       const initialMessage = receiveTarget.initialMessage;
       if (initialMessage !== undefined && requestedConversationId !== undefined) {
         throw new Error(
@@ -693,12 +693,6 @@ function attachTelegramDeliver(channel: TelegramChannel): void {
 }
 
 function readChatId(value: unknown): string | undefined {
-  if (typeof value === "string" && value.length > 0) return value;
-  if (typeof value === "number" && Number.isFinite(value)) return String(value);
-  return undefined;
-}
-
-function readOptionalString(value: unknown): string | undefined {
   if (typeof value === "string" && value.length > 0) return value;
   if (typeof value === "number" && Number.isFinite(value)) return String(value);
   return undefined;


### PR DESCRIPTION
### Summary

Trusted Sources configures which Vercel projects and environments may pass a target's Deployment Protection, but callers still need to present their OIDC token in `x-vercel-trusted-oidc-idp-token`. Remote-agent `vercelOidc()` only sent the route bearer, so protected targets were rejected before the request reached eve.

This sends the same token in both headers, matching `eve/client`: the trusted-IDP header passes Deployment Protection, and `Authorization` passes the eve channel's `vercelOidc()` auth. Our internal agents already work around this by manually adding both headers in their shared remote-agent helpers; this moves that behavior into eve's standard helper. Cross-project callers still need both a Trusted Sources rule and an explicit eve subject allowlist.

### Validation

Adds unit coverage for the outbound headers and scoped token options. Also tested two vendored `eve@0.44.4` deployments in Internal Playground against the same receiver and caller token: the existing Authorization-only helper received the Deployment Protection SSO redirect, while this helper reached the receiver's authenticated eve route with HTTP 200.

Full typechecking is currently blocked by unrelated generated-artifact errors in the registry and Linq adapter.

### Diff size

**Docs** — 2 files · `+29 / -7`

Documents the receiving-side eve and Trusted Sources setup and adds the release changeset.

**Implementation** — 2 files · `+20 / -18`

Keeps the second header in the existing outbound Vercel OIDC helper. Also deduplicates two identical Telegram value readers to keep the current source within the repository's line-count invariant.

**Tests** — 1 file · `+41 / -0`

Covers protected-deployment headers and token resolution behavior.
