### PR TITLE
feat(eve): identify TUI endpoint requests via useragent

### DIFF
--- a/.changeset/bright-tuis-identify.md
+++ b/.changeset/bright-tuis-identify.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Identify requests from the `eve dev` terminal UI with an `eve-tui/<version>` User-Agent product token while preserving caller-supplied User-Agent values.

--- a/packages/eve/src/cli/dev/tui/tui.test.ts
+++ b/packages/eve/src/cli/dev/tui/tui.test.ts
@@ -66,6 +66,7 @@ describe("runDevelopmentTui", () => {
       await runDevelopmentTui({
         headers: {
           authorization: "Basic dGVzdDpzZWNyZXQ=",
+          "User-Agent": "caller/1.0",
           "x-tenant": "acme",
         },
         target,
@@ -81,6 +82,7 @@ describe("runDevelopmentTui", () => {
 
       const headers = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
       expect(headers.get("authorization")).toBe("Basic dGVzdDpzZWNyZXQ=");
+      expect(headers.get("user-agent")).toMatch(/^caller\/1\.0 eve-tui\/.+/);
       expect(headers.get("x-tenant")).toBe("acme");
     },
   );

--- a/packages/eve/src/cli/dev/tui/tui.ts
+++ b/packages/eve/src/cli/dev/tui/tui.ts
@@ -1,5 +1,7 @@
 import { Client } from "#client/index.js";
 import type { DevBootProgressReporter } from "#internal/dev-boot-progress.js";
+import { resolveInstalledPackageInfo } from "#internal/application/package.js";
+import { appendUserAgentProduct } from "#internal/user-agent.js";
 import type { CommandLifecycle } from "#cli/shutdown.js";
 import {
   resolveLocalDevelopmentClientOptions,
@@ -117,6 +119,14 @@ function prepareDevelopmentTarget(target: DevelopmentTuiTarget): PreparedDevelop
     : { kind: "remote", target, remote: prepareRemoteTarget(target) };
 }
 
+function withTuiUserAgent(
+  headers: Readonly<Record<string, string>> | undefined,
+): Readonly<Record<string, string>> {
+  const resolved = new Headers(headers);
+  appendUserAgentProduct(resolved, `eve-tui/${resolveInstalledPackageInfo().version}`);
+  return Object.fromEntries(resolved.entries());
+}
+
 /**
  * Runs the `eve dev` terminal UI against the given server URL until the
  * user exits.
@@ -139,7 +149,7 @@ export async function runDevelopmentTui(input: RunDevelopmentTuiInput): Promise<
   } = input;
   const prepared = prepareDevelopmentTarget(target);
   const { serverUrl } = target;
-  const headerOptions = headers === undefined ? {} : { headers };
+  const headerOptions = { headers: withTuiUserAgent(headers) };
 
   const client = new Client(
     prepared.kind === "local"

--- a/packages/eve/src/internal/user-agent.ts
+++ b/packages/eve/src/internal/user-agent.ts
@@ -17,13 +17,17 @@ function joinUserAgentProducts(...products: (string | null | undefined)[]): stri
   return products.filter(Boolean).join(" ");
 }
 
-/** Appends the installed package product without discarding an existing User-Agent. */
-export function appendPackageUserAgent(headers: Headers): Headers {
-  const product = buildPackageUserAgent();
+/** Appends one product token without discarding an existing User-Agent. */
+export function appendUserAgentProduct(headers: Headers, product: string): Headers {
   const existing = headers.get("user-agent");
   if (existing?.split(/\s+/).includes(product)) return headers;
   headers.set("user-agent", joinUserAgentProducts(existing, product));
   return headers;
+}
+
+/** Appends the installed package product without discarding an existing User-Agent. */
+export function appendPackageUserAgent(headers: Headers): Headers {
+  return appendUserAgentProduct(headers, buildPackageUserAgent());
 }
 
 /**


### PR DESCRIPTION
### Summary

Requests from `eve dev` were indistinguishable from other eve client traffic in endpoint logs and telemetry. The TUI now appends an `eve-tui/<version>` User-Agent product token for local and remote targets while preserving caller-supplied User-Agent values. `eve invoke` and the public client remain unchanged.

### Validation

Focused unit coverage confirms both local and remote TUI clients append the identifying token without replacing an existing User-Agent; 7 targeted tests passed.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

The changeset records the new request attribution behavior for release notes; no user guide changes are needed.

**Implementation** — 2 files · `+18 / -4`

Keeps TUI attribution at the TUI client-construction boundary and reuses the existing User-Agent product joining behavior.

**Tests** — 1 file · `+2 / -0`

Extends the existing local/remote client test to cover preservation and appending in both paths.
