### PR TITLE
feat(self-modification): prepare isolated proposal workspaces

### DIFF
--- a/.changeset/selfmod-git-workspace.md
+++ b/.changeset/selfmod-git-workspace.md
@@ -1,0 +1,8 @@
+---
+"@eve/self-modification": patch
+"eve": patch
+---
+
+Prepare isolated deployed repository workspaces with transient, brokered GitHub authentication and capture proposed source changes as validated immutable Git trees. Reject proposals with policy-excluded changes so every accepted proposal is complete and publishable.
+
+Expose shared Git credential-brokering, command, and identifier primitives for eve-owned integrations.

--- a/packages/eve-self-modification/src/git-workspace.test.ts
+++ b/packages/eve-self-modification/src/git-workspace.test.ts
@@ -1,0 +1,265 @@
+import { createHash } from "node:crypto";
+
+import type { SandboxNetworkPolicy } from "eve/sandbox";
+import { describe, expect, it } from "vitest";
+
+import {
+  captureSelfModificationProposal,
+  parseRawDiff,
+  prepareSelfModificationWorkspace,
+  readProposalBlob,
+  type PreparedSelfModificationWorkspace,
+  type ProposalChange,
+  type SelfModificationCheckoutSandbox,
+} from "./git-workspace.js";
+
+const DEPLOYED_SHA = "1".repeat(40);
+const BASE_SHA = "2".repeat(40);
+const TREE_SHA = "3".repeat(40);
+const BASE_TREE_SHA = "4".repeat(40);
+const BLOB_SHA = "6".repeat(40);
+const workspace: PreparedSelfModificationWorkspace = {
+  baseSha: BASE_SHA,
+  deployedPath: "/workspace/self-modification/deployed",
+  deployedSha: DEPLOYED_SHA,
+  repositoryPath: "/workspace/self-modification/repository",
+  rootDirectory: ".",
+};
+
+function createSandbox(
+  respond: (command: string) => {
+    exitCode?: number;
+    stderr?: string;
+    stdout?: string;
+  } = () => ({}),
+) {
+  const commands: string[] = [];
+  const policies: Array<SandboxNetworkPolicy | "allow-all" | "deny-all"> = [];
+  const sandbox: SelfModificationCheckoutSandbox = {
+    async run({ command }: { command: string }) {
+      commands.push(command);
+      return { exitCode: 0, stderr: "", stdout: "", ...respond(command) };
+    },
+    async setNetworkPolicy(policy: SandboxNetworkPolicy | "allow-all" | "deny-all") {
+      policies.push(policy);
+    },
+  };
+  return { commands, policies, sandbox };
+}
+
+describe("prepareSelfModificationWorkspace", () => {
+  it("fetches through brokered credentials and leaves the sandbox offline", async () => {
+    const token = "secret-read-token";
+    const { commands, policies, sandbox } = createSandbox((command) =>
+      command.includes("rev-parse refs/eve-self-modification/base")
+        ? { stdout: `${BASE_SHA}\n` }
+        : command.includes("rev-parse refs/eve-self-modification/deployed")
+          ? { stdout: `${DEPLOYED_SHA}\n` }
+          : {},
+    );
+
+    await expect(
+      prepareSelfModificationWorkspace({
+        deployedSha: DEPLOYED_SHA,
+        token: token,
+        repository: { owner: "acme", pullRequestBase: "main", repo: "agent" },
+        rootDirectory: ".",
+        sandbox,
+      }),
+    ).resolves.toEqual(workspace);
+
+    expect(commands.join("\n")).not.toContain(token);
+    expect(commands.join("\n")).toContain("https://github.com/acme/agent.git");
+    expect(commands.join("\n")).toContain(`fetch --no-tags --depth=50 origin '${DEPLOYED_SHA}'`);
+    expect(commands.join("\n")).toContain("refs/heads/main");
+    expect(policies).toHaveLength(2);
+    expect(policies[1]).toBe("deny-all");
+  });
+
+  it("removes brokered credentials when checkout fails", async () => {
+    const { policies, sandbox } = createSandbox((command) =>
+      command.includes(" fetch ") ? { exitCode: 1, stderr: "fetch failed" } : {},
+    );
+    await expect(
+      prepareSelfModificationWorkspace({
+        deployedSha: DEPLOYED_SHA,
+        token: "token",
+        repository: { owner: "acme", pullRequestBase: "main", repo: "agent" },
+        rootDirectory: ".",
+        sandbox,
+      }),
+    ).rejects.toThrow(/fetch failed/u);
+    expect(policies.at(-1)).toBe("deny-all");
+  });
+
+  it("rejects unsafe branch names before opening the sandbox network", async () => {
+    const { policies, sandbox } = createSandbox();
+    await expect(
+      prepareSelfModificationWorkspace({
+        deployedSha: DEPLOYED_SHA,
+        token: "token",
+        repository: { owner: "acme", pullRequestBase: "main; curl bad", repo: "agent" },
+        rootDirectory: ".",
+        sandbox,
+      }),
+    ).rejects.toThrow(/valid Git ref/u);
+    expect(policies).toEqual([]);
+  });
+});
+
+describe("captureSelfModificationProposal", () => {
+  it("captures an immutable tree and returns a Git-object manifest", async () => {
+    const raw = [
+      `:100644 100644 ${"7".repeat(40)} ${BLOB_SHA} M`,
+      "agent/instructions.md",
+      `:100644 000000 ${"8".repeat(40)} ${"0".repeat(40)} D`,
+      "agent/old.md",
+      "",
+    ].join("\0");
+    const { commands, sandbox } = createSandbox((command) => {
+      if (command.endsWith("write-tree")) return { stdout: TREE_SHA };
+      if (command.includes("^{tree}")) return { stdout: BASE_TREE_SHA };
+      if (command.includes("diff-tree")) return { stdout: raw };
+      if (command.includes("cat-file -s")) return { stdout: "42" };
+      return {};
+    });
+
+    await expect(captureSelfModificationProposal({ sandbox, workspace })).resolves.toEqual({
+      baseSha: BASE_SHA,
+      baseTreeSha: BASE_TREE_SHA,
+      changedBytes: 42,
+      changes: [
+        {
+          bytes: 42,
+          kind: "modify",
+          mode: "100644",
+          objectId: BLOB_SHA,
+          path: "agent/instructions.md",
+        },
+        { bytes: 0, kind: "delete", mode: null, objectId: null, path: "agent/old.md" },
+      ],
+      proposedTreeSha: TREE_SHA,
+    });
+    expect(commands.join("\n")).toContain(`read-tree '${BASE_SHA}'`);
+    expect(commands.join("\n")).toContain("add -A -- .");
+    expect(commands.join("\n")).not.toContain("commit-tree");
+    expect(commands.join("\n")).toContain("diff-tree -r --no-commit-id --raw -z --no-renames");
+  });
+
+  it("rejects unsupported file modes", async () => {
+    const raw = [`:100644 120000 ${"7".repeat(40)} ${BLOB_SHA} T`, "agent/link", ""].join("\0");
+    const { sandbox } = createSandbox((command) => {
+      if (command.endsWith("write-tree")) return { stdout: TREE_SHA };
+      if (command.includes("^{tree}")) return { stdout: BASE_TREE_SHA };
+      if (command.includes("diff-tree")) return { stdout: raw };
+      return {};
+    });
+
+    await expect(captureSelfModificationProposal({ sandbox, workspace })).rejects.toThrow(
+      /unsupported Git mode 120000/u,
+    );
+  });
+
+  it.each([
+    ["outside the fixed agent source scope", "package.json"],
+    [
+      "the protected self-modification configuration",
+      "agent/subagents/self-modification/config.ts",
+    ],
+  ])("rejects changes %s", async (_description, path) => {
+    const raw = [
+      `:100644 100644 ${"7".repeat(40)} ${BLOB_SHA} M`,
+      "agent/instructions.md",
+      `:100644 100644 ${"8".repeat(40)} ${BLOB_SHA} M`,
+      path,
+      "",
+    ].join("\0");
+    const { sandbox } = createSandbox((command) => {
+      if (command.endsWith("write-tree")) return { stdout: TREE_SHA };
+      if (command.includes("^{tree}")) return { stdout: BASE_TREE_SHA };
+      if (command.includes("diff-tree")) return { stdout: raw };
+      return {};
+    });
+
+    await expect(captureSelfModificationProposal({ sandbox, workspace })).rejects.toThrow(
+      new RegExp(`policy-excluded changes: .*${path.replaceAll("/", "\\/")}`, "u"),
+    );
+  });
+
+  it("uses the deployment root to scope changes", async () => {
+    const raw = [
+      `:100644 100644 ${"7".repeat(40)} ${BLOB_SHA} M`,
+      "apps/weather/agent/agent.ts",
+      "",
+    ].join("\0");
+    const { sandbox } = createSandbox((command) => {
+      if (command.endsWith("write-tree")) return { stdout: TREE_SHA };
+      if (command.includes("^{tree}")) return { stdout: BASE_TREE_SHA };
+      if (command.includes("diff-tree")) return { stdout: raw };
+      if (command.includes("cat-file -s")) return { stdout: "42" };
+      return {};
+    });
+
+    await expect(
+      captureSelfModificationProposal({
+        sandbox,
+        workspace: { ...workspace, rootDirectory: "apps/weather" },
+      }),
+    ).resolves.toMatchObject({ changes: [{ path: "apps/weather/agent/agent.ts" }] });
+  });
+});
+
+describe("parseRawDiff", () => {
+  it("rejects malformed and rename output", () => {
+    expect(() => parseRawDiff(":bad\0agent/a.ts\0")).toThrow(/malformed/u);
+    expect(() =>
+      parseRawDiff(
+        `:100644 100644 ${"1".repeat(40)} ${"2".repeat(40)} R100\0agent/a.ts\0agent/b.ts\0`,
+      ),
+    ).toThrow(/malformed/u);
+  });
+});
+
+describe("readProposalBlob", () => {
+  const content = "hello";
+  const objectId = createHash("sha1")
+    .update(`blob ${Buffer.byteLength(content)}\0`)
+    .update(content)
+    .digest("hex");
+  const change: ProposalChange = {
+    bytes: Buffer.byteLength(content),
+    kind: "modify",
+    mode: "100644",
+    objectId,
+    path: "agent/instructions.md",
+  };
+
+  it("returns base64 content that hashes back to the captured object id", async () => {
+    const { commands, sandbox } = createSandbox(() => ({
+      stdout: Buffer.from(content).toString("base64"),
+    }));
+
+    await expect(readProposalBlob({ change, sandbox, workspace })).resolves.toBe(
+      Buffer.from(content).toString("base64"),
+    );
+    expect(commands.join("\n")).toContain(`cat-file blob '${objectId}'`);
+  });
+
+  it("rejects content the sandbox substituted for the captured object", async () => {
+    const { sandbox } = createSandbox(() => ({
+      stdout: Buffer.from("hellp").toString("base64"),
+    }));
+
+    await expect(readProposalBlob({ change, sandbox, workspace })).rejects.toThrow(
+      /changed after validation/u,
+    );
+  });
+
+  it("rejects truncated sandbox output", async () => {
+    const { sandbox } = createSandbox(() => ({ stdout: Buffer.from("hel").toString("base64") }));
+
+    await expect(readProposalBlob({ change, sandbox, workspace })).rejects.toThrow(
+      /changed after validation/u,
+    );
+  });
+});

--- a/packages/eve-self-modification/src/git-workspace.ts
+++ b/packages/eve-self-modification/src/git-workspace.ts
@@ -1,0 +1,397 @@
+import { createHash } from "node:crypto";
+
+import type { SandboxNetworkPolicy, SandboxSession } from "eve/sandbox";
+
+import {
+  buildBrokerNetworkPolicy,
+  gitOutput,
+  runGitCommand,
+  shellQuote,
+  withBrokeredGitEgress,
+} from "./git.js";
+import { assertFullSha, assertGitRef, assertRepositoryPart } from "./identifiers.js";
+export const SELF_MODIFICATION_CONFIG_PATH = "agent/subagents/self-modification/config.ts";
+
+export const CHECKOUT_ROOT = "/workspace/self-modification";
+export const REPOSITORY_PATH = `${CHECKOUT_ROOT}/repository`;
+export const DEPLOYED_PATH = `${CHECKOUT_ROOT}/deployed`;
+export const BASE_REF = "refs/eve-self-modification/base";
+export const DEPLOYED_REF = "refs/eve-self-modification/deployed";
+const INITIAL_FETCH_DEPTH = 50;
+const MAX_FETCH_DEPTH = 1_000;
+const MAX_CHANGED_BYTES = 1_000_000;
+const MAX_CHANGED_FILES = 100;
+
+export type SelfModificationCommandSandbox = Pick<SandboxSession, "run">;
+export type SelfModificationCheckoutSandbox = Pick<SandboxSession, "run" | "setNetworkPolicy">;
+export type SelfModificationPersonalAccessTokenResolver = () => Promise<string> | string;
+export interface SelfModificationRepository {
+  readonly owner: string;
+  readonly pullRequestBase: string;
+  readonly repo: string;
+}
+export interface PreparedSelfModificationWorkspace {
+  readonly baseSha: string;
+  readonly deployedPath: string;
+  readonly deployedSha: string;
+  readonly repositoryPath: string;
+  readonly rootDirectory: string;
+}
+export interface ProposalChange {
+  readonly bytes: number;
+  readonly kind: "add" | "delete" | "modify";
+  readonly mode: "100644" | "100755" | null;
+  readonly objectId: string | null;
+  readonly path: string;
+}
+export interface SelfModificationProposal {
+  readonly baseSha: string;
+  readonly baseTreeSha: string;
+  readonly changedBytes: number;
+  readonly changes: readonly ProposalChange[];
+  readonly proposedTreeSha: string;
+}
+
+/** Called once from the sandbox definition's once-per-live-session `onSession` hook. */
+export async function prepareSelfModificationWorkspace(input: {
+  readonly deployedSha: string;
+  readonly token: string;
+  readonly rootDirectory: string;
+  readonly repository: SelfModificationRepository;
+  readonly sandbox: SelfModificationCheckoutSandbox;
+}): Promise<PreparedSelfModificationWorkspace> {
+  assertFullSha(input.deployedSha, "deployed revision");
+  assertRepositoryPart(input.repository.owner, "repository owner");
+  assertRepositoryPart(input.repository.repo, "repository name");
+  assertGitRef(input.repository.pullRequestBase);
+  assertRootDirectory(input.rootDirectory);
+  if (input.token.length === 0)
+    throw new Error("Self-modification checkout requires a GitHub personal access token.");
+  const remote = `https://github.com/${input.repository.owner}/${input.repository.repo}.git`;
+  await withBrokeredGitEgress(
+    input.sandbox,
+    { policy: checkoutNetworkPolicy(input.token), restore: "deny-all" },
+    async () => {
+      await run(
+        input.sandbox,
+        `rm -rf ${quote(CHECKOUT_ROOT)} && mkdir -p ${quote(REPOSITORY_PATH)}`,
+      );
+      await run(input.sandbox, `git -C ${quote(REPOSITORY_PATH)} init`);
+      await run(
+        input.sandbox,
+        `git -C ${quote(REPOSITORY_PATH)} remote add origin ${quote(remote)}`,
+      );
+      await run(
+        input.sandbox,
+        `GIT_LFS_SKIP_SMUDGE=1 GIT_TERMINAL_PROMPT=0 git -C ${quote(REPOSITORY_PATH)} fetch --no-tags --depth=${INITIAL_FETCH_DEPTH} origin ${quote(input.deployedSha)}`,
+      );
+      await run(
+        input.sandbox,
+        `git -C ${quote(REPOSITORY_PATH)} update-ref ${DEPLOYED_REF} FETCH_HEAD`,
+      );
+      await run(
+        input.sandbox,
+        `GIT_LFS_SKIP_SMUDGE=1 GIT_TERMINAL_PROMPT=0 git -C ${quote(REPOSITORY_PATH)} fetch --no-tags --depth=${INITIAL_FETCH_DEPTH} origin ${quote(`refs/heads/${input.repository.pullRequestBase}`)}`,
+      );
+      await run(
+        input.sandbox,
+        `git -C ${quote(REPOSITORY_PATH)} update-ref ${BASE_REF} FETCH_HEAD`,
+      );
+      await deepenUntilRelated(input.sandbox, {
+        base: input.repository.pullRequestBase,
+        deployedSha: input.deployedSha,
+      });
+    },
+  );
+  const workspace = await readPreparedWorkspace(
+    input.sandbox,
+    input.deployedSha,
+    input.rootDirectory,
+  );
+  await run(input.sandbox, `git -C ${quote(REPOSITORY_PATH)} checkout --detach ${BASE_REF}`);
+  await run(
+    input.sandbox,
+    `git -C ${quote(REPOSITORY_PATH)} worktree add --detach ${quote(DEPLOYED_PATH)} ${DEPLOYED_REF}`,
+  );
+  return workspace;
+}
+
+export async function readPreparedWorkspace(
+  sandbox: SelfModificationCommandSandbox,
+  deployedSha: string,
+  rootDirectory: string,
+): Promise<PreparedSelfModificationWorkspace> {
+  assertFullSha(deployedSha, "deployed revision");
+  assertRootDirectory(rootDirectory);
+  const baseSha = await output(sandbox, `git -C ${quote(REPOSITORY_PATH)} rev-parse ${BASE_REF}`);
+  assertFullSha(baseSha, "pull request base revision");
+  const deployed = await output(
+    sandbox,
+    `git -C ${quote(REPOSITORY_PATH)} rev-parse ${DEPLOYED_REF}`,
+  );
+  assertFullSha(deployed, "workspace deployed revision");
+  if (deployed !== deployedSha.toLowerCase())
+    throw new Error(
+      "Self-modification deployment source changed after the workspace was prepared.",
+    );
+  await run(
+    sandbox,
+    `git -C ${quote(REPOSITORY_PATH)} cat-file -e ${quote(`${deployed}^{commit}`)}`,
+  );
+  return {
+    baseSha,
+    deployedPath: DEPLOYED_PATH,
+    deployedSha: deployed,
+    repositoryPath: REPOSITORY_PATH,
+    rootDirectory,
+  };
+}
+
+export async function captureSelfModificationProposal(input: {
+  readonly sandbox: SelfModificationCommandSandbox;
+  readonly workspace: PreparedSelfModificationWorkspace;
+}): Promise<SelfModificationProposal> {
+  const { sandbox, workspace } = input;
+  assertFullSha(workspace.baseSha, "proposal base revision");
+  assertRootDirectory(workspace.rootDirectory);
+  await run(
+    sandbox,
+    `git -C ${quote(workspace.repositoryPath)} read-tree ${quote(workspace.baseSha)}`,
+  );
+  await run(sandbox, `git -C ${quote(workspace.repositoryPath)} add -A -- .`);
+  const proposedTreeSha = await output(
+    sandbox,
+    `git -C ${quote(workspace.repositoryPath)} write-tree`,
+  );
+  const baseTreeSha = await output(
+    sandbox,
+    `git -C ${quote(workspace.repositoryPath)} rev-parse ${quote(`${workspace.baseSha}^{tree}`)}`,
+  );
+  const raw = await output(
+    sandbox,
+    `git -C ${quote(workspace.repositoryPath)} diff-tree -r --no-commit-id --raw -z --no-renames ${quote(workspace.baseSha)} ${quote(proposedTreeSha)}`,
+    false,
+  );
+  const records = parseRawDiff(raw);
+  for (const record of records)
+    if (!isSafeProposalPath(record.path))
+      throw new Error(`Self-modification proposal may not change ${JSON.stringify(record.path)}.`);
+  const excludedPaths = records
+    .filter((record) => !isAllowedProposalPath(record.path, workspace.rootDirectory))
+    .map((record) => record.path);
+  if (excludedPaths.length > 0)
+    throw new Error(
+      `Self-modification proposal contains policy-excluded changes: ${summarizePaths(excludedPaths)}. Revert them before publishing.`,
+    );
+  if (records.length === 0) throw new Error("Self-modification proposal contains no changes.");
+  if (records.length > MAX_CHANGED_FILES)
+    throw new Error(
+      `Self-modification proposal changes ${records.length} files; limit is ${MAX_CHANGED_FILES}.`,
+    );
+  const check = await sandbox.run({
+    command: `git -C ${quote(workspace.repositoryPath)} diff --check ${quote(workspace.baseSha)} ${quote(proposedTreeSha)} --`,
+  });
+  const conflicts = String(check.stdout ?? "")
+    .split("\n")
+    .filter((line) => line.includes("leftover conflict marker"));
+  if (conflicts.length > 0)
+    throw new Error(
+      `Self-modification proposal contains conflict markers: ${conflicts.join("\n")}`,
+    );
+  const changes: ProposalChange[] = [];
+  let changedBytes = 0;
+  for (const record of records) {
+    const mode = normalizeMode(record.status === "D" ? null : record.newMode, record.path);
+    const objectId = record.status === "D" ? null : record.newObjectId;
+    const size =
+      objectId === null
+        ? "0"
+        : await output(
+            sandbox,
+            `git -C ${quote(workspace.repositoryPath)} cat-file -s ${quote(objectId)}`,
+          );
+    if (!/^\d+$/u.test(size))
+      throw new Error(`Git returned an invalid blob size for ${JSON.stringify(record.path)}.`);
+    const bytes = Number(size);
+    if (!Number.isSafeInteger(bytes))
+      throw new Error(`Git returned an invalid blob size for ${JSON.stringify(record.path)}.`);
+    changedBytes += bytes;
+    if (changedBytes > MAX_CHANGED_BYTES)
+      throw new Error(`Self-modification proposal changes more than ${MAX_CHANGED_BYTES} bytes.`);
+    changes.push({
+      bytes,
+      kind: record.status === "A" ? "add" : record.status === "D" ? "delete" : "modify",
+      mode,
+      objectId,
+      path: record.path,
+    });
+  }
+  return {
+    baseSha: workspace.baseSha,
+    baseTreeSha,
+    changedBytes,
+    changes,
+    proposedTreeSha,
+  };
+}
+
+/**
+ * Reads one captured proposal blob out of the sandbox as base64.
+ *
+ * The sandbox runs model-controlled commands, so the bytes are re-hashed as a Git
+ * blob and compared against the object id recorded during capture. That catches
+ * truncated sandbox output and any substitution between capture and publication.
+ */
+export async function readProposalBlob(input: {
+  readonly change: ProposalChange;
+  readonly sandbox: SelfModificationCommandSandbox;
+  readonly workspace: PreparedSelfModificationWorkspace;
+}): Promise<string> {
+  const { change } = input;
+  if (change.objectId === null)
+    throw new Error(
+      `Self-modification cannot read a deleted blob for ${JSON.stringify(change.path)}.`,
+    );
+  assertFullSha(change.objectId, "proposal blob object id");
+  const base64 = await output(
+    input.sandbox,
+    `git -C ${quote(input.workspace.repositoryPath)} cat-file blob ${quote(change.objectId)} | base64 | tr -d '\\n'`,
+  );
+  const bytes = Buffer.from(base64, "base64");
+  const objectId = createHash("sha1")
+    .update(`blob ${bytes.byteLength}\0`)
+    .update(bytes)
+    .digest("hex");
+  if (bytes.byteLength !== change.bytes || objectId !== change.objectId.toLowerCase())
+    throw new Error(
+      `Self-modification proposal blob for ${JSON.stringify(change.path)} changed after validation.`,
+    );
+  return base64;
+}
+
+interface RawDiffRecord {
+  readonly newMode: string;
+  readonly newObjectId: string;
+  readonly path: string;
+  readonly status: "A" | "D" | "M" | "T";
+}
+export function parseRawDiff(raw: string): RawDiffRecord[] {
+  if (raw.length === 0) return [];
+  const fields = raw.split("\0");
+  if (fields.at(-1) === "") fields.pop();
+  if (fields.length % 2 !== 0) throw new Error("Git returned malformed raw diff output.");
+  return fields.reduce<RawDiffRecord[]>((records, metadata, index) => {
+    if (index % 2 !== 0) return records;
+    const path = fields[index + 1]!;
+    const matched = /^:[0-7]{6} ([0-7]{6}) [a-f0-9]{40} ([a-f0-9]{40}) ([ADMT])$/u.exec(metadata);
+    if (matched === null || path.length === 0 || path.includes("\n") || path.includes("\r"))
+      throw new Error("Git returned malformed raw diff output.");
+    records.push({
+      newMode: matched[1]!,
+      newObjectId: matched[2]!,
+      path,
+      status: matched[3]! as RawDiffRecord["status"],
+    });
+    return records;
+  }, []);
+}
+async function deepenUntilRelated(
+  sandbox: SelfModificationCommandSandbox,
+  refs: { readonly base: string; readonly deployedSha: string },
+): Promise<void> {
+  let depth = INITIAL_FETCH_DEPTH;
+  while (!(await commandSucceeds(sandbox, ancestryCommand()))) {
+    const shallow = await output(
+      sandbox,
+      `git -C ${quote(REPOSITORY_PATH)} rev-parse --is-shallow-repository`,
+    );
+    if (shallow !== "true")
+      throw new Error(
+        "The deployed revision is not an ancestor of the configured pull request base.",
+      );
+    if (depth >= MAX_FETCH_DEPTH)
+      throw new Error(
+        `Could not prove the deployed revision is an ancestor of the pull request base within ${MAX_FETCH_DEPTH} commits.`,
+      );
+    const deepenBy = Math.min(depth, MAX_FETCH_DEPTH - depth);
+    await run(
+      sandbox,
+      `GIT_LFS_SKIP_SMUDGE=1 GIT_TERMINAL_PROMPT=0 git -C ${quote(REPOSITORY_PATH)} fetch --no-tags --deepen=${deepenBy} origin ${quote(refs.deployedSha)} ${quote(`refs/heads/${refs.base}`)}`,
+    );
+    depth += deepenBy;
+  }
+}
+function ancestryCommand(): string {
+  return `git -C ${quote(REPOSITORY_PATH)} merge-base --is-ancestor ${DEPLOYED_REF} ${BASE_REF}`;
+}
+function checkoutNetworkPolicy(token: string): SandboxNetworkPolicy {
+  return buildBrokerNetworkPolicy(token, ["github.com", "codeload.github.com"]);
+}
+function isAllowedProposalPath(path: string, rootDirectory: string): boolean {
+  const agentRoot = rootDirectory === "." ? "agent/" : `${rootDirectory}/agent/`;
+  return path.startsWith(agentRoot) && !isHardExcludedPath(path, rootDirectory);
+}
+function summarizePaths(paths: readonly string[]): string {
+  const visible = paths.slice(0, 5).map((path) => JSON.stringify(path));
+  const remaining = paths.length - visible.length;
+  return remaining === 0 ? visible.join(", ") : `${visible.join(", ")} and ${remaining} more`;
+}
+function isSafeProposalPath(path: string): boolean {
+  return (
+    path.length > 0 &&
+    !path.startsWith("/") &&
+    !path.includes("\\") &&
+    !path.split("/").some((segment) => segment === "" || segment === "." || segment === "..")
+  );
+}
+function isHardExcludedPath(path: string, rootDirectory: string): boolean {
+  const basename = path.split("/").at(-1) ?? "";
+  const configPath =
+    rootDirectory === "."
+      ? SELF_MODIFICATION_CONFIG_PATH
+      : `${rootDirectory}/${SELF_MODIFICATION_CONFIG_PATH}`;
+  return (
+    path === configPath ||
+    path.startsWith(`${configPath}/`) ||
+    path.split("/").some((segment) => [".next", "dist", "node_modules"].includes(segment)) ||
+    basename === ".env" ||
+    basename.startsWith(".env.")
+  );
+}
+function assertRootDirectory(rootDirectory: string): void {
+  if (
+    rootDirectory !== "." &&
+    (rootDirectory.length === 0 ||
+      rootDirectory.startsWith("/") ||
+      rootDirectory.includes("\\") ||
+      rootDirectory
+        .split("/")
+        .some((segment) => segment === "" || segment === "." || segment === ".."))
+  )
+    throw new Error("Self-modification root directory is invalid.");
+}
+function normalizeMode(mode: string | null, path: string): "100644" | "100755" | null {
+  if (mode === null || mode === "100644" || mode === "100755") return mode;
+  throw new Error(
+    `Self-modification proposal uses unsupported Git mode ${mode} for ${JSON.stringify(path)}.`,
+  );
+}
+async function commandSucceeds(
+  sandbox: SelfModificationCommandSandbox,
+  command: string,
+): Promise<boolean> {
+  return (await sandbox.run({ command })).exitCode === 0;
+}
+async function output(
+  sandbox: SelfModificationCommandSandbox,
+  command: string,
+  trim = true,
+): Promise<string> {
+  return await gitOutput(sandbox, command, trim);
+}
+async function run(sandbox: SelfModificationCommandSandbox, command: string): Promise<void> {
+  await runGitCommand(sandbox, command);
+}
+function quote(value: string): string {
+  return shellQuote(value);
+}

--- a/packages/eve-self-modification/src/git.ts
+++ b/packages/eve-self-modification/src/git.ts
@@ -1,0 +1,117 @@
+import { Buffer } from "node:buffer";
+
+import type { SandboxNetworkPolicy, SandboxSession } from "eve/sandbox";
+
+const MAX_ERROR_OUTPUT = 2_000;
+type CommandSandbox = Pick<SandboxSession, "run">;
+
+export function buildBrokerNetworkPolicy(
+  token: string,
+  hosts: readonly string[],
+  allowOtherEgress = false,
+): SandboxNetworkPolicy {
+  const authorization = `Basic ${Buffer.from(`x-access-token:${token}`).toString("base64")}`;
+  const rule = [{ transform: [{ headers: { Authorization: authorization } }] }];
+  const allow: Record<string, typeof rule> = Object.fromEntries(hosts.map((host) => [host, rule]));
+  if (allowOtherEgress) allow["*"] = [];
+  return { allow };
+}
+
+export async function withBrokeredGitEgress<T>(
+  sandbox: Pick<SandboxSession, "setNetworkPolicy">,
+  input: { readonly policy: SandboxNetworkPolicy; readonly restore: SandboxNetworkPolicy },
+  operation: () => Promise<T>,
+): Promise<T> {
+  await sandbox.setNetworkPolicy(input.policy);
+  let operationError: unknown;
+  let value: T | undefined;
+  try {
+    value = await operation();
+  } catch (error) {
+    operationError = error;
+  }
+  try {
+    await sandbox.setNetworkPolicy(input.restore);
+  } catch (revertError) {
+    throw new Error(
+      "Could not revoke brokered GitHub credentials; the sandbox is unsafe for model use.",
+      {
+        cause:
+          operationError === undefined
+            ? revertError
+            : new AggregateError([operationError, revertError]),
+      },
+    );
+  }
+  if (operationError !== undefined) throw operationError;
+  return value as T;
+}
+
+export async function gitOutput(
+  sandbox: CommandSandbox,
+  command: string,
+  trim = true,
+): Promise<string> {
+  const result = await sandbox.run({ command });
+  if (result.exitCode !== 0) throw gitCommandError(command, result);
+  const stdout = String(result.stdout ?? "");
+  return trim ? stdout.trim() : stdout;
+}
+
+export async function runGitCommand(sandbox: CommandSandbox, command: string): Promise<void> {
+  const result = await sandbox.run({ command });
+  if (result.exitCode !== 0) throw gitCommandError(command, result);
+}
+
+function gitCommandError(
+  command: string,
+  result: { readonly exitCode: number; readonly stderr?: unknown; readonly stdout?: unknown },
+): Error {
+  const stderr = truncate(String(result.stderr ?? "").trim());
+  const stdout = truncate(String(result.stdout ?? "").trim());
+  return new Error(
+    [
+      `Git command failed with exit ${result.exitCode}: ${command}`,
+      stderr && `stderr: ${stderr}`,
+      stdout && `stdout: ${stdout}`,
+    ]
+      .filter(Boolean)
+      .join("; "),
+  );
+}
+
+export function assertFullGitSha(value: string, label: string): void {
+  if (!/^[a-f0-9]{40}$/u.test(value)) throw new Error(`${label} must be a lowercase full Git SHA.`);
+}
+
+export function assertRepositoryPart(value: string, label: string): void {
+  if (
+    !/^[A-Za-z0-9_.-]+$/u.test(value) ||
+    value === "." ||
+    value === ".." ||
+    value.startsWith("-")
+  ) {
+    throw new Error(`${label} is invalid.`);
+  }
+}
+
+export function assertGitRef(value: string, label = "Git ref"): void {
+  if (
+    !/^[A-Za-z0-9][A-Za-z0-9._/-]*$/u.test(value) ||
+    value.endsWith(".") ||
+    value.endsWith("/") ||
+    value.includes("..") ||
+    value.includes("//") ||
+    value.includes("@{") ||
+    value.split("/").some((part) => part.endsWith(".lock"))
+  )
+    throw new Error(`${label} is not a valid Git ref.`);
+}
+
+export function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function truncate(value: string): string {
+  return value.length <= MAX_ERROR_OUTPUT ? value : `${value.slice(0, MAX_ERROR_OUTPUT)}…`;
+}

--- a/packages/eve-self-modification/src/identifiers.test.ts
+++ b/packages/eve-self-modification/src/identifiers.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { assertFullSha, assertGitRef, assertRepositoryPart } from "./identifiers.js";
+
+describe("Git identifiers", () => {
+  it("accepts deployment SHAs case-insensitively", () => {
+    expect(() => assertFullSha("A".repeat(40), "revision")).not.toThrow();
+  });
+
+  it("rejects unsafe repository parts", () => {
+    for (const value of [".", "..", "-owner", "owner/name"]) {
+      expect(() => assertRepositoryPart(value, "repository owner")).toThrow(/invalid/u);
+    }
+  });
+
+  it("rejects Git lock refs", () => {
+    expect(() => assertGitRef("main.lock")).toThrow(/valid Git ref/u);
+    expect(() => assertGitRef("heads/main.lock/next")).toThrow(/valid Git ref/u);
+  });
+});

--- a/packages/eve-self-modification/src/identifiers.ts
+++ b/packages/eve-self-modification/src/identifiers.ts
@@ -1,0 +1,35 @@
+import {
+  assertFullGitSha,
+  assertGitRef as assertRef,
+  assertRepositoryPart as assertPart,
+} from "./git.js";
+
+export function assertFullSha(value: string, label: string): void {
+  try {
+    assertFullGitSha(value.toLowerCase(), `SelfModification ${label}`);
+  } catch {
+    throw new Error(`SelfModification ${label} must be a full Git SHA.`);
+  }
+}
+
+export function assertRepositoryPart(value: string, label: string): void {
+  try {
+    assertPart(value, `SelfModification ${label}`);
+  } catch {
+    throw new Error(`SelfModification ${label} is invalid.`);
+  }
+}
+
+export function assertGitRef(value: string, label = "pull request base"): void {
+  try {
+    assertRef(value, `SelfModification ${label}`);
+  } catch {
+    throw new Error(`SelfModification ${label} is not a valid Git ref.`);
+  }
+}
+
+export function assertOperationId(operationId: string): void {
+  if (operationId.length === 0 || operationId.length > 512) {
+    throw new Error("Self-modification operation id must contain 1–512 characters.");
+  }
+}


### PR DESCRIPTION
### Summary

Deployed selfmod should run in isolated temporary checkouts.  Has transient authentication, integrity checks, and bounded diff capture. The deployed application tree remains untouched.

The workspace does an initial shallow checkout based on the deployment source information, and then deepens until the correct ancestor is found between the deployed version and the targeted base branch.

### Validation

Not rerun while packaging the stack; focused tests cover workspace preparation, repository validation, diff limits, cleanup, and identifier normalization.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+8 / -0`

The changeset summarizes the new isolated production workspace behavior.

**Implementation** — 4 files · `+507 / -6`

Most of the implementation handles Git process boundaries, checkout lifecycle, validation, and bounded diff collection.

**Tests** — 2 files · `+285 / -0`

Exercises both workspace security invariants and deterministic proposal identifiers.
