### PR TITLE
docs(agents): add security baseline to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,3 +235,28 @@ changed and what they'll see differently, in 1–2 sentences.
 
 Docs-only, internal-tooling, and fixture changes do not need a changeset. When
 in doubt, add one.
+
+## Security
+
+Baseline invariants for authorization, injection, disclosure, and untrusted
+input. Use established patterns in the codebase when existing (libraries, etc.)
+instead of reinventing the wheel.
+
+- **Authorize every access on the server, keyed to the resource.** Check the
+  caller's session against the specific resource id from the request — never
+  trust a client-supplied id, role, or `isAdmin` flag (IDOR / privilege
+  escalation).
+- **Never render untrusted input as HTML.** Use framework escaping (JSX text) or
+  an explicit sanitizer — no `dangerouslySetInnerHTML`, `innerHTML`, or HTML
+  built from template literals on user or third-party data (XSS).
+- **Errors and logs must not leak internals.** Client-facing errors stay
+  generic; stack traces, SQL, internal hostnames, tokens, and other users' data
+  go to server logs only — and logs never persist secrets, credentials, or PII
+  in cleartext.
+- **Bound work derived from untrusted input.** Request-driven loops, pagination,
+  recursion, and body/file reads need explicit caps (page size, timeout, max
+  depth, max bytes) so one caller can't force unbounded work.
+- **Validate outbound destinations before fetching.** Server-side fetches,
+  webhooks, and imports whose URL or host comes from user input must block
+  access to internal resources (SSRF). Could use the NPM guarded-fetch library
+  or @vercel/safe-fetch when available.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,5 +258,5 @@ instead of reinventing the wheel.
   depth, max bytes) so one caller can't force unbounded work.
 - **Validate outbound destinations before fetching.** Server-side fetches,
   webhooks, and imports whose URL or host comes from user input must block
-  access to internal resources (SSRF). Could use the NPM guarded-fetch library
-  or @vercel/safe-fetch when available.
+  access to internal resources (SSRF). Use established patterns / libraries from
+  the project already.


### PR DESCRIPTION
## What

Adds a shared **Security** section of baseline invariants to this repo's agent-context file — authorization, injection, disclosure, bounded work, and outbound-destination validation.

## Why

We've seen patterns in the vuln reports we get and this is a light way of steering agents to fix those patterns when working in the repo.