### PR TITLE
fix(eve): workflow - abort local deliveries on shutdown

### DIFF
--- a/.changeset/fast-local-shutdown.md
+++ b/.changeset/fast-local-shutdown.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Allow local Workflow worlds with unbounded deliveries to shut down promptly while a turn is still running.

--- a/packages/eve/scripts/vendor-compiled/@workflow/world-local.mjs
+++ b/packages/eve/scripts/vendor-compiled/@workflow/world-local.mjs
@@ -56,10 +56,39 @@ const workflowWorldLocalVersionPlugin = {
   },
 };
 
+const GRACEFUL_AGENT_CLOSE_SOURCE = "await httpAgent?.close();";
+const ABORTING_AGENT_CLOSE_SOURCE = "await httpAgent?.destroy();";
+
+function createAbortingQueueShutdownPlugin() {
+  let patched = false;
+
+  return {
+    name: "eve-workflow-world-local-aborting-queue-shutdown",
+    transform(source, id) {
+      if (!id.replaceAll("\\", "/").endsWith("/@workflow/world-local/dist/queue.js")) {
+        return undefined;
+      }
+      if (!source.includes(GRACEFUL_AGENT_CLOSE_SOURCE)) {
+        throw new Error("@workflow/world-local's queue shutdown contract changed.");
+      }
+      patched = true;
+      return {
+        code: source.replace(GRACEFUL_AGENT_CLOSE_SOURCE, ABORTING_AGENT_CLOSE_SOURCE),
+        map: null,
+      };
+    },
+    buildEnd() {
+      if (!patched) {
+        throw new Error("@workflow/world-local's queue shutdown was not patched.");
+      }
+    },
+  };
+}
+
 export default {
   packageName: "@workflow/world-local",
   compiledPath: "@workflow/world-local",
   chunkGroup: "workflow",
   declaration: await loadDeclaration("workflow-world-local.d.ts"),
-  plugins: [workflowWorldLocalVersionPlugin],
+  plugins: [workflowWorldLocalVersionPlugin, createAbortingQueueShutdownPlugin()],
 };


### PR DESCRIPTION
### Summary

Related to #2425. Follow-up to #2609. Unbounded local delivery deadlines exposed that world-local shuts down its undici agent with `close()`, which waits for an active request to drain; `eve dev` could therefore hang while crashing or stopping during a turn. eve's vendored world-local now destroys that agent on shutdown, aborting only the process-owned transport request while preserving the durable run for restart. The vendoring transform fails loudly if upstream's shutdown contract changes.

### Validation

Reproduced the CI failure in `dev-server-workflow-generations.scenario.test.ts`: it failed with the unbounded defaults and passed when the former 30-second timeout was restored. After the fix, all three workflow-generation scenarios pass with unbounded defaults, including the interrupted-turn recovery case.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the patch changeset for prompt shutdown of active local deliveries.

**Implementation** — 1 file · `+30 / -1`

Adds a guarded vendoring transform that changes only world-local's undici shutdown from graceful draining to active cancellation.

**Tests** — 0 files · `+0 / -0`

The existing workflow-generation scenario already covers the regression end to end.
