### PR TITLE
feat(eve): progressively disclose the dev TUI during startup

### DIFF
--- a/.changeset/paint-dev-startup-draft.md
+++ b/.changeset/paint-dev-startup-draft.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Show a compact agent card and editing-only prompt while `eve dev` builds the local agent. Text typed during startup is preserved for the initialized terminal UI, while submission remains disabled until startup completes.
+Show the agent card and an editing-only prompt while `eve dev` builds the local agent, and simplify the card to branding, agent name, and a Tip. Text typed during startup is preserved for the initialized terminal UI, while submission remains disabled until startup completes.

--- a/.changeset/paint-dev-startup-draft.md
+++ b/.changeset/paint-dev-startup-draft.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Show a compact agent card and editing-only prompt while `eve dev` builds the local agent. Text typed during startup is preserved for the initialized terminal UI, while submission remains disabled until startup completes.

--- a/packages/eve/src/cli/dev/run-interactive-ui.ts
+++ b/packages/eve/src/cli/dev/run-interactive-ui.ts
@@ -1,0 +1,75 @@
+import { devBootPhase, type DevBootProgressReporter } from "#internal/dev-boot-progress.js";
+import {
+  resumeDevelopmentRuntimeArtifacts,
+  suspendDevelopmentRuntimeArtifacts,
+} from "#services/dev-client/runtime-artifacts.js";
+
+import type { DevelopmentCliOptions } from "./command-options.js";
+import { resolveTuiDisplayOptions } from "./ui-options.js";
+import type { DevelopmentTuiStartup, RunDevelopmentTuiInput } from "./tui/tui.js";
+import { resolveTuiTitle } from "./tui/target.js";
+import type { DevelopmentUrlTarget } from "./url-target.js";
+import type { CommandLifecycle } from "../shutdown.js";
+
+export async function runInteractiveDevelopmentUi(input: {
+  readonly applicationRoot: string;
+  readonly existingLocalServer: boolean;
+  readonly lifecycle?: CommandLifecycle;
+  readonly options: DevelopmentCliOptions;
+  readonly remoteTarget?: DevelopmentUrlTarget;
+  readonly report?: DevBootProgressReporter;
+  readonly runDevelopmentTui?: (input: RunDevelopmentTuiInput) => Promise<void>;
+  readonly server: { readonly appRoot?: string; readonly serverUrl: string };
+  readonly startup?: DevelopmentTuiStartup;
+}): Promise<void> {
+  const runDevelopmentTui = await devBootPhase(
+    "loading interactive UI",
+    async () => input.runDevelopmentTui ?? (await import("#cli/dev/tui/tui.js")).runDevelopmentTui,
+    input.report,
+  );
+  const target =
+    input.remoteTarget === undefined || input.existingLocalServer
+      ? {
+          kind: "local" as const,
+          serverUrl: input.server.serverUrl,
+          workspaceRoot: input.server.appRoot ?? input.applicationRoot,
+        }
+      : {
+          kind: "remote" as const,
+          serverUrl: input.server.serverUrl,
+          workspaceRoot: input.applicationRoot,
+        };
+  const display = resolveTuiDisplayOptions(input.options);
+  const name = resolveTuiTitle({ name: input.options.name, target });
+  if (name !== undefined) display.name = name;
+
+  const tuiInput: RunDevelopmentTuiInput = {
+    target,
+    initialInput: input.options.input,
+    onBootProgress: input.report,
+    lifecycle: input.lifecycle,
+    ...display,
+  };
+  if (input.startup !== undefined) tuiInput.startup = input.startup;
+  if (target.kind === "local") {
+    tuiInput.withExclusiveTerminal = async <T>(task: () => Promise<T>): Promise<T> => {
+      if (!(await suspendDevelopmentRuntimeArtifacts({ serverUrl: input.server.serverUrl }))) {
+        throw new Error("Could not pause the development server for integration setup.");
+      }
+      try {
+        return await task();
+      } finally {
+        await resumeDevelopmentRuntimeArtifacts({
+          serverUrl: input.server.serverUrl,
+          silent: true,
+        });
+      }
+    };
+  }
+
+  if (input.remoteTarget?.headers === undefined) {
+    await runDevelopmentTui(tuiInput);
+  } else {
+    await runDevelopmentTui({ ...tuiInput, headers: input.remoteTarget.headers });
+  }
+}

--- a/packages/eve/src/cli/dev/tui/agent-header.test.ts
+++ b/packages/eve/src/cli/dev/tui/agent-header.test.ts
@@ -21,15 +21,13 @@ describe("buildAgentHeader", () => {
     const plain = lines.map(stripAnsi);
     const card = plain.join("\n");
     const titleIndex = plain.findIndex((line) => line.includes("Weather Agent"));
-    const logoIndex = plain.findIndex((line) => line.includes("⣿⣿⣿⣿⣿⣿⣿⣿⣿"));
 
     expect(plain[0]).toBe(`╭${"─".repeat(66)}╮`);
     expect(plain[titleIndex]).toMatch(/^│ ☰eve \(v\d+\.\d+\.\d+\) +Weather Agent │$/u);
-    expect(titleIndex).toBeLessThan(logoIndex);
     expect(card).not.toContain("model");
     expect(card).not.toContain("instructions");
+    expect(card).not.toContain("⣿");
     expect(lines[0]).toBe(theme.colors.dim(plain[0]!));
-    expect(lines[logoIndex]).toContain(theme.colors.cyan("⣿⣿⣿⣿⣿⣿⣿⣿⣿    ⠏⣿⣿⣿⣿⣿⣿⣿⣿⣿"));
   });
 
   it("renders only known fields before agent inspection", () => {

--- a/packages/eve/src/cli/dev/tui/agent-header.test.ts
+++ b/packages/eve/src/cli/dev/tui/agent-header.test.ts
@@ -98,6 +98,34 @@ describe("buildAgentHeader", () => {
     expect(lines[modelIndex]).toContain(colorTheme.colors.dim("via "));
   });
 
+  it("renders only known fields while the agent is loading", () => {
+    const colorTheme = createTheme({ color: true, unicode: true });
+    const card = buildAgentHeader({
+      name: "weather-agent",
+      theme: colorTheme,
+      tip: "Use the /help command to see every command.",
+      width: 120,
+    })
+      .map(stripAnsi)
+      .join("\n");
+
+    expect(card).toContain("weather-agent");
+    expect(card).toContain("Tip: Use the /help command to see every command.");
+    expect(card).not.toContain("loading");
+    for (const label of [
+      "model",
+      "instructions",
+      "tools",
+      "agent",
+      "dynamic",
+      "skills",
+      "subagents",
+      "schedules",
+    ]) {
+      expect(card).not.toMatch(new RegExp(`^│ +${label}`, "mu"));
+    }
+  });
+
   it("bounds every collection for large agents", () => {
     const source = (name: string) => ({
       logicalPath: `${name}.ts`,

--- a/packages/eve/src/cli/dev/tui/agent-header.test.ts
+++ b/packages/eve/src/cli/dev/tui/agent-header.test.ts
@@ -1,211 +1,65 @@
 import { describe, expect, it } from "vitest";
 
-import type {
-  AgentInfoInstructionsEntry,
-  AgentInfoRemoteAgentEntry,
-  AgentInfoResult,
-  AgentInfoScheduleEntry,
-  AgentInfoSkillEntry,
-  AgentInfoToolEntry,
-} from "#client/index.js";
+import type { AgentInfoResult } from "#client/index.js";
 import { stripAnsi } from "#cli/ui/terminal-text.js";
 import { createTestAgentInfoResult } from "#internal/testing/agent-info-fixture.js";
 
 import { AGENT_HEADER_TIPS, buildAgentHeader, pickAgentHeaderTip } from "./agent-header.js";
 import { createTheme } from "./theme.js";
 
-const FRAMEWORK_TOOL: AgentInfoToolEntry = {
-  description: "Run a shell command.",
-  hasAuth: false,
-  hasExecute: true,
-  hasModelOutputProjection: false,
-  hasOutputSchema: true,
-  inputSchema: { type: "object" },
-  logicalPath: "eve:framework/bash",
-  name: "bash",
-  owner: { feature: "test", kind: "framework" },
-  outputSchema: { type: "object" },
-  requiresApproval: false,
-  sourceId: "eve:defaults:tools/bash.ts",
-  sourceKind: "module",
-};
-
-const AUTHORED_TOOL: AgentInfoToolEntry = {
-  description: "Get the weather.",
-  hasAuth: false,
-  hasExecute: true,
-  hasModelOutputProjection: false,
-  hasOutputSchema: false,
-  inputSchema: { type: "object" },
-  logicalPath: "agent/tools/get_weather.ts",
-  name: "get_weather",
-  owner: { kind: "application" },
-  outputSchema: null,
-  requiresApproval: false,
-  sourceId: "tools/get_weather.ts",
-  sourceKind: "module",
-};
-
-const TEST_INFO = createTestAgentInfoResult({
+const INFO = createTestAgentInfoResult({
   agentRoot: "/tmp/weather-agent/agent",
   appRoot: "/tmp/weather-agent",
-  modelId: "anthropic/claude-opus-4.7",
+  modelId: "zai/glm-5.2",
   name: "Weather Agent",
 });
-const INFO: AgentInfoResult = {
-  ...TEST_INFO,
-  tools: { dynamic: [], static: [FRAMEWORK_TOOL, AUTHORED_TOOL] },
-};
 
 describe("buildAgentHeader", () => {
-  const theme = createTheme({ color: false, unicode: false });
-
-  it("renders the startup card", () => {
-    const colorTheme = createTheme({ color: true, unicode: true });
-    const info: AgentInfoResult = {
-      ...INFO,
-      agent: {
-        ...INFO.agent,
-        model: {
-          id: "zai/glm-5.2",
-          routing: { kind: "gateway", target: "zai" },
-          endpoint: { kind: "gateway", connected: true, credential: "api-key" },
-        },
-      },
-    };
-    const lines = buildAgentHeader({ info, theme: colorTheme, width: 120 });
+  it("renders a compact agent card", () => {
+    const theme = createTheme({ color: true, unicode: true });
+    const lines = buildAgentHeader({ info: INFO, theme, width: 120 });
     const plain = lines.map(stripAnsi);
-
     const card = plain.join("\n");
     const titleIndex = plain.findIndex((line) => line.includes("Weather Agent"));
     const logoIndex = plain.findIndex((line) => line.includes("⣿⣿⣿⣿⣿⣿⣿⣿⣿"));
-    const modelIndex = plain.findIndex((line) => line.includes("model"));
 
     expect(plain[0]).toBe(`╭${"─".repeat(66)}╮`);
     expect(plain[titleIndex]).toMatch(/^│ ☰eve \(v\d+\.\d+\.\d+\) +Weather Agent │$/u);
     expect(titleIndex).toBeLessThan(logoIndex);
-    expect(logoIndex).toBeLessThan(modelIndex);
-    expect(card).toContain("model         zai/glm-5.2 via ai-gateway(api-key)");
-    expect(card).toContain("instructions  none");
-    expect(card).toContain("agent       get_weather");
-    expect(card).toContain("eve         bash");
-    expect(card).toContain("skills        none");
-    expect(card).toContain("subagents     none");
-    expect(card).toContain("schedules     none");
-    expect(plain.at(-2)).toContain("schedules     none");
-    expect(lines[0]).toBe(colorTheme.colors.dim(plain[0]!));
-    expect(lines[logoIndex]).toContain(colorTheme.colors.cyan("⣿⣿⣿⣿⣿⣿⣿⣿⣿    ⠏⣿⣿⣿⣿⣿⣿⣿⣿⣿"));
-    expect(lines[modelIndex]).toContain(colorTheme.colors.dim("via "));
+    expect(card).not.toContain("model");
+    expect(card).not.toContain("instructions");
+    expect(lines[0]).toBe(theme.colors.dim(plain[0]!));
+    expect(lines[logoIndex]).toContain(theme.colors.cyan("⣿⣿⣿⣿⣿⣿⣿⣿⣿    ⠏⣿⣿⣿⣿⣿⣿⣿⣿⣿"));
   });
 
-  it("renders only known fields while the agent is loading", () => {
-    const colorTheme = createTheme({ color: true, unicode: true });
+  it("renders only known fields before agent inspection", () => {
+    const theme = createTheme({ color: false, unicode: true });
     const card = buildAgentHeader({
       name: "weather-agent",
-      theme: colorTheme,
+      theme,
       tip: "Use the /help command to see every command.",
       width: 120,
-    })
-      .map(stripAnsi)
-      .join("\n");
+    }).join("\n");
 
     expect(card).toContain("weather-agent");
     expect(card).toContain("Tip: Use the /help command to see every command.");
-    expect(card).not.toContain("loading");
-    for (const label of [
-      "model",
-      "instructions",
-      "tools",
-      "agent",
-      "dynamic",
-      "skills",
-      "subagents",
-      "schedules",
-    ]) {
-      expect(card).not.toMatch(new RegExp(`^│ +${label}`, "mu"));
-    }
-  });
-
-  it("bounds every collection for large agents", () => {
-    const source = (name: string) => ({
-      logicalPath: `${name}.ts`,
-      owner: { kind: "application" as const },
-      sourceId: `${name}.ts`,
-      sourceKind: "module" as const,
-    });
-    const instructions: AgentInfoInstructionsEntry[] = Array.from({ length: 12 }, (_, index) => ({
-      ...source(`instructions-${index}`),
-      content: "Instructions.",
-      name: `instructions-${index}`,
-      role: "system",
-    }));
-    const skills: AgentInfoSkillEntry[] = Array.from({ length: 12 }, (_, index) => ({
-      ...source(`skill-${index}`),
-      description: "Skill.",
-      markdown: "# Skill",
-      name: `skill-${index}`,
-    }));
-    const schedules: AgentInfoScheduleEntry[] = Array.from({ length: 12 }, (_, index) => ({
-      ...source(`schedule-${index}`),
-      cron: "0 0 * * *",
-      hasRun: true,
-      name: `schedule-${index}`,
-    }));
-    const remoteAgents: AgentInfoRemoteAgentEntry[] = Array.from({ length: 12 }, (_, index) => ({
-      ...source(`subagent-${index}`),
-      description: "Subagent.",
-      name: `subagent-${index}`,
-      nodeId: `remote-${index}`,
-      parentNodeId: "__root__",
-    }));
-    const extensionTools = Array.from({ length: 6 }, (_, index): AgentInfoToolEntry => ({
-      ...AUTHORED_TOOL,
-      logicalPath: `extension-${index}/tool.ts`,
-      name: `extension_tool_${index}`,
-      owner: {
-        kind: "extension",
-        namespace: `extension-${index}`,
-        packageName: `@example/extension-${index}`,
-      },
-      sourceId: `extension-${index}/tool.ts`,
-    }));
-    const info: AgentInfoResult = {
-      ...INFO,
-      instructions: { dynamic: [], static: instructions },
-      remoteAgents: { entries: remoteAgents, total: remoteAgents.length },
-      schedules,
-      skills: { dynamic: [], static: skills },
-      tools: { dynamic: [], static: [AUTHORED_TOOL, ...extensionTools, FRAMEWORK_TOOL] },
-    };
-
-    const card = buildAgentHeader({ info, theme, width: 120 }).join("\n");
-
-    for (const label of ["instructions", "skills", "subagents", "schedules"]) {
-      expect(card.match(new RegExp(`${label}.*\\+\\d+ more`, "u"))).not.toBeNull();
-    }
-    expect(card).toContain("  +4 groups");
-    expect(card).not.toContain("  eve         bash");
   });
 
   it("renders the /add tip with a blue command", () => {
-    const colorTheme = createTheme({ color: true, unicode: false });
+    const theme = createTheme({ color: true, unicode: false });
     const tip = AGENT_HEADER_TIPS.find((candidate) => candidate.includes("/add"));
 
     expect(tip).toBe("Use the /add command to install an integration.");
     if (tip === undefined) return;
 
-    const line = buildAgentHeader({
-      info: INFO,
-      theme: colorTheme,
-      width: 120,
-      tip,
-    }).at(-1);
+    const line = buildAgentHeader({ info: INFO, theme, width: 120, tip }).at(-1);
 
     expect(stripAnsi(line ?? "")).toBe(`  Tip: ${tip}`);
-    expect(line).toContain(colorTheme.colors.blue("/add"));
+    expect(line).toContain(theme.colors.blue("/add"));
   });
 
   it("keeps the discovery-diagnostics line when the compiler reported problems", () => {
+    const theme = createTheme({ color: false, unicode: false });
     const info: AgentInfoResult = {
       ...INFO,
       diagnostics: { discoveryErrors: 1, discoveryWarnings: 2 },

--- a/packages/eve/src/cli/dev/tui/agent-header.test.ts
+++ b/packages/eve/src/cli/dev/tui/agent-header.test.ts
@@ -52,9 +52,11 @@ describe("buildAgentHeader", () => {
     expect(tip).toBe("Use the /add command to install an integration.");
     if (tip === undefined) return;
 
-    const line = buildAgentHeader({ info: INFO, theme, width: 120, tip }).at(-1);
+    const line = buildAgentHeader({ info: INFO, theme, width: 120, tip }).find((candidate) =>
+      candidate.includes("Tip:"),
+    );
 
-    expect(stripAnsi(line ?? "")).toBe(`  Tip: ${tip}`);
+    expect(stripAnsi(line ?? "")).toContain(`| Tip: ${tip}`);
     expect(line).toContain(theme.colors.blue("/add"));
   });
 

--- a/packages/eve/src/cli/dev/tui/agent-header.ts
+++ b/packages/eve/src/cli/dev/tui/agent-header.ts
@@ -28,8 +28,6 @@ export const AGENT_HEADER_TIPS: readonly string[] = [
   "Use the /help command to see every command.",
 ];
 
-const MAX_TOOL_GROUPS = 4;
-
 const EVE_LOGO = [
   "⣿⣿⣿⣿⣿⣿⣿⣿⣿    ⠏⣿⣿⣿⣿⣿⣿⣿⣿⣿",
   "            ⠇⣿⠏",
@@ -89,38 +87,6 @@ export function buildAgentHeader(input: AgentHeaderInput): string[] {
     );
   }
 
-  const detail = (label: string, value: string): string =>
-    row(`${c.dim(label.padEnd(14))}${value}`);
-  const model = formatHeaderModel(info?.agent.model, theme);
-  if (model !== undefined) lines.push(detail("model", model));
-  if (info !== undefined) {
-    lines.push(detail("instructions", formatInstructions(info, innerWidth - 18)));
-    lines.push(row());
-    const toolGroups = groupTools(info);
-    if (toolGroups.length === 0) {
-      lines.push(detail("tools", "none"));
-    } else {
-      lines.push(detail("tools", ""));
-      for (const group of toolGroups.slice(0, MAX_TOOL_GROUPS)) {
-        lines.push(detail(`  ${group.label}`, fitNames(group.names, innerWidth - 18)));
-      }
-      const omittedGroups = toolGroups.length - MAX_TOOL_GROUPS;
-      if (omittedGroups > 0) {
-        lines.push(detail(`  +${omittedGroups} ${pluralize(omittedGroups, "group")}`, ""));
-      }
-    }
-    lines.push(detail("skills", fitNames(skillNames(info), innerWidth - 18)));
-    lines.push(detail("subagents", fitNames(subagentNames(info), innerWidth - 18)));
-    lines.push(
-      detail(
-        "schedules",
-        fitNames(
-          info.schedules.map((schedule) => schedule.name),
-          innerWidth - 18,
-        ),
-      ),
-    );
-  }
   lines.push(c.dim(`${bottomLeft}${border}${bottomRight}`));
 
   if (info && (info.diagnostics.discoveryErrors > 0 || info.diagnostics.discoveryWarnings > 0)) {
@@ -164,90 +130,6 @@ function spreadRow(left: string, right: string, width: number, ambiguousWidth: n
   return `${clippedLeft}${" ".repeat(gap)}${clippedRight}`;
 }
 
-function groupTools(info: AgentInfoResult): Array<{ label: string; names: string[] }> {
-  const groups = new Map<string, string[]>();
-  for (const tool of info.tools.static) {
-    const label =
-      tool.owner.kind === "application"
-        ? "agent"
-        : tool.owner.kind === "framework"
-          ? "eve"
-          : tool.owner.namespace;
-    const names = groups.get(label) ?? [];
-    names.push(tool.name);
-    groups.set(label, names);
-  }
-  if (info.tools.dynamic.length > 0) {
-    groups.set(
-      "dynamic",
-      info.tools.dynamic.map((resolver) => resolver.slug),
-    );
-  }
-  const priority = (label: string): number => {
-    if (label === "agent") return 0;
-    if (label === "dynamic") return 2;
-    if (label === "eve") return 3;
-    return 1;
-  };
-  return [...groups]
-    .map(([label, names]) => ({ label, names: names.sort() }))
-    .sort((a, b) => priority(a.label) - priority(b.label) || a.label.localeCompare(b.label));
-}
-
-function skillNames(info: AgentInfoResult): string[] {
-  return [
-    ...info.skills.static.map((skill) => skill.name),
-    ...info.skills.dynamic.map((resolver) => `${resolver.slug} (dynamic)`),
-  ].sort();
-}
-
-function subagentNames(info: AgentInfoResult): string[] {
-  return [...info.subagents.local, ...info.remoteAgents.entries]
-    .map((subagent) => subagent.name)
-    .sort();
-}
-
-function formatInstructions(info: AgentInfoResult, width: number): string {
-  const names = [
-    ...info.instructions.static.map(
-      (instructions) => `${instructions.logicalPath} (${instructions.role})`,
-    ),
-    ...info.instructions.dynamic.map((resolver) => `${resolver.slug} (dynamic)`),
-  ];
-  return fitNames(names, width);
-}
-
-function fitNames(names: readonly string[], width: number): string {
-  if (names.length === 0) return "none";
-  for (let count = names.length; count > 0; count -= 1) {
-    const hidden = names.length - count;
-    const value = `${names.slice(0, count).join(", ")}${hidden > 0 ? `, +${hidden} more` : ""}`;
-    if (visibleLength(value) <= width) return value;
-  }
-  return clipVisible(names[0]!, width);
-}
-
-function formatHeaderModel(
-  model: AgentInfoResult["agent"]["model"] | undefined,
-  theme: Theme,
-): string | undefined {
-  if (model?.id === undefined) return undefined;
-  const endpoint = model.endpoint;
-  if (endpoint === undefined) return model.id;
-
-  const via = theme.colors.dim("via ");
-  switch (endpoint.kind) {
-    case "external":
-      return `${model.id} ${via}${endpoint.provider}`;
-    case "chatgpt":
-      return `${model.id} ${via}chatgpt-sub`;
-    case "gateway":
-      return endpoint.connected
-        ? `${model.id} ${via}ai-gateway(${endpoint.credential})`
-        : `${model.id} ${via}ai-gateway(not connected)`;
-  }
-}
-
 function renderTip(tip: string, width: number, theme: Theme): string {
   return clipVisible(
     tip
@@ -262,8 +144,4 @@ function renderTip(tip: string, width: number, theme: Theme): string {
 
 function plural(count: number): string {
   return count === 1 ? "" : "s";
-}
-
-function pluralize(count: number, noun: string): string {
-  return `${noun}${plural(count)}`;
 }

--- a/packages/eve/src/cli/dev/tui/agent-header.ts
+++ b/packages/eve/src/cli/dev/tui/agent-header.ts
@@ -87,6 +87,9 @@ export function buildAgentHeader(input: AgentHeaderInput): string[] {
     );
   }
 
+  if (input.tip !== undefined) {
+    lines.push(row(`${c.bold("Tip:")} ${renderTip(input.tip, innerWidth - 7, theme)}`));
+  }
   lines.push(c.dim(`${bottomLeft}${border}${bottomRight}`));
 
   if (info && (info.diagnostics.discoveryErrors > 0 || info.diagnostics.discoveryWarnings > 0)) {
@@ -108,10 +111,6 @@ export function buildAgentHeader(input: AgentHeaderInput): string[] {
       );
     }
     lines.push("", `  ${c.dim(theme.glyph.warning)} ${parts.join(c.dim(" · "))}`);
-  }
-
-  if (input.tip !== undefined) {
-    lines.push("", `  ${c.bold("Tip:")} ${renderTip(input.tip, Math.max(8, width - 7), theme)}`);
   }
 
   return lines;

--- a/packages/eve/src/cli/dev/tui/agent-header.ts
+++ b/packages/eve/src/cli/dev/tui/agent-header.ts
@@ -28,14 +28,6 @@ export const AGENT_HEADER_TIPS: readonly string[] = [
   "Use the /help command to see every command.",
 ];
 
-const EVE_LOGO = [
-  "⣿⣿⣿⣿⣿⣿⣿⣿⣿    ⠏⣿⣿⣿⣿⣿⣿⣿⣿⣿",
-  "            ⠇⣿⠏",
-  "⣿⣿⣿⣿⣿⣿⠇    ⠇⣿⠏   ⠇⣿⣿⣿⣿⣿",
-  "          ⠃⣿⠏",
-  "⣿⣿⣿⣿⣿⣿⠏  ⠃⣿⠏   ⠇⣿⣿⣿⣿⣿⣿⣿",
-] as const;
-
 /** Picks one tip; `random` is a test seam over Math.random. */
 export function pickAgentHeaderTip(random: () => number = Math.random): string {
   const index = Math.min(
@@ -79,14 +71,7 @@ export function buildAgentHeader(input: AgentHeaderInput): string[] {
   // U+2630 is East Asian Ambiguous and renders as two cells in some
   // terminals, so reserve its second cell explicitly inside the card.
   lines.push(row(title, 1));
-  const logoWidth = Math.max(...EVE_LOGO.map((line) => visibleLength(line)));
-  if (theme.unicode && innerWidth - 2 >= logoWidth) {
-    lines.push(
-      ...EVE_LOGO.map((line) => row(centerLogoLine(line, logoWidth, innerWidth - 2, theme))),
-      row(),
-    );
-  }
-
+  lines.push(row());
   if (input.tip !== undefined) {
     lines.push(row(`${c.bold("Tip:")} ${renderTip(input.tip, innerWidth - 7, theme)}`));
   }
@@ -114,11 +99,6 @@ export function buildAgentHeader(input: AgentHeaderInput): string[] {
   }
 
   return lines;
-}
-
-function centerLogoLine(text: string, logoWidth: number, width: number, theme: Theme): string {
-  const padding = Math.max(0, Math.floor((width - logoWidth) / 2));
-  return `${" ".repeat(padding)}${theme.colors.cyan(text)}`;
 }
 
 function spreadRow(left: string, right: string, width: number, ambiguousWidth: number): string {

--- a/packages/eve/src/cli/dev/tui/agent-header.ts
+++ b/packages/eve/src/cli/dev/tui/agent-header.ts
@@ -80,7 +80,7 @@ export function buildAgentHeader(input: AgentHeaderInput): string[] {
   const lines = [c.dim(`${topLeft}${border}${topRight}`)];
   // U+2630 is East Asian Ambiguous and renders as two cells in some
   // terminals, so reserve its second cell explicitly inside the card.
-  lines.push(row(title, 1), row());
+  lines.push(row(title, 1));
   const logoWidth = Math.max(...EVE_LOGO.map((line) => visibleLength(line)));
   if (theme.unicode && innerWidth - 2 >= logoWidth) {
     lines.push(

--- a/packages/eve/src/cli/dev/tui/runner.test.ts
+++ b/packages/eve/src/cli/dev/tui/runner.test.ts
@@ -1431,6 +1431,35 @@ describe("EveTUIRunner /traces", () => {
 });
 
 describe("EveTUIRunner initial input", () => {
+  it("uses the startup draft captured after the agent info probe", async () => {
+    const info = createDeferred<typeof AGENT_INFO>();
+    const client = stubClient();
+    vi.spyOn(client, "info").mockReturnValue(info.promise);
+    const startup = {
+      finish: vi.fn(() => "typed while loading"),
+      headerTip: "Use the /help command to see every command.",
+    };
+    const renderer = fakeRenderer();
+    const runner = new EveTUIRunner({
+      session: stubSession(),
+      client,
+      renderer,
+      serverUrl: "http://localhost:3000",
+      startup,
+    });
+
+    const running = runner.run();
+    await settleAsyncWork();
+    expect(startup.finish).not.toHaveBeenCalled();
+    info.resolve(AGENT_INFO);
+    await running;
+
+    expect(startup.finish).toHaveBeenCalledOnce();
+    expect(renderer.readPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({ initialDraft: "typed while loading" }),
+    );
+  });
+
   it("seeds only the first prompt's editable buffer with --input text", async () => {
     const seenOptions: Array<AgentTUISessionOptions | undefined> = [];
     const prompts: Array<string | undefined> = ["edited and sent", undefined];

--- a/packages/eve/src/cli/dev/tui/runner.ts
+++ b/packages/eve/src/cli/dev/tui/runner.ts
@@ -402,6 +402,11 @@ export interface PromptCommandHandler {
   ): Promise<PromptCommandOutcome | undefined>;
 }
 
+type TuiStartup = {
+  readonly headerTip: string;
+  finish(): string;
+};
+
 export type EveTUIRunnerOptions = TuiDisplayOptions & {
   session?: ClientSession;
   /** Production TUI probe injected by the launcher; omitted in hermetic runners. */
@@ -465,6 +470,8 @@ export type EveTUIRunnerOptions = TuiDisplayOptions & {
   /** Parent-owned diagnostics recorder; omitted for remote and test renderers. */
   diagnostics?: DevDiagnostics;
   lifecycle?: CommandLifecycle;
+  /** Editing-only startup state retained until the final agent header is ready to paint. */
+  startup?: TuiStartup;
 };
 
 /** The attention-line issue for a Vercel auth state, or undefined when nothing's wrong. */
@@ -494,6 +501,7 @@ export class EveTUIRunner {
    * fresh-agent onboarding.
    */
   readonly #initialInput?: string;
+  readonly #startup?: TuiStartup;
   readonly #promptCommandHandler?: PromptCommandHandler;
   readonly #availablePromptCommands: readonly PromptCommandSpec[];
   readonly #withExclusiveTerminal?: <T>(task: () => Promise<T>) => Promise<T>;
@@ -528,7 +536,7 @@ export class EveTUIRunner {
    * refreshes don't re-roll it mid-session. Local sessions only — every
    * tip references local-only slash commands.
    */
-  readonly #headerTip = pickAgentHeaderTip();
+  readonly #headerTip: string;
   #agentInfo?: AgentInfoResult;
   /**
    * approval-id → input-request map populated as `input.requested` events
@@ -585,6 +593,7 @@ export class EveTUIRunner {
     if (this.#renderer.subagents !== undefined) pumpOptions.view = this.#renderer.subagents;
     this.#subagentPump = new SubagentPump(pumpOptions);
     this.#name = options.name ?? "eve";
+    this.#headerTip = options.startup?.headerTip ?? pickAgentHeaderTip();
     this.#withExclusiveTerminal = options.withExclusiveTerminal;
     this.#tools = options.tools ?? "full";
     this.#reasoning = options.reasoning ?? "full";
@@ -594,6 +603,7 @@ export class EveTUIRunner {
     this.#contextSize = options.contextSize;
     this.#formatTransportError = options.formatTransportError ?? toErrorMessage;
     if (options.initialInput !== undefined) this.#initialInput = options.initialInput;
+    if (options.startup !== undefined) this.#startup = options.startup;
     if (options.appRoot !== undefined) {
       this.#appRoot = options.appRoot;
       const trackerOptions: VercelStatusTrackerOptions = {
@@ -645,12 +655,12 @@ export class EveTUIRunner {
    * header. Never throws: a missing or unauthorized `/eve/v1/info` simply
    * yields a header without the agent's configuration detail.
    */
-  async #renderAgentHeader(): Promise<void> {
+  async #renderAgentHeader(): Promise<string | undefined> {
     const serverUrl = this.#serverUrl;
     if (serverUrl === undefined) {
       this.#reportBeforeFirstPaint();
       await this.#renderSetupIssues(undefined);
-      return;
+      return this.#startup?.finish() ?? this.#initialInput;
     }
 
     let info: AgentInfoResult | undefined;
@@ -672,9 +682,11 @@ export class EveTUIRunner {
         }
       }
     }
+    const initialDraft = this.#startup?.finish() ?? this.#initialInput;
     this.#reportBeforeFirstPaint();
     const headerInfo = this.#replaceAgentInfo(info);
     await this.#renderSetupIssues(headerInfo);
+    return initialDraft;
   }
 
   #replaceAgentInfo(info: AgentInfoResult | undefined): AgentInfoResult | undefined {
@@ -730,11 +742,7 @@ export class EveTUIRunner {
     let hasRunTurn = false;
     let followCurrentSession = false;
     let streamWithoutPrompt = false;
-    // `--input` seed: applied to the first prompt's editable buffer, then
-    // cleared so later prompts open empty.
-    let initialDraft = this.#initialInput;
-
-    await this.#renderAgentHeader();
+    let initialDraft = await this.#renderAgentHeader();
     if (this.#remoteConnection?.current().connection.state === "auth-required") {
       await this.#executeExtensionCommand(
         { type: "extension", name: "vc:login", argument: "" },

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
@@ -2322,6 +2322,64 @@ describe("TerminalRenderer (inline scrollback)", () => {
     renderer.shutdown();
   });
 
+  it("keeps an editable startup draft inert and hands it to the first prompt", async () => {
+    const screen = new MockScreen({ columns: 80, rows: 30 });
+    const input = new MockUserInput();
+    const requestStop = vi.fn();
+    const startupRenderer = new TerminalRenderer({
+      input,
+      output: screen,
+      captureForeignOutput: false,
+      unicode: true,
+      onExitRequest: requestStop,
+    });
+
+    startupRenderer.beginStartupDraft({
+      initialDraft: "weather",
+      tip: "Use the /help command to see every command.",
+      title: "weather-agent",
+    });
+    expect(screen.snapshot()).toContain("weather-agent");
+    expect(screen.snapshot()).toContain("Tip: Use the /help command");
+    expect(screen.snapshot()).not.toContain("model");
+    expect(screen.snapshot()).not.toContain("loading");
+    expect(screen.snapshot()).toContain("Building your agent");
+    expect(screen.snapshot()).toContain("weather");
+
+    input.type(" tomorrow");
+    input.enter();
+    expect(screen.snapshot()).toContain("weather tomorrow");
+
+    const draft = startupRenderer.finishStartupDraft();
+    expect(draft).toBe("weather tomorrow");
+    const prompt = startupRenderer.readPrompt({ initialDraft: draft });
+    input.enter();
+    await expect(prompt).resolves.toBe("weather tomorrow");
+    expect(requestStop).not.toHaveBeenCalled();
+    startupRenderer.shutdown();
+  });
+
+  it("lets Ctrl-C stop an editing-only startup draft", () => {
+    const screen = new MockScreen({ columns: 80, rows: 30 });
+    const input = new MockUserInput();
+    const requestStop = vi.fn();
+    const renderer = new TerminalRenderer({
+      input,
+      output: screen,
+      captureForeignOutput: false,
+      onExitRequest: requestStop,
+    });
+
+    renderer.beginStartupDraft({
+      tip: "Use the /help command to see every command.",
+      title: "weather-agent",
+    });
+    input.ctrlC();
+
+    expect(requestStop).toHaveBeenCalledOnce();
+    renderer.shutdown();
+  });
+
   it("seeds the editable buffer with an initial draft without auto-submitting", async () => {
     const { screen, input, renderer } = makeRenderer();
 

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
@@ -191,7 +191,7 @@ describe("TerminalRenderer (inline scrollback)", () => {
     expect(snapshot).not.toContain("http://localhost:3000");
   });
 
-  it("refreshes the committed agent header with the latest model", async () => {
+  it("updates the status model without repeating an unchanged agent card", async () => {
     const { screen, renderer } = makeRenderer();
     renderer.renderAgentHeader({
       info: agentInfoWithModel("old-model"),
@@ -215,9 +215,8 @@ describe("TerminalRenderer (inline scrollback)", () => {
 
     const snapshot = screen.snapshot();
     expect(snapshot).toContain("new-model");
-    // Header refreshes append to scrollback, preserving the prior startup card.
-    expect(snapshot).toContain("old-model");
-    expect(snapshot.lastIndexOf("new-model")).toBeGreaterThan(snapshot.lastIndexOf("old-model"));
+    expect(snapshot).not.toContain("old-model");
+    expect(snapshot.match(/☰eve/gu)).toHaveLength(1);
     expect(snapshot).toContain("hello");
     expect(snapshot).toContain("still here");
     renderer.shutdown();

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.ts
@@ -398,6 +398,7 @@ export class TerminalRenderer implements AgentTUIRenderer {
   readonly #fileContents = new FileContentCache();
   readonly #subagentHeaders = new Set<string>();
   #agentHeader?: AgentHeaderOptions;
+  #startupHeader?: { readonly name: string; readonly tip: string };
   #agentHeaderRendered = false;
   /** The last committed header body, to skip re-committing an unchanged banner. */
   #agentHeaderBody?: string;
@@ -654,6 +655,43 @@ export class TerminalRenderer implements AgentTUIRenderer {
     // paints the input line beneath it. Startup intentionally preserves the
     // user's existing scrollback instead of clearing the terminal.
     this.#live.flush(this.#renderAgentHeaderRows(), []);
+  }
+
+  beginStartupDraft(options: { initialDraft?: string; tip: string; title: string }): void {
+    this.#start({ title: options.title });
+    this.#inputActive = true;
+    this.#promptPlaceholderActive = true;
+    this.#startupHeader = { name: options.title, tip: options.tip };
+    let editor = lineOf(stripPromptControlCharacters(options.initialDraft ?? ""));
+    this.#syncInput(editor);
+    this.#startCaretBlink();
+    this.#paint();
+
+    const apply = (next: LineState) => {
+      editor = next;
+      this.#showCaret();
+      this.#syncInput(editor);
+      this.#paint();
+    };
+    this.#consumeKey = (key) => {
+      const edited = applyLineEditorKey(editor, key, { multiline: true });
+      if (edited !== undefined) {
+        apply(edited);
+        return;
+      }
+      if (key.type === "ctrl-c") this.#onExitRequest?.();
+    };
+    this.#attachInput();
+  }
+
+  finishStartupDraft(): string {
+    const draft = this.#inputText;
+    this.#detachInput();
+    this.#stopCaretBlink();
+    this.#inputActive = false;
+    this.#startupHeader = undefined;
+    this.#promptPlaceholderActive = false;
+    return draft;
   }
 
   async readPrompt(options?: AgentTUISessionOptions): Promise<string> {
@@ -3810,7 +3848,8 @@ export class TerminalRenderer implements AgentTUIRenderer {
 
     const width = this.#width();
     const footer = this.#footerRows(width);
-    const maxBlockRows = Math.max(1, this.#height() - footer.length);
+    const startupHeader = this.#startupHeader === undefined ? [] : this.#renderAgentHeaderRows();
+    const maxBlockRows = Math.max(1, this.#height() - startupHeader.length - footer.length);
     const committed: string[] = [];
     let previous = this.#lastCommitted;
 
@@ -3863,6 +3902,7 @@ export class TerminalRenderer implements AgentTUIRenderer {
     }
 
     const liveRows = [
+      ...startupHeader,
       ...clipLiveRows(
         flat.map((entry) => entry.row),
         maxBlockRows,
@@ -3972,14 +4012,16 @@ export class TerminalRenderer implements AgentTUIRenderer {
 
   #renderAgentHeaderRows(): string[] {
     const header = this.#agentHeader;
-    if (header === undefined) return [];
+    const startup = this.#startupHeader;
+    if (header === undefined && startup === undefined) return [];
     const input: Parameters<typeof buildAgentHeader>[0] = {
-      name: header.name,
+      name: header?.name ?? startup?.name,
       theme: this.#theme,
       width: this.#width(),
     };
-    if (header.info !== undefined) input.info = header.info;
-    if (header.tip !== undefined) input.tip = header.tip;
+    if (header?.info !== undefined) input.info = header.info;
+    const tip = header?.tip ?? startup?.tip;
+    if (tip !== undefined) input.tip = tip;
     return buildAgentHeader(input);
   }
 
@@ -4147,6 +4189,9 @@ export class TerminalRenderer implements AgentTUIRenderer {
       const isCommand = isPromptControlCommand(this.#inputText);
       const ghost = inlineHint ? c.dim(` ${inlineHint}`) : "";
       const statusRows: string[] = [];
+      if (this.#startupHeader !== undefined) {
+        statusRows.push(clip(c.dim(`${this.#theme.glyph.dot} Building your agent…`), width));
+      }
       this.#pushStatusLine(statusRows, width);
       // Keep one transcript row above the footer and one separator below the
       // prompt. Everything already in `rows` has higher-level footer ownership

--- a/packages/eve/src/cli/dev/tui/tui.ts
+++ b/packages/eve/src/cli/dev/tui/tui.ts
@@ -13,13 +13,15 @@ import {
 import { isVercelAuthChallenge } from "#services/dev-client/vercel-auth-error.js";
 import { resolveVercelDeployment } from "#setup/vercel-deployment.js";
 import { toErrorMessage } from "#shared/errors.js";
-import { createDevDiagnostics } from "../diagnostics.js";
+import { createDevDiagnostics, type DevDiagnostics } from "../diagnostics.js";
 
 import { createPromptCommandHandler } from "./prompt-command-handler.js";
 import { promptCommandsFor } from "./prompt-commands.js";
+import { pickAgentHeaderTip } from "./agent-header.js";
 import { formatRemoteAuthChallengeMessage } from "./remote-auth-result.js";
 import { probeMcpConnection } from "./mcp-connection-status.js";
 import { EveTUIRunner, type EveTUIRunnerOptions } from "./runner.js";
+import { TerminalRenderer } from "./terminal-renderer.js";
 import { remoteHost, type DevelopmentTuiTarget, type RemoteDevelopmentTarget } from "./target.js";
 import type { TuiDisplayOptions } from "./types.js";
 
@@ -40,6 +42,47 @@ export interface RunDevelopmentTuiInput extends TuiDisplayOptions {
   /** Gives setup subprocesses exclusive terminal and development-host ownership. */
   withExclusiveTerminal?: <T>(task: () => Promise<T>) => Promise<T>;
   readonly lifecycle?: CommandLifecycle;
+  /** Prepared editing-only startup UI reused by the initialized local runner. */
+  startup?: DevelopmentTuiStartup;
+}
+
+export interface DevelopmentTuiStartup {
+  readonly diagnostics: DevDiagnostics | undefined;
+  readonly headerTip: string;
+  readonly renderer: TerminalRenderer;
+  finish(): string;
+  shutdown(): Promise<void>;
+}
+
+export async function startDevelopmentTuiStartup(
+  input: TuiDisplayOptions & {
+    readonly appRoot: string;
+    readonly initialInput?: string;
+    readonly onExitRequest: () => void;
+  },
+): Promise<DevelopmentTuiStartup> {
+  const diagnostics = await createDevDiagnostics(input.appRoot).catch(() => undefined);
+  const headerTip = pickAgentHeaderTip();
+  const renderer = new TerminalRenderer({
+    ...input,
+    diagnostics,
+    onExitRequest: input.onExitRequest,
+  });
+  renderer.beginStartupDraft({
+    initialDraft: input.initialInput,
+    tip: headerTip,
+    title: input.name ?? "eve",
+  });
+  return {
+    diagnostics,
+    headerTip,
+    renderer,
+    finish: () => renderer.finishStartupDraft(),
+    async shutdown() {
+      renderer.shutdown();
+      await diagnostics?.close();
+    },
+  };
 }
 
 function prepareRemoteTarget(target: RemoteDevelopmentTarget) {
@@ -90,6 +133,7 @@ export async function runDevelopmentTui(input: RunDevelopmentTuiInput): Promise<
     initialInput,
     onBootProgress,
     lifecycle,
+    startup,
     withExclusiveTerminal,
     ...display
   } = input;
@@ -129,14 +173,19 @@ export async function runDevelopmentTui(input: RunDevelopmentTuiInput): Promise<
     options.remote = prepared.remote;
   }
   if (initialInput !== undefined) options.initialInput = initialInput;
+  if (startup !== undefined) {
+    options.renderer = startup.renderer;
+    options.startup = startup;
+  }
   if (onBootProgress !== undefined) options.onBootProgress = onBootProgress;
   if (lifecycle !== undefined) options.lifecycle = lifecycle;
   if (withExclusiveTerminal !== undefined) options.withExclusiveTerminal = withExclusiveTerminal;
 
   const diagnostics =
-    prepared.kind === "local"
+    startup?.diagnostics ??
+    (prepared.kind === "local"
       ? await createDevDiagnostics(prepared.target.workspaceRoot).catch(() => undefined)
-      : undefined;
+      : undefined);
   if (diagnostics !== undefined) options.diagnostics = diagnostics;
   try {
     await new EveTUIRunner(options).run();

--- a/packages/eve/src/cli/run.ts
+++ b/packages/eve/src/cli/run.ts
@@ -1,6 +1,6 @@
 import { Command, CommanderError, InvalidArgumentError } from "#compiled/commander/index.js";
 import { registerBuildCommand, type BuildHost } from "#cli/commands/build.js";
-import { devBootPhase, type DevBootProgressReporter } from "#internal/dev-boot-progress.js";
+import type { DevBootProgressReporter } from "#internal/dev-boot-progress.js";
 import { resolveApplicationRoot } from "#internal/application/paths.js";
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
 import { isCodingAgentLaunch } from "#cli/agent-detection.js";
@@ -10,6 +10,7 @@ import { eveCliBanner } from "#cli/banner.js";
 import { registerIntegrationCommands } from "#cli/commands/register-integration-commands.js";
 import { registerProjectCommands } from "#cli/commands/register-project-commands.js";
 import { registerRegistryCommands } from "#cli/commands/register-registry-commands.js";
+import { runInteractiveDevelopmentUi } from "#cli/dev/run-interactive-ui.js";
 import { resolveDevUiMode, resolveTuiDisplayOptions } from "#cli/dev/ui-options.js";
 import {
   registerAcpCommand,
@@ -19,7 +20,6 @@ import {
 import {
   FORCED_EXIT_BACKSTOP_MS,
   installShutdownSignal,
-  type CommandLifecycle,
   waitForShutdownSignal,
 } from "#cli/shutdown.js";
 import { waitForServerOrStop, waitForUiOrServer } from "#cli/dev/wait-for-ui.js";
@@ -40,11 +40,6 @@ import {
   parseStatsMode,
 } from "#cli/option-parsers.js";
 import type { AgentReasoningDefinition } from "#shared/agent-definition.js";
-import { resolveTuiTitle, type DevelopmentTuiTarget } from "#cli/dev/tui/target.js";
-import {
-  resumeDevelopmentRuntimeArtifacts,
-  suspendDevelopmentRuntimeArtifacts,
-} from "#services/dev-client/runtime-artifacts.js";
 import { parseDevelopmentServerUrl } from "#cli/dev/url.js";
 import { startCliLiveRow } from "#cli/ui/live-row.js";
 import { createCliTheme, renderCliTaggedLine } from "#cli/ui/output.js";
@@ -398,69 +393,6 @@ function createCliProgram(
           serverUrl: remoteServerUrl,
         });
       }
-      const runInteractiveUi = async (
-        input: {
-          readonly appRoot?: string;
-          readonly serverUrl: string;
-        },
-        report?: DevBootProgressReporter,
-        lifecycle?: CommandLifecycle,
-        startup?: DevelopmentTuiStartup,
-      ): Promise<void> => {
-        const runDevelopmentTui = await devBootPhase(
-          "loading interactive UI",
-          async () =>
-            runtime.runDevelopmentTui ?? (await loadDevelopmentTuiModule()).runDevelopmentTui,
-          report,
-        );
-        const display = resolveTuiDisplayOptions(options);
-        const target: DevelopmentTuiTarget =
-          remoteServerUrl === undefined || existingLocalDevelopmentServer
-            ? {
-                kind: "local",
-                serverUrl: input.serverUrl,
-                workspaceRoot: input.appRoot ?? applicationContext.root,
-              }
-            : {
-                kind: "remote",
-                serverUrl: input.serverUrl,
-                workspaceRoot: applicationContext.root,
-              };
-        const title = resolveTuiTitle({ name: options.name, target });
-        if (title !== undefined) display.name = title;
-        const tuiInput: RunDevelopmentTuiInput = {
-          target,
-          initialInput: options.input,
-          onBootProgress: report,
-          lifecycle,
-          ...display,
-        };
-        if (startup !== undefined) tuiInput.startup = startup;
-        if (target.kind === "local") {
-          tuiInput.withExclusiveTerminal = async <T>(task: () => Promise<T>): Promise<T> => {
-            const run = async (): Promise<T> => {
-              if (!(await suspendDevelopmentRuntimeArtifacts({ serverUrl: input.serverUrl }))) {
-                throw new Error("Could not pause the development server for integration setup.");
-              }
-              try {
-                return await task();
-              } finally {
-                await resumeDevelopmentRuntimeArtifacts({
-                  serverUrl: input.serverUrl,
-                  silent: true,
-                });
-              }
-            };
-            return await run();
-          };
-        }
-        if (remoteTarget?.headers !== undefined) {
-          await runDevelopmentTui({ ...tuiInput, headers: remoteTarget.headers });
-        } else {
-          await runDevelopmentTui(tuiInput);
-        }
-      };
-
       if (remoteServerUrl) {
         const { loadDevelopmentEnvironmentFiles } = await import("#cli/dev/environment.js");
         loadDevelopmentEnvironmentFiles(applicationContext.root);
@@ -481,7 +413,15 @@ function createCliProgram(
         logger.log("");
         const lifecycle = installShutdownSignal({ exitAfterMs: FORCED_EXIT_BACKSTOP_MS });
         try {
-          await runInteractiveUi({ serverUrl: remoteServerUrl }, undefined, lifecycle);
+          await runInteractiveDevelopmentUi({
+            applicationRoot: applicationContext.root,
+            existingLocalServer: existingLocalDevelopmentServer,
+            lifecycle,
+            options,
+            remoteTarget,
+            runDevelopmentTui: runtime.runDevelopmentTui,
+            server: { serverUrl: remoteServerUrl },
+          });
         } finally {
           lifecycle.dispose();
         }
@@ -574,12 +514,16 @@ function createCliProgram(
           lifecycle,
           server,
           runUi: async () =>
-            await runInteractiveUi(
-              { appRoot: handle.appRoot, serverUrl: handle.url },
-              onBootProgress,
+            await runInteractiveDevelopmentUi({
+              applicationRoot: applicationContext.root,
+              existingLocalServer: false,
               lifecycle,
-              tuiStartup,
-            ),
+              options,
+              report: onBootProgress,
+              runDevelopmentTui: runtime.runDevelopmentTui,
+              server: { appRoot: handle.appRoot, serverUrl: handle.url },
+              startup: tuiStartup,
+            }),
         });
       } finally {
         buildProgress?.stop();

--- a/packages/eve/src/cli/run.ts
+++ b/packages/eve/src/cli/run.ts
@@ -25,7 +25,7 @@ import {
 import { waitForServerOrStop, waitForUiOrServer } from "#cli/dev/wait-for-ui.js";
 import { parseDevelopmentHeaderOption, resolveDevelopmentUrlTarget } from "#cli/dev/url-target.js";
 import type { DevelopmentCliOptions, ProductionCliOptions } from "#cli/dev/command-options.js";
-import type { RunDevelopmentTuiInput } from "#cli/dev/tui/tui.js";
+import type { DevelopmentTuiStartup, RunDevelopmentTuiInput } from "#cli/dev/tui/tui.js";
 import type { EvalCliOptions } from "#evals/cli/eval.js";
 import {
   registerRuntimeInvokeCommand,
@@ -127,8 +127,8 @@ async function loadPrintApplicationInfo(): Promise<CliRuntimeDependencies["print
   return (await import("#cli/commands/info.js")).printApplicationInfo;
 }
 
-async function loadRunDevelopmentTui(): Promise<CliRuntimeDependencies["runDevelopmentTui"]> {
-  return (await import("#cli/dev/tui/tui.js")).runDevelopmentTui;
+async function loadDevelopmentTuiModule() {
+  return await import("#cli/dev/tui/tui.js");
 }
 
 async function loadRunEvalCommand(): Promise<CliRuntimeDependencies["runEvalCommand"]> {
@@ -405,10 +405,12 @@ function createCliProgram(
         },
         report?: DevBootProgressReporter,
         lifecycle?: CommandLifecycle,
+        startup?: DevelopmentTuiStartup,
       ): Promise<void> => {
         const runDevelopmentTui = await devBootPhase(
           "loading interactive UI",
-          async () => runtime.runDevelopmentTui ?? (await loadRunDevelopmentTui()),
+          async () =>
+            runtime.runDevelopmentTui ?? (await loadDevelopmentTuiModule()).runDevelopmentTui,
           report,
         );
         const display = resolveTuiDisplayOptions(options);
@@ -433,6 +435,7 @@ function createCliProgram(
           lifecycle,
           ...display,
         };
+        if (startup !== undefined) tuiInput.startup = startup;
         if (target.kind === "local") {
           tuiInput.withExclusiveTerminal = async <T>(task: () => Promise<T>): Promise<T> => {
             const run = async (): Promise<T> => {
@@ -504,6 +507,20 @@ function createCliProgram(
         },
       });
 
+      let tuiStartup: DevelopmentTuiStartup | undefined;
+      const tuiStartupPromise =
+        mode === "tui" && runtime.runDevelopmentTui === undefined
+          ? loadDevelopmentTuiModule().then((module) => {
+              onBootProgress({ type: "before-first-paint" });
+              return module.startDevelopmentTuiStartup({
+                appRoot: applicationContext.root,
+                initialInput: options.input,
+                onExitRequest: lifecycle.requestStop,
+                ...resolveTuiDisplayOptions(options),
+              });
+            })
+          : undefined;
+
       try {
         const startHost = runtime.startHost ?? (await loadStartHost());
         server = startHost(applicationContext.root, {
@@ -512,12 +529,20 @@ function createCliProgram(
           onBootProgress,
           port: options.port,
         });
-        const outcome = await Promise.race([
-          server.start().then((handle) => ({ handle })),
-          lifecycle.stopped.then(() => ({ handle: undefined })),
+        const [outcome, startup] = await Promise.all([
+          Promise.race([
+            server.start().then((handle) => ({ handle })),
+            lifecycle.stopped.then(() => ({ handle: undefined })),
+          ]),
+          tuiStartupPromise,
         ]);
         const handle = outcome.handle;
-        if (handle === undefined) return;
+        if (handle === undefined) {
+          tuiStartup = startup;
+          await tuiStartup?.shutdown();
+          return;
+        }
+        tuiStartup = startup;
 
         if (mode !== "tui") {
           logger.log(
@@ -553,10 +578,15 @@ function createCliProgram(
               { appRoot: handle.appRoot, serverUrl: handle.url },
               onBootProgress,
               lifecycle,
+              tuiStartup,
             ),
         });
       } finally {
         buildProgress?.stop();
+        if (tuiStartup === undefined) {
+          tuiStartup = await tuiStartupPromise?.catch(() => undefined);
+          await tuiStartup?.shutdown();
+        }
         await closeServer();
         lifecycle.dispose();
       }


### PR DESCRIPTION
### Summary

The `eve dev` TUI currently stays hidden until the local agent is fully built and its endpoint is live. This change progressively discloses the TUI: it immediately paints the branded agent card, Tip, and an editing-only prompt while the agent build and endpoint-readiness work continue concurrently. Once the endpoint is ready, the existing renderer transfers the startup draft into the normal prompt and enables submission; Ctrl-C and startup failures retain the existing terminal cleanup behavior. The card is also simplified to omit model, instructions, tools, skills, subagents, and schedules; live model information remains available in the status line.

### Validation

Focused CLI, structural, and TUI coverage passes with 354 tests, including inert Enter behavior, Ctrl-C, post-probe draft handoff, the compact agent card, and the source file line-count limit. An isolated PTY smoke test also confirmed that text sent immediately after process spawn remains visible through endpoint startup and can be submitted afterward; five-run comparison testing reduced mean time to rendered typed text from 1,534.7 ms to 301.6 ms.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

A patch changeset describes the progressive startup and simplified card.

**Implementation** — 6 files · `+247 / -218`

The TUI renderer begins accepting draft edits while local agent build and endpoint startup proceed concurrently, then hands that state to the normal runner when the endpoint is ready. Removing the card's agent-detail section deletes its formatting and grouping machinery, while interactive launch orchestration is isolated from the CLI command registry.

**Tests** — 3 files · `+114 / -146`

Focused tests cover the compact card, startup input ownership, inert submission, cancellation, and draft transfer after the asynchronous agent-info probe; obsolete detail-layout fixtures are removed.
