### PR TITLE
fix(eve): workflow - prevent local delivery replays

### DIFF
--- a/.changeset/calm-local-turns.md
+++ b/.changeset/calm-local-turns.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Prevent long local Workflow deliveries from timing out and replaying an in-flight turn. Explicit local delivery timeout overrides continue to take precedence.

--- a/packages/eve/src/internal/application/compiled-artifacts.test.ts
+++ b/packages/eve/src/internal/application/compiled-artifacts.test.ts
@@ -37,6 +37,10 @@ describe("createWorkflowWorldPluginSource", () => {
 
     expect(source).toContain("/compiled/@workflow/world-local/index.js");
     expect(source).toContain("resolveLocalWorkflowWorldDataDirectory(process.cwd())");
+    expect(source).toContain("applyLocalWorkflowWorldDeliveryTimeoutDefaults");
+    expect(source.indexOf("applyLocalWorkflowWorldDeliveryTimeoutDefaults();")).toBeLessThan(
+      source.indexOf("workflowWorldModule.createWorld"),
+    );
     expect(source).not.toContain("createWorldFromModule(workflowWorldModule)");
   });
 

--- a/packages/eve/src/internal/application/compiled-artifacts.ts
+++ b/packages/eve/src/internal/application/compiled-artifacts.ts
@@ -349,12 +349,17 @@ function resolveWorkflowWorldWiring(packageName: string): WorkflowWorldWiring {
     const dataDirectoryImportSpecifier = stringifyEsmImportSpecifier(
       resolvePackageSourceFilePath("src/internal/workflow/local-world-data-directory.ts"),
     );
+    const deliveryTimeoutsImportSpecifier = stringifyEsmImportSpecifier(
+      resolvePackageSourceFilePath("src/internal/workflow/local-world-delivery-timeouts.ts"),
+    );
     const moduleImportSpecifier = resolvePackageCompiledFilePath(
       `src/compiled/${packageName}/index.js`,
     );
     const importLines = `
+import { applyLocalWorkflowWorldDeliveryTimeoutDefaults } from ${deliveryTimeoutsImportSpecifier};
 import { resolveLocalWorkflowWorldDataDirectory } from ${dataDirectoryImportSpecifier};`.trimStart();
     const createWorldSource = `
+applyLocalWorkflowWorldDeliveryTimeoutDefaults();
 const workflowWorld = await workflowWorldModule.createWorld({
   dataDir: resolveLocalWorkflowWorldDataDirectory(process.cwd()),
 });`.trimStart();

--- a/packages/eve/src/internal/workflow/development-world-server.integration.test.ts
+++ b/packages/eve/src/internal/workflow/development-world-server.integration.test.ts
@@ -34,6 +34,13 @@ const SECRET = "workflow-transport-secret";
 const RUN_ID = "wrun_01J00000000000000000000000";
 const AGENT_NAME = "workflow-world-test";
 const QUEUE_PREFIX = deriveEveWorkflowQueuePrefix(AGENT_NAME);
+const LOCAL_DELIVERY_TIMEOUT_ENV_NAMES = [
+  "WORKFLOW_LOCAL_BODY_TIMEOUT_MS",
+  "WORKFLOW_LOCAL_HEADERS_TIMEOUT_MS",
+] as const;
+const originalLocalDeliveryTimeoutEnv = new Map(
+  LOCAL_DELIVERY_TIMEOUT_ENV_NAMES.map((name) => [name, process.env[name]]),
+);
 
 const originalFetch = globalThis.fetch;
 
@@ -42,9 +49,46 @@ afterEach(() => {
   delete process.env[DEVELOPMENT_WORKFLOW_SECRET_ENV];
   delete process.env[DEVELOPMENT_WORKER_APP_ROOT_ENV];
   delete process.env.WORKFLOW_LOCAL_BASE_URL;
+  for (const name of LOCAL_DELIVERY_TIMEOUT_ENV_NAMES) {
+    const originalValue = originalLocalDeliveryTimeoutEnv.get(name);
+    if (originalValue === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = originalValue;
+    }
+  }
 });
 
 describe("parent development Workflow World", () => {
+  it("defaults local delivery timeouts to unbounded", async () => {
+    for (const name of LOCAL_DELIVERY_TIMEOUT_ENV_NAMES) {
+      delete process.env[name];
+    }
+    const appRoot = await createScratchDirectory("eve-parent-workflow-timeouts-");
+    const world = createWorld({ activeGenerationId: () => "generation-a", appRoot });
+
+    try {
+      expect(process.env.WORKFLOW_LOCAL_BODY_TIMEOUT_MS).toBe("0");
+      expect(process.env.WORKFLOW_LOCAL_HEADERS_TIMEOUT_MS).toBe("0");
+    } finally {
+      await world.close();
+    }
+  });
+
+  it("preserves explicit local delivery timeouts", async () => {
+    process.env.WORKFLOW_LOCAL_BODY_TIMEOUT_MS = "123";
+    process.env.WORKFLOW_LOCAL_HEADERS_TIMEOUT_MS = "456";
+    const appRoot = await createScratchDirectory("eve-parent-workflow-explicit-timeouts-");
+    const world = createWorld({ activeGenerationId: () => "generation-a", appRoot });
+
+    try {
+      expect(process.env.WORKFLOW_LOCAL_BODY_TIMEOUT_MS).toBe("123");
+      expect(process.env.WORKFLOW_LOCAL_HEADERS_TIMEOUT_MS).toBe("456");
+    } finally {
+      await world.close();
+    }
+  });
+
   it("stores local Workflow state under .eve/.workflow-data", async () => {
     const appRoot = await createScratchDirectory("eve-parent-workflow-data-dir-");
     const world = createWorld({ activeGenerationId: () => "generation-a", appRoot });

--- a/packages/eve/src/internal/workflow/development-world-server.ts
+++ b/packages/eve/src/internal/workflow/development-world-server.ts
@@ -9,6 +9,7 @@ import {
   LOCAL_WORKFLOW_WORLD_DATA_DIRECTORY_RELATIVE_PATH,
   resolveLocalWorkflowWorldDataDirectory,
 } from "#internal/workflow/local-world-data-directory.js";
+import { applyLocalWorkflowWorldDeliveryTimeoutDefaults } from "#internal/workflow/local-world-delivery-timeouts.js";
 import {
   decodeDevelopmentWorldValue,
   encodeDevelopmentWorldValue,
@@ -77,6 +78,7 @@ class LocalParentDevelopmentWorkflowWorld implements ParentDevelopmentWorkflowWo
     this.#appRoot = input.appRoot;
     this.#resolveActiveGenerationId = input.resolveActiveGenerationId;
     this.#transportSecret = input.transportSecret;
+    applyLocalWorkflowWorldDeliveryTimeoutDefaults();
     this.#world = createWorld({
       dataDir: resolveLocalWorkflowWorldDataDirectory(input.appRoot),
       recoverActiveRuns: false,

--- a/packages/eve/src/internal/workflow/local-world-delivery-timeouts.test.ts
+++ b/packages/eve/src/internal/workflow/local-world-delivery-timeouts.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { applyLocalWorkflowWorldDeliveryTimeoutDefaults } from "#internal/workflow/local-world-delivery-timeouts.js";
+
+describe("applyLocalWorkflowWorldDeliveryTimeoutDefaults", () => {
+  it("defaults unset and empty local delivery timeouts to unbounded", () => {
+    const env: Record<string, string | undefined> = {
+      WORKFLOW_LOCAL_HEADERS_TIMEOUT_MS: "",
+    };
+
+    applyLocalWorkflowWorldDeliveryTimeoutDefaults(env);
+
+    expect(env.WORKFLOW_LOCAL_BODY_TIMEOUT_MS).toBe("0");
+    expect(env.WORKFLOW_LOCAL_HEADERS_TIMEOUT_MS).toBe("0");
+  });
+
+  it("preserves explicit local delivery timeouts", () => {
+    const env: Record<string, string | undefined> = {
+      WORKFLOW_LOCAL_BODY_TIMEOUT_MS: "123",
+      WORKFLOW_LOCAL_HEADERS_TIMEOUT_MS: "456",
+    };
+
+    applyLocalWorkflowWorldDeliveryTimeoutDefaults(env);
+
+    expect(env.WORKFLOW_LOCAL_BODY_TIMEOUT_MS).toBe("123");
+    expect(env.WORKFLOW_LOCAL_HEADERS_TIMEOUT_MS).toBe("456");
+  });
+});

--- a/packages/eve/src/internal/workflow/local-world-delivery-timeouts.ts
+++ b/packages/eve/src/internal/workflow/local-world-delivery-timeouts.ts
@@ -1,0 +1,20 @@
+const LOCAL_WORKFLOW_DELIVERY_TIMEOUT_ENV_NAMES = [
+  "WORKFLOW_LOCAL_BODY_TIMEOUT_MS",
+  "WORKFLOW_LOCAL_HEADERS_TIMEOUT_MS",
+] as const;
+
+/**
+ * Disables world-local's delivery deadlines unless the operator supplied an
+ * override. world-local snapshots these values when `createWorld()` constructs
+ * its queue and supports `0` as an unbounded timeout. Without this default, a
+ * long inline turn can be retried while its original provider call is active.
+ */
+export function applyLocalWorkflowWorldDeliveryTimeoutDefaults(
+  env: Record<string, string | undefined> = process.env as Record<string, string | undefined>,
+): void {
+  for (const name of LOCAL_WORKFLOW_DELIVERY_TIMEOUT_ENV_NAMES) {
+    if (env[name] === undefined || env[name] === "") {
+      env[name] = "0";
+    }
+  }
+}


### PR DESCRIPTION
### Summary

Related to #2425. Supersedes the closed bot-authored draft #2427. Long local agent steps can exceed world-local's 30-second transport deadline, causing the same healthy queue delivery to be retried while its original provider or tool call remains active. This change defaults local delivery timeouts to unbounded before eve constructs either the parent-owned development world or the generated self-hosted world, while preserving explicit timeout overrides and leaving custom and Vercel worlds unchanged. A genuinely stuck local delivery will now remain in flight until the local server exits, which avoids automatically duplicating provider charges or tool side effects.

### Validation

The eve 0.45.0 reporter log reproduced the 30-second deadline plus 5-second backoff cadence. Focused unit coverage passed 7 tests, the parent-world integration suite passed 10 tests, and `pnpm test:unit` passed 7,148 tests with one skipped.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the required patch changeset describing the user-visible local delivery fix.

**Implementation** — 3 files · `+27 / -0`

Keeps the timeout policy in one eve-owned helper and applies it at both local-world construction boundaries.

**Tests** — 3 files · `+76 / -0`

Covers default and explicit timeout behavior, the development-world integration, and generated self-hosted world wiring.
