### PR TITLE
test(e2e): use wall-clock task status timeout

### DIFF
--- a/e2e/fixtures/fixture-tasks/evals/shared.ts
+++ b/e2e/fixtures/fixture-tasks/evals/shared.ts
@@ -166,7 +166,9 @@ export async function waitForTaskStatus(
   status: string,
 ): Promise<EveEvalTurn> {
   let currentSession = session;
-  for (let attempt = 0; attempt < 20; attempt += 1) {
+  const deadline = performance.now() + 15_000;
+  let attempt = 0;
+  while (performance.now() < deadline) {
     const followed = await sendAndFollowQueuedTurn(
       t,
       `${verificationMessage} ${taskId}`,
@@ -190,9 +192,12 @@ export async function waitForTaskStatus(
       );
       return turn;
     }
+    attempt += 1;
     await t.sleep(100);
   }
-  throw new Error(`Task ${taskId} did not reach "${status}" after 20 verification attempts.`);
+  throw new Error(
+    `Task ${taskId} did not reach "${status}" within 15 seconds (${attempt} verification attempts).`,
+  );
 }
 
 function messageText(message: unknown): string {


### PR DESCRIPTION
### Summary

Related to #2611. Fast Postgres turns can exhaust the task-status helper's 20 polling attempts before the fixture's intentional five-second hold finishes, producing a false timeout. Use a monotonic 15-second deadline instead while preserving the polling cadence and attempt diagnostics. Production behavior is unchanged.

### Validation

The exact deterministic `task.agent.continue.rejected-agent-busy` eval passed all 53 gates. The fixture build, transition validation, TypeScript check, formatter, linter, and invariant guard also passed; the Postgres world remains covered by CI.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 0 files · `+0 / -0`

Production behavior is unchanged.

**Tests** — 1 file · `+7 / -2`

Keeps the correction inside the shared fixture eval helper that owns the timeout policy.
