### PR TITLE
feat(self-modification): publish replay-safe draft pull requests

### DIFF
--- a/.changeset/selfmod-trusted-publisher.md
+++ b/.changeset/selfmod-trusted-publisher.md
@@ -1,0 +1,5 @@
+---
+"@eve/self-modification": patch
+---
+
+Add a trusted, replay-safe GitHub publication core that can create only namespaced branches and draft pull requests from validated deployed self-modification proposals.

--- a/packages/eve-self-modification/src/git-workspace.test.ts
+++ b/packages/eve-self-modification/src/git-workspace.test.ts
@@ -62,7 +62,7 @@ describe("prepareSelfModificationWorkspace", () => {
       prepareSelfModificationWorkspace({
         deployedSha: DEPLOYED_SHA,
         token: token,
-        repository: { owner: "acme", pullRequestBase: "main", repo: "agent" },
+        repository: { owner: "acme", targetBranch: "main", repo: "agent" },
         rootDirectory: ".",
         sandbox,
       }),
@@ -84,7 +84,7 @@ describe("prepareSelfModificationWorkspace", () => {
       prepareSelfModificationWorkspace({
         deployedSha: DEPLOYED_SHA,
         token: "token",
-        repository: { owner: "acme", pullRequestBase: "main", repo: "agent" },
+        repository: { owner: "acme", targetBranch: "main", repo: "agent" },
         rootDirectory: ".",
         sandbox,
       }),
@@ -98,7 +98,7 @@ describe("prepareSelfModificationWorkspace", () => {
       prepareSelfModificationWorkspace({
         deployedSha: DEPLOYED_SHA,
         token: "token",
-        repository: { owner: "acme", pullRequestBase: "main; curl bad", repo: "agent" },
+        repository: { owner: "acme", targetBranch: "main; curl bad", repo: "agent" },
         rootDirectory: ".",
         sandbox,
       }),

--- a/packages/eve-self-modification/src/git-workspace.ts
+++ b/packages/eve-self-modification/src/git-workspace.ts
@@ -24,10 +24,10 @@ const MAX_CHANGED_FILES = 100;
 
 export type SelfModificationCommandSandbox = Pick<SandboxSession, "run">;
 export type SelfModificationCheckoutSandbox = Pick<SandboxSession, "run" | "setNetworkPolicy">;
-export type SelfModificationPersonalAccessTokenResolver = () => Promise<string> | string;
 export interface SelfModificationRepository {
   readonly owner: string;
-  readonly pullRequestBase: string;
+  /** The branch against which the proposal is prepared. */
+  readonly targetBranch: string;
   readonly repo: string;
 }
 export interface PreparedSelfModificationWorkspace {
@@ -63,7 +63,7 @@ export async function prepareSelfModificationWorkspace(input: {
   assertFullSha(input.deployedSha, "deployed revision");
   assertRepositoryPart(input.repository.owner, "repository owner");
   assertRepositoryPart(input.repository.repo, "repository name");
-  assertGitRef(input.repository.pullRequestBase);
+  assertGitRef(input.repository.targetBranch);
   assertRootDirectory(input.rootDirectory);
   if (input.token.length === 0)
     throw new Error("Self-modification checkout requires a GitHub personal access token.");
@@ -91,14 +91,14 @@ export async function prepareSelfModificationWorkspace(input: {
       );
       await run(
         input.sandbox,
-        `GIT_LFS_SKIP_SMUDGE=1 GIT_TERMINAL_PROMPT=0 git -C ${quote(REPOSITORY_PATH)} fetch --no-tags --depth=${INITIAL_FETCH_DEPTH} origin ${quote(`refs/heads/${input.repository.pullRequestBase}`)}`,
+        `GIT_LFS_SKIP_SMUDGE=1 GIT_TERMINAL_PROMPT=0 git -C ${quote(REPOSITORY_PATH)} fetch --no-tags --depth=${INITIAL_FETCH_DEPTH} origin ${quote(`refs/heads/${input.repository.targetBranch}`)}`,
       );
       await run(
         input.sandbox,
         `git -C ${quote(REPOSITORY_PATH)} update-ref ${BASE_REF} FETCH_HEAD`,
       );
       await deepenUntilRelated(input.sandbox, {
-        base: input.repository.pullRequestBase,
+        base: input.repository.targetBranch,
         deployedSha: input.deployedSha,
       });
     },

--- a/packages/eve-self-modification/src/github-publisher.test.ts
+++ b/packages/eve-self-modification/src/github-publisher.test.ts
@@ -1,0 +1,479 @@
+import { createHash } from "node:crypto";
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { SelfModificationCommandSandbox } from "./git-workspace.js";
+import { publishSelfModificationProposal, selfModificationBranchName } from "./github-publisher.js";
+
+const DEPLOYED_SHA = "1".repeat(40);
+const BASE_SHA = "2".repeat(40);
+const PROPOSED_TREE_SHA = "3".repeat(40);
+const BASE_TREE_SHA = "4".repeat(40);
+const GITHUB_BLOB_SHA = "7".repeat(40);
+const GITHUB_COMMIT_SHA = "9".repeat(40);
+const OPERATION_ID = "session/root-turn/subagent-call";
+const BRANCH = selfModificationBranchName(DEPLOYED_SHA, OPERATION_ID);
+const REPOSITORY = { owner: "acme", pullRequestBase: "main", repo: "agent" };
+const CONTENT = "hello";
+
+interface RecordedRequest {
+  readonly body: unknown;
+  readonly headers: Headers;
+  readonly method: string;
+  readonly path: string;
+  readonly search: string;
+  readonly signal: unknown;
+}
+
+type ResponseOverride = (init?: RequestInit) => Response;
+
+function gitBlobSha(content: string): string {
+  const bytes = Buffer.from(content);
+  return createHash("sha1").update(`blob ${bytes.byteLength}\0`).update(bytes).digest("hex");
+}
+
+function rawDiff(entries: readonly string[]): string {
+  return `${entries.join("\0")}\0`;
+}
+
+const MODIFIED_DIFF = rawDiff([
+  `:100644 100644 ${"a".repeat(40)} ${gitBlobSha(CONTENT)} M`,
+  "agent/instructions.md",
+]);
+const DELETED_DIFF = rawDiff([
+  `:100644 000000 ${"a".repeat(40)} ${"0".repeat(40)} D`,
+  "agent/removed.md",
+]);
+
+function createSandbox(raw = MODIFIED_DIFF) {
+  const commands: string[] = [];
+  const sandbox: SelfModificationCommandSandbox = {
+    async run({ command }: { command: string }) {
+      commands.push(command);
+      if (command.endsWith("write-tree")) return success(PROPOSED_TREE_SHA);
+      if (command.includes("^{tree}")) return success(BASE_TREE_SHA);
+      if (command.includes("diff-tree")) return success(raw);
+      if (command.includes("cat-file -s")) return success(String(Buffer.byteLength(CONTENT)));
+      if (command.includes("cat-file blob"))
+        return success(Buffer.from(CONTENT).toString("base64"));
+      return success();
+    },
+  };
+  return { commands, sandbox };
+}
+
+function success(stdout = "") {
+  return { exitCode: 0, stderr: "", stdout };
+}
+
+function json(body: unknown, status = 200, headers: Record<string, string> = {}) {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json", ...headers },
+    status,
+  });
+}
+
+function pullRequest(number: number, overrides: Record<string, unknown> = {}) {
+  return {
+    base: { ref: "main" },
+    draft: true,
+    head: { ref: BRANCH },
+    html_url: `https://github.com/acme/agent/pull/${number}`,
+    number,
+    state: "open",
+    ...overrides,
+  };
+}
+
+/** Records every request and answers it, letting `overrides` replace a path suffix. */
+function githubFetch(
+  answer: (path: string, init?: RequestInit) => Response,
+  overrides: Record<string, ResponseOverride>,
+) {
+  const requests: RecordedRequest[] = [];
+  const apiFetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    const parsed = new URL(String(url));
+    requests.push({
+      body: init?.body === undefined ? undefined : JSON.parse(String(init.body)),
+      headers: new Headers(init?.headers),
+      method: String(init?.method),
+      path: parsed.pathname,
+      search: parsed.search,
+      signal: init?.signal,
+    });
+    for (const [suffix, respond] of Object.entries(overrides)) {
+      if (parsed.pathname.endsWith(suffix)) return respond(init);
+    }
+    return answer(parsed.pathname, init);
+  }) as typeof fetch;
+  return { apiFetch, requests };
+}
+
+/** Answers the path that creates a branch and pull request for the first time. */
+function createFlowFetch(overrides: Record<string, ResponseOverride> = {}) {
+  return githubFetch((path) => {
+    if (path.endsWith(`/git/ref/heads/${BRANCH}`)) return json({}, 404);
+    if (path.endsWith("/git/ref/heads/main")) {
+      return json({ object: { sha: BASE_SHA }, ref: "refs/heads/main" });
+    }
+    if (path.endsWith("/git/blobs")) return json({ sha: GITHUB_BLOB_SHA }, 201);
+    if (path.endsWith("/git/trees")) return json({ sha: PROPOSED_TREE_SHA }, 201);
+    if (path.endsWith("/git/commits")) return json({ sha: GITHUB_COMMIT_SHA }, 201);
+    if (path.endsWith("/git/refs")) return json({}, 201);
+    if (path.endsWith("/pulls")) return json(pullRequest(7), 201);
+    throw new Error(`Unexpected request: ${path}`);
+  }, overrides);
+}
+
+/** Answers a replay against a branch this operation already published. */
+function replayFlowFetch(overrides: Record<string, ResponseOverride> = {}) {
+  return githubFetch((path) => {
+    if (path.endsWith(`/git/ref/heads/${BRANCH}`)) {
+      return json({ object: { sha: GITHUB_COMMIT_SHA }, ref: `refs/heads/${BRANCH}` });
+    }
+    if (path.endsWith(`/git/commits/${GITHUB_COMMIT_SHA}`)) {
+      return json({
+        parents: [{ sha: BASE_SHA }],
+        sha: GITHUB_COMMIT_SHA,
+        tree: { sha: PROPOSED_TREE_SHA },
+      });
+    }
+    if (path.endsWith("/pulls")) return json([pullRequest(7)]);
+    throw new Error(`Unexpected request: ${path}`);
+  }, overrides);
+}
+
+function publicationInput(sandbox: SelfModificationCommandSandbox, apiFetch: typeof fetch) {
+  return {
+    body: "Generated from a deployed request.",
+    personalAccessToken: () => "github-token",
+    deployedSha: DEPLOYED_SHA,
+    fetch: apiFetch,
+    operationId: OPERATION_ID,
+    repository: REPOSITORY,
+    sandbox,
+    title: "Update agent instructions",
+    workspace: {
+      baseSha: BASE_SHA,
+      deployedPath: "/workspace/self-modification/deployed",
+      deployedSha: DEPLOYED_SHA,
+      repositoryPath: "/workspace/self-modification/repository",
+      rootDirectory: ".",
+    },
+  };
+}
+
+async function publicationError(
+  sandbox: SelfModificationCommandSandbox,
+  apiFetch: typeof fetch,
+): Promise<Error> {
+  return await publishSelfModificationProposal(publicationInput(sandbox, apiFetch)).then(
+    () => {
+      throw new Error("Expected publication to fail.");
+    },
+    (thrown: unknown) => thrown as Error,
+  );
+}
+
+describe("publishSelfModificationProposal", () => {
+  it("rejects a workspace from another deployed revision", async () => {
+    const { sandbox } = createSandbox();
+    const input = publicationInput(sandbox, vi.fn() as typeof fetch);
+
+    await expect(
+      publishSelfModificationProposal({
+        ...input,
+        workspace: { ...input.workspace, deployedSha: "f".repeat(40) },
+      }),
+    ).rejects.toThrow(/does not match the deployed revision/u);
+  });
+
+  it("rejects a title that spans more than one line", async () => {
+    const { sandbox } = createSandbox();
+    const input = publicationInput(sandbox, vi.fn() as typeof fetch);
+
+    await expect(
+      publishSelfModificationProposal({ ...input, title: "Update instructions\nand tools" }),
+    ).rejects.toThrow(/single line/u);
+  });
+
+  it("uploads validated blobs and creates one namespaced draft pull request", async () => {
+    const { commands, sandbox } = createSandbox();
+    const { apiFetch, requests } = createFlowFetch();
+
+    await expect(
+      publishSelfModificationProposal(publicationInput(sandbox, apiFetch)),
+    ).resolves.toEqual({
+      base: "main",
+      branch: BRANCH,
+      changedPaths: ["agent/instructions.md"],
+      commitSha: GITHUB_COMMIT_SHA,
+      deployedSha: DEPLOYED_SHA,
+      draft: true,
+      pullRequestState: "open",
+      pullRequestUrl: "https://github.com/acme/agent/pull/7",
+    });
+
+    expect(commands.join("\n")).not.toContain("github-token");
+    expect(requests.find((request) => request.path.endsWith("/git/blobs"))?.body).toEqual({
+      content: Buffer.from(CONTENT).toString("base64"),
+      encoding: "base64",
+    });
+    expect(requests.find((request) => request.path.endsWith("/git/trees"))?.body).toEqual({
+      base_tree: BASE_TREE_SHA,
+      tree: [{ mode: "100644", path: "agent/instructions.md", sha: GITHUB_BLOB_SHA, type: "blob" }],
+    });
+    const commitBody = requests.find((request) => request.path.endsWith("/git/commits"))?.body;
+    expect(commitBody).toMatchObject({ parents: [BASE_SHA], tree: PROPOSED_TREE_SHA });
+    expect(commitBody).not.toHaveProperty("author");
+    expect(commitBody).not.toHaveProperty("committer");
+    expect(requests.find((request) => request.path.endsWith("/pulls"))?.body).toMatchObject({
+      base: "main",
+      draft: true,
+      head: BRANCH,
+    });
+  });
+
+  it("rejects policy-excluded changes before resolving credentials or calling GitHub", async () => {
+    const { sandbox } = createSandbox(
+      rawDiff([
+        `:100644 100644 ${"a".repeat(40)} ${gitBlobSha(CONTENT)} M`,
+        "agent/instructions.md",
+        `:100644 100644 ${"b".repeat(40)} ${gitBlobSha(CONTENT)} M`,
+        "package.json",
+      ]),
+    );
+    const personalAccessToken = vi.fn(() => "github-token");
+    const apiFetch = vi.fn() as typeof fetch;
+
+    await expect(
+      publishSelfModificationProposal({
+        ...publicationInput(sandbox, apiFetch),
+        personalAccessToken,
+      }),
+    ).rejects.toThrow(/policy-excluded changes: .*package\.json/u);
+
+    expect(personalAccessToken).not.toHaveBeenCalled();
+    expect(apiFetch).not.toHaveBeenCalled();
+  });
+
+  it("looks up refs with unencoded path separators", async () => {
+    const { sandbox } = createSandbox();
+    const { apiFetch, requests } = createFlowFetch();
+
+    await publishSelfModificationProposal(publicationInput(sandbox, apiFetch));
+
+    const refPaths = requests
+      .map((request) => request.path)
+      .filter((path) => path.includes("/git/ref/"));
+    expect(refPaths).toEqual([
+      `/repos/acme/agent/git/ref/heads/${BRANCH}`,
+      "/repos/acme/agent/git/ref/heads/main",
+    ]);
+  });
+
+  it("sends a mode and blob type for a deleted path", async () => {
+    const { sandbox } = createSandbox(DELETED_DIFF);
+    const { apiFetch, requests } = createFlowFetch();
+
+    await publishSelfModificationProposal(publicationInput(sandbox, apiFetch));
+
+    expect(requests.find((request) => request.path.endsWith("/git/trees"))?.body).toEqual({
+      base_tree: BASE_TREE_SHA,
+      tree: [{ mode: "100644", path: "agent/removed.md", sha: null, type: "blob" }],
+    });
+    expect(requests.some((request) => request.path.endsWith("/git/blobs"))).toBe(false);
+  });
+
+  it("fails closed when GitHub reassembles a different tree", async () => {
+    const { sandbox } = createSandbox();
+    const { apiFetch } = createFlowFetch({
+      "/git/trees": () => json({ sha: "b".repeat(40) }, 201),
+    });
+
+    await expect(
+      publishSelfModificationProposal(publicationInput(sandbox, apiFetch)),
+    ).rejects.toThrow(/did not reassemble into the validated Git tree/u);
+  });
+
+  it("fails closed when a sandbox blob does not match its captured object id", async () => {
+    const { sandbox } = createSandbox(
+      rawDiff([`:100644 100644 ${"a".repeat(40)} ${"c".repeat(40)} M`, "agent/instructions.md"]),
+    );
+    const { apiFetch } = createFlowFetch();
+
+    await expect(
+      publishSelfModificationProposal(publicationInput(sandbox, apiFetch)),
+    ).rejects.toThrow(/changed after validation/u);
+  });
+
+  it("fails closed when GitHub opens the pull request ready for review", async () => {
+    const { sandbox } = createSandbox();
+    const { apiFetch } = createFlowFetch({
+      "/pulls": () => json(pullRequest(7, { draft: false }), 201),
+    });
+
+    await expect(
+      publishSelfModificationProposal(publicationInput(sandbox, apiFetch)),
+    ).rejects.toThrow(/did not open the self-modification pull request as a draft/u);
+  });
+
+  it("fails closed when GitHub returns a pull request for another branch", async () => {
+    const { sandbox } = createSandbox();
+    const { apiFetch } = createFlowFetch({
+      "/pulls": () => json(pullRequest(7, { head: { ref: "main" } }), 201),
+    });
+
+    await expect(
+      publishSelfModificationProposal(publicationInput(sandbox, apiFetch)),
+    ).rejects.toThrow(/invalid self-modification pull request/u);
+  });
+
+  it("reuses an existing branch and pull request without rewriting Git objects", async () => {
+    const { sandbox } = createSandbox();
+    const { apiFetch, requests } = replayFlowFetch();
+
+    const result = await publishSelfModificationProposal(publicationInput(sandbox, apiFetch));
+
+    expect(result.commitSha).toBe(GITHUB_COMMIT_SHA);
+    expect(result.pullRequestUrl).toBe("https://github.com/acme/agent/pull/7");
+    expect(requests.map((request) => request.method)).toEqual(["GET", "GET", "GET"]);
+    expect(requests.at(-1)?.search).toContain("state=all");
+  });
+
+  it("reports a replayed pull request that a reviewer already closed", async () => {
+    const { sandbox } = createSandbox();
+    const { apiFetch } = replayFlowFetch({
+      "/pulls": () => json([pullRequest(7, { draft: false, state: "closed" })]),
+    });
+
+    const result = await publishSelfModificationProposal(publicationInput(sandbox, apiFetch));
+
+    expect(result).toMatchObject({ draft: false, pullRequestState: "closed" });
+  });
+
+  it("opens a draft pull request for an existing operation branch", async () => {
+    const { sandbox } = createSandbox();
+    const { apiFetch, requests } = replayFlowFetch({
+      "/pulls": (init) => (init?.method === "POST" ? json(pullRequest(8), 201) : json([])),
+    });
+
+    const result = await publishSelfModificationProposal(publicationInput(sandbox, apiFetch));
+
+    expect(result.pullRequestUrl).toBe("https://github.com/acme/agent/pull/8");
+    expect(requests.some((request) => request.path.endsWith("/git/blobs"))).toBe(false);
+  });
+
+  it("rejects replay when the existing operation branch has a different tree", async () => {
+    const { sandbox } = createSandbox();
+    const { apiFetch } = replayFlowFetch({
+      [`/git/commits/${GITHUB_COMMIT_SHA}`]: () =>
+        json({
+          parents: [{ sha: BASE_SHA }],
+          sha: GITHUB_COMMIT_SHA,
+          tree: { sha: "a".repeat(40) },
+        }),
+    });
+
+    await expect(
+      publishSelfModificationProposal(publicationInput(sandbox, apiFetch)),
+    ).rejects.toThrow(/already published a different proposal/u);
+  });
+
+  it("rejects replay when the existing branch targets another base revision", async () => {
+    const { sandbox } = createSandbox();
+    const { apiFetch } = replayFlowFetch({
+      [`/git/commits/${GITHUB_COMMIT_SHA}`]: () =>
+        json({
+          parents: [{ sha: "e".repeat(40) }],
+          sha: GITHUB_COMMIT_SHA,
+          tree: { sha: PROPOSED_TREE_SHA },
+        }),
+    });
+
+    await expect(
+      publishSelfModificationProposal(publicationInput(sandbox, apiFetch)),
+    ).rejects.toThrow(/different pull request base revision/u);
+  });
+
+  it("treats an ambiguous ref match as an absent branch", async () => {
+    const { sandbox } = createSandbox();
+    const { apiFetch } = createFlowFetch({
+      [`/git/ref/heads/${BRANCH}`]: () =>
+        json([{ object: { sha: GITHUB_COMMIT_SHA }, ref: `refs/heads/${BRANCH}-other` }]),
+    });
+
+    const result = await publishSelfModificationProposal(publicationInput(sandbox, apiFetch));
+
+    expect(result.commitSha).toBe(GITHUB_COMMIT_SHA);
+  });
+
+  it("distinguishes a missing pull request base from one that moved", async () => {
+    const { sandbox } = createSandbox();
+    const { apiFetch } = createFlowFetch({ "/git/ref/heads/main": () => json({}, 404) });
+
+    await expect(
+      publishSelfModificationProposal(publicationInput(sandbox, apiFetch)),
+    ).rejects.toThrow(/base "main" does not exist in acme\/agent/u);
+  });
+
+  it("fails closed when the configured base moves", async () => {
+    const { sandbox } = createSandbox();
+    const { apiFetch } = createFlowFetch({
+      "/git/ref/heads/main": () =>
+        json({ object: { sha: "f".repeat(40) }, ref: "refs/heads/main" }),
+    });
+
+    await expect(
+      publishSelfModificationProposal(publicationInput(sandbox, apiFetch)),
+    ).rejects.toThrow(/base moved/u);
+  });
+
+  it("surfaces the GitHub failure explanation without the access token", async () => {
+    const { sandbox } = createSandbox();
+    const { apiFetch } = createFlowFetch({
+      "/git/blobs": () =>
+        json(
+          {
+            errors: [{ code: "missing", field: "contents", resource: "Blob" }],
+            message: "Resource not accessible by personal access token",
+          },
+          403,
+          { "retry-after": "60" },
+        ),
+    });
+
+    const error = await publicationError(sandbox, apiFetch);
+
+    expect(error.message).toContain("HTTP 403");
+    expect(error.message).toContain("Resource not accessible by personal access token");
+    expect(error.message).toContain("Blob.contents.missing");
+    expect(error.message).toContain("retry after 60s");
+    expect(error.message).not.toContain("github-token");
+  });
+
+  it("identifies itself and bounds every GitHub request", async () => {
+    const { sandbox } = createSandbox();
+    const { apiFetch, requests } = createFlowFetch();
+
+    await publishSelfModificationProposal(publicationInput(sandbox, apiFetch));
+
+    expect(requests.length).toBeGreaterThan(0);
+    for (const request of requests) {
+      expect(request.headers.get("user-agent")).toBe("eve-self-modification");
+      expect(request.headers.get("authorization")).toBe("Bearer github-token");
+      expect(request.signal).toBeInstanceOf(AbortSignal);
+    }
+  });
+
+  it("rejects a malformed GitHub response instead of dereferencing it", async () => {
+    const { sandbox } = createSandbox();
+    const { apiFetch } = createFlowFetch({
+      "/git/ref/heads/main": () => json({ ref: "refs/heads/main" }),
+    });
+
+    await expect(
+      publishSelfModificationProposal(publicationInput(sandbox, apiFetch)),
+    ).rejects.toThrow(/unexpected ref response/u);
+  });
+});

--- a/packages/eve-self-modification/src/github-publisher.test.ts
+++ b/packages/eve-self-modification/src/github-publisher.test.ts
@@ -13,7 +13,7 @@ const GITHUB_BLOB_SHA = "7".repeat(40);
 const GITHUB_COMMIT_SHA = "9".repeat(40);
 const OPERATION_ID = "session/root-turn/subagent-call";
 const BRANCH = selfModificationBranchName(DEPLOYED_SHA, OPERATION_ID);
-const REPOSITORY = { owner: "acme", pullRequestBase: "main", repo: "agent" };
+const REPOSITORY = { owner: "acme", targetBranch: "main", repo: "agent" };
 const CONTENT = "hello";
 
 interface RecordedRequest {
@@ -212,6 +212,7 @@ describe("publishSelfModificationProposal", () => {
       draft: true,
       pullRequestState: "open",
       pullRequestUrl: "https://github.com/acme/agent/pull/7",
+      targetBranch: "main",
     });
 
     expect(commands.join("\n")).not.toContain("github-token");
@@ -393,7 +394,7 @@ describe("publishSelfModificationProposal", () => {
 
     await expect(
       publishSelfModificationProposal(publicationInput(sandbox, apiFetch)),
-    ).rejects.toThrow(/different pull request base revision/u);
+    ).rejects.toThrow(/different target branch revision/u);
   });
 
   it("treats an ambiguous ref match as an absent branch", async () => {
@@ -414,7 +415,7 @@ describe("publishSelfModificationProposal", () => {
 
     await expect(
       publishSelfModificationProposal(publicationInput(sandbox, apiFetch)),
-    ).rejects.toThrow(/base "main" does not exist in acme\/agent/u);
+    ).rejects.toThrow(/target branch "main" does not exist in acme\/agent/u);
   });
 
   it("fails closed when the configured base moves", async () => {
@@ -426,7 +427,7 @@ describe("publishSelfModificationProposal", () => {
 
     await expect(
       publishSelfModificationProposal(publicationInput(sandbox, apiFetch)),
-    ).rejects.toThrow(/base moved/u);
+    ).rejects.toThrow(/target branch moved/u);
   });
 
   it("surfaces the GitHub failure explanation without the access token", async () => {

--- a/packages/eve-self-modification/src/github-publisher.ts
+++ b/packages/eve-self-modification/src/github-publisher.ts
@@ -6,7 +6,6 @@ import {
   type PreparedSelfModificationWorkspace,
   type ProposalChange,
   type SelfModificationCommandSandbox,
-  type SelfModificationPersonalAccessTokenResolver,
   type SelfModificationProposal,
   type SelfModificationRepository,
 } from "./git-workspace.js";
@@ -16,6 +15,11 @@ import {
   assertOperationId,
   assertRepositoryPart,
 } from "./identifiers.js";
+import type {
+  SelfModificationProposalPublisher,
+  SelfModificationPublicationReceipt,
+  SelfModificationPublicationRequest,
+} from "./publisher.js";
 
 const API_BASE_URL = "https://api.github.com";
 const REQUEST_TIMEOUT_MS = 30_000;
@@ -29,7 +33,7 @@ const DELETED_ENTRY_MODE = "100644";
 
 export interface PublishSelfModificationProposalInput {
   readonly body: string;
-  readonly personalAccessToken: SelfModificationPersonalAccessTokenResolver;
+  readonly personalAccessToken: () => Promise<string> | string;
   readonly deployedSha: string;
   readonly fetch?: typeof fetch;
   readonly operationId: string;
@@ -39,7 +43,7 @@ export interface PublishSelfModificationProposalInput {
   readonly title: string;
 }
 
-export interface PublishedSelfModificationProposal {
+export interface PublishedSelfModificationProposal extends SelfModificationPublicationReceipt {
   readonly base: string;
   readonly branch: string;
   readonly changedPaths: readonly string[];
@@ -48,6 +52,32 @@ export interface PublishedSelfModificationProposal {
   readonly draft: boolean;
   readonly pullRequestState: "closed" | "open";
   readonly pullRequestUrl: string;
+}
+
+export interface GitHubDraftPullRequestPublisherOptions {
+  readonly fetch?: typeof fetch;
+  readonly personalAccessToken: () => Promise<string> | string;
+  readonly repository: SelfModificationRepository;
+}
+
+/** Creates the GitHub implementation of the provider-neutral publisher contract. */
+export function createGitHubDraftPullRequestPublisher(
+  options: GitHubDraftPullRequestPublisherOptions,
+): SelfModificationProposalPublisher<PublishedSelfModificationProposal> {
+  return {
+    publish: async (input: SelfModificationPublicationRequest) =>
+      await publishSelfModificationProposal({
+        body: input.description,
+        deployedSha: input.deployedSha,
+        fetch: options.fetch,
+        operationId: input.operationId,
+        personalAccessToken: options.personalAccessToken,
+        repository: options.repository,
+        sandbox: input.sandbox,
+        title: input.title,
+        workspace: input.workspace,
+      }),
+  };
 }
 
 interface GitHubRef {
@@ -107,16 +137,14 @@ export async function publishSelfModificationProposal(
     });
   }
 
-  const baseRef = await github.getRef(input.repository, input.repository.pullRequestBase);
+  const baseRef = await github.getRef(input.repository, input.repository.targetBranch);
   if (baseRef === null) {
     throw new Error(
-      `Self-modification pull request base "${input.repository.pullRequestBase}" does not exist in ${input.repository.owner}/${input.repository.repo}.`,
+      `Self-modification target branch "${input.repository.targetBranch}" does not exist in ${input.repository.owner}/${input.repository.repo}.`,
     );
   }
   if (baseRef.object.sha !== input.workspace.baseSha) {
-    throw new Error(
-      "Self-modification pull request base moved while the proposal was being prepared.",
-    );
+    throw new Error("Self-modification target branch moved while the proposal was being prepared.");
   }
 
   const commitSha = await uploadProposal({ github, input, proposal });
@@ -152,7 +180,7 @@ async function reconcileExistingPublication(context: {
   const existingCommit = await github.getCommit(input.repository, ref.object.sha);
   if (existingCommit.parents.length !== 1 || existingCommit.parents[0]?.sha !== proposal.baseSha) {
     throw new Error(
-      `Self-modification operation conflict: ${branch} targets a different pull request base revision than this proposal.`,
+      `Self-modification operation conflict: ${branch} targets a different target branch revision than this proposal.`,
     );
   }
   if (existingCommit.tree.sha !== proposal.proposedTreeSha) {
@@ -231,7 +259,7 @@ function assertPublicationInput(input: PublishSelfModificationProposalInput): vo
   }
   assertRepositoryPart(input.repository.owner, "repository owner");
   assertRepositoryPart(input.repository.repo, "repository name");
-  assertGitRef(input.repository.pullRequestBase);
+  assertGitRef(input.repository.targetBranch);
   if (
     input.title.trim().length === 0 ||
     input.title.length > MAX_TITLE_LENGTH ||
@@ -255,7 +283,7 @@ function hasControlCharacter(value: string): boolean {
 
 function pullRequestPayload(input: PublishSelfModificationProposalInput, branch: string) {
   return {
-    base: input.repository.pullRequestBase,
+    base: input.repository.targetBranch,
     body: input.body,
     branch,
     title: input.title.trim(),
@@ -270,7 +298,7 @@ function publishedProposal(context: {
   readonly pullRequest: GitHubPullRequest;
 }): PublishedSelfModificationProposal {
   return {
-    base: context.input.repository.pullRequestBase,
+    base: context.input.repository.targetBranch,
     branch: context.branch,
     changedPaths: context.proposal.changes.map((change) => change.path),
     commitSha: context.commitSha,
@@ -278,6 +306,7 @@ function publishedProposal(context: {
     draft: context.pullRequest.draft,
     pullRequestState: context.pullRequest.state,
     pullRequestUrl: context.pullRequest.html_url,
+    targetBranch: context.input.repository.targetBranch,
   };
 }
 
@@ -378,7 +407,7 @@ class GitHubPublisherClient {
     branch: string,
   ): Promise<GitHubPullRequest | null> {
     const query = new URLSearchParams({
-      base: repository.pullRequestBase,
+      base: repository.targetBranch,
       head: `${repository.owner}:${branch}`,
       state: "all",
     });
@@ -467,7 +496,7 @@ function validatePullRequest(
     typeof draft !== "boolean" ||
     (state !== "closed" && state !== "open") ||
     asRecord(record.head, "pull request head").ref !== branch ||
-    asRecord(record.base, "pull request base").ref !== repository.pullRequestBase
+    asRecord(record.base, "pull request base").ref !== repository.targetBranch
   ) {
     throw new Error("GitHub returned an invalid self-modification pull request.");
   }

--- a/packages/eve-self-modification/src/github-publisher.ts
+++ b/packages/eve-self-modification/src/github-publisher.ts
@@ -1,0 +1,553 @@
+import { createHash } from "node:crypto";
+
+import {
+  captureSelfModificationProposal,
+  readProposalBlob,
+  type PreparedSelfModificationWorkspace,
+  type ProposalChange,
+  type SelfModificationCommandSandbox,
+  type SelfModificationPersonalAccessTokenResolver,
+  type SelfModificationProposal,
+  type SelfModificationRepository,
+} from "./git-workspace.js";
+import {
+  assertFullSha,
+  assertGitRef,
+  assertOperationId,
+  assertRepositoryPart,
+} from "./identifiers.js";
+
+const API_BASE_URL = "https://api.github.com";
+const REQUEST_TIMEOUT_MS = 30_000;
+const USER_AGENT = "eve-self-modification";
+const MAX_TITLE_LENGTH = 256;
+const MAX_BODY_LENGTH = 65_536;
+const MAX_ERROR_DETAIL_LENGTH = 500;
+
+/** GitHub requires a mode on every tree entry, including the entries that delete a path. */
+const DELETED_ENTRY_MODE = "100644";
+
+export interface PublishSelfModificationProposalInput {
+  readonly body: string;
+  readonly personalAccessToken: SelfModificationPersonalAccessTokenResolver;
+  readonly deployedSha: string;
+  readonly fetch?: typeof fetch;
+  readonly operationId: string;
+  readonly repository: SelfModificationRepository;
+  readonly sandbox: SelfModificationCommandSandbox;
+  readonly workspace: PreparedSelfModificationWorkspace;
+  readonly title: string;
+}
+
+export interface PublishedSelfModificationProposal {
+  readonly base: string;
+  readonly branch: string;
+  readonly changedPaths: readonly string[];
+  readonly commitSha: string;
+  readonly deployedSha: string;
+  readonly draft: boolean;
+  readonly pullRequestState: "closed" | "open";
+  readonly pullRequestUrl: string;
+}
+
+interface GitHubRef {
+  readonly object: { readonly sha: string };
+  readonly ref: string;
+}
+
+interface GitHubCommit {
+  readonly parents: readonly { readonly sha: string }[];
+  readonly sha: string;
+  readonly tree: { readonly sha: string };
+}
+
+interface GitHubPullRequest {
+  readonly draft: boolean;
+  readonly html_url: string;
+  readonly number: number;
+  readonly state: "closed" | "open";
+}
+
+interface GitHubTreeEntry {
+  readonly mode: string;
+  readonly path: string;
+  readonly sha: string | null;
+  readonly type: "blob";
+}
+
+export function selfModificationBranchName(deployedSha: string, operationId: string): string {
+  assertFullSha(deployedSha, "deployed revision");
+  return `eve-self-modification/${deployedSha.slice(0, 12)}/${hashOperationId(operationId)}`;
+}
+
+export async function publishSelfModificationProposal(
+  input: PublishSelfModificationProposalInput,
+): Promise<PublishedSelfModificationProposal> {
+  assertPublicationInput(input);
+
+  const proposal = await captureSelfModificationProposal({
+    sandbox: input.sandbox,
+    workspace: input.workspace,
+  });
+  const branch = selfModificationBranchName(input.deployedSha, input.operationId);
+  const token = await input.personalAccessToken();
+  if (typeof token !== "string" || token.trim().length === 0) {
+    throw new Error("Self-modification publication requires a GitHub personal access token.");
+  }
+  const github = new GitHubPublisherClient({ fetch: input.fetch ?? fetch, token: token.trim() });
+
+  const existingRef = await github.getRef(input.repository, branch);
+  if (existingRef !== null) {
+    return await reconcileExistingPublication({
+      branch,
+      github,
+      input,
+      proposal,
+      ref: existingRef,
+    });
+  }
+
+  const baseRef = await github.getRef(input.repository, input.repository.pullRequestBase);
+  if (baseRef === null) {
+    throw new Error(
+      `Self-modification pull request base "${input.repository.pullRequestBase}" does not exist in ${input.repository.owner}/${input.repository.repo}.`,
+    );
+  }
+  if (baseRef.object.sha !== input.workspace.baseSha) {
+    throw new Error(
+      "Self-modification pull request base moved while the proposal was being prepared.",
+    );
+  }
+
+  const commitSha = await uploadProposal({ github, input, proposal });
+  try {
+    await github.createRef(input.repository, branch, commitSha);
+  } catch (error) {
+    const racedRef = await github.getRef(input.repository, branch);
+    if (racedRef === null) throw error;
+    return await reconcileExistingPublication({ branch, github, input, proposal, ref: racedRef });
+  }
+
+  const pullRequest = await github.createPullRequest(
+    input.repository,
+    pullRequestPayload(input, branch),
+  );
+  return publishedProposal({ branch, commitSha, input, proposal, pullRequest });
+}
+
+/**
+ * Resolves a replayed publication against what this operation already published.
+ *
+ * Both comparisons use locally captured Git object ids, so reconciliation neither writes
+ * to the repository nor trusts the retry to describe the earlier attempt.
+ */
+async function reconcileExistingPublication(context: {
+  readonly branch: string;
+  readonly github: GitHubPublisherClient;
+  readonly input: PublishSelfModificationProposalInput;
+  readonly proposal: SelfModificationProposal;
+  readonly ref: GitHubRef;
+}): Promise<PublishedSelfModificationProposal> {
+  const { branch, github, input, proposal, ref } = context;
+  const existingCommit = await github.getCommit(input.repository, ref.object.sha);
+  if (existingCommit.parents.length !== 1 || existingCommit.parents[0]?.sha !== proposal.baseSha) {
+    throw new Error(
+      `Self-modification operation conflict: ${branch} targets a different pull request base revision than this proposal.`,
+    );
+  }
+  if (existingCommit.tree.sha !== proposal.proposedTreeSha) {
+    throw new Error(
+      "Self-modification operation conflict: this operation already published a different proposal.",
+    );
+  }
+
+  const pullRequest =
+    (await github.findPullRequest(input.repository, branch)) ??
+    (await github.createPullRequest(input.repository, pullRequestPayload(input, branch)));
+  return publishedProposal({ branch, commitSha: ref.object.sha, input, proposal, pullRequest });
+}
+
+async function uploadProposal(context: {
+  readonly github: GitHubPublisherClient;
+  readonly input: PublishSelfModificationProposalInput;
+  readonly proposal: SelfModificationProposal;
+}): Promise<string> {
+  const treeSha = await uploadProposalTree(context);
+  return await context.github.createCommit(context.input.repository, {
+    // No author or committer: GitHub attributes the commit to the account that owns the
+    // personal access token, which is the operator accountable for the proposal. A
+    // synthetic author would only add unverifiable metadata.
+    message: `eve self-modification proposal\n\nOperation: ${hashOperationId(context.input.operationId)}`,
+    parent: context.proposal.baseSha,
+    tree: treeSha,
+  });
+}
+
+async function uploadProposalTree(context: {
+  readonly github: GitHubPublisherClient;
+  readonly input: PublishSelfModificationProposalInput;
+  readonly proposal: SelfModificationProposal;
+}): Promise<string> {
+  const tree: GitHubTreeEntry[] = [];
+  for (const change of context.proposal.changes) tree.push(await uploadTreeEntry(context, change));
+  const treeSha = await context.github.createTree(
+    context.input.repository,
+    context.proposal.baseTreeSha,
+    tree,
+  );
+  // Git trees are content addressed, so an identical id proves GitHub reassembled exactly
+  // the tree that proposal capture checked against the path and size policy.
+  if (treeSha !== context.proposal.proposedTreeSha) {
+    throw new Error("Self-modification proposal did not reassemble into the validated Git tree.");
+  }
+  return treeSha;
+}
+
+async function uploadTreeEntry(
+  context: {
+    readonly github: GitHubPublisherClient;
+    readonly input: PublishSelfModificationProposalInput;
+  },
+  change: ProposalChange,
+): Promise<GitHubTreeEntry> {
+  if (change.objectId === null || change.mode === null) {
+    return { mode: DELETED_ENTRY_MODE, path: change.path, sha: null, type: "blob" };
+  }
+  const content = await readProposalBlob({
+    change,
+    sandbox: context.input.sandbox,
+    workspace: context.input.workspace,
+  });
+  const sha = await context.github.createBlob(context.input.repository, content);
+  return { mode: change.mode, path: change.path, sha, type: "blob" };
+}
+
+function assertPublicationInput(input: PublishSelfModificationProposalInput): void {
+  assertFullSha(input.workspace.baseSha, "proposal base revision");
+  assertFullSha(input.workspace.deployedSha, "workspace deployed revision");
+  assertFullSha(input.deployedSha, "deployed revision");
+  if (input.workspace.deployedSha !== input.deployedSha) {
+    throw new Error("Self-modification workspace does not match the deployed revision.");
+  }
+  assertRepositoryPart(input.repository.owner, "repository owner");
+  assertRepositoryPart(input.repository.repo, "repository name");
+  assertGitRef(input.repository.pullRequestBase);
+  if (
+    input.title.trim().length === 0 ||
+    input.title.length > MAX_TITLE_LENGTH ||
+    hasControlCharacter(input.title)
+  ) {
+    throw new Error(
+      `Self-modification pull request title must be a single line of 1-${MAX_TITLE_LENGTH} characters.`,
+    );
+  }
+  if (input.body.length > MAX_BODY_LENGTH) {
+    throw new Error("Self-modification pull request body is too large.");
+  }
+}
+
+function hasControlCharacter(value: string): boolean {
+  return [...value].some((character) => {
+    const code = character.codePointAt(0) ?? 0;
+    return code < 0x20 || code === 0x7f;
+  });
+}
+
+function pullRequestPayload(input: PublishSelfModificationProposalInput, branch: string) {
+  return {
+    base: input.repository.pullRequestBase,
+    body: input.body,
+    branch,
+    title: input.title.trim(),
+  };
+}
+
+function publishedProposal(context: {
+  readonly branch: string;
+  readonly commitSha: string;
+  readonly input: PublishSelfModificationProposalInput;
+  readonly proposal: SelfModificationProposal;
+  readonly pullRequest: GitHubPullRequest;
+}): PublishedSelfModificationProposal {
+  return {
+    base: context.input.repository.pullRequestBase,
+    branch: context.branch,
+    changedPaths: context.proposal.changes.map((change) => change.path),
+    commitSha: context.commitSha,
+    deployedSha: context.input.deployedSha,
+    draft: context.pullRequest.draft,
+    pullRequestState: context.pullRequest.state,
+    pullRequestUrl: context.pullRequest.html_url,
+  };
+}
+
+class GitHubPublisherClient {
+  readonly #fetch: typeof fetch;
+  readonly #token: string;
+
+  constructor(input: { readonly fetch: typeof fetch; readonly token: string }) {
+    this.#fetch = input.fetch;
+    this.#token = input.token;
+  }
+
+  async getRef(repository: SelfModificationRepository, branch: string): Promise<GitHubRef | null> {
+    const payload = await this.#request(
+      repository,
+      "GET",
+      `/git/ref/${encodeRefPath(`heads/${branch}`)}`,
+      undefined,
+      true,
+    );
+    if (payload === null) return null;
+    // GitHub answers an ambiguous ref prefix with every match; only an exact ref counts.
+    if (Array.isArray(payload)) return null;
+    const record = asRecord(payload, "ref");
+    if (record.ref !== `refs/heads/${branch}`) {
+      throw new Error("GitHub returned an unexpected self-modification ref.");
+    }
+    const object = asRecord(record.object, "ref");
+    return { object: { sha: asSha(object.sha, "GitHub ref revision") }, ref: record.ref };
+  }
+
+  async getCommit(repository: SelfModificationRepository, sha: string): Promise<GitHubCommit> {
+    assertFullSha(sha, "GitHub commit revision");
+    const record = asRecord(
+      await this.#request(repository, "GET", `/git/commits/${encodeURIComponent(sha)}`),
+      "commit",
+    );
+    if (!Array.isArray(record.parents)) {
+      throw new Error("GitHub returned an unexpected commit response.");
+    }
+    return {
+      parents: record.parents.map((parent) => ({
+        sha: asSha(asRecord(parent, "commit parent").sha, "GitHub parent revision"),
+      })),
+      sha: asSha(record.sha, "GitHub commit revision"),
+      tree: { sha: asSha(asRecord(record.tree, "commit tree").sha, "GitHub tree revision") },
+    };
+  }
+
+  async createBlob(repository: SelfModificationRepository, content: string): Promise<string> {
+    const record = asRecord(
+      await this.#request(repository, "POST", "/git/blobs", { content, encoding: "base64" }),
+      "blob",
+    );
+    return asSha(record.sha, "GitHub blob");
+  }
+
+  async createTree(
+    repository: SelfModificationRepository,
+    baseTree: string,
+    tree: readonly GitHubTreeEntry[],
+  ): Promise<string> {
+    const record = asRecord(
+      await this.#request(repository, "POST", "/git/trees", { base_tree: baseTree, tree }),
+      "tree",
+    );
+    return asSha(record.sha, "GitHub tree");
+  }
+
+  async createCommit(
+    repository: SelfModificationRepository,
+    input: { readonly message: string; readonly parent: string; readonly tree: string },
+  ): Promise<string> {
+    const record = asRecord(
+      await this.#request(repository, "POST", "/git/commits", {
+        message: input.message,
+        parents: [input.parent],
+        tree: input.tree,
+      }),
+      "commit",
+    );
+    return asSha(record.sha, "GitHub commit");
+  }
+
+  async createRef(
+    repository: SelfModificationRepository,
+    branch: string,
+    commitSha: string,
+  ): Promise<void> {
+    await this.#request(repository, "POST", "/git/refs", {
+      ref: `refs/heads/${branch}`,
+      sha: commitSha,
+    });
+  }
+
+  async findPullRequest(
+    repository: SelfModificationRepository,
+    branch: string,
+  ): Promise<GitHubPullRequest | null> {
+    const query = new URLSearchParams({
+      base: repository.pullRequestBase,
+      head: `${repository.owner}:${branch}`,
+      state: "all",
+    });
+    const payload = await this.#request(repository, "GET", `/pulls?${query}`);
+    if (!Array.isArray(payload)) {
+      throw new Error("GitHub returned an unexpected pull request list.");
+    }
+    const first = payload[0];
+    return first === undefined ? null : validatePullRequest(repository, branch, first);
+  }
+
+  async createPullRequest(
+    repository: SelfModificationRepository,
+    input: {
+      readonly base: string;
+      readonly body: string;
+      readonly branch: string;
+      readonly title: string;
+    },
+  ): Promise<GitHubPullRequest> {
+    const pullRequest = validatePullRequest(
+      repository,
+      input.branch,
+      await this.#request(repository, "POST", "/pulls", {
+        base: input.base,
+        body: input.body,
+        draft: true,
+        head: input.branch,
+        title: input.title,
+      }),
+    );
+    // The draft state is the review boundary, so a pull request that opened ready for
+    // review is a publication failure rather than a cosmetic difference.
+    if (!pullRequest.draft) {
+      throw new Error("GitHub did not open the self-modification pull request as a draft.");
+    }
+    return pullRequest;
+  }
+
+  async #request(
+    repository: SelfModificationRepository,
+    method: "GET" | "POST",
+    path: string,
+    body?: Record<string, unknown>,
+    allowNotFound = false,
+  ): Promise<unknown> {
+    const headers: Record<string, string> = {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${this.#token}`,
+      "user-agent": USER_AGENT,
+      "x-github-api-version": "2022-11-28",
+    };
+    if (body !== undefined) headers["content-type"] = "application/json";
+    const response = await this.#fetch(
+      `${API_BASE_URL}/repos/${encodeURIComponent(repository.owner)}/${encodeURIComponent(repository.repo)}${path}`,
+      {
+        body: body === undefined ? undefined : JSON.stringify(body),
+        headers,
+        method,
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      },
+    );
+    if (allowNotFound && response.status === 404) return null;
+    if (!response.ok) throw await requestError(method, path, response);
+    return await response.json();
+  }
+}
+
+/** GitHub routes a ref as a multi-segment path; percent-encoded separators do not match. */
+function encodeRefPath(ref: string): string {
+  return ref.split("/").map(encodeURIComponent).join("/");
+}
+
+function validatePullRequest(
+  repository: SelfModificationRepository,
+  branch: string,
+  payload: unknown,
+): GitHubPullRequest {
+  const record = asRecord(payload, "pull request");
+  const { draft, html_url: htmlUrl, number, state } = record;
+  if (
+    typeof number !== "number" ||
+    !Number.isSafeInteger(number) ||
+    number <= 0 ||
+    htmlUrl !== `https://github.com/${repository.owner}/${repository.repo}/pull/${number}` ||
+    typeof draft !== "boolean" ||
+    (state !== "closed" && state !== "open") ||
+    asRecord(record.head, "pull request head").ref !== branch ||
+    asRecord(record.base, "pull request base").ref !== repository.pullRequestBase
+  ) {
+    throw new Error("GitHub returned an invalid self-modification pull request.");
+  }
+  return { draft, html_url: htmlUrl, number, state };
+}
+
+function asRecord(value: unknown, context: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`GitHub returned an unexpected ${context} response.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function asSha(value: unknown, label: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`SelfModification ${label} must be a full Git SHA.`);
+  }
+  assertFullSha(value, label);
+  return value;
+}
+
+/**
+ * Turns a GitHub failure into a message an operator can act on.
+ *
+ * GitHub explains permission, plan, and rate limit failures in the response body, and
+ * that body never carries credential material, so it is safe to surface.
+ */
+async function requestError(method: string, path: string, response: Response): Promise<Error> {
+  const details = [`HTTP ${response.status}`];
+  const message = await responseMessage(response);
+  if (message.length > 0) details.push(message);
+  const retryAfter = response.headers.get("retry-after");
+  if (retryAfter !== null && (response.status === 403 || response.status === 429)) {
+    details.push(`retry after ${retryAfter}s`);
+  }
+  return new Error(`GitHub ${method} ${path} failed: ${details.join("; ")}.`);
+}
+
+async function responseMessage(response: Response): Promise<string> {
+  const text = await response.text().catch(() => "");
+  if (text.length === 0) return "";
+  let payload: unknown;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    return collapse(text);
+  }
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) {
+    return collapse(text);
+  }
+  const record = payload as Record<string, unknown>;
+  const message = typeof record.message === "string" ? record.message : "";
+  const errors = Array.isArray(record.errors)
+    ? record.errors
+        .map(describeResponseError)
+        .filter((entry) => entry.length > 0)
+        .join(", ")
+    : "";
+  const combined = [message, errors].filter((entry) => entry.length > 0).join(" - ");
+  return collapse(combined.length === 0 ? text : combined);
+}
+
+function describeResponseError(entry: unknown): string {
+  if (typeof entry === "string") return entry;
+  if (typeof entry !== "object" || entry === null) return "";
+  const record = entry as Record<string, unknown>;
+  if (typeof record.message === "string") return record.message;
+  return [record.resource, record.field, record.code]
+    .filter((part): part is string => typeof part === "string")
+    .join(".");
+}
+
+function collapse(value: string): string {
+  const single = value.replaceAll(/\s+/gu, " ").trim();
+  return single.length > MAX_ERROR_DETAIL_LENGTH
+    ? `${single.slice(0, MAX_ERROR_DETAIL_LENGTH)}...`
+    : single;
+}
+
+function hashOperationId(operationId: string): string {
+  assertOperationId(operationId);
+  return createHash("sha256").update(operationId).digest("hex").slice(0, 24);
+}

--- a/packages/eve-self-modification/src/publisher.ts
+++ b/packages/eve-self-modification/src/publisher.ts
@@ -1,0 +1,38 @@
+import type {
+  PreparedSelfModificationWorkspace,
+  SelfModificationCommandSandbox,
+} from "./git-workspace.js";
+
+/** Provider-neutral metadata and trusted workspace for one publication operation. */
+export interface SelfModificationPublicationRequest {
+  readonly deployedSha: string;
+  readonly description: string;
+  readonly operationId: string;
+  readonly sandbox: SelfModificationCommandSandbox;
+  readonly title: string;
+  readonly workspace: PreparedSelfModificationWorkspace;
+}
+
+export interface SelfModificationPublicationReceipt {
+  readonly changedPaths: readonly string[];
+  readonly commitSha: string;
+  readonly deployedSha: string;
+  readonly targetBranch: string;
+}
+
+/** A trusted destination for a complete self-modification proposal. */
+export interface SelfModificationProposalPublisher<
+  Receipt extends SelfModificationPublicationReceipt = SelfModificationPublicationReceipt,
+> {
+  publish(input: SelfModificationPublicationRequest): Promise<Receipt>;
+}
+
+/** Publishes through the destination selected by trusted application configuration. */
+export async function publishSelfModification<
+  Receipt extends SelfModificationPublicationReceipt,
+>(input: {
+  readonly publisher: SelfModificationProposalPublisher<Receipt>;
+  readonly request: SelfModificationPublicationRequest;
+}): Promise<Receipt> {
+  return await input.publisher.publish(input.request);
+}


### PR DESCRIPTION
### Summary

Adds a provider-neutral proposal-publication contract while retaining GitHub draft pull requests as the configured implementation. The GitHub publisher publishes only a namespaced branch and draft PR, validates the reconstructed tree, and reconciles retries without overwriting divergent remote state.

The workspace boundary now uses `targetBranch`, which describes both PR targets and future direct-branch destinations without embedding PR semantics in checkout preparation.

### Validation

Focused publisher and workspace unit coverage exercises publication, retry reconciliation, conflicts, and target-branch validation.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

The changeset records replay-safe trusted publication.

**Implementation** — 3 files · `+625 / -5`

The GitHub adapter and provider-neutral contract keep destination selection outside model input while preserving the existing draft-PR safeguards.

**Tests** — 2 files · `+483 / -3`

Focused coverage proves the GitHub publisher behavior and the renamed workspace target boundary.
