### PR TITLE
add slack custom error rendering

### DIFF
--- a/packages/eve/src/public/channels/slack/defaults.ts
+++ b/packages/eve/src/public/channels/slack/defaults.ts
@@ -33,6 +33,80 @@ const log = createLogger("slack.defaults");
 const REASONING_TYPING_REFRESH_INTERVAL_MS = 5_000;
 const REASONING_TYPING_MIN_PROGRESS_CHARS = 4;
 
+interface SlackSemanticErrorSummary {
+  readonly hint?: string;
+  readonly message: string;
+  readonly name: string;
+}
+
+function extractSemanticErrorSummary(event: {
+  readonly details?: unknown;
+  readonly message?: string;
+}): SlackSemanticErrorSummary | null {
+  if (typeof event.details !== "object" || event.details === null) return null;
+  const details = event.details as {
+    readonly hint?: unknown;
+    readonly message?: unknown;
+    readonly name?: unknown;
+    readonly semanticErrorId?: unknown;
+  };
+  if (
+    typeof details.semanticErrorId !== "string" ||
+    details.semanticErrorId.length === 0 ||
+    typeof details.name !== "string" ||
+    details.name.length === 0
+  ) {
+    return null;
+  }
+
+  const message =
+    typeof details.message === "string" && details.message.trim().length > 0
+      ? details.message.trim()
+      : event.message?.trim();
+  if (!message) return null;
+
+  const hint =
+    typeof details.hint === "string" && details.hint.trim().length > 0
+      ? details.hint.trim()
+      : undefined;
+  return hint === undefined
+    ? { message, name: details.name }
+    : { hint, message, name: details.name };
+}
+
+function formatSemanticErrorBlock(
+  summary: SlackSemanticErrorSummary,
+  errorId: string | undefined,
+): string {
+  const lines = [
+    `### ${summary.name}`,
+    "",
+    summary.message,
+    ...(summary.hint ? ["", "**How to fix**", summary.hint] : []),
+    ...(errorId ? ["", `_Error id: \`${errorId}\`_`] : []),
+  ];
+  return lines
+    .flatMap((line) => line.split("\n"))
+    .map((line) => (line.length > 0 ? `> ${line}` : "> "))
+    .join("\n");
+}
+
+function formatSemanticErrorReply(input: {
+  readonly errorId: string | undefined;
+  readonly followUp?: string;
+  readonly introduction: string;
+  readonly nextStep: string;
+  readonly summary: SlackSemanticErrorSummary;
+}): string {
+  return [
+    `${input.introduction}.`,
+    "",
+    formatSemanticErrorBlock(input.summary, input.errorId),
+    ...(!input.summary.hint ? ["", input.nextStep] : []),
+    ...(input.followUp ? ["", input.followUp] : []),
+  ].join("\n");
+}
+
 function blockContainsRequestAction(block: unknown, requestId: string): boolean {
   if (typeof block !== "object" || block === null) return false;
   const candidate = block as { actions?: unknown; elements?: unknown };
@@ -294,11 +368,24 @@ export const defaultEvents: SlackChannelInternalEvents = {
   },
 
   async "turn.failed"(event, channel, _ctx) {
-    const hint = formatErrorHint(event);
     const errorId = extractErrorId(event.details);
+    const semanticSummary = extractSemanticErrorSummary(event);
+    if (semanticSummary !== null) {
+      await channel.thread.post(
+        formatSemanticErrorReply({
+          errorId,
+          introduction: "I hit an error while handling your request",
+          nextStep: "Please try again, rephrase, or reach out if it keeps failing.",
+          summary: semanticSummary,
+        }),
+      );
+      return;
+    }
+
+    const summary = formatErrorHint(event);
     await channel.thread.post(
       [
-        `I hit an error while handling your request${hint}.`,
+        `I hit an error while handling your request${summary}.`,
         "",
         "Please try again, rephrase, or reach out if it keeps failing.",
         ...(errorId ? ["", `_Error id: \`${errorId}\`_`] : []),
@@ -307,11 +394,25 @@ export const defaultEvents: SlackChannelInternalEvents = {
   },
 
   async "session.failed"(event, channel) {
-    const hint = formatErrorHint(event);
     const errorId = extractErrorId(event.details);
+    const semanticSummary = extractSemanticErrorSummary(event);
+    if (semanticSummary !== null) {
+      await channel.thread.post(
+        formatSemanticErrorReply({
+          errorId,
+          followUp: "Start a new thread to continue — I can't pick this one back up.",
+          introduction: "This session couldn't recover from an error",
+          nextStep: "Resolve the issue, then start a new thread — I can't pick this one back up.",
+          summary: semanticSummary,
+        }),
+      );
+      return;
+    }
+
+    const summary = formatErrorHint(event);
     await channel.thread.post(
       [
-        `This session couldn't recover from an error${hint}.`,
+        `This session couldn't recover from an error${summary}.`,
         "",
         "Start a new thread to continue — I can't pick this one back up.",
         ...(errorId ? ["", `_Error id: \`${errorId}\`_`] : []),

--- a/packages/eve/src/public/channels/slack/defaults.ts
+++ b/packages/eve/src/public/channels/slack/defaults.ts
@@ -83,7 +83,7 @@ function formatSemanticErrorBlock(
     "",
     summary.message,
     ...(summary.hint ? ["", "**How to fix**", summary.hint] : []),
-    ...(errorId ? ["", `_Error id: \`${errorId}\`_`] : []),
+    ...(errorId ? ["", "**Error id:**", `\`${errorId}\``] : []),
   ];
   return lines
     .flatMap((line) => line.split("\n"))
@@ -103,7 +103,7 @@ function formatSemanticErrorReply(input: {
     "",
     formatSemanticErrorBlock(input.summary, input.errorId),
     ...(!input.summary.hint ? ["", input.nextStep] : []),
-    ...(input.followUp ? ["", input.followUp] : []),
+    ...(input.summary.hint && input.followUp ? ["", input.followUp] : []),
   ].join("\n");
 }
 

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -1016,7 +1016,89 @@ describe("slackChannel() default event handlers", () => {
     expect(statuses).toEqual(["Need to inspect the repo.", "Working...", "Fresh turn reasoning."]);
   });
 
-  it("session.failed posts a terminal markdown message with error hint and id", async () => {
+  it("turn.failed posts a semantic error's remediation hint", async () => {
+    const adapter = withState(
+      getAdapter(slackChannel({ credentials: { botToken: "xoxb-test" } })),
+      THREAD_STATE,
+    );
+    const ctx = buildAdapterContext(adapter, stubAccessor());
+
+    const message =
+      "AI Gateway requires a valid credit card on file to service requests. Please visit https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai%3Fmodal%3Dadd-credit-card to continue.";
+    await callEvent(
+      adapter,
+      makeEvent("turn.failed", {
+        code: "MODEL_CALL_FAILED",
+        details: {
+          errorId: "abc-123",
+          hint: "Add a valid credit card or credits in the Vercel dashboard, then retry in the same thread.",
+          message,
+          name: "AI Gateway billing setup required",
+          semanticErrorId: "gateway-billing-required",
+        },
+        message,
+        sequence: 0,
+        turnId: "t1",
+      }),
+      ctx,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = parseSlackRequestBody(fetchMock.mock.calls[0]![1] as RequestInit);
+    expect(body.markdown_text).toBe(
+      [
+        "I hit an error while handling your request.",
+        "",
+        "> ### AI Gateway billing setup required",
+        "> ",
+        `> ${message}`,
+        "> ",
+        "> **How to fix**",
+        "> Add a valid credit card or credits in the Vercel dashboard, then retry in the same thread.",
+        "> ",
+        "> _Error id: `abc-123`_",
+      ].join("\n"),
+    );
+  });
+
+  it("keeps fallback remediation outside a semantic error block without a hint", async () => {
+    const adapter = withState(
+      getAdapter(slackChannel({ credentials: { botToken: "xoxb-test" } })),
+      THREAD_STATE,
+    );
+    const ctx = buildAdapterContext(adapter, stubAccessor());
+
+    await callEvent(
+      adapter,
+      makeEvent("turn.failed", {
+        code: "MODEL_CALL_FAILED",
+        details: {
+          message: "The model did not respond.",
+          name: "Model request failed",
+          semanticErrorId: "model-request-failed",
+        },
+        message: "The model did not respond.",
+        sequence: 0,
+        turnId: "t1",
+      }),
+      ctx,
+    );
+
+    const body = parseSlackRequestBody(fetchMock.mock.calls[0]![1] as RequestInit);
+    expect(body.markdown_text).toBe(
+      [
+        "I hit an error while handling your request.",
+        "",
+        "> ### Model request failed",
+        "> ",
+        "> The model did not respond.",
+        "",
+        "Please try again, rephrase, or reach out if it keeps failing.",
+      ].join("\n"),
+    );
+  });
+
+  it("session.failed posts a terminal markdown message with remediation and id", async () => {
     const adapter = withState(
       getAdapter(slackChannel({ credentials: { botToken: "xoxb-test" } })),
       THREAD_STATE,
@@ -1027,7 +1109,13 @@ describe("slackChannel() default event handlers", () => {
       adapter,
       makeEvent("session.failed", {
         code: "internal",
-        details: { errorId: "abc-123", name: "WorkflowExecutionFailed" },
+        details: {
+          errorId: "abc-123",
+          hint: "Resolve the configuration issue before trying again.",
+          message: "boom",
+          name: "Workflow execution failed",
+          semanticErrorId: "workflow-execution-failed",
+        },
         message: "boom",
         sessionId: "s1",
       }),
@@ -1036,10 +1124,22 @@ describe("slackChannel() default event handlers", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const body = parseSlackRequestBody(fetchMock.mock.calls[0]![1] as RequestInit);
-    expect(body.markdown_text).toContain("couldn't recover");
-    expect(body.markdown_text).toContain("Start a new thread");
-    expect(body.markdown_text).toContain("WorkflowExecutionFailed");
-    expect(body.markdown_text).toContain("abc-123");
+    expect(body.markdown_text).toBe(
+      [
+        "This session couldn't recover from an error.",
+        "",
+        "> ### Workflow execution failed",
+        "> ",
+        "> boom",
+        "> ",
+        "> **How to fix**",
+        "> Resolve the configuration issue before trying again.",
+        "> ",
+        "> _Error id: `abc-123`_",
+        "",
+        "Start a new thread to continue — I can't pick this one back up.",
+      ].join("\n"),
+    );
   });
 
   it("actions.requested typing indicator is truncated to Slack's length cap", async () => {

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -1056,7 +1056,8 @@ describe("slackChannel() default event handlers", () => {
         "> **How to fix**",
         "> Add a valid credit card or credits in the Vercel dashboard, then retry in the same thread.",
         "> ",
-        "> _Error id: `abc-123`_",
+        "> **Error id:**",
+        "> `abc-123`",
       ].join("\n"),
     );
   });
@@ -1135,9 +1136,50 @@ describe("slackChannel() default event handlers", () => {
         "> **How to fix**",
         "> Resolve the configuration issue before trying again.",
         "> ",
-        "> _Error id: `abc-123`_",
+        "> **Error id:**",
+        "> `abc-123`",
         "",
         "Start a new thread to continue — I can't pick this one back up.",
+      ].join("\n"),
+    );
+  });
+
+  it("session.failed does not repeat its fallback remediation without a hint", async () => {
+    const adapter = withState(
+      getAdapter(slackChannel({ credentials: { botToken: "xoxb-test" } })),
+      THREAD_STATE,
+    );
+    const ctx = buildAdapterContext(adapter, stubAccessor());
+
+    await callEvent(
+      adapter,
+      makeEvent("session.failed", {
+        code: "internal",
+        details: {
+          errorId: "abc-123",
+          message: "boom",
+          name: "Workflow execution failed",
+          semanticErrorId: "workflow-execution-failed",
+        },
+        message: "boom",
+        sessionId: "s1",
+      }),
+      ctx,
+    );
+
+    const body = parseSlackRequestBody(fetchMock.mock.calls[0]![1] as RequestInit);
+    expect(body.markdown_text).toBe(
+      [
+        "This session couldn't recover from an error.",
+        "",
+        "> ### Workflow execution failed",
+        "> ",
+        "> boom",
+        "> ",
+        "> **Error id:**",
+        "> `abc-123`",
+        "",
+        "Resolve the issue, then start a new thread — I can't pick this one back up.",
       ].join("\n"),
     );
   });


### PR DESCRIPTION
### Summary

Adds better slack formatting for structured errors:

old:
<img width="411" height="239" alt="Screenshot 2026-08-28 at 3 02 07 PM" src="https://github.com/user-attachments/assets/207b4cd0-a6b0-477c-bd91-12ebbb229794" />

new: 
<img width="404" height="287" alt="Screenshot 2026-08-28 at 3 25 38 PM" src="https://github.com/user-attachments/assets/634b3f03-3430-4845-8eb4-8695a2722f1a" />

### Checklist

- [ ] This change was requested or approved by a maintainer
- [ ] I ran the relevant checks from `CONTRIBUTING.md`
- [ ] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [ ] DCO sign-off passes for every commit (`git commit --signoff`)
