### PR TITLE
fix(slack): include shared message content

### DIFF
--- a/.changeset/slack-crosspost-content.md
+++ b/.changeset/slack-crosspost-content.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Include the original message body when Slack users share a message into an eve conversation. Agents now receive Slack crosspost content instead of only the sender's short top-level comment or crosspost marker.
+Include the original message body when Slack users share a message into an eve conversation. Agents now receive Slack crosspost content alongside distinct top-level comments without repeating content already present in the comment.

--- a/.changeset/slack-crosspost-content.md
+++ b/.changeset/slack-crosspost-content.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Include the original message body when Slack users share a message into an eve conversation. Agents now receive Slack crosspost content instead of only the sender's short top-level comment or crosspost marker.

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -158,6 +158,8 @@ Only the first available handler runs. A message hook returning `null` drops the
 
 The model-visible `<slack_message>` includes `sender_id`, `bot_user_id` when available, and the `is_mentioned` value from `ctx.isBotMentioned()`. Its `<content>` keeps `<@USER_ID>` intact while converting other mrkdwn to Markdown; routing is unchanged.
 
+When a Slack message shares another Slack message, eve extracts the forwarded message body from Slack's message-unfurl attachment and includes it in `<content>`. The original top-level comment, when present, remains alongside the forwarded content.
+
 #### Restrict who can invoke the agent
 
 A valid Slack signature proves that Slack sent the event. It does not decide which channel or person your agent should trust. Fail closed in the inbound handler before returning auth, especially when the app is installed in a shared Slack Connect channel:

--- a/packages/eve/src/public/channels/slack/inbound-content.test.ts
+++ b/packages/eve/src/public/channels/slack/inbound-content.test.ts
@@ -431,6 +431,31 @@ describe("resolveSlackInboundMrkdwn", () => {
     );
   });
 
+  it.each(["is_share", "is_msg_unfurl", "is_reply_unfurl"])(
+    "keeps short shared-message content alongside a longer human comment for %s attachments",
+    (sharedMessageFlag) => {
+      const result = resolveSlackInboundMrkdwn("<@U123> :eyes:", {
+        attachments: [
+          {
+            [sharedMessageFlag]: true,
+            text: "Ship it",
+            from_url: "https://example.slack.com/archives/C123/p1234567890000100",
+          },
+        ],
+      });
+
+      expect(result).toBe("<@U123> :eyes:\nShip it");
+    },
+  );
+
+  it("does not repeat shared-message content already present in the human comment", () => {
+    const result = resolveSlackInboundMrkdwn("Please review: Ship it", {
+      attachments: [{ is_share: true, text: "Ship it" }],
+    });
+
+    expect(result).toBe("Please review: Ship it");
+  });
+
   it("keeps top-level text when rich_text blocks mirror it", () => {
     const result = resolveSlackInboundMrkdwn("Status update", {
       blocks: [

--- a/packages/eve/src/public/channels/slack/inbound-content.test.ts
+++ b/packages/eve/src/public/channels/slack/inbound-content.test.ts
@@ -360,6 +360,77 @@ describe("resolveSlackInboundMrkdwn", () => {
     expect(result).toBe("nested body");
   });
 
+  it("extracts shared Slack messages from message unfurl attachments", () => {
+    const result = resolveSlackInboundMrkdwn(":crosspost:", {
+      attachments: [
+        {
+          from_url: "https://example.slack.com/archives/C_SOURCE/p1700000000000100",
+          is_msg_unfurl: true,
+          message_blocks: [
+            {
+              channel: "C_SOURCE",
+              message: {
+                blocks: [
+                  {
+                    type: "rich_text",
+                    elements: [
+                      {
+                        type: "rich_text_section",
+                        elements: [
+                          {
+                            type: "text",
+                            text: "I can't find deployment protection or agent runs in the new sidebar.",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+              team: "T_SOURCE",
+              ts: "1700000000.000100",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result).toBe(
+      ":crosspost:\nI can't find deployment protection or agent runs in the new sidebar.",
+    );
+  });
+
+  it("falls back to shared Slack message text when its blocks are absent", () => {
+    const result = resolveSlackInboundMrkdwn("", {
+      attachments: [
+        {
+          is_msg_unfurl: true,
+          message_blocks: [{ message: { text: "Forwarded feedback" } }],
+        },
+      ],
+    });
+
+    expect(result).toBe("Forwarded feedback");
+  });
+
+  it("keeps a top-level comment alongside a shorter shared Slack message", () => {
+    const result = resolveSlackInboundMrkdwn(
+      "This seems related to the navigation feedback we discussed yesterday.",
+      {
+        attachments: [
+          {
+            is_msg_unfurl: true,
+            message_blocks: [{ message: { text: "Agent runs are missing." } }],
+          },
+        ],
+      },
+    );
+
+    expect(result).toBe(
+      "This seems related to the navigation feedback we discussed yesterday.\nAgent runs are missing.",
+    );
+  });
+
   it("keeps top-level text when rich_text blocks mirror it", () => {
     const result = resolveSlackInboundMrkdwn("Status update", {
       blocks: [

--- a/packages/eve/src/public/channels/slack/inbound-content.ts
+++ b/packages/eve/src/public/channels/slack/inbound-content.ts
@@ -28,7 +28,8 @@ function resolveSlackInboundMrkdwnUnsafe(text: string, raw: Record<string, unkno
     return extracted;
   }
 
-  if (hasSlackMessageUnfurl(raw.attachments)) {
+  if (hasSharedMessageAttachment(raw.attachments)) {
+    if (normalizedTrimmed.includes(normalizedExtracted)) return text;
     return `${text}\n${extracted}`;
   }
 
@@ -160,12 +161,15 @@ function extractLegacyAttachmentLines(legacyAttachments: unknown): string[] {
   return lines;
 }
 
-function hasSlackMessageUnfurl(legacyAttachments: unknown): boolean {
-  return (
-    Array.isArray(legacyAttachments) &&
-    legacyAttachments.some(
-      (attachment) => isObject(attachment) && Array.isArray(attachment.message_blocks),
-    )
+function hasSharedMessageAttachment(legacyAttachments: unknown): boolean {
+  if (!Array.isArray(legacyAttachments)) return false;
+  return legacyAttachments.some(
+    (attachment) =>
+      isObject(attachment) &&
+      (Array.isArray(attachment.message_blocks) ||
+        attachment.is_share === true ||
+        attachment.is_msg_unfurl === true ||
+        attachment.is_reply_unfurl === true),
   );
 }
 

--- a/packages/eve/src/public/channels/slack/inbound-content.ts
+++ b/packages/eve/src/public/channels/slack/inbound-content.ts
@@ -28,6 +28,10 @@ function resolveSlackInboundMrkdwnUnsafe(text: string, raw: Record<string, unkno
     return extracted;
   }
 
+  if (hasSlackMessageUnfurl(raw.attachments)) {
+    return `${text}\n${extracted}`;
+  }
+
   if (extracted.length >= trimmedText.length * 2) {
     const hasLegacyAttachments = Array.isArray(raw.attachments) && raw.attachments.length > 0;
     if (hasLegacyAttachments && !normalizedExtracted.includes(normalizedTrimmed)) {
@@ -140,6 +144,7 @@ function extractLegacyAttachmentLines(legacyAttachments: unknown): string[] {
       lines.push(attachment.footer);
     }
     lines.push(...extractBlockKitLines(attachment.blocks));
+    lines.push(...extractSlackMessageUnfurlLines(attachment.message_blocks));
     // Fallback is per-attachment and only when this attachment has no other
     // visible fields; nested blocks count, and earlier attachments must not
     // suppress a later fallback.
@@ -149,6 +154,36 @@ function extractLegacyAttachmentLines(legacyAttachments: unknown): string[] {
       attachment.fallback.length > 0
     ) {
       lines.push(attachment.fallback);
+    }
+  }
+
+  return lines;
+}
+
+function hasSlackMessageUnfurl(legacyAttachments: unknown): boolean {
+  return (
+    Array.isArray(legacyAttachments) &&
+    legacyAttachments.some(
+      (attachment) => isObject(attachment) && Array.isArray(attachment.message_blocks),
+    )
+  );
+}
+
+function extractSlackMessageUnfurlLines(messageBlocks: unknown): string[] {
+  if (!Array.isArray(messageBlocks)) return [];
+
+  const lines: string[] = [];
+  for (const messageBlock of messageBlocks) {
+    if (!isObject(messageBlock) || !isObject(messageBlock.message)) continue;
+
+    const blockLines = extractBlockKitLines(messageBlock.message.blocks);
+    if (blockLines.length > 0) {
+      lines.push(...blockLines);
+    } else if (
+      typeof messageBlock.message.text === "string" &&
+      messageBlock.message.text.length > 0
+    ) {
+      lines.push(messageBlock.message.text);
     }
   }
 

--- a/packages/eve/src/public/channels/slack/inbound.test.ts
+++ b/packages/eve/src/public/channels/slack/inbound.test.ts
@@ -434,6 +434,39 @@ describe("parseDirectMessageEvent", () => {
       },
     ]);
   });
+
+  it.each(["is_share", "is_msg_unfurl", "is_reply_unfurl"])(
+    "includes an app mention's %s attachment",
+    (sharedMessageFlag) => {
+      const payload = parseSlackWebhookBody(
+        JSON.stringify({
+          type: "event_callback",
+          team_id: "T01",
+          event: {
+            type: "app_mention",
+            user: "U01",
+            text: "<@U123> :eyes:",
+            channel: "C01",
+            ts: "1700000000.000200",
+            attachments: [
+              {
+                [sharedMessageFlag]: true,
+                text: "Ship it",
+                from_url: "https://example.slack.com/archives/C02/p1700000000000100",
+              },
+            ],
+          },
+        }),
+      );
+      expect(payload.kind).toBe("app_mention");
+      if (payload.kind !== "app_mention") throw new Error("expected app_mention");
+
+      const message = slackMessageFromWebhookPayload(payload);
+
+      expect(message?.text).toBe("<@U123> :eyes:\nShip it");
+      expect(message?.markdown).toContain("Ship it");
+    },
+  );
 });
 
 describe("Block Kit inbound markdown", () => {


### PR DESCRIPTION
### Summary

Slack shared-message crossposts can nest the original body under `message_blocks[].message` or mark attachment content with `is_share`, `is_msg_unfurl`, or `is_reply_unfurl`; eve's existing length heuristic could consequently omit a short shared message when it accompanied a longer comment. This extends structured Slack-content extraction to flatten forwarded Block Kit or text content, treats the three shared-message flags as evidence that extracted content is model-relevant, and preserves distinct top-level comments without repeating content they already contain. Ordinary messages and other legacy attachments keep their existing selection behavior.

### Validation

Regression coverage passes for nested Block Kit crossposts, text fallback, all three Slack shared-message flags through webhook parsing, longer sender comments, and containment-based deduplication. The focused Slack suite passed 78 tests. An isolated `test-agent` build using the local package accepted signed Slack webhooks for both nested message content and flagged attachment text.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+7 / -0`

Documents model-visible crosspost behavior and includes the required patch changeset.

**Implementation** — 1 file · `+39 / -0`

Keeps message-unfurl traversal and shared-attachment selection inside the existing Slack structured-content normalizer.

**Tests** — 2 files · `+129 / -0`

Uses realistic nested message-unfurl fixtures and webhook payloads to cover Block Kit extraction, text fallback, comment preservation, all supported share flags, and deduplication.
