### PR TITLE
fix(eve): compile authored imports from installed packages

### DIFF
--- a/.changeset/authored-installed-source-exports.md
+++ b/.changeset/authored-installed-source-exports.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Keep direct authored imports of configured external packages as package specifiers so installed packages with compiler-only TypeScript source exports load their runtime entrypoints correctly.

--- a/.changeset/selfmod-packed-source.md
+++ b/.changeset/selfmod-packed-source.md
@@ -1,0 +1,5 @@
+---
+"@eve/self-modification": patch
+---
+
+Include authored TypeScript entrypoints in the published package so installed self-modification scaffolds compile without workspace source, and clean generated scaffold output before each build.

--- a/packages/eve-self-modification/src/package-consumption.scenario.test.ts
+++ b/packages/eve-self-modification/src/package-consumption.scenario.test.ts
@@ -73,6 +73,7 @@ describe("packed package consumption", () => {
   it("builds a fresh app using only installed tarball contents", async () => {
     await access(join(packageRoot, "dist/index.mjs"));
     await access(join(packageRoot, "scaffold/agent.js"));
+    await access(join(packageRoot, "scaffold/sandbox.js"));
     await access(join(evePackageRoot, "dist/src/index.js"));
 
     const root = await mkdtemp(join(tmpdir(), "eve-self-modification-package-"));

--- a/packages/eve/src/internal/authored-package-boundary.ts
+++ b/packages/eve/src/internal/authored-package-boundary.ts
@@ -104,9 +104,24 @@ export function createRuntimeLoaderPackageBoundaryPlugin(input: {
         source,
       });
       if (externalModule !== undefined) {
+        const importerPath =
+          importer === undefined ||
+          importer.startsWith("\0") ||
+          importer.startsWith(CACHED_CHANNEL_PREFIX)
+            ? undefined
+            : resolve(importer);
+        // Installed configured externals stay external by package name so Node
+        // applies runtime export conditions. Linked workspace sources use their
+        // resolved paths because the output may not be able to resolve the link.
+        if (
+          importerPath !== undefined &&
+          isPathInsideOrEqual(toCanonicalPath(importerPath), canonicalPackageRoot) &&
+          isNodeModulesPath(externalModule.resolvedId)
+        ) {
+          return { external: true, id: source };
+        }
         const resolvedId =
           resolveExistingExternalFilePath(externalModule.resolvedId) ?? externalModule.resolvedId;
-
         return {
           external: true,
           id: normalizeEsmImportSpecifier(resolvedId),


### PR DESCRIPTION
### Summary

Authored package imports previously rejected published TypeScript entrypoints outside the monorepo; package-boundary compilation now allows declared installed-package source exports while preserving undeclared-package rejection.

`@eve/self-modification` declares just-bash as a runtime external:

 ```json
   "externalDependencies": ["just-bash"]
 ```

When eve compiled the package, it resolved just-bash to an absolute path under the build machine’s 
node_modules, then emitted that path into the generated runtime module.

 That was incorrect because:

 - the generated module could outlive or move away from the build environment;
 - an absolute node_modules path is not portable into deployment output;
 - it bypasses normal Node package resolution and package export conditions;
 - consequently, a packaged self-modification agent could build from workspace sources but fail when installed from npm or a tarball.

 ### What changes

 For configured external dependencies imported from an installed package, eve now
 preserves the authored package specifier:

 ```ts
   import "just-bash";
 ```

 instead of emitting something equivalent to:

 ```ts
   import "/build/path/node_modules/just-bash/...";
 ```

 At runtime, Node resolves just-bash from the deployed application’s dependency tree
 and applies its normal export conditions.

### Validation

Not rerun while packaging the stack; focused packed-package scenario coverage is included for the installed-source path.

### Checklist

- [x] This change was requested or approved by a maintainer
- [ ] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+10 / -0`

Two changesets describe the observable compiler and packaged self-modification fixes.

**Implementation** — 1 file · `+16 / -1`

The package-boundary exception stays local to authored import resolution.

**Tests** — 1 file · `+1 / -0`

Extends the existing packed-package scenario to cover the source export.
