### PR TITLE
fix(eve): use integration setup subtitles

### DIFF
--- a/.changeset/fresh-setup-subtitles.md
+++ b/.changeset/fresh-setup-subtitles.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Integration setup banners now describe the integration being configured instead of showing eve's generic framework tagline.

--- a/packages/eve/src/setup/integrations/runner.ts
+++ b/packages/eve/src/setup/integrations/runner.ts
@@ -52,7 +52,7 @@ export async function runIntegrationSetup(
   deps: IntegrationSetupRunnerDeps = defaultDeps,
 ): Promise<IntegrationSetupResult> {
   const integration = setupIntegration(kind);
-  options.prompter.intro(`Set up ${integration.label}`);
+  options.prompter.intro(`Set up ${integration.label}`, integration.hint);
   options.prompter.log.message("Checking Vercel setup...");
   const [deployment, authStatus] = await Promise.all([
     deps.detectDeployment(options.appRoot, { signal: options.signal }),


### PR DESCRIPTION
### Summary

Integration setup banners currently show eve's generic framework tagline instead of describing the integration being configured. This uses the integration's existing picker hint as the subtitle instead.

Before:

```text
▲   Set up Discord
    Production-grade agent framework.
```

After:

```text
▲   Set up Discord
    Slash commands and interactions
```

### Validation

Focused tests were blocked before starting because pnpm attempted a workspace install and the `eve-self-modification` prepare build failed on existing compiled export errors.

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the release changeset for the user-facing setup change.

**Implementation** — 1 file · `+1 / -1`

Passes the existing integration hint to the shared setup banner.

**Tests** — 0 files · `+0 / -0`

Not applicable for this copy-only wiring change.
