### PR TITLE
fix(eve): preserve headless setup answers

### DIFF
--- a/.changeset/headless-setup-answers.md
+++ b/.changeset/headless-setup-answers.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Headless registry setup continuation commands now preserve answers supplied in earlier steps, so multi-question setup flows can resume without looping.

--- a/packages/eve/src/cli/commands/registry-declared-setups.ts
+++ b/packages/eve/src/cli/commands/registry-declared-setups.ts
@@ -69,6 +69,7 @@ export async function runDeclaredSetups(input: {
             next: headlessSetupContinuation({
               item: input.item,
               installed: true,
+              answers: input.options.answers,
               question:
                 result.blocker.status === "input_required" ? result.blocker.question : undefined,
             }),
@@ -92,7 +93,11 @@ export async function runDeclaredSetups(input: {
           item: input.item,
           completedItems: [],
           message,
-          next: headlessSetupContinuation({ item: input.item, installed: true }),
+          next: headlessSetupContinuation({
+            item: input.item,
+            installed: true,
+            answers: input.options.answers,
+          }),
         }),
       );
       process.exitCode = 1;

--- a/packages/eve/src/cli/commands/registry-package.ts
+++ b/packages/eve/src/cli/commands/registry-package.ts
@@ -94,7 +94,12 @@ async function selectComponents(
         installed: false,
         completedItems: [],
         question: wireQuestion,
-        next: headlessSetupContinuation({ item, installed: false, question: wireQuestion }),
+        next: headlessSetupContinuation({
+          item,
+          installed: false,
+          answers: options.answers,
+          question: wireQuestion,
+        }),
       }),
     );
     process.exitCode = 2;

--- a/packages/eve/src/cli/commands/setup-answers.test.ts
+++ b/packages/eve/src/cli/commands/setup-answers.test.ts
@@ -35,6 +35,31 @@ describe("setup answers", () => {
     });
   });
 
+  it("preserves accumulated answers in a resume command", () => {
+    expect(
+      headlessSetupContinuation({
+        item: "channel/github",
+        installed: true,
+        answers: { mode: "portable", events: ["issues", "pull_request"] },
+        question: { key: "team", kind: "text", message: "Team?", required: true },
+      }),
+    ).toEqual({
+      command: "eve",
+      args: [
+        "add",
+        "channel/github",
+        "--non-interactive",
+        "--skip-install",
+        "--answer",
+        'mode="portable"',
+        "--answer",
+        'events=["issues","pull_request"]',
+        "--answer",
+        "team=<JSON value>",
+      ],
+    });
+  });
+
   it("does not put a secret answer placeholder on the command line", () => {
     expect(
       headlessSetupContinuation({

--- a/packages/eve/src/cli/commands/setup-headless.ts
+++ b/packages/eve/src/cli/commands/setup-headless.ts
@@ -60,9 +60,14 @@ export type HeadlessSetupEvent =
 export function headlessSetupContinuation(input: {
   item: string;
   installed: boolean;
+  answers?: Readonly<Record<string, unknown>>;
   question?: Extract<RegistrySetupBlocker, { status: "input_required" }>["question"];
 }): HeadlessSetupCommand {
-  const answer =
+  const answers = Object.entries(input.answers ?? {}).flatMap(([key, value]) => [
+    "--answer",
+    `${key}=${JSON.stringify(value)}`,
+  ]);
+  const nextAnswer =
     input.question?.kind === "environment"
       ? []
       : input.question === undefined
@@ -75,7 +80,8 @@ export function headlessSetupContinuation(input: {
       input.item,
       "--non-interactive",
       ...(input.installed ? ["--skip-install"] : []),
-      ...answer,
+      ...answers,
+      ...nextAnswer,
     ],
   };
 }


### PR DESCRIPTION
### Summary
Fixes headless registry setup continuations so answers supplied in earlier steps remain present when a later question blocks the flow. Multi-question setup can now resume from the emitted command without discarding prior choices and looping back through already answered questions; secret environment prompts remain excluded from command-line placeholders.

### Validation

Focused setup-answer coverage verifies scalar and array answer serialization, accumulated continuation arguments, and preservation of the existing secret-placeholder behavior.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

The changeset records the observable fix for resumable multi-question setup.

**Implementation** — 3 files · `+20 / -4`

The change threads accumulated answers through existing continuation builders and serializes them before the next unanswered prompt.

**Tests** — 1 file · `+25 / -0`

The regression test exercises mixed scalar and array answers in the exact resume command shape.
