### PR TITLE
chore: align quickstart and dev fixture model with the CLI default

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Choose the model in `agent/agent.ts`:
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "zai/glm-5.2",
+  model: "openai/gpt-5.6-luna-fast",
 });
 ```
 

--- a/apps/fixtures/weather-agent/README.md
+++ b/apps/fixtures/weather-agent/README.md
@@ -4,7 +4,7 @@ The weather-focused eve fixture. It backs the repo root `pnpm dev`, the
 bundle-analysis workflow, and manual smoke testing as a small representative
 eve app:
 
-- `agent/agent.ts` — model config (`openai/gpt-5.5` with adaptive
+- `agent/agent.ts` — model config (`openai/gpt-5.6-luna-fast` with adaptive
   thinking)
 - `agent/instructions.md` — the always-on instructions prompt
 - `agent/tools/get_weather.ts` — a typed weather lookup tool

--- a/apps/fixtures/weather-agent/agent/agent.ts
+++ b/apps/fixtures/weather-agent/agent/agent.ts
@@ -1,7 +1,7 @@
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "zai/glm-5.2",
+  model: "openai/gpt-5.6-luna-fast",
   modelOptions: {
     providerOptions: {
       openai: {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -52,11 +52,11 @@ Coding-agent launches and non-interactive terminals cannot answer the location p
 
 After scaffolding, a human terminal usually continues into `eve dev`. If a coding-agent REPL is on `PATH`, the handoff menu can open it instead or exit without starting either process. Coding-agent launches print the next steps instead of opening the TUI, so the session does not get stuck. Fresh projects use the parent workspace's package manager when there is one; otherwise they use the manager that launched `eve init`.
 
-| Flag                   | Type   | Default          | Description                                                                                                              |
-| ---------------------- | ------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Flag                   | Type   | Default                    | Description                                                                                                              |
+| ---------------------- | ------ | -------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `--model <model>`      | string | `openai/gpt-5.6-luna-fast` | Set the root agent's AI Gateway model ID.                                                                                |
-| `--reasoning <effort>` | enum   | provider default | Set reasoning to `none`, `minimal`, `low`, `medium`, `high`, or `xhigh`. `provider-default` leaves the field unauthored. |
-| `--channel-web-nextjs` | flag   | off              | Add the Web Chat app (Next.js). Not for existing projects — run `eve add channel/web` there instead.                     |
+| `--reasoning <effort>` | enum   | provider default           | Set reasoning to `none`, `minimal`, `low`, `medium`, `high`, or `xhigh`. `provider-default` leaves the field unauthored. |
+| `--channel-web-nextjs` | flag   | off                        | Add the Web Chat app (Next.js). Not for existing projects — run `eve add channel/web` there instead.                     |
 
 ## `eve extension`
 


### PR DESCRIPTION
## Problem

`eve init` and the setup model picker default to `openai/gpt-5.6-luna-fast` (#2683), but two places a new user hits first were still on the previous default, `zai/glm-5.2`:

- the README quickstart's "Choose the model in `agent/agent.ts`" snippet
- the `weather-agent` fixture, the agent behind the repo root `pnpm dev`

The fixture had drifted further: it already carried `providerOptions.openai` reasoning settings that a `zai/` model never applies, and its README advertised a third model id (`openai/gpt-5.5`).

## Solution

Point both at the CLI default and fix the fixture README line. No code paths change — these are the model id strings the quickstart shows and the local dev fixture runs. `pnpm fmt` also reflowed the `eve init` flag table in `docs/reference/cli.md`, whose column widths were left stale when the default id got longer in #2683.

## Scope

Deliberately untouched: `apps/benchmarks` (GLM 5.2 is a benchmark subject, not a default) and `docs/guides/dynamic-capabilities.md` (GLM there is one arm of a deliberate two-model example, and the surrounding prose names it).

## Validation

`pnpm fmt`, `pnpm lint`, `pnpm typecheck`, `pnpm test:unit` (7282 passed), `pnpm docs:check`, `pnpm guard:invariants`. No changeset: fixture and docs only, nothing in the published `eve` package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
