### PR TITLE
fix(eve): model catalog - refresh stale or missing metadata

### DIFF
--- a/.changeset/fresh-model-catalog.md
+++ b/.changeset/fresh-model-catalog.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Cache AI Gateway model metadata for five minutes and refresh immediately on a cache miss, while continuing to fall back to cached metadata when refreshes fail.

--- a/packages/eve/src/compiler/model-catalog.ts
+++ b/packages/eve/src/compiler/model-catalog.ts
@@ -10,11 +10,10 @@ import {
   modelCatalogLimitsFromProvider,
   modelCatalogResponseSchema,
   normalizeCatalogModelId,
-  type CatalogModel,
 } from "#internal/model-catalog.js";
 const COMPILED_RUNTIME_MODEL_CATALOG_CACHE_KIND = "eve-model-catalog-cache";
 const COMPILED_RUNTIME_MODEL_CATALOG_CACHE_VERSION = 2;
-const COMPILED_RUNTIME_MODEL_CATALOG_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const COMPILED_RUNTIME_MODEL_CATALOG_CACHE_TTL_MS = 5 * 60 * 1000;
 export {
   catalogModelProviderSchema,
   catalogModelSchema,
@@ -90,7 +89,7 @@ export function resolveCompiledRuntimeModelCatalogCachePath(appRoot: string): st
 
 /**
  * Creates a per-build loader that caches the AI Gateway model catalog in
- * memory and on disk.
+ * memory and on disk, with stale-on-error fallback.
  */
 export function createCompiledRuntimeModelCatalogLoader(
   appRoot: string,
@@ -126,13 +125,12 @@ export function createCompiledRuntimeModelCatalogLoader(
     }
   };
 
-  const resolveModelsFromCacheOrFetch = async (): Promise<{
-    models: readonly CatalogModel[];
-    providerAliases: Readonly<Record<string, string>>;
-  } | null> => {
+  const resolveModelsFromCacheOrFetch = async (options?: {
+    forceRefresh?: boolean;
+  }): Promise<CompiledRuntimeModelCatalogCache | null> => {
     const cachedCatalog = await getCachedCatalog();
 
-    if (cachedCatalog !== null && isCacheFresh(cachedCatalog)) {
+    if (options?.forceRefresh !== true && cachedCatalog !== null && isCacheFresh(cachedCatalog)) {
       return cachedCatalog;
     }
 
@@ -154,16 +152,21 @@ export function createCompiledRuntimeModelCatalogLoader(
         return builtInLimits;
       }
 
-      const resolved = await resolveModelsFromCacheOrFetch();
+      let resolved = await resolveModelsFromCacheOrFetch();
+      if (resolved === null) return null;
 
-      if (resolved !== null) {
-        const model = findCatalogModelBySlug(resolved.models, normalizedId);
-        if (model) {
-          for (const p of model.providers) {
-            const limits = modelCatalogLimitsFromProvider(p);
-            if (limits !== null) {
-              return limits;
-            }
+      let model = findCatalogModelBySlug(resolved.models, normalizedId);
+      if (model === undefined) {
+        resolved = await resolveModelsFromCacheOrFetch({ forceRefresh: true });
+        if (resolved === null) return null;
+        model = findCatalogModelBySlug(resolved.models, normalizedId);
+      }
+
+      if (model !== undefined) {
+        for (const provider of model.providers) {
+          const limits = modelCatalogLimitsFromProvider(provider);
+          if (limits !== null) {
+            return limits;
           }
         }
       }
@@ -172,17 +175,26 @@ export function createCompiledRuntimeModelCatalogLoader(
     },
 
     async getByProviderModelId(provider, providerModelId) {
-      const resolved = await resolveModelsFromCacheOrFetch();
-      if (resolved === null) {
-        return null;
-      }
+      let resolved = await resolveModelsFromCacheOrFetch();
+      if (resolved === null) return null;
 
-      const match = findCatalogModelByProviderModelId({
+      let match = findCatalogModelByProviderModelId({
         models: resolved.models,
         provider,
         providerAliases: resolved.providerAliases,
         providerModelId,
       });
+      if (match === null) {
+        resolved = await resolveModelsFromCacheOrFetch({ forceRefresh: true });
+        if (resolved === null) return null;
+        match = findCatalogModelByProviderModelId({
+          models: resolved.models,
+          provider,
+          providerAliases: resolved.providerAliases,
+          providerModelId,
+        });
+      }
+
       if (match !== null) {
         const limits = modelCatalogLimitsFromProvider(match.provider);
         if (limits !== null) {

--- a/packages/eve/test/scenarios/compiler-model-catalog.scenario.test.ts
+++ b/packages/eve/test/scenarios/compiler-model-catalog.scenario.test.ts
@@ -177,6 +177,72 @@ describe("compiler model catalog", () => {
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
   });
 
+  it("reuses fresh metadata and refreshes early for a missing model", async () => {
+    const { agentRoot, appRoot } = await createAppRoot(
+      "eve-model-catalog-refresh-",
+      APP_ROOT_OPTIONS,
+    );
+
+    await writeFile(
+      join(agentRoot, "agent.ts"),
+      ["export default {", '  model: "example/cached-model",', "};", ""].join("\n"),
+    );
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockImplementationOnce(async () =>
+      mockCatalogResponse([
+        {
+          slug: "example/cached-model",
+          providers: [
+            {
+              provider: "example",
+              providerModelId: "cached-model",
+              contextWindowTokens: 100_000,
+              maxOutputTokens: 10_000,
+            },
+          ],
+        },
+      ]),
+    );
+    fetchSpy.mockImplementationOnce(async () =>
+      mockCatalogResponse([
+        {
+          slug: "example/new-model",
+          providers: [
+            {
+              provider: "example",
+              providerModelId: "new-model",
+              contextWindowTokens: 200_000,
+              maxOutputTokens: 20_000,
+            },
+          ],
+        },
+      ]),
+    );
+
+    const first = await compileAgent({ startPath: appRoot });
+    const second = await compileAgent({ startPath: appRoot });
+    await writeFile(
+      join(agentRoot, "agent.ts"),
+      ["export default {", '  model: "example/new-model",', "};", ""].join("\n"),
+    );
+    const third = await compileAgent({ startPath: appRoot });
+
+    expect(first.manifest.config.model).toMatchObject({
+      contextWindowTokens: 100_000,
+      id: "example/cached-model",
+    });
+    expect(second.manifest.config.model).toMatchObject({
+      contextWindowTokens: 100_000,
+      id: "example/cached-model",
+    });
+    expect(third.manifest.config.model).toMatchObject({
+      contextWindowTokens: 200_000,
+      id: "example/new-model",
+    });
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
   it("hydrates compaction limits when model IDs end in -thinking", async () => {
     const { agentRoot, appRoot } = await createAppRoot(
       "eve-model-catalog-thinking-",
@@ -316,6 +382,43 @@ describe("compiler model catalog", () => {
         id: "example/stale-summary-model",
       },
     });
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses fresh cached metadata when a cache-miss refresh fails", async () => {
+    const { agentRoot, appRoot } = await createAppRoot(
+      "eve-model-catalog-cache-miss-",
+      APP_ROOT_OPTIONS,
+    );
+
+    await writeFile(
+      join(agentRoot, "agent.ts"),
+      ["export default {", '  model: "example/missing-model",', "};", ""].join("\n"),
+    );
+    await mkdir(join(appRoot, ".eve", "cache"), {
+      recursive: true,
+    });
+    await writeFile(
+      resolveCompiledRuntimeModelCatalogCachePath(appRoot),
+      `${JSON.stringify(
+        {
+          fetchedAt: new Date().toISOString(),
+          kind: "eve-model-catalog-cache",
+          models: [],
+          providerAliases: {},
+          version: 2,
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"));
+
+    await expect(compileAgent({ startPath: appRoot })).rejects.toThrow(
+      'Cannot compile agent compaction because the primary compaction trigger model "example/missing-model" does not have known AI Gateway context window metadata.',
+    );
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
### Summary

The compiler's 24-hour AI Gateway model catalog cache could delay newly released models. Catalog metadata is now cached for five minutes, while a lookup miss bypasses the TTL and refreshes immediately. Every failed refresh falls back to the persisted catalog regardless of its age; without any cached catalog, the original fetch error still propagates.

### Validation

Confirmed with the model-catalog unit suite (23 passing) and compiler model-catalog scenario suite (12 passing), including fresh-cache reuse, cache-miss refresh, stale fallback, and failed cache-miss refresh coverage.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the patch changeset describing the release-visible cache behavior.

**Implementation** — 1 file · `+34 / -22`

Keeps the policy in the compiler catalog loader and applies cache-miss refreshes consistently to gateway and direct-provider model lookups.

**Tests** — 1 file · `+103 / -0`

Covers the five-minute reuse, early refresh, and both fresh and stale fallback paths with real compilation scenarios.
