### PR TITLE
chore: add .vercel.approvers with @vercel/eve:team

### DIFF
--- a/.vercel.approvers
+++ b/.vercel.approvers
@@ -1,0 +1,1 @@
+@vercel/eve:team


### PR DESCRIPTION
Adds a `.vercel.approvers` file containing `@vercel/eve:team` as the sole approver entry, so PRs to this repo route to the eve team for approval.\n\nNo code or behavior changes; no tests run.

https://vercel.com/docs/code-owners/code-approvers