### PR TITLE
RFC: recover interrupted sandbox command streams without replay

### DIFF
--- a/.changeset/reattach-interrupted-sandbox-streams.md
+++ b/.changeset/reattach-interrupted-sandbox-streams.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Recover interrupted Vercel command streams by reattaching the persistent sandbox without replaying commands whose completion is unknown.

--- a/docs/concepts/built-in-tools.md
+++ b/docs/concepts/built-in-tools.md
@@ -33,6 +33,7 @@ Notes:
 - **`connection_search`** surfaces a connection's tools by their qualified name (e.g. `linear__list_issues`), which the model can then call directly. The model sees it only when the agent has connections.
 - **`web_search`** has no local executor; the provider runs it. AI Gateway models use Exa by default. To use Parallel instead, export `webSearch({ provider: "parallel" })` from `agent/tools/web_search.ts`. Direct provider models continue to use their native search implementation. To supply your own implementation, override it with `defineTool()`.
 - **`web_fetch`** follows up to ten redirects, rechecking every destination for SSRF safety. Non-success HTTP responses return a plain-text failure result with the response body when available instead of failing the tool call.
+- **`bash`** never replays a submitted command when its output stream is interrupted because the command may have already changed state. On Vercel, eve reattaches the persistent sandbox and tells the model that command completion is unknown so it can inspect state before deciding whether to retry.
 
 Review these default tools before production use. Disable, wrap, restrict, or require approval for any tool that can access the filesystem, network, shell, or sensitive data.
 

--- a/packages/eve/src/execution/sandbox/bindings/vercel-command-session.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel-command-session.ts
@@ -1,0 +1,78 @@
+import type {
+  InternalSandboxSession,
+  SandboxProcess,
+  SandboxReadFileOptions,
+  SandboxRemovePathOptions,
+  SandboxSpawnOptions,
+  SandboxWriteFileOptions,
+} from "#shared/sandbox-session.js";
+import { WORKSPACE_ROOT } from "#runtime/workspace/types.js";
+import {
+  SandboxCommandOutcomeUnknownError,
+  SandboxCommandRecoveryError,
+} from "#execution/sandbox/command-errors.js";
+import { isVercelCommandStreamInterruptedError } from "#execution/sandbox/bindings/vercel-errors.js";
+import { normalizeVercelReadStream } from "#execution/sandbox/bindings/vercel-read-stream.js";
+import type { VercelSandbox } from "#execution/sandbox/bindings/vercel-sdk-types.js";
+import { adaptMultiplexedCommandToSandboxProcess } from "#execution/sandbox/multiplexed-command.js";
+import { streamToBuffer } from "#execution/sandbox/stream-utils.js";
+
+/** Builds the eve sandbox primitives for one replaceable Vercel SDK handle. */
+export function createVercelInternalSandboxSession(input: {
+  readonly getSandbox: () => VercelSandbox;
+  readonly id: string;
+  readonly reattach?: () => Promise<void>;
+}): InternalSandboxSession {
+  return {
+    id: input.id,
+    resolvePath: resolveVercelSandboxPath,
+    async spawn(options: SandboxSpawnOptions): Promise<SandboxProcess> {
+      const command = await input.getSandbox().runCommand({
+        args: ["-lc", options.command],
+        cmd: "bash",
+        cwd: options.workingDirectory ?? WORKSPACE_ROOT,
+        detached: true,
+        env: options.env,
+        signal: options.abortSignal,
+      });
+      return adaptMultiplexedCommandToSandboxProcess({
+        command,
+        getOutput: (log) => log.stream,
+        mapError: async (error) => await recoverInterruptedCommandStream(input, error),
+      });
+    },
+    async readFile(options: SandboxReadFileOptions) {
+      return normalizeVercelReadStream(await input.getSandbox().readFile({ path: options.path }));
+    },
+    async writeFile(options: SandboxWriteFileOptions) {
+      const bytes = await streamToBuffer(options.content);
+      await input.getSandbox().writeFiles([{ content: bytes, path: options.path }]);
+    },
+    async removePath(options: SandboxRemovePathOptions) {
+      await input.getSandbox().fs.rm(options.path, {
+        force: options.force,
+        recursive: options.recursive,
+        signal: options.abortSignal,
+      });
+    },
+  };
+}
+
+async function recoverInterruptedCommandStream(
+  input: { readonly reattach?: () => Promise<void> },
+  error: unknown,
+): Promise<unknown> {
+  if (input.reattach === undefined || !isVercelCommandStreamInterruptedError(error)) {
+    return error;
+  }
+  try {
+    await input.reattach();
+    return new SandboxCommandOutcomeUnknownError(error);
+  } catch (recoveryError) {
+    return new SandboxCommandRecoveryError({ commandError: error, recoveryError });
+  }
+}
+
+function resolveVercelSandboxPath(path: string): string {
+  return path.startsWith("/") ? path : `${WORKSPACE_ROOT}/${path}`;
+}

--- a/packages/eve/src/execution/sandbox/bindings/vercel-errors.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel-errors.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { isVercelCommandStreamInterruptedError } from "./vercel-errors.js";
+
+describe("isVercelCommandStreamInterruptedError", () => {
+  it.each(["sandbox_stream_closed", "stream_ended_early", "UND_ERR_SOCKET"])(
+    "recognizes %s through a cause chain",
+    (code) => {
+      expect(
+        isVercelCommandStreamInterruptedError(
+          new Error("wrapped", { cause: Object.assign(new Error("transport"), { code }) }),
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it("recognizes undici's terminated fetch error", () => {
+    expect(isVercelCommandStreamInterruptedError(new TypeError("terminated"))).toBe(true);
+  });
+
+  it("does not classify command failures as transport interruptions", () => {
+    expect(isVercelCommandStreamInterruptedError(new Error("command exited with code 1"))).toBe(
+      false,
+    );
+  });
+});

--- a/packages/eve/src/execution/sandbox/bindings/vercel-errors.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel-errors.ts
@@ -1,5 +1,24 @@
+import { walkCauseChain } from "#shared/errors.js";
+
+const INTERRUPTED_COMMAND_STREAM_CODES = new Set([
+  "sandbox_stream_closed",
+  "stream_ended_early",
+  "UND_ERR_SOCKET",
+]);
+
+/** Whether a submitted command lost the transport carrying its output or completion. */
+export function isVercelCommandStreamInterruptedError(error: unknown): boolean {
+  for (const candidate of walkCauseChain(error)) {
+    const code = (candidate as { readonly code?: unknown }).code;
+    if (typeof code === "string" && INTERRUPTED_COMMAND_STREAM_CODES.has(code)) {
+      return true;
+    }
+  }
+  return error instanceof TypeError && error.message === "terminated";
+}
+
 export function isVercelSnapshotUnavailableError(error: unknown): boolean {
-  for (const candidate of walkErrorChain(error)) {
+  for (const candidate of walkCauseChain(error)) {
     const status =
       (candidate as { response?: { status?: number } }).response?.status ??
       (candidate as { status?: number }).status ??
@@ -13,7 +32,7 @@ export function isVercelSnapshotUnavailableError(error: unknown): boolean {
 }
 
 export function isVercelSandboxMissingError(error: unknown): boolean {
-  for (const candidate of walkErrorChain(error)) {
+  for (const candidate of walkCauseChain(error)) {
     const status =
       (candidate as { response?: { status?: number } }).response?.status ??
       (candidate as { status?: number }).status ??
@@ -24,14 +43,4 @@ export function isVercelSandboxMissingError(error: unknown): boolean {
   }
 
   return false;
-}
-
-function* walkErrorChain(error: unknown): Generator<unknown> {
-  let current = error;
-  const seen = new Set<unknown>();
-  while (current !== undefined && current !== null && !seen.has(current)) {
-    seen.add(current);
-    yield current;
-    current = (current as { cause?: unknown }).cause;
-  }
 }

--- a/packages/eve/src/execution/sandbox/bindings/vercel-lookup.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel-lookup.ts
@@ -11,6 +11,7 @@ import type {
 
 export async function getNamedVercelSandbox(input: {
   readonly createOptions: VercelCreateOptions;
+  readonly resume?: boolean;
   readonly sandboxModule: VercelModule;
   readonly sandboxName: string;
 }): Promise<VercelSandbox | null> {
@@ -32,12 +33,13 @@ export async function getNamedVercelSandbox(input: {
 
 async function getVercelSandboxGetOptions(input: {
   readonly createOptions: VercelCreateOptions;
+  readonly resume?: boolean;
   readonly sandboxName: string;
 }): Promise<VercelGetOptions> {
   const baseOptions = {
     fetch: getVercelSandboxFetch(input.createOptions),
     name: input.sandboxName,
-    resume: false,
+    resume: input.resume ?? false,
   };
 
   try {

--- a/packages/eve/src/execution/sandbox/bindings/vercel.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel.test.ts
@@ -29,9 +29,9 @@ function createMockCommandResult() {
  * drains `logs()` alongside `wait()`. By default this mock yields no log
  * lines and exits 0 so `spawn` and `run` resolve without real I/O.
  */
-function createMockDetachedCommand(
-  logs: ReadonlyArray<{ readonly data: string; readonly stream: "stderr" | "stdout" }> = [],
-) {
+type MockVercelLog = { readonly data: string; readonly stream: "stderr" | "stdout" };
+
+function createMockDetachedCommand(logs: ReadonlyArray<MockVercelLog> = []) {
   return {
     kill: vi.fn().mockResolvedValue(undefined),
     logs() {
@@ -39,6 +39,16 @@ function createMockDetachedCommand(
         yield* logs;
       })();
     },
+    wait: vi.fn().mockResolvedValue({ exitCode: 0 }),
+  };
+}
+
+function createFailingMockDetachedCommand(error: unknown) {
+  return {
+    kill: vi.fn().mockResolvedValue(undefined),
+    logs: () => ({
+      [Symbol.asyncIterator]: () => ({ next: async () => await Promise.reject(error) }),
+    }),
     wait: vi.fn().mockResolvedValue({ exitCode: 0 }),
   };
 }
@@ -117,7 +127,7 @@ async function createTestVercelSession() {
     templateKey: "template-key",
   });
 
-  return { handle, sessionSandbox };
+  return { handle, sandboxModule, sessionSandbox };
 }
 
 async function consumeWebStream(stream: ReadableStream<Uint8Array>): Promise<string> {
@@ -1625,6 +1635,50 @@ describe("createVercelSandbox", () => {
     await expect(handle.session.readFile({ path: "/workspace/message.txt" })).rejects.toThrow(
       "Vercel Sandbox returned an unsupported file stream.",
     );
+  });
+
+  it("reattaches after a submitted command loses its output stream without replaying it", async () => {
+    const { handle, sandboxModule, sessionSandbox } = await createTestVercelSession();
+    const streamError = Object.assign(new Error("Sandbox stream was closed."), {
+      code: "sandbox_stream_closed",
+    });
+    const replacementSandbox = createMockSandbox({ name: "session" });
+    replacementSandbox.runCommand.mockResolvedValue(createMockDetachedCommand());
+    const command = createFailingMockDetachedCommand(streamError);
+    sessionSandbox.runCommand.mockResolvedValueOnce(command);
+    sessionSandbox.runCommand.mockClear();
+    sandboxModule.Sandbox.get.mockResolvedValueOnce(replacementSandbox);
+
+    await expect(handle.session.run({ command: "deploy" })).rejects.toThrow(
+      "The command’s output stream was interrupted after submission. Its completion state is unknown; the sandbox was reattached. Inspect state before retrying.",
+    );
+
+    expect(sandboxModule.Sandbox.get).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "session", resume: true }),
+    );
+    expect(sessionSandbox.runCommand).toHaveBeenCalledOnce();
+
+    await expect(handle.session.run({ command: "inspect state" })).resolves.toEqual({
+      exitCode: 0,
+      stderr: "",
+      stdout: "",
+    });
+    expect(replacementSandbox.runCommand).toHaveBeenCalledOnce();
+  });
+
+  it("reports when recovery after an interrupted command stream also fails", async () => {
+    const { handle, sandboxModule, sessionSandbox } = await createTestVercelSession();
+    const streamError = Object.assign(new Error("Stream ended before command finished."), {
+      code: "stream_ended_early",
+    });
+    sessionSandbox.runCommand.mockResolvedValueOnce(createFailingMockDetachedCommand(streamError));
+    sandboxModule.Sandbox.get.mockRejectedValueOnce(new Error("snapshot unavailable"));
+
+    await expect(handle.session.run({ command: "deploy" })).rejects.toThrow(
+      'The command’s output stream was interrupted after submission, so its completion state is unknown. The sandbox could not be reattached: Failed to look up Vercel sandbox "session": snapshot unavailable',
+    );
+
+    expect(sessionSandbox.runCommand).toHaveBeenCalledOnce();
   });
 
   it("forwards env to runCommand when spawning a process", async () => {

--- a/packages/eve/src/execution/sandbox/bindings/vercel.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel.ts
@@ -4,15 +4,7 @@ import {
 } from "#execution/sandbox/bindings/vercel-base-runtime.js";
 import type { SandboxBootstrapContext } from "#public/definitions/sandbox.js";
 import type { SandboxNetworkPolicy } from "#shared/sandbox-network-policy.js";
-import type {
-  InternalSandboxSession,
-  SandboxProcess,
-  SandboxReadFileOptions,
-  SandboxRemovePathOptions,
-  SandboxSession,
-  SandboxSpawnOptions,
-  SandboxWriteFileOptions,
-} from "#shared/sandbox-session.js";
+import type { SandboxSession } from "#shared/sandbox-session.js";
 import type {
   SandboxBackend,
   SandboxBackendCreateInput,
@@ -29,11 +21,9 @@ import type {
   VercelSandboxSessionCreateOptions,
   VercelSandboxSessionUseOptions,
 } from "#public/sandbox/vercel-sandbox.js";
-import { WORKSPACE_ROOT } from "#runtime/workspace/types.js";
 import { createLoggingSandboxSession } from "#execution/sandbox/logging-session.js";
-import { adaptMultiplexedCommandToSandboxProcess } from "#execution/sandbox/multiplexed-command.js";
+import { createVercelInternalSandboxSession } from "#execution/sandbox/bindings/vercel-command-session.js";
 import { buildSandboxSession } from "#execution/sandbox/session.js";
-import { streamToBuffer } from "#execution/sandbox/stream-utils.js";
 import {
   createVercelEveImageSandbox,
   type CreateVercelSandbox,
@@ -44,7 +34,6 @@ import {
   isVercelSnapshotUnavailableError,
 } from "#execution/sandbox/bindings/vercel-errors.js";
 import { getNamedVercelSandbox } from "#execution/sandbox/bindings/vercel-lookup.js";
-import { normalizeVercelReadStream } from "#execution/sandbox/bindings/vercel-read-stream.js";
 import { resolveSandboxModelPath } from "#shared/skill-paths.js";
 import type {
   VercelCreateOptions,
@@ -141,7 +130,22 @@ export function createVercelSandbox(
         await applyInitialVercelNetworkPolicy(session.sandbox, createOptions.networkPolicy);
       }
 
-      return createHandle(session.sandbox, createInput.sessionKey);
+      return createHandle({
+        reattach: async () => {
+          const resumed = await getNamedVercelSandbox({
+            createOptions,
+            resume: true,
+            sandboxModule,
+            sandboxName: session.sandbox.name,
+          });
+          if (resumed === null) {
+            throw new Error(`Vercel sandbox "${session.sandbox.name}" no longer exists.`);
+          }
+          return resumed;
+        },
+        sandbox: session.sandbox,
+        sessionKey: createInput.sessionKey,
+      });
     },
     async prewarm(
       prewarmInput: SandboxBackendPrewarmInput<VercelSandboxBootstrapUseOptions>,
@@ -324,7 +328,7 @@ async function ensureTemplate(input: EnsureTemplateInput): Promise<EnsureTemplat
   await applyInitialVercelNetworkPolicy(sandbox, input.createOptions.networkPolicy);
 
   const templateSession = buildSandboxSession(
-    createVercelInternalSandboxSession(sandbox, input.templateKey),
+    createVercelInternalSandboxSession({ getSandbox: () => sandbox, id: input.templateKey }),
     createVercelNetworkPolicySetter(sandbox),
   );
 
@@ -449,29 +453,38 @@ function withBaseSetupNetworkPolicy(
   return { ...createOptions, networkPolicy: "allow-all" };
 }
 
-function createHandle(
-  sandbox: VercelSandbox,
-  sessionKey: string,
-): SandboxBackendHandle<VercelSandboxSessionUseOptions> {
+function createHandle(input: {
+  readonly reattach: () => Promise<VercelSandbox>;
+  readonly sandbox: VercelSandbox;
+  readonly sessionKey: string;
+}): SandboxBackendHandle<VercelSandboxSessionUseOptions> {
+  let sandbox = input.sandbox;
+  const reattach = async () => {
+    sandbox = await input.reattach();
+  };
+  const createSession = () =>
+    buildSandboxSession(
+      createVercelInternalSandboxSession({
+        getSandbox: () => sandbox,
+        id: input.sessionKey,
+        reattach,
+      }),
+      async (policy) => await sandbox.update({ networkPolicy: policy }),
+    );
+
   return {
-    session: buildSandboxSession(
-      createVercelInternalSandboxSession(sandbox, sessionKey),
-      createVercelNetworkPolicySetter(sandbox),
-    ),
+    session: createSession(),
     useSessionFn: async (options?: VercelSandboxSessionUseOptions) => {
       if (options !== undefined) {
         await sandbox.update(options);
       }
-      return buildSandboxSession(
-        createVercelInternalSandboxSession(sandbox, sessionKey),
-        createVercelNetworkPolicySetter(sandbox),
-      );
+      return createSession();
     },
     async captureState() {
       return {
         backendName: "vercel",
         metadata: { sandboxName: sandbox.name },
-        sessionKey,
+        sessionKey: input.sessionKey,
       };
     },
     async stop() {
@@ -502,44 +515,6 @@ function createVercelNetworkPolicySetter(
   };
 }
 
-function createVercelInternalSandboxSession(
-  sandbox: VercelSandbox,
-  id: string,
-): InternalSandboxSession {
-  return {
-    id,
-    resolvePath: resolveVercelSandboxPath,
-    async spawn(options: SandboxSpawnOptions): Promise<SandboxProcess> {
-      const command = await sandbox.runCommand({
-        args: ["-lc", options.command],
-        cmd: "bash",
-        cwd: options.workingDirectory ?? WORKSPACE_ROOT,
-        detached: true,
-        env: options.env,
-        signal: options.abortSignal,
-      });
-      return adaptMultiplexedCommandToSandboxProcess({
-        command,
-        getOutput: (log) => log.stream,
-      });
-    },
-    async readFile(options: SandboxReadFileOptions) {
-      return normalizeVercelReadStream(await sandbox.readFile({ path: options.path }));
-    },
-    async writeFile(options: SandboxWriteFileOptions) {
-      const bytes = await streamToBuffer(options.content);
-      await sandbox.writeFiles([{ content: bytes, path: options.path }]);
-    },
-    async removePath(options: SandboxRemovePathOptions) {
-      await sandbox.fs.rm(options.path, {
-        force: options.force,
-        recursive: options.recursive,
-        signal: options.abortSignal,
-      });
-    },
-  };
-}
-
 async function writeVercelSandboxSeedFiles(input: {
   readonly sandbox: VercelSandbox;
   readonly seedFiles: ReadonlyArray<SandboxSeedFile>;
@@ -560,13 +535,6 @@ async function writeVercelSandboxSeedFiles(input: {
   );
 
   await input.sandbox.writeFiles(files);
-}
-
-function resolveVercelSandboxPath(path: string): string {
-  if (path.startsWith("/")) {
-    return path;
-  }
-  return `${WORKSPACE_ROOT}/${path}`;
 }
 
 function isUnprovisionedTerminalTemplateSandbox(

--- a/packages/eve/src/execution/sandbox/command-errors.ts
+++ b/packages/eve/src/execution/sandbox/command-errors.ts
@@ -1,0 +1,25 @@
+import { toErrorMessage } from "#shared/errors.js";
+
+export const SANDBOX_COMMAND_OUTCOME_UNKNOWN_MESSAGE =
+  "The command’s output stream was interrupted after submission. Its completion state is unknown; the sandbox was reattached. Inspect state before retrying.";
+
+/** A submitted command lost its result transport, so replay would be unsafe. */
+export class SandboxCommandOutcomeUnknownError extends Error {
+  constructor(cause: unknown) {
+    super(SANDBOX_COMMAND_OUTCOME_UNKNOWN_MESSAGE, { cause });
+    this.name = "SandboxCommandOutcomeUnknownError";
+  }
+}
+
+/** A submitted command lost its result transport and sandbox recovery also failed. */
+export class SandboxCommandRecoveryError extends Error {
+  constructor(input: { readonly commandError: unknown; readonly recoveryError: unknown }) {
+    super(
+      `The command’s output stream was interrupted after submission, so its completion state is unknown. The sandbox could not be reattached: ${toErrorMessage(input.recoveryError)}`,
+      {
+        cause: new AggregateError([input.commandError, input.recoveryError]),
+      },
+    );
+    this.name = "SandboxCommandRecoveryError";
+  }
+}

--- a/packages/eve/src/execution/sandbox/multiplexed-command.test.ts
+++ b/packages/eve/src/execution/sandbox/multiplexed-command.test.ts
@@ -26,6 +26,14 @@ function logs(...values: ReadonlyArray<TestLog>): () => AsyncIterable<TestLog> {
   };
 }
 
+function failingLogs(error: unknown): AsyncIterable<TestLog> {
+  return {
+    [Symbol.asyncIterator]() {
+      return { next: async () => await Promise.reject(error) };
+    },
+  };
+}
+
 describe("adaptMultiplexedCommandToSandboxProcess", () => {
   it("splits logs and waits for both command and log completion", async () => {
     const releaseLogs = Promise.withResolvers<void>();
@@ -85,6 +93,28 @@ describe("adaptMultiplexedCommandToSandboxProcess", () => {
     await expect(readText(process.stdout)).rejects.toBe(failure);
     await expect(readText(process.stderr)).rejects.toBe(failure);
     await expect(process.wait()).rejects.toBe(failure);
+  });
+
+  it("maps a log failure once across both streams and wait", async () => {
+    const failure = new Error("log transport failed");
+    const mapped = new Error("completion unknown");
+    const mapError = vi.fn(async () => mapped);
+    const command = {
+      kill: vi.fn(async () => undefined),
+      logs: () => failingLogs(failure),
+      wait: vi.fn(async () => ({ exitCode: 0 })),
+    };
+    const process = adaptMultiplexedCommandToSandboxProcess({
+      command,
+      getOutput: (log) => log.output,
+      mapError,
+    });
+
+    await expect(readText(process.stdout)).rejects.toBe(mapped);
+    await expect(readText(process.stderr)).rejects.toBe(mapped);
+    await expect(process.wait()).rejects.toBe(mapped);
+    expect(mapError).toHaveBeenCalledOnce();
+    expect(mapError).toHaveBeenCalledWith(failure);
   });
 
   it("continues routing logs after one output is canceled", async () => {

--- a/packages/eve/src/execution/sandbox/multiplexed-command.ts
+++ b/packages/eve/src/execution/sandbox/multiplexed-command.ts
@@ -56,11 +56,15 @@ export function adaptMultiplexedCommandToSandboxProcess<
 >(input: {
   readonly command: MultiplexedCommand<Log>;
   readonly getOutput: (log: Log) => OutputName;
+  readonly mapError?: (error: unknown) => Promise<unknown> | unknown;
 }): SandboxProcess {
   const encoder = new TextEncoder();
   const stdout = createOutputChannel();
   const stderr = createOutputChannel();
   const outputs: Record<OutputName, OutputChannel> = { stderr, stdout };
+  let mappedError: Promise<unknown> | undefined;
+  const mapError = (error: unknown): Promise<unknown> =>
+    (mappedError ??= Promise.resolve(input.mapError?.(error) ?? error));
 
   const logsDone = (async () => {
     try {
@@ -70,9 +74,10 @@ export function adaptMultiplexedCommandToSandboxProcess<
       stdout.close();
       stderr.close();
     } catch (error) {
-      stdout.error(error);
-      stderr.error(error);
-      throw error;
+      const mapped = await mapError(error);
+      stdout.error(mapped);
+      stderr.error(mapped);
+      throw mapped;
     }
   })();
   // The streams surface log failures immediately; retain the rejection for wait().
@@ -85,11 +90,15 @@ export function adaptMultiplexedCommandToSandboxProcess<
     stderr: stderr.stream,
     stdout: stdout.stream,
     wait() {
-      return (waitPromise ??= Promise.resolve().then(async () => {
-        const finished = await input.command.wait();
-        await logsDone;
-        return { exitCode: finished.exitCode };
-      }));
+      return (waitPromise ??= Promise.resolve()
+        .then(async () => {
+          const finished = await input.command.wait();
+          await logsDone;
+          return { exitCode: finished.exitCode };
+        })
+        .catch(async (error: unknown) => {
+          throw await mapError(error);
+        }));
     },
     kill() {
       return (killPromise ??= Promise.resolve().then(() => input.command.kill()));


### PR DESCRIPTION
### Summary

Related to #440. When a detached Vercel command loses its output or completion stream after submission, eve cannot safely infer whether the shell command finished. This RFC prototype never replays the command: it resumes the named persistent sandbox, replaces the handle used by subsequent operations, and reports that completion is unknown so the model can inspect state before deciding whether to retry.

The prototype recognizes structured Vercel stream failures and the observed undici socket termination. Ordinary command failures remain unchanged, and failed sandbox reattachment is reported separately. This is independent of #2573's command deadline; review should focus on the no-replay boundary and whether reattaching before returning the tool error is the right recovery contract.

### Validation

Focused coverage verifies transport classification, one-time error mapping, exactly one command submission, successful reattachment, subsequent use of the replacement handle, failed reattachment, and the production file-length invariant. The full unit tier passed with 7,085 tests and one skip.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+6 / -0`

Documents the no-replay recovery semantics and includes the required release note.

**Implementation** — 6 files · `+185 / -94`

Adds transport classification, explicit unknown-outcome errors, supported Vercel reattachment, and replaceable session handles. Command-session handling is extracted from `vercel.ts` to keep each production file within the repository line-count limit.

**Tests** — 3 files · `+114 / -4`

Covers classification, error mapping, the no-replay invariant, successful recovery, replacement-handle use, and recovery failure without remote sandbox provisioning.
