### PR TITLE
[2/2] feat(eve): let tools report activity updates

### DIFF
--- a/.changeset/calm-tool-activity.md
+++ b/.changeset/calm-tool-activity.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Allow authored tools to publish presentation-only progress through `ctx.activity.update()`. Updates flow to configured channel activity renderers without entering model context or waking a parent session.

--- a/.changeset/calm-tool-activity.md
+++ b/.changeset/calm-tool-activity.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Allow authored tools to publish presentation-only progress through `ctx.activity.update()`. Updates flow to configured channel activity renderers without entering model context or waking a parent session.
+Allow authored tools to publish presentation-only progress through `ctx.activity.update()`. Updates persist as `action.updated` session events and flow to configured channel activity renderers without entering model context or waking a parent session.

--- a/docs/concepts/sessions-runs-and-streaming.md
+++ b/docs/concepts/sessions-runs-and-streaming.md
@@ -51,6 +51,7 @@ The stream is newline-delimited JSON (NDJSON), one event per line:
 | `step.started`            | A model step began.                                                                                              |
 | `action.input.appended`   | A raw tool-input text delta, its character offset, and tool-call identity.                                       |
 | `actions.requested`       | The model requested one or more actions, including tool calls; calls stream before execution.                    |
+| `action.updated`          | An authored tool reported presentation-only progress while it was running.                                       |
 | `action.partial`          | A locally executed tool generator yielded a preliminary output snapshot.                                         |
 | `action.result`           | A tool call returned.                                                                                            |
 | `input.requested`         | The run paused for human input ([HITL](/docs/human-in-the-loop) approval or `ask_question`); carries `requests`. |
@@ -80,6 +81,8 @@ The optional `data.trace` on session and turn starts contains eve-owned W3C trac
 `reasoning.appended`, `message.appended`, and `action.input.appended` stream incremental output as it arrives. When the durable stream writer is busy, eve may coalesce adjacent deltas for the same text block or tool call; the text remains in source order, and a different event type, tool `callId`, or stream coordinate forms an ordering barrier. Text and reasoning appends carry both the new delta and the cumulative text for the current block. The finalized blocks show up on `message.completed` and `reasoning.completed`, which is the compatibility path for clients that don't render incremental streaming.
 
 When a streamed tool input becomes a validated call, its `action.input.appended` events precede the matching `actions.requested` event. Each append carries `callId`, `toolName`, `inputTextDelta`, and `inputTextOffset`; the offset is the zero-based UTF-16 code-unit position where the delta begins. Storing only the delta and offset avoids repeating the cumulative input in every durable event. The default client reducer starts or restarts accumulation at offset `0`, ignores a nonzero offset that is not contiguous, and projects the potentially incomplete JSON as a `dynamic-tool` part with `state: "input-streaming"` and cumulative text in `inputText`. `actions.requested` replaces that part with `state: "input-available"` and the validated `input`. Excluded internal actions never publish their input stream.
+
+`action.updated` records a message passed to `ctx.activity.update()` while an authored tool is running. It carries the tool `callId`, turn ID, and turn sequence. The message does not enter model history or replace the tool result. Treat updates as last-write-wins status: an interrupted durable step can retry and emit them again.
 
 `action.partial` carries one complete preliminary output snapshot from an authored async-generator tool. A later partial for the same `callId` replaces it, and `action.result` is the final snapshot. When the durable writer is busy, eve may keep only the newest adjacent partial for a call. Treat partials as last-write-wins: a durable step can retry and replay overlapping event runs. Provider-executed tool progress and MCP progress notifications are not projected as `action.partial` events.
 
@@ -114,7 +117,7 @@ Alongside `type` and `data`, every event carries a `meta` envelope:
 
 `meta.id` is stable. eve mints it once, when the event is written to the durable stream, and stores it with the event. Reconnecting from a cursor, rewinding to `startIndex=0`, or replaying a finished session all return the same id for the same event.
 
-`meta.at` has always been there; `meta.id` arrived in stream version 20, and `action.input.appended` arrived in version 24. Events written by an earlier version are stored with the envelope but no id inside it, so rewinding into the part of a session that ran before you upgraded yields events whose `meta.id` is absent, even though the type says it is always a string. eve passes those events through rather than dropping them, and they cannot be deduplicated. The exposure ends when the sessions that predate your upgrade do.
+`meta.at` has always been there; `meta.id` arrived in stream version 20, `action.input.appended` arrived in version 24, and `action.updated` arrived in version 25. Events written by an earlier version are stored with the envelope but no id inside it, so rewinding into the part of a session that ran before you upgraded yields events whose `meta.id` is absent, even though the type says it is always a string. eve passes those events through rather than dropping them, and they cannot be deduplicated. The exposure ends when the sessions that predate your upgrade do.
 
 That makes it the key for ingesting a stream into a database without duplicating rows when you re-read it:
 

--- a/docs/reference/typescript-api.md
+++ b/docs/reference/typescript-api.md
@@ -91,6 +91,7 @@ import template from "../../prompts/template.txt?raw";
 | Member                      | Use                                                                          |
 | --------------------------- | ---------------------------------------------------------------------------- |
 | `ctx.session`               | Current session, turn, auth, and optional parent lineage (read-only)         |
+| `ctx.activity.update()`     | Publish presentation-only progress for the current tool call                 |
 | `ctx.getSandbox()`          | Live sandbox handle; `stop()` releases compute but preserves durable state   |
 | `ctx.getSkill(identifier)`  | Handle for a named skill visible to the current agent                        |
 | `ctx.getToken(provider)`    | Resolve a bearer token for an inline auth provider such as `connect("...")`  |

--- a/docs/tools/overview.mdx
+++ b/docs/tools/overview.mdx
@@ -103,7 +103,7 @@ async execute(input, ctx) {
 }
 ```
 
-Activity delivery is best-effort and only runs when the current channel has activity renderers configured. Awaiting an update waits for the bounded delivery attempt, but a delivery failure does not fail the tool. A retried tool execution may replay updates, so treat them as last-write-wins status rather than an append-only log.
+Each update is first written as an `action.updated` event on the durable session stream. The activity observer then projects that event to configured channel activity renderers. Awaiting an update waits for event emission, but a renderer delivery failure does not fail the tool. A retried tool execution may replay updates, so treat them as last-write-wins status rather than an append-only log.
 
 eve never runs authored tools during discovery. The model sees descriptors first, and only what it actually calls gets executed. Completed steps never re-run; eve replays the recorded result. A step interrupted mid-execution re-runs, so make non-idempotent side effects like charges or emails idempotent, or gate them with approval.
 

--- a/docs/tools/overview.mdx
+++ b/docs/tools/overview.mdx
@@ -86,10 +86,24 @@ task is terminal, the state includes their outputs so the model can combine the 
 - `ctx.callId`: the id of the current tool call, carried by the call's [stream events](/docs/concepts/sessions-runs-and-streaming) and approval context.
 - `ctx.toolName`: the final runtime name the model called, including any namespace qualification.
 - `ctx.abortSignal`: aborts when the active turn is cancelled. Pass it to cancellation-aware work; sandbox sessions from `ctx.getSandbox()` are already bound to it.
+- `ctx.activity.update(message)`: publishes the latest human-readable progress for this tool call to configured channel activity renderers. The update does not enter model context, wake a parent session, or change the tool result.
 - `ctx.getSandbox()`: the live [sandbox](/docs/sandbox) handle.
 - `ctx.getSkill(id)`: read a packaged [skill](/docs/skills)'s metadata and files.
 
 Running in the app runtime is what lets a tool import shared code from `lib/`, read `process.env`, and take part in eve’s durable pause/resume model.
+
+Use `ctx.activity.update()` for occasional milestones during a long-running call:
+
+```ts
+async execute(input, ctx) {
+  await ctx.activity.update("Preparing the deployment");
+  const build = await prepare(input);
+  await ctx.activity.update("Uploading build artifacts");
+  return await deploy(build);
+}
+```
+
+Activity delivery is best-effort and only runs when the current channel has activity renderers configured. Awaiting an update waits for the bounded delivery attempt, but a delivery failure does not fail the tool. A retried tool execution may replay updates, so treat them as last-write-wins status rather than an append-only log.
 
 eve never runs authored tools during discovery. The model sees descriptors first, and only what it actually calls gets executed. Completed steps never re-run; eve replays the recorded result. A step interrupted mid-execution re-runs, so make non-idempotent side effects like charges or emails idempotent, or gate them with approval.
 

--- a/packages/eve/extension-contracts/compatibility/channel/v12.ts
+++ b/packages/eve/extension-contracts/compatibility/channel/v12.ts
@@ -1,0 +1,3 @@
+import { disableRoute } from "#public/channels/index.js";
+
+export default disableRoute();

--- a/packages/eve/extension-contracts/compatibility/dynamicInstructions/v14.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicInstructions/v14.ts
@@ -1,0 +1,10 @@
+import { defineDynamic, defineInstructions } from "#public/instructions/index.js";
+
+export default defineDynamic({
+  events: {
+    "session.started": (_event, ctx) =>
+      defineInstructions({
+        markdown: `Use session ${ctx.session.id} when correlating evidence.`,
+      }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/dynamicSkill/v13.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicSkill/v13.ts
@@ -1,0 +1,11 @@
+import { defineDynamic, defineSkill } from "#public/skills/index.js";
+
+export default defineDynamic({
+  events: {
+    "turn.started": (_event, ctx) =>
+      defineSkill({
+        description: `Review evidence for session ${ctx.session.id}.`,
+        markdown: "# Evidence review\n\nCheck every claim against its source.",
+      }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/dynamicTool/v21.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicTool/v21.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+import { defineDynamic, defineTool } from "#public/tools/index.js";
+
+export default defineDynamic({
+  events: {
+    "turn.started": () =>
+      defineTool({
+        description: "Echo the current tool call.",
+        inputSchema: z.object({ value: z.string() }),
+        execute: ({ value }, ctx) => ({ callId: ctx.callId, toolName: ctx.toolName, value }),
+      }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/dynamicTool/v22.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicTool/v22.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+import { defineDynamic, defineTool } from "#public/tools/index.js";
+
+export default defineDynamic({
+  events: {
+    "turn.started": () =>
+      defineTool({
+        description: "Echo the current tool call.",
+        inputSchema: z.object({ value: z.string() }),
+        execute: ({ value }, ctx) => ({ callId: ctx.callId, toolName: ctx.toolName, value }),
+      }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/hook/v16.ts
+++ b/packages/eve/extension-contracts/compatibility/hook/v16.ts
@@ -1,0 +1,13 @@
+import { defineHook } from "#public/hooks/index.js";
+
+export default defineHook({
+  events: {
+    "subagent.completed"(event, ctx) {
+      console.info("subagent completed", {
+        output: event.data.output,
+        sessionId: ctx.session.id,
+        subagentName: event.data.subagentName,
+      });
+    },
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/schedule/v5.ts
+++ b/packages/eve/extension-contracts/compatibility/schedule/v5.ts
@@ -1,0 +1,18 @@
+import channel from "../channel/v7.js";
+import { defineSchedule } from "#public/schedules/index.js";
+
+export default defineSchedule({
+  cron: "0 0 * * *",
+  async run({ appAuth, to, waitUntil }) {
+    waitUntil(
+      (async () => {
+        const session = await to(channel, { sessionRef: "daily" }).send("Start review", {
+          auth: appAuth,
+        });
+        await session.respond([{ optionId: "approve", requestId: "approval-1" }], {
+          auth: appAuth,
+        });
+      })(),
+    );
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/subagent/v5.ts
+++ b/packages/eve/extension-contracts/compatibility/subagent/v5.ts
@@ -1,0 +1,7 @@
+import { defineAgent } from "#public/index.js";
+
+export default defineAgent({
+  compaction: { thresholdPercent: 0.8 },
+  description: "Delegate research tasks.",
+  model: "anthropic/claude-sonnet-5",
+});

--- a/packages/eve/extension-contracts/compatibility/tool/v21.ts
+++ b/packages/eve/extension-contracts/compatibility/tool/v21.ts
@@ -1,0 +1,7 @@
+import { defineTool } from "#public/tools/index.js";
+
+export default defineTool({
+  description: "Return the current tool call identity.",
+  inputSchema: { type: "object" },
+  execute: async (_input, ctx) => ({ callId: ctx.callId, toolName: ctx.toolName }),
+});

--- a/packages/eve/extension-contracts/reports/channel/v13.json
+++ b/packages/eve/extension-contracts/reports/channel/v13.json
@@ -1,0 +1,21 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "channel",
+  "epoch": 13,
+  "sha256": "e5ee05fe654f434d048f4b5ad0a8aba9979a30553a5b8c725a99f722040018e1",
+  "exports": [
+    "DELETE",
+    "GET",
+    "HEAD",
+    "OPTIONS",
+    "PATCH",
+    "POST",
+    "PUT",
+    "WS",
+    "createWebSocketUpgradeServer",
+    "defineChannel",
+    "disableRoute",
+    "isChannel",
+    "isDisabledRouteSentinel"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/dynamicInstructions/v15.json
+++ b/packages/eve/extension-contracts/reports/dynamicInstructions/v15.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicInstructions",
+  "epoch": 15,
+  "sha256": "1cde51ae268d34d7cc523ad0ac9ec6d4aad0c088bb8ed0a688bac13cfb2064ab",
+  "exports": ["defineDynamic"]
+}

--- a/packages/eve/extension-contracts/reports/dynamicSkill/v14.json
+++ b/packages/eve/extension-contracts/reports/dynamicSkill/v14.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicSkill",
+  "epoch": 14,
+  "sha256": "a59549e003b0fa00d74e19e4b9ed5473d8db25279955597ee850a1b9c8a57429",
+  "exports": ["defineDynamic"]
+}

--- a/packages/eve/extension-contracts/reports/dynamicTool/v22.json
+++ b/packages/eve/extension-contracts/reports/dynamicTool/v22.json
@@ -1,0 +1,13 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicTool",
+  "epoch": 22,
+  "sha256": "75e2c881789c99ab379865814805e8fb8e210a263bc77b20b478b1c073161e3e",
+  "exports": [
+    "DynamicToolEntry",
+    "DynamicToolEvents",
+    "DynamicToolResult",
+    "DynamicToolSet",
+    "defineDynamic"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/dynamicTool/v23.json
+++ b/packages/eve/extension-contracts/reports/dynamicTool/v23.json
@@ -1,0 +1,13 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicTool",
+  "epoch": 23,
+  "sha256": "c97515cd201b297103ae8409b94e12d0741f00b87807bd21cf286427c9d9a550",
+  "exports": [
+    "DynamicToolEntry",
+    "DynamicToolEvents",
+    "DynamicToolResult",
+    "DynamicToolSet",
+    "defineDynamic"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/hook/v17.json
+++ b/packages/eve/extension-contracts/reports/hook/v17.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "hook",
+  "epoch": 17,
+  "sha256": "506a20fa0ca68f203636680bb92f928017417413da77f3beccc7325812cb17ec",
+  "exports": ["defineHook"]
+}

--- a/packages/eve/extension-contracts/reports/schedule/v6.json
+++ b/packages/eve/extension-contracts/reports/schedule/v6.json
@@ -1,0 +1,14 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "schedule",
+  "epoch": 6,
+  "sha256": "d24d088e0ed5ba23b4f0dbe8d3195e44029e2c064566aa6f95e32f929466311c",
+  "exports": [
+    "ScheduleDefinition",
+    "ScheduleHandlerArgs",
+    "ScheduleRunHandler",
+    "ScheduleToFn",
+    "TypedReceiveTarget",
+    "defineSchedule"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/subagent/v6.json
+++ b/packages/eve/extension-contracts/reports/subagent/v6.json
@@ -1,0 +1,20 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "subagent",
+  "epoch": 6,
+  "sha256": "cda6f21fa91f4a4c4d8745df5a71af01f5bb91ba40680a65fb7cc599f2bdc30a",
+  "exports": [
+    "AgentCompactionDefinition",
+    "AgentDefinition",
+    "AgentModelDefinition",
+    "AgentStaticModelDefinition",
+    "DefinedAgent",
+    "DynamicLocalSubagentDefinition",
+    "DynamicSubagentDefinition",
+    "RemoteAgentDefinition",
+    "RemoteAgentDefinitionInput",
+    "defineAgent",
+    "defineDynamic",
+    "defineRemoteAgent"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/tool/v22.json
+++ b/packages/eve/extension-contracts/reports/tool/v22.json
@@ -1,0 +1,19 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "tool",
+  "epoch": 22,
+  "sha256": "f55c03160c7fc6972ffaf0e49387058f652d8de7dee7a1f4ef023d2bc2362468",
+  "exports": [
+    "defaultWebSearch",
+    "defineTool",
+    "disableTool",
+    "experimental_workflow",
+    "isDisabledToolSentinel",
+    "isExperimentalWorkflowToolDefinition",
+    "isWebSearchToolDefinition",
+    "toolOutput",
+    "toolOutputPart",
+    "toolResultFrom",
+    "webSearch"
+  ]
+}

--- a/packages/eve/src/client/index.ts
+++ b/packages/eve/src/client/index.ts
@@ -96,6 +96,7 @@ export type {
 export type {
   ActionPartialStreamEvent,
   ActionResultStreamEvent,
+  ActionUpdatedStreamEvent,
   ActionsRequestedStreamEvent,
   AssistantStepFinishReason,
   AuthorizationOutcome,

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -22,13 +22,13 @@ interface ExtensionCapabilityContract {
 const EXTENSION_CAPABILITY_CONTRACTS = {
   extension: { current: 1, supported: [1], dropped: {} },
   tool: {
-    current: 21,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 18, 19, 20, 21],
+    current: 22,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 18, 19, 20, 21, 22],
     dropped: { 15: "TaskExec replaces stageEffect with send" },
   },
   dynamicTool: {
-    current: 21,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21],
+    current: 22,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22],
     dropped: {},
   },
   channel: { current: 12, supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], dropped: {} },

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -27,15 +27,15 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     dropped: { 15: "TaskExec replaces stageEffect with send" },
   },
   dynamicTool: {
-    current: 22,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22],
+    current: 23,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
     dropped: {},
   },
-  channel: { current: 12, supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], dropped: {} },
-  schedule: { current: 5, supported: [1, 2, 3, 4, 5], dropped: {} },
+  channel: { current: 13, supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], dropped: {} },
+  schedule: { current: 6, supported: [1, 2, 3, 4, 5, 6], dropped: {} },
   subagent: {
-    current: 5,
-    supported: [3, 4, 5],
+    current: 6,
+    supported: [3, 4, 5, 6],
     dropped: {
       1: "Persistent subagent sessions are now the default and the experimental opt-in was removed",
       2: "Persistent subagent sessions are now the default and the experimental opt-in was removed",
@@ -47,8 +47,8 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     dropped: {},
   },
   hook: {
-    current: 16,
-    supported: [10, 11, 12, 13, 14, 15, 16],
+    current: 17,
+    supported: [10, 11, 12, 13, 14, 15, 16, 17],
     dropped: {
       1: "Model identity moved from session.started runtime metadata to step.started call attribution.",
       2: "Model identity moved from session.started runtime metadata to step.started call attribution.",
@@ -63,14 +63,14 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
   },
   skill: { current: 1, supported: [1], dropped: {} },
   dynamicSkill: {
-    current: 13,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
+    current: 14,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
     dropped: {},
   },
   instructions: { current: 2, supported: [1, 2], dropped: {} },
   dynamicInstructions: {
-    current: 14,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+    current: 15,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
     dropped: {},
   },
   config: { current: 1, supported: [1], dropped: {} },

--- a/packages/eve/src/execution/activity-events.test.ts
+++ b/packages/eve/src/execution/activity-events.test.ts
@@ -188,6 +188,28 @@ describe("projectActivityEvents", () => {
     ]);
   });
 
+  it("projects stamped authored tool updates", () => {
+    expect(
+      projectActivityEvents({
+        at: "2026-01-01T00:00:00.000Z",
+        event: {
+          data: { callId: "tool-1", message: "Working", sequence: 1, turnId: "turn" },
+          type: "action.updated",
+        },
+        lineage,
+        sourceEventId: "event-1",
+      }),
+    ).toEqual([
+      {
+        actionId: "action:work:root:turn:tool-1",
+        eventId: "event-1",
+        kind: "action.updated",
+        message: "Working",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+  });
+
   it("settles delegated work from its parent action result", () => {
     const workId = deriveChildActivityWorkId({
       callId: "child-1",

--- a/packages/eve/src/execution/activity-events.ts
+++ b/packages/eve/src/execution/activity-events.ts
@@ -36,6 +36,18 @@ export function projectActivityEvents(input: {
       ];
     });
   }
+  if (event.type === "action.updated") {
+    const actionId = deriveActivityActionId({ callId: event.data.callId, workId: lineage.id });
+    return [
+      {
+        actionId,
+        eventId: input.sourceEventId ?? `${actionId}:updated:${event.data.sequence}`,
+        kind: "action.updated",
+        message: event.data.message,
+        updatedAt: input.at,
+      },
+    ];
+  }
   if (event.type === "action.result") {
     const result = event.data.result;
     if (result.kind === "subagent-result") {

--- a/packages/eve/src/execution/activity-events.ts
+++ b/packages/eve/src/execution/activity-events.ts
@@ -1,5 +1,5 @@
 import { normalizeActivityText } from "#execution/activity-text.js";
-import { deriveChildActivityWorkId } from "#execution/activity-work-id.js";
+import { deriveActivityActionId, deriveChildActivityWorkId } from "#execution/activity-work-id.js";
 import type { ActivityEventV1, ActivityWorkIdentityV1 } from "#protocol/activity.js";
 import type { UnstampedMessageStreamEvent } from "#protocol/message.js";
 import { TASK_UPDATE_TOOL_NAME } from "#tools/framework/task-contract.js";
@@ -18,7 +18,7 @@ export function projectActivityEvents(input: {
       const kind = action.kind === "load-skill" ? ("skill" as const) : ("tool" as const);
       const rawName = action.kind === "load-skill" ? "load_skill" : action.toolName;
       const name = normalizeActivityText(rawName) || (kind === "skill" ? "Skill" : "Tool");
-      const id = actionId(lineage.id, action.callId);
+      const id = deriveActivityActionId({ callId: action.callId, workId: lineage.id });
       return [
         {
           action: {
@@ -63,7 +63,7 @@ export function projectActivityEvents(input: {
         },
       ];
     }
-    const id = actionId(lineage.id, result.callId);
+    const id = deriveActivityActionId({ callId: result.callId, workId: lineage.id });
     const settled = {
       actionId: id,
       eventId: `${id}:settled:${event.data.status}`,
@@ -169,7 +169,10 @@ export function projectActivityEvents(input: {
           id,
           kind,
           label: activityLabel(request.prompt),
-          parentActionId: actionId(lineage.id, request.action.callId),
+          parentActionId: deriveActivityActionId({
+            callId: request.action.callId,
+            workId: lineage.id,
+          }),
           parentWorkId: lineage.id,
           rootTurnId: lineage.rootTurnId,
         },
@@ -251,10 +254,6 @@ function readAcceptedTaskUpdate(
 function activityLabel(value: string): string | undefined {
   const normalized = normalizeActivityText(value);
   return normalized === "" ? undefined : normalized;
-}
-
-function actionId(parentWorkId: string, callId: string): string {
-  return `action:${parentWorkId}:${callId}`;
 }
 
 function blockerId(

--- a/packages/eve/src/execution/activity-work-id.ts
+++ b/packages/eve/src/execution/activity-work-id.ts
@@ -9,6 +9,13 @@ export function deriveRootTurnActivityWorkId(input: {
   return `root:${hashTuple([input.sessionId, input.turnId])}`;
 }
 
+export function deriveActivityActionId(input: {
+  readonly callId: string;
+  readonly workId: string;
+}): string {
+  return `action:${input.workId}:${input.callId}`;
+}
+
 export function deriveChildActivityWorkId(input: {
   readonly callId: string;
   readonly parentSessionId: string;

--- a/packages/eve/src/execution/session-activity.test.ts
+++ b/packages/eve/src/execution/session-activity.test.ts
@@ -138,7 +138,10 @@ describe("activity protocol and reducer", () => {
     });
   });
 
-  it("retains normalized action updates and ignores them after settlement", () => {
+  it.each([
+    ["newer before older", ["work", "action", "newer", "older"]],
+    ["settlement before updates", ["work", "action", "settled", "newer", "older"]],
+  ] as const)("converges action updates for %s delivery", (_name, order) => {
     const action = {
       id: "action",
       kind: "tool" as const,
@@ -147,35 +150,38 @@ describe("activity protocol and reducer", () => {
       rootTurnId: "turn",
       stepIndex: 0,
     };
-    const snapshot = reduce([
-      { eventId: "work", kind: "work.started", startedAt: "1", work },
-      { action, eventId: "action", kind: "action.started", startedAt: "2" },
-      {
+    const events: Record<string, ActivityEventV1> = {
+      work: { eventId: "work", kind: "work.started", startedAt: "1", work },
+      action: { action, eventId: "action", kind: "action.started", startedAt: "2" },
+      older: {
         actionId: action.id,
-        eventId: "updated",
+        eventId: "updated-1",
         kind: "action.updated",
-        message: "Uploading\u0007   artifacts",
+        message: "Older update",
         updatedAt: "3",
       },
-      {
+      newer: {
+        actionId: action.id,
+        eventId: "updated-2",
+        kind: "action.updated",
+        message: "Newer update",
+        updatedAt: "4",
+      },
+      settled: {
         actionId: action.id,
         eventId: "settled-action",
         kind: "action.settled",
         outcome: "completed",
-        settledAt: "4",
+        settledAt: "5",
       },
-      {
-        actionId: action.id,
-        eventId: "late-update",
-        kind: "action.updated",
-        message: "Stale update",
-        updatedAt: "5",
-      },
-    ]);
+    };
+
+    const snapshot = reduce(order.map((key) => events[key]!));
 
     expect(snapshot.actions.action?.update).toEqual({
-      message: "Uploading artifacts",
-      updatedAt: "3",
+      eventId: "updated-2",
+      message: "Newer update",
+      updatedAt: "4",
     });
   });
 
@@ -201,6 +207,7 @@ describe("activity protocol and reducer", () => {
     ]);
 
     expect(snapshot.actions.action?.update).toEqual({
+      eventId: "updated",
       message: "Uploading artifacts",
       updatedAt: "3",
     });

--- a/packages/eve/src/execution/session-activity.test.ts
+++ b/packages/eve/src/execution/session-activity.test.ts
@@ -43,6 +43,12 @@ describe("activity protocol and reducer", () => {
         version: 1,
       }),
     ).toBeUndefined();
+    expect(
+      parseActivityBatchV1({
+        events: [{ actionId: "action", eventId: "updated", kind: "action.updated" }],
+        version: 1,
+      }),
+    ).toBeUndefined();
   });
 
   it("deduplicates only by event id", () => {
@@ -130,6 +136,75 @@ describe("activity protocol and reducer", () => {
       message: "Newer update",
       updatedAt: "3",
     });
+  });
+
+  it("retains normalized action updates and ignores them after settlement", () => {
+    const action = {
+      id: "action",
+      kind: "tool" as const,
+      name: "deploy",
+      parentWorkId: work.id,
+      rootTurnId: "turn",
+      stepIndex: 0,
+    };
+    const snapshot = reduce([
+      { eventId: "work", kind: "work.started", startedAt: "1", work },
+      { action, eventId: "action", kind: "action.started", startedAt: "2" },
+      {
+        actionId: action.id,
+        eventId: "updated",
+        kind: "action.updated",
+        message: "Uploading\u0007   artifacts",
+        updatedAt: "3",
+      },
+      {
+        actionId: action.id,
+        eventId: "settled-action",
+        kind: "action.settled",
+        outcome: "completed",
+        settledAt: "4",
+      },
+      {
+        actionId: action.id,
+        eventId: "late-update",
+        kind: "action.updated",
+        message: "Stale update",
+        updatedAt: "5",
+      },
+    ]);
+
+    expect(snapshot.actions.action?.update).toEqual({
+      message: "Uploading artifacts",
+      updatedAt: "3",
+    });
+  });
+
+  it("retains an action update that arrives before action startup", () => {
+    const action = {
+      id: "action",
+      kind: "tool" as const,
+      name: "deploy",
+      parentWorkId: work.id,
+      rootTurnId: "turn",
+      stepIndex: 0,
+    };
+    const snapshot = reduce([
+      {
+        actionId: action.id,
+        eventId: "updated",
+        kind: "action.updated",
+        message: "Uploading artifacts",
+        updatedAt: "3",
+      },
+      { eventId: "work", kind: "work.started", startedAt: "1", work },
+      { action, eventId: "action", kind: "action.started", startedAt: "2" },
+    ]);
+
+    expect(snapshot.actions.action?.update).toEqual({
+      message: "Uploading artifacts",
+      updatedAt: "3",
+    });
+    expect(snapshot.pendingActionUpdates).toEqual({});
   });
 
   it("applies settlement before start and never reopens terminal work", () => {

--- a/packages/eve/src/execution/session-activity.ts
+++ b/packages/eve/src/execution/session-activity.ts
@@ -19,6 +19,7 @@ export function createActivitySnapshot(): ActivitySnapshotV1 {
   return {
     actions: {},
     blockers: {},
+    pendingActionUpdates: {},
     pendingSettlements: {},
     pendingWorkUpdates: {},
     revision: 0,
@@ -70,6 +71,8 @@ function reduceEvent(snapshot: ActivitySnapshotV1, event: ActivityEventV1): Acti
       return startAction(snapshot, event);
     case "action.settled":
       return settleAction(snapshot, event);
+    case "action.updated":
+      return updateAction(snapshot, event);
     case "blocker.started":
       return startBlocker(snapshot, event);
     case "blocker.settled":
@@ -162,6 +165,7 @@ function startAction(
 ): ActivitySnapshotV1 {
   if (snapshot.actions[event.action.id] !== undefined) return snapshot;
   const pending = pendingFor(snapshot, "action", event.action.id);
+  const pendingUpdate = snapshot.pendingActionUpdates[event.action.id];
   const parent = snapshot.work[event.action.parentWorkId];
   const phase =
     pending?.outcome ??
@@ -174,7 +178,12 @@ function startAction(
       phase: phase as ActivityActionPhase,
       settledAt: pending?.settledAt ?? (phase === "cancelled" ? parent?.settledAt : undefined),
       startedAt: event.startedAt,
+      update:
+        phase === "running" && pendingUpdate !== undefined
+          ? { message: pendingUpdate.message, updatedAt: pendingUpdate.updatedAt }
+          : undefined,
     }),
+    pendingActionUpdates: removeKey(snapshot.pendingActionUpdates, event.action.id),
     pendingSettlements: removeKey(
       snapshot.pendingSettlements,
       pendingKey("action", event.action.id),
@@ -195,6 +204,37 @@ function settleAction(
       ...current,
       phase: event.outcome,
       settledAt: event.settledAt,
+    }),
+  };
+}
+
+function updateAction(
+  snapshot: ActivitySnapshotV1,
+  event: Extract<ActivityEventV1, { readonly kind: "action.updated" }>,
+): ActivitySnapshotV1 {
+  const current = snapshot.actions[event.actionId];
+  if (current === undefined) {
+    if (pendingFor(snapshot, "action", event.actionId) !== undefined) return snapshot;
+    return {
+      ...snapshot,
+      pendingActionUpdates: replaceBounded(
+        snapshot.pendingActionUpdates,
+        event.actionId,
+        {
+          eventId: event.eventId,
+          message: normalizeActivityText(event.message),
+          updatedAt: event.updatedAt,
+        },
+        MAX_ACTIVITY_PENDING_WORK_UPDATES,
+      ),
+    };
+  }
+  if (current.phase !== "running") return snapshot;
+  return {
+    ...snapshot,
+    actions: replaceBounded(snapshot.actions, event.actionId, {
+      ...current,
+      update: { message: normalizeActivityText(event.message), updatedAt: event.updatedAt },
     }),
   };
 }

--- a/packages/eve/src/execution/session-activity.ts
+++ b/packages/eve/src/execution/session-activity.ts
@@ -178,10 +178,7 @@ function startAction(
       phase: phase as ActivityActionPhase,
       settledAt: pending?.settledAt ?? (phase === "cancelled" ? parent?.settledAt : undefined),
       startedAt: event.startedAt,
-      update:
-        phase === "running" && pendingUpdate !== undefined
-          ? { message: pendingUpdate.message, updatedAt: pendingUpdate.updatedAt }
-          : undefined,
+      update: pendingUpdate,
     }),
     pendingActionUpdates: removeKey(snapshot.pendingActionUpdates, event.action.id),
     pendingSettlements: removeKey(
@@ -212,30 +209,29 @@ function updateAction(
   snapshot: ActivitySnapshotV1,
   event: Extract<ActivityEventV1, { readonly kind: "action.updated" }>,
 ): ActivitySnapshotV1 {
+  const update = {
+    eventId: event.eventId,
+    message: normalizeActivityText(event.message),
+    updatedAt: event.updatedAt,
+  };
   const current = snapshot.actions[event.actionId];
   if (current === undefined) {
-    if (pendingFor(snapshot, "action", event.actionId) !== undefined) return snapshot;
+    const pending = snapshot.pendingActionUpdates[event.actionId];
+    if (pending !== undefined && !isNewerUpdate(update, pending)) return snapshot;
     return {
       ...snapshot,
       pendingActionUpdates: replaceBounded(
         snapshot.pendingActionUpdates,
         event.actionId,
-        {
-          eventId: event.eventId,
-          message: normalizeActivityText(event.message),
-          updatedAt: event.updatedAt,
-        },
+        update,
         MAX_ACTIVITY_PENDING_WORK_UPDATES,
       ),
     };
   }
-  if (current.phase !== "running") return snapshot;
+  if (current.update !== undefined && !isNewerUpdate(update, current.update)) return snapshot;
   return {
     ...snapshot,
-    actions: replaceBounded(snapshot.actions, event.actionId, {
-      ...current,
-      update: { message: normalizeActivityText(event.message), updatedAt: event.updatedAt },
-    }),
+    actions: replaceBounded(snapshot.actions, event.actionId, { ...current, update }),
   };
 }
 

--- a/packages/eve/src/execution/tasks/child/workflow.test.ts
+++ b/packages/eve/src/execution/tasks/child/workflow.test.ts
@@ -316,12 +316,17 @@ describe("taskRunWorkflow", () => {
     ]);
 
     await taskRunWorkflow({
+      activityObserver,
       taskInboxToken: "task-token",
       initialView: createWorkingView(),
       parentContinuationToken: "parent-session-token",
     });
 
     expect(appendedStatuses()).toEqual(["working", "failed"]);
+    expect(appendTaskViewStep).toHaveBeenLastCalledWith({
+      activityObserver,
+      view: expect.objectContaining({ status: "failed" }),
+    });
     expect(wakeTaskParentStep).not.toHaveBeenCalled();
     expect(disposeHook).toHaveBeenCalledTimes(1);
   });

--- a/packages/eve/src/execution/tool-activity.test.ts
+++ b/packages/eve/src/execution/tool-activity.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ContextContainer, contextStorage } from "#context/container.js";
+import { ActivityObserverKey, SessionKey } from "#context/keys.js";
+import { createToolActivity } from "#execution/tool-activity.js";
+import { deriveRootTurnActivityWorkId } from "#execution/activity-work-id.js";
+
+const session = {
+  auth: { current: null, initiator: null },
+  sessionId: "session-1",
+  turn: { id: "turn-1", sequence: 1 },
+};
+
+describe("createToolActivity", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("publishes bounded action updates without session delivery", async () => {
+    const requests: unknown[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+        requests.push(JSON.parse(String(init?.body)));
+        return new Response(null, { status: 202 });
+      }),
+    );
+    const ctx = new ContextContainer();
+    ctx.set(SessionKey, session);
+    ctx.set(ActivityObserverKey, {
+      sink: {
+        url: "https://parent.example/eve/v1/activity/abcdefghijklmnopqrstuvwxyz123456",
+        version: 1,
+      },
+    });
+
+    await contextStorage.run(ctx, async () => {
+      const activity = createToolActivity({
+        callId: "call-1",
+        sessionId: session.sessionId,
+        turnId: session.turn.id,
+      });
+      await activity.update("Comparing\u0007   the renderer");
+      await activity.update("Validating the projection");
+    });
+
+    const workId = deriveRootTurnActivityWorkId({ sessionId: "session-1", turnId: "turn-1" });
+    expect(requests).toEqual([
+      {
+        events: [
+          expect.objectContaining({
+            actionId: `action:${workId}:call-1`,
+            eventId: expect.stringMatching(`^action:${workId}:call-1:updated:`),
+            kind: "action.updated",
+            message: "Comparing the renderer",
+          }),
+        ],
+        version: 1,
+      },
+      {
+        events: [
+          expect.objectContaining({
+            actionId: `action:${workId}:call-1`,
+            eventId: expect.stringMatching(`^action:${workId}:call-1:updated:`),
+            kind: "action.updated",
+            message: "Validating the projection",
+          }),
+        ],
+        version: 1,
+      },
+    ]);
+  });
+
+  it("is a no-op when the session has no activity collector", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const ctx = new ContextContainer();
+    ctx.set(SessionKey, session);
+
+    await contextStorage.run(ctx, async () => {
+      await createToolActivity({
+        callId: "call-1",
+        sessionId: session.sessionId,
+        turnId: session.turn.id,
+      }).update("Working");
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/eve/src/execution/tool-activity.test.ts
+++ b/packages/eve/src/execution/tool-activity.test.ts
@@ -1,9 +1,8 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { ContextContainer, contextStorage } from "#context/container.js";
-import { ActivityObserverKey, SessionKey } from "#context/keys.js";
+import { HandleEventKey, SessionKey } from "#context/keys.js";
 import { createToolActivity } from "#execution/tool-activity.js";
-import { deriveRootTurnActivityWorkId } from "#execution/activity-work-id.js";
 
 const session = {
   auth: { current: null, initiator: null },
@@ -12,77 +11,54 @@ const session = {
 };
 
 describe("createToolActivity", () => {
-  afterEach(() => vi.unstubAllGlobals());
-
-  it("publishes bounded action updates without session delivery", async () => {
-    const requests: unknown[] = [];
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
-        requests.push(JSON.parse(String(init?.body)));
-        return new Response(null, { status: 202 });
-      }),
-    );
+  it("emits normalized action updates through the canonical session event handler", async () => {
+    const events: unknown[] = [];
     const ctx = new ContextContainer();
     ctx.set(SessionKey, session);
-    ctx.set(ActivityObserverKey, {
-      sink: {
-        url: "https://parent.example/eve/v1/activity/abcdefghijklmnopqrstuvwxyz123456",
-        version: 1,
-      },
+    ctx.setVirtualContext(HandleEventKey, async (event) => {
+      events.push(event);
     });
 
     await contextStorage.run(ctx, async () => {
-      const activity = createToolActivity({
-        callId: "call-1",
-        sessionId: session.sessionId,
-        turnId: session.turn.id,
-      });
+      const activity = createToolActivity({ callId: "call-1" });
       await activity.update("Comparing\u0007   the renderer");
       await activity.update("Validating the projection");
     });
 
-    const workId = deriveRootTurnActivityWorkId({ sessionId: "session-1", turnId: "turn-1" });
-    expect(requests).toEqual([
+    expect(events).toEqual([
       {
-        events: [
-          expect.objectContaining({
-            actionId: `action:${workId}:call-1`,
-            eventId: expect.stringMatching(`^action:${workId}:call-1:updated:`),
-            kind: "action.updated",
-            message: "Comparing the renderer",
-          }),
-        ],
-        version: 1,
+        data: {
+          callId: "call-1",
+          message: "Comparing the renderer",
+          sequence: 1,
+          turnId: "turn-1",
+        },
+        type: "action.updated",
       },
       {
-        events: [
-          expect.objectContaining({
-            actionId: `action:${workId}:call-1`,
-            eventId: expect.stringMatching(`^action:${workId}:call-1:updated:`),
-            kind: "action.updated",
-            message: "Validating the projection",
-          }),
-        ],
-        version: 1,
+        data: {
+          callId: "call-1",
+          message: "Validating the projection",
+          sequence: 1,
+          turnId: "turn-1",
+        },
+        type: "action.updated",
       },
     ]);
   });
 
-  it("is a no-op when the session has no activity collector", async () => {
-    const fetchMock = vi.fn();
-    vi.stubGlobal("fetch", fetchMock);
+  it("does not let event-emission failure alter the tool result", async () => {
     const ctx = new ContextContainer();
     ctx.set(SessionKey, session);
+    ctx.setVirtualContext(
+      HandleEventKey,
+      vi.fn(async () => Promise.reject(new Error("unavailable"))),
+    );
 
-    await contextStorage.run(ctx, async () => {
-      await createToolActivity({
-        callId: "call-1",
-        sessionId: session.sessionId,
-        turnId: session.turn.id,
-      }).update("Working");
-    });
-
-    expect(fetchMock).not.toHaveBeenCalled();
+    await expect(
+      contextStorage.run(ctx, async () => {
+        await createToolActivity({ callId: "call-1" }).update("Working");
+      }),
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/eve/src/execution/tool-activity.ts
+++ b/packages/eve/src/execution/tool-activity.ts
@@ -1,41 +1,33 @@
-import { randomUUID } from "node:crypto";
-
 import { contextStorage } from "#context/container.js";
-import { ActivityObserverKey } from "#context/keys.js";
+import { HandleEventKey, SessionKey } from "#context/keys.js";
 import { normalizeActivityText } from "#execution/activity-text.js";
-import {
-  deriveActivityActionId,
-  deriveRootTurnActivityWorkId,
-} from "#execution/activity-work-id.js";
-import { submitActivity } from "#execution/submit-activity.js";
+import { logError, createLogger } from "#internal/logging.js";
+import { createActionUpdatedEvent } from "#protocol/message.js";
 import type { ToolActivity } from "#tools/definition.js";
 
-export function createToolActivity(input: {
-  readonly callId: string;
-  readonly sessionId: string;
-  readonly turnId: string;
-}): ToolActivity {
-  const observer = contextStorage.getStore()?.get(ActivityObserverKey);
-  const workId =
-    observer?.workIdentity?.id ??
-    deriveRootTurnActivityWorkId({ sessionId: input.sessionId, turnId: input.turnId });
-  const actionId = deriveActivityActionId({ callId: input.callId, workId });
+const log = createLogger("execution.tool-activity");
+
+export function createToolActivity(input: { readonly callId: string }): ToolActivity {
   return {
     async update(message) {
       const normalized = normalizeActivityText(message);
-      if (observer === undefined || normalized === "") return;
-      await submitActivity({
-        events: [
-          {
-            actionId,
-            eventId: `${actionId}:updated:${randomUUID()}`,
-            kind: "action.updated",
+      if (normalized === "") return;
+      const ctx = contextStorage.getStore();
+      const emit = ctx?.get(HandleEventKey);
+      const session = ctx?.get(SessionKey);
+      if (emit === undefined || session === undefined) return;
+      try {
+        await emit(
+          createActionUpdatedEvent({
+            callId: input.callId,
             message: normalized,
-            updatedAt: new Date().toISOString(),
-          },
-        ],
-        sink: observer.sink,
-      });
+            sequence: session.turn.sequence,
+            turnId: session.turn.id,
+          }),
+        );
+      } catch (error) {
+        logError(log, "tool activity emission failed", error, { callId: input.callId });
+      }
     },
   };
 }

--- a/packages/eve/src/execution/tool-activity.ts
+++ b/packages/eve/src/execution/tool-activity.ts
@@ -1,0 +1,41 @@
+import { randomUUID } from "node:crypto";
+
+import { contextStorage } from "#context/container.js";
+import { ActivityObserverKey } from "#context/keys.js";
+import { normalizeActivityText } from "#execution/activity-text.js";
+import {
+  deriveActivityActionId,
+  deriveRootTurnActivityWorkId,
+} from "#execution/activity-work-id.js";
+import { submitActivity } from "#execution/submit-activity.js";
+import type { ToolActivity } from "#tools/definition.js";
+
+export function createToolActivity(input: {
+  readonly callId: string;
+  readonly sessionId: string;
+  readonly turnId: string;
+}): ToolActivity {
+  const observer = contextStorage.getStore()?.get(ActivityObserverKey);
+  const workId =
+    observer?.workIdentity?.id ??
+    deriveRootTurnActivityWorkId({ sessionId: input.sessionId, turnId: input.turnId });
+  const actionId = deriveActivityActionId({ callId: input.callId, workId });
+  return {
+    async update(message) {
+      const normalized = normalizeActivityText(message);
+      if (observer === undefined || normalized === "") return;
+      await submitActivity({
+        events: [
+          {
+            actionId,
+            eventId: `${actionId}:updated:${randomUUID()}`,
+            kind: "action.updated",
+            message: normalized,
+            updatedAt: new Date().toISOString(),
+          },
+        ],
+        sink: observer.sink,
+      });
+    },
+  };
+}

--- a/packages/eve/src/execution/tool-auth.integration.test.ts
+++ b/packages/eve/src/execution/tool-auth.integration.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { buildApprovalResponseAuth } from "#execution/tool-auth.js";
 import { evictScopedToken, resolveScopedToken } from "#runtime/connections/scoped-authorization.js";
 import { loadContext } from "#context/container.js";
-import { AuthKey, SessionIdKey } from "#context/keys.js";
+import { ActivityObserverKey, AuthKey, SessionIdKey } from "#context/keys.js";
 import {
   CallbackBaseUrlKey,
   PendingAuthorizationResultKey,
@@ -161,6 +161,8 @@ describe("approval response authorization", () => {
 });
 
 describe("tool-hosted authorization", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
   it("resolves and caches the bearer through ctx.getToken(provider)", async () => {
     let calls = 0;
     const auth: AuthorizationDefinition = {
@@ -200,6 +202,49 @@ describe("tool-hosted authorization", () => {
 
     // The test harness dispatches every executeTool call as "call_test".
     expect(result).toEqual({ callId: "call_test", toolName: "observe_call_metadata" });
+  });
+
+  it("publishes presentation-only activity from the authored context", async () => {
+    const requests: unknown[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+        requests.push(JSON.parse(String(init?.body)));
+        return new Response(null, { status: 202 });
+      }),
+    );
+    const tool = authoredTool({
+      name: "deploy",
+      async execute(_input, ctx) {
+        await ctx.activity.update("Uploading artifacts");
+        return "deployed";
+      },
+    });
+    const runtime = await createTestRuntime({ tools: [tool] });
+
+    const result = await runtime.runAsSession(undefined, async () => {
+      loadContext().set(ActivityObserverKey, {
+        sink: {
+          url: "https://parent.example/eve/v1/activity/abcdefghijklmnopqrstuvwxyz123456",
+          version: 1,
+        },
+      });
+      return await runtime.executeTool(tool, {});
+    });
+
+    expect(result).toBe("deployed");
+    expect(requests).toEqual([
+      {
+        events: [
+          expect.objectContaining({
+            actionId: expect.stringContaining(":call_test"),
+            kind: "action.updated",
+            message: "Uploading artifacts",
+          }),
+        ],
+        version: 1,
+      },
+    ]);
   });
 
   it("resolves and caches an inline provider on a plain tool", async () => {

--- a/packages/eve/src/execution/tool-auth.integration.test.ts
+++ b/packages/eve/src/execution/tool-auth.integration.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildApprovalResponseAuth } from "#execution/tool-auth.js";
 import { evictScopedToken, resolveScopedToken } from "#runtime/connections/scoped-authorization.js";
 import { loadContext } from "#context/container.js";
-import { ActivityObserverKey, AuthKey, SessionIdKey } from "#context/keys.js";
+import { AuthKey, HandleEventKey, SessionIdKey } from "#context/keys.js";
 import {
   CallbackBaseUrlKey,
   PendingAuthorizationResultKey,
@@ -204,15 +204,8 @@ describe("tool-hosted authorization", () => {
     expect(result).toEqual({ callId: "call_test", toolName: "observe_call_metadata" });
   });
 
-  it("publishes presentation-only activity from the authored context", async () => {
-    const requests: unknown[] = [];
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
-        requests.push(JSON.parse(String(init?.body)));
-        return new Response(null, { status: 202 });
-      }),
-    );
+  it("emits canonical activity updates from the authored context", async () => {
+    const events: unknown[] = [];
     const tool = authoredTool({
       name: "deploy",
       async execute(_input, ctx) {
@@ -223,26 +216,22 @@ describe("tool-hosted authorization", () => {
     const runtime = await createTestRuntime({ tools: [tool] });
 
     const result = await runtime.runAsSession(undefined, async () => {
-      loadContext().set(ActivityObserverKey, {
-        sink: {
-          url: "https://parent.example/eve/v1/activity/abcdefghijklmnopqrstuvwxyz123456",
-          version: 1,
-        },
+      loadContext().setVirtualContext(HandleEventKey, async (event) => {
+        events.push(event);
       });
       return await runtime.executeTool(tool, {});
     });
 
     expect(result).toBe("deployed");
-    expect(requests).toEqual([
+    expect(events).toEqual([
       {
-        events: [
-          expect.objectContaining({
-            actionId: expect.stringContaining(":call_test"),
-            kind: "action.updated",
-            message: "Uploading artifacts",
-          }),
-        ],
-        version: 1,
+        data: {
+          callId: "call_test",
+          message: "Uploading artifacts",
+          sequence: 1,
+          turnId: "turn_test_001",
+        },
+        type: "action.updated",
       },
     ]);
   });

--- a/packages/eve/src/execution/tool-auth.ts
+++ b/packages/eve/src/execution/tool-auth.ts
@@ -13,6 +13,7 @@
  */
 
 import { buildBaseToolContext } from "#context/build-base-tool-context.js";
+import { createToolActivity } from "#execution/tool-activity.js";
 import type { SessionAuthContext } from "#channel/types.js";
 import {
   ConnectionAuthorizationFailedError,
@@ -190,6 +191,11 @@ function buildToolContext(input: {
   const base = buildBaseToolContext({ options: input.options, toolName: scope });
   return {
     ...base,
+    activity: createToolActivity({
+      callId: base.callId,
+      sessionId: base.session.id,
+      turnId: base.session.turn.id,
+    }),
     async getToken(provider?: ToolAuthProvider, options?: ToolAuthOptions): Promise<TokenResult> {
       if (provider === undefined) throw missingProviderError("ctx.getToken");
       return await resolveInlineToken({

--- a/packages/eve/src/execution/tool-auth.ts
+++ b/packages/eve/src/execution/tool-auth.ts
@@ -191,11 +191,7 @@ function buildToolContext(input: {
   const base = buildBaseToolContext({ options: input.options, toolName: scope });
   return {
     ...base,
-    activity: createToolActivity({
-      callId: base.callId,
-      sessionId: base.session.id,
-      turnId: base.session.turn.id,
-    }),
+    activity: createToolActivity({ callId: base.callId }),
     async getToken(provider?: ToolAuthProvider, options?: ToolAuthOptions): Promise<TokenResult> {
       if (provider === undefined) throw missingProviderError("ctx.getToken");
       return await resolveInlineToken({

--- a/packages/eve/src/protocol/activity.ts
+++ b/packages/eve/src/protocol/activity.ts
@@ -54,6 +54,7 @@ export interface ActivityActionStateV1 extends ActivityActionIdentityV1 {
   readonly phase: ActivityActionPhase;
   readonly settledAt?: string;
   readonly startedAt: string;
+  readonly update?: ActivityUpdateV1;
 }
 
 export interface ActivityBlockerIdentityV1 {
@@ -106,6 +107,13 @@ export type ActivityEventV1 =
       readonly settledAt: string;
     }
   | {
+      readonly actionId: string;
+      readonly eventId: string;
+      readonly kind: "action.updated";
+      readonly message: string;
+      readonly updatedAt: string;
+    }
+  | {
       readonly blocker: ActivityBlockerIdentityV1;
       readonly eventId: string;
       readonly kind: "blocker.started";
@@ -127,6 +135,7 @@ export interface ActivityBatchV1 {
 export interface ActivitySnapshotV1 {
   readonly actions: Readonly<Record<string, ActivityActionStateV1>>;
   readonly blockers: Readonly<Record<string, ActivityBlockerStateV1>>;
+  readonly pendingActionUpdates: Readonly<Record<string, PendingActivityUpdateV1>>;
   readonly pendingSettlements: Readonly<Record<string, PendingActivitySettlementV1>>;
   readonly pendingWorkUpdates: Readonly<Record<string, PendingActivityUpdateV1>>;
   readonly revision: number;
@@ -267,6 +276,24 @@ function parseKnownEvent(value: Record<string, unknown>): ActivityEventV1 | null
         kind: "action.settled",
         outcome: value.outcome,
         settledAt: value.settledAt,
+      };
+    }
+    case "action.updated": {
+      if (!hasOnlyKeys(value, ["actionId", "eventId", "kind", "message", "updatedAt"]))
+        return undefined;
+      if (
+        !isIdentity(value.actionId) ||
+        !isIdentity(value.eventId) ||
+        !isBoundedString(value.message) ||
+        !isBoundedString(value.updatedAt)
+      )
+        return undefined;
+      return {
+        actionId: value.actionId,
+        eventId: value.eventId,
+        kind: "action.updated",
+        message: value.message,
+        updatedAt: value.updatedAt,
       };
     }
     case "blocker.started": {

--- a/packages/eve/src/protocol/message.test.ts
+++ b/packages/eve/src/protocol/message.test.ts
@@ -6,6 +6,7 @@ import { serializeUrlFilePart } from "#internal/attachments/url-refs.js";
 import {
   EVE_MESSAGE_STREAM_VERSION,
   createActionPartialEvent,
+  createActionUpdatedEvent,
   createActionResultEvent,
   createAuthorizationCompletedEvent,
   createAuthorizationRequiredEvent,
@@ -25,7 +26,7 @@ import { createEveConnectionCallbackRoutePath } from "#protocol/routes.js";
 
 describe("message stream protocol", () => {
   it("pins the stream version for timed session events", () => {
-    expect(EVE_MESSAGE_STREAM_VERSION).toBe("24");
+    expect(EVE_MESSAGE_STREAM_VERSION).toBe("25");
   });
 
   it("creates authoritative input resolution batches", () => {
@@ -68,6 +69,25 @@ describe("message stream protocol", () => {
         turnId: "turn-1",
       },
       type: "input.resolved",
+    });
+  });
+
+  it("creates authored tool progress updates", () => {
+    expect(
+      createActionUpdatedEvent({
+        callId: "call_1",
+        message: "Uploading artifacts",
+        sequence: 1,
+        turnId: "turn_1",
+      }),
+    ).toEqual({
+      data: {
+        callId: "call_1",
+        message: "Uploading artifacts",
+        sequence: 1,
+        turnId: "turn_1",
+      },
+      type: "action.updated",
     });
   });
 

--- a/packages/eve/src/protocol/message.ts
+++ b/packages/eve/src/protocol/message.ts
@@ -27,7 +27,7 @@ export const EVE_STREAM_TAIL_INDEX_HEADER = "x-eve-stream-tail-index";
 export const EVE_STREAM_VERSION_HEADER = "x-eve-stream-version";
 export const EVE_MESSAGE_STREAM_CONTENT_TYPE = "application/x-ndjson; charset=utf-8";
 export const EVE_MESSAGE_STREAM_FORMAT = "ndjson";
-export const EVE_MESSAGE_STREAM_VERSION = "24";
+export const EVE_MESSAGE_STREAM_VERSION = "25";
 
 /**
  * eve-owned finish reason for one completed assistant step.
@@ -229,6 +229,17 @@ export interface ActionsRequestedStreamEvent {
     turnId: string;
   };
   type: "actions.requested";
+}
+
+/** Stream event emitted when an authored tool reports progress. */
+export interface ActionUpdatedStreamEvent {
+  data: {
+    callId: string;
+    message: string;
+    sequence: number;
+    turnId: string;
+  };
+  type: "action.updated";
 }
 
 export type ApprovalCandidateOutcome = "pending" | "rejected" | "failed" | "timed-out" | "stale";
@@ -733,6 +744,7 @@ export interface SessionCompletedStreamEvent {
  * consumers receive {@link MessageStreamEvent}.
  */
 export type UnstampedMessageStreamEvent =
+  | ActionUpdatedStreamEvent
   | ActionInputAppendedStreamEvent
   | ApprovalCandidateStreamEvent
   | ApprovalSettledStreamEvent
@@ -1259,6 +1271,16 @@ export function createInputResolvedEvent(input: {
     },
     type: "input.resolved",
   };
+}
+
+/** Creates an `action.updated` event for authored tool progress. */
+export function createActionUpdatedEvent(input: {
+  readonly callId: string;
+  readonly message: string;
+  readonly sequence: number;
+  readonly turnId: string;
+}): ActionUpdatedStreamEvent {
+  return { data: input, type: "action.updated" };
 }
 
 /**

--- a/packages/eve/src/public/definitions/exact.test.ts
+++ b/packages/eve/src/public/definitions/exact.test.ts
@@ -77,7 +77,8 @@ describe("definition helper exact inputs", () => {
     const ordinaryTool = defineTool({
       description: "React to a message.",
       inputSchema: z.object({ reaction: z.string() }),
-      async execute(input) {
+      async execute(input, ctx) {
+        expectTypeOf(ctx.activity.update).toEqualTypeOf<(message: string) => Promise<void>>();
         return { ok: input.reaction.length > 0 };
       },
     });

--- a/packages/eve/src/public/definitions/hook.ts
+++ b/packages/eve/src/public/definitions/hook.ts
@@ -18,6 +18,7 @@ export interface HookEventMap {
   readonly "action.input.appended": ProtocolEvent<"action.input.appended">;
   readonly "action.partial": ProtocolEvent<"action.partial">;
   readonly "action.result": ProtocolEvent<"action.result">;
+  readonly "action.updated": ProtocolEvent<"action.updated">;
   readonly "approval.candidate": ProtocolEvent<"approval.candidate">;
   readonly "approval.settled": ProtocolEvent<"approval.settled">;
   readonly "actions.requested": ProtocolEvent<"actions.requested">;

--- a/packages/eve/src/public/tools/index.ts
+++ b/packages/eve/src/public/tools/index.ts
@@ -14,6 +14,7 @@ export {
   type TaskExecutorBinding,
   type TaskReceipt,
   type ToolAuthOptions,
+  type ToolActivity,
   type ToolAuthProvider,
   type ToolDefinition,
   type ToolContext,

--- a/packages/eve/src/tools/definition.ts
+++ b/packages/eve/src/tools/definition.ts
@@ -33,6 +33,11 @@ export type {
 
 export type ToolExecuteOptions = Omit<ToolExecutionOptions<unknown>, "context">;
 
+export interface ToolActivity {
+  /** Publishes presentation-only progress for the current tool call. */
+  update(message: string): Promise<void>;
+}
+
 export type ToolExecuteFn<TInput = unknown, TOutput = unknown> = (
   input: TInput,
   options: ToolExecuteOptions,
@@ -113,6 +118,11 @@ export type ToolContext = SessionContext & {
    * stream events and its {@link ApprovalContext}.
    */
   readonly callId: string;
+  /**
+   * Publishes presentation-only progress for this call. Updates do not enter
+   * model context, wake a parent session, or change tool lifecycle.
+   */
+  readonly activity: ToolActivity;
   /**
    * Final runtime name of the current tool, including any namespace
    * qualification. This is the same `toolName` carried by stream events and

--- a/packages/eve/test/scenarios/mounted-extension-installed.scenario.test.ts
+++ b/packages/eve/test/scenarios/mounted-extension-installed.scenario.test.ts
@@ -249,7 +249,7 @@ describe("mounted extension installed under node_modules", () => {
     );
     expect(
       JSON.parse(extensionFiles[`node_modules/${PACKAGE_NAME}/dist/extension/_manifest.json`]!),
-    ).toMatchObject({ requires: { channel: 12, schedule: 5, subagent: 5 } });
+    ).toMatchObject({ requires: { channel: 13, schedule: 6, subagent: 6 } });
     const app = await scenarioApp({
       name: "mounted-extension-installed",
       installDependencies: true,


### PR DESCRIPTION
### Summary

Related to #1673. Adds `ctx.activity.update(message)` for reporting progress from inside a long-running authored tool.

The lifecycle is:

```text
ctx.activity.update(message)
  -> action.updated in the session event log
  -> activity observer
  -> activity collector
  -> channel renderer
```

The update is durable and available to stream consumers and hooks, but remains presentation-only: it does not enter model context, wake a parent session, or change the tool result. An activity renderer failure also does not fail the tool.

Built on #2711. MCP progress remains a follow-up.

### Validation

Adds integration coverage through the real authored tool context, plus coverage for event emission, replay-safe projection, updates around action startup and settlement, and failure isolation.

### Diff size

**Docs** — 4 files · `+24 / -1`

Documents the tool API and the new `action.updated` stream event, plus the release note.

**Implementation** — 20 files · `+298 / -23`

Adds the tool emitter, stream event, activity projection, and context wiring. Generated extension metadata accounts for 121 added lines because extension callbacks share the event union.

**Tests** — 15 files · `+317 / -4`

Covers the public type and end-to-end emission path. Compatibility fixtures account for 97 added lines.

