### PR TITLE
fix(eve): preserve sessions for gateway billing errors

### DIFF
--- a/.changeset/warm-gateways-recover.md
+++ b/.changeset/warm-gateways-recover.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Keep conversation sessions active when AI Gateway requests require billing setup or hit free-tier model restrictions, so users can resolve the plan limit and retry in the same thread.

--- a/packages/eve/src/harness/model-call-error.test.ts
+++ b/packages/eve/src/harness/model-call-error.test.ts
@@ -211,6 +211,26 @@ describe("classifyModelCallError", () => {
     expect(classifyModelCallError(err)).toBe("recoverable");
   });
 
+  it("returns recoverable when AI Gateway billing can be fixed outside the session", () => {
+    expect(
+      classifyModelCallError(Object.assign(new Error("payment required"), { statusCode: 402 })),
+    ).toBe("recoverable");
+  });
+
+  it.each([
+    "AI Gateway requires a valid credit card on file to service requests.",
+    "Model call failed: Free tier users do not have access to this model.",
+    "Model call failed: Free tier requests on this model are rate-limited.",
+  ])("returns recoverable for the AI Gateway plan error: %s", (message) => {
+    const err = Object.assign(new Error(message), {
+      name: "GatewayInvalidRequestError",
+      statusCode: 403,
+      type: "invalid_request_error",
+    });
+
+    expect(classifyModelCallError(err)).toBe("recoverable");
+  });
+
   it("returns terminal for explicit Gateway invalid-request errors", () => {
     const err = gatewayModelCallError({
       gatewayName: "GatewayInvalidRequestError",

--- a/packages/eve/src/harness/model-call-error.ts
+++ b/packages/eve/src/harness/model-call-error.ts
@@ -280,10 +280,13 @@ export function classifyModelCallError(error: unknown): "retry" | "recoverable" 
   }
 
   // The catalog's tags carry the recovery judgment for every failure
-  // shape it can see on the cause chain: a fixable configuration mistake
-  // is terminal (repeating the request cannot fix a credential), a
-  // transient provider condition retries.
+  // shape it can see on the cause chain. Some configuration failures can
+  // be fixed externally while preserving the conversation; otherwise a
+  // configuration mistake is terminal. Transient provider conditions retry.
   const summary = summarizeKnownError(error);
+  if (summary?.tags.includes("recoverable") === true) {
+    return "recoverable";
+  }
   if (summary?.tags.includes("config") === true) {
     return "terminal";
   }
@@ -292,6 +295,12 @@ export function classifyModelCallError(error: unknown): "retry" | "recoverable" 
   }
 
   const signals = readModelCallErrorSignals(error);
+  // Payment-required responses can be fixed outside the running process;
+  // keep the conversation available so the user can retry afterward.
+  if (signals.statusCode === 402) {
+    return "recoverable";
+  }
+
   // The catalog matches structural fields on the chain; these checks
   // cover the one channel it deliberately does not model — discriminators
   // that only exist inside the deep-parsed upstream response body — plus

--- a/packages/eve/src/harness/semantic-errors/rule.ts
+++ b/packages/eve/src/harness/semantic-errors/rule.ts
@@ -7,6 +7,8 @@ import type { ErrorLink, ErrorSignals } from "./signals.js";
  *   invalid credentials, unknown model id). The model-call classifier
  *   treats a matched `config` rule as terminal.
  * - `transient` — the failure is expected to clear on retry.
+ * - `recoverable` — the current request cannot proceed, but the same session
+ *   remains useful after an external fix.
  */
 export type SemanticErrorTag =
   | "gateway"
@@ -15,7 +17,8 @@ export type SemanticErrorTag =
   | "sandbox"
   | "system"
   | "config"
-  | "transient";
+  | "transient"
+  | "recoverable";
 
 /** A predicate over one extracted cause-chain link. */
 export type LinkPredicate = (link: ErrorLink) => boolean;
@@ -56,7 +59,8 @@ export interface SemanticErrorSummary {
   /**
    * The matched rule's tags, carried so consumers with a recovery policy
    * (the model-call classifier) can read the catalog's judgment —
-   * `config` is terminal, `transient` retries — without a second registry
+   * `config` is terminal, `transient` retries, and `recoverable` parks the
+   * session — without a second registry
    * of the same knowledge.
    */
   readonly tags: readonly SemanticErrorTag[];

--- a/packages/eve/src/harness/semantic-errors/rules/gateway.ts
+++ b/packages/eve/src/harness/semantic-errors/rules/gateway.ts
@@ -31,6 +31,30 @@ const gatewayAuthenticationFailure = anyOf(
  */
 export const GATEWAY_RULES: readonly SemanticErrorRule[] = [
   {
+    id: "gateway-billing-required",
+    name: "AI Gateway billing setup required",
+    tags: ["gateway", "config", "recoverable"],
+    when: messageMatches(/AI Gateway requires a valid credit card on file/),
+    message: (link) => link.message,
+    hint: "Add a valid credit card or credits in the Vercel dashboard, then retry.",
+  },
+  {
+    id: "gateway-free-tier-model-restricted",
+    name: "Model unavailable on AI Gateway free tier",
+    tags: ["gateway", "config", "recoverable"],
+    when: messageMatches(/Free tier users do not have access to this model/),
+    message: (link) => link.message,
+    hint: "Switch to a model available on the free tier or upgrade your Vercel plan, then retry.",
+  },
+  {
+    id: "gateway-free-tier-rate-limited",
+    name: "AI Gateway free tier rate limit exceeded",
+    tags: ["gateway", "recoverable"],
+    when: messageMatches(/Free tier requests on this model are rate-limited/),
+    message: (link) => link.message,
+    hint: "Wait for the free-tier limit to reset or upgrade your Vercel plan, then retry.",
+  },
+  {
     id: "gateway-auth-invalid-api-key",
     name: GATEWAY_AUTH_FAILURE_SUMMARY_NAME,
     tags: ["gateway", "config"],

--- a/packages/eve/src/harness/semantic-errors/semantic-errors.test.ts
+++ b/packages/eve/src/harness/semantic-errors/semantic-errors.test.ts
@@ -17,6 +17,30 @@ describe("summarizeKnownError (catalog table)", () => {
     readonly id: string;
   }[] = [
     {
+      title: "gateway billing setup required",
+      error: named(
+        "GatewayInvalidRequestError",
+        "AI Gateway requires a valid credit card on file to service requests.",
+      ),
+      id: "gateway-billing-required",
+    },
+    {
+      title: "gateway free-tier model restriction",
+      error: named(
+        "GatewayInvalidRequestError",
+        "Model call failed: Free tier users do not have access to this model.",
+      ),
+      id: "gateway-free-tier-model-restricted",
+    },
+    {
+      title: "gateway free-tier model rate limit",
+      error: named(
+        "GatewayInvalidRequestError",
+        "Model call failed: Free tier requests on this model are rate-limited.",
+      ),
+      id: "gateway-free-tier-rate-limited",
+    },
+    {
       title: "gateway invalid api key",
       error: named(
         "GatewayAuthenticationError",
@@ -182,6 +206,16 @@ describe("summarizeKnownError (catalog table)", () => {
       expect(summarizeKnownError(testCase.error)?.id).toBe(testCase.id);
     });
   }
+
+  it.each([
+    "AI Gateway requires a valid credit card on file to service requests.",
+    "Model call failed: Free tier users do not have access to this model.",
+    "Model call failed: Free tier requests on this model are rate-limited.",
+  ])("preserves recoverable AI Gateway messages", (message) => {
+    expect(summarizeKnownError(named("GatewayInvalidRequestError", message))?.message).toBe(
+      message,
+    );
+  });
 
   it("prefers the structured code as network evidence over the generic wrapper message", () => {
     const error = new TypeError("fetch failed", {

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -4326,6 +4326,45 @@ describe("createToolLoopHarness", () => {
     expect((stepFailed!.data as { details?: { errorId?: string } }).details?.errorId).toBeDefined();
   });
 
+  it.each([
+    {
+      message: "AI Gateway requires a valid credit card on file to service requests.",
+      hint: "Add a valid credit card or credits",
+    },
+    {
+      message: "Model call failed: Free tier users do not have access to this model.",
+      hint: "Switch to a model available on the free tier",
+    },
+    {
+      message: "Model call failed: Free tier requests on this model are rate-limited.",
+      hint: "Wait for the free-tier limit to reset",
+    },
+  ])(
+    "parks the session for the recoverable AI Gateway error: $message",
+    async ({ message, hint }) => {
+      setupMockAgentError(
+        Object.assign(new Error(message), {
+          name: "GatewayInvalidRequestError",
+          statusCode: 403,
+          type: "invalid_request_error",
+        }),
+      );
+
+      const { emit, events } = createEventCollector();
+      const runStep = createToolLoopHarness(createTestConfig("conversation", emit));
+
+      const result = await runStep(createTestSession(), { message: "Hi" });
+
+      expect(result.next).toBeNull();
+      expect(result.settledTurn).toEqual({
+        isError: true,
+        output: expect.stringContaining(hint),
+      });
+      expect(events.map((event) => event.type)).toContain("session.waiting");
+      expect(events.map((event) => event.type)).not.toContain("session.failed");
+    },
+  );
+
   it("rethrows a recoverable task-mode model error for durable step retry", async () => {
     setupMockAgentError(new Error("Model blew up"));
 


### PR DESCRIPTION
### Summary

AI Gateway billing failures currently terminate conversation sessions even though users can fix billing externally and retry. Billing-setup errors and HTTP 402 responses are now classified as recoverable: conversation sessions wait instead of failing, preserving the thread for a later retry. Other gateway configuration errors remain terminal, and transient failures retain their existing retry behavior.

### Validation

The focused model-call classification, semantic-error catalog, and tool-loop suites passed with 291 tests, covering billing-message recognition, preserved provider guidance, HTTP 402 classification, and conversation parking without `session.failed`.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

User-facing documentation is not otherwise needed because this changes failure recovery rather than an authoring surface.

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the required release note for the changed session recovery behavior.

**Implementation** — 3 files · `+26 / -5`

Adds a reusable recoverable semantic-error classification and the focused AI Gateway billing rule.

**Tests** — 3 files · `+58 / -0`

Covers classification, catalog output, and the resulting end-to-end harness lifecycle within the unit tier.
