### PR TITLE
feat(eve): add provider trace policies

### DIFF
--- a/.changeset/add-provider-trace-policy.md
+++ b/.changeset/add-provider-trace-policy.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Instrumentation providers can now define a `tracePolicy` to independently control event admission and input or output content capture. The deprecated `capture` setting continues to work through an equivalent policy mapping, while providers that omit both settings capture content only for public audiences.

--- a/docs/guides/instrumentation.md
+++ b/docs/guides/instrumentation.md
@@ -40,46 +40,6 @@ export default defineInstrumentation({
 
 Export the result of `defineInstrumentation` as the default export.
 
-## Provider trace policies
-
-With `experimental.instrumentationProviders` enabled, each file under
-`agent/instrumentation/` is an independent lifecycle provider. Use its
-`tracePolicy` to decide whether the provider receives events and which content
-directions those events include. Enable the layout with
-`experimental: { instrumentationProviders: true }` in `defineAgent`:
-
-```ts title="agent/instrumentation/audit.ts"
-import { defineInstrumentation } from "eve/instrumentation";
-
-export default defineInstrumentation({
-  tracePolicy: ({ audience }) => ({
-    emit: true,
-    recordInputs: audience !== "private",
-    recordOutputs: true,
-  }),
-  events: {
-    "model.call.completed"(event) {
-      // event.content follows this provider's recordOutputs decision.
-    },
-  },
-});
-```
-
-An omitted policy emits events with content for public conversations and
-metadata only for private or unknown audiences. Returning `true` uses the same
-audience-aware content rule. Returning `false` or `{ emit: false }` skips this
-provider. An explicit `{ emit: true, recordInputs, recordOutputs }` decision is
-authoritative and can admit either content direction for any audience. A thrown
-error fails closed for that provider only. The callback receives the agent name,
-normalized `audience`, and channel type when available.
-
-Provider policies can run again across durable steps and must be deterministic.
-They are independent of the process-wide `tracePolicy` declared by `otel()`:
-one provider can retain content while OTel records metadata only, or vice versa.
-The former `capture: "content" | "metadata"` provider option is deprecated and
-automatically mapped to an equivalent fixed policy. Use `tracePolicy` for new
-providers.
-
 ## OpenTelemetry
 
 Use the `setup` callback to register your OTel provider (for example `registerOTel` from `@vercel/otel`). The framework invokes it at server startup with the resolved agent name. `context.agentName` is resolved at compile time from your project (the package's `name`, falling back to the app directory name), so you never hard-code a service name.

--- a/docs/guides/instrumentation.md
+++ b/docs/guides/instrumentation.md
@@ -76,8 +76,9 @@ normalized `audience`, and channel type when available.
 Provider policies can run again across durable steps and must be deterministic.
 They are independent of the process-wide `tracePolicy` declared by `otel()`:
 one provider can retain content while OTel records metadata only, or vice versa.
-The former `capture: "content" | "metadata"` provider option is no longer
-supported; use an explicit emitted decision when you need fixed behavior.
+The former `capture: "content" | "metadata"` provider option is deprecated and
+automatically mapped to an equivalent fixed policy. Use `tracePolicy` for new
+providers.
 
 ## OpenTelemetry
 

--- a/docs/guides/instrumentation.md
+++ b/docs/guides/instrumentation.md
@@ -40,6 +40,45 @@ export default defineInstrumentation({
 
 Export the result of `defineInstrumentation` as the default export.
 
+## Provider trace policies
+
+With `experimental.instrumentationProviders` enabled, each file under
+`agent/instrumentation/` is an independent lifecycle provider. Use its
+`tracePolicy` to decide whether the provider receives events and which content
+directions those events include. Enable the layout with
+`experimental: { instrumentationProviders: true }` in `defineAgent`:
+
+```ts title="agent/instrumentation/audit.ts"
+import { defineInstrumentation } from "eve/instrumentation";
+
+export default defineInstrumentation({
+  tracePolicy: ({ audience }) => ({
+    emit: true,
+    recordInputs: audience !== "private",
+    recordOutputs: true,
+  }),
+  events: {
+    "model.call.completed"(event) {
+      // event.content follows this provider's recordOutputs decision.
+    },
+  },
+});
+```
+
+An omitted policy emits events with content for public conversations and
+metadata only for private or unknown audiences. Returning `true` uses the same
+audience-aware content rule. Returning `false` or `{ emit: false }` skips this
+provider. An explicit `{ emit: true, recordInputs, recordOutputs }` decision is
+authoritative and can admit either content direction for any audience. A thrown
+error fails closed for that provider only. The callback receives the agent name,
+normalized `audience`, and channel type when available.
+
+Provider policies can run again across durable steps and must be deterministic.
+They are independent of the process-wide `tracePolicy` declared by `otel()`:
+one provider can retain content while OTel records metadata only, or vice versa.
+The former `capture: "content" | "metadata"` provider option is no longer
+supported; use an explicit emitted decision when you need fixed behavior.
+
 ## OpenTelemetry
 
 Use the `setup` callback to register your OTel provider (for example `registerOTel` from `@vercel/otel`). The framework invokes it at server startup with the resolved agent name. `context.agentName` is resolved at compile time from your project (the package's `name`, falling back to the app directory name), so you never hard-code a service name.

--- a/docs/reference/typescript-api.md
+++ b/docs/reference/typescript-api.md
@@ -122,7 +122,7 @@ import template from "../../prompts/template.txt?raw";
 | `eve/memory/file/vercel`                                                    | `vercelBlob` and Vercel Blob backend options                              |
 | `eve/context`                                                               | `defineState`, session and state types                                    |
 | `eve/sandbox`                                                               | `defineSandbox`, backends                                                 |
-| `eve/instrumentation`                                                       | `defineInstrumentation`, `isChannel`, provider and trace-policy types     |
+| `eve/instrumentation`                                                       | `defineInstrumentation`, `isChannel`                                      |
 | `eve/models/openai`                                                         | `chatgpt`, deprecated `experimental_chatgpt`                              |
 | `eve/evals`                                                                 | `defineEval`, `defineEvalConfig`, `mockModel`, eval types                 |
 | `eve/evals/expect`                                                          | `includes`, `equals`, `matches`, `similarity`                             |

--- a/docs/reference/typescript-api.md
+++ b/docs/reference/typescript-api.md
@@ -122,7 +122,7 @@ import template from "../../prompts/template.txt?raw";
 | `eve/memory/file/vercel`                                                    | `vercelBlob` and Vercel Blob backend options                              |
 | `eve/context`                                                               | `defineState`, session and state types                                    |
 | `eve/sandbox`                                                               | `defineSandbox`, backends                                                 |
-| `eve/instrumentation`                                                       | `defineInstrumentation`, `isChannel`                                      |
+| `eve/instrumentation`                                                       | `defineInstrumentation`, `isChannel`, provider and trace-policy types     |
 | `eve/models/openai`                                                         | `chatgpt`, deprecated `experimental_chatgpt`                              |
 | `eve/evals`                                                                 | `defineEval`, `defineEvalConfig`, `mockModel`, eval types                 |
 | `eve/evals/expect`                                                          | `includes`, `equals`, `matches`, `similarity`                             |

--- a/packages/eve/src/context/keys.ts
+++ b/packages/eve/src/context/keys.ts
@@ -85,6 +85,7 @@ export const TurnTaskDeliveryKey = new ContextKey<"none" | "initiating" | "pendi
 export const TurnTaskStateKey = new ContextKey<string>("eve.turnTaskState");
 export interface ActiveChannelDelivery {
   readonly agentName?: string;
+  readonly channelType?: string;
   readonly delivery: InstrumentationChannelDeliveryRef;
   readonly rootSessionId: string;
   readonly sequence: number;

--- a/packages/eve/src/context/keys.ts
+++ b/packages/eve/src/context/keys.ts
@@ -87,6 +87,7 @@ export interface ActiveChannelDelivery {
   readonly agentName?: string;
   readonly channelType?: string;
   readonly delivery: InstrumentationChannelDeliveryRef;
+  readonly policyAgentName?: string;
   readonly rootSessionId: string;
   readonly sequence: number;
   readonly sessionId: string;

--- a/packages/eve/src/execution/settle-cancelled-turn-step.ts
+++ b/packages/eve/src/execution/settle-cancelled-turn-step.ts
@@ -73,7 +73,7 @@ export async function settleCancelledTurnStep(input: {
     turnAgent: effectiveAgent.turnAgent,
   });
   const instrumentation = bindSessionInstrumentation({
-    agentName: effectiveAgent.turnAgent.id,
+    agentName: bundle.graph.root.agent?.config?.name,
     ctx,
     rootSessionId: session.rootSessionId ?? session.sessionId,
     sessionId: session.sessionId,

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -11184,7 +11184,11 @@ describe("createToolLoopHarness", () => {
       await contextStorage.run(ctx, () => runStep(createTestSession(), { message: "private" }));
 
       expect(attemptCompleted).toHaveBeenCalledOnce();
-      expect(mockCreateAiSdkHookBridge.mock.calls[0]?.[1]).toBe(hooks);
+      expect(mockCreateAiSdkHookBridge.mock.calls[0]?.[1]).toMatchObject({
+        capturesContent: true,
+        capturesInputs: true,
+        capturesOutputs: true,
+      });
       const agentCall = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0] as {
         telemetry?: { integrations?: unknown[] };
       };
@@ -11215,7 +11219,11 @@ describe("createToolLoopHarness", () => {
 
       await runStep(createTestSession(), { message: "private" });
 
-      expect(mockCreateAiSdkHookBridge.mock.calls[0]?.[1]).toBe(hooks);
+      expect(mockCreateAiSdkHookBridge.mock.calls[0]?.[1]).toMatchObject({
+        capturesContent: true,
+        capturesInputs: true,
+        capturesOutputs: true,
+      });
       const agentCall = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0] as {
         telemetry?: { recordInputs?: boolean; recordOutputs?: boolean };
       };
@@ -11447,7 +11455,11 @@ describe("createToolLoopHarness", () => {
           stepIndex: 0,
           turnId: "turn_0",
         }),
-        hooks,
+        expect.objectContaining({
+          capturesContent: false,
+          capturesInputs: false,
+          capturesOutputs: false,
+        }),
         runInContext,
         {},
       );

--- a/packages/eve/src/instrumentation/ai-sdk-hook-bridge.test.ts
+++ b/packages/eve/src/instrumentation/ai-sdk-hook-bridge.test.ts
@@ -24,6 +24,29 @@ const scope: InstrumentationAttemptScope = {
 };
 
 describe("createAiSdkHookBridge", () => {
+  it("binds an unscoped bridge to its public attempt before projecting content", async () => {
+    const started = vi.fn();
+    const hooks = createInstrumentationHooks([
+      { events: { "model.call.started": started }, name: "default-policy" },
+    ]);
+    const bridge = createAiSdkHookBridge({ ...scope, channelAudience: "public" }, hooks);
+
+    await Reflect.apply(bridge.onLanguageModelCallStart!, bridge, [
+      {
+        callId: "call-1",
+        instructions: "private instructions",
+        messages: [{ content: "private message", role: "user" }],
+        modelId: "model",
+        provider: "test",
+      },
+    ]);
+
+    expect(started.mock.calls[0]?.[0].input).toMatchObject({
+      instructions: "private instructions",
+      messages: [{ content: "private message", role: "user" }],
+    });
+  });
+
   it("publishes normalized model lifecycle to every provider", async () => {
     const calls: string[] = [];
     const provider = (name: string): InstrumentationProviderDefinition => {
@@ -316,7 +339,11 @@ describe("createAiSdkHookBridge", () => {
   it("terminalizes started operations when the attempt errors", async () => {
     const after = vi.fn();
     const hooks = createInstrumentationHooks([
-      { capture: "content", events: { "model.call.failed": after }, name: "after" },
+      {
+        events: { "model.call.failed": after },
+        name: "after",
+        tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: true }),
+      },
     ]);
     const bridge = createAiSdkHookBridge(scope, hooks);
 
@@ -335,7 +362,11 @@ describe("createAiSdkHookBridge", () => {
   it("terminalizes started operations with the abort reason", async () => {
     const after = vi.fn();
     const hooks = createInstrumentationHooks([
-      { capture: "content", events: { "tool.call.failed": after }, name: "after" },
+      {
+        events: { "tool.call.failed": after },
+        name: "after",
+        tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: true }),
+      },
     ]);
     const bridge = createAiSdkHookBridge(scope, hooks);
     const toolCall = { input: {}, toolCallId: "tool-1", toolName: "search" };
@@ -399,7 +430,7 @@ describe("createAiSdkHookBridge", () => {
     });
     const hooks = createInstrumentationHooks([
       {
-        capture: "content",
+        tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: true }),
         events: { "model.call.completed": after, "model.call.started": before },
         name: "spy",
       },
@@ -520,7 +551,7 @@ describe("createAiSdkHookBridge", () => {
       const actionStarted = vi.fn();
       const hooks = createInstrumentationHooks([
         {
-          capture: "content",
+          tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: true }),
           events: {
             "action.started": actionStarted,
             "tool.call.completed": after,
@@ -626,7 +657,7 @@ describe("createAiSdkHookBridge", () => {
     const hooks = createInstrumentationHooks([
       { events: { "tool.call.started": metadataOnly }, name: "metadata-only" },
       {
-        capture: "content",
+        tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: true }),
         events: { "tool.call.started": wantsContent },
         name: "wants-content",
       },

--- a/packages/eve/src/instrumentation/ai-sdk-hook-bridge.test.ts
+++ b/packages/eve/src/instrumentation/ai-sdk-hook-bridge.test.ts
@@ -24,7 +24,7 @@ const scope: InstrumentationAttemptScope = {
 };
 
 describe("createAiSdkHookBridge", () => {
-  it("binds an unscoped bridge to its public attempt before projecting content", async () => {
+  it("withholds content when a bridge is not bound to a trace", async () => {
     const started = vi.fn();
     const hooks = createInstrumentationHooks([
       { events: { "model.call.started": started }, name: "default-policy" },
@@ -41,10 +41,7 @@ describe("createAiSdkHookBridge", () => {
       },
     ]);
 
-    expect(started.mock.calls[0]?.[0].input).toMatchObject({
-      instructions: "private instructions",
-      messages: [{ content: "private message", role: "user" }],
-    });
+    expect(started.mock.calls[0]?.[0].input).toBeUndefined();
   });
 
   it("publishes normalized model lifecycle to every provider", async () => {
@@ -339,11 +336,7 @@ describe("createAiSdkHookBridge", () => {
   it("terminalizes started operations when the attempt errors", async () => {
     const after = vi.fn();
     const hooks = createInstrumentationHooks([
-      {
-        events: { "model.call.failed": after },
-        name: "after",
-        tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: true }),
-      },
+      { capture: "content", events: { "model.call.failed": after }, name: "after" },
     ]);
     const bridge = createAiSdkHookBridge(scope, hooks);
 
@@ -362,11 +355,7 @@ describe("createAiSdkHookBridge", () => {
   it("terminalizes started operations with the abort reason", async () => {
     const after = vi.fn();
     const hooks = createInstrumentationHooks([
-      {
-        events: { "tool.call.failed": after },
-        name: "after",
-        tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: true }),
-      },
+      { capture: "content", events: { "tool.call.failed": after }, name: "after" },
     ]);
     const bridge = createAiSdkHookBridge(scope, hooks);
     const toolCall = { input: {}, toolCallId: "tool-1", toolName: "search" };
@@ -430,7 +419,7 @@ describe("createAiSdkHookBridge", () => {
     });
     const hooks = createInstrumentationHooks([
       {
-        tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: true }),
+        capture: "content",
         events: { "model.call.completed": after, "model.call.started": before },
         name: "spy",
       },
@@ -551,7 +540,7 @@ describe("createAiSdkHookBridge", () => {
       const actionStarted = vi.fn();
       const hooks = createInstrumentationHooks([
         {
-          tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: true }),
+          capture: "content",
           events: {
             "action.started": actionStarted,
             "tool.call.completed": after,
@@ -657,7 +646,7 @@ describe("createAiSdkHookBridge", () => {
     const hooks = createInstrumentationHooks([
       { events: { "tool.call.started": metadataOnly }, name: "metadata-only" },
       {
-        tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: true }),
+        capture: "content",
         events: { "tool.call.started": wantsContent },
         name: "wants-content",
       },

--- a/packages/eve/src/instrumentation/ai-sdk-hook-bridge.ts
+++ b/packages/eve/src/instrumentation/ai-sdk-hook-bridge.ts
@@ -42,10 +42,9 @@ export function createAiSdkHookBridge(
   runInContext: InstrumentationContextRunner = directRunInContext,
   runtimeContext?: Readonly<Record<string, unknown>>,
 ): Telemetry {
-  const providerHooks = hooks;
   const state: AttemptState = {
-    capturesInputs: providerHooks.capturesInputs ?? providerHooks.capturesContent,
-    capturesOutputs: providerHooks.capturesOutputs ?? providerHooks.capturesContent,
+    capturesInputs: hooks.capturesInputs ?? hooks.capturesContent,
+    capturesOutputs: hooks.capturesOutputs ?? hooks.capturesContent,
     modelKeys: new Map(),
     runtimeContext:
       runtimeContext !== undefined && Object.keys(runtimeContext).length > 0
@@ -66,13 +65,13 @@ export function createAiSdkHookBridge(
     async onStepStart(event) {
       state.stepNumber = event.stepNumber;
       const started = toStepAttemptStarted(state);
-      if (started !== undefined) await providerHooks.publish(started);
+      if (started !== undefined) await hooks.publish(started);
     },
     async onLanguageModelCallStart(event) {
       const key = modelCallIdempotencyKey(state.scope, state.stepNumber ?? 0);
       state.modelKeys.set(event.callId, key);
       const started = toModelCallStarted(state, key, event);
-      await providerHooks.publish(started);
+      await hooks.publish(started);
     },
     executeLanguageModelCall({ callId, execute }) {
       const key = state.modelKeys.get(callId);
@@ -85,7 +84,7 @@ export function createAiSdkHookBridge(
       if (key === undefined) return;
       state.modelKeys.delete(event.callId);
       const completed = toModelCallCompleted(state, key, event);
-      await providerHooks.publish(completed);
+      await hooks.publish(completed);
     },
     async onStepEnd(event) {
       // Step results carry provider metadata (e.g. Vercel AI Gateway cost)
@@ -95,7 +94,7 @@ export function createAiSdkHookBridge(
       const providerMetadata = state.capturesOutputs
         ? event.providerMetadata
         : structuralProviderMetadata(event.providerMetadata);
-      await providerHooks.publish(
+      await hooks.publish(
         Object.freeze({
           idempotencyKey: attemptIdempotencyKey(state.scope),
           providerMetadata,
@@ -112,7 +111,7 @@ export function createAiSdkHookBridge(
       );
       state.toolKeys.set(event.toolCall.toolCallId, key);
       const started = toToolCallStarted(state, key, event);
-      await providerHooks.publish(started);
+      await hooks.publish(started);
     },
     executeTool({ toolCallId, execute }) {
       const key = state.toolKeys.get(toolCallId);
@@ -126,7 +125,7 @@ export function createAiSdkHookBridge(
       if (key === undefined) return;
       state.toolKeys.delete(toolCallId);
       const completed = toToolCallCompleted(state, key, event);
-      await providerHooks.publish(completed);
+      await hooks.publish(completed);
     },
     async onAbort(event) {
       await failOpenOperations(event.reason);
@@ -140,16 +139,12 @@ export function createAiSdkHookBridge(
     const pending: Promise<void>[] = [];
     for (const idempotencyKey of state.modelKeys.values()) {
       pending.push(
-        providerHooks.publish(
-          Object.freeze({ error, idempotencyKey, scope, type: "model.call.failed" }),
-        ),
+        hooks.publish(Object.freeze({ error, idempotencyKey, scope, type: "model.call.failed" })),
       );
     }
     for (const idempotencyKey of state.toolKeys.values()) {
       pending.push(
-        providerHooks.publish(
-          Object.freeze({ error, idempotencyKey, scope, type: "tool.call.failed" }),
-        ),
+        hooks.publish(Object.freeze({ error, idempotencyKey, scope, type: "tool.call.failed" })),
       );
     }
     state.modelKeys.clear();

--- a/packages/eve/src/instrumentation/ai-sdk-hook-bridge.ts
+++ b/packages/eve/src/instrumentation/ai-sdk-hook-bridge.ts
@@ -24,8 +24,8 @@ import { structuralProviderMetadata } from "#instrumentation/content.js";
 type TelemetryEvent<TKey extends keyof Telemetry> = Parameters<NonNullable<Telemetry[TKey]>>[0];
 
 interface AttemptState {
-  /** False when no provider asked for content, so none is projected at all. */
-  readonly capturesContent: boolean;
+  readonly capturesInputs: boolean;
+  readonly capturesOutputs: boolean;
   readonly modelKeys: Map<string, string>;
   readonly runtimeContext?: Readonly<Record<string, unknown>>;
   readonly scope: InstrumentationAttemptScope;
@@ -42,8 +42,10 @@ export function createAiSdkHookBridge(
   runInContext: InstrumentationContextRunner = directRunInContext,
   runtimeContext?: Readonly<Record<string, unknown>>,
 ): Telemetry {
+  const providerHooks = hooks;
   const state: AttemptState = {
-    capturesContent: hooks.capturesContent,
+    capturesInputs: providerHooks.capturesInputs ?? providerHooks.capturesContent,
+    capturesOutputs: providerHooks.capturesOutputs ?? providerHooks.capturesContent,
     modelKeys: new Map(),
     runtimeContext:
       runtimeContext !== undefined && Object.keys(runtimeContext).length > 0
@@ -64,13 +66,13 @@ export function createAiSdkHookBridge(
     async onStepStart(event) {
       state.stepNumber = event.stepNumber;
       const started = toStepAttemptStarted(state);
-      if (started !== undefined) await hooks.publish(started);
+      if (started !== undefined) await providerHooks.publish(started);
     },
     async onLanguageModelCallStart(event) {
       const key = modelCallIdempotencyKey(state.scope, state.stepNumber ?? 0);
       state.modelKeys.set(event.callId, key);
       const started = toModelCallStarted(state, key, event);
-      await hooks.publish(started);
+      await providerHooks.publish(started);
     },
     executeLanguageModelCall({ callId, execute }) {
       const key = state.modelKeys.get(callId);
@@ -83,17 +85,17 @@ export function createAiSdkHookBridge(
       if (key === undefined) return;
       state.modelKeys.delete(event.callId);
       const completed = toModelCallCompleted(state, key, event);
-      await hooks.publish(completed);
+      await providerHooks.publish(completed);
     },
     async onStepEnd(event) {
       // Step results carry provider metadata (e.g. Vercel AI Gateway cost)
       // that the per-call telemetry events don't. Publish it for providers
       // that know what to do with it; skip when there is none.
       if (event.providerMetadata === undefined) return;
-      const providerMetadata = state.capturesContent
+      const providerMetadata = state.capturesOutputs
         ? event.providerMetadata
         : structuralProviderMetadata(event.providerMetadata);
-      await hooks.publish(
+      await providerHooks.publish(
         Object.freeze({
           idempotencyKey: attemptIdempotencyKey(state.scope),
           providerMetadata,
@@ -110,7 +112,7 @@ export function createAiSdkHookBridge(
       );
       state.toolKeys.set(event.toolCall.toolCallId, key);
       const started = toToolCallStarted(state, key, event);
-      await hooks.publish(started);
+      await providerHooks.publish(started);
     },
     executeTool({ toolCallId, execute }) {
       const key = state.toolKeys.get(toolCallId);
@@ -124,7 +126,7 @@ export function createAiSdkHookBridge(
       if (key === undefined) return;
       state.toolKeys.delete(toolCallId);
       const completed = toToolCallCompleted(state, key, event);
-      await hooks.publish(completed);
+      await providerHooks.publish(completed);
     },
     async onAbort(event) {
       await failOpenOperations(event.reason);
@@ -138,12 +140,16 @@ export function createAiSdkHookBridge(
     const pending: Promise<void>[] = [];
     for (const idempotencyKey of state.modelKeys.values()) {
       pending.push(
-        hooks.publish(Object.freeze({ error, idempotencyKey, scope, type: "model.call.failed" })),
+        providerHooks.publish(
+          Object.freeze({ error, idempotencyKey, scope, type: "model.call.failed" }),
+        ),
       );
     }
     for (const idempotencyKey of state.toolKeys.values()) {
       pending.push(
-        hooks.publish(Object.freeze({ error, idempotencyKey, scope, type: "tool.call.failed" })),
+        providerHooks.publish(
+          Object.freeze({ error, idempotencyKey, scope, type: "tool.call.failed" }),
+        ),
       );
     }
     state.modelKeys.clear();
@@ -174,7 +180,7 @@ function toModelCallStarted(
 ): InstrumentationModelCallStartedEvent {
   return Object.freeze({
     idempotencyKey,
-    input: state.capturesContent
+    input: state.capturesInputs
       ? Object.freeze({
           instructions: source.instructions,
           messages: Object.freeze([...source.messages]),
@@ -193,7 +199,7 @@ function toModelCallCompleted(
   source: TelemetryEvent<"onLanguageModelCallEnd">,
 ): InstrumentationModelCallCompletedEvent {
   return Object.freeze({
-    content: state.capturesContent ? toContentParts(source.content) : undefined,
+    content: state.capturesOutputs ? toContentParts(source.content) : undefined,
     finishReason: source.finishReason,
     idempotencyKey,
     scope: state.scope,
@@ -271,7 +277,7 @@ function toToolCallStarted(
   return Object.freeze({
     callId: source.toolCall.toolCallId,
     idempotencyKey,
-    input: state.capturesContent ? source.toolCall.input : undefined,
+    input: state.capturesInputs ? source.toolCall.input : undefined,
     scope: state.scope,
     toolName: source.toolCall.toolName,
     type: "tool.call.started",
@@ -285,7 +291,7 @@ function toToolCallCompleted(
 ): InstrumentationToolCallCompletedEvent {
   return Object.freeze({
     idempotencyKey,
-    output: toToolOutput(source.toolOutput, state.capturesContent),
+    output: toToolOutput(source.toolOutput, state.capturesOutputs),
     scope: state.scope,
     type: "tool.call.completed",
   });

--- a/packages/eve/src/instrumentation/channel-delivery.test.ts
+++ b/packages/eve/src/instrumentation/channel-delivery.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { ContextContainer, contextStorage } from "#context/container.js";
 import { ChannelInstrumentationKey, ParentTraceContextKey } from "#context/keys.js";
@@ -31,7 +31,7 @@ describe("channel delivery instrumentation", () => {
     const metadata: InstrumentationEvent[] = [];
     const hooks = createInstrumentationHooks([
       {
-        capture: "content",
+        tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: true }),
         events: {
           "channel.delivery.started": (event) => {
             content.push(event);
@@ -40,6 +40,7 @@ describe("channel delivery instrumentation", () => {
         name: "content",
       },
       {
+        tracePolicy: () => ({ emit: true, recordInputs: false, recordOutputs: false }),
         events: {
           "channel.delivery.started": (event) => {
             metadata.push(event);
@@ -100,7 +101,7 @@ describe("channel delivery instrumentation", () => {
     const events: InstrumentationEvent[] = [];
     const hooks = createInstrumentationHooks([
       {
-        capture: "content",
+        tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: true }),
         events: {
           "channel.delivery.started": (event) => {
             events.push(event);
@@ -138,5 +139,54 @@ describe("channel delivery instrumentation", () => {
     );
 
     expect(events[0]).toMatchObject({ input: { message: "secret" } });
+  });
+
+  it("uses delivery-start context when a bound turn publishes the terminal", async () => {
+    const completed = vi.fn();
+    const hooks = createInstrumentationHooks([
+      {
+        events: { "channel.delivery.completed": completed },
+        name: "public-only",
+        tracePolicy: ({ audience }) => audience === "public",
+      },
+    ]);
+    const ctx = new ContextContainer();
+    ctx.set(ChannelInstrumentationKey, {
+      channelType: "slack",
+      kind: "channel:slack",
+      metadata: { audience: "public" },
+    });
+
+    await contextStorage.run(ctx, async () => {
+      await instrumentChannelDelivery({
+        agentName: "weather",
+        ctx,
+        delivery: {
+          deliveryMetadata: [
+            {
+              channelKind: "channel:slack",
+              channelName: "slack",
+              deliveryId: "delivery-1",
+              payloadIndex: 0,
+            },
+          ],
+          kind: "deliver",
+          payloads: [{ message: "hello" }],
+        },
+        hooks,
+        rootSessionId: "session-1",
+        sequence: 0,
+        sessionId: "session-1",
+        turnId: "turn_0",
+      });
+      await instrumentChannelDelivery({
+        ctx,
+        hooks: hooks.forTrace!({ audience: "private" }),
+        includeTurn: true,
+        outcome: "completed",
+      });
+    });
+
+    expect(completed).toHaveBeenCalledOnce();
   });
 });

--- a/packages/eve/src/instrumentation/channel-delivery.test.ts
+++ b/packages/eve/src/instrumentation/channel-delivery.test.ts
@@ -143,11 +143,12 @@ describe("channel delivery instrumentation", () => {
 
   it("uses delivery-start context when a bound turn publishes the terminal", async () => {
     const completed = vi.fn();
+    const tracePolicy = vi.fn(({ audience }) => audience === "public");
     const hooks = createInstrumentationHooks([
       {
         events: { "channel.delivery.completed": completed },
         name: "public-only",
-        tracePolicy: ({ audience }) => audience === "public",
+        tracePolicy,
       },
     ]);
     const ctx = new ContextContainer();
@@ -174,6 +175,7 @@ describe("channel delivery instrumentation", () => {
           payloads: [{ message: "hello" }],
         },
         hooks,
+        policyAgentName: "Weather Display Name",
         rootSessionId: "session-1",
         sequence: 0,
         sessionId: "session-1",
@@ -188,5 +190,11 @@ describe("channel delivery instrumentation", () => {
     });
 
     expect(completed).toHaveBeenCalledOnce();
+    expect(completed.mock.calls[0]?.[0].agentName).toBe("weather");
+    expect(tracePolicy.mock.calls[0]?.[0]).toEqual({
+      agentName: "Weather Display Name",
+      audience: "public",
+      channelType: "slack",
+    });
   });
 });

--- a/packages/eve/src/instrumentation/channel-delivery.test.ts
+++ b/packages/eve/src/instrumentation/channel-delivery.test.ts
@@ -11,7 +11,11 @@ import {
   type InstrumentationRuntime,
 } from "#instrumentation/runtime.js";
 
-function bindHooks(hooks: InstrumentationRuntime["hooks"], ctx: ContextContainer) {
+function bindHooks(
+  hooks: InstrumentationRuntime["hooks"],
+  ctx: ContextContainer,
+  agentName?: string,
+) {
   return bindInstrumentationRuntime(
     {
       forceFlush: async () => undefined,
@@ -21,7 +25,7 @@ function bindHooks(hooks: InstrumentationRuntime["hooks"], ctx: ContextContainer
       shutdown: async () => undefined,
     },
     ctx,
-    { rootSessionId: "session-1", sessionId: "session-1" },
+    { agentName, rootSessionId: "session-1", sessionId: "session-1" },
   );
 }
 
@@ -157,9 +161,10 @@ describe("channel delivery instrumentation", () => {
       kind: "channel:slack",
       metadata: { audience: "public" },
     });
+    const instrumentation = bindHooks(hooks, ctx, "Weather Display Name");
 
     await contextStorage.run(ctx, async () => {
-      await instrumentChannelDelivery({
+      await instrumentation?.instrumentChannelDelivery({
         agentName: "weather",
         ctx,
         delivery: {
@@ -174,16 +179,18 @@ describe("channel delivery instrumentation", () => {
           kind: "deliver",
           payloads: [{ message: "hello" }],
         },
-        hooks,
-        policyAgentName: "Weather Display Name",
         rootSessionId: "session-1",
         sequence: 0,
         sessionId: "session-1",
         turnId: "turn_0",
       });
-      await instrumentChannelDelivery({
+      ctx.set(ChannelInstrumentationKey, {
+        channelType: "slack",
+        kind: "channel:slack",
+        metadata: { audience: "private" },
+      });
+      await instrumentation?.instrumentChannelDelivery({
         ctx,
-        hooks: hooks.forTrace!({ audience: "private" }),
         includeTurn: true,
         outcome: "completed",
       });

--- a/packages/eve/src/instrumentation/channel-delivery.ts
+++ b/packages/eve/src/instrumentation/channel-delivery.ts
@@ -44,7 +44,13 @@ export async function instrumentChannelDelivery(
     const type =
       `channel.delivery.${input.outcome}` as InstrumentationChannelDeliveryTerminalEvent["type"];
     for (const item of active) {
-      await input.hooks.publish({
+      const hooks =
+        input.hooks.forTrace?.({
+          agentName: item.agentName,
+          audience: normalizeChannelAudience(item.delivery.channelAudience),
+          channelType: item.channelType,
+        }) ?? input.hooks;
+      await hooks.publish({
         agentName: item.agentName,
         delivery: item.delivery,
         error: input.error,
@@ -65,10 +71,14 @@ export async function instrumentChannelDelivery(
   if (input.hooks === undefined || input.delivery.deliveryMetadata === undefined) return;
 
   const active: ActiveChannelDelivery[] = [];
-  const channelAudience = normalizeChannelAudience(
-    input.ctx.get(ChannelInstrumentationKey)?.metadata.audience,
-  );
-  const hooks = input.hooks;
+  const channel = input.ctx.get(ChannelInstrumentationKey);
+  const channelAudience = normalizeChannelAudience(channel?.metadata.audience);
+  const hooks =
+    input.hooks.forTrace?.({
+      agentName: input.agentName,
+      audience: channelAudience,
+      channelType: channel?.channelType,
+    }) ?? input.hooks;
   for (const metadata of input.delivery.deliveryMetadata) {
     const payload = input.delivery.payloads[metadata.payloadIndex];
     const delivery = {
@@ -79,10 +89,12 @@ export async function instrumentChannelDelivery(
       requestId: metadata.requestId,
       requestTraceContext: metadata.requestTraceContext,
     };
+    const capturesInputs = hooks.capturesInputs ?? hooks.capturesContent;
     const deliveryInput =
-      !hooks?.capturesContent || payload === undefined ? undefined : projectDeliveryInput(payload);
+      !capturesInputs || payload === undefined ? undefined : projectDeliveryInput(payload);
     const item: ActiveChannelDelivery = {
       agentName: input.agentName,
+      channelType: channel?.channelType,
       delivery,
       rootSessionId: input.rootSessionId,
       sequence: input.sequence,

--- a/packages/eve/src/instrumentation/channel-delivery.ts
+++ b/packages/eve/src/instrumentation/channel-delivery.ts
@@ -20,6 +20,7 @@ export interface ChannelDeliveryStartInstrumentation {
   readonly ctx: AlsContext;
   readonly delivery: DeliverHookPayload;
   readonly hooks: InstrumentationHooks | undefined;
+  readonly policyAgentName?: string;
   readonly rootSessionId: string;
   readonly sequence: number;
   readonly sessionId: string;
@@ -46,7 +47,7 @@ export async function instrumentChannelDelivery(
     for (const item of active) {
       const hooks =
         input.hooks.forTrace?.({
-          agentName: item.agentName,
+          agentName: item.policyAgentName,
           audience: normalizeChannelAudience(item.delivery.channelAudience),
           channelType: item.channelType,
         }) ?? input.hooks;
@@ -75,7 +76,7 @@ export async function instrumentChannelDelivery(
   const channelAudience = normalizeChannelAudience(channel?.metadata.audience);
   const hooks =
     input.hooks.forTrace?.({
-      agentName: input.agentName,
+      agentName: input.policyAgentName,
       audience: channelAudience,
       channelType: channel?.channelType,
     }) ?? input.hooks;
@@ -96,6 +97,7 @@ export async function instrumentChannelDelivery(
       agentName: input.agentName,
       channelType: channel?.channelType,
       delivery,
+      policyAgentName: input.policyAgentName,
       rootSessionId: input.rootSessionId,
       sequence: input.sequence,
       sessionId: input.sessionId,

--- a/packages/eve/src/instrumentation/dispatch.ts
+++ b/packages/eve/src/instrumentation/dispatch.ts
@@ -40,11 +40,11 @@ export function createInstrumentationDispatcher(
 ): InstrumentationHooks {
   const handlerTimeoutMs = options.handlerTimeoutMs ?? DEFAULT_HANDLER_TIMEOUT_MS;
   const groups = normalizeDispatchGroups(input);
-  const snapshots = new WeakMap<object, unknown>();
   const providers = [...groups.serialBefore, ...groups.parallel, ...groups.serialAfter];
   const warnedPolicyFailures = new Set<InstrumentationProviderDefinition>();
 
   const forTrace = (trace: TraceCaptureContext): InstrumentationHooks => {
+    const snapshots = new WeakMap<object, unknown>();
     const decisions = new Map(
       providers.map((provider) => [
         provider,
@@ -78,6 +78,7 @@ export function createInstrumentationDispatcher(
           recordOutputs: capturesOutputs,
         }),
         snapshots,
+        event,
       );
       const cleanupSession =
         snapshot.type === "session.completed" || snapshot.type === "session.failed";
@@ -161,12 +162,19 @@ export function createInstrumentationDispatcher(
   };
 
   let unboundHooks: InstrumentationHooks | undefined;
+  let loggedUnboundPublish = false;
   return {
     capturesContent: providers.some(
       (provider) => provider.tracePolicy === undefined && provider.capture === "content",
     ),
     forTrace,
     async publish(event) {
+      if (!loggedUnboundPublish) {
+        loggedUnboundPublish = true;
+        log.debug("instrumentation event published without trace binding", {
+          eventType: event.type,
+        });
+      }
       unboundHooks ??= forTrace({ audience: "unknown" });
       await unboundHooks.publish(event);
     },
@@ -176,8 +184,13 @@ export function createInstrumentationDispatcher(
 function snapshotInstrumentationEvent(
   event: InstrumentationEvent,
   snapshots: WeakMap<object, unknown>,
+  source: InstrumentationEvent,
 ): InstrumentationEvent {
-  return snapshotPlainValue(event, snapshots) as InstrumentationEvent;
+  const existing = snapshots.get(source);
+  if (existing !== undefined) return existing as InstrumentationEvent;
+  const snapshot = snapshotPlainValue(event, snapshots) as InstrumentationEvent;
+  snapshots.set(source, snapshot);
+  return snapshot;
 }
 
 function snapshotPlainValue(value: unknown, seen: WeakMap<object, unknown>): unknown {

--- a/packages/eve/src/instrumentation/dispatch.ts
+++ b/packages/eve/src/instrumentation/dispatch.ts
@@ -8,8 +8,13 @@ import {
   takeInstrumentationActionScopes,
   type InstrumentationStateOwner,
 } from "#instrumentation/state.js";
-import { withoutInstrumentationContent } from "#instrumentation/content.js";
+import {
+  withInstrumentationDecision,
+  withoutInstrumentationContent,
+} from "#instrumentation/content.js";
 import { createLogger, formatError } from "#internal/logging.js";
+import { resolveTracePolicy } from "#shared/trace-policy.js";
+import type { TraceCaptureContext } from "#shared/trace-policy.js";
 
 import type {
   CreateInstrumentationHooksOptions,
@@ -37,75 +42,144 @@ export function createInstrumentationDispatcher(
   const groups = normalizeDispatchGroups(input);
   const snapshots = new WeakMap<object, unknown>();
   const providers = [...groups.serialBefore, ...groups.parallel, ...groups.serialAfter];
-  const capturesContent = providers.some((provider) => provider.capture === "content");
 
-  const publish = async (event: InstrumentationEvent): Promise<void> => {
-    const snapshot = snapshotInstrumentationEvent(event, snapshots);
-    const cleanupSession =
-      snapshot.type === "session.completed" || snapshot.type === "session.failed";
-    const cleanupTurn = snapshot.type === "turn.cancelled" || snapshot.type === "turn.failed";
-    if (cleanupSession || cleanupTurn) {
-      const pendingActions = takeInstrumentationActionScopes(
-        snapshot.sessionId,
-        cleanupTurn ? snapshot.turnId : undefined,
-      );
-      const failure = terminalActionFailure(snapshot);
-      for (const action of pendingActions) {
-        await publish({
-          ...failure,
-          idempotencyKey: action.idempotencyKey,
-          scope: action.scope,
-          type: "action.failed",
-        });
-      }
-    }
+  const forTrace = (trace: TraceCaptureContext): InstrumentationHooks => {
+    const decisions = new Map(
+      providers.map((provider) => [provider, resolveTracePolicy(provider.tracePolicy, trace)]),
+    );
+    const capturesInputs = [...decisions.values()].some(
+      (decision) => decision.action === "record" && decision.recordInputs,
+    );
+    const capturesOutputs = [...decisions.values()].some(
+      (decision) => decision.action === "record" && decision.recordOutputs,
+    );
+    const capturesContent = capturesInputs || capturesOutputs;
 
-    let stripped: InstrumentationEvent | undefined;
-    const visibleEvent = (provider: InstrumentationProviderDefinition): InstrumentationEvent => {
-      if (provider.capture === "content") return snapshot;
-      stripped ??= withoutInstrumentationContent(snapshot);
-      return stripped;
-    };
-
-    try {
-      try {
-        for (const provider of groups.serialBefore) {
-          await dispatchToProvider(provider, snapshot, handlerTimeoutMs, () =>
-            visibleEvent(provider),
-          );
+    const publish = async (event: InstrumentationEvent): Promise<void> => {
+      const snapshot = snapshotInstrumentationEvent(event, snapshots);
+      const cleanupSession =
+        snapshot.type === "session.completed" || snapshot.type === "session.failed";
+      const cleanupTurn = snapshot.type === "turn.cancelled" || snapshot.type === "turn.failed";
+      if (cleanupSession || cleanupTurn) {
+        const pendingActions = takeInstrumentationActionScopes(
+          snapshot.sessionId,
+          cleanupTurn ? snapshot.turnId : undefined,
+        );
+        const failure = terminalActionFailure(snapshot);
+        for (const action of pendingActions) {
+          await publish({
+            ...failure,
+            idempotencyKey: action.idempotencyKey,
+            scope: action.scope,
+            type: "action.failed",
+          });
         }
+      }
 
-        if (groups.parallel.length === 1) {
-          const provider = groups.parallel[0]!;
-          await dispatchToProvider(provider, snapshot, handlerTimeoutMs, () =>
-            visibleEvent(provider),
-          );
-        } else if (groups.parallel.length > 1) {
-          const results = await Promise.allSettled(
-            groups.parallel.map((provider) =>
-              dispatchToProvider(provider, snapshot, handlerTimeoutMs, () =>
-                visibleEvent(provider),
+      const projections = new Map<string, InstrumentationEvent>();
+      const visibleEvent = (provider: InstrumentationProviderDefinition): InstrumentationEvent => {
+        const decision = decisions.get(provider)!;
+        if (decision.action === "drop") return snapshot;
+        if (decision.recordInputs && decision.recordOutputs) return snapshot;
+        const key = `${String(decision.recordInputs)}:${String(decision.recordOutputs)}`;
+        let projected = projections.get(key);
+        if (projected === undefined) {
+          projected = withInstrumentationDecision(snapshot, decision);
+          projections.set(key, projected);
+        }
+        return projected;
+      };
+      const admitted = (provider: InstrumentationProviderDefinition): boolean =>
+        decisions.get(provider)?.action === "record";
+
+      try {
+        try {
+          for (const provider of groups.serialBefore) {
+            if (!admitted(provider)) continue;
+            await dispatchToProvider(provider, snapshot, handlerTimeoutMs, () =>
+              visibleEvent(provider),
+            );
+          }
+
+          const parallel = groups.parallel.filter(admitted);
+          if (parallel.length === 1) {
+            const provider = parallel[0]!;
+            await dispatchToProvider(provider, snapshot, handlerTimeoutMs, () =>
+              visibleEvent(provider),
+            );
+          } else if (parallel.length > 1) {
+            const results = await Promise.allSettled(
+              parallel.map((provider) =>
+                dispatchToProvider(provider, snapshot, handlerTimeoutMs, () =>
+                  visibleEvent(provider),
+                ),
               ),
-            ),
-          );
-          const rejected = results.find(
-            (result): result is PromiseRejectedResult => result.status === "rejected",
-          );
-          if (rejected !== undefined) throw rejected.reason;
+            );
+            const rejected = results.find(
+              (result): result is PromiseRejectedResult => result.status === "rejected",
+            );
+            if (rejected !== undefined) throw rejected.reason;
+          }
+        } finally {
+          for (const provider of groups.serialAfter) {
+            if (!admitted(provider)) continue;
+            await dispatchToProvider(provider, snapshot, handlerTimeoutMs, () =>
+              visibleEvent(provider),
+            );
+          }
         }
       } finally {
-        for (const provider of groups.serialAfter) {
-          await dispatchToProvider(provider, snapshot, handlerTimeoutMs, () =>
-            visibleEvent(provider),
-          );
-        }
+        releaseTerminalState(snapshot);
       }
-    } finally {
-      releaseTerminalState(snapshot);
-    }
+    };
+
+    return { capturesContent, capturesInputs, capturesOutputs, forTrace, publish };
   };
 
-  return { capturesContent, publish };
+  const boundBySession = new Map<string, InstrumentationHooks>();
+  return {
+    capturesContent: providers.length > 0,
+    forTrace,
+    async publish(event) {
+      const sessionId = sessionIdForEvent(event);
+      let bound = boundBySession.get(sessionId);
+      if (bound === undefined) {
+        bound = forTrace(traceContextForEvent(event));
+        boundBySession.set(sessionId, bound);
+      }
+      await bound.publish(event);
+      if (event.type === "session.completed" || event.type === "session.failed") {
+        boundBySession.delete(sessionId);
+      }
+    },
+  };
+}
+
+function sessionIdForEvent(event: InstrumentationEvent): string {
+  return "scope" in event ? event.scope.sessionId : event.sessionId;
+}
+
+function traceContextForEvent(event: InstrumentationEvent): TraceCaptureContext {
+  if (event.type === "session.started") {
+    return {
+      agentName: event.agentName,
+      audience: event.channelAudience ?? "unknown",
+      channelType: event.channelType,
+    };
+  }
+  if ("delivery" in event) {
+    return {
+      agentName: event.agentName,
+      audience: event.delivery.channelAudience ?? "unknown",
+    };
+  }
+  if ("scope" in event) {
+    return {
+      agentName: event.scope.functionId,
+      audience: event.scope.channelAudience ?? "unknown",
+    };
+  }
+  return { audience: "unknown" };
 }
 
 function snapshotInstrumentationEvent(

--- a/packages/eve/src/instrumentation/dispatch.ts
+++ b/packages/eve/src/instrumentation/dispatch.ts
@@ -13,7 +13,7 @@ import {
   withoutInstrumentationContent,
 } from "#instrumentation/content.js";
 import { createLogger, formatError } from "#internal/logging.js";
-import { resolveTracePolicy } from "#shared/trace-policy.js";
+import { legacyCaptureTracePolicy, resolveTracePolicy } from "#shared/trace-policy.js";
 import type { TraceCaptureContext } from "#shared/trace-policy.js";
 
 import type {
@@ -42,10 +42,25 @@ export function createInstrumentationDispatcher(
   const groups = normalizeDispatchGroups(input);
   const snapshots = new WeakMap<object, unknown>();
   const providers = [...groups.serialBefore, ...groups.parallel, ...groups.serialAfter];
+  const warnedPolicyFailures = new Set<InstrumentationProviderDefinition>();
 
   const forTrace = (trace: TraceCaptureContext): InstrumentationHooks => {
     const decisions = new Map(
-      providers.map((provider) => [provider, resolveTracePolicy(provider.tracePolicy, trace)]),
+      providers.map((provider) => [
+        provider,
+        resolveTracePolicy(
+          provider.tracePolicy ?? legacyCaptureTracePolicy(provider.capture),
+          trace,
+          (error) => {
+            if (warnedPolicyFailures.has(provider)) return;
+            warnedPolicyFailures.add(provider);
+            log.warn("instrumentation provider trace policy failed", {
+              error: formatError(error),
+              provider: provider.name,
+            });
+          },
+        ),
+      ]),
     );
     const capturesInputs = [...decisions.values()].some(
       (decision) => decision.action === "record" && decision.recordInputs,
@@ -56,7 +71,14 @@ export function createInstrumentationDispatcher(
     const capturesContent = capturesInputs || capturesOutputs;
 
     const publish = async (event: InstrumentationEvent): Promise<void> => {
-      const snapshot = snapshotInstrumentationEvent(event, snapshots);
+      const snapshot = snapshotInstrumentationEvent(
+        withInstrumentationDecision(event, {
+          action: "record",
+          recordInputs: capturesInputs,
+          recordOutputs: capturesOutputs,
+        }),
+        snapshots,
+      );
       const cleanupSession =
         snapshot.type === "session.completed" || snapshot.type === "session.failed";
       const cleanupTurn = snapshot.type === "turn.cancelled" || snapshot.type === "turn.failed";
@@ -78,8 +100,10 @@ export function createInstrumentationDispatcher(
 
       const projections = new Map<string, InstrumentationEvent>();
       const visibleEvent = (provider: InstrumentationProviderDefinition): InstrumentationEvent => {
-        const decision = decisions.get(provider)!;
-        if (decision.action === "drop") return snapshot;
+        const decision = decisions.get(provider);
+        if (decision === undefined || decision.action === "drop") {
+          return withoutInstrumentationContent(snapshot);
+        }
         if (decision.recordInputs && decision.recordOutputs) return snapshot;
         const key = `${String(decision.recordInputs)}:${String(decision.recordOutputs)}`;
         let projected = projections.get(key);
@@ -136,50 +160,17 @@ export function createInstrumentationDispatcher(
     return { capturesContent, capturesInputs, capturesOutputs, forTrace, publish };
   };
 
-  const boundBySession = new Map<string, InstrumentationHooks>();
+  let unboundHooks: InstrumentationHooks | undefined;
   return {
-    capturesContent: providers.length > 0,
+    capturesContent: providers.some(
+      (provider) => provider.tracePolicy === undefined && provider.capture === "content",
+    ),
     forTrace,
     async publish(event) {
-      const sessionId = sessionIdForEvent(event);
-      let bound = boundBySession.get(sessionId);
-      if (bound === undefined) {
-        bound = forTrace(traceContextForEvent(event));
-        boundBySession.set(sessionId, bound);
-      }
-      await bound.publish(event);
-      if (event.type === "session.completed" || event.type === "session.failed") {
-        boundBySession.delete(sessionId);
-      }
+      unboundHooks ??= forTrace({ audience: "unknown" });
+      await unboundHooks.publish(event);
     },
   };
-}
-
-function sessionIdForEvent(event: InstrumentationEvent): string {
-  return "scope" in event ? event.scope.sessionId : event.sessionId;
-}
-
-function traceContextForEvent(event: InstrumentationEvent): TraceCaptureContext {
-  if (event.type === "session.started") {
-    return {
-      agentName: event.agentName,
-      audience: event.channelAudience ?? "unknown",
-      channelType: event.channelType,
-    };
-  }
-  if ("delivery" in event) {
-    return {
-      agentName: event.agentName,
-      audience: event.delivery.channelAudience ?? "unknown",
-    };
-  }
-  if ("scope" in event) {
-    return {
-      agentName: event.scope.functionId,
-      audience: event.scope.channelAudience ?? "unknown",
-    };
-  }
-  return { audience: "unknown" };
 }
 
 function snapshotInstrumentationEvent(

--- a/packages/eve/src/instrumentation/lifecycle.test.ts
+++ b/packages/eve/src/instrumentation/lifecycle.test.ts
@@ -848,39 +848,30 @@ describe("trace policies", () => {
     expect(tracePolicy).toHaveBeenCalledExactlyOnceWith(trace);
   });
 
-  it("keeps one unbound policy decision across a session lifecycle", async () => {
-    const observed: string[] = [];
-    const tracePolicy = vi.fn(
-      ({ agentName, channelType }) => agentName === "weather" && channelType === "slack",
-    );
-    const hooks = createInstrumentationHooks([
-      {
-        events: {
-          "session.completed": (event) => void observed.push(event.type),
-          "session.started": (event) => void observed.push(event.type),
-        },
-        name: "provider",
-        tracePolicy,
-      },
-    ]);
+  it("evaluates unbound policies once with an unknown trace", async () => {
+    const tracePolicy = vi.fn(() => true);
+    const hooks = createInstrumentationHooks([{ name: "provider", tracePolicy }]);
 
     await hooks.publish({
-      agentName: "weather",
-      channelAudience: "public",
-      channelType: "slack",
-      idempotencyKey: sessionIdempotencyKey("session-1"),
+      idempotencyKey: turnIdempotencyKey("session-1", "turn-1"),
       rootSessionId: "session-1",
+      sequence: 0,
       sessionId: "session-1",
-      type: "session.started",
+      turnId: "turn-1",
+      type: "turn.started",
     });
     await hooks.publish({
-      idempotencyKey: sessionIdempotencyKey("session-1"),
+      idempotencyKey: turnIdempotencyKey("session-1", "turn-1"),
       sessionId: "session-1",
-      type: "session.completed",
+      turnId: "turn-1",
+      type: "turn.completed",
     });
 
-    expect(observed).toEqual(["session.started", "session.completed"]);
-    expect(tracePolicy).toHaveBeenCalledOnce();
+    expect(tracePolicy).toHaveBeenCalledExactlyOnceWith({
+      agentName: undefined,
+      audience: "unknown",
+      channelType: undefined,
+    });
   });
 
   it("lets an explicit provider policy authorize private content", async () => {
@@ -952,7 +943,54 @@ describe("trace policies", () => {
     ]);
   });
 
+  it("does not snapshot denied error content", async () => {
+    const observed = vi.fn();
+    const error = Object.defineProperty({}, "secret", {
+      enumerable: true,
+      get: () => {
+        throw new Error("error content was read");
+      },
+    });
+    const hooks = createInstrumentationHooks([
+      {
+        events: { "turn.failed": observed },
+        name: "inputs-only",
+        tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: false }),
+      },
+    ]).forTrace!({ audience: "public" });
+
+    await hooks.publish({
+      error,
+      idempotencyKey: turnIdempotencyKey("session-1", "turn-1"),
+      sessionId: "session-1",
+      turnId: "turn-1",
+      type: "turn.failed",
+    });
+
+    expect(observed.mock.calls[0]?.[0].error).toBeUndefined();
+  });
+
   it("reports content capture only when an admitted provider requests it", () => {
+    expect(
+      createInstrumentationHooks([
+        {
+          name: "unbound",
+          tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: true }),
+        },
+      ]).capturesContent,
+    ).toBe(false);
+    expect(
+      createInstrumentationHooks([{ capture: "content", name: "legacy" }]).capturesContent,
+    ).toBe(true);
+    expect(
+      createInstrumentationHooks([
+        {
+          capture: "content",
+          name: "explicit-policy",
+          tracePolicy: () => ({ emit: true, recordInputs: false, recordOutputs: false }),
+        },
+      ]).capturesContent,
+    ).toBe(false);
     expect(
       createInstrumentationHooks([{ name: "quiet" }]).forTrace!({ audience: "private" })
         .capturesContent,
@@ -1015,7 +1053,7 @@ describe("trace policies", () => {
   it("isolates a throwing policy to its provider", async () => {
     const rejected = vi.fn();
     const observed = vi.fn();
-    const hooks = createInstrumentationHooks([
+    const unboundHooks = createInstrumentationHooks([
       {
         events: { "turn.started": rejected },
         name: "rejected",
@@ -1028,7 +1066,9 @@ describe("trace policies", () => {
         name: "observed",
         tracePolicy: () => ({ emit: true, recordInputs: false, recordOutputs: false }),
       },
-    ]).forTrace!({ audience: "public" });
+    ]);
+    const hooks = unboundHooks.forTrace!({ audience: "public" });
+    unboundHooks.forTrace!({ audience: "private" });
 
     await hooks.publish({
       idempotencyKey: turnIdempotencyKey("session-1", "turn-1"),
@@ -1041,6 +1081,15 @@ describe("trace policies", () => {
 
     expect(rejected).not.toHaveBeenCalled();
     expect(observed).toHaveBeenCalledOnce();
+    expect(logWarn).toHaveBeenCalledWith(
+      "instrumentation provider trace policy failed",
+      expect.objectContaining({ provider: "rejected" }),
+    );
+    expect(
+      logWarn.mock.calls.filter(
+        ([message]) => message === "instrumentation provider trace policy failed",
+      ),
+    ).toHaveLength(1);
   });
 
   it("allows only structural provider metadata by default", async () => {

--- a/packages/eve/src/instrumentation/lifecycle.test.ts
+++ b/packages/eve/src/instrumentation/lifecycle.test.ts
@@ -12,6 +12,7 @@ import {
   toolCallIdempotencyKey,
   turnIdempotencyKey,
   type InstrumentationAttemptScope,
+  type InstrumentationEvent,
   type InstrumentationModelCallStartedEvent,
   type InstrumentationProviderDefinition,
   type InstrumentationToolCallCompletedEvent,
@@ -821,22 +822,225 @@ describe("provider dispatch groups", () => {
   });
 });
 
-describe("capture", () => {
-  it("reports content capture only when some provider asked for it", () => {
-    expect(createInstrumentationHooks([{ name: "quiet" }]).capturesContent).toBe(false);
+describe("trace policies", () => {
+  it("defaults provider content to the audience-aware policy", () => {
+    const hooks = createInstrumentationHooks([{ name: "provider" }]);
+
+    expect(hooks.forTrace?.({ audience: "public" }).capturesContent).toBe(true);
+    expect(hooks.forTrace?.({ audience: "private" }).capturesContent).toBe(false);
+  });
+
+  it("passes trace context to each provider policy", () => {
+    const tracePolicy = vi.fn(() => ({
+      emit: true as const,
+      recordInputs: true,
+      recordOutputs: false,
+    }));
+    const hooks = createInstrumentationHooks([{ name: "provider", tracePolicy }]);
+    const trace = {
+      agentName: "weather",
+      audience: "private" as const,
+      channelType: "slack",
+    };
+
+    tracePolicy.mockClear();
+    expect(hooks.forTrace?.(trace).capturesContent).toBe(true);
+    expect(tracePolicy).toHaveBeenCalledExactlyOnceWith(trace);
+  });
+
+  it("keeps one unbound policy decision across a session lifecycle", async () => {
+    const observed: string[] = [];
+    const tracePolicy = vi.fn(
+      ({ agentName, channelType }) => agentName === "weather" && channelType === "slack",
+    );
+    const hooks = createInstrumentationHooks([
+      {
+        events: {
+          "session.completed": (event) => void observed.push(event.type),
+          "session.started": (event) => void observed.push(event.type),
+        },
+        name: "provider",
+        tracePolicy,
+      },
+    ]);
+
+    await hooks.publish({
+      agentName: "weather",
+      channelAudience: "public",
+      channelType: "slack",
+      idempotencyKey: sessionIdempotencyKey("session-1"),
+      rootSessionId: "session-1",
+      sessionId: "session-1",
+      type: "session.started",
+    });
+    await hooks.publish({
+      idempotencyKey: sessionIdempotencyKey("session-1"),
+      sessionId: "session-1",
+      type: "session.completed",
+    });
+
+    expect(observed).toEqual(["session.started", "session.completed"]);
+    expect(tracePolicy).toHaveBeenCalledOnce();
+  });
+
+  it("lets an explicit provider policy authorize private content", async () => {
+    const observed = vi.fn();
+    const hooks = createInstrumentationHooks([
+      {
+        events: { "action.started": observed },
+        name: "private-audit",
+        tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: false }),
+      },
+    ]).forTrace!({ audience: "private" });
+
+    await hooks.publish({
+      callId: "call-1",
+      idempotencyKey: actionIdempotencyKey(scope.sessionId, scope.turnId, "call-1"),
+      input: { secret: "private" },
+      kind: "tool-call",
+      name: "weather",
+      scope,
+      type: "action.started",
+    });
+
+    expect(observed.mock.calls[0]?.[0].input).toEqual({ secret: "private" });
+  });
+
+  it("projects input and output content independently per provider", async () => {
+    const inputEvents: InstrumentationEvent[] = [];
+    const outputEvents: InstrumentationEvent[] = [];
+    const events = (target: InstrumentationEvent[]) => ({
+      "model.call.completed": (event: InstrumentationEvent) => void target.push(event),
+      "model.call.started": (event: InstrumentationEvent) => void target.push(event),
+    });
+    const hooks = createInstrumentationHooks([
+      {
+        events: events(inputEvents),
+        name: "inputs",
+        tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: false }),
+      },
+      {
+        events: events(outputEvents),
+        name: "outputs",
+        tracePolicy: () => ({ emit: true, recordInputs: false, recordOutputs: true }),
+      },
+    ]).forTrace!({ audience: "public" });
+
+    await hooks.publish({
+      idempotencyKey: "model-1",
+      input: { instructions: "private prompt", messages: [] },
+      model: { modelId: "test", provider: "test" },
+      scope,
+      type: "model.call.started",
+    });
+    await hooks.publish({
+      content: [{ text: "private answer", type: "text" }],
+      finishReason: "stop",
+      idempotencyKey: "model-1",
+      scope,
+      type: "model.call.completed",
+      usage: {},
+    });
+
+    expect(inputEvents).toMatchObject([
+      { input: { instructions: "private prompt" } },
+      { content: undefined },
+    ]);
+    expect(outputEvents).toMatchObject([
+      { input: undefined },
+      { content: [{ text: "private answer", type: "text" }] },
+    ]);
+  });
+
+  it("reports content capture only when an admitted provider requests it", () => {
     expect(
-      createInstrumentationHooks([{ capture: "metadata", name: "quiet" }, { name: "also-quiet" }])
+      createInstrumentationHooks([{ name: "quiet" }]).forTrace!({ audience: "private" })
         .capturesContent,
     ).toBe(false);
     expect(
-      createInstrumentationHooks([{ name: "quiet" }, { capture: "content", name: "loud" }])
-        .capturesContent,
+      createInstrumentationHooks([
+        {
+          name: "quiet",
+          tracePolicy: () => ({ emit: true, recordInputs: false, recordOutputs: false }),
+        },
+        {
+          name: "also-quiet",
+          tracePolicy: () => ({ emit: true, recordInputs: false, recordOutputs: false }),
+        },
+      ]).forTrace!({ audience: "public" }).capturesContent,
+    ).toBe(false);
+    expect(
+      createInstrumentationHooks([
+        { name: "quiet" },
+        {
+          name: "loud",
+          tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: true }),
+        },
+      ]).forTrace!({ audience: "public" }).capturesContent,
     ).toBe(true);
     expect(
       createInstrumentationHooks({
-        parallel: [{ capture: "content", name: "loud" }],
-      }).capturesContent,
+        parallel: [
+          {
+            name: "loud",
+            tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: true }),
+          },
+        ],
+      }).forTrace!({ audience: "public" }).capturesContent,
     ).toBe(true);
+  });
+
+  it("does not invoke a provider whose policy drops the trace", async () => {
+    const observed = vi.fn();
+    const hooks = createInstrumentationHooks([
+      {
+        events: { "turn.started": observed },
+        name: "dropped",
+        tracePolicy: () => false,
+      },
+    ]).forTrace!({ audience: "public" });
+
+    await hooks.publish({
+      idempotencyKey: turnIdempotencyKey("session-1", "turn-1"),
+      rootSessionId: "session-1",
+      sequence: 0,
+      sessionId: "session-1",
+      turnId: "turn-1",
+      type: "turn.started",
+    });
+
+    expect(observed).not.toHaveBeenCalled();
+  });
+
+  it("isolates a throwing policy to its provider", async () => {
+    const rejected = vi.fn();
+    const observed = vi.fn();
+    const hooks = createInstrumentationHooks([
+      {
+        events: { "turn.started": rejected },
+        name: "rejected",
+        tracePolicy: () => {
+          throw new Error("policy failed");
+        },
+      },
+      {
+        events: { "turn.started": observed },
+        name: "observed",
+        tracePolicy: () => ({ emit: true, recordInputs: false, recordOutputs: false }),
+      },
+    ]).forTrace!({ audience: "public" });
+
+    await hooks.publish({
+      idempotencyKey: turnIdempotencyKey("session-1", "turn-1"),
+      rootSessionId: "session-1",
+      sequence: 0,
+      sessionId: "session-1",
+      turnId: "turn-1",
+      type: "turn.started",
+    });
+
+    expect(rejected).not.toHaveBeenCalled();
+    expect(observed).toHaveBeenCalledOnce();
   });
 
   it("allows only structural provider metadata by default", async () => {
@@ -845,7 +1049,7 @@ describe("capture", () => {
     const hooks = createInstrumentationHooks([
       { events: { "step.attempt.metadata": metadataOnly }, name: "metadata" },
       {
-        capture: "content",
+        tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: true }),
         events: { "step.attempt.metadata": wantsContent },
         name: "content",
       },
@@ -883,7 +1087,11 @@ describe("capture", () => {
     const wantsContent = vi.fn();
     const hooks = createInstrumentationHooks([
       { events: { "action.failed": metadataOnly }, name: "metadata" },
-      { capture: "content", events: { "action.failed": wantsContent }, name: "content" },
+      {
+        events: { "action.failed": wantsContent },
+        name: "content",
+        tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: true }),
+      },
     ]);
     const error = { output: "private tool output", requestBody: "private request" };
     const actionScope = { ...scope };
@@ -944,7 +1152,7 @@ describe("capture", () => {
         name: "metadata",
       },
       {
-        capture: "content",
+        tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: true }),
         events: {
           "input.requested": (event) => void contentEvents.push(event),
           "input.resolved": (event) => void contentEvents.push(event),
@@ -998,7 +1206,7 @@ describe("capture", () => {
         { events: { "tool.call.completed": mutator }, name: "first" },
         { events: { "tool.call.completed": observed }, name: "second" },
         {
-          capture: "content",
+          tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: true }),
           events: { "tool.call.completed": content },
           name: "content",
         },

--- a/packages/eve/src/instrumentation/lifecycle.test.ts
+++ b/packages/eve/src/instrumentation/lifecycle.test.ts
@@ -23,9 +23,9 @@ import {
   rememberInstrumentationActionScope,
 } from "#instrumentation/state.js";
 
-const { logWarn } = vi.hoisted(() => ({ logWarn: vi.fn() }));
+const { logDebug, logWarn } = vi.hoisted(() => ({ logDebug: vi.fn(), logWarn: vi.fn() }));
 vi.mock("#internal/logging.js", () => ({
-  createLogger: () => ({ warn: logWarn }),
+  createLogger: () => ({ debug: logDebug, warn: logWarn }),
   formatError: (error: unknown) => error,
 }));
 

--- a/packages/eve/src/instrumentation/lifecycle.ts
+++ b/packages/eve/src/instrumentation/lifecycle.ts
@@ -3,7 +3,11 @@ import type { InstrumentationStateSlot } from "#instrumentation/state.js";
 import type { RuntimeTraceContext } from "#protocol/message.js";
 import type { ChannelAudience } from "#shared/channel-audience.js";
 import type { InstrumentationDecision } from "#shared/instrumentation-decision.js";
-import type { TraceCaptureContext, TraceCapturePolicy } from "#shared/trace-policy.js";
+import type {
+  InstrumentationCapture,
+  TraceCaptureContext,
+  TraceCapturePolicy,
+} from "#shared/trace-policy.js";
 
 /**
  * Stable eve identity for one actual model attempt.
@@ -522,6 +526,8 @@ export type InstrumentationEventHandler<TEvent> = (
 /** Internal provider shape mirrored by the future public hook contract. */
 export interface InstrumentationProviderDefinition {
   readonly name: string;
+  /** @deprecated Use `tracePolicy` to select directional content. */
+  readonly capture?: InstrumentationCapture;
   /** Durable state identity, separate from the human-readable log name. */
   readonly stateNamespace?: string;
   /** Internal provider-specific projection applied after capture filtering. */

--- a/packages/eve/src/instrumentation/lifecycle.ts
+++ b/packages/eve/src/instrumentation/lifecycle.ts
@@ -3,6 +3,7 @@ import type { InstrumentationStateSlot } from "#instrumentation/state.js";
 import type { RuntimeTraceContext } from "#protocol/message.js";
 import type { ChannelAudience } from "#shared/channel-audience.js";
 import type { InstrumentationDecision } from "#shared/instrumentation-decision.js";
+import type { TraceCaptureContext, TraceCapturePolicy } from "#shared/trace-policy.js";
 
 /**
  * Stable eve identity for one actual model attempt.
@@ -103,23 +104,6 @@ export type InstrumentationActionOutput =
   | { readonly type: "error"; readonly error?: unknown };
 
 /**
- * How much of an event a provider is handed.
- *
- * `"metadata"` — the default — is structure, identity, usage, and timing: every
- * field except what the conversation actually said. `"content"` adds the
- * prompt, the response, tool arguments, and tool results.
- *
- * Declared per provider rather than per process, because two consumers of one
- * bus rarely have the same retention path. Content is built at all only when
- * some provider asked for it, and a provider that did not ask never receives
- * it — which is the same guarantee a destination that declines content gets,
- * one layer lower and without an OpenTelemetry pipeline to route it through.
- * OpenTelemetry trace policy is applied only inside the OTel provider and does
- * not narrow this provider-level projection.
- */
-export type InstrumentationCapture = "content" | "metadata";
-
-/**
  * Every event carries an `idempotencyKey` naming the operation it is about: a
  * start and its terminal share one, and two operations never collide.
  *
@@ -195,7 +179,7 @@ interface InstrumentationChannelDeliveryScope {
 export interface InstrumentationChannelDeliveryStartedEvent extends InstrumentationChannelDeliveryScope {
   readonly parentTraceContext?: InstrumentationTraceContext;
   readonly type: "channel.delivery.started";
-  /** Content. Absent unless this provider declared `capture: "content"`. */
+  /** Content. Absent unless this provider's trace policy records this direction. */
   readonly input?: InstrumentationChannelDeliveryInput;
 }
 
@@ -206,7 +190,7 @@ export interface InstrumentationChannelDeliveryTerminalEvent extends Instrumenta
     | "channel.delivery.cancelled"
     | "channel.delivery.completed"
     | "channel.delivery.failed";
-  /** Content. Absent unless this provider declared `capture: "content"`. */
+  /** Content. Absent unless this provider's trace policy records this direction. */
   readonly error?: unknown;
   readonly errorCode?: string;
   readonly outcome: InstrumentationChannelDeliveryOutcome;
@@ -253,7 +237,7 @@ export interface InstrumentationInputRequestedEvent {
   };
   readonly idempotencyKey: string;
   readonly kind: InstrumentationInputKind;
-  /** Content. Absent unless this provider declared `capture: "content"`. */
+  /** Content. Absent unless this provider's trace policy records this direction. */
   readonly request?: InstrumentationInputRequest;
   readonly requestId: string;
   readonly scope: InstrumentationAttemptScope;
@@ -266,7 +250,7 @@ export interface InstrumentationInputResolvedEvent {
   readonly kind: InstrumentationInputKind;
   readonly outcome: InstrumentationInputOutcome;
   readonly requestId: string;
-  /** Content. Absent unless this provider declared `capture: "content"`. */
+  /** Content. Absent unless this provider's trace policy records this direction. */
   readonly response?: InstrumentationInputResponse;
   readonly scope: InstrumentationAttemptScope;
 }
@@ -329,7 +313,7 @@ export interface InstrumentationSessionSettledEvent {
 
 export interface InstrumentationSessionFailedEvent {
   readonly type: "session.failed";
-  /** Content. Absent unless this provider declared `capture: "content"`. */
+  /** Content. Absent unless this provider's trace policy records this direction. */
   readonly error?: unknown;
   readonly idempotencyKey: string;
   readonly sessionId: string;
@@ -367,7 +351,7 @@ export interface InstrumentationTurnSettledEvent {
 
 export interface InstrumentationTurnFailedEvent {
   readonly type: "turn.failed";
-  /** Content. Absent unless this provider declared `capture: "content"`. */
+  /** Content. Absent unless this provider's trace policy records this direction. */
   readonly error?: unknown;
   readonly idempotencyKey: string;
   readonly sessionId: string;
@@ -386,7 +370,7 @@ export interface InstrumentationStepAttemptCompletedEvent {
 
 export interface InstrumentationStepAttemptFailedEvent {
   readonly type: "step.attempt.failed";
-  /** Content. Absent unless this provider declared `capture: "content"`. */
+  /** Content. Absent unless this provider's trace policy records this direction. */
   readonly error?: unknown;
   readonly idempotencyKey: string;
   readonly scope: InstrumentationAttemptScope;
@@ -411,7 +395,7 @@ export interface InstrumentationStepAttemptMetadataEvent {
 export interface InstrumentationModelCallStartedEvent {
   readonly type: "model.call.started";
   readonly idempotencyKey: string;
-  /** Content. Absent unless this provider declared `capture: "content"`. */
+  /** Content. Absent unless this provider's trace policy records this direction. */
   readonly input?: InstrumentationModelInput;
   readonly model: InstrumentationModelRef;
   readonly runtimeContext?: Readonly<Record<string, unknown>>;
@@ -420,7 +404,7 @@ export interface InstrumentationModelCallStartedEvent {
 
 export interface InstrumentationModelCallCompletedEvent {
   readonly type: "model.call.completed";
-  /** Content. Absent unless this provider declared `capture: "content"`. */
+  /** Content. Absent unless this provider's trace policy records this direction. */
   readonly content?: readonly InstrumentationContentPart[];
   readonly finishReason: string;
   readonly idempotencyKey: string;
@@ -430,7 +414,7 @@ export interface InstrumentationModelCallCompletedEvent {
 
 export interface InstrumentationModelCallFailedEvent {
   readonly type: "model.call.failed";
-  /** Content. Absent unless this provider declared `capture: "content"`. */
+  /** Content. Absent unless this provider's trace policy records this direction. */
   readonly error?: unknown;
   readonly idempotencyKey: string;
   readonly scope: InstrumentationAttemptScope;
@@ -460,7 +444,7 @@ export interface InstrumentationToolCallCompletedEvent {
 
 export interface InstrumentationToolCallFailedEvent {
   readonly type: "tool.call.failed";
-  /** Content. Absent unless this provider declared `capture: "content"`. */
+  /** Content. Absent unless this provider's trace policy records this direction. */
   readonly error?: unknown;
   readonly idempotencyKey: string;
   readonly scope: InstrumentationAttemptScope;
@@ -479,7 +463,7 @@ export interface InstrumentationActionStartedEvent {
   readonly type: "action.started";
   readonly callId: string;
   readonly idempotencyKey: string;
-  /** Content. Absent unless this provider declared `capture: "content"`. */
+  /** Content. Absent unless this provider's trace policy records this direction. */
   readonly input?: unknown;
   readonly kind: InstrumentationActionKind;
   readonly name: string;
@@ -506,7 +490,7 @@ export interface InstrumentationActionCompletedEvent {
 export interface InstrumentationActionFailedEvent {
   readonly type: "action.failed";
   readonly acceptedAtMs?: number;
-  /** Content. Absent unless this provider declared `capture: "content"`. */
+  /** Content. Absent unless this provider's trace policy records this direction. */
   readonly error?: unknown;
   readonly errorCode?: string;
   readonly idempotencyKey: string;
@@ -544,8 +528,8 @@ export interface InstrumentationProviderDefinition {
   readonly projectEvent?: (
     event: InstrumentationEvent,
   ) => InstrumentationEvent | PromiseLike<InstrumentationEvent>;
-  /** Defaults to `"metadata"`. See {@link InstrumentationCapture}. */
-  readonly capture?: InstrumentationCapture;
+  /** Provider-specific event admission and directional content policy. */
+  readonly tracePolicy?: TraceCapturePolicy;
   readonly events?: {
     readonly "channel.delivery.started"?: InstrumentationEventHandler<InstrumentationChannelDeliveryStartedEvent>;
     readonly "channel.delivery.cancelled"?: InstrumentationEventHandler<InstrumentationChannelDeliveryTerminalEvent>;
@@ -641,13 +625,18 @@ export type InstrumentationExecutionOperation =
 /** Provider-neutral hook operations consumed by the AI SDK bridge. */
 export interface InstrumentationHooks {
   /**
-   * Whether any registered provider declared `capture: "content"`.
+   * Whether any provider admitted by this bound trace requests content.
    *
    * False means nothing downstream can read what was said, so the publisher
    * should not serialize it in the first place. This is the only way the
    * projection is skipped rather than merely withheld.
    */
   readonly capturesContent: boolean;
+  /** Input-content demand for publishers that can project directions separately. */
+  readonly capturesInputs?: boolean;
+  /** Output-content demand for publishers that can project directions separately. */
+  readonly capturesOutputs?: boolean;
+  readonly forTrace?: (trace: TraceCaptureContext) => InstrumentationHooks;
   publish(event: InstrumentationEvent): Promise<void>;
 }
 

--- a/packages/eve/src/instrumentation/native-events.ts
+++ b/packages/eve/src/instrumentation/native-events.ts
@@ -113,6 +113,7 @@ async function publishInputStarts(
 ): Promise<void> {
   const scope = input.getAttemptScope?.();
   if (scope === undefined) return;
+  const capturesOutputs = hooks.capturesOutputs ?? hooks.capturesContent;
 
   for (const request of event.data.requests) {
     const idempotencyKey = inputIdempotencyKey(
@@ -131,7 +132,7 @@ async function publishInputStarts(
         }),
         idempotencyKey,
         kind: request.kind,
-        request: hooks.capturesContent
+        request: capturesOutputs
           ? Object.freeze({
               allowFreeform: request.allowFreeform,
               display: request.display,
@@ -153,6 +154,7 @@ export async function publishInputResolutions(input: {
   readonly hooks: InstrumentationHooks;
   readonly sessionId: string;
 }): Promise<void> {
+  const capturesInputs = input.hooks.capturesInputs ?? input.hooks.capturesContent;
   for (const resolved of input.batch.inputs) {
     const idempotencyKey = inputIdempotencyKey(
       input.sessionId,
@@ -168,7 +170,7 @@ export async function publishInputResolutions(input: {
         outcome: resolved.outcome,
         requestId: resolved.request.requestId,
         response:
-          !input.hooks.capturesContent || resolved.response === undefined
+          !capturesInputs || resolved.response === undefined
             ? undefined
             : Object.freeze({
                 optionId: resolved.response.optionId,
@@ -189,6 +191,7 @@ async function publishActionStarts(
 ): Promise<void> {
   const scope = input.getAttemptScope?.();
   if (scope === undefined) return;
+  const capturesInputs = hooks.capturesInputs ?? hooks.capturesContent;
 
   for (const action of event.data.actions) {
     const idempotencyKey = actionIdempotencyKey(input.sessionId, event.data.turnId, action.callId);
@@ -199,7 +202,7 @@ async function publishActionStarts(
       Object.freeze({
         callId: action.callId,
         idempotencyKey,
-        input: hooks.capturesContent ? action.input : undefined,
+        input: capturesInputs ? action.input : undefined,
         kind: action.kind,
         name: actionName(action),
         scope,
@@ -220,6 +223,7 @@ async function publishActionTerminal(
   );
   if (correlation === undefined) return;
   const { idempotencyKey, scope } = correlation;
+  const capturesOutputs = hooks.capturesOutputs ?? hooks.capturesContent;
 
   if (event.data.status === "completed") {
     await hooks.publish(
@@ -230,7 +234,7 @@ async function publishActionTerminal(
         idempotencyKey,
         outcome: "completed",
         output: Object.freeze(
-          hooks.capturesContent
+          capturesOutputs
             ? { output: event.data.result.output, type: "result" }
             : { type: "result" },
         ),
@@ -242,10 +246,11 @@ async function publishActionTerminal(
     return;
   }
 
-  const error =
-    event.data.error === undefined
+  const error = capturesOutputs
+    ? event.data.error === undefined
       ? event.data.result.output
-      : Object.assign(new Error(event.data.error.message), { code: event.data.error.code });
+      : Object.assign(new Error(event.data.error.message), { code: event.data.error.code })
+    : undefined;
   await hooks.publish(
     Object.freeze({
       acceptedAtMs: contextStorage.getStore()?.get(RuntimeActionSettlementTimesKey)?.[

--- a/packages/eve/src/instrumentation/provider.ts
+++ b/packages/eve/src/instrumentation/provider.ts
@@ -154,7 +154,7 @@ export type ProviderEvents = {
  * completion order.
  */
 export interface ProviderDefinition {
-  /** @deprecated Use `tracePolicy` to select directional content. */
+  /** @deprecated Use `tracePolicy`. Ignored when `tracePolicy` is also set. */
   readonly capture?: InstrumentationCapture;
   /**
    * Whether this provider receives events and which content directions they

--- a/packages/eve/src/instrumentation/provider.ts
+++ b/packages/eve/src/instrumentation/provider.ts
@@ -9,8 +9,9 @@
 // runtime. The event shapes are eve's own vocabulary; deriving the handler map
 // from the union below is what keeps the public contract from drifting away
 // from the bus that feeds it.
-import type { InstrumentationCapture, InstrumentationEvent } from "#instrumentation/lifecycle.js";
+import type { InstrumentationEvent } from "#instrumentation/lifecycle.js";
 import type { JsonValue } from "#shared/json.js";
+import type { InstrumentationCapture, TraceCapturePolicy } from "#shared/trace-policy.js";
 
 export type { JsonValue } from "#shared/json.js";
 
@@ -22,7 +23,6 @@ export type {
   InstrumentationActionOutput,
   InstrumentationActionStartedEvent,
   InstrumentationAttemptScope,
-  InstrumentationCapture,
   InstrumentationChannelDeliveryInput,
   InstrumentationChannelDeliveryOutcome,
   InstrumentationChannelDeliveryRef,
@@ -63,6 +63,12 @@ export type {
   InstrumentationTurnTerminalEvent,
   InstrumentationUsage,
 } from "#instrumentation/lifecycle.js";
+export type {
+  InstrumentationCapture,
+  TraceCaptureContext,
+  TraceCapturePolicy,
+  TracePolicyDecision,
+} from "#shared/trace-policy.js";
 
 /**
  * Marks a value as having come from `defineInstrumentation` or a built-in
@@ -148,15 +154,17 @@ export type ProviderEvents = {
  * completion order.
  */
 export interface ProviderDefinition {
-  /**
-   * How much of each event this provider is handed. Defaults to `"metadata"`:
-   * structure, identity, usage, and timing, but not what was said.
-   *
-   * `"content"` adds the prompt, the response, tool arguments, and tool
-   * results. Asking is what makes eve build the projection at all, so a
-   * directory in which nobody asks never serializes a prompt.
-   */
+  /** @deprecated Use `tracePolicy` to select directional content. */
   readonly capture?: InstrumentationCapture;
+  /**
+   * Whether this provider receives events and which content directions they
+   * include. Defaults to emitting every audience, with content only for public
+   * conversations. Boolean `true` uses the same audience-aware content rule;
+   * an explicit emitted decision can authorize either direction independently.
+   * A thrown error disables this provider for the trace. The policy can run
+   * again across durable steps, so it must be deterministic.
+   */
+  readonly tracePolicy?: TraceCapturePolicy;
   readonly events?: ProviderEvents;
   /** Runs once at server startup, before any event is published. */
   readonly setup?: (context: ProviderSetupContext) => void | PromiseLike<void>;

--- a/packages/eve/src/instrumentation/providers-otel-policy.test.ts
+++ b/packages/eve/src/instrumentation/providers-otel-policy.test.ts
@@ -46,7 +46,7 @@ describe("otel and authored provider composition", () => {
         agentName: "weather-agent",
         slot: "rows",
         value: defineInstrumentation({
-          capture: "content",
+          tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: true }),
           events: { "model.call.started": modelStarted },
         }),
       });

--- a/packages/eve/src/instrumentation/providers.test.ts
+++ b/packages/eve/src/instrumentation/providers.test.ts
@@ -215,6 +215,34 @@ describe("finalizeInstrumentationProviders", () => {
     expect(started.mock.calls[0]?.[0]).toMatchObject({ turnId: "turn-1" });
   });
 
+  it.each([
+    ["content", true],
+    ["metadata", false],
+  ] as const)(
+    "maps the deprecated %s capture setting to provider policy",
+    async (capture, expected) => {
+      await register("legacy", defineInstrumentation({ capture }));
+
+      const runtime = finalizeInstrumentationProviders({ serviceName: "weather-agent" });
+
+      expect(runtime.hooks.forTrace?.({ audience: "private" }).capturesContent).toBe(expected);
+    },
+  );
+
+  it("prefers provider tracePolicy over deprecated capture", async () => {
+    await register(
+      "provider",
+      defineInstrumentation({
+        capture: "metadata",
+        tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: true }),
+      }),
+    );
+
+    const runtime = finalizeInstrumentationProviders({ serviceName: "weather-agent" });
+
+    expect(runtime.hooks.forTrace?.({ audience: "private" }).capturesContent).toBe(true);
+  });
+
   it("still runs execution when no destination was declared", async () => {
     // A directory with no `otel()` has nothing to hang a span on, so
     // `runInContext` degrades to running the work directly rather than

--- a/packages/eve/src/instrumentation/providers.ts
+++ b/packages/eve/src/instrumentation/providers.ts
@@ -12,10 +12,8 @@ import { collectOtelPipeline } from "#tracing/otel-declaration.js";
 import {
   isInstrumentationDisabled,
   isInstrumentationProvider,
-  type InstrumentationCapture,
   type InstrumentationProvider,
 } from "#public/instrumentation/provider.js";
-import type { TraceCapturePolicy } from "#shared/trace-policy.js";
 
 /**
  * Process-global registry of the providers authored under
@@ -148,6 +146,7 @@ function toProviderDefinition(
   entry: RegisteredInstrumentationProvider,
 ): InstrumentationProviderDefinition {
   return {
+    capture: entry.provider.capture,
     events: entry.provider.events as InstrumentationProviderDefinition["events"],
     flush: entry.provider.flush,
     // The file the provider came from, which is the only name an author can
@@ -155,18 +154,6 @@ function toProviderDefinition(
     name: entry.slot,
     shutdown: entry.provider.shutdown,
     stateNamespace: `authored:${entry.slot}`,
-    tracePolicy: entry.provider.tracePolicy ?? legacyCaptureTracePolicy(entry.provider.capture),
+    tracePolicy: entry.provider.tracePolicy,
   };
-}
-
-function legacyCaptureTracePolicy(
-  capture: InstrumentationCapture | undefined,
-): TraceCapturePolicy | undefined {
-  if (capture === undefined) return undefined;
-  const recordsContent = capture === "content";
-  return () => ({
-    emit: true,
-    recordInputs: recordsContent,
-    recordOutputs: recordsContent,
-  });
 }

--- a/packages/eve/src/instrumentation/providers.ts
+++ b/packages/eve/src/instrumentation/providers.ts
@@ -12,8 +12,10 @@ import { collectOtelPipeline } from "#tracing/otel-declaration.js";
 import {
   isInstrumentationDisabled,
   isInstrumentationProvider,
+  type InstrumentationCapture,
   type InstrumentationProvider,
 } from "#public/instrumentation/provider.js";
+import type { TraceCapturePolicy } from "#shared/trace-policy.js";
 
 /**
  * Process-global registry of the providers authored under
@@ -153,6 +155,18 @@ function toProviderDefinition(
     name: entry.slot,
     shutdown: entry.provider.shutdown,
     stateNamespace: `authored:${entry.slot}`,
-    tracePolicy: entry.provider.tracePolicy,
+    tracePolicy: entry.provider.tracePolicy ?? legacyCaptureTracePolicy(entry.provider.capture),
   };
+}
+
+function legacyCaptureTracePolicy(
+  capture: InstrumentationCapture | undefined,
+): TraceCapturePolicy | undefined {
+  if (capture === undefined) return undefined;
+  const recordsContent = capture === "content";
+  return () => ({
+    emit: true,
+    recordInputs: recordsContent,
+    recordOutputs: recordsContent,
+  });
 }

--- a/packages/eve/src/instrumentation/providers.ts
+++ b/packages/eve/src/instrumentation/providers.ts
@@ -146,7 +146,6 @@ function toProviderDefinition(
   entry: RegisteredInstrumentationProvider,
 ): InstrumentationProviderDefinition {
   return {
-    capture: entry.provider.capture,
     events: entry.provider.events as InstrumentationProviderDefinition["events"],
     flush: entry.provider.flush,
     // The file the provider came from, which is the only name an author can
@@ -154,5 +153,6 @@ function toProviderDefinition(
     name: entry.slot,
     shutdown: entry.provider.shutdown,
     stateNamespace: `authored:${entry.slot}`,
+    tracePolicy: entry.provider.tracePolicy,
   };
 }

--- a/packages/eve/src/instrumentation/runtime.test.ts
+++ b/packages/eve/src/instrumentation/runtime.test.ts
@@ -89,6 +89,30 @@ describe("bindInstrumentationRuntime", () => {
     });
   });
 
+  it("binds provider hooks to the step-entry agent and channel", async () => {
+    const boundHooks: InstrumentationHooks = { capturesContent: false, publish: vi.fn() };
+    const forTrace = vi.fn(() => boundHooks);
+    const ctx = createContext("private");
+    ctx.set(ChannelInstrumentationKey, {
+      channelType: "slack",
+      kind: "channel:test",
+      metadata: { audience: "private" },
+    });
+    const instrumentation = bindInstrumentationRuntime(
+      createRuntime({ capturesContent: false, forTrace, publish: vi.fn() }),
+      ctx,
+      { ...boundSession, agentName: "Weather Display Name" },
+    );
+
+    await readTelemetry(instrumentation);
+
+    expect(forTrace).toHaveBeenCalledExactlyOnceWith({
+      agentName: "Weather Display Name",
+      audience: "private",
+      channelType: "slack",
+    });
+  });
+
   it("keeps the step-entry audience for the rest of the step", async () => {
     const ctx = createContext("private");
     const instrumentation = bindInstrumentationRuntime(

--- a/packages/eve/src/instrumentation/runtime.ts
+++ b/packages/eve/src/instrumentation/runtime.ts
@@ -181,7 +181,7 @@ export interface ExecutionInstrumentation {
   readonly flush: () => Promise<void>;
   readonly instrumentChannelDelivery: (
     input:
-      | Omit<ChannelDeliveryStartInstrumentation, "hooks">
+      | Omit<ChannelDeliveryStartInstrumentation, "hooks" | "policyAgentName">
       | Omit<ChannelDeliveryTerminalInstrumentation, "hooks">,
   ) => Promise<void>;
   readonly prepareExecution: () => SessionInstrumentation;
@@ -194,7 +194,7 @@ export function bindInstrumentationRuntime(
   boundSession: BoundInstrumentationSession,
 ): ExecutionInstrumentation | undefined {
   if (runtime === undefined) return undefined;
-  const hooks = runtime.hooks;
+  const baseHooks = runtime.hooks;
   const readSessionContext = () => {
     const context = contextStorage.getStore() ?? ctx;
     return {
@@ -205,6 +205,16 @@ export function bindInstrumentationRuntime(
       parentTraceContext: context.get(ParentTraceContextKey),
       traceSeed: context.get(SessionTraceSeedKey),
     };
+  };
+  const bindHooks = (sessionContext: ReturnType<typeof readSessionContext>) => {
+    const channel = sessionContext.instrumentation;
+    return (
+      baseHooks.forTrace?.({
+        agentName: boundSession.agentName,
+        audience: normalizeChannelAudience(channel?.metadata.audience),
+        channelType: channel?.channelType,
+      }) ?? baseHooks
+    );
   };
   const captureExecutionRuntime = () => {
     const otelSettings = runtime.otelSettings;
@@ -240,6 +250,7 @@ export function bindInstrumentationRuntime(
     return {
       runStep: async (input, execute) => {
         const policyContext = readSessionContext();
+        const hooks = bindHooks(policyContext);
         const settings = executionRuntime.otelSettings;
         const decision = resolveStepInstrumentationDecision(
           settings,
@@ -435,17 +446,24 @@ export function bindInstrumentationRuntime(
     };
   };
   return {
-    createCancellationHandleEvent: (input) =>
-      createInstrumentationHandleEvent({
+    createCancellationHandleEvent: (input) => {
+      const sessionContext = readSessionContext();
+      return createInstrumentationHandleEvent({
         agentName: boundSession.agentName,
-        channelKind: readSessionContext().instrumentation?.kind,
+        channelKind: sessionContext.instrumentation?.kind,
         handleEvent: input.handleEvent,
-        hooks,
+        hooks: bindHooks(sessionContext),
         sessionId: boundSession.sessionId,
         turnId: input.turnId,
-      }),
+      });
+    },
     flush: runtime.forceFlush,
-    instrumentChannelDelivery: (input) => instrumentChannelDelivery({ ...input, hooks }),
+    instrumentChannelDelivery: (input) =>
+      instrumentChannelDelivery({
+        ...input,
+        hooks: baseHooks,
+        policyAgentName: boundSession.agentName,
+      }),
     prepareExecution,
     preparePreamble: (input) => preparePreamble(input, readSessionContext()),
   };

--- a/packages/eve/src/public/definitions/exact.test.ts
+++ b/packages/eve/src/public/definitions/exact.test.ts
@@ -308,10 +308,7 @@ function typeOnlyFixtures(): void {
     },
   });
 
-  const providerWithCapture: ProviderDefinition = {
-    // @ts-expect-error Instrumentation providers use tracePolicy instead of capture.
-    capture: "content",
-  };
+  const providerWithCapture: ProviderDefinition = { capture: "content" };
   void providerWithCapture;
 
   defineInstrumentation({

--- a/packages/eve/src/public/definitions/exact.test.ts
+++ b/packages/eve/src/public/definitions/exact.test.ts
@@ -18,7 +18,10 @@ import {
   defineDynamic as defineDynamicInstructions,
   defineInstructions,
 } from "#public/definitions/instructions.js";
-import { defineInstrumentation } from "#public/definitions/instrumentation.js";
+import {
+  defineInstrumentation,
+  type ProviderDefinition,
+} from "#public/definitions/instrumentation.js";
 import { defineSandbox } from "#public/definitions/sandbox.js";
 import { defineSchedule } from "#public/definitions/schedule.js";
 import { defineSkill } from "#public/definitions/skill.js";
@@ -304,6 +307,12 @@ function typeOnlyFixtures(): void {
       },
     },
   });
+
+  const providerWithCapture: ProviderDefinition = {
+    // @ts-expect-error Instrumentation providers use tracePolicy instead of capture.
+    capture: "content",
+  };
+  void providerWithCapture;
 
   defineInstrumentation({
     // @ts-expect-error Instrumentation event hooks are authored through `events`.

--- a/packages/eve/src/public/instrumentation/provider.test.ts
+++ b/packages/eve/src/public/instrumentation/provider.test.ts
@@ -27,6 +27,17 @@ describe("defineInstrumentation", () => {
     expect(isInstrumentationProvider(provider)).toBe(true);
   });
 
+  it("preserves a provider trace policy", () => {
+    const tracePolicy = ({ audience }: { audience: string }) => ({
+      emit: true as const,
+      recordInputs: audience === "public",
+      recordOutputs: false,
+    });
+    const provider = defineInstrumentation({ tracePolicy });
+
+    expect(provider.tracePolicy).toBe(tracePolicy);
+  });
+
   it("brands a legacy config-shaped declaration", () => {
     const config = defineInstrumentation({ functionId: "support", recordInputs: false });
 

--- a/packages/eve/src/shared/trace-policy.ts
+++ b/packages/eve/src/shared/trace-policy.ts
@@ -1,0 +1,62 @@
+import type { ChannelAudience } from "#shared/channel-audience.js";
+import { shouldCaptureInstrumentationContent } from "#shared/instrumentation-content.js";
+import {
+  DROP_INSTRUMENTATION,
+  type InstrumentationDecision,
+} from "#shared/instrumentation-decision.js";
+
+export interface TraceCaptureContext {
+  readonly agentName?: string;
+  readonly audience: ChannelAudience;
+  readonly channelType?: string;
+}
+
+export type TracePolicyDecision =
+  | { readonly emit: false }
+  | {
+      readonly emit: true;
+      readonly recordInputs: boolean;
+      readonly recordOutputs: boolean;
+    };
+
+export type TraceCapturePolicy = (trace: TraceCaptureContext) => TracePolicyDecision | boolean;
+
+export function resolveTracePolicy(
+  policy: TraceCapturePolicy | undefined,
+  trace: TraceCaptureContext,
+): InstrumentationDecision {
+  try {
+    const decision = policy?.({
+      agentName: trace.agentName,
+      audience: trace.audience,
+      channelType: trace.channelType,
+    });
+    return resolveTracePolicyDecision(
+      decision ?? {
+        emit: true,
+        recordInputs: trace.audience === "public",
+        recordOutputs: trace.audience === "public",
+      },
+      trace.audience,
+    );
+  } catch {
+    return DROP_INSTRUMENTATION;
+  }
+}
+
+export function resolveTracePolicyDecision(
+  decision: TracePolicyDecision | boolean,
+  audience: ChannelAudience,
+): InstrumentationDecision {
+  if (decision === false) return DROP_INSTRUMENTATION;
+  if (decision === true) {
+    const content = shouldCaptureInstrumentationContent(audience);
+    return { action: "record", recordInputs: content, recordOutputs: content };
+  }
+  if (!decision.emit) return DROP_INSTRUMENTATION;
+  return {
+    action: "record",
+    recordInputs: decision.recordInputs,
+    recordOutputs: decision.recordOutputs,
+  };
+}

--- a/packages/eve/src/shared/trace-policy.ts
+++ b/packages/eve/src/shared/trace-policy.ts
@@ -5,6 +5,9 @@ import {
   type InstrumentationDecision,
 } from "#shared/instrumentation-decision.js";
 
+/** @deprecated Use `TraceCapturePolicy` to select directional content. */
+export type InstrumentationCapture = "content" | "metadata";
+
 export interface TraceCaptureContext {
   readonly agentName?: string;
   readonly audience: ChannelAudience;
@@ -21,9 +24,22 @@ export type TracePolicyDecision =
 
 export type TraceCapturePolicy = (trace: TraceCaptureContext) => TracePolicyDecision | boolean;
 
+export function legacyCaptureTracePolicy(
+  capture: InstrumentationCapture | undefined,
+): TraceCapturePolicy | undefined {
+  if (capture === undefined) return undefined;
+  const recordsContent = capture === "content";
+  return () => ({
+    emit: true,
+    recordInputs: recordsContent,
+    recordOutputs: recordsContent,
+  });
+}
+
 export function resolveTracePolicy(
   policy: TraceCapturePolicy | undefined,
   trace: TraceCaptureContext,
+  onError?: (error: unknown) => void,
 ): InstrumentationDecision {
   try {
     const decision = policy?.({
@@ -39,7 +55,8 @@ export function resolveTracePolicy(
       },
       trace.audience,
     );
-  } catch {
+  } catch (error) {
+    onError?.(error);
     return DROP_INSTRUMENTATION;
   }
 }

--- a/packages/eve/src/shared/trace-policy.ts
+++ b/packages/eve/src/shared/trace-policy.ts
@@ -56,7 +56,9 @@ export function resolveTracePolicy(
       trace.audience,
     );
   } catch (error) {
-    onError?.(error);
+    try {
+      onError?.(error);
+    } catch {}
     return DROP_INSTRUMENTATION;
   }
 }

--- a/packages/eve/src/tracing/agent-otel-provider.test.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.test.ts
@@ -131,16 +131,16 @@ async function emitAttempt(input: {
     stepIndex: 0,
     turnId: input.turnId,
   };
+  const hooks =
+    input.hooks.forTrace?.({
+      agentName: "weather",
+      audience: scope.channelAudience ?? "unknown",
+    }) ?? input.hooks;
   if (input.turnAlreadyStarted !== true) {
-    await publishTurnStarted(input);
+    await publishTurnStarted({ ...input, hooks });
   }
 
-  const bridge = createAiSdkHookBridge(
-    scope,
-    input.hooks,
-    input.runInContext,
-    input.runtimeContext,
-  );
+  const bridge = createAiSdkHookBridge(scope, hooks, input.runInContext, input.runtimeContext);
   Reflect.apply(bridge.onStart!, bridge, [
     {
       callId: "call-1",
@@ -203,7 +203,7 @@ async function emitAttempt(input: {
     ]);
   }
   const actionKey = actionIdempotencyKey(input.sessionId, input.turnId, "tool-1");
-  await input.hooks.publish({
+  await hooks.publish({
     callId: "tool-1",
     idempotencyKey: actionKey,
     input: { secret: "value" },
@@ -236,7 +236,7 @@ async function emitAttempt(input: {
             : { error: input.toolError, type: "tool-error" },
       },
     ]);
-    await input.hooks.publish(
+    await hooks.publish(
       input.toolError === undefined
         ? {
             idempotencyKey: actionKey,
@@ -258,7 +258,7 @@ async function emitAttempt(input: {
   }
 
   if (input.providerMetadata !== undefined) {
-    await input.hooks.publish({
+    await hooks.publish({
       idempotencyKey: attemptIdempotencyKey(scope),
       providerMetadata: input.providerMetadata,
       scope,
@@ -266,7 +266,7 @@ async function emitAttempt(input: {
     });
   }
 
-  await input.hooks.publish(
+  await hooks.publish(
     input.attemptError === undefined
       ? {
           idempotencyKey: attemptIdempotencyKey(scope),
@@ -280,13 +280,13 @@ async function emitAttempt(input: {
           type: "step.attempt.failed",
         },
   );
-  await input.hooks.publish({
+  await hooks.publish({
     idempotencyKey: turnIdempotencyKey(input.sessionId, input.turnId),
     sessionId: input.sessionId,
     turnId: input.turnId,
     type: "turn.completed",
   });
-  await input.hooks.publish({
+  await hooks.publish({
     idempotencyKey: sessionIdempotencyKey(input.sessionId),
     sessionId: input.sessionId,
     turnId: input.turnId,
@@ -1548,7 +1548,8 @@ describe("createAgentOtelInstrumentation", () => {
       stepIndex: 0,
       turnId: "turn-1",
     };
-    await runtime.hooks.publish({
+    const hooks = runtime.hooks.forTrace!({ agentName: "weather", audience: "public" });
+    await hooks.publish({
       agentName: "weather",
       channelAudience: "public",
       channelKind: "http",
@@ -1557,7 +1558,7 @@ describe("createAgentOtelInstrumentation", () => {
       sessionId: "session-1",
       type: "session.started",
     });
-    await runtime.hooks.publish({
+    await hooks.publish({
       idempotencyKey: turnIdempotencyKey("session-1", "turn-1"),
       rootSessionId: "session-1",
       sequence: 0,
@@ -1565,7 +1566,7 @@ describe("createAgentOtelInstrumentation", () => {
       turnId: "turn-1",
       type: "turn.started",
     });
-    const bridge = createAiSdkHookBridge(scope, runtime.hooks, runtime.runInContext);
+    const bridge = createAiSdkHookBridge(scope, hooks, runtime.runInContext);
     Reflect.apply(bridge.onStart!, bridge, [
       {
         callId: "call-1",

--- a/packages/eve/src/tracing/agent-otel-provider.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.ts
@@ -476,10 +476,6 @@ export function createAgentOtelInstrumentation(
 
   return {
     hook: {
-      // The destinations behind this pipeline filter content per exporter, but
-      // that filter only runs on a span that has it. Declining both here is
-      // what stops the projection from being built upstream.
-      capture: recordInputs || recordOutputs ? "content" : "metadata",
       events: {
         ...channelDeliveries,
         "action.completed": actions.events["action.completed"],
@@ -508,6 +504,7 @@ export function createAgentOtelInstrumentation(
       },
       name: "eve.otel",
       projectEvent,
+      tracePolicy: () => ({ emit: true, recordInputs, recordOutputs }),
     },
     prepareSessionTrace,
     prepareTurnTrace,

--- a/packages/eve/src/tracing/otel-declaration.ts
+++ b/packages/eve/src/tracing/otel-declaration.ts
@@ -14,7 +14,12 @@ import { batchSpanProcessor } from "#tracing/batch-span-processor.js";
 import type { ResolvedContentOptions } from "#tracing/content-attributes.js";
 import { contentFilteringProcessor } from "#tracing/content-span-processor.js";
 import { vercelRuntimeSpanProcessor } from "#tracing/vercel-runtime-span-exporter.js";
-import type { ChannelAudience } from "#shared/channel-audience.js";
+import type { TraceCapturePolicy } from "#shared/trace-policy.js";
+export type {
+  TraceCaptureContext,
+  TraceCapturePolicy,
+  TracePolicyDecision,
+} from "#shared/trace-policy.js";
 import {
   composeSpanExportPolicies,
   redactSpanInputs,
@@ -112,22 +117,6 @@ export interface ContentOptions {
   readonly recordInputs?: boolean;
   readonly recordOutputs?: boolean;
 }
-
-export interface TraceCaptureContext {
-  readonly agentName?: string;
-  readonly audience: ChannelAudience;
-  readonly channelType?: string;
-}
-
-export type TracePolicyDecision =
-  | { readonly emit: false }
-  | {
-      readonly emit: true;
-      readonly recordInputs: boolean;
-      readonly recordOutputs: boolean;
-    };
-
-export type TraceCapturePolicy = (trace: TraceCaptureContext) => TracePolicyDecision | boolean;
 
 /** Where one `otelIntegration()` sends spans and metrics. */
 export interface OtelIntegrationOptions extends ContentOptions {

--- a/packages/eve/src/tracing/sampled-trace.test.ts
+++ b/packages/eve/src/tracing/sampled-trace.test.ts
@@ -63,6 +63,20 @@ describe("resolveTracePolicyDecision", () => {
     ).toEqual({ action: "drop" });
   });
 
+  it("fails closed when policy error reporting also throws", () => {
+    expect(
+      resolveTracePolicy(
+        () => {
+          throw new Error("policy failed");
+        },
+        { audience: "public" },
+        () => {
+          throw new Error("reporting failed");
+        },
+      ),
+    ).toEqual({ action: "drop" });
+  });
+
   it.each([
     ["public", true],
     ["private", false],

--- a/packages/eve/src/tracing/sampled-trace.ts
+++ b/packages/eve/src/tracing/sampled-trace.ts
@@ -1,10 +1,4 @@
-import type { ChannelAudience } from "#shared/channel-audience.js";
-import { shouldCaptureInstrumentationContent } from "#shared/instrumentation-content.js";
-import {
-  DROP_INSTRUMENTATION,
-  type InstrumentationDecision,
-} from "#shared/instrumentation-decision.js";
-import type { TraceCapturePolicy, TracePolicyDecision } from "#tracing/otel-declaration.js";
+export { resolveTracePolicy, resolveTracePolicyDecision } from "#shared/trace-policy.js";
 
 // W3C sampled flag; written as a literal so this module stays out of the
 // vendored OTel chunk, which the workflow driver bundle cannot include.
@@ -12,59 +6,4 @@ const TRACE_FLAGS_SAMPLED = 0x01;
 
 export function isSampledTrace(context: { readonly traceFlags: number }): boolean {
   return (context.traceFlags & TRACE_FLAGS_SAMPLED) === TRACE_FLAGS_SAMPLED;
-}
-
-export function evaluateTracePolicy(
-  policy: TraceCapturePolicy | undefined,
-  trace: {
-    readonly agentName?: string;
-    readonly audience: ChannelAudience;
-    readonly channelType?: string;
-  },
-): boolean {
-  return resolveTracePolicy(policy, trace).action === "record";
-}
-
-export function resolveTracePolicy(
-  policy: TraceCapturePolicy | undefined,
-  trace: {
-    readonly agentName?: string;
-    readonly audience: ChannelAudience;
-    readonly channelType?: string;
-  },
-): InstrumentationDecision {
-  try {
-    const decision = policy?.({
-      agentName: trace.agentName,
-      audience: trace.audience,
-      channelType: trace.channelType,
-    });
-    return resolveTracePolicyDecision(
-      decision ?? {
-        emit: true,
-        recordInputs: trace.audience === "public",
-        recordOutputs: trace.audience === "public",
-      },
-      trace.audience,
-    );
-  } catch {
-    return DROP_INSTRUMENTATION;
-  }
-}
-
-export function resolveTracePolicyDecision(
-  decision: TracePolicyDecision | boolean,
-  audience: ChannelAudience,
-): InstrumentationDecision {
-  if (decision === false) return DROP_INSTRUMENTATION;
-  if (decision === true) {
-    const content = shouldCaptureInstrumentationContent(audience);
-    return { action: "record", recordInputs: content, recordOutputs: content };
-  }
-  if (!decision.emit) return DROP_INSTRUMENTATION;
-  return {
-    action: "record",
-    recordInputs: decision.recordInputs,
-    recordOutputs: decision.recordOutputs,
-  };
 }

--- a/packages/eve/test/scenarios/compiled-artifacts-bootstrap.scenario.test.ts
+++ b/packages/eve/test/scenarios/compiled-artifacts-bootstrap.scenario.test.ts
@@ -149,6 +149,11 @@ describe("writeCompiledArtifactsFiles", () => {
           "const container = globalThis as Record<string, unknown>;",
           "",
           "export default defineInstrumentation({",
+          "  tracePolicy: ({ audience }) => ({",
+          "    emit: true,",
+          '    recordInputs: audience === "public",',
+          "    recordOutputs: false,",
+          "  }),",
           "  setup(context) {",
           "    container.__eveProviderSetups ??= [];",
           `    (container.__eveProviderSetups as string[]).push(\`${slot}:\${context.agentName}\`);`,
@@ -206,7 +211,13 @@ describe("writeCompiledArtifactsFiles", () => {
       "local:compiled-artifacts-providers-test-agent",
       "otel:compiled-artifacts-providers-test-agent",
     ]);
-    expect(getInstrumentationProviders().map((entry) => entry.slot)).toEqual(["local", "otel"]);
+    const providers = getInstrumentationProviders();
+    expect(providers.map((entry) => entry.slot)).toEqual(["local", "otel"]);
+    expect(providers[0]?.provider.tracePolicy?.({ audience: "public" })).toEqual({
+      emit: true,
+      recordInputs: true,
+      recordOutputs: false,
+    });
     expect(closeHandlers).toHaveLength(1);
     await closeHandlers[0]?.();
   });

--- a/research/channel-audience-content-policy.md
+++ b/research/channel-audience-content-policy.md
@@ -1,7 +1,7 @@
 ---
 issue: https://github.com/vercel/eve/issues/2331
 status: proposed
-last_updated: "2026-08-20"
+last_updated: "2026-08-28"
 ---
 
 # Audience-aware trace content policy
@@ -34,8 +34,7 @@ The process-wide declaration owns trace creation:
 interface TraceCaptureContext {
   readonly agentName?: string;
   readonly audience: ChannelAudience;
-  readonly rootSessionId: string;
-  readonly sessionId: string;
+  readonly channelType?: string;
 }
 
 type TracePolicyDecision =
@@ -53,13 +52,20 @@ interface OtelOptions {
   readonly tracePolicy?: TraceCapturePolicy;
 }
 
+interface ProviderDefinition {
+  readonly tracePolicy?: TraceCapturePolicy;
+}
+
 declare function otel(options?: OtelOptions): OtelDeclaration;
 ```
 
-The trace decision is a process-wide ceiling. Each delivery is intersected with
-its own audience classification, and destination capture settings may narrow it
-further. A boolean return keeps the existing behavior: `false` drops trace
-production, while `true` records content only where the audience ceiling permits.
+The `otel()` trace decision is a process-wide OTel ceiling. Each delivery is
+intersected with its own audience classification, and destination settings may
+narrow it further. A provider's `defineInstrumentation({ tracePolicy })` decision
+is independent: `false` skips that provider, `true` uses audience-aware content,
+and an explicit emitted decision authorizes its input and output directions even
+for private channels. An omitted provider policy uses the default audience-aware
+behavior.
 
 Agent Runs and local traces expose the managed export policy:
 
@@ -148,11 +154,14 @@ The default authored and production head policy is equivalent to:
 });
 ```
 
-| Audience  | Trace created by default | Content when admitted by a custom trace policy |
-| --------- | ------------------------ | ---------------------------------------------- |
-| `public`  | Yes                      | Yes                                            |
-| `private` | Yes                      | No                                             |
-| `unknown` | Yes                      | No                                             |
+| Audience  | Trace created by default | Content by default |
+| --------- | ------------------------ | ------------------ |
+| `public`  | Yes                      | Yes                |
+| `private` | Yes                      | No                 |
+| `unknown` | Yes                      | No                 |
+
+An explicit provider policy can authorize content for any audience. The OTel
+policy remains subject to its process-wide audience ceiling.
 
 The default policy for local tracing for `eve dev` is equivalent to:
 
@@ -170,12 +179,21 @@ The runtime order is:
 4. Run each managed destination's composed export policies in declaration order. Custom integrations run their declared span processors.
 5. Hand the resulting facade to that destination's processors or exporter.
 
+The lifecycle bus separately evaluates each instrumentation provider's policy
+against the same agent and channel context, skips rejected providers, and applies
+directional content projection before invoking accepted handlers.
+
 There is no implicit content redaction after a custom trace policy admits an audience. Redaction occurs only when the export pipeline includes `redactSpanInputs()` or `redactSpanOutputs()` (or when a retained compatibility option explicitly requests the equivalent redaction).
 
 Policies fail closed at their boundary: a throwing trace policy rejects the trace, a throwing span policy drops the span, a throwing attribute policy drops the attribute, and a throwing content-redaction predicate redacts that content direction. Missing, malformed, or conflicting audience evidence normalizes to `unknown`.
 
 ## Compatibility
 
-The existing `recordInputs` and `recordOutputs` destination options remain accepted as deprecated source-compatible aliases. An explicit `false` prepends the corresponding redaction policy; these options no longer prevent accepted spans from capturing content upstream. `EVE_TRACES_CONTENT=off` similarly prepends both redactors for local traces.
+Instrumentation providers replace the experimental `capture` field with
+`tracePolicy`. The existing OTel destination `recordInputs` and `recordOutputs`
+options remain accepted as deprecated source-compatible aliases. An explicit
+`false` prepends the corresponding redaction policy; these options no longer
+prevent accepted spans from capturing content upstream. `EVE_TRACES_CONTENT=off`
+similarly prepends both redactors for local traces.
 
 Filtering remains a span-processor responsibility because local trace persistence and authored processors are processors rather than uniform exporters. Keeping the filtering boundary immediately above each destination prevents one destination's policy from mutating what another destination receives.

--- a/research/channel-audience-content-policy.md
+++ b/research/channel-audience-content-policy.md
@@ -189,11 +189,13 @@ Policies fail closed at their boundary: a throwing trace policy rejects the trac
 
 ## Compatibility
 
-Instrumentation providers replace the experimental `capture` field with
-`tracePolicy`. The existing OTel destination `recordInputs` and `recordOutputs`
-options remain accepted as deprecated source-compatible aliases. An explicit
-`false` prepends the corresponding redaction policy; these options no longer
-prevent accepted spans from capturing content upstream. `EVE_TRACES_CONTENT=off`
-similarly prepends both redactors for local traces.
+Instrumentation providers deprecate the experimental `capture` field in favor
+of `tracePolicy`; `"content"` and `"metadata"` are mapped to equivalent fixed
+policies while integrations migrate. The existing OTel destination
+`recordInputs` and `recordOutputs` options remain accepted as deprecated
+source-compatible aliases. An explicit `false` prepends the corresponding
+redaction policy; these options no longer prevent accepted spans from capturing
+content upstream. `EVE_TRACES_CONTENT=off` similarly prepends both redactors for
+local traces.
 
 Filtering remains a span-processor responsibility because local trace persistence and authored processors are processors rather than uniform exporters. Keeping the filtering boundary immediately above each destination prevents one destination's policy from mutating what another destination receives.

--- a/research/provider-neutral-local-observability.md
+++ b/research/provider-neutral-local-observability.md
@@ -37,7 +37,7 @@ events, assigns stable attempt/model-call/tool-call identities, terminalizes ope
 error and abort, and invokes the trusted `runInContext` while calling execution exactly once. AI
 SDK `callId` values are bridge correlation details, not provider run identities.
 
-The bridge does not create spans, export records, apply capture policy, or publish durable
+The bridge does not create spans, export records, apply provider policy, or publish durable
 eve-native events. Session, turn, compaction, suspension, and canonical step-terminal events are
 published by the harness.
 
@@ -90,9 +90,9 @@ backends can recognize agent invocations and tool calls without eve-specific map
 
 The `agent.*` namespace carries cheap structural attributes only: session/turn/step/attempt
 identity, action identity, and agent and framework identity. Standard `gen_ai.*` attributes describe
-the operation, agent, conversation, and tool. Message content, model output, and tool payloads are
-optional capture. The OTel provider owns this mapping; the bridge and hooks contain no span names,
-attributes, or parent contexts.
+the operation, agent, conversation, and tool. Message content, model output, and tool payloads follow
+each provider's audience-aware `tracePolicy`. The OTel provider owns this mapping; the bridge and
+hooks contain no span names, attributes, or parent contexts.
 
 ### The session root is a real span
 


### PR DESCRIPTION
### Summary

Instrumentation providers receive events about agent runs, such as model calls, tool calls, and session changes. This PR adds `tracePolicy`, which lets each provider decide whether to receive those events and whether inputs or outputs should include their full content.

By default, providers receive content from public channels and metadata only from private or unknown audiences. Existing `capture` settings continue to work, and an explicit `tracePolicy` takes precedence. Provider policies are independent from `otel({ tracePolicy })`, so disabling one provider does not affect other instrumentation. If a policy throws, only that provider is skipped and eve logs a warning.

### Validation

- Focused instrumentation, runtime, OTel, and tool-loop tests: 9 files, 386 passed
- `pnpm --filter eve test:unit`: 7,421 passed, 1 skipped; one unrelated TUI test exceeded the 5-second default and passed alone with a 15-second timeout
- `pnpm test:integration`: 93 files, 678 passed
- Compiled-artifacts bootstrap scenario: 1 file, 6 passed
- `pnpm --filter eve build`
- `pnpm --filter eve typecheck`
- `pnpm lint`
- `pnpm guard:invariants`
- `pnpm docs:check`
- `oxfmt` on changed files

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs**: 3 files, `+47 / -17`

Updates internal research and release metadata. Published docs remain unchanged while the API is behind its experimental flag.

**Implementation**: 14 files, `+337 / -214`

Evaluates each provider policy through the centralized instrumentation runtime, removes content before delivery when it is not allowed, and keeps start and terminal events paired.

**Tests**: 12 files, `+490 / -41`

Covers public and private defaults, custom input and output rules, failing policies, existing `capture` behavior, OpenTelemetry independence, runtime binding, delivery completion, and compiled providers.
