### PR TITLE
fix(eve): preserve response-authorized follow-ups

### DIFF
--- a/.changeset/responder-approval-followups.md
+++ b/.changeset/responder-approval-followups.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Preserve normal follow-up messages while an approval with responder authorization remains pending.

--- a/packages/eve/src/harness/approval-delivery-coordinator.test.ts
+++ b/packages/eve/src/harness/approval-delivery-coordinator.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { SessionAuthContext } from "#channel/types.js";
 import { settleDirectApprovalResponse } from "#harness/approval-candidates.js";
 import { coordinateApprovalDelivery } from "#harness/approval-delivery-coordinator.js";
-import { appendPendingInputBatch } from "#harness/pending-input-batches.js";
+import { appendPendingInputBatch, getPendingInputBatches } from "#harness/pending-input-batches.js";
 import type { HarnessSession } from "#harness/types.js";
 import type { InputRequest } from "#shared/input.js";
 
@@ -81,5 +81,28 @@ describe("coordinateApprovalDelivery", () => {
     expect(result.stepInput?.inputResponses).toEqual([
       { optionId: "cancel", requestId: request.requestId },
     ]);
+  });
+
+  it("forwards an unrelated message while a response-authorized approval remains pending", async () => {
+    const messageAuth: SessionAuthContext = { ...responder, principalId: "user-2" };
+    const result = await coordinateApprovalDelivery({
+      now: 100,
+      session: parkedSession(),
+      stepInput: {
+        message: "What else can you help with?",
+        messageAuth,
+      },
+      tools: new Map(),
+    });
+
+    expect(result.kind).toBe("continue");
+    expect(result.feedback).toEqual([]);
+    expect(result.stepInput?.message).toBe("What else can you help with?");
+    expect(result.stepInput?.messageAuth).toEqual(messageAuth);
+    expect(
+      getPendingInputBatches(result.session.state).flatMap((batch) =>
+        batch.requests.map((pending) => pending.requestId),
+      ),
+    ).toEqual([request.requestId]);
   });
 });

--- a/packages/eve/src/harness/approval-delivery-coordinator.ts
+++ b/packages/eve/src/harness/approval-delivery-coordinator.ts
@@ -31,8 +31,6 @@ import type { HarnessSession, HarnessToolMap, StepInput } from "#harness/types.j
 import type { InputRequest } from "#shared/input.js";
 
 const UNAUTHENTICATED_APPROVAL_FEEDBACK = "Authentication is required to respond to this approval.";
-const TEXT_APPROVAL_FEEDBACK =
-  "Please use the Approve or Cancel buttons to respond to this approval.";
 const APPROVAL_AUTHORIZER_TIMEOUT_MS = 10_000;
 const APPROVAL_CANDIDATE_TTL_MS = 10 * 60_000;
 
@@ -142,21 +140,6 @@ export async function coordinateApprovalDelivery(input: {
   );
   const allRequests = batches.flatMap((batch) => batch.requests);
   const requests = new Map(allRequests.map((request) => [request.requestId, request]));
-  if (
-    stepInput?.message !== undefined &&
-    (stepInput.attributedInputResponses?.length ?? 0) === 0 &&
-    (stepInput.inputResponses?.length ?? 0) === 0 &&
-    audit.activeCandidates.length === 0 &&
-    authorizationRequiredRequestIds.size > 0
-  ) {
-    return deliveryResult(
-      session,
-      { ...stepInput, message: undefined, messageAuth: undefined },
-      "park",
-      [],
-      [TEXT_APPROVAL_FEEDBACK],
-    );
-  }
   const challenges: AuthorizationChallenge[] = [];
   const feedback: string[] = [];
   const consumed = new Set<string>();


### PR DESCRIPTION
### Summary

Related to #1021 and #1868. An unrelated message delivered while a tool approval requires `approval.response` was consumed by the approval coordinator: it cleared the message and its actor attribution, then parked the session. The coordinator now passes that delivery to the ordinary HITL path, so conversation turns run normally while the approval stays pending; non-conversation deliveries keep their existing deferred-and-replay behavior.

### Validation

The new coordinator regression test proves the message, its `messageAuth`, and the pending approval survive together. The focused test and the full eve unit suite pass (7,283 passed, 1 skipped); package typecheck and invariant guards also pass.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

The patch changeset records the restored published behavior.

**Implementation** — 1 file · `+0 / -17`

Removing the coordinator-only early return routes the delivery through the existing HITL resolver.

**Tests** — 1 file · `+24 / -1`

One deterministic unit test covers the message, responder attribution, and pending-approval invariants.
