### PR TITLE
fix(eve): suppress rejected AI SDK telemetry

### DIFF
--- a/.changeset/suppress-rejected-ai-sdk-telemetry.md
+++ b/.changeset/suppress-rejected-ai-sdk-telemetry.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Stop producing AI SDK telemetry spans when `tracePolicy` rejects an agent trace.

--- a/docs/guides/instrumentation.md
+++ b/docs/guides/instrumentation.md
@@ -60,6 +60,8 @@ The third configurable surface, [runtime context events](#runtime-context), atta
 
 Built-in messaging channels classify their instrumentation metadata with an `audience`: `public`, `private`, or `unknown`. Slack public channels and Chat SDK workspace-visible threads are public; direct and private conversations are private; platform surfaces without enough visibility evidence remain unknown.
 
+When an instrumentation-provider `tracePolicy` rejects a trace, eve does not enable AI SDK telemetry for that execution. Rejection prevents model and tool spans from being created rather than exporting metadata-only versions of them.
+
 ## Channel delivery traces
 
 Instrumentation providers receive `channel.delivery.started` followed by

--- a/docs/guides/instrumentation.md
+++ b/docs/guides/instrumentation.md
@@ -60,8 +60,6 @@ The third configurable surface, [runtime context events](#runtime-context), atta
 
 Built-in messaging channels classify their instrumentation metadata with an `audience`: `public`, `private`, or `unknown`. Slack public channels and Chat SDK workspace-visible threads are public; direct and private conversations are private; platform surfaces without enough visibility evidence remain unknown.
 
-When an instrumentation-provider `tracePolicy` rejects a trace, eve does not enable AI SDK telemetry for that execution. Rejection prevents model and tool spans from being created rather than exporting metadata-only versions of them.
-
 ## Channel delivery traces
 
 Instrumentation providers receive `channel.delivery.started` followed by

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -21,6 +21,7 @@ import {
   LiveStepDynamicModelSelectionKey,
   ParentSessionKey,
   SandboxKey,
+  SessionTraceSeedKey,
   SessionKey,
   SessionIdKey,
   SessionDynamicInstructionsKey,
@@ -10767,7 +10768,7 @@ describe("createToolLoopHarness", () => {
         toolResults: [{ toolCallId: "call-1", toolName: "add", output: "42" }],
       });
 
-      declareTelemetry({});
+      declareTelemetry({ tracePolicy: () => true });
       const config = createTestConfig("conversation");
       const runStep = createToolLoopHarness(config);
       const result = await runStep(createTestSession(), { message: "add stuff" });
@@ -10884,6 +10885,57 @@ describe("createToolLoopHarness", () => {
   });
 
   describe("telemetry metadata", () => {
+    it("does not enable AI SDK telemetry when the trace policy rejects the trace", async () => {
+      setupMockAgent({
+        finishReason: "stop",
+        response: { messages: [{ content: "Hello!", role: "assistant" }] },
+        text: "Hello!",
+        toolCalls: [],
+        toolResults: [],
+      });
+      declareTelemetry({
+        recordInputs: true,
+        recordOutputs: true,
+        tracePolicy: () => false,
+      });
+      const runStep = createToolLoopHarness(createTestConfig());
+
+      await runStep(createTestSession(), { message: "private" });
+
+      const agentCall = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0] as {
+        telemetry?: unknown;
+      };
+      expect(agentCall.telemetry).toBeUndefined();
+      expect(mockCreateAiSdkHookBridge).not.toHaveBeenCalled();
+    });
+
+    it("reuses the persisted rejected trace decision", async () => {
+      setupMockAgent({
+        finishReason: "stop",
+        response: { messages: [{ content: "Hello!", role: "assistant" }] },
+        text: "Hello!",
+        toolCalls: [],
+        toolResults: [],
+      });
+      const tracePolicy = vi.fn(() => true);
+      declareTelemetry({ recordInputs: true, recordOutputs: true, tracePolicy });
+      const runStep = createToolLoopHarness(createTestConfig());
+      const ctx = new ContextContainer();
+      ctx.set(SessionTraceSeedKey, {
+        spanId: "1".repeat(16),
+        traceFlags: 0,
+        traceId: "2".repeat(32),
+      });
+
+      await contextStorage.run(ctx, () => runStep(createTestSession(), { message: "private" }));
+
+      const agentCall = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0] as {
+        telemetry?: unknown;
+      };
+      expect(agentCall.telemetry).toBeUndefined();
+      expect(tracePolicy).not.toHaveBeenCalled();
+    });
+
     it("emits the authored turn trace with the session and turn preamble", async () => {
       const authoredTrace = {
         spanId: "0123456789abcdef",
@@ -10932,7 +10984,7 @@ describe("createToolLoopHarness", () => {
         toolResults: [],
       });
 
-      declareTelemetry({});
+      declareTelemetry({ tracePolicy: () => true });
       const config = createTestConfig("conversation");
       const runStep = createToolLoopHarness(config);
       await runStep(createTestSession(), { message: "hi" });
@@ -11105,7 +11157,7 @@ describe("createToolLoopHarness", () => {
       });
     });
 
-    it("forces hosted unknown model telemetry to metadata only", async () => {
+    it("does not emit hosted unknown model telemetry", async () => {
       setupMockAgent({
         finishReason: "stop",
         response: { messages: [{ content: "Hello!", role: "assistant" }] },
@@ -11121,10 +11173,7 @@ describe("createToolLoopHarness", () => {
       const agentCall = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0] as {
         telemetry?: { recordInputs?: boolean; recordOutputs?: boolean };
       };
-      expect(agentCall.telemetry).toMatchObject({
-        recordInputs: false,
-        recordOutputs: false,
-      });
+      expect(agentCall.telemetry).toBeUndefined();
     });
 
     it("keeps unknown model telemetry content in a local development worker", async () => {
@@ -11136,7 +11185,11 @@ describe("createToolLoopHarness", () => {
         toolCalls: [],
         toolResults: [],
       });
-      declareTelemetry({ recordInputs: true, recordOutputs: true });
+      declareTelemetry({
+        recordInputs: true,
+        recordOutputs: true,
+        tracePolicy: () => true,
+      });
 
       const runStep = createToolLoopHarness(createTestConfig("conversation"));
       await runStep(createTestSession(), { message: "hi" });

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -184,6 +184,7 @@ import {
 import { getInstrumentationConfig } from "#harness/instrumentation/config.js";
 import { getInstrumentationRuntime } from "#harness/instrumentation/runtime.js";
 import type { OtelHarnessSettings } from "#tracing/otel-declaration.js";
+import { evaluateTracePolicy, isSampledTrace } from "#tracing/sampled-trace.js";
 import {
   normalizeModelMessages,
   normalizeUserContent,
@@ -335,12 +336,16 @@ const MODEL_CALL_MAX_ATTEMPTS = 3;
 const MODEL_CALL_RETRY_BASE_DELAY_MS = 500;
 
 function enrichTelemetry(
+  enabled: boolean,
   settings: OtelHarnessSettings | undefined,
   channelAudience: ChannelAudience,
   agentName: string | undefined,
   runtimeContext?: Readonly<Record<string, unknown>>,
   bridgeIntegration?: Telemetry,
 ): TelemetryOptions | undefined {
+  if (!enabled) {
+    return undefined;
+  }
   if (settings === undefined && bridgeIntegration === undefined) {
     return undefined;
   }
@@ -611,6 +616,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     initialSession: Readonly<Parameters<StepFn>[0]>,
     input?: StepInput,
   ): Promise<StepResult> {
+    const aiSdkTelemetryEnabled = shouldEnableAiSdkTelemetry(otelSettings, agentName);
     // --- Turn span lifecycle ------------------------------------------------
 
     // First step of a turn: open a new parent span. Continuation steps
@@ -632,7 +638,8 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     // Run the step body inside the turn span's (or restored parent's)
     // OTel context so AI SDK spans nest as children.
     const parentContext = resolveStepOtelContext(tracer, turnSpan, initialSession);
-    const executeStep = () => executeStepBody(initialSession, input, turnSpan);
+    const executeStep = () =>
+      executeStepBody(initialSession, input, turnSpan, aiSdkTelemetryEnabled);
 
     try {
       if (parentContext) {
@@ -648,6 +655,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     initialSession: Readonly<Parameters<StepFn>[0]>,
     input?: StepInput,
     turnSpan?: Span,
+    aiSdkTelemetryEnabled = true,
   ): Promise<StepResult> {
     let session = initialSession;
     const prepareHistory = createHistoryViewPreparer({
@@ -806,7 +814,9 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
             resolveModel: config.resolveModel,
             runtimeIdentity: config.runtimeIdentity,
             session,
-            telemetry: enrichTelemetry(otelSettings, channelAudience, agentName) ?? undefined,
+            telemetry:
+              enrichTelemetry(aiSdkTelemetryEnabled, otelSettings, channelAudience, agentName) ??
+              undefined,
           });
 
           session = {
@@ -1315,7 +1325,9 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       resolveModel: config.resolveModel,
       runtimeIdentity: config.runtimeIdentity,
       session,
-      telemetry: enrichTelemetry(otelSettings, channelAudience, agentName) ?? undefined,
+      telemetry:
+        enrichTelemetry(aiSdkTelemetryEnabled, otelSettings, channelAudience, agentName) ??
+        undefined,
     });
     session = compaction.session;
     if (compaction.compacted) {
@@ -1560,7 +1572,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
             };
       activeAttemptScope = attemptScope;
       const bridgeIntegration =
-        attemptScope === undefined || instrumentationHooks === undefined
+        !aiSdkTelemetryEnabled || attemptScope === undefined || instrumentationHooks === undefined
           ? undefined
           : createAiSdkHookBridge(
               attemptScope,
@@ -1617,6 +1629,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         runtimeContext: telemetryRuntimeContext,
         stopWhen: isStepCount(1),
         telemetry: enrichTelemetry(
+          aiSdkTelemetryEnabled,
           otelSettings,
           channelAudience,
           agentName,
@@ -2043,6 +2056,24 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
   }
 
   return runStep;
+}
+
+function shouldEnableAiSdkTelemetry(
+  settings: OtelHarnessSettings | undefined,
+  agentName: string | undefined,
+): boolean {
+  if (settings === undefined) return true;
+
+  const store = contextStorage.getStore();
+  const traceSeed = store?.get(SessionTraceSeedKey);
+  if (traceSeed !== undefined) return isSampledTrace(traceSeed);
+
+  const channel = store?.get(ChannelInstrumentationKey);
+  return evaluateTracePolicy(settings.tracePolicy, {
+    agentName,
+    audience: normalizeChannelAudience(channel?.metadata.audience),
+    channelType: channel?.channelType,
+  });
 }
 
 function isValidSpanContext(spanContext: SpanContext): boolean {


### PR DESCRIPTION
### Summary

`tracePolicy` rejection currently makes the Eve agent trace non-recording but still enables the AI SDK's OpenTelemetry spans on the Workflow trace. Those spans can carry model or tool content independently of the rejected agent trace.

Use the persisted session trace seed as the authoritative decision, falling back to one policy evaluation for legacy or unseeded sessions. Rejected traces now pass no telemetry configuration or lifecycle bridge to the AI SDK; explicitly admitted traces, including local unknown-audience traces, keep their existing behavior.

Related to #2335.

### Validation

The regression first reproduced AI SDK telemetry remaining enabled under a rejecting policy. Focused tool-loop and Workflow-runtime coverage now passes all 239 tests, including persisted rejection, hosted unknown-audience rejection, and explicitly admitted local unknown-audience behavior. The Eve package typecheck and documentation validation pass.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the patch release note while the flagged provider API remains out of the published guide.

**Implementation** — 1 file · `+35 / -4`

Keeps the decision local to the tool-loop telemetry boundary and reuses the durable trace seed instead of introducing new session state.

**Tests** — 1 file · `+61 / -8`

Covers direct policy rejection, persisted rejection without re-evaluation, hosted unknown audiences, and explicitly admitted telemetry paths.
