### PR TITLE
feat(eve): expose metricReaders on otelIntegration

### DIFF
--- a/.changeset/builtin-session-health-metrics.md
+++ b/.changeset/builtin-session-health-metrics.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Exposes `metricReaders` on `otelIntegration()` so destinations can declare OTLP metric readers alongside span processors. Readers from every destination are collected in declaration order and passed to `registerOTel`, which builds the process's meter provider. Also adds the metrics API surface to the vendored `@opentelemetry/api` declarations so user-land instrumentation code can typecheck against `metrics.getMeter()`.

--- a/packages/eve/scripts/vendor-compiled/declarations/@opentelemetry/api.d.ts
+++ b/packages/eve/scripts/vendor-compiled/declarations/@opentelemetry/api.d.ts
@@ -95,6 +95,42 @@ export declare const trace: {
   wrapSpanContext(spanContext: SpanContext): Span;
 };
 
+export interface MetricOptions {
+  readonly description?: string;
+  readonly unit?: string;
+}
+
+export interface ObservableResult {
+  observe(value: number, attributes?: Attributes): void;
+}
+
+export interface Counter {
+  add(value: number, attributes?: Attributes): void;
+}
+
+export interface Histogram {
+  record(value: number, attributes?: Attributes): void;
+}
+
+export interface ObservableGauge {
+  addCallback(callback: (result: ObservableResult) => void): void;
+}
+
+export interface ObservableUpDownCounter {
+  addCallback(callback: (result: ObservableResult) => void): void;
+}
+
+export interface Meter {
+  createCounter(name: string, options?: MetricOptions): Counter;
+  createHistogram(name: string, options?: MetricOptions): Histogram;
+  createObservableGauge(name: string, options?: MetricOptions): ObservableGauge;
+  createObservableUpDownCounter(name: string, options?: MetricOptions): ObservableUpDownCounter;
+}
+
+export declare const metrics: {
+  getMeter(name: string, version?: string): Meter;
+};
+
 export declare enum SpanKind {
   INTERNAL = 0,
   SERVER = 1,

--- a/packages/eve/scripts/vendor-compiled/declarations/@vercel/otel.d.ts
+++ b/packages/eve/scripts/vendor-compiled/declarations/@vercel/otel.d.ts
@@ -51,11 +51,22 @@ export type SamplerOrName =
   | "parentbased_traceidratio"
   | "traceidratio";
 
+/**
+ * A `MetricReader`. Structural for the same reason the exporter is: the
+ * instance comes from whichever `@opentelemetry/sdk-metrics` build the app
+ * installed, and eve only ever hands it to `registerOTel`.
+ */
+export interface MetricReader {
+  forceFlush(): Promise<void>;
+  shutdown(): Promise<void>;
+}
+
 export interface Configuration {
   readonly attributes?: Readonly<Record<string, unknown>>;
   readonly autoDetectResources?: boolean;
   readonly idGenerator?: IdGenerator;
   readonly instrumentations?: readonly unknown[];
+  readonly metricReaders?: readonly MetricReader[];
   readonly propagators?: readonly PropagatorOrName[];
   readonly serviceName?: string;
   readonly spanProcessors?: readonly SpanProcessorOrName[];

--- a/packages/eve/src/tracing/otel-declaration.ts
+++ b/packages/eve/src/tracing/otel-declaration.ts
@@ -1,4 +1,5 @@
 import type {
+  MetricReader,
   PropagatorOrName,
   SamplerOrName,
   SpanExporter,
@@ -128,12 +129,19 @@ export type TracePolicyDecision =
 
 export type TraceCapturePolicy = (trace: TraceCaptureContext) => TracePolicyDecision | boolean;
 
-/** Where one `otelIntegration()` sends spans. */
+/** Where one `otelIntegration()` sends spans and metrics. */
 export interface OtelIntegrationOptions extends ContentOptions {
   /** Merged into the pipeline in declaration order. */
   readonly spanProcessors?: readonly SpanProcessor[];
   /** Wrapped in eve's batching processor and appended after `spanProcessors`. */
   readonly traceExporter?: SpanExporter;
+  /**
+   * Metric readers collected into the process's one meter provider in
+   * declaration order. Without any, the meter provider is not created and
+   * `metrics.getMeter()` returns a no-op meter. Readers come from the app's
+   * own `@opentelemetry/sdk-metrics` install.
+   */
+  readonly metricReaders?: readonly MetricReader[];
   /**
    * Contributes runtime context that the AI SDK merges into telemetry spans
    * for each model call. Child spans inherit the values, so a destination can
@@ -164,6 +172,7 @@ export interface OtelIntegration extends InstrumentationProvider {
   readonly [OTEL_INTEGRATION]: true;
   /** @deprecated Content is captured upstream and redacted by destination policies. */
   readonly content: ResolvedContentOptions;
+  readonly metricReaders: readonly MetricReader[];
   readonly runtimeContext?: (input: InstrumentationRuntimeContextInput) => JsonObject | undefined;
   readonly spanProcessors: readonly SpanProcessorOrName[];
 }
@@ -214,6 +223,7 @@ function createOtelIntegration(
     [OTEL_INTEGRATION]: true,
     [PROVIDER]: true,
     content: resolveContentOptions(options),
+    metricReaders: options.metricReaders ?? [],
     runtimeContext: options.runtimeContext,
     spanProcessors: spanProcessors.map((processor) =>
       withExportPolicies(processor, legacyContentRedactionPolicy(options), exportPolicy),
@@ -227,6 +237,7 @@ export function agentRunsIntegration(options: ManagedTraceOptions = {}): OtelInt
     [OTEL_INTEGRATION]: true,
     [PROVIDER]: true,
     content: resolveContentOptions(options),
+    metricReaders: [],
     spanProcessors: [
       withExportPolicies(
         vercelRuntimeSpanProcessor(),
@@ -281,6 +292,7 @@ export function isOtelIntegration(value: unknown): value is OtelIntegration {
 /** The one pipeline a process can register. @internal */
 export interface OtelPipeline {
   readonly instrumentations?: readonly unknown[];
+  readonly metricReaders?: readonly MetricReader[];
   readonly propagators?: readonly PropagatorOrName[];
   readonly resource?: Readonly<Record<string, unknown>>;
   readonly sampler?: SamplerOrName;
@@ -326,6 +338,7 @@ export interface CollectedOtel {
  */
 export function collectOtelPipeline(values: readonly unknown[]): CollectedOtel {
   const spanProcessors: SpanProcessorOrName[] = [];
+  const metricReaders: MetricReader[] = [];
   const runtimeContextResolvers: RuntimeContextResolver[] = [];
   let declaration: OtelDeclaration | undefined;
   let declared = false;
@@ -336,6 +349,7 @@ export function collectOtelPipeline(values: readonly unknown[]): CollectedOtel {
       declared = true;
       capturesContent = true;
       spanProcessors.push(...value.spanProcessors);
+      metricReaders.push(...value.metricReaders);
       if (value.runtimeContext !== undefined) {
         runtimeContextResolvers.push(value.runtimeContext);
       }
@@ -365,6 +379,7 @@ export function collectOtelPipeline(values: readonly unknown[]): CollectedOtel {
     declared,
     pipeline: {
       instrumentations: options.instrumentations,
+      metricReaders: metricReaders.length > 0 ? metricReaders : undefined,
       propagators: options.propagators,
       resource: options.resource,
       sampler: options.sampler,

--- a/packages/eve/src/tracing/otel-registration.ts
+++ b/packages/eve/src/tracing/otel-registration.ts
@@ -120,6 +120,7 @@ export function registerOtelPipeline(input: {
     autoDetectResources: false,
     idGenerator,
     instrumentations: pipeline.instrumentations ?? [],
+    metricReaders: pipeline.metricReaders,
     propagators: [...(pipeline.propagators ?? ["auto"]), markerPropagator],
     serviceName: input.serviceName,
     spanProcessors: pipeline.spanProcessors.map((processor) =>


### PR DESCRIPTION
### Summary

eve's OTel pipeline was traces-only: `@vercel/otel` supports `metricReaders` on its `Configuration`, but eve had no way to pass them through. This adds `metricReaders` to `otelIntegration()` so destinations can declare metric readers alongside span processors:

```ts
otelIntegration({
  traceExporter: new OTLPHttpProtoTraceExporter({ url: "..." }),
  metricReaders: [
    new PeriodicExportingMetricReader({
      exporter: new OTLPMetricExporter({ url: "..." }),
      exportIntervalMillis: 60_000,
    }),
  ],
})
```

Readers from every destination are collected in declaration order and passed to `registerOTel`, which builds the process's meter provider via `@vercel/otel`. Without any readers the meter provider is not created and `metrics.getMeter()` returns a no-op meter — same pattern as span processors today. The `service.name` resource attribute (agent directory name) tags every metric point, so backends can filter globally or per-agent.

Also adds the metrics API surface (`Meter`, `ObservableGauge`, `Counter`, etc.) to the vendored `@opentelemetry/api` declarations, and a structural `MetricReader` type to the vendored `@vercel/otel` declarations, so user-land instrumentation code can typecheck against `metrics.getMeter()`.

Scope: plumbing only — no built-in metrics, no auto-created readers. All metric instruments are authored in user land.

### Validation

- `pnpm typecheck`, `pnpm lint`, `pnpm guard:invariants` — all pass

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Changeset only.

**Implementation** — 4 files · `+64 / -1`

`metricReaders` threaded through `OtelIntegrationOptions` → `OtelIntegration` → `collectOtelPipeline` → `OtelPipeline` → `registerOtelPipeline` → `Configuration`. Plus the metrics type surface on the two vendored declarations.

**Tests** — 0 files · `+0 / -0`

Plumbing change; existing `otel-declaration.test.ts` covers the collection path.
