### PR TITLE
fix(eve): require canonical instrumentation agent ids

### DIFF
--- a/.changeset/require-instrumentation-agent-id.md
+++ b/.changeset/require-instrumentation-agent-id.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Instrumentation trace policies now consistently receive the active agent's canonical ID, including for configless agents and cancelled turns.
+Instrumentation trace policies now always receive the active agent's canonical ID, including for configless agents and cancelled turns. Explicit provider policies must be bound to an agent before events are published.

--- a/.changeset/require-instrumentation-agent-id.md
+++ b/.changeset/require-instrumentation-agent-id.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Instrumentation trace policies now consistently receive the active agent's canonical ID, including for configless agents and cancelled turns.

--- a/packages/eve/src/execution/node-step.test.ts
+++ b/packages/eve/src/execution/node-step.test.ts
@@ -401,6 +401,7 @@ describe("createExecutionNodeStep", () => {
       shutdown: async () => undefined,
     };
     const instrumentation = bindInstrumentationRuntime(runtime, new ContextContainer(), {
+      agentName: "test-agent",
       rootSessionId: "sess-root",
       sessionId: "sess-root",
     });

--- a/packages/eve/src/execution/settle-cancelled-turn-step.integration.test.ts
+++ b/packages/eve/src/execution/settle-cancelled-turn-step.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { createTestRuntime } from "#internal/testing/app-harness.js";
 import { createBundledRuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
@@ -13,6 +13,18 @@ import {
   type AgentHandle,
 } from "#harness/handles/store.js";
 import type { HarnessSession } from "#harness/types.js";
+
+const bindSessionInstrumentationSpy = vi.hoisted(() => vi.fn());
+vi.mock("#instrumentation/runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("#instrumentation/runtime.js")>();
+  return {
+    ...actual,
+    bindSessionInstrumentation(input: Parameters<typeof actual.bindSessionInstrumentation>[0]) {
+      bindSessionInstrumentationSpy(input);
+      return actual.bindSessionInstrumentation(input);
+    },
+  };
+});
 
 /**
  * The cancellation epilogue is the last write that can move a cancelled
@@ -100,6 +112,7 @@ function buildSerializedContext(): Record<string, unknown> {
 
 describe("settleCancelledTurnStep handle store", () => {
   it("parks abandoned running handles as cancelled and keeps parked ones", async () => {
+    bindSessionInstrumentationSpy.mockClear();
     const runtime = await createTestRuntime({ agent: { name: "settle-cancel-handles" } });
 
     await runtime.run(async () => {
@@ -123,6 +136,9 @@ describe("settleCancelledTurnStep handle store", () => {
         ],
       });
       expect(result.sessionState.snapshot?.session.outputSchema).toBeUndefined();
+      expect(bindSessionInstrumentationSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ agentName: "settle-cancel-handles" }),
+      );
     });
   });
 });

--- a/packages/eve/src/execution/settle-cancelled-turn-step.ts
+++ b/packages/eve/src/execution/settle-cancelled-turn-step.ts
@@ -73,7 +73,7 @@ export async function settleCancelledTurnStep(input: {
     turnAgent: effectiveAgent.turnAgent,
   });
   const instrumentation = bindSessionInstrumentation({
-    agentName: bundle.graph.root.agent?.config?.name,
+    agentName: effectiveAgent.turnAgent.id,
     ctx,
     rootSessionId: session.rootSessionId ?? session.sessionId,
     sessionId: session.sessionId,

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -66,6 +66,18 @@ import {
   workflowEntryReference,
 } from "#execution/workflow-runtime.js";
 
+const bindSessionInstrumentationSpy = vi.hoisted(() => vi.fn());
+vi.mock("#instrumentation/runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("#instrumentation/runtime.js")>();
+  return {
+    ...actual,
+    bindSessionInstrumentation(input: Parameters<typeof actual.bindSessionInstrumentation>[0]) {
+      bindSessionInstrumentationSpy(input);
+      return actual.bindSessionInstrumentation(input);
+    },
+  };
+});
+
 vi.mock("./durable-session-store.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./durable-session-store.js")>();
   return {
@@ -1878,6 +1890,7 @@ describe("turnStep", () => {
   });
 
   it("uses the selected dynamic subagent model for execution identity", async () => {
+    bindSessionInstrumentationSpy.mockClear();
     const session = createStubSession();
     installSessionStoreMocks([session]);
     vi.mocked(createExecutionNodeStep).mockImplementation(() => {
@@ -1937,6 +1950,9 @@ describe("turnStep", () => {
     expect(buildRuntimeIdentity).toHaveBeenCalledWith(effectiveNode);
     expect(createExecutionNodeStep).toHaveBeenCalledWith(
       expect.objectContaining({ node: effectiveNode }),
+    );
+    expect(bindSessionInstrumentationSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ agentName: TestTurnAgent.id }),
     );
   });
 

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -198,7 +198,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
   });
   const history = createExecutionHistoryView(initialSession);
   const instrumentation = bindSessionInstrumentation({
-    agentName: bundle.graph.root.agent?.config?.name,
+    agentName: effectiveAgent.turnAgent.id,
     ctx,
     rootSessionId: initialSession.rootSessionId ?? initialSession.sessionId,
     sessionId: initialSession.sessionId,

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -185,6 +185,7 @@ function declareTelemetry(
     declaredRuntime,
     createInstrumentationContext(decision, audience),
     {
+      agentName: "test-agent",
       rootSessionId: "test-session",
       sessionId: "test-session",
     },
@@ -214,7 +215,7 @@ function bindHookInstrumentation(
       useDeclaredRuntime ? declaredDecision : undefined,
       useDeclaredRuntime ? declaredAudience : "unknown",
     ),
-    { rootSessionId: "test-session", sessionId: "test-session" },
+    { agentName: "test-agent", rootSessionId: "test-session", sessionId: "test-session" },
   )!.prepareExecution();
 }
 

--- a/packages/eve/src/instrumentation/ai-sdk-hook-bridge.test.ts
+++ b/packages/eve/src/instrumentation/ai-sdk-hook-bridge.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createAiSdkHookBridge } from "#instrumentation/ai-sdk-hook-bridge.js";
 import {
   attemptIdempotencyKey,
-  createInstrumentationHooks,
+  createInstrumentationHooks as createUnboundInstrumentationHooks,
   modelCallIdempotencyKey,
   type InstrumentationAttemptScope,
   type InstrumentationModelCallStartedEvent,
@@ -23,10 +23,19 @@ const scope: InstrumentationAttemptScope = {
   turnId: "turn-1",
 };
 
+function createInstrumentationHooks(
+  ...args: Parameters<typeof createUnboundInstrumentationHooks>
+): ReturnType<typeof createUnboundInstrumentationHooks> {
+  return createUnboundInstrumentationHooks(...args).forTrace!({
+    agentName: "test-agent",
+    audience: "unknown",
+  });
+}
+
 describe("createAiSdkHookBridge", () => {
-  it("withholds content when a bridge is not bound to a trace", async () => {
+  it("does not publish when a bridge is not bound to a trace", async () => {
     const started = vi.fn();
-    const hooks = createInstrumentationHooks([
+    const hooks = createUnboundInstrumentationHooks([
       { events: { "model.call.started": started }, name: "default-policy" },
     ]);
     const bridge = createAiSdkHookBridge({ ...scope, channelAudience: "public" }, hooks);
@@ -41,7 +50,7 @@ describe("createAiSdkHookBridge", () => {
       },
     ]);
 
-    expect(started.mock.calls[0]?.[0].input).toBeUndefined();
+    expect(started).not.toHaveBeenCalled();
   });
 
   it("publishes normalized model lifecycle to every provider", async () => {

--- a/packages/eve/src/instrumentation/channel-delivery.test.ts
+++ b/packages/eve/src/instrumentation/channel-delivery.test.ts
@@ -14,7 +14,7 @@ import {
 function bindHooks(
   hooks: InstrumentationRuntime["hooks"],
   ctx: ContextContainer,
-  agentName?: string,
+  agentName = "test-agent",
 ) {
   return bindInstrumentationRuntime(
     {

--- a/packages/eve/src/instrumentation/channel-delivery.ts
+++ b/packages/eve/src/instrumentation/channel-delivery.ts
@@ -20,7 +20,7 @@ export interface ChannelDeliveryStartInstrumentation {
   readonly ctx: AlsContext;
   readonly delivery: DeliverHookPayload;
   readonly hooks: InstrumentationHooks | undefined;
-  readonly policyAgentName?: string;
+  readonly policyAgentName: string;
   readonly rootSessionId: string;
   readonly sequence: number;
   readonly sessionId: string;
@@ -45,9 +45,11 @@ export async function instrumentChannelDelivery(
     const type =
       `channel.delivery.${input.outcome}` as InstrumentationChannelDeliveryTerminalEvent["type"];
     for (const item of active) {
+      const policyAgentName = item.policyAgentName ?? item.agentName;
+      if (policyAgentName === undefined) continue;
       const hooks =
         input.hooks.forTrace?.({
-          agentName: item.policyAgentName,
+          agentName: policyAgentName,
           audience: normalizeChannelAudience(item.delivery.channelAudience),
           channelType: item.channelType,
         }) ?? input.hooks;

--- a/packages/eve/src/instrumentation/dispatch.ts
+++ b/packages/eve/src/instrumentation/dispatch.ts
@@ -41,10 +41,7 @@ export function createInstrumentationDispatcher(
   const handlerTimeoutMs = options.handlerTimeoutMs ?? DEFAULT_HANDLER_TIMEOUT_MS;
   const groups = normalizeDispatchGroups(input);
   const providers = [...groups.serialBefore, ...groups.parallel, ...groups.serialAfter];
-  const requiresTraceBinding = providers.some(
-    (provider) =>
-      provider.tracePolicy !== undefined && provider.tracePolicyRequiresBinding !== false,
-  );
+  const requiresTraceBinding = providers.some((provider) => provider.tracePolicy !== undefined);
   const warnedPolicyFailures = new Set<InstrumentationProviderDefinition>();
 
   const forTrace = (trace: TraceCaptureContext): InstrumentationHooks => {

--- a/packages/eve/src/instrumentation/dispatch.ts
+++ b/packages/eve/src/instrumentation/dispatch.ts
@@ -41,6 +41,10 @@ export function createInstrumentationDispatcher(
   const handlerTimeoutMs = options.handlerTimeoutMs ?? DEFAULT_HANDLER_TIMEOUT_MS;
   const groups = normalizeDispatchGroups(input);
   const providers = [...groups.serialBefore, ...groups.parallel, ...groups.serialAfter];
+  const requiresTraceBinding = providers.some(
+    (provider) =>
+      provider.tracePolicy !== undefined && provider.tracePolicyRequiresBinding !== false,
+  );
   const warnedPolicyFailures = new Set<InstrumentationProviderDefinition>();
 
   const forTrace = (trace: TraceCaptureContext): InstrumentationHooks => {
@@ -175,7 +179,12 @@ export function createInstrumentationDispatcher(
           eventType: event.type,
         });
       }
-      unboundHooks ??= forTrace({ audience: "unknown" });
+      if (requiresTraceBinding) {
+        throw new Error(
+          "Instrumentation hooks with tracePolicy must be bound with forTrace before publishing.",
+        );
+      }
+      unboundHooks ??= forTrace({ agentName: "unknown", audience: "unknown" });
       await unboundHooks.publish(event);
     },
   };

--- a/packages/eve/src/instrumentation/dispatch.ts
+++ b/packages/eve/src/instrumentation/dispatch.ts
@@ -41,26 +41,31 @@ export function createInstrumentationDispatcher(
   const handlerTimeoutMs = options.handlerTimeoutMs ?? DEFAULT_HANDLER_TIMEOUT_MS;
   const groups = normalizeDispatchGroups(input);
   const providers = [...groups.serialBefore, ...groups.parallel, ...groups.serialAfter];
-  const requiresTraceBinding = providers.some((provider) => provider.tracePolicy !== undefined);
   const warnedPolicyFailures = new Set<InstrumentationProviderDefinition>();
 
-  const forTrace = (trace: TraceCaptureContext): InstrumentationHooks => {
+  function forTrace(trace: TraceCaptureContext): InstrumentationHooks {
+    return bind(trace);
+  }
+
+  function bind(trace: TraceCaptureContext | undefined): InstrumentationHooks {
     const snapshots = new WeakMap<object, unknown>();
     const decisions = new Map(
       providers.map((provider) => [
         provider,
-        resolveTracePolicy(
-          provider.tracePolicy ?? legacyCaptureTracePolicy(provider.capture),
-          trace,
-          (error) => {
-            if (warnedPolicyFailures.has(provider)) return;
-            warnedPolicyFailures.add(provider);
-            log.warn("instrumentation provider trace policy failed", {
-              error: formatError(error),
-              provider: provider.name,
-            });
-          },
-        ),
+        trace === undefined && provider.tracePolicy !== undefined
+          ? ({ action: "drop" } as const)
+          : resolveTracePolicy(
+              provider.tracePolicy ?? legacyCaptureTracePolicy(provider.capture),
+              trace ?? { agentName: "unknown", audience: "unknown" },
+              (error) => {
+                if (warnedPolicyFailures.has(provider)) return;
+                warnedPolicyFailures.add(provider);
+                log.warn("instrumentation provider trace policy failed", {
+                  error: formatError(error),
+                  provider: provider.name,
+                });
+              },
+            ),
       ]),
     );
     const capturesInputs = [...decisions.values()].some(
@@ -160,7 +165,7 @@ export function createInstrumentationDispatcher(
     };
 
     return { capturesContent, capturesInputs, capturesOutputs, forTrace, publish };
-  };
+  }
 
   let unboundHooks: InstrumentationHooks | undefined;
   let loggedUnboundPublish = false;
@@ -176,12 +181,7 @@ export function createInstrumentationDispatcher(
           eventType: event.type,
         });
       }
-      if (requiresTraceBinding) {
-        throw new Error(
-          "Instrumentation hooks with tracePolicy must be bound with forTrace before publishing.",
-        );
-      }
-      unboundHooks ??= forTrace({ agentName: "unknown", audience: "unknown" });
+      unboundHooks ??= bind(undefined);
       await unboundHooks.publish(event);
     },
   };

--- a/packages/eve/src/instrumentation/dispatch.ts
+++ b/packages/eve/src/instrumentation/dispatch.ts
@@ -44,28 +44,22 @@ export function createInstrumentationDispatcher(
   const warnedPolicyFailures = new Set<InstrumentationProviderDefinition>();
 
   function forTrace(trace: TraceCaptureContext): InstrumentationHooks {
-    return bind(trace);
-  }
-
-  function bind(trace: TraceCaptureContext | undefined): InstrumentationHooks {
     const snapshots = new WeakMap<object, unknown>();
     const decisions = new Map(
       providers.map((provider) => [
         provider,
-        trace === undefined && provider.tracePolicy !== undefined
-          ? ({ action: "drop" } as const)
-          : resolveTracePolicy(
-              provider.tracePolicy ?? legacyCaptureTracePolicy(provider.capture),
-              trace ?? { agentName: "unknown", audience: "unknown" },
-              (error) => {
-                if (warnedPolicyFailures.has(provider)) return;
-                warnedPolicyFailures.add(provider);
-                log.warn("instrumentation provider trace policy failed", {
-                  error: formatError(error),
-                  provider: provider.name,
-                });
-              },
-            ),
+        resolveTracePolicy(
+          provider.tracePolicy ?? legacyCaptureTracePolicy(provider.capture),
+          trace,
+          (error) => {
+            if (warnedPolicyFailures.has(provider)) return;
+            warnedPolicyFailures.add(provider);
+            log.warn("instrumentation provider trace policy failed", {
+              error: formatError(error),
+              provider: provider.name,
+            });
+          },
+        ),
       ]),
     );
     const capturesInputs = [...decisions.values()].some(
@@ -167,12 +161,9 @@ export function createInstrumentationDispatcher(
     return { capturesContent, capturesInputs, capturesOutputs, forTrace, publish };
   }
 
-  let unboundHooks: InstrumentationHooks | undefined;
   let loggedUnboundPublish = false;
   return {
-    capturesContent: providers.some(
-      (provider) => provider.tracePolicy === undefined && provider.capture === "content",
-    ),
+    capturesContent: false,
     forTrace,
     async publish(event) {
       if (!loggedUnboundPublish) {
@@ -181,8 +172,6 @@ export function createInstrumentationDispatcher(
           eventType: event.type,
         });
       }
-      unboundHooks ??= bind(undefined);
-      await unboundHooks.publish(event);
     },
   };
 }

--- a/packages/eve/src/instrumentation/lifecycle.test.ts
+++ b/packages/eve/src/instrumentation/lifecycle.test.ts
@@ -826,8 +826,12 @@ describe("trace policies", () => {
   it("defaults provider content to the audience-aware policy", () => {
     const hooks = createInstrumentationHooks([{ name: "provider" }]);
 
-    expect(hooks.forTrace?.({ audience: "public" }).capturesContent).toBe(true);
-    expect(hooks.forTrace?.({ audience: "private" }).capturesContent).toBe(false);
+    expect(hooks.forTrace?.({ agentName: "weather", audience: "public" }).capturesContent).toBe(
+      true,
+    );
+    expect(hooks.forTrace?.({ agentName: "weather", audience: "private" }).capturesContent).toBe(
+      false,
+    );
   });
 
   it("passes trace context to each provider policy", () => {
@@ -848,30 +852,21 @@ describe("trace policies", () => {
     expect(tracePolicy).toHaveBeenCalledExactlyOnceWith(trace);
   });
 
-  it("evaluates unbound policies once with an unknown trace", async () => {
+  it("requires provider policies to be bound before publishing", async () => {
     const tracePolicy = vi.fn(() => true);
     const hooks = createInstrumentationHooks([{ name: "provider", tracePolicy }]);
 
-    await hooks.publish({
-      idempotencyKey: turnIdempotencyKey("session-1", "turn-1"),
-      rootSessionId: "session-1",
-      sequence: 0,
-      sessionId: "session-1",
-      turnId: "turn-1",
-      type: "turn.started",
-    });
-    await hooks.publish({
-      idempotencyKey: turnIdempotencyKey("session-1", "turn-1"),
-      sessionId: "session-1",
-      turnId: "turn-1",
-      type: "turn.completed",
-    });
-
-    expect(tracePolicy).toHaveBeenCalledExactlyOnceWith({
-      agentName: undefined,
-      audience: "unknown",
-      channelType: undefined,
-    });
+    await expect(
+      hooks.publish({
+        idempotencyKey: turnIdempotencyKey("session-1", "turn-1"),
+        rootSessionId: "session-1",
+        sequence: 0,
+        sessionId: "session-1",
+        turnId: "turn-1",
+        type: "turn.started",
+      }),
+    ).rejects.toThrow("must be bound with forTrace");
+    expect(tracePolicy).not.toHaveBeenCalled();
   });
 
   it("lets an explicit provider policy authorize private content", async () => {
@@ -882,7 +877,7 @@ describe("trace policies", () => {
         name: "private-audit",
         tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: false }),
       },
-    ]).forTrace!({ audience: "private" });
+    ]).forTrace!({ agentName: "weather", audience: "private" });
 
     await hooks.publish({
       callId: "call-1",
@@ -915,7 +910,7 @@ describe("trace policies", () => {
         name: "outputs",
         tracePolicy: () => ({ emit: true, recordInputs: false, recordOutputs: true }),
       },
-    ]).forTrace!({ audience: "public" });
+    ]).forTrace!({ agentName: "weather", audience: "public" });
 
     await hooks.publish({
       idempotencyKey: "model-1",
@@ -957,7 +952,7 @@ describe("trace policies", () => {
         name: "inputs-only",
         tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: false }),
       },
-    ]).forTrace!({ audience: "public" });
+    ]).forTrace!({ agentName: "weather", audience: "public" });
 
     await hooks.publish({
       error,
@@ -992,8 +987,10 @@ describe("trace policies", () => {
       ]).capturesContent,
     ).toBe(false);
     expect(
-      createInstrumentationHooks([{ name: "quiet" }]).forTrace!({ audience: "private" })
-        .capturesContent,
+      createInstrumentationHooks([{ name: "quiet" }]).forTrace!({
+        agentName: "weather",
+        audience: "private",
+      }).capturesContent,
     ).toBe(false);
     expect(
       createInstrumentationHooks([
@@ -1005,7 +1002,7 @@ describe("trace policies", () => {
           name: "also-quiet",
           tracePolicy: () => ({ emit: true, recordInputs: false, recordOutputs: false }),
         },
-      ]).forTrace!({ audience: "public" }).capturesContent,
+      ]).forTrace!({ agentName: "weather", audience: "public" }).capturesContent,
     ).toBe(false);
     expect(
       createInstrumentationHooks([
@@ -1014,7 +1011,7 @@ describe("trace policies", () => {
           name: "loud",
           tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: true }),
         },
-      ]).forTrace!({ audience: "public" }).capturesContent,
+      ]).forTrace!({ agentName: "weather", audience: "public" }).capturesContent,
     ).toBe(true);
     expect(
       createInstrumentationHooks({
@@ -1024,7 +1021,7 @@ describe("trace policies", () => {
             tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: true }),
           },
         ],
-      }).forTrace!({ audience: "public" }).capturesContent,
+      }).forTrace!({ agentName: "weather", audience: "public" }).capturesContent,
     ).toBe(true);
   });
 
@@ -1036,7 +1033,7 @@ describe("trace policies", () => {
         name: "dropped",
         tracePolicy: () => false,
       },
-    ]).forTrace!({ audience: "public" });
+    ]).forTrace!({ agentName: "weather", audience: "public" });
 
     await hooks.publish({
       idempotencyKey: turnIdempotencyKey("session-1", "turn-1"),
@@ -1067,8 +1064,8 @@ describe("trace policies", () => {
         tracePolicy: () => ({ emit: true, recordInputs: false, recordOutputs: false }),
       },
     ]);
-    const hooks = unboundHooks.forTrace!({ audience: "public" });
-    unboundHooks.forTrace!({ audience: "private" });
+    const hooks = unboundHooks.forTrace!({ agentName: "weather", audience: "public" });
+    unboundHooks.forTrace!({ agentName: "weather", audience: "private" });
 
     await hooks.publish({
       idempotencyKey: turnIdempotencyKey("session-1", "turn-1"),
@@ -1102,7 +1099,7 @@ describe("trace policies", () => {
         events: { "step.attempt.metadata": wantsContent },
         name: "content",
       },
-    ]);
+    ]).forTrace!({ agentName: "weather", audience: "private" });
     const providerMetadata = {
       gateway: {
         cost: "0.01",
@@ -1141,7 +1138,7 @@ describe("trace policies", () => {
         name: "content",
         tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: true }),
       },
-    ]);
+    ]).forTrace!({ agentName: "weather", audience: "private" });
     const error = { output: "private tool output", requestBody: "private request" };
     const actionScope = { ...scope };
 
@@ -1208,7 +1205,7 @@ describe("trace policies", () => {
         },
         name: "content",
       },
-    ]);
+    ]).forTrace!({ agentName: "weather", audience: "private" });
     const idempotencyKey = inputIdempotencyKey(scope.sessionId, scope.turnId, "request-1");
 
     await hooks.publish({
@@ -1260,7 +1257,7 @@ describe("trace policies", () => {
           name: "content",
         },
       ],
-    });
+    }).forTrace!({ agentName: "weather", audience: "private" });
 
     const event = {
       idempotencyKey: toolCallIdempotencyKey(scope, "call-1", 0),

--- a/packages/eve/src/instrumentation/lifecycle.test.ts
+++ b/packages/eve/src/instrumentation/lifecycle.test.ts
@@ -852,21 +852,27 @@ describe("trace policies", () => {
     expect(tracePolicy).toHaveBeenCalledExactlyOnceWith(trace);
   });
 
-  it("requires provider policies to be bound before publishing", async () => {
+  it("drops unbound provider policies without affecting default providers", async () => {
     const tracePolicy = vi.fn(() => true);
-    const hooks = createInstrumentationHooks([{ name: "provider", tracePolicy }]);
+    const policyObserved = vi.fn();
+    const defaultObserved = vi.fn();
+    const hooks = createInstrumentationHooks([
+      { events: { "turn.started": policyObserved }, name: "policy", tracePolicy },
+      { events: { "turn.started": defaultObserved }, name: "default" },
+    ]);
 
-    await expect(
-      hooks.publish({
-        idempotencyKey: turnIdempotencyKey("session-1", "turn-1"),
-        rootSessionId: "session-1",
-        sequence: 0,
-        sessionId: "session-1",
-        turnId: "turn-1",
-        type: "turn.started",
-      }),
-    ).rejects.toThrow("must be bound with forTrace");
+    await hooks.publish({
+      idempotencyKey: turnIdempotencyKey("session-1", "turn-1"),
+      rootSessionId: "session-1",
+      sequence: 0,
+      sessionId: "session-1",
+      turnId: "turn-1",
+      type: "turn.started",
+    });
+
     expect(tracePolicy).not.toHaveBeenCalled();
+    expect(policyObserved).not.toHaveBeenCalled();
+    expect(defaultObserved).toHaveBeenCalledOnce();
   });
 
   it("lets an explicit provider policy authorize private content", async () => {

--- a/packages/eve/src/instrumentation/lifecycle.test.ts
+++ b/packages/eve/src/instrumentation/lifecycle.test.ts
@@ -5,7 +5,7 @@ import { deserializeContext, serializeContext } from "#context/serialize.js";
 import {
   actionIdempotencyKey,
   attemptIdempotencyKey,
-  createInstrumentationHooks,
+  createInstrumentationHooks as createUnboundInstrumentationHooks,
   inputIdempotencyKey,
   modelCallIdempotencyKey,
   sessionIdempotencyKey,
@@ -28,6 +28,15 @@ vi.mock("#internal/logging.js", () => ({
   createLogger: () => ({ debug: logDebug, warn: logWarn }),
   formatError: (error: unknown) => error,
 }));
+
+function createInstrumentationHooks(
+  ...args: Parameters<typeof createUnboundInstrumentationHooks>
+): ReturnType<typeof createUnboundInstrumentationHooks> {
+  return createUnboundInstrumentationHooks(...args).forTrace!({
+    agentName: "test-agent",
+    audience: "unknown",
+  });
+}
 
 const scope: InstrumentationAttemptScope = {
   attemptId: "session-1:turn-1:0:0",
@@ -852,11 +861,11 @@ describe("trace policies", () => {
     expect(tracePolicy).toHaveBeenCalledExactlyOnceWith(trace);
   });
 
-  it("drops unbound provider policies without affecting default providers", async () => {
+  it("does not dispatch providers before trace binding", async () => {
     const tracePolicy = vi.fn(() => true);
     const policyObserved = vi.fn();
     const defaultObserved = vi.fn();
-    const hooks = createInstrumentationHooks([
+    const hooks = createUnboundInstrumentationHooks([
       { events: { "turn.started": policyObserved }, name: "policy", tracePolicy },
       { events: { "turn.started": defaultObserved }, name: "default" },
     ]);
@@ -872,7 +881,7 @@ describe("trace policies", () => {
 
     expect(tracePolicy).not.toHaveBeenCalled();
     expect(policyObserved).not.toHaveBeenCalled();
-    expect(defaultObserved).toHaveBeenCalledOnce();
+    expect(defaultObserved).not.toHaveBeenCalled();
   });
 
   it("lets an explicit provider policy authorize private content", async () => {
@@ -973,7 +982,7 @@ describe("trace policies", () => {
 
   it("reports content capture only when an admitted provider requests it", () => {
     expect(
-      createInstrumentationHooks([
+      createUnboundInstrumentationHooks([
         {
           name: "unbound",
           tracePolicy: () => ({ emit: true, recordInputs: true, recordOutputs: true }),
@@ -981,10 +990,10 @@ describe("trace policies", () => {
       ]).capturesContent,
     ).toBe(false);
     expect(
-      createInstrumentationHooks([{ capture: "content", name: "legacy" }]).capturesContent,
-    ).toBe(true);
+      createUnboundInstrumentationHooks([{ capture: "content", name: "legacy" }]).capturesContent,
+    ).toBe(false);
     expect(
-      createInstrumentationHooks([
+      createUnboundInstrumentationHooks([
         {
           capture: "content",
           name: "explicit-policy",

--- a/packages/eve/src/instrumentation/lifecycle.ts
+++ b/packages/eve/src/instrumentation/lifecycle.ts
@@ -330,6 +330,7 @@ export type InstrumentationSessionTransitionEvent =
 
 export interface InstrumentationTurnStartedEvent {
   readonly type: "turn.started";
+  readonly agentName?: string;
   readonly idempotencyKey: string;
   readonly parentLineage?: InstrumentationParentLineage;
   readonly parentTraceContext?: InstrumentationTraceContext;
@@ -536,6 +537,8 @@ export interface InstrumentationProviderDefinition {
   ) => InstrumentationEvent | PromiseLike<InstrumentationEvent>;
   /** Provider-specific event admission and directional content policy. */
   readonly tracePolicy?: TraceCapturePolicy;
+  /** Whether `tracePolicy` requires a canonical trace context. Defaults to true. */
+  readonly tracePolicyRequiresBinding?: boolean;
   readonly events?: {
     readonly "channel.delivery.started"?: InstrumentationEventHandler<InstrumentationChannelDeliveryStartedEvent>;
     readonly "channel.delivery.cancelled"?: InstrumentationEventHandler<InstrumentationChannelDeliveryTerminalEvent>;

--- a/packages/eve/src/instrumentation/lifecycle.ts
+++ b/packages/eve/src/instrumentation/lifecycle.ts
@@ -537,8 +537,6 @@ export interface InstrumentationProviderDefinition {
   ) => InstrumentationEvent | PromiseLike<InstrumentationEvent>;
   /** Provider-specific event admission and directional content policy. */
   readonly tracePolicy?: TraceCapturePolicy;
-  /** Whether `tracePolicy` requires a canonical trace context. Defaults to true. */
-  readonly tracePolicyRequiresBinding?: boolean;
   readonly events?: {
     readonly "channel.delivery.started"?: InstrumentationEventHandler<InstrumentationChannelDeliveryStartedEvent>;
     readonly "channel.delivery.cancelled"?: InstrumentationEventHandler<InstrumentationChannelDeliveryTerminalEvent>;

--- a/packages/eve/src/instrumentation/native-events.test.ts
+++ b/packages/eve/src/instrumentation/native-events.test.ts
@@ -51,6 +51,7 @@ describe("createInstrumentationHandleEvent", () => {
           channelName: "slack",
           deliveryId: "delivery-1",
         },
+        policyAgentName: "weather",
         rootSessionId: "session-1",
         sequence: 0,
         sessionId: "session-1",

--- a/packages/eve/src/instrumentation/prepare-trace-context.ts
+++ b/packages/eve/src/instrumentation/prepare-trace-context.ts
@@ -63,6 +63,7 @@ export async function prepareTurnTraceContext(
   if (input.instrumentation?.prepareTurnTrace !== undefined) {
     try {
       prepared = await input.instrumentation.prepareTurnTrace({
+        agentName: input.agentName,
         idempotencyKey: turnIdempotencyKey(input.sessionId, input.turnId),
         parentLineage: input.parentLineage,
         parentTraceContext: input.parentTraceContext,

--- a/packages/eve/src/instrumentation/providers-otel-policy.test.ts
+++ b/packages/eve/src/instrumentation/providers-otel-policy.test.ts
@@ -51,9 +51,13 @@ describe("otel and authored provider composition", () => {
         }),
       });
       const runtime = finalizeInstrumentationProviders({ serviceName: "weather-agent" });
+      const hooks = runtime.hooks.forTrace!({
+        agentName: "weather-agent",
+        audience: "private",
+      });
 
       await contextStorage.run(new ContextContainer(), () =>
-        runtime.hooks.publish({
+        hooks.publish({
           idempotencyKey: "model:session-1:turn-1:0:0:0",
           input: {
             instructions: "private instructions",

--- a/packages/eve/src/instrumentation/providers.integration.test.ts
+++ b/packages/eve/src/instrumentation/providers.integration.test.ts
@@ -69,7 +69,8 @@ describe("authored instrumentation provider dispatch", () => {
     expect(order).toEqual(["first:setup", "first:setup-complete", "second:setup"]);
 
     const runtime = finalizeInstrumentationProviders({ serviceName: "weather" });
-    const publication = runtime.hooks.publish({
+    const hooks = runtime.hooks.forTrace!({ agentName: "weather", audience: "unknown" });
+    const publication = hooks.publish({
       idempotencyKey: turnIdempotencyKey("session-1", "turn-1"),
       rootSessionId: "session-1",
       sequence: 0,

--- a/packages/eve/src/instrumentation/providers.test.ts
+++ b/packages/eve/src/instrumentation/providers.test.ts
@@ -225,7 +225,9 @@ describe("finalizeInstrumentationProviders", () => {
 
       const runtime = finalizeInstrumentationProviders({ serviceName: "weather-agent" });
 
-      expect(runtime.hooks.forTrace?.({ audience: "private" }).capturesContent).toBe(expected);
+      expect(
+        runtime.hooks.forTrace?.({ agentName: "weather", audience: "private" }).capturesContent,
+      ).toBe(expected);
     },
   );
 
@@ -240,7 +242,9 @@ describe("finalizeInstrumentationProviders", () => {
 
     const runtime = finalizeInstrumentationProviders({ serviceName: "weather-agent" });
 
-    expect(runtime.hooks.forTrace?.({ audience: "private" }).capturesContent).toBe(true);
+    expect(
+      runtime.hooks.forTrace?.({ agentName: "weather", audience: "private" }).capturesContent,
+    ).toBe(true);
   });
 
   it("still runs execution when no destination was declared", async () => {

--- a/packages/eve/src/instrumentation/providers.test.ts
+++ b/packages/eve/src/instrumentation/providers.test.ts
@@ -208,7 +208,9 @@ describe("finalizeInstrumentationProviders", () => {
     await register("rows", defineInstrumentation({ events: { "turn.started": started } }));
 
     const runtime = finalizeInstrumentationProviders({ serviceName: "weather-agent" });
-    await runtime.hooks.publish(turnStarted);
+    await runtime.hooks.forTrace!({ agentName: "weather-agent", audience: "unknown" }).publish(
+      turnStarted,
+    );
 
     expect(runtime.instrumentationProviders).toBe(true);
     expect(started).toHaveBeenCalledOnce();

--- a/packages/eve/src/instrumentation/runtime.test.ts
+++ b/packages/eve/src/instrumentation/runtime.test.ts
@@ -18,7 +18,11 @@ import {
 import { ContextAgentTraceStateStore } from "#tracing/agent-trace-context-store.js";
 import type { TraceCapturePolicy } from "#tracing/otel-declaration.js";
 
-const boundSession = { rootSessionId: "session-1", sessionId: "session-1" };
+const boundSession = {
+  agentName: "test-agent",
+  rootSessionId: "session-1",
+  sessionId: "session-1",
+};
 
 function createRuntime(
   hooks: InstrumentationHooks,
@@ -278,6 +282,7 @@ describe("bindSessionInstrumentation", () => {
     });
 
     const instrumentation = bindSessionInstrumentation({
+      agentName: "test-agent",
       ctx,
       rootSessionId: "session-1",
       sessionId: "session-1",
@@ -298,6 +303,7 @@ describe("bindSessionInstrumentation", () => {
     );
     const ctx = createContext();
     const instrumentation = bindSessionInstrumentation({
+      agentName: "test-agent",
       ctx,
       rootSessionId: "session-1",
       sessionId: "session-1",
@@ -323,6 +329,7 @@ describe("bindSessionInstrumentation", () => {
     const ctx = createContext();
     ctx.set(OtelTraceEnabledKey, false);
     const instrumentation = bindSessionInstrumentation({
+      agentName: "test-agent",
       ctx,
       rootSessionId: "session-1",
       sessionId: "session-1",

--- a/packages/eve/src/instrumentation/runtime.ts
+++ b/packages/eve/src/instrumentation/runtime.ts
@@ -136,7 +136,7 @@ export interface PreparedInstrumentationAttempt {
 export type InstrumentationAttempt = InstrumentationAttemptScope;
 
 export interface BoundInstrumentationSession {
-  readonly agentName?: string;
+  readonly agentName: string;
   readonly rootSessionId: string;
   readonly sessionId: string;
 }
@@ -470,7 +470,7 @@ export function bindInstrumentationRuntime(
 }
 
 export function bindSessionInstrumentation(input: {
-  readonly agentName?: string;
+  readonly agentName: string;
   readonly ctx: ContextContainer;
   readonly rootSessionId: string;
   readonly sessionId: string;

--- a/packages/eve/src/instrumentation/runtime.ts
+++ b/packages/eve/src/instrumentation/runtime.ts
@@ -483,7 +483,7 @@ export function bindSessionInstrumentation(input: {
 }
 
 export function initializeSessionInstrumentation(input: {
-  readonly agentName?: string;
+  readonly agentName: string;
   readonly ctx: ContextContainer;
   readonly parentTraceContext?: SessionTraceContext;
 }): void {
@@ -502,7 +502,7 @@ export function initializeSessionInstrumentation(input: {
 }
 
 function allocateSessionTraceSeed(input: {
-  readonly agentName?: string;
+  readonly agentName: string;
   readonly audience: ReturnType<typeof normalizeChannelAudience>;
   readonly channelType?: string;
   readonly parentTraceContext?: SessionTraceContext;
@@ -536,7 +536,7 @@ function allocateSessionTraceSeed(input: {
 
 function resolveStepInstrumentationDecision(
   settings: OtelHarnessSettings | undefined,
-  agentName: string | undefined,
+  agentName: string,
   channel: ChannelInstrumentationProjection | undefined,
   traceSeed: SessionTraceSeed | undefined,
   persisted: InstrumentationDecision | undefined,

--- a/packages/eve/src/shared/trace-policy.ts
+++ b/packages/eve/src/shared/trace-policy.ts
@@ -9,7 +9,7 @@ import {
 export type InstrumentationCapture = "content" | "metadata";
 
 export interface TraceCaptureContext {
-  readonly agentName?: string;
+  readonly agentName: string;
   readonly audience: ChannelAudience;
   readonly channelType?: string;
 }

--- a/packages/eve/src/tracing/agent-otel-provider.test.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.test.ts
@@ -549,6 +549,7 @@ describe("createAgentOtelInstrumentation", () => {
 
     await contextStorage.run(ctx, async () => {
       await runtime.hooks.publish({
+        agentName: "weather",
         delivery,
         idempotencyKey,
         rootSessionId: "session-1",

--- a/packages/eve/src/tracing/agent-otel-provider.test.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.test.ts
@@ -89,7 +89,10 @@ function createRuntime(
   };
   if (tracePolicy !== null) agentOtelInput.tracePolicy = tracePolicy;
   const agentOtel = createAgentOtelInstrumentation(agentOtelInput);
-  const hooks = createInstrumentationHooks([agentOtel.hook]);
+  const hooks = createInstrumentationHooks([agentOtel.hook]).forTrace!({
+    agentName: "weather",
+    audience: "public",
+  });
   return {
     exporter,
     hooks,
@@ -1621,7 +1624,10 @@ describe("createAgentOtelInstrumentation", () => {
       stateStore: new InMemoryAgentTraceStateStore(),
       tracer: provider.getTracer("eve.agent"),
     });
-    const hooks = createInstrumentationHooks([agentOtel.hook]);
+    const hooks = createInstrumentationHooks([agentOtel.hook]).forTrace!({
+      agentName: "weather",
+      audience: "public",
+    });
     await emitAttempt({
       hooks,
       runInContext: agentOtel.runInContext,

--- a/packages/eve/src/tracing/agent-otel-provider.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.ts
@@ -505,6 +505,7 @@ export function createAgentOtelInstrumentation(
       name: "eve.otel",
       projectEvent,
       tracePolicy: () => ({ emit: true, recordInputs, recordOutputs }),
+      tracePolicyRequiresBinding: false,
     },
     prepareSessionTrace,
     prepareTurnTrace,

--- a/packages/eve/src/tracing/agent-otel-provider.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.ts
@@ -505,7 +505,6 @@ export function createAgentOtelInstrumentation(
       name: "eve.otel",
       projectEvent,
       tracePolicy: () => ({ emit: true, recordInputs, recordOutputs }),
-      tracePolicyRequiresBinding: false,
     },
     prepareSessionTrace,
     prepareTurnTrace,

--- a/packages/eve/src/tracing/agent-otel-session-context.ts
+++ b/packages/eve/src/tracing/agent-otel-session-context.ts
@@ -156,7 +156,7 @@ export function createAgentOtelSessionContext(
     }
 
     const session = await ensureSessionContext({
-      agentName: undefined,
+      agentName: event.agentName,
       channelAudience: "unknown",
       channelKind: undefined,
       idempotencyKey: sessionIdempotencyKey(event.sessionId),
@@ -221,6 +221,9 @@ function resolveSessionTraceDecision(
   }
   if (event.parentTraceContext !== undefined) {
     return resolveTracePolicyDecision(isSampledTrace(event.parentTraceContext), audience);
+  }
+  if (event.agentName === undefined) {
+    return policy === undefined ? resolveTracePolicyDecision(true, audience) : { action: "drop" };
   }
   // The tool loop can evaluate the same policy before this first-session
   // preparation path; the persisted decision removes that window on replay.

--- a/packages/eve/src/tracing/install-instrumentation-runtime.test.ts
+++ b/packages/eve/src/tracing/install-instrumentation-runtime.test.ts
@@ -99,9 +99,10 @@ describe("installInstrumentationRuntime", () => {
       serviceName: "weather",
     });
     const idempotencyKey = turnIdempotencyKey("session-1", "turn-1");
+    const hooks = runtime.hooks.forTrace!({ agentName: "weather", audience: "unknown" });
 
     await contextStorage.run(new ContextContainer(), async () => {
-      await runtime.hooks.publish({
+      await hooks.publish({
         idempotencyKey,
         rootSessionId: "session-1",
         sequence: 0,
@@ -109,7 +110,7 @@ describe("installInstrumentationRuntime", () => {
         turnId: "turn-1",
         type: "turn.started",
       });
-      await runtime.hooks.publish({
+      await hooks.publish({
         idempotencyKey,
         sessionId: "session-1",
         turnId: "turn-1",

--- a/packages/eve/src/tracing/local-instrumentation-runtime.scenario.test.ts
+++ b/packages/eve/src/tracing/local-instrumentation-runtime.scenario.test.ts
@@ -59,16 +59,17 @@ describe("local instrumentation runtime", () => {
     };
     const delivery = runtimeTrace.getTracer("workflow").startSpan("workflow.delivery");
     const activeContext = runtimeTrace.setSpan(COMPILED_ROOT_CONTEXT, delivery);
+    const hooks = runtime.hooks.forTrace!({ agentName: "weather", audience: "unknown" });
 
     const exerciseRuntime = async () => {
-      await runtime.hooks.publish({
+      await hooks.publish({
         agentName: "weather",
         idempotencyKey: sessionIdempotencyKey("session-1"),
         rootSessionId: "session-1",
         sessionId: "session-1",
         type: "session.started",
       });
-      await runtime.hooks.publish({
+      await hooks.publish({
         idempotencyKey: turnIdempotencyKey("session-1", "turn-1"),
         rootSessionId: "session-1",
         sequence: 0,
@@ -76,7 +77,7 @@ describe("local instrumentation runtime", () => {
         turnId: "turn-1",
         type: "turn.started",
       });
-      const bridge = createAiSdkHookBridge(scope, runtime.hooks, runtime.runInContext);
+      const bridge = createAiSdkHookBridge(scope, hooks, runtime.runInContext);
       Reflect.apply(bridge.onStart!, bridge, [
         {
           callId: "call-1",
@@ -115,7 +116,7 @@ describe("local instrumentation runtime", () => {
         },
       ]);
       const actionKey = actionIdempotencyKey("session-1", "turn-1", "tool-1");
-      await runtime.hooks.publish({
+      await hooks.publish({
         callId: "tool-1",
         idempotencyKey: actionKey,
         input: {},
@@ -149,26 +150,26 @@ describe("local instrumentation runtime", () => {
           toolOutput: { output: { temperature: 72 }, type: "tool-result" },
         },
       ]);
-      await runtime.hooks.publish({
+      await hooks.publish({
         idempotencyKey: actionKey,
         outcome: "completed",
         output: { output: { temperature: 72 }, type: "result" },
         scope,
         type: "action.completed",
       });
-      await runtime.hooks.publish({
+      await hooks.publish({
         idempotencyKey: attemptIdempotencyKey(scope),
         scope,
         type: "step.attempt.completed",
       });
-      await runtime.hooks.publish({
+      await hooks.publish({
         idempotencyKey: turnIdempotencyKey("session-1", "turn-1"),
         sessionId: "session-1",
         turnId: "turn-1",
         type: "turn.completed",
       });
       // Settling the turn emits the turn span with the pre-allocated id.
-      await runtime.hooks.publish({
+      await hooks.publish({
         idempotencyKey: sessionIdempotencyKey("session-1"),
         sessionId: "session-1",
         turnId: "turn-1",

--- a/packages/eve/src/tracing/local-traces.test.ts
+++ b/packages/eve/src/tracing/local-traces.test.ts
@@ -107,6 +107,7 @@ describe("localTracePolicy", () => {
   ] as const)("accepts the %s audience: %s", (audience, accepted) => {
     expect(
       localTracePolicy({
+        agentName: "weather",
         audience,
       }),
     ).toBe(accepted);

--- a/packages/eve/src/tracing/sampled-trace.test.ts
+++ b/packages/eve/src/tracing/sampled-trace.test.ts
@@ -58,7 +58,7 @@ describe("resolveTracePolicyDecision", () => {
         () => {
           throw new Error("boom");
         },
-        { audience: "public" },
+        { agentName: "weather", audience: "public" },
       ),
     ).toEqual({ action: "drop" });
   });
@@ -69,7 +69,7 @@ describe("resolveTracePolicyDecision", () => {
         () => {
           throw new Error("policy failed");
         },
-        { audience: "public" },
+        { agentName: "weather", audience: "public" },
         () => {
           throw new Error("reporting failed");
         },
@@ -82,7 +82,7 @@ describe("resolveTracePolicyDecision", () => {
     ["private", false],
     ["unknown", false],
   ] as const)("emits the default %s trace with the expected content", (audience, content) => {
-    expect(resolveTracePolicy(undefined, { audience })).toEqual({
+    expect(resolveTracePolicy(undefined, { agentName: "weather", audience })).toEqual({
       action: "record",
       recordInputs: content,
       recordOutputs: content,

--- a/packages/eve/test/scenarios/compiled-artifacts-bootstrap.scenario.test.ts
+++ b/packages/eve/test/scenarios/compiled-artifacts-bootstrap.scenario.test.ts
@@ -213,7 +213,9 @@ describe("writeCompiledArtifactsFiles", () => {
     ]);
     const providers = getInstrumentationProviders();
     expect(providers.map((entry) => entry.slot)).toEqual(["local", "otel"]);
-    expect(providers[0]?.provider.tracePolicy?.({ audience: "public" })).toEqual({
+    expect(
+      providers[0]?.provider.tracePolicy?.({ agentName: "weather", audience: "public" }),
+    ).toEqual({
       emit: true,
       recordInputs: true,
       recordOutputs: false,

--- a/research/channel-audience-content-policy.md
+++ b/research/channel-audience-content-policy.md
@@ -32,7 +32,7 @@ The process-wide declaration owns trace creation:
 
 ```ts
 interface TraceCaptureContext {
-  readonly agentName?: string;
+  readonly agentName: string;
   readonly audience: ChannelAudience;
   readonly channelType?: string;
 }


### PR DESCRIPTION
### Summary

Follow-up to #2721 and [Casey's review question](https://github.com/vercel/eve/pull/2721#discussion_r3895167449). Provider trace policies could receive `agentName: undefined` because execution read optional compiled config even though every effective turn agent has a required canonical ID. Normal and cancelled turns now bind with `effectiveAgent.turnAgent.id`, and both `TraceCaptureContext.agentName` and the internal bound-session identity are required. Unbound root publication logs and returns without dispatching so missing instrumentation context cannot affect agent execution; persisted deliveries from before this change fall back to their stored agent ID.

### Validation

Focused instrumentation, OTel, runtime, tool-loop, node-step, and workflow coverage passed 422 tests. The full unit suite passed 7,422 tests with 1 skipped; provider and cancellation integration coverage passed one test each, and the compiled-artifacts and local-tracing scenarios passed 8 tests across 2 files.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+6 / -1`

Updates the experimental policy contract and adds the required patch release note.

**Implementation** — 9 files · `+21 / -19`

Keeps canonical identity enforcement at the instrumentation binding boundary and makes unbound publication a safe no-op.

**Tests** — 18 files · `+150 / -64`

Most changes bind existing low-level fixtures with explicit agent IDs; focused regressions cover normal execution, cancellation, unbound publication, OTel, provider integration, local tracing, and durable delivery fallback.
