### PR TITLE
fix(eve): omit non-replayable OpenAI reasoning

### DIFF
--- a/.changeset/tidy-reasoning-replays.md
+++ b/.changeset/tidy-reasoning-replays.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Prevent non-replayable reasoning from being sent to OpenAI Responses models, avoiding warnings that could expose reasoning content in application logs.

--- a/packages/eve/src/harness/messages.test.ts
+++ b/packages/eve/src/harness/messages.test.ts
@@ -5,6 +5,7 @@ import {
   coalesceTurnInputs,
   normalizeModelMessages,
   normalizeUserContent,
+  removeNonReplayableOpenAIReasoning,
   resolveAssistantStepText,
 } from "#harness/messages.js";
 import type { StepInput } from "#harness/types.js";
@@ -243,6 +244,44 @@ describe("normalizeModelMessages", () => {
         visible,
       ]),
     ).toEqual([{ content: [toolCall], role: "assistant" }, visible]);
+  });
+});
+
+describe("removeNonReplayableOpenAIReasoning", () => {
+  it("removes reasoning without OpenAI replay metadata", () => {
+    expect(
+      removeNonReplayableOpenAIReasoning([
+        {
+          content: [
+            { text: "private reasoning", type: "reasoning" },
+            { text: "Visible reply", type: "text" },
+          ],
+          role: "assistant",
+        },
+      ]),
+    ).toEqual([
+      {
+        content: [{ text: "Visible reply", type: "text" }],
+        role: "assistant",
+      },
+    ]);
+  });
+
+  it("preserves reasoning with OpenAI replay metadata", () => {
+    const messages: ModelMessage[] = [
+      {
+        content: [
+          {
+            providerOptions: { openai: { itemId: "reasoning-1" } },
+            text: "replayable reasoning",
+            type: "reasoning",
+          },
+        ],
+        role: "assistant",
+      },
+    ];
+
+    expect(removeNonReplayableOpenAIReasoning(messages)).toEqual(messages);
   });
 });
 

--- a/packages/eve/src/harness/messages.ts
+++ b/packages/eve/src/harness/messages.ts
@@ -81,6 +81,29 @@ export function normalizeUserContent(
   return parts.length === content.length ? content : parts;
 }
 
+/** Removes non-replayable reasoning before an OpenAI Responses model sees history. */
+export function removeNonReplayableOpenAIReasoning(
+  messages: readonly ModelMessage[],
+): ModelMessage[] {
+  return messages.flatMap((message) => {
+    if (message.role !== "assistant" || !Array.isArray(message.content)) return [message];
+
+    const content = message.content.filter((part) => {
+      if (part.type !== "reasoning") return true;
+
+      const openai = part.providerOptions?.openai as Record<string, unknown> | undefined;
+      return (
+        typeof openai?.itemId === "string" || typeof openai?.reasoningEncryptedContent === "string"
+      );
+    });
+
+    if (content.length === 0) return [];
+    return content.length === message.content.length
+      ? [message]
+      : [{ ...message, content } as ModelMessage];
+  });
+}
+
 /** Removes blank text blocks that some providers reject from model-bound history. */
 export function normalizeModelMessages(messages: readonly ModelMessage[]): ModelMessage[] {
   return messages.flatMap((message) => {

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -886,6 +886,48 @@ describe("createToolLoopHarness", () => {
     ]);
   });
 
+  it("removes non-replayable reasoning from OpenAI Responses model calls", async () => {
+    setupMockAgent({
+      finishReason: "stop",
+      response: { messages: [{ content: "Continued.", role: "assistant" }] },
+      text: "Continued.",
+      toolCalls: [],
+      toolResults: [],
+    });
+
+    const history: ModelMessage[] = [
+      {
+        content: [
+          { text: "private reasoning", type: "reasoning" },
+          { text: "Previous reply", type: "text" },
+        ],
+        role: "assistant",
+      },
+    ];
+    const runStep = createToolLoopHarness(
+      createTestConfig("conversation", undefined, {
+        resolveModel: vi.fn().mockResolvedValue({
+          modelId: "openai/gpt-5.6-luna-fast",
+          provider: "gateway",
+        } as LanguageModel),
+      }),
+    );
+
+    const result = await runStep(createTestSession({ history }), { message: "Continue" });
+    const agent = vi.mocked(ToolLoopAgent).mock.results[0]?.value as {
+      generate: ReturnType<typeof vi.fn>;
+    };
+
+    expect(agent.generate.mock.calls[0]?.[0].messages).toEqual([
+      {
+        content: [{ text: "Previous reply", type: "text" }],
+        role: "assistant",
+      },
+      { content: "Continue", role: "user" },
+    ]);
+    expect(result.session.history[0]).toEqual(history[0]);
+  });
+
   it.each([
     ["literal", EMPTY_DELIVERY_SENTINEL],
     ["HTML-escaped", "&lt;eve-empty-delivery/&gt;"],

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -199,6 +199,7 @@ import {
 import {
   normalizeModelMessages,
   normalizeUserContent,
+  removeNonReplayableOpenAIReasoning,
   resolveAssistantStepText,
 } from "#harness/messages.js";
 import { normalizeProviderToolHistory } from "#harness/provider-tool-history.js";
@@ -414,6 +415,13 @@ function mergeSystemInstructions(
     merged.providerOptions = providerOptions;
   }
   return merged;
+}
+
+function usesOpenAIResponses(model: LanguageModel): boolean {
+  if (typeof model === "string") return model.startsWith("openai/");
+  if (typeof model.provider !== "string" || typeof model.modelId !== "string") return false;
+  if (model.provider === "openai.responses") return true;
+  return model.provider.split(".")[0] === "gateway" && model.modelId.startsWith("openai/");
 }
 
 /**
@@ -1349,6 +1357,9 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       messages = compaction.messages;
     }
     projectedMessages = normalizeModelMessages(projectHistory(messages, session.state));
+    if (usesOpenAIResponses(model)) {
+      projectedMessages = removeNonReplayableOpenAIReasoning(projectedMessages);
+    }
 
     if (emit) {
       await emitStepStarted(


### PR DESCRIPTION
### Summary

OpenAI Responses adapters warn when conversation history contains reasoning without OpenAI replay metadata, and that warning includes the reasoning text in application logs. eve now removes those non-replayable parts only from OpenAI-bound model input while preserving durable session history and reasoning with valid OpenAI replay metadata. Other providers and persisted history remain unchanged.

### Validation

Focused message and tool-loop unit coverage passes with 248 tests, including an OpenAI Gateway regression and preservation of replayable reasoning; the eve package also typechecks successfully.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

A patch changeset describes the user-visible logging fix.

**Implementation** — 2 files · `+34 / -0`

Keeps the filter local to model-bound message preparation and limits it to OpenAI Responses calls.

**Tests** — 2 files · `+81 / -0`

Covers metadata-aware filtering directly and verifies the complete harness behavior without mutating durable history.
