### PR TITLE
Show dev reload status in the TUI

### DIFF
--- a/.changeset/dev-reload-status.md
+++ b/.changeset/dev-reload-status.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Show authored-source rebuild and load progress in the `eve dev` status bar, even when server logs are hidden.

--- a/packages/eve/src/cli/dev/tui/status-line.test.ts
+++ b/packages/eve/src/cli/dev/tui/status-line.test.ts
@@ -144,6 +144,28 @@ describe("buildStatusLine", () => {
     expect(noProject).toBe("m via ai-gateway(oidc)");
   });
 
+  it("right-aligns monochrome build status and preserves it at narrow widths", () => {
+    const status = (phase: "building" | "complete", width = 120) =>
+      buildStatusLine({
+        devBuild: { phase, summary: "agent/instructions.md changed" },
+        model: "anthropic/claude-sonnet-5",
+        theme,
+        width,
+      })!;
+
+    const building = status("building");
+    const complete = status("complete");
+    expect(stripAnsi(building)).toMatch(
+      /^anthropic\/claude-sonnet-5 +▪ agent\/instructions\.md updating…$/u,
+    );
+    expect(stripAnsi(complete)).toMatch(
+      /^anthropic\/claude-sonnet-5 +✓ agent\/instructions\.md updated$/u,
+    );
+    expect(visibleLength(complete)).toBe(120);
+    expect(complete).not.toContain("\x1b[32m");
+    expect(stripAnsi(status("complete", 20))).toBe("✓ agent/instructions");
+  });
+
   it("leads with the transient logs hint and keeps it as width narrows", () => {
     const input = {
       logLevel: "sandbox",

--- a/packages/eve/src/cli/dev/tui/status-line.ts
+++ b/packages/eve/src/cli/dev/tui/status-line.ts
@@ -7,7 +7,23 @@ import type { VercelStatusSnapshot } from "./vercel-status.js";
 import type { ModelEndpointStatus } from "#shared/model-endpoint-status.js";
 import { formatModelSummary } from "#shared/model-summary.js";
 
+export interface DevBuildStatus {
+  readonly phase: "building" | "complete";
+  readonly summary: string;
+}
+
+function formatDevBuildStatus(status: DevBuildStatus, theme: Theme): string {
+  const complete = status.phase === "complete";
+  const glyph = complete ? theme.glyph.success : theme.glyph.validating;
+  const summary = complete
+    ? status.summary.replace(/ changed$/u, " updated")
+    : `${status.summary.replace(/ (?:added|changed|removed)$/u, "")} updating…`;
+  return `${glyph} ${summary}`;
+}
+
 export interface StatusLineInput {
+  /** Transient authored-source build state, independent of the server log filter. */
+  devBuild?: DevBuildStatus;
   /** Port of the connected local development server; omitted for remote sessions. */
   serverPort?: string;
   /** Resolved model slug, e.g. "anthropic/claude-sonnet-5"; absent when `/eve/v1/info` failed. */
@@ -128,6 +144,8 @@ export function buildStatusLine(input: StatusLineInput): string | undefined {
   const { theme, width } = input;
   const c = theme.colors;
 
+  const devBuild =
+    input.devBuild === undefined ? undefined : formatDevBuildStatus(input.devBuild, theme);
   const logLevel = input.logLevel === undefined ? undefined : c.cyan(`logs: ${input.logLevel}`);
   const serverPort = renderServerPort(input);
   const model = renderModel(input);
@@ -153,24 +171,31 @@ export function buildStatusLine(input: StatusLineInput): string | undefined {
     return `${target} ${body}`;
   };
 
-  // Descending fidelity; the first variant that fits wins. The server badge
-  // leads every variant and gets the final stand-alone fallback. Without one,
-  // the logs hint retains its previous priority.
-  const variants = [
+  const leftVariants = [
     compose(leading, [logLevel, modelSegment, endpointSegment]),
     compose(leading, [logLevel, model]),
-    compose(leading, [logLevel]),
     compose(leading, [logLevel]),
     compose(badge, [logLevel]),
     compose(badge, []),
   ];
 
-  if (variants[0]!.length === 0) return undefined;
-  for (const variant of variants) {
+  if (devBuild !== undefined) {
+    for (const left of leftVariants) {
+      const leftWidth = visibleLength(left);
+      const rightWidth = visibleLength(devBuild);
+      const gap = leftWidth > 0 ? 2 : 0;
+      if (leftWidth + gap + rightWidth > width) continue;
+      return `${left}${" ".repeat(width - leftWidth - rightWidth)}${devBuild}`;
+    }
+    return clipVisible(devBuild, width);
+  }
+
+  if (leftVariants[0]!.length === 0) return undefined;
+  for (const variant of leftVariants) {
     if (variant.length > 0 && visibleLength(variant) <= width) return variant;
   }
   // Later variants can be empty, for example when a badge-only line has no hint.
-  const narrowest = variants.findLast((variant) => variant.length > 0)!;
+  const narrowest = leftVariants.findLast((variant) => variant.length > 0)!;
   return clipVisible(narrowest, width);
 }
 

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
@@ -3087,6 +3087,51 @@ describe("TerminalRenderer (inline scrollback)", () => {
     renderer.shutdown();
   });
 
+  it("shows delayed build progress and immediate completion when logs are hidden", () => {
+    vi.useFakeTimers();
+    const screen = new MockScreen({ columns: 100, rows: 30 });
+    const input = new MockUserInput();
+    const renderer = new TerminalRenderer({
+      input,
+      output: screen,
+      captureForeignOutput: true,
+      unicode: true,
+    });
+    try {
+      renderer.renderAgentHeader({ name: "Weather Agent", serverUrl: "http://localhost:3000" });
+
+      process.stdout.write(
+        `${formatChangeDetectedLogLine("/app", [
+          { event: "change", path: "/app/agent/instructions.md" },
+        ])}\n`,
+      );
+      expect(renderer.logDisplayMode()).toBe("none");
+      expect(screen.snapshot()).not.toContain("agent/instructions.md changed");
+      expect(screen.snapshot()).not.toContain("○ stdout");
+
+      vi.advanceTimersByTime(250);
+      expect(screen.snapshot()).toContain("▪ agent/instructions.md updating…");
+
+      process.stdout.write(`${AUTHORED_ARTIFACTS_UPDATED_LOG_LINE}\n`);
+      expect(screen.snapshot()).toContain("✓ agent/instructions.md updated");
+
+      vi.advanceTimersByTime(4_000);
+      expect(screen.snapshot()).not.toContain("✓ agent/instructions.md updated");
+
+      process.stdout.write(
+        `${formatChangeDetectedLogLine("/app", [
+          { event: "change", path: "/app/agent/agent.ts" },
+        ])}\n`,
+      );
+      process.stdout.write(`${AUTHORED_ARTIFACTS_UPDATED_LOG_LINE}\n`);
+      expect(screen.snapshot()).toContain("✓ agent/agent.ts updated");
+      expect(screen.snapshot()).not.toContain("agent/agent.ts updating");
+    } finally {
+      renderer.shutdown();
+      vi.useRealTimers();
+    }
+  });
+
   it("hides logs by default, then reveals buffered lines at their original positions", () => {
     const screen = new MockScreen({ columns: 80, rows: 30 });
     const input = new MockUserInput();

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.ts
@@ -116,7 +116,7 @@ import { AltScreen } from "#cli/ui/alt-screen.js";
 import { copyTextToClipboard } from "./clipboard.js";
 import type { TraceViewerOpenOptions, TraceViewerRenderer } from "./traces/trace-viewer-session.js";
 import { TraceViewerSession } from "./traces/trace-viewer-session.js";
-import { buildStatusLine } from "./status-line.js";
+import { buildStatusLine, type DevBuildStatus } from "./status-line.js";
 import { nextLogDisplayMode } from "./log-display-mode.js";
 import { createTheme, detectUnicode, type Theme } from "./theme.js";
 import {
@@ -336,6 +336,10 @@ const incompletePasteFlushMs = 1_000;
 // How long the transient Ctrl+L log-mode hint stays in the status line after
 // the last cycle before it clears itself.
 const logLevelHintMs = 5_000;
+// Fast authored-source rebuilds skip their intermediate state to avoid a
+// distracting status-bar flash; genuinely slow builds still show progress.
+const devBuildProgressDelayMs = 250;
+const devBuildLoadedStatusMs = 4_000;
 
 const STATUS = {
   processing: "Working…",
@@ -520,6 +524,10 @@ export class TerminalRenderer implements AgentTUIRenderer {
    * an ordinary log block, and the next rebuild line opens a fresh cycle.
    */
   #devRebuild?: { id: string; summary: string };
+  /** Log-filter-independent authored-source state shown in the bottom status bar. */
+  #devBuildStatus?: DevBuildStatus;
+  #devBuildStatusVisible = false;
+  #devBuildStatusTimer?: ReturnType<typeof setTimeout>;
   /** Monotonic id source — committed cycle ids must never be reused. */
   #devRebuildSequence = 0;
   #pendingEchoedPrompt?: string;
@@ -2964,6 +2972,7 @@ export class TerminalRenderer implements AgentTUIRenderer {
       this.#logLevelHintTimer = undefined;
     }
     this.#logLevelHintActive = false;
+    this.#clearDevBuildStatus();
 
     if (!this.#isInteractive) return;
 
@@ -4345,6 +4354,9 @@ export class TerminalRenderer implements AgentTUIRenderer {
       theme: this.#theme,
       width: contentWidth,
     };
+    if (this.#devBuildStatusVisible && this.#devBuildStatus !== undefined) {
+      input.devBuild = this.#devBuildStatus;
+    }
     if (this.#logLevelHintActive) input.logLevel = this.#logs;
     const serverUrl = this.#agentHeader?.serverUrl;
     if (serverUrl !== undefined && this.#remoteConnection === undefined) {
@@ -4601,6 +4613,7 @@ export class TerminalRenderer implements AgentTUIRenderer {
   }
 
   #handleDevRebuildFailure(body: string): void {
+    this.#clearDevBuildStatus();
     if (this.#logs === "all") {
       if (body.trim().length === 0) return;
       this.#pushBlock({ kind: "log", title: "stderr", body, live: true });
@@ -4627,6 +4640,7 @@ export class TerminalRenderer implements AgentTUIRenderer {
 
     if (update.kind === "rebuilding") {
       const summary = summarizeChangedFiles(update.events, update.more);
+      this.#setDevBuildStatus({ phase: "building", summary });
       if (cycle !== undefined) {
         cycle.state.summary = summary;
         cycle.block.body = formatDevRebuildStatus(summary, "rebuilding");
@@ -4645,6 +4659,8 @@ export class TerminalRenderer implements AgentTUIRenderer {
       return;
     }
 
+    const summary = cycle?.state.summary ?? this.#devBuildStatus?.summary;
+    if (summary !== undefined) this.#setDevBuildStatus({ phase: "complete", summary });
     if (cycle !== undefined) {
       cycle.block.body = formatDevRebuildStatus(cycle.state.summary, update.kind);
       if (update.kind === "rebuilt") this.#delayedDevBuildError = undefined;
@@ -4652,6 +4668,31 @@ export class TerminalRenderer implements AgentTUIRenderer {
     }
     if (update.kind === "rebuilt") this.#delayedDevBuildError = undefined;
     this.#pushBlock({ kind: "log", title: "stdout", body: line, live: true });
+  }
+
+  #setDevBuildStatus(status: DevBuildStatus): void {
+    if (this.#devBuildStatusTimer !== undefined) clearTimeout(this.#devBuildStatusTimer);
+    this.#devBuildStatus = status;
+    this.#devBuildStatusVisible = status.phase === "complete";
+    this.#devBuildStatusTimer = setTimeout(
+      () => {
+        if (status.phase === "building") {
+          this.#devBuildStatusVisible = true;
+          this.#devBuildStatusTimer = undefined;
+        } else {
+          this.#clearDevBuildStatus();
+        }
+        this.#paint();
+      },
+      status.phase === "building" ? devBuildProgressDelayMs : devBuildLoadedStatusMs,
+    );
+  }
+
+  #clearDevBuildStatus(): void {
+    if (this.#devBuildStatusTimer !== undefined) clearTimeout(this.#devBuildStatusTimer);
+    this.#devBuildStatus = undefined;
+    this.#devBuildStatusVisible = false;
+    this.#devBuildStatusTimer = undefined;
   }
 
   /** The rebuild status block still cycling in place, if any. */


### PR DESCRIPTION
### Summary

`eve dev` rebuilds authored sources such as `agent/instructions.md`, but its TUI hides the existing rebuild feedback with server logs by default. This adds a log-level-independent, right-aligned monochrome status-bar indicator: slow builds show an `updating…` state after a short delay, while successful builds briefly show that the file was `updated` without flickering through an intermediate state.

https://github.com/user-attachments/assets/244882ca-dc46-41cb-a444-3362947cde18

### Validation

Focused status-line and terminal-renderer coverage passes with 207 tests, including hidden logs, fast and slow rebuilds, expiration, right alignment, monochrome presentation, and narrow terminals. The `eve` TypeScript check also passes.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

A patch changeset records the visible TUI behavior.

**Implementation** — 2 files · `+75 / -9`

Keeps rebuild lifecycle state in the existing terminal renderer and extends the existing status-line width-degradation logic.

**Tests** — 2 files · `+67 / -0`

Covers renderer timing independently from pure status-line presentation and responsive layout.
