### PR TITLE
feat(eve): version stable workflow inputs

### DIFF
--- a/.changeset/stable-workflow-inputs.md
+++ b/.changeset/stable-workflow-inputs.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Stable workflow inputs now carry explicit versions and migrate inputs created by older eve deployments, including task runs that use the historical inbox token field.

--- a/packages/eve/src/execution/durable-session-migrations/session-timeout-workflow-v0-to-v1.ts
+++ b/packages/eve/src/execution/durable-session-migrations/session-timeout-workflow-v0-to-v1.ts
@@ -1,0 +1,23 @@
+import type { VersionMigration } from "./chain.js";
+import type { SessionTimeoutWorkflowInput } from "./session-timeout-workflow.js";
+
+/** Frozen migration for the original session-timeout workflow input. */
+export const sessionTimeoutWorkflowInputV0ToV1: VersionMigration = {
+  from: 0,
+  migrate(prior: unknown): SessionTimeoutWorkflowInput {
+    if (
+      typeof prior !== "object" ||
+      prior === null ||
+      !("deadline" in prior) ||
+      !(prior.deadline instanceof Date) ||
+      !("token" in prior) ||
+      typeof prior.token !== "string"
+    ) {
+      throw new Error(
+        "session timeout workflow input: version 0 value is not a recognized pre-version shape.",
+      );
+    }
+    return { ...prior, version: 1 } as SessionTimeoutWorkflowInput;
+  },
+  to: 1,
+};

--- a/packages/eve/src/execution/durable-session-migrations/session-timeout-workflow.test.ts
+++ b/packages/eve/src/execution/durable-session-migrations/session-timeout-workflow.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createSessionTimeoutWorkflowInput,
+  migrateSessionTimeoutWorkflowInput,
+  SESSION_TIMEOUT_WORKFLOW_INPUT_VERSION,
+} from "./session-timeout-workflow.js";
+
+describe("session timeout workflow input migrations", () => {
+  it("stamps new workflow inputs with v1", () => {
+    const deadline = new Date("2026-02-01T00:00:00.000Z");
+
+    expect(createSessionTimeoutWorkflowInput({ deadline, token: "session-timeout" })).toEqual({
+      deadline,
+      token: "session-timeout",
+      version: SESSION_TIMEOUT_WORKFLOW_INPUT_VERSION,
+    });
+  });
+
+  it("migrates pre-version inputs without dropping additive fields", () => {
+    const input = {
+      additiveField: { retained: true },
+      deadline: new Date("2026-02-01T00:00:00.000Z"),
+      token: "session-timeout",
+    };
+
+    expect(migrateSessionTimeoutWorkflowInput(input)).toEqual({
+      ...input,
+      version: SESSION_TIMEOUT_WORKFLOW_INPUT_VERSION,
+    });
+  });
+
+  it("returns current inputs unchanged and rejects newer versions", () => {
+    const input = {
+      additiveField: "retained",
+      deadline: new Date("2026-02-01T00:00:00.000Z"),
+      token: "session-timeout",
+      version: SESSION_TIMEOUT_WORKFLOW_INPUT_VERSION,
+    };
+
+    expect(migrateSessionTimeoutWorkflowInput(input)).toBe(input);
+    expect(() => migrateSessionTimeoutWorkflowInput({ version: 2 })).toThrow(
+      /session timeout workflow input: encountered version 2/,
+    );
+  });
+
+  it("rejects malformed pre-version inputs", () => {
+    expect(() =>
+      migrateSessionTimeoutWorkflowInput({ deadline: "tomorrow", token: "timeout" }),
+    ).toThrow(/not a recognized pre-version shape/);
+    expect(() =>
+      migrateSessionTimeoutWorkflowInput({
+        deadline: new Date("2026-02-01T00:00:00.000Z"),
+        token: "timeout",
+        version: "1",
+      }),
+    ).toThrow(/has no numeric "version" field/);
+  });
+});

--- a/packages/eve/src/execution/durable-session-migrations/session-timeout-workflow.ts
+++ b/packages/eve/src/execution/durable-session-migrations/session-timeout-workflow.ts
@@ -1,0 +1,32 @@
+import { runMigrationChain, type VersionMigration } from "./chain.js";
+import { sessionTimeoutWorkflowInputV0ToV1 } from "./session-timeout-workflow-v0-to-v1.js";
+
+export const SESSION_TIMEOUT_WORKFLOW_INPUT_VERSION = 1;
+
+export interface SessionTimeoutWorkflowInput {
+  readonly deadline: Date;
+  readonly token: string;
+  readonly version: typeof SESSION_TIMEOUT_WORKFLOW_INPUT_VERSION;
+}
+
+export type SessionTimeoutWorkflowDispatchInput = Omit<SessionTimeoutWorkflowInput, "version">;
+
+const sessionTimeoutWorkflowInputMigrations: readonly VersionMigration[] = [
+  sessionTimeoutWorkflowInputV0ToV1,
+];
+
+export function createSessionTimeoutWorkflowInput(
+  input: SessionTimeoutWorkflowDispatchInput,
+): SessionTimeoutWorkflowInput {
+  return { ...input, version: SESSION_TIMEOUT_WORKFLOW_INPUT_VERSION };
+}
+
+export function migrateSessionTimeoutWorkflowInput(value: unknown): SessionTimeoutWorkflowInput {
+  return runMigrationChain<SessionTimeoutWorkflowInput>({
+    initialVersion: 0,
+    label: "session timeout workflow input",
+    migrations: sessionTimeoutWorkflowInputMigrations,
+    targetVersion: SESSION_TIMEOUT_WORKFLOW_INPUT_VERSION,
+    value,
+  });
+}

--- a/packages/eve/src/execution/durable-session-migrations/task-run-workflow-v0-to-v1.ts
+++ b/packages/eve/src/execution/durable-session-migrations/task-run-workflow-v0-to-v1.ts
@@ -1,0 +1,41 @@
+import type { VersionMigration } from "./chain.js";
+import type { TaskRunWorkflowInput } from "./task-run-workflow.js";
+
+/** Frozen migration for both pre-version task inbox token names. */
+export const taskRunWorkflowInputV0ToV1: VersionMigration = {
+  from: 0,
+  migrate(prior: unknown): TaskRunWorkflowInput {
+    if (typeof prior !== "object" || prior === null) {
+      throw new Error(
+        "task run workflow input: version 0 value is not a recognized pre-version shape.",
+      );
+    }
+    const candidate = prior as {
+      readonly continuationToken?: unknown;
+      readonly initialView?: unknown;
+      readonly parentContinuationToken?: unknown;
+      readonly taskInboxToken?: unknown;
+    };
+    const taskInboxToken =
+      typeof candidate.taskInboxToken === "string"
+        ? candidate.taskInboxToken
+        : candidate.continuationToken;
+    if (
+      typeof taskInboxToken !== "string" ||
+      typeof candidate.initialView !== "object" ||
+      candidate.initialView === null ||
+      typeof candidate.parentContinuationToken !== "string"
+    ) {
+      throw new Error(
+        "task run workflow input: version 0 value is not a recognized pre-version shape.",
+      );
+    }
+    return {
+      ...prior,
+      continuationToken: taskInboxToken,
+      taskInboxToken,
+      version: 1,
+    } as TaskRunWorkflowInput;
+  },
+  to: 1,
+};

--- a/packages/eve/src/execution/durable-session-migrations/task-run-workflow.test.ts
+++ b/packages/eve/src/execution/durable-session-migrations/task-run-workflow.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import type { TaskView } from "#tasks/types.js";
+
+import {
+  createTaskRunWorkflowInput,
+  migrateTaskRunWorkflowInput,
+  TASK_RUN_WORKFLOW_INPUT_VERSION,
+} from "./task-run-workflow.js";
+
+describe("task run workflow input migrations", () => {
+  it("stamps v1 and dual-writes the current and historical inbox token names", () => {
+    expect(
+      createTaskRunWorkflowInput({
+        initialView: createWorkingView(),
+        parentContinuationToken: "parent-token",
+        taskInboxToken: "task-token",
+      }),
+    ).toEqual({
+      continuationToken: "task-token",
+      initialView: createWorkingView(),
+      parentContinuationToken: "parent-token",
+      taskInboxToken: "task-token",
+      version: TASK_RUN_WORKFLOW_INPUT_VERSION,
+    });
+  });
+
+  it("migrates the historical continuationToken shape without dropping additive fields", () => {
+    const input = {
+      additiveField: { retained: true },
+      continuationToken: "historical-task-token",
+      initialView: createWorkingView(),
+      parentContinuationToken: "parent-token",
+    };
+
+    expect(migrateTaskRunWorkflowInput(input)).toEqual({
+      ...input,
+      continuationToken: "historical-task-token",
+      taskInboxToken: "historical-task-token",
+      version: TASK_RUN_WORKFLOW_INPUT_VERSION,
+    });
+  });
+
+  it("migrates the current pre-version taskInboxToken shape", () => {
+    expect(
+      migrateTaskRunWorkflowInput({
+        initialView: createWorkingView(),
+        parentContinuationToken: "parent-token",
+        taskInboxToken: "task-token",
+      }),
+    ).toMatchObject({
+      continuationToken: "task-token",
+      taskInboxToken: "task-token",
+      version: TASK_RUN_WORKFLOW_INPUT_VERSION,
+    });
+  });
+
+  it("returns current inputs unchanged and rejects newer versions", () => {
+    const input = {
+      additiveField: "retained",
+      continuationToken: "task-token",
+      initialView: createWorkingView(),
+      parentContinuationToken: "parent-token",
+      taskInboxToken: "task-token",
+      version: TASK_RUN_WORKFLOW_INPUT_VERSION,
+    };
+
+    expect(migrateTaskRunWorkflowInput(input)).toBe(input);
+    expect(() => migrateTaskRunWorkflowInput({ version: 2 })).toThrow(
+      /task run workflow input: encountered version 2/,
+    );
+  });
+
+  it("rejects malformed pre-version inputs", () => {
+    expect(() => migrateTaskRunWorkflowInput({ taskInboxToken: "task-token" })).toThrow(
+      /not a recognized pre-version shape/,
+    );
+    expect(() =>
+      migrateTaskRunWorkflowInput({
+        initialView: createWorkingView(),
+        parentContinuationToken: "parent-token",
+        taskInboxToken: "task-token",
+        version: "1",
+      }),
+    ).toThrow(/has no numeric "version" field/);
+  });
+});
+
+function createWorkingView(): TaskView {
+  return {
+    metadata: {
+      agentId: "ag_research:abcdef123456",
+      kind: "subagent",
+      mode: "local",
+      name: "research",
+    },
+    status: "working",
+    taskId: "task_abc123",
+  };
+}

--- a/packages/eve/src/execution/durable-session-migrations/task-run-workflow.ts
+++ b/packages/eve/src/execution/durable-session-migrations/task-run-workflow.ts
@@ -1,0 +1,42 @@
+import type { TaskView } from "#tasks/types.js";
+
+import { runMigrationChain, type VersionMigration } from "./chain.js";
+import { taskRunWorkflowInputV0ToV1 } from "./task-run-workflow-v0-to-v1.js";
+
+export const TASK_RUN_WORKFLOW_INPUT_VERSION = 1;
+
+export interface TaskRunWorkflowInput {
+  /** Historical task inbox name retained for older workflow consumers. */
+  readonly continuationToken: string;
+  readonly initialView: TaskView;
+  readonly parentContinuationToken: string;
+  readonly taskInboxToken: string;
+  readonly version: typeof TASK_RUN_WORKFLOW_INPUT_VERSION;
+}
+
+export type TaskRunWorkflowDispatchInput = Omit<
+  TaskRunWorkflowInput,
+  "continuationToken" | "version"
+>;
+
+const taskRunWorkflowInputMigrations: readonly VersionMigration[] = [taskRunWorkflowInputV0ToV1];
+
+export function createTaskRunWorkflowInput(
+  input: TaskRunWorkflowDispatchInput,
+): TaskRunWorkflowInput {
+  return {
+    ...input,
+    continuationToken: input.taskInboxToken,
+    version: TASK_RUN_WORKFLOW_INPUT_VERSION,
+  };
+}
+
+export function migrateTaskRunWorkflowInput(value: unknown): TaskRunWorkflowInput {
+  return runMigrationChain<TaskRunWorkflowInput>({
+    initialVersion: 0,
+    label: "task run workflow input",
+    migrations: taskRunWorkflowInputMigrations,
+    targetVersion: TASK_RUN_WORKFLOW_INPUT_VERSION,
+    value,
+  });
+}

--- a/packages/eve/src/execution/durable-session-migrations/workflow-entry-v0-to-v1.ts
+++ b/packages/eve/src/execution/durable-session-migrations/workflow-entry-v0-to-v1.ts
@@ -1,0 +1,23 @@
+import type { VersionMigration } from "./chain.js";
+import type { WorkflowEntryInput } from "./workflow-entry.js";
+
+/** Frozen migration for every pre-version workflow-entry input shape. */
+export const workflowEntryInputV0ToV1: VersionMigration = {
+  from: 0,
+  migrate(prior: unknown): WorkflowEntryInput {
+    if (
+      typeof prior !== "object" ||
+      prior === null ||
+      !("input" in prior) ||
+      !("serializedContext" in prior) ||
+      typeof prior.serializedContext !== "object" ||
+      prior.serializedContext === null
+    ) {
+      throw new Error(
+        "workflow entry input: version 0 value is not a recognized pre-version shape.",
+      );
+    }
+    return { ...prior, version: 1 } as WorkflowEntryInput;
+  },
+  to: 1,
+};

--- a/packages/eve/src/execution/durable-session-migrations/workflow-entry.test.ts
+++ b/packages/eve/src/execution/durable-session-migrations/workflow-entry.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createWorkflowEntryInput,
+  migrateWorkflowEntryInput,
+  WORKFLOW_ENTRY_INPUT_VERSION,
+} from "./workflow-entry.js";
+
+describe("workflow entry input migrations", () => {
+  it("stamps new workflow inputs with v1", () => {
+    expect(
+      createWorkflowEntryInput({
+        input: { message: "hello" },
+        serializedContext: { mode: "conversation" },
+      }),
+    ).toEqual({
+      input: { message: "hello" },
+      serializedContext: { mode: "conversation" },
+      version: WORKFLOW_ENTRY_INPUT_VERSION,
+    });
+  });
+
+  it("migrates pre-version inputs without dropping additive fields", () => {
+    const input = {
+      additiveField: { retained: true },
+      input: { message: "hello" },
+      serializedContext: { mode: "conversation" },
+    };
+
+    expect(migrateWorkflowEntryInput(input)).toEqual({
+      ...input,
+      version: WORKFLOW_ENTRY_INPUT_VERSION,
+    });
+  });
+
+  it("returns current inputs unchanged and rejects newer versions", () => {
+    const input = {
+      additiveField: "retained",
+      input: { message: "hello" },
+      serializedContext: {},
+      version: WORKFLOW_ENTRY_INPUT_VERSION,
+    };
+
+    expect(migrateWorkflowEntryInput(input)).toBe(input);
+    expect(() => migrateWorkflowEntryInput({ version: 2 })).toThrow(
+      /workflow entry input: encountered version 2/,
+    );
+  });
+
+  it("rejects malformed pre-version inputs", () => {
+    expect(() => migrateWorkflowEntryInput({ input: { message: "hello" } })).toThrow(
+      /not a recognized pre-version shape/,
+    );
+    expect(() => migrateWorkflowEntryInput({ input: { message: "hello" }, version: "1" })).toThrow(
+      /has no numeric "version" field/,
+    );
+  });
+});

--- a/packages/eve/src/execution/durable-session-migrations/workflow-entry.ts
+++ b/packages/eve/src/execution/durable-session-migrations/workflow-entry.ts
@@ -1,0 +1,32 @@
+import type { RunInput } from "#channel/types.js";
+
+import { runMigrationChain, type VersionMigration } from "./chain.js";
+import { workflowEntryInputV0ToV1 } from "./workflow-entry-v0-to-v1.js";
+
+export const WORKFLOW_ENTRY_INPUT_VERSION = 1;
+
+export interface WorkflowEntryInput {
+  readonly input: RunInput["input"];
+  readonly limits?: RunInput["limits"];
+  readonly sessionTimeoutMs?: number | false;
+  readonly serializedContext: Record<string, unknown>;
+  readonly version: typeof WORKFLOW_ENTRY_INPUT_VERSION;
+}
+
+export type WorkflowEntryDispatchInput = Omit<WorkflowEntryInput, "version">;
+
+const workflowEntryInputMigrations: readonly VersionMigration[] = [workflowEntryInputV0ToV1];
+
+export function createWorkflowEntryInput(input: WorkflowEntryDispatchInput): WorkflowEntryInput {
+  return { ...input, version: WORKFLOW_ENTRY_INPUT_VERSION };
+}
+
+export function migrateWorkflowEntryInput(value: unknown): WorkflowEntryInput {
+  return runMigrationChain<WorkflowEntryInput>({
+    initialVersion: 0,
+    label: "workflow entry input",
+    migrations: workflowEntryInputMigrations,
+    targetVersion: WORKFLOW_ENTRY_INPUT_VERSION,
+    value,
+  });
+}

--- a/packages/eve/src/execution/session-timeout-steps.test.ts
+++ b/packages/eve/src/execution/session-timeout-steps.test.ts
@@ -5,6 +5,7 @@ import {
   signalSessionTimeoutStep,
   startSessionTimeoutStep,
 } from "#execution/session-timeout-steps.js";
+import { SESSION_TIMEOUT_WORKFLOW_INPUT_VERSION } from "#execution/durable-session-migrations/session-timeout-workflow.js";
 import { sessionTimeoutWorkflowReference } from "#execution/workflow-runtime.js";
 
 const cancelRunMock = vi.fn();
@@ -50,7 +51,9 @@ describe("session timeout steps", () => {
     };
 
     await expect(startSessionTimeoutStep(input)).resolves.toEqual({ runId: "timer-run" });
-    expect(startMock).toHaveBeenCalledWith(sessionTimeoutWorkflowReference, [input]);
+    expect(startMock).toHaveBeenCalledWith(sessionTimeoutWorkflowReference, [
+      { ...input, version: SESSION_TIMEOUT_WORKFLOW_INPUT_VERSION },
+    ]);
   });
 
   it("signals the owning session hook", async () => {

--- a/packages/eve/src/execution/session-timeout-steps.ts
+++ b/packages/eve/src/execution/session-timeout-steps.ts
@@ -9,18 +9,23 @@ import {
   startWorkflowPreferLatest,
   sessionTimeoutWorkflowReference,
 } from "#execution/workflow-runtime.js";
-import type { SessionTimeoutWorkflowInput } from "#execution/session-timeout-workflow.js";
+import {
+  createSessionTimeoutWorkflowInput,
+  type SessionTimeoutWorkflowDispatchInput,
+} from "#execution/durable-session-migrations/session-timeout-workflow.js";
 import { resumeSessionInbox } from "#execution/wire/session-inbox-resume.js";
 import { cancelRun, getWorld } from "#internal/workflow/runtime.js";
 import { walkCauseChain } from "#shared/errors.js";
 
 /** Starts the durable timer that signals one session deadline. */
 export async function startSessionTimeoutStep(
-  input: SessionTimeoutWorkflowInput,
+  input: SessionTimeoutWorkflowDispatchInput,
 ): Promise<{ readonly runId: string }> {
   "use step";
 
-  const run = await startWorkflowPreferLatest(sessionTimeoutWorkflowReference, [input]);
+  const run = await startWorkflowPreferLatest(sessionTimeoutWorkflowReference, [
+    createSessionTimeoutWorkflowInput(input),
+  ]);
   return { runId: run.runId };
 }
 

--- a/packages/eve/src/execution/session-timeout-workflow.ts
+++ b/packages/eve/src/execution/session-timeout-workflow.ts
@@ -1,16 +1,14 @@
 import { sleep } from "#compiled/@workflow/core/index.js";
 
+import { migrateSessionTimeoutWorkflowInput } from "#execution/durable-session-migrations/session-timeout-workflow.js";
+export type { SessionTimeoutWorkflowInput } from "#execution/durable-session-migrations/session-timeout-workflow.js";
 import { signalSessionTimeoutStep } from "#execution/session-timeout-steps.js";
 
-export interface SessionTimeoutWorkflowInput {
-  readonly deadline: Date;
-  readonly token: string;
-}
-
 /** Sleeps until the session deadline, then signals its driver. */
-export async function sessionTimeoutWorkflow(input: SessionTimeoutWorkflowInput): Promise<void> {
+export async function sessionTimeoutWorkflow(value: unknown): Promise<void> {
   "use workflow";
 
+  const input = migrateSessionTimeoutWorkflowInput(value);
   await sleep(input.deadline);
   await signalSessionTimeoutStep({ token: input.token });
 }

--- a/packages/eve/src/execution/tasks/child/workflow.ts
+++ b/packages/eve/src/execution/tasks/child/workflow.ts
@@ -1,6 +1,8 @@
 import { createHook } from "#compiled/@workflow/core/index.js";
 
 import type { SubagentAuthorizationEventHookPayload } from "#channel/types.js";
+import { migrateTaskRunWorkflowInput } from "#execution/durable-session-migrations/task-run-workflow.js";
+export type { TaskRunWorkflowInput } from "#execution/durable-session-migrations/task-run-workflow.js";
 import { claimHookOwnership, disposeHook, isHookConflictError } from "#execution/hook-ownership.js";
 import {
   appendTaskViewStep,
@@ -25,16 +27,6 @@ import {
   type TaskRunInboundPayload,
   type TaskView,
 } from "#tasks/types.js";
-
-/** Input for one durable task run. */
-export interface TaskRunWorkflowInput {
-  /** Private task inbox token; a routing credential, never model-visible. */
-  readonly taskInboxToken: string;
-  /** The creation view, normally `working`. */
-  readonly initialView: TaskView;
-  /** Parent session delivery token used to wake the task's owning parent. */
-  readonly parentContinuationToken: string;
-}
 
 type TaskRunHookPayload = TaskRunInboundPayload | SubagentAuthorizationEventHookPayload;
 
@@ -66,9 +58,10 @@ function isTaskRunFinished(view: TaskView, dispatchAcknowledged: boolean): boole
  * disposed hook makes any later command fail loudly instead of queueing
  * against a finished task.
  */
-export async function taskRunWorkflow(input: TaskRunWorkflowInput): Promise<void> {
+export async function taskRunWorkflow(value: unknown): Promise<void> {
   "use workflow";
 
+  const input = migrateTaskRunWorkflowInput(value);
   const commands = createHook<TaskRunHookPayload>({ token: input.taskInboxToken });
   // The iterator shares the hook's durable cursor; create it before
   // claiming so conflict replay is consumed by getConflict(), not a

--- a/packages/eve/src/execution/tasks/parent/run-parent.ts
+++ b/packages/eve/src/execution/tasks/parent/run-parent.ts
@@ -1,4 +1,7 @@
-import type { TaskRunWorkflowInput } from "#execution/tasks/child/workflow.js";
+import {
+  createTaskRunWorkflowInput,
+  type TaskRunWorkflowDispatchInput,
+} from "#execution/durable-session-migrations/task-run-workflow.js";
 import { isTaskWorkflowTargetGone } from "#execution/tasks/workflow-target.js";
 import {
   startWorkflowPreferLatest,
@@ -28,8 +31,8 @@ const TASK_VIEW_READ_TIMEOUT_MS = 10_000;
  */
 
 /** Starts the durable run owning one task's lifecycle. */
-export async function startTaskRun(input: TaskRunWorkflowInput): Promise<void> {
-  await startWorkflowPreferLatest(taskRunWorkflowReference, [input]);
+export async function startTaskRun(input: TaskRunWorkflowDispatchInput): Promise<void> {
+  await startWorkflowPreferLatest(taskRunWorkflowReference, [createTaskRunWorkflowInput(input)]);
 }
 
 /** Resolves the task run that won ownership of one replay-stable command token. */

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -24,6 +24,8 @@ import {
   createDelegatedSubagentSuccessResult,
 } from "#execution/delegated-parent-result.js";
 import type { DurableSessionState } from "#execution/durable-session-store.js";
+import { migrateWorkflowEntryInput } from "#execution/durable-session-migrations/workflow-entry.js";
+export type { WorkflowEntryInput } from "#execution/durable-session-migrations/workflow-entry.js";
 import type { NextDriverAction } from "#execution/next-driver-action.js";
 import { nextTurnDelivery, type NextTurnInstruction } from "#execution/parked-delivery-wait.js";
 import { SessionStateCursor } from "#execution/session-state-cursor.js";
@@ -54,18 +56,6 @@ const SAFE_OUTER_WORKFLOW_FAILURE_MESSAGE =
 // workflow-entry.ts is the durable workflow body — the bundler rejects
 // node built-ins here, so `internal/logging.ts` cannot be imported.
 // Error logging happens inside `emitTerminalSessionFailureStep`.
-
-/**
- * Serializable workflow-entry input. All runtime state travels via
- * `serializedContext`, which is produced by `serializeContext(ctx)`
- * and deserialized at each `"use step"` boundary.
- */
-export interface WorkflowEntryInput {
-  readonly input: RunInput["input"];
-  readonly limits?: RunInput["limits"];
-  readonly sessionTimeoutMs?: number | false;
-  readonly serializedContext: Record<string, unknown>;
-}
 
 export interface WorkflowEntryResult {
   readonly output: unknown;
@@ -131,9 +121,10 @@ interface CrashCleanupState {
  * `hasProxyInputRequests`, the documented short-circuit for hook-payload
  * routing to any descendant still active when the parent parks.
  */
-export async function workflowEntry(input: WorkflowEntryInput): Promise<WorkflowEntryResult> {
+export async function workflowEntry(value: unknown): Promise<WorkflowEntryResult> {
   "use workflow";
 
+  const input = migrateWorkflowEntryInput(value);
   const { workflowRunId: sessionId, workflowStartedAt } = getWorkflowMetadata();
   const continuationToken = (input.serializedContext["eve.continuationToken"] as string) || "";
   const mode = input.serializedContext["eve.mode"] as RunMode;

--- a/packages/eve/src/execution/workflow-runtime.test.ts
+++ b/packages/eve/src/execution/workflow-runtime.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ChannelAdapter } from "#channel/adapter.js";
 import { ChannelRequestIdKey } from "#context/keys.js";
+import { WORKFLOW_ENTRY_INPUT_VERSION } from "#execution/durable-session-migrations/workflow-entry.js";
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
 import {
   createWorkflowRuntime,
@@ -358,6 +359,7 @@ describe("createWorkflowRuntime#createSession", () => {
             "eve.mode": "task",
             "eve.otelTraceEnabled": false,
           }),
+          version: WORKFLOW_ENTRY_INPUT_VERSION,
         },
       ],
       {
@@ -469,6 +471,7 @@ describe("createWorkflowRuntime#createSession", () => {
           serializedContext: expect.objectContaining({
             [ChannelRequestIdKey.name]: "req_run",
           }),
+          version: WORKFLOW_ENTRY_INPUT_VERSION,
         },
       ],
       {

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -49,7 +49,10 @@ import { buildRunContext } from "#execution/runtime-context.js";
 import { resolveEffectiveAgentRuntime } from "#execution/effective-agent-config.js";
 import { parseNdjsonStream } from "#execution/ndjson-stream.js";
 import { RuntimeSessionOwnershipConflictError } from "#execution/runtime-errors.js";
-import type { WorkflowEntryInput } from "#execution/workflow-entry.js";
+import {
+  createWorkflowEntryInput,
+  type WorkflowEntryDispatchInput,
+} from "#execution/durable-session-migrations/workflow-entry.js";
 import { walkCauseChain } from "#shared/errors.js";
 import { buildInvocationAttributes } from "#internal/invocation/metadata.js";
 import { sessionCommandHookToken } from "#execution/session-command-token.js";
@@ -139,16 +142,17 @@ export function createWorkflowRuntime(config: {
       const serializedContext = serializeContext(ctx);
       const parentLineage = readParentLineage(serializedContext);
       const sessionTimeoutMs = effectiveAgent.limits?.sessionTimeoutMs;
-      const workflowInput: {
-        -readonly [K in keyof WorkflowEntryInput]: WorkflowEntryInput[K];
+      const workflowDispatchInput: {
+        -readonly [K in keyof WorkflowEntryDispatchInput]: WorkflowEntryDispatchInput[K];
       } = {
         input: input.input,
         limits: input.limits,
         serializedContext,
       };
       if (sessionTimeoutMs !== undefined) {
-        workflowInput.sessionTimeoutMs = sessionTimeoutMs;
+        workflowDispatchInput.sessionTimeoutMs = sessionTimeoutMs;
       }
+      const workflowInput = createWorkflowEntryInput(workflowDispatchInput);
       const sessionAttributes =
         parentLineage.sessionId === undefined
           ? buildSessionAttributes({

--- a/packages/eve/src/internal/durable-contract-registry.test.ts
+++ b/packages/eve/src/internal/durable-contract-registry.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import { DURABLE_SESSION_VERSION } from "#execution/durable-session-store.js";
+import { SESSION_TIMEOUT_WORKFLOW_INPUT_VERSION } from "#execution/durable-session-migrations/session-timeout-workflow.js";
+import { TASK_RUN_WORKFLOW_INPUT_VERSION } from "#execution/durable-session-migrations/task-run-workflow.js";
 import { TURN_WORKFLOW_INPUT_VERSION } from "#execution/durable-session-migrations/turn-workflow.js";
+import { WORKFLOW_ENTRY_INPUT_VERSION } from "#execution/durable-session-migrations/workflow-entry.js";
 import {
   sessionTimeoutWorkflowReference,
   taskRunWorkflowReference,
@@ -41,10 +44,10 @@ describe("durable contract registry", () => {
 
   it("matches the explicit versions owned by existing durable contracts", () => {
     expect(DURABLE_WORKFLOW_CONTRACTS).toMatchObject({
-      sessionTimeoutWorkflow: { inputVersion: null },
-      taskRunWorkflow: { inputVersion: null },
+      sessionTimeoutWorkflow: { inputVersion: SESSION_TIMEOUT_WORKFLOW_INPUT_VERSION },
+      taskRunWorkflow: { inputVersion: TASK_RUN_WORKFLOW_INPUT_VERSION },
       turnWorkflow: { inputVersion: TURN_WORKFLOW_INPUT_VERSION },
-      workflowEntry: { inputVersion: null },
+      workflowEntry: { inputVersion: WORKFLOW_ENTRY_INPUT_VERSION },
     });
     expect(DURABLE_DATA_CONTRACTS).toEqual({
       attachmentRef: {
@@ -112,12 +115,12 @@ describe("durable contract registry", () => {
   "kind": "eve-durable-contracts",
   "workflows": [
     {
-      "inputVersion": null,
+      "inputVersion": 1,
       "name": "sessionTimeoutWorkflow",
       "workflowId": "workflow//eve//sessionTimeoutWorkflow"
     },
     {
-      "inputVersion": null,
+      "inputVersion": 1,
       "name": "taskRunWorkflow",
       "workflowId": "workflow//eve//taskRunWorkflow"
     },
@@ -127,7 +130,7 @@ describe("durable contract registry", () => {
       "workflowId": "workflow//eve//turnWorkflow"
     },
     {
-      "inputVersion": null,
+      "inputVersion": 1,
       "name": "workflowEntry",
       "workflowId": "workflow//eve//workflowEntry"
     }

--- a/packages/eve/src/internal/durable-contract-registry.ts
+++ b/packages/eve/src/internal/durable-contract-registry.ts
@@ -33,10 +33,10 @@ function stableWorkflowContract<TName extends string>(
 
 /** Cross-deployment workflow entrypoints and their existing input versions. */
 export const DURABLE_WORKFLOW_CONTRACTS = {
-  sessionTimeoutWorkflow: stableWorkflowContract("sessionTimeoutWorkflow", null),
-  taskRunWorkflow: stableWorkflowContract("taskRunWorkflow", null),
+  sessionTimeoutWorkflow: stableWorkflowContract("sessionTimeoutWorkflow", 1),
+  taskRunWorkflow: stableWorkflowContract("taskRunWorkflow", 1),
   turnWorkflow: stableWorkflowContract("turnWorkflow", 1),
-  workflowEntry: stableWorkflowContract("workflowEntry", null),
+  workflowEntry: stableWorkflowContract("workflowEntry", 1),
 } as const satisfies Record<string, DurableWorkflowContract>;
 
 /** Existing explicitly versioned values that cross durable boundaries. */

--- a/research/durable-deployment-compatibility.md
+++ b/research/durable-deployment-compatibility.md
@@ -50,9 +50,10 @@ initial inventory includes:
 Stable workflow IDs are immutable routing keys. A workflow input without an
 explicit version is recorded as `null`; this identifies an unsafe gap rather
 than treating the historical shape as version zero or claiming compatibility.
-Existing numeric versions identify only the current emitted contract. Supported
-version ranges and schema identities are added when each family adopts a
-declared schema and migration chain.
+Every current stable workflow input now emits version 1 and treats the prior
+unversioned shape as version 0 for migration. Existing numeric versions identify
+only the current emitted contract. Supported version ranges and schema identities
+are added when each family adopts a declared schema and migration chain.
 
 Every versioned family follows the same rules:
 
@@ -85,11 +86,21 @@ currently owns:
   "workflows": [
     {
       "inputVersion": 1,
+      "name": "sessionTimeoutWorkflow",
+      "workflowId": "workflow//eve//sessionTimeoutWorkflow"
+    },
+    {
+      "inputVersion": 1,
+      "name": "taskRunWorkflow",
+      "workflowId": "workflow//eve//taskRunWorkflow"
+    },
+    {
+      "inputVersion": 1,
       "name": "turnWorkflow",
       "workflowId": "workflow//eve//turnWorkflow"
     },
     {
-      "inputVersion": null,
+      "inputVersion": 1,
       "name": "workflowEntry",
       "workflowId": "workflow//eve//workflowEntry"
     }
@@ -97,10 +108,15 @@ currently owns:
 }
 ```
 
-The excerpt omits the other stable workflows for brevity. The actual artifact
-is complete and lexically sorted. It contains no timestamp, absolute path, Git
-SHA, or deployment-local value, so identical package inputs produce identical
-bytes.
+The artifact is complete and lexically sorted. It contains no timestamp,
+absolute path, Git SHA, or deployment-local value, so identical package inputs
+produce identical bytes.
+
+The version-1 task input dual-writes `taskInboxToken` and its historical name,
+`continuationToken`, so a new producer can still start an older task workflow
+during a deployment transition. Its migration accepts either pre-version name;
+the other version-1 migrations are identity stamps that preserve additive
+fields.
 
 The registry that creates the manifest also owns the stable workflow IDs used
 by runtime references and the workflow bundler. Tests transform every real


### PR DESCRIPTION
## Problem

Three stable workflow entrypoints still accepted only emergent, unversioned TypeScript shapes. Older pinned producers can start those workflows on a newer deployment, and task-run history includes two different inbox token field names.

## Solution

- Add explicit v1 inputs and frozen v0-to-v1 migrations for workflow entry, session timeout, and task run workflows.
- Migrate raw input before any workflow body reads it.
- Stamp all current producers with v1.
- Dual-write task `taskInboxToken` and historical `continuationToken` so new producers remain readable by both old task consumer cohorts.
- Preserve additive fields through historical migrations.
- Update the durable manifest and compatibility research document.

## Behavior

Existing unversioned inputs remain accepted as v0. Unknown newer or malformed versions fail explicitly. Runtime routing and workflow IDs are unchanged.

## Stack

Depends on #2626.

## Validation

- 57 focused unit tests
- `pnpm --filter eve run build:js`
- Durable manifest scenario test
- Eve TypeScript check
- `pnpm guard:invariants`
- Formatting and diff checks