### PR TITLE
registry: add Stacktree connection

### DIFF
--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -1696,6 +1696,18 @@ const connectionPresentations: Record<string, ConnectionPresentation> = {
     configureNote:
       "Browser Use runs tasks in managed cloud browsers. Add approval gates or tool filters before allowing unattended browser actions.",
   },
+  stacktree: {
+    logo: "stacktree",
+    docsHref: "https://stacktr.ee/developers",
+    keywords: ["mcp", "publish", "html", "private link", "client delivery", "hosting"],
+    authModes: ["apiKey"],
+    apiKey: {
+      env: "STACKTREE_API_KEY",
+      header: "authorization",
+    },
+    configureNote:
+      "Send the key as `Authorization: Bearer <key>`. Keys are minted on a free account at https://app.stacktr.ee/api-keys; anonymous 24-hour publishes need no key at all.",
+  },
   agentcard: {
     logo: "agentcard",
     docsHref: "/docs/connections/mcp",

--- a/apps/docs/lib/integrations/logos.tsx
+++ b/apps/docs/lib/integrations/logos.tsx
@@ -77,6 +77,19 @@ export const BuzzLogo = (props: LogoProps) => (
   </svg>
 );
 
+export const stacktreeLogo = (props: LogoProps) => (
+  <svg fill="none" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <defs>
+      <linearGradient id="stacktree-logo-g" x1="0" y1="0" x2="0" y2="64" gradientUnits="userSpaceOnUse">
+        <stop offset="0" stopColor="#bd9af4" />
+        <stop offset="1" stopColor="#4a32f9" />
+      </linearGradient>
+    </defs>
+    <path d="M32 26 L54 42 L32 58 L10 42 Z" fill="url(#stacktree-logo-g)" opacity="0.55" />
+    <path d="M32 6 L54 22 L32 38 L10 22 Z" fill="url(#stacktree-logo-g)" opacity="0.95" />
+  </svg>
+);
+
 export const browserUseLogo = (props: LogoProps) => (
   <svg fill="none" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg" {...props}>
     <path
@@ -729,6 +742,7 @@ export const logos = {
   web: webLogo,
   buzz: BuzzLogo,
   "browser-use": browserUseLogo,
+  stacktree: stacktreeLogo,
   github: githubLogo,
   slack: slackLogo,
   discord: discordLogo,

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -1064,6 +1064,22 @@
       ]
     },
     {
+      "name": "connection/stacktree",
+      "type": "registry:item",
+      "title": "Stacktree",
+      "description": "Publish and update private HTML pages through Stacktree's MCP server.",
+      "envVars": {
+        "STACKTREE_API_KEY": ""
+      },
+      "files": [
+        {
+          "path": "registry/connections/stacktree.ts",
+          "type": "registry:file",
+          "target": "agent/connections/stacktree.ts"
+        }
+      ]
+    },
+    {
       "name": "connection/stripe",
       "type": "registry:item",
       "title": "Stripe",

--- a/apps/docs/registry/connections/stacktree.ts
+++ b/apps/docs/registry/connections/stacktree.ts
@@ -1,0 +1,10 @@
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://api.stacktr.ee/mcp",
+  description:
+    "Stacktree: publish HTML to a live private link, update it in place so an already-sent link stays current, gate pages with a passcode or one email domain, file pages under client spaces, and read viewer feedback.",
+  headers: () => ({
+    authorization: `Bearer ${process.env.STACKTREE_API_KEY!}`,
+  }),
+});

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -354,6 +354,18 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     },
   },
   {
+    slug: "stacktree",
+    name: "Stacktree",
+    kind: "connection",
+    tagline: "Publish and update private HTML pages through Stacktree's MCP server.",
+    surfaces: { scaffoldable: false, registry: true, gallery: true },
+    connection: {
+      description:
+        "Stacktree: publish HTML to a live private link, update it in place so an already-sent link stays current, gate pages with a passcode or one email domain, file pages under client spaces, and read viewer feedback.",
+      mcp: { url: "https://api.stacktr.ee/mcp" },
+    },
+  },
+  {
     slug: "vercel",
     name: "Vercel",
     kind: "connection",


### PR DESCRIPTION
Adds a `connection/stacktree` registry item, as proposed in #2718.

Stacktree (https://stacktr.ee) publishes HTML to private, unguessable links
from agents: `publish_html` returns a live URL in one call, `update_site`
revises it in place so an already-shared link stays current, and pages can be
gated with a passcode or a single email domain. Remote MCP server at
`https://api.stacktr.ee/mcp`, 21 tools, all annotated with `title` +
`readOnlyHint`/`destructiveHint`.

Follows the `browser-use` pattern: `defineMcpClientConnection` with
API-key headers and `envVars` declaring `STACKTREE_API_KEY` (minted on a free
account at https://app.stacktr.ee/api-keys). The server also supports OAuth
2.0 with dynamic client registration if a Vercel Connect connector is
preferred down the line.

Verified against production: initialize, tools/list (21 tools), and tool
calls all succeed over a static Bearer key.

I have not run `pnpm --filter eve-docs registry:check` locally (monorepo
install); happy to adjust anything it or review flags.

Docs: https://stacktr.ee/developers · https://stacktr.ee/docs
