### PR TITLE
docs(eve): update @vercel/geistdocs to 1.25.0

### DIFF
--- a/apps/docs/AGENTS.md
+++ b/apps/docs/AGENTS.md
@@ -7,7 +7,9 @@ All user-facing UI changes must be mobile-responsive. Before completing a UI cha
 ## Geistdocs
 
 - Read `node_modules/@vercel/geistdocs/docs/agents.md` and the focused pages under `node_modules/@vercel/geistdocs/docs/pages/` before changing package-backed behavior.
+- Keep `createGeistdocs` from `@vercel/geistdocs/next` as the `next.config.ts` wrapper. It composes Fumadocs MDX and generates the app-route manifest used by `createProxy`; do not replace it with `createMDX` directly.
 - Keep `cacheComponents: true` and `partialPrefetching: true` in `next.config.ts`.
+- Restart `next dev` after adding, deleting, or renaming an App Router page or route so `createGeistdocs` regenerates its route manifest.
 - Do not export `dynamic`, `dynamicParams`, `revalidate`, or `fetchCache` from App Router pages or route handlers.
 - Generate every supported root language. Read `[lang]` through `next/root-params` only in Server Components; retain route context `params` in Route Handlers and Server Actions.
 - Set `prefetch={true}` on app-owned links to statically generated docs, integrations, and templates so navigation reveals the complete destination immediately.

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -1,5 +1,5 @@
 import { createRequire } from "node:module";
-import { createMDX } from "fumadocs-mdx/next";
+import { createGeistdocs } from "@vercel/geistdocs/next";
 import type { NextConfig } from "next";
 import {
   compatibilityRedirects,
@@ -8,7 +8,7 @@ import {
   rootMarkdownRedirects,
 } from "./lib/geistdocs/redirects";
 
-const withMDX = createMDX();
+const withGeistdocs = createGeistdocs();
 const require = createRequire(import.meta.url);
 const wgslLoader = require.resolve("@vgpu/wgsl/loader-webpack");
 
@@ -68,4 +68,4 @@ const config: NextConfig = {
   },
 };
 
-export default withMDX(config);
+export default withGeistdocs(config);

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -24,7 +24,7 @@
     "@icons-pack/react-simple-icons": "13.13.0",
     "@streamdown/code": "1.1.1",
     "@vercel/analytics": "2.0.1",
-    "@vercel/geistdocs": "1.23.1",
+    "@vercel/geistdocs": "1.25.0",
     "@vercel/speed-insights": "2.0.0",
     "@vgpu/core": "0.0.7",
     "@vgpu/render": "0.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,8 +179,8 @@ importers:
         specifier: 2.0.1
         version: 2.0.1(@sveltejs/kit@2.63.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(next@16.3.1(@babel/core@7.29.0(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nuxt@4.4.6(eddae254238b412d8a46133f9d7579b6))(react@19.2.6)(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vue@3.5.35(typescript@6.0.3))
       '@vercel/geistdocs':
-        specifier: 1.23.1
-        version: 1.23.1(af419ac2f77fc42ec3d0d44b87253972)
+        specifier: 1.25.0
+        version: 1.25.0(af419ac2f77fc42ec3d0d44b87253972)
       '@vercel/speed-insights':
         specifier: 2.0.0
         version: 2.0.0(@sveltejs/kit@2.63.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(next@16.3.1(@babel/core@7.29.0(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nuxt@4.4.6(eddae254238b412d8a46133f9d7579b6))(react@19.2.6)(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vue@3.5.35(typescript@6.0.3))
@@ -7902,8 +7902,8 @@ packages:
   '@vercel/gatsby-plugin-vercel-builder@2.2.35':
     resolution: {integrity: sha512-H1qNhnvyRIhek/esVnVK+RoFsxrSOLl4qiM4iyV2IcjDoqY4H0Ped65tc5ZgZEP/P2KGNYfEDSBEukdBZa+kCg==}
 
-  '@vercel/geistdocs@1.23.1':
-    resolution: {integrity: sha512-XjXfZe7a4NrB0+dFoUthH5wQTVApxtTscbh4QPbtAjAgly6MJtL6R4+vPs88m4/x0HsaX76R7qllCv53DnISvw==}
+  '@vercel/geistdocs@1.25.0':
+    resolution: {integrity: sha512-trBbRWB9+uIBnJMMqy5viYa/YVs1GuKQmm1ur+zvbYxRlk0ipI+cCE/YLAhld2yoKGxYXXUyyQhBioPudWzZyA==}
     hasBin: true
     peerDependencies:
       next: ^16.3.0
@@ -22338,7 +22338,7 @@ snapshots:
       etag: 1.8.1
       fs-extra: 11.1.0
 
-  '@vercel/geistdocs@1.23.1(af419ac2f77fc42ec3d0d44b87253972)':
+  '@vercel/geistdocs@1.25.0(af419ac2f77fc42ec3d0d44b87253972)':
     dependencies:
       '@ai-sdk/react': 3.0.193(react@19.2.6)(zod@4.4.3)
       '@clack/prompts': 0.11.0


### PR DESCRIPTION
### Summary

Related to vercel/geistdocs#260. Updates the docs site to `@vercel/geistdocs` 1.25.0 and adopts its `createGeistdocs` Next.js config wrapper, which derives valid app routes at build time. Agents and Markdown clients now get a recoverable Markdown 404 for unknown paths, while valid HTML routes (`/templates`, `/benchmarks`, dynamic pages, localized routes) and redirect-only legacy paths keep their existing responses — no consumer-maintained route list needed, so the opt-in `markdownNotFound` predicate is never required.

### Review notes

- Deferred (root cause upstream, no appropriate consumer-side fix): the 1.25.0 route scanner only recognizes `page.*`/`route.*` files, so the eight `opengraph-image`/`twitter-image` metadata routes are absent from the generated manifest. An AI-agent UA or `Accept: text/markdown` fetch of those extensionless image URLs (e.g. `/templates/eve-chat-template/opengraph-image`) now gets `404 text/markdown` instead of the PNG — reproduced against the production build. Human browser and traditional unfurl-bot traffic is unaffected. The durable fix belongs in the upstream scanner; this PR stays draft until that lands and can be consumed as a patch release.

### Validation

Built the docs app for production and smoke-tested the request contract with `next start`: HTML routes and dynamic template pages stay HTML under Markdown/agent negotiation, `/docs/*` still rewrites to page Markdown, unknown paths return a Markdown 404 for agents and the browser HTML 404 otherwise, and redirect-only paths (`/evals`, `/getting-started.md`) still 308 before the proxy runs. `pnpm --filter eve-docs test:unit` passes (162 tests) and the lockfile delta is limited to the `@vercel/geistdocs` importer, resolution, and snapshot.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+2 / -0`

Adds the two `createGeistdocs` guidance bullets the 1.25.0 template mandates to `apps/docs/AGENTS.md`.

**Implementation** — 3 files · `+9 / -9`

Dependency bump plus the one-line wrapper swap in `next.config.ts`; the lockfile moves only the `@vercel/geistdocs` importer, resolution, and snapshot.

**Tests** — 0 files · `+0 / -0`

Not applicable; the behavior contract is covered by the production-build smoke checks above.
