### PR TITLE
fix(eve): version authorization inbox callbacks

### DIFF
--- a/.changeset/warm-hooks-wait.md
+++ b/.changeset/warm-hooks-wait.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Connection authorization callbacks now honor the target session inbox wire version, preventing callback loss across mixed eve deployments and reporting unknown versions while the session stays parked.

--- a/packages/eve/src/execution/connections/callback-route.ts
+++ b/packages/eve/src/execution/connections/callback-route.ts
@@ -10,7 +10,7 @@
  *
  * 1. Parses the inbound request into a JSON-serializable
  *    {@link AuthorizationCallback} (params only — never request headers).
- * 2. Calls `resumeHook(token, payload)` to wake the suspended workflow.
+ * 2. Encodes for the target session inbox and resumes the suspended workflow.
  * 3. Renders the standard "Authorization complete" landing page so the
  *    user sees a friendly UI instead of an empty `202 Accepted`.
  *
@@ -22,7 +22,7 @@
  * internet.
  */
 
-import { resumeHook } from "#internal/workflow/runtime.js";
+import { resumeSessionInbox } from "#execution/wire/session-inbox-resume.js";
 import type { RouteContext } from "#public/definitions/channel.js";
 import { buildAuthorizationCompletePage } from "#runtime/connections/authorization-complete-page.js";
 import type { AuthorizationCallback } from "#shared/connection-types.js";
@@ -83,7 +83,7 @@ async function handleCallbackRequest(
     const authorizationCallback = legacy
       ? { callback, connectionName: name, legacy: true as const }
       : { attemptId: attemptId!, callback, connectionName: name };
-    await resumeHook(token, {
+    await resumeSessionInbox(token, {
       kind: "deliver" as const,
       payloads: [{ authorizationCallback }],
     });

--- a/packages/eve/src/execution/parked-delivery-wait.test.ts
+++ b/packages/eve/src/execution/parked-delivery-wait.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { DeliverHookPayload } from "#channel/types.js";
 import { nextTurnDelivery } from "#execution/parked-delivery-wait.js";
+import { reportDroppedWirePayloadStep } from "#execution/report-dropped-wire-payload-step.js";
 import { routeDeliverToChildren } from "#execution/route-child-delivery.js";
 import type {
   SessionCommandInbox,
@@ -13,6 +14,9 @@ import { SessionStateCursor } from "#execution/session-state-cursor.js";
 
 vi.mock("./route-child-delivery.js", () => ({
   routeDeliverToChildren: vi.fn(),
+}));
+vi.mock("./report-dropped-wire-payload-step.js", () => ({
+  reportDroppedWirePayloadStep: vi.fn(),
 }));
 
 interface ScriptedRead {
@@ -58,22 +62,27 @@ function createMockInbox(reads: readonly ScriptedRead[], authorizationReady = fa
 }
 
 function authorizationRead(): ScriptedRead {
+  const payload = authorizationPayload();
   return {
     result: {
       done: false,
       value: {
         kind: "deliver",
-        payloads: [
-          {
-            authorizationCallback: {
-              callback: { method: "GET", params: { code: "abc" } },
-              connectionName: "weather",
-            },
-          },
-        ],
-      } satisfies DeliverHookPayload,
+        payload,
+        payloads: [payload],
+        version: 1,
+      } as SessionInboxPayload,
     },
     source: "authorization",
+  };
+}
+
+function authorizationPayload() {
+  return {
+    authorizationCallback: {
+      callback: { method: "GET", params: { code: "abc" } },
+      connectionName: "weather",
+    },
   };
 }
 
@@ -109,9 +118,10 @@ function waitInput(inbox: SessionCommandInbox): Parameters<typeof nextTurnDelive
 describe("nextTurnDelivery", () => {
   afterEach(() => {
     vi.mocked(routeDeliverToChildren).mockReset();
+    vi.mocked(reportDroppedWirePayloadStep).mockReset();
   });
 
-  it("surfaces an authorization callback as its own instruction", async () => {
+  it("decodes a stamped authorization callback before surfacing it", async () => {
     const inbox = createMockInbox([authorizationRead()]);
 
     const next = await nextTurnDelivery(waitInput(inbox));
@@ -120,6 +130,46 @@ describe("nextTurnDelivery", () => {
     if (next.kind !== "authorization") throw new Error("unreachable");
     expect(next.closed).toBe(false);
     expect(next.payloads).toHaveLength(1);
+    expect(inbox.windowTransitions).toEqual([true, false]);
+  });
+
+  it("decodes a markerless legacy send from the authorization alias", async () => {
+    const payload = authorizationPayload();
+    const inbox = createMockInbox([
+      {
+        result: {
+          done: false,
+          value: { kind: "send", payload } as SessionInboxPayload,
+        },
+        source: "authorization",
+      },
+    ]);
+
+    const next = await nextTurnDelivery(waitInput(inbox));
+
+    expect(next).toEqual({ closed: false, kind: "authorization", payloads: [payload] });
+  });
+
+  it("reports an unknown authorization wire version and stays parked", async () => {
+    const inbox = createMockInbox([
+      {
+        result: {
+          done: false,
+          value: { kind: "deliver", payloads: [], version: 99 } as SessionInboxPayload,
+        },
+        source: "authorization",
+      },
+      authorizationRead(),
+    ]);
+
+    const next = await nextTurnDelivery(waitInput(inbox));
+
+    expect(next.kind).toBe("authorization");
+    expect(reportDroppedWirePayloadStep).toHaveBeenCalledOnce();
+    expect(reportDroppedWirePayloadStep).toHaveBeenCalledWith({
+      detail: expect.stringMatching(/newer than the supported version/),
+      family: "session-inbox",
+    });
     expect(inbox.windowTransitions).toEqual([true, false]);
   });
 

--- a/packages/eve/src/execution/parked-delivery-wait.ts
+++ b/packages/eve/src/execution/parked-delivery-wait.ts
@@ -176,10 +176,20 @@ async function waitForNextSessionAction(input: {
       if (first.done) {
         return { closed: true, kind: "authorization", payloads: [] };
       }
+
+      let decoded: DecodedSessionInbox;
+      try {
+        decoded = sessionInboxWire.decode(first.value);
+      } catch (error) {
+        if (!(error instanceof SessionInboxWireError)) throw error;
+        // Keep the challenge parked after reporting the dropped callback.
+        await reportDroppedWirePayloadStep({ detail: error.message, family: "session-inbox" });
+        continue;
+      }
       return {
         closed: false,
         kind: "authorization",
-        payloads: first.value.kind === "deliver" ? first.value.payloads : [],
+        payloads: decoded.kind === "deliver" ? decoded.payloads : [],
       };
     }
 

--- a/packages/eve/src/execution/workflow-entry.integration.test.ts
+++ b/packages/eve/src/execution/workflow-entry.integration.test.ts
@@ -14,6 +14,7 @@ import {
 } from "#execution/eve-workflow-attributes.js";
 import { createToolExecuteWithAuth } from "#execution/tool-auth.js";
 import { createWorkflowRuntime } from "#execution/workflow-runtime.js";
+import { resumeSessionInbox } from "#execution/wire/session-inbox-resume.js";
 import { normalizeEveAttributes } from "#runtime/attributes/normalize.js";
 import { ROOT_COMPILED_AGENT_NODE_ID } from "#compiler/manifest.js";
 import { ConnectionAuthorizationRequiredError } from "#connections/errors.js";
@@ -237,7 +238,7 @@ describe("workflowEntry integration", () => {
         );
         expect(parkBoundary.at(-1)?.type).toBe("session.waiting");
 
-        await resumeHook(`${run.runId}:auth`, {
+        await resumeSessionInbox(`${run.runId}:auth`, {
           kind: "deliver",
           payloads: [
             {

--- a/packages/eve/src/runtime/connections/callback-route.test.ts
+++ b/packages/eve/src/runtime/connections/callback-route.test.ts
@@ -2,15 +2,18 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createEveConnectionCallbackRoutePath } from "#protocol/routes.js";
 import type { RouteContext } from "#public/definitions/channel.js";
+import { sessionCommandHookToken } from "#execution/session-command-token.js";
 import {
   handleConnectionCallbackRequest,
   handleLegacyConnectionCallbackRequest,
 } from "#execution/connections/callback-route.js";
 
+const getHookByTokenMock = vi.fn();
 const resumeHookMock = vi.fn();
 
 vi.mock("#compiled/@workflow/core/runtime.js", () => ({
-  resumeHook: (token: string, payload: unknown) => resumeHookMock(token, payload),
+  getHookByToken: (...args: unknown[]) => getHookByTokenMock(...args),
+  resumeHook: (...args: unknown[]) => resumeHookMock(...args),
 }));
 
 function buildRouteContext(params: Readonly<Record<string, string>>): RouteContext {
@@ -23,6 +26,7 @@ function buildRouteContext(params: Readonly<Record<string, string>>): RouteConte
 
 describe("handleConnectionCallbackRequest", () => {
   beforeEach(() => {
+    getHookByTokenMock.mockReset();
     resumeHookMock.mockReset();
   });
 
@@ -53,7 +57,8 @@ describe("handleConnectionCallbackRequest", () => {
     expect(resumeHookMock).not.toHaveBeenCalled();
   });
 
-  it("forwards a GET callback into resumeHook as parsed params with no request headers", async () => {
+  it("encodes a GET callback for a stamped current authorization hook", async () => {
+    const hook = installCurrentHook("tok123");
     resumeHookMock.mockResolvedValueOnce(undefined);
     const url = `https://app.example.com${createEveConnectionCallbackRoutePath("linear", "attempt-1", "tok123")}?code=abc&state=xyz`;
     const response = await handleConnectionCallbackRequest(
@@ -73,12 +78,22 @@ describe("handleConnectionCallbackRequest", () => {
     expect(body).toContain('class="icon" aria-hidden="true"');
 
     expect(resumeHookMock).toHaveBeenCalledTimes(1);
-    const [token, payload] = resumeHookMock.mock.calls[0] ?? [];
-    expect(token).toBe("tok123");
+    const [target, payload] = resumeHookMock.mock.calls[0] ?? [];
+    expect(target).toBe(hook);
     // Exact match: only parsed params + method cross into the hook
     // payload. The inbound `x-probe` header (and any `Cookie`) is dropped.
     expect(payload).toEqual({
       kind: "deliver",
+      payload: {
+        authorizationCallback: {
+          attemptId: "attempt-1",
+          connectionName: "linear",
+          callback: {
+            params: { code: "abc", state: "xyz" },
+            method: "GET",
+          },
+        },
+      },
       payloads: [
         {
           authorizationCallback: {
@@ -91,10 +106,12 @@ describe("handleConnectionCallbackRequest", () => {
           },
         },
       ],
+      version: 1,
     });
   });
 
   it("keeps pre-attempt callback URLs resumable for pinned workflows", async () => {
+    const hook = installCurrentHook("tok123");
     resumeHookMock.mockResolvedValueOnce(undefined);
     const response = await handleLegacyConnectionCallbackRequest(
       new Request("https://app.example.com/eve/v1/connections/linear/callback/tok123?code=abc"),
@@ -102,21 +119,60 @@ describe("handleConnectionCallbackRequest", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(resumeHookMock).toHaveBeenCalledWith("tok123", {
+    const authorizationCallback = {
+      callback: { method: "GET", params: { code: "abc" } },
+      connectionName: "linear",
+      legacy: true,
+    };
+    expect(resumeHookMock).toHaveBeenCalledWith(hook, {
       kind: "deliver",
-      payloads: [
-        {
-          authorizationCallback: {
-            callback: { method: "GET", params: { code: "abc" } },
-            connectionName: "linear",
-            legacy: true,
-          },
+      payload: { authorizationCallback },
+      payloads: [{ authorizationCallback }],
+      version: 1,
+    });
+  });
+
+  it("uses the markerless stable-inbox cohort's legacy send encoding", async () => {
+    const runId = "legacy-session";
+    const hook = { metadata: undefined, runId, token: "tok123" };
+    const stableHook = {
+      metadata: undefined,
+      runId,
+      token: sessionCommandHookToken(runId),
+    };
+    getHookByTokenMock.mockResolvedValueOnce(hook).mockResolvedValueOnce(stableHook);
+    resumeHookMock.mockResolvedValueOnce(undefined);
+
+    const response = await handleConnectionCallbackRequest(
+      new Request(
+        `https://app.example.com${createEveConnectionCallbackRoutePath("linear", "attempt-1", "tok123")}?code=abc`,
+      ),
+      buildRouteContext({ attemptId: "attempt-1", name: "linear", token: "tok123" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(getHookByTokenMock).toHaveBeenNthCalledWith(1, "tok123");
+    expect(getHookByTokenMock).toHaveBeenNthCalledWith(2, sessionCommandHookToken(runId));
+    expect(resumeHookMock).toHaveBeenCalledWith(hook, {
+      auth: undefined,
+      caller: undefined,
+      delivery: undefined,
+      kind: "send",
+      payload: {
+        authorizationCallback: {
+          attemptId: "attempt-1",
+          callback: { method: "GET", params: { code: "abc" } },
+          connectionName: "linear",
         },
-      ],
+      },
+      requestId: undefined,
+      taskDeliveryId: undefined,
+      turnPolicy: undefined,
     });
   });
 
   it("captures form-encoded POST bodies before resuming the hook", async () => {
+    installCurrentHook("tok123");
     resumeHookMock.mockResolvedValueOnce(undefined);
     const url = `https://app.example.com${createEveConnectionCallbackRoutePath("linear", "attempt-1", "tok123")}`;
     await handleConnectionCallbackRequest(
@@ -131,6 +187,17 @@ describe("handleConnectionCallbackRequest", () => {
     const [, payload] = resumeHookMock.mock.calls[0] ?? [];
     expect(payload).toEqual({
       kind: "deliver",
+      payload: {
+        authorizationCallback: {
+          attemptId: "attempt-1",
+          connectionName: "linear",
+          callback: {
+            params: { code: "abc", state: "xyz" },
+            method: "POST",
+            body: "code=abc&state=xyz",
+          },
+        },
+      },
       payloads: [
         {
           authorizationCallback: {
@@ -144,14 +211,15 @@ describe("handleConnectionCallbackRequest", () => {
           },
         },
       ],
+      version: 1,
     });
   });
 
   it("returns 404 when the workflow runtime reports no hook for the supplied token", async () => {
-    // `resumeHook` throws when no workflow run is currently waiting on
+    // Target lookup fails when no workflow run is currently waiting on
     // the supplied token, e.g. the workflow already completed,
     // disposed the hook, or the user replayed a stale callback URL.
-    resumeHookMock.mockRejectedValueOnce(new Error("hook not found"));
+    getHookByTokenMock.mockRejectedValueOnce(new Error("hook not found"));
     const response = await handleConnectionCallbackRequest(
       new Request(
         `https://app.example.com${createEveConnectionCallbackRoutePath("linear", "attempt-1", "tok")}`,
@@ -163,3 +231,13 @@ describe("handleConnectionCallbackRequest", () => {
     expect(body).toEqual(expect.objectContaining({ ok: false }));
   });
 });
+
+function installCurrentHook(token: string) {
+  const hook = {
+    metadata: { sessionInboxWireVersion: 1 },
+    runId: "current-session",
+    token,
+  };
+  getHookByTokenMock.mockResolvedValueOnce(hook);
+  return hook;
+}

--- a/research/durable-deployment-compatibility.md
+++ b/research/durable-deployment-compatibility.md
@@ -118,6 +118,14 @@ during a deployment transition. Its migration accepts either pre-version name;
 the other version-1 migrations are identity stamps that preserve additive
 fields.
 
+Connection authorization callbacks use the same target-aware `sessionInboxWire`
+boundary as stable and continuation session deliveries. The callback route
+inspects the target hook before encoding, including the existing markerless
+stable-inbox classification, and the authorization source decodes before it
+interprets callback payloads. An unknown payload version is reported through the
+dropped-wire step and leaves the authorization challenge parked rather than
+reinterpreting or consuming it silently.
+
 The registry that creates the manifest also owns the stable workflow IDs used
 by runtime references and the workflow bundler. Tests transform every real
 stable workflow declaration and compare the emitted ID with the registry. A


### PR DESCRIPTION
## Problem

Connection authorization callbacks resume an alias owned by a pinned session driver, but that path bypassed the versioned session-inbox encoder and decoder. A callback from current code could therefore be silently lost or misread by an older session.

## Solution

- Route authorization callbacks through `resumeSessionInbox` and its target capability lookup.
- Decode authorization-source values through `sessionInboxWire` before interpreting them.
- Preserve markerless historical `send` and `deliver` selection.
- Report unknown wire versions and continue the parked authorization wait.
- Cover current stamped hooks, markerless historical hooks, and dropped future versions.

## Behavior

Unknown callback versions are reported and dropped while the session remains parked for a later compatible callback. Current and historical supported callbacks retain their existing authorization behavior.

## Stack

Depends on #2629, which depends on #2626.

## Validation

- 24 focused unit tests
- Authorization workflow integration test
- Eve typecheck and build
- `pnpm guard:invariants`
- Focused lint, formatting, and diff checks