### PR TITLE
fix(eve): preserve declared subagent output schema floors

### DIFF
--- a/.changeset/firm-schema-floors.md
+++ b/.changeset/firm-schema-floors.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Make per-call subagent output schemas narrow declared output schemas instead of replacing them, so caller constraints cannot weaken an agent's declared structured-output contract.

--- a/docs/subagents/index.mdx
+++ b/docs/subagents/index.mdx
@@ -149,6 +149,8 @@ The root built-in `agent` tool is the exception. Its children share the root's s
 
 eve lowers every subagent visible to the current agent (the root built-in copy, declared, or [remote](./guides/remote-agents)) into a model-visible tool with the same `{ message, agentId?, outputSchema? }` shape. The parent packs `message` with everything the child needs, since the child never sees the parent's history. Set `outputSchema` to require structured output for that turn; the child remains available for follow-up messages afterward.
 
+On a fresh delegation to an agent that declares its own `outputSchema`, a non-empty per-call schema narrows the declaration instead of replacing it. eve flattens compatible object, array, type, enum, required-field, and bound constraints into one effective schema. Omitting the per-call schema, or passing an empty object, leaves the declaration in force. A per-call schema that conflicts with the declaration or uses composition that cannot be flattened fails the dispatch instead of weakening the declared contract.
+
 Declared subagents can call nested subagents defined under their own directories. eve does not apply a separate depth limit; nesting ends where the authored directory tree ends. The built-in `agent` follows the stricter root-only rule above, so `limits.maxSubagentDepth` no longer exists.
 
 `Workflow` is also root-only. Child sessions can still call their own declared or remote subagents, but they receive neither `Workflow` nor the built-in `agent`. The Workflow tool's `maxSubagents` option caps the number of calls made by one program (default 100); see [Workflow tool](./concepts/built-in-tools#workflow-tool).

--- a/packages/eve/src/execution/dispatch-action-failures.ts
+++ b/packages/eve/src/execution/dispatch-action-failures.ts
@@ -1,4 +1,4 @@
-import { REMOTE_AGENT_START_FAILED } from "#harness/agent-handle-errors.js";
+import { REMOTE_AGENT_START_FAILED, SUBAGENT_START_FAILED } from "#harness/agent-handle-errors.js";
 import type {
   RuntimeRemoteAgentCallActionRequest,
   RuntimeSubagentCallActionRequest,
@@ -43,6 +43,23 @@ export function createRemoteAgentStartFailureResult(input: {
       message: toErrorMessage(input.error),
     },
     subagentName: input.action.remoteAgentName,
+  };
+}
+
+export function createLocalSubagentStartFailureResult(input: {
+  readonly action: RuntimeSubagentCallActionRequest;
+  readonly error: unknown;
+}): RuntimeSubagentDispatchFailure {
+  return {
+    callId: input.action.callId,
+    isError: true,
+    kind: "subagent-result",
+    origin: "dispatch",
+    output: {
+      code: SUBAGENT_START_FAILED,
+      message: toErrorMessage(input.error),
+    },
+    subagentName: input.action.subagentName,
   };
 }
 

--- a/packages/eve/src/execution/dispatch-runtime-actions-step.integration.test.ts
+++ b/packages/eve/src/execution/dispatch-runtime-actions-step.integration.test.ts
@@ -22,6 +22,7 @@ import {
   type AgentHandle,
 } from "#harness/handles/store.js";
 import type { HarnessSession } from "#harness/types.js";
+import type { JsonObject } from "#shared/json.js";
 import { getSessionTaskIndex } from "#tasks/session-index.js";
 import { recordSessionTask } from "#tasks/session-index.js";
 import * as taskRunControl from "#execution/tasks/parent/run-parent.js";
@@ -572,6 +573,40 @@ describe("dispatchRuntimeActionsStep child starts", () => {
     expect(getAgentHandleStore(readResultSessionState(result, session))).toEqual({
       handles: [],
     });
+  });
+
+  it("returns a per-call failure when a local output schema cannot be narrowed", async () => {
+    const session = createStartSession({
+      kind: "local",
+      outputSchema: { allOf: [{ type: "object" }] },
+    });
+    installContext(
+      session,
+      {
+        definition: { description: "Research", kind: "subagent" },
+        nodeId: "subagents/research",
+      },
+      false,
+      null,
+      { properties: { result: { type: "string" } }, type: "object" },
+    );
+
+    const result = await dispatchRuntimeActionsStep({
+      parentContinuationToken: "turn-inbox",
+      parentWritable: createWritable(),
+      serializedContext: {},
+      sessionState: BASE_STATE,
+    });
+
+    expect(result.results[0]).toMatchObject({
+      isError: true,
+      output: {
+        code: "SUBAGENT_START_FAILED",
+        message: expect.stringContaining('cannot flatten the composition keyword "allOf"'),
+      },
+    });
+    expect(mocks.createSession).not.toHaveBeenCalled();
+    expect(getAgentHandleStore(readResultSessionState(result, session))).toBeUndefined();
   });
 
   it("adopts the child a replayed start already created instead of failing it", async () => {
@@ -1208,14 +1243,20 @@ function createStartSession(input: {
     readonly turnId: string;
   };
   readonly kind: "local" | "remote";
+  readonly outputSchema?: JsonObject;
 }): HarnessSession {
+  const actionInput: { message: string; outputSchema?: JsonObject } = {
+    message: "research this",
+  };
+  if (input.outputSchema !== undefined) actionInput.outputSchema = input.outputSchema;
+
   return setPendingRuntimeActionBatch({
     actions: [
       input.kind === "local"
         ? {
             callId: "call-1",
             description: "Research",
-            input: { message: "research this" },
+            input: actionInput,
             kind: "subagent-call",
             name: "research",
             nodeId: "subagents/research",
@@ -1287,6 +1328,7 @@ function installContext(
   remote?: { readonly definition: unknown; readonly nodeId: string },
   tasks = false,
   auth: SessionAuthContext | null = null,
+  localOutputSchema?: JsonObject,
 ): void {
   const subagentsByNodeId = new Map<string, { definition: unknown }>();
   if (remote !== undefined) {
@@ -1298,6 +1340,21 @@ function installContext(
       config: tasks ? { experimental: { tasks: true } } : {},
     },
     subagentRegistry: { subagentsByNodeId },
+    ...(localOutputSchema === undefined
+      ? {}
+      : {
+          graph: {
+            nodesByNodeId: new Map([
+              [
+                "subagents/research",
+                {
+                  sandboxRegistry: { sandbox: { definition: {} } },
+                  turnAgent: { outputSchema: localOutputSchema },
+                },
+              ],
+            ]),
+          },
+        }),
     turnAgent: {
       id: "test-agent",
       instructions: [],

--- a/packages/eve/src/execution/remote-agent-dispatch.test.ts
+++ b/packages/eve/src/execution/remote-agent-dispatch.test.ts
@@ -403,6 +403,90 @@ describe("startRemoteAgentSession", () => {
     expect(body.capabilities).toEqual({});
   });
 
+  it("narrows a remote agent's declared outputSchema with per-call constraints", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          sessionId: "remote-session",
+          status: "accepted",
+        }),
+        { status: 202 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const action = createAction();
+    await startRemoteAgentSession({
+      action: {
+        ...action,
+        input: {
+          ...action.input,
+          outputSchema: {
+            properties: {
+              artifacts: {
+                items: { properties: { id: { enum: ["manifest-a", "manifest-b"] } } },
+                maxItems: 2,
+                minItems: 2,
+              },
+            },
+          },
+        },
+      },
+      callbackBaseUrl: "https://caller.example.com",
+      remote: {
+        ...createRemoteAgent(),
+        outputSchema: {
+          additionalProperties: false,
+          properties: {
+            artifacts: {
+              items: {
+                additionalProperties: false,
+                properties: { id: { type: "string" } },
+                required: ["id"],
+                type: "object",
+              },
+              minItems: 1,
+              type: "array",
+            },
+          },
+          required: ["artifacts"],
+          type: "object",
+        },
+      },
+      session: {
+        agent: { modelReference: { id: "mock/test" }, system: "", tools: [] },
+        compaction: { recentWindowSize: 10, threshold: 100000 },
+        continuationToken: "eve:parent-token",
+        history: [],
+        sessionId: "parent-session",
+        state: {},
+      },
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string);
+    expect(body.outputSchema).toEqual({
+      additionalProperties: false,
+      properties: {
+        artifacts: {
+          items: {
+            additionalProperties: false,
+            properties: {
+              id: { enum: ["manifest-a", "manifest-b"], type: "string" },
+            },
+            required: ["id"],
+            type: "object",
+          },
+          maxItems: 2,
+          minItems: 2,
+          type: "array",
+        },
+      },
+      required: ["artifacts"],
+      type: "object",
+    });
+  });
+
   it("ignores an empty model-passed outputSchema instead of forwarding it", async () => {
     // Models routinely pass `outputSchema: {}` despite the tool schema saying
     // to omit it. An empty schema constrains nothing, but forwarding it flips

--- a/packages/eve/src/execution/remote-agent-dispatch.ts
+++ b/packages/eve/src/execution/remote-agent-dispatch.ts
@@ -21,7 +21,7 @@ import { createRemoteAgentRouteUrl } from "#execution/remote-agent-route-url.js"
 import { formatTraceparent } from "#protocol/traceparent.js";
 import {
   formatSubagentInput,
-  normalizeRequestedOutputSchema,
+  resolveSubagentOutputSchema,
 } from "#execution/subagent-invocation.js";
 import type { HarnessSession } from "#harness/types.js";
 import type { RuntimeRemoteAgentCallActionRequest } from "#shared/action-types.js";
@@ -113,8 +113,10 @@ export async function startRemoteAgentSession(input: {
       remote: input.remote,
     }),
     mode: "conversation",
-    outputSchema:
-      normalizeRequestedOutputSchema(input.action.input.outputSchema) ?? input.remote.outputSchema,
+    outputSchema: resolveSubagentOutputSchema({
+      declared: input.remote.outputSchema,
+      requested: input.action.input.outputSchema,
+    }),
   };
   if (input.activityObserver !== undefined) requestBody.activityObserver = input.activityObserver;
   if (forwardedPrincipal !== undefined) {

--- a/packages/eve/src/execution/subagent-invocation.test.ts
+++ b/packages/eve/src/execution/subagent-invocation.test.ts
@@ -1,6 +1,11 @@
+import { asSchema } from "ai";
 import { describe, expect, it } from "vitest";
 
-import { normalizeRequestedOutputSchema } from "#execution/subagent-invocation.js";
+import {
+  normalizeRequestedOutputSchema,
+  resolveSubagentOutputSchema,
+} from "#execution/subagent-invocation.js";
+import { toInputSchema } from "#tools/schema.js";
 
 describe("normalizeRequestedOutputSchema", () => {
   it("passes a non-empty object schema through", () => {
@@ -21,5 +26,196 @@ describe("normalizeRequestedOutputSchema", () => {
 
   it("normalizes an absent value to undefined", () => {
     expect(normalizeRequestedOutputSchema(undefined)).toBeUndefined();
+  });
+});
+
+describe("resolveSubagentOutputSchema", () => {
+  const declared = {
+    additionalProperties: false,
+    properties: {
+      artifacts: {
+        items: {
+          additionalProperties: false,
+          properties: { id: { type: "string" } },
+          required: ["id"],
+          type: "object",
+        },
+        minItems: 1,
+        type: "array",
+      },
+    },
+    required: ["artifacts"],
+    type: "object",
+  } as const;
+
+  it("preserves declared-only, caller-only, and empty-caller behavior", () => {
+    const requested = { properties: { answer: { type: "string" } }, type: "object" };
+
+    expect(resolveSubagentOutputSchema({ declared, requested: undefined })).toBe(declared);
+    expect(resolveSubagentOutputSchema({ declared, requested: {} })).toBe(declared);
+    expect(resolveSubagentOutputSchema({ declared: undefined, requested })).toBe(requested);
+  });
+
+  it("rejects fabricated ids and the wrong shard size after flattening the intersection", async () => {
+    const effective = resolveSubagentOutputSchema({
+      declared,
+      requested: {
+        properties: {
+          artifacts: {
+            items: { properties: { id: { enum: ["manifest-a", "manifest-b"] } } },
+            maxItems: 2,
+            minItems: 2,
+          },
+        },
+      },
+    });
+    const validate = asSchema(toInputSchema(effective!)).validate;
+
+    await expect(
+      validate?.({ artifacts: [{ id: "manifest-a" }, { id: "fabricated" }] }),
+    ).resolves.toMatchObject({ success: false });
+    await expect(validate?.({ artifacts: [{ id: "manifest-a" }] })).resolves.toMatchObject({
+      success: false,
+    });
+    await expect(
+      validate?.({ artifacts: [{ id: "manifest-a" }, { id: "manifest-b" }] }),
+    ).resolves.toMatchObject({ success: true });
+  });
+
+  it("fails closed when a requested schema cannot be flattened safely", () => {
+    expect(() =>
+      resolveSubagentOutputSchema({
+        declared,
+        requested: { allOf: [{ type: "object" }] },
+      }),
+    ).toThrow('cannot flatten the composition keyword "allOf"');
+    expect(() =>
+      resolveSubagentOutputSchema({
+        declared,
+        requested: { properties: { artifacts: { type: "string" } } },
+      }),
+    ).toThrow("declared and requested types do not overlap");
+    expect(() =>
+      resolveSubagentOutputSchema({
+        declared,
+        requested: {
+          properties: {
+            artifacts: {
+              contains: { allOf: [{ properties: { id: { const: "manifest-a" } } }] },
+            },
+          },
+        },
+      }),
+    ).toThrow(
+      'outputSchema.properties.artifacts.contains: cannot flatten the composition keyword "allOf"',
+    );
+  });
+
+  it("does not broaden a closed object with requested-only properties", async () => {
+    const effective = resolveSubagentOutputSchema({
+      declared: {
+        additionalProperties: false,
+        properties: { retained: { type: "string" } },
+        type: "object",
+      },
+      requested: {
+        properties: {
+          requestedOnly: { type: "number" },
+          retained: { maxLength: 10 },
+        },
+        type: "object",
+      },
+    });
+    expect(effective).toEqual({
+      additionalProperties: false,
+      properties: { retained: { maxLength: 10, type: "string" } },
+      type: "object",
+    });
+    await expect(
+      asSchema(toInputSchema(effective!)).validate?.({ requestedOnly: 3 }),
+    ).resolves.toMatchObject({ success: false });
+
+    expect(() =>
+      resolveSubagentOutputSchema({
+        declared: {
+          additionalProperties: false,
+          properties: { retained: { type: "string" } },
+          type: "object",
+        },
+        requested: {
+          properties: { requestedOnly: { type: "number" } },
+          required: ["requestedOnly"],
+          type: "object",
+        },
+      }),
+    ).toThrow("required properties are forbidden by the other schema: requestedOnly");
+  });
+
+  it("constrains a one-sided property map by the opposite additionalProperties", async () => {
+    const effective = resolveSubagentOutputSchema({
+      declared: { additionalProperties: false, type: "object" },
+      requested: { properties: { requestedOnly: { type: "number" } }, type: "object" },
+    });
+
+    expect(effective).toEqual({
+      additionalProperties: false,
+      properties: {},
+      type: "object",
+    });
+    await expect(
+      asSchema(toInputSchema(effective!)).validate?.({ requestedOnly: 3 }),
+    ).resolves.toMatchObject({ success: false });
+    expect(() =>
+      resolveSubagentOutputSchema({
+        declared: { additionalProperties: false, type: "object" },
+        requested: {
+          properties: { requestedOnly: { type: "number" } },
+          required: ["requestedOnly"],
+          type: "object",
+        },
+      }),
+    ).toThrow("required properties are forbidden by the other schema: requestedOnly");
+  });
+
+  it("rejects malformed one-sided schema keywords before runtime rehydration", () => {
+    expect(() =>
+      resolveSubagentOutputSchema({
+        declared: { type: "object" },
+        requested: { properties: { status: { enum: "oops" } }, type: "object" },
+      }),
+    ).toThrow("outputSchema.properties.status.enum: expected a non-empty array");
+    expect(() =>
+      resolveSubagentOutputSchema({
+        declared: { type: "object" },
+        requested: { properties: { status: { mysteryKeyword: true } }, type: "object" },
+      }),
+    ).toThrow("outputSchema.properties.status.mysteryKeyword: unsupported schema keyword");
+  });
+
+  it("applies an additionalProperties schema to properties explicit only on the other side", () => {
+    expect(
+      resolveSubagentOutputSchema({
+        declared: {
+          additionalProperties: { type: "string" },
+          properties: {},
+          type: "object",
+        },
+        requested: {
+          properties: { requestedOnly: { maxLength: 10 } },
+          type: "object",
+        },
+      }),
+    ).toEqual({
+      additionalProperties: { type: "string" },
+      properties: { requestedOnly: { maxLength: 10, type: "string" } },
+      type: "object",
+    });
+
+    expect(() =>
+      resolveSubagentOutputSchema({
+        declared: { patternProperties: { "^x": { type: "string" } }, type: "object" },
+        requested: { properties: { x: { maxLength: 10 } }, type: "object" },
+      }),
+    ).toThrow('cannot flatten the property-evaluation keyword "patternProperties"');
   });
 });

--- a/packages/eve/src/execution/subagent-invocation.ts
+++ b/packages/eve/src/execution/subagent-invocation.ts
@@ -1,5 +1,11 @@
 import type { StepInput } from "#harness/types.js";
-import { isJsonObjectValue, type JsonObject, type JsonValue } from "#shared/json.js";
+import {
+  isJsonObjectValue,
+  jsonValuesEqual,
+  type JsonArray,
+  type JsonObject,
+  type JsonValue,
+} from "#shared/json.js";
 
 /**
  * Narrowed form of {@link StepInput} whose `message` is always a plain string.
@@ -23,6 +29,501 @@ export function normalizeRequestedOutputSchema(
   return isJsonObjectValue(outputSchema) && Object.keys(outputSchema).length > 0
     ? outputSchema
     : undefined;
+}
+
+const SCHEMA_COMPOSITION_KEYS = new Set(["$ref", "allOf", "anyOf", "if", "not", "oneOf"]);
+const SCHEMA_PROPERTY_EVALUATION_KEYS = new Set(["patternProperties", "unevaluatedProperties"]);
+const SCHEMA_ANNOTATION_KEYS = new Set([
+  "$comment",
+  "$id",
+  "$schema",
+  "default",
+  "deprecated",
+  "description",
+  "examples",
+  "readOnly",
+  "title",
+  "writeOnly",
+]);
+const LOWER_BOUND_KEYS = new Set([
+  "exclusiveMinimum",
+  "minContains",
+  "minItems",
+  "minLength",
+  "minProperties",
+  "minimum",
+]);
+const UPPER_BOUND_KEYS = new Set([
+  "exclusiveMaximum",
+  "maxContains",
+  "maxItems",
+  "maxLength",
+  "maxProperties",
+  "maximum",
+]);
+const NON_NEGATIVE_INTEGER_KEYS = new Set([
+  "maxContains",
+  "maxItems",
+  "maxLength",
+  "maxProperties",
+  "minContains",
+  "minItems",
+  "minLength",
+  "minProperties",
+]);
+const SCHEMA_NODE_KEYS = new Set([
+  "additionalItems",
+  "additionalProperties",
+  "contains",
+  "propertyNames",
+]);
+const STRING_SCHEMA_KEYS = new Set([
+  "$comment",
+  "$id",
+  "$schema",
+  "contentEncoding",
+  "contentMediaType",
+  "description",
+  "format",
+  "pattern",
+  "title",
+]);
+const BOOLEAN_SCHEMA_KEYS = new Set(["deprecated", "readOnly", "uniqueItems", "writeOnly"]);
+const SUPPORTED_SCHEMA_TYPES = new Set([
+  "array",
+  "boolean",
+  "integer",
+  "null",
+  "number",
+  "object",
+  "string",
+]);
+
+/**
+ * Resolves the schema for a fresh subagent turn. A per-call schema refines an
+ * agent declaration; it cannot replace or weaken that declaration.
+ */
+export function resolveSubagentOutputSchema(input: {
+  readonly declared: JsonObject | undefined;
+  readonly requested: JsonValue | undefined;
+}): JsonObject | undefined {
+  const requested = normalizeRequestedOutputSchema(input.requested);
+  if (input.declared === undefined) return requested;
+  if (requested === undefined) return input.declared;
+  return intersectJsonSchemaObjects(input.declared, requested, "outputSchema");
+}
+
+function intersectJsonSchemaObjects(
+  declared: JsonObject,
+  requested: JsonObject,
+  path: string,
+): JsonObject {
+  for (const key of SCHEMA_COMPOSITION_KEYS) {
+    if (Object.hasOwn(declared, key) || Object.hasOwn(requested, key)) {
+      throw schemaIntersectionError(path, `cannot flatten the composition keyword "${key}"`);
+    }
+  }
+  for (const key of SCHEMA_PROPERTY_EVALUATION_KEYS) {
+    if (Object.hasOwn(declared, key) || Object.hasOwn(requested, key)) {
+      throw schemaIntersectionError(
+        path,
+        `cannot flatten the property-evaluation keyword "${key}"`,
+      );
+    }
+  }
+  validateFlattenableSchemaObject(declared, path);
+  validateFlattenableSchemaObject(requested, path);
+
+  const result: Record<string, JsonValue> = {};
+  const keys = new Set([...Object.keys(declared), ...Object.keys(requested)]);
+
+  for (const key of keys) {
+    const declaredHas = Object.hasOwn(declared, key);
+    const requestedHas = Object.hasOwn(requested, key);
+    const declaredValue = declared[key];
+    const requestedValue = requested[key];
+
+    if (key === "properties") {
+      result[key] = intersectProperties({
+        declared: declaredHas ? declaredValue : {},
+        declaredAdditionalProperties: declared.additionalProperties,
+        path: `${path}.${key}`,
+        requested: requestedHas ? requestedValue : {},
+        requestedAdditionalProperties: requested.additionalProperties,
+      });
+      continue;
+    }
+
+    if (key === "required") {
+      result[key] = unionStringArrays(
+        declaredHas ? declaredValue : [],
+        requestedHas ? requestedValue : [],
+        `${path}.${key}`,
+      );
+      continue;
+    }
+
+    if (!declaredHas) {
+      result[key] = requestedValue!;
+      continue;
+    }
+    if (!requestedHas) {
+      result[key] = declaredValue!;
+      continue;
+    }
+
+    if (SCHEMA_ANNOTATION_KEYS.has(key)) {
+      result[key] = declaredValue!;
+      continue;
+    }
+
+    if (LOWER_BOUND_KEYS.has(key)) {
+      result[key] = Math.max(
+        readNumericKeyword(declaredValue, path, key),
+        readNumericKeyword(requestedValue, path, key),
+      );
+      continue;
+    }
+
+    if (UPPER_BOUND_KEYS.has(key)) {
+      result[key] = Math.min(
+        readNumericKeyword(declaredValue, path, key),
+        readNumericKeyword(requestedValue, path, key),
+      );
+      continue;
+    }
+
+    switch (key) {
+      case "additionalProperties":
+        result[key] = intersectSchemaNodes(declaredValue, requestedValue, `${path}.${key}`);
+        break;
+      case "const":
+        if (!jsonValuesEqual(declaredValue, requestedValue)) {
+          throw schemaIntersectionError(`${path}.${key}`, "declared and requested values conflict");
+        }
+        result[key] = declaredValue!;
+        break;
+      case "enum":
+        result[key] = intersectEnumValues(declaredValue, requestedValue, `${path}.${key}`);
+        break;
+      case "items":
+        result[key] = intersectItems(declaredValue, requestedValue, `${path}.${key}`);
+        break;
+      case "type":
+        result[key] = intersectTypes(declaredValue, requestedValue, `${path}.${key}`);
+        break;
+      case "uniqueItems":
+        result[key] =
+          readBooleanKeyword(declaredValue, path, key) ||
+          readBooleanKeyword(requestedValue, path, key);
+        break;
+      default:
+        if (!jsonValuesEqual(declaredValue, requestedValue)) {
+          throw schemaIntersectionError(
+            `${path}.${key}`,
+            "cannot flatten differing values for this keyword",
+          );
+        }
+        result[key] = declaredValue!;
+    }
+  }
+
+  assertCompatibleBounds(result, path, "minItems", "maxItems");
+  assertCompatibleBounds(result, path, "minLength", "maxLength");
+  assertCompatibleBounds(result, path, "minProperties", "maxProperties");
+  assertCompatibleBounds(result, path, "minimum", "maximum");
+  assertCompatibleBounds(result, path, "exclusiveMinimum", "exclusiveMaximum");
+  assertCompatibleBounds(result, path, "minContains", "maxContains");
+  assertClosedObjectRequirements(result, path);
+  return result;
+}
+
+function validateFlattenableSchemaObject(schema: JsonObject, path: string): void {
+  for (const [key, value] of Object.entries(schema)) {
+    if (SCHEMA_COMPOSITION_KEYS.has(key)) {
+      throw schemaIntersectionError(path, `cannot flatten the composition keyword "${key}"`);
+    }
+    if (SCHEMA_PROPERTY_EVALUATION_KEYS.has(key)) {
+      throw schemaIntersectionError(
+        path,
+        `cannot flatten the property-evaluation keyword "${key}"`,
+      );
+    }
+
+    if (STRING_SCHEMA_KEYS.has(key)) {
+      if (typeof value !== "string") {
+        throw schemaIntersectionError(`${path}.${key}`, "expected a string");
+      }
+      continue;
+    }
+
+    if (BOOLEAN_SCHEMA_KEYS.has(key)) {
+      if (typeof value !== "boolean") {
+        throw schemaIntersectionError(`${path}.${key}`, "expected a boolean");
+      }
+      continue;
+    }
+
+    if (NON_NEGATIVE_INTEGER_KEYS.has(key)) {
+      if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+        throw schemaIntersectionError(`${path}.${key}`, "expected a non-negative integer");
+      }
+      continue;
+    }
+
+    if (LOWER_BOUND_KEYS.has(key) || UPPER_BOUND_KEYS.has(key)) {
+      if (typeof value !== "number") {
+        throw schemaIntersectionError(`${path}.${key}`, "expected a number");
+      }
+      continue;
+    }
+
+    if (SCHEMA_NODE_KEYS.has(key)) {
+      validateSchemaNode(value, `${path}.${key}`);
+      continue;
+    }
+
+    switch (key) {
+      case "const":
+      case "default":
+        break;
+      case "enum":
+        if (!Array.isArray(value) || value.length === 0) {
+          throw schemaIntersectionError(`${path}.${key}`, "expected a non-empty array");
+        }
+        break;
+      case "examples":
+        if (!Array.isArray(value)) {
+          throw schemaIntersectionError(`${path}.${key}`, "expected an array");
+        }
+        break;
+      case "items":
+        if (Array.isArray(value)) {
+          value.forEach((item, index) => validateSchemaNode(item, `${path}.${key}[${index}]`));
+        } else {
+          validateSchemaNode(value, `${path}.${key}`);
+        }
+        break;
+      case "multipleOf":
+        if (typeof value !== "number" || value <= 0) {
+          throw schemaIntersectionError(`${path}.${key}`, "expected a positive number");
+        }
+        break;
+      case "properties":
+        if (!isJsonObjectValue(value)) {
+          throw schemaIntersectionError(`${path}.${key}`, "expected a property map");
+        }
+        for (const [name, propertySchema] of Object.entries(value)) {
+          validateSchemaNode(propertySchema, `${path}.${key}.${name}`);
+        }
+        break;
+      case "required":
+        if (!Array.isArray(value) || !value.every((name) => typeof name === "string")) {
+          throw schemaIntersectionError(`${path}.${key}`, "expected a string array");
+        }
+        break;
+      case "type":
+        readTypeNames(value, `${path}.${key}`);
+        break;
+      default:
+        throw schemaIntersectionError(`${path}.${key}`, "unsupported schema keyword");
+    }
+  }
+}
+
+function validateSchemaNode(value: JsonValue, path: string): void {
+  if (typeof value === "boolean") return;
+  if (isJsonObjectValue(value)) {
+    validateFlattenableSchemaObject(value, path);
+    return;
+  }
+  throw schemaIntersectionError(path, "expected a boolean or object schema");
+}
+
+function intersectSchemaNodes(
+  declared: JsonValue | undefined,
+  requested: JsonValue | undefined,
+  path: string,
+): JsonValue {
+  if (declared === false || requested === false) return false;
+  if (declared === true) return requested!;
+  if (requested === true) return declared!;
+  if (isJsonObjectValue(declared) && isJsonObjectValue(requested)) {
+    return intersectJsonSchemaObjects(declared, requested, path);
+  }
+  throw schemaIntersectionError(path, "expected boolean or object schemas");
+}
+
+function intersectItems(
+  declared: JsonValue | undefined,
+  requested: JsonValue | undefined,
+  path: string,
+): JsonValue {
+  if (Array.isArray(declared) || Array.isArray(requested)) {
+    if (jsonValuesEqual(declared, requested)) return declared!;
+    throw schemaIntersectionError(path, "cannot flatten differing tuple schemas");
+  }
+  return intersectSchemaNodes(declared, requested, path);
+}
+
+function intersectProperties(input: {
+  readonly declared: JsonValue | undefined;
+  readonly declaredAdditionalProperties: JsonValue | undefined;
+  readonly path: string;
+  readonly requested: JsonValue | undefined;
+  readonly requestedAdditionalProperties: JsonValue | undefined;
+}): JsonObject {
+  const { declared, path, requested } = input;
+  if (!isJsonObjectValue(declared) || !isJsonObjectValue(requested)) {
+    throw schemaIntersectionError(path, "expected property maps");
+  }
+
+  const properties: Record<string, JsonValue> = {};
+  const names = new Set([...Object.keys(declared), ...Object.keys(requested)]);
+  for (const name of names) {
+    const declaredHas = Object.hasOwn(declared, name);
+    const requestedHas = Object.hasOwn(requested, name);
+    if (declaredHas && requestedHas) {
+      properties[name] = intersectSchemaNodes(declared[name], requested[name], `${path}.${name}`);
+      continue;
+    }
+
+    const constrained = declaredHas
+      ? constrainExplicitProperty({
+          additionalProperties: input.requestedAdditionalProperties,
+          explicit: declared[name]!,
+          path: `${path}.${name}`,
+        })
+      : constrainExplicitProperty({
+          additionalProperties: input.declaredAdditionalProperties,
+          explicit: requested[name]!,
+          path: `${path}.${name}`,
+        });
+    if (constrained !== undefined) properties[name] = constrained;
+  }
+  return properties;
+}
+
+function constrainExplicitProperty(input: {
+  readonly additionalProperties: JsonValue | undefined;
+  readonly explicit: JsonValue;
+  readonly path: string;
+}): JsonValue | undefined {
+  if (input.additionalProperties === false) return undefined;
+  if (input.additionalProperties === undefined || input.additionalProperties === true) {
+    return input.explicit;
+  }
+  if (isJsonObjectValue(input.additionalProperties)) {
+    return intersectSchemaNodes(input.explicit, input.additionalProperties, input.path);
+  }
+  throw schemaIntersectionError(
+    input.path,
+    "expected additionalProperties to be boolean or object",
+  );
+}
+
+function intersectEnumValues(
+  declared: JsonValue | undefined,
+  requested: JsonValue | undefined,
+  path: string,
+): JsonArray {
+  if (!Array.isArray(declared) || !Array.isArray(requested)) {
+    throw schemaIntersectionError(path, "expected arrays");
+  }
+  const intersection = declared.filter((value) =>
+    requested.some((candidate) => jsonValuesEqual(value, candidate)),
+  );
+  if (intersection.length === 0) {
+    throw schemaIntersectionError(path, "declared and requested enums do not overlap");
+  }
+  return intersection;
+}
+
+function intersectTypes(
+  declared: JsonValue | undefined,
+  requested: JsonValue | undefined,
+  path: string,
+): JsonValue {
+  const declaredTypes = readTypeNames(declared, path);
+  const requestedTypes = readTypeNames(requested, path);
+  const intersection = declaredTypes.filter((type) => requestedTypes.includes(type));
+  if (intersection.length === 0) {
+    throw schemaIntersectionError(path, "declared and requested types do not overlap");
+  }
+  return intersection.length === 1 ? intersection[0]! : intersection;
+}
+
+function readTypeNames(value: JsonValue | undefined, path: string): readonly string[] {
+  const types = typeof value === "string" ? [value] : Array.isArray(value) ? value : undefined;
+  if (
+    types !== undefined &&
+    types.length > 0 &&
+    types.every((entry) => typeof entry === "string" && SUPPORTED_SCHEMA_TYPES.has(entry)) &&
+    new Set(types).size === types.length
+  ) {
+    return types as readonly string[];
+  }
+  throw schemaIntersectionError(path, "expected a string or string array");
+}
+
+function unionStringArrays(
+  declared: JsonValue | undefined,
+  requested: JsonValue | undefined,
+  path: string,
+): JsonArray {
+  if (
+    !Array.isArray(declared) ||
+    !declared.every((value) => typeof value === "string") ||
+    !Array.isArray(requested) ||
+    !requested.every((value) => typeof value === "string")
+  ) {
+    throw schemaIntersectionError(path, "expected string arrays");
+  }
+  return [...new Set([...declared, ...requested])];
+}
+
+function readNumericKeyword(value: JsonValue | undefined, path: string, key: string): number {
+  if (typeof value === "number") return value;
+  throw schemaIntersectionError(`${path}.${key}`, "expected a number");
+}
+
+function readBooleanKeyword(value: JsonValue | undefined, path: string, key: string): boolean {
+  if (typeof value === "boolean") return value;
+  throw schemaIntersectionError(`${path}.${key}`, "expected a boolean");
+}
+
+function assertCompatibleBounds(
+  schema: JsonObject,
+  path: string,
+  lowerKey: string,
+  upperKey: string,
+): void {
+  const lower = schema[lowerKey];
+  const upper = schema[upperKey];
+  if (typeof lower === "number" && typeof upper === "number" && lower > upper) {
+    throw schemaIntersectionError(path, `${lowerKey} exceeds ${upperKey}`);
+  }
+}
+
+function assertClosedObjectRequirements(schema: JsonObject, path: string): void {
+  if (schema.additionalProperties !== false || !Array.isArray(schema.required)) return;
+  const properties = schema.properties;
+  if (!isJsonObjectValue(properties)) {
+    throw schemaIntersectionError(path, "a closed object requires an explicit property map");
+  }
+  const missing = schema.required.filter(
+    (name) => typeof name === "string" && !Object.hasOwn(properties, name),
+  );
+  if (missing.length > 0) {
+    throw schemaIntersectionError(
+      path,
+      `required properties are forbidden by the other schema: ${missing.join(", ")}`,
+    );
+  }
+}
+
+function schemaIntersectionError(path: string, detail: string): TypeError {
+  return new TypeError(`Cannot narrow the declared output schema at ${path}: ${detail}.`);
 }
 
 type RuntimeSubagentInputFormatRequest = {

--- a/packages/eve/src/execution/subagent-start-local.ts
+++ b/packages/eve/src/execution/subagent-start-local.ts
@@ -1,10 +1,10 @@
 import type { DispatchOutcome, RuntimeSession } from "#execution/agent-handle-dispatch.js";
 import { deriveChildActivityObserverConfig } from "#execution/activity-work.js";
+import { createLocalSubagentStartFailureResult } from "#execution/dispatch-action-failures.js";
 import { mintStartOperation } from "#execution/dispatch-start-operation.js";
 import { isRuntimeSessionOwnershipConflictError } from "#execution/runtime-errors.js";
 import { buildSubagentRunInput, type SubagentInputSource } from "#execution/subagent-tool.js";
 import { createWorkflowRuntime } from "#execution/workflow-runtime.js";
-import { SUBAGENT_START_FAILED } from "#harness/agent-handle-errors.js";
 import {
   confirmAgentStarted,
   confirmTaskAgentAddress,
@@ -14,7 +14,6 @@ import {
 import { createLogger, logError } from "#internal/logging.js";
 import type { RuntimeSubagentCallActionRequest } from "#shared/action-types.js";
 import type { CompiledBundle } from "#runtime/sessions/runtime-context-keys.js";
-import { toErrorMessage } from "#shared/errors.js";
 
 const log = createLogger("execution.subagent-start-local");
 
@@ -56,22 +55,37 @@ export async function startLocalSubagent(input: {
     dynamicSubagentAgentConfig: input.dynamicSubagentAgentConfig,
     nodeId: action.nodeId,
   });
-  const { childContinuationToken, runInput } = buildSubagentRunInput({
-    action,
-    auth: input.auth,
-    batchEvent: input.batchEvent,
-    capabilities: input.capabilities,
-    channelMetadata: input.channelMetadata,
-    fanoutSize: input.fanoutSize,
-    initiatorAuth: input.initiatorAuth,
-    graph: input.bundle.graph,
-    parentContinuationToken: input.parentContinuationToken,
-    parentTraceContext: input.parentTraceContext,
-    activityObserver,
-    sandboxSessionId: input.sandboxSessionId,
-    session: input.session,
-    source,
-  });
+  let built: ReturnType<typeof buildSubagentRunInput>;
+  try {
+    built = buildSubagentRunInput({
+      action,
+      auth: input.auth,
+      batchEvent: input.batchEvent,
+      capabilities: input.capabilities,
+      channelMetadata: input.channelMetadata,
+      fanoutSize: input.fanoutSize,
+      initiatorAuth: input.initiatorAuth,
+      graph: input.bundle.graph,
+      parentContinuationToken: input.parentContinuationToken,
+      parentTraceContext: input.parentTraceContext,
+      activityObserver,
+      sandboxSessionId: input.sandboxSessionId,
+      session: input.session,
+      source,
+    });
+  } catch (error) {
+    logError(log, "local subagent start failed", error, {
+      callId: action.callId,
+      nodeId: action.nodeId,
+      subagentName: action.subagentName,
+    });
+    return {
+      kind: "error",
+      result: createLocalSubagentStartFailureResult({ action, error }),
+      session: input.currentSession,
+    };
+  }
+  const { childContinuationToken, runInput } = built;
 
   const targetKind = source.type === "runtime" ? ("agent/self" as const) : ("agent/local" as const);
   const { identity, operation } = mintStartOperation({
@@ -105,17 +119,7 @@ export async function startLocalSubagent(input: {
       });
       return {
         kind: "error",
-        result: {
-          callId: action.callId,
-          isError: true,
-          kind: "subagent-result",
-          origin: "dispatch",
-          output: {
-            code: SUBAGENT_START_FAILED,
-            message: toErrorMessage(error),
-          },
-          subagentName: action.subagentName,
-        },
+        result: createLocalSubagentStartFailureResult({ action, error }),
         session: rejectAgentEffect(preparedSession, {
           disposition: "dead",
           operationId: operation.id,

--- a/packages/eve/src/execution/subagent-tool.test.ts
+++ b/packages/eve/src/execution/subagent-tool.test.ts
@@ -233,9 +233,37 @@ describe("buildSubagentRunInput", () => {
     expect(runInput.mode).toBe("conversation");
   });
 
-  it("lets a per-call outputSchema override the local child's declared schema", () => {
-    const declared = { properties: { declared: { type: "string" } }, type: "object" };
-    const requested = { properties: { requested: { type: "number" } }, type: "object" };
+  it("narrows the local child's declared outputSchema with per-call constraints", () => {
+    const declared = {
+      additionalProperties: false,
+      properties: {
+        artifacts: {
+          items: {
+            additionalProperties: false,
+            properties: {
+              digest: { maxLength: 2000, type: "string" },
+              id: { type: "string" },
+              status: { enum: ["ok", "error"], type: "string" },
+            },
+            required: ["id", "status", "digest"],
+            type: "object",
+          },
+          minItems: 1,
+          type: "array",
+        },
+      },
+      required: ["artifacts"],
+      type: "object",
+    };
+    const requested = {
+      properties: {
+        artifacts: {
+          items: { properties: { id: { enum: ["manifest-a", "manifest-b"] } } },
+          maxItems: 2,
+          minItems: 2,
+        },
+      },
+    };
     const { runInput } = buildSubagentRunInput({
       action: { ...makeAction(), input: { message: "do something", outputSchema: requested } },
       auth: null,
@@ -245,7 +273,50 @@ describe("buildSubagentRunInput", () => {
       source: { description: "Research the request.", outputSchema: declared, type: "local" },
     });
 
-    expect(runInput.input.outputSchema).toEqual(requested);
+    expect(runInput.input.outputSchema).toEqual({
+      additionalProperties: false,
+      properties: {
+        artifacts: {
+          items: {
+            additionalProperties: false,
+            properties: {
+              digest: { maxLength: 2000, type: "string" },
+              id: { enum: ["manifest-a", "manifest-b"], type: "string" },
+              status: { enum: ["ok", "error"], type: "string" },
+            },
+            required: ["id", "status", "digest"],
+            type: "object",
+          },
+          maxItems: 2,
+          minItems: 2,
+          type: "array",
+        },
+      },
+      required: ["artifacts"],
+      type: "object",
+    });
+  });
+
+  it("does not let a loose per-call outputSchema weaken the local child's declaration", () => {
+    const declared = {
+      additionalProperties: false,
+      properties: { result: { type: "string" } },
+      required: ["result"],
+      type: "object",
+    };
+    const { runInput } = buildSubagentRunInput({
+      action: {
+        ...makeAction(),
+        input: { message: "do something", outputSchema: { type: "object" } },
+      },
+      auth: null,
+      batchEvent: { sequence: 0, turnId: "turn-0" },
+      initiatorAuth: null,
+      session: makeSession(),
+      source: { description: "Research the request.", outputSchema: declared, type: "local" },
+    });
+
+    expect(runInput.input.outputSchema).toEqual(declared);
   });
 
   it("hands the parent's trace window down to the child, and omits it when absent", () => {

--- a/packages/eve/src/execution/subagent-tool.ts
+++ b/packages/eve/src/execution/subagent-tool.ts
@@ -1,7 +1,7 @@
 import { SUBAGENT_ADAPTER_KIND } from "#execution/subagent-adapter-state.js";
 import {
   formatSubagentInput,
-  normalizeRequestedOutputSchema,
+  resolveSubagentOutputSchema,
 } from "#execution/subagent-invocation.js";
 import type {
   ActivityObserverConfig,
@@ -130,7 +130,10 @@ export function buildSubagentRunInput(input: {
   const inheritedLimits: {
     -readonly [K in keyof RunSessionLimits]: RunSessionLimits[K];
   } = resolveRemainingSessionTokenLimits(session, input.fanoutSize);
-  const requestedOutputSchema = normalizeRequestedOutputSchema(action.input.outputSchema);
+  const outputSchema = resolveSubagentOutputSchema({
+    declared: source.outputSchema,
+    requested: action.input.outputSchema,
+  });
   const adapterState: Record<string, unknown> = {
     callId: action.callId,
     parentContinuationToken: input.parentContinuationToken ?? session.continuationToken,
@@ -164,7 +167,7 @@ export function buildSubagentRunInput(input: {
         action,
         source,
       }),
-      outputSchema: requestedOutputSchema ?? source.outputSchema,
+      outputSchema,
     },
     limits: inheritedLimits,
     mode: "conversation",


### PR DESCRIPTION
### Summary

Related to #2747. A per-call subagent output schema currently replaces the agent's declared schema, so a loose or malformed caller can silently remove the declared validation floor. Fresh local and remote subagent dispatches now fail closed on unsupported schema constructs and structurally intersect supported caller constraints with the declared schema; direct runs keep their existing override semantics. An incompatible local caller returns a per-call `SUBAGENT_START_FAILED` without creating a child or ownership record.

### Validation

Regression coverage first reproduced local and remote caller replacement, including extraction-shaped malformed schemas, then proved a weak caller cannot broaden a closed object or bypass nested validation. The focused schema suite passes 65 tests, the full unit suite passes 7,404 tests with one existing skip, and the full integration suite passes 679 tests, including the no-child/no-handle failure path.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+7 / -0`

Documents the narrowing rule and carries the patch release metadata.

**Implementation** — 5 files · `+564 / -37`

The recursive intersection is deliberately explicit and fail-closed: every supported keyword is validated and flattened for provider portability, while unsupported composition or property-evaluation constructs are rejected instead of falling through to permissive conversion. The local start adjustment keeps those expected rejections inside the existing per-call failure boundary.

**Tests** — 4 files · `+414 / -6`

Covers local and remote dispatch, incompatible constraints, closed-object behavior, nested bypass attempts, malformed schemas, the no-caller fallback, and failure before child ownership.
