### PR TITLE
fix(eve): vendor private integration catalog

### DIFF
--- a/.changeset/vendor-private-catalog.md
+++ b/.changeset/vendor-private-catalog.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Bundle eve's private integration catalog into the published package so setup runtime code and TypeScript declarations no longer reference an unavailable workspace dependency.

--- a/packages/eve/scripts/vendor-compiled.mjs
+++ b/packages/eve/scripts/vendor-compiled.mjs
@@ -9,6 +9,7 @@
  * `scripts/vendor-compiled/declarations/`, and importing the config from
  * `scripts/vendor-compiled/index.mjs`.
  */
+import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -17,6 +18,7 @@ import { collectFilesRecursively, runVendor } from "./vendor-compiled/_shared.mj
 import { MODULES } from "./vendor-compiled/index.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
 const packageRoot = dirname(here);
 const compiledRoot = join(packageRoot, ".generated", "compiled");
 const vendorCompiledDir = join(here, "vendor-compiled");
@@ -37,5 +39,8 @@ await runVendor({
   compiledRoot,
   modules: MODULES,
   scriptFiles,
-  toolVersions: { rolldown: resolveNitroRolldownVersion() },
+  toolVersions: {
+    rolldown: resolveNitroRolldownVersion(),
+    typescript: require("typescript/package.json").version,
+  },
 });

--- a/packages/eve/scripts/vendor-compiled/@eve/catalog.mjs
+++ b/packages/eve/scripts/vendor-compiled/@eve/catalog.mjs
@@ -1,0 +1,33 @@
+import { execFile } from "node:child_process";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { promisify } from "node:util";
+
+import { createDeclarationCopier } from "../_shared.mjs";
+
+const execFileAsync = promisify(execFile);
+const require = createRequire(import.meta.url);
+const tscPath = join(dirname(require.resolve("typescript/package.json")), "bin", "tsc");
+const copyDeclarations = createDeclarationCopier({ declarationRoot: "dist/src" });
+
+/** Bundle the private workspace catalog so the published eve package stays self-contained. */
+export default {
+  packageName: "@eve/catalog",
+  compiledPath: "@eve/catalog",
+  bundling: "standalone",
+  fingerprintFiles: [
+    "../../tsconfig.json",
+    "package.json",
+    "src/index.ts",
+    "tsconfig.build.json",
+    "tsconfig.json",
+  ],
+  copyDeclarations: async (context) => {
+    await execFileAsync(
+      process.execPath,
+      [tscPath, "-p", "tsconfig.build.json", "--emitDeclarationOnly", "--declarationMap", "false"],
+      { cwd: context.packageInfo.packageRoot },
+    );
+    await copyDeclarations(context);
+  },
+};

--- a/packages/eve/scripts/vendor-compiled/_shared.mjs
+++ b/packages/eve/scripts/vendor-compiled/_shared.mjs
@@ -34,6 +34,7 @@
  *   banner?: string,               // standalone bundle prelude
  *   chunkGroup?: string,                  // default "node"
  *   typeOnly?: boolean,                   // skips JS bundling entirely
+ *   fingerprintFiles?: string[],          // package-relative files included in the stamp
  * }
  * ```
  */
@@ -838,17 +839,31 @@ async function computeStamp({ scriptFiles, modules, packageRoot, toolVersions })
     scriptHash.update("\0");
   }
 
+  const moduleFingerprints = {};
   const moduleVersions = {};
   for (const module of modules) {
-    const { packageJson } = await findPackageJson(
+    const packageInfo = await findPackageJson(
       module.packageName,
       packageRoot,
       module.packageJsonName,
     );
-    moduleVersions[module.packageName] = packageJson.version ?? "0.0.0";
+    moduleVersions[module.packageName] = packageInfo.packageJson.version ?? "0.0.0";
+
+    if (module.fingerprintFiles !== undefined) {
+      const moduleHash = createHash("sha256");
+      for (const file of [...module.fingerprintFiles].sort()) {
+        const content = await readFile(join(packageInfo.packageRoot, file), "utf8");
+        moduleHash.update(file);
+        moduleHash.update("\0");
+        moduleHash.update(content);
+        moduleHash.update("\0");
+      }
+      moduleFingerprints[module.packageName] = moduleHash.digest("hex");
+    }
   }
 
   return {
+    moduleFingerprints,
     moduleVersions,
     scriptHash: scriptHash.digest("hex"),
     toolVersions: Object.fromEntries(

--- a/packages/eve/scripts/vendor-compiled/index.mjs
+++ b/packages/eve/scripts/vendor-compiled/index.mjs
@@ -16,6 +16,7 @@ import providerUtils from "./@ai-sdk/provider-utils.mjs";
 import chatAdapterSlack from "./@chat-adapter/slack.mjs";
 import chatAdapterStateMemory from "./@chat-adapter/state-memory.mjs";
 import chatAdapterTwilio from "./@chat-adapter/twilio.mjs";
+import eveCatalog from "./@eve/catalog.mjs";
 import photonChatAdapterIMessage from "./@photon-ai/chat-adapter-imessage.mjs";
 import linqChatSdkAdapter from "./@linqapp/chat-sdk-adapter.mjs";
 
@@ -67,6 +68,7 @@ export const MODULES = [
   commander,
   eventsourceParserStream,
   envRunner,
+  eveCatalog,
   google,
   grayMatter,
   jose,

--- a/packages/eve/src/setup/scaffold/channels-catalog.ts
+++ b/packages/eve/src/setup/scaffold/channels-catalog.ts
@@ -10,7 +10,7 @@
  * overlay and the catalog cannot drift apart.
  */
 
-import { channelEntries } from "@eve/catalog";
+import { channelEntries } from "#compiled/@eve/catalog/index.js";
 import type { ChannelKind } from "./update/channels.js";
 
 /** Scaffolder overlay for one catalog channel the CLI can scaffold. */

--- a/packages/eve/src/setup/scaffold/connections/catalog.ts
+++ b/packages/eve/src/setup/scaffold/connections/catalog.ts
@@ -17,7 +17,7 @@ import {
   type ConnectionProtocol,
   connectionEntries,
   connectionProtocols,
-} from "@eve/catalog";
+} from "#compiled/@eve/catalog/index.js";
 
 /** Wire protocol a connection speaks at runtime. */
 export type { ConnectionProtocol };

--- a/packages/eve/test/scenarios/compiled-vendor-assets.scenario.test.ts
+++ b/packages/eve/test/scenarios/compiled-vendor-assets.scenario.test.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
 import { readdir, readFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
@@ -8,6 +9,14 @@ import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 
 const EVE_PACKAGE_ROOT = fileURLToPath(new URL("../../", import.meta.url));
+const EVE_CATALOG_ROOT = join(EVE_PACKAGE_ROOT, "..", "eve-catalog");
+const EVE_CATALOG_FINGERPRINT_FILES = [
+  "../../tsconfig.json",
+  "package.json",
+  "src/index.ts",
+  "tsconfig.build.json",
+  "tsconfig.json",
+] as const;
 const COMPILED_VENDOR_ROOT = join(EVE_PACKAGE_ROOT, ".generated", "compiled");
 const VENDOR_WARNING_LOG_PATH = join(EVE_PACKAGE_ROOT, "scripts", "vendor-warning-log.mjs");
 const execFileAsync = promisify(execFile);
@@ -78,14 +87,39 @@ describe("compiled vendor assets", () => {
     expect(schema._zod.bag.validator).toBeTypeOf("function");
   });
 
-  it("stamps the Nitro-resolved Rolldown version", async () => {
+  it("stamps the compiler versions that drive vendored output", async () => {
     const stamp = JSON.parse(
       await readFile(join(COMPILED_VENDOR_ROOT, ".vendor-stamp.json"), "utf8"),
-    ) as { toolVersions?: { rolldown?: string } };
+    ) as { toolVersions?: { rolldown?: string; typescript?: string } };
     const nitroRequire = createRequire(require.resolve("nitro/package.json"));
     const rolldownPackage = nitroRequire("rolldown/package.json") as { version: string };
+    const typescriptPackage = require("typescript/package.json") as { version: string };
 
     expect(stamp.toolVersions?.rolldown).toBe(rolldownPackage.version);
+    expect(stamp.toolVersions?.typescript).toBe(typescriptPackage.version);
+  });
+
+  it("copies generated catalog declarations and fingerprints their sources", async () => {
+    const sourceHash = createHash("sha256");
+    for (const file of EVE_CATALOG_FINGERPRINT_FILES) {
+      sourceHash.update(file);
+      sourceHash.update("\0");
+      sourceHash.update(await readFile(join(EVE_CATALOG_ROOT, file), "utf8"));
+      sourceHash.update("\0");
+    }
+
+    const stamp = JSON.parse(
+      await readFile(join(COMPILED_VENDOR_ROOT, ".vendor-stamp.json"), "utf8"),
+    ) as { moduleFingerprints?: Record<string, string> };
+    const [catalogDeclaration, vendoredDeclaration] = await Promise.all([
+      readFile(join(EVE_CATALOG_ROOT, "dist", "src", "index.d.ts"), "utf8"),
+      readFile(join(COMPILED_VENDOR_ROOT, "@eve", "catalog", "index.d.ts"), "utf8"),
+    ]);
+
+    expect(stamp.moduleFingerprints?.["@eve/catalog"]).toBe(sourceHash.digest("hex"));
+    expect(vendoredDeclaration.trimEnd()).toBe(
+      catalogDeclaration.replace(/\n?\/\/# sourceMappingURL=.*$/u, "").trimEnd(),
+    );
   });
 
   it("shares the OpenTelemetry provider registered through @vercel/otel", async () => {

--- a/scripts/guard-invariants.mjs
+++ b/scripts/guard-invariants.mjs
@@ -50,8 +50,8 @@
  *             return shapes must carry only what the harness consumes;
  *             durable state belongs on `ctx.eve`.
  *   rule 28 — Imports under `packages/eve/src/setup/scaffold/**` stay within
- *             their layer: node:* builtins, relative siblings, and the shared
- *             `@eve/catalog` data package. The scaffold stays free of
+ *             their layer: node:* builtins, relative siblings, and eve's
+ *             vendored integration catalog. The scaffold stays free of
  *             framework runtime, compiler, terminal UI, and provider SDK
  *             dependencies.
  *   rule 29 — Changeset package keys must match workspace package names.
@@ -916,15 +916,14 @@ function checkRule27(posix, lines, violations) {
 
 const SCAFFOLD_PREFIX = "packages/eve/src/setup/scaffold/";
 
-// The curated connection and channel catalogs (and any future surface
-// overlays) read canonical identity from `@eve/catalog`, a
-// dependency-free data package shared across the scaffolder and docs. It
-// carries no runtime, compiler, or provider-SDK weight, so the entire scaffold
-// layer may import it. The terminal UI adapters (which carry @clack/core and
-// picocolors) live outside the scaffold, in `packages/eve/src/setup/cli/`.
-const SCAFFOLD_ALLOWED_PACKAGES = new Set(["@eve/catalog"]);
+// The curated connection and channel catalogs read canonical identity from
+// the private `@eve/catalog` workspace package through eve's vendored copy.
+// This keeps the published package self-contained without allowing the
+// scaffold layer to reach into runtime, compiler, or provider SDK modules.
+// Terminal UI adapters live outside the scaffold in `packages/eve/src/setup/cli/`.
+const SCAFFOLD_ALLOWED_PACKAGES = new Set([]);
 
-const SCAFFOLD_ALLOWED_INTERNAL_IMPORTS = new Set([]);
+const SCAFFOLD_ALLOWED_INTERNAL_IMPORTS = new Set(["#compiled/@eve/catalog/index.js"]);
 
 // Only match top-of-line `import` statements, not strings nested inside
 // template literals (e.g. the channel templates embed `from "react"` as
@@ -963,7 +962,7 @@ function checkRule28(posix, lines, violations) {
             rule: 28,
             file: posix,
             line: idx + 1,
-            message: `import from "${spec}" not allowed in the packages/eve/src/setup/scaffold source layer. Scaffold modules allow only node:* builtins, relative files, and @eve/catalog. Keep runtime, compiler, terminal UI, and provider SDK dependencies in their owning package.`,
+            message: `import from "${spec}" not allowed in the packages/eve/src/setup/scaffold source layer. Scaffold modules allow only node:* builtins, relative files, and #compiled/@eve/catalog/index.js. Keep runtime, compiler, terminal UI, and provider SDK dependencies in their owning package.`,
           });
         }
       }


### PR DESCRIPTION
### Summary

Published `eve` declarations referenced the unpublished `@eve/catalog` workspace package, so consumers using the setup types could not resolve `ConnectionProtocol`. This vendors the catalog under eve's existing `#compiled/*` boundary and generates then copies declarations from the catalog's real TypeScript source instead of maintaining a handwritten stub. Catalog source/configuration and the TypeScript version now participate in vendor cache invalidation; runtime behavior and the public API remain unchanged.

### Validation

Focused vendor and scaffold coverage passed (13 scenario assertions and 24 unit tests), including the declaration-map ordering that previously failed CI. A freshly packed tarball imported at runtime and passed strict TypeScript consumer compilation without `@eve/catalog` installed; the full unit suite passed 7,765 tests with one skipped.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the required patch changeset describing the corrected published package boundary.

**Implementation** — 7 files · `+70 / -16`

Adds source-derived catalog vendoring and cache inputs, then routes scaffold imports through the established compiled boundary. Generated catalog artifacts remain build output rather than committed files.

**Tests** — 1 file · `+36 / -2`

Extends the compiled-vendor scenario to cover source-derived declarations, cache invalidation, and declaration-map build ordering.
