### PR TITLE
fix(self-modification): release CI - resolve packed eve locally

### DIFF
--- a/packages/eve-self-modification/src/package-consumption.scenario.test.ts
+++ b/packages/eve-self-modification/src/package-consumption.scenario.test.ts
@@ -104,6 +104,11 @@ describe("packed package consumption", () => {
     );
     await writeAppFile(
       appRoot,
+      "pnpm-workspace.yaml",
+      `overrides:\n  eve: ${JSON.stringify(`file:${eveTarball}`)}\n`,
+    );
+    await writeAppFile(
+      appRoot,
       "agent/agent.ts",
       'import { defineAgent } from "eve";\n\nexport default defineAgent({ model: "openai/gpt-5.4" });\n',
     );


### PR DESCRIPTION
### Summary

Release PR #2514 exposed that the packed-package scenario resolves `@eve/self-modification`'s rewritten `eve` dependency from npm, where the Changesets-bumped version is not published yet. The disposable consumer now writes a pnpm workspace override that resolves every `eve` dependency from the locally packed tarball. This is test-only and does not change published package behavior.

### Validation

Reproduced with `eve@0.45.0` on `changeset-release/main`, then confirmed the focused package-consumption scenario passes and the replacement CI workflow on #2514 is green.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 0 files · `+0 / -0`

Not applicable; published package behavior is unchanged.

**Tests** — 1 file · `+5 / -0`

Makes the existing package-consumption scenario hermetic when Changesets has bumped `eve` to an unpublished version.
