### PR TITLE
docs: propose multi-agent workspace subagents

### DIFF
--- a/research/multi-agent-workspaces.md
+++ b/research/multi-agent-workspaces.md
@@ -20,6 +20,7 @@ customer-operations/
 ├── pnpm-workspace.yaml
 └── agents/
     ├── foreman/
+    │   ├── package.json (optional)
     │   └── agent/
     │       ├── agent.ts
     │       └── subagents/
@@ -46,37 +47,34 @@ customer-operations/
 }
 ```
 
-A member's root `defineAgent` description is its workspace delegation
-description. The workspace compiler records the ID, description, and deployment
-locator for each member in a build-time catalog. It never asks a running agent
-for this information.
+When deploying an eve workspace to vercel using `eve deploy`, services config
+is automatically generated to allow each agent to be deployed behind separate
+routes.
 
-A member opts in to model-visible delegation candidates by authoring a normal
-subagent source that expands its workspace selection:
+Agents within are able to easily declare other members of the workspace as
+subagents. A member opts in by adding a file underneath their `subagents/`
+directory containing a `defineWorkspaceSubagents()`.
+
+Without arguments, this adds all other members of the workspace as subagents.
+Users can filter which agents are included using path filtering.
 
 ```ts title="agents/foreman/agent/subagents/workspace.ts"
 import { defineWorkspaceSubagents } from "eve";
 
 export default defineWorkspaceSubagents({
   include: ["agents/tasks/*", "agents/utilities/*"],
-  exclude: ["triage"],
+  exclude: ["agents/triage"],
 });
 ```
 
-`defineWorkspaceSubagents()` compiles the selected members into ordinary remote
-subagent entries. To the calling model they are named subagent tools; at runtime
+`defineWorkspaceSubagents()` functions by compiling the selected members into
+remote subagent entries. To the calling model, they are named subagent tools; at runtime
 they use the existing `defineRemoteAgent` execution protocol, including isolated
 child sessions, durable callbacks, cancellation and reset, output schemas,
-trace propagation, and optional forwarded caller identity. The workspace
-feature owns topology discovery and target resolution; it does not introduce a
-second subagent execution path.
+trace propagation, and optional forwarded caller identity.
 
-This plan builds on the agent-workspace deployment stack beginning with
-[PR #2043](https://github.com/vercel/eve/pull/2043). That stack establishes
-explicit workspace membership, optional member packages, workspace-root builds,
-and independently deployed member services. Workspace subagents extend that
-foundation; they do not replace independent `defineRemoteAgent()` declarations
-or make every multi-package repository an eve workspace.
+The description of the agent is sourced from the original agent's description field --
+it does not need to be duplicated in the consumer's code.
 
 ## Goals
 
@@ -145,8 +143,9 @@ monorepo marker.
 ### Names and paths
 
 A workspace member's final directory name is its **agent name**. Names must be
-unique across the entire workspace, including nested groups. The existing
-workspace deployment stack already uses this name for its public route and
+unique across the entire workspace, including nested groups.
+
+The existing workspace deployment stack already uses this name for its public route and
 service identity, so this proposal preserves that model:
 
 ```text
@@ -160,7 +159,7 @@ products/escalation                     escalation       /eve/agents/escalation/
 
 If two members would otherwise be named `review`, authors must choose distinct
 names such as `security-review` and `content-review`. This is an intentional
-workspace constraint, not an authored `name` field.
+workspace constraint, as it simplifies routing and identity logic considerably.
 
 The agent name is the shared identity in catalog entries, routes, generated
 tool names, diagnostics, and trace attributes. The member's workspace-relative
@@ -169,7 +168,7 @@ does not change its name, public route, or model-facing tool name.
 
 ### Descriptions and the catalog
 
-Every workspace member must author a non-empty root description:
+Every workspace member that is declared as a subagent must author a non-empty root description:
 
 ```ts title="agents/utilities/company-knowledge/agent/agent.ts"
 import { defineAgent } from "eve";
@@ -225,38 +224,27 @@ export default defineWorkspaceSubagents({
 });
 ```
 
-This follows the existing dynamic-tool precedent: one authored source can
-produce multiple named capabilities. Workspace selection is static rather than
-session-dependent, so the compiler can validate the complete tool set,
-descriptions, and targets before deployment.
+Workspace selection is static rather than session-dependent, so the compiler
+can validate the complete tool set, descriptions, and targets before deployment.
 
 The initial input is:
 
 ```ts
 type WorkspaceSubagentsDefinition = {
-  readonly include: readonly string[];
+  readonly include?: readonly string[];
   readonly exclude?: readonly string[];
 };
 ```
 
-- `include` is required. A bare value matches a unique agent name; a value
-  containing `/` or glob syntax matches workspace-relative member paths.
-- `exclude` is optional and wins over `include`.
+- `include` and `exclude` accept glob patterns, e.g. `agents/utilities/*`
+- `exclude` wins over `include`.
 - A member never selects itself, even when a selector matches it.
 - An unmatched name or path is a build error. A glob that matches no members
   also fails by default: silently deploying an expected delegation surface with
-  no tools is difficult to diagnose. A future explicit optional-selector form
-  can address intentionally empty groups.
+  no tools is difficult to diagnose.
 - Results are sorted by agent name and frozen into the deployment artifact.
   Adding a matching agent changes the tool surface only after a new build and
   deployment.
-
-`include` and `exclude` describe composition, not access control. A broad
-selector such as `agents/utilities/*` intentionally makes future matching
-utility agents available as delegation tools after deployment. It does not
-authorize their HTTP requests; a direct `defineRemoteAgent()` could also target
-the same endpoint. Use receiving-channel authentication and separate projects
-when a true security or deployment boundary is required.
 
 ### Generated subagent names
 
@@ -300,19 +288,7 @@ compiled remote subagent entries
 subagent tool registry → remote session dispatch → callback / continuation
 ```
 
-The resulting tools have the normal remote-agent contract:
-
-- The child has a separate session, state, prompt, tools, connections, sandbox,
-  and conversation history.
-- The parent supplies a complete task message; child history is not implicitly
-  shared.
-- The parent parks durably for remote completion and receives normal subagent
-  lifecycle events and results.
-- Cancellation and session finalization request remote cancel and reset.
-- Each call has existing structured-output, task-mode, trace, token-usage, and
-  callback behavior.
-- A workspace member can itself expose local or remote subagents, subject to
-  the ordinary delegation rules.
+The resulting tools have the normal remote-agent contract.
 
 `defineWorkspaceSubagents()` does not itself need to expose a URL, `auth`, or
 `headers` field. It describes a same-workspace target. Direct
@@ -337,11 +313,6 @@ build. The existing remote-agent callback mechanism continues to use the
 parent's active deployment origin and callback route, so callbacks route back
 to the calling service even when parent and child have different route
 prefixes.
-
-The generated Vercel graph must route both inbound member traffic and internal
-workspace calls correctly. Coverage should exercise parent-to-child creation,
-callback delivery, continuation, cancellation, and reset through distinct
-member prefixes rather than treating this as an in-process call.
 
 ### Authentication and forwarded identity
 
@@ -398,10 +369,6 @@ self-hosted workspace build should fail clearly when it contains workspace
 subagents but has no configured target resolver. It must not guess that an
 `/eve/agents/...` route exists.
 
-An optional future workspace host could start member processes, provide stable
-internal routing, and issue service credentials. That is a hosting integration,
-not a prerequisite or hidden responsibility of the core authoring API.
-
 ## Compatibility and boundaries
 
 - A standalone agent cannot author `defineWorkspaceSubagents()`.
@@ -416,10 +383,6 @@ not a prerequisite or hidden responsibility of the core authoring API.
 - Moving a member preserves its agent name, route, and generated tool name,
   but can change path-based selectors. This is intentional: paths organize a
   workspace, while names identify its agents.
-- A workspace deploy is atomic as an artifact, but long-lived child sessions
-  can still encounter rolling-version or deployment-retention concerns. The
-  existing remote-agent compatibility guidance applies when persistent remote
-  sessions are resumed across versions.
 
 ## Implementation plan
 
@@ -427,23 +390,19 @@ not a prerequisite or hidden responsibility of the core authoring API.
    parent deployment stack: explicit `eve.agents` discovery, member package
    membership checks, workspace-root build/deploy ownership, and Vercel service
    assembly.
-2. **Preserve workspace-unique member names.** Carry the existing final-
-   directory name through discovery, service naming, public routing, project
-   context, build results, diagnostics, and tests; retain the member path only
-   for organization and selector matching.
-3. **Compile a workspace catalog.** Resolve every member's root config and
+2. **Compile a workspace catalog.** Resolve every member's root config and
    required description before compiling individual consumer manifests. Keep
    catalog provenance and resolved route targets available to build planning
    and inspection.
-4. **Add `defineWorkspaceSubagents()`.** Permit it only for a workspace
+3. **Add `defineWorkspaceSubagents()`.** Permit it only for a workspace
    member's `subagents/` source; validate selectors against the catalog;
    expand matches into deterministic remote subagent nodes; and register them
    through the existing subagent compiler and runtime registry.
-5. **Add deployment target adapters.** Vercel resolves same-deployment member
+4. **Add deployment target adapters.** Vercel resolves same-deployment member
    routes from the active origin and uses explicit service authentication.
    Self-hosting supplies an operator-owned resolver. Keep `defineRemoteAgent()`
    as the configuration surface for non-workspace calls.
-6. **Expose topology in inspection and diagnostics.** `eve info` and
+5. **Expose topology in inspection and diagnostics.** `eve info` and
    agent-info should show the workspace ID, resolved workspace members,
    workspace-expanded subagents, and unresolved configuration errors without
    exposing credential material.

--- a/research/multi-agent-workspaces.md
+++ b/research/multi-agent-workspaces.md
@@ -269,6 +269,44 @@ generated name, description, route target, and source file. Diagnostics should d
 - an invalid agent name;
 - a workspace-subagent source authored outside a workspace.
 
+### Dynamic subagent maps
+
+Today a dynamic subagent selects one `defineAgent(...)`, one
+`defineRemoteAgent(...)`, or `null`. Extend `defineDynamic()` to also accept a
+record of named remote definitions:
+
+```ts title="agent/subagents/specialists.ts"
+export default defineDynamic({
+  events: {
+    "session.started": () => ({
+      triage: defineRemoteAgent({/* … */}),
+      "company-knowledge": defineRemoteAgent({/* … */}),
+    }),
+  },
+});
+```
+
+The record keys are bare model tool names (`triage`, `company-knowledge`), not
+`specialists__triage`. A single-definition return retains its existing
+path-derived name; an empty record is the map equivalent of no subagents.
+
+Each map entry needs a durable internal identity: resolver node plus record
+key, such as `subagents/specialists#triage`. Session and turn selections persist
+one map per resolver; a turn map replaces that resolver's session map, and an
+empty turn map hides its session entries. Dispatch, continuation, cancellation,
+reset, and inspection resolve this durable identity without rerunning the
+resolver.
+
+Dynamic entries must not collide with authored tools/subagents or entries from
+another dynamic resolver. The initial map form permits only
+`defineRemoteAgent()` entries. Mapping local `defineAgent()` values would make
+several apparent agents share one subagent directory's resources, so local
+agents remain one-per-directory.
+
+`defineWorkspaceSubagents()` remains build-time/static, but can compile to the
+same keyed delegation representation with catalog-derived names, descriptions,
+and targets.
+
 ### Lowering and execution
 
 The compiler expands the selected catalog entries into remote subagent nodes in
@@ -394,18 +432,22 @@ subagents but has no configured target resolver. It must not guess that an
    required description before compiling individual consumer manifests. Keep
    catalog provenance and resolved route targets available to build planning
    and inspection.
-3. **Add `defineWorkspaceSubagents()`.** Permit it only for a workspace
-   member's `subagents/` source; validate selectors against the catalog;
-   expand matches into deterministic remote subagent nodes; and register them
-   through the existing subagent compiler and runtime registry.
-4. **Add deployment target adapters.** Vercel resolves same-deployment member
-   routes from the active origin and uses explicit service authentication.
-   Self-hosting supplies an operator-owned resolver. Keep `defineRemoteAgent()`
-   as the configuration surface for non-workspace calls.
-5. **Expose topology in inspection and diagnostics.** `eve info` and
-   agent-info should show the workspace ID, resolved workspace members,
-   workspace-expanded subagents, and unresolved configuration errors without
-   exposing credential material.
+3. **Add keyed dynamic subagent maps.** Preserve single-entry dynamic
+   subagent behavior, then add durable resolver-node-plus-key identities,
+   record selection snapshots, remote-entry validation, collision handling,
+   and lifecycle lookup for map entries.
+4. **Add `defineWorkspaceSubagents()`.** Permit it only for a workspace
+   member's `subagents/` source; validate selectors against the catalog; and
+   expand matches into deterministic remote entries using the keyed delegation
+   representation.
+5. **Resolve workspace members to remote targets.** Vercel derives each
+   member's same-deployment route and service authentication from the generated
+   workspace deployment. Other hosts must provide an explicit workspace
+   routing/authentication integration; until one exists, use
+   `defineRemoteAgent()` for non-Vercel targets.
+6. **Expose topology in inspection and diagnostics.** `eve info` and
+   agent-info should show workspace members, workspace-expanded subagents, and
+   unresolved configuration errors without exposing credential material.
 
 ## Validation
 
@@ -416,6 +458,10 @@ subagents but has no configured target resolver. It must not guess that an
   route uniqueness, route-prefix preservation, and per-member outputs.
 - Catalog: description required, deterministic order, source provenance, and
   no runtime network lookup.
+- Dynamic subagent maps: single-entry compatibility, key-derived internal
+  identities, session/turn replacement and empty-map hiding, duplicate and
+  authored-name conflicts, durable dispatch and continuation, cancellation,
+  reset, and map-entry inspection.
 - `defineWorkspaceSubagents`: exact and glob selection, exclusion precedence,
   self omission, name and path-glob matching, empty/unmatched selector
   failures, agent-name preservation, stable tool order, and standalone

--- a/research/multi-agent-workspaces.md
+++ b/research/multi-agent-workspaces.md
@@ -63,7 +63,7 @@ import { defineWorkspaceSubagents } from "eve";
 
 export default defineWorkspaceSubagents({
   include: ["agents/tasks/*", "agents/utilities/*"],
-  exclude: ["agents/triage"],
+  exclude: ["agents/tasks/triage"],
 });
 ```
 
@@ -101,8 +101,6 @@ it does not need to be duplicated in the consumer's code.
   workspace, hand-selected endpoints, or custom transport configuration.
 - Providing an eve-managed reverse proxy, service mesh, or process supervisor
   for every self-hosted deployment.
-- Inferring agent roles, tool descriptions, or capabilities from directory
-  names.
 
 ## Workspace format and member identity
 
@@ -146,7 +144,7 @@ A workspace member's final directory name is its **agent name**. Names must be
 unique across the entire workspace, including nested groups.
 
 The existing workspace deployment stack already uses this name for its public route and
-service identity, so this proposal preserves that model:
+service identity, and this proposal preserves that model:
 
 ```text
 member directory                       agent name       public route
@@ -157,8 +155,9 @@ agents/utilities/company-knowledge      company-knowledge /eve/agents/company-kn
 products/escalation                     escalation       /eve/agents/escalation/eve/v1/*
 ```
 
-If two members would otherwise be named `review`, authors must choose distinct
-names such as `security-review` and `content-review`. This is an intentional
+If two members share a name, e.g. `agents/tasks/review` and `agents/utilities/review`
+both mapping to `review`, this results in a compile-time error. Authors must choose
+distinct names such as `security-review` and `content-review`. This is an intentional
 workspace constraint, as it simplifies routing and identity logic considerably.
 
 The agent name is the shared identity in catalog entries, routes, generated
@@ -195,9 +194,7 @@ type WorkspaceAgentCatalogEntry = {
 
 The exact serialized artifact is internal. The key invariant is that all member
 artifacts arise from the same resolved catalog in one build. The catalog is
-build input and inspection data, not a public live-discovery API. Fetching
-`/eve/v1/info` from candidate agents would make tool availability depend on
-network availability, runtime authorization, and deployment version skew.
+build input and inspection data, not a public live-discovery API.
 
 ## Workspace subagents
 
@@ -219,13 +216,10 @@ Several selectors can organize a larger delegation surface:
 
 ```ts
 export default defineWorkspaceSubagents({
-  include: ["content-review", "agents/utilities/*"],
-  exclude: ["experimental-knowledge"],
+  include: ["agents/content-review", "agents/utilities/*"],
+  exclude: ["agents/experimental-knowledge"],
 });
 ```
-
-Workspace selection is static rather than session-dependent, so the compiler
-can validate the complete tool set, descriptions, and targets before deployment.
 
 The initial input is:
 
@@ -233,11 +227,15 @@ The initial input is:
 type WorkspaceSubagentsDefinition = {
   readonly include?: readonly string[];
   readonly exclude?: readonly string[];
+  readonly forwardPrincipal?: boolean;
 };
 ```
 
 - `include` and `exclude` accept glob patterns, e.g. `agents/utilities/*`
 - `exclude` wins over `include`.
+- `forwardPrincipal` defaults to `false`. When enabled, generated remote-agent
+  calls carry the caller's current and initiating principal assertions, as with
+  `defineRemoteAgent({ forwardPrincipal: true })`.
 - A member never selects itself, even when a selector matches it.
 - An unmatched name or path is a build error. A glob that matches no members
   also fails by default: silently deploying an expected delegation surface with
@@ -248,13 +246,7 @@ type WorkspaceSubagentsDefinition = {
 
 ### Generated subagent names
 
-Each selected member's workspace-unique agent name becomes its model tool name:
-
-```text
-content-review       → content-review
-company-knowledge    → company-knowledge
-```
-
+Each selected member's workspace-unique agent name becomes its model tool name.
 The agent name remains the durable identity and the model-facing projection; no
 path encoding or generated disambiguation is needed.
 
@@ -286,9 +278,10 @@ export default defineDynamic({
 });
 ```
 
-The record keys are bare model tool names (`triage`, `company-knowledge`), not
-`specialists__triage`. A single-definition return retains its existing
-path-derived name; an empty record is the map equivalent of no subagents.
+The resolver path namespaces each record key into a model tool name:
+`agent/subagents/specialists.ts` maps `triage` to `specialists__triage`. A
+single-definition return retains its existing path-derived name; an empty record
+is the map equivalent of no subagents.
 
 Each map entry needs a durable internal identity: resolver node plus record
 key, such as `subagents/specialists#triage`. Session and turn selections persist
@@ -298,9 +291,9 @@ reset, and inspection resolve this durable identity without rerunning the
 resolver.
 
 Dynamic entries must not collide with authored tools/subagents or entries from
-another dynamic resolver. The initial map form permits only
-`defineRemoteAgent()` entries. Mapping local `defineAgent()` values would make
-several apparent agents share one subagent directory's resources, so local
+another dynamic resolver after name derivation. The initial map form permits
+only `defineRemoteAgent()` entries. Mapping local `defineAgent()` values would
+make several apparent agents share one subagent directory's resources, so local
 agents remain one-per-directory.
 
 `defineWorkspaceSubagents()` remains build-time/static, but can compile to the
@@ -326,7 +319,13 @@ compiled remote subagent entries
 subagent tool registry → remote session dispatch → callback / continuation
 ```
 
-The resulting tools have the normal remote-agent contract.
+The resulting tools have the normal remote-agent contract. For a Vercel
+workspace deployment, lowering binds every selected catalog entry to that
+member's generated service route. At runtime, the target URL is derived from
+the active deployment origin and that route, rather than from an authored fixed
+URL. The generated request can use the caller's ambient Vercel OIDC token, so
+members configured to accept same-project Vercel OIDC calls need no pairwise
+URL or service-credential configuration.
 
 `defineWorkspaceSubagents()` does not itself need to expose a URL, `auth`, or
 `headers` field. It describes a same-workspace target. Direct
@@ -354,15 +353,18 @@ prefixes.
 
 ### Authentication and forwarded identity
 
-Workspace membership does not relax remote-agent trust requirements. A
-workspace call is an HTTP call from one independently running service to
-another.
+On Vercel, members in the generated Services graph share a Vercel project. A
+receiving member that includes `vercelOidc()` accepts Vercel OIDC tokens minted
+for that project, allowing workspace service-to-service calls without
+configuring each sibling as an external OIDC subject.
 
-On Vercel, a workspace transport helper may select Vercel OIDC for the calling
-service. The receiving member still owns its normal eve-channel authentication
-policy. If the child needs to act as the end user, the caller must opt in to
-`forwardPrincipal`, and the receiver must explicitly trust the verified
-forwarding service through `eveChannel({ trustedForwarders })`.
+Forwarded principals remain separately opt-in. A caller enables
+`forwardPrincipal` only for workspace subagents that need user-scoped behavior;
+otherwise the child runs under the verified calling service identity. A
+receiving member enables `trustedForwarders` only when it is willing to accept
+principal assertions from authenticated same-project callers. In a workspace,
+that is deliberately project-wide trust rather than a guarantee that only a
+specific catalog member made the request.
 
 This preserves the split already established for `defineRemoteAgent()`:
 
@@ -372,10 +374,9 @@ This preserves the split already established for `defineRemoteAgent()`:
 - only principal metadata crosses the hop; per-user tokens and connections are
   resolved by the receiving deployment.
 
-A convenience helper must not silently make all workspace members trusted
-forwarders or bypass a member's channel policy. Being in the same repository or
-Vercel project is not a substitute for explicit receiver-side authentication
-configuration.
+A convenience helper must not bypass a member's channel policy. Being in the
+same repository or Vercel project is not a substitute for explicit
+receiver-side authentication and forwarded-principal configuration.
 
 ### Self-hosting
 
@@ -383,13 +384,9 @@ A workspace build outside Vercel can build all member outputs, but it does not
 create network routing or service identity. The operator remains responsible
 for process topology, DNS or ingress, TLS, and authentication.
 
-For self-hosting, workspace-subagent compilation requires an operator-provided
-workspace target resolver. It maps a workspace agent name to a base URL and
-supplies whatever outbound transport authentication the deployment
-uses. The concrete public configuration is intentionally unresolved; it must
-be deployment-level configuration rather than authored per calling agent so it
-can vary between Docker Compose, Kubernetes, Nomad, and separate hosts without
-baking secrets into the compiled catalog.
+For self-hosting, workspace-subagent compilation requires additional
+configuration to map a workspace agent name to a base URL and supply
+whatever outbound transport authentication the deployment uses.
 
 Conceptually:
 
@@ -402,10 +399,7 @@ type WorkspaceTargetResolver = (agent: { readonly name: string }) => {
 ```
 
 The resolver is resolved at runtime like function-valued remote-agent URLs and
-must not serialize credentials into durable state or the build artifact. A
-self-hosted workspace build should fail clearly when it contains workspace
-subagents but has no configured target resolver. It must not guess that an
-`/eve/agents/...` route exists.
+must not serialize credentials into durable state or the build artifact.
 
 ## Compatibility and boundaries
 
@@ -448,32 +442,3 @@ subagents but has no configured target resolver. It must not guess that an
 6. **Expose topology in inspection and diagnostics.** `eve info` and
    agent-info should show workspace members, workspace-expanded subagents, and
    unresolved configuration errors without exposing credential material.
-
-## Validation
-
-- Workspace discovery: exact paths, `*` and `**` patterns, nested members,
-  invalid segments, duplicate agent names, missing `agent/`, and child package
-  membership.
-- Build planning: member build scripts, plain eve members, Vercel services,
-  route uniqueness, route-prefix preservation, and per-member outputs.
-- Catalog: description required, deterministic order, source provenance, and
-  no runtime network lookup.
-- Dynamic subagent maps: single-entry compatibility, key-derived internal
-  identities, session/turn replacement and empty-map hiding, duplicate and
-  authored-name conflicts, durable dispatch and continuation, cancellation,
-  reset, and map-entry inspection.
-- `defineWorkspaceSubagents`: exact and glob selection, exclusion precedence,
-  self omission, name and path-glob matching, empty/unmatched selector
-  failures, agent-name preservation, stable tool order, and standalone
-  rejection.
-- Runtime: generated tools use remote dispatch, preserve output schemas,
-  callbacks, continuation, task receipts, cancellation, reset, tracing, and
-  token usage.
-- Auth: same-workspace service authentication remains enforced; forwarding is
-  rejected until both the sender and receiver opt in; no tokens or credentials
-  appear in the catalog or durable action state.
-- Deployment-shaped scenario: at least three nested members (foreman, task,
-  utility), distinct prefixes, a delegated call and callback, and a selector
-  that includes a future-facing category but excludes one task member.
-- Self-hosting: target-resolution success, missing resolver failure, invalid
-  resolved URL, and credentials kept runtime-only.

--- a/research/multi-agent-workspaces.md
+++ b/research/multi-agent-workspaces.md
@@ -1,0 +1,474 @@
+---
+issue: "TBD"
+status: proposed
+last_updated: "2026-08-26"
+---
+
+# Multi-agent workspaces and workspace subagents
+
+## Decision
+
+An eve workspace is one deployable project containing an explicit set of root
+agents. The workspace root declares its members in `package.json`; each member
+owns an ordinary `agent/` directory and may optionally be a package-manager
+workspace package. A workspace build compiles every member and gives every
+member a stable, workspace-unique agent name.
+
+```text
+customer-operations/
+├── package.json
+├── pnpm-workspace.yaml
+└── agents/
+    ├── foreman/
+    │   └── agent/
+    │       ├── agent.ts
+    │       └── subagents/
+    │           └── workspace.ts
+    ├── tasks/
+    │   ├── triage/
+    │   │   └── agent/
+    │   │       └── agent.ts
+    │   └── review/
+    │       └── agent/
+    │           └── agent.ts
+    └── utilities/
+        └── company-knowledge/
+            └── agent/
+                └── agent.ts
+```
+
+```json title="package.json"
+{
+  "private": true,
+  "eve": {
+    "agents": ["agents/**"]
+  }
+}
+```
+
+A member's root `defineAgent` description is its workspace delegation
+description. The workspace compiler records the ID, description, and deployment
+locator for each member in a build-time catalog. It never asks a running agent
+for this information.
+
+A member opts in to model-visible delegation candidates by authoring a normal
+subagent source that expands its workspace selection:
+
+```ts title="agents/foreman/agent/subagents/workspace.ts"
+import { defineWorkspaceSubagents } from "eve";
+
+export default defineWorkspaceSubagents({
+  include: ["agents/tasks/*", "agents/utilities/*"],
+  exclude: ["triage"],
+});
+```
+
+`defineWorkspaceSubagents()` compiles the selected members into ordinary remote
+subagent entries. To the calling model they are named subagent tools; at runtime
+they use the existing `defineRemoteAgent` execution protocol, including isolated
+child sessions, durable callbacks, cancellation and reset, output schemas,
+trace propagation, and optional forwarded caller identity. The workspace
+feature owns topology discovery and target resolution; it does not introduce a
+second subagent execution path.
+
+This plan builds on the agent-workspace deployment stack beginning with
+[PR #2043](https://github.com/vercel/eve/pull/2043). That stack establishes
+explicit workspace membership, optional member packages, workspace-root builds,
+and independently deployed member services. Workspace subagents extend that
+foundation; they do not replace independent `defineRemoteAgent()` declarations
+or make every multi-package repository an eve workspace.
+
+## Goals
+
+- Let one project deploy several independently rooted eve agents as one
+  operational unit.
+- Give every workspace member a workspace-unique name and a useful
+  parent-facing delegation description.
+- Let a member expose a selected subset of workspace agents as subagent tools
+  without hard-coding each peer URL and description in a separate
+  `defineRemoteAgent()` file.
+- Preserve remote-agent isolation, durability, observability, authentication,
+  and identity-forwarding semantics.
+- Support organized agent trees and future additions through path selectors.
+- Keep distinct projects as the boundary for separate deployment lifecycles,
+  credential isolation, and stronger operational isolation.
+
+## Non-goals
+
+- Discovering arbitrary agents at runtime by scanning the repository or calling
+  other agents' inspection endpoints.
+- Making workspace membership an authorization decision. The receiving agent's
+  channel authentication and deployment transport policy remain authoritative.
+- Replacing direct `defineRemoteAgent()` declarations for agents outside the
+  workspace, hand-selected endpoints, or custom transport configuration.
+- Providing an eve-managed reverse proxy, service mesh, or process supervisor
+  for every self-hosted deployment.
+- Inferring agent roles, tool descriptions, or capabilities from directory
+  names.
+
+## Workspace format and member identity
+
+### Membership
+
+The root package declares the agent application directories it owns:
+
+```json title="package.json"
+{
+  "eve": {
+    "agents": ["agents/**", "products/escalation"]
+  }
+}
+```
+
+Each path or glob match is a workspace-relative directory that contains an
+`agent/` directory. The workspace root cannot also contain its own root
+`agent/` directory. A member may have a `package.json`, but its package manager
+workspace must claim that package; otherwise the root installation and member
+build cannot be made reliable.
+
+These are the core membership and build semantics in the PR #2043 stack:
+
+- the root owns workspace discovery, environment loading, linking, and deploy;
+- a member without a build script is built with `eve build` from its member
+  directory;
+- a member package with a build script runs that script instead;
+- Vercel builds assemble one service per member when eve owns the service
+  graph;
+- outside Vercel, workspace build produces each member's normal output and the
+  operator owns process startup and ingress routing.
+
+A repository may be a package-manager monorepo without declaring `eve.agents`.
+Such packages remain independent eve projects, with their own build, link, and
+deploy lifecycle. The workspace declaration is deliberately not a generic
+monorepo marker.
+
+### Names and paths
+
+A workspace member's final directory name is its **agent name**. Names must be
+unique across the entire workspace, including nested groups. The existing
+workspace deployment stack already uses this name for its public route and
+service identity, so this proposal preserves that model:
+
+```text
+member directory                       agent name       public route
+─────────────────────────────────────  ───────────────  ──────────────────────────────────
+agents/foreman                          foreman          /eve/agents/foreman/eve/v1/*
+agents/tasks/triage                     triage           /eve/agents/triage/eve/v1/*
+agents/utilities/company-knowledge      company-knowledge /eve/agents/company-knowledge/eve/v1/*
+products/escalation                     escalation       /eve/agents/escalation/eve/v1/*
+```
+
+If two members would otherwise be named `review`, authors must choose distinct
+names such as `security-review` and `content-review`. This is an intentional
+workspace constraint, not an authored `name` field.
+
+The agent name is the shared identity in catalog entries, routes, generated
+tool names, diagnostics, and trace attributes. The member's workspace-relative
+path remains available for organization and selector globs, but moving a member
+does not change its name, public route, or model-facing tool name.
+
+### Descriptions and the catalog
+
+Every workspace member must author a non-empty root description:
+
+```ts title="agents/utilities/company-knowledge/agent/agent.ts"
+import { defineAgent } from "eve";
+
+export default defineAgent({
+  description: "Answers questions from the company knowledge base and internal policies.",
+  model: "openai/gpt-5.5",
+});
+```
+
+The description tells another agent when to delegate. It should describe the
+work the member can complete, not merely its organizational name.
+
+Workspace compilation creates an internal catalog similar to:
+
+```ts
+type WorkspaceAgentCatalogEntry = {
+  readonly name: "company-knowledge";
+  readonly path: "agents/utilities/company-knowledge";
+  readonly description: "Answers questions from the company knowledge base and internal policies.";
+  readonly target: WorkspaceAgentTarget;
+};
+```
+
+The exact serialized artifact is internal. The key invariant is that all member
+artifacts arise from the same resolved catalog in one build. The catalog is
+build input and inspection data, not a public live-discovery API. Fetching
+`/eve/v1/info` from candidate agents would make tool availability depend on
+network availability, runtime authorization, and deployment version skew.
+
+## Workspace subagents
+
+### Authoring API
+
+`defineWorkspaceSubagents()` is valid only in a workspace member's
+`agent/subagents/` source. It selects catalog members and expands one authored
+source into multiple remote subagent tools:
+
+```ts title="agents/tasks/triage/agent/subagents/workspace.ts"
+import { defineWorkspaceSubagents } from "eve";
+
+export default defineWorkspaceSubagents({
+  include: ["agents/utilities/company-knowledge"],
+});
+```
+
+Several selectors can organize a larger delegation surface:
+
+```ts
+export default defineWorkspaceSubagents({
+  include: ["content-review", "agents/utilities/*"],
+  exclude: ["experimental-knowledge"],
+});
+```
+
+This follows the existing dynamic-tool precedent: one authored source can
+produce multiple named capabilities. Workspace selection is static rather than
+session-dependent, so the compiler can validate the complete tool set,
+descriptions, and targets before deployment.
+
+The initial input is:
+
+```ts
+type WorkspaceSubagentsDefinition = {
+  readonly include: readonly string[];
+  readonly exclude?: readonly string[];
+};
+```
+
+- `include` is required. A bare value matches a unique agent name; a value
+  containing `/` or glob syntax matches workspace-relative member paths.
+- `exclude` is optional and wins over `include`.
+- A member never selects itself, even when a selector matches it.
+- An unmatched name or path is a build error. A glob that matches no members
+  also fails by default: silently deploying an expected delegation surface with
+  no tools is difficult to diagnose. A future explicit optional-selector form
+  can address intentionally empty groups.
+- Results are sorted by agent name and frozen into the deployment artifact.
+  Adding a matching agent changes the tool surface only after a new build and
+  deployment.
+
+`include` and `exclude` describe composition, not access control. A broad
+selector such as `agents/utilities/*` intentionally makes future matching
+utility agents available as delegation tools after deployment. It does not
+authorize their HTTP requests; a direct `defineRemoteAgent()` could also target
+the same endpoint. Use receiving-channel authentication and separate projects
+when a true security or deployment boundary is required.
+
+### Generated subagent names
+
+Each selected member's workspace-unique agent name becomes its model tool name:
+
+```text
+content-review       → content-review
+company-knowledge    → company-knowledge
+```
+
+The agent name remains the durable identity and the model-facing projection; no
+path encoding or generated disambiguation is needed.
+
+The compiler should make the source visible in `eve info` and agent-info as a
+workspace-expanded remote subagent, including its agent name, member path,
+generated name, description, route target, and source file. Diagnostics should distinguish:
+
+- an invalid selector;
+- an exact selector with no matching member;
+- a glob with no matches;
+- a selected member with no description;
+- an invalid agent name;
+- a workspace-subagent source authored outside a workspace.
+
+### Lowering and execution
+
+The compiler expands the selected catalog entries into remote subagent nodes in
+the calling member's ordinary subagent registry. It reuses the same lowerings
+and runtime path as `defineRemoteAgent()`:
+
+```text
+agent/subagents/workspace.ts
+          │
+          ▼
+workspace catalog + selector expansion
+          │
+          ▼
+compiled remote subagent entries
+          │
+          ▼
+subagent tool registry → remote session dispatch → callback / continuation
+```
+
+The resulting tools have the normal remote-agent contract:
+
+- The child has a separate session, state, prompt, tools, connections, sandbox,
+  and conversation history.
+- The parent supplies a complete task message; child history is not implicitly
+  shared.
+- The parent parks durably for remote completion and receives normal subagent
+  lifecycle events and results.
+- Cancellation and session finalization request remote cancel and reset.
+- Each call has existing structured-output, task-mode, trace, token-usage, and
+  callback behavior.
+- A workspace member can itself expose local or remote subagents, subject to
+  the ordinary delegation rules.
+
+`defineWorkspaceSubagents()` does not itself need to expose a URL, `auth`, or
+`headers` field. It describes a same-workspace target. Direct
+`defineRemoteAgent()` remains the explicit escape hatch for a different
+endpoint or transport policy.
+
+## Deployment and transport
+
+### Vercel workspace deployments
+
+When eve generates the Vercel Services graph, it already has a service and
+public route for every workspace member. A workspace target resolves against
+the current deployment origin plus the selected member's generated route:
+
+```text
+https://<deployment>/eve/agents/<agent-name>/eve/v1/session
+```
+
+The parent therefore does not need a deployment URL at compile time. This is
+important for Preview deployments, whose final host name is unknown during the
+build. The existing remote-agent callback mechanism continues to use the
+parent's active deployment origin and callback route, so callbacks route back
+to the calling service even when parent and child have different route
+prefixes.
+
+The generated Vercel graph must route both inbound member traffic and internal
+workspace calls correctly. Coverage should exercise parent-to-child creation,
+callback delivery, continuation, cancellation, and reset through distinct
+member prefixes rather than treating this as an in-process call.
+
+### Authentication and forwarded identity
+
+Workspace membership does not relax remote-agent trust requirements. A
+workspace call is an HTTP call from one independently running service to
+another.
+
+On Vercel, a workspace transport helper may select Vercel OIDC for the calling
+service. The receiving member still owns its normal eve-channel authentication
+policy. If the child needs to act as the end user, the caller must opt in to
+`forwardPrincipal`, and the receiver must explicitly trust the verified
+forwarding service through `eveChannel({ trustedForwarders })`.
+
+This preserves the split already established for `defineRemoteAgent()`:
+
+- transport authentication establishes which service made the request;
+- forwarded-principal trust establishes whether that service may assert a user
+  identity;
+- only principal metadata crosses the hop; per-user tokens and connections are
+  resolved by the receiving deployment.
+
+A convenience helper must not silently make all workspace members trusted
+forwarders or bypass a member's channel policy. Being in the same repository or
+Vercel project is not a substitute for explicit receiver-side authentication
+configuration.
+
+### Self-hosting
+
+A workspace build outside Vercel can build all member outputs, but it does not
+create network routing or service identity. The operator remains responsible
+for process topology, DNS or ingress, TLS, and authentication.
+
+For self-hosting, workspace-subagent compilation requires an operator-provided
+workspace target resolver. It maps a workspace agent name to a base URL and
+supplies whatever outbound transport authentication the deployment
+uses. The concrete public configuration is intentionally unresolved; it must
+be deployment-level configuration rather than authored per calling agent so it
+can vary between Docker Compose, Kubernetes, Nomad, and separate hosts without
+baking secrets into the compiled catalog.
+
+Conceptually:
+
+```ts
+type WorkspaceTargetResolver = (agent: { readonly name: string }) => {
+  readonly url: string;
+  readonly auth?: OutboundAuthFn;
+  readonly headers?: HeadersValue;
+};
+```
+
+The resolver is resolved at runtime like function-valued remote-agent URLs and
+must not serialize credentials into durable state or the build artifact. A
+self-hosted workspace build should fail clearly when it contains workspace
+subagents but has no configured target resolver. It must not guess that an
+`/eve/agents/...` route exists.
+
+An optional future workspace host could start member processes, provide stable
+internal routing, and issue service credentials. That is a hosting integration,
+not a prerequisite or hidden responsibility of the core authoring API.
+
+## Compatibility and boundaries
+
+- A standalone agent cannot author `defineWorkspaceSubagents()`.
+- An agent in a package-manager monorepo but outside a declared `eve.agents`
+  workspace remains standalone for this feature.
+- Existing local declared subagents and direct `defineRemoteAgent()` files are
+  unchanged.
+- A workspace build does not automatically expose every member to every other
+  member. Each caller selects its own model-visible delegation surface.
+- A workspace member description is required because a generated remote tool
+  without a meaningful delegation description is not usable by the model.
+- Moving a member preserves its agent name, route, and generated tool name,
+  but can change path-based selectors. This is intentional: paths organize a
+  workspace, while names identify its agents.
+- A workspace deploy is atomic as an artifact, but long-lived child sessions
+  can still encounter rolling-version or deployment-retention concerns. The
+  existing remote-agent compatibility guidance applies when persistent remote
+  sessions are resumed across versions.
+
+## Implementation plan
+
+1. **Land and stabilize the workspace foundation.** Build on PR #2043 and its
+   parent deployment stack: explicit `eve.agents` discovery, member package
+   membership checks, workspace-root build/deploy ownership, and Vercel service
+   assembly.
+2. **Preserve workspace-unique member names.** Carry the existing final-
+   directory name through discovery, service naming, public routing, project
+   context, build results, diagnostics, and tests; retain the member path only
+   for organization and selector matching.
+3. **Compile a workspace catalog.** Resolve every member's root config and
+   required description before compiling individual consumer manifests. Keep
+   catalog provenance and resolved route targets available to build planning
+   and inspection.
+4. **Add `defineWorkspaceSubagents()`.** Permit it only for a workspace
+   member's `subagents/` source; validate selectors against the catalog;
+   expand matches into deterministic remote subagent nodes; and register them
+   through the existing subagent compiler and runtime registry.
+5. **Add deployment target adapters.** Vercel resolves same-deployment member
+   routes from the active origin and uses explicit service authentication.
+   Self-hosting supplies an operator-owned resolver. Keep `defineRemoteAgent()`
+   as the configuration surface for non-workspace calls.
+6. **Expose topology in inspection and diagnostics.** `eve info` and
+   agent-info should show the workspace ID, resolved workspace members,
+   workspace-expanded subagents, and unresolved configuration errors without
+   exposing credential material.
+
+## Validation
+
+- Workspace discovery: exact paths, `*` and `**` patterns, nested members,
+  invalid segments, duplicate agent names, missing `agent/`, and child package
+  membership.
+- Build planning: member build scripts, plain eve members, Vercel services,
+  route uniqueness, route-prefix preservation, and per-member outputs.
+- Catalog: description required, deterministic order, source provenance, and
+  no runtime network lookup.
+- `defineWorkspaceSubagents`: exact and glob selection, exclusion precedence,
+  self omission, name and path-glob matching, empty/unmatched selector
+  failures, agent-name preservation, stable tool order, and standalone
+  rejection.
+- Runtime: generated tools use remote dispatch, preserve output schemas,
+  callbacks, continuation, task receipts, cancellation, reset, tracing, and
+  token usage.
+- Auth: same-workspace service authentication remains enforced; forwarding is
+  rejected until both the sender and receiver opt in; no tokens or credentials
+  appear in the catalog or durable action state.
+- Deployment-shaped scenario: at least three nested members (foreman, task,
+  utility), distinct prefixes, a delegated call and callback, and a selector
+  that includes a future-facing category but excludes one task member.
+- Self-hosting: target-resolution success, missing resolver failure, invalid
+  resolved URL, and credentials kept runtime-only.


### PR DESCRIPTION
### Summary

Related to #2043. Adds a research proposal for the next layer of agent workspaces: workspace-unique member names, build-time metadata, and `defineWorkspaceSubagents()` expansion into existing remote-subagent dispatch. Nested member paths organize glob selectors, while unique final directory names preserve the current service and route model. It also proposes map-returning dynamic subagents for multiple runtime-selected remote targets, with a durable resolver-node-plus-key identity shared by static workspace expansion. The proposal documents Vercel routing and explicit transport/forwarded-identity boundaries, plus an operator-owned target-resolution model for self-hosting.

### Validation

Reviewed the proposal against the current remote-agent implementation and the workspace deployment stack in #2043. The research document passed direct oxfmt validation; no runtime behavior changes in this PR.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

No changeset is needed: this is a research-only proposal.

### Diff size

**Docs** — 1 file · `+479 / -0`

The research document records the combined workspace, dynamic-subagent-map, and workspace-subagent proposal, implementation boundaries, and validation plan for review before code changes begin.

**Implementation** — 0 files · `+0 / -0`

Not applicable.

**Tests** — 0 files · `+0 / -0`

Not applicable.
