### PR TITLE
chore(eve): tests - temporarily skip local workflow restart scenario

### DIFF
--- a/packages/eve/test/scenarios/dev-server-workflow-generations.scenario.test.ts
+++ b/packages/eve/test/scenarios/dev-server-workflow-generations.scenario.test.ts
@@ -189,7 +189,9 @@ describe("eve dev server workflow generations", () => {
     DEV_SERVER_SCENARIO_TIMEOUT_MS,
   );
 
-  it(
+  // Re-enable after https://github.com/vercel/workflow/pull/3824 ships and eve
+  // vendors the release with abortable local queue deliveries.
+  it.skip(
     "recovers a nonterminal child Workflow on its selected generation after restart",
     async () => {
       const app = await scenarioApp(WORKFLOW_GENERATION_DESCRIPTOR);


### PR DESCRIPTION
### Summary

Related to #2425. Temporarily skips the local child-Workflow restart scenario while [vercel/workflow#3824](https://github.com/vercel/workflow/pull/3824) fixes aborting active `world-local` deliveries during shutdown. The other workflow-generation scenarios continue to run, and no product behavior changes. Re-enable this scenario after eve vendors the released upstream fix.

### Validation

After a fresh workspace build, the focused workflow-generation scenario file completed with 2 tests passing and exactly this 1 test skipped.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 0 files · `+0 / -0`

No runtime or configuration changes.

**Tests** — 1 file · `+3 / -1`

Skips only the blocked restart scenario and records the upstream PR that determines when to restore it.
