### PR TITLE
fix(eve): fail parent runs when child turns fail irrevocably instead of waiting forever

### DIFF
--- a/.changeset/turn-child-terminal-failure-recovery.md
+++ b/.changeset/turn-child-terminal-failure-recovery.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Sessions now fail visibly instead of hanging when an active turn workflow terminates before reporting its result.

--- a/packages/eve/src/execution/turn-dispatch.test.ts
+++ b/packages/eve/src/execution/turn-dispatch.test.ts
@@ -8,9 +8,14 @@ import type { SessionCommandInbox, SessionInboxPayload } from "#execution/sessio
 import type { TurnControlPayload } from "#execution/turn-control-protocol.js";
 
 const createHookMock = vi.fn();
+const getRunMock = vi.fn();
 
 vi.mock("#compiled/@workflow/core/index.js", () => ({
   createHook: (...args: unknown[]) => createHookMock(...args),
+}));
+
+vi.mock("#compiled/@workflow/core/runtime.js", () => ({
+  getRun: (...args: unknown[]) => getRunMock(...args),
 }));
 
 vi.mock("./dispatch-turn-step.js", () => ({
@@ -25,6 +30,103 @@ describe("dispatchAndAwaitTurn", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     createHookMock.mockReset();
+    getRunMock.mockReturnValue({ returnValue: Promise.resolve() });
+  });
+
+  it("fails and disposes the control hook when its child run terminates", async () => {
+    const childError = Object.assign(new Error("queue exhausted"), { delivery: 49 });
+    getRunMock.mockReturnValue({ returnValue: Promise.reject(childError) });
+    installControlHook([]);
+
+    const failure = await dispatchAndAwaitTurn({
+      bufferedDeliveries: [],
+      bufferedSessionControls: [],
+      commandInbox: createCommandInbox(),
+      controlToken: "turn-control",
+      delivery: { kind: "deliver", payloads: [{ message: "start" }] },
+      mode: "conversation",
+      parentWritable: new WritableStream<Uint8Array>(),
+      serializedContext: {},
+      sessionState: createState("http:test"),
+    }).catch((error: unknown) => error);
+
+    expect(failure).toMatchObject({
+      name: "TurnWorkflowTerminalError",
+      message: "Turn workflow turn-run terminated before reporting a result.",
+      runId: "turn-run",
+    });
+    expect((failure as Error).cause).toMatchObject({ message: "queue exhausted", delivery: 49 });
+    const hook = createHookMock.mock.results[0]?.value as { dispose: ReturnType<typeof vi.fn> };
+    expect(hook.dispose).toHaveBeenCalledOnce();
+  });
+
+  it("keeps waiting for terminal control when the child completes first", async () => {
+    const state = createState("http:test");
+    let releaseControl: (() => void) | undefined;
+    let signalControlStarted: (() => void) | undefined;
+    const controlReady = new Promise<void>((resolve) => {
+      releaseControl = resolve;
+    });
+    const controlStarted = new Promise<void>((resolve) => {
+      signalControlStarted = resolve;
+    });
+    createHookMock.mockReturnValue(
+      createMockHook(async () => {
+        signalControlStarted?.();
+        await controlReady;
+        return {
+          done: false,
+          value: {
+            action: { kind: "park", serializedContext: {}, sessionState: state },
+            kind: "turn-result",
+          },
+        };
+      }),
+    );
+
+    const turn = dispatchAndAwaitTurn({
+      bufferedDeliveries: [],
+      bufferedSessionControls: [],
+      commandInbox: createCommandInbox(),
+      controlToken: "turn-control",
+      delivery: { kind: "deliver", payloads: [{ message: "start" }] },
+      mode: "conversation",
+      parentWritable: new WritableStream<Uint8Array>(),
+      serializedContext: {},
+      sessionState: state,
+    });
+    await controlStarted;
+    releaseControl?.();
+
+    expect((await turn).action.kind).toBe("park");
+  });
+
+  it("keeps an accepted control action when the child rejects later", async () => {
+    const state = createState("http:test");
+    let rejectChild: ((error: Error) => void) | undefined;
+    const returnValue = new Promise<void>((_resolve, reject) => {
+      rejectChild = reject;
+    });
+    getRunMock.mockReturnValue({ returnValue });
+    installControlHook([
+      { action: { kind: "park", serializedContext: {}, sessionState: state }, kind: "turn-result" },
+    ]);
+
+    const turn = await dispatchAndAwaitTurn({
+      bufferedDeliveries: [],
+      bufferedSessionControls: [],
+      commandInbox: createCommandInbox(),
+      controlToken: "turn-control",
+      delivery: { kind: "deliver", payloads: [{ message: "start" }] },
+      mode: "conversation",
+      parentWritable: new WritableStream<Uint8Array>(),
+      serializedContext: {},
+      sessionState: state,
+    });
+    rejectChild?.(new Error("late child failure"));
+    await Promise.resolve();
+
+    expect(turn.action.kind).toBe("park");
   });
 
   it("rekeys the public hook when the active turn changes its continuation token", async () => {

--- a/packages/eve/src/execution/turn-dispatch.ts
+++ b/packages/eve/src/execution/turn-dispatch.ts
@@ -1,11 +1,27 @@
 import type { DeliverHookPayload, HookPayload, SessionCapabilities } from "#channel/types.js";
 import { dispatchTurnStep } from "#execution/dispatch-turn-step.js";
 import { TurnControlReceiver } from "#execution/turn-control-receiver.js";
+import {
+  rebuildSerializableError,
+  normalizeSerializableError,
+} from "#execution/workflow-errors.js";
+import { getRun } from "#compiled/@workflow/core/runtime.js";
 import type { DurableSessionState } from "#execution/durable-session-store.js";
 import type { SessionCommandInbox } from "#execution/session-command-inbox.js";
 import type { TurnDriverAction } from "#execution/turn-control-receiver.js";
 import type { RunMode } from "#shared/run-mode.js";
 import { activeTurnId } from "#harness/active-turn-id.js";
+
+/** A turn run ended without publishing its required terminal control message. */
+class TurnWorkflowTerminalError extends Error {
+  readonly runId: string;
+
+  constructor(runId: string, cause: unknown) {
+    super(`Turn workflow ${runId} terminated before reporting a result.`, { cause });
+    this.name = "TurnWorkflowTerminalError";
+    this.runId = runId;
+  }
+}
 
 /** One settled turn: its terminal driver action plus deferred hook cleanup. */
 export interface DispatchedTurn {
@@ -47,7 +63,7 @@ export async function dispatchAndAwaitTurn(input: {
   });
 
   try {
-    await dispatchTurnStep({
+    const { runId } = await dispatchTurnStep({
       capabilities: input.capabilities,
       completionToken: control.token,
       delivery: input.delivery,
@@ -56,7 +72,26 @@ export async function dispatchAndAwaitTurn(input: {
       serializedContext: input.serializedContext,
       sessionState: input.sessionState,
     });
-    const action = await control.waitForAction();
+    const controlAction = control.waitForAction();
+    const childOutcome = getRun(runId).returnValue.then(
+      () => ({ kind: "child-completed" as const }),
+      (error) => ({ error: normalizeSerializableError(error), kind: "child-failed" as const }),
+    );
+    const outcome = await Promise.race([
+      controlAction.then((action) => ({ action, kind: "control" as const })),
+      childOutcome,
+    ]);
+
+    if (outcome.kind === "control") {
+      return { action: outcome.action, dispose: () => control.dispose() };
+    }
+    if (outcome.kind === "child-failed") {
+      throw new TurnWorkflowTerminalError(runId, rebuildSerializableError(outcome.error));
+    }
+
+    // The terminal control send precedes a successful return, but its hook
+    // delivery may lose this scheduling race. Reuse the existing consumer.
+    const action = await controlAction;
     return { action, dispose: () => control.dispose() };
   } catch (error) {
     await control.dispose();


### PR DESCRIPTION
### Summary


### Validation


### Checklist

- [ ] This change was requested or approved by a maintainer
- [ ] I ran the relevant checks from `CONTRIBUTING.md`
- [ ] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [ ] DCO sign-off passes for every commit (`git commit --signoff`)
