### PR TITLE
feat(eve): add `/info` command to eve tui

### DIFF
--- a/.changeset/tidy-tuis-report.md
+++ b/.changeset/tidy-tuis-report.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add a local dev TUI `/info` command that shows the same application, artifact, diagnostic, and messaging details as `eve info`. The human-readable report now begins directly with its application details instead of repeating an `eve Info` heading.

--- a/docs/guides/dev-tui.md
+++ b/docs/guides/dev-tui.md
@@ -20,6 +20,7 @@ The transcript remains in your terminal scrollback after you exit. Run `/help` i
 | `/deploy`     | Deploy the agent to Vercel production. Links the directory first if needed.                                                                               |
 | `/vc:install` | Install the Vercel CLI.                                                                                                                                   |
 | `/vc:login`   | Log in to Vercel or restore access to a remote deployment.                                                                                                |
+| `/info`       | Show the resolved application, compiled artifacts, discovery diagnostics, and messaging routes.                                                           |
 | `/loglevel`   | Choose which server and agent logs appear in the transcript.                                                                                              |
 | `/traces`     | Open the local trace viewer. Pass a trace ID prefix to open a specific trace.                                                                             |
 | `/reset`      | Start a fresh session.                                                                                                                                    |
@@ -29,7 +30,7 @@ The transcript remains in your terminal scrollback after you exit. Run `/help` i
 | `/exit`       | Quit the UI.                                                                                                                                              |
 | `/help`       | List available commands.                                                                                                                                  |
 
-`/model`, `/add`, `/deploy`, and `/traces` are available when `eve dev` runs locally. They are unavailable when the UI connects to a server with `--url`.
+`/model`, `/add`, `/deploy`, `/info`, and `/traces` are available when `eve dev` runs locally. They are unavailable when the UI connects to a server with `--url`.
 
 ## Add an integration
 

--- a/packages/eve/src/cli/commands/info.ts
+++ b/packages/eve/src/cli/commands/info.ts
@@ -1,6 +1,6 @@
 import { type ApplicationInspection, inspectApplication } from "#services/inspect-application.js";
 import type { CompiledInstructionsDefinition } from "#compiler/manifest.js";
-import { type CliRow, createCliTheme, renderCliBanner, renderCliSection } from "#cli/ui/output.js";
+import { type CliRow, createCliTheme, renderCliSection } from "#cli/ui/output.js";
 
 interface CliInfoLogger {
   log(message: string): void;
@@ -126,6 +126,11 @@ export async function printApplicationInfo(
     return;
   }
 
+  logger.log(renderApplicationInfo(inspection));
+}
+
+/** Renders the human-readable `eve info` report for CLI and TUI surfaces. */
+export function renderApplicationInfo(inspection: ApplicationInspection): string {
   const compiledState = inspection.compiledState;
   const info = inspection.application;
   const theme = createCliTheme();
@@ -240,60 +245,53 @@ export async function printApplicationInfo(
     });
   }
 
-  logger.log(
-    [
-      renderCliBanner(theme, {
-        subtitle: "Resolved application paths and the active message contract.",
-        title: "eve Info",
-      }),
-      "",
-      renderCliSection(theme, {
-        rows: applicationRows,
-        title: "Application",
-      }),
-      "",
-      renderCliSection(theme, {
-        rows: artifactRows,
-        title: "Artifacts",
-      }),
-      ...(compiledState === null
-        ? []
-        : [
-            "",
-            renderCliSection(theme, {
-              rows: instructionsRows,
-              title: "Instructions",
-            }),
-          ]),
-      "",
-      renderCliSection(theme, {
-        rows: [
-          {
-            label: "Workflow ID",
-            value: info.workflowId,
-          },
-          {
-            label: "Source Dir",
-            value: info.workflowSourceDir,
-          },
-          {
-            label: "Create",
-            tone: "info",
-            value: `POST ${inspection.messaging.createSessionRoutePath}`,
-          },
-          {
-            label: "Messages",
-            tone: "info",
-            value: `POST ${inspection.messaging.sessionMessagesRoutePattern}`,
-          },
-          {
-            label: "Stream",
-            tone: "info",
-            value: `GET ${inspection.messaging.streamRoutePattern}`,
-          },
-        ],
-        title: "Messaging",
-      }),
-    ].join("\n"),
-  );
+  return [
+    renderCliSection(theme, {
+      rows: applicationRows,
+      title: "Application",
+    }),
+    "",
+    renderCliSection(theme, {
+      rows: artifactRows,
+      title: "Artifacts",
+    }),
+    ...(compiledState === null
+      ? []
+      : [
+          "",
+          renderCliSection(theme, {
+            rows: instructionsRows,
+            title: "Instructions",
+          }),
+        ]),
+    "",
+    renderCliSection(theme, {
+      rows: [
+        {
+          label: "Workflow ID",
+          value: info.workflowId,
+        },
+        {
+          label: "Source Dir",
+          value: info.workflowSourceDir,
+        },
+        {
+          label: "Create",
+          tone: "info",
+          value: `POST ${inspection.messaging.createSessionRoutePath}`,
+        },
+        {
+          label: "Messages",
+          tone: "info",
+          value: `POST ${inspection.messaging.sessionMessagesRoutePattern}`,
+        },
+        {
+          label: "Stream",
+          tone: "info",
+          value: `GET ${inspection.messaging.streamRoutePattern}`,
+        },
+      ],
+      title: "Messaging",
+    }),
+  ].join("\n");
 }

--- a/packages/eve/src/cli/dev/tui/command-typeahead.test.ts
+++ b/packages/eve/src/cli/dev/tui/command-typeahead.test.ts
@@ -169,11 +169,13 @@ describe("renderCommandSuggestions", () => {
   });
 
   it("windows long lists around the highlight without a count row", () => {
-    const many = Array.from({ length: 14 }, (_, index) => spec(`command-${index}`));
-    const state = { ...typeaheadFor(many, "/"), selectedIndex: 13 };
+    const many = Array.from({ length: PROMPT_COMMANDS.length + 1 }, (_, index) =>
+      spec(`command-${index}`),
+    );
+    const state = { ...typeaheadFor(many, "/"), selectedIndex: many.length - 1 };
     const rows = renderCommandSuggestions(state, theme, 80).map(stripAnsi);
     expect(rows).toHaveLength(PROMPT_COMMANDS.length);
-    expect(rows.some((row) => row.includes("command-13"))).toBe(true);
+    expect(rows.some((row) => row.includes(`command-${many.length - 1}`))).toBe(true);
     expect(rows.some((row) => row.includes("command-0"))).toBe(false);
     expect(rows.some((row) => row.includes("commands, showing"))).toBe(false);
   });

--- a/packages/eve/src/cli/dev/tui/prompt-commands.test.ts
+++ b/packages/eve/src/cli/dev/tui/prompt-commands.test.ts
@@ -95,8 +95,10 @@ describe("parsePromptCommand", () => {
     });
   });
 
-  it("parses /help and rejects /help with an argument", () => {
+  it("parses /help and /info without arguments", () => {
     expect(parsePromptCommand("/help")).toEqual({ type: "help" });
+    expect(parsePromptCommand("/info")).toEqual({ type: "info" });
+    expect(parsePromptCommand("/info verbose")).toBeNull();
     expect(parsePromptCommand("/help model")).toBeNull();
   });
 
@@ -121,6 +123,7 @@ describe("parsePromptCommand", () => {
 describe("promptCommandsFor", () => {
   it("exposes project commands only for local sessions", () => {
     const names = promptCommandsFor("local").map((command) => command.name);
+    expect(names).toContain("info");
     expect(names).toContain("model");
     expect(names).toContain("add");
     expect(names).toContain("deploy");
@@ -134,6 +137,7 @@ describe("promptCommandsFor", () => {
     expect(names).toContain("vc:install");
     expect(names).toContain("vc:login");
     expect(names).not.toContain("vc:auth");
+    expect(names).not.toContain("info");
     expect(names).not.toContain("model");
     expect(names).not.toContain("add");
     expect(names).not.toContain("deploy");

--- a/packages/eve/src/cli/dev/tui/prompt-commands.ts
+++ b/packages/eve/src/cli/dev/tui/prompt-commands.ts
@@ -10,6 +10,7 @@ export type PromptCommand =
   | { type: "compact" }
   | { type: "exit" }
   | { type: "help" }
+  | { type: "info" }
   | { type: "loglevel"; argument: string }
   | { type: "traces"; argument: string }
   | { type: "extension"; name: PromptCommandExtensionName; argument: string };
@@ -52,6 +53,14 @@ const PROMPT_COMMAND_DEFINITIONS = [
     takesArgument: false,
     build: () => ({ type: "help" }),
     targets: ["local", "remote"],
+  },
+  {
+    name: "info",
+    aliases: [],
+    description: "Show application and messaging information",
+    takesArgument: false,
+    build: () => ({ type: "info" }),
+    targets: ["local"],
   },
   {
     name: "reset",

--- a/packages/eve/src/cli/dev/tui/runner.test.ts
+++ b/packages/eve/src/cli/dev/tui/runner.test.ts
@@ -8,6 +8,7 @@ import {
   type ClientSession,
   type MessageStreamEvent,
 } from "#client/index.js";
+import { getApplicationInfo } from "#internal/application/paths.js";
 import { stampTestEvent } from "#internal/testing/events.js";
 import { createTestAgentInfoResult } from "#internal/testing/agent-info-fixture.js";
 import { resolveTestVercelTarget } from "#internal/testing/verified-vercel-target.js";
@@ -3415,6 +3416,39 @@ describe("EveTUIRunner command outcome rendering", () => {
     expect(results).toHaveLength(1);
     expect(results[0]).toContain("/model");
     expect(results[0]).not.toContain("/channels");
+    expect(session.send).not.toHaveBeenCalled();
+  });
+
+  it("renders /info from the local application inspector", async () => {
+    const results: string[] = [];
+    const prompts: Array<string | undefined> = ["/info", undefined];
+    const session = sessionYielding([]);
+    const inspectApplication = vi.fn(async () => ({
+      application: getApplicationInfo("/tmp/weather-agent"),
+      compiledState: null,
+      messaging: {
+        createSessionRoutePath: "/eve/v1/session",
+        sessionMessagesRoutePattern: "/eve/v1/session/:sessionId",
+        streamRoutePattern: "/eve/v1/session/:sessionId/stream",
+      },
+    }));
+
+    const runner = new EveTUIRunner({
+      appRoot: "/tmp/weather-agent",
+      inspectApplication,
+      name: "Weather Agent",
+      renderer: {
+        readPrompt: vi.fn(async () => prompts.shift()),
+        renderCommandResult: (text) => results.push(text),
+        renderStream: vi.fn(async () => {}),
+      },
+      session,
+    });
+    await runner.run();
+
+    expect(inspectApplication).toHaveBeenCalledWith("/tmp/weather-agent");
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatch(/^Application\n/u);
     expect(session.send).not.toHaveBeenCalled();
   });
 

--- a/packages/eve/src/cli/dev/tui/runner.ts
+++ b/packages/eve/src/cli/dev/tui/runner.ts
@@ -19,6 +19,7 @@ import {
   Client,
   ClientSession,
 } from "#client/index.js";
+import { renderApplicationInfo } from "#cli/commands/info.js";
 import { loadDevelopmentEnvironmentFiles } from "#cli/dev/environment.js";
 import { subscribeDevelopmentSandboxPrewarmLogs } from "#execution/sandbox/development-prewarm.js";
 import { createEventDeduper } from "#protocol/event-dedupe.js";
@@ -27,6 +28,7 @@ import {
   createDevelopmentRuntimeArtifactRefresher,
   type DevelopmentRuntimeArtifactRefresher,
 } from "#services/dev-client.js";
+import { inspectApplication } from "#services/inspect-application.js";
 import { toErrorMessage } from "#shared/errors.js";
 import { SubagentPump, type SubagentPumpOptions, type SubagentView } from "./subagent-pump.js";
 export type {
@@ -454,6 +456,8 @@ export type EveTUIRunnerOptions = TuiDisplayOptions & {
   bootDetections?: readonly BootDetection[];
   /** Test seam for the status line's Vercel link probe; defaults to the real one. */
   detectProjectIdentity?: typeof detectProjectIdentity;
+  /** Test seam for `/info`; defaults to the filesystem application inspector. */
+  inspectApplication?: typeof inspectApplication;
   /** Test seam for the off-critical-path boot login probe; defaults to the real one. */
   getVercelAuthStatus?: typeof getVercelAuthStatus;
   /** Reports phases from this runner's initial local-dev connection. */
@@ -496,6 +500,7 @@ export class EveTUIRunner {
   readonly #remoteConnection?: RemoteConnectionController;
   readonly #bootDetections: readonly BootDetection[];
   readonly #getVercelAuthStatus: typeof getVercelAuthStatus;
+  readonly #inspectApplication: typeof inspectApplication;
   #onBootProgress?: DevBootProgressReporter;
   /** Set when the run loop unwinds, so a late boot login probe cannot paint into a torn-down terminal. */
   #disposed = false;
@@ -625,6 +630,7 @@ export class EveTUIRunner {
     }
     this.#bootDetections = options.bootDetections ?? BOOT_DETECTIONS;
     this.#getVercelAuthStatus = options.getVercelAuthStatus ?? getVercelAuthStatus;
+    this.#inspectApplication = options.inspectApplication ?? inspectApplication;
     if (options.onBootProgress !== undefined) this.#onBootProgress = options.onBootProgress;
     if (options.serverUrl !== undefined) this.#serverUrl = options.serverUrl;
     if (options.serverUrl !== undefined && options.remote === undefined) {
@@ -930,6 +936,14 @@ export class EveTUIRunner {
         // without a prompt-command handler (e.g. remote --url sessions).
         if (command?.type === "help") {
           this.#renderCommandOutcome(formatPromptCommandHelp(this.#availablePromptCommands));
+          pendingInputResponses = undefined;
+          streamWithoutPrompt = false;
+          prompt = undefined;
+          continue;
+        }
+
+        if (command?.type === "info") {
+          await this.#showApplicationInfo();
           pendingInputResponses = undefined;
           streamWithoutPrompt = false;
           prompt = undefined;
@@ -1751,6 +1765,22 @@ export class EveTUIRunner {
     } catch (error) {
       if (isInterruptedError(error)) return;
       throw error;
+    }
+  }
+
+  async #showApplicationInfo(): Promise<void> {
+    const appRoot = this.#appRoot;
+    if (appRoot === undefined) {
+      this.#renderCommandOutcome("/info is only available in local dev sessions.");
+      return;
+    }
+    try {
+      this.#renderCommandOutcome(renderApplicationInfo(await this.#inspectApplication(appRoot)));
+    } catch (error) {
+      this.#renderCommandOutcome(
+        `Couldn't inspect the application: ${toErrorMessage(error)}`,
+        "error",
+      );
     }
   }
 

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
@@ -4735,9 +4735,9 @@ describe("TerminalRenderer command typeahead", () => {
     input.type("/");
     input.down();
     input.enter();
-    // Down moved /help → /reset; history recall would have submitted the
+    // Down moved /help → /info; history recall would have submitted the
     // earlier prompt instead.
-    expect(await second).toBe("/reset");
+    expect(await second).toBe("/info");
     renderer.shutdown();
   });
 

--- a/packages/eve/test/scenarios/cli.scenario.test.ts
+++ b/packages/eve/test/scenarios/cli.scenario.test.ts
@@ -242,7 +242,7 @@ describe("runCli", () => {
     await runCli(["info"], logger);
 
     expect(logger.log).toHaveBeenCalled();
-    expect(getLogOutput(logger)).toContain("eve Info");
+    expect(getLogOutput(logger)).not.toContain("eve Info");
     expect(getLogOutput(logger)).toContain("Application");
     expect(getLogOutput(logger)).toContain("Workflow ID");
     expect(getLogOutput(logger)).toContain(`POST ${EVE_SESSION_ROUTE_PATH}`);


### PR DESCRIPTION
### Summary

Mirror `/info` from `eve info`.

### Validation

Focused unit coverage verifies command parsing and discovery, local inspection dispatch, shared report rendering, and typeahead behavior after adding the command. The published TUI guide documents the command and its local-only boundary.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+7 / -1`

Documents `/info` in the TUI command reference and records the published behavior change in a patch changeset.

**Implementation** — 3 files · `+94 / -57`

Adds local command dispatch and extracts the existing `eve info` presentation into one shared renderer; most deletions are the prior inline rendering wrapper moving behind that function.

**Tests** — 5 files · `+47 / -7`

Covers the local-only command registry, runner dispatch, typeahead behavior, and the updated CLI and TUI output contracts.



