### PR TITLE
feat(eve): emit traces by default

### DIFF
--- a/.changeset/trace-policy-capture-decisions.md
+++ b/.changeset/trace-policy-capture-decisions.md
@@ -2,4 +2,4 @@
 "eve": minor
 ---
 
-Allow `tracePolicy` to explicitly disable emission or select directional content capture while preserving existing boolean policies, lifecycle delivery, and per-delivery audience ceilings.
+Emit traces for every audience by default while recording content only for public conversations. `tracePolicy` can explicitly disable emission or select directional content capture, and existing boolean policies retain their current behavior.

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -11295,7 +11295,7 @@ describe("createToolLoopHarness", () => {
       });
     });
 
-    it("does not emit hosted unknown model telemetry", async () => {
+    it("emits hosted unknown model telemetry without content", async () => {
       setupMockAgent({
         finishReason: "stop",
         response: { messages: [{ content: "Hello!", role: "assistant" }] },
@@ -11311,7 +11311,10 @@ describe("createToolLoopHarness", () => {
       const agentCall = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0] as {
         telemetry?: { recordInputs?: boolean; recordOutputs?: boolean };
       };
-      expect(agentCall.telemetry).toBeUndefined();
+      expect(agentCall.telemetry).toMatchObject({
+        recordInputs: false,
+        recordOutputs: false,
+      });
     });
 
     it("keeps unknown model telemetry content in a local development worker", async () => {

--- a/packages/eve/src/tracing/agent-otel-provider.test.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.test.ts
@@ -800,7 +800,7 @@ describe("createAgentOtelInstrumentation", () => {
   });
 
   it.each(["private", "unknown"] as const)(
-    "does not record %s conversation traces by default",
+    "records %s conversation traces by default",
     async (audience) => {
       const runtime = createRuntime(new InMemoryAgentTraceStateStore(), null);
 
@@ -814,7 +814,7 @@ describe("createAgentOtelInstrumentation", () => {
       });
       await runtime.provider.forceFlush();
 
-      expect(runtime.exporter.getFinishedSpans()).toEqual([]);
+      expect(byName(runtime.exporter.getFinishedSpans(), "agent.session")).toHaveLength(1);
     },
   );
 

--- a/packages/eve/src/tracing/agent-otel-provider.test.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.test.ts
@@ -818,6 +818,28 @@ describe("createAgentOtelInstrumentation", () => {
     },
   );
 
+  it.each([
+    ["legacy false", (): boolean => false],
+    ["explicit emit false", (): { readonly emit: false } => ({ emit: false })],
+  ] as const)(
+    "does not emit a trace when the policy overrides the default with %s",
+    async (_name, tracePolicy) => {
+      const runtime = createRuntime(new InMemoryAgentTraceStateStore(), tracePolicy);
+
+      await emitAttempt({
+        channelAudience: "public",
+        hooks: runtime.hooks,
+        runInContext: runtime.runInContext,
+        sessionId: "session-rejected",
+        turnId: "turn-rejected",
+        turnSequence: 0,
+      });
+      await runtime.provider.forceFlush();
+
+      expect(runtime.exporter.getFinishedSpans()).toEqual([]);
+    },
+  );
+
   it("preserves the parent's sampling decision for adopted traces", async () => {
     const runtime = createRuntime(new InMemoryAgentTraceStateStore(), null);
 

--- a/packages/eve/src/tracing/otel-declaration.ts
+++ b/packages/eve/src/tracing/otel-declaration.ts
@@ -62,8 +62,8 @@ export interface OtelOptions {
   /**
    * Process-wide trace and content decision. Boolean returns preserve the
    * existing audience-aware behavior; explicit decisions can disable emission
-   * or select input and output capture independently. Defaults to retaining
-   * public conversations with content. The result is a capture ceiling:
+   * or select input and output capture independently. Defaults to emitting
+   * every audience, with content only for public conversations. The result is a capture ceiling:
    * per-delivery audience and destination settings can only narrow it. A thrown
    * error rejects trace production without silencing lifecycle providers.
    */

--- a/packages/eve/src/tracing/sampled-trace.test.ts
+++ b/packages/eve/src/tracing/sampled-trace.test.ts
@@ -62,4 +62,16 @@ describe("resolveTracePolicyDecision", () => {
       ),
     ).toEqual({ action: "drop" });
   });
+
+  it.each([
+    ["public", true],
+    ["private", false],
+    ["unknown", false],
+  ] as const)("emits the default %s trace with the expected content", (audience, content) => {
+    expect(resolveTracePolicy(undefined, { audience })).toEqual({
+      action: "record",
+      recordInputs: content,
+      recordOutputs: content,
+    });
+  });
 });

--- a/packages/eve/src/tracing/sampled-trace.ts
+++ b/packages/eve/src/tracing/sampled-trace.ts
@@ -34,12 +34,17 @@ export function resolveTracePolicy(
   },
 ): InstrumentationDecision {
   try {
+    const decision = policy?.({
+      agentName: trace.agentName,
+      audience: trace.audience,
+      channelType: trace.channelType,
+    });
     return resolveTracePolicyDecision(
-      policy?.({
-        agentName: trace.agentName,
-        audience: trace.audience,
-        channelType: trace.channelType,
-      }) ?? trace.audience === "public",
+      decision ?? {
+        emit: true,
+        recordInputs: trace.audience === "public",
+        recordOutputs: trace.audience === "public",
+      },
       trace.audience,
     );
   } catch {

--- a/research/channel-audience-content-policy.md
+++ b/research/channel-audience-content-policy.md
@@ -141,14 +141,18 @@ export default agentRuns({
 The default authored and production head policy is equivalent to:
 
 ```ts
-({ audience }) => audience === "public";
+({ audience }) => ({
+  emit: true,
+  recordInputs: audience === "public",
+  recordOutputs: audience === "public",
+});
 ```
 
 | Audience  | Trace created by default | Content when admitted by a custom trace policy |
 | --------- | ------------------------ | ---------------------------------------------- |
-| `public`  | Yes                      | Unchanged unless an export policy redacts it   |
-| `private` | No                       | Unchanged unless an export policy redacts it   |
-| `unknown` | No                       | Unchanged unless an export policy redacts it   |
+| `public`  | Yes                      | Yes                                            |
+| `private` | Yes                      | No                                             |
+| `unknown` | Yes                      | No                                             |
 
 The default policy for local tracing for `eve dev` is equivalent to:
 


### PR DESCRIPTION
### Summary

Change the no-policy default from public-only trace emission to emitting every audience: public conversations retain inputs and outputs, while private and unknown conversations emit metadata-only traces. This preserves trace topology, counts, latency, errors, tokens, and cost for instrumentation consumers without adding non-public conversation content.

Explicit policies remain authoritative. Both legacy `tracePolicy: () => false` and `{ emit: false }` still produce no agent trace. The separate local development policy is unchanged.

Related to #2335 and #2619.

### Validation

The full Eve unit suite passes 7,228 tests across 672 files with one existing skip. Coverage verifies public/private/unknown defaults, metadata-only hosted AI SDK telemetry, agent trace emission for non-public audiences, and both legacy and object no-emission overrides. Eve package typecheck, invariants, formatting, and linting pass.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+9 / -5`

Updates the existing research contract and the stack's minor release note with the new default.

**Implementation** — 2 files · `+12 / -7`

Changes only the no-policy resolver fallback and its public API description.

**Tests** — 3 files · `+40 / -3`

Covers the three audience defaults and proves both compatibility forms can still disable emission.
