### PR TITLE
fix(eve): surface turn version skew

### DIFF
--- a/.changeset/loud-turn-version-skew.md
+++ b/.changeset/loud-turn-version-skew.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fail resumed sessions visibly when a newer turn deployment returns an unsupported control or driver action, instead of leaving the pinned session driver waiting without a response.

--- a/packages/eve/src/execution/turn-control-codec.ts
+++ b/packages/eve/src/execution/turn-control-codec.ts
@@ -1,0 +1,63 @@
+import type { NextDriverAction } from "#execution/next-driver-action.js";
+import type { TurnControlPayload } from "#execution/turn-control-protocol.js";
+import { isObject } from "#shared/guards.js";
+
+/** Rejects control values a pinned driver cannot safely interpret. */
+export function decodeTurnControlPayload(value: unknown): TurnControlPayload {
+  if (!isObject(value)) return unsupportedControl(value);
+
+  const payload = value as TurnControlPayload;
+  switch (payload.kind) {
+    case "turn-error":
+    case "turn-continuation-token":
+    case "turn-delivery-request":
+    case "turn-delivery-accepted":
+    case "turn-delivery-cancelled":
+      return payload;
+    case "turn-result":
+      decodeDriverAction(payload.action);
+      return payload;
+    default: {
+      const unsupported: never = payload;
+      return unsupportedControl(unsupported);
+    }
+  }
+}
+
+function decodeDriverAction(value: unknown): NextDriverAction {
+  if (!isObject(value)) return unsupportedDriverAction(value);
+
+  const action = value as NextDriverAction;
+  switch (action.kind) {
+    case "done":
+    case "park":
+    case "dispatch-runtime-actions":
+    case "dispatch-workflow-runtime-actions":
+      break;
+    default: {
+      const unsupported: never = action;
+      return unsupportedDriverAction(unsupported);
+    }
+  }
+
+  if (!isObject(action.sessionState) || typeof action.sessionState.version !== "number") {
+    throw new Error("Turn result from a newer eve deployment has no versioned session state.");
+  }
+  if (!isObject(action.serializedContext)) {
+    throw new Error("Turn result from a newer eve deployment has no serialized context.");
+  }
+
+  return action;
+}
+
+function unsupportedControl(value: unknown): never {
+  throw new Error(
+    `Turn received unsupported control kind ${JSON.stringify(isObject(value) ? value.kind : undefined)} from a newer eve deployment.`,
+  );
+}
+
+function unsupportedDriverAction(value: unknown): never {
+  throw new Error(
+    `Turn received unsupported driver action ${JSON.stringify(isObject(value) ? value.kind : undefined)} from a newer eve deployment.`,
+  );
+}

--- a/packages/eve/src/execution/turn-control-protocol.test.ts
+++ b/packages/eve/src/execution/turn-control-protocol.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { HookNotFoundError } from "#compiled/@workflow/errors/index.js";
+import { decodeTurnControlPayload } from "#execution/turn-control-codec.js";
 import { sendTurnControlStep } from "#execution/turn-control-protocol.js";
 import { resumeHook } from "#internal/workflow/runtime.js";
 
@@ -8,7 +9,35 @@ vi.mock("#compiled/@workflow/core/runtime.js", () => ({
   resumeHook: vi.fn(),
 }));
 
-describe("sendTurnControlStep", () => {
+describe("turn control compatibility", () => {
+  it("preserves additive fields understood only by a newer turn", () => {
+    const payload = {
+      action: {
+        futureActionDetail: { enabled: true },
+        kind: "park",
+        serializedContext: { futureContext: true },
+        sessionState: { futureState: true, version: 1 },
+      },
+      futureControlDetail: true,
+      kind: "turn-result",
+    };
+
+    expect(decodeTurnControlPayload(payload)).toBe(payload);
+  });
+
+  it("allows a newer session state version when its driver-facing shape is compatible", () => {
+    const payload = {
+      action: {
+        kind: "park",
+        serializedContext: {},
+        sessionState: { version: 2 },
+      },
+      kind: "turn-result",
+    };
+
+    expect(decodeTurnControlPayload(payload)).toBe(payload);
+  });
+
   it("ignores an obsolete send after the session driver releases its hook", async () => {
     vi.mocked(resumeHook).mockRejectedValue(new HookNotFoundError("turn-control"));
 

--- a/packages/eve/src/execution/turn-control-protocol.ts
+++ b/packages/eve/src/execution/turn-control-protocol.ts
@@ -1,5 +1,6 @@
 import type { DeliverHookPayload, HookPayload } from "#channel/types.js";
 import { HookNotFoundError } from "#compiled/@workflow/errors/index.js";
+import { decodeTurnControlPayload } from "#execution/turn-control-codec.js";
 import type { NextDriverAction } from "#execution/next-driver-action.js";
 import { resumeHook } from "#internal/workflow/runtime.js";
 
@@ -38,7 +39,8 @@ export async function sendTurnControlStep(input: {
   "use step";
 
   try {
-    await resumeHook(input.controlToken, input.payload);
+    const payload = decodeTurnControlPayload(input.payload);
+    await resumeHook(input.controlToken, payload);
   } catch (error) {
     // Reset and timeout terminally stop the session driver while its child
     // turn may still be unwinding. A final at-least-once control send then

--- a/packages/eve/src/execution/turn-control-receiver.test.ts
+++ b/packages/eve/src/execution/turn-control-receiver.test.ts
@@ -119,6 +119,27 @@ describe("TurnControlReceiver", () => {
     await expect(runReceiver([])).rejects.toThrow("boom");
   });
 
+  it("fails instead of ignoring a control kind from a newer deployment", async () => {
+    installControlHook([{ kind: "future-terminal-control" } as never]);
+
+    await expect(runReceiver([])).rejects.toThrow(
+      'unsupported control kind "future-terminal-control"',
+    );
+  });
+
+  it("fails instead of returning a driver action from a newer deployment", async () => {
+    installControlHook([
+      {
+        action: { kind: "future-driver-action" },
+        kind: "turn-result",
+      } as never,
+    ]);
+
+    await expect(runReceiver([])).rejects.toThrow(
+      'unsupported driver action "future-driver-action"',
+    );
+  });
+
   it("buffers current and legacy sends that arrive during a turn", async () => {
     installControlHook([parkResult()], true);
     const bufferedDeliveries: DeliverHookPayload[] = [];

--- a/packages/eve/src/execution/turn-control-receiver.ts
+++ b/packages/eve/src/execution/turn-control-receiver.ts
@@ -2,6 +2,7 @@ import { createHook, type Hook } from "#compiled/@workflow/core/index.js";
 
 import type { DeliverHookPayload } from "#channel/types.js";
 import { forwardTurnCancellationStep } from "#execution/forward-turn-cancellation-step.js";
+import { decodeTurnControlPayload } from "#execution/turn-control-codec.js";
 import type { TurnControlPayload } from "#execution/turn-control-protocol.js";
 import { forwardTurnDeliveryStep } from "#execution/forward-turn-delivery-step.js";
 import { closeHookIterator, disposeHook } from "#execution/hook-ownership.js";
@@ -187,7 +188,7 @@ export class TurnControlReceiver {
     if (winner.value.done) {
       throw new Error("Turn control hook closed before delivering a result.");
     }
-    const payload = winner.value.value;
+    const payload = decodeTurnControlPayload(winner.value.value);
     if (payload.kind === "turn-error") throw rebuildSerializableError(payload.error);
     if (payload.kind === "turn-continuation-token") {
       await this.commandInbox.rekeyContinuation(payload.continuationToken);
@@ -224,12 +225,10 @@ export class TurnControlReceiver {
           await this.commandInbox.rekeyContinuation(winner.value.value.continuationToken);
           continue;
         }
-        const terminal = this.readTerminalControl(winner.value.value);
+        const payload = decodeTurnControlPayload(winner.value.value);
+        const terminal = this.readTerminalControl(payload);
         if (terminal !== undefined) return terminal;
-        if (
-          winner.value.value.kind === "turn-delivery-cancelled" &&
-          winner.value.value.requestId === request.requestId
-        ) {
+        if (payload.kind === "turn-delivery-cancelled" && payload.requestId === request.requestId) {
           return undefined;
         }
         continue;

--- a/packages/eve/src/execution/turn-workflow.test.ts
+++ b/packages/eve/src/execution/turn-workflow.test.ts
@@ -301,6 +301,21 @@ describe("turnWorkflow", () => {
     );
   });
 
+  it("reports malformed cross-version input to the pinned driver", async () => {
+    await expect(turnWorkflow({ completionToken: "turn-token", version: 999 })).rejects.toThrow(
+      "newer than the supported version",
+    );
+
+    expect(resumeHookMock.mock.calls.map((call) => call[1])).toEqual([
+      expect.objectContaining({
+        error: expect.objectContaining({
+          message: expect.stringContaining("newer than the supported version"),
+        }),
+        kind: "turn-error",
+      }),
+    ]);
+  });
+
   it("reports task-mode waits as turn errors", async () => {
     const sessionState = createSessionState();
     vi.mocked(turnStep).mockResolvedValueOnce({

--- a/packages/eve/src/execution/turn-workflow.ts
+++ b/packages/eve/src/execution/turn-workflow.ts
@@ -34,6 +34,7 @@ import { activeTurnId } from "#harness/active-turn-id.js";
 import { getRuntimeActionResultKey } from "#runtime/actions/keys.js";
 import { resolveRuntimeActionResultsForKeys } from "#runtime/actions/results.js";
 import type { RuntimeActionResult } from "#shared/action-types.js";
+import { isObject } from "#shared/guards.js";
 
 const TASK_MODE_WAIT_ERROR_MESSAGE = "Task mode cannot wait for follow-up input (`next: null`).";
 
@@ -51,7 +52,18 @@ export type { TurnWorkflowInput };
 export async function turnWorkflow(rawInput: unknown): Promise<void> {
   "use workflow";
 
-  const input = migrateTurnWorkflowInput(rawInput);
+  let input: TurnWorkflowInput;
+  try {
+    input = migrateTurnWorkflowInput(rawInput);
+  } catch (error) {
+    if (isObject(rawInput) && typeof rawInput.completionToken === "string") {
+      await sendTurnControlStep({
+        controlToken: rawInput.completionToken,
+        payload: { error: normalizeSerializableError(error), kind: "turn-error" },
+      });
+    }
+    throw error;
+  }
 
   if (input.driverCapabilities?.turnInbox !== true) {
     return runLegacyTurnWorkflow(input);

--- a/packages/eve/src/execution/workflow-entry.test.ts
+++ b/packages/eve/src/execution/workflow-entry.test.ts
@@ -542,6 +542,38 @@ describe("workflowEntry", () => {
     expect(createSessionTimeoutControl).not.toHaveBeenCalled();
   });
 
+  it("surfaces an incompatible newer turn protocol as a terminal session failure", async () => {
+    const sessionState = createBaseSessionState();
+    vi.mocked(createSessionStep).mockResolvedValue(createSessionStepResultForMock(sessionState));
+    installHookMocks({
+      turnControls: [{ kind: "future-terminal-control" } as never],
+    });
+
+    await expect(
+      workflowEntry({
+        input: { message: "resume old thread" },
+        serializedContext: createSerializedContext(),
+      }),
+    ).rejects.toMatchObject({
+      message: "Agent workflow failed. Inspect the private session trace for details.",
+      name: "EveWorkflowFailure",
+    });
+
+    expect(emitTerminalSessionFailureStep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          message: expect.stringContaining('unsupported control kind "future-terminal-control"'),
+        }),
+      }),
+    );
+    expect(notifyTurnCallerStep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lifecycle: "terminal",
+        settled: expect.objectContaining({ isError: true }),
+      }),
+    );
+  });
+
   it("notifies a delegated parent once when a turn fails terminally", async () => {
     const sessionState = createBaseSessionState();
     const caller = {


### PR DESCRIPTION
### Summary

Resuming a parked session can run its next turn on a newer deployment. If that turn returns a control message or driver action the pinned driver does not understand, the driver can currently keep waiting with no acknowledgement to the user.

This makes those detectable compatibility breaks fail through the existing terminal session error path instead. Additive fields and newer compatible session-state versions remain supported, and this does not change the latest-deployment behavior from #2378.

### Validation

Adds regression coverage for unknown controls and actions, pre-turn migration failures, and the resulting terminal caller notification. Also covers preserving additive fields and compatible newer session-state versions without false positives. Built the package and the weather and TUI fixtures to exercise workflow bundling.

### Diff size

**Docs** — 1 file · `+5 / -0`

Patch changeset for the user-visible failure behavior.

**Implementation** — 4 files · `+84 / -8`

Keeps the checks at the existing turn control send/receive boundaries and input migration error path. The decoder is separate from the step module so it remains available inside workflow bundles.

**Tests** — 4 files · `+98 / -1`

Covers each detectable skew case, compatible state evolution, and the terminal session failure path.
