### PR TITLE
fix(eve): preserve grouped Slack approvals

### DIFF
--- a/.changeset/quiet-pandas-settle.md
+++ b/.changeset/quiet-pandas-settle.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Keep earlier Slack approval cards visibly settled when several approvals share one message and are answered out of order.

--- a/packages/eve/src/public/channels/slack/defaults.test.ts
+++ b/packages/eve/src/public/channels/slack/defaults.test.ts
@@ -224,6 +224,51 @@ describe("defaultEvents approval lifecycle", () => {
     };
     expect(JSON.stringify(update.blocks)).not.toContain("eve_input:tool-approval:approval-1");
   });
+
+  it("keeps earlier grouped cards settled when approvals are answered out of order", async () => {
+    const requestIds = Array.from({ length: 5 }, (_, index) => `approval-${index + 1}`);
+    const messageBlocks = requestIds.map((requestId) => ({
+      actions: [
+        { action_id: `eve_input:tool-approval:${requestId}:button:0` },
+        { action_id: `eve_input:tool-approval:${requestId}:button:1` },
+      ],
+      body: { text: `Approve ${requestId}?`, type: "mrkdwn" },
+      type: "card",
+    }));
+    const { channel, request } = buildChannelStub({
+      approvalResponderUsers: { "slack:T1:U777": "U777" },
+      pendingApprovalCards: Object.fromEntries(
+        requestIds.map((requestId) => [requestId, { messageBlocks, messageTs: "123.456" }]),
+      ),
+    });
+    const settlementOrder = ["approval-5", "approval-2", "approval-1"];
+
+    for (const [index, requestId] of settlementOrder.entries()) {
+      await defaultEvents["approval.settled"]!(
+        {
+          outcome: "approved",
+          requestId,
+          responderPrincipalId: "slack:T1:U777",
+          sequence: index + 1,
+          stepIndex: index,
+          turnId: "turn-1",
+        },
+        channel,
+        sessionCtx,
+      );
+
+      const update = request.mock.calls[index]?.[1] as { blocks?: unknown[] };
+      const rendered = JSON.stringify(update.blocks);
+      for (const settledRequestId of settlementOrder.slice(0, index + 1)) {
+        expect(rendered).not.toContain(`eve_input:tool-approval:${settledRequestId}`);
+      }
+      for (const pendingRequestId of requestIds.filter(
+        (candidate) => !settlementOrder.slice(0, index + 1).includes(candidate),
+      )) {
+        expect(rendered).toContain(`eve_input:tool-approval:${pendingRequestId}`);
+      }
+    }
+  });
 });
 
 describe("defaultEvents authorization.required", () => {

--- a/packages/eve/src/public/channels/slack/defaults.ts
+++ b/packages/eve/src/public/channels/slack/defaults.ts
@@ -235,6 +235,11 @@ export const defaultEvents: SlackChannelInternalEvents = {
     });
     const next = { ...cards };
     delete next[event.requestId];
+    for (const [requestId, pendingCard] of Object.entries(next)) {
+      if (pendingCard.messageTs === card.messageTs) {
+        next[requestId] = { ...pendingCard, messageBlocks: blocks };
+      }
+    }
     channel.state.pendingApprovalCards = next;
   },
 


### PR DESCRIPTION
### Summary

Closes #2471 and #2226. When multiple Slack approvals share a message, settling a later request currently redraws the message from its original block snapshot and makes earlier controls appear live again. This keeps each remaining approval's snapshot in sync with the updated message, so approvals stay visibly settled regardless of answer order.

The same fix was proposed in [#2227](https://github.com/vercel/eve/pull/2227), but that draft was never merged. [#1371](https://github.com/vercel/eve/pull/1371) introduced the approval lifecycle and Slack settlement handler, and [#2212](https://github.com/vercel/eve/pull/2212) later revised that handler without addressing shared-message snapshots.

### Validation

Adds a five-card regression test which answers later approvals first. The test fails on `main` when an earlier card's controls reappear, and passes with this change.

### Diff size

**Docs** — 1 file · `+5 / -0`

Patch changeset for the Slack behavior fix.

**Implementation** — 1 file · `+5 / -0`

Updates sibling approval snapshots after a shared Slack message is settled.

**Tests** — 1 file · `+45 / -0`

Covers five grouped approvals settling out of order while unanswered controls remain active.
