### PR TITLE
[1/2] feat(eve): project task milestones into activity

### DIFF
--- a/.changeset/bright-task-milestones.md
+++ b/.changeset/bright-task-milestones.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Carry background task `task_update` milestones through activity snapshots so channel renderers can show what delegated work is currently doing.

--- a/.changeset/bright-task-milestones.md
+++ b/.changeset/bright-task-milestones.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Carry background task `task_update` milestones through activity snapshots so channel renderers can show what delegated work is currently doing.
+Carry accepted background task `task_update` milestones from the durable session event log into activity snapshots, so channel renderers can show what delegated work is currently doing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,12 @@ line of defense, and every required check must pass before merge.
     why, an invariant, a surprising edge case. Public API docs (principle 1) are
     the exception.
 
+11. **Activity is an event-log projection.** Activity presentation must derive
+    from canonical durable session or task events, not feature code posting ad
+    hoc facts to the activity collector. Keep semantic behavior such as parent
+    notification on its own durable path; observing activity must never become
+    required for it.
+
 Machine-checkable invariants are enforced by `pnpm guard:invariants`, which
 runs in the CI lint job. If the guard fails, fix the violation rather than
 editing the baseline — baselines may only shrink.

--- a/packages/eve/src/execution/activity-events.test.ts
+++ b/packages/eve/src/execution/activity-events.test.ts
@@ -143,6 +143,51 @@ describe("projectActivityEvents", () => {
     ]);
   });
 
+  it("projects accepted task_update results as task work updates", () => {
+    const event = {
+      data: {
+        result: {
+          callId: "task-update-1",
+          kind: "tool-result" as const,
+          output: { message: "Working", status: "sent", taskId: "task-1" },
+          toolName: "task_update",
+        },
+        sequence: 1,
+        status: "completed" as const,
+        stepIndex: 2,
+        turnId: "turn",
+      },
+      type: "action.result" as const,
+    };
+    const taskLineage = { ...lineage, id: "work:task", kind: "task" as const };
+    expect(
+      projectActivityEvents({
+        at: "2026-01-01T00:00:00.000Z",
+        event,
+        lineage: taskLineage,
+        sourceEventId: "event-1",
+      }),
+    ).toEqual([
+      {
+        eventId: "event-1",
+        kind: "work.updated",
+        message: "Working",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        workId: "work:task",
+      },
+      {
+        actionId: "action:work:task:task-update-1",
+        eventId: "action:work:task:task-update-1:settled:completed",
+        kind: "action.settled",
+        outcome: "completed",
+        settledAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+    expect(projectActivityEvents({ at: "2026-01-01T00:00:00.000Z", event, lineage })).toEqual([
+      expect.objectContaining({ kind: "action.settled" }),
+    ]);
+  });
+
   it("settles delegated work from its parent action result", () => {
     const workId = deriveChildActivityWorkId({
       callId: "child-1",

--- a/packages/eve/src/execution/activity-events.ts
+++ b/packages/eve/src/execution/activity-events.ts
@@ -2,11 +2,14 @@ import { normalizeActivityText } from "#execution/activity-text.js";
 import { deriveChildActivityWorkId } from "#execution/activity-work-id.js";
 import type { ActivityEventV1, ActivityWorkIdentityV1 } from "#protocol/activity.js";
 import type { UnstampedMessageStreamEvent } from "#protocol/message.js";
+import { TASK_UPDATE_TOOL_NAME } from "#tools/framework/task-contract.js";
 
 export function projectActivityEvents(input: {
   readonly at: string;
   readonly event: UnstampedMessageStreamEvent;
   readonly lineage: ActivityWorkIdentityV1;
+  /** Durable source event identity when projecting a persisted session event. */
+  readonly sourceEventId?: string;
 }): readonly ActivityEventV1[] {
   const { event, lineage } = input;
   if (event.type === "actions.requested") {
@@ -61,14 +64,24 @@ export function projectActivityEvents(input: {
       ];
     }
     const id = actionId(lineage.id, result.callId);
+    const settled = {
+      actionId: id,
+      eventId: `${id}:settled:${event.data.status}`,
+      kind: "action.settled" as const,
+      outcome: event.data.status,
+      settledAt: input.at,
+    };
+    const taskUpdate = readAcceptedTaskUpdate(result);
+    if (lineage.kind !== "task" || taskUpdate === undefined) return [settled];
     return [
       {
-        actionId: id,
-        eventId: `${id}:settled:${event.data.status}`,
-        kind: "action.settled",
-        outcome: event.data.status,
-        settledAt: input.at,
+        eventId: input.sourceEventId ?? `${lineage.id}:updated:${event.data.sequence}`,
+        kind: "work.updated",
+        message: taskUpdate,
+        updatedAt: input.at,
+        workId: lineage.id,
       },
+      settled,
     ];
   }
   if (event.type === "authorization.required") {
@@ -208,6 +221,31 @@ export function projectActivityEvents(input: {
     ];
   }
   return [];
+}
+
+function readAcceptedTaskUpdate(
+  result: Extract<UnstampedMessageStreamEvent, { type: "action.result" }>["data"]["result"],
+): string | undefined {
+  if (
+    result.kind !== "tool-result" ||
+    result.isError === true ||
+    result.toolName !== TASK_UPDATE_TOOL_NAME
+  ) {
+    return undefined;
+  }
+  const output: unknown = result.output;
+  if (
+    typeof output !== "object" ||
+    output === null ||
+    !("status" in output) ||
+    output.status !== "sent" ||
+    !("message" in output) ||
+    typeof output.message !== "string"
+  ) {
+    return undefined;
+  }
+  const message = normalizeActivityText(output.message);
+  return message === "" ? undefined : message;
 }
 
 function activityLabel(value: string): string | undefined {

--- a/packages/eve/src/execution/session-activity-projection.ts
+++ b/packages/eve/src/execution/session-activity-projection.ts
@@ -46,7 +46,12 @@ export function projectSessionActivity(input: {
     });
   }
   events.push(
-    ...projectActivityEvents({ at: input.event.meta.at, event: input.event, lineage: work }),
+    ...projectActivityEvents({
+      at: input.event.meta.at,
+      event: input.event,
+      lineage: work,
+      sourceEventId: input.event.meta.id,
+    }),
   );
   return events;
 }

--- a/packages/eve/src/execution/session-activity.test.ts
+++ b/packages/eve/src/execution/session-activity.test.ts
@@ -37,6 +37,12 @@ describe("activity protocol and reducer", () => {
         version: 1,
       }),
     ).toBeUndefined();
+    expect(
+      parseActivityBatchV1({
+        events: [{ eventId: "updated", kind: "work.updated", message: "Working", workId: work.id }],
+        version: 1,
+      }),
+    ).toBeUndefined();
   });
 
   it("deduplicates only by event id", () => {
@@ -44,6 +50,70 @@ describe("activity protocol and reducer", () => {
     const first = reduce([event]);
     const duplicate = reduceActivityBatch(first, { events: [event], version: 1 });
     expect(duplicate).toBe(first);
+  });
+
+  it("retains the latest normalized milestone while work is running", () => {
+    const snapshot = reduce([
+      { eventId: "started", kind: "work.started", startedAt: "1", work },
+      {
+        eventId: "updated-1",
+        kind: "work.updated",
+        message: "Comparing\u0007   the renderer",
+        updatedAt: "2",
+        workId: work.id,
+      },
+      {
+        eventId: "updated-2",
+        kind: "work.updated",
+        message: "Validating the projection",
+        updatedAt: "3",
+        workId: work.id,
+      },
+    ]);
+
+    expect(snapshot.work[work.id]).toMatchObject({
+      update: { message: "Validating the projection", updatedAt: "3" },
+    });
+  });
+
+  it("retains a milestone that arrives before work starts", () => {
+    const snapshot = reduce([
+      {
+        eventId: "updated",
+        kind: "work.updated",
+        message: "Comparing the renderer",
+        updatedAt: "2",
+        workId: work.id,
+      },
+      { eventId: "started", kind: "work.started", startedAt: "1", work },
+    ]);
+
+    expect(snapshot.work[work.id]).toMatchObject({
+      update: { message: "Comparing the renderer", updatedAt: "2" },
+    });
+    expect(snapshot.pendingWorkUpdates).toEqual({});
+  });
+
+  it("ignores milestones after work settles", () => {
+    const snapshot = reduce([
+      { eventId: "started", kind: "work.started", startedAt: "1", work },
+      {
+        eventId: "settled",
+        kind: "work.settled",
+        outcome: "completed",
+        settledAt: "2",
+        workId: work.id,
+      },
+      {
+        eventId: "late-update",
+        kind: "work.updated",
+        message: "Stale update",
+        updatedAt: "3",
+        workId: work.id,
+      },
+    ]);
+
+    expect(snapshot.work[work.id]?.update).toBeUndefined();
   });
 
   it("applies settlement before start and never reopens terminal work", () => {

--- a/packages/eve/src/execution/session-activity.test.ts
+++ b/packages/eve/src/execution/session-activity.test.ts
@@ -94,26 +94,42 @@ describe("activity protocol and reducer", () => {
     expect(snapshot.pendingWorkUpdates).toEqual({});
   });
 
-  it("ignores milestones after work settles", () => {
-    const snapshot = reduce([
-      { eventId: "started", kind: "work.started", startedAt: "1", work },
-      {
-        eventId: "settled",
-        kind: "work.settled",
-        outcome: "completed",
-        settledAt: "2",
+  it.each([
+    ["newer before older", ["started", "newer", "older"]],
+    ["settlement before updates", ["started", "settled", "newer", "older"]],
+  ] as const)("converges work updates for %s delivery", (_name, order) => {
+    const events: Record<string, ActivityEventV1> = {
+      started: { eventId: "started", kind: "work.started", startedAt: "1", work },
+      older: {
+        eventId: "updated-1",
+        kind: "work.updated",
+        message: "Older update",
+        updatedAt: "2",
         workId: work.id,
       },
-      {
-        eventId: "late-update",
+      newer: {
+        eventId: "updated-2",
         kind: "work.updated",
-        message: "Stale update",
+        message: "Newer update",
         updatedAt: "3",
         workId: work.id,
       },
-    ]);
+      settled: {
+        eventId: "settled",
+        kind: "work.settled",
+        outcome: "completed",
+        settledAt: "4",
+        workId: work.id,
+      },
+    };
 
-    expect(snapshot.work[work.id]?.update).toBeUndefined();
+    const snapshot = reduce(order.map((key) => events[key]!));
+
+    expect(snapshot.work[work.id]?.update).toEqual({
+      eventId: "updated-2",
+      message: "Newer update",
+      updatedAt: "3",
+    });
   });
 
   it("applies settlement before start and never reopens terminal work", () => {

--- a/packages/eve/src/execution/session-activity.ts
+++ b/packages/eve/src/execution/session-activity.ts
@@ -95,10 +95,7 @@ function startWork(
     phase: phase as ActivityWorkPhase,
     settledAt: pending?.settledAt ?? (phase === "cancelled" ? parent?.settledAt : undefined),
     startedAt: event.startedAt,
-    update:
-      phase === "running" && pendingUpdate !== undefined
-        ? { message: pendingUpdate.message, updatedAt: pendingUpdate.updatedAt }
-        : undefined,
+    update: pendingUpdate,
   };
   const started = {
     ...snapshot,
@@ -133,30 +130,29 @@ function updateWork(
   snapshot: ActivitySnapshotV1,
   event: Extract<ActivityEventV1, { readonly kind: "work.updated" }>,
 ): ActivitySnapshotV1 {
+  const update = {
+    eventId: event.eventId,
+    message: normalizeActivityText(event.message),
+    updatedAt: event.updatedAt,
+  };
   const current = snapshot.work[event.workId];
   if (current === undefined) {
-    if (pendingFor(snapshot, "work", event.workId) !== undefined) return snapshot;
+    const pending = snapshot.pendingWorkUpdates[event.workId];
+    if (pending !== undefined && !isNewerUpdate(update, pending)) return snapshot;
     return {
       ...snapshot,
       pendingWorkUpdates: replaceBounded(
         snapshot.pendingWorkUpdates,
         event.workId,
-        {
-          eventId: event.eventId,
-          message: normalizeActivityText(event.message),
-          updatedAt: event.updatedAt,
-        },
+        update,
         MAX_ACTIVITY_PENDING_WORK_UPDATES,
       ),
     };
   }
-  if (current.phase !== "running") return snapshot;
+  if (current.update !== undefined && !isNewerUpdate(update, current.update)) return snapshot;
   return {
     ...snapshot,
-    work: replaceBounded(snapshot.work, event.workId, {
-      ...current,
-      update: { message: normalizeActivityText(event.message), updatedAt: event.updatedAt },
-    }),
+    work: replaceBounded(snapshot.work, event.workId, { ...current, update }),
   };
 }
 
@@ -345,6 +341,16 @@ function replaceBounded<T>(
   const overflow = Object.keys(next).length - max;
   for (const oldKey of Object.keys(next).slice(0, Math.max(0, overflow))) delete next[oldKey];
   return next;
+}
+
+function isNewerUpdate(
+  left: { eventId: string; updatedAt: string },
+  right: { eventId: string; updatedAt: string },
+): boolean {
+  return (
+    left.updatedAt > right.updatedAt ||
+    (left.updatedAt === right.updatedAt && left.eventId > right.eventId)
+  );
 }
 
 function removeKey<T>(

--- a/packages/eve/src/execution/session-activity.ts
+++ b/packages/eve/src/execution/session-activity.ts
@@ -12,6 +12,7 @@ import {
 
 export const MAX_ACTIVITY_EVENT_IDS = 1_000;
 export const MAX_ACTIVITY_PENDING_SETTLEMENTS = 500;
+export const MAX_ACTIVITY_PENDING_WORK_UPDATES = 500;
 export const MAX_ACTIVITY_ENTITIES = 500;
 
 export function createActivitySnapshot(): ActivitySnapshotV1 {
@@ -19,6 +20,7 @@ export function createActivitySnapshot(): ActivitySnapshotV1 {
     actions: {},
     blockers: {},
     pendingSettlements: {},
+    pendingWorkUpdates: {},
     revision: 0,
     seenEventIds: [],
     version: 1,
@@ -62,6 +64,8 @@ function reduceEvent(snapshot: ActivitySnapshotV1, event: ActivityEventV1): Acti
       return startWork(snapshot, event);
     case "work.settled":
       return settleWork(snapshot, event);
+    case "work.updated":
+      return updateWork(snapshot, event);
     case "action.started":
       return startAction(snapshot, event);
     case "action.settled":
@@ -80,6 +84,7 @@ function startWork(
   const current = snapshot.work[event.work.id];
   if (current !== undefined) return snapshot;
   const pending = pendingFor(snapshot, "work", event.work.id);
+  const pendingUpdate = snapshot.pendingWorkUpdates[event.work.id];
   const parent = event.work.parentId === undefined ? undefined : snapshot.work[event.work.parentId];
   const phase =
     pending?.outcome ??
@@ -90,10 +95,15 @@ function startWork(
     phase: phase as ActivityWorkPhase,
     settledAt: pending?.settledAt ?? (phase === "cancelled" ? parent?.settledAt : undefined),
     startedAt: event.startedAt,
+    update:
+      phase === "running" && pendingUpdate !== undefined
+        ? { message: pendingUpdate.message, updatedAt: pendingUpdate.updatedAt }
+        : undefined,
   };
   const started = {
     ...snapshot,
     pendingSettlements: removeKey(snapshot.pendingSettlements, pendingKey("work", work.id)),
+    pendingWorkUpdates: removeKey(snapshot.pendingWorkUpdates, work.id),
     work: replaceBounded(snapshot.work, work.id, work),
   };
   return work.phase === "running"
@@ -117,6 +127,37 @@ function settleWork(
     settledAt: event.settledAt,
     workId: event.workId,
   });
+}
+
+function updateWork(
+  snapshot: ActivitySnapshotV1,
+  event: Extract<ActivityEventV1, { readonly kind: "work.updated" }>,
+): ActivitySnapshotV1 {
+  const current = snapshot.work[event.workId];
+  if (current === undefined) {
+    if (pendingFor(snapshot, "work", event.workId) !== undefined) return snapshot;
+    return {
+      ...snapshot,
+      pendingWorkUpdates: replaceBounded(
+        snapshot.pendingWorkUpdates,
+        event.workId,
+        {
+          eventId: event.eventId,
+          message: normalizeActivityText(event.message),
+          updatedAt: event.updatedAt,
+        },
+        MAX_ACTIVITY_PENDING_WORK_UPDATES,
+      ),
+    };
+  }
+  if (current.phase !== "running") return snapshot;
+  return {
+    ...snapshot,
+    work: replaceBounded(snapshot.work, event.workId, {
+      ...current,
+      update: { message: normalizeActivityText(event.message), updatedAt: event.updatedAt },
+    }),
+  };
 }
 
 function startAction(

--- a/packages/eve/src/execution/task-activity-projection.test.ts
+++ b/packages/eve/src/execution/task-activity-projection.test.ts
@@ -58,6 +58,12 @@ describe("projectTaskActivity", () => {
         }),
       ).toEqual([
         {
+          eventId: "work:task:started",
+          kind: "work.started",
+          startedAt: "2026-01-01T00:00:00.000Z",
+          work: activityObserver.workIdentity,
+        },
+        {
           eventId: `work:task:settled:${status}`,
           kind: "work.settled",
           outcome: status,
@@ -68,13 +74,20 @@ describe("projectTaskActivity", () => {
     },
   );
 
-  it("ignores nonterminal task views", () => {
+  it("starts work from the initial task view", () => {
     expect(
       projectTaskActivity({
         activityObserver,
         settledAt: "2026-01-01T00:00:00.000Z",
         view: view("working"),
       }),
-    ).toEqual([]);
+    ).toEqual([
+      {
+        eventId: "work:task:started",
+        kind: "work.started",
+        startedAt: "2026-01-01T00:00:00.000Z",
+        work: activityObserver.workIdentity,
+      },
+    ]);
   });
 });

--- a/packages/eve/src/execution/task-activity-projection.test.ts
+++ b/packages/eve/src/execution/task-activity-projection.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { projectTaskActivity } from "#execution/task-activity-projection.js";
+import type { TaskView } from "#tasks/types.js";
+
+const metadata = {
+  agentId: "agent-reviewer",
+  kind: "subagent" as const,
+  mode: "local" as const,
+  name: "reviewer",
+};
+
+function view(status: TaskView["status"]): TaskView {
+  if (status === "completed") {
+    return {
+      lastOutput: { data: "done", type: "result" },
+      metadata,
+      status,
+      taskId: "task-1",
+    };
+  }
+  if (status === "failed") {
+    return {
+      lastOutput: { data: "failed", type: "error" },
+      metadata,
+      status,
+      taskId: "task-1",
+    };
+  }
+  if (status === "input_required") {
+    return { inputRequests: [], metadata, status, taskId: "task-1" };
+  }
+  return { metadata, status, taskId: "task-1" };
+}
+
+const activityObserver = {
+  sink: {
+    url: "https://parent.example/eve/v1/activity/abcdefghijklmnopqrstuvwxyz123456",
+    version: 1 as const,
+  },
+  workIdentity: {
+    id: "work:task",
+    kind: "task" as const,
+    rootSessionId: "root",
+    rootTurnId: "turn",
+  },
+};
+
+describe("projectTaskActivity", () => {
+  it.each(["completed", "failed", "cancelled"] as const)(
+    "projects authoritative %s task settlement",
+    (status) => {
+      expect(
+        projectTaskActivity({
+          activityObserver,
+          settledAt: "2026-01-01T00:00:00.000Z",
+          view: view(status),
+        }),
+      ).toEqual([
+        {
+          eventId: `work:task:settled:${status}`,
+          kind: "work.settled",
+          outcome: status,
+          settledAt: "2026-01-01T00:00:00.000Z",
+          workId: "work:task",
+        },
+      ]);
+    },
+  );
+
+  it("ignores nonterminal task views", () => {
+    expect(
+      projectTaskActivity({
+        activityObserver,
+        settledAt: "2026-01-01T00:00:00.000Z",
+        view: view("working"),
+      }),
+    ).toEqual([]);
+  });
+});

--- a/packages/eve/src/execution/task-activity-projection.ts
+++ b/packages/eve/src/execution/task-activity-projection.ts
@@ -1,0 +1,40 @@
+import type { ActivityObserverConfig } from "#channel/types.js";
+import { submitActivity } from "#execution/submit-activity.js";
+import type { ActivityEventV1 } from "#protocol/activity.js";
+import type { TaskView } from "#tasks/types.js";
+
+/** Projects one canonical task-view event into best-effort activity presentation. */
+export async function observeTaskActivity(input: {
+  readonly activityObserver: ActivityObserverConfig | undefined;
+  readonly settledAt: string;
+  readonly view: TaskView;
+}): Promise<void> {
+  await submitActivity({
+    events: projectTaskActivity(input),
+    sink: input.activityObserver?.sink,
+  });
+}
+
+export function projectTaskActivity(input: {
+  readonly activityObserver: ActivityObserverConfig | undefined;
+  readonly settledAt: string;
+  readonly view: TaskView;
+}): readonly ActivityEventV1[] {
+  const work = input.activityObserver?.workIdentity;
+  const status = input.view.status;
+  if (
+    work === undefined ||
+    (status !== "completed" && status !== "failed" && status !== "cancelled")
+  ) {
+    return [];
+  }
+  return [
+    {
+      eventId: `${work.id}:settled:${status}`,
+      kind: "work.settled",
+      outcome: status,
+      settledAt: input.settledAt,
+      workId: work.id,
+    },
+  ];
+}

--- a/packages/eve/src/execution/task-activity-projection.ts
+++ b/packages/eve/src/execution/task-activity-projection.ts
@@ -21,14 +21,17 @@ export function projectTaskActivity(input: {
   readonly view: TaskView;
 }): readonly ActivityEventV1[] {
   const work = input.activityObserver?.workIdentity;
+  if (work === undefined) return [];
+  const started: ActivityEventV1 = {
+    eventId: `${work.id}:started`,
+    kind: "work.started",
+    startedAt: input.settledAt,
+    work,
+  };
   const status = input.view.status;
-  if (
-    work === undefined ||
-    (status !== "completed" && status !== "failed" && status !== "cancelled")
-  ) {
-    return [];
-  }
+  if (status !== "completed" && status !== "failed" && status !== "cancelled") return [started];
   return [
+    started,
     {
       eventId: `${work.id}:settled:${status}`,
       kind: "work.settled",

--- a/packages/eve/src/execution/tasks/child/steps.test.ts
+++ b/packages/eve/src/execution/tasks/child/steps.test.ts
@@ -1,10 +1,6 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
-import {
-  formatTaskNotification,
-  projectTaskActivitySettlement,
-  projectTaskUpdateActivity,
-} from "#execution/tasks/child/steps.js";
+import { formatTaskNotification } from "#execution/tasks/child/steps.js";
 import type { TaskView } from "#tasks/types.js";
 
 const metadata = {
@@ -43,87 +39,6 @@ const notificationCases: readonly { readonly expected: string; readonly view: Ta
     },
   },
 ];
-
-describe("projectTaskActivitySettlement", () => {
-  afterEach(() => vi.unstubAllGlobals());
-
-  it("projects terminal task settlement", () => {
-    expect(
-      projectTaskActivitySettlement({
-        activityObserver: {
-          sink: {
-            url: "https://parent.example/eve/v1/activity/abcdefghijklmnopqrstuvwxyz123456",
-            version: 1,
-          },
-          workIdentity: {
-            id: "work:task",
-            kind: "task",
-            rootSessionId: "root",
-            rootTurnId: "turn",
-          },
-        },
-        settledAt: "2026-01-01T00:00:00.000Z",
-        view: notificationCases[0]!.view,
-      }),
-    ).toEqual([
-      expect.objectContaining({ kind: "work.settled", outcome: "completed", workId: "work:task" }),
-    ]);
-  });
-
-  it("projects an existing task update as a work milestone", () => {
-    const working = { metadata, status: "working", taskId: "task-1" } satisfies TaskView;
-    const input = {
-      activityObserver: {
-        sink: {
-          url: "https://parent.example/eve/v1/activity/abcdefghijklmnopqrstuvwxyz123456",
-          version: 1 as const,
-        },
-        workIdentity: {
-          id: "work:task",
-          kind: "task" as const,
-          name: "reviewer",
-          rootSessionId: "root",
-          rootTurnId: "turn",
-        },
-      },
-      update: {
-        callId: "call-update",
-        kind: "task-update" as const,
-        message: "Comparing the plan projection with the current renderer",
-        updateEpoch: "epoch-1",
-        updateIndex: 2,
-      },
-      updatedAt: "2026-01-01T00:00:01.000Z",
-      view: working,
-    };
-
-    expect(projectTaskUpdateActivity(input)).toEqual([
-      {
-        eventId: "work:task:updated:epoch-1:2",
-        kind: "work.updated",
-        message: "Comparing the plan projection with the current renderer",
-        updatedAt: "2026-01-01T00:00:01.000Z",
-        workId: "work:task",
-      },
-    ]);
-    expect(
-      projectTaskUpdateActivity({
-        ...input,
-        view: { ...working, lastOutput: { data: "done", type: "result" }, status: "completed" },
-      }),
-    ).toEqual([]);
-  });
-
-  it("does nothing for nonterminal task views", () => {
-    expect(
-      projectTaskActivitySettlement({
-        activityObserver: undefined,
-        settledAt: "2026-01-01T00:00:00.000Z",
-        view: { metadata, status: "working", taskId: "task-1" },
-      }),
-    ).toEqual([]);
-  });
-});
 
 describe("formatTaskNotification", () => {
   it.each(notificationCases)(

--- a/packages/eve/src/execution/tasks/child/steps.test.ts
+++ b/packages/eve/src/execution/tasks/child/steps.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   formatTaskNotification,
   projectTaskActivitySettlement,
+  projectTaskUpdateActivity,
 } from "#execution/tasks/child/steps.js";
 import type { TaskView } from "#tasks/types.js";
 
@@ -67,6 +68,50 @@ describe("projectTaskActivitySettlement", () => {
     ).toEqual([
       expect.objectContaining({ kind: "work.settled", outcome: "completed", workId: "work:task" }),
     ]);
+  });
+
+  it("projects an existing task update as a work milestone", () => {
+    const working = { metadata, status: "working", taskId: "task-1" } satisfies TaskView;
+    const input = {
+      activityObserver: {
+        sink: {
+          url: "https://parent.example/eve/v1/activity/abcdefghijklmnopqrstuvwxyz123456",
+          version: 1 as const,
+        },
+        workIdentity: {
+          id: "work:task",
+          kind: "task" as const,
+          name: "reviewer",
+          rootSessionId: "root",
+          rootTurnId: "turn",
+        },
+      },
+      update: {
+        callId: "call-update",
+        kind: "task-update" as const,
+        message: "Comparing the plan projection with the current renderer",
+        updateEpoch: "epoch-1",
+        updateIndex: 2,
+      },
+      updatedAt: "2026-01-01T00:00:01.000Z",
+      view: working,
+    };
+
+    expect(projectTaskUpdateActivity(input)).toEqual([
+      {
+        eventId: "work:task:updated:epoch-1:2",
+        kind: "work.updated",
+        message: "Comparing the plan projection with the current renderer",
+        updatedAt: "2026-01-01T00:00:01.000Z",
+        workId: "work:task",
+      },
+    ]);
+    expect(
+      projectTaskUpdateActivity({
+        ...input,
+        view: { ...working, lastOutput: { data: "done", type: "result" }, status: "completed" },
+      }),
+    ).toEqual([]);
   });
 
   it("does nothing for nonterminal task views", () => {

--- a/packages/eve/src/execution/tasks/child/steps.ts
+++ b/packages/eve/src/execution/tasks/child/steps.ts
@@ -6,12 +6,10 @@ import type {
   SubagentAuthorizationEventHookPayload,
   SubagentInputRequestHookPayload,
 } from "#channel/types.js";
-import { normalizeActivityText } from "#execution/activity-text.js";
-import { submitActivity } from "#execution/submit-activity.js";
+import { observeTaskActivity } from "#execution/task-activity-projection.js";
 import { isTaskWorkflowTargetGone } from "#execution/tasks/workflow-target.js";
 import { resumeSessionInbox } from "#execution/wire/session-inbox-resume.js";
 import { createLogger } from "#internal/logging.js";
-import type { ActivityEventV1 } from "#protocol/activity.js";
 import type { JsonValue } from "#shared/json.js";
 import {
   isTerminalTaskStatus,
@@ -45,35 +43,11 @@ export async function appendTaskViewStep(input: {
     writer.releaseLock();
   }
 
-  const events = projectTaskActivitySettlement({
+  void observeTaskActivity({
     activityObserver: input.activityObserver,
     settledAt: new Date().toISOString(),
     view: input.view,
   });
-  void submitActivity({ events, sink: input.activityObserver?.sink });
-}
-
-export function projectTaskActivitySettlement(input: {
-  readonly activityObserver: ActivityObserverConfig | undefined;
-  readonly settledAt: string;
-  readonly view: TaskView;
-}): readonly ActivityEventV1[] {
-  const work = input.activityObserver?.workIdentity;
-  const status = input.view.status;
-  if (
-    work === undefined ||
-    (status !== "completed" && status !== "failed" && status !== "cancelled")
-  )
-    return [];
-  return [
-    {
-      eventId: `${work.id}:settled:${status}`,
-      kind: "work.settled",
-      outcome: status,
-      settledAt: input.settledAt,
-      workId: work.id,
-    },
-  ];
 }
 
 /** Re-emits a task-owned child authorization event through the parent channel. */
@@ -156,22 +130,11 @@ export async function wakeTaskParentStep(input: {
 
 /** Forwards a running child's intermediate update to its parent session. */
 export async function wakeTaskUpdateParentStep(input: {
-  readonly activityObserver?: ActivityObserverConfig;
   readonly token: string;
   readonly update: TaskInboundUpdate;
   readonly view: TaskView;
 }): Promise<void> {
   "use step";
-
-  void submitActivity({
-    events: projectTaskUpdateActivity({
-      activityObserver: input.activityObserver,
-      update: input.update,
-      updatedAt: new Date().toISOString(),
-      view: input.view,
-    }),
-    sink: input.activityObserver?.sink,
-  });
 
   const command: SessionCommand = {
     kind: "send",
@@ -186,26 +149,6 @@ export async function wakeTaskUpdateParentStep(input: {
     if (isTaskWorkflowTargetGone(error)) return;
     throw error;
   }
-}
-
-export function projectTaskUpdateActivity(input: {
-  readonly activityObserver: ActivityObserverConfig | undefined;
-  readonly update: TaskInboundUpdate;
-  readonly updatedAt: string;
-  readonly view: TaskView;
-}): readonly ActivityEventV1[] {
-  const work = input.activityObserver?.workIdentity;
-  const message = normalizeActivityText(input.update.message);
-  if (work === undefined || message === "" || isTerminalTaskStatus(input.view.status)) return [];
-  return [
-    {
-      eventId: `${work.id}:updated:${input.update.updateEpoch}:${input.update.updateIndex}`,
-      kind: "work.updated",
-      message,
-      updatedAt: input.updatedAt,
-      workId: work.id,
-    },
-  ];
 }
 
 /** Sends an exact local-task HITL batch to the parent's pre-model router. */

--- a/packages/eve/src/execution/tasks/child/steps.ts
+++ b/packages/eve/src/execution/tasks/child/steps.ts
@@ -6,6 +6,7 @@ import type {
   SubagentAuthorizationEventHookPayload,
   SubagentInputRequestHookPayload,
 } from "#channel/types.js";
+import { normalizeActivityText } from "#execution/activity-text.js";
 import { submitActivity } from "#execution/submit-activity.js";
 import { isTaskWorkflowTargetGone } from "#execution/tasks/workflow-target.js";
 import { resumeSessionInbox } from "#execution/wire/session-inbox-resume.js";
@@ -155,11 +156,22 @@ export async function wakeTaskParentStep(input: {
 
 /** Forwards a running child's intermediate update to its parent session. */
 export async function wakeTaskUpdateParentStep(input: {
+  readonly activityObserver?: ActivityObserverConfig;
   readonly token: string;
   readonly update: TaskInboundUpdate;
   readonly view: TaskView;
 }): Promise<void> {
   "use step";
+
+  void submitActivity({
+    events: projectTaskUpdateActivity({
+      activityObserver: input.activityObserver,
+      update: input.update,
+      updatedAt: new Date().toISOString(),
+      view: input.view,
+    }),
+    sink: input.activityObserver?.sink,
+  });
 
   const command: SessionCommand = {
     kind: "send",
@@ -174,6 +186,26 @@ export async function wakeTaskUpdateParentStep(input: {
     if (isTaskWorkflowTargetGone(error)) return;
     throw error;
   }
+}
+
+export function projectTaskUpdateActivity(input: {
+  readonly activityObserver: ActivityObserverConfig | undefined;
+  readonly update: TaskInboundUpdate;
+  readonly updatedAt: string;
+  readonly view: TaskView;
+}): readonly ActivityEventV1[] {
+  const work = input.activityObserver?.workIdentity;
+  const message = normalizeActivityText(input.update.message);
+  if (work === undefined || message === "" || isTerminalTaskStatus(input.view.status)) return [];
+  return [
+    {
+      eventId: `${work.id}:updated:${input.update.updateEpoch}:${input.update.updateIndex}`,
+      kind: "work.updated",
+      message,
+      updatedAt: input.updatedAt,
+      workId: work.id,
+    },
+  ];
 }
 
 /** Sends an exact local-task HITL batch to the parent's pre-model router. */

--- a/packages/eve/src/execution/tasks/child/update.test.ts
+++ b/packages/eve/src/execution/tasks/child/update.test.ts
@@ -47,7 +47,9 @@ describe("executeTaskUpdate", () => {
       kind: "task-update",
       message: "Found three matching records.",
     });
-    expect(result).toMatchObject({ output: { status: "sent", taskId: "task_abc" } });
+    expect(result).toMatchObject({
+      output: { message: "Found three matching records.", status: "sent", taskId: "task_abc" },
+    });
   });
 
   it("sends remote updates through the owning task callback", async () => {
@@ -74,6 +76,8 @@ describe("executeTaskUpdate", () => {
       updateEpoch: "turn-child",
       message: "Found three matching records.",
     });
-    expect(result).toMatchObject({ output: { status: "sent", taskId: "task_abc" } });
+    expect(result).toMatchObject({
+      output: { message: "Found three matching records.", status: "sent", taskId: "task_abc" },
+    });
   });
 });

--- a/packages/eve/src/execution/tasks/child/update.ts
+++ b/packages/eve/src/execution/tasks/child/update.ts
@@ -36,7 +36,7 @@ export async function executeTaskUpdate(input: {
     if (taskId === undefined) {
       return createTaskControlError(input.action, "This session is not owned by a parent task.");
     }
-    return createTaskUpdateResult(input.action, taskId);
+    return createTaskUpdateResult(input.action, taskId, message);
   }
 
   const adapter = input.adapter;
@@ -56,7 +56,7 @@ export async function executeTaskUpdate(input: {
     message,
   };
   await resumeHook(token, update);
-  return createTaskUpdateResult(input.action, taskId);
+  return createTaskUpdateResult(input.action, taskId, message);
 }
 
 function readUpdateMessage(input: Record<string, unknown>): string | undefined {
@@ -68,11 +68,12 @@ function readUpdateMessage(input: Record<string, unknown>): string | undefined {
 function createTaskUpdateResult(
   action: RuntimeToolCallActionRequest,
   taskId: string,
+  message: string,
 ): RuntimeActionResult {
   return {
     callId: action.callId,
     kind: "tool-result",
-    output: { status: "sent", taskId },
+    output: { message, status: "sent", taskId },
     toolName: action.toolName,
   };
 }

--- a/packages/eve/src/execution/tasks/child/workflow.test.ts
+++ b/packages/eve/src/execution/tasks/child/workflow.test.ts
@@ -114,13 +114,11 @@ describe("taskRunWorkflow", () => {
     });
 
     expect(wakeTaskUpdateParentStep).toHaveBeenNthCalledWith(1, {
-      activityObserver,
       token: "parent-session-token",
       update,
       view,
     });
     expect(wakeTaskUpdateParentStep).toHaveBeenNthCalledWith(2, {
-      activityObserver,
       token: "parent-session-token",
       update: { ...update, callId: "update-call-2" },
       view,

--- a/packages/eve/src/execution/tasks/child/workflow.test.ts
+++ b/packages/eve/src/execution/tasks/child/workflow.test.ts
@@ -42,6 +42,20 @@ afterEach(() => {
   vi.resetAllMocks();
 });
 
+const activityObserver = {
+  sink: {
+    url: "https://parent.example/eve/v1/activity/abcdefghijklmnopqrstuvwxyz123456",
+    version: 1 as const,
+  },
+  workIdentity: {
+    id: "work:task",
+    kind: "task" as const,
+    name: "research",
+    rootSessionId: "root",
+    rootTurnId: "turn",
+  },
+};
+
 function createWorkingView(): TaskView {
   return {
     metadata: {
@@ -93,17 +107,20 @@ describe("taskRunWorkflow", () => {
 
     const view = createWorkingView();
     await taskRunWorkflow({
+      activityObserver,
       taskInboxToken: "task-token",
       initialView: view,
       parentContinuationToken: "parent-session-token",
     });
 
     expect(wakeTaskUpdateParentStep).toHaveBeenNthCalledWith(1, {
+      activityObserver,
       token: "parent-session-token",
       update,
       view,
     });
     expect(wakeTaskUpdateParentStep).toHaveBeenNthCalledWith(2, {
+      activityObserver,
       token: "parent-session-token",
       update: { ...update, callId: "update-call-2" },
       view,

--- a/packages/eve/src/execution/tasks/child/workflow.ts
+++ b/packages/eve/src/execution/tasks/child/workflow.ts
@@ -132,9 +132,6 @@ export async function taskRunWorkflow(input: TaskRunWorkflowInput): Promise<void
       if (payload.kind === "task-update") {
         if (dispatchAcknowledged && !isTerminalTaskStatus(view.status)) {
           await wakeTaskUpdateParentStep({
-            ...(input.activityObserver === undefined
-              ? {}
-              : { activityObserver: input.activityObserver }),
             token: input.parentContinuationToken,
             update: payload,
             view,
@@ -164,9 +161,6 @@ export async function taskRunWorkflow(input: TaskRunWorkflowInput): Promise<void
       if (isReadinessCommand && isTerminalTaskStatus(view.status)) {
         for (const update of pendingUpdates) {
           await wakeTaskUpdateParentStep({
-            ...(input.activityObserver === undefined
-              ? {}
-              : { activityObserver: input.activityObserver }),
             token: input.parentContinuationToken,
             update,
             view,
@@ -195,9 +189,6 @@ export async function taskRunWorkflow(input: TaskRunWorkflowInput): Promise<void
       if (dispatchAcknowledged && pendingUpdates.length > 0 && !isTerminalTaskStatus(view.status)) {
         for (const update of pendingUpdates) {
           await wakeTaskUpdateParentStep({
-            ...(input.activityObserver === undefined
-              ? {}
-              : { activityObserver: input.activityObserver }),
             token: input.parentContinuationToken,
             update,
             view,

--- a/packages/eve/src/execution/tasks/child/workflow.ts
+++ b/packages/eve/src/execution/tasks/child/workflow.ts
@@ -132,6 +132,9 @@ export async function taskRunWorkflow(input: TaskRunWorkflowInput): Promise<void
       if (payload.kind === "task-update") {
         if (dispatchAcknowledged && !isTerminalTaskStatus(view.status)) {
           await wakeTaskUpdateParentStep({
+            ...(input.activityObserver === undefined
+              ? {}
+              : { activityObserver: input.activityObserver }),
             token: input.parentContinuationToken,
             update: payload,
             view,
@@ -161,6 +164,9 @@ export async function taskRunWorkflow(input: TaskRunWorkflowInput): Promise<void
       if (isReadinessCommand && isTerminalTaskStatus(view.status)) {
         for (const update of pendingUpdates) {
           await wakeTaskUpdateParentStep({
+            ...(input.activityObserver === undefined
+              ? {}
+              : { activityObserver: input.activityObserver }),
             token: input.parentContinuationToken,
             update,
             view,
@@ -189,6 +195,9 @@ export async function taskRunWorkflow(input: TaskRunWorkflowInput): Promise<void
       if (dispatchAcknowledged && pendingUpdates.length > 0 && !isTerminalTaskStatus(view.status)) {
         for (const update of pendingUpdates) {
           await wakeTaskUpdateParentStep({
+            ...(input.activityObserver === undefined
+              ? {}
+              : { activityObserver: input.activityObserver }),
             token: input.parentContinuationToken,
             update,
             view,

--- a/packages/eve/src/protocol/activity.ts
+++ b/packages/eve/src/protocol/activity.ts
@@ -27,13 +27,12 @@ export interface PendingActivitySettlementV1 {
 }
 
 export interface ActivityUpdateV1 {
+  readonly eventId: string;
   readonly message: string;
   readonly updatedAt: string;
 }
 
-export interface PendingActivityUpdateV1 extends ActivityUpdateV1 {
-  readonly eventId: string;
-}
+export interface PendingActivityUpdateV1 extends ActivityUpdateV1 {}
 
 export interface ActivityWorkStateV1 extends ActivityWorkIdentityV1 {
   readonly phase: ActivityWorkPhase;

--- a/packages/eve/src/protocol/activity.ts
+++ b/packages/eve/src/protocol/activity.ts
@@ -26,12 +26,12 @@ export interface PendingActivitySettlementV1 {
   readonly settledAt: string;
 }
 
-export interface ActivityWorkUpdateV1 {
+export interface ActivityUpdateV1 {
   readonly message: string;
   readonly updatedAt: string;
 }
 
-export interface PendingActivityWorkUpdateV1 extends ActivityWorkUpdateV1 {
+export interface PendingActivityUpdateV1 extends ActivityUpdateV1 {
   readonly eventId: string;
 }
 
@@ -39,7 +39,7 @@ export interface ActivityWorkStateV1 extends ActivityWorkIdentityV1 {
   readonly phase: ActivityWorkPhase;
   readonly settledAt?: string;
   readonly startedAt: string;
-  readonly update?: ActivityWorkUpdateV1;
+  readonly update?: ActivityUpdateV1;
 }
 
 export interface ActivityActionIdentityV1 {
@@ -129,7 +129,7 @@ export interface ActivitySnapshotV1 {
   readonly actions: Readonly<Record<string, ActivityActionStateV1>>;
   readonly blockers: Readonly<Record<string, ActivityBlockerStateV1>>;
   readonly pendingSettlements: Readonly<Record<string, PendingActivitySettlementV1>>;
-  readonly pendingWorkUpdates: Readonly<Record<string, PendingActivityWorkUpdateV1>>;
+  readonly pendingWorkUpdates: Readonly<Record<string, PendingActivityUpdateV1>>;
   readonly revision: number;
   readonly seenEventIds: readonly string[];
   readonly version: 1;

--- a/packages/eve/src/protocol/activity.ts
+++ b/packages/eve/src/protocol/activity.ts
@@ -26,10 +26,20 @@ export interface PendingActivitySettlementV1 {
   readonly settledAt: string;
 }
 
+export interface ActivityWorkUpdateV1 {
+  readonly message: string;
+  readonly updatedAt: string;
+}
+
+export interface PendingActivityWorkUpdateV1 extends ActivityWorkUpdateV1 {
+  readonly eventId: string;
+}
+
 export interface ActivityWorkStateV1 extends ActivityWorkIdentityV1 {
   readonly phase: ActivityWorkPhase;
   readonly settledAt?: string;
   readonly startedAt: string;
+  readonly update?: ActivityWorkUpdateV1;
 }
 
 export interface ActivityActionIdentityV1 {
@@ -77,6 +87,13 @@ export type ActivityEventV1 =
       readonly workId: string;
     }
   | {
+      readonly eventId: string;
+      readonly kind: "work.updated";
+      readonly message: string;
+      readonly updatedAt: string;
+      readonly workId: string;
+    }
+  | {
       readonly action: ActivityActionIdentityV1;
       readonly eventId: string;
       readonly kind: "action.started";
@@ -112,6 +129,7 @@ export interface ActivitySnapshotV1 {
   readonly actions: Readonly<Record<string, ActivityActionStateV1>>;
   readonly blockers: Readonly<Record<string, ActivityBlockerStateV1>>;
   readonly pendingSettlements: Readonly<Record<string, PendingActivitySettlementV1>>;
+  readonly pendingWorkUpdates: Readonly<Record<string, PendingActivityWorkUpdateV1>>;
   readonly revision: number;
   readonly seenEventIds: readonly string[];
   readonly version: 1;
@@ -206,6 +224,24 @@ function parseKnownEvent(value: Record<string, unknown>): ActivityEventV1 | null
         kind: "work.settled",
         outcome: value.outcome,
         settledAt: value.settledAt,
+        workId: value.workId,
+      };
+    }
+    case "work.updated": {
+      if (!hasOnlyKeys(value, ["eventId", "kind", "message", "updatedAt", "workId"]))
+        return undefined;
+      if (
+        !isIdentity(value.eventId) ||
+        !isBoundedString(value.message) ||
+        !isBoundedString(value.updatedAt) ||
+        !isIdentity(value.workId)
+      )
+        return undefined;
+      return {
+        eventId: value.eventId,
+        kind: "work.updated",
+        message: value.message,
+        updatedAt: value.updatedAt,
         workId: value.workId,
       };
     }

--- a/research/activity-event-log-invariant.md
+++ b/research/activity-event-log-invariant.md
@@ -1,0 +1,80 @@
+---
+issue: https://github.com/vercel/eve/issues/1673
+status: implemented
+last_updated: "2026-08-28"
+---
+
+# Keep activity as an event-log projection
+
+## Decision
+
+Canonical durable session and task events are the sole source of activity facts. Feature code may emit a canonical event, but only the corresponding activity observer may project that event and submit it to the activity collector.
+
+Semantic behavior stays independent of activity. In particular, a task update continues through the durable task hook and parent inbox whether or not an activity collector exists or presentation succeeds.
+
+```text
+producer -> canonical event -> activity observer -> collector -> renderer
+        \-> durable semantic path (when required)
+```
+
+This restates the architecture agreed during #2306: sessions produce `MessageStreamEvent`s, while activity is a best-effort external projection. #2711 and #2712 accidentally bypassed that boundary by calling `submitActivity` from task and tool feature code.
+
+## Current violations
+
+### #2711: task milestones
+
+`wakeTaskUpdateParentStep` receives a durable `TaskInboundUpdate`, posts `work.updated` directly to the collector, and separately sends the update to the parent inbox. The task update is durable, but the collector fact is not projected from the child session event log.
+
+Task terminal settlement has the same older exception: `appendTaskViewStep` posts `work.settled` directly after writing the task view stream. Updating #2711 should remove both task-owned activity submissions so the first PR leaves no nearby exception to the invariant.
+
+### #2712: authored tool updates
+
+`createToolActivity` posts `action.updated` directly to the collector. The message does not exist in the session event log, so replay and inspection cannot explain the rendered state.
+
+## Event semantics
+
+Add a canonical `action.updated` message-stream event with the current `callId`, normalized `message`, turn ID, and turn sequence. The authored tool context does not own a step index, and activity identity does not need one: the matching `actions.requested` event already establishes the action's step.
+
+Its stamped `meta.id` is the durable update identity. Activity projection derives the action ID from `(workId, callId)` and uses `meta.id` to derive a replay-stable `action.updated` activity event ID. The event does not alter model history, tool output, or action settlement.
+
+For `task_update`, use its canonical successful `action.result`. Include the accepted message in the framework tool result, then project that result to `work.updated` only when the observed work is a delegated task. This keeps the event on the ordinary harness emission path and avoids a second event for one accepted tool action.
+
+Do not project `actions.requested` alone: an invalid or unowned update can still fail during dispatch.
+
+Task settlement comes from the canonical task-view stream, whose task workflow is the single writer. A dedicated task activity observer projects terminal views after they are appended. Child `turn.completed`, `turn.failed`, and `turn.cancelled` events are not authoritative because cancellation can race child settlement; the task transition decides the final state.
+
+## Execution plan
+
+### 1. Repair #2711
+
+1. Include the accepted message in a successful `task_update` tool result so its ordinary canonical `action.result` is self-contained.
+2. Teach `projectSessionActivity` / `projectActivityEvents` to map that result under task work to `work.updated`, using the stamped source event ID for deduplication.
+3. Remove `projectTaskUpdateActivity`, activity-observer plumbing from `wakeTaskUpdateParentStep`, and its direct `submitActivity` call. Preserve the existing task hook and `resumeSessionInbox` parent notification unchanged.
+4. Project terminal task views through a dedicated task activity observer after `appendTaskViewStep` writes the canonical task stream.
+5. Test successful, rejected, duplicate/replayed, out-of-order-start, and post-settlement updates. Assert the parent still wakes when activity is absent or submission fails.
+
+### 2. Rebase and repair #2712
+
+1. Add `action.updated` to `packages/eve/src/protocol/message.ts`, bump the message-stream version, and update channel/hook compatibility reports required by the expanded public event union.
+2. Change `createToolActivity` to use the existing virtual `HandleEventKey`. Normalize the message, emit `action.updated`, and swallow/log emission failure so progress cannot change the tool result.
+3. Remove direct access to `ActivityObserverKey` and `submitActivity` from authored tool execution. Emit the canonical event even when no activity renderer is configured.
+4. Project stamped `action.updated` events to activity using `meta.at` and a deterministic ID derived from `meta.id`.
+5. Test multiple updates, concurrent tool calls, update-before-start reduction, update-after-settlement rejection, no-renderer event persistence, replay deduplication, and emission failure isolation.
+
+### 3. Guard the boundary
+
+Add a focused invariant check that limits imports/calls of `submitActivity` to canonical session and task activity observers and their transport tests.
+
+## Validation
+
+Run the narrow unit and integration files for message protocol, activity projection/reduction, task updates/workflow, tool execution, and extension compatibility. Then run:
+
+```sh
+pnpm fmt
+pnpm lint
+pnpm typecheck
+pnpm guard:invariants
+pnpm test:unit
+```
+
+Both PRs touch the published `eve` package, so retain their changesets and update their release notes if the canonical event becomes user-visible through channel handlers or hooks.

--- a/scripts/guard-invariants.mjs
+++ b/scripts/guard-invariants.mjs
@@ -109,6 +109,9 @@
  *             version as current. Wire versions are append-only protocol
  *             history: change the contract by adding a version and migration,
  *             never by updating a historical schema and its snapshot together.
+ *   rule 41 — Only canonical event observers may submit facts to the activity
+ *             collector. Feature code emits durable session or task events;
+ *             their observers alone project and transport the activity view.
  *
  * Baselines for rules with pre-existing violations live in
  * `guard-invariants-baseline.json`. Counts and allowlists in that file
@@ -1123,6 +1126,31 @@ const NESTED_EVE_BUILD_RE = /\bpnpm\s+(?:--filter(?:=|\s+)eve|-F\s+eve)\s+(?:run
 /**
  * @returns {Promise<Violation[]>}
  */
+async function checkRule41ActivitySubmissionBoundary() {
+  const executionRoot = join(REPO_ROOT, "packages/eve/src/execution");
+  const allowed = new Set([
+    "packages/eve/src/execution/session-activity-projection.ts",
+    "packages/eve/src/execution/submit-activity.ts",
+    "packages/eve/src/execution/task-activity-projection.ts",
+  ]);
+  /** @type {Violation[]} */
+  const violations = [];
+
+  for await (const { absPath, relPath } of walkFiles(executionRoot)) {
+    if (!relPath.endsWith(".ts") || relPath.includes(".test.") || allowed.has(relPath)) continue;
+    const source = await readFile(absPath, "utf8");
+    if (!source.includes("submitActivity")) continue;
+    violations.push({
+      rule: 41,
+      file: relPath,
+      message:
+        "submits activity outside a canonical event observer. Emit a durable session or task event, then project it from the corresponding activity observer.",
+    });
+  }
+
+  return violations;
+}
+
 async function checkRule38NoNestedEveBuild() {
   /** @type {Violation[]} */
   const violations = [];
@@ -1416,6 +1444,9 @@ async function main() {
 
   // Rule 40
   violations.push(...(await checkRule40WireContracts()));
+
+  // Rule 41
+  violations.push(...(await checkRule41ActivitySubmissionBoundary()));
 
   if (violations.length === 0) {
     process.stdout.write("[eve:guard:invariants] ok — all mechanical lints passed.\n");


### PR DESCRIPTION
### Summary

Related to #1673. Shows accepted `task_update` messages as the latest status for a background task.

The lifecycle is:

```text
task_update -> task workflow -> parent inbox (notifies/wakes the parent)
            -> action.result in the child session event log
            -> activity observer -> activity collector -> channel renderer
```

The parent notification and activity rendering are separate: activity can fail or be disabled without affecting delivery to the parent. Task settlement follows the same event-log rule, projecting terminal views from the task workflow's single-writer stream rather than posting to the collector from task code.

#2712 builds the authored-tool API on this state.

### Validation

Adds focused coverage for accepted task updates, event replay, updates arriving before work starts, terminal task views, and parent workflow forwarding.

### Diff size

**Docs** — 3 files · `+91 / -0`

Records the event-log rule, the implementation decision, and the release note.

**Implementation** — 8 files · `+203 / -36`

Moves task update and settlement rendering behind observers of the existing durable session and task streams. The invariant guard accounts for 31 added lines.

**Tests** — 6 files · `+218 / -44`

Replaces direct collector-submission tests with event projection and task-view observer coverage.
