### PR TITLE
feat: add orcarouter model factory

### DIFF
--- a/.changeset/orcarouter-model.md
+++ b/.changeset/orcarouter-model.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add `eve/models/orcarouter`, a named model factory for the [OrcaRouter](https://www.orcarouter.ai) AI gateway. `orcarouter()` returns an OpenAI-compatible chat model served through `https://api.orcarouter.ai/v1`, defaulting to the `orcarouter/auto` router model and reading `ORCAROUTER_API_KEY` for credentials.

--- a/docs/reference/typescript-api.md
+++ b/docs/reference/typescript-api.md
@@ -124,6 +124,7 @@ import template from "../../prompts/template.txt?raw";
 | `eve/sandbox`                                                               | `defineSandbox`, backends                                                 |
 | `eve/instrumentation`                                                       | `defineInstrumentation`, `isChannel`                                      |
 | `eve/models/openai`                                                         | `chatgpt`, deprecated `experimental_chatgpt`                              |
+| `eve/models/orcarouter`                                                     | `orcarouter`                                                              |
 | `eve/evals`                                                                 | `defineEval`, `defineEvalConfig`, `mockModel`, eval types                 |
 | `eve/evals/expect`                                                          | `includes`, `equals`, `matches`, `similarity`                             |
 | `eve/evals/reporters`                                                       | `Braintrust`, `JUnit`, `EvalReporter`                                     |
@@ -163,6 +164,35 @@ Troubleshooting:
 - **`chatgpt-sub unavailable`**: ensure `codex` is installed, current, and available on `PATH`; then restart the command.
 - **Model rejected by the backend**: model availability depends on the signed-in ChatGPT account. Pick another supported OpenAI model.
 - **SSH/headless login**: run `codex login --device-auth` in another terminal, then return to the still-running `eve dev` session.
+
+## OrcaRouter models
+
+`orcarouter()` from `eve/models/orcarouter` serves a model through the
+[OrcaRouter](https://www.orcarouter.ai) AI gateway, an OpenAI-compatible
+endpoint that routes across many models behind one API key. With no argument,
+it selects the `orcarouter/auto` router model, which picks a live model
+automatically:
+
+```ts title="agent/agent.ts"
+import { defineAgent } from "eve";
+import { orcarouter } from "eve/models/orcarouter";
+
+export default defineAgent({
+  model: orcarouter(),
+});
+```
+
+Pass any gateway model id in OrcaRouter's `vendor/model` namespace to pin a
+specific model:
+
+```ts title="agent/agent.ts"
+export default defineAgent({
+  model: orcarouter({ model: "anthropic/claude-sonnet-5" }),
+});
+```
+
+Credentials come from the `ORCAROUTER_API_KEY` environment variable unless you
+pass `apiKey` explicitly.
 
 ## What to read next
 

--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -186,6 +186,11 @@
       "import": "./dist/src/public/models/openai/index.js",
       "default": "./dist/src/public/models/openai/index.js"
     },
+    "./models/orcarouter": {
+      "types": "./dist/src/public/models/orcarouter/index.d.ts",
+      "import": "./dist/src/public/models/orcarouter/index.js",
+      "default": "./dist/src/public/models/orcarouter/index.js"
+    },
     "./connections": {
       "types": "./dist/src/public/connections/index.d.ts",
       "import": "./dist/src/public/connections/index.js",

--- a/packages/eve/src/public/models/orcarouter/index.test.ts
+++ b/packages/eve/src/public/models/orcarouter/index.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_ORCAROUTER_MODEL_ID, ORCAROUTER_BASE_URL, orcarouter } from "./index.js";
+
+describe("orcarouter", () => {
+  it("defaults to the auto router model", () => {
+    const model = orcarouter({ apiKey: "sk-orca-test" });
+    expect(model.modelId).toBe(DEFAULT_ORCAROUTER_MODEL_ID);
+  });
+
+  it("creates a chat model under the orcarouter provider namespace", () => {
+    const model = orcarouter({ apiKey: "sk-orca-test", model: "anthropic/claude-sonnet-5" });
+    expect(model.modelId).toBe("anthropic/claude-sonnet-5");
+    expect(model.provider).toBe("orcarouter.chat");
+  });
+
+  it("targets the OrcaRouter OpenAI-compatible endpoint", () => {
+    expect(ORCAROUTER_BASE_URL).toBe("https://api.orcarouter.ai/v1");
+  });
+
+  it("rejects an empty model id", () => {
+    expect(() => orcarouter({ apiKey: "sk-orca-test", model: " " })).toThrow(
+      'Expected orcarouter "model" to name a gateway model id.',
+    );
+  });
+});

--- a/packages/eve/src/public/models/orcarouter/index.ts
+++ b/packages/eve/src/public/models/orcarouter/index.ts
@@ -1,0 +1,37 @@
+import { createOpenAI } from "#compiled/@ai-sdk/openai/index.js";
+import type { LanguageModelV4 } from "#compiled/@ai-sdk/provider/index.js";
+
+/** OrcaRouter's OpenAI-compatible API endpoint. */
+export const ORCAROUTER_BASE_URL = "https://api.orcarouter.ai/v1";
+
+/** The router model that picks a live model automatically. */
+export const DEFAULT_ORCAROUTER_MODEL_ID = "orcarouter/auto";
+
+/** Configures the model served through the OrcaRouter gateway. */
+export interface OrcaRouterModelOptions {
+  /** API key, read from `ORCAROUTER_API_KEY` by default. */
+  readonly apiKey?: string;
+  /** Model id in OrcaRouter's `vendor/model` namespace. */
+  readonly model?: string;
+}
+
+/**
+ * Creates a language model served through [OrcaRouter](https://www.orcarouter.ai),
+ * an OpenAI-compatible gateway. Defaults to the `orcarouter/auto` router
+ * model, which selects a live model automatically; pass any gateway model id
+ * (for example `anthropic/claude-sonnet-5`) to pin a specific model.
+ *
+ * The key is read from `ORCAROUTER_API_KEY` unless passed explicitly.
+ */
+export function orcarouter(options: OrcaRouterModelOptions = {}): LanguageModelV4 {
+  const model = options.model ?? DEFAULT_ORCAROUTER_MODEL_ID;
+  if (model.trim().length === 0) {
+    throw new Error('Expected orcarouter "model" to name a gateway model id.');
+  }
+
+  return createOpenAI({
+    baseURL: ORCAROUTER_BASE_URL,
+    apiKey: options.apiKey ?? process.env.ORCAROUTER_API_KEY,
+    name: "orcarouter",
+  }).chat(model);
+}


### PR DESCRIPTION
Add `eve/models/orcarouter`, a named model factory for [OrcaRouter](https://www.orcarouter.ai) that mirrors how `chatgpt()` from `eve/models/openai` serves a provider-backed model in this filesystem-first framework for durable AI agents.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. `orcarouter()` returns an AI SDK `LanguageModel` served through `https://api.orcarouter.ai/v1`, defaulting to the `orcarouter/auto` router model and reading `ORCAROUTER_API_KEY`, so eve users can use that stack directly without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Validation: `pnpm run typecheck`, `pnpm lint`, `pnpm fmt`, and `pnpm docs:check` pass; new unit tests pass (4 tests); live-tested the factory against the real endpoint (`orcarouter/auto` → `ORCA_OK`).

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter — I'm an engineer on the OrcaRouter team.
