### PR TITLE
fix(eve): update Linq chat adapter

### DIFF
--- a/.changeset/curly-dingos-style.md
+++ b/.changeset/curly-dingos-style.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Update the Linq channel adapter to preserve supported text decorations, including bold, italic, strikethrough, and underline, in outbound messages.

--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -401,7 +401,7 @@
     "@chat-adapter/twilio": "4.34.0",
     "@clack/core": "1.3.1",
     "@eve/catalog": "workspace:*",
-    "@linqapp/chat-sdk-adapter": "^0.3.0",
+    "@linqapp/chat-sdk-adapter": "^0.5.1",
     "@modelcontextprotocol/server": "2.0.0",
     "@nuxt/kit": "^4.0.0",
     "@opentelemetry/context-async-hooks": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1273,8 +1273,8 @@ importers:
         specifier: workspace:*
         version: link:../eve-catalog
       '@linqapp/chat-sdk-adapter':
-        specifier: ^0.3.0
-        version: 0.3.0(chat@4.34.0(ai@7.0.58(zod@4.4.3))(supports-color@10.2.2)(zod@4.4.3))
+        specifier: ^0.5.1
+        version: 0.5.1(chat@4.34.0(ai@7.0.58(zod@4.4.3))(supports-color@10.2.2)(zod@4.4.3))
       '@modelcontextprotocol/server':
         specifier: 2.0.0
         version: 2.0.0
@@ -3446,13 +3446,13 @@ packages:
   '@larksuiteoapi/node-sdk@1.63.1':
     resolution: {integrity: sha512-bVC2QVkITZ1i6kLP7hI7DXtp61ic9shP/F+bp/2qZ0ISSvrcHp2euu1xt6C29jPJVNieRgvdsBPuapOlybviVw==}
 
-  '@linqapp/chat-sdk-adapter@0.3.0':
-    resolution: {integrity: sha512-mOh3y3G+xL6y8yztmB58CC6juxu3JAThSdLzV07+4Cjy+zHk9auDjSlbs+QyxSQC1ZW0Hu2Y60I5Y5J04Dr/BA==}
+  '@linqapp/chat-sdk-adapter@0.5.1':
+    resolution: {integrity: sha512-3NE5yLb/ihPFd/gsUbT1SNWGftManyfzIUKUARGQqH4p8N2BRaHidIXS6xJFosw54mUGS++cFS9CoR63qTXl6w==}
     peerDependencies:
       chat: ^4.28.1
 
-  '@linqapp/sdk@0.40.0':
-    resolution: {integrity: sha512-t5Kilu+MPQQucAXy9bG3jlLvDHnlR36banKC74TbpJ9ZOrPa8nHyUHPk9/Y4eAVzaM+TzlxV8dZrkit4kuhWWw==}
+  '@linqapp/sdk@0.47.0':
+    resolution: {integrity: sha512-ys89cpDrYUWtOF3smW2sHsHnA4tWjlHp9t9dzykvArI/xy5XTGkrRE0YmuJ928Fm+axCdoKwIWAfj1TTP1UeCA==}
 
   '@liveblocks/chat-sdk-adapter@3.23.0':
     resolution: {integrity: sha512-tQo6AElxPKkI7g5XuiFLHa+EcT48S3TxPXykGUMf4IdIDt7YqVPCcFPDaI9oyN3AMyrZcavoz7+lTZZZznGC4w==}
@@ -17766,13 +17766,13 @@ snapshots:
       - debug
       - utf-8-validate
 
-  '@linqapp/chat-sdk-adapter@0.3.0(chat@4.34.0(ai@7.0.58(zod@4.4.3))(supports-color@10.2.2)(zod@4.4.3))':
+  '@linqapp/chat-sdk-adapter@0.5.1(chat@4.34.0(ai@7.0.58(zod@4.4.3))(supports-color@10.2.2)(zod@4.4.3))':
     dependencies:
-      '@linqapp/sdk': 0.40.0
+      '@linqapp/sdk': 0.47.0
       chat: 4.34.0(ai@7.0.58(zod@4.4.3))(supports-color@10.2.2)(zod@4.4.3)
       standardwebhooks: 1.0.0
 
-  '@linqapp/sdk@0.40.0':
+  '@linqapp/sdk@0.47.0':
     dependencies:
       standardwebhooks: 1.0.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -64,6 +64,7 @@ minimumReleaseAge: 2880 # 2 days
 
 minimumReleaseAgeExclude:
   - "@linqapp/chat-sdk-adapter"
+  - "@linqapp/sdk"
   - "@vercel/*"
   - "@workflow/*"
   - nitro


### PR DESCRIPTION
### Summary

Closes #2579. Updating the Linq chat adapter to 0.5.1 preserves supported text decorations—bold, italic, strikethrough, and underline—when eve sends outbound Linq messages. The adapter's required Linq SDK is also allowed through the workspace's minimum-release-age policy so fresh installs accept the updated dependency graph.

### Validation

The focused Linq channel unit suite passes (3 tests), the updated vendored module builds successfully, and the eve package typechecks. A frozen-lockfile install also passes the repository's supply-chain checks.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

A patch changeset communicates the restored Linq styling behavior in release notes.

**Implementation** — 3 files · `+11 / -10`

Updates the adapter and transitive SDK lock entries, plus the install-policy exception needed for the newly released SDK.

**Tests** — 0 files · `+0 / -0`

The existing focused Linq channel tests cover the integration boundary; this change only updates the vendored adapter implementation.
