### PR TITLE
feat(eve): register public Next.js routes

### DIFF
--- a/.changeset/restore-next-channel-routes.md
+++ b/.changeset/restore-next-channel-routes.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Allow `withEve()` projects to publish custom channel paths outside `/eve/v1/*` by registering them with the new `publicRoutes` option.

--- a/docs/channels/custom.mdx
+++ b/docs/channels/custom.mdx
@@ -60,6 +60,8 @@ export default defineChannel({
 
 A route's `path` is its app URL; the channel filename does not prefix it. The route above answers at `POST /threads/:threadId/messages`, not `/support/threads/:threadId/messages`. Use a unique method-and-path pair for each route, and do not use the framework-owned `/eve/v1/*` namespace.
 
+When a Next.js app hosts the agent with `withEve()`, add each channel path outside `/eve/v1/*` to [`publicRoutes`](../guides/frontend/nextjs). Otherwise, Next.js handles the URL instead of the eve service.
+
 Each route receives these operation surfaces:
 
 - `from(address)` binds `send`, `respond`, `cancel`, `compact`, `clear`, and `reset` to a channel-local continuation address.

--- a/docs/guides/frontend/nextjs.mdx
+++ b/docs/guides/frontend/nextjs.mdx
@@ -30,7 +30,7 @@ export default withEve(nextConfig, {
 });
 ```
 
-For multiple agents, use `agents`. String values are agent roots; object values can override the build command or private production service prefix for that agent:
+For multiple agents, use `agents`. String values are agent roots; object values can override the build command, private production service prefix, or public channel routes for that agent:
 
 ```ts
 export default withEve(nextConfig, {
@@ -39,6 +39,7 @@ export default withEve(nextConfig, {
     billing: {
       root: "./agents/billing",
       buildCommand: "pnpm build:billing-agent",
+      publicRoutes: ["/.well-known/ucp"],
       servicePrefix: "/_eve_internal/billing",
     },
   },
@@ -54,6 +55,18 @@ const billing = useEveAgent({ agent: "billing" });
 
 Use either `eveRoot` or `agents`, not both. `eveRoot` remains the shorthand for a single unnamed agent mounted at `/eve/v1/*`.
 
+`withEve()` always publishes `/eve/v1/*`. Register any channel routes outside that namespace explicitly with `publicRoutes`:
+
+```ts
+export default withEve(nextConfig, {
+  publicRoutes: ["/.well-known/ucp"],
+});
+```
+
+The path must match the route declared by the channel. A registered route takes precedence over a Next.js filesystem route at the same URL. Named-agent routes receive the `/eve/agents/<name>` public prefix while the eve service receives the original registered path.
+
+When `vercel.json` defines `services`, that file owns routing. Add the `publicRoutes` paths to its routes yourself, or remove `services` so `withEve()` can generate them.
+
 Generated agent services build with `EVE_PUBLIC_ROUTE_PREFIX` set to the agent's public mount (for example `/eve/agents/support`) so framework-minted callback URLs — OAuth connection callbacks and remote-subagent session callbacks — resolve to the public per-agent path. If you configure eve services manually in `vercel.json` instead, export that variable in each named agent's build command.
 
 ### `withEve` options
@@ -63,9 +76,10 @@ All fields are optional.
 | Option               | Type                  | Default                | Purpose                                                                                                                                                    |
 | -------------------- | --------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `eveRoot`            | `string`              | Next.js app root       | Path to one unnamed eve app root, relative to `process.cwd()` unless absolute. Do not combine with `agents`.                                               |
-| `agents`             | `Record<string, ...>` | unset                  | Named eve agents to mount under `/eve/agents/<name>/eve/v1/*`. Each value is a root string or `{ root, buildCommand?, servicePrefix? }`.                   |
+| `agents`             | `Record<string, ...>` | unset                  | Named eve agents to mount under `/eve/agents/<name>/eve/v1/*`. Each value is a root string or `{ root, buildCommand?, servicePrefix?, publicRoutes? }`.    |
 | `eveBuildCommand`    | `string`              | generated              | Build command for generated eve Vercel services. In multi-agent mode this is the default for agents without their own `buildCommand`.                      |
 | `servicePrefix`      | `string`              | `"/_eve_internal/eve"` | Private route namespace for legacy manual Vercel service configs and non-Vercel production proxying. Named agents derive unique defaults from this prefix. |
+| `publicRoutes`       | `readonly string[]`   | `[]`                   | Channel routes outside `/eve/v1/*` to publish through the Next.js host.                                                                                    |
 | `devServerTimeoutMs` | `number`              | `180000`               | Maximum time to wait for each eve development server to become available.                                                                                  |
 
 For slow cold starts, increase the development timeout:
@@ -116,7 +130,7 @@ See [Resumable sessions](./overview#resumable-sessions) for persistence and repl
 ## Dev vs deploy topology
 
 - **Local dev.** `npm run dev` boots the eve dev server next to `next dev` and rewrites the eve routes over to it. The browser only ever talks to the Next.js origin.
-- **Vercel.** The web app and the eve runtime deploy as a single project. `withEve()` writes Build Output `services` for eve and `routes` that send `/eve/v1/**` to that service before filesystem routing; the Next.js app itself remains the default app. Vercel assembles authored [schedules](../../schedules) into the project config as Vercel Cron Jobs, including correctly prefixed jobs for named agents, while cron entries owned by the Next.js app are preserved. By default, generated services run the installed eve binary from the agent root, so the agent directory does not need its own `package.json`. When the agent needs its own build step, set `eveBuildCommand`:
+- **Vercel.** The web app and the eve runtime deploy as a single project. `withEve()` writes Build Output `services` for eve and sends `/eve/v1/**` plus each registered `publicRoutes` path to that service before filesystem routing; the Next.js app itself remains the default app. Vercel assembles authored [schedules](../../schedules) into the project config as Vercel Cron Jobs, including correctly prefixed jobs for named agents, while cron entries owned by the Next.js app are preserved. By default, generated services run the installed eve binary from the agent root, so the agent directory does not need its own `package.json`. When the agent needs its own build step, set `eveBuildCommand`:
 
   ```ts
   export default withEve(nextConfig, {

--- a/docs/protocols/ucp.mdx
+++ b/docs/protocols/ucp.mdx
@@ -112,6 +112,21 @@ export default defineChannel({
 });
 ```
 
+When a Next.js app hosts this agent with `withEve()`, register the profile path in `next.config.ts`:
+
+```ts title="next.config.ts"
+import type { NextConfig } from "next";
+import { withEve } from "eve/next";
+
+const nextConfig: NextConfig = {};
+
+export default withEve(nextConfig, {
+  publicRoutes: ["/.well-known/ucp"],
+});
+```
+
+Register any commerce channel paths the same way. See the [Next.js integration guide](../guides/frontend/nextjs) for named-agent routing and deployment details.
+
 - **Caching**: The spec requires `public` and a `max-age` of at least 60 seconds, and forbids `private`, `no-store`, and `no-cache`. See [Profile Requirements](https://ucp.dev/2026-04-08/specification/overview#hosting).
 - **CORS**: `cors: true` suits public discovery metadata. Pass a `cors` options object to narrow origins. See [CORS](../channels/custom#cors).
 - **HTTPS, no redirects**: The spec requires HTTPS and forbids 3xx responses on the profile endpoint.

--- a/packages/eve/src/internal/testing/scenario-apps/next-eve-proxy.ts
+++ b/packages/eve/src/internal/testing/scenario-apps/next-eve-proxy.ts
@@ -32,9 +32,15 @@ export function createNextEveProxyDescriptor(
 export default defineAgent({ model: "openai/gpt-5.4" });
 `,
       "agent/instructions.md": "You are a test agent.\n",
+      "agent/channels/custom.mjs": `import { defineChannel, GET } from "eve/channels";
+
+export default defineChannel({
+  routes: [GET("/.well-known/ucp", async () => Response.json({ ucp: true }))],
+});
+`,
       "next.config.mjs": `import { withEve } from "eve/next";
 
-export default withEve({});
+export default withEve({}, { publicRoutes: ["/.well-known/ucp"] });
 `,
       "pnpm-workspace.yaml": "minimumReleaseAge: 0\n",
       "src/app/layout.js": `export default function RootLayout({ children }) {

--- a/packages/eve/src/internal/vercel/assemble-eve-services.ts
+++ b/packages/eve/src/internal/vercel/assemble-eve-services.ts
@@ -33,7 +33,7 @@ export function assembleEveVercelServices(input: {
   const existingServices = input.services ?? {};
   const services: Record<string, VercelServiceConfig> = { ...existingServices };
   const rootDirectories: string[] = [];
-  const eveRoutes: { routeSrc: string; serviceName: string }[] = [];
+  const eveRoutes: { requestPath?: string; routeSrc: string; serviceName: string }[] = [];
 
   for (const { agent, target } of input.agents) {
     const contribution = compileEveVercelService({ agent, target });
@@ -52,6 +52,13 @@ export function assembleEveVercelServices(input: {
             ),
           };
     eveRoutes.push({ routeSrc: contribution.routeSrc, serviceName });
+    for (const route of agent.publicRoutes ?? []) {
+      eveRoutes.push({
+        requestPath: route.requestPath,
+        routeSrc: route.routeSrc,
+        serviceName,
+      });
+    }
   }
 
   return {

--- a/packages/eve/src/internal/vercel/eve-service-contribution.ts
+++ b/packages/eve/src/internal/vercel/eve-service-contribution.ts
@@ -28,6 +28,12 @@ export interface EveVercelAgentTarget {
   readonly buildCommand: string;
   readonly name?: string;
   readonly publicRoutePrefix: string;
+  readonly publicRoutes?: readonly EveVercelPublicRoute[];
+}
+
+export interface EveVercelPublicRoute {
+  readonly requestPath?: string;
+  readonly routeSrc: string;
 }
 
 export interface EveVercelBuildTarget {

--- a/packages/eve/src/internal/vercel/vercel-service-config-operations.ts
+++ b/packages/eve/src/internal/vercel/vercel-service-config-operations.ts
@@ -115,33 +115,47 @@ export function insertEveServiceRequestPathRoute(
   ];
 }
 
-function isEveServiceRoute(
-  route: VercelRouteConfig,
-  serviceName: string,
-  routeSrc: string,
-): boolean {
-  const destination = route.destination;
-  return (
-    route.src === routeSrc &&
-    typeof destination === "object" &&
-    destination.type === "service" &&
-    destination.service === serviceName
-  );
-}
-
 export function insertEveServiceRoutes(
   routes: readonly VercelRouteConfig[],
-  eveRoutes: readonly { readonly routeSrc: string; readonly serviceName: string }[],
+  eveRoutes: readonly {
+    readonly requestPath?: string;
+    readonly routeSrc: string;
+    readonly serviceName: string;
+  }[],
 ): readonly VercelRouteConfig[] {
-  const retained = routes.filter(
-    (route) =>
-      !eveRoutes.some(({ routeSrc, serviceName }) =>
-        isEveServiceRoute(route, serviceName, routeSrc),
-      ),
-  );
-  const generated = eveRoutes.map(({ routeSrc, serviceName }) =>
+  const serviceNamesByRouteSource = new Map<string, Set<string>>();
+  for (const eveRoute of eveRoutes) {
+    const serviceNames = serviceNamesByRouteSource.get(eveRoute.routeSrc) ?? new Set<string>();
+    serviceNames.add(eveRoute.serviceName);
+    serviceNamesByRouteSource.set(eveRoute.routeSrc, serviceNames);
+  }
+
+  const retained = routes.filter((route) => {
+    if (route.src === undefined) return true;
+
+    const serviceNames = serviceNamesByRouteSource.get(route.src);
+    if (serviceNames === undefined) return true;
+
+    const destination = route.destination;
+    const isGeneratedServiceRoute =
+      typeof destination === "object" &&
+      typeof destination.service === "string" &&
+      destination.type === "service" &&
+      serviceNames.has(destination.service);
+
+    return route.transforms === undefined && !isGeneratedServiceRoute;
+  });
+  const generated = eveRoutes.flatMap(({ requestPath, routeSrc, serviceName }) => [
+    ...(requestPath === undefined
+      ? []
+      : [
+          {
+            src: routeSrc,
+            transforms: [{ args: requestPath, op: "set" as const, type: "request.path" as const }],
+          },
+        ]),
     createEvePublicRoute(serviceName, routeSrc),
-  );
+  ]);
   const filesystemIndex = retained.findIndex((route) => route.handle === "filesystem");
   return filesystemIndex < 0
     ? [...generated, ...retained]

--- a/packages/eve/src/public/next/index.integration.test.ts
+++ b/packages/eve/src/public/next/index.integration.test.ts
@@ -107,6 +107,24 @@ describe("withEve Vercel config", () => {
     expect(rewrites).toBeUndefined();
   });
 
+  it("reconciles large public route sets idempotently", async () => {
+    const appRoot = await createTempAppRoot();
+    process.chdir(appRoot);
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("VERCEL", "1");
+
+    const publicRoutes = Array.from({ length: 10_000 }, (_, index) => `/public/${String(index)}`);
+    const config = withEve<TestConfig>({}, { publicRoutes });
+
+    await resolveConfig(config);
+    await resolveConfig(config);
+
+    const outputConfig = (await readJsonFile(
+      join(appRoot, ".vercel", "output", "config.json"),
+    )) as { routes: unknown[] };
+    expect(outputConfig.routes).toHaveLength(publicRoutes.length + 1);
+  });
+
   it("isolates a colocated generated eve service from the Next.js Build Output", async () => {
     const appRoot = await createTempAppRoot();
     process.chdir(appRoot);

--- a/packages/eve/src/public/next/index.test.ts
+++ b/packages/eve/src/public/next/index.test.ts
@@ -119,17 +119,31 @@ describe("withEve", () => {
     expect(beforeFiles.every((rewrite) => rewrite.source.startsWith("/eve/v1/"))).toBe(true);
   });
 
-  it("rewrites authored channel routes under the eve protocol prefix", async () => {
+  it("rewrites explicitly registered public routes", async () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("EVE_NEXT_PRODUCTION_ORIGIN", "https://agent.example.com");
 
-    const config = await resolveConfig(withEve<TestConfig>({}));
+    const config = await resolveConfig(
+      withEve<TestConfig>({}, { publicRoutes: ["/.well-known/ucp"] }),
+    );
     const rewrites = await config.rewrites?.();
 
     expect(getBeforeFiles(rewrites)).toContainEqual({
-      destination: `https://agent.example.com${EVE_NEXT_SERVICE_PREFIX}/eve/v1/:path+`,
-      source: "/eve/v1/:path+",
+      destination: `https://agent.example.com${EVE_NEXT_SERVICE_PREFIX}/.well-known/ucp`,
+      source: "/.well-known/ucp",
     });
+  });
+
+  it("rejects invalid or protocol-owned public routes", () => {
+    expect(() => withEve<TestConfig>({}, { publicRoutes: ["/"] })).toThrow(
+      "must identify a non-root route",
+    );
+    expect(() => withEve<TestConfig>({}, { publicRoutes: ["eve/ucp"] })).toThrow(
+      'must start with "/"',
+    );
+    expect(() => withEve<TestConfig>({}, { publicRoutes: ["/eve/v1/info"] })).toThrow(
+      "already covered by the eve protocol mount",
+    );
   });
 
   it("uses EVE_BASE_URL in development instead of starting a server", async () => {
@@ -323,6 +337,7 @@ describe("withEve", () => {
             billing: {
               buildCommand: "pnpm build:billing-agent",
               root: "./agents/billing",
+              publicRoutes: ["/.well-known/ucp"],
               servicePrefix: "/_eve_internal/billing",
             },
             support: "./agents/support",
@@ -342,6 +357,10 @@ describe("withEve", () => {
           destination: "https://agent.example.com/_eve_internal/billing/eve/v1/:path+",
           source: "/eve/agents/billing/eve/v1/:path+",
         },
+        {
+          destination: "https://agent.example.com/_eve_internal/billing/.well-known/ucp",
+          source: "/eve/agents/billing/.well-known/ucp",
+        },
       ]),
     );
     expect(ensureEveVercelOutputConfig).toHaveBeenCalledWith({
@@ -349,6 +368,12 @@ describe("withEve", () => {
         {
           appRoot: expect.stringContaining("/agents/billing"),
           buildCommand: "pnpm build:billing-agent",
+          publicRouteMounts: [
+            {
+              publicPath: "/eve/agents/billing/.well-known/ucp",
+              routePath: "/.well-known/ucp",
+            },
+          ],
           name: "billing",
           publicRoutePrefix: "/eve/agents/billing",
           servicePrefix: "/_eve_internal/billing",
@@ -356,6 +381,7 @@ describe("withEve", () => {
         {
           appRoot: expect.stringContaining("/agents/support"),
           buildCommand: "node 'node_modules/eve/bin/eve.js' build",
+          publicRouteMounts: [],
           name: "support",
           publicRoutePrefix: "/eve/agents/support",
           servicePrefix: `${EVE_NEXT_SERVICE_PREFIX}/support`,
@@ -409,6 +435,18 @@ describe("withEve", () => {
         ]),
       }),
     );
+  });
+
+  it("rejects top-level public routes when named agents are configured", () => {
+    expect(() =>
+      withEve<TestConfig>(
+        {},
+        {
+          agents: { support: "./agents/support" },
+          publicRoutes: ["/.well-known/ucp"],
+        },
+      ),
+    ).toThrow("Register routes on each named agent");
   });
 
   it("rejects eveRoot when named agents are configured", () => {

--- a/packages/eve/src/public/next/index.ts
+++ b/packages/eve/src/public/next/index.ts
@@ -6,6 +6,7 @@ import { assertValidPublicAgentName } from "#internal/agent-name.js";
 import { quoteVercelShellArgument, toVercelRelativePath } from "#internal/vercel/build-command.js";
 import { EVE_ROUTE_PREFIX } from "#protocol/routes.js";
 import { resolveEveBinaryPath } from "#shared/resolve-eve-binary.js";
+import { createEvePublicRouteMounts, type EvePublicRouteMount } from "./public-route-mounts.js";
 import { resolveEveDestinationPrefix } from "./server.js";
 import { ensureEveVercelOutputConfig } from "./vercel-output-config.js";
 
@@ -91,6 +92,8 @@ export interface WithEveAgentOptions {
    * service and non-Vercel production proxying.
    */
   readonly servicePrefix?: string;
+  /** Channel route paths to expose through the Next.js host for this agent. */
+  readonly publicRoutes?: readonly string[];
 }
 
 /**
@@ -137,6 +140,11 @@ export interface WithEveOptions {
    * root route.
    */
   readonly servicePrefix?: string;
+  /**
+   * Channel route paths to expose through the Next.js host. Registered paths
+   * take precedence over Next.js filesystem routes at the same URL.
+   */
+  readonly publicRoutes?: readonly string[];
 }
 
 interface ResolvedEveNextAgent {
@@ -144,6 +152,7 @@ interface ResolvedEveNextAgent {
   readonly buildCommand: string;
   readonly localProductionPortOffset: number;
   readonly name?: string;
+  readonly publicRouteMounts: readonly EvePublicRouteMount[];
   readonly publicRoutePrefix: string;
   readonly servicePrefix: string;
 }
@@ -264,6 +273,16 @@ function createEveRewriteRule(input: {
   };
 }
 
+function createChannelRewriteRule(input: {
+  readonly destinationPrefix: string;
+  readonly mount: EvePublicRouteMount;
+}): EveNextRewriteRule {
+  return {
+    destination: joinRoutePrefix(input.destinationPrefix, input.mount.routePath),
+    source: input.mount.publicPath,
+  };
+}
+
 async function resolveExistingRewrites(
   rewrites: EveNextConfig["rewrites"],
 ): Promise<EveNextRewrites | undefined> {
@@ -333,6 +352,10 @@ function normalizeAgentsConfig(options: WithEveOptions): readonly ResolvedEveNex
         appRoot,
         buildCommand: resolveBuildCommand(appRoot, undefined),
         localProductionPortOffset: 0,
+        publicRouteMounts: createEvePublicRouteMounts({
+          publicRoutePrefix: "",
+          publicRoutes: options.publicRoutes ?? [],
+        }),
         publicRoutePrefix: "",
         servicePrefix: servicePrefixBase,
       },
@@ -341,6 +364,11 @@ function normalizeAgentsConfig(options: WithEveOptions): readonly ResolvedEveNex
 
   if (options.eveRoot !== undefined) {
     throw new Error("withEve cannot combine eveRoot with agents. Use one configuration form.");
+  }
+  if (options.publicRoutes !== undefined) {
+    throw new Error(
+      "withEve cannot combine top-level publicRoutes with agents. Register routes on each named agent.",
+    );
   }
 
   const entries = Object.entries(options.agents);
@@ -353,13 +381,18 @@ function normalizeAgentsConfig(options: WithEveOptions): readonly ResolvedEveNex
 
     const agentConfig = typeof config === "string" ? { root: config } : config;
     const appRoot = resolveApplicationRoot(agentConfig.root);
+    const publicRoutePrefix = createNamedAgentRoutePrefix(name);
 
     return {
       appRoot,
       buildCommand: resolveBuildCommand(appRoot, agentConfig.buildCommand),
       localProductionPortOffset: index,
       name,
-      publicRoutePrefix: createNamedAgentRoutePrefix(name),
+      publicRouteMounts: createEvePublicRouteMounts({
+        publicRoutePrefix,
+        publicRoutes: agentConfig.publicRoutes ?? [],
+      }),
+      publicRoutePrefix,
       servicePrefix: normalizeRoutePrefix(
         agentConfig.servicePrefix ?? createNamedAgentServicePrefix(servicePrefixBase, name),
       ),
@@ -372,9 +405,9 @@ function normalizeAgentsConfig(options: WithEveOptions): readonly ResolvedEveNex
  * service.
  *
  * In development, starts `eve dev --no-ui --port 0` for the eve app and
- * rewrites eve protocol endpoints to that local URL. In Vercel production,
- * writes Build Output service routes so Vercel sends eve protocol endpoints to
- * the eve service directly.
+ * rewrites eve protocol and channel endpoints to that local URL. In Vercel
+ * production, writes Build Output service routes so Vercel sends those
+ * endpoints to the eve service directly.
  * Outside Vercel production, serves an existing `.output/server/index.mjs` build
  * on a stable local port when present; otherwise set `EVE_NEXT_PRODUCTION_ORIGIN`
  * to the origin serving the eve service namespace.
@@ -394,6 +427,7 @@ export function withEve<TConfig extends EveNextConfig>(
       agents: agents.map((agent) => ({
         appRoot: agent.appRoot,
         buildCommand: agent.buildCommand,
+        publicRouteMounts: agent.publicRouteMounts,
         name: agent.name,
         publicRoutePrefix: agent.publicRoutePrefix,
         servicePrefix: agent.servicePrefix,
@@ -437,15 +471,20 @@ export function withEve<TConfig extends EveNextConfig>(
                 productionServerOrigin: agent.productionDestination.localServerOrigin,
               });
 
-              return createEveRewriteRule({
-                destinationPrefix,
-                publicRoutePrefix: agent.publicRoutePrefix,
-              });
+              return [
+                createEveRewriteRule({
+                  destinationPrefix,
+                  publicRoutePrefix: agent.publicRoutePrefix,
+                }),
+                ...agent.publicRouteMounts.map((mount) =>
+                  createChannelRewriteRule({ destinationPrefix, mount }),
+                ),
+              ];
             }),
           ),
         ]);
 
-        return mergeRewriteRules(existing, eveRules);
+        return mergeRewriteRules(existing, eveRules.flat());
       },
     };
   };

--- a/packages/eve/src/public/next/public-route-mounts.test.ts
+++ b/packages/eve/src/public/next/public-route-mounts.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createEvePublicRouteMounts,
+  createVercelRequestPath,
+  createVercelRouteSource,
+} from "./public-route-mounts.js";
+
+describe("eve Next.js public route mounts", () => {
+  it("normalizes, deduplicates, and sorts registered paths", () => {
+    expect(
+      createEvePublicRouteMounts({
+        publicRoutePrefix: "",
+        publicRoutes: ["/mcp", "/.well-known/ucp", "/mcp"],
+      }),
+    ).toEqual([
+      {
+        publicPath: "/.well-known/ucp",
+        routePath: "/.well-known/ucp",
+      },
+      { publicPath: "/mcp", routePath: "/mcp" },
+    ]);
+  });
+
+  it("prefixes named-agent paths while preserving the service request path", () => {
+    expect(
+      createEvePublicRouteMounts({
+        publicRoutePrefix: "/eve/agents/support",
+        publicRoutes: ["/.well-known/ucp"],
+      }),
+    ).toEqual([
+      {
+        publicPath: "/eve/agents/support/.well-known/ucp",
+        routePath: "/.well-known/ucp",
+      },
+    ]);
+  });
+
+  it("converts route parameters to Vercel named captures", () => {
+    expect(createVercelRouteSource("/api/stream/:sessionId")).toBe(
+      "^/api/stream/(?<sessionId>[^/]+)$",
+    );
+    expect(createVercelRequestPath("/api/stream/:sessionId")).toBe("/api/stream/$sessionId");
+  });
+
+  it("rejects paths the host cannot mount safely", () => {
+    expect(() =>
+      createEvePublicRouteMounts({ publicRoutePrefix: "", publicRoutes: ["relative"] }),
+    ).toThrow('must start with "/"');
+    expect(() =>
+      createEvePublicRouteMounts({ publicRoutePrefix: "", publicRoutes: ["/eve/v1/info"] }),
+    ).toThrow("already covered by the eve protocol mount");
+    expect(() =>
+      createEvePublicRouteMounts({ publicRoutePrefix: "", publicRoutes: ["/api/:bad-name"] }),
+    ).toThrow("unsupported segment");
+    expect(() =>
+      createEvePublicRouteMounts({ publicRoutePrefix: "", publicRoutes: ["/api/:id/:id"] }),
+    ).toThrow("repeats parameter");
+  });
+});

--- a/packages/eve/src/public/next/public-route-mounts.ts
+++ b/packages/eve/src/public/next/public-route-mounts.ts
@@ -1,0 +1,84 @@
+export interface EvePublicRouteMount {
+  readonly publicPath: string;
+  readonly routePath: string;
+}
+
+function joinRoutePrefix(prefix: string, path: string): string {
+  return `${prefix.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
+}
+
+function normalizePublicRoute(path: string): string {
+  if (!path.startsWith("/")) {
+    throw new Error(`eve Next.js public route ${JSON.stringify(path)} must start with "/".`);
+  }
+  if (path === "/eve/v1" || path.startsWith("/eve/v1/")) {
+    throw new Error(
+      `eve Next.js public route ${JSON.stringify(path)} is already covered by the eve protocol mount.`,
+    );
+  }
+  if (path === "/" || path.endsWith("/")) {
+    throw new Error(
+      `eve Next.js public route ${JSON.stringify(path)} must identify a non-root route without a trailing slash.`,
+    );
+  }
+
+  const parameterNames = new Set<string>();
+  for (const segment of path.slice(1).split("/")) {
+    if (/^[A-Za-z0-9._~-]+$/.test(segment)) continue;
+    const name = segment.startsWith(":") ? segment.slice(1) : "";
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+      throw new Error(
+        `eve Next.js public route ${JSON.stringify(path)} has unsupported segment ${JSON.stringify(segment)}. Use URL-safe literal segments or ":name" parameters.`,
+      );
+    }
+    if (parameterNames.has(name)) {
+      throw new Error(
+        `eve Next.js public route ${JSON.stringify(path)} repeats parameter ${JSON.stringify(name)}.`,
+      );
+    }
+    parameterNames.add(name);
+  }
+  return path;
+}
+
+export function createEvePublicRouteMounts(input: {
+  readonly publicRoutePrefix: string;
+  readonly publicRoutes: readonly string[];
+}): readonly EvePublicRouteMount[] {
+  return [...new Set(input.publicRoutes.map(normalizePublicRoute))].sort().map((routePath) => ({
+    publicPath:
+      input.publicRoutePrefix.length === 0
+        ? routePath
+        : joinRoutePrefix(input.publicRoutePrefix, routePath),
+    routePath,
+  }));
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function parseRoutePath(
+  path: string,
+): readonly { readonly name?: string; readonly value: string }[] {
+  return normalizePublicRoute(path)
+    .split("/")
+    .slice(1)
+    .map((segment) =>
+      segment.startsWith(":") ? { name: segment.slice(1), value: segment } : { value: segment },
+    );
+}
+
+export function createVercelRouteSource(path: string): string {
+  const segments = parseRoutePath(path).map((segment) =>
+    segment.name === undefined ? escapeRegExp(segment.value) : `(?<${segment.name}>[^/]+)`,
+  );
+  return `^/${segments.join("/")}$`;
+}
+
+export function createVercelRequestPath(path: string): string {
+  const segments = parseRoutePath(path).map((segment) =>
+    segment.name === undefined ? segment.value : `$${segment.name}`,
+  );
+  return `/${segments.join("/")}`;
+}

--- a/packages/eve/src/public/next/vercel-output-config.ts
+++ b/packages/eve/src/public/next/vercel-output-config.ts
@@ -17,7 +17,11 @@ import {
   findClosestLinkedVercelDirectory,
   findClosestVercelOutputDirectory,
 } from "#shared/vercel-output-directory.js";
-import { createVercelRequestPath, createVercelRouteSource } from "./public-route-mounts.js";
+import {
+  createVercelRequestPath,
+  createVercelRouteSource,
+  type EvePublicRouteMount,
+} from "./public-route-mounts.js";
 
 const VERCEL_JSON_FILE_NAME = "vercel.json";
 const VERCEL_OUTPUT_CONFIG_FILE_NAME = ".vercel/output/config.json";
@@ -35,6 +39,7 @@ export interface EnsureVercelOutputConfigAgentInput {
   readonly appRoot: string;
   readonly buildCommand: string;
   readonly name?: string;
+  readonly publicRouteMounts?: readonly EvePublicRouteMount[];
   readonly publicRoutePrefix: string;
   readonly servicePrefix: string;
 }

--- a/packages/eve/src/public/next/vercel-output-config.ts
+++ b/packages/eve/src/public/next/vercel-output-config.ts
@@ -17,6 +17,7 @@ import {
   findClosestLinkedVercelDirectory,
   findClosestVercelOutputDirectory,
 } from "#shared/vercel-output-directory.js";
+import { createVercelRequestPath, createVercelRouteSource } from "./public-route-mounts.js";
 
 const VERCEL_JSON_FILE_NAME = "vercel.json";
 const VERCEL_OUTPUT_CONFIG_FILE_NAME = ".vercel/output/config.json";
@@ -164,7 +165,16 @@ export async function ensureEveVercelOutputConfig(input: {
 
   const assembled = assembleEveVercelServices({
     agents: input.agents.map((agent) => ({
-      agent,
+      agent: {
+        ...agent,
+        publicRoutes: agent.publicRouteMounts?.map((mount) => ({
+          requestPath:
+            mount.publicPath === mount.routePath
+              ? undefined
+              : createVercelRequestPath(mount.routePath),
+          routeSrc: createVercelRouteSource(mount.publicPath),
+        })),
+      },
       target: {
         hostOutputDirectory: dirname(outputConfigPath),
         projectRoot: input.nextRoot,

--- a/packages/eve/test/scenarios/framework-next-build.scenario.test.ts
+++ b/packages/eve/test/scenarios/framework-next-build.scenario.test.ts
@@ -153,6 +153,10 @@ describe("framework-next build", () => {
           destination: { service: "eve", type: "service" },
           src: "^/eve/v1/(.*)$",
         }),
+        expect.objectContaining({
+          destination: { service: "eve", type: "service" },
+          src: "^/\\.well-known/ucp$",
+        }),
       ]),
     );
     await expect(

--- a/packages/eve/test/vercel/next-eve-proxy.vercel.test.ts
+++ b/packages/eve/test/vercel/next-eve-proxy.vercel.test.ts
@@ -47,6 +47,17 @@ describe.sequential("Next.js proxy with generated eve service", () => {
 
     expect(deploymentFixture.deploymentUrl).toMatch(/^https:\/\//u);
   });
+
+  it("serves a custom channel route outside the eve protocol prefix", async () => {
+    if (deploymentFixture === undefined) {
+      throw new Error("Expected Vercel deployment fixture to be initialized.");
+    }
+
+    const response = await fetch(new URL("/.well-known/ucp", deploymentFixture.deploymentUrl));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ucp: true });
+  });
 });
 
 function hasEnvironmentVariable(name: string): boolean {


### PR DESCRIPTION
### Summary

Related to #2118. Custom channel paths outside `/eve/v1/*`, such as `/.well-known/ucp`, currently return a Next.js 404. This draft adds explicit `publicRoutes` registration for local rewrites and generated Vercel services.

```ts
import type { NextConfig } from "next";
import { withEve } from "eve/next";

const nextConfig: NextConfig = {};

export default withEve(nextConfig, {
  publicRoutes: ["/.well-known/ucp"],
});
```

This avoids compiling the agent or attempting to discover and reconcile every Next.js route. Registered paths intentionally take precedence over matching Next.js filesystem routes; named-agent paths retain their public agent prefix while the eve service receives the original path. Vercel output reconciliation uses route-source indexes so repeated assembly remains linear as registrations grow.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/public/next/index.integration.test.ts` — 12 passed, including two-pass reconciliation of 10,000 routes
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/next/index.test.ts src/public/next/public-route-mounts.test.ts` — 24 passed
- `pnpm docs:check`
- `pnpm typecheck` — 44 tasks passed
- `pnpm guard:invariants`
- Focused `oxlint` on the changed Next.js implementation and integration test

The credential-dependent deployed Vercel test is retained but was not run locally.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 4 files · `+39 / -3`

Documents the explicit registration API where Next.js, custom channels, and UCP are configured, and records the published package change.

**Implementation** — 3 files · `+187 / -39`

Adds the public option, shared validation and route serialization, Vercel request-path transforms, and linear-time generated-route reconciliation. The implementation performs no project scan or config-time agent compilation.

**Tests** — 6 files · `+142 / -5`

Covers single- and multi-agent registration, validation failures, large idempotent route sets, assembled Vercel output, and the deployed custom-channel route.
