### PR TITLE
feat(eve): UCP connection preset and checkout-handoff contract

### DIFF
--- a/.changeset/ucp-commerce-agents.md
+++ b/.changeset/ucp-commerce-agents.md
@@ -1,0 +1,16 @@
+---
+"eve": patch
+---
+
+Add `eve/commerce/ucp` for building agents that buy over the Universal Commerce
+Protocol. `defineUcpConnection` connects to a merchant's UCP shopping service
+and takes the protocol headers off the model — agent profile identity,
+retry-safe `Idempotency-Key`/`Request-Id` derived from the replay-stable call
+id, and RFC 9421 request signing. `resolveUcpCheckoutHandoff` collapses a
+checkout response into one typed outcome: conversational continuation,
+`continue_url` redirect, or embedded checkout.
+
+OpenAPI connections also gain a `prepareRequest` hook, which receives the
+fully-built request — including the serialized body — and merges the headers it
+returns. Use it for signatures and content digests that `headers` cannot
+express.

--- a/apps/templates/commerce-agent/.env.example
+++ b/apps/templates/commerce-agent/.env.example
@@ -1,0 +1,20 @@
+# The merchant's UCP shopping endpoint, from
+# services["dev.ucp.shopping"][transport="rest"].endpoint in their
+# https://<merchant>/.well-known/ucp profile.
+UCP_MERCHANT_ENDPOINT="https://merchant.example.com/ucp/v1"
+
+# Credential the merchant issued you. UCP allows an API key or OAuth token
+# instead of message signatures.
+UCP_MERCHANT_TOKEN=""
+
+# Public https origin serving this app's /.well-known/ucp. Merchants fetch it
+# to resolve who is calling, so it must be reachable from their network.
+# Unset on Vercel, where VERCEL_PROJECT_PRODUCTION_URL is used instead.
+UCP_AGENT_ORIGIN=""
+
+# Optional: sign every request with HTTP Message Signatures (RFC 9421).
+# UCP_SIGNING_KEY_ID must match the `kid` published in /.well-known/ucp.
+# Generate a P-256 key with:
+#   node --input-type=module -e 'const k=await crypto.subtle.generateKey({name:"ECDSA",namedCurve:"P-256"},true,["sign"]);console.log(JSON.stringify(await crypto.subtle.exportKey("jwk",k.privateKey)))'
+UCP_SIGNING_KEY_ID=""
+UCP_SIGNING_KEY_JWK=""

--- a/apps/templates/commerce-agent/.gitignore
+++ b/apps/templates/commerce-agent/.gitignore
@@ -1,0 +1,48 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# env files (can opt-in for committing if needed)
+.env*
+!.env.example
+
+# eve
+.eve
+.swc
+.output
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts
+.env*.local

--- a/apps/templates/commerce-agent/.vercelignore
+++ b/apps/templates/commerce-agent/.vercelignore
@@ -1,0 +1,9 @@
+.output
+.swc
+.eve
+.turbo
+.agents
+.github
+dist
+research
+node_modules

--- a/apps/templates/commerce-agent/README.md
+++ b/apps/templates/commerce-agent/README.md
@@ -1,0 +1,84 @@
+# Commerce agent template
+
+An eve agent that shops one merchant over the
+[Universal Commerce Protocol](https://ucp.dev/), with a Next.js front end that
+renders the checkout handoff.
+
+The template is the buying side of UCP. It does not implement a store: it
+talks to a merchant that already publishes a UCP profile.
+
+## What is in here
+
+```
+agent/
+  agent.ts                  the agent
+  instructions.md           how it works a checkout and when it stops
+  connections/merchant.ts   defineUcpConnection against the merchant endpoint
+  channels/eve.ts           chat transport for the browser client
+  channels/ucp.ts           this agent's own /.well-known/ucp profile
+lib/ucp.ts                  identity, signing key, and a small read client
+app/
+  _commerce/Chat.tsx            minimal chat, tracks the active checkout id
+  _commerce/CheckoutHandoff.tsx renders every branch of the handoff union
+  api/checkout/[id]/route.ts    re-reads the session and resolves the handoff
+```
+
+## Setup
+
+```sh
+cp .env.example .env.local   # fill in the merchant endpoint and token
+pnpm install
+pnpm dev:eve                 # eve dev
+pnpm dev                     # next dev, in a second terminal
+```
+
+`agent/connections/merchant.ts` throws at build time if
+`UCP_MERCHANT_ENDPOINT` or `UCP_AGENT_ORIGIN` is missing, rather than sending
+requests a merchant will reject.
+
+### Local development and the agent profile
+
+A merchant resolves who is calling by fetching the URL in your `UCP-Agent`
+header, so that URL has to be reachable from the merchant's network.
+`http://localhost:3000/.well-known/ucp` is not. Either point
+`UCP_AGENT_ORIGIN` at a tunnel (`ngrok http 3000`), or use the example agent
+profile the merchant publishes for testing, if they have one.
+
+Check what you are serving:
+
+```sh
+curl -i "$UCP_AGENT_ORIGIN/.well-known/ucp"
+```
+
+### Signing
+
+Signing is optional: UCP accepts an API key or OAuth token instead. Set
+`UCP_SIGNING_KEY_ID` and `UCP_SIGNING_KEY_JWK` and every request is signed per
+RFC 9421, with the public half published in `/.well-known/ucp` so the merchant
+can verify it. Merchants that require signatures answer unsigned requests with
+`signature_missing`.
+
+## How the handoff works
+
+The agent drives the checkout through connection tools. Each response says
+what has to happen next, and `resolveUcpCheckoutHandoff` turns that into one
+of three outcomes the UI can render:
+
+- **conversational** — the agent keeps working: collect what is missing and
+  call Update Checkout, or the session is ready and waiting on the buyer.
+- **embedded** — the merchant enabled Embedded Checkout for this session, so
+  their checkout loads in an iframe with the negotiated `ec_*` parameters.
+- **continue_url** — the buyer finishes on the merchant's own site.
+
+Plus the terminal `completed`, `canceled`, and `failed`.
+
+The agent never places the order on its own. UCP requires the buyer to review
+and authorize a checkout in a trusted UI, and the instructions in
+`agent/instructions.md` hold the agent to that.
+
+## Read next
+
+- [UCP commerce agents](../../../docs/protocols/ucp-agent.mdx) — the preset and
+  the handoff contract in detail.
+- [Universal Commerce Protocol (UCP)](../../../docs/protocols/ucp.mdx) —
+  publishing your own profile as a business.

--- a/apps/templates/commerce-agent/agent/agent.ts
+++ b/apps/templates/commerce-agent/agent/agent.ts
@@ -1,0 +1,5 @@
+import { defineAgent } from "eve";
+
+export default defineAgent({
+  model: "anthropic/claude-opus-4.6",
+});

--- a/apps/templates/commerce-agent/agent/channels/eve.ts
+++ b/apps/templates/commerce-agent/agent/channels/eve.ts
@@ -1,0 +1,13 @@
+import { localDev, vercelOidc } from "eve/channels/auth";
+import { eveChannel } from "eve/channels/eve";
+
+/**
+ * The chat transport the browser client talks to.
+ *
+ * `localDev` opens it up on `eve dev`; `vercelOidc` covers deployed
+ * preview and production. Add your own `AuthFn` ahead of these before
+ * exposing a real storefront to real buyers.
+ */
+export default eveChannel({
+  auth: [vercelOidc(), localDev()],
+});

--- a/apps/templates/commerce-agent/agent/channels/ucp.ts
+++ b/apps/templates/commerce-agent/agent/channels/ucp.ts
@@ -1,0 +1,27 @@
+import { defineChannel, GET } from "eve/channels";
+import { agentProfile } from "@/lib/ucp";
+
+/**
+ * Serves this agent's UCP profile.
+ *
+ * UCP has no registration step: a merchant learns who is calling by
+ * fetching the URL in the `UCP-Agent` header, and finds the public key to
+ * verify signatures in this document's `signing_keys`. If this endpoint is
+ * unreachable, merchants answer with `profile_unreachable` (HTTP 424).
+ *
+ * The spec requires HTTPS, forbids 3xx responses, and requires a
+ * `Cache-Control` of `public` with `max-age` of at least 60 seconds.
+ */
+export default defineChannel({
+  cors: true,
+  routes: [
+    GET("/.well-known/ucp", async () => {
+      return new Response(JSON.stringify(agentProfile()), {
+        headers: {
+          "cache-control": "public, max-age=300",
+          "content-type": "application/json",
+        },
+      });
+    }),
+  ],
+});

--- a/apps/templates/commerce-agent/agent/connections/merchant.ts
+++ b/apps/templates/commerce-agent/agent/connections/merchant.ts
@@ -1,0 +1,29 @@
+import { defineUcpConnection, type UcpConnectionDefinition } from "eve/commerce/ucp";
+import { agentMetadata, merchantEndpoint, signingKey } from "@/lib/ucp";
+
+const definition: UcpConnectionDefinition = {
+  agent: agentMetadata(),
+  auth: {
+    getToken: async () => ({ token: process.env.UCP_MERCHANT_TOKEN ?? "" }),
+  },
+  description:
+    "The merchant's UCP shopping service: search the catalog and drive a checkout session.",
+  endpoint: merchantEndpoint(),
+  // Checkout and catalog are what this template drives. Widen the list
+  // once the merchant's profile advertises other capabilities you want.
+  operations: {
+    allow: [
+      "cancel_checkout",
+      "complete_checkout",
+      "create_checkout",
+      "get_checkout",
+      "lookup_catalog",
+      "search_catalog",
+      "update_checkout",
+    ],
+  },
+};
+
+const signing = signingKey();
+
+export default defineUcpConnection(signing === undefined ? definition : { ...definition, signing });

--- a/apps/templates/commerce-agent/agent/instructions.md
+++ b/apps/templates/commerce-agent/agent/instructions.md
@@ -1,0 +1,41 @@
+You are a shopping assistant for one merchant. You help a buyer find items
+and get a checkout session ready, and you hand the buyer the controls before
+an order is placed.
+
+## Working the checkout
+
+Every `merchant__*_checkout` response carries a `status` and a `messages`
+array. Read both before deciding what to do next.
+
+- `incomplete`: something is missing or contested. Read `messages`. For each
+  error with `severity: "recoverable"`, gather what is needed — ask the buyer
+  in the conversation if you do not already have it — and call
+  `merchant__update_checkout` with the full checkout resource. Update
+  replaces the resource, so send every field you want to keep.
+- `ready_for_complete`: everything is collected. Do not place the order
+  yourself. Tell the buyer the checkout is ready and let them review it.
+- `complete_in_progress`: the merchant is placing the order. Call
+  `merchant__get_checkout` to follow it rather than retrying the completion.
+- `requires_escalation`: the buyer has to take over on the merchant's own
+  surface. Say what is needed, in the buyer's words, and stop calling
+  checkout operations. The app renders the handoff.
+- `completed` / `canceled`: terminal. Report the order or offer to start over.
+
+Any message with `severity: "requires_buyer_input"` or
+`"requires_buyer_review"` means the buyer must act, whatever the status says.
+Summarize it and stop.
+
+## What you never do
+
+- Never invent buyer details: addresses, emails, and payment instruments come
+  from the buyer or from what the merchant already has.
+- Never call `merchant__complete_checkout` on your own initiative. The buyer
+  reviews and authorizes the order; you prepare it.
+- Never state a total, tax, shipping cost, or availability that did not come
+  from a merchant response.
+
+## Talking to the buyer
+
+Be brief and concrete. Name items, quantities, and amounts exactly as the
+merchant reported them. When you are blocked, say what you need in one
+sentence and ask for that one thing.

--- a/apps/templates/commerce-agent/app/_commerce/Chat.tsx
+++ b/apps/templates/commerce-agent/app/_commerce/Chat.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { defaultMessageReducer, useEveAgent, type EveMessage } from "eve/react";
+import { type FormEvent, useMemo, useState } from "react";
+
+import { CheckoutHandoff } from "./CheckoutHandoff";
+
+const MERCHANT_TOOL_PREFIX = "merchant__";
+
+export function Chat() {
+  const reducer = useMemo(() => defaultMessageReducer(), []);
+  const agent = useEveAgent({ reducer });
+  const [draft, setDraft] = useState("");
+
+  const messages = agent.data.messages;
+  const checkout = latestCheckout(messages);
+  const isBusy = agent.status === "submitted" || agent.status === "streaming";
+
+  async function onSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const text = draft.trim();
+    if (text.length === 0 || isBusy) {
+      return;
+    }
+    setDraft("");
+    await agent.send(text);
+  }
+
+  return (
+    <main className="layout">
+      <section className="conversation">
+        <ul className="feed">
+          {messages.map((message) => (
+            <li className={`row role-${message.role}`} key={message.id}>
+              <div className="bubble">{renderText(message)}</div>
+            </li>
+          ))}
+          {isBusy ? (
+            <li className="row role-assistant">
+              <div className="bubble muted">Thinking…</div>
+            </li>
+          ) : null}
+        </ul>
+
+        <form className="composer" onSubmit={onSubmit}>
+          <input
+            aria-label="Message"
+            onChange={(event) => setDraft(event.target.value)}
+            placeholder="What are you shopping for?"
+            value={draft}
+          />
+          <button disabled={isBusy || draft.trim().length === 0} type="submit">
+            Send
+          </button>
+        </form>
+      </section>
+
+      {checkout === undefined ? null : (
+        // Keying on the tool call remounts the panel for each new merchant
+        // response, so the handoff is re-resolved from fresh state.
+        <CheckoutHandoff
+          checkoutId={checkout.checkoutId}
+          key={`${checkout.checkoutId}:${checkout.toolCallId}`}
+        />
+      )}
+    </main>
+  );
+}
+
+function renderText(message: EveMessage): string {
+  return message.parts
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .join("");
+}
+
+/**
+ * Finds the checkout the merchant most recently reported on.
+ *
+ * The id is all this takes from the stream; the panel re-reads the
+ * session server-side rather than trusting the browser's copy.
+ */
+function latestCheckout(
+  messages: readonly EveMessage[],
+): { checkoutId: string; toolCallId: string } | undefined {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const parts = messages[index]?.parts ?? [];
+    for (let partIndex = parts.length - 1; partIndex >= 0; partIndex--) {
+      const part = parts[partIndex];
+      if (
+        part === undefined ||
+        part.type !== "dynamic-tool" ||
+        part.state !== "output-available" ||
+        !part.toolName.startsWith(MERCHANT_TOOL_PREFIX)
+      ) {
+        continue;
+      }
+      const checkoutId = readCheckoutId(part.output);
+      if (checkoutId !== undefined) {
+        return { checkoutId, toolCallId: part.toolCallId };
+      }
+    }
+  }
+  return undefined;
+}
+
+function readCheckoutId(output: unknown): string | undefined {
+  if (typeof output !== "object" || output === null) {
+    return undefined;
+  }
+  const body = (output as { body?: unknown }).body;
+  if (typeof body !== "object" || body === null) {
+    return undefined;
+  }
+  const id = (body as { id?: unknown }).id;
+  return typeof id === "string" && id.length > 0 ? id : undefined;
+}

--- a/apps/templates/commerce-agent/app/_commerce/CheckoutHandoff.tsx
+++ b/apps/templates/commerce-agent/app/_commerce/CheckoutHandoff.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import type { UcpCheckoutHandoff } from "eve/commerce/ucp";
+import { useEffect, useState } from "react";
+
+/**
+ * Renders the three ways a checkout can continue.
+ *
+ * Every branch of the union is handled here, which is the point of the
+ * contract: `conversational` means the agent is still working and the panel
+ * stays out of the way, `embedded` means the merchant's own checkout can be
+ * framed in place, and `continue_url` means the buyer leaves for the
+ * merchant's site.
+ */
+export function CheckoutHandoff(props: { readonly checkoutId: string }) {
+  const handoff = useHandoff(props.checkoutId);
+
+  if (handoff === undefined) {
+    return <aside className="panel">Reading checkout…</aside>;
+  }
+
+  switch (handoff.kind) {
+    case "conversational":
+      return (
+        <aside className="panel">
+          <h2>Working on it</h2>
+          <p className="muted">Next step: {handoff.next}</p>
+          <Messages messages={handoff.blockers} />
+        </aside>
+      );
+
+    case "embedded":
+      return (
+        <aside className="panel">
+          <h2>Review and place your order</h2>
+          <iframe
+            allow="payment"
+            className="embedded-checkout"
+            src={handoff.url}
+            title="Merchant checkout"
+          />
+          <p className="muted">
+            <a href={handoff.continueUrl} rel="noreferrer" target="_blank">
+              Open on the merchant's site instead
+            </a>
+          </p>
+        </aside>
+      );
+
+    case "continue_url":
+      return (
+        <aside className="panel">
+          <h2>Finish on the merchant's site</h2>
+          <Messages messages={handoff.messages} />
+          <a className="button" href={handoff.url} rel="noreferrer" target="_blank">
+            Continue checkout
+          </a>
+        </aside>
+      );
+
+    case "completed":
+      return (
+        <aside className="panel">
+          <h2>Order placed</h2>
+          {handoff.order?.permalink_url === undefined ? (
+            <p className="muted">Order {handoff.order?.id ?? handoff.checkoutId}</p>
+          ) : (
+            <a href={handoff.order.permalink_url} rel="noreferrer" target="_blank">
+              View your order
+            </a>
+          )}
+        </aside>
+      );
+
+    case "canceled":
+      return (
+        <aside className="panel">
+          <h2>Checkout canceled</h2>
+          <p className="muted">Start a new one to keep shopping.</p>
+        </aside>
+      );
+
+    case "failed":
+      return (
+        <aside className="panel variant-error">
+          <h2>Checkout unavailable</h2>
+          <p className="muted">{handoff.reason}</p>
+          <Messages messages={handoff.messages} />
+          {handoff.continueUrl === undefined ? null : (
+            <a className="button" href={handoff.continueUrl} rel="noreferrer" target="_blank">
+              Open the merchant's site
+            </a>
+          )}
+        </aside>
+      );
+  }
+}
+
+function Messages(props: { readonly messages: UcpCheckoutHandoff["messages"] }) {
+  if (props.messages.length === 0) {
+    return null;
+  }
+  return (
+    <ul className="messages">
+      {props.messages.map((message, index) => (
+        <li className={`message type-${message.type}`} key={`${message.code ?? "m"}:${index}`}>
+          {message.content ?? message.code ?? message.type}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function useHandoff(checkoutId: string): UcpCheckoutHandoff | undefined {
+  const [handoff, setHandoff] = useState<UcpCheckoutHandoff | undefined>(undefined);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setHandoff(undefined);
+
+    void fetch(`/api/checkout/${encodeURIComponent(checkoutId)}`, { signal: controller.signal })
+      .then((response) => response.json() as Promise<UcpCheckoutHandoff>)
+      .then(setHandoff)
+      .catch(() => {
+        if (!controller.signal.aborted) {
+          setHandoff({ kind: "failed", messages: [], reason: "http_error" });
+        }
+      });
+
+    return () => controller.abort();
+  }, [checkoutId]);
+
+  return handoff;
+}

--- a/apps/templates/commerce-agent/app/api/checkout/[id]/route.ts
+++ b/apps/templates/commerce-agent/app/api/checkout/[id]/route.ts
@@ -1,0 +1,30 @@
+import { resolveUcpCheckoutHandoff } from "eve/commerce/ucp";
+import { getCheckout } from "@/lib/ucp";
+
+/**
+ * Resolves what should happen next for one checkout session.
+ *
+ * The state is re-read from the merchant rather than taken from the
+ * browser, so the handoff — and the embedded URL it may contain — is
+ * derived from the merchant's own response.
+ */
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const { id } = await context.params;
+
+  try {
+    const handoff = resolveUcpCheckoutHandoff(await getCheckout(id), {
+      // Delegations this app is prepared to handle natively. The merchant
+      // intersects them with what it allows for the session.
+      embedded: { delegate: ["fulfillment.address_change", "window.open"] },
+    });
+    return Response.json(handoff, { headers: { "cache-control": "no-store" } });
+  } catch (error) {
+    return Response.json(
+      { kind: "failed", messages: [], reason: "http_error", error: String(error) },
+      { status: 502 },
+    );
+  }
+}

--- a/apps/templates/commerce-agent/app/globals.css
+++ b/apps/templates/commerce-agent/app/globals.css
@@ -1,0 +1,166 @@
+:root {
+  --bg: #0b0b0c;
+  --fg: #ededed;
+  --muted: #9a9a9f;
+  --line: #26262a;
+  --accent: #4a7cff;
+  --error: #ff6b6b;
+  color-scheme: dark;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  background: var(--bg);
+  color: var(--fg);
+  font-family:
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    sans-serif;
+  margin: 0;
+}
+
+.layout {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 1fr);
+  margin: 0 auto;
+  max-width: 1080px;
+  min-height: 100dvh;
+  padding: 32px 24px;
+}
+
+@media (min-width: 900px) {
+  .layout:has(.panel) {
+    grid-template-columns: minmax(0, 1fr) 380px;
+  }
+}
+
+.conversation {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-height: 0;
+}
+
+.feed {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 12px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.row {
+  display: flex;
+}
+
+.row.role-user {
+  justify-content: flex-end;
+}
+
+.bubble {
+  background: #16161a;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  max-width: 46ch;
+  padding: 10px 14px;
+  white-space: pre-wrap;
+}
+
+.row.role-user .bubble {
+  background: var(--accent);
+  border-color: transparent;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.composer {
+  display: flex;
+  gap: 8px;
+}
+
+.composer input {
+  background: #16161a;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  color: inherit;
+  flex: 1;
+  font: inherit;
+  padding: 10px 12px;
+}
+
+.composer button,
+.button {
+  background: var(--accent);
+  border: none;
+  border-radius: 10px;
+  color: #fff;
+  cursor: pointer;
+  display: inline-block;
+  font: inherit;
+  padding: 10px 16px;
+  text-decoration: none;
+}
+
+.composer button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.panel {
+  align-self: start;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 20px;
+}
+
+.panel h2 {
+  font-size: 15px;
+  letter-spacing: 0.01em;
+  margin: 0;
+}
+
+.panel.variant-error {
+  border-color: var(--error);
+}
+
+.embedded-checkout {
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  height: 560px;
+  width: 100%;
+}
+
+.messages {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.message {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.message.type-error {
+  color: var(--error);
+}
+
+a {
+  color: var(--accent);
+}

--- a/apps/templates/commerce-agent/app/layout.tsx
+++ b/apps/templates/commerce-agent/app/layout.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+import "./globals.css";
+
+export const metadata: Metadata = {
+  description: "A shopping agent that talks to a merchant over the Universal Commerce Protocol.",
+  title: "Commerce agent",
+};
+
+export default function RootLayout(props: { readonly children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{props.children}</body>
+    </html>
+  );
+}

--- a/apps/templates/commerce-agent/app/page.tsx
+++ b/apps/templates/commerce-agent/app/page.tsx
@@ -1,0 +1,5 @@
+import { Chat } from "./_commerce/Chat";
+
+export default function Home() {
+  return <Chat />;
+}

--- a/apps/templates/commerce-agent/lib/ucp.ts
+++ b/apps/templates/commerce-agent/lib/ucp.ts
@@ -1,0 +1,135 @@
+/**
+ * Everything this app needs to act as a UCP platform: who it says it is,
+ * the key it signs with, and a small client for the reads the UI needs.
+ *
+ * The agent connection (`agent/connections/merchant.ts`) and the checkout
+ * route both read from here so the identity on the wire is the same one
+ * published at `/.well-known/ucp`.
+ */
+
+import {
+  createUcpSigner,
+  ucpAgentHeaderValue,
+  UCP_VERSION,
+  type UcpAgentMetadata,
+  type UcpSigner,
+  type UcpSigningKey,
+} from "eve/commerce/ucp";
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (value === undefined || value.length === 0) {
+    throw new Error(`Missing ${name}. Copy .env.example to .env.local and fill it in.`);
+  }
+  return value;
+}
+
+/**
+ * Public origin of this deployment.
+ *
+ * Merchants fetch the agent profile from here, so it has to be a host
+ * they can reach — a `localhost` dev server is not one. See the README
+ * for how to test locally.
+ */
+export function publicOrigin(): string {
+  const configured = process.env.UCP_AGENT_ORIGIN;
+  if (configured !== undefined && configured.length > 0) {
+    return configured.replace(/\/$/, "");
+  }
+  const vercel = process.env.VERCEL_PROJECT_PRODUCTION_URL ?? process.env.VERCEL_URL;
+  if (vercel !== undefined && vercel.length > 0) {
+    return `https://${vercel}`;
+  }
+  throw new Error("Set UCP_AGENT_ORIGIN to the public https origin serving /.well-known/ucp.");
+}
+
+/** Identity this agent advertises to merchants on every request. */
+export function agentMetadata(): UcpAgentMetadata {
+  return { profile: `${publicOrigin()}/.well-known/ucp` };
+}
+
+/** The merchant's REST endpoint from their `/.well-known/ucp` profile. */
+export function merchantEndpoint(): string {
+  return required("UCP_MERCHANT_ENDPOINT");
+}
+
+/**
+ * The signing key, when one is configured.
+ *
+ * UCP lets a platform authenticate with an API key alone, so signing is
+ * optional here; merchants that require signatures answer unsigned
+ * requests with `signature_missing`.
+ */
+export function signingKey(): UcpSigningKey | undefined {
+  const jwk = process.env.UCP_SIGNING_KEY_JWK;
+  const keyId = process.env.UCP_SIGNING_KEY_ID;
+  if (jwk === undefined || jwk.length === 0 || keyId === undefined || keyId.length === 0) {
+    return undefined;
+  }
+  return { keyId, privateKey: JSON.parse(jwk) as Record<string, string> };
+}
+
+/**
+ * This agent's UCP profile document.
+ *
+ * The public half of the signing key goes here: it is how a merchant
+ * verifies a signature it just received, and the `kid` must match the
+ * `keyid` the signer emits.
+ */
+export function agentProfile(): Record<string, unknown> {
+  const key = signingKey();
+  const signingKeys: Record<string, unknown>[] = [];
+  if (key !== undefined && typeof key.privateKey !== "string") {
+    const { d: _private, ...publicJwk } = key.privateKey as Record<string, string>;
+    signingKeys.push({ ...publicJwk, alg: "ES256", kid: key.keyId, use: "sig" });
+  }
+
+  return {
+    signing_keys: signingKeys,
+    ucp: {
+      capabilities: {
+        "dev.ucp.shopping.checkout": [{ version: UCP_VERSION }],
+      },
+      version: UCP_VERSION,
+    },
+  };
+}
+
+let signer: UcpSigner | undefined;
+
+/**
+ * Reads one checkout session straight from the merchant.
+ *
+ * The agent drives create/update/complete through its connection; the UI
+ * reads state here so what it renders comes from the merchant rather than
+ * from whatever the browser happens to be holding.
+ */
+export async function getCheckout(
+  id: string,
+): Promise<{ status: number; statusText: string; body: unknown }> {
+  const url = `${merchantEndpoint()}/checkout-sessions/${encodeURIComponent(id)}`;
+  const headers: Record<string, string> = {
+    accept: "application/json",
+    authorization: `Bearer ${required("UCP_MERCHANT_TOKEN")}`,
+    "Request-Id": crypto.randomUUID(),
+    "UCP-Agent": ucpAgentHeaderValue(agentMetadata()),
+  };
+
+  const key = signingKey();
+  if (key !== undefined) {
+    signer ??= createUcpSigner(key);
+    Object.assign(headers, await signer({ headers, method: "GET", url }));
+  }
+
+  const response = await fetch(url, { headers });
+  const text = await response.text();
+  let body: unknown = null;
+  if (text.length > 0) {
+    try {
+      body = JSON.parse(text);
+    } catch {
+      body = text;
+    }
+  }
+  return { body, status: response.status, statusText: response.statusText };
+}

--- a/apps/templates/commerce-agent/next.config.ts
+++ b/apps/templates/commerce-agent/next.config.ts
@@ -1,0 +1,6 @@
+import { withEve } from "eve/next";
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {};
+
+export default withEve(nextConfig);

--- a/apps/templates/commerce-agent/package.json
+++ b/apps/templates/commerce-agent/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "commerce-agent-template",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "next build",
+    "dev": "next dev",
+    "dev:eve": "eve dev",
+    "build:eve": "eve build",
+    "typecheck": "tsc"
+  },
+  "dependencies": {
+    "eve": "workspace:*",
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "typescript": "6.0.3"
+  }
+}

--- a/apps/templates/commerce-agent/tsconfig.json
+++ b/apps/templates/commerce-agent/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/docs/connections/openapi.mdx
+++ b/docs/connections/openapi.mdx
@@ -92,6 +92,26 @@ eve removes configured keys from every operation's model-facing input schema and
 
 Use `headers` for transport-wide headers that are not operation inputs. Use `providedArguments` when the OpenAPI document declares the value as an operation parameter and it should remain outside model control. Approval policies continue to receive only the model-authored input.
 
+## Sign or digest the outgoing request
+
+`headers` and `providedArguments` are both resolved before the request body exists, so neither can produce a value that depends on the bytes being sent. `prepareRequest` runs after the request is fully built and merges the headers it returns:
+
+```ts title="agent/connections/ledger.ts"
+import { defineOpenAPIConnection } from "eve/connections";
+
+export default defineOpenAPIConnection({
+  spec: "https://api.example.com/openapi.json",
+  description: "Ledger entries and balances.",
+  prepareRequest: async ({ method, url, body }) => ({
+    "X-Signature": await sign(`${method} ${new URL(url).pathname}\n${body ?? ""}`),
+  }),
+});
+```
+
+It receives the uppercase `method`, the absolute `url` including the query string, the `headers` already resolved for the request (auth, static headers, and header parameters), the serialized `body` when there is one, and the replay-stable `callId` plus the bare `toolName`. Return `undefined` to leave the request unchanged. Throwing fails the tool call before anything is sent.
+
+This is where HTTP Message Signatures, content digests, and request-signing schemes such as AWS SigV4 belong. Body-independent values belong in `headers`, and operation parameters in `providedArguments`. For UCP specifically, [`defineUcpConnection`](../protocols/ucp-agent) already wires this up.
+
 ## Operation filters
 
 Most OpenAPI specs describe far more than the model should use. Narrow generated tools with exactly one of `operations.allow` or `operations.block`:

--- a/docs/protocols/meta.json
+++ b/docs/protocols/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Protocols",
   "defaultOpen": false,
-  "pages": ["acp", "ucp"]
+  "pages": ["acp", "ucp", "ucp-agent"]
 }

--- a/docs/protocols/ucp-agent.mdx
+++ b/docs/protocols/ucp-agent.mdx
@@ -1,0 +1,261 @@
+---
+title: "UCP Commerce Agents"
+description: "Connect an eve agent to a merchant's UCP shopping service, and resolve what happens after each checkout response."
+---
+
+The [Universal Commerce Protocol](https://ucp.dev/) (UCP) has two sides. A
+business publishes a profile and serves commerce endpoints — see
+[Universal Commerce Protocol (UCP)](./ucp) for that. This page is the other
+side: your agent as the **platform**, calling a merchant that already speaks
+UCP.
+
+Two pieces cover it:
+
+- `defineUcpConnection` — a connection preset that owns identity, retry-safe
+  request ids, and request signing, so the model never sees them.
+- `resolveUcpCheckoutHandoff` — turns a checkout response into one typed
+  answer: keep going in the conversation, hand the buyer off to the merchant's
+  site, or embed the merchant's checkout.
+
+## Connect to a merchant
+
+Take the merchant's REST endpoint from their profile at
+`https://<merchant>/.well-known/ucp`, under
+`services["dev.ucp.shopping"]` where `transport` is `"rest"`:
+
+```ts title="agent/connections/acme.ts"
+import { defineUcpConnection } from "eve/commerce/ucp";
+
+export default defineUcpConnection({
+  endpoint: "https://acme.example.com/ucp/v1",
+  description: "Acme storefront: catalog search and checkout.",
+  agent: { profile: "https://my-agent.example.com/.well-known/ucp" },
+  auth: { getToken: async () => ({ token: process.env.ACME_TOKEN! }) },
+});
+```
+
+The connection name comes from the filename, so this registers as `acme` and
+its operations become `acme__create_checkout`, `acme__update_checkout`, and so
+on. `endpoint` is required: the canonical contract declares its server as a
+template variable with a placeholder default, so there is nothing safe to fall
+back to.
+
+By default the preset loads the canonical UCP shopping REST contract for the
+version in `UCP_VERSION`. Pass `version` for a merchant on an older version, or
+`spec` to use a contract the merchant publishes themselves.
+
+### What the preset takes off the model's plate
+
+The published UCP contract types `UCP-Agent`, `Idempotency-Key`, `Request-Id`,
+`Authorization`, `Signature`, `Signature-Input`, and `Content-Digest` as
+ordinary header parameters — and marks the first three **required**. Wired up as
+a plain [OpenAPI connection](../connections/openapi), all of them land in the
+model-facing input schema, and the model is asked to invent your identity, your
+credentials, and your signatures.
+
+The preset makes them application-owned instead. `acme__create_checkout` is
+left with `body`; `acme__get_checkout` with `id`. A value the model does try to
+pass for one of those headers is discarded, so a prompt-injected
+`Authorization` cannot displace the connection's own credential.
+
+`Accept`, `Accept-Encoding`, `Accept-Language`, `Content-Type`, and
+`User-Agent` are hidden too. To send one anyway, name it in
+`providedArguments`, which is applied last:
+
+```ts
+export default defineUcpConnection({
+  // ...
+  providedArguments: { "Accept-Language": ({ session }) => localeFor(session) },
+});
+```
+
+### Agent profile metadata
+
+`agent.profile` is the URL the merchant fetches to find out who is calling.
+UCP has no registration step, so this document is your identity: it declares
+your capabilities and publishes the `signing_keys` a merchant uses to verify
+your signatures. The preset serializes it into
+`UCP-Agent: profile="..."` on every request.
+
+It must be an absolute `https` URL reachable from the merchant's network —
+`defineUcpConnection` throws otherwise. That rules out `localhost`, so during
+local development either expose the route through a tunnel or use an example
+agent profile the merchant publishes for testing.
+
+Serve your own profile from a [custom channel](../channels/custom):
+
+```ts title="agent/channels/ucp.ts"
+import { defineChannel, GET } from "eve/channels";
+import { profile } from "../ucp-profile";
+
+export default defineChannel({
+  cors: true,
+  routes: [
+    GET(
+      "/.well-known/ucp",
+      async () =>
+        new Response(JSON.stringify(profile), {
+          headers: {
+            "content-type": "application/json",
+            "cache-control": "public, max-age=300",
+          },
+        }),
+    ),
+  ],
+});
+```
+
+### Retry-safe request ids
+
+UCP handles replay protection at the business layer: a repeated
+`Idempotency-Key` returns the cached response instead of re-executing, which is
+what stops a retried Complete Checkout from placing a second order.
+
+The preset derives both `Idempotency-Key` and `Request-Id` from eve's
+replay-stable `callId`, so a durable turn that resumes and re-issues the same
+tool call sends the same key and the merchant recognizes it as a retry.
+`Idempotency-Key` is sent on `POST`, `PUT`, `PATCH`, and `DELETE`; reads get a
+`Request-Id` only.
+
+Two different tool calls always get different keys, so the model retrying an
+operation with corrected inputs is a new request, not a replay.
+
+### Signing
+
+Signing is optional in UCP: a platform may authenticate with an API key,
+OAuth, or mTLS instead. When you do sign, pass the key:
+
+```ts
+export default defineUcpConnection({
+  // ...
+  signing: {
+    keyId: "platform-2026",
+    privateKey: process.env.UCP_SIGNING_KEY!, // PKCS#8 PEM or a JWK
+  },
+});
+```
+
+Every request is then signed per [RFC 9421](https://www.rfc-editor.org/rfc/rfc9421),
+with a [RFC 9530](https://www.rfc-editor.org/rfc/rfc9530) `Content-Digest` over
+the exact bytes sent. `keyId` must match a `kid` in your profile's
+`signing_keys` — that is how the merchant finds the key to verify with.
+
+Merchants that require signatures reject unsigned requests with
+`signature_missing`. If one reports `signature_invalid`, print the base the
+signer covered and compare it to what the verifier reconstructed:
+
+```ts
+import { ucpSignatureBase } from "eve/commerce/ucp";
+
+const { base } = ucpSignatureBase(
+  { method: "POST", url, headers, body },
+  { keyId: "platform-2026" },
+);
+```
+
+`ES256` (P-256) is the default and is the curve every UCP verifier must
+support; `ES384` is optional. eve signs through WebCrypto, whose ECDSA output
+is already the fixed-width `r||s` encoding the RFC requires — the DER encoding
+that most server-side crypto libraries emit by default would fail verification.
+
+## Resolve the checkout handoff
+
+A checkout response spreads "what now" across four fields: `status`,
+`messages[].severity`, `continue_url`, and the embedded service binding.
+`resolveUcpCheckoutHandoff` reads all four and returns one discriminated union:
+
+```ts title="app/api/checkout/[id]/route.ts"
+import { resolveUcpCheckoutHandoff } from "eve/commerce/ucp";
+
+const handoff = resolveUcpCheckoutHandoff(checkoutResponse, {
+  embedded: { delegate: ["payment.credential"], colorScheme: "dark" },
+});
+
+switch (handoff.kind) {
+  case "conversational":
+    // handoff.next is "update", "complete", or "poll".
+    // handoff.blockers holds the errors to clear first.
+    break;
+  case "embedded":
+    // handoff.url is continue_url plus the negotiated `ec_*` parameters.
+    break;
+  case "continue_url":
+    // Send the buyer to handoff.url.
+    break;
+  case "completed":
+    // handoff.order carries the placed order.
+    break;
+  case "canceled":
+    break;
+  case "failed":
+    // handoff.reason says why nothing can continue.
+    break;
+}
+```
+
+It accepts either a raw checkout body or an eve OpenAPI connection tool result
+(`{ status, statusText, body }`), so you can pass a connection tool's output
+straight in.
+
+### How the outcome is chosen
+
+The buyer takes over when the merchant sets `status: requires_escalation`, or
+when any message carries `requires_buyer_input` or `requires_buyer_review` —
+those two severities mean the buyer must act whatever the status says. An
+`unrecoverable` error on its own stays conversational, because the spec allows
+retrying with different inputs.
+
+Between the two buyer-facing outcomes: `embedded` is chosen only when the
+merchant included an embedded service binding with `config.delegate` in _this
+checkout response_. Service-level support in the profile is not enough — the
+merchant decides per session. Everything else resolves to `continue_url`. Pass
+`embedded: false` to always redirect.
+
+The requested `delegate` list is intersected with what the merchant accepted,
+and the result is both returned as `handoff.delegate` and encoded into
+`handoff.url` as `ec_delegate`, alongside `ec_version` and any `ec_auth` or
+`ec_color_scheme` you passed.
+
+`failed` means neither continuing nor handing off is possible: a `ucp.status:
+"error"` envelope (`protocol_error`), an escalation with no `continue_url`
+(`handoff_unavailable`), a non-2xx response with no usable payload
+(`http_error`), or a body that is not a checkout (`unrecognized_response`).
+When the merchant offered a URL anyway, it is on `handoff.continueUrl`.
+
+### The agent does not place the order
+
+UCP requires the buyer to review and authorize a checkout in a trusted,
+deterministic UI before the order is placed. Keep that in your instructions —
+the handoff contract tells your application what to render, not the model what
+it is allowed to do:
+
+```md title="agent/instructions.md"
+Never call complete_checkout on your own initiative. Prepare the checkout and
+tell the buyer it is ready; they review and authorize it.
+```
+
+## Verify
+
+Confirm your agent profile is reachable and correctly cached:
+
+```sh
+curl -i https://my-agent.example.com/.well-known/ucp
+```
+
+Then check what the connection exposes to the model — `connection_search` for
+`acme` should list operations whose inputs are `id` and `body`, with no
+protocol headers.
+
+## What's not covered
+
+Cart, catalog, and order semantics beyond transport; payment-handler
+execution; webhook signature verification; and the Embedded Checkout message
+channel itself. `resolveUcpCheckoutHandoff` gets you to the embedded URL; the
+`ec.*` JSON-RPC conversation inside the frame is yours.
+
+## Read next
+
+- [Universal Commerce Protocol (UCP)](./ucp): the business side — publishing a
+  profile and serving commerce endpoints.
+- [OpenAPI connections](../connections/openapi): the connection type this
+  preset builds on, including `prepareRequest`.

--- a/docs/protocols/ucp.mdx
+++ b/docs/protocols/ucp.mdx
@@ -177,5 +177,6 @@ Commerce operation semantics are author-owned: the checkout, cart, and order sta
 
 ## Read next
 
+- [UCP commerce agents](./ucp-agent): The other side — connecting an agent to a merchant's UCP service.
 - [Channels overview](../channels/overview): The channel contract this builds on.
 - [Custom channels](../channels/custom): The route helpers, CORS, and metadata this page uses.

--- a/packages/eve/extension-contracts/compatibility/connection/v8.ts
+++ b/packages/eve/extension-contracts/compatibility/connection/v8.ts
@@ -1,0 +1,15 @@
+import { defineOpenAPIConnection } from "#public/connections/index.js";
+
+export default defineOpenAPIConnection({
+  auth: { getToken: async () => ({ token: "token" }) },
+  baseUrl: "https://api.example.com",
+  description: "Tenant-aware OpenAPI service",
+  headers: { "X-Tenant": ({ session }) => session.id },
+  operations: { allow: ["getProject"] },
+  spec: "https://api.example.com/openapi.json",
+  toolCall: {
+    providedArguments: {
+      teamId: ({ callId, session, toolName }) => `${session.id}:${toolName}:${callId}`,
+    },
+  },
+});

--- a/packages/eve/extension-contracts/reports/connection/v9.json
+++ b/packages/eve/extension-contracts/reports/connection/v9.json
@@ -1,0 +1,15 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "connection",
+  "epoch": 9,
+  "sha256": "ec79d44ad4379b4a259f910dce0cc754160696e5abab4aa39656b11b2cde76d1",
+  "exports": [
+    "ConnectionAuthorizationFailedError",
+    "ConnectionAuthorizationRequiredError",
+    "defineInteractiveAuthorization",
+    "defineMcpClientConnection",
+    "defineOpenAPIConnection",
+    "isConnectionAuthorizationFailedError",
+    "isConnectionAuthorizationRequiredError"
+  ]
+}

--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -191,6 +191,11 @@
       "import": "./dist/src/public/connections/index.js",
       "default": "./dist/src/public/connections/index.js"
     },
+    "./commerce/ucp": {
+      "types": "./dist/src/public/commerce/ucp/index.d.ts",
+      "import": "./dist/src/public/commerce/ucp/index.js",
+      "default": "./dist/src/public/commerce/ucp/index.js"
+    },
     "./agents/auth": {
       "types": "./dist/src/public/agents/auth.d.ts",
       "import": "./dist/src/public/agents/auth.js",

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -41,11 +41,7 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
       2: "Persistent subagent sessions are now the default and the experimental opt-in was removed",
     },
   },
-  connection: {
-    current: 8,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8],
-    dropped: {},
-  },
+  connection: { current: 9, supported: [1, 2, 3, 4, 5, 6, 7, 8, 9], dropped: {} },
   hook: {
     current: 16,
     supported: [10, 11, 12, 13, 14, 15, 16],

--- a/packages/eve/src/internal/authored-definition/connection.ts
+++ b/packages/eve/src/internal/authored-definition/connection.ts
@@ -1,6 +1,9 @@
 import { normalizeApproval } from "#internal/authored-definition/approval.js";
 import type { McpClientConnectionDefinition } from "#public/definitions/connections/mcp.js";
-import type { OpenAPIConnectionDefinition } from "#public/definitions/connections/openapi.js";
+import type {
+  ConnectionRequestPreparer,
+  OpenAPIConnectionDefinition,
+} from "#public/definitions/connections/openapi.js";
 import type {
   ConnectionToolCallDefinition,
   ProvidedArgumentsDefinition,
@@ -30,6 +33,7 @@ const KNOWN_OPENAPI_TOP_LEVEL_KEYS = [
   "description",
   "headers",
   "operations",
+  "prepareRequest",
   "spec",
   "toolCall",
 ] as const;
@@ -208,6 +212,12 @@ export function normalizeOpenApiConnectionDefinition(
   }
   if (operations !== undefined) {
     result.operations = operations;
+  }
+  if (record.prepareRequest !== undefined) {
+    if (typeof record.prepareRequest !== "function") {
+      throw new Error(`${message} The "prepareRequest" field must be a function.`);
+    }
+    result.prepareRequest = record.prepareRequest as ConnectionRequestPreparer;
   }
 
   if (record.approval !== undefined) {

--- a/packages/eve/src/internal/authored-definition/openapi-connection.test.ts
+++ b/packages/eve/src/internal/authored-definition/openapi-connection.test.ts
@@ -67,6 +67,18 @@ describe("normalizeOpenApiConnectionDefinition", () => {
       expect(result.auth).toBe(auth);
       expect(calls).toBe(0);
     });
+
+    it("preserves a prepareRequest hook without invoking it at build time", () => {
+      let calls = 0;
+      const prepareRequest = () => {
+        calls += 1;
+        return {};
+      };
+      const result = normalizeOpenApiConnectionDefinition(validInput({ prepareRequest }), MSG);
+
+      expect(result.prepareRequest).toBe(prepareRequest);
+      expect(calls).toBe(0);
+    });
   });
 
   describe("validation", () => {
@@ -92,6 +104,12 @@ describe("normalizeOpenApiConnectionDefinition", () => {
       expect(() =>
         normalizeOpenApiConnectionDefinition(validInput({ url: "https://x.com" }), MSG),
       ).toThrow();
+    });
+
+    it("rejects a non-function prepareRequest", () => {
+      expect(() =>
+        normalizeOpenApiConnectionDefinition(validInput({ prepareRequest: {} }), MSG),
+      ).toThrow(/prepareRequest/);
     });
 
     it("rejects operations specifying both allow and block", () => {

--- a/packages/eve/src/public/commerce/ucp/checkout.ts
+++ b/packages/eve/src/public/commerce/ucp/checkout.ts
@@ -1,0 +1,249 @@
+/**
+ * Minimal typed projection of a UCP checkout response.
+ *
+ * This is deliberately not a full model of the checkout schema: it types
+ * only the fields the handoff decision reads, and carries everything
+ * else through untouched on {@link UcpCheckout.raw}. Extensions add
+ * fields to checkout responses continuously, and a partial projection
+ * that never has to be exhaustive is the one that keeps working.
+ */
+
+import { isObject } from "#shared/guards.js";
+
+/** Checkout lifecycle phase set by the business. */
+export type UcpCheckoutStatus =
+  | "incomplete"
+  | "requires_escalation"
+  | "ready_for_complete"
+  | "complete_in_progress"
+  | "completed"
+  | "canceled";
+
+/**
+ * Recommended platform action for one error message.
+ *
+ * `recoverable` is the only severity a platform can clear on its own;
+ * the other three all mean the buyer has to be brought in.
+ */
+export type UcpErrorSeverity =
+  | "recoverable"
+  | "requires_buyer_input"
+  | "requires_buyer_review"
+  | "unrecoverable";
+
+/** One entry of a checkout response's `messages` array. */
+export interface UcpMessage {
+  readonly type: "error" | "warning" | "info";
+  readonly code?: string;
+  readonly content?: string;
+  readonly content_type?: "plain" | "markdown";
+  /** RFC 9535 JSONPath pointing at the component the message is about. */
+  readonly path?: string;
+  /** Present on `type: "error"`. */
+  readonly severity?: UcpErrorSeverity;
+}
+
+/** A transport binding the business declared for this checkout session. */
+export interface UcpServiceBinding {
+  readonly transport?: string;
+  readonly version?: string;
+  readonly endpoint?: string;
+  readonly config?: {
+    /** Delegations the business accepted for this session. */
+    readonly delegate?: readonly string[];
+  };
+}
+
+/** The order a completed checkout carries. */
+export interface UcpOrder {
+  readonly id?: string;
+  readonly permalink_url?: string;
+}
+
+/** Typed projection of one checkout response body. */
+export interface UcpCheckout {
+  readonly id?: string;
+  readonly status?: UcpCheckoutStatus;
+  /** Absolute HTTPS URL the buyer can be handed off to. */
+  readonly continue_url?: string;
+  readonly messages: readonly UcpMessage[];
+  readonly order?: UcpOrder;
+  readonly expires_at?: string;
+  /** Negotiated protocol version from the response envelope. */
+  readonly version?: string;
+  /** `ucp.status` — the envelope's shape discriminator. */
+  readonly envelopeStatus?: "success" | "error";
+  /** `ucp.services["dev.ucp.shopping"]` bindings, if any. */
+  readonly serviceBindings: readonly UcpServiceBinding[];
+  /** The response body exactly as received. */
+  readonly raw: Readonly<Record<string, unknown>>;
+}
+
+/** The eve OpenAPI connection tool result shape. */
+interface HttpToolResult {
+  readonly status: number;
+  readonly statusText?: string;
+  readonly body: unknown;
+}
+
+/** A checkout response paired with the HTTP status it arrived with. */
+export interface ParsedUcpCheckoutResponse {
+  readonly checkout?: UcpCheckout;
+  /** Present when the value came from an eve OpenAPI connection tool result. */
+  readonly httpStatus?: number;
+}
+
+const SHOPPING_SERVICE = "dev.ucp.shopping";
+
+const CHECKOUT_STATUSES = new Set<string>([
+  "incomplete",
+  "requires_escalation",
+  "ready_for_complete",
+  "complete_in_progress",
+  "completed",
+  "canceled",
+]);
+
+const SEVERITIES = new Set<string>([
+  "recoverable",
+  "requires_buyer_input",
+  "requires_buyer_review",
+  "unrecoverable",
+]);
+
+/**
+ * Parses a checkout response.
+ *
+ * Accepts either a raw checkout body or an eve OpenAPI connection tool
+ * result (`{ status, statusText, body }`), so the same call works whether
+ * you hold the connection tool's output or a body you fetched yourself.
+ * `checkout` is absent when the value is not a JSON object.
+ */
+export function parseUcpCheckoutResponse(value: unknown): ParsedUcpCheckoutResponse {
+  if (isHttpToolResult(value)) {
+    const checkout = parseCheckoutBody(value.body);
+    return checkout === undefined
+      ? { httpStatus: value.status }
+      : { checkout, httpStatus: value.status };
+  }
+  const checkout = parseCheckoutBody(value);
+  return checkout === undefined ? {} : { checkout };
+}
+
+function isHttpToolResult(value: unknown): value is HttpToolResult {
+  return isObject(value) && typeof value.status === "number" && "body" in value;
+}
+
+function parseCheckoutBody(value: unknown): UcpCheckout | undefined {
+  if (!isObject(value)) {
+    return undefined;
+  }
+
+  const envelope = isObject(value.ucp) ? value.ucp : undefined;
+  const result: {
+    -readonly [K in keyof UcpCheckout]: UcpCheckout[K];
+  } = {
+    messages: parseMessages(value.messages),
+    raw: value,
+    serviceBindings: parseServiceBindings(envelope?.services),
+  };
+
+  if (typeof value.id === "string") {
+    result.id = value.id;
+  }
+  if (typeof value.status === "string" && CHECKOUT_STATUSES.has(value.status)) {
+    result.status = value.status as UcpCheckoutStatus;
+  }
+  if (typeof value.continue_url === "string") {
+    result.continue_url = value.continue_url;
+  }
+  if (typeof value.expires_at === "string") {
+    result.expires_at = value.expires_at;
+  }
+  if (isObject(value.order)) {
+    const order: { id?: string; permalink_url?: string } = {};
+    if (typeof value.order.id === "string") {
+      order.id = value.order.id;
+    }
+    if (typeof value.order.permalink_url === "string") {
+      order.permalink_url = value.order.permalink_url;
+    }
+    result.order = order;
+  }
+  if (typeof envelope?.version === "string") {
+    result.version = envelope.version;
+  }
+  if (envelope?.status === "success" || envelope?.status === "error") {
+    result.envelopeStatus = envelope.status;
+  }
+
+  return result;
+}
+
+function parseMessages(value: unknown): readonly UcpMessage[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const messages: UcpMessage[] = [];
+  for (const entry of value) {
+    if (!isObject(entry)) {
+      continue;
+    }
+    const type = entry.type;
+    if (type !== "error" && type !== "warning" && type !== "info") {
+      continue;
+    }
+    const message: {
+      -readonly [K in keyof UcpMessage]: UcpMessage[K];
+    } = { type };
+    if (typeof entry.code === "string") {
+      message.code = entry.code;
+    }
+    if (typeof entry.content === "string") {
+      message.content = entry.content;
+    }
+    if (entry.content_type === "plain" || entry.content_type === "markdown") {
+      message.content_type = entry.content_type;
+    }
+    if (typeof entry.path === "string") {
+      message.path = entry.path;
+    }
+    if (typeof entry.severity === "string" && SEVERITIES.has(entry.severity)) {
+      message.severity = entry.severity as UcpErrorSeverity;
+    }
+    messages.push(message);
+  }
+  return messages;
+}
+
+function parseServiceBindings(value: unknown): readonly UcpServiceBinding[] {
+  if (!isObject(value) || !Array.isArray(value[SHOPPING_SERVICE])) {
+    return [];
+  }
+  const bindings: UcpServiceBinding[] = [];
+  for (const entry of value[SHOPPING_SERVICE]) {
+    if (!isObject(entry)) {
+      continue;
+    }
+    const binding: {
+      -readonly [K in keyof UcpServiceBinding]: UcpServiceBinding[K];
+    } = {};
+    if (typeof entry.transport === "string") {
+      binding.transport = entry.transport;
+    }
+    if (typeof entry.version === "string") {
+      binding.version = entry.version;
+    }
+    if (typeof entry.endpoint === "string") {
+      binding.endpoint = entry.endpoint;
+    }
+    if (isObject(entry.config)) {
+      const delegate = entry.config.delegate;
+      binding.config = Array.isArray(delegate)
+        ? { delegate: delegate.filter((item): item is string => typeof item === "string") }
+        : {};
+    }
+    bindings.push(binding);
+  }
+  return bindings;
+}

--- a/packages/eve/src/public/commerce/ucp/connection.integration.test.ts
+++ b/packages/eve/src/public/commerce/ucp/connection.integration.test.ts
@@ -1,0 +1,335 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { ContextContainer, contextStorage } from "#context/container.js";
+import { AuthKey, SessionKey } from "#context/keys.js";
+import {
+  defineUcpConnection,
+  type UcpConnectionDefinition,
+} from "#public/commerce/ucp/connection.js";
+import { resolveUcpCheckoutHandoff } from "#public/commerce/ucp/handoff.js";
+import { ucpSignatureBase } from "#public/commerce/ucp/signing.js";
+import type { OpenAPIConnectionDefinition } from "#public/definitions/connections/openapi.js";
+import { OpenApiConnectionClient } from "#runtime/connections/openapi-client.js";
+import type { ResolvedConnectionDefinition } from "#runtime/types.js";
+
+/**
+ * Trimmed copy of the canonical UCP shopping REST contract: the two
+ * operations under test, with the header parameters the published
+ * document actually declares — including the three it marks required.
+ */
+const UCP_SPEC: Record<string, unknown> = {
+  components: {
+    parameters: {
+      authorization: { in: "header", name: "Authorization", schema: { type: "string" } },
+      checkout_session_id_path: {
+        in: "path",
+        name: "id",
+        required: true,
+        schema: { type: "string" },
+      },
+      content_digest: { in: "header", name: "Content-Digest", schema: { type: "string" } },
+      idempotency_key: {
+        in: "header",
+        name: "Idempotency-Key",
+        required: true,
+        schema: { format: "uuid", type: "string" },
+      },
+      request_id: {
+        in: "header",
+        name: "Request-Id",
+        required: true,
+        schema: { format: "uuid", type: "string" },
+      },
+      signature: { in: "header", name: "Signature", schema: { type: "string" } },
+      signature_input: { in: "header", name: "Signature-Input", schema: { type: "string" } },
+      ucp_agent: { in: "header", name: "UCP-Agent", required: true, schema: { type: "string" } },
+    },
+  },
+  info: { title: "UCP Shopping Service", version: "1.0.0" },
+  openapi: "3.1.0",
+  paths: {
+    "/checkout-sessions": {
+      post: {
+        operationId: "create_checkout",
+        parameters: [
+          { $ref: "#/components/parameters/authorization" },
+          { $ref: "#/components/parameters/signature" },
+          { $ref: "#/components/parameters/signature_input" },
+          { $ref: "#/components/parameters/content_digest" },
+          { $ref: "#/components/parameters/idempotency_key" },
+          { $ref: "#/components/parameters/request_id" },
+          { $ref: "#/components/parameters/ucp_agent" },
+        ],
+        requestBody: {
+          content: { "application/json": { schema: { type: "object" } } },
+          required: true,
+        },
+        responses: { "201": { description: "created" } },
+        summary: "Create a checkout session",
+      },
+    },
+    "/checkout-sessions/{id}": {
+      get: {
+        operationId: "get_checkout",
+        parameters: [
+          { $ref: "#/components/parameters/checkout_session_id_path" },
+          { $ref: "#/components/parameters/authorization" },
+          { $ref: "#/components/parameters/request_id" },
+          { $ref: "#/components/parameters/ucp_agent" },
+        ],
+        responses: { "200": { description: "ok" } },
+        summary: "Get a checkout session",
+      },
+    },
+  },
+};
+
+const CHECKOUT_RESPONSE = {
+  continue_url: "https://acme.example.com/checkout/chk_1",
+  currency: "USD",
+  id: "chk_1",
+  line_items: [],
+  messages: [{ code: "eligibility_invalid", severity: "requires_buyer_input", type: "error" }],
+  status: "requires_escalation",
+  ucp: { capabilities: {}, version: "2026-04-08" },
+};
+
+let keyPair: { privateKey: CryptoKey; publicKey: CryptoKey };
+let jwk: Record<string, unknown>;
+
+beforeAll(async () => {
+  keyPair = (await crypto.subtle.generateKey({ name: "ECDSA", namedCurve: "P-256" }, true, [
+    "sign",
+    "verify",
+  ])) as { privateKey: CryptoKey; publicKey: CryptoKey };
+  jwk = (await crypto.subtle.exportKey("jwk", keyPair.privateKey)) as Record<string, unknown>;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** Mirrors what `resolveConnectionDefinition` hands the runtime client. */
+function resolve(definition: OpenAPIConnectionDefinition): ResolvedConnectionDefinition {
+  const resolved: {
+    -readonly [K in keyof ResolvedConnectionDefinition]: ResolvedConnectionDefinition[K];
+  } = {
+    connectionName: "acme",
+    description: definition.description,
+    logicalPath: "connections/acme.ts",
+    protocol: "openapi",
+    sourceId: "connections/acme",
+    sourceKind: "module",
+    spec: UCP_SPEC,
+    url: definition.baseUrl ?? "",
+  };
+  if (definition.auth !== undefined) {
+    resolved.authorization = definition.auth as ResolvedConnectionDefinition["authorization"];
+  }
+  if (definition.headers !== undefined) {
+    resolved.headers = definition.headers;
+  }
+  if (definition.toolCall !== undefined) {
+    resolved.toolCall = definition.toolCall;
+  }
+  if (definition.prepareRequest !== undefined) {
+    resolved.prepareRequest = definition.prepareRequest;
+  }
+  return resolved;
+}
+
+function client(options: { readonly signed: boolean }): OpenApiConnectionClient {
+  const definition: UcpConnectionDefinition = {
+    agent: { profile: "https://agent.example/.well-known/ucp" },
+    auth: { getToken: async () => ({ token: "merchant-token" }) },
+    description: "Acme storefront.",
+    endpoint: "https://acme.example.com/ucp/v1",
+  };
+  const signing = { keyId: "platform-2026", privateKey: jwk };
+  return new OpenApiConnectionClient(
+    resolve(defineUcpConnection(options.signed ? { ...definition, signing } : definition)),
+  );
+}
+
+function stubFetch() {
+  const fetchMock = vi.fn(
+    async (_url: URL, _init: RequestInit) =>
+      new Response(JSON.stringify(CHECKOUT_RESPONSE), {
+        headers: { "content-type": "application/json" },
+        status: 201,
+      }),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function withContext<T>(run: () => Promise<T>): Promise<T> {
+  const ctx = new ContextContainer();
+  ctx.set(AuthKey, null);
+  ctx.set(SessionKey, {
+    auth: { current: null, initiator: null },
+    sessionId: "session-1",
+    turn: { id: "turn-1", sequence: 0 },
+  });
+  return contextStorage.run(ctx, run);
+}
+
+function sentHeaders(init: RequestInit): Record<string, string> {
+  return init.headers as Record<string, string>;
+}
+
+describe("defineUcpConnection over the OpenAPI connection client", () => {
+  it("leaves the model only the operation's own inputs", async () => {
+    const metadata = await client({ signed: true }).getToolMetadata();
+
+    expect(metadata.find((item) => item.name === "create_checkout")?.inputSchema).toEqual({
+      properties: { body: { type: "object" } },
+      required: ["body"],
+      type: "object",
+    });
+    expect(metadata.find((item) => item.name === "get_checkout")?.inputSchema).toEqual({
+      properties: { id: { type: "string" } },
+      required: ["id"],
+      type: "object",
+    });
+  });
+
+  it("sends the agent profile, retry-safe ids, and a verifiable signature", async () => {
+    const fetchMock = stubFetch();
+
+    await withContext(() =>
+      client({ signed: true }).executeTool(
+        "create_checkout",
+        { body: { line_items: [{ item: { id: "item_123" }, quantity: 1 }] } },
+        { callId: "call-1" },
+      ),
+    );
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    const headers = sentHeaders(init);
+
+    expect(String(url)).toBe("https://acme.example.com/ucp/v1/checkout-sessions");
+    expect(init.method).toBe("POST");
+    expect(headers["UCP-Agent"]).toBe('profile="https://agent.example/.well-known/ucp"');
+    expect(headers.Authorization).toBe("Bearer merchant-token");
+    expect(headers["Request-Id"]).toMatch(/^[0-9a-f-]{36}$/);
+    expect(headers["Idempotency-Key"]).toMatch(/^[0-9a-f-]{36}$/);
+    expect(headers["Idempotency-Key"]).not.toBe(headers["Request-Id"]);
+
+    const base = ucpSignatureBase(
+      {
+        body: init.body as string,
+        headers,
+        method: "POST",
+        url: String(url),
+      },
+      { contentDigest: headers["Content-Digest"], keyId: "platform-2026" },
+    ).base;
+    expect(headers["Signature-Input"]).toBe(
+      ucpSignatureBase(
+        { body: init.body as string, headers, method: "POST", url: String(url) },
+        { keyId: "platform-2026" },
+      ).signatureInput,
+    );
+
+    const signature = headers.Signature ?? "";
+    const raw = signature.slice("sig1=:".length, -1);
+    await expect(
+      crypto.subtle.verify(
+        { hash: "SHA-256", name: "ECDSA" },
+        keyPair.publicKey,
+        Uint8Array.from(atob(raw), (char) => char.charCodeAt(0)),
+        new TextEncoder().encode(base),
+      ),
+    ).resolves.toBe(true);
+  });
+
+  it("reuses the idempotency key when the same call is replayed", async () => {
+    const fetchMock = stubFetch();
+    const connection = client({ signed: false });
+
+    const run = (callId: string) =>
+      withContext(() =>
+        connection.executeTool("create_checkout", { body: { line_items: [] } }, { callId }),
+      );
+
+    await run("call-1");
+    await run("call-1");
+    await run("call-2");
+
+    const keys = fetchMock.mock.calls.map((call) => sentHeaders(call[1])["Idempotency-Key"]);
+    expect(keys[1]).toBe(keys[0]);
+    expect(keys[2]).not.toBe(keys[0]);
+  });
+
+  it("omits the idempotency key on a read", async () => {
+    const fetchMock = stubFetch();
+
+    await withContext(() =>
+      client({ signed: false }).executeTool("get_checkout", { id: "chk_1" }, { callId: "call-1" }),
+    );
+
+    const headers = sentHeaders(fetchMock.mock.calls[0]![1]);
+    expect(headers["Idempotency-Key"]).toBeUndefined();
+    expect(headers["Request-Id"]).toBeDefined();
+    expect(headers["UCP-Agent"]).toBeDefined();
+  });
+
+  it("ignores protocol headers a model tries to supply", async () => {
+    const fetchMock = stubFetch();
+
+    await withContext(() =>
+      client({ signed: false }).executeTool(
+        "create_checkout",
+        {
+          Authorization: "Bearer stolen",
+          body: { line_items: [] },
+          "Idempotency-Key": "00000000-0000-4000-8000-000000000000",
+          "UCP-Agent": 'profile="https://attacker.example/p.json"',
+        },
+        { callId: "call-1" },
+      ),
+    );
+
+    const headers = sentHeaders(fetchMock.mock.calls[0]![1]);
+    expect(headers.Authorization).toBe("Bearer merchant-token");
+    expect(headers["UCP-Agent"]).toBe('profile="https://agent.example/.well-known/ucp"');
+    expect(headers["Idempotency-Key"]).not.toBe("00000000-0000-4000-8000-000000000000");
+  });
+
+  it("sends no signature headers when the connection is unsigned", async () => {
+    const fetchMock = stubFetch();
+
+    await withContext(() =>
+      client({ signed: false }).executeTool(
+        "create_checkout",
+        { body: { line_items: [] } },
+        { callId: "call-1" },
+      ),
+    );
+
+    const headers = sentHeaders(fetchMock.mock.calls[0]![1]);
+    expect(headers.Signature).toBeUndefined();
+    expect(headers["Signature-Input"]).toBeUndefined();
+    expect(headers["Content-Digest"]).toBeUndefined();
+  });
+
+  it("resolves the tool result straight into a handoff", async () => {
+    stubFetch();
+
+    const result = await withContext(() =>
+      client({ signed: false }).executeTool(
+        "create_checkout",
+        { body: { line_items: [] } },
+        { callId: "call-1" },
+      ),
+    );
+
+    expect(resolveUcpCheckoutHandoff(result)).toMatchObject({
+      checkoutId: "chk_1",
+      kind: "continue_url",
+      reason: "requires_buyer_input",
+      url: "https://acme.example.com/checkout/chk_1",
+    });
+  });
+});

--- a/packages/eve/src/public/commerce/ucp/connection.test.ts
+++ b/packages/eve/src/public/commerce/ucp/connection.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+import { defineUcpConnection } from "#public/commerce/ucp/connection.js";
+import { UCP_VERSION } from "#public/commerce/ucp/protocol.js";
+import { normalizeOpenApiConnectionDefinition } from "#internal/authored-definition/connection.js";
+import { readConnectionProtocol } from "#public/definitions/connections/protocol.js";
+import type { SessionContext } from "#public/definitions/callback-context.js";
+
+const AGENT = { profile: "https://agent.example/.well-known/ucp" } as const;
+
+function sessionContext(id: string): SessionContext {
+  return {
+    getSandbox: () => Promise.reject(new Error("no sandbox in this test")),
+    getSkill: () => {
+      throw new Error("no skills in this test");
+    },
+    session: {
+      auth: { current: null, initiator: null },
+      id,
+      turn: { id: "turn-1", sequence: 0 },
+    },
+  };
+}
+
+function define(overrides: Record<string, unknown> = {}) {
+  return defineUcpConnection({
+    agent: AGENT,
+    description: "Acme storefront.",
+    endpoint: "https://acme.example.com/ucp/v1",
+    ...overrides,
+  });
+}
+
+describe("defineUcpConnection", () => {
+  it("produces an OpenAPI connection against the merchant endpoint", () => {
+    const connection = define();
+    expect(readConnectionProtocol(connection)).toBe("openapi");
+    expect(connection.baseUrl).toBe("https://acme.example.com/ucp/v1");
+    expect(connection.spec).toBe(
+      `https://ucp.dev/${UCP_VERSION}/services/shopping/rest.openapi.json`,
+    );
+  });
+
+  it("loads the contract for an older protocol version", () => {
+    expect(define({ version: "2026-01-11" }).spec).toBe(
+      "https://ucp.dev/2026-01-11/services/shopping/rest.openapi.json",
+    );
+  });
+
+  it("accepts a merchant-published contract override", () => {
+    const spec = { openapi: "3.1.0", paths: {} };
+    expect(define({ spec }).spec).toBe(spec);
+  });
+
+  it("advertises the agent profile on every request", () => {
+    expect(define().headers).toMatchObject({
+      "UCP-Agent": 'profile="https://agent.example/.well-known/ucp"',
+    });
+  });
+
+  it("merges authored static headers after its own", () => {
+    expect(define({ headers: { "X-Tenant": "acme" } }).headers).toMatchObject({
+      "UCP-Agent": 'profile="https://agent.example/.well-known/ucp"',
+      "X-Tenant": "acme",
+    });
+  });
+
+  it("composes with an authored header resolver", async () => {
+    const headers = define({
+      headers: (ctx: SessionContext) => ({ "X-Session": ctx.session.id }),
+    }).headers;
+    if (typeof headers !== "function") {
+      throw new Error("expected a header resolver");
+    }
+    await expect(headers(sessionContext("s_1"))).resolves.toEqual({
+      "UCP-Agent": 'profile="https://agent.example/.well-known/ucp"',
+      "X-Session": "s_1",
+    });
+  });
+
+  it("takes protocol header parameters away from the model", () => {
+    const provided = define().toolCall?.providedArguments ?? {};
+    for (const name of [
+      "Authorization",
+      "Content-Digest",
+      "Idempotency-Key",
+      "Request-Id",
+      "Signature",
+      "Signature-Input",
+      "UCP-Agent",
+      "X-API-Key",
+    ]) {
+      expect(provided).toHaveProperty(name, null);
+      expect(provided).toHaveProperty(name.toLowerCase(), null);
+    }
+  });
+
+  it("lets authored provided arguments re-expose a managed parameter", () => {
+    const provided =
+      define({ providedArguments: { "Accept-Language": "de-DE" } }).toolCall?.providedArguments ??
+      {};
+    expect(provided["Accept-Language"]).toBe("de-DE");
+  });
+
+  it("passes auth, approval, and the operation filter through", () => {
+    const auth = { getToken: async () => ({ token: "t" }) };
+    const connection = define({ auth, operations: { allow: ["create_checkout"] } });
+    expect(connection.auth).toBeDefined();
+    expect(connection.operations).toEqual({ allow: ["create_checkout"] });
+  });
+
+  it("passes the authored-definition validator eve applies at build time", () => {
+    expect(() =>
+      normalizeOpenApiConnectionDefinition(define(), 'Connection "acme":'),
+    ).not.toThrow();
+  });
+
+  it("rejects an agent profile a merchant could not verify", () => {
+    expect(() => define({ agent: { profile: "http://localhost:2000/.well-known/ucp" } })).toThrow(
+      /must use https/,
+    );
+  });
+});

--- a/packages/eve/src/public/commerce/ucp/connection.ts
+++ b/packages/eve/src/public/commerce/ucp/connection.ts
@@ -1,0 +1,241 @@
+/**
+ * The generic UCP connection preset.
+ *
+ * A UCP shopping service is an ordinary OpenAPI service, so this builds
+ * an {@link OpenAPIConnectionDefinition} rather than introducing a new
+ * connection protocol. What it adds is the protocol plumbing the
+ * canonical contract leaves to the caller: the published REST spec types
+ * `UCP-Agent`, `Idempotency-Key`, `Request-Id`, `Authorization`,
+ * `Signature`, `Signature-Input`, and `Content-Digest` as ordinary header
+ * parameters, so without a preset every one of them lands in the
+ * model-facing input schema and the model is asked to invent identity,
+ * credentials, and signatures. Here they are application-owned: hidden
+ * from the model and filled in from the connection's configuration.
+ */
+
+import type { Approval } from "#public/definitions/approval.js";
+import type {
+  ConnectionRequestPreparation,
+  OpenAPIConnectionDefinition,
+  OpenAPISpecSource,
+} from "#public/definitions/connections/openapi.js";
+import { defineOpenAPIConnection } from "#public/definitions/connections/openapi.js";
+import type {
+  ProvidedArgumentsDefinition,
+  ProvidedArgumentValue,
+} from "#public/definitions/connections/tool-call.js";
+import type {
+  ConnectionAuthDefinition,
+  HeadersDefinition,
+  ToolFilterDefinition,
+} from "#shared/connection-types.js";
+import {
+  deriveUcpRequestUuid,
+  ucpAgentHeaderValue,
+  ucpShoppingRestSpecUrl,
+  UCP_VERSION,
+  type UcpAgentMetadata,
+} from "#public/commerce/ucp/protocol.js";
+import { createUcpSigner, type UcpSigningKey } from "#public/commerce/ucp/signing.js";
+
+/**
+ * Header parameters the preset owns.
+ *
+ * Each is suppressed from the model-facing schema by resolving to
+ * `null` — eve strips a provided argument from the schema and, because
+ * `null` parameters are skipped when the request is built, writes no
+ * header for it. Both the canonical and lower-cased spellings are
+ * suppressed so the preset stays correct against merchant-published
+ * specs that differ in header casing.
+ */
+const MANAGED_HEADER_PARAMETERS = [
+  "Accept",
+  "Accept-Encoding",
+  "Accept-Language",
+  "Authorization",
+  "Content-Digest",
+  "Content-Type",
+  "Idempotency-Key",
+  "Request-Id",
+  "Signature",
+  "Signature-Input",
+  "UCP-Agent",
+  "User-Agent",
+  "X-API-Key",
+] as const;
+
+/** Methods that carry a retry-safe `Idempotency-Key`. */
+const IDEMPOTENT_METHODS = new Set(["DELETE", "PATCH", "POST", "PUT"]);
+
+export interface UcpConnectionDefinition {
+  /**
+   * The shopping service base URL, taken from the merchant's
+   * `/.well-known/ucp` profile at
+   * `services["dev.ucp.shopping"][transport="rest"].endpoint`.
+   *
+   * Required: the canonical contract declares its server as an
+   * `{endpoint}` template variable with a placeholder default, so there
+   * is nothing usable to fall back to.
+   */
+  readonly endpoint: string;
+  /** Human-readable summary used in the system prompt and `connection_search`. */
+  readonly description: string;
+  /** Identity this agent advertises on every request. */
+  readonly agent: UcpAgentMetadata;
+  /** UCP version whose REST contract to load. Defaults to {@link UCP_VERSION}. */
+  readonly version?: string;
+  /**
+   * Override the OpenAPI document. Defaults to the canonical UCP
+   * shopping REST contract for `version`.
+   *
+   * Point this at the merchant's own `schema` URL when they publish an
+   * extended contract, or at a pinned inline document.
+   */
+  readonly spec?: OpenAPISpecSource;
+  /**
+   * Credential for the merchant's API (API key, OAuth, pre-provisioned
+   * token). Sent as `Authorization: Bearer <token>`.
+   *
+   * UCP allows API keys, OAuth, and mTLS as alternatives to message
+   * signatures, so a connection may authenticate with `auth` alone.
+   */
+  readonly auth?: ConnectionAuthDefinition;
+  /** Approval gate for the connection's tool calls. */
+  readonly approval?: Approval;
+  /** Extra headers merged after the preset's own. */
+  readonly headers?: HeadersDefinition;
+  /** Operation filter, keyed on `operationId` (e.g. `"create_checkout"`). */
+  readonly operations?: ToolFilterDefinition;
+  /**
+   * Application-owned operation arguments, hidden from the model and
+   * resolved per call.
+   *
+   * Applied after the preset's own, so an entry here can re-expose or
+   * override a managed header parameter.
+   */
+  readonly providedArguments?: ProvidedArgumentsDefinition;
+  /**
+   * Sign every request with HTTP Message Signatures (RFC 9421).
+   *
+   * The key's `keyId` must match a `kid` in the `signing_keys` of the
+   * profile named by {@link agent}, since that is how the merchant
+   * resolves the verification key. Omit to authenticate with `auth`
+   * alone; merchants that require signatures reject unsigned requests
+   * with `signature_missing`.
+   */
+  readonly signing?: UcpSigningKey;
+}
+
+/**
+ * Defines a connection to a UCP shopping service.
+ *
+ * The connection name comes from the filename, as with every eve
+ * connection: `agent/connections/acme.ts` registers as `acme` and its
+ * operations become `acme__create_checkout` and friends.
+ *
+ * @example
+ * ```ts
+ * // agent/connections/acme.ts
+ * import { defineUcpConnection } from "eve/commerce/ucp";
+ *
+ * export default defineUcpConnection({
+ *   endpoint: "https://acme.example.com/ucp/v1",
+ *   description: "Acme storefront: carts, checkout, and orders.",
+ *   agent: { profile: "https://my-agent.example.com/.well-known/ucp" },
+ *   auth: { getToken: async () => ({ token: process.env.ACME_TOKEN! }) },
+ *   signing: {
+ *     keyId: "platform-2026",
+ *     privateKey: process.env.UCP_SIGNING_KEY!,
+ *   },
+ * });
+ * ```
+ */
+export function defineUcpConnection(
+  definition: UcpConnectionDefinition,
+): OpenAPIConnectionDefinition {
+  const version = definition.version ?? UCP_VERSION;
+  const agentHeader = ucpAgentHeaderValue(definition.agent);
+  const sign = definition.signing === undefined ? undefined : createUcpSigner(definition.signing);
+
+  const openapi: {
+    -readonly [K in keyof OpenAPIConnectionDefinition]: OpenAPIConnectionDefinition[K];
+  } = {
+    baseUrl: definition.endpoint,
+    description: definition.description,
+    headers: mergeHeaders({ "UCP-Agent": agentHeader }, definition.headers),
+    prepareRequest: (request) => prepareUcpRequest(request, sign),
+    spec: definition.spec ?? ucpShoppingRestSpecUrl(version),
+    toolCall: {
+      providedArguments: {
+        ...suppressedHeaderParameters(),
+        ...definition.providedArguments,
+      },
+    },
+  };
+
+  if (definition.auth !== undefined) {
+    openapi.auth = definition.auth;
+  }
+  if (definition.approval !== undefined) {
+    openapi.approval = definition.approval;
+  }
+  if (definition.operations !== undefined) {
+    openapi.operations = definition.operations;
+  }
+
+  return defineOpenAPIConnection(openapi);
+}
+
+/**
+ * Adds the retry-safe request identifiers, then signs.
+ *
+ * Order matters: `Idempotency-Key` is a covered component of the
+ * signature base, so it has to exist before the signature is computed.
+ */
+async function prepareUcpRequest(
+  request: ConnectionRequestPreparation,
+  sign: ReturnType<typeof createUcpSigner> | undefined,
+): Promise<Record<string, string>> {
+  const headers: Record<string, string> = {
+    "Request-Id": await deriveUcpRequestUuid(`request:${request.callId}:${request.toolName}`),
+  };
+  if (IDEMPOTENT_METHODS.has(request.method)) {
+    headers["Idempotency-Key"] = await deriveUcpRequestUuid(
+      `idempotency:${request.callId}:${request.toolName}`,
+    );
+  }
+
+  if (sign === undefined) {
+    return headers;
+  }
+
+  const signed = await sign({
+    body: request.body,
+    headers: { ...request.headers, ...headers },
+    method: request.method,
+    url: request.url,
+  });
+  return { ...headers, ...signed };
+}
+
+function suppressedHeaderParameters(): ProvidedArgumentsDefinition {
+  const suppressed: Record<string, ProvidedArgumentValue> = {};
+  for (const name of MANAGED_HEADER_PARAMETERS) {
+    suppressed[name] = null;
+    suppressed[name.toLowerCase()] = null;
+  }
+  return suppressed;
+}
+
+function mergeHeaders(
+  preset: Readonly<Record<string, string>>,
+  authored: HeadersDefinition | undefined,
+): HeadersDefinition {
+  if (authored === undefined) {
+    return preset;
+  }
+  if (typeof authored === "function") {
+    return async (ctx) => ({ ...preset, ...(await authored(ctx)) });
+  }
+  return { ...preset, ...authored };
+}

--- a/packages/eve/src/public/commerce/ucp/handoff.test.ts
+++ b/packages/eve/src/public/commerce/ucp/handoff.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveUcpCheckoutHandoff } from "#public/commerce/ucp/handoff.js";
+
+const VERSION = "2026-04-08";
+
+function checkout(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    currency: "USD",
+    id: "chk_1",
+    line_items: [],
+    ucp: { capabilities: {}, version: VERSION },
+    ...overrides,
+  };
+}
+
+function embeddedEnvelope(delegate: readonly string[]): Record<string, unknown> {
+  return {
+    services: {
+      "dev.ucp.shopping": [{ config: { delegate }, transport: "embedded", version: VERSION }],
+    },
+    version: VERSION,
+  };
+}
+
+describe("resolveUcpCheckoutHandoff: conversational continuation", () => {
+  it("asks for an update while the checkout is incomplete", () => {
+    const handoff = resolveUcpCheckoutHandoff(
+      checkout({
+        messages: [
+          {
+            code: "missing",
+            content: "Buyer email is required",
+            path: "$.buyer.email",
+            severity: "recoverable",
+            type: "error",
+          },
+        ],
+        status: "incomplete",
+      }),
+    );
+
+    expect(handoff.kind).toBe("conversational");
+    if (handoff.kind !== "conversational") return;
+    expect(handoff.next).toBe("update");
+    expect(handoff.blockers.map((message) => message.code)).toEqual(["missing"]);
+    expect(handoff.checkoutId).toBe("chk_1");
+    expect(handoff.version).toBe(VERSION);
+  });
+
+  it("asks for completion once the business is ready", () => {
+    const handoff = resolveUcpCheckoutHandoff(checkout({ status: "ready_for_complete" }));
+    expect(handoff).toMatchObject({ blockers: [], kind: "conversational", next: "complete" });
+  });
+
+  it("asks for polling while the order is being placed", () => {
+    const handoff = resolveUcpCheckoutHandoff(checkout({ status: "complete_in_progress" }));
+    expect(handoff).toMatchObject({ kind: "conversational", next: "poll" });
+  });
+
+  it("surfaces an available continue_url without forcing a handoff", () => {
+    const handoff = resolveUcpCheckoutHandoff(
+      checkout({ continue_url: "https://merchant.example.com/c/chk_1", status: "incomplete" }),
+    );
+    expect(handoff).toMatchObject({
+      continueUrl: "https://merchant.example.com/c/chk_1",
+      kind: "conversational",
+    });
+  });
+
+  it("keeps an unrecoverable error conversational, since new inputs may still work", () => {
+    const handoff = resolveUcpCheckoutHandoff(
+      checkout({
+        continue_url: "https://merchant.example.com/c/chk_1",
+        messages: [{ code: "out_of_stock", severity: "unrecoverable", type: "error" }],
+        status: "incomplete",
+      }),
+    );
+    expect(handoff.kind).toBe("conversational");
+  });
+});
+
+describe("resolveUcpCheckoutHandoff: continue_url", () => {
+  it("hands off on escalation and reports why", () => {
+    const handoff = resolveUcpCheckoutHandoff(
+      checkout({
+        continue_url: "https://merchant.example.com/c/chk_1",
+        messages: [
+          { code: "eligibility_invalid", severity: "requires_buyer_input", type: "error" },
+        ],
+        status: "requires_escalation",
+      }),
+    );
+
+    expect(handoff).toMatchObject({
+      kind: "continue_url",
+      reason: "requires_buyer_input",
+      url: "https://merchant.example.com/c/chk_1",
+    });
+  });
+
+  it("hands off when a buyer-review severity appears under a non-escalated status", () => {
+    const handoff = resolveUcpCheckoutHandoff(
+      checkout({
+        continue_url: "https://merchant.example.com/c/chk_1",
+        messages: [{ severity: "requires_buyer_review", type: "error" }],
+        status: "ready_for_complete",
+      }),
+    );
+    expect(handoff).toMatchObject({ kind: "continue_url", reason: "requires_buyer_review" });
+  });
+
+  it("falls back to escalation when no severity names a buyer action", () => {
+    const handoff = resolveUcpCheckoutHandoff(
+      checkout({
+        continue_url: "https://merchant.example.com/c/chk_1",
+        status: "requires_escalation",
+      }),
+    );
+    expect(handoff).toMatchObject({ kind: "continue_url", reason: "escalation" });
+  });
+
+  it("fails when the business escalates without a continue_url", () => {
+    const handoff = resolveUcpCheckoutHandoff(checkout({ status: "requires_escalation" }));
+    expect(handoff).toMatchObject({ kind: "failed", reason: "handoff_unavailable" });
+  });
+});
+
+describe("resolveUcpCheckoutHandoff: embedded checkout", () => {
+  it("builds an embedded URL from the session's accepted delegations", () => {
+    const handoff = resolveUcpCheckoutHandoff(
+      checkout({
+        continue_url: "https://merchant.example.com/checkout/abc123?ref=agent",
+        status: "requires_escalation",
+        ucp: embeddedEnvelope(["payment.credential", "window.open"]),
+      }),
+      { embedded: { colorScheme: "dark", delegate: ["payment.credential"] } },
+    );
+
+    expect(handoff.kind).toBe("embedded");
+    if (handoff.kind !== "embedded") return;
+    expect(handoff.delegate).toEqual(["payment.credential"]);
+    expect(handoff.protocolVersion).toBe(VERSION);
+    expect(handoff.continueUrl).toBe("https://merchant.example.com/checkout/abc123?ref=agent");
+
+    const url = new URL(handoff.url);
+    expect(url.searchParams.get("ref")).toBe("agent");
+    expect(url.searchParams.get("ec_version")).toBe(VERSION);
+    expect(url.searchParams.get("ec_delegate")).toBe("payment.credential");
+    expect(url.searchParams.get("ec_color_scheme")).toBe("dark");
+    expect(url.searchParams.get("ec_auth")).toBeNull();
+  });
+
+  it("offers every accepted delegation when the host requests none specifically", () => {
+    const handoff = resolveUcpCheckoutHandoff(
+      checkout({
+        continue_url: "https://merchant.example.com/checkout/abc123",
+        status: "requires_escalation",
+        ucp: embeddedEnvelope(["payment.credential", "window.open"]),
+      }),
+    );
+    expect(handoff).toMatchObject({ delegate: ["payment.credential", "window.open"] });
+  });
+
+  it("redirects instead when the session offers no embedded binding", () => {
+    const handoff = resolveUcpCheckoutHandoff(
+      checkout({
+        continue_url: "https://merchant.example.com/checkout/abc123",
+        status: "requires_escalation",
+        ucp: {
+          services: {
+            "dev.ucp.shopping": [
+              { endpoint: "https://merchant.example.com/ucp/v1", transport: "rest" },
+            ],
+          },
+          version: VERSION,
+        },
+      }),
+    );
+    expect(handoff.kind).toBe("continue_url");
+  });
+
+  it("redirects when the embedded binding omits config.delegate", () => {
+    const handoff = resolveUcpCheckoutHandoff(
+      checkout({
+        continue_url: "https://merchant.example.com/checkout/abc123",
+        status: "requires_escalation",
+        ucp: {
+          services: { "dev.ucp.shopping": [{ transport: "embedded", version: VERSION }] },
+          version: VERSION,
+        },
+      }),
+    );
+    expect(handoff.kind).toBe("continue_url");
+  });
+
+  it("redirects when the caller opts out", () => {
+    const handoff = resolveUcpCheckoutHandoff(
+      checkout({
+        continue_url: "https://merchant.example.com/checkout/abc123",
+        status: "requires_escalation",
+        ucp: embeddedEnvelope(["payment.credential"]),
+      }),
+      { embedded: false },
+    );
+    expect(handoff.kind).toBe("continue_url");
+  });
+
+  it("applies the business-defined embedded auth token", () => {
+    const handoff = resolveUcpCheckoutHandoff(
+      checkout({
+        continue_url: "https://merchant.example.com/checkout/abc123",
+        status: "requires_escalation",
+        ucp: embeddedEnvelope([]),
+      }),
+      { embedded: { auth: "tok_123" } },
+    );
+    expect(handoff.kind).toBe("embedded");
+    if (handoff.kind !== "embedded") return;
+    const url = new URL(handoff.url);
+    expect(url.searchParams.get("ec_auth")).toBe("tok_123");
+    expect(url.searchParams.get("ec_delegate")).toBeNull();
+  });
+});
+
+describe("resolveUcpCheckoutHandoff: terminal states", () => {
+  it("reports the placed order", () => {
+    const handoff = resolveUcpCheckoutHandoff(
+      checkout({
+        order: { id: "ord_1", permalink_url: "https://merchant.example.com/orders/ord_1" },
+        status: "completed",
+      }),
+    );
+    expect(handoff).toMatchObject({
+      kind: "completed",
+      order: { id: "ord_1", permalink_url: "https://merchant.example.com/orders/ord_1" },
+    });
+  });
+
+  it("reports cancellation", () => {
+    expect(resolveUcpCheckoutHandoff(checkout({ status: "canceled" }))).toMatchObject({
+      kind: "canceled",
+    });
+  });
+});
+
+describe("resolveUcpCheckoutHandoff: failures", () => {
+  it("treats a ucp.status error envelope as a protocol error and keeps the offered URL", () => {
+    const handoff = resolveUcpCheckoutHandoff({
+      continue_url: "https://merchant.example.com/",
+      messages: [{ code: "out_of_stock", severity: "unrecoverable", type: "error" }],
+      ucp: { status: "error", version: VERSION },
+    });
+
+    expect(handoff).toMatchObject({
+      continueUrl: "https://merchant.example.com/",
+      kind: "failed",
+      reason: "protocol_error",
+    });
+    expect(handoff.messages).toHaveLength(1);
+  });
+
+  it("reports an HTTP failure with no usable payload", () => {
+    const handoff = resolveUcpCheckoutHandoff({
+      body: "Bad Gateway",
+      status: 502,
+      statusText: "Bad Gateway",
+    });
+    expect(handoff).toMatchObject({ httpStatus: 502, kind: "failed", reason: "http_error" });
+  });
+
+  it("reports an unrecognized body", () => {
+    expect(resolveUcpCheckoutHandoff(null)).toMatchObject({
+      kind: "failed",
+      reason: "unrecognized_response",
+    });
+  });
+
+  it("reports a body carrying no recognizable status", () => {
+    expect(resolveUcpCheckoutHandoff(checkout())).toMatchObject({
+      kind: "failed",
+      reason: "unrecognized_response",
+    });
+  });
+});
+
+describe("resolveUcpCheckoutHandoff: connection tool results", () => {
+  it("unwraps an eve OpenAPI connection tool result", () => {
+    const handoff = resolveUcpCheckoutHandoff({
+      body: checkout({ status: "ready_for_complete" }),
+      status: 201,
+      statusText: "Created",
+    });
+    expect(handoff).toMatchObject({ kind: "conversational", next: "complete" });
+  });
+
+  it("trusts a 4xx body that still carries a checkout status", () => {
+    const handoff = resolveUcpCheckoutHandoff({
+      body: checkout({
+        continue_url: "https://merchant.example.com/c/chk_1",
+        status: "requires_escalation",
+      }),
+      status: 409,
+      statusText: "Conflict",
+    });
+    expect(handoff.kind).toBe("continue_url");
+  });
+});

--- a/packages/eve/src/public/commerce/ucp/handoff.ts
+++ b/packages/eve/src/public/commerce/ucp/handoff.ts
@@ -1,0 +1,355 @@
+/**
+ * The checkout-handoff result contract.
+ *
+ * A UCP checkout response answers one question the application actually
+ * has to act on: does the agent keep working in the conversation, does
+ * the buyer take over, or is this over? UCP encodes the answer across
+ * `status`, `messages[].severity`, `continue_url`, and the embedded
+ * service binding. This module collapses those four signals into a
+ * single discriminated union so callers switch on `kind` instead of
+ * re-deriving the rules.
+ */
+
+import {
+  parseUcpCheckoutResponse,
+  type UcpCheckout,
+  type UcpCheckoutStatus,
+  type UcpMessage,
+  type UcpOrder,
+  type UcpServiceBinding,
+} from "#public/commerce/ucp/checkout.js";
+
+/** What the agent should do next, in band, without involving the buyer. */
+export type UcpConversationalNextStep =
+  /** Resolve the blockers and call Update Checkout. */
+  | "update"
+  /** Everything is collected; call Complete Checkout. */
+  | "complete"
+  /** The business is placing the order; call Get Checkout until it settles. */
+  | "poll";
+
+/** Why the buyer has to take over. */
+export type UcpHandoffReason =
+  /** The business needs input its API cannot collect. */
+  | "requires_buyer_input"
+  /** The checkout is complete but the buyer must authorize it. */
+  | "requires_buyer_review"
+  /** No resource remains to act on programmatically. */
+  | "unrecoverable"
+  /** The business escalated without naming a buyer-facing severity. */
+  | "escalation";
+
+/** Why neither continuation nor handoff is possible. */
+export type UcpHandoffFailureReason =
+  /** The response was not a UCP checkout body. */
+  | "unrecognized_response"
+  /** `ucp.status` was `"error"`: the response carries messages, not a checkout. */
+  | "protocol_error"
+  /** The business escalated but supplied no `continue_url`. */
+  | "handoff_unavailable"
+  /** A non-2xx response with no usable UCP payload. */
+  | "http_error";
+
+interface UcpHandoffBase {
+  readonly checkoutId?: string;
+  readonly status?: UcpCheckoutStatus;
+  /** Every message from the response, in the order the business sent them. */
+  readonly messages: readonly UcpMessage[];
+  /** Negotiated protocol version from the response envelope. */
+  readonly version?: string;
+  /** The parsed checkout, absent only when the response could not be parsed. */
+  readonly checkout?: UcpCheckout;
+}
+
+/** The agent keeps driving the checkout itself. */
+export interface UcpConversationalHandoff extends UcpHandoffBase {
+  readonly kind: "conversational";
+  readonly next: UcpConversationalNextStep;
+  /** Errors the agent must clear before `next`, in the spec's processing order. */
+  readonly blockers: readonly UcpMessage[];
+  /** Available as an early exit even though handoff is not required yet. */
+  readonly continueUrl?: string;
+}
+
+/** The buyer finishes on the business's own site. */
+export interface UcpContinueUrlHandoff extends UcpHandoffBase {
+  readonly kind: "continue_url";
+  readonly url: string;
+  readonly reason: UcpHandoffReason;
+}
+
+/** The buyer finishes in the business's checkout embedded in this app. */
+export interface UcpEmbeddedHandoff extends UcpHandoffBase {
+  readonly kind: "embedded";
+  /** `continue_url` with the `ec_*` session parameters applied; load this. */
+  readonly url: string;
+  /** `continue_url` unmodified, for a redirect fallback. */
+  readonly continueUrl: string;
+  /** Protocol version pinned for the embedded session's lifetime. */
+  readonly protocolVersion: string;
+  /** Delegations the business accepted for this session. */
+  readonly delegate: readonly string[];
+  readonly reason: UcpHandoffReason;
+}
+
+/** The order was placed. */
+export interface UcpCompletedHandoff extends UcpHandoffBase {
+  readonly kind: "completed";
+  readonly order?: UcpOrder;
+}
+
+/** The session is invalid or expired; start a new one. */
+export interface UcpCanceledHandoff extends UcpHandoffBase {
+  readonly kind: "canceled";
+}
+
+/** Neither continuation nor handoff is possible. */
+export interface UcpFailedHandoff extends UcpHandoffBase {
+  readonly kind: "failed";
+  readonly reason: UcpHandoffFailureReason;
+  /** HTTP status, when the response came from a connection tool result. */
+  readonly httpStatus?: number;
+  /** A `continue_url` the business supplied anyway, if any. */
+  readonly continueUrl?: string;
+}
+
+/** The resolved next move for one checkout response. */
+export type UcpCheckoutHandoff =
+  | UcpConversationalHandoff
+  | UcpContinueUrlHandoff
+  | UcpEmbeddedHandoff
+  | UcpCompletedHandoff
+  | UcpCanceledHandoff
+  | UcpFailedHandoff;
+
+/** Embedded Checkout session parameters this host wants to negotiate. */
+export interface UcpEmbeddedCheckoutOptions {
+  /**
+   * Interactions the host wants to handle natively (e.g.
+   * `"payment.credential"`). Intersected with what the business accepted
+   * for this session.
+   */
+  readonly delegate?: readonly string[];
+  readonly colorScheme?: "light" | "dark";
+  /** Business-defined authentication token for the embedded context. */
+  readonly auth?: string;
+}
+
+export interface UcpCheckoutHandoffOptions {
+  /**
+   * Embedded Checkout preferences, or `false` to always hand off by
+   * redirect.
+   *
+   * Embedded checkout is only ever chosen when the business offered it
+   * for this specific session, so leaving this set is safe: businesses
+   * that do not support it still resolve to `continue_url`.
+   */
+  readonly embedded?: false | UcpEmbeddedCheckoutOptions;
+}
+
+const BUYER_SEVERITIES = new Set(["requires_buyer_input", "requires_buyer_review"]);
+
+const REASON_PRECEDENCE = [
+  "requires_buyer_input",
+  "requires_buyer_review",
+  "unrecoverable",
+] as const;
+
+/**
+ * Resolves a checkout response into the next move.
+ *
+ * Accepts a raw checkout body or an eve OpenAPI connection tool result
+ * (`{ status, statusText, body }`).
+ *
+ * The buyer takes over when the business set `status:
+ * requires_escalation`, or when any message carries
+ * `requires_buyer_input` or `requires_buyer_review` — those two severities
+ * mean the buyer must act regardless of the status the business reported.
+ * `unrecoverable` on its own does not force a handoff: the spec allows
+ * retrying with different inputs, which is conversational work.
+ */
+export function resolveUcpCheckoutHandoff(
+  response: unknown,
+  options: UcpCheckoutHandoffOptions = {},
+): UcpCheckoutHandoff {
+  const parsed = parseUcpCheckoutResponse(response);
+  const checkout = parsed.checkout;
+  const httpStatus = parsed.httpStatus;
+
+  if (checkout === undefined) {
+    return {
+      httpStatus,
+      kind: "failed",
+      messages: [],
+      reason: isHttpFailure(httpStatus) ? "http_error" : "unrecognized_response",
+    };
+  }
+
+  const base: Mutable<UcpHandoffBase> = { checkout, messages: checkout.messages };
+  if (checkout.id !== undefined) {
+    base.checkoutId = checkout.id;
+  }
+  if (checkout.status !== undefined) {
+    base.status = checkout.status;
+  }
+  if (checkout.version !== undefined) {
+    base.version = checkout.version;
+  }
+
+  if (checkout.envelopeStatus === "error") {
+    return failed(base, "protocol_error", httpStatus);
+  }
+
+  if (checkout.status === undefined) {
+    return failed(
+      base,
+      isHttpFailure(httpStatus) ? "http_error" : "unrecognized_response",
+      httpStatus,
+    );
+  }
+
+  if (checkout.status === "completed") {
+    const completed: Mutable<UcpCompletedHandoff> = { ...base, kind: "completed" };
+    if (checkout.order !== undefined) {
+      completed.order = checkout.order;
+    }
+    return completed;
+  }
+  if (checkout.status === "canceled") {
+    return { ...base, kind: "canceled" };
+  }
+
+  const requiresBuyer =
+    checkout.status === "requires_escalation" ||
+    checkout.messages.some(
+      (message) => message.severity !== undefined && BUYER_SEVERITIES.has(message.severity),
+    );
+
+  if (requiresBuyer) {
+    if (checkout.continue_url === undefined) {
+      return failed(base, "handoff_unavailable", httpStatus);
+    }
+    return buyerHandoff(base, checkout, checkout.continue_url, options);
+  }
+
+  const conversational: Mutable<UcpConversationalHandoff> = {
+    ...base,
+    blockers: checkout.messages.filter(
+      (message) => message.type === "error" && message.severity !== undefined,
+    ),
+    kind: "conversational",
+    next: nextStepFor(checkout.status),
+  };
+  if (checkout.continue_url !== undefined) {
+    conversational.continueUrl = checkout.continue_url;
+  }
+  return conversational;
+}
+
+function nextStepFor(
+  status: Exclude<UcpCheckoutStatus, "completed" | "canceled" | "requires_escalation">,
+): UcpConversationalNextStep {
+  if (status === "ready_for_complete") {
+    return "complete";
+  }
+  if (status === "complete_in_progress") {
+    return "poll";
+  }
+  return "update";
+}
+
+function buyerHandoff(
+  base: UcpHandoffBase,
+  checkout: UcpCheckout,
+  continueUrl: string,
+  options: UcpCheckoutHandoffOptions,
+): UcpContinueUrlHandoff | UcpEmbeddedHandoff {
+  const reason = handoffReason(checkout.messages);
+  const embedded = options.embedded === undefined ? {} : options.embedded;
+
+  if (embedded !== false) {
+    const binding = embeddedBinding(checkout.serviceBindings);
+    const protocolVersion = checkout.version ?? binding?.version;
+    if (binding !== undefined && protocolVersion !== undefined) {
+      const accepted = binding.config?.delegate ?? [];
+      const requested = embedded.delegate;
+      const delegate =
+        requested === undefined ? accepted : accepted.filter((entry) => requested.includes(entry));
+      return {
+        ...base,
+        continueUrl,
+        delegate,
+        kind: "embedded",
+        protocolVersion,
+        reason,
+        url: embeddedUrl(continueUrl, protocolVersion, delegate, embedded),
+      };
+    }
+  }
+
+  return { ...base, kind: "continue_url", reason, url: continueUrl };
+}
+
+/**
+ * Finds the embedded binding the business enabled for this session.
+ *
+ * Service-level discovery only says the business supports embedded
+ * checkout; per the spec, availability for a given session is signalled
+ * by an embedded binding carrying `config.delegate` in the checkout
+ * response itself.
+ */
+function embeddedBinding(bindings: readonly UcpServiceBinding[]): UcpServiceBinding | undefined {
+  return bindings.find(
+    (binding) => binding.transport === "embedded" && binding.config?.delegate !== undefined,
+  );
+}
+
+function embeddedUrl(
+  continueUrl: string,
+  protocolVersion: string,
+  delegate: readonly string[],
+  options: UcpEmbeddedCheckoutOptions,
+): string {
+  const url = new URL(continueUrl);
+  url.searchParams.set("ec_version", protocolVersion);
+  if (delegate.length > 0) {
+    url.searchParams.set("ec_delegate", delegate.join(","));
+  }
+  if (options.auth !== undefined) {
+    url.searchParams.set("ec_auth", options.auth);
+  }
+  if (options.colorScheme !== undefined) {
+    url.searchParams.set("ec_color_scheme", options.colorScheme);
+  }
+  return url.toString();
+}
+
+function handoffReason(messages: readonly UcpMessage[]): UcpHandoffReason {
+  for (const severity of REASON_PRECEDENCE) {
+    if (messages.some((message) => message.severity === severity)) {
+      return severity;
+    }
+  }
+  return "escalation";
+}
+
+function isHttpFailure(httpStatus: number | undefined): boolean {
+  return httpStatus !== undefined && httpStatus >= 400;
+}
+
+function failed(
+  base: UcpHandoffBase,
+  reason: UcpHandoffFailureReason,
+  httpStatus: number | undefined,
+): UcpFailedHandoff {
+  const result: Mutable<UcpFailedHandoff> = { ...base, kind: "failed", reason };
+  if (httpStatus !== undefined) {
+    result.httpStatus = httpStatus;
+  }
+  if (base.checkout?.continue_url !== undefined) {
+    result.continueUrl = base.checkout.continue_url;
+  }
+  return result;
+}
+
+type Mutable<T> = { -readonly [K in keyof T]: T[K] };

--- a/packages/eve/src/public/commerce/ucp/index.ts
+++ b/packages/eve/src/public/commerce/ucp/index.ts
@@ -1,0 +1,56 @@
+/**
+ * Universal Commerce Protocol support for the buying side of a
+ * transaction: connecting an agent to a merchant's UCP shopping service,
+ * and deciding what happens after each checkout response.
+ *
+ * For the selling side — publishing your own `/.well-known/ucp` profile
+ * and serving commerce endpoints — see the UCP protocol guide.
+ */
+
+export {
+  defineUcpConnection,
+  type UcpConnectionDefinition,
+} from "#public/commerce/ucp/connection.js";
+export {
+  deriveUcpRequestUuid,
+  ucpAgentHeaderValue,
+  ucpShoppingRestSpecUrl,
+  UCP_VERSION,
+  type UcpAgentMetadata,
+} from "#public/commerce/ucp/protocol.js";
+export {
+  createUcpSigner,
+  ucpContentDigest,
+  ucpSignatureBase,
+  ucpSignatureComponents,
+  type UcpSignatureAlgorithm,
+  type UcpSignatureHeaders,
+  type UcpSignatureRequest,
+  type UcpSigner,
+  type UcpSigningKey,
+} from "#public/commerce/ucp/signing.js";
+export {
+  parseUcpCheckoutResponse,
+  type ParsedUcpCheckoutResponse,
+  type UcpCheckout,
+  type UcpCheckoutStatus,
+  type UcpErrorSeverity,
+  type UcpMessage,
+  type UcpOrder,
+  type UcpServiceBinding,
+} from "#public/commerce/ucp/checkout.js";
+export {
+  resolveUcpCheckoutHandoff,
+  type UcpCanceledHandoff,
+  type UcpCheckoutHandoff,
+  type UcpCheckoutHandoffOptions,
+  type UcpCompletedHandoff,
+  type UcpContinueUrlHandoff,
+  type UcpConversationalHandoff,
+  type UcpConversationalNextStep,
+  type UcpEmbeddedCheckoutOptions,
+  type UcpEmbeddedHandoff,
+  type UcpFailedHandoff,
+  type UcpHandoffFailureReason,
+  type UcpHandoffReason,
+} from "#public/commerce/ucp/handoff.js";

--- a/packages/eve/src/public/commerce/ucp/protocol.test.ts
+++ b/packages/eve/src/public/commerce/ucp/protocol.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveUcpRequestUuid,
+  ucpAgentHeaderValue,
+  ucpShoppingRestSpecUrl,
+  UCP_VERSION,
+} from "#public/commerce/ucp/protocol.js";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-8[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe("ucpAgentHeaderValue", () => {
+  it("serializes the profile as a quoted dictionary member", () => {
+    expect(ucpAgentHeaderValue({ profile: "https://agent.example/.well-known/ucp" })).toBe(
+      'profile="https://agent.example/.well-known/ucp"',
+    );
+  });
+
+  it("appends extra dictionary members after profile", () => {
+    expect(
+      ucpAgentHeaderValue({
+        parameters: { deployment: "prod" },
+        profile: "https://agent.example/p.json",
+      }),
+    ).toBe('profile="https://agent.example/p.json", deployment="prod"');
+  });
+
+  it("escapes quotes and backslashes in member values", () => {
+    expect(
+      ucpAgentHeaderValue({
+        parameters: { note: 'a"b\\c' },
+        profile: "https://agent.example/p.json",
+      }),
+    ).toBe('profile="https://agent.example/p.json", note="a\\"b\\\\c"');
+  });
+
+  it("rejects a non-https profile", () => {
+    expect(() => ucpAgentHeaderValue({ profile: "http://agent.example/p.json" })).toThrow(
+      /must use https/,
+    );
+  });
+
+  it("rejects a relative profile", () => {
+    expect(() => ucpAgentHeaderValue({ profile: "/.well-known/ucp" })).toThrow(
+      /must be an absolute https URL/,
+    );
+  });
+});
+
+describe("deriveUcpRequestUuid", () => {
+  it("produces a version 8 UUID", async () => {
+    expect(await deriveUcpRequestUuid("idempotency:call-1:create_checkout")).toMatch(UUID_RE);
+  });
+
+  it("is stable for the same seed, so a replayed call reuses its key", async () => {
+    const first = await deriveUcpRequestUuid("idempotency:call-1:create_checkout");
+    const second = await deriveUcpRequestUuid("idempotency:call-1:create_checkout");
+    expect(second).toBe(first);
+  });
+
+  it("differs across call ids and across purposes for one call", async () => {
+    const [a, b, c] = await Promise.all([
+      deriveUcpRequestUuid("idempotency:call-1:create_checkout"),
+      deriveUcpRequestUuid("idempotency:call-2:create_checkout"),
+      deriveUcpRequestUuid("request:call-1:create_checkout"),
+    ]);
+    expect(new Set([a, b, c]).size).toBe(3);
+  });
+});
+
+describe("ucpShoppingRestSpecUrl", () => {
+  it("defaults to the targeted protocol version", () => {
+    expect(ucpShoppingRestSpecUrl()).toBe(
+      `https://ucp.dev/${UCP_VERSION}/services/shopping/rest.openapi.json`,
+    );
+  });
+
+  it("resolves an older version", () => {
+    expect(ucpShoppingRestSpecUrl("2026-01-11")).toBe(
+      "https://ucp.dev/2026-01-11/services/shopping/rest.openapi.json",
+    );
+  });
+});

--- a/packages/eve/src/public/commerce/ucp/protocol.ts
+++ b/packages/eve/src/public/commerce/ucp/protocol.ts
@@ -1,0 +1,100 @@
+/**
+ * Protocol constants and identity plumbing shared by the UCP connection
+ * preset and the checkout-handoff contract.
+ */
+
+/**
+ * UCP specification version this preset targets by default.
+ *
+ * UCP versions are dated (`YYYY-MM-DD`) and a business advertises the
+ * versions it accepts in its `/.well-known/ucp` profile. Override it per
+ * connection when a merchant has not yet adopted this one.
+ */
+export const UCP_VERSION = "2026-04-08";
+
+/** Canonical URL of the UCP shopping REST contract for a given version. */
+export function ucpShoppingRestSpecUrl(version: string = UCP_VERSION): string {
+  return `https://ucp.dev/${version}/services/shopping/rest.openapi.json`;
+}
+
+/**
+ * Identity a UCP platform (the calling agent) advertises on every
+ * request.
+ *
+ * UCP has no registration step: a business resolves who is calling by
+ * fetching the `profile` document named here, then reads its declared
+ * capabilities and its `signing_keys` to verify signatures. The profile
+ * must therefore be reachable over HTTPS from the merchant's network —
+ * a `localhost` dev server is not, which is why merchants publish
+ * example agent profiles for local testing.
+ */
+export interface UcpAgentMetadata {
+  /** Absolute HTTPS URL of this agent's UCP profile document. */
+  readonly profile: string;
+  /**
+   * Extra `UCP-Agent` dictionary members, serialized as quoted strings.
+   *
+   * The spec requires `profile` and allows platforms to add their own
+   * members; anything here is appended verbatim after it.
+   */
+  readonly parameters?: Readonly<Record<string, string>>;
+}
+
+/**
+ * Serializes {@link UcpAgentMetadata} into a `UCP-Agent` header value —
+ * an RFC 8941 dictionary whose `profile` member is a quoted string.
+ *
+ * @throws when `profile` is not an absolute `https` URL, which the spec
+ * requires and verifiers reject.
+ */
+export function ucpAgentHeaderValue(agent: UcpAgentMetadata): string {
+  let url: URL;
+  try {
+    url = new URL(agent.profile);
+  } catch {
+    throw new Error(
+      `UCP agent profile must be an absolute https URL, got "${agent.profile}". Publish the profile on a host the merchant can reach.`,
+    );
+  }
+  if (url.protocol !== "https:") {
+    throw new Error(
+      `UCP agent profile must use https, got "${url.protocol}//${url.host}". Merchants reject non-https profile URLs.`,
+    );
+  }
+
+  const members = [`profile="${escapeDictionaryString(agent.profile)}"`];
+  for (const [key, value] of Object.entries(agent.parameters ?? {})) {
+    members.push(`${key}="${escapeDictionaryString(value)}"`);
+  }
+  return members.join(", ");
+}
+
+function escapeDictionaryString(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+/**
+ * Derives a stable UUID from `seed`.
+ *
+ * UCP requires retry-safe request identifiers with at least 128 bits of
+ * entropy, and its REST contract types them as UUIDs. Deriving them from
+ * eve's replay-stable `callId` rather than minting random ones is what
+ * makes them retry-safe: a durable turn that resumes and re-issues the
+ * same tool call sends the same key, so the merchant replays its cached
+ * response instead of charging twice.
+ *
+ * The result is a version 8 (custom) UUID over the SHA-256 of `seed`.
+ */
+export async function deriveUcpRequestUuid(seed: string): Promise<string> {
+  const digest = new Uint8Array(
+    await crypto.subtle.digest("SHA-256", new TextEncoder().encode(seed)),
+  );
+  const bytes = digest.slice(0, 16);
+  // RFC 9562: version in the high nibble of octet 6, variant in the two
+  // high bits of octet 8.
+  bytes[6] = (bytes[6]! & 0x0f) | 0x80;
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/packages/eve/src/public/commerce/ucp/signing.test.ts
+++ b/packages/eve/src/public/commerce/ucp/signing.test.ts
@@ -1,0 +1,207 @@
+import { beforeAll, describe, expect, it } from "vitest";
+
+import {
+  createUcpSigner,
+  ucpContentDigest,
+  ucpSignatureBase,
+  ucpSignatureComponents,
+} from "#public/commerce/ucp/signing.js";
+
+const AGENT_HEADER = 'profile="https://agent.example/.well-known/ucp"';
+const IDEMPOTENCY_KEY = "550e8400-e29b-41d4-a716-446655440000";
+
+const POST_REQUEST = {
+  body: '{"line_items":[{"item":{"id":"item_123"},"quantity":1}]}',
+  headers: {
+    "content-type": "application/json",
+    "Idempotency-Key": IDEMPOTENCY_KEY,
+    "UCP-Agent": AGENT_HEADER,
+  },
+  method: "POST",
+  url: "https://merchant.example.com/ucp/v1/checkout-sessions",
+} as const;
+
+let keyPair: { privateKey: CryptoKey; publicKey: CryptoKey };
+let jwk: Record<string, unknown>;
+
+beforeAll(async () => {
+  keyPair = (await crypto.subtle.generateKey({ name: "ECDSA", namedCurve: "P-256" }, true, [
+    "sign",
+    "verify",
+  ])) as { privateKey: CryptoKey; publicKey: CryptoKey };
+  jwk = (await crypto.subtle.exportKey("jwk", keyPair.privateKey)) as Record<string, unknown>;
+});
+
+describe("ucpSignatureComponents", () => {
+  it("covers the components UCP requires for a POST with a body", () => {
+    expect(ucpSignatureComponents(POST_REQUEST)).toEqual([
+      "@method",
+      "@authority",
+      "@path",
+      "ucp-agent",
+      "idempotency-key",
+      "content-digest",
+      "content-type",
+    ]);
+  });
+
+  it("omits body and idempotency components for a bodyless GET", () => {
+    expect(
+      ucpSignatureComponents({
+        headers: { "UCP-Agent": AGENT_HEADER },
+        method: "GET",
+        url: "https://merchant.example.com/ucp/v1/checkout-sessions/chk_1",
+      }),
+    ).toEqual(["@method", "@authority", "@path", "ucp-agent"]);
+  });
+
+  it("omits content-type for a body sent without one", () => {
+    expect(
+      ucpSignatureComponents({
+        body: "{}",
+        headers: { "UCP-Agent": AGENT_HEADER },
+        method: "POST",
+        url: "https://merchant.example.com/ucp/v1/checkout-sessions",
+      }),
+    ).toEqual(["@method", "@authority", "@path", "ucp-agent", "content-digest"]);
+  });
+
+  it("covers @query only when the URL carries one", () => {
+    expect(
+      ucpSignatureComponents({
+        headers: {},
+        method: "GET",
+        url: "https://merchant.example.com/ucp/v1/orders/o_1?expand=line_items",
+      }),
+    ).toContain("@query");
+  });
+});
+
+describe("ucpSignatureBase", () => {
+  it("builds the RFC 9421 base and matching Signature-Input", async () => {
+    const contentDigest = await ucpContentDigest(POST_REQUEST.body);
+    const { base, signatureInput } = ucpSignatureBase(POST_REQUEST, {
+      contentDigest,
+      keyId: "platform-2026",
+    });
+
+    expect(base).toBe(
+      [
+        `"@method": POST`,
+        `"@authority": merchant.example.com`,
+        `"@path": /ucp/v1/checkout-sessions`,
+        `"ucp-agent": ${AGENT_HEADER}`,
+        `"idempotency-key": ${IDEMPOTENCY_KEY}`,
+        `"content-digest": ${contentDigest}`,
+        `"content-type": application/json`,
+        `"@signature-params": ("@method" "@authority" "@path" "ucp-agent" "idempotency-key" "content-digest" "content-type");keyid="platform-2026"`,
+      ].join("\n"),
+    );
+    expect(signatureInput).toBe(
+      `sig1=("@method" "@authority" "@path" "ucp-agent" "idempotency-key" "content-digest" "content-type");keyid="platform-2026"`,
+    );
+  });
+
+  it("omits alg and includes created only when asked", () => {
+    const withCreated = ucpSignatureBase(
+      { ...POST_REQUEST, body: undefined, created: 1738617601.9 },
+      { keyId: "platform-2026" },
+    );
+    expect(withCreated.signatureInput).toContain(';created=1738617601;keyid="platform-2026"');
+    expect(withCreated.signatureInput).not.toContain("alg=");
+  });
+
+  it("lowercases the authority and preserves an explicit port", () => {
+    const { base } = ucpSignatureBase(
+      { headers: {}, method: "GET", url: "https://Merchant.Example.com:8443/ucp/v1/carts/c_1" },
+      { keyId: "k" },
+    );
+    expect(base).toContain(`"@authority": merchant.example.com:8443`);
+  });
+});
+
+describe("ucpContentDigest", () => {
+  it("formats an RFC 9530 sha-256 digest over the raw bytes", async () => {
+    expect(await ucpContentDigest("{}")).toBe(
+      "sha-256=:RBNvo1WzZ4oRRq0W9+hknpT7T8If536DEMBg9hyq/4o=:",
+    );
+  });
+
+  it("changes when the serialized bytes change, even for equivalent JSON", async () => {
+    const compact = await ucpContentDigest('{"a":1}');
+    const spaced = await ucpContentDigest('{"a": 1}');
+    expect(spaced).not.toBe(compact);
+  });
+});
+
+describe("createUcpSigner", () => {
+  it("produces a signature the public key verifies", async () => {
+    const sign = createUcpSigner({ keyId: "platform-2026", privateKey: jwk });
+    const headers = await sign(POST_REQUEST);
+
+    expect(headers["Content-Digest"]).toBe(await ucpContentDigest(POST_REQUEST.body));
+    expect(headers["Signature-Input"]).toMatch(/^sig1=\(/);
+    expect(headers.Signature).toMatch(/^sig1=:.+:$/);
+
+    const { base } = ucpSignatureBase(POST_REQUEST, {
+      contentDigest: headers["Content-Digest"],
+      keyId: "platform-2026",
+    });
+    const raw = headers.Signature.slice("sig1=:".length, -1);
+    const signature = Uint8Array.from(atob(raw), (char) => char.charCodeAt(0));
+
+    // RFC 9421 requires fixed-width r||s, so P-256 signatures are exactly
+    // 64 bytes — a DER-encoded signature would be a different length and
+    // would fail verification here.
+    expect(signature.byteLength).toBe(64);
+    await expect(
+      crypto.subtle.verify(
+        { hash: "SHA-256", name: "ECDSA" },
+        keyPair.publicKey,
+        signature,
+        new TextEncoder().encode(base),
+      ),
+    ).resolves.toBe(true);
+  });
+
+  it("omits Content-Digest for a bodyless request", async () => {
+    const sign = createUcpSigner({ keyId: "platform-2026", privateKey: jwk });
+    const headers = await sign({
+      headers: { "UCP-Agent": AGENT_HEADER },
+      method: "GET",
+      url: "https://merchant.example.com/ucp/v1/checkout-sessions/chk_1",
+    });
+    expect(headers["Content-Digest"]).toBeUndefined();
+    expect(headers["Signature-Input"]).not.toContain("content-digest");
+  });
+
+  it("honors a custom signature label", async () => {
+    const sign = createUcpSigner({ keyId: "platform-2026", privateKey: jwk });
+    const headers = await sign({ ...POST_REQUEST, label: "ucp1" });
+    expect(headers["Signature-Input"]).toMatch(/^ucp1=\(/);
+    expect(headers.Signature).toMatch(/^ucp1=:/);
+  });
+
+  it("signs with a PKCS#8 PEM key", async () => {
+    const pkcs8 = new Uint8Array(await crypto.subtle.exportKey("pkcs8", keyPair.privateKey));
+    let base64 = "";
+    for (const byte of pkcs8) {
+      base64 += String.fromCharCode(byte);
+    }
+    const pem = `-----BEGIN PRIVATE KEY-----\n${btoa(base64)}\n-----END PRIVATE KEY-----\n`;
+
+    const sign = createUcpSigner({ keyId: "platform-2026", privateKey: pem });
+    await expect(sign(POST_REQUEST)).resolves.toHaveProperty("Signature");
+  });
+
+  it("reports an undecodable key against its keyId", async () => {
+    const sign = createUcpSigner({ keyId: "platform-2026", privateKey: "not-a-pem" });
+    await expect(sign(POST_REQUEST)).rejects.toThrow(/platform-2026/);
+  });
+
+  it("rejects an unsupported JWK curve", () => {
+    expect(() =>
+      createUcpSigner({ keyId: "platform-2026", privateKey: { crv: "P-521", kty: "EC" } }),
+    ).toThrow(/unsupported curve "P-521"/);
+  });
+});

--- a/packages/eve/src/public/commerce/ucp/signing.ts
+++ b/packages/eve/src/public/commerce/ucp/signing.ts
@@ -1,0 +1,302 @@
+/**
+ * HTTP Message Signatures (RFC 9421) and content digests (RFC 9530) as
+ * UCP profiles them.
+ *
+ * UCP verifiers resolve the signing key by matching the `keyid`
+ * parameter against a `kid` in the signer's profile `signing_keys[]`, so
+ * `keyId` here must be the `kid` published in the agent profile named by
+ * the `UCP-Agent` header.
+ */
+
+/** Signature algorithms UCP allows. P-256 verification is mandatory; P-384 is optional. */
+export type UcpSignatureAlgorithm = "ES256" | "ES384";
+
+/**
+ * The JWK fields an EC private key needs, as published alongside its
+ * public counterpart in a profile's `signing_keys`.
+ */
+export interface UcpJsonWebKey {
+  readonly kty?: string;
+  readonly crv?: string;
+  readonly d?: string;
+  readonly x?: string;
+  readonly y?: string;
+  readonly alg?: string;
+  readonly use?: string;
+}
+
+/** Private key material used to sign outgoing UCP requests. */
+export interface UcpSigningKey {
+  /** `kid` of the matching public key in the agent profile's `signing_keys`. */
+  readonly keyId: string;
+  /**
+   * The private key, as a PKCS#8 PEM string or a JWK.
+   *
+   * A JWK's `crv` determines the algorithm; for PEM, set
+   * {@link algorithm} (it defaults to `ES256`).
+   */
+  readonly privateKey: string | UcpJsonWebKey;
+  readonly algorithm?: UcpSignatureAlgorithm;
+}
+
+/** The request a signer covers. `headers` must be the ones actually sent. */
+export interface UcpSignatureRequest {
+  readonly method: string;
+  /** Absolute request URL, including the query string. */
+  readonly url: string;
+  readonly headers: Readonly<Record<string, string>>;
+  /** Serialized request body, absent for requests that send none. */
+  readonly body?: string;
+  /** Signature label. Defaults to `sig1`. */
+  readonly label?: string;
+  /**
+   * `created` signature parameter, in seconds since the Unix epoch.
+   *
+   * Optional in UCP: replay protection lives at the business layer via
+   * `Idempotency-Key`, not signature freshness. Omitting it keeps the
+   * signature reproducible across retries of the same request.
+   */
+  readonly created?: number;
+}
+
+/** Headers a signer produces, ready to merge into the outgoing request. */
+export interface UcpSignatureHeaders {
+  /** Present only when the request carries a body. */
+  readonly "Content-Digest"?: string;
+  readonly "Signature-Input": string;
+  readonly Signature: string;
+}
+
+/** Signs one request. Returned by {@link createUcpSigner}. */
+export type UcpSigner = (request: UcpSignatureRequest) => Promise<UcpSignatureHeaders>;
+
+const DEFAULT_LABEL = "sig1";
+
+const CURVES: Record<UcpSignatureAlgorithm, { namedCurve: string; hash: string }> = {
+  ES256: { namedCurve: "P-256", hash: "SHA-256" },
+  ES384: { namedCurve: "P-384", hash: "SHA-384" },
+};
+
+const JWK_CURVE_ALGORITHMS: Record<string, UcpSignatureAlgorithm> = {
+  "P-256": "ES256",
+  "P-384": "ES384",
+};
+
+/**
+ * The components UCP requires a REST request signature to cover, in the
+ * order they are emitted.
+ *
+ * `@query` is covered only when the URL has one, `ucp-agent` and
+ * `idempotency-key` only when those headers are sent, and
+ * `content-digest`/`content-type` only when there is a body — so the base
+ * is always built from what the request actually contains.
+ */
+export function ucpSignatureComponents(request: UcpSignatureRequest): readonly string[] {
+  const url = new URL(request.url);
+  const components = ["@method", "@authority", "@path"];
+  if (url.search.length > 0) {
+    components.push("@query");
+  }
+  if (findHeader(request.headers, "ucp-agent") !== undefined) {
+    components.push("ucp-agent");
+  }
+  if (findHeader(request.headers, "idempotency-key") !== undefined) {
+    components.push("idempotency-key");
+  }
+  if (request.body !== undefined) {
+    components.push("content-digest");
+    // Only cover `content-type` when the request actually sends it, so the
+    // base never claims a component the verifier will not see.
+    if (findHeader(request.headers, "content-type") !== undefined) {
+      components.push("content-type");
+    }
+  }
+  return components;
+}
+
+/**
+ * Builds the RFC 9421 signature base and the matching `Signature-Input`
+ * value.
+ *
+ * Exported because the base is the contract: when a merchant reports
+ * `signature_invalid`, comparing this string against what the verifier
+ * reconstructed is the fastest way to find the disagreement.
+ */
+export function ucpSignatureBase(
+  request: UcpSignatureRequest,
+  options: { readonly keyId: string; readonly contentDigest?: string },
+): { readonly base: string; readonly signatureInput: string } {
+  const url = new URL(request.url);
+  const components = ucpSignatureComponents(request);
+  const lines: string[] = [];
+
+  for (const component of components) {
+    lines.push(`"${component}": ${componentValue(component, request, url, options.contentDigest)}`);
+  }
+
+  const label = request.label ?? DEFAULT_LABEL;
+  const serializedComponents = components.map((component) => `"${component}"`).join(" ");
+  const parameters =
+    request.created === undefined
+      ? `;keyid="${options.keyId}"`
+      : `;created=${Math.floor(request.created)};keyid="${options.keyId}"`;
+  const signatureParams = `(${serializedComponents})${parameters}`;
+
+  lines.push(`"@signature-params": ${signatureParams}`);
+
+  return { base: lines.join("\n"), signatureInput: `${label}=${signatureParams}` };
+}
+
+/**
+ * Computes an RFC 9530 `Content-Digest` header value over the raw body
+ * bytes.
+ *
+ * The digest covers the exact bytes sent. Nothing between the signer and
+ * `fetch` may re-serialize the JSON, or the digest — and the signature
+ * over it — stops matching.
+ */
+export async function ucpContentDigest(body: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(body));
+  return `sha-256=:${toBase64(new Uint8Array(digest))}:`;
+}
+
+/**
+ * Creates a signer bound to one key, importing the key material once and
+ * reusing it across requests.
+ */
+export function createUcpSigner(key: UcpSigningKey): UcpSigner {
+  const algorithm = resolveAlgorithm(key);
+  const curve = CURVES[algorithm];
+  let imported: Promise<CryptoKey> | undefined;
+  const getKey = () => (imported ??= importPrivateKey(key, curve.namedCurve));
+
+  return async (request) => {
+    const contentDigest =
+      request.body === undefined ? undefined : await ucpContentDigest(request.body);
+    const { base, signatureInput } = ucpSignatureBase(request, {
+      contentDigest,
+      keyId: key.keyId,
+    });
+
+    // WebCrypto's ECDSA output is already the fixed-width r||s encoding
+    // RFC 9421 mandates, not the ASN.1/DER that most server-side crypto
+    // libraries emit by default.
+    const signature = await crypto.subtle.sign(
+      { name: "ECDSA", hash: curve.hash },
+      await getKey(),
+      new TextEncoder().encode(base),
+    );
+
+    const label = request.label ?? DEFAULT_LABEL;
+    const headers: {
+      "Content-Digest"?: string;
+      "Signature-Input": string;
+      Signature: string;
+    } = {
+      Signature: `${label}=:${toBase64(new Uint8Array(signature))}:`,
+      "Signature-Input": signatureInput,
+    };
+    if (contentDigest !== undefined) {
+      headers["Content-Digest"] = contentDigest;
+    }
+    return headers;
+  };
+}
+
+function resolveAlgorithm(key: UcpSigningKey): UcpSignatureAlgorithm {
+  if (key.algorithm !== undefined) {
+    return key.algorithm;
+  }
+  if (typeof key.privateKey !== "string" && typeof key.privateKey.crv === "string") {
+    const derived = JWK_CURVE_ALGORITHMS[key.privateKey.crv];
+    if (derived === undefined) {
+      throw new Error(
+        `UCP signing key "${key.keyId}" uses unsupported curve "${key.privateKey.crv}". Use P-256 (ES256) or P-384 (ES384).`,
+      );
+    }
+    return derived;
+  }
+  return "ES256";
+}
+
+async function importPrivateKey(key: UcpSigningKey, namedCurve: string): Promise<CryptoKey> {
+  const algorithm = { name: "ECDSA", namedCurve } as const;
+  if (typeof key.privateKey !== "string") {
+    return crypto.subtle.importKey("jwk", key.privateKey, algorithm, false, ["sign"]);
+  }
+  return crypto.subtle.importKey(
+    "pkcs8",
+    decodePkcs8Pem(key.privateKey, key.keyId),
+    algorithm,
+    false,
+    ["sign"],
+  );
+}
+
+function decodePkcs8Pem(pem: string, keyId: string): Uint8Array<ArrayBuffer> {
+  const body = pem
+    .replace(/-----BEGIN [^-]+-----/g, "")
+    .replace(/-----END [^-]+-----/g, "")
+    .replace(/\s+/g, "");
+  if (body.length === 0) {
+    throw new Error(
+      `UCP signing key "${keyId}" is empty. Provide a PKCS#8 PEM private key ("-----BEGIN PRIVATE KEY-----") or a JWK.`,
+    );
+  }
+  try {
+    return fromBase64(body);
+  } catch {
+    throw new Error(
+      `UCP signing key "${keyId}" could not be decoded. Provide a PKCS#8 PEM private key ("-----BEGIN PRIVATE KEY-----") or a JWK.`,
+    );
+  }
+}
+
+function componentValue(
+  component: string,
+  request: UcpSignatureRequest,
+  url: URL,
+  contentDigest: string | undefined,
+): string {
+  switch (component) {
+    case "@method":
+      return request.method.toUpperCase();
+    case "@authority":
+      return url.host.toLowerCase();
+    case "@path":
+      return url.pathname;
+    case "@query":
+      return url.search;
+    case "content-digest":
+      return contentDigest ?? findHeader(request.headers, "content-digest") ?? "";
+    default:
+      return findHeader(request.headers, component) ?? "";
+  }
+}
+
+/** Case-insensitive header lookup, since header names are not case-sensitive. */
+function findHeader(headers: Readonly<Record<string, string>>, name: string): string | undefined {
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === name) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function toBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}
+
+function fromBase64(value: string): Uint8Array<ArrayBuffer> {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index++) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}

--- a/packages/eve/src/public/connections/index.ts
+++ b/packages/eve/src/public/connections/index.ts
@@ -28,6 +28,8 @@ export type {
   ProvidedArgumentValue,
 } from "#public/definitions/connections/tool-call.js";
 export {
+  type ConnectionRequestPreparation,
+  type ConnectionRequestPreparer,
   defineOpenAPIConnection,
   type OpenAPIConnectionDefinition,
   type OpenAPISpecSource,

--- a/packages/eve/src/public/definitions/connections/openapi.ts
+++ b/packages/eve/src/public/definitions/connections/openapi.ts
@@ -17,6 +17,55 @@ import type { ConnectionToolCallDefinition } from "#public/definitions/connectio
 export type OpenAPISpecSource = string | Record<string, unknown>;
 
 /**
+ * The fully-built outgoing HTTP request for one connection tool call,
+ * handed to {@link ConnectionRequestPreparer} immediately before eve
+ * dispatches it.
+ *
+ * `headers` already carries the connection's resolved auth, static
+ * headers, and any header parameters the operation declared. `body` is
+ * the serialized request body exactly as it will be sent, so a preparer
+ * can digest or sign the bytes the server will receive.
+ */
+export interface ConnectionRequestPreparation {
+  /** Uppercase HTTP method (e.g. `"POST"`). */
+  readonly method: string;
+  /** Absolute request URL, including the query string. */
+  readonly url: string;
+  readonly headers: Readonly<Record<string, string>>;
+  /** Serialized request body, absent for requests that send none. */
+  readonly body?: string;
+  /** Replay-stable id of the connection tool call issuing this request. */
+  readonly callId: string;
+  /** Bare operation name published by the connection (e.g. `"create_checkout"`). */
+  readonly toolName: string;
+}
+
+/**
+ * Last-mile hook that derives extra request headers from the fully-built
+ * request.
+ *
+ * Runs once per connection tool call, immediately before dispatch. The
+ * returned headers are merged over the request's own headers. Return
+ * `undefined` to leave the request unchanged.
+ *
+ * This is the only place a connection can observe the serialized body,
+ * so it is where body-dependent schemes belong: HTTP Message Signatures
+ * (RFC 9421), content digests (RFC 9530), and request-signing schemes
+ * such as AWS SigV4. Header values that do not depend on the body should
+ * use `headers` instead, and operation parameters should use
+ * `toolCall.providedArguments`.
+ *
+ * Throwing aborts the tool call; the error surfaces to the model as the
+ * tool's failure.
+ */
+export type ConnectionRequestPreparer = (
+  request: ConnectionRequestPreparation,
+) =>
+  | Readonly<Record<string, string>>
+  | undefined
+  | Promise<Readonly<Record<string, string>> | undefined>;
+
+/**
  * Public definition for an OpenAPI connection authored in
  * `connections/*.ts`.
  *
@@ -100,6 +149,16 @@ export interface OpenAPIConnectionDefinition {
    * resolved values immediately before building the HTTP request.
    */
   toolCall?: ConnectionToolCallDefinition;
+  /**
+   * Hook invoked with the fully-built request immediately before eve
+   * dispatches it; the headers it returns are merged over the request's
+   * own headers.
+   *
+   * Use it for anything that must observe the serialized body — HTTP
+   * Message Signatures, content digests, request-signing schemes. Use
+   * `headers` for body-independent values.
+   */
+  prepareRequest?: ConnectionRequestPreparer;
   /**
    * Operation filter keyed on `operationId`. When set, the model sees
    * only operations whose id passes the filter; `connection_search`

--- a/packages/eve/src/runtime/connections/openapi-client.test.ts
+++ b/packages/eve/src/runtime/connections/openapi-client.test.ts
@@ -933,6 +933,71 @@ describe("OpenApiConnectionClient", () => {
     const [, init] = fetchMock.mock.calls[0]!;
     expect((init.headers as Record<string, string>).Authorization).toBe("Bearer secret");
   });
+
+  it("hands prepareRequest the fully-built request and merges the headers it returns", async () => {
+    const fetchMock = vi.fn(
+      async (_url: unknown, _init: RequestInit) => new Response(null, { status: 201 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const prepareRequest = vi.fn(() => ({
+      Authorization: "Bearer signed",
+      "X-Digest": "computed",
+    }));
+    const client = new OpenApiConnectionClient(
+      makeConnection({
+        authorization: { getToken: async () => ({ token: "secret" }), principalType: "app" },
+        prepareRequest,
+      }),
+    );
+
+    await client.executeTool("createProject", { body: { name: "eve" } }, EXECUTE_OPTIONS);
+
+    expect(prepareRequest).toHaveBeenCalledWith({
+      body: '{"name":"eve"}',
+      callId: "call-1",
+      headers: { Authorization: "Bearer secret", "content-type": "application/json" },
+      method: "POST",
+      toolName: "createProject",
+      url: "https://api.example.com/v1/projects",
+    });
+
+    const headers = fetchMock.mock.calls[0]![1].headers as Record<string, string>;
+    expect(headers["X-Digest"]).toBe("computed");
+    expect(headers.Authorization).toBe("Bearer signed");
+  });
+
+  it("leaves the request unchanged when prepareRequest returns nothing", async () => {
+    const fetchMock = vi.fn(
+      async (_url: unknown, _init: RequestInit) => new Response(null, { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new OpenApiConnectionClient(makeConnection({ prepareRequest: () => undefined }));
+    await client.executeTool("getProject", { id: "prj_1" }, EXECUTE_OPTIONS);
+
+    expect(fetchMock.mock.calls[0]![1].headers).toEqual({});
+  });
+
+  it("fails the tool call when prepareRequest throws", async () => {
+    const fetchMock = vi.fn(
+      async (_url: unknown, _init: RequestInit) => new Response(null, { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new OpenApiConnectionClient(
+      makeConnection({
+        prepareRequest: () => {
+          throw new Error("signing key unavailable");
+        },
+      }),
+    );
+
+    await expect(
+      client.executeTool("getProject", { id: "prj_1" }, EXECUTE_OPTIONS),
+    ).rejects.toThrow("signing key unavailable");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });
 
 /** Builds a minimal spec whose single operation requires `scheme`. */

--- a/packages/eve/src/runtime/connections/openapi-client.ts
+++ b/packages/eve/src/runtime/connections/openapi-client.ts
@@ -474,8 +474,21 @@ export class OpenApiConnectionClient implements ConnectionClient {
       headers["content-type"] = operation.requestBody.contentType;
     }
 
+    const method = operation.method.toUpperCase();
+    const prepared = await this.#connection.prepareRequest?.({
+      body,
+      callId: options.callId,
+      headers: { ...headers },
+      method,
+      toolName: operation.toolName,
+      url: url.toString(),
+    });
+    if (prepared !== undefined) {
+      Object.assign(headers, prepared);
+    }
+
     const response = await fetch(url, {
-      method: operation.method.toUpperCase(),
+      method,
       headers,
       body,
       signal: options?.abortSignal,

--- a/packages/eve/src/runtime/resolve-connection.ts
+++ b/packages/eve/src/runtime/resolve-connection.ts
@@ -74,6 +74,7 @@ export async function resolveConnectionDefinition(
       exportName: typeof definition.exportName;
       headers?: Readonly<HeadersDefinition>;
       logicalPath: string;
+      prepareRequest?: ResolvedConnectionDefinition["prepareRequest"];
       protocol: ResolvedConnectionDefinition["protocol"];
       sourceId: string;
       sourceKind: "module";
@@ -122,8 +123,14 @@ export async function resolveConnectionDefinition(
       result.tools = filter as Readonly<ToolFilterDefinition>;
     }
 
-    if (definition.protocol === "openapi" && resolvedRecord.spec !== undefined) {
-      result.spec = resolvedRecord.spec as ResolvedConnectionDefinition["spec"];
+    if (definition.protocol === "openapi") {
+      if (resolvedRecord.spec !== undefined) {
+        result.spec = resolvedRecord.spec as ResolvedConnectionDefinition["spec"];
+      }
+      if (typeof resolvedRecord.prepareRequest === "function") {
+        result.prepareRequest =
+          resolvedRecord.prepareRequest as ResolvedConnectionDefinition["prepareRequest"];
+      }
     }
 
     if (typeof resolvedRecord.approval === "function") {

--- a/packages/eve/src/runtime/types.ts
+++ b/packages/eve/src/runtime/types.ts
@@ -18,7 +18,10 @@ import type {
   HeadersDefinition,
   ToolFilterDefinition,
 } from "#shared/connection-types.js";
-import type { OpenAPISpecSource } from "#public/definitions/connections/openapi.js";
+import type {
+  ConnectionRequestPreparer,
+  OpenAPISpecSource,
+} from "#public/definitions/connections/openapi.js";
 import type { CompiledWorkspaceResourceRoot } from "#compiler/manifest.js";
 import type { WorkspaceRuntimeSpec } from "#runtime/workspace/types.js";
 import type { JsonObject } from "#shared/json.js";
@@ -114,6 +117,12 @@ export interface ResolvedConnectionDefinition extends ResolvedModuleSourceRef {
    * OpenAPI connections).
    */
   readonly protocol: ConnectionProtocol;
+  /**
+   * Last-mile request hook. Present only for `protocol: "openapi"`
+   * connections; the OpenAPI client calls it with the fully-built
+   * request and merges the headers it returns.
+   */
+  readonly prepareRequest?: ConnectionRequestPreparer;
   /**
    * OpenAPI document source (URL or inline object). Present only for
    * `protocol: "openapi"` connections; the OpenAPI client fetches and

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -582,6 +582,34 @@ importers:
         specifier: 'catalog:'
         version: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(vite@8.1.5(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  apps/templates/commerce-agent:
+    dependencies:
+      eve:
+        specifier: workspace:*
+        version: link:../../../packages/eve
+      next:
+        specifier: 'catalog:'
+        version: 16.3.0-preview.6(@babel/core@7.29.0(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.15)
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+
   e2e/fixtures/agent-authored-bundling:
     dependencies:
       '@eve-e2e/config':
@@ -14923,6 +14951,7 @@ packages:
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
+    hasBin: true
 
   typescript@7.0.2:
     resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}


### PR DESCRIPTION
## Problem

An eve agent that wants to *buy* over the [Universal Commerce Protocol](https://ucp.dev/) can already point an OpenAPI connection at a merchant's shopping service — and it goes badly. The canonical UCP REST contract types `UCP-Agent`, `Idempotency-Key`, `Request-Id`, `Authorization`, `X-API-Key`, `Signature`, `Signature-Input`, and `Content-Digest` as ordinary header *parameters*, and marks the first three **required**. So all of them land in the model-facing input schema, and the model is asked to invent the agent's identity, its credentials, and its cryptographic signatures. Two of the thirteen inputs on `create_checkout` are actually the operation's own.

The second problem is downstream. A checkout response spreads "what happens next" across four places — `status`, `messages[].severity`, `continue_url`, and the per-session embedded service binding — and every application that touches UCP has to re-derive the same rules to decide whether the agent keeps working, the buyer gets redirected, or the merchant's checkout gets embedded.

The existing `docs/protocols/ucp.mdx` covers the *selling* side only: publishing a profile and serving endpoints.

## Solution

Three parts.

**`eve/commerce/ucp` — a generic UCP connection preset.** `defineUcpConnection` returns an `OpenAPIConnectionDefinition`, so there is no new connection protocol and no new runtime client. What it adds is the protocol plumbing:

- **Agent profile metadata** — serializes `agent.profile` into `UCP-Agent: profile="..."` as an RFC 8941 dictionary, and rejects a profile a merchant could not verify (non-`https`, relative) at definition time rather than on the first `profile_unreachable`.
- **Request arguments** — every managed header parameter resolves to `null` in `toolCall.providedArguments`, which strips it from the model-facing schema (including from `required`) and writes no header. `create_checkout` is left with `body`, `get_checkout` with `id`. As a side effect a prompt-injected `Authorization` can no longer displace the connection's credential. Authored `providedArguments` are applied last, so a caller can re-expose one.
- **Retry-safe ids** — `Idempotency-Key` (mutating methods) and `Request-Id` (all methods) are derived from eve's replay-stable `callId`, so a durable turn that resumes and re-issues the same tool call sends the same key and the merchant replays its cached response instead of placing a second order. Distinct tool calls always get distinct keys.
- **Signing** — optional, per the spec's allowance for API keys/OAuth/mTLS. When a key is present, RFC 9421 signatures with an RFC 9530 `Content-Digest` over the exact bytes sent. Signing goes through WebCrypto, whose ECDSA output is already the fixed-width `r||s` encoding the RFC requires rather than the DER most server-side libraries emit by default.

**A `prepareRequest` hook on OpenAPI connections.** `headers` and `providedArguments` both resolve before the body exists, so no existing primitive can produce a value derived from the bytes being sent — which is what a content digest, and a signature over it, are. `prepareRequest` receives the fully-built request (method, absolute URL, resolved headers, serialized body, `callId`, `toolName`) and merges the headers it returns. It is generic on purpose: HTTP Message Signatures, content digests, AWS SigV4. The UCP preset is its first consumer.

**`resolveUcpCheckoutHandoff` — the checkout-handoff contract.** One discriminated union over `conversational` (with `next: "update" | "complete" | "poll"` and the blockers to clear), `continue_url`, `embedded`, `completed`, `canceled`, and `failed`. It accepts either a raw checkout body or an eve OpenAPI tool result, so a connection tool's output goes straight in. Notable rules: the buyer takes over on `requires_escalation` **or** on any `requires_buyer_input` / `requires_buyer_review` severity regardless of the status the merchant reported, while `unrecoverable` alone stays conversational because the spec allows retrying with new inputs; `embedded` is chosen only when *this* response carries an embedded binding with `config.delegate` (service-level support in the profile is not enough), and the returned URL has `ec_version`, the intersected `ec_delegate`, and any `ec_auth`/`ec_color_scheme` applied.

**Template.** `apps/templates/commerce-agent` — an agent with the UCP connection, instructions that hold it to preparing rather than placing orders, a channel serving its own `/.well-known/ucp`, and a Next.js UI that renders all three handoff branches. Its route handler re-reads the session from the merchant rather than trusting the browser's copy, which also exercises the signer and identity helpers outside a connection.

## Scope boundaries

Buying side only; the selling-side guide is unchanged apart from a cross-link. No Shopify-specific behavior — the existing `eve init` Shopify integration is untouched. No multi-protocol abstraction: MCP, A2A, and Embedded Checkout's `ec.*` message channel are out, and `prepareRequest` is OpenAPI-only because MCP request construction lives inside the SDK. Cart, catalog, order, and payment-handler semantics stay author-owned.

## Validation

- `pnpm test:unit` (7345 passed), `pnpm test:integration` (685 passed), `pnpm typecheck` (45/45), `pnpm lint`, `pnpm guard:invariants`, `pnpm guard:fixtures`, `pnpm check:deps`, `pnpm docs:check`.
- New coverage: 59 unit + 7 integration tests. The integration test drives `defineUcpConnection` through the real `OpenApiConnectionClient` against a trimmed copy of the published contract (same header parameters, same `required` flags) and asserts the projected schema, the sent headers, idempotency-key reuse across a replayed `callId`, that model-supplied protocol headers are discarded, and that the emitted signature verifies against the public key over the base built from the headers actually sent.
- `next build` and `eve build` both run clean in the new template, so the connection passes eve's authored-definition validator and compiler for real.
- Connection capability contract regenerated with `pnpm update:extension-contracts --update connection`: classified structurally backward compatible, epoch 8 retained, bumped to 9.
- Not run locally: `pnpm test:scenario`, `pnpm test:tui`, and the e2e suites.

The commit carries the DCO `Signed-off-by` trailer but is not GPG-signed — no verified signing key was available in the environment it was authored in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
