### PR TITLE
fix(eve): set up Agentcard MCP connectors

### DIFF
--- a/.changeset/fix-agentcard-connection-setup.md
+++ b/.changeset/fix-agentcard-connection-setup.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Agentcard setup now uses the correct MCP discovery and creation identifiers, then writes the selected connector into the installed connection template.

--- a/apps/docs/lib/integrations/connection-setup.test.ts
+++ b/apps/docs/lib/integrations/connection-setup.test.ts
@@ -36,6 +36,7 @@ describe("Agentcard connection setup", () => {
 
     expect(quickStart).toContain("Agentcard: the agent's wallet.");
     expect(quickStart).toContain('auth: connect("agentcard")');
+    expect(quickStart).not.toContain("AGENTCARD_CONNECTOR");
     expect(setup.configureVariants["mcp:user"]).toContain("vercel connect create agentcard");
     expect(setup.configureVariants["mcp:user"]).not.toContain("--name");
   });

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -347,7 +347,17 @@
             "command": "eve",
             "package": "eve",
             "bin": "eve",
-            "args": ["integration", "connect", "agentcard", "agentcard", "agentcard"]
+            "args": [
+              "integration",
+              "connect",
+              "agentcard",
+              "mcp.agentcard.sh/mcp",
+              "agentcard",
+              "--creation-type",
+              "agentcard",
+              "--connection-method",
+              "mcp"
+            ]
           },
           "requires": ">=0.29.0"
         }

--- a/apps/docs/registry/connections/agentcard.ts
+++ b/apps/docs/registry/connections/agentcard.ts
@@ -7,7 +7,7 @@ export default defineMcpClientConnection({
   url: "https://mcp.agentcard.sh/mcp",
   description:
     "Agentcard: the agent's wallet. Shop and check out at real merchants (DoorDash, Good Eggs, flights) with the conversational `buy` tool (thread conversation_id on follow-ups), issue a single-use virtual card to pay at any checkout, let the user add their own card, and manage the cash that funds it: balance, top-ups, transactions, KYC, human support.",
-  auth: connect(process.env.AGENTCARD_CONNECTOR ?? "agentcard"),
+  auth: connect("agentcard"),
   tools: {
     allow: [
       // Shopping

--- a/apps/docs/scripts/validate-connection-registry.ts
+++ b/apps/docs/scripts/validate-connection-registry.ts
@@ -44,6 +44,7 @@ const expectedSlugs = connectionEntries()
   .map((entry) => entry.slug);
 const actualSlugs = items.map((item) => item.name.slice("connection/".length));
 const CONNECT_SERVICES: Readonly<Record<string, string>> = {
+  agentcard: "mcp.agentcard.sh/mcp",
   vercel: "vercel",
   linear: "mcp.linear.app",
   notion: "mcp.notion.com",
@@ -51,6 +52,12 @@ const CONNECT_SERVICES: Readonly<Record<string, string>> = {
   honeycomb: "mcp.honeycomb.io",
   context: "mcp.context.dev",
   natural: "mcp.natural.com",
+};
+const CONNECT_CREATION_TYPES: Readonly<Record<string, string>> = {
+  agentcard: "agentcard",
+};
+const CONNECT_METHODS: Readonly<Record<string, "mcp" | "oauth">> = {
+  agentcard: "mcp",
 };
 
 if (JSON.stringify(actualSlugs) !== JSON.stringify(expectedSlugs)) {
@@ -83,11 +90,21 @@ for (const item of items) {
 
   const slug = item.name.slice("connection/".length);
   if (slug !== "browser-use") {
+    const creationType = CONNECT_CREATION_TYPES[slug];
+    const connectionMethod = CONNECT_METHODS[slug];
     const expectedSetup = {
       command: "eve",
       package: "eve",
       bin: "eve",
-      args: ["integration", "connect", slug, CONNECT_SERVICES[slug] ?? slug, slug],
+      args: [
+        "integration",
+        "connect",
+        slug,
+        CONNECT_SERVICES[slug] ?? slug,
+        slug,
+        ...(creationType === undefined ? [] : ["--creation-type", creationType]),
+        ...(connectionMethod === undefined ? [] : ["--connection-method", connectionMethod]),
+      ],
     };
     if (JSON.stringify(setups) !== JSON.stringify([expectedSetup])) {
       throw new Error(

--- a/packages/eve/src/cli/commands/integration-connect.test.ts
+++ b/packages/eve/src/cli/commands/integration-connect.test.ts
@@ -58,6 +58,22 @@ describe("runIntegrationConnect", () => {
     );
   });
 
+  it("passes connector creation options to setup", async () => {
+    const deps = dependencies();
+
+    await runIntegrationConnect({
+      appRoot: "/project",
+      slug: "agentcard",
+      service: "mcp.agentcard.sh/mcp",
+      options: { creationType: "agentcard", connectionMethod: "mcp" },
+      dependencies: deps,
+    });
+
+    expect(deps.setupConnectionConnector).toHaveBeenCalledWith(
+      expect.objectContaining({ creationType: "agentcard", connectionMethod: "mcp" }),
+    );
+  });
+
   it("links an unlinked project before connector setup", async () => {
     const deps = dependencies({ readProjectLink: vi.fn(async () => undefined) });
 

--- a/packages/eve/src/cli/commands/integration-connect.ts
+++ b/packages/eve/src/cli/commands/integration-connect.ts
@@ -22,6 +22,8 @@ import type { RegistryCommandLogger } from "./registry.js";
 import { serializeHeadlessSetupEvent } from "./setup-headless.js";
 
 export interface IntegrationConnectOptions {
+  creationType?: string;
+  connectionMethod?: "mcp" | "oauth";
   nonInteractive?: boolean;
   signal?: AbortSignal;
 }
@@ -93,6 +95,8 @@ export async function runIntegrationConnect(input: {
     projectRoot: input.appRoot,
     slug: input.slug,
     service: input.service,
+    creationType: input.options?.creationType,
+    connectionMethod: input.options?.connectionMethod,
     canonicalConnectorName: input.canonicalConnectorName ?? input.slug,
     project,
     signal,

--- a/packages/eve/src/cli/commands/register-integration-commands.ts
+++ b/packages/eve/src/cli/commands/register-integration-commands.ts
@@ -53,6 +53,8 @@ export function registerIntegrationCommands(input: {
     applicationContext,
   )
     .option("-y, --yes")
+    .option("--creation-type <type>", "Select the Vercel Connect creation type.")
+    .option("--connection-method <method>", "Select the Vercel Connect connection method.")
     .option(
       "--non-interactive",
       "Run without interactive prompts, instead emit structured NDJSON when further input is required",
@@ -62,7 +64,11 @@ export function registerIntegrationCommands(input: {
         slug: string,
         service: string,
         canonicalName: string | undefined,
-        options: { nonInteractive?: boolean },
+        options: {
+          creationType?: string;
+          connectionMethod?: "mcp" | "oauth";
+          nonInteractive?: boolean;
+        },
       ) => {
         const { runIntegrationConnectCommand } = await import("./integration-connect.js");
         await runIntegrationConnectCommand(

--- a/packages/eve/src/setup/connection-connector.integration.test.ts
+++ b/packages/eve/src/setup/connection-connector.integration.test.ts
@@ -232,6 +232,48 @@ describe("setupConnectionConnector", () => {
     );
   });
 
+  it("uses separate discovery and creation services when requested", async () => {
+    run.mockResolvedValue(true);
+    capture.mockResolvedValue(jsonResult({ connectors: [] }));
+    create.mockResolvedValue(connectorResult("mcp.agentcard.sh/agentcard", "scl_created", "user"));
+    const fake = createFakePrompter({ single: () => "create", text: () => "agentcard" });
+
+    await expect(
+      setupConnectionConnector({
+        ...options(fake.prompter),
+        slug: "agentcard",
+        service: "mcp.agentcard.sh/mcp",
+        creationType: "agentcard",
+        canonicalConnectorName: "agentcard",
+        connectionMethod: "mcp",
+      }),
+    ).resolves.toEqual({
+      kind: "created",
+      connectorId: "scl_created",
+      connectorUid: "mcp.agentcard.sh/agentcard",
+    });
+    expect(capture).toHaveBeenCalledWith(
+      expect.arrayContaining(["--service", "mcp.agentcard.sh/mcp"]),
+      expect.any(Object),
+    );
+    expect(create).toHaveBeenCalledWith(
+      [
+        "connect",
+        "create",
+        "agentcard",
+        "--name",
+        "agentcard",
+        "--connection-method",
+        "mcp",
+        "-F",
+        "json",
+        "--scope",
+        "org_1",
+      ],
+      expect.any(Object),
+    );
+  });
+
   it("recovers a partially created connector id from CLI progress and removes it", async () => {
     run.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
     capture.mockResolvedValue(jsonResult({ connectors: [] }));

--- a/packages/eve/src/setup/connection-connector.ts
+++ b/packages/eve/src/setup/connection-connector.ts
@@ -11,6 +11,8 @@ export interface SetupConnectionConnectorOptions {
   projectRoot: string;
   slug: string;
   service: string;
+  creationType?: string;
+  connectionMethod?: "mcp" | "oauth";
   canonicalConnectorName: string;
   project: VercelProjectReference;
   signal?: AbortSignal;
@@ -298,9 +300,12 @@ async function resolveFallbackConnector(
           [
             "connect",
             "create",
-            options.service,
+            options.creationType ?? options.service,
             "--name",
             name,
+            ...(options.connectionMethod === undefined
+              ? []
+              : ["--connection-method", options.connectionMethod]),
             "-F",
             "json",
             "--scope",


### PR DESCRIPTION
### Summary

Agentcard registry setup assumed the identifier used to create a connector matched the service reported after creation. Vercel instead creates Agentcard through the managed `agentcard` type with the `mcp` method, while existing connectors are discovered as `mcp.agentcard.sh/mcp`.

This change lets connection setup carry separate creation-type and connection-method options, configures Agentcard with the correct values, and restores its standard patchable `connect("agentcard")` placeholder so setup can write the selected connector UID into the installed template.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/cli/commands/integration-connect.test.ts` — 8 tests passed
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/setup/connection-connector.integration.test.ts` — 9 tests passed
- `pnpm --filter eve-docs exec vitest run --config vitest.config.ts lib/integrations/connection-setup.test.ts` — 5 tests passed
- `pnpm --filter eve-docs registry:validate`
- `pnpm --filter eve typecheck`
- `pnpm guard:invariants`
- Manually packed the local eve package and served the local registry; `/add connection/agentcard` created or attached the MCP connector and rewrote the installed connection to its Vercel connector UID.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the release-note changeset for the published `eve` fix.

**Implementation** — 6 files · `+47 / -5`

Separates connector discovery from Vercel creation metadata and corrects the Agentcard registry template and setup declaration.

**Tests** — 3 files · `+59 / -0`

Covers option propagation, the exact Agentcard discovery/create command split, and the patchable template shape.
