### PR TITLE
research: let self-modification drive registry installs

### DIFF
--- a/research/self-modification-registry-install.md
+++ b/research/self-modification-registry-install.md
@@ -1,0 +1,360 @@
+---
+issue: https://github.com/vercel/eve/issues/742
+status: proposed
+last_updated: "2026-08-26"
+---
+
+# Self-modification: driving registry installs
+
+## Proposal
+
+The self-modification subagent can search the registry but cannot install from
+it. Asked to "add a Slack channel", it finds `channel/slack` and then tells the
+developer to type `/add channel/slack` themselves. The developer has to leave
+the conversation to complete a request the agent already understood.
+
+The subagent should install registry items itself, under approval, and hand off
+to the dev TUI only for the steps that genuinely require a terminal.
+
+It should do that by driving the install contract eve already publishes —
+`eve add <item> --non-interactive` — through one tool, rather than through a new
+programmatic registry API. Anything that would ask the developer a question
+goes to the wizard built to ask it.
+
+The constraint that looks like it blocks all of this — the subagent's narrow
+sandbox — is not the constraint. Extension tools do not run in the sandbox.
+
+## Where the boundary sits
+
+Three surfaces, with different privileges, are involved in one install. Today
+the subagent only reaches the first.
+
+```text
+┌─ just-bash sandbox ────────────────┐  agent/ mounted at /source, read-write.
+│  bash, read_file, write_file,      │  No process execution at all. No network.
+│  selfmod__edit_file                │  Widening the mount cannot change this.
+└────────────────────────────────────┘
+┌─ dev-server process (host) ────────┐  Extension tool bodies run here. Full
+│  selfmod__search_registry          │  Node privileges, real network, and the
+│  ← proposed install tool           │  ability to spawn a child process.
+└────────────────────────────────────┘
+┌─ dev TUI process (terminal) ───────┐  Owns stdin and the Prompter. The only
+│  /add <address>                    │  surface with a TTY, and the only one
+└────────────────────────────────────┘  that may see secrets.
+```
+
+The sandbox is a red herring. `just-bash` executes no binaries — it rejects
+`setNetworkPolicy` outright because it "runs no binaries to govern"
+(`shared/sandbox-network-policy.ts`). Mounting the whole repository and opening
+the network would still leave no process to run `pnpm`, `eve`, or a declared
+setup command, while making `package.json` hand-editable by the model and
+`.env.local` readable into the transcript. The `/source` mount stays as narrow
+as it is today.
+
+The host tool layer already has what installation needs.
+`selfmod__search_registry` performs a real `fetch()` against `eve.dev/r` from
+that layer, and nothing prevents a tool there from spawning a child process.
+
+### Why a wrapped CLI rather than a raw binary or a new API
+
+Issue #742 leaves "allowlisted host commands" as the expected follow-up. Handing
+the subagent a general `eve` is the wrong shape: `eve add` alone accepts
+namespaces, URLs, `--overwrite`, and setup-bearing flags, so an allowlist entry
+either admits far more than registry installation or degenerates into argument
+parsing in the wrong layer.
+
+A tool that hard-codes the subcommand, forces `--non-interactive`, validates the
+address, and builds argv itself is not exposing the binary. It is exactly as
+constrained as an in-process adapter would be, and it avoids introducing a
+second implementation of address resolution, eve-version checking, dependency
+installation, and `envVars` reporting. The package manager also runs
+out-of-process, where a slow or failing install cannot block the agent runtime.
+
+The eve binary is located the way eve already locates setup binaries:
+`findPackageJSON("eve", <appRoot>/package.json)` plus the package's declared bin
+(`cli/commands/registry-setup-command.ts`), never a `PATH` lookup.
+
+## What an install actually involves
+
+Of 86 official items: 36 are plain file installs (32 of those also add npm
+dependencies), 49 declare an interactive setup command, and 1 is a component
+bundle. 33 of the plain items additionally declare `envVars` the developer must
+supply — installation completes without them, but the integration does not work
+until they are set.
+
+`channel/slack` is the worked example, because it exercises everything. Its
+`prepare` asks first whether to use Vercel Connect or portable credentials
+(`setup/integrations/slack/setup.ts`), and the two answers fail differently:
+
+- **Portable credentials** completes headlessly and exits 0, then reports that
+  the developer must set `SLACK_BOT_TOKEN` and `SLACK_SIGNING_SECRET`, point a
+  hand-made Slack app at `/eve/v1/slack`, and deploy for a public URL.
+- **Vercel Connect** reaches `apply`, which runs
+  `vercel connect create slack --triggers …` (`setup/slack-connect-create.ts`).
+  That opens a browser and polls up to five minutes for the workspace to appear.
+  Nothing headless can make that click; a timeout degrades to `not-installed`,
+  whose documented recovery is to re-run, and the re-run detects the connector
+  that already exists.
+
+Setup integrations are structured `prepare(ctx) → Plan` then
+`apply(plan, ctx)` (`setup/integrations/types.ts`): every question lives in
+`prepare`, every effect in `apply`. That is why re-running a setup flow is safe,
+and why the TUI wizard can recover from an abandoned browser step by simply
+being run again — the questions replay, the effects do not.
+
+## The irreducible human steps
+
+Two things no automated driver can do, in any of these designs: **click through
+a browser authorization**, and **supply a secret**. They are identical whether
+the driver is Claude Code at a shell, the subagent in chat, or a script in CI.
+
+This is what fixes the architecture. The design question is not _how much can
+the agent automate_ — every design bottoms out at the same two steps. It is
+**where the developer is standing when they are reached.** Today they are asked
+to leave the conversation and retype a command. They should be asked in place.
+
+## Authoring API
+
+### The rule: the tool installs, the wizard asks
+
+**An item that declares no setup and no components is installed by the tool. An
+item that declares either is handed to the TUI whole, before anything is
+installed.**
+
+The split is decidable from the catalog index, which already carries
+`meta.eve.setup` and `meta.eve.components` and which `selfmod__search_registry`
+has fetched and cached. No extra process, no prediction, no judgment.
+
+The alternative — proxying setup questions into chat so the model can answer or
+relay them — was considered and rejected. Both directions fail:
+
+- **Model answers them.** `withPolicy("assume")` takes `detected`, then
+  `recommended` (`setup/ask.ts`). Slack's credentials question has no `detected`
+  and recommends Vercel Connect, so a developer who wanted portable credentials
+  gets an `eve link` prerequisite for a path they never chose. Bundles behave
+  the same way: `linear` silently installs both components. Wrong, and invisible
+  — the tool reports success.
+- **Developer answers them in chat.** Safe, but each question costs a model turn
+  and a process spawn, and the wire format loses fidelity on the way:
+  `SetupWireOption` carries `hint`, `disabled` + `disabledReason`, and `locked` +
+  `lockedReason`, and the question carries `recommended`, while
+  `inputOptionSchema` carries `{ id, label, description?, style? }`. The
+  developer is shown options they cannot pick with the explanation of why
+  stripped out.
+
+Over-asking is slow and lossy; under-asking is silently wrong. Handing off
+avoids choosing, renders the question properly, and covers the browser and
+secret steps in the same motion.
+
+### `selfmod__registry_add`
+
+One tool, one fixed argv shape, one terminal event to parse.
+
+```ts
+{
+  address: string;
+} // relative official address
+```
+
+It spawns the local eve bin as `eve add <address> --non-interactive
+--skip-setup`. With no setup and no questions the run cannot block: it exits 0
+or 1. There is no continuation loop, no `--answer`, and no argv composed by the
+model.
+
+`--skip-setup` is redundant given the split rule and is passed anyway. The rule
+reads a cached catalog index; the manifest is fetched fresh at install. If those
+ever disagree, the flag is what keeps a setup flow from starting in a process
+with no way to answer it.
+
+The result reports outstanding work rather than a success boolean, because an
+installed item can still be non-functional through unset `envVars` — 33 of the
+36 items this tool handles declare them. Naming a required variable is not a
+secret, so that report belongs in chat.
+
+Approval is `once()` — approved once per session, then quiet. The request
+renders the tool input, which is the address. That is the same disclosure the
+equivalent shell command gives a human, and it needs no new core mechanism.
+
+### The development capability
+
+The tool needs two things from its host, and neither should come from the
+environment.
+
+`appRoot` is ambiguous in development: the runtime's own `appRoot` can point at
+an **immutable runtime snapshot**, with the authored application carried
+separately as `sandboxAppRoot` (`runtime/compiled-artifacts-source.ts`); the
+runtime already reconciles three roots (`execution/sandbox/development-prewarm.ts`).
+An install that targets the snapshot writes into a directory that is discarded
+and looks like it succeeded. `EVE_DEV_WORKER_APP_ROOT` is not the answer either.
+It is installed and torn down by `installWorkflowTransportEnvironment`
+unconditionally on every `eve dev` boot — not gated on the parent-owned dev
+World — but it belongs to the workflow-world transport by ownership, not by
+name: nothing about the development capability should depend on a variable
+another subsystem happens to also have set. Publish a dedicated one.
+
+Suspension is the second. Installing mutates `package.json` and the authored
+tree while the authored-source watcher is live, in the same process the tool is
+running in. The primitive already exists and already lives here:
+`AuthoredSourceWatcherHandle` exposes `suspend()`, `resume()`, `flush()`, and
+`rebuild()` (`internal/nitro/host/dev-authored-source-watcher.ts`), and its
+suspension is **reference counted**, so a tool-driven install and a concurrent
+`/add` cannot un-suspend each other. What the TUI calls `withExclusiveTerminal`
+is only an HTTP client for it (`services/dev-client/runtime-artifacts.ts`,
+`cli/run.ts`), dispatched onto that same handle by the host. The gap is
+reachability, not capability.
+
+Both arrive together as a **development-only capability object** resolved from
+the tool context, not as new `ToolContext` fields. Both are meaningless in a
+deployed runtime, and a capability absent in production should be absent from
+the type every tool sees rather than present-and-undefined. Its absence is also
+the correct signal for a tool that must refuse to run outside `eve dev`.
+
+Installation holds the capability for the whole operation and serializes
+against concurrent `selfmod__edit_file` writes. It does not need to force a
+rebuild on completion: `resume()` already does this itself once the last
+suspension lifts (`dev-authored-source-watcher.ts`), so releasing the
+capability is sufficient.
+
+### TUI handoff
+
+The dev server child is forked with `stdio: ["ignore", "pipe", "pipe", "ipc"]`.
+It has no TTY, so no wrapping makes an interactive `eve add` possible from the
+tool layer. Browser authorization and secret entry are structurally the TUI's,
+permanently — not a stage to be removed later.
+
+When the tool declines an item, its result carries a structured next action and
+the TUI renders it as an affordance that opens the existing flow inline.
+
+`initialAddress` needs no change at all, precisely because the tool did not
+pre-install. `/add channel/slack` already routes to that item's confirmation
+screen and then installs and runs setup in one pass
+(`setup/flows/registry.ts`); `inspectItem` has no installed-aware, setup-only
+mode and does not need one. Do not add a parallel argument path, and do not
+bypass `offerItem` — that confirmation is the disclosure.
+
+The observable change is the whole point: the developer confirms an offer
+instead of retyping a command the agent already composed.
+
+`eve dev` also has a headless mode with no TUI to offer. There, the tool reports
+the command and stops — today's behavior, correctly scoped to the one case that
+has no better answer.
+
+## Invariant: secrets never round-trip through the model
+
+`SetupWireQuestion` marks `kind: "environment"` as `sensitive: true`, and
+`headlessSetupContinuation` deliberately emits no `--answer` for it
+(`cli/commands/setup-headless.ts`). The published guidance is explicit: never
+pass a secret in `--answer`.
+
+A chat transcript is persisted and model-visible, so the same rule binds here.
+Under this design the question never reaches the model at all: a setup-bearing
+item is handed to the TUI before it is installed, and the TUI collects the
+secret directly.
+
+## Preserving discovery behavior
+
+`selfmod__search_registry` stays as it is. It already reports whether an item is
+installed (read through the `/source` mount), the eve version it requires, and
+paged results, and it matches bundles against a requested category by inspecting
+their components. Nothing here should regress those four.
+
+## What this deliberately does not add
+
+An earlier draft of this plan proposed a public `eve/registry` export, a
+resolve/install split, and a core mechanism for tools to contribute disclosure
+to their own approval requests. Driving the published CLI contract removes the
+need for all three:
+
+- **No new public registry API.** No `resolveRegistryAddress`, no
+  `installResolvedItem`, no second implementation of address resolution,
+  component selection, or version checking.
+- **No core approval-disclosure hook.** Approval requests are built by the
+  harness with a fixed prompt and the raw tool input
+  (`harness/input-extraction.ts`). Rendering `{ address, answers }` is adequate
+  disclosure for a command-shaped tool; a general hook would touch `harness/`,
+  the input-request schema, and every channel renderer, which is out of
+  proportion to one tool. Revisit only when a second tool needs it.
+- **No setup question loop in the agent at all.** No `--answer` accumulation, no
+  blocked-event handling, no classification of which questions the model may
+  answer. The wizard asks; the tool never does.
+
+## Staging
+
+1. `selfmod__registry_add` and the development capability it needs. Completes
+   all 36 no-setup items in conversation.
+2. The TUI handoff. Turns the retyped command into a one-keystroke offer for the
+   other 50.
+
+There is no third stage. The remaining human steps are irreducible, and the
+surface that handles them already exists.
+
+Instructions and the extension README change with (1) — today they instruct the
+model to stop at discovery and explicitly forbid it from acting.
+
+## Out of scope
+
+- **Third-party, URL, and `@skills` addresses.** v1 installs official items
+  only; everything else routes to the TUI.
+- **Changes to `eve add`, `eve registry`, or `/add` behavior**, beyond fixing
+  the continuation bug below. `/add` gains no new flags.
+- **Production self-modification.** Applying an approved item to an isolated
+  proposal checkout with no connected TUI needs its own authorization,
+  sandboxing, egress, integrity, and publication design.
+
+## Adjacent fix
+
+`headlessSetupContinuation` should echo the accumulated answers, not only the
+newest one. Today every headless driver — Claude Code, CI, a shell script — has
+to know to merge, while the documentation tells them to run `next.command` as
+printed, which drops earlier answers and loops.
+
+This plan no longer depends on it: the tool never drives a continuation. It is
+still a real defect for the drivers that do, and worth fixing on its own.
+
+## Completion criteria
+
+- The subagent installs a no-setup official item end to end without the
+  developer typing a command, and reports unset `envVars` rather than reporting
+  bare success.
+- A setup-bearing or component-bearing item is never partially installed by the
+  tool: it reaches the TUI whole, or in headless dev it reaches the developer as
+  a command.
+- No setup question is ever answered by the model, and none reaches the
+  transcript.
+- Installation suspends the authored-source watcher for its whole duration,
+  rebuilds on completion, targets the authored application root rather than a
+  runtime snapshot, and cannot race a concurrent `selfmod__edit_file`.
+- `/add` and `runRegistryFlow` are unchanged.
+- Registry resolution, component selection, and setup have exactly one
+  implementation.
+
+## Implementation notes
+
+The tool lives beside the existing one in
+`packages/eve-self-modification/extension/tools/`, and its instructions and the
+package README change with it — both currently tell the model to stop at
+discovery and forbid it from acting.
+
+Everything else is in `packages/eve`: exposing the development capability from
+the host that already holds the watcher handle
+(`internal/nitro/host/start-development-server.ts`) through to the tool context.
+No changes to `cli/commands/registry.ts`, `setup/flows/registry.ts`, or the
+`/add` command surface.
+
+Both packages are published, so the change needs a changeset covering `eve` and
+`@eve/self-modification`.
+
+For tests, the tightest tier that holds each assertion: unit for the split rule
+over catalog metadata; integration for the tool's result shape and its refusal
+to run without the development capability; scenario for anything that actually
+spawns the eve bin. E2E is CI-only — see `e2e/README.md`.
+
+## Open questions
+
+- How the tool detects that no TUI is listening, so it can fall back to
+  reporting the command. Headless `eve dev` is the only case, and nothing in the
+  runtime advertises the difference today.
+- Whether declaring setup is too conservative a proxy for asking a question. An
+  item whose setup resolves every answer from detection would hand off to a
+  wizard that asks nothing. Erring this way is safe and keeps the rule
+  mechanical; it is worth revisiting only if a real item lands in that gap.


### PR DESCRIPTION
### Summary

Related to #742. This research plan proposes letting the development-only self-modification subagent install official registry items through eve's existing noninteractive CLI contract, while handing setup-bearing items to the dev TUI. It keeps credentials and setup questions out of the model transcript and avoids widening the source sandbox or introducing a parallel registry API.

This is the first PR in a five-PR stack and supersedes the earlier direction in #2502. Review should focus on the host-tool/TUI boundary and the decision to wrap `eve add` rather than expose a new public registry API.

### Validation

No behavioral tests are applicable to this research-only PR; the complete stack adds focused coverage for the proposed contracts and flows.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+360 / -0`

The research plan records the security boundary, authoring contract, observable behavior, and staged implementation needed to review the proposal before its implementation PRs.

**Implementation** — 0 files · `+0 / -0`

Not applicable.

**Tests** — 0 files · `+0 / -0`

Not applicable for a research-only proposal.
