### PR TITLE
test(eve): gate mixed-version workflow continuation

### DIFF
--- a/packages/eve/test/helpers/mixed-version-workflow.ts
+++ b/packages/eve/test/helpers/mixed-version-workflow.ts
@@ -1,0 +1,409 @@
+import { mkdir, readFile, realpath, rm, symlink } from "node:fs/promises";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import type { Runtime } from "#channel/types.js";
+import { resolvePackageRoot } from "#internal/application/package.js";
+import type { ScenarioApp, ScenarioAppDescriptor } from "#internal/testing/scenario-app.js";
+import { materializeScenarioApp } from "#internal/testing/scenario-app.js";
+import {
+  deriveEveWorkflowQueuePrefix,
+  installEveWorkflowQueueNamespace,
+} from "#internal/workflow/queue-namespace.js";
+import {
+  createRuntimeSession,
+  getActiveRuntimeSession,
+  type RuntimeSession,
+  withRuntimeSession,
+} from "#runtime/sessions/runtime-session.js";
+import { createWorld, type LocalWorld } from "#compiled/@workflow/world-local/index.js";
+import type { World } from "#compiled/@workflow/world/index.js";
+
+const HISTORICAL_EVE_VERSION = "0.30.8";
+// The vendored World runtime is stubbed in published eve packages, so its
+// protocol version cannot be imported. These values are pinned by the cohort
+// scenario and must move only when that package's Workflow runtime moves.
+const HISTORICAL_WORKFLOW_SPEC_VERSION = 5;
+const CANDIDATE_WORKFLOW_SPEC_VERSION = 6;
+
+interface WorkflowBundleBuilderConstructor {
+  new (options: {
+    readonly agentName: string;
+    readonly appRoot: string;
+    readonly compiledArtifactsBootstrapPath: string;
+    readonly outDir: string;
+    readonly rootDir: string;
+    readonly watch: boolean;
+  }): {
+    build(): Promise<void>;
+  };
+}
+
+interface VersionCompilerModule {
+  compileAgent(input: { readonly startPath: string }): Promise<VersionCompileResult>;
+}
+
+interface VersionCompileResult {
+  readonly manifest: unknown;
+  readonly metadata: unknown;
+  readonly paths: unknown;
+}
+
+interface VersionCompiledArtifactsModule {
+  writeCompiledArtifactsFiles(input: {
+    readonly compileResult: VersionCompileResult;
+    readonly defaultWorkflowWorld: "local";
+    readonly outDir: string;
+  }): Promise<{ readonly bootstrapPath: string }>;
+}
+
+interface WorkflowDiscoveredEntries {
+  readonly discoveredSerdeFiles: string[];
+  readonly discoveredSteps: string[];
+  readonly discoveredWorkflows: string[];
+}
+
+interface VersionWorkflowBuilderSupportModule {
+  bundleWorkflowStepRegistrations(input: {
+    readonly builtinsPath: string;
+    readonly discoveredEntries: WorkflowDiscoveredEntries;
+    readonly outfile: string;
+    readonly projectRoot: string;
+    readonly workingDir: string;
+  }): Promise<void>;
+  collectWorkflowInputFiles(root: string): Promise<string[]>;
+}
+
+interface VersionWorkflowBuildersModule {
+  detectWorkflowPatterns(source: string): {
+    readonly hasSerde: boolean;
+    readonly hasUseStep: boolean;
+    readonly hasUseWorkflow: boolean;
+  };
+}
+
+interface VersionWorkflowRuntimeModule {
+  createWorkflowRuntime(config: { readonly compiledArtifactsSource: unknown }): Runtime;
+}
+
+interface VersionCompiledArtifactsSourceModule {
+  createBundledRuntimeCompiledArtifactsSource(): unknown;
+}
+
+interface VersionWorkflowCoreRuntimeModule {
+  setWorld(world: unknown): void;
+}
+
+export interface MixedVersionDeployment {
+  readonly deploymentId: string;
+  readonly eveVersion: string;
+  readonly handler: (request: Request) => Promise<Response>;
+  readonly packageRoot: string;
+  readonly specVersion: number;
+  activateArtifacts(): Promise<void>;
+  createRuntime(): Promise<Runtime>;
+}
+
+export interface WorkflowHandlerDelivery {
+  readonly deploymentId: string;
+  readonly runId: string;
+}
+
+export interface PromotableWorkflowWorld {
+  readonly deliveries: readonly WorkflowHandlerDelivery[];
+  readonly world: World;
+  close(): Promise<void>;
+  promote(deploymentId: string): void;
+  runInDeployment<T>(deploymentId: string, callback: () => Promise<T>): Promise<T>;
+  start(): Promise<void>;
+}
+
+/** Materializes one descriptor against either the candidate or the published cohort. */
+export async function materializeMixedVersionWorkflowApp(input: {
+  readonly descriptor: ScenarioAppDescriptor;
+  readonly eveVersion: "current" | typeof HISTORICAL_EVE_VERSION;
+}): Promise<ScenarioApp> {
+  const app = await materializeScenarioApp({
+    ...input.descriptor,
+    installDependencies: true,
+  });
+  if (input.eveVersion === "current") return app;
+
+  const appEvePackage = join(app.appRoot, "node_modules", "eve");
+  const historicalPackage = await realpath(
+    join(resolvePackageRoot(), "node_modules", "historical-eve-0-30-8"),
+  );
+  await rm(appEvePackage, { force: true, recursive: true });
+  await symlink(historicalPackage, appEvePackage, "dir");
+  return app;
+}
+
+/** Builds and loads a handler using only the eve installation under that app. */
+export async function buildMixedVersionWorkflowDeployment(input: {
+  readonly agentName: string;
+  readonly appRoot: string;
+  readonly deploymentId: string;
+  readonly eveVersion: "current" | typeof HISTORICAL_EVE_VERSION;
+}): Promise<MixedVersionDeployment> {
+  const packageRoot = await realpath(join(input.appRoot, "node_modules", "eve"));
+  const outputRoot = join(input.appRoot, ".eve", "mixed-version", input.deploymentId);
+  const bootstrapPath = join(input.appRoot, ".eve", "mixed-version-bootstrap", input.deploymentId);
+  await mkdir(outputRoot, { recursive: true });
+  await mkdir(bootstrapPath, { recursive: true });
+
+  const [builderModule, compilerModule, compiledArtifactsModule, builderSupport, workflowBuilders] =
+    (await Promise.all([
+      importPackageModule(packageRoot, "internal/workflow-bundle/builder.js"),
+      importPackageModule(packageRoot, "compiler/compile-agent.js"),
+      importPackageModule(packageRoot, "internal/application/compiled-artifacts.js"),
+      importPackageModule(packageRoot, "internal/workflow-bundle/builder-support.js"),
+      importPackageModule(packageRoot, "internal/workflow-bundle/workflow-builders.js"),
+    ])) as [
+      { WorkflowBundleBuilder: WorkflowBundleBuilderConstructor },
+      VersionCompilerModule,
+      VersionCompiledArtifactsModule,
+      VersionWorkflowBuilderSupportModule,
+      VersionWorkflowBuildersModule,
+    ];
+  const compileResult = await compilerModule.compileAgent({ startPath: input.appRoot });
+  const generatedArtifacts = await compiledArtifactsModule.writeCompiledArtifactsFiles({
+    compileResult,
+    defaultWorkflowWorld: "local",
+    outDir: bootstrapPath,
+  });
+  const builder = new builderModule.WorkflowBundleBuilder({
+    agentName: input.agentName,
+    appRoot: input.appRoot,
+    compiledArtifactsBootstrapPath: generatedArtifacts.bootstrapPath,
+    outDir: outputRoot,
+    rootDir: packageRoot,
+    watch: false,
+  });
+  await builder.build();
+  const discoveredEntries = await discoverWorkflowEntries({
+    builderSupport,
+    packageRoot,
+    workflowBuilders,
+  });
+  await builderSupport.bundleWorkflowStepRegistrations({
+    builtinsPath: join(packageRoot, "dist", "src", "internal", "workflow", "builtins.js"),
+    discoveredEntries,
+    outfile: join(outputRoot, "steps.mjs"),
+    projectRoot: input.appRoot,
+    workingDir: packageRoot,
+  });
+
+  const handlerModule = (await import(pathToFileURL(join(outputRoot, "workflows.mjs")).href)) as {
+    POST: (request: Request) => Promise<Response>;
+  };
+  const bootstrapModule = (await import(pathToFileURL(generatedArtifacts.bootstrapPath).href)) as {
+    installCompiledArtifactsBootstrap: () => void;
+  };
+  return {
+    deploymentId: input.deploymentId,
+    eveVersion: input.eveVersion,
+    handler: handlerModule.POST,
+    packageRoot,
+    specVersion:
+      input.eveVersion === HISTORICAL_EVE_VERSION
+        ? HISTORICAL_WORKFLOW_SPEC_VERSION
+        : CANDIDATE_WORKFLOW_SPEC_VERSION,
+    async activateArtifacts() {
+      bootstrapModule.installCompiledArtifactsBootstrap();
+    },
+    async createRuntime() {
+      const [runtimeModule, sourceModule] = (await Promise.all([
+        importPackageModule(packageRoot, "execution/workflow-runtime.js"),
+        importPackageModule(packageRoot, "runtime/compiled-artifacts-source.js"),
+      ])) as [VersionWorkflowRuntimeModule, VersionCompiledArtifactsSourceModule];
+      return runtimeModule.createWorkflowRuntime({
+        compiledArtifactsSource: sourceModule.createBundledRuntimeCompiledArtifactsSource(),
+      });
+    },
+  };
+}
+
+/**
+ * Hosts immutable version handlers on one local World and dispatches every
+ * delivery from the run's persisted deployment identity.
+ */
+export async function createPromotableWorkflowWorld(input: {
+  readonly agentName: string;
+  readonly dataDir: string;
+  readonly deployments: readonly MixedVersionDeployment[];
+  readonly initialDeploymentId: string;
+}): Promise<PromotableWorkflowWorld> {
+  const localWorld = createWorld({ dataDir: input.dataDir, recoverActiveRuns: false });
+  const deployments = new Map(input.deployments.map((entry) => [entry.deploymentId, entry]));
+  const runtimeSessions = new Map(
+    input.deployments.map((deployment) => [
+      deployment.deploymentId,
+      createRuntimeSession(`mixed-version:${deployment.deploymentId}`),
+    ]),
+  );
+  const deploymentByRuntimeSession = new WeakMap<RuntimeSession, MixedVersionDeployment>();
+  for (const deployment of input.deployments) {
+    deploymentByRuntimeSession.set(getRuntimeSession(deployment.deploymentId), deployment);
+  }
+  const deliveries: WorkflowHandlerDelivery[] = [];
+  let promotedDeploymentId = input.initialDeploymentId;
+  installEveWorkflowQueueNamespace(input.agentName);
+
+  const world = new Proxy(localWorld, {
+    get(target, property, receiver) {
+      if (property === "specVersion") {
+        return (
+          deploymentByRuntimeSession.get(getActiveRuntimeSession())?.specVersion ??
+          getDeployment(promotedDeploymentId).specVersion
+        );
+      }
+      if (property === "getDeploymentId") {
+        return async () =>
+          deploymentByRuntimeSession.get(getActiveRuntimeSession())?.deploymentId ??
+          getDeployment(promotedDeploymentId).deploymentId;
+      }
+      if (property === "resolveLatestDeploymentId") {
+        return async () => getDeployment(promotedDeploymentId).deploymentId;
+      }
+      const value = Reflect.get(target, property, receiver) as unknown;
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  }) as World;
+
+  for (const deployment of input.deployments) {
+    const runtimeModule = (await importPackageModule(
+      deployment.packageRoot,
+      "compiled/@workflow/core/runtime.js",
+    )) as VersionWorkflowCoreRuntimeModule;
+    runtimeModule.setWorld(world);
+  }
+
+  localWorld.registerHandler(deriveEveWorkflowQueuePrefix(input.agentName), async (request) => {
+    const payload = (await request.clone().json()) as unknown;
+    const runId = readDeliveryRunId(payload);
+    const deploymentId = await resolveDeliveryDeploymentId(
+      localWorld,
+      payload,
+      runId,
+      promotedDeploymentId,
+      request.headers.get("x-vqs-queue-name")?.endsWith("_health_check") === true,
+    );
+    const deployment = getDeployment(deploymentId);
+    deliveries.push({ deploymentId, runId });
+    return await withRuntimeSession(getRuntimeSession(deploymentId), async () => {
+      await deployment.activateArtifacts();
+      return await deployment.handler(request);
+    });
+  });
+
+  function getDeployment(deploymentId: string): MixedVersionDeployment {
+    const deployment = deployments.get(deploymentId);
+    if (deployment === undefined) {
+      throw new Error(`No mixed-version Workflow handler is registered for "${deploymentId}".`);
+    }
+    return deployment;
+  }
+
+  function getRuntimeSession(deploymentId: string): RuntimeSession {
+    const session = runtimeSessions.get(deploymentId);
+    if (session === undefined) {
+      throw new Error(`No mixed-version runtime session is registered for "${deploymentId}".`);
+    }
+    return session;
+  }
+
+  return {
+    deliveries,
+    world,
+    async close() {
+      for (const deployment of input.deployments) {
+        const runtimeModule = (await importPackageModule(
+          deployment.packageRoot,
+          "compiled/@workflow/core/runtime.js",
+        )) as VersionWorkflowCoreRuntimeModule;
+        runtimeModule.setWorld(undefined);
+      }
+      await localWorld.close?.();
+    },
+    promote(deploymentId) {
+      getDeployment(deploymentId);
+      promotedDeploymentId = deploymentId;
+    },
+    async runInDeployment(deploymentId, callback) {
+      const deployment = getDeployment(deploymentId);
+      return await withRuntimeSession(getRuntimeSession(deploymentId), async () => {
+        await deployment.activateArtifacts();
+        return await callback();
+      });
+    },
+    async start() {
+      await localWorld.start?.();
+    },
+  };
+}
+
+async function importPackageModule(packageRoot: string, relativePath: string): Promise<unknown> {
+  return await import(pathToFileURL(join(packageRoot, "dist", "src", relativePath)).href);
+}
+
+async function discoverWorkflowEntries(input: {
+  readonly builderSupport: VersionWorkflowBuilderSupportModule;
+  readonly packageRoot: string;
+  readonly workflowBuilders: VersionWorkflowBuildersModule;
+}): Promise<WorkflowDiscoveredEntries> {
+  const entries: WorkflowDiscoveredEntries = {
+    discoveredSerdeFiles: [],
+    discoveredSteps: [],
+    discoveredWorkflows: [],
+  };
+  const files = await input.builderSupport.collectWorkflowInputFiles(
+    join(input.packageRoot, "dist", "src", "execution"),
+  );
+  for (const filePath of files) {
+    const patterns = input.workflowBuilders.detectWorkflowPatterns(
+      await readFile(filePath, "utf8"),
+    );
+    if (patterns.hasSerde) entries.discoveredSerdeFiles.push(filePath);
+    if (patterns.hasUseStep) entries.discoveredSteps.push(filePath);
+    if (patterns.hasUseWorkflow) entries.discoveredWorkflows.push(filePath);
+  }
+  return entries;
+}
+
+function readDeliveryRunId(payload: unknown): string {
+  if (!isRecord(payload)) throw new Error("Workflow delivery payload is not an object.");
+  const runId =
+    typeof payload.runId === "string"
+      ? payload.runId
+      : typeof payload.workflowRunId === "string"
+        ? payload.workflowRunId
+        : undefined;
+  if (runId === undefined) throw new Error("Workflow delivery payload does not identify its run.");
+  return runId;
+}
+
+async function resolveDeliveryDeploymentId(
+  world: LocalWorld,
+  payload: unknown,
+  runId: string,
+  fallbackDeploymentId: string,
+  isHealthCheck: boolean,
+): Promise<string> {
+  if (isRecord(payload) && isRecord(payload.runInput)) {
+    const deploymentId = payload.runInput.deploymentId;
+    if (typeof deploymentId === "string") return deploymentId;
+  }
+  try {
+    return (await world.runs.get(runId, { resolveData: "none" })).deploymentId;
+  } catch (error) {
+    if (isHealthCheck) {
+      // Workflow's queue health check intentionally uses a synthetic run id.
+      return fallbackDeploymentId;
+    }
+    throw error;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/eve/test/scenarios/mixed-version-workflow-compatibility.scenario.test.ts
+++ b/packages/eve/test/scenarios/mixed-version-workflow-compatibility.scenario.test.ts
@@ -1,0 +1,230 @@
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import type { MessageStreamEvent } from "#protocol/message.js";
+import type { ScenarioAppDescriptor } from "#internal/testing/scenario-app.js";
+import {
+  buildMixedVersionWorkflowDeployment,
+  createPromotableWorkflowWorld,
+  materializeMixedVersionWorkflowApp,
+  type PromotableWorkflowWorld,
+} from "../helpers/mixed-version-workflow.js";
+
+const AGENT_NAME = "mixed-version-workflow";
+const HISTORICAL_DEPLOYMENT_ID = "historical-eve-0-30-8";
+const CANDIDATE_DEPLOYMENT_ID = "candidate-current";
+const WORKFLOW_ENTRY_ID = "workflow//eve//workflowEntry";
+const TURN_WORKFLOW_ID = "workflow//eve//turnWorkflow";
+const SCENARIO_TIMEOUT_MS = 360_000;
+
+const APP_DESCRIPTOR: ScenarioAppDescriptor = {
+  files: {
+    "agent/agent.ts": [
+      'import { defineAgent } from "eve";',
+      "",
+      "export default defineAgent({",
+      '  model: "openai/gpt-5.4-mini",',
+      "});",
+      "",
+    ].join("\n"),
+    "agent/instructions.md": "Reply briefly to each message.\n",
+  },
+  name: AGENT_NAME,
+};
+
+describe("mixed-version Workflow compatibility", () => {
+  it(
+    "keeps the 0.30.8 driver pinned while the promoted candidate owns the next turn",
+    async () => {
+      const apps: Array<Awaited<ReturnType<typeof materializeMixedVersionWorkflowApp>>> = [];
+      let workflowWorld: PromotableWorkflowWorld | undefined;
+      const previousVercelEnvironment = process.env.VERCEL_ENV;
+
+      try {
+        const historicalApp = await materializeMixedVersionWorkflowApp({
+          descriptor: APP_DESCRIPTOR,
+          eveVersion: "0.30.8",
+        });
+        apps.push(historicalApp);
+        const candidateApp = await materializeMixedVersionWorkflowApp({
+          descriptor: APP_DESCRIPTOR,
+          eveVersion: "current",
+        });
+        apps.push(candidateApp);
+
+        const [historical, candidate] = await Promise.all([
+          buildMixedVersionWorkflowDeployment({
+            agentName: AGENT_NAME,
+            appRoot: historicalApp.appRoot,
+            deploymentId: HISTORICAL_DEPLOYMENT_ID,
+            eveVersion: "0.30.8",
+          }),
+          buildMixedVersionWorkflowDeployment({
+            agentName: AGENT_NAME,
+            appRoot: candidateApp.appRoot,
+            deploymentId: CANDIDATE_DEPLOYMENT_ID,
+            eveVersion: "current",
+          }),
+        ]);
+        workflowWorld = await createPromotableWorkflowWorld({
+          agentName: AGENT_NAME,
+          dataDir: join(candidateApp.appRoot, ".eve", "mixed-version-world"),
+          deployments: [historical, candidate],
+          initialDeploymentId: HISTORICAL_DEPLOYMENT_ID,
+        });
+        await workflowWorld.start();
+        const world = workflowWorld.world;
+        process.env.VERCEL_ENV = "production";
+
+        const historicalRuntime = await historical.createRuntime();
+        const session = await workflowWorld.runInDeployment(HISTORICAL_DEPLOYMENT_ID, async () =>
+          historicalRuntime.createSession({
+            adapter: { kind: "http" },
+            auth: null,
+            input: { message: "First historical turn." },
+            mode: "conversation",
+          }),
+        );
+        const firstEvents = await workflowWorld.runInDeployment(
+          HISTORICAL_DEPLOYMENT_ID,
+          async () => await readUntilWaiting(session.events),
+        );
+        expect(firstEvents.map((event) => event.type)).not.toContain("turn.failed");
+        expect(firstEvents.map((event) => event.type)).not.toContain("session.failed");
+
+        const driverBeforePromotion = await world.runs.get(session.sessionId, {
+          resolveData: "none",
+        });
+        expect(driverBeforePromotion).toMatchObject({
+          deploymentId: HISTORICAL_DEPLOYMENT_ID,
+          status: "running",
+          workflowName: WORKFLOW_ENTRY_ID,
+        });
+
+        const deliveryCountBeforePromotion = workflowWorld.deliveries.length;
+        workflowWorld.promote(CANDIDATE_DEPLOYMENT_ID);
+        const followUpStartIndex = firstEvents.length;
+        await expect(
+          workflowWorld.runInDeployment(HISTORICAL_DEPLOYMENT_ID, async () =>
+            historicalRuntime.dispatchSession({
+              command: { kind: "send", payload: { message: "Compatible follow-up." } },
+              sessionId: session.sessionId,
+            }),
+          ),
+        ).resolves.toEqual({ sessionId: session.sessionId, status: "accepted" });
+        const followUpEvents = await workflowWorld.runInDeployment(
+          HISTORICAL_DEPLOYMENT_ID,
+          async () =>
+            await readUntilWaiting(
+              await historicalRuntime.getEventStream(session.sessionId, {
+                startIndex: followUpStartIndex,
+              }),
+            ),
+        );
+
+        const driverAfterPromotion = await world.runs.get(session.sessionId, {
+          resolveData: "none",
+        });
+        expect(driverAfterPromotion).toMatchObject({
+          deploymentId: HISTORICAL_DEPLOYMENT_ID,
+          status: "running",
+          workflowName: WORKFLOW_ENTRY_ID,
+        });
+
+        const turnRuns = await world.runs.list({
+          pagination: { limit: 100 },
+          resolveData: "none",
+          workflowName: TURN_WORKFLOW_ID,
+        });
+        expect(turnRuns.data).toHaveLength(2);
+        const settledTurnRuns = await Promise.all(
+          turnRuns.data.map(async (run) => await waitForRunToSettle(world, run.runId)),
+        );
+        expect(settledTurnRuns.map((run) => run.status)).toEqual(["completed", "completed"]);
+        expect(turnRuns.data.map((run) => run.deploymentId).sort()).toEqual(
+          [HISTORICAL_DEPLOYMENT_ID, CANDIDATE_DEPLOYMENT_ID].sort(),
+        );
+        const candidateTurn = turnRuns.data.find(
+          (run) => run.deploymentId === CANDIDATE_DEPLOYMENT_ID,
+        );
+        expect(candidateTurn).toBeDefined();
+        const followUpDeliveries = workflowWorld.deliveries.slice(deliveryCountBeforePromotion);
+        expect(
+          followUpDeliveries.some(
+            (delivery) =>
+              delivery.runId === candidateTurn?.runId &&
+              delivery.deploymentId === CANDIDATE_DEPLOYMENT_ID,
+          ),
+        ).toBe(true);
+        expect(followUpDeliveries).toContainEqual({
+          deploymentId: HISTORICAL_DEPLOYMENT_ID,
+          runId: session.sessionId,
+        });
+
+        const failedRuns = await world.runs.list({
+          pagination: { limit: 100 },
+          resolveData: "none",
+          status: "failed",
+        });
+        expect(failedRuns.data).toEqual([]);
+        expect(followUpEvents.map((event) => event.type)).toContain("message.completed");
+        expect(followUpEvents.map((event) => event.type)).toContain("session.waiting");
+        expect(followUpEvents.map((event) => event.type)).not.toContain("turn.failed");
+        expect(followUpEvents.map((event) => event.type)).not.toContain("session.failed");
+      } finally {
+        if (previousVercelEnvironment === undefined) {
+          delete process.env.VERCEL_ENV;
+        } else {
+          process.env.VERCEL_ENV = previousVercelEnvironment;
+        }
+        try {
+          await workflowWorld?.close();
+        } finally {
+          await Promise.all(apps.map(async (app) => await app.cleanup()));
+        }
+      }
+    },
+    SCENARIO_TIMEOUT_MS,
+  );
+});
+
+async function readUntilWaiting(
+  stream: ReadableStream<MessageStreamEvent>,
+): Promise<MessageStreamEvent[]> {
+  const reader = stream.getReader();
+  const events: MessageStreamEvent[] = [];
+  const timeout = AbortSignal.timeout(60_000);
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    timeout.addEventListener("abort", () => reject(timeout.reason), { once: true });
+  });
+  try {
+    while (!timeout.aborted) {
+      const next = await Promise.race([reader.read(), timeoutPromise]);
+      if (next.done) break;
+      events.push(next.value);
+      if (next.value.type === "session.waiting") return events;
+      if (next.value.type === "session.failed") {
+        throw new Error(`Session failed: ${JSON.stringify(next.value.data)}`);
+      }
+    }
+  } finally {
+    await reader.cancel().catch(() => undefined);
+  }
+  throw new Error(`Session did not park. Events: ${events.map((event) => event.type).join(", ")}`);
+}
+
+async function waitForRunToSettle(
+  world: PromotableWorkflowWorld["world"],
+  runId: string,
+): Promise<Awaited<ReturnType<typeof world.runs.get>>> {
+  const deadline = Date.now() + 10_000;
+  while (true) {
+    const run = await world.runs.get(runId, { resolveData: "none" });
+    if (run.status !== "pending" && run.status !== "running") return run;
+    if (Date.now() >= deadline) {
+      throw new Error(`Workflow run "${runId}" did not settle from ${run.status}.`);
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 20));
+  }
+}

--- a/research/durable-deployment-compatibility.md
+++ b/research/durable-deployment-compatibility.md
@@ -165,6 +165,13 @@ the candidate in the development world, and continue those sessions through
 parked turns, active turns, cancellation, runtime actions, subagents, tasks,
 and timeouts.
 
+The first required local cohort builds the published eve 0.30.8 handler and the
+candidate handler independently against one test-only promotable Workflow
+World. It proves the historical session driver remains deployment-affine while
+its next turn is created and delivered by the promoted candidate. Additional
+cohorts and suspension points are added only when they represent a distinct
+shipped protocol contract; package releases alone do not grow the matrix.
+
 Production routing ultimately targets the latest compatibility-approved
 deployment rather than the most recently created deployment. Promotion is not
 long-lived blue/green routing: after approval, every new turn takes the promoted

--- a/research/durable-deployment-compatibility.md
+++ b/research/durable-deployment-compatibility.md
@@ -179,6 +179,15 @@ code. The pointer exists to keep an unverified build out of the latest path and
 to provide an immediate demotion control if a semantic regression escapes the
 build gate.
 
+Two implementation boundaries remain outside this stack. Turn-control producer
+gating builds on the fail-loud decoder and terminal skew path in #2625; it should
+land after that work rather than duplicate its workflow-bundle changes. An
+immediate production demotion control requires Vercel's dynamic
+`resolve-latest-deployment` path to return an audited approved deployment. An
+eve-only resolver can protect newly deployed drivers, but it cannot retrofit
+that behavior into older immutable drivers already calling the platform's
+existing latest resolver.
+
 ## Why history replay is insufficient
 
 Workflow history replay is useful when new code must reconstruct an existing


### PR DESCRIPTION
## Problem

Schema and fixture checks cannot prove Eve's real production topology: an old session driver must remain on its immutable deployment while a new child turn starts on the promoted latest deployment.

## Solution

- Add a test-only promotable Workflow World with persisted-run deployment affinity.
- Independently build and load published `eve@0.30.8` and the candidate workflow/step handlers.
- Share one local durable store while routing each delivery to its owning deployment.
- Start and park a historical session, promote the candidate, and continue the same session.
- Assert the driver stays historical, the next turn is candidate-owned, both turns complete, and no run/session failure occurs.

The scenario uses the repository's pinned historical package and does not require a registry download during execution.

## Stack

Depends on #2630, #2629, and #2626.

## Validation

- Mixed-version scenario test
- Development World routing integration tests
- Eve typecheck
- `pnpm guard:invariants`
- `pnpm guard:fixtures`
- Formatting and diff checks

No changeset: test infrastructure only.