### PR TITLE
fix(eve): memory - remove definition tool opt-out

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -239,11 +239,10 @@ canonical namespace and scope input is limited to 4,096 bytes. Provider tool
 names must satisfy the normal tool-name grammar after the `<slot>__` prefix is
 added.
 
-Set `tools: false` to disable a provider's tool factory while keeping recall
-and capture. An application-owned `agent/tools/<slot>.ts` also replaces the
-generated provider-tool wrapper; export `disableTool()` there to remove it.
-Extensions cannot contribute memory slots because scope and lifecycle
-ownership remain with the consuming agent or subagent.
+An application-owned `agent/tools/<slot>.ts` replaces the generated
+provider-tool wrapper; export `disableTool()` there to remove it. Extensions
+cannot contribute memory slots because scope and lifecycle ownership remain
+with the consuming agent or subagent.
 
 ## What to read next
 

--- a/packages/eve/src/client/agent-info-schema.ts
+++ b/packages/eve/src/client/agent-info-schema.ts
@@ -205,7 +205,6 @@ const memory = source
   .extend({
     description: z.string().optional(),
     slot: z.string(),
-    tools: z.literal(false).optional(),
     visibility: z.enum(["scope", "session"]),
   })
   .strict();

--- a/packages/eve/src/compiler/manifest.ts
+++ b/packages/eve/src/compiler/manifest.ts
@@ -258,7 +258,6 @@ export interface CompiledDynamicToolDefinition extends ModuleSourceRef {
 export interface CompiledMemoryDefinition extends ModuleSourceRef {
   readonly description?: string;
   readonly slot: string;
-  readonly tools?: false;
   readonly visibility: "scope" | "session";
 }
 
@@ -831,7 +830,6 @@ const compiledMemoryDefinitionSchema: z.ZodType<CompiledMemoryDefinition> = z
     slot: z.string(),
     sourceId: z.string(),
     sourceKind: z.literal("module"),
-    tools: z.literal(false).optional(),
     visibility: z.enum(["scope", "session"]),
   })
   .strict();

--- a/packages/eve/src/compiler/normalize-memory.ts
+++ b/packages/eve/src/compiler/normalize-memory.ts
@@ -27,7 +27,6 @@ export async function compileMemoryDefinition(
     slot: deriveMemorySlot(source.logicalPath),
     sourceId: source.sourceId,
     sourceKind: "module",
-    tools: definition.tools,
     visibility: definition.visibility ?? "scope",
   };
 }

--- a/packages/eve/src/context/memory-tools.test.ts
+++ b/packages/eve/src/context/memory-tools.test.ts
@@ -132,17 +132,13 @@ describe("memory provider tools", () => {
     expect(output).toBe("2:user_1");
   });
 
-  it("omits tools for a disabled slot or tools:false", async () => {
+  it("omits tools when the provider has no tool factory", async () => {
     const ctx = createContext("user_1");
     const definition = defineMemory({
       provider: {
         recall: { "turn.started": async () => null },
-        tools: async () => ({
-          save: defineTool({ description: "Save.", execute: async () => null, inputSchema: {} }),
-        }),
       },
       scope: "unused",
-      tools: false,
     });
     const dynamic = createMemoryToolDynamicDefinition(definition, "profile");
     const result = await contextStorage.run(

--- a/packages/eve/src/context/memory-tools.ts
+++ b/packages/eve/src/context/memory-tools.ts
@@ -15,11 +15,7 @@ export function createMemoryToolDynamicDefinition(definition: MemoryDefinition, 
       events: {
         "turn.started": async (_event, resolveContext) => {
           const lock = loadContext().get(TurnMemoryLocksKey)?.[slot];
-          if (
-            lock === undefined ||
-            definition.tools === false ||
-            definition.provider.tools === undefined
-          ) {
+          if (lock === undefined || definition.provider.tools === undefined) {
             return null;
           }
           const context: MemoryToolsContext = {

--- a/packages/eve/src/internal/authored-definition/memory.ts
+++ b/packages/eve/src/internal/authored-definition/memory.ts
@@ -7,7 +7,7 @@ export function normalizeMemoryDefinition(value: unknown, message: string): Memo
   const record = expectObjectRecord(value, message);
   expectOnlyKnownKeys(
     record,
-    ["description", "namespace", "provider", "scope", "tools", "visibility"],
+    ["description", "namespace", "provider", "scope", "visibility"],
     message,
   );
   if (
@@ -73,9 +73,6 @@ export function normalizeMemoryDefinition(value: unknown, message: string): Memo
   }
   if (provider.tools !== undefined && typeof provider.tools !== "function") {
     throw new Error(`${message} "provider.tools" must be a function when provided.`);
-  }
-  if (record.tools !== undefined && record.tools !== false) {
-    throw new Error(`${message} "tools" may only be false when provided.`);
   }
   if (
     record.visibility !== undefined &&

--- a/packages/eve/src/internal/nitro/routes/agent-info/build-agent-info-response.ts
+++ b/packages/eve/src/internal/nitro/routes/agent-info/build-agent-info-response.ts
@@ -135,7 +135,6 @@ export function buildAgentInfoResponse(
       ...toModuleSource(manifest, memory),
       description: memory.description,
       slot: memory.slot,
-      tools: memory.tools,
       visibility: memory.visibility,
     })),
     mode: input.mode,

--- a/packages/eve/src/public/memory/index.ts
+++ b/packages/eve/src/public/memory/index.ts
@@ -144,7 +144,6 @@ export interface MemoryDefinition {
   readonly namespace?: MemoryNamespaceDefinition;
   readonly provider: MemoryProvider;
   readonly scope: MemoryScopeDefinition;
-  readonly tools?: false;
   readonly visibility?: MemoryVisibility;
 }
 

--- a/packages/eve/src/runtime/resolve-memory.ts
+++ b/packages/eve/src/runtime/resolve-memory.ts
@@ -29,7 +29,6 @@ export async function resolveMemoryDefinition(
       slot: compiled.slot,
       sourceId: compiled.sourceId,
       sourceKind: "module",
-      tools: compiled.tools,
       visibility: compiled.visibility,
     };
   } catch (error) {

--- a/research/first-class-memory.md
+++ b/research/first-class-memory.md
@@ -116,25 +116,6 @@ includes the slot identity, so each slot receives a distinct provider scope
 key. Definitions that resolve the same custom namespace and scope intentionally
 share a scope key.
 
-A read-only slot sets `tools: false`. The provider's `tools` method is not
-invoked and the slot exposes no model tools, while recall and capture continue
-to run:
-
-```ts title="agent/memory/policies.ts"
-import { defineMemory } from "eve/memory";
-import { policyMemory } from "../lib/policy-memory";
-
-export default defineMemory({
-  provider: policyMemory,
-  scope: "workspace",
-  tools: false,
-});
-```
-
-`tools: false` is the only memory-specific tool control. Finer policy — per-tool
-approval, overrides, or denial — reuses the ordinary dynamic-tool approval
-surface, because provider tools are ordinary dynamic tools.
-
 ## Compilation and provider tools
 
 Memory is a source-graph primitive, not a post-compile runtime attachment. For
@@ -187,9 +168,9 @@ The wrapper resolves on `turn.started` after recall commits. It reads the
 already locked slot, invokes `provider.tools(context)`, requires a map of
 branded `defineTool()` values, qualifies each key as
 `<slot>__<provider tool key>`, and prepends the slot description. A disabled
-slot, `tools: false`, `null`, or an empty result contributes no tools. Provider
-factories use eve's durable callback helpers when their callbacks cannot be
-stamped by authored-source transformation.
+slot, `null`, or an empty result contributes no tools. Provider factories use
+eve's durable callback helpers when their callbacks cannot be stamped by
+authored-source transformation.
 
 Every module-map load also memoizes zero-argument definition-factory results
 within each module namespace. The direct memory binding and its derived wrapper
@@ -220,7 +201,6 @@ interface MemoryDefinition {
   readonly namespace?: MemoryNamespaceDefinition;
   readonly provider: MemoryProvider;
   readonly scope: MemoryScopeDefinition;
-  readonly tools?: false;
   readonly visibility?: MemoryVisibility;
 }
 ```
@@ -859,13 +839,12 @@ exactly once.
 
 ### Turn tools
 
-After turn-start recall settles, eve resolves `tools` once for the active turn
-unless the definition sets `tools: false`. The function may be synchronous or
-asynchronous. Its context contains the same session, authentication, channel,
-and message fields as a `defineDynamic` resolver, plus the locked memory scope,
-slot, and turn. Its messages include the projected turn-start recall results
-followed by the admitted turn input. Returning `null` or an empty record
-exposes no tools for the slot.
+After turn-start recall settles, eve resolves `tools` once for the active turn.
+The function may be synchronous or asynchronous. Its context contains the same
+session, authentication, channel, and message fields as a `defineDynamic`
+resolver, plus the locked memory scope, slot, and turn. Its messages include the
+projected turn-start recall results followed by the admitted turn input.
+Returning `null` or an empty record exposes no tools for the slot.
 
 The compiler-owned wrapper makes the memory definition implicit
 `defineDynamic` authoring: it adapts each implemented `tools` method to a


### PR DESCRIPTION
### Summary

`defineMemory` exposed a definition-level tool opt-out that duplicated the ordinary filesystem override and had to flow through the authoring, compiler, runtime, and agent-info contracts. This removes that option end to end: memory tools now depend only on `provider.tools()`, while `agent/tools/<slot>.ts` remains the supported replacement or disable surface. Recall, capture, and provider tool behavior are otherwise unchanged. First-class memory has not shipped, so this cleanup changes only the pre-release API and intentionally carries no changeset.

### Validation

Focused memory/compiler/agent-info coverage passed (33 tests), followed by `pnpm test:unit` (7,129 passed, one skipped), `pnpm test:integration` (668 passed), `pnpm guard:invariants`, and `pnpm docs:check`.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package — not applicable; memory is unreleased
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+13 / -35`

Removes the obsolete option from the published memory guide and its unreleased research plan.

**Implementation** — 8 files · `+2 / -16`

Deletes the option from public and runtime types, validation, compilation, hydration, agent-info output, and the turn resolver.

**Tests** — 1 file · `+1 / -5`

Replaces option-specific coverage with the supported no-provider-tool case.
