### PR TITLE
fix(eve): harden batch setup recovery

### DIFF
--- a/.changeset/calm-batch-setup.md
+++ b/.changeset/calm-batch-setup.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Make batch setup navigation and failure recovery more predictable while preserving completed registry results.

--- a/.changeset/gentle-onboarding-flow.md
+++ b/.changeset/gentle-onboarding-flow.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Guide newly created agents through model configuration and channel or integration selection before the first chat prompt. Setup results now preserve installed-item facts and skipped installation errors in the TUI transcript.

--- a/.changeset/gentle-onboarding-flow.md
+++ b/.changeset/gentle-onboarding-flow.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Guide newly created agents through model configuration and channel or integration selection before the first chat prompt. Setup results now preserve installed-item facts and skipped installation errors in the TUI transcript.
+Guide newly created agents through model configuration and a channel and integration planner before the first chat prompt. `/add` now installs multiple selections as one batch and reports each result.

--- a/docs/guides/dev-tui.md
+++ b/docs/guides/dev-tui.md
@@ -13,35 +13,41 @@ The transcript remains in your terminal scrollback after you exit. Run `/help` i
 
 ## Commands
 
-| Command       | Description                                                                                                                                               |
-| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `/model`      | Configure the model and its provider. Pass a model ID to set it directly: `/model provider/model-id`.                                                     |
-| `/add`        | Browse and install channels, MCP connections, extensions, and observability integrations. Pass an item address to open it directly: `/add channel/slack`. |
-| `/deploy`     | Deploy the agent to Vercel production. Links the directory first if needed.                                                                               |
-| `/vc:install` | Install the Vercel CLI.                                                                                                                                   |
-| `/vc:login`   | Log in to Vercel or restore access to a remote deployment.                                                                                                |
-| `/info`       | Show the resolved application, compiled artifacts, discovery diagnostics, and messaging routes.                                                           |
-| `/loglevel`   | Choose which server and agent logs appear in the transcript.                                                                                              |
-| `/traces`     | Open the local trace viewer. Pass a trace ID prefix to open a specific trace.                                                                             |
-| `/reset`      | Start a fresh session.                                                                                                                                    |
-| `/cancel`     | Cancel the current turn without discarding settled context.                                                                                               |
-| `/clear`      | Clear the session's model-message history. `/new` is an alias.                                                                                            |
-| `/compact`    | Compact the current session's context.                                                                                                                    |
-| `/exit`       | Quit the UI.                                                                                                                                              |
-| `/help`       | List available commands.                                                                                                                                  |
+| Command       | Description                                                                                                                                           |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/model`      | Configure the model and its provider. Pass a model ID to set it directly: `/model provider/model-id`.                                                 |
+| `/add`        | Select and install channels, MCP connections, extensions, and observability integrations. Pass an item address to preselect it: `/add channel/slack`. |
+| `/deploy`     | Deploy the agent to Vercel production. Links the directory first if needed.                                                                           |
+| `/vc:install` | Install the Vercel CLI.                                                                                                                               |
+| `/vc:login`   | Log in to Vercel or restore access to a remote deployment.                                                                                            |
+| `/info`       | Show the resolved application, compiled artifacts, discovery diagnostics, and messaging routes.                                                       |
+| `/loglevel`   | Choose which server and agent logs appear in the transcript.                                                                                          |
+| `/traces`     | Open the local trace viewer. Pass a trace ID prefix to open a specific trace.                                                                         |
+| `/reset`      | Start a fresh session.                                                                                                                                |
+| `/cancel`     | Cancel the current turn without discarding settled context.                                                                                           |
+| `/clear`      | Clear the session's model-message history. `/new` is an alias.                                                                                        |
+| `/compact`    | Compact the current session's context.                                                                                                                |
+| `/exit`       | Quit the UI.                                                                                                                                          |
+| `/help`       | List available commands.                                                                                                                              |
 
 `/model`, `/add`, `/deploy`, `/info`, and `/traces` are available when `eve dev` runs locally. They are unavailable when the UI connects to a server with `--url`.
 
 ## Add an integration
 
-Bare `/add` opens the categorized registry browser. Pass an item address — `<category>/<name>`, where category is `channel`, `connection`, `extension`, or `instrumentation` — to skip the category and search screens and open that item directly:
+Bare `/add` opens the planner on **Integrations**. Fresh-agent onboarding starts on **Channels**, while `/add <item>` preselects the requested item and opens **Review**. The tab rail shows selection counts as you move between **Channels**, **Integrations**, and **Review**.
+
+Press `Right Arrow` or `Enter` to preserve the current selections and continue. Press `Left Arrow` to preserve them and go back, or `Esc` to cancel. Installation still requires `Enter` on **Install and set up** from the Review tab. If an item fails, you can skip it and continue with the remaining items.
+
+Pass an official item address — `<category>/<name>`, where category is `channel`, `connection`, `extension`, or `instrumentation` — to preselect it in the planner. Product presets and configured registry addresses are also supported:
 
 ```text
 /add channel/slack
 /add extension/agent-browser
+/add linear
+/add @acme/analytics
 ```
 
-Either way the UI shows the item's details and asks to confirm before installing, then runs the same installation and setup prompts. Choosing **Back** on a directly addressed item returns to the registry browser.
+Product presets expand into their individual channels and integrations on Review. The UI installs selected items in order and offers deployment once after the batch when an installed item requires it.
 
 ## Work with the agent
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -210,7 +210,7 @@ Pass a bare URL and the UI connects to that server instead of booting a local on
 | `-H, --header <header>`             | string | none               | Request header for a URL target, in `Name: value` form; repeat for multiple headers       |
 | `--no-ui`                           | flag   | UI on              | Start the server without an interactive UI                                                |
 | `--name <name>`                     | string | app folder name    | Title shown in the terminal UI                                                            |
-| `--input <text>`                    | string | none               | Pre-fill the prompt input; bare local `/model` starts onboarding                          |
+| `--input <text>`                    | string | none               | Pre-fill the prompt input                                                                 |
 | `--tools <mode>`                    | enum   | `auto-collapsed`   | Tool-call rendering: `full` \| `collapsed` \| `auto-collapsed` \| `hidden`                |
 | `--reasoning <mode>`                | enum   | `full`             | Reasoning rendering: `full` \| `collapsed` \| `auto-collapsed` \| `hidden`                |
 | `--subagents <mode>`                | enum   | `auto-collapsed`   | Subagent-section rendering: `full` \| `collapsed` \| `auto-collapsed` \| `hidden`         |
@@ -221,7 +221,7 @@ Pass a bare URL and the UI connects to that server instead of booting a local on
 
 `eve acp` reserves stdin and stdout for newline-delimited JSON-RPC and sends diagnostics to stderr. Without a URL, it supervises an isolated local development server. With a URL, it bridges ACP to that server's existing eve HTTP API and accepts the same URL credentials and request headers as `eve dev <url>`. Pass `--scope <team>` when the active Vercel scope does not own the deployment; `EVE_VERCEL_SCOPE` provides the same value for managed harnesses. See [Agent Client Protocol (ACP)](../protocols/acp) for client configuration and capability limits.
 
-A fresh `eve init` passes `--input /model`. That bare local input starts onboarding: the TUI installs the Vercel CLI if needed, asks you to log in if needed, opens `/model`, then offers categorized registry next steps before the first prompt. Other input stays editable in the prompt.
+A fresh `eve init` starts onboarding before the first prompt: the TUI installs the Vercel CLI if needed, asks you to log in if needed, guides you through model configuration, then lets you choose channels and integrations. Other `--input` text stays editable in the prompt.
 
 For a URL target protected by HTTP Basic auth, put the credentials in the URL. eve sends them as a Basic `Authorization` header and strips them from the server URL before connecting:
 

--- a/packages/eve/src/cli/dev/tui/prompt-command-handler.ts
+++ b/packages/eve/src/cli/dev/tui/prompt-command-handler.ts
@@ -122,7 +122,10 @@ export function createPromptCommandHandler(
         if (context.initialModelStep !== undefined) {
           commandInput.initialModelStep = context.initialModelStep;
         }
-        // `/add <item>` opens that registry item directly; bare `/add` browses.
+        if (context.initialRegistryScreen !== undefined) {
+          commandInput.initialRegistryScreen = context.initialRegistryScreen;
+        }
+        // `/add <item>` preselects that registry item; bare `/add` starts empty.
         if (command.name === "add" && command.argument.length > 0) {
           commandInput.initialRegistryAddress = command.argument;
         }

--- a/packages/eve/src/cli/dev/tui/registry-result-message.test.ts
+++ b/packages/eve/src/cli/dev/tui/registry-result-message.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { formatRegistrySessionResult } from "./registry-result-message.js";
+
+describe("formatRegistrySessionResult", () => {
+  it("keeps installed-item facts and skipped installation errors after setup closes", () => {
+    expect(
+      formatRegistrySessionResult({
+        items: [
+          {
+            address: "channel/photon-imessage",
+            title: "Photon iMessage",
+            facts: [{ label: "Agent phone number", value: "+15551234567", kind: "phone" }],
+            output: [],
+          },
+        ],
+        failures: [
+          {
+            address: "channel/slack",
+            title: "Slack",
+            message: "Vercel CLI is not authenticated.",
+            detail: "Vercel CLI is not authenticated.\nError: session missing",
+          },
+        ],
+      }),
+    ).toBe(
+      "Added Photon iMessage\n\n" +
+        "Photon iMessage\n" +
+        "  Agent phone number  +15551234567\n\n" +
+        "Couldn't add Slack\n" +
+        "  Vercel CLI is not authenticated.\n" +
+        "  Vercel CLI is not authenticated.\nError: session missing",
+    );
+  });
+});

--- a/packages/eve/src/cli/dev/tui/registry-result-message.test.ts
+++ b/packages/eve/src/cli/dev/tui/registry-result-message.test.ts
@@ -3,33 +3,34 @@ import { describe, expect, it } from "vitest";
 import { formatRegistrySessionResult } from "./registry-result-message.js";
 
 describe("formatRegistrySessionResult", () => {
-  it("keeps installed-item facts and skipped installation errors after setup closes", () => {
+  it("formats installed items and multiline failures in one report", () => {
     expect(
       formatRegistrySessionResult({
         items: [
+          { title: "Web Chat", facts: [], output: [] },
           {
-            address: "channel/photon-imessage",
             title: "Photon iMessage",
             facts: [{ label: "Agent phone number", value: "+15551234567", kind: "phone" }],
-            output: [],
+            output: ["Configured MCP connection."],
           },
         ],
         failures: [
           {
-            address: "channel/slack",
             title: "Slack",
-            message: "Vercel CLI is not authenticated.",
-            detail: "Vercel CLI is not authenticated.\nError: session missing",
+            message: "Vercel CLI is not authenticated.\nRun /vc:login, then try again.",
           },
         ],
       }),
     ).toBe(
-      "Added Photon iMessage\n\n" +
+      "Added Web Chat and Photon iMessage\n\n" +
+        "Web Chat\n" +
+        "  Installed.\n\n" +
         "Photon iMessage\n" +
-        "  Agent phone number  +15551234567\n\n" +
+        "  Agent phone number  +15551234567\n" +
+        "  Configured MCP connection.\n\n" +
         "Couldn't add Slack\n" +
         "  Vercel CLI is not authenticated.\n" +
-        "  Vercel CLI is not authenticated.\nError: session missing",
+        "  Run /vc:login, then try again.",
     );
   });
 });

--- a/packages/eve/src/cli/dev/tui/registry-result-message.ts
+++ b/packages/eve/src/cli/dev/tui/registry-result-message.ts
@@ -1,0 +1,60 @@
+import type {
+  RegistrySessionItemFailure,
+  RegistrySessionItemResult,
+} from "#setup/flows/registry-session.js";
+
+export type RegistryResultReport = {
+  items: readonly RegistrySessionItemResult[];
+  failures?: readonly RegistrySessionItemFailure[];
+};
+
+export type RegistryResultReportEntry = {
+  title: string;
+  status: "success" | "error";
+  lines: readonly string[];
+  detail?: string;
+};
+
+export function registryResultReportEntries(
+  result: RegistryResultReport,
+): readonly RegistryResultReportEntry[] {
+  return [
+    ...result.items.map((item) => ({
+      title: item.title,
+      status: "success" as const,
+      lines: [...item.facts.map((fact) => `${fact.label}  ${fact.value}`), ...item.output],
+    })),
+    ...(result.failures ?? []).map((failure) => ({
+      title: failure.title,
+      status: "error" as const,
+      lines: [failure.message],
+      detail: failure.detail,
+    })),
+  ];
+}
+
+function joinedTitles(titles: readonly string[]): string {
+  if (titles.length === 0) return "";
+  if (titles.length === 1) return titles[0]!;
+  if (titles.length === 2) return `${titles[0]} and ${titles[1]}`;
+  return `${titles.slice(0, -1).join(", ")}, and ${titles.at(-1)}`;
+}
+
+/** Formats structured registry setup results after their temporary panel closes. */
+export function formatRegistrySessionResult(result: RegistryResultReport): string {
+  const lines: string[] = [];
+  if (result.items.length > 0)
+    lines.push(`Added ${joinedTitles(result.items.map((item) => item.title))}`);
+  for (const item of result.items) {
+    if (item.facts.length === 0 && item.output.length === 0) continue;
+    lines.push("", item.title);
+    const width = Math.max(0, ...item.facts.map((fact) => fact.label.length));
+    for (const fact of item.facts) lines.push(`  ${fact.label.padEnd(width)}  ${fact.value}`);
+    for (const output of item.output) lines.push(`  ${output}`);
+  }
+  for (const failure of result.failures ?? []) {
+    lines.push("", `Couldn't add ${failure.title}`, `  ${failure.message}`);
+    if (failure.detail !== failure.message) lines.push(`  ${failure.detail}`);
+  }
+  return lines.join("\n");
+}

--- a/packages/eve/src/cli/dev/tui/registry-result-message.ts
+++ b/packages/eve/src/cli/dev/tui/registry-result-message.ts
@@ -1,36 +1,26 @@
-import type {
-  RegistrySessionItemFailure,
-  RegistrySessionItemResult,
-} from "#setup/flows/registry-session.js";
+import type { RegistryCatalogItem } from "#cli/commands/registry.js";
+import type { RegistrySessionResult } from "#setup/flows/registry-session.js";
 
-export type RegistryResultReport = {
-  items: readonly RegistrySessionItemResult[];
-  failures?: readonly RegistrySessionItemFailure[];
-};
+/** Builds the shared transient progress update for `/add` and initial onboarding. */
+export function registryItemProgress(renderer: {
+  replaceContent?(content?: {
+    headline: string;
+    facts: readonly { label: string; value: string }[];
+  }): void;
+  setStatus(status: string | undefined): void;
+}): (item: RegistryCatalogItem, index: number, total: number) => void {
+  return (item, index, total) => {
+    renderer.replaceContent?.({
+      headline: `Adding ${item.title ?? item.name} · ${index + 1} of ${total}`,
+      facts: [],
+    });
+    renderer.setStatus("Installing files and dependencies…");
+  };
+}
 
-export type RegistryResultReportEntry = {
-  title: string;
-  status: "success" | "error";
-  lines: readonly string[];
-  detail?: string;
-};
-
-export function registryResultReportEntries(
-  result: RegistryResultReport,
-): readonly RegistryResultReportEntry[] {
-  return [
-    ...result.items.map((item) => ({
-      title: item.title,
-      status: "success" as const,
-      lines: [...item.facts.map((fact) => `${fact.label}  ${fact.value}`), ...item.output],
-    })),
-    ...(result.failures ?? []).map((failure) => ({
-      title: failure.title,
-      status: "error" as const,
-      lines: [failure.message],
-      detail: failure.detail,
-    })),
-  ];
+export function registryResultTone(result: RegistrySessionResult): "success" | "error" | undefined {
+  if (result.failures.length > 0) return "error";
+  return result.items.length > 0 ? "success" : undefined;
 }
 
 function joinedTitles(titles: readonly string[]): string {
@@ -41,20 +31,29 @@ function joinedTitles(titles: readonly string[]): string {
 }
 
 /** Formats structured registry setup results after their temporary panel closes. */
-export function formatRegistrySessionResult(result: RegistryResultReport): string {
+export function formatRegistrySessionResult(result: RegistrySessionResult): string {
   const lines: string[] = [];
   if (result.items.length > 0)
     lines.push(`Added ${joinedTitles(result.items.map((item) => item.title))}`);
   for (const item of result.items) {
-    if (item.facts.length === 0 && item.output.length === 0) continue;
     lines.push("", item.title);
+    if (item.facts.length === 0 && item.output.length === 0) {
+      lines.push("  Installed.");
+      continue;
+    }
     const width = Math.max(0, ...item.facts.map((fact) => fact.label.length));
     for (const fact of item.facts) lines.push(`  ${fact.label.padEnd(width)}  ${fact.value}`);
     for (const output of item.output) lines.push(`  ${output}`);
   }
-  for (const failure of result.failures ?? []) {
-    lines.push("", `Couldn't add ${failure.title}`, `  ${failure.message}`);
-    if (failure.detail !== failure.message) lines.push(`  ${failure.detail}`);
+  for (const failure of result.failures) {
+    lines.push(
+      "",
+      `Couldn't add ${failure.title}`,
+      ...failure.message.split("\n").map((line) => `  ${line}`),
+    );
+  }
+  if (result.cancelled === true) {
+    lines.push("", "Setup cancelled before the remaining selections were added.");
   }
   return lines.join("\n");
 }

--- a/packages/eve/src/cli/dev/tui/setup-commands.test.ts
+++ b/packages/eve/src/cli/dev/tui/setup-commands.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { createFakePrompter } from "#internal/testing/fake-prompter.js";
+import { RegistryFlowFailedError } from "#setup/flows/registry.js";
 import { HumanActionRequiredError } from "#setup/human-action.js";
 
 import {
@@ -47,29 +48,19 @@ function fakePanelRenderer(): TuiSetupCommandRenderer & {
 
 function registryResult(
   overrides: Partial<{
-    addedItems: readonly string[];
     items: readonly {
-      address: string;
       title: string;
       facts: readonly never[];
       output: readonly string[];
     }[];
     failures: readonly never[];
-    facts: readonly never[];
+    cancelled: true;
     deployed: "production";
   }> = {},
 ) {
   return {
     kind: "done" as const,
-    result: {
-      kind: "done" as const,
-      addedItems: [],
-      items: [],
-      failures: [],
-      facts: [],
-      output: [],
-      ...overrides,
-    },
+    result: { items: [], failures: [], ...overrides },
   };
 }
 
@@ -98,6 +89,8 @@ function run(input: {
   flows: TuiSetupFlows;
   renderer?: TuiSetupCommandRenderer;
   initialModelStep?: "provider";
+  initialRegistryScreen?: "channels" | "integrations";
+  useDefaultPrompter?: boolean;
   upgradeChoice?: "upgrade" | "later";
   withExclusiveTerminal?: TuiSetupCommandInput["withExclusiveTerminal"];
 }) {
@@ -109,11 +102,14 @@ function run(input: {
     command: input.command,
     appRoot: APP_ROOT,
     renderer: input.renderer ?? fakePanelRenderer(),
-    createPrompter: () => fake.prompter,
     flows: input.flows,
   };
+  if (input.useDefaultPrompter !== true) commandInput.createPrompter = () => fake.prompter;
   if (input.initialModelStep !== undefined) {
     commandInput.initialModelStep = input.initialModelStep;
+  }
+  if (input.initialRegistryScreen !== undefined) {
+    commandInput.initialRegistryScreen = input.initialRegistryScreen;
   }
   if (input.withExclusiveTerminal !== undefined) {
     commandInput.withExclusiveTerminal = input.withExclusiveTerminal;
@@ -128,7 +124,39 @@ describe("runTuiSetupCommand", () => {
 
     await run({ command: "add", flows: fakeFlows({ runRegistryFlow }), renderer });
 
+    expect(runRegistryFlow).toHaveBeenCalledWith(
+      expect.objectContaining({ initialScreen: "integrations" }),
+    );
     expect(renderer.waitForInterrupt).toHaveBeenCalledWith();
+  });
+
+  it("uses the requested initial registry screen and suspends the runtime during installation", async () => {
+    const calls: string[] = [];
+    const runRegistryFlow = vi.fn<TuiSetupFlows["runRegistryFlow"]>(async (input) => {
+      await input.prompter.withExclusiveTerminal?.(async () => {
+        calls.push("install");
+      });
+      return registryResult();
+    });
+    const withExclusiveTerminal = async <T>(task: () => Promise<T>): Promise<T> => {
+      calls.push("suspend");
+      const result = await task();
+      calls.push("resume");
+      return result;
+    };
+
+    await run({
+      command: "add",
+      flows: fakeFlows({ runRegistryFlow }),
+      initialRegistryScreen: "channels",
+      useDefaultPrompter: true,
+      withExclusiveTerminal,
+    });
+
+    expect(runRegistryFlow).toHaveBeenCalledWith(
+      expect.objectContaining({ initialScreen: "channels" }),
+    );
+    expect(calls).toEqual(["suspend", "install", "resume"]);
   });
 
   it("describes dependency installation while adding an item", async () => {
@@ -329,6 +357,7 @@ describe("runTuiSetupCommand", () => {
 
     await expect(run({ command: "model", flows, upgradeChoice: "upgrade" })).resolves.toEqual({
       message: "Upgraded the Vercel CLI. Retry /model.",
+      tone: "error",
       preserveFlowDiagnostics: false,
     });
     expect(flows.runInstallVercelCliFlow).toHaveBeenCalledWith(
@@ -352,6 +381,7 @@ describe("runTuiSetupCommand", () => {
 
     await expect(run({ command: "model", flows, upgradeChoice: "later" })).resolves.toEqual({
       message: "The Vercel CLI needs an update — run `vercel upgrade`, then retry /model.",
+      tone: "error",
       preserveFlowDiagnostics: true,
     });
     expect(flows.runInstallVercelCliFlow).not.toHaveBeenCalled();
@@ -374,6 +404,7 @@ describe("runTuiSetupCommand", () => {
     await expect(run({ command: "model", flows, upgradeChoice: "upgrade" })).resolves.toEqual({
       message:
         "Couldn't upgrade the Vercel CLI (package manager failed) — run `vercel upgrade`, then retry /model.",
+      tone: "error",
       preserveFlowDiagnostics: true,
     });
   });
@@ -396,6 +427,7 @@ describe("runTuiSetupCommand", () => {
     await expect(run({ command: "model", flows, upgradeChoice: "upgrade" })).resolves.toEqual({
       message:
         "Couldn't upgrade the Vercel CLI (ERR_PNPM_NO_GLOBAL_BIN_DIR Unable to find the global bin directory) — run `vercel upgrade`, then retry /model.",
+      tone: "error",
       preserveFlowDiagnostics: true,
     });
   });
@@ -404,10 +436,9 @@ describe("runTuiSetupCommand", () => {
     [
       "added",
       registryResult({
-        addedItems: ["extension/browser"],
-        items: [{ address: "extension/browser", title: "Agent Browser", facts: [], output: [] }],
+        items: [{ title: "Agent Browser", facts: [], output: [] }],
       }),
-      "Added Agent Browser",
+      "Added Agent Browser\n\nAgent Browser\n  Installed.",
     ],
     ["empty", registryResult(), "No integrations selected."],
     ["deployed", registryResult({ deployed: "production" }), "No integrations selected."],
@@ -429,11 +460,8 @@ describe("runTuiSetupCommand", () => {
       runRegistryFlow: vi.fn<TuiSetupFlows["runRegistryFlow"]>(async () => ({
         kind: "done",
         result: {
-          kind: "done",
-          addedItems: ["channel/photon-imessage"],
           items: [
             {
-              address: "channel/photon-imessage",
               title: "Photon iMessage",
               output: [],
               facts: [{ label: "Agent phone number", value: "+15551234567" }],
@@ -441,14 +469,10 @@ describe("runTuiSetupCommand", () => {
           ],
           failures: [
             {
-              address: "channel/github",
               title: "GitHub",
               message: "Refusing to overwrite github.ts",
-              detail: "Refusing to overwrite github.ts",
             },
           ],
-          output: [],
-          facts: [],
         },
       })),
     });
@@ -470,6 +494,40 @@ describe("runTuiSetupCommand", () => {
     expect(flows.runDeployFlow).toHaveBeenCalledWith(
       expect.objectContaining({ interactive: true }),
     );
+  });
+
+  it("preserves settled registry results when batch setup is interrupted", async () => {
+    const renderer = fakePanelRenderer();
+    const flows = fakeFlows({
+      runRegistryFlow: vi.fn<TuiSetupFlows["runRegistryFlow"]>(
+        ({ signal }) =>
+          new Promise((resolve) => {
+            signal?.addEventListener(
+              "abort",
+              () =>
+                resolve(
+                  registryResult({
+                    items: [{ title: "Web Chat", facts: [], output: [] }],
+                    cancelled: true,
+                  }),
+                ),
+              { once: true },
+            );
+          }),
+      ),
+    });
+
+    const result = run({ command: "add", flows, renderer });
+    renderer.fireInterrupt();
+
+    await expect(result).resolves.toEqual({
+      message:
+        "Added Web Chat\n\nWeb Chat\n  Installed.\n\n" +
+        "Setup cancelled before the remaining selections were added.",
+      partial: true,
+      tone: "error",
+      preserveFlowDiagnostics: true,
+    });
   });
 
   it("preserves model access refreshes when provider setup is interrupted", async () => {
@@ -545,19 +603,25 @@ describe("runTuiSetupCommand", () => {
     });
   });
 
-  it("routes a vercel-login action error to /vc:login instead of a raw failure", async () => {
+  it("routes a vercel-login action error without dropping completed registry items", async () => {
+    const cause = new HumanActionRequiredError({
+      kind: "vercel-login",
+      command: "vercel login",
+      reason: "Provisioning requires Vercel authentication.",
+    });
     const flows = fakeFlows({
-      runDeployFlow: vi.fn<TuiSetupFlows["runDeployFlow"]>(async () => {
-        throw new HumanActionRequiredError({
-          kind: "vercel-login",
-          command: "vercel login",
-          reason: "Provisioning a Vercel project requires you to be logged in to Vercel.",
+      runRegistryFlow: vi.fn(async () => {
+        throw new RegistryFlowFailedError(cause, {
+          items: [{ title: "Web Chat", facts: [], output: [] }],
+          failures: [],
         });
       }),
     });
-    await expect(run({ command: "deploy", flows })).resolves.toEqual({
-      message: "You're not logged in to Vercel — run /vc:login, then retry /deploy.",
-      preserveFlowDiagnostics: true,
+
+    await expect(run({ command: "add", flows })).resolves.toMatchObject({
+      message: expect.stringMatching(/^Added Web Chat[\s\S]*run \/vc:login/),
+      partial: true,
+      tone: "error",
     });
   });
 
@@ -574,6 +638,7 @@ describe("runTuiSetupCommand", () => {
     await expect(run({ command: "deploy", flows })).resolves.toEqual({
       message:
         "Vercel denied access to that team — run /vc:login to re-authenticate (for example to complete SSO), or pick a team you can access, then retry /deploy.",
+      tone: "error",
       preserveFlowDiagnostics: true,
     });
   });
@@ -606,6 +671,7 @@ describe("runTuiSetupCommand", () => {
     await expect(run({ command: "deploy", flows })).resolves.toEqual({
       message:
         "The Vercel CLI isn't installed — run /vc:install to install it, then retry /deploy.",
+      tone: "error",
       preserveFlowDiagnostics: true,
     });
   });

--- a/packages/eve/src/cli/dev/tui/setup-commands.test.ts
+++ b/packages/eve/src/cli/dev/tui/setup-commands.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from "vitest";
 
 import { createFakePrompter } from "#internal/testing/fake-prompter.js";
 import { HumanActionRequiredError } from "#setup/human-action.js";
-import { RegistryFlowFailedError, runRegistryFlow } from "#setup/flows/registry.js";
 
 import {
   runTuiSetupCommand,
@@ -46,6 +45,34 @@ function fakePanelRenderer(): TuiSetupCommandRenderer & {
   };
 }
 
+function registryResult(
+  overrides: Partial<{
+    addedItems: readonly string[];
+    items: readonly {
+      address: string;
+      title: string;
+      facts: readonly never[];
+      output: readonly string[];
+    }[];
+    failures: readonly never[];
+    facts: readonly never[];
+    deployed: "production";
+  }> = {},
+) {
+  return {
+    kind: "done" as const,
+    result: {
+      kind: "done" as const,
+      addedItems: [],
+      items: [],
+      failures: [],
+      facts: [],
+      output: [],
+      ...overrides,
+    },
+  };
+}
+
 function fakeFlows(overrides: Partial<TuiSetupFlows> = {}): TuiSetupFlows {
   return {
     runInstallVercelCliFlow: vi.fn<TuiSetupFlows["runInstallVercelCliFlow"]>(async () => ({
@@ -57,12 +84,7 @@ function fakeFlows(overrides: Partial<TuiSetupFlows> = {}): TuiSetupFlows {
       accessChanged: true,
       modelMessage: "Model changed to openai/gpt-5.5. Live on your next prompt.",
     })),
-    runRegistryFlow: vi.fn<TuiSetupFlows["runRegistryFlow"]>(async () => ({
-      kind: "done",
-      addedItems: [],
-      items: [],
-      facts: [],
-    })),
+    runRegistryFlow: vi.fn<TuiSetupFlows["runRegistryFlow"]>(async () => registryResult()),
     runDeployFlow: vi.fn<TuiSetupFlows["runDeployFlow"]>(async () => ({
       kind: "deployed",
       productionUrl: "https://my-agent.vercel.app",
@@ -76,7 +98,6 @@ function run(input: {
   flows: TuiSetupFlows;
   renderer?: TuiSetupCommandRenderer;
   initialModelStep?: "provider";
-  initialRegistryAddress?: string;
   upgradeChoice?: "upgrade" | "later";
   withExclusiveTerminal?: TuiSetupCommandInput["withExclusiveTerminal"];
 }) {
@@ -94,9 +115,6 @@ function run(input: {
   if (input.initialModelStep !== undefined) {
     commandInput.initialModelStep = input.initialModelStep;
   }
-  if (input.initialRegistryAddress !== undefined) {
-    commandInput.initialRegistryAddress = input.initialRegistryAddress;
-  }
   if (input.withExclusiveTerminal !== undefined) {
     commandInput.withExclusiveTerminal = input.withExclusiveTerminal;
   }
@@ -106,16 +124,31 @@ function run(input: {
 describe("runTuiSetupCommand", () => {
   it("keeps registry setup interruptible through the parent drawer", async () => {
     const renderer = fakePanelRenderer();
-    const runRegistryFlow = vi.fn<TuiSetupFlows["runRegistryFlow"]>(async () => ({
-      kind: "done",
-      addedItems: [],
-      items: [],
-      facts: [],
-    }));
+    const runRegistryFlow = vi.fn<TuiSetupFlows["runRegistryFlow"]>(async () => registryResult());
 
     await run({ command: "add", flows: fakeFlows({ runRegistryFlow }), renderer });
 
     expect(renderer.waitForInterrupt).toHaveBeenCalledWith();
+  });
+
+  it("describes dependency installation while adding an item", async () => {
+    const renderer = fakePanelRenderer();
+    const runRegistryFlow = vi.fn<TuiSetupFlows["runRegistryFlow"]>(async (input) => {
+      input.onItemStart?.(
+        { address: "channel/web", name: "channel/web", title: "Web Chat", source: "Vercel" },
+        0,
+        4,
+      );
+      return registryResult();
+    });
+
+    await run({ command: "add", flows: fakeFlows({ runRegistryFlow }), renderer });
+
+    expect(renderer.replaceContent).toHaveBeenCalledWith({
+      headline: "Adding Web Chat · 1 of 4",
+      facts: [],
+    });
+    expect(renderer.setStatus).toHaveBeenCalledWith("Installing files and dependencies…");
   });
 
   it("uses the build pulse for every setup command except deploy", () => {
@@ -306,34 +339,6 @@ describe("runTuiSetupCommand", () => {
     );
   });
 
-  it("prompts to upgrade when an installed registry item's setup needs a newer CLI", async () => {
-    const flows = fakeFlows({
-      runRegistryFlow: vi.fn<TuiSetupFlows["runRegistryFlow"]>(async () => {
-        throw new RegistryFlowFailedError(
-          new HumanActionRequiredError({
-            kind: "vercel-cli-upgrade",
-            command: "vercel upgrade",
-            reason: "The installed Vercel CLI does not support Linq trigger options.",
-          }),
-          {
-            kind: "done",
-            addedItems: ["channel/linq"],
-            items: [{ address: "channel/linq", title: "Linq", facts: [], output: [] }],
-            facts: [],
-          },
-        );
-      }),
-      runInstallVercelCliFlow: vi.fn<TuiSetupFlows["runInstallVercelCliFlow"]>(async () => ({
-        kind: "installed",
-      })),
-    });
-
-    await expect(run({ command: "add", flows, upgradeChoice: "upgrade" })).resolves.toEqual({
-      message: "Upgraded the Vercel CLI. Retry /add.",
-      preserveFlowDiagnostics: false,
-    });
-  });
-
   it("gives the manual upgrade command when the old-CLI prompt is declined", async () => {
     const flows = fakeFlows({
       runModelFlow: vi.fn<TuiSetupFlows["runModelFlow"]>(async () => {
@@ -398,134 +403,32 @@ describe("runTuiSetupCommand", () => {
   it.each([
     [
       "added",
-      {
-        kind: "done",
+      registryResult({
         addedItems: ["extension/browser"],
         items: [{ address: "extension/browser", title: "Agent Browser", facts: [], output: [] }],
-        facts: [],
-      },
+      }),
       "Added Agent Browser",
     ],
-    ["empty", { kind: "done", addedItems: [], items: [], facts: [] }, "No registry items added."],
-    [
-      "deployed",
-      { kind: "done", addedItems: [], items: [], facts: [], deployed: "production" },
-      "No registry items added.",
-    ],
-    ["cancelled", { kind: "cancelled" }, "/add dismissed."],
+    ["empty", registryResult(), "No integrations selected."],
+    ["deployed", registryResult({ deployed: "production" }), "No integrations selected."],
+    ["cancelled", { kind: "cancelled" as const }, "/add dismissed."],
   ] as const)("reports a %s registry flow", async (_case, result, message) => {
     const runRegistryFlow = vi.fn(async () => result);
     const outcome = await run({ command: "add", flows: fakeFlows({ runRegistryFlow }) });
-    const expected: {
-      message: string;
-      tone?: "success";
-      preserveFlowDiagnostics: boolean;
-      effect?: { kind: "deployed" };
-    } = {
-      message,
-      preserveFlowDiagnostics: true,
-    };
-    if (result.kind === "done" && result.addedItems.length > 0) expected.tone = "success";
-    if (result.kind === "done" && "deployed" in result && result.deployed === "production") {
-      expected.effect = { kind: "deployed" };
+    expect(outcome).toMatchObject({ message, preserveFlowDiagnostics: true });
+    if (result.kind === "done" && result.result.items.length > 0)
+      expect(outcome.tone).toBe("success");
+    if (result.kind === "done" && result.result.deployed === "production") {
+      expect(outcome.effect).toEqual({ kind: "deployed" });
     }
-    expect(outcome).toEqual(expected);
     expect(runRegistryFlow).toHaveBeenCalledWith(expect.objectContaining({ appRoot: APP_ROOT }));
   });
 
-  it("forwards a /add argument as the registry flow's initial address", async () => {
-    const flows = fakeFlows();
-
-    await run({ command: "add", flows, initialRegistryAddress: "channel/slack" });
-
-    expect(flows.runRegistryFlow).toHaveBeenCalledWith(
-      expect.objectContaining({ appRoot: APP_ROOT, initialAddress: "channel/slack" }),
-    );
-  });
-
-  it("omits an initial address for bare /add", async () => {
-    const flows = fakeFlows();
-
-    await run({ command: "add", flows });
-
-    expect(flows.runRegistryFlow).toHaveBeenCalledWith(
-      expect.not.objectContaining({ initialAddress: expect.anything() }),
-    );
-  });
-
-  it.each([
-    ["bare /add browses the catalog", undefined, "Add an integration"],
-    ["/add <item> opens the item", "channel/slack", "Slack"],
-  ])("composes with the real registry flow: %s", async (_case, address, firstPrompt) => {
-    const prompts: string[] = [];
-    const registryDeps = {
-      browseRegistryCatalog: vi.fn(async () => ({
-        items: [{ address: "channel/slack", name: "channel/slack", source: "Vercel" }],
-        total: 1,
-        errors: [],
-      })),
-      getRegistryItemManifest: vi.fn(async () => ({ name: "channel/slack", title: "Slack" })),
-      installRegistryItem: vi.fn(async () => ({ output: [] })),
-      detectDeployment: vi.fn(async () => ({ state: "unlinked" as const })),
-      runDeployFlow: vi.fn(async () => ({ kind: "deployed" as const })),
-    };
-    // The real flow behind the command seam, so the parsed argument is proven
-    // to reach `initialAddress` rather than stopping at a mock.
+  it("reports completed items and skipped failures together", async () => {
     const flows = fakeFlows({
-      runRegistryFlow: (input) => {
-        const fake = createFakePrompter({
-          single: (options) => {
-            prompts.push(options.message);
-            return options.message === "Add an integration" ? "action:done" : "add";
-          },
-        });
-        return runRegistryFlow({ ...input, prompter: fake.prompter, deps: registryDeps });
-      },
-    });
-
-    const commandRun: Parameters<typeof run>[0] = { command: "add", flows };
-    if (address !== undefined) commandRun.initialRegistryAddress = address;
-    await run(commandRun);
-
-    expect(prompts[0]).toBe(firstPrompt);
-    expect(registryDeps.browseRegistryCatalog).toHaveBeenCalledTimes(address === undefined ? 1 : 0);
-  });
-
-  it("overrides a settled success tone when add is interrupted", async () => {
-    const renderer = fakePanelRenderer();
-    const flows = fakeFlows({
-      runRegistryFlow: vi.fn<TuiSetupFlows["runRegistryFlow"]>(
-        ({ signal }) =>
-          new Promise((resolve) => {
-            signal?.addEventListener(
-              "abort",
-              () =>
-                resolve({
-                  kind: "done",
-                  addedItems: ["channel/github"],
-                  items: [{ address: "channel/github", title: "GitHub", facts: [], output: [] }],
-                  facts: [],
-                }),
-              { once: true },
-            );
-          }),
-      ),
-    });
-
-    const result = run({ command: "add", flows, renderer });
-    renderer.fireInterrupt();
-
-    await expect(result).resolves.toEqual({
-      message: "/add interrupted.",
-      tone: "error",
-      preserveFlowDiagnostics: true,
-    });
-  });
-
-  it("reports completed items and facts when a later add fails", async () => {
-    const flows = fakeFlows({
-      runRegistryFlow: vi.fn<TuiSetupFlows["runRegistryFlow"]>(async () => {
-        throw new RegistryFlowFailedError(new Error("Refusing to overwrite github.ts"), {
+      runRegistryFlow: vi.fn<TuiSetupFlows["runRegistryFlow"]>(async () => ({
+        kind: "done",
+        result: {
           kind: "done",
           addedItems: ["channel/photon-imessage"],
           items: [
@@ -533,28 +436,25 @@ describe("runTuiSetupCommand", () => {
               address: "channel/photon-imessage",
               title: "Photon iMessage",
               output: [],
-              facts: [
-                { label: "Agent phone number", value: "+15551234567" },
-                { label: "Photon project dashboard", value: "https://app.photon.codes/project" },
-              ],
+              facts: [{ label: "Agent phone number", value: "+15551234567" }],
+            },
+          ],
+          failures: [
+            {
+              address: "channel/github",
+              title: "GitHub",
+              message: "Refusing to overwrite github.ts",
+              detail: "Refusing to overwrite github.ts",
             },
           ],
           output: [],
-          facts: [
-            { label: "Agent phone number", value: "+15551234567" },
-            { label: "Photon project dashboard", value: "https://app.photon.codes/project" },
-          ],
-        });
-      }),
+          facts: [],
+        },
+      })),
     });
 
-    await expect(run({ command: "add", flows })).resolves.toEqual({
-      message:
-        "Added Photon iMessage\n\n" +
-        "Photon iMessage\n" +
-        "  Agent phone number        +15551234567\n" +
-        "  Photon project dashboard  https://app.photon.codes/project\n\n" +
-        "Refusing to overwrite github.ts",
+    await expect(run({ command: "add", flows })).resolves.toMatchObject({
+      message: expect.stringContaining("Couldn't add GitHub"),
       tone: "error",
       preserveFlowDiagnostics: true,
     });

--- a/packages/eve/src/cli/dev/tui/setup-commands.ts
+++ b/packages/eve/src/cli/dev/tui/setup-commands.ts
@@ -8,11 +8,19 @@ import { runLoginFlow, type LoginFlowResult } from "#setup/flows/login.js";
 import { runModelFlow } from "#setup/flows/model.js";
 import type { ProviderSelection } from "#setup/provider-settings.js";
 import { runProviderFlow, type ProviderPicker } from "#setup/flows/provider.js";
-import { runRegistryFlow } from "#setup/flows/registry.js";
+import {
+  RegistryFlowFailedError,
+  runRegistryFlow,
+  type RegistryPlannerSection,
+} from "#setup/flows/registry.js";
 import type { Prompter } from "#setup/prompter.js";
 import { WizardCancelledError } from "#setup/step.js";
 
-import { formatRegistrySessionResult } from "./registry-result-message.js";
+import {
+  formatRegistrySessionResult,
+  registryItemProgress,
+  registryResultTone,
+} from "./registry-result-message.js";
 import { createTuiPrompter, type TuiPrompterRenderer } from "./tui-prompter.js";
 import type { PromptCommandExtensionName } from "./prompt-commands.js";
 import type { SetupFlowIndicator, SetupFlowRenderer } from "./setup-flow.js";
@@ -48,6 +56,8 @@ export interface TuiSetupCommandInput {
   renderer: TuiSetupCommandRenderer;
   /** Initial model-flow step authorized by the runner's boot evidence. */
   initialModelStep?: "provider";
+  /** First registry planner section for an unaddressed setup flow. */
+  initialRegistryScreen?: RegistryPlannerSection;
   /** Registry address supplied by `/add <item>`, preselected in the batch planner. */
   initialRegistryAddress?: string;
   /** Live ChatGPT identity shown only inside model configuration UI. */
@@ -71,6 +81,8 @@ export interface TuiSetupFlows {
 
 export interface TuiSetupCommandResult {
   message: string;
+  /** Keep settled batch results instead of replacing them with an interrupt notice. */
+  partial?: true;
   /** Promotes an outcome to a top-level status. */
   tone?: "success" | "error";
   /** Keep warning/error lines after the bordered panel closes. */
@@ -152,12 +164,14 @@ export async function runTuiSetupCommand(
     interrupted = true;
     controller.abort(new WizardCancelledError());
     const settled = await execution;
-    return {
-      ...settled,
-      message: `/${command} interrupted.`,
-      tone: "error",
-      preserveFlowDiagnostics: true,
-    };
+    return settled.partial === true
+      ? settled
+      : {
+          ...settled,
+          message: `/${command} interrupted.`,
+          tone: "error",
+          preserveFlowDiagnostics: true,
+        };
   } finally {
     interrupt.dispose();
     // A flow that threw or was abandoned mid-wait must not leave the footer spinning.
@@ -245,13 +259,8 @@ async function executeSetupCommand(
           prompter,
           signal,
           initialAddress: input.initialRegistryAddress,
-          onItemStart: (item, index, total) => {
-            renderer.replaceContent?.({
-              headline: `Adding ${item.title ?? item.name} · ${index + 1} of ${total}`,
-              facts: [],
-            });
-            renderer.setStatus("Installing files and dependencies…");
-          },
+          initialScreen: input.initialRegistryScreen ?? "integrations",
+          onItemStart: registryItemProgress(renderer),
         });
         if (flow.kind === "cancelled") {
           return { message: "/add dismissed.", preserveFlowDiagnostics: true };
@@ -264,8 +273,11 @@ async function executeSetupCommand(
               : "No integrations selected.",
           preserveFlowDiagnostics: true,
         };
-        if (result.failures.length > 0) outcome.tone = "error";
-        else if (result.items.length > 0) outcome.tone = "success";
+        const tone = registryResultTone(result);
+        if (result.cancelled === true) {
+          outcome.partial = true;
+          outcome.tone = "error";
+        } else if (tone !== undefined) outcome.tone = tone;
         if (result.deployed === "production") outcome.effect = { kind: "deployed" };
         return outcome;
       }
@@ -302,23 +314,46 @@ async function executeSetupCommand(
         preserveFlowDiagnostics: command !== "model",
       };
     }
-    const upgrade = await vercelCliUpgradeOutcome(error, command, flows, {
+    const actionableError = error instanceof RegistryFlowFailedError ? error.cause : error;
+    const upgrade = await vercelCliUpgradeOutcome(actionableError, command, flows, {
       appRoot,
       prompter,
       signal,
     });
-    if (upgrade !== undefined) return upgrade;
+    if (upgrade !== undefined) return withRegistryResults(upgrade, error);
     // Provisioning steps (link, deploy, Slack) throw a Vercel human action when
     // `whoami` fails or a scope is denied. Route it to the in-TUI fix instead of
     // dumping the raw "Human action required" message.
-    const routed = vercelActionOutcome(error, command);
-    if (routed !== undefined) return routed;
+    const routed = vercelActionOutcome(actionableError, command);
+    if (routed !== undefined) return withRegistryResults(routed, error);
+    if (error instanceof RegistryFlowFailedError) {
+      return {
+        message: `${formatRegistrySessionResult(error.completed)}\n\n${error.message}`,
+        partial: true,
+        tone: "error",
+        preserveFlowDiagnostics: true,
+      };
+    }
     return {
       message: `/${command} failed: ${error instanceof Error ? error.message : String(error)}`,
       tone: "error",
       preserveFlowDiagnostics: true,
     };
   }
+}
+
+function withRegistryResults(
+  outcome: TuiSetupCommandResult,
+  error: unknown,
+): TuiSetupCommandResult {
+  if (!(error instanceof RegistryFlowFailedError)) return outcome;
+  return {
+    ...outcome,
+    message: `${formatRegistrySessionResult(error.completed)}\n\n${outcome.message}`,
+    partial: true,
+    tone: "error",
+    preserveFlowDiagnostics: true,
+  };
 }
 
 /**
@@ -358,6 +393,7 @@ async function vercelCliUpgradeOutcome(
   if (choice === "later") {
     return {
       message: `The Vercel CLI needs an update — run \`vercel upgrade\`, then retry /${command}.`,
+      tone: "error",
       preserveFlowDiagnostics: true,
     };
   }
@@ -373,6 +409,7 @@ async function vercelCliUpgradeOutcome(
   } catch (error) {
     return {
       message: vercelCliUpgradeFailureMessage(command, errorMessage(error)),
+      tone: "error",
       preserveFlowDiagnostics: true,
     };
   }
@@ -380,21 +417,25 @@ async function vercelCliUpgradeOutcome(
     case "installed":
       return {
         message: `Upgraded the Vercel CLI. Retry /${command}.`,
+        tone: "error",
         preserveFlowDiagnostics: false,
       };
     case "failed":
       return {
         message: vercelCliUpgradeFailureMessage(command, result.reason),
+        tone: "error",
         preserveFlowDiagnostics: true,
       };
     case "cancelled":
       return {
         message: `Vercel CLI upgrade cancelled — run \`vercel upgrade\`, then retry /${command}.`,
+        tone: "error",
         preserveFlowDiagnostics: true,
       };
     case "already":
       return {
         message: `The Vercel CLI is already up to date. Retry /${command}.`,
+        tone: "error",
         preserveFlowDiagnostics: false,
       };
   }
@@ -421,7 +462,9 @@ function vercelCliUpgradeFailureMessage(command: string, reason?: string): strin
 function vercelActionOutcome(error: unknown, command: string): TuiSetupCommandResult | undefined {
   if (!(error instanceof HumanActionRequiredError)) return undefined;
   const message = vercelActionMessage(error.action.kind, command);
-  return message === undefined ? undefined : { message, preserveFlowDiagnostics: true };
+  return message === undefined
+    ? undefined
+    : { message, tone: "error", preserveFlowDiagnostics: true };
 }
 
 /** The one-line fix message per Vercel action kind, or `undefined` for others. */

--- a/packages/eve/src/cli/dev/tui/setup-commands.ts
+++ b/packages/eve/src/cli/dev/tui/setup-commands.ts
@@ -8,10 +8,11 @@ import { runLoginFlow, type LoginFlowResult } from "#setup/flows/login.js";
 import { runModelFlow } from "#setup/flows/model.js";
 import type { ProviderSelection } from "#setup/provider-settings.js";
 import { runProviderFlow, type ProviderPicker } from "#setup/flows/provider.js";
-import { RegistryFlowFailedError, runRegistryFlow } from "#setup/flows/registry.js";
+import { runRegistryFlow } from "#setup/flows/registry.js";
 import type { Prompter } from "#setup/prompter.js";
 import { WizardCancelledError } from "#setup/step.js";
 
+import { formatRegistrySessionResult } from "./registry-result-message.js";
 import { createTuiPrompter, type TuiPrompterRenderer } from "./tui-prompter.js";
 import type { PromptCommandExtensionName } from "./prompt-commands.js";
 import type { SetupFlowIndicator, SetupFlowRenderer } from "./setup-flow.js";
@@ -47,7 +48,7 @@ export interface TuiSetupCommandInput {
   renderer: TuiSetupCommandRenderer;
   /** Initial model-flow step authorized by the runner's boot evidence. */
   initialModelStep?: "provider";
-  /** Registry address from `/add <item>`, opening that item instead of the browser. */
+  /** Registry address supplied by `/add <item>`, preselected in the batch planner. */
   initialRegistryAddress?: string;
   /** Live ChatGPT identity shown only inside model configuration UI. */
   chatGptAccountLabel?: string;
@@ -66,27 +67,6 @@ export interface TuiSetupFlows {
   runModelFlow: typeof runModelFlow;
   runRegistryFlow: typeof runRegistryFlow;
   runDeployFlow: typeof runDeployFlow;
-}
-
-function joinedTitles(titles: readonly string[]): string {
-  if (titles.length === 0) return "";
-  if (titles.length === 1) return titles[0]!;
-  if (titles.length === 2) return `${titles[0]} and ${titles[1]}`;
-  return `${titles.slice(0, -1).join(", ")}, and ${titles.at(-1)}`;
-}
-
-function registryResultMessage(
-  result: Extract<Awaited<ReturnType<typeof runRegistryFlow>>, { kind: "done" }>,
-): string {
-  const lines = [`Added ${joinedTitles(result.items.map((item) => item.title))}`];
-  for (const item of result.items) {
-    if (item.facts.length === 0 && item.output.length === 0) continue;
-    lines.push("", item.title);
-    const width = Math.max(0, ...item.facts.map((fact) => fact.label.length));
-    for (const fact of item.facts) lines.push(`  ${fact.label.padEnd(width)}  ${fact.value}`);
-    for (const output of item.output) lines.push(`  ${output}`);
-  }
-  return lines.join("\n");
 }
 
 export interface TuiSetupCommandResult {
@@ -260,26 +240,32 @@ async function executeSetupCommand(
         return outcome;
       }
       case "add": {
-        const registryInput: Parameters<TuiSetupFlows["runRegistryFlow"]>[0] = {
+        const flow = await flows.runRegistryFlow({
           appRoot,
           prompter,
           signal,
-        };
-        if (input.initialRegistryAddress !== undefined) {
-          registryInput.initialAddress = input.initialRegistryAddress;
-        }
-        const result = await flows.runRegistryFlow(registryInput);
-        if (result.kind === "cancelled") {
+          initialAddress: input.initialRegistryAddress,
+          onItemStart: (item, index, total) => {
+            renderer.replaceContent?.({
+              headline: `Adding ${item.title ?? item.name} · ${index + 1} of ${total}`,
+              facts: [],
+            });
+            renderer.setStatus("Installing files and dependencies…");
+          },
+        });
+        if (flow.kind === "cancelled") {
           return { message: "/add dismissed.", preserveFlowDiagnostics: true };
         }
+        const result = flow.result;
         const outcome: TuiSetupCommandResult = {
           message:
-            result.addedItems.length > 0
-              ? registryResultMessage(result)
-              : "No registry items added.",
+            result.items.length > 0 || result.failures.length > 0
+              ? formatRegistrySessionResult(result)
+              : "No integrations selected.",
           preserveFlowDiagnostics: true,
         };
-        if (result.addedItems.length > 0) outcome.tone = "success";
+        if (result.failures.length > 0) outcome.tone = "error";
+        else if (result.items.length > 0) outcome.tone = "success";
         if (result.deployed === "production") outcome.effect = { kind: "deployed" };
         return outcome;
       }
@@ -310,27 +296,18 @@ async function executeSetupCommand(
       }
     }
   } catch (error) {
-    const actionableError = error instanceof RegistryFlowFailedError ? error.cause : error;
-    const upgrade = await vercelCliUpgradeOutcome(actionableError, command, flows, {
-      appRoot,
-      prompter,
-      signal,
-    });
-    if (upgrade !== undefined) return upgrade;
-    if (error instanceof RegistryFlowFailedError) {
-      const completed = error.completed;
-      return {
-        message: `${registryResultMessage(completed)}\n\n${error.message}`,
-        tone: "error",
-        preserveFlowDiagnostics: true,
-      };
-    }
     if (error instanceof WizardCancelledError) {
       return {
         message: `/${command} dismissed.`,
         preserveFlowDiagnostics: command !== "model",
       };
     }
+    const upgrade = await vercelCliUpgradeOutcome(error, command, flows, {
+      appRoot,
+      prompter,
+      signal,
+    });
+    if (upgrade !== undefined) return upgrade;
     // Provisioning steps (link, deploy, Slack) throw a Vercel human action when
     // `whoami` fails or a scope is denied. Route it to the in-TUI fix instead of
     // dumping the raw "Human action required" message.
@@ -363,7 +340,7 @@ async function vercelCliUpgradeOutcome(
   let choice: "upgrade" | "later";
   try {
     choice = await input.prompter.select({
-      message: "Your Vercel CLI needs an update to continue setup. Upgrade now?",
+      message: "Your Vercel CLI needs an update to list your teams. Upgrade now?",
       options: [
         {
           value: "upgrade",

--- a/packages/eve/src/cli/dev/tui/setup-flow.ts
+++ b/packages/eve/src/cli/dev/tui/setup-flow.ts
@@ -2,7 +2,7 @@ import type { ChannelSetupChoice, ChannelSetupChoiceOptions } from "#setup/cli/i
 import type { SearchActionOption } from "#setup/cli/select-state.js";
 import type { ModelSettingsRequest, ModelSettingsResult } from "#setup/flows/model.js";
 import type { ProviderPickerChoice, ProviderPickerRequest } from "#setup/flows/provider.js";
-import type { SelectMetadata, SelectNotice } from "#setup/prompter.js";
+import type { PlannerNavigation, SelectMetadata, SelectNotice } from "#setup/prompter.js";
 
 import type { SetupPanelOption } from "./setup-panel.js";
 
@@ -22,9 +22,7 @@ interface SetupSelectRequestBase {
   metadata?: readonly SelectMetadata[];
   options: readonly SetupPanelOption[];
   notices?: readonly SelectNotice[];
-  plannerNavigation?: true;
-  plannerContinue?: string;
-  plannerBack?: true;
+  navigation?: PlannerNavigation;
 }
 
 interface SetupSingleSelectRequest extends SetupSelectRequestBase {
@@ -69,10 +67,15 @@ export type SetupSelectRequest =
   | SetupMultiSelectRequest
   | SetupSearchableMultiSelectRequest;
 
+export type SetupSelectResult =
+  | readonly string[]
+  | { kind: "navigate"; direction: "back" | "forward"; values: readonly string[] }
+  | undefined;
+
 export interface SetupFlowRenderer {
   begin(title: string, indicator?: SetupFlowIndicator): void;
   end(options?: { preserveDiagnostics?: boolean }): void;
-  readSelect(options: SetupSelectRequest): Promise<readonly string[] | undefined>;
+  readSelect(options: SetupSelectRequest): Promise<SetupSelectResult>;
   readEditableSelect(options: {
     message: string;
     options: readonly SetupPanelOption[];

--- a/packages/eve/src/cli/dev/tui/setup-flow.ts
+++ b/packages/eve/src/cli/dev/tui/setup-flow.ts
@@ -22,6 +22,9 @@ interface SetupSelectRequestBase {
   metadata?: readonly SelectMetadata[];
   options: readonly SetupPanelOption[];
   notices?: readonly SelectNotice[];
+  plannerNavigation?: true;
+  plannerContinue?: string;
+  plannerBack?: true;
 }
 
 interface SetupSingleSelectRequest extends SetupSelectRequestBase {
@@ -49,6 +52,7 @@ interface SetupMultiSelectRequest extends SetupSelectRequestBase {
 
 interface SetupSearchableMultiSelectRequest extends SetupSelectRequestBase {
   kind: "searchable-multi";
+  layout?: "stacked";
   initialValues?: readonly string[];
   placeholder?: string;
   required: boolean;
@@ -56,8 +60,8 @@ interface SetupSearchableMultiSelectRequest extends SetupSelectRequestBase {
 
 /**
  * A setup select's complete interaction grammar. The discriminant prevents
- * callers from combining incompatible modes such as multi-select plus a
- * single-select layout.
+ * callers from combining incompatible modes; searchable multi-select supports
+ * the stable stacked checklist layout but not single-select task actions.
  */
 export type SetupSelectRequest =
   | SetupSingleSelectRequest

--- a/packages/eve/src/cli/dev/tui/setup-panel.test.ts
+++ b/packages/eve/src/cli/dev/tui/setup-panel.test.ts
@@ -20,6 +20,11 @@ const OPTIONS = [
   { value: "new", label: "Create a new project", hint: "fastest" },
   { value: "link", label: "Link an existing project" },
 ];
+const PLANNER_NAVIGATION = {
+  kind: "planner" as const,
+  activeStep: 0,
+  steps: [{ label: "Channels" }, { label: "Integrations" }, { label: "Review" }],
+};
 
 describe("renderFlowPanel", () => {
   it("aligns the base-foreground title, progress, and question content", () => {
@@ -858,31 +863,6 @@ describe("renderSelectQuestion", () => {
     expect(text).toContain("space to toggle");
   });
 
-  it("keeps searchable checklist descriptions under their own stable rows", () => {
-    const options = [
-      { value: "web", label: "Web Chat", hint: "A built-in chat UI" },
-      { value: "slack", label: "Slack", hint: "Connect your Slack workspace" },
-    ];
-    const text = renderSelectQuestion(
-      {
-        kind: "searchable-multi",
-        layout: "stacked",
-        message: "Where should people reach your agent?",
-        options,
-        placeholder: "Search channels",
-        select: initialSelectState({ options, submitRow: true }),
-      },
-      theme,
-      80,
-    ).join("\n");
-
-    expect(text).toContain("▶ Web Chat");
-    expect(text).toContain("A built-in chat UI");
-    expect(text).toContain("Slack");
-    expect(text).toContain("Connect your Slack workspace");
-    expect(text).toContain("Submit");
-  });
-
   it("shows beyond featured planner choices in its initial compact viewport", () => {
     const options = [
       { value: "web", label: "Web Chat", featured: true },
@@ -895,7 +875,7 @@ describe("renderSelectQuestion", () => {
     const text = renderSelectQuestion(
       {
         kind: "searchable-multi",
-        plannerNavigation: true,
+        navigation: PLANNER_NAVIGATION,
         message: "Where should people reach your agent?",
         options,
         placeholder: "Search channels",
@@ -910,25 +890,27 @@ describe("renderSelectQuestion", () => {
     expect(text).toContain("Telegram");
   });
 
-  it("uses a non-focusable planner footer for count and page navigation", () => {
+  it("renders planner progress and navigation without a Submit row", () => {
     const options = [{ value: "web", label: "Web Chat", hint: "Built-in chat UI" }];
     const text = renderSelectQuestion(
       {
         kind: "searchable-multi",
-        plannerNavigation: true,
+        navigation: PLANNER_NAVIGATION,
         message: "Where should people reach your agent?",
         options,
-        placeholder: "Search channels",
         select: initialSelectState({ options, initialValues: ["web"] }),
       },
-      theme,
+      colorTheme,
       80,
     ).join("\n");
+    const plain = stripAnsi(text);
 
-    expect(text).toContain("1 selected");
-    expect(text).toContain("space toggle · enter continue · ← / esc back");
-    expect(text).not.toContain("Submit");
-    expect(text).toContain("✓ Web Chat · Built-in chat UI");
+    expect(text).toContain(
+      colorTheme.colors.inverse(colorTheme.colors.blue(colorTheme.colors.bold(" Channels (1) "))),
+    );
+    expect(plain).toContain("1 selected");
+    expect(plain).toContain("enter / → next · ← back");
+    expect(plain).not.toContain("Submit");
   });
 
   it("windows the railed list to five rows with an Esc-only footer", () => {

--- a/packages/eve/src/cli/dev/tui/setup-panel.test.ts
+++ b/packages/eve/src/cli/dev/tui/setup-panel.test.ts
@@ -858,6 +858,79 @@ describe("renderSelectQuestion", () => {
     expect(text).toContain("space to toggle");
   });
 
+  it("keeps searchable checklist descriptions under their own stable rows", () => {
+    const options = [
+      { value: "web", label: "Web Chat", hint: "A built-in chat UI" },
+      { value: "slack", label: "Slack", hint: "Connect your Slack workspace" },
+    ];
+    const text = renderSelectQuestion(
+      {
+        kind: "searchable-multi",
+        layout: "stacked",
+        message: "Where should people reach your agent?",
+        options,
+        placeholder: "Search channels",
+        select: initialSelectState({ options, submitRow: true }),
+      },
+      theme,
+      80,
+    ).join("\n");
+
+    expect(text).toContain("▶ Web Chat");
+    expect(text).toContain("A built-in chat UI");
+    expect(text).toContain("Slack");
+    expect(text).toContain("Connect your Slack workspace");
+    expect(text).toContain("Submit");
+  });
+
+  it("shows beyond featured planner choices in its initial compact viewport", () => {
+    const options = [
+      { value: "web", label: "Web Chat", featured: true },
+      { value: "slack", label: "Slack", featured: true },
+      { value: "github", label: "GitHub", featured: true },
+      { value: "linear-agent", label: "Linear Agent", featured: true },
+      { value: "discord", label: "Discord" },
+      { value: "telegram", label: "Telegram" },
+    ];
+    const text = renderSelectQuestion(
+      {
+        kind: "searchable-multi",
+        plannerNavigation: true,
+        message: "Where should people reach your agent?",
+        options,
+        placeholder: "Search channels",
+        select: initialSelectState({ options }),
+      },
+      theme,
+      100,
+    ).join("\n");
+
+    expect(text).toContain("Linear Agent");
+    expect(text).toContain("Discord");
+    expect(text).toContain("Telegram");
+  });
+
+  it("uses a non-focusable planner footer for count and page navigation", () => {
+    const options = [{ value: "web", label: "Web Chat", hint: "Built-in chat UI" }];
+    const text = renderSelectQuestion(
+      {
+        kind: "searchable-multi",
+        plannerNavigation: true,
+        message: "Where should people reach your agent?",
+        options,
+        placeholder: "Search channels",
+        select: initialSelectState({ options, initialValues: ["web"] }),
+      },
+      theme,
+      80,
+    ).join("\n");
+
+    expect(text).toContain("1 selected");
+    expect(text).toContain("space toggle · enter continue · ← / esc back");
+    expect(text).not.toContain("Submit");
+    expect(text).toContain("✓ Web Chat · Built-in chat UI");
+  });
+
   it("windows the railed list to five rows with an Esc-only footer", () => {
     const many = Array.from({ length: 20 }, (_, index) => ({
       value: `model-${index}`,

--- a/packages/eve/src/cli/dev/tui/setup-panel.ts
+++ b/packages/eve/src/cli/dev/tui/setup-panel.ts
@@ -63,6 +63,12 @@ interface SetupQuestionPanelBase {
   error?: string;
   /** Outcome lines from earlier menu laps, shown beneath the options. */
   notices?: readonly SelectNotice[];
+  /** Batch-planner checklist navigation: Space toggles, Enter continues, Left/Esc goes back. */
+  plannerNavigation?: true;
+  /** Destination named beside Enter in a batch-planner checklist footer. */
+  plannerContinue?: string;
+  /** Batch-planner review navigation: Enter selects, Left/Esc goes back. */
+  plannerBack?: true;
 }
 
 interface SetupSelectPanelBase extends SetupQuestionPanelBase {
@@ -113,7 +119,11 @@ type SetupOptionSelectPanelState =
       placeholder?: string;
     })
   | (SetupSelectPanelBase & { kind: "multi" })
-  | (SetupSelectPanelBase & { kind: "searchable-multi"; placeholder?: string })
+  | (SetupSelectPanelBase & {
+      kind: "searchable-multi";
+      layout?: "stacked";
+      placeholder?: string;
+    })
   | (SetupSelectPanelBase & { kind: "stacked" })
   | (SetupSelectPanelBase & { kind: "task-list" })
   | (SetupSelectPanelBase & {
@@ -413,7 +423,7 @@ function selectPresentation(state: SetupOptionSelectPanelState): SelectPresentat
       return {
         selection: "multiple",
         filter: { placeholder: state.placeholder },
-        layout: "plain",
+        layout: state.layout ?? "plain",
         edit: undefined,
       };
     case "stacked":
@@ -476,17 +486,18 @@ function isRailedSearch(presentation: SelectPresentation): boolean {
 function selectViewSize(input: {
   search: boolean;
   filter: string;
-  featuredLead: number;
   optionCount: number;
   railed: boolean;
+  stacked: boolean;
 }): number {
   if (!input.search) return input.optionCount;
-  // The railed list keeps a constant five-row viewport; other searchable
-  // presentations open on their featured lead when one exists.
+  // The railed list keeps a constant five-row viewport. Stacked search rows
+  // need the same minimum breadth: a single visible card reads like it changes
+  // into the next choice when the cursor moves.
   if (input.railed) return RAILED_VIEW_SIZE;
-  if (input.filter === "" && input.featuredLead > 0) {
-    return Math.min(input.featuredLead, SEARCH_VIEW_SIZE);
-  }
+  if (input.stacked) return Math.min(input.optionCount, SEARCH_VIEW_SIZE);
+  // Featured choices are ordered to the top, not treated as the whole initial
+  // viewport. The planner still opens on a useful compact window after them.
   return SEARCH_VIEW_SIZE;
 }
 
@@ -739,6 +750,9 @@ function selectFooterHints(
   presentation: SelectPresentation,
   visible: readonly SetupPanelOption[],
   cursor: number,
+  plannerNavigation: boolean,
+  plannerContinue: string | undefined,
+  plannerBack: boolean,
 ): string[] {
   const hints: string[] = [];
   let cancelHint = "esc to cancel";
@@ -757,9 +771,15 @@ function selectFooterHints(
   }
   if (presentation.filter !== undefined) hints.push("type to filter");
   hints.push("↑/↓ move");
+  if (plannerNavigation) {
+    hints.push("space toggle");
+    hints.push(`enter ${plannerContinue ?? "continue"}`);
+    hints.push("← / esc back");
+    return hints;
+  }
   hints.push(presentation.selection === "multiple" ? "space to toggle" : "enter to select");
   if (presentation.selection === "multiple") hints.push("enter on Submit to confirm");
-  hints.push(cancelHint);
+  hints.push(plannerBack ? "← / esc back" : cancelHint);
   return hints;
 }
 
@@ -805,7 +825,11 @@ export function renderSelectQuestion(
   const visible = presentation.filter
     ? filterOptions(state.options, state.select.filter, state.searchAction)
     : state.options;
-  const submitIndex = presentation.selection === "multiple" ? submitRowIndex(visible) : -1;
+  const plannerNavigation = state.plannerNavigation === true;
+  const plannerContinue = state.plannerContinue;
+  const plannerBack = state.plannerBack === true;
+  const submitIndex =
+    presentation.selection === "multiple" && !plannerNavigation ? submitRowIndex(visible) : -1;
   const cursor = state.select.cursor;
 
   const railed = isRailedSearch(presentation);
@@ -842,14 +866,12 @@ export function renderSelectQuestion(
     );
   }
 
-  let featuredLead = 0;
-  while (visible[featuredLead]?.featured) featuredLead += 1;
   const viewSize = selectViewSize({
     search: presentation.filter !== undefined,
     filter: state.select.filter,
-    featuredLead,
     optionCount: visible.length,
     railed,
+    stacked: presentation.layout === "stacked",
   });
   const start = Math.max(
     0,
@@ -883,6 +905,10 @@ export function renderSelectQuestion(
     theme,
   });
   appendSubmitRow(rows, cursor, submitIndex, theme);
+  if (plannerNavigation) {
+    const count = state.select.selected.size;
+    rows.push("", `  ${c.dim(`${count} selected`)}`);
+  }
 
   // The railed list scrolls silently: no count row, and Esc is the only
   // footer hint — typing, arrows, and the ↵ badge carry themselves.
@@ -900,7 +926,16 @@ export function renderSelectQuestion(
 
   rows.push(
     ...questionFooter(
-      railed ? ["esc to cancel"] : selectFooterHints(presentation, visible, cursor),
+      railed
+        ? ["esc to cancel"]
+        : selectFooterHints(
+            presentation,
+            visible,
+            cursor,
+            plannerNavigation,
+            plannerContinue,
+            plannerBack,
+          ),
       theme,
     ),
   );

--- a/packages/eve/src/cli/dev/tui/setup-panel.ts
+++ b/packages/eve/src/cli/dev/tui/setup-panel.ts
@@ -27,7 +27,7 @@ import {
   type SearchActionOption,
   type SelectState,
 } from "#setup/cli/select-state.js";
-import type { SelectMetadata, SelectNotice } from "#setup/prompter.js";
+import type { PlannerNavigation, SelectMetadata, SelectNotice } from "#setup/prompter.js";
 import type { ModelSettingsRequest } from "#setup/flows/model.js";
 
 import {
@@ -63,12 +63,8 @@ interface SetupQuestionPanelBase {
   error?: string;
   /** Outcome lines from earlier menu laps, shown beneath the options. */
   notices?: readonly SelectNotice[];
-  /** Batch-planner checklist navigation: Space toggles, Enter continues, Left/Esc goes back. */
-  plannerNavigation?: true;
-  /** Destination named beside Enter in a batch-planner checklist footer. */
-  plannerContinue?: string;
-  /** Batch-planner review navigation: Enter selects, Left/Esc goes back. */
-  plannerBack?: true;
+  /** Optional batch-planner navigation grammar. */
+  navigation?: PlannerNavigation;
 }
 
 interface SetupSelectPanelBase extends SetupQuestionPanelBase {
@@ -435,6 +431,22 @@ function selectPresentation(state: SetupOptionSelectPanelState): SelectPresentat
   }
 }
 
+function plannerStepRows(
+  navigation: Extract<SetupQuestionPanelBase["navigation"], { kind: "planner" }>,
+  activeCount: number | undefined,
+  theme: Theme,
+): string[] {
+  const labels = navigation.steps.map((step, index) => {
+    const resolvedCount = index === navigation.activeStep ? activeCount : step.count;
+    const count = resolvedCount === undefined || resolvedCount === 0 ? "" : ` (${resolvedCount})`;
+    const text = `${step.label}${count}`;
+    return index === navigation.activeStep
+      ? theme.colors.inverse(theme.colors.blue(theme.colors.bold(` ${text} `)))
+      : theme.colors.dim(text);
+  });
+  return [`  ${labels.join(theme.colors.dim("  ·  "))}`, ""];
+}
+
 function selectMessageRows(message: string, layout: SelectLayout, theme: Theme): string[] {
   if (message === "") return [];
 
@@ -751,8 +763,6 @@ function selectFooterHints(
   visible: readonly SetupPanelOption[],
   cursor: number,
   plannerNavigation: boolean,
-  plannerContinue: string | undefined,
-  plannerBack: boolean,
 ): string[] {
   const hints: string[] = [];
   let cancelHint = "esc to cancel";
@@ -772,14 +782,15 @@ function selectFooterHints(
   if (presentation.filter !== undefined) hints.push("type to filter");
   hints.push("↑/↓ move");
   if (plannerNavigation) {
-    hints.push("space toggle");
-    hints.push(`enter ${plannerContinue ?? "continue"}`);
-    hints.push("← / esc back");
+    if (presentation.selection === "multiple") hints.push("space toggle");
+    hints.push(presentation.selection === "multiple" ? "enter / → next" : "enter to select");
+    hints.push("← back");
+    hints.push(cancelHint);
     return hints;
   }
   hints.push(presentation.selection === "multiple" ? "space to toggle" : "enter to select");
   if (presentation.selection === "multiple") hints.push("enter on Submit to confirm");
-  hints.push(plannerBack ? "← / esc back" : cancelHint);
+  hints.push(cancelHint);
   return hints;
 }
 
@@ -825,15 +836,22 @@ export function renderSelectQuestion(
   const visible = presentation.filter
     ? filterOptions(state.options, state.select.filter, state.searchAction)
     : state.options;
-  const plannerNavigation = state.plannerNavigation === true;
-  const plannerContinue = state.plannerContinue;
-  const plannerBack = state.plannerBack === true;
+  const plannerNavigation = state.navigation?.kind === "planner";
   const submitIndex =
     presentation.selection === "multiple" && !plannerNavigation ? submitRowIndex(visible) : -1;
   const cursor = state.select.cursor;
 
   const railed = isRailedSearch(presentation);
-  const rows = selectMessageRows(state.message, presentation.layout, theme);
+  const rows = [
+    ...(state.navigation?.kind === "planner"
+      ? plannerStepRows(
+          state.navigation,
+          presentation.selection === "multiple" ? state.select.selected.size : undefined,
+          theme,
+        )
+      : []),
+    ...selectMessageRows(state.message, presentation.layout, theme),
+  ];
   if (state.description !== undefined || state.metadata !== undefined) {
     if (rows.at(-1) === "") rows.pop();
     if (state.description !== undefined) {
@@ -905,7 +923,7 @@ export function renderSelectQuestion(
     theme,
   });
   appendSubmitRow(rows, cursor, submitIndex, theme);
-  if (plannerNavigation) {
+  if (plannerNavigation && presentation.selection === "multiple") {
     const count = state.select.selected.size;
     rows.push("", `  ${c.dim(`${count} selected`)}`);
   }
@@ -928,14 +946,7 @@ export function renderSelectQuestion(
     ...questionFooter(
       railed
         ? ["esc to cancel"]
-        : selectFooterHints(
-            presentation,
-            visible,
-            cursor,
-            plannerNavigation,
-            plannerContinue,
-            plannerBack,
-          ),
+        : selectFooterHints(presentation, visible, cursor, plannerNavigation),
       theme,
     ),
   );

--- a/packages/eve/src/cli/dev/tui/setup-selection-input.test.ts
+++ b/packages/eve/src/cli/dev/tui/setup-selection-input.test.ts
@@ -105,29 +105,27 @@ describe("setupSelectionIntent", () => {
     ).toMatchObject({ kind: "update", select: { filter: "j" } });
   });
 
-  it("uses Space to toggle and Enter to continue a planner checklist", () => {
-    const options = [
-      { value: "web", label: "Web Chat" },
-      { value: "slack", label: "Slack" },
-    ];
-    const select = initialSelectState({ options });
-
+  it("uses Space to toggle a planner checklist", () => {
+    const options = [{ value: "web", label: "Web Chat" }];
     const toggled = reduceSetupSelectInput({
       key: { type: "text", value: " ", framing: "unframed" },
       kind: "searchable-multi",
       options,
-      select,
+      select: initialSelectState({ options }),
       required: false,
       plannerNavigation: true,
     });
     expect(toggled).toMatchObject({ kind: "update", select: { selected: new Set(["web"]) } });
-    if (toggled.kind !== "update") return;
+  });
+
+  it("continues a planner checklist without a Submit row", () => {
+    const options = [{ value: "web", label: "Web Chat" }];
     expect(
       reduceSetupSelectInput({
         key: { type: "enter" },
         kind: "searchable-multi",
         options,
-        select: toggled.select,
+        select: initialSelectState({ options, initialValues: ["web"] }),
         required: false,
         plannerNavigation: true,
       }),

--- a/packages/eve/src/cli/dev/tui/setup-selection-input.test.ts
+++ b/packages/eve/src/cli/dev/tui/setup-selection-input.test.ts
@@ -105,6 +105,35 @@ describe("setupSelectionIntent", () => {
     ).toMatchObject({ kind: "update", select: { filter: "j" } });
   });
 
+  it("uses Space to toggle and Enter to continue a planner checklist", () => {
+    const options = [
+      { value: "web", label: "Web Chat" },
+      { value: "slack", label: "Slack" },
+    ];
+    const select = initialSelectState({ options });
+
+    const toggled = reduceSetupSelectInput({
+      key: { type: "text", value: " ", framing: "unframed" },
+      kind: "searchable-multi",
+      options,
+      select,
+      required: false,
+      plannerNavigation: true,
+    });
+    expect(toggled).toMatchObject({ kind: "update", select: { selected: new Set(["web"]) } });
+    if (toggled.kind !== "update") return;
+    expect(
+      reduceSetupSelectInput({
+        key: { type: "enter" },
+        kind: "searchable-multi",
+        options,
+        select: toggled.select,
+        required: false,
+        plannerNavigation: true,
+      }),
+    ).toEqual({ kind: "submit", values: ["web"] });
+  });
+
   it("applies filter text and submits the visible match", () => {
     const options = [
       { value: "web", label: "Web Chat" },

--- a/packages/eve/src/cli/dev/tui/setup-selection-input.ts
+++ b/packages/eve/src/cli/dev/tui/setup-selection-input.ts
@@ -69,6 +69,7 @@ type SetupSingleSelectInput = SetupSelectInput & {
 type SetupMultiSelectInput = SetupSelectInput & {
   kind: "multi" | "searchable-multi";
   required: boolean;
+  plannerNavigation?: true;
 };
 
 type SetupSelectInputState = SetupSingleSelectInput | SetupMultiSelectInput;
@@ -90,9 +91,16 @@ function updatedSelect(
     select: reduceSelect(input.select, event, {
       options: input.options,
       searchAction: input.searchAction,
-      submitRow: isMultiSelect(input),
+      submitRow: isMultiSelect(input) && input.plannerNavigation !== true,
     }),
   };
+}
+
+function continueSetupSelect(input: SetupMultiSelectInput): SetupSelectInputResult {
+  if (input.required && input.select.selected.size === 0) {
+    return { kind: "error", message: "Select at least one option, then continue." };
+  }
+  return { kind: "submit", values: orderedSelection(input.options, input.select.selected) };
 }
 
 function submitSetupSelect(input: SetupSelectInputState): SetupSelectInputResult {
@@ -100,6 +108,7 @@ function submitSetupSelect(input: SetupSelectInputState): SetupSelectInputResult
     ? filterOptions(input.options, input.select.filter, input.searchAction)
     : [...input.options];
   if (isMultiSelect(input)) {
+    if (input.plannerNavigation === true) return continueSetupSelect(input);
     if (input.select.cursor !== submitRowIndex(visible)) {
       return updatedSelect(input, { type: "toggle" });
     }
@@ -134,7 +143,7 @@ function editSetupSelect(input: SetupSelectInputState): SetupSelectInputResult {
       const context = {
         options: input.options,
         searchAction: input.searchAction,
-        submitRow: isMultiSelect(input),
+        submitRow: isMultiSelect(input) && input.plannerNavigation !== true,
       };
       for (const char of input.key.value.replaceAll("\n", " ")) {
         if (char >= " " && char !== "\u007f") {

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
@@ -1651,32 +1651,6 @@ describe("TerminalRenderer (inline scrollback)", () => {
     expect(screen.snapshot()).toContain("⎿  ✓ Registry items added: connection/linear.");
   });
 
-  it("renders each initial registry item as its own durable elbow result", () => {
-    const { screen, renderer } = makeRenderer();
-    renderer.renderRegistryResult([
-      {
-        title: "Telegram",
-        status: "success",
-        lines: ["Installed."],
-      },
-      {
-        title: "Slack",
-        status: "error",
-        lines: ["pnpm add failed."],
-        detail: "Error: pnpm add failed.\n    at installSlack (setup.ts:42:7)",
-      },
-    ]);
-    renderer.shutdown();
-
-    const snapshot = screen.snapshot();
-    expect(snapshot).toContain("Telegram");
-    expect(snapshot).toContain("⎿  ✓ Installed.");
-    expect(snapshot).toContain("⨯ Slack");
-    expect(snapshot).toContain("⎿  pnpm add failed.");
-    expect(snapshot).toContain("at installSlack (setup.ts:42:7)");
-    expect(screen.rawOutput()).toContain("\u001b[2m    at installSlack");
-  });
-
   it("marks a failed automatic command and keeps its multiline outcome in one result block", () => {
     const { screen, renderer } = makeRenderer();
     renderer.renderCommandInvocation("/vc:login", "failed");
@@ -3794,7 +3768,11 @@ describe("TerminalRenderer setup panel", () => {
     const { screen, input, renderer } = makeRenderer();
     const answer = renderer.setupFlow.readSelect({
       kind: "single",
-      plannerBack: true,
+      navigation: {
+        kind: "planner",
+        activeStep: 2,
+        steps: [{ label: "Channels" }, { label: "Integrations" }, { label: "Review" }],
+      },
       message: "Review your agent",
       options: [
         { value: "install", label: "Install and set up" },
@@ -3802,15 +3780,47 @@ describe("TerminalRenderer setup panel", () => {
       ],
     });
 
-    expect(screen.snapshot()).toContain("enter to select · ← / esc back");
+    expect(screen.snapshot()).toContain("enter to select · ← back · esc to cancel");
     input.left();
-    await expect(answer).resolves.toBeUndefined();
+    await expect(answer).resolves.toEqual({
+      kind: "navigate",
+      direction: "back",
+      values: [],
+    });
     renderer.shutdown();
   });
 
-  it("renders a compact checklist and confirms selected entries from Submit", async () => {
+  it("proceeds from a planner checklist with Right Arrow and preserves its selections", async () => {
     const { screen, input, renderer } = makeRenderer();
+    const answer = renderer.setupFlow.readSelect({
+      kind: "searchable-multi",
+      navigation: {
+        kind: "planner",
+        activeStep: 0,
+        steps: [{ label: "Channels" }, { label: "Integrations" }, { label: "Review" }],
+      },
+      message: "Where should people reach your agent?",
+      options: [
+        { value: "web", label: "Web Chat" },
+        { value: "slack", label: "Slack" },
+      ],
+      required: false,
+    });
 
+    expect(screen.snapshot()).not.toContain("Channels (1)");
+    input.type(" ");
+    expect(screen.snapshot()).toContain("Channels (1)");
+    input.right();
+    await expect(answer).resolves.toEqual({
+      kind: "navigate",
+      direction: "forward",
+      values: ["web"],
+    });
+    renderer.shutdown();
+  });
+
+  it("confirms selected entries from a multi-select's Submit row", async () => {
+    const { input, renderer } = makeRenderer();
     const answer = renderer.setupFlow.readSelect({
       kind: "multi",
       message: "Select channels",
@@ -3821,46 +3831,11 @@ describe("TerminalRenderer setup panel", () => {
       required: true,
     });
 
-    const snapshot = screen.snapshot();
-    expect(snapshot).toContain("Select channels");
-    expect(snapshot).toContain("▶ Web Chat");
-    expect(snapshot).toContain("◦ Slack");
-    expect(snapshot).toContain("Submit");
-    expect(snapshot).toContain("space to toggle · enter on Submit to confirm");
-
     input.type(" ");
-    expect(screen.snapshot()).toContain("✓ Web Chat");
     input.down();
     input.down();
     input.enter();
     await expect(answer).resolves.toEqual(["web"]);
-    renderer.shutdown();
-  });
-
-  it("keeps a compact planner checklist usable in a short terminal and clears its filter before backing out", async () => {
-    const { screen, input, renderer } = makeRenderer(80, 12);
-    const answer = renderer.setupFlow.readSelect({
-      kind: "searchable-multi",
-      plannerNavigation: true,
-      plannerContinue: "integrations",
-      message: "Where should people reach your agent?",
-      options: [
-        { value: "web", label: "Web Chat", hint: "Built-in chat UI" },
-        { value: "slack", label: "Slack", hint: "Slack workspace" },
-        { value: "github", label: "GitHub", hint: "Issues and pull requests" },
-      ],
-      placeholder: "Search channels",
-      required: false,
-    });
-
-    expect(screen.snapshot()).toContain("Where should people reach your agent?");
-    expect(screen.snapshot()).toContain("space toggle · enter integrations · ← / esc back");
-    input.type("sla");
-    expect(screen.snapshot()).toContain("Slack");
-    input.send("\x1b");
-    await vi.waitFor(() => expect(screen.snapshot()).toContain("Web Chat"));
-    input.send("\x1b");
-    await expect(answer).resolves.toBeUndefined();
     renderer.shutdown();
   });
 
@@ -4486,6 +4461,32 @@ describe("TerminalRenderer setup flow session", () => {
 
     input.enter();
     await expect(answer).resolves.toEqual(["add-more"]);
+    renderer.setupFlow.end({ preserveDiagnostics: false });
+    renderer.shutdown();
+  });
+
+  it("clears the completed item and install status before the batch follow-up", async () => {
+    const { screen, input, renderer } = makeRenderer();
+
+    renderer.setupFlow.begin("Set up your agent");
+    renderer.setupFlow.replaceContent?.({ headline: "Adding GitHub · 2 of 3", facts: [] });
+    renderer.setupFlow.setStatus("Installing files and dependencies…");
+    const answer = renderer.setupFlow.readSelect({
+      kind: "single",
+      message: "What would you like to do next?",
+      options: [
+        { value: "deploy", label: "Deploy" },
+        { value: "finish", label: "Start chatting" },
+      ],
+    });
+
+    const snapshot = screen.snapshot();
+    expect(snapshot).not.toContain("Adding GitHub · 2 of 3");
+    expect(snapshot).not.toContain("Installing files and dependencies");
+    expect(snapshot).toContain("What would you like to do next?");
+
+    input.enter();
+    await expect(answer).resolves.toEqual(["deploy"]);
     renderer.setupFlow.end({ preserveDiagnostics: false });
     renderer.shutdown();
   });

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
@@ -1651,6 +1651,32 @@ describe("TerminalRenderer (inline scrollback)", () => {
     expect(screen.snapshot()).toContain("⎿  ✓ Registry items added: connection/linear.");
   });
 
+  it("renders each initial registry item as its own durable elbow result", () => {
+    const { screen, renderer } = makeRenderer();
+    renderer.renderRegistryResult([
+      {
+        title: "Telegram",
+        status: "success",
+        lines: ["Installed."],
+      },
+      {
+        title: "Slack",
+        status: "error",
+        lines: ["pnpm add failed."],
+        detail: "Error: pnpm add failed.\n    at installSlack (setup.ts:42:7)",
+      },
+    ]);
+    renderer.shutdown();
+
+    const snapshot = screen.snapshot();
+    expect(snapshot).toContain("Telegram");
+    expect(snapshot).toContain("⎿  ✓ Installed.");
+    expect(snapshot).toContain("⨯ Slack");
+    expect(snapshot).toContain("⎿  pnpm add failed.");
+    expect(snapshot).toContain("at installSlack (setup.ts:42:7)");
+    expect(screen.rawOutput()).toContain("\u001b[2m    at installSlack");
+  });
+
   it("marks a failed automatic command and keeps its multiline outcome in one result block", () => {
     const { screen, renderer } = makeRenderer();
     renderer.renderCommandInvocation("/vc:login", "failed");
@@ -3764,8 +3790,26 @@ describe("TerminalRenderer setup panel", () => {
     renderer.shutdown();
   });
 
-  it("toggles a multi-select with space and confirms from the Submit row", async () => {
-    const { input, renderer } = makeRenderer();
+  it("returns from a planner review with Left Arrow instead of selecting an action", async () => {
+    const { screen, input, renderer } = makeRenderer();
+    const answer = renderer.setupFlow.readSelect({
+      kind: "single",
+      plannerBack: true,
+      message: "Review your agent",
+      options: [
+        { value: "install", label: "Install and set up" },
+        { value: "back", label: "Back" },
+      ],
+    });
+
+    expect(screen.snapshot()).toContain("enter to select · ← / esc back");
+    input.left();
+    await expect(answer).resolves.toBeUndefined();
+    renderer.shutdown();
+  });
+
+  it("renders a compact checklist and confirms selected entries from Submit", async () => {
+    const { screen, input, renderer } = makeRenderer();
 
     const answer = renderer.setupFlow.readSelect({
       kind: "multi",
@@ -3777,11 +3821,46 @@ describe("TerminalRenderer setup panel", () => {
       required: true,
     });
 
+    const snapshot = screen.snapshot();
+    expect(snapshot).toContain("Select channels");
+    expect(snapshot).toContain("▶ Web Chat");
+    expect(snapshot).toContain("◦ Slack");
+    expect(snapshot).toContain("Submit");
+    expect(snapshot).toContain("space to toggle · enter on Submit to confirm");
+
     input.type(" ");
+    expect(screen.snapshot()).toContain("✓ Web Chat");
     input.down();
     input.down();
     input.enter();
     await expect(answer).resolves.toEqual(["web"]);
+    renderer.shutdown();
+  });
+
+  it("keeps a compact planner checklist usable in a short terminal and clears its filter before backing out", async () => {
+    const { screen, input, renderer } = makeRenderer(80, 12);
+    const answer = renderer.setupFlow.readSelect({
+      kind: "searchable-multi",
+      plannerNavigation: true,
+      plannerContinue: "integrations",
+      message: "Where should people reach your agent?",
+      options: [
+        { value: "web", label: "Web Chat", hint: "Built-in chat UI" },
+        { value: "slack", label: "Slack", hint: "Slack workspace" },
+        { value: "github", label: "GitHub", hint: "Issues and pull requests" },
+      ],
+      placeholder: "Search channels",
+      required: false,
+    });
+
+    expect(screen.snapshot()).toContain("Where should people reach your agent?");
+    expect(screen.snapshot()).toContain("space toggle · enter integrations · ← / esc back");
+    input.type("sla");
+    expect(screen.snapshot()).toContain("Slack");
+    input.send("\x1b");
+    await vi.waitFor(() => expect(screen.snapshot()).toContain("Web Chat"));
+    input.send("\x1b");
+    await expect(answer).resolves.toBeUndefined();
     renderer.shutdown();
   });
 

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.ts
@@ -17,6 +17,7 @@ import type {
   SubagentView,
   SubagentToolUpdate,
 } from "./runner.js";
+import type { RegistryResultReportEntry } from "./registry-result-message.js";
 import { interruptedError } from "./errors.js";
 import {
   dismissTypeahead,
@@ -1801,6 +1802,30 @@ export class TerminalRenderer implements AgentTUIRenderer {
     this.#paint();
   }
 
+  renderRegistryResult(entries: readonly RegistryResultReportEntry[]): void {
+    if (entries.length === 0) return;
+    this.#start();
+    for (const entry of entries) {
+      this.#pushBlock({
+        kind: "command",
+        body: entry.title,
+        live: false,
+        ...(entry.status === "error" ? { status: "error" } : {}),
+      });
+      const body = [
+        ...(entry.lines.length > 0 ? entry.lines : ["Installed."]),
+        ...(entry.detail === undefined ? [] : ["", entry.detail]),
+      ].join("\n");
+      this.#pushBlock({
+        kind: "result",
+        body,
+        live: false,
+        ...(entry.status === "success" ? { status: "done" } : {}),
+      });
+    }
+    this.#paint();
+  }
+
   /**
    * Opens the bordered flow panel for one setup command. Until the flow ends,
    * every flow line, question, and status renders inside it; the transcript
@@ -1882,7 +1907,7 @@ export class TerminalRenderer implements AgentTUIRenderer {
     const initial: Parameters<typeof initialSelectState>[0] = {
       options: selectOptions,
       searchAction,
-      submitRow: multiple,
+      submitRow: multiple && opts.plannerNavigation !== true,
     };
     if ("initialValue" in opts && opts.initialValue !== undefined) {
       initial.defaultValue = opts.initialValue;
@@ -1905,7 +1930,7 @@ export class TerminalRenderer implements AgentTUIRenderer {
         {
           options: selectOptions,
           searchAction,
-          submitRow: multiple,
+          submitRow: multiple && opts.plannerNavigation !== true,
         },
       );
       this.#paint();
@@ -1926,7 +1951,11 @@ export class TerminalRenderer implements AgentTUIRenderer {
         const filter = select.filter;
         selectOptions = options;
         select = {
-          ...initialSelectState({ options, searchAction, submitRow: multiple }),
+          ...initialSelectState({
+            options,
+            searchAction,
+            submitRow: multiple && opts.plannerNavigation !== true,
+          }),
           filter,
         };
       } catch (reason) {
@@ -1975,9 +2004,19 @@ export class TerminalRenderer implements AgentTUIRenderer {
         return;
       }
 
+      if ((opts.plannerNavigation === true || opts.plannerBack === true) && key.type === "left") {
+        close(undefined);
+        return;
+      }
+
       const base = { key, options: selectOptions, searchAction, select };
       const result = multiple
-        ? reduceSetupSelectInput({ ...base, kind: opts.kind, required: opts.required })
+        ? reduceSetupSelectInput({
+            ...base,
+            kind: opts.kind,
+            required: opts.required,
+            plannerNavigation: opts.plannerNavigation,
+          })
         : reduceSetupSelectInput({ ...base, kind: opts.kind });
       switch (result.kind) {
         case "cancel":

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.ts
@@ -17,7 +17,6 @@ import type {
   SubagentView,
   SubagentToolUpdate,
 } from "./runner.js";
-import type { RegistryResultReportEntry } from "./registry-result-message.js";
 import { interruptedError } from "./errors.js";
 import {
   dismissTypeahead,
@@ -61,12 +60,14 @@ import type {
   SetupFlowRenderer,
   SetupFlowStatus,
   SetupSelectRequest,
+  SetupSelectResult,
 } from "./setup-flow.js";
 import type { SelectNotice } from "#setup/prompter.js";
 import type { ModelSettingsRequest, ModelSettingsResult } from "#setup/flows/model.js";
 import type { ProviderPickerChoice, ProviderPickerRequest } from "#setup/flows/provider.js";
 import {
   initialSelectState,
+  orderedSelection,
   reduceSelect,
   searchActionQuery,
   selectValueAtCursor,
@@ -1802,30 +1803,6 @@ export class TerminalRenderer implements AgentTUIRenderer {
     this.#paint();
   }
 
-  renderRegistryResult(entries: readonly RegistryResultReportEntry[]): void {
-    if (entries.length === 0) return;
-    this.#start();
-    for (const entry of entries) {
-      this.#pushBlock({
-        kind: "command",
-        body: entry.title,
-        live: false,
-        ...(entry.status === "error" ? { status: "error" } : {}),
-      });
-      const body = [
-        ...(entry.lines.length > 0 ? entry.lines : ["Installed."]),
-        ...(entry.detail === undefined ? [] : ["", entry.detail]),
-      ].join("\n");
-      this.#pushBlock({
-        kind: "result",
-        body,
-        live: false,
-        ...(entry.status === "success" ? { status: "done" } : {}),
-      });
-    }
-    this.#paint();
-  }
-
   /**
    * Opens the bordered flow panel for one setup command. Until the flow ends,
    * every flow line, question, and status renders inside it; the transcript
@@ -1898,16 +1875,17 @@ export class TerminalRenderer implements AgentTUIRenderer {
    * clears an active search first. One question at a time; it vanishes on
    * resolve.
    */
-  async #readSetupSelect(opts: SetupSelectRequest): Promise<readonly string[] | undefined> {
+  async #readSetupSelect(opts: SetupSelectRequest): Promise<SetupSelectResult> {
     const flow = this.#beginSetupQuestion();
     const multiple = isMultiSelectRequest(opts);
     const searchAction = opts.kind === "search" ? opts.searchAction : undefined;
     let selectOptions: readonly SetupPanelOption[] = opts.options;
 
+    const plannerNavigation = opts.navigation?.kind === "planner";
     const initial: Parameters<typeof initialSelectState>[0] = {
       options: selectOptions,
       searchAction,
-      submitRow: multiple && opts.plannerNavigation !== true,
+      submitRow: multiple && !plannerNavigation,
     };
     if ("initialValue" in opts && opts.initialValue !== undefined) {
       initial.defaultValue = opts.initialValue;
@@ -1930,7 +1908,7 @@ export class TerminalRenderer implements AgentTUIRenderer {
         {
           options: selectOptions,
           searchAction,
-          submitRow: multiple && opts.plannerNavigation !== true,
+          submitRow: multiple && !plannerNavigation,
         },
       );
       this.#paint();
@@ -1954,7 +1932,7 @@ export class TerminalRenderer implements AgentTUIRenderer {
           ...initialSelectState({
             options,
             searchAction,
-            submitRow: multiple && opts.plannerNavigation !== true,
+            submitRow: multiple && !plannerNavigation,
           }),
           filter,
         };
@@ -1992,8 +1970,8 @@ export class TerminalRenderer implements AgentTUIRenderer {
     flow.question = (width) => renderSelectQuestion(panelState(), this.#theme, width);
     this.#paint();
 
-    const question = this.#captureSetupQuestion<readonly string[] | undefined>((key, settle) => {
-      const close = (value: readonly string[] | undefined): void => {
+    const question = this.#captureSetupQuestion<SetupSelectResult>((key, settle) => {
+      const close = (value: SetupSelectResult): void => {
         searchVersion += 1;
         settle(value);
       };
@@ -2004,8 +1982,21 @@ export class TerminalRenderer implements AgentTUIRenderer {
         return;
       }
 
-      if ((opts.plannerNavigation === true || opts.plannerBack === true) && key.type === "left") {
-        close(undefined);
+      const plannerStep = opts.navigation?.kind === "planner" ? opts.navigation : undefined;
+      const plannerDirection =
+        key.type === "left" && (plannerStep?.activeStep ?? 0) > 0
+          ? "back"
+          : key.type === "right" &&
+              plannerStep !== undefined &&
+              plannerStep.activeStep < plannerStep.steps.length - 1
+            ? "forward"
+            : undefined;
+      if (plannerDirection !== undefined) {
+        close({
+          kind: "navigate",
+          direction: plannerDirection,
+          values: multiple ? orderedSelection(selectOptions, select.selected) : [],
+        });
         return;
       }
 
@@ -2015,7 +2006,7 @@ export class TerminalRenderer implements AgentTUIRenderer {
             ...base,
             kind: opts.kind,
             required: opts.required,
-            plannerNavigation: opts.plannerNavigation,
+            plannerNavigation: plannerNavigation || undefined,
           })
         : reduceSetupSelectInput({ ...base, kind: opts.kind });
       switch (result.kind) {
@@ -2555,7 +2546,15 @@ export class TerminalRenderer implements AgentTUIRenderer {
     this.#inputActive = false;
     this.#turnIndicator = { kind: "idle" };
     this.#status = "";
-    return this.#requireSetupFlow();
+    const flow = this.#requireSetupFlow();
+    // A standard question means the preceding background operation settled.
+    // Clear its transient item summary and timer before painting the prompt.
+    if (flow.status !== undefined) {
+      flow.status = undefined;
+      flow.summary = undefined;
+      flow.preview = undefined;
+    }
+    return flow;
   }
 
   /** A flow is implicitly opened for a bare question (tests, future hosts). */
@@ -2775,6 +2774,7 @@ export class TerminalRenderer implements AgentTUIRenderer {
     flow.lines = [];
     flow.outputBuffer = [];
     flow.preview = undefined;
+    flow.status = undefined;
     flow.summary =
       content === undefined
         ? undefined

--- a/packages/eve/src/cli/dev/tui/tui-prompter.test.ts
+++ b/packages/eve/src/cli/dev/tui/tui-prompter.test.ts
@@ -156,6 +156,32 @@ describe("createTuiPrompter", () => {
     );
   });
 
+  it("returns decoded selections with a planner navigation request", async () => {
+    const renderer = fakeRenderer({
+      readSelect: vi.fn(async () => ({
+        kind: "navigate" as const,
+        direction: "forward" as const,
+        values: ["option-1"],
+      })),
+    });
+    const prompter = createTuiPrompter(renderer);
+
+    await expect(
+      prompter.select({
+        message: "Select channels",
+        multiple: true,
+        options: [
+          { value: "web", label: "Web Chat" },
+          { value: "slack", label: "Slack" },
+        ],
+      }),
+    ).rejects.toMatchObject({
+      name: "PlannerNavigationError",
+      direction: "forward",
+      values: ["slack"],
+    });
+  });
+
   it("round-trips an inline-edited select value", async () => {
     const renderer = fakeRenderer({
       readEditableSelect: vi.fn(async () => ({

--- a/packages/eve/src/cli/dev/tui/tui-prompter.test.ts
+++ b/packages/eve/src/cli/dev/tui/tui-prompter.test.ts
@@ -138,6 +138,24 @@ describe("createTuiPrompter", () => {
     );
   });
 
+  it("maps a searchable multi-select's stacked hints to stable checklist cards", async () => {
+    const renderer = fakeRenderer({ readSelect: vi.fn(async () => ["option-0"]) });
+    const prompter = createTuiPrompter(renderer);
+
+    await expect(
+      prompter.select({
+        message: "Select channels",
+        multiple: true,
+        search: true,
+        hintLayout: "stacked",
+        options: [{ value: "web", label: "Web Chat", hint: "A built-in chat UI" }],
+      }),
+    ).resolves.toEqual(["web"]);
+    expect(renderer.readSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "searchable-multi", layout: "stacked" }),
+    );
+  });
+
   it("round-trips an inline-edited select value", async () => {
     const renderer = fakeRenderer({
       readEditableSelect: vi.fn(async () => ({

--- a/packages/eve/src/cli/dev/tui/tui-prompter.ts
+++ b/packages/eve/src/cli/dev/tui/tui-prompter.ts
@@ -1,3 +1,4 @@
+import { PlannerNavigationError } from "#setup/prompter.js";
 import type {
   EditableSelectOptions,
   EditableSelectResult,
@@ -36,11 +37,9 @@ function setupSelectRequest<T extends PrompterValue>(
   } = { message: opts.message, options };
   if (opts.description !== undefined) base.description = opts.description;
   if (opts.metadata !== undefined) base.metadata = opts.metadata;
-  const withNavigation = <Request extends SetupSelectRequest>(request: Request): Request => {
+  const withContext = <Request extends SetupSelectRequest>(request: Request): Request => {
     if (opts.notices !== undefined) request.notices = opts.notices;
-    if (opts.plannerNavigation === true) request.plannerNavigation = true;
-    if (opts.plannerContinue !== undefined) request.plannerContinue = opts.plannerContinue;
-    if (opts.plannerBack === true) request.plannerBack = true;
+    if (opts.navigation !== undefined) request.navigation = opts.navigation;
     return request;
   };
 
@@ -67,7 +66,7 @@ function setupSelectRequest<T extends PrompterValue>(
     if (opts.initialValues !== undefined) {
       request.initialValues = opts.initialValues.map(encode);
     }
-    return withNavigation(request);
+    return withContext(request);
   }
 
   if (opts.search === true && opts.hintLayout === "stacked") {
@@ -92,7 +91,7 @@ function setupSelectRequest<T extends PrompterValue>(
     request = { ...base, kind };
   }
   if (opts.initialValue !== undefined) request.initialValue = encode(opts.initialValue);
-  return withNavigation(request);
+  return withContext(request);
 }
 
 /**
@@ -119,8 +118,11 @@ export function createTuiPrompter(renderer: TuiPrompterRenderer): Prompter {
     const codec = createSelectOptionCodec(opts.options);
     const request = setupSelectRequest(opts, codec.options, codec.encode, codec.encodeOptions);
 
-    const keys = guardCancel(await renderer.readSelect(request));
-    const values = keys.map((key) => {
+    const result = guardCancel(await renderer.readSelect(request));
+    if ("kind" in result) {
+      throw new PlannerNavigationError(result.direction, result.values.map(codec.decode));
+    }
+    const values = result.map((key) => {
       const query = searchActionQuery(key);
       if (query !== undefined && opts.multiple !== true && opts.searchAction !== undefined) {
         return opts.searchAction.value(query);
@@ -207,6 +209,8 @@ export function createTuiPrompter(renderer: TuiPrompterRenderer): Prompter {
     replaceContent: (content) => renderer.replaceContent?.(content),
 
     withInheritedStdio: (task) => renderer.withInheritedStdio(task),
+
+    withExclusiveTerminal: (task) => renderer.withExclusiveTerminal?.(task) ?? task(),
 
     log: {
       message: line("info"),

--- a/packages/eve/src/cli/dev/tui/tui-prompter.ts
+++ b/packages/eve/src/cli/dev/tui/tui-prompter.ts
@@ -36,16 +36,15 @@ function setupSelectRequest<T extends PrompterValue>(
   } = { message: opts.message, options };
   if (opts.description !== undefined) base.description = opts.description;
   if (opts.metadata !== undefined) base.metadata = opts.metadata;
-  const withNotices = <Request extends SetupSelectRequest>(request: Request): Request => {
+  const withNavigation = <Request extends SetupSelectRequest>(request: Request): Request => {
     if (opts.notices !== undefined) request.notices = opts.notices;
+    if (opts.plannerNavigation === true) request.plannerNavigation = true;
+    if (opts.plannerContinue !== undefined) request.plannerContinue = opts.plannerContinue;
+    if (opts.plannerBack === true) request.plannerBack = true;
     return request;
   };
 
   if (opts.multiple === true) {
-    if (opts.hintLayout !== undefined) {
-      throw new Error("Multi-select setup questions do not support a hint layout.");
-    }
-
     let request: SetupSelectRequest;
     if (opts.search === true) {
       request = {
@@ -53,6 +52,10 @@ function setupSelectRequest<T extends PrompterValue>(
         kind: "searchable-multi",
         required: opts.required ?? false,
       };
+      if (opts.hintLayout === "stacked") request.layout = "stacked";
+      if (opts.hintLayout === "inline") {
+        throw new Error("Multi-select setup questions do not support inline hint layout.");
+      }
       if (opts.placeholder !== undefined) request.placeholder = opts.placeholder;
     } else {
       request = {
@@ -64,7 +67,7 @@ function setupSelectRequest<T extends PrompterValue>(
     if (opts.initialValues !== undefined) {
       request.initialValues = opts.initialValues.map(encode);
     }
-    return withNotices(request);
+    return withNavigation(request);
   }
 
   if (opts.search === true && opts.hintLayout === "stacked") {
@@ -89,7 +92,7 @@ function setupSelectRequest<T extends PrompterValue>(
     request = { ...base, kind };
   }
   if (opts.initialValue !== undefined) request.initialValue = encode(opts.initialValue);
-  return withNotices(request);
+  return withNavigation(request);
 }
 
 /**

--- a/packages/eve/src/setup/cli/prompt-ui.ts
+++ b/packages/eve/src/setup/cli/prompt-ui.ts
@@ -42,6 +42,11 @@ export interface PromptOption<T extends PromptValue> {
   /** Short inline annotation shown dimmed only while the cursor is on this row. */
   focusHint?: string;
   /**
+   * Longer explanation rendered in the picker's reserved context area while
+   * this row is focused. The stable slot keeps neighboring rows stationary.
+   */
+  focusDescription?: string;
+  /**
    * Longer, display-only explanation for the highlighted option. Its prompt
    * chooses the placement; it is hidden once a choice is submitted.
    */

--- a/packages/eve/src/setup/cli/prompt-ui.ts
+++ b/packages/eve/src/setup/cli/prompt-ui.ts
@@ -42,11 +42,6 @@ export interface PromptOption<T extends PromptValue> {
   /** Short inline annotation shown dimmed only while the cursor is on this row. */
   focusHint?: string;
   /**
-   * Longer explanation rendered in the picker's reserved context area while
-   * this row is focused. The stable slot keeps neighboring rows stationary.
-   */
-  focusDescription?: string;
-  /**
    * Longer, display-only explanation for the highlighted option. Its prompt
    * chooses the placement; it is hidden once a choice is submitted.
    */

--- a/packages/eve/src/setup/flows/registry-session.ts
+++ b/packages/eve/src/setup/flows/registry-session.ts
@@ -1,6 +1,5 @@
 import type { Prompter } from "#setup/prompter.js";
 import { detectDeployment } from "#setup/project-resolution.js";
-import { mergeRegistrySetupCompletions } from "#setup/registry-setup-completion.js";
 import type { RegistrySetupCompletion, RegistrySetupFact } from "#setup/registry-setup-protocol.js";
 
 import { runDeployFlow } from "./deploy.js";
@@ -11,7 +10,6 @@ export interface RegistrySessionDeps {
 }
 
 export interface RegistrySessionItemResult {
-  address: string;
   title: string;
   facts: readonly RegistrySetupFact[];
   output: readonly string[];
@@ -19,33 +17,23 @@ export interface RegistrySessionItemResult {
 
 /** An item the user chose to skip after its installation could not complete. */
 export interface RegistrySessionItemFailure {
-  address: string;
   title: string;
-  /** Concise error shown while the setup panel asks whether to skip the item. */
+  /** User-facing installation error, including any actionable follow-up lines. */
   message: string;
-  /** Full diagnostic preserved for the permanent setup report. */
-  detail: string;
 }
 
 export interface RegistrySessionResult {
-  kind: "done";
-  addedItems: readonly string[];
   items: readonly RegistrySessionItemResult[];
   /** Installation failures retained when a user skips an item. */
   failures: readonly RegistrySessionItemFailure[];
-  facts: readonly RegistrySetupFact[];
-  output: readonly string[];
+  /** Setup stopped after preserving already-settled item results. */
+  cancelled?: true;
   deployed?: "production";
 }
 
 export interface RegistrySession {
-  add(
-    item: string,
-    title: string,
-    output: readonly string[],
-    setup?: RegistrySetupCompletion,
-  ): void;
-  addFailure(item: string, title: string, message: string, detail: string): void;
+  add(title: string, output: readonly string[], setup?: RegistrySetupCompletion): void;
+  addFailure(title: string, message: string): void;
   result(deployed?: "production"): RegistrySessionResult;
   continueAfterInstall(input: {
     appRoot: string;
@@ -56,52 +44,34 @@ export interface RegistrySession {
 
 /** Owns the accumulated output and deployment decision for one `/add` session. */
 export function createRegistrySession(deps: RegistrySessionDeps): RegistrySession {
-  const addedItems: string[] = [];
   const items: RegistrySessionItemResult[] = [];
   const failures: RegistrySessionItemFailure[] = [];
-  const output: string[] = [];
-  let completion: RegistrySetupCompletion = { facts: [] };
-  let currentItem = "";
-  let currentFacts: readonly RegistrySetupFact[] = [];
+  let deploymentRequired = false;
 
   function result(deployed?: "production"): RegistrySessionResult {
-    const session: RegistrySessionResult = {
-      kind: "done",
-      addedItems,
-      items,
-      failures,
-      facts: completion.facts,
-      output,
-    };
+    const session: RegistrySessionResult = { items, failures };
     if (deployed !== undefined) session.deployed = deployed;
     return session;
   }
 
   return {
-    add(item, title, itemOutput, setup = { facts: [] }) {
-      addedItems.push(item);
-      items.push({ address: item, title, facts: setup.facts, output: itemOutput });
-      output.push(...itemOutput);
-      currentItem = title;
-      currentFacts = setup.facts;
-      completion = mergeRegistrySetupCompletions(completion, setup);
+    add(title, itemOutput, setup = { facts: [] }) {
+      items.push({ title, facts: setup.facts, output: itemOutput });
+      deploymentRequired ||= setup.deploymentRequired === true;
     },
 
-    addFailure(item, title, message, detail) {
-      failures.push({ address: item, title, message, detail });
+    addFailure(title, message) {
+      failures.push({ title, message });
     },
 
     result,
 
     async continueAfterInstall(input) {
-      if (completion.deploymentRequired !== true) return result();
+      if (!deploymentRequired) return result();
 
       const deployment = await deps.detectDeployment(input.appRoot, { signal: input.signal });
       const canDeploy = deployment.state === "linked" || deployment.state === "deployed";
-      input.prompter.replaceContent?.({
-        headline: `Added ${currentItem}`,
-        facts: currentFacts,
-      });
+      input.prompter.replaceContent?.();
       while (true) {
         const action = await input.prompter.select<"deploy" | "finish">({
           message: "What would you like to do next?",

--- a/packages/eve/src/setup/flows/registry-session.ts
+++ b/packages/eve/src/setup/flows/registry-session.ts
@@ -17,10 +17,22 @@ export interface RegistrySessionItemResult {
   output: readonly string[];
 }
 
+/** An item the user chose to skip after its installation could not complete. */
+export interface RegistrySessionItemFailure {
+  address: string;
+  title: string;
+  /** Concise error shown while the setup panel asks whether to skip the item. */
+  message: string;
+  /** Full diagnostic preserved for the permanent setup report. */
+  detail: string;
+}
+
 export interface RegistrySessionResult {
   kind: "done";
   addedItems: readonly string[];
   items: readonly RegistrySessionItemResult[];
+  /** Installation failures retained when a user skips an item. */
+  failures: readonly RegistrySessionItemFailure[];
   facts: readonly RegistrySetupFact[];
   output: readonly string[];
   deployed?: "production";
@@ -33,18 +45,20 @@ export interface RegistrySession {
     output: readonly string[],
     setup?: RegistrySetupCompletion,
   ): void;
+  addFailure(item: string, title: string, message: string, detail: string): void;
   result(deployed?: "production"): RegistrySessionResult;
   continueAfterInstall(input: {
     appRoot: string;
     prompter: Prompter;
     signal?: AbortSignal;
-  }): Promise<"add-more" | RegistrySessionResult>;
+  }): Promise<RegistrySessionResult>;
 }
 
 /** Owns the accumulated output and deployment decision for one `/add` session. */
 export function createRegistrySession(deps: RegistrySessionDeps): RegistrySession {
   const addedItems: string[] = [];
   const items: RegistrySessionItemResult[] = [];
+  const failures: RegistrySessionItemFailure[] = [];
   const output: string[] = [];
   let completion: RegistrySetupCompletion = { facts: [] };
   let currentItem = "";
@@ -55,6 +69,7 @@ export function createRegistrySession(deps: RegistrySessionDeps): RegistrySessio
       kind: "done",
       addedItems,
       items,
+      failures,
       facts: completion.facts,
       output,
     };
@@ -72,6 +87,10 @@ export function createRegistrySession(deps: RegistrySessionDeps): RegistrySessio
       completion = mergeRegistrySetupCompletions(completion, setup);
     },
 
+    addFailure(item, title, message, detail) {
+      failures.push({ address: item, title, message, detail });
+    },
+
     result,
 
     async continueAfterInstall(input) {
@@ -84,20 +103,15 @@ export function createRegistrySession(deps: RegistrySessionDeps): RegistrySessio
         facts: currentFacts,
       });
       while (true) {
-        const action = await input.prompter.select<"deploy" | "add-more" | "finish">({
+        const action = await input.prompter.select<"deploy" | "finish">({
           message: "What would you like to do next?",
-          initialValue: "add-more",
+          initialValue: "finish",
           hintLayout: "inline",
           options: [
-            { value: "add-more", label: "Add more" },
             ...(canDeploy ? [{ value: "deploy" as const, label: "Deploy" }] : []),
-            { value: "finish", label: "Finish" },
+            { value: "finish", label: "Start chatting" },
           ],
         });
-        if (action === "add-more") {
-          input.prompter.replaceContent?.();
-          return "add-more";
-        }
         if (action === "finish") return result();
 
         const confirmed = await input.prompter.select<"yes" | "back">({

--- a/packages/eve/src/setup/flows/registry.test.ts
+++ b/packages/eve/src/setup/flows/registry.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { createFakePrompter } from "#internal/testing/fake-prompter.js";
-import { WizardCancelledError } from "#setup/step.js";
 
-import { RegistryFlowFailedError, runRegistryFlow, type RegistryFlowDeps } from "./registry.js";
+import { runRegistryFlow, type RegistryFlowDeps } from "./registry.js";
 
 const APP_ROOT = "/tmp/agent";
 
@@ -12,23 +11,22 @@ function deps(overrides: Partial<RegistryFlowDeps> = {}): RegistryFlowDeps {
     browseRegistryCatalog: vi.fn(async () => ({
       items: [
         {
-          address: "extension/agent-browser",
-          name: "extension/agent-browser",
-          type: "registry:item",
-          description: "Browser automation",
+          address: "channel/web",
+          name: "channel/web",
+          title: "Web Chat",
+          description: "A chat UI for your agent",
+          source: "Vercel",
+        },
+        {
+          address: "connection/linear",
+          name: "connection/linear",
+          title: "Linear",
+          description: "Issue tracking",
           source: "Vercel",
         },
       ],
-      total: 1,
+      total: 2,
       errors: [],
-    })),
-    getRegistryItemManifest: vi.fn(async () => ({
-      name: "extension/agent-browser",
-      title: "agent-browser",
-      description: "Browser automation",
-      dependencies: ["@agent-browser/eve"],
-      envVars: { AGENT_BROWSER_TOKEN: "" },
-      files: [{ target: "agent/extensions/browser.ts" }],
     })),
     installRegistryItem: vi.fn(async () => ({ output: [] })),
     detectDeployment: vi.fn(async () => ({ state: "unlinked" as const })),
@@ -38,491 +36,237 @@ function deps(overrides: Partial<RegistryFlowDeps> = {}): RegistryFlowDeps {
 }
 
 describe("runRegistryFlow", () => {
-  it("browses a category, shows an item's manifest details, and exits after installing", async () => {
-    const answers = ["category:extension", "item:0", "add"];
+  it("plans channels and integrations together, then installs the full plan in order", async () => {
+    const answers = ["install"];
+    const selections = [["channel/web"], ["connection/linear"]];
+    const fake = createFakePrompter({
+      single: () => answers.shift()!,
+      multiple: () => selections.shift()!,
+    });
+    const flowDeps = deps();
+    const starts: string[] = [];
+
+    await expect(
+      runRegistryFlow({
+        appRoot: APP_ROOT,
+        prompter: fake.prompter,
+        deps: flowDeps,
+        onItemStart: (item, index, total) => starts.push(`${item.address}:${index + 1}/${total}`),
+      }),
+    ).resolves.toEqual({
+      kind: "done",
+      result: {
+        kind: "done",
+        addedItems: ["channel/web", "connection/linear"],
+        items: [
+          { address: "channel/web", title: "Web Chat", facts: [], output: [] },
+          { address: "connection/linear", title: "Linear", facts: [], output: [] },
+        ],
+        failures: [],
+        facts: [],
+        output: [],
+      },
+    });
+
+    expect(starts).toEqual(["channel/web:1/2", "connection/linear:2/2"]);
+    expect(flowDeps.installRegistryItem).toHaveBeenNthCalledWith(
+      1,
+      APP_ROOT,
+      "channel/web",
+      expect.objectContaining({ silent: true, prompter: fake.prompter }),
+    );
+    expect(flowDeps.installRegistryItem).toHaveBeenNthCalledWith(
+      2,
+      APP_ROOT,
+      "connection/linear",
+      expect.objectContaining({ silent: true, prompter: fake.prompter }),
+    );
+  });
+
+  it("lets the user browse, retain selections, and review the plan before installing", async () => {
+    const answers = ["install"];
     const prompts: unknown[] = [];
     const fake = createFakePrompter({
       single: (options) => {
         prompts.push(options);
         return answers.shift()!;
       },
+      multiple: (options) => {
+        prompts.push(options);
+        return options.message === "What should your agent be able to work with?"
+          ? ["connection/linear"]
+          : [];
+      },
     });
-    const flowDeps = deps();
 
-    await expect(
-      runRegistryFlow({ appRoot: APP_ROOT, prompter: fake.prompter, deps: flowDeps }),
-    ).resolves.toEqual({
-      kind: "done",
-      addedItems: ["extension/agent-browser"],
-      items: [
-        {
-          address: "extension/agent-browser",
-          title: "Agent Browser",
-          facts: [],
-          output: ["Environment: AGENT_BROWSER_TOKEN"],
-        },
-      ],
-      facts: [],
-      output: ["Environment: AGENT_BROWSER_TOKEN"],
-    });
-    expect(flowDeps.installRegistryItem).toHaveBeenCalledWith(
-      APP_ROOT,
-      "extension/agent-browser",
-      expect.objectContaining({ silent: true, prompter: fake.prompter }),
-    );
+    await runRegistryFlow({ appRoot: APP_ROOT, prompter: fake.prompter, deps: deps() });
+
     expect(prompts[0]).toMatchObject({
-      message: "Add an integration",
-      hintLayout: "inline",
-      options: expect.arrayContaining([
-        expect.objectContaining({
-          value: "category:channel",
-          label: "Channels",
-          hint: "Where people talk to your agent — Web, Slack, Discord, Teams",
-        }),
-        expect.objectContaining({
-          value: "category:connection",
-          label: "MCP connections",
-          hint: "Connect services like Linear, Notion, GitHub, and Vercel",
-        }),
-        expect.objectContaining({
-          value: "category:extension",
-          label: "Extensions",
-          hint: "Add browser automation, memory, and developer tools",
-        }),
-        expect.objectContaining({
-          value: "category:instrumentation",
-          label: "Observability",
-          hint: "Trace, evaluate, and monitor your agent",
-        }),
-        expect.objectContaining({ value: "category:all", label: "Browse all" }),
-        expect.objectContaining({ value: "action:done", label: "Return to chat" }),
-      ]),
+      message: "Where should people reach your agent?",
+      description: "You can add more later with /add.",
+      multiple: true,
+      search: true,
+      placeholder: "Search channels",
     });
     expect(prompts[1]).toMatchObject({
-      message: "Browse extensions",
-      options: [
-        expect.objectContaining({
-          label: "Agent Browser",
-          hint: "Browser automation",
-        }),
-        expect.objectContaining({ value: "action:back", label: "Back" }),
-      ],
+      message: "What should your agent be able to work with?",
+      multiple: true,
+      search: true,
+      placeholder: "Search integrations",
     });
     expect(prompts[2]).toMatchObject({
-      message: "agent-browser",
-      description: "Browser automation",
-      metadata: [
-        { label: "Source", value: "Vercel" },
-        { label: "Packages", value: "@agent-browser/eve" },
-        { label: "Environment", value: "AGENT_BROWSER_TOKEN" },
-        { label: "Files", value: "agent/extensions/browser.ts" },
-      ],
+      message: "Review your agent",
+      plannerBack: true,
+      metadata: [{ label: "Integration", value: "Linear" }],
       options: [
-        { value: "add", label: "Add to project" },
+        { value: "install", label: "Install and set up" },
         { value: "back", label: "Back" },
       ],
     });
   });
 
-  it("prints an installed registry item's environment and documentation", async () => {
-    const answers = ["category:extension", "item:0", "add"];
-    const fake = createFakePrompter({ single: () => answers.shift()! });
-
-    await expect(
-      runRegistryFlow({
-        appRoot: APP_ROOT,
-        prompter: fake.prompter,
-        deps: deps({
-          getRegistryItemManifest: vi.fn(async () => ({
-            description: "Browser automation",
-            envVars: { BROWSER_TOKEN: "", BROWSER_URL: "" },
-            meta: { eve: { docs: "/integrations/browser" } },
-            name: "extension/agent-browser",
-          })),
-        }),
-      }),
-    ).resolves.toMatchObject({
-      items: [
-        {
-          output: [
-            "Environment: BROWSER_TOKEN, BROWSER_URL",
-            "Setup: https://eve.dev/integrations/browser",
-          ],
-        },
-      ],
-    });
-  });
-
-  it("uses the registry title when labeling an item", async () => {
-    const answers = ["category:channel", "action:back", "action:done"];
+  it("puts curated choices first while preserving registry order for the remaining entries", async () => {
     const prompts: unknown[] = [];
     const fake = createFakePrompter({
-      single: (options) => {
+      multiple: (options) => {
         prompts.push(options);
-        return answers.shift()!;
+        return [];
       },
     });
-    const flowDeps = deps({
-      browseRegistryCatalog: vi.fn(async () => ({
-        items: [
-          {
-            address: "channel/photon-imessage",
-            name: "channel/photon-imessage",
-            title: "Photon",
-            source: "Vercel",
-          },
-        ],
-        total: 1,
-        errors: [],
-      })),
-    });
-
-    await runRegistryFlow({ appRoot: APP_ROOT, prompter: fake.prompter, deps: flowDeps });
-
-    expect(prompts[1]).toMatchObject({
-      options: expect.arrayContaining([expect.objectContaining({ label: "Photon" })]),
-    });
-  });
-
-  it("keeps setup on the parent prompter without leasing the terminal", async () => {
-    const answers = ["category:channel", "item:0", "add"];
-    const fake = createFakePrompter({ single: () => answers.shift()! });
-    const inherited = vi.fn(async (task: () => Promise<unknown>): Promise<unknown> => task());
-    fake.prompter.withInheritedStdio = <T>(task: () => Promise<T>): Promise<T> =>
-      inherited(task) as Promise<T>;
-    fake.prompter.withExclusiveTerminal = <T>(task: () => Promise<T>): Promise<T> => task();
-    const flowDeps = deps({
-      browseRegistryCatalog: vi.fn(async () => ({
-        items: [{ address: "channel/slack", name: "channel/slack", source: "Vercel" }],
-        total: 1,
-        errors: [],
-      })),
-    });
-
-    await runRegistryFlow({ appRoot: APP_ROOT, prompter: fake.prompter, deps: flowDeps });
-
-    expect(inherited).not.toHaveBeenCalled();
-    expect(flowDeps.installRegistryItem).toHaveBeenCalledWith(
-      APP_ROOT,
-      "channel/slack",
-      expect.objectContaining({ prompter: fake.prompter }),
-    );
-  });
-
-  it("summarizes long package, environment, and file lists", async () => {
-    const answers = ["category:channel", "item:0", "add"];
-    const prompts: unknown[] = [];
-    const fake = createFakePrompter({
-      single: (options) => {
-        prompts.push(options);
-        return answers.shift()!;
-      },
-    });
-    const flowDeps = deps({
-      browseRegistryCatalog: vi.fn(async () => ({
-        items: [
-          {
-            address: "channel/web",
-            name: "channel/web",
-            source: "Vercel",
-          },
-        ],
-        total: 1,
-        errors: [],
-      })),
-      getRegistryItemManifest: vi.fn(async () => ({
-        dependencies: ["next", "react", "react-dom", "streamdown", "tailwindcss"],
-        envVars: { FIRST: "", SECOND: "", THIRD: "", FOURTH: "" },
-        files: ["one", "two", "three", "four", "five"].map((target) => ({ target })),
-      })),
-    });
-
-    await runRegistryFlow({ appRoot: APP_ROOT, prompter: fake.prompter, deps: flowDeps });
-
-    expect(prompts[2]).toMatchObject({
-      metadata: [
-        { label: "Source", value: "Vercel" },
-        { label: "Packages", value: "next, react, react-dom … (+2 more)" },
-        { label: "Environment", value: "FIRST, SECOND, THIRD … (+1 more)" },
-        { label: "Files", value: "one, two, three … (+2 more)" },
-      ],
-    });
-  });
-
-  it("omits external registry sources from result rows", async () => {
-    const answers = ["category:extension", "action:back", "action:done"];
-    const prompts: unknown[] = [];
-    const fake = createFakePrompter({
-      single: (options) => {
-        prompts.push(options);
-        return answers.shift()!;
-      },
-    });
-    const flowDeps = deps({
-      browseRegistryCatalog: vi.fn(async () => ({
-        items: [
-          {
-            address: "@acme/analytics",
-            name: "extension/analytics",
-            description: "Product analytics",
-            source: "@acme",
-          },
-        ],
-        total: 1,
-        errors: [],
-      })),
-    });
-
-    await runRegistryFlow({ appRoot: APP_ROOT, prompter: fake.prompter, deps: flowDeps });
-
-    expect(prompts[1]).toMatchObject({
-      options: [
-        expect.objectContaining({
-          label: "Analytics",
-          hint: "Product analytics",
-        }),
-        expect.objectContaining({ value: "action:back" }),
-      ],
-    });
-  });
-
-  it("resolves a direct address before offering installation", async () => {
-    const answers = ["category:all", "address:@acme/analytics", "add"];
-    const prompts: unknown[] = [];
-    const fake = createFakePrompter({
-      single: (options) => {
-        prompts.push(options);
-        return answers.shift()!;
-      },
-    });
-    const flowDeps = deps({
-      getRegistryItemManifest: vi.fn(async () => ({
-        name: "analytics",
-        description: "Analytics integration",
-      })),
-    });
-
-    await runRegistryFlow({ appRoot: APP_ROOT, prompter: fake.prompter, deps: flowDeps });
-
-    expect(prompts[1]).toMatchObject({
-      placeholder: "Search integrations or enter an item address",
-      searchAction: { label: expect.any(Function), value: expect.any(Function) },
-    });
-    const searchAction = (prompts[1] as { searchAction: { label(query: string): string } })
-      .searchAction;
-    expect(searchAction.label("@acme/analytics")).toBe("Add “@acme/analytics”");
-    expect(flowDeps.getRegistryItemManifest).toHaveBeenCalledWith(APP_ROOT, "@acme/analytics");
-    expect(flowDeps.installRegistryItem).toHaveBeenCalledWith(
-      APP_ROOT,
-      "@acme/analytics",
-      expect.objectContaining({ silent: true, prompter: fake.prompter }),
-    );
-  });
-
-  it("opens an initial address without the category or search screens", async () => {
-    const answers = ["add"];
-    const prompts: unknown[] = [];
-    const fake = createFakePrompter({
-      single: (options) => {
-        prompts.push(options);
-        return answers.shift()!;
-      },
-    });
-    const flowDeps = deps({
-      getRegistryItemManifest: vi.fn(async () => ({
-        name: "channel/slack",
-        title: "Slack",
-        description: "Talk to your agent in Slack",
-        dependencies: ["@slack/web-api"],
-      })),
-    });
-
-    await expect(
-      runRegistryFlow({
-        appRoot: APP_ROOT,
-        prompter: fake.prompter,
-        initialAddress: "channel/slack",
-        deps: flowDeps,
-      }),
-    ).resolves.toEqual({
-      kind: "done",
-      addedItems: ["channel/slack"],
-      items: [{ address: "channel/slack", title: "Slack", facts: [], output: [] }],
-      facts: [],
-      output: [],
-    });
-    expect(flowDeps.browseRegistryCatalog).not.toHaveBeenCalled();
-    expect(flowDeps.getRegistryItemManifest).toHaveBeenCalledWith(APP_ROOT, "channel/slack");
-    expect(prompts).toHaveLength(1);
-    expect(prompts[0]).toMatchObject({
-      message: "Slack",
-      description: "Talk to your agent in Slack",
-      metadata: [
-        { label: "Source", value: "Vercel" },
-        { label: "Packages", value: "@slack/web-api" },
-      ],
-      options: [
-        { value: "add", label: "Add to project" },
-        { value: "back", label: "Back" },
-      ],
-    });
-    expect(flowDeps.installRegistryItem).toHaveBeenCalledWith(
-      APP_ROOT,
-      "channel/slack",
-      expect.objectContaining({ silent: true, prompter: fake.prompter }),
-    );
-  });
-
-  it("falls back to the category hub when an initial address is not added", async () => {
-    const answers = ["back", "action:done"];
-    const fake = createFakePrompter({ single: () => answers.shift()! });
-    const flowDeps = deps();
-
-    await expect(
-      runRegistryFlow({
-        appRoot: APP_ROOT,
-        prompter: fake.prompter,
-        initialAddress: "channel/slack",
-        deps: flowDeps,
-      }),
-    ).resolves.toEqual({ kind: "done", addedItems: [], items: [], facts: [], output: [] });
-
-    expect(fake.selectMessages).toEqual(["agent-browser", "Add an integration"]);
-    expect(flowDeps.installRegistryItem).not.toHaveBeenCalled();
-  });
-
-  it("ignores a blank initial address", async () => {
-    const answers = ["action:done"];
-    const fake = createFakePrompter({ single: () => answers.shift()! });
-    const flowDeps = deps();
-
     await runRegistryFlow({
       appRoot: APP_ROOT,
       prompter: fake.prompter,
-      initialAddress: "   ",
-      deps: flowDeps,
-    });
-
-    expect(flowDeps.getRegistryItemManifest).not.toHaveBeenCalled();
-    expect(fake.selectMessages).toEqual(["Add an integration"]);
-  });
-
-  it("surfaces an unresolvable initial address", async () => {
-    const fake = createFakePrompter({ single: () => "add" });
-    const flowDeps = deps({
-      getRegistryItemManifest: vi.fn(async () => {
-        throw new Error('Registry item "channel/slak" was not found.');
+      deps: deps({
+        browseRegistryCatalog: vi.fn(async () => ({
+          items: [
+            {
+              address: "channel/discord",
+              name: "channel/discord",
+              title: "Discord",
+              source: "Vercel",
+            },
+            { address: "channel/slack", name: "channel/slack", title: "Slack", source: "Vercel" },
+            { address: "channel/web", name: "channel/web", title: "Web Chat", source: "Vercel" },
+            {
+              address: "channel/github",
+              name: "channel/github",
+              title: "GitHub",
+              source: "Vercel",
+            },
+            {
+              address: "channel/telegram",
+              name: "channel/telegram",
+              title: "Telegram",
+              source: "Vercel",
+            },
+          ],
+          total: 5,
+          errors: [],
+        })),
       }),
     });
 
-    await expect(
-      runRegistryFlow({
-        appRoot: APP_ROOT,
-        prompter: fake.prompter,
-        initialAddress: "channel/slak",
-        deps: flowDeps,
-      }),
-    ).rejects.toThrow('Registry item "channel/slak" was not found.');
-    expect(flowDeps.installRegistryItem).not.toHaveBeenCalled();
+    expect(
+      (prompts[0] as { options: { value: string }[] }).options.map((option) => option.value),
+    ).toEqual([
+      "channel/web",
+      "channel/slack",
+      "channel/github",
+      "channel/discord",
+      "channel/telegram",
+    ]);
   });
 
-  it("reports cancellation from an initial address as a dismissed flow", async () => {
-    const fake = createFakePrompter({
-      single: () => {
-        throw new WizardCancelledError();
-      },
-    });
-
-    await expect(
-      runRegistryFlow({
-        appRoot: APP_ROOT,
-        prompter: fake.prompter,
-        initialAddress: "channel/slack",
-        deps: deps(),
-      }),
-    ).resolves.toEqual({ kind: "cancelled" });
-  });
-
-  it("collects deployable setups, adds another, then deploys once", async () => {
-    const answers = [
-      "category:channel",
-      "item:0",
-      "add",
-      "add-more",
-      "category:channel",
-      "item:0",
-      "add",
-      "deploy",
-      "yes",
-    ];
+  it("recommends Linear MCP after Linear Agent and hides the overlapping preset", async () => {
     const prompts: unknown[] = [];
     const fake = createFakePrompter({
-      single: (options) => {
+      single: () => "install",
+      multiple: (options) => {
         prompts.push(options);
-        return answers.shift()!;
+        return options.message === "Where should people reach your agent?"
+          ? ["channel/linear-agent"]
+          : [];
       },
     });
-    const flowDeps = deps({
-      browseRegistryCatalog: vi.fn(async () => ({
-        items: [{ address: "channel/slack", name: "channel/slack", source: "Vercel" }],
-        total: 1,
-        errors: [],
-      })),
-      detectDeployment: vi.fn(async () => ({ state: "linked" as const, projectId: "prj_1" })),
-      installRegistryItem: vi.fn(async () => ({
-        output: [],
-        setup: {
-          facts: [
-            { label: "Workspace", value: "Acme" },
-            { label: "Open Slack", value: "https://slack.com/app", kind: "url" as const },
+    await runRegistryFlow({
+      appRoot: APP_ROOT,
+      prompter: fake.prompter,
+      deps: deps({
+        browseRegistryCatalog: vi.fn(async () => ({
+          items: [
+            { address: "linear", name: "linear", title: "Linear", source: "Vercel" },
+            {
+              address: "channel/linear-agent",
+              name: "channel/linear-agent",
+              title: "Linear Agent",
+              source: "Vercel",
+            },
+            {
+              address: "connection/linear",
+              name: "connection/linear",
+              title: "Linear",
+              description: "Issues, projects, cycles, and comments via Linear's MCP server.",
+              source: "Vercel",
+            },
           ],
-          deploymentRequired: true as const,
-        },
-      })),
+          total: 3,
+          errors: [],
+        })),
+      }),
     });
 
-    await expect(
-      runRegistryFlow({ appRoot: APP_ROOT, prompter: fake.prompter, deps: flowDeps }),
-    ).resolves.toMatchObject({
-      kind: "done",
-      addedItems: ["channel/slack", "channel/slack"],
-      deployed: "production",
-      facts: [
-        { label: "Workspace", value: "Acme" },
-        { label: "Open Slack", value: "https://slack.com/app", kind: "url" },
-        { label: "Workspace", value: "Acme" },
-        { label: "Open Slack", value: "https://slack.com/app", kind: "url" },
-      ],
-    });
-    expect(flowDeps.runDeployFlow).toHaveBeenCalledTimes(1);
-    expect(prompts[3]).toMatchObject({
-      initialValue: "add-more",
-      hintLayout: "inline",
-      options: [
-        { value: "add-more", label: "Add more" },
-        { value: "deploy", label: "Deploy" },
-        { value: "finish", label: "Finish" },
-      ],
-    });
-    expect(prompts[8]).toMatchObject({
-      message: "Deploy to prod?",
-      initialValue: "yes",
-      options: [
-        { value: "yes", label: "Yes" },
-        { value: "back", label: "Back" },
-      ],
-    });
+    const channelOptions = (prompts[0] as { options: { value: string }[] }).options;
+    const integrationOptions = (
+      prompts[1] as {
+        options: { value: string; label: string; hint?: string }[];
+      }
+    ).options;
+    expect(channelOptions.map((option) => option.value)).toEqual(["channel/linear-agent"]);
+    expect(integrationOptions).toEqual([
+      {
+        value: "connection/linear",
+        label: "Linear MCP",
+        hint: "Recommended with Linear Agent · Issues, projects, cycles, and comments via Linear's MCP server.",
+        featured: true,
+      },
+    ]);
   });
 
-  it("returns to continuation options when production deployment is not confirmed", async () => {
-    const answers = ["category:channel", "item:0", "add", "deploy", "back", "finish"];
-    const fake = createFakePrompter({ single: () => answers.shift()! });
+  it("keeps a skipped installation failure in the result and proceeds with later items", async () => {
+    const answers = ["install", "skip"];
+    const selections = [["channel/web"], ["connection/linear"]];
+    const fake = createFakePrompter({
+      single: () => answers.shift()!,
+      multiple: () => selections.shift()!,
+    });
+    const installRegistryItem = vi
+      .fn<RegistryFlowDeps["installRegistryItem"]>()
+      .mockRejectedValueOnce(new Error("Missing WEB_TOKEN\nSet it in your environment."))
+      .mockResolvedValueOnce({ output: [] });
+
+    await expect(
+      runRegistryFlow({
+        appRoot: APP_ROOT,
+        prompter: fake.prompter,
+        deps: deps({ installRegistryItem }),
+      }),
+    ).resolves.toMatchObject({
+      kind: "done",
+      result: {
+        addedItems: ["connection/linear"],
+        failures: [expect.objectContaining({ title: "Web Chat", message: "Missing WEB_TOKEN" })],
+      },
+    });
+    expect(fake.selectMessages).toContain("Couldn't add Web Chat");
+  });
+
+  it("offers deployment once after the selected batch completes", async () => {
+    const answers = ["install", "deploy", "yes"];
+    const fake = createFakePrompter({
+      single: () => answers.shift()!,
+      multiple: () => ["channel/web"],
+    });
     const flowDeps = deps({
-      browseRegistryCatalog: vi.fn(async () => ({
-        items: [{ address: "channel/github", name: "channel/github", source: "Vercel" }],
-        total: 1,
-        errors: [],
-      })),
       detectDeployment: vi.fn(async () => ({ state: "linked" as const, projectId: "prj_1" })),
       installRegistryItem: vi.fn(async () => ({
         output: [],
@@ -532,80 +276,8 @@ describe("runRegistryFlow", () => {
 
     await expect(
       runRegistryFlow({ appRoot: APP_ROOT, prompter: fake.prompter, deps: flowDeps }),
-    ).resolves.toMatchObject({ addedItems: ["channel/github"] });
-    expect(flowDeps.runDeployFlow).not.toHaveBeenCalled();
-  });
-
-  it("preserves earlier setup results when a later item fails", async () => {
-    const answers = [
-      "category:channel",
-      "item:0",
-      "add",
-      "add-more",
-      "category:channel",
-      "item:0",
-      "add",
-    ];
-    const fake = createFakePrompter({ single: () => answers.shift()! });
-    let installs = 0;
-    const flowDeps = deps({
-      browseRegistryCatalog: vi.fn(async () => ({
-        items: [
-          { address: "channel/photon-imessage", name: "channel/photon-imessage", source: "Vercel" },
-        ],
-        total: 1,
-        errors: [],
-      })),
-      installRegistryItem: vi.fn(async () => {
-        installs += 1;
-        if (installs === 2) throw new Error("Refusing to overwrite photon.ts");
-        return {
-          output: [],
-          setup: {
-            facts: [{ label: "Agent phone number", value: "+15551234567" }],
-            deploymentRequired: true as const,
-          },
-        };
-      }),
-    });
-
-    const error = await runRegistryFlow({
-      appRoot: APP_ROOT,
-      prompter: fake.prompter,
-      deps: flowDeps,
-    }).catch((reason: unknown) => reason);
-
-    expect(error).toBeInstanceOf(RegistryFlowFailedError);
-    expect(error).toMatchObject({
-      message: "Refusing to overwrite photon.ts",
-      completed: {
-        addedItems: ["channel/photon-imessage"],
-        facts: [{ label: "Agent phone number", value: "+15551234567" }],
-      },
-    });
-  });
-
-  it("does not offer another item or deployment after a non-deployable setup", async () => {
-    const answers = ["category:extension", "item:0", "add"];
-    const fake = createFakePrompter({ single: () => answers.shift()! });
-
-    await runRegistryFlow({ appRoot: APP_ROOT, prompter: fake.prompter, deps: deps() });
-
-    expect(fake.selectMessages).not.toContain("What would you like to do next?");
-  });
-
-  it("returns to the category hub from a registry list", async () => {
-    const answers = ["category:channel", "action:back", "action:done"];
-    const fake = createFakePrompter({ single: () => answers.shift()! });
-
-    await expect(
-      runRegistryFlow({ appRoot: APP_ROOT, prompter: fake.prompter, deps: deps() }),
-    ).resolves.toEqual({ kind: "done", addedItems: [], items: [], facts: [], output: [] });
-
-    expect(fake.selectMessages).toEqual([
-      "Add an integration",
-      "Browse channels",
-      "Add an integration",
-    ]);
+    ).resolves.toMatchObject({ kind: "done", result: { deployed: "production" } });
+    expect(flowDeps.runDeployFlow).toHaveBeenCalledOnce();
+    expect(fake.selectMessages).not.toContain("Add an integration");
   });
 });

--- a/packages/eve/src/setup/flows/registry.test.ts
+++ b/packages/eve/src/setup/flows/registry.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { createFakePrompter } from "#internal/testing/fake-prompter.js";
+import { HumanActionRequiredError } from "#setup/human-action.js";
+import { PlannerNavigationError } from "#setup/prompter.js";
+import { WizardCancelledError } from "#setup/step.js";
 
 import { runRegistryFlow, type RegistryFlowDeps } from "./registry.js";
 
@@ -28,6 +31,7 @@ function deps(overrides: Partial<RegistryFlowDeps> = {}): RegistryFlowDeps {
       total: 2,
       errors: [],
     })),
+    getRegistryItemManifest: vi.fn(async (_appRoot, item) => ({ name: item })),
     installRegistryItem: vi.fn(async () => ({ output: [] })),
     detectDeployment: vi.fn(async () => ({ state: "unlinked" as const })),
     runDeployFlow: vi.fn(async () => ({ kind: "deployed" as const })),
@@ -56,15 +60,11 @@ describe("runRegistryFlow", () => {
     ).resolves.toEqual({
       kind: "done",
       result: {
-        kind: "done",
-        addedItems: ["channel/web", "connection/linear"],
         items: [
-          { address: "channel/web", title: "Web Chat", facts: [], output: [] },
-          { address: "connection/linear", title: "Linear", facts: [], output: [] },
+          { title: "Web Chat", facts: [], output: [] },
+          { title: "Linear", facts: [], output: [] },
         ],
         failures: [],
-        facts: [],
-        output: [],
       },
     });
 
@@ -116,7 +116,11 @@ describe("runRegistryFlow", () => {
     });
     expect(prompts[2]).toMatchObject({
       message: "Review your agent",
-      plannerBack: true,
+      navigation: {
+        kind: "planner",
+        activeStep: 2,
+        steps: [{ label: "Channels" }, { label: "Integrations", count: 1 }, { label: "Review" }],
+      },
       metadata: [{ label: "Integration", value: "Linear" }],
       options: [
         { value: "install", label: "Install and set up" },
@@ -125,9 +129,72 @@ describe("runRegistryFlow", () => {
     });
   });
 
+  it("starts bare /add on integrations when requested and keeps empty Review open", async () => {
+    const prompts: unknown[] = [];
+    const fake = createFakePrompter({
+      single: (options) => {
+        prompts.push(options);
+        return "install";
+      },
+      multiple: (options) => {
+        prompts.push(options);
+        return [];
+      },
+    });
+
+    await runRegistryFlow({
+      appRoot: APP_ROOT,
+      prompter: fake.prompter,
+      initialScreen: "integrations",
+      deps: deps(),
+    });
+
+    expect(prompts).toMatchObject([
+      { message: "What should your agent be able to work with?" },
+      {
+        message: "Review your agent",
+        description: "No channels or integrations selected.",
+        options: [
+          { value: "install", label: "Finish without adding" },
+          { value: "back", label: "Back" },
+        ],
+      },
+    ]);
+  });
+
+  it("preserves selections while navigating forward and back with arrow keys", async () => {
+    let lap = 0;
+    const fake = createFakePrompter({
+      single: () => "install",
+      multiple: (options) => {
+        lap += 1;
+        if (lap === 1) throw new PlannerNavigationError("forward", ["channel/web"]);
+        if (lap === 2) throw new PlannerNavigationError("back", ["connection/linear"]);
+        if (lap === 3) {
+          expect(options.initialValues).toEqual(["channel/web"]);
+          return ["channel/web"];
+        }
+        expect(options.initialValues).toEqual(["connection/linear"]);
+        return ["connection/linear"];
+      },
+    });
+    const installRegistryItem = vi.fn<RegistryFlowDeps["installRegistryItem"]>(async () => ({
+      output: [],
+    }));
+
+    await runRegistryFlow({
+      appRoot: APP_ROOT,
+      prompter: fake.prompter,
+      deps: deps({ installRegistryItem }),
+    });
+
+    expect(installRegistryItem).toHaveBeenCalledTimes(2);
+  });
+
   it("puts curated choices first while preserving registry order for the remaining entries", async () => {
     const prompts: unknown[] = [];
     const fake = createFakePrompter({
+      single: () => "install",
       multiple: (options) => {
         prompts.push(options);
         return [];
@@ -177,20 +244,22 @@ describe("runRegistryFlow", () => {
     ]);
   });
 
-  it("recommends Linear MCP after Linear Agent and hides the overlapping preset", async () => {
+  it("expands an explicitly requested product preset into its reviewable components", async () => {
     const prompts: unknown[] = [];
     const fake = createFakePrompter({
-      single: () => "install",
-      multiple: (options) => {
+      single: (options) => {
         prompts.push(options);
-        return options.message === "Where should people reach your agent?"
-          ? ["channel/linear-agent"]
-          : [];
+        return "install";
       },
     });
+    const installRegistryItem = vi.fn<RegistryFlowDeps["installRegistryItem"]>(async () => ({
+      output: [],
+    }));
+
     await runRegistryFlow({
       appRoot: APP_ROOT,
       prompter: fake.prompter,
+      initialAddress: "linear",
       deps: deps({
         browseRegistryCatalog: vi.fn(async () => ({
           items: [
@@ -205,31 +274,163 @@ describe("runRegistryFlow", () => {
               address: "connection/linear",
               name: "connection/linear",
               title: "Linear",
-              description: "Issues, projects, cycles, and comments via Linear's MCP server.",
               source: "Vercel",
             },
           ],
           total: 3,
           errors: [],
         })),
+        getRegistryItemManifest: vi.fn(async () => ({
+          name: "linear",
+          meta: {
+            eve: {
+              components: [{ item: "channel/linear-agent" }, { item: "connection/linear" }],
+            },
+          },
+        })),
+        installRegistryItem,
       }),
     });
 
-    const channelOptions = (prompts[0] as { options: { value: string }[] }).options;
-    const integrationOptions = (
-      prompts[1] as {
-        options: { value: string; label: string; hint?: string }[];
-      }
-    ).options;
-    expect(channelOptions.map((option) => option.value)).toEqual(["channel/linear-agent"]);
-    expect(integrationOptions).toEqual([
-      {
-        value: "connection/linear",
-        label: "Linear MCP",
-        hint: "Recommended with Linear Agent · Issues, projects, cycles, and comments via Linear's MCP server.",
-        featured: true,
+    expect(prompts[0]).toMatchObject({
+      message: "Review your agent",
+      metadata: [
+        { label: "Channel", value: "Linear Agent" },
+        { label: "Integration", value: "Linear" },
+      ],
+    });
+    expect(installRegistryItem).toHaveBeenNthCalledWith(
+      1,
+      APP_ROOT,
+      "channel/linear-agent",
+      expect.objectContaining({ silent: true }),
+    );
+    expect(installRegistryItem).toHaveBeenNthCalledWith(
+      2,
+      APP_ROOT,
+      "connection/linear",
+      expect.objectContaining({ silent: true }),
+    );
+  });
+
+  it("resolves an explicitly requested external address that is not in the catalog", async () => {
+    const fake = createFakePrompter({
+      single: () => "install",
+      multiple: (options) => options.initialValues ?? [],
+    });
+    const getRegistryItemManifest = vi.fn(async () => ({
+      name: "extension/analytics",
+      title: "Analytics",
+    }));
+    const installRegistryItem = vi.fn<RegistryFlowDeps["installRegistryItem"]>(async () => ({
+      output: [],
+    }));
+
+    await runRegistryFlow({
+      appRoot: APP_ROOT,
+      prompter: fake.prompter,
+      initialAddress: "@acme/analytics",
+      deps: deps({ getRegistryItemManifest, installRegistryItem }),
+    });
+
+    expect(getRegistryItemManifest).toHaveBeenCalledWith(APP_ROOT, "@acme/analytics");
+    expect(installRegistryItem).toHaveBeenCalledWith(
+      APP_ROOT,
+      "@acme/analytics",
+      expect.objectContaining({ silent: true }),
+    );
+  });
+
+  it("reports an explicitly requested address that cannot be resolved", async () => {
+    const fake = createFakePrompter();
+    const getRegistryItemManifest = vi.fn(async () => {
+      throw new Error('Registry item "channel/slak" was not found.');
+    });
+
+    await expect(
+      runRegistryFlow({
+        appRoot: APP_ROOT,
+        prompter: fake.prompter,
+        initialAddress: "channel/slak",
+        deps: deps({ getRegistryItemManifest }),
+      }),
+    ).rejects.toThrow('Registry item "channel/slak" was not found.');
+    expect(fake.selectMessages).toEqual([]);
+  });
+
+  it("surfaces registry source failures on the planner", async () => {
+    const prompts: unknown[] = [];
+    const fake = createFakePrompter({
+      single: () => "install",
+      multiple: (options) => {
+        prompts.push(options);
+        return [];
       },
-    ]);
+    });
+
+    await runRegistryFlow({
+      appRoot: APP_ROOT,
+      prompter: fake.prompter,
+      initialScreen: "integrations",
+      deps: deps({
+        browseRegistryCatalog: vi.fn(async () => ({
+          items: [],
+          total: 0,
+          errors: [{ registry: "@acme", message: "Authentication required" }],
+        })),
+      }),
+    });
+
+    expect(prompts[0]).toMatchObject({
+      notices: [{ tone: "warning", text: "@acme: Authentication required" }],
+    });
+  });
+
+  it("propagates cancellation during installation instead of recording a failure", async () => {
+    const answers = ["install"];
+    const selections = [["channel/web"], []];
+    const fake = createFakePrompter({
+      single: () => answers.shift()!,
+      multiple: () => selections.shift()!,
+    });
+    const controller = new AbortController();
+    const reason = new Error("Setup interrupted");
+    const installRegistryItem = vi.fn<RegistryFlowDeps["installRegistryItem"]>(async () => {
+      controller.abort(reason);
+      throw reason;
+    });
+
+    await expect(
+      runRegistryFlow({
+        appRoot: APP_ROOT,
+        prompter: fake.prompter,
+        signal: controller.signal,
+        deps: deps({ installRegistryItem }),
+      }),
+    ).rejects.toBe(reason);
+    expect(fake.selectMessages).not.toContain("Couldn't add Web Chat");
+  });
+
+  it("treats setup-prompt cancellation as a dismissed flow, not an installation failure", async () => {
+    const answers = ["install"];
+    const selections = [["channel/web"], []];
+    const fake = createFakePrompter({
+      single: () => answers.shift()!,
+      multiple: () => selections.shift()!,
+    });
+
+    await expect(
+      runRegistryFlow({
+        appRoot: APP_ROOT,
+        prompter: fake.prompter,
+        deps: deps({
+          installRegistryItem: vi.fn(async () => {
+            throw new WizardCancelledError();
+          }),
+        }),
+      }),
+    ).resolves.toEqual({ kind: "cancelled" });
+    expect(fake.selectMessages).not.toContain("Couldn't add Web Chat");
   });
 
   it("keeps a skipped installation failure in the result and proceeds with later items", async () => {
@@ -253,11 +454,96 @@ describe("runRegistryFlow", () => {
     ).resolves.toMatchObject({
       kind: "done",
       result: {
-        addedItems: ["connection/linear"],
-        failures: [expect.objectContaining({ title: "Web Chat", message: "Missing WEB_TOKEN" })],
+        items: [expect.objectContaining({ title: "Linear" })],
+        failures: [
+          expect.objectContaining({
+            title: "Web Chat",
+            message: "Missing WEB_TOKEN\nSet it in your environment.",
+          }),
+        ],
       },
     });
     expect(fake.selectMessages).toContain("Couldn't add Web Chat");
+  });
+
+  it("preserves an installation failure when its recovery prompt is cancelled", async () => {
+    let prompt = 0;
+    const fake = createFakePrompter({
+      single: () => (++prompt === 1 ? "install" : Promise.reject(new WizardCancelledError())),
+    });
+
+    await expect(
+      runRegistryFlow({
+        appRoot: APP_ROOT,
+        prompter: fake.prompter,
+        initialAddress: "channel/web",
+        deps: deps({
+          installRegistryItem: vi.fn(async () => {
+            throw new Error("Missing WEB_TOKEN\nSet it in your environment.");
+          }),
+        }),
+      }),
+    ).resolves.toMatchObject({
+      result: {
+        failures: [{ title: "Web Chat", message: expect.stringContaining("WEB_TOKEN") }],
+        cancelled: true,
+      },
+    });
+  });
+
+  it("preserves settled items when a later installation is cancelled", async () => {
+    const answers = ["install"];
+    const selections = [["channel/web"], ["connection/linear"]];
+    const fake = createFakePrompter({
+      single: () => answers.shift()!,
+      multiple: () => selections.shift()!,
+    });
+    const installRegistryItem = vi
+      .fn<RegistryFlowDeps["installRegistryItem"]>()
+      .mockResolvedValueOnce({ output: [] })
+      .mockRejectedValueOnce(new WizardCancelledError());
+
+    await expect(
+      runRegistryFlow({
+        appRoot: APP_ROOT,
+        prompter: fake.prompter,
+        deps: deps({ installRegistryItem }),
+      }),
+    ).resolves.toEqual({
+      kind: "done",
+      result: {
+        items: [{ title: "Web Chat", facts: [], output: [] }],
+        failures: [],
+        cancelled: true,
+      },
+    });
+  });
+
+  it("lets structured setup failures reach the command boundary", async () => {
+    const answers = ["install"];
+    const selections = [["channel/web"], []];
+    const fake = createFakePrompter({
+      single: () => answers.shift()!,
+      multiple: () => selections.shift()!,
+    });
+    const error = new HumanActionRequiredError({
+      kind: "vercel-cli-upgrade",
+      command: "vercel upgrade",
+      reason: "The installed Vercel CLI is too old.",
+    });
+
+    await expect(
+      runRegistryFlow({
+        appRoot: APP_ROOT,
+        prompter: fake.prompter,
+        deps: deps({
+          installRegistryItem: vi.fn(async () => {
+            throw error;
+          }),
+        }),
+      }),
+    ).rejects.toBe(error);
+    expect(fake.selectMessages).not.toContain("Couldn't add Web Chat");
   });
 
   it("offers deployment once after the selected batch completes", async () => {
@@ -266,6 +552,8 @@ describe("runRegistryFlow", () => {
       single: () => answers.shift()!,
       multiple: () => ["channel/web"],
     });
+    const replaceContent = vi.fn();
+    fake.prompter.replaceContent = replaceContent;
     const flowDeps = deps({
       detectDeployment: vi.fn(async () => ({ state: "linked" as const, projectId: "prj_1" })),
       installRegistryItem: vi.fn(async () => ({
@@ -278,6 +566,7 @@ describe("runRegistryFlow", () => {
       runRegistryFlow({ appRoot: APP_ROOT, prompter: fake.prompter, deps: flowDeps }),
     ).resolves.toMatchObject({ kind: "done", result: { deployed: "production" } });
     expect(flowDeps.runDeployFlow).toHaveBeenCalledOnce();
+    expect(replaceContent).toHaveBeenCalledWith();
     expect(fake.selectMessages).not.toContain("Add an integration");
   });
 });

--- a/packages/eve/src/setup/flows/registry.ts
+++ b/packages/eve/src/setup/flows/registry.ts
@@ -1,17 +1,43 @@
 import type { RegistryCatalogItem } from "#cli/commands/registry.js";
-import type { Prompter, SelectOption } from "#setup/prompter.js";
+import { HumanActionRequiredError } from "#setup/human-action.js";
+import { PlannerNavigationError } from "#setup/prompter.js";
+import type {
+  MultiSelectOptions,
+  Prompter,
+  SelectNotice,
+  SelectOption,
+  SingleSelectOptions,
+} from "#setup/prompter.js";
 import { WizardCancelledError } from "#setup/step.js";
 import { withSpinner } from "#setup/with-spinner.js";
 
 import { createRegistrySession, type RegistrySessionResult } from "./registry-session.js";
 
 type Item = RegistryCatalogItem;
+export type RegistryPlannerSection = keyof typeof SECTIONS;
+type Section = RegistryPlannerSection;
+type PlannerScreen = Section | "review";
+
+const PLANNER_STEPS = ["Channels", "Integrations", "Review"] as const;
+
 export interface RegistryFlowDeps {
   browseRegistryCatalog: (typeof import("#cli/commands/registry.js"))["browseRegistryCatalog"];
+  getRegistryItemManifest: (typeof import("#cli/commands/registry.js"))["getRegistryItemManifest"];
   installRegistryItem: (typeof import("#cli/commands/registry.js"))["installRegistryItem"];
   detectDeployment: (typeof import("#setup/project-resolution.js"))["detectDeployment"];
   runDeployFlow: (typeof import("./deploy.js"))["runDeployFlow"];
 }
+
+export class RegistryFlowFailedError extends Error {
+  readonly completed: RegistrySessionResult;
+
+  constructor(error: unknown, completed: RegistrySessionResult) {
+    super(error instanceof Error ? error.message : String(error), { cause: error });
+    this.name = "RegistryFlowFailedError";
+    this.completed = completed;
+  }
+}
+
 const SECTIONS = {
   channels: {
     title: "Where should people reach your agent?",
@@ -37,12 +63,14 @@ function label(item: Item): string {
   return item.title ?? item.name.split("/").at(-1) ?? item.name;
 }
 
-function orderedSectionItems(section: keyof typeof SECTIONS, catalog: readonly Item[]): Item[] {
-  // Composite registry presets span multiple planner sections. The batch
-  // planner presents their channel and capability components independently.
-  const matching = catalog.filter(
-    (item) => item.name.includes("/") && SECTIONS[section].includes(item),
-  );
+function isPlannerItem(section: Section, item: Item): boolean {
+  return item.name.includes("/") && SECTIONS[section].includes(item);
+}
+
+function orderedSectionItems(section: Section, catalog: readonly Item[]): Item[] {
+  // Product-level presets are installed as one item when explicitly requested;
+  // the bare planner presents their independently installable components.
+  const matching = catalog.filter((item) => isPlannerItem(section, item));
   const featured = SECTIONS[section].featured
     .map((name) => matching.find((item) => item.name === name))
     .filter((item): item is Item => item !== undefined);
@@ -54,113 +82,234 @@ function plannerLabel(item: Item): string {
   return item.name === "connection/linear" ? "Linear MCP" : label(item);
 }
 
-function sectionRows(
-  section: keyof typeof SECTIONS,
-  catalog: readonly Item[],
-  selected: ReadonlySet<string>,
-): SelectOption<string>[] {
-  const featured = new Set<string>(SECTIONS[section].featured);
-  return orderedSectionItems(section, catalog).map((item) => {
-    const linearAgentSelected = selected.has("channel/linear-agent");
-    const recommendation =
-      item.name === "connection/linear" && linearAgentSelected
-        ? "Recommended with Linear Agent"
-        : undefined;
-    return {
-      value: item.address,
-      label: plannerLabel(item),
-      hint:
-        recommendation === undefined
-          ? item.description
-          : item.description === undefined
-            ? recommendation
-            : `${recommendation} · ${item.description}`,
-      ...(featured.has(item.name) ? { featured: true } : {}),
-    };
-  });
+function sectionRows(section: Section, catalog: readonly Item[]): SelectOption<string>[] {
+  return orderedSectionItems(section, catalog).map((item) => ({
+    value: item.address,
+    label: plannerLabel(item),
+    hint: item.description,
+  }));
 }
 
 function selectedInSection(
-  section: keyof typeof SECTIONS,
+  section: Section,
   catalog: readonly Item[],
   selected: ReadonlySet<string>,
 ): string[] {
   return catalog
-    .filter((item) => SECTIONS[section].includes(item) && selected.has(item.address))
+    .filter((item) => isPlannerItem(section, item) && selected.has(item.address))
     .map((item) => item.address);
 }
 
+function plannerNavigation(
+  activeStep: number,
+  input: {
+    catalog: readonly Item[];
+    selected: ReadonlySet<string>;
+  },
+): NonNullable<MultiSelectOptions<string>["navigation"]> {
+  return {
+    kind: "planner",
+    activeStep,
+    steps: PLANNER_STEPS.map((label, index) => {
+      if (index === 2) return { label };
+      const section = index === 0 ? "channels" : "integrations";
+      const count = selectedInSection(section, input.catalog, input.selected).length;
+      return count === 0 ? { label } : { label, count };
+    }),
+  };
+}
+
+function replaceSectionSelection(input: {
+  section: Section;
+  catalog: readonly Item[];
+  selected: Set<string>;
+  addresses: readonly string[];
+}): void {
+  for (const item of input.catalog) {
+    if (isPlannerItem(input.section, item)) input.selected.delete(item.address);
+  }
+  for (const address of input.addresses) input.selected.add(address);
+}
+
 async function editSection(input: {
-  section: keyof typeof SECTIONS;
+  section: Section;
   prompter: Prompter;
   catalog: readonly Item[];
   selected: Set<string>;
-}): Promise<void> {
+  notices?: readonly SelectNotice[];
+}): Promise<"back" | "forward"> {
   const { section, catalog, prompter, selected } = input;
-  const selectedAddresses = await prompter.select({
+  const request: MultiSelectOptions<string> = {
     message: SECTIONS[section].title,
-    ...(section === "channels" ? { description: SECTIONS.channels.description } : {}),
     multiple: true,
     search: true,
     placeholder: section === "channels" ? "Search channels" : "Search integrations",
-    plannerNavigation: true,
-    plannerContinue: section === "channels" ? "integrations" : "review",
+    navigation: plannerNavigation(section === "channels" ? 0 : 1, input),
     initialValues: selectedInSection(section, catalog, selected),
-    options: sectionRows(section, catalog, selected),
-  });
-  for (const item of catalog) {
-    if (!SECTIONS[section].includes(item)) continue;
-    selected.delete(item.address);
+    options: sectionRows(section, catalog),
+  };
+  if (section === "channels") request.description = SECTIONS.channels.description;
+  if (input.notices !== undefined) request.notices = input.notices;
+  try {
+    const addresses = await prompter.select(request);
+    replaceSectionSelection({ section, catalog, selected, addresses });
+    return "forward";
+  } catch (error) {
+    if (!(error instanceof PlannerNavigationError)) throw error;
+    const addresses = error.values.map((value) => {
+      if (typeof value !== "string")
+        throw new Error("Registry planner returned a non-string item.");
+      return value;
+    });
+    replaceSectionSelection({ section, catalog, selected, addresses });
+    return error.direction;
   }
-  for (const address of selectedAddresses) selected.add(address);
 }
 
 async function editPlan(input: {
   prompter: Prompter;
   catalog: readonly Item[];
+  itemsByAddress: ReadonlyMap<string, Item>;
   selected: Set<string>;
+  notices?: readonly SelectNotice[];
+  initialScreen: PlannerScreen;
 }): Promise<"install" | "cancelled"> {
-  let screen: "channels" | "integrations" | "review" = "channels";
+  let screen = input.initialScreen;
+  let notices = input.notices;
   while (true) {
     if (screen !== "review") {
       try {
-        await editSection({ ...input, section: screen });
+        const direction = await editSection({
+          ...input,
+          section: screen,
+          notices,
+        });
+        notices = undefined;
+        if (direction === "back") {
+          if (screen === "integrations") screen = "channels";
+        } else {
+          screen = screen === "channels" ? "integrations" : "review";
+        }
       } catch (error) {
         if (!(error instanceof WizardCancelledError)) throw error;
-        if (screen === "channels") return "cancelled";
-        screen = "channels";
-        continue;
+        return "cancelled";
       }
-      screen = screen === "channels" ? "integrations" : "review";
       continue;
     }
 
-    if (input.selected.size === 0) return "install";
-    let review: "install" | "back";
     try {
-      review = await input.prompter.select({
+      const hasSelections = input.selected.size > 0;
+      const request: SingleSelectOptions<"install" | "back"> = {
         message: "Review your agent",
         metadata: [...input.selected].map((address) => {
-          const item = input.catalog.find((candidate) => candidate.address === address)!;
+          const item = input.itemsByAddress.get(address);
+          if (item === undefined)
+            throw new Error(`Registry item "${address}" is no longer available.`);
           return {
             label: item.name.startsWith("channel/") ? "Channel" : "Integration",
             value: label(item),
           };
         }),
-        plannerBack: true,
+        navigation: plannerNavigation(2, input),
         options: [
-          { value: "install", label: "Install and set up" },
+          {
+            value: "install",
+            label: hasSelections ? "Install and set up" : "Finish without adding",
+          },
           { value: "back", label: "Back" },
         ],
-      });
+      };
+      if (!hasSelections) request.description = "No channels or integrations selected.";
+      if (notices !== undefined) request.notices = notices;
+      const review = await input.prompter.select(request);
+      notices = undefined;
+      if (review === "install") return "install";
     } catch (error) {
+      if (error instanceof PlannerNavigationError && error.direction === "back") {
+        screen = "integrations";
+        continue;
+      }
       if (!(error instanceof WizardCancelledError)) throw error;
-      screen = "integrations";
-      continue;
+      return "cancelled";
     }
-    if (review === "install") return "install";
     screen = "integrations";
   }
+}
+
+function itemSource(address: string): string {
+  if (address.startsWith("@")) return address.split("/")[0] ?? address;
+  if (/^https?:\/\//u.test(address)) {
+    try {
+      return new URL(address).host;
+    } catch {
+      return address;
+    }
+  }
+  return "Vercel";
+}
+
+function manifestRecord(manifest: unknown): Record<string, unknown> {
+  return typeof manifest === "object" && manifest !== null && !Array.isArray(manifest)
+    ? (manifest as Record<string, unknown>)
+    : {};
+}
+
+function manifestComponents(manifest: Record<string, unknown>): string[] {
+  const meta = manifest.meta;
+  if (typeof meta !== "object" || meta === null || Array.isArray(meta)) return [];
+  const eve = (meta as Record<string, unknown>).eve;
+  if (typeof eve !== "object" || eve === null || Array.isArray(eve)) return [];
+  const components = (eve as Record<string, unknown>).components;
+  if (!Array.isArray(components)) return [];
+  return components.flatMap((component) => {
+    if (typeof component !== "object" || component === null || Array.isArray(component)) return [];
+    const item = (component as Record<string, unknown>).item;
+    return typeof item === "string" ? [item] : [];
+  });
+}
+
+async function resolveInitialItems(input: {
+  appRoot: string;
+  address: string;
+  catalog: readonly Item[];
+  prompter: Prompter;
+  getRegistryItemManifest: RegistryFlowDeps["getRegistryItemManifest"];
+}): Promise<Item[]> {
+  const known = input.catalog.find(
+    (item) => item.address === input.address || item.name === input.address,
+  );
+  if (known !== undefined && known.name.includes("/")) return [known];
+
+  const manifest = manifestRecord(
+    await withSpinner(input.prompter, "Loading registry item…", () =>
+      input.getRegistryItemManifest(input.appRoot, input.address),
+    ),
+  );
+  const components = manifestComponents(manifest);
+  if (components.length > 0) {
+    return components.map((address) => {
+      const component = input.catalog.find(
+        (item) => item.address === address || item.name === address,
+      );
+      if (component === undefined) {
+        throw new Error(
+          `Registry package "${input.address}" references unavailable item "${address}".`,
+        );
+      }
+      return component;
+    });
+  }
+  if (known !== undefined) return [known];
+
+  const item: Item = {
+    address: input.address,
+    name: typeof manifest.name === "string" ? manifest.name : input.address,
+    source: itemSource(input.address),
+  };
+  if (typeof manifest.title === "string") item.title = manifest.title;
+  if (typeof manifest.type === "string") item.type = manifest.type;
+  if (typeof manifest.description === "string") item.description = manifest.description;
+  return [item];
 }
 
 /** Collects a channel and integration plan, then installs every chosen item in order. */
@@ -170,78 +319,128 @@ export async function runRegistryFlow(input: {
   signal?: AbortSignal;
   /** Registry item supplied by `/add <item>`, preselected before the planner opens. */
   initialAddress?: string;
+  /** First screen for an unaddressed flow; onboarding defaults to channels. */
+  initialScreen?: RegistryPlannerSection;
   onItemStart?: (item: Item, index: number, total: number) => void;
   deps?: Partial<RegistryFlowDeps>;
 }): Promise<{ kind: "done"; result: RegistrySessionResult } | { kind: "cancelled" }> {
+  let session: ReturnType<typeof createRegistrySession> | undefined;
   try {
+    const registry =
+      input.deps?.browseRegistryCatalog === undefined ||
+      input.deps?.getRegistryItemManifest === undefined ||
+      input.deps?.installRegistryItem === undefined
+        ? await import("#cli/commands/registry.js")
+        : undefined;
     const browseRegistryCatalog =
-      input.deps?.browseRegistryCatalog ??
-      (await import("#cli/commands/registry.js")).browseRegistryCatalog;
-    const catalog = await withSpinner(input.prompter, "Loading registry…", () =>
+      input.deps?.browseRegistryCatalog ?? registry!.browseRegistryCatalog;
+    const getRegistryItemManifest =
+      input.deps?.getRegistryItemManifest ?? registry!.getRegistryItemManifest;
+    const installRegistryItem = input.deps?.installRegistryItem ?? registry!.installRegistryItem;
+    const catalogResult = await withSpinner(input.prompter, "Loading registry…", () =>
       browseRegistryCatalog(input.appRoot),
     );
+    const catalog = [...catalogResult.items];
     const selected = new Set<string>();
-    if (input.initialAddress !== undefined) {
-      const initialItem = catalog.items.find(
-        (item) => item.address === input.initialAddress || item.name === input.initialAddress,
-      );
-      if (initialItem !== undefined) selected.add(initialItem.address);
+    const initialAddress = input.initialAddress?.trim();
+    if (initialAddress !== undefined && initialAddress !== "") {
+      const items = await resolveInitialItems({
+        appRoot: input.appRoot,
+        address: initialAddress,
+        catalog,
+        prompter: input.prompter,
+        getRegistryItemManifest,
+      });
+      for (const item of items) {
+        if (!catalog.some((candidate) => candidate.address === item.address)) catalog.push(item);
+        selected.add(item.address);
+      }
     }
+    const notices = catalogResult.errors.map((error) => ({
+      tone: "warning" as const,
+      text: `${error.registry}: ${error.message}`,
+    }));
+    const itemsByAddress = new Map(catalog.map((item) => [item.address, item]));
     if (
-      (await editPlan({ prompter: input.prompter, catalog: catalog.items, selected })) !== "install"
-    )
+      (await editPlan({
+        prompter: input.prompter,
+        catalog,
+        itemsByAddress,
+        selected,
+        notices,
+        initialScreen:
+          initialAddress !== undefined && initialAddress !== ""
+            ? "review"
+            : (input.initialScreen ?? "channels"),
+      })) !== "install"
+    ) {
       return { kind: "cancelled" };
+    }
+
     const detectDeployment =
       input.deps?.detectDeployment ??
       (await import("#setup/project-resolution.js")).detectDeployment;
     const runDeployFlow = input.deps?.runDeployFlow ?? (await import("./deploy.js")).runDeployFlow;
-    const session = createRegistrySession({ detectDeployment, runDeployFlow });
-    const install =
-      input.deps?.installRegistryItem ??
-      (await import("#cli/commands/registry.js")).installRegistryItem;
-    const items = [...selected].map((address) =>
-      catalog.items.find((item) => item.address === address)!,
-    );
+    session = createRegistrySession({ detectDeployment, runDeployFlow });
+    const items = [...selected].map((address) => {
+      const item = itemsByAddress.get(address);
+      if (item === undefined) throw new Error(`Registry item "${address}" is no longer available.`);
+      return item;
+    });
     for (const [index, item] of items.entries()) {
+      input.signal?.throwIfAborted();
       input.onItemStart?.(item, index, items.length);
       try {
-        const installed = await (input.prompter.withExclusiveTerminal?.(() =>
-          install(input.appRoot, item.address, {
+        const install = () =>
+          installRegistryItem(input.appRoot, item.address, {
             silent: true,
             prompter: input.prompter,
             signal: input.signal,
-          }),
-        ) ??
-          install(input.appRoot, item.address, {
-            silent: true,
-            prompter: input.prompter,
-            signal: input.signal,
-          }));
-        session.add(item.address, label(item), installed.output, installed.setup);
+          });
+        const installed = await (input.prompter.withExclusiveTerminal?.(install) ?? install());
+        session.add(label(item), installed.output, installed.setup);
       } catch (error) {
+        input.signal?.throwIfAborted();
+        if (error instanceof WizardCancelledError || error instanceof HumanActionRequiredError) {
+          throw error;
+        }
         const message = error instanceof Error ? error.message : String(error);
-        const detail = message.split("\n").find((line) => line.trim() !== "");
-        const fullDetail = error instanceof Error ? (error.stack ?? message) : message;
-        const action = await input.prompter.select({
+        const failureMessage = message.trim() || "Installation failed.";
+        const summary = failureMessage.split("\n").find((line) => line.trim() !== "");
+        session.addFailure(label(item), failureMessage);
+        const request: SingleSelectOptions<"skip" | "cancel"> = {
           message: `Couldn't add ${label(item)}`,
-          ...(detail === undefined ? {} : { description: detail }),
           options: [
             { value: "skip", label: `Skip ${label(item)}` },
             { value: "cancel", label: "Cancel setup" },
           ],
-        });
-        session.addFailure(item.address, label(item), detail ?? "Installation failed.", fullDetail);
-        if (action === "cancel") return { kind: "done", result: session.result() };
+        };
+        if (summary !== undefined) request.description = summary;
+        const action = await input.prompter.select(request);
+        if (action === "cancel") {
+          return { kind: "done", result: { ...session.result(), cancelled: true } };
+        }
       }
     }
-    const result = await session.continueAfterInstall({
-      appRoot: input.appRoot,
-      prompter: input.prompter,
-      signal: input.signal,
-    });
-    return { kind: "done", result };
+    return {
+      kind: "done",
+      result: await session.continueAfterInstall({
+        appRoot: input.appRoot,
+        prompter: input.prompter,
+        signal: input.signal,
+      }),
+    };
   } catch (error) {
-    if (error instanceof WizardCancelledError) return { kind: "cancelled" };
+    if (error instanceof WizardCancelledError) {
+      const settled = session?.result();
+      return settled !== undefined && (settled.items.length > 0 || settled.failures.length > 0)
+        ? { kind: "done", result: { ...settled, cancelled: true } }
+        : { kind: "cancelled" };
+    }
+    const settled = session?.result();
+    if (settled !== undefined && (settled.items.length > 0 || settled.failures.length > 0)) {
+      throw new RegistryFlowFailedError(error, settled);
+    }
     throw error;
   }
 }

--- a/packages/eve/src/setup/flows/registry.ts
+++ b/packages/eve/src/setup/flows/registry.ts
@@ -1,439 +1,247 @@
-import { z } from "#compiled/zod/index.js";
 import type { RegistryCatalogItem } from "#cli/commands/registry.js";
-import type {
-  Prompter,
-  SelectMetadata,
-  SelectNotice,
-  SelectOption,
-  SingleSelectOptions,
-} from "#setup/prompter.js";
-import { runDeployFlow } from "#setup/flows/deploy.js";
-import { detectDeployment } from "#setup/project-resolution.js";
-import type { RegistrySetupFact } from "#setup/registry-setup-protocol.js";
+import type { Prompter, SelectOption } from "#setup/prompter.js";
 import { WizardCancelledError } from "#setup/step.js";
 import { withSpinner } from "#setup/with-spinner.js";
 
-import { createRegistrySession, type RegistrySession } from "./registry-session.js";
+import { createRegistrySession, type RegistrySessionResult } from "./registry-session.js";
 
-const ADDRESS_PREFIX = "address:";
-const BACK = "action:back";
-const DONE = "action:done";
-const ALL = "category:all";
-
-type RegistryRow = string;
-type RegistryCategory = "channel" | "connection" | "extension" | "instrumentation";
-
-const REGISTRY_CATEGORIES: ReadonlyArray<{
-  value: `category:${RegistryCategory}`;
-  prefix: `${RegistryCategory}/`;
-  label: string;
-  hint: string;
-  browseLabel: string;
-}> = [
-  {
-    value: "category:channel",
-    prefix: "channel/",
-    label: "Channels",
-    hint: "Where people talk to your agent — Web, Slack, Discord, Teams",
-    browseLabel: "Browse channels",
-  },
-  {
-    value: "category:connection",
-    prefix: "connection/",
-    label: "MCP connections",
-    hint: "Connect services like Linear, Notion, GitHub, and Vercel",
-    browseLabel: "Browse MCP connections",
-  },
-  {
-    value: "category:extension",
-    prefix: "extension/",
-    label: "Extensions",
-    hint: "Add browser automation, memory, and developer tools",
-    browseLabel: "Browse extensions",
-  },
-  {
-    value: "category:instrumentation",
-    prefix: "instrumentation/",
-    label: "Observability",
-    hint: "Trace, evaluate, and monitor your agent",
-    browseLabel: "Browse observability integrations",
-  },
-];
-
+type Item = RegistryCatalogItem;
 export interface RegistryFlowDeps {
   browseRegistryCatalog: (typeof import("#cli/commands/registry.js"))["browseRegistryCatalog"];
-  detectDeployment: typeof detectDeployment;
-  getRegistryItemManifest: (typeof import("#cli/commands/registry.js"))["getRegistryItemManifest"];
   installRegistryItem: (typeof import("#cli/commands/registry.js"))["installRegistryItem"];
-  runDeployFlow: typeof runDeployFlow;
+  detectDeployment: (typeof import("#setup/project-resolution.js"))["detectDeployment"];
+  runDeployFlow: (typeof import("./deploy.js"))["runDeployFlow"];
+}
+const SECTIONS = {
+  channels: {
+    title: "Where should people reach your agent?",
+    description: "You can add more later with /add.",
+    featured: ["channel/web", "channel/slack", "channel/github", "channel/linear-agent"],
+    includes: (item: Item) => item.name.startsWith("channel/"),
+  },
+  integrations: {
+    title: "What should your agent be able to work with?",
+    featured: [
+      "extension/github-tools",
+      "connection/linear",
+      "connection/notion",
+      "connection/vercel",
+      "extension/agent-browser",
+    ],
+    includes: (item: Item) =>
+      !item.name.startsWith("channel/") && !item.name.startsWith("experimental/"),
+  },
+} as const;
+
+function label(item: Item): string {
+  return item.title ?? item.name.split("/").at(-1) ?? item.name;
 }
 
-export type RegistryFlowResult =
-  | {
-      kind: "done";
-      addedItems: readonly string[];
-      items: readonly import("./registry-session.js").RegistrySessionItemResult[];
-      facts: readonly RegistrySetupFact[];
-      output?: readonly string[];
-      deployed?: "production";
-    }
-  | { kind: "cancelled" };
-
-export class RegistryFlowFailedError extends Error {
-  readonly completed: Extract<RegistryFlowResult, { kind: "done" }>;
-
-  constructor(error: unknown, completed: Extract<RegistryFlowResult, { kind: "done" }>) {
-    super(error instanceof Error ? error.message : String(error), { cause: error });
-    this.name = "RegistryFlowFailedError";
-    this.completed = completed;
-  }
+function orderedSectionItems(section: keyof typeof SECTIONS, catalog: readonly Item[]): Item[] {
+  // Composite registry presets span multiple planner sections. The batch
+  // planner presents their channel and capability components independently.
+  const matching = catalog.filter(
+    (item) => item.name.includes("/") && SECTIONS[section].includes(item),
+  );
+  const featured = SECTIONS[section].featured
+    .map((name) => matching.find((item) => item.name === name))
+    .filter((item): item is Item => item !== undefined);
+  const featuredAddresses = new Set(featured.map((item) => item.address));
+  return [...featured, ...matching.filter((item) => !featuredAddresses.has(item.address))];
 }
 
-function itemLabel(item: RegistryCatalogItem): string {
-  if (item.title !== undefined) return item.title;
-  const name = item.name.split("/").at(-1) ?? item.name;
-  return name
-    .split("-")
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
+function plannerLabel(item: Item): string {
+  return item.name === "connection/linear" ? "Linear MCP" : label(item);
 }
 
-function itemRows(items: readonly RegistryCatalogItem[]): SelectOption<RegistryRow>[] {
-  return items.map((item, index) => ({
-    value: `item:${index}`,
-    label: itemLabel(item),
-    hint: item.description ?? item.type,
-  }));
-}
-
-function categoryRows(): SelectOption<RegistryRow>[] {
-  return [
-    ...REGISTRY_CATEGORIES.map((category) => ({
-      value: category.value,
-      label: category.label,
-      hint: category.hint,
-    })),
-    {
-      value: ALL,
-      label: "Browse all",
-      hint: "Search every integration or enter an item address",
-    },
-    { value: DONE, label: "Return to chat", trailingAction: true },
-  ];
-}
-
-function categoryFor(selectedCategory: RegistryRow) {
-  return REGISTRY_CATEGORIES.find((entry) => entry.value === selectedCategory);
-}
-
-function itemsForCategory(
-  items: readonly RegistryCatalogItem[],
-  selectedCategory: RegistryRow,
-): readonly RegistryCatalogItem[] {
-  if (selectedCategory === ALL) return items;
-  const category = categoryFor(selectedCategory);
-  return category === undefined
-    ? items
-    : items.filter(
-        (item) => item.address.startsWith(category.prefix) || item.name.startsWith(category.prefix),
-      );
-}
-
-function stringArray(value: unknown): string[] {
-  return Array.isArray(value)
-    ? value.filter((entry): entry is string => typeof entry === "string")
-    : [];
-}
-
-function itemSource(address: string): string {
-  if (address.startsWith("@")) return address.split("/")[0] ?? address;
-  if (/^https?:\/\//u.test(address)) {
-    try {
-      return new URL(address).host;
-    } catch {
-      return address;
-    }
-  }
-  return "Vercel";
-}
-
-function manifestRecord(manifest: unknown): Record<string, unknown> {
-  return typeof manifest === "object" && manifest !== null && !Array.isArray(manifest)
-    ? (manifest as Record<string, unknown>)
-    : {};
-}
-
-const RegistryDocumentationSchema = z.object({
-  meta: z
-    .object({
-      eve: z.object({ docs: z.string().min(1).optional() }).optional(),
-    })
-    .optional(),
-});
-
-function documentationLink(manifest: Record<string, unknown>): string | undefined {
-  const docs = RegistryDocumentationSchema.safeParse(manifest).data?.meta?.eve?.docs;
-  if (docs === undefined) return undefined;
-  return docs.startsWith("/") ? `https://eve.dev${docs}` : docs;
-}
-
-function summarizeDetails(values: readonly string[], limit = 3): string {
-  const visible = values.slice(0, limit);
-  const remaining = values.length - visible.length;
-  return remaining > 0 ? `${visible.join(", ")} … (+${remaining} more)` : visible.join(", ");
-}
-
-function environmentVariables(manifest: Record<string, unknown>): string[] {
-  const envVars = manifest.envVars;
-  return typeof envVars === "object" && envVars !== null && !Array.isArray(envVars)
-    ? Object.keys(envVars)
-    : [];
-}
-
-function itemDetails(
-  item: RegistryCatalogItem,
-  manifest: Record<string, unknown>,
-): SelectMetadata[] {
-  const details: SelectMetadata[] = [{ label: "Source", value: item.source }];
-  const dependencies = [
-    ...stringArray(manifest.dependencies),
-    ...stringArray(manifest.devDependencies),
-    ...stringArray(manifest.registryDependencies),
-  ];
-  if (dependencies.length > 0)
-    details.push({ label: "Packages", value: summarizeDetails(dependencies) });
-  const environment = environmentVariables(manifest);
-  if (environment.length > 0) {
-    details.push({ label: "Environment", value: summarizeDetails(environment) });
-  }
-  const files = Array.isArray(manifest.files) ? manifest.files : [];
-  const targets = files.flatMap((file) => {
-    if (typeof file !== "object" || file === null || Array.isArray(file)) return [];
-    const target = (file as Record<string, unknown>).target;
-    return typeof target === "string" ? [target] : [];
-  });
-  if (targets.length > 0) details.push({ label: "Files", value: summarizeDetails(targets) });
-  return details;
-}
-
-async function inspectItem(
-  prompter: Prompter,
-  deps: RegistryFlowDeps,
-  appRoot: string,
-  item: RegistryCatalogItem,
-  resolvedManifest?: Record<string, unknown>,
-  signal?: AbortSignal,
-): Promise<
-  | {
-      kind: "added";
-      output: readonly string[];
-      documentation?: string;
-      environment?: readonly string[];
-      setup?: Awaited<ReturnType<RegistryFlowDeps["installRegistryItem"]>>["setup"];
-    }
-  | { kind: "back" }
-> {
-  const manifest =
-    resolvedManifest ??
-    manifestRecord(
-      await withSpinner(prompter, "Loading registry item…", () =>
-        deps.getRegistryItemManifest(appRoot, item.address),
-      ),
-    );
-  while (true) {
-    const request: SingleSelectOptions<string> = {
-      message: typeof manifest.title === "string" ? manifest.title : item.name,
-      metadata: itemDetails(item, manifest),
-      options: [
-        { value: "add", label: "Add to project" },
-        { value: "back", label: "Back" },
-      ],
+function sectionRows(
+  section: keyof typeof SECTIONS,
+  catalog: readonly Item[],
+  selected: ReadonlySet<string>,
+): SelectOption<string>[] {
+  const featured = new Set<string>(SECTIONS[section].featured);
+  return orderedSectionItems(section, catalog).map((item) => {
+    const linearAgentSelected = selected.has("channel/linear-agent");
+    const recommendation =
+      item.name === "connection/linear" && linearAgentSelected
+        ? "Recommended with Linear Agent"
+        : undefined;
+    return {
+      value: item.address,
+      label: plannerLabel(item),
+      hint:
+        recommendation === undefined
+          ? item.description
+          : item.description === undefined
+            ? recommendation
+            : `${recommendation} · ${item.description}`,
+      ...(featured.has(item.name) ? { featured: true } : {}),
     };
-    const description =
-      typeof manifest.description === "string" ? manifest.description : item.description;
-    if (description !== undefined) request.description = description;
-    const action = await prompter.select(request);
-    if (action === "back") return { kind: "back" };
-    const spinner = prompter.log.spinner?.(`Installing ${itemLabel(item)} and dependencies…`);
-    try {
-      spinner?.stop();
-      const install = () =>
-        deps.installRegistryItem(appRoot, item.address, {
-          silent: true,
-          prompter,
-          signal,
-        });
-      const result = await (prompter.withExclusiveTerminal?.(install) ?? install());
-      return {
-        kind: "added",
-        documentation: documentationLink(manifest),
-        environment: environmentVariables(manifest),
-        ...result,
-      };
-    } finally {
-      spinner?.stop();
-    }
-  }
-}
-
-async function resolveAddressItem(
-  prompter: Prompter,
-  deps: RegistryFlowDeps,
-  appRoot: string,
-  address: string,
-): Promise<{ item: RegistryCatalogItem; manifest: Record<string, unknown> }> {
-  const manifest = await withSpinner(prompter, "Loading registry item…", () =>
-    deps.getRegistryItemManifest(appRoot, address),
-  );
-  const record = manifestRecord(manifest);
-  const item: RegistryCatalogItem = {
-    address,
-    name: typeof record.name === "string" ? record.name : address,
-    source: itemSource(address),
-  };
-  if (typeof record.type === "string") item.type = record.type;
-  if (typeof record.description === "string") item.description = record.description;
-  return { item, manifest: record };
-}
-
-/**
- * Confirms, installs, and settles one resolved item. `undefined` means the flow
- * keeps browsing — the user backed out of the item, or asked to add more.
- */
-async function offerItem(
-  input: { appRoot: string; prompter: Prompter; signal?: AbortSignal },
-  deps: RegistryFlowDeps,
-  session: RegistrySession,
-  item: RegistryCatalogItem,
-  manifest?: Record<string, unknown>,
-): Promise<RegistryFlowResult | undefined> {
-  const inspected = await inspectItem(
-    input.prompter,
-    deps,
-    input.appRoot,
-    item,
-    manifest,
-    input.signal,
-  );
-  if (inspected.kind !== "added") return undefined;
-  const output = [...inspected.output];
-  if (inspected.environment !== undefined && inspected.environment.length > 0) {
-    output.push(`Environment: ${inspected.environment.join(", ")}`);
-  }
-  if (inspected.documentation !== undefined) {
-    output.push(`Setup: ${inspected.documentation}`);
-  }
-  session.add(item.address, itemLabel(item), output, inspected.setup);
-  const next = await session.continueAfterInstall({
-    appRoot: input.appRoot,
-    prompter: input.prompter,
-    signal: input.signal,
   });
-  return next === "add-more" ? undefined : next;
 }
 
-/**
- * Runs the categorized interactive registry catalog used by the dev TUI's
- * `/add`. `initialAddress` — `/add channel/slack` — skips the category and
- * search screens and opens that item's confirmation directly; backing out of it
- * lands on the same category hub the browser starts from.
- */
+function selectedInSection(
+  section: keyof typeof SECTIONS,
+  catalog: readonly Item[],
+  selected: ReadonlySet<string>,
+): string[] {
+  return catalog
+    .filter((item) => SECTIONS[section].includes(item) && selected.has(item.address))
+    .map((item) => item.address);
+}
+
+async function editSection(input: {
+  section: keyof typeof SECTIONS;
+  prompter: Prompter;
+  catalog: readonly Item[];
+  selected: Set<string>;
+}): Promise<void> {
+  const { section, catalog, prompter, selected } = input;
+  const selectedAddresses = await prompter.select({
+    message: SECTIONS[section].title,
+    ...(section === "channels" ? { description: SECTIONS.channels.description } : {}),
+    multiple: true,
+    search: true,
+    placeholder: section === "channels" ? "Search channels" : "Search integrations",
+    plannerNavigation: true,
+    plannerContinue: section === "channels" ? "integrations" : "review",
+    initialValues: selectedInSection(section, catalog, selected),
+    options: sectionRows(section, catalog, selected),
+  });
+  for (const item of catalog) {
+    if (!SECTIONS[section].includes(item)) continue;
+    selected.delete(item.address);
+  }
+  for (const address of selectedAddresses) selected.add(address);
+}
+
+async function editPlan(input: {
+  prompter: Prompter;
+  catalog: readonly Item[];
+  selected: Set<string>;
+}): Promise<"install" | "cancelled"> {
+  let screen: "channels" | "integrations" | "review" = "channels";
+  while (true) {
+    if (screen !== "review") {
+      try {
+        await editSection({ ...input, section: screen });
+      } catch (error) {
+        if (!(error instanceof WizardCancelledError)) throw error;
+        if (screen === "channels") return "cancelled";
+        screen = "channels";
+        continue;
+      }
+      screen = screen === "channels" ? "integrations" : "review";
+      continue;
+    }
+
+    if (input.selected.size === 0) return "install";
+    let review: "install" | "back";
+    try {
+      review = await input.prompter.select({
+        message: "Review your agent",
+        metadata: [...input.selected].map((address) => {
+          const item = input.catalog.find((candidate) => candidate.address === address)!;
+          return {
+            label: item.name.startsWith("channel/") ? "Channel" : "Integration",
+            value: label(item),
+          };
+        }),
+        plannerBack: true,
+        options: [
+          { value: "install", label: "Install and set up" },
+          { value: "back", label: "Back" },
+        ],
+      });
+    } catch (error) {
+      if (!(error instanceof WizardCancelledError)) throw error;
+      screen = "integrations";
+      continue;
+    }
+    if (review === "install") return "install";
+    screen = "integrations";
+  }
+}
+
+/** Collects a channel and integration plan, then installs every chosen item in order. */
 export async function runRegistryFlow(input: {
   appRoot: string;
   prompter: Prompter;
   signal?: AbortSignal;
+  /** Registry item supplied by `/add <item>`, preselected before the planner opens. */
   initialAddress?: string;
+  onItemStart?: (item: Item, index: number, total: number) => void;
   deps?: Partial<RegistryFlowDeps>;
-}): Promise<RegistryFlowResult> {
-  let loaded: typeof import("#cli/commands/registry.js") | undefined;
-  if (
-    input.deps?.browseRegistryCatalog === undefined ||
-    input.deps.getRegistryItemManifest === undefined ||
-    input.deps.installRegistryItem === undefined
-  ) {
-    loaded = await import("#cli/commands/registry.js");
-  }
-  const deps: RegistryFlowDeps = {
-    browseRegistryCatalog: input.deps?.browseRegistryCatalog ?? loaded!.browseRegistryCatalog,
-    detectDeployment: input.deps?.detectDeployment ?? detectDeployment,
-    getRegistryItemManifest: input.deps?.getRegistryItemManifest ?? loaded!.getRegistryItemManifest,
-    installRegistryItem: input.deps?.installRegistryItem ?? loaded!.installRegistryItem,
-    runDeployFlow: input.deps?.runDeployFlow ?? runDeployFlow,
-  };
-  let notices: SelectNotice[] = [];
-  const session = createRegistrySession(deps);
-  const initialAddress = input.initialAddress?.trim();
-  let pendingAddress = initialAddress === "" ? undefined : initialAddress;
-
+}): Promise<{ kind: "done"; result: RegistrySessionResult } | { kind: "cancelled" }> {
   try {
-    while (true) {
-      input.signal?.throwIfAborted();
-      if (pendingAddress !== undefined) {
-        const address = pendingAddress;
-        pendingAddress = undefined;
-        const resolved = await resolveAddressItem(input.prompter, deps, input.appRoot, address);
-        const settled = await offerItem(input, deps, session, resolved.item, resolved.manifest);
-        if (settled !== undefined) return settled;
-        continue;
-      }
-      const catalog = await withSpinner(input.prompter, "Loading registry…", () =>
-        deps.browseRegistryCatalog(input.appRoot),
+    const browseRegistryCatalog =
+      input.deps?.browseRegistryCatalog ??
+      (await import("#cli/commands/registry.js")).browseRegistryCatalog;
+    const catalog = await withSpinner(input.prompter, "Loading registry…", () =>
+      browseRegistryCatalog(input.appRoot),
+    );
+    const selected = new Set<string>();
+    if (input.initialAddress !== undefined) {
+      const initialItem = catalog.items.find(
+        (item) => item.address === input.initialAddress || item.name === input.initialAddress,
       );
-      notices = [
-        ...notices,
-        ...catalog.errors.map((error) => ({
-          tone: "warning" as const,
-          text: `${error.registry}: ${error.message}`,
-        })),
-      ];
-      const selectedCategory = await input.prompter.select<RegistryRow>({
-        message: "Add an integration",
-        options: categoryRows(),
-        hintLayout: "inline",
-        notices,
-      });
-      notices = [];
-      if (selectedCategory === DONE) return session.result();
-
-      const categoryItems = itemsForCategory(catalog.items, selectedCategory);
-      const rows = itemRows(categoryItems);
-      rows.push({ value: BACK, label: "Back", trailingAction: true });
-      const selected = await input.prompter.select<RegistryRow>({
-        message: categoryFor(selectedCategory)?.browseLabel ?? "Browse integrations",
-        options: rows,
-        search: true,
-        placeholder: "Search integrations or enter an item address",
-        searchAction: {
-          label: (query) => `Add “${query}”`,
-          value: (query) => `${ADDRESS_PREFIX}${query.trim()}`,
-        },
-        hintLayout: "inline",
-      });
-      if (selected === BACK) continue;
-      const resolved = selected.startsWith(ADDRESS_PREFIX)
-        ? await resolveAddressItem(
-            input.prompter,
-            deps,
-            input.appRoot,
-            selected.slice(ADDRESS_PREFIX.length),
-          )
-        : { item: categoryItems[Number(selected.slice("item:".length))] };
-      if (resolved.item === undefined) {
-        throw new Error("The selected registry item is no longer available.");
-      }
-      const settled = await offerItem(
-        input,
-        deps,
-        session,
-        resolved.item,
-        "manifest" in resolved ? resolved.manifest : undefined,
-      );
-      if (settled !== undefined) return settled;
+      if (initialItem !== undefined) selected.add(initialItem.address);
     }
+    if (
+      (await editPlan({ prompter: input.prompter, catalog: catalog.items, selected })) !== "install"
+    )
+      return { kind: "cancelled" };
+    const detectDeployment =
+      input.deps?.detectDeployment ??
+      (await import("#setup/project-resolution.js")).detectDeployment;
+    const runDeployFlow = input.deps?.runDeployFlow ?? (await import("./deploy.js")).runDeployFlow;
+    const session = createRegistrySession({ detectDeployment, runDeployFlow });
+    const install =
+      input.deps?.installRegistryItem ??
+      (await import("#cli/commands/registry.js")).installRegistryItem;
+    const items = [...selected].map((address) =>
+      catalog.items.find((item) => item.address === address)!,
+    );
+    for (const [index, item] of items.entries()) {
+      input.onItemStart?.(item, index, items.length);
+      try {
+        const installed = await (input.prompter.withExclusiveTerminal?.(() =>
+          install(input.appRoot, item.address, {
+            silent: true,
+            prompter: input.prompter,
+            signal: input.signal,
+          }),
+        ) ??
+          install(input.appRoot, item.address, {
+            silent: true,
+            prompter: input.prompter,
+            signal: input.signal,
+          }));
+        session.add(item.address, label(item), installed.output, installed.setup);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        const detail = message.split("\n").find((line) => line.trim() !== "");
+        const fullDetail = error instanceof Error ? (error.stack ?? message) : message;
+        const action = await input.prompter.select({
+          message: `Couldn't add ${label(item)}`,
+          ...(detail === undefined ? {} : { description: detail }),
+          options: [
+            { value: "skip", label: `Skip ${label(item)}` },
+            { value: "cancel", label: "Cancel setup" },
+          ],
+        });
+        session.addFailure(item.address, label(item), detail ?? "Installation failed.", fullDetail);
+        if (action === "cancel") return { kind: "done", result: session.result() };
+      }
+    }
+    const result = await session.continueAfterInstall({
+      appRoot: input.appRoot,
+      prompter: input.prompter,
+      signal: input.signal,
+    });
+    return { kind: "done", result };
   } catch (error) {
     if (error instanceof WizardCancelledError) return { kind: "cancelled" };
-    const completed = session.result();
-    if (completed.addedItems.length > 0) throw new RegistryFlowFailedError(error, completed);
     throw error;
   }
 }

--- a/packages/eve/src/setup/integrations/web/setup.test.ts
+++ b/packages/eve/src/setup/integrations/web/setup.test.ts
@@ -23,7 +23,6 @@ function deps(): WebSetupDeps {
       nodeEngineOverride: undefined,
       competingNextConfigFiles: [],
     })),
-    installScaffoldDependencies: vi.fn(async () => {}),
   };
 }
 
@@ -41,9 +40,6 @@ describe("Web setup", () => {
     await applyWebSetup(plan, ctx.apply, effects);
     expect(effects.ensureChannel).toHaveBeenCalledWith(
       expect.objectContaining({ configureVercelServices: false, skipDependencyMutation: true }),
-    );
-    expect(effects.installScaffoldDependencies).toHaveBeenCalledWith(
-      expect.objectContaining({ changed: true, projectPath: "/project" }),
     );
   });
 });

--- a/packages/eve/src/setup/integrations/web/setup.ts
+++ b/packages/eve/src/setup/integrations/web/setup.ts
@@ -2,7 +2,7 @@ import { detectPackageManager } from "#setup/package-manager.js";
 import { formatNodeEngineOverrideWarning } from "#setup/node-engine.js";
 import { ensureChannel, type EnsureChannelOptions } from "#setup/scaffold/index.js";
 
-import { installScaffoldDependencies, reportOverwrittenFiles } from "../shared/scaffold.js";
+import { reportOverwrittenFiles } from "../shared/scaffold.js";
 import {
   defineSetupIntegration,
   type SetupApplyContext,
@@ -23,14 +23,9 @@ function reportCompetingNextConfigFiles(
 export interface WebSetupDeps {
   detectPackageManager: typeof detectPackageManager;
   ensureChannel: typeof ensureChannel;
-  installScaffoldDependencies: typeof installScaffoldDependencies;
 }
 
-const defaultDeps: WebSetupDeps = {
-  detectPackageManager,
-  ensureChannel,
-  installScaffoldDependencies,
-};
+const defaultDeps: WebSetupDeps = { detectPackageManager, ensureChannel };
 
 export interface WebSetupPlan {
   configureVercelServices: boolean;
@@ -79,12 +74,8 @@ export async function applyWebSetup(
     return { facts: [] };
   }
   context.presenter.log.success("Scaffolded channel: web");
-  await deps.installScaffoldDependencies({
-    changed: result.packageJsonUpdated.length > 0,
-    log: context.presenter.log,
-    projectPath: context.appRoot,
-    signal: context.signal,
-  });
+  // The registry item owns dependency installation; this setup only applies
+  // native scripts and host configuration through `skipDependencyMutation`.
   return { facts: [], deploymentRequired: true as const };
 }
 

--- a/packages/eve/src/setup/prompter.ts
+++ b/packages/eve/src/setup/prompter.ts
@@ -40,11 +40,6 @@ export interface SelectOption<T extends PrompterValue> {
   /** Short inline annotation shown dimmed only while the cursor is on this row. */
   focusHint?: string;
   /**
-   * Longer explanation rendered in the picker's reserved context area while
-   * this row is focused. The stable slot keeps neighboring rows stationary.
-   */
-  focusDescription?: string;
-  /**
    * Longer, display-only explanation shown dimmed alongside the option while it
    * is highlighted during navigation. Hidden once a choice is submitted.
    */
@@ -101,6 +96,26 @@ export interface SelectMetadata {
   value: string;
 }
 
+/** Directional transition requested from a batch-planner step. */
+export class PlannerNavigationError extends Error {
+  readonly direction: "back" | "forward";
+  readonly values: readonly PrompterValue[];
+
+  constructor(direction: "back" | "forward", values: readonly PrompterValue[]) {
+    super(`Planner requested ${direction} navigation.`);
+    this.name = "PlannerNavigationError";
+    this.direction = direction;
+    this.values = values;
+  }
+}
+
+/** Progress rail and directional controls for a multi-step picker. */
+export interface PlannerNavigation {
+  kind: "planner";
+  activeStep: number;
+  steps: readonly { label: string; count?: number }[];
+}
+
 /** Options common to every {@link Prompter.select} call. */
 export interface SelectCommonOptions<T extends PrompterValue> {
   message: string;
@@ -133,12 +148,8 @@ export interface SelectCommonOptions<T extends PrompterValue> {
   hintLayout?: "stacked" | "inline";
   /** Outcome lines from earlier laps of a looping menu. */
   notices?: readonly SelectNotice[];
-  /** Batch-planner checklist navigation: Space toggles, Enter continues, Left/Esc goes back. */
-  plannerNavigation?: true;
-  /** Destination named beside Enter in a batch-planner checklist footer. */
-  plannerContinue?: string;
-  /** Batch-planner review navigation: Enter selects, Left/Esc goes back. */
-  plannerBack?: true;
+  /** Optional batch-planner navigation grammar. */
+  navigation?: PlannerNavigation;
 }
 
 /** A selectable action appended after local matches for a non-empty query. */

--- a/packages/eve/src/setup/prompter.ts
+++ b/packages/eve/src/setup/prompter.ts
@@ -40,6 +40,11 @@ export interface SelectOption<T extends PrompterValue> {
   /** Short inline annotation shown dimmed only while the cursor is on this row. */
   focusHint?: string;
   /**
+   * Longer explanation rendered in the picker's reserved context area while
+   * this row is focused. The stable slot keeps neighboring rows stationary.
+   */
+  focusDescription?: string;
+  /**
    * Longer, display-only explanation shown dimmed alongside the option while it
    * is highlighted during navigation. Hidden once a choice is submitted.
    */
@@ -120,14 +125,20 @@ export interface SelectCommonOptions<T extends PrompterValue> {
   /**
    * How option hints are laid out in the dev TUI panel (the CLI prompter ignores
    * it and keeps its default inline, unnumbered rendering). "stacked" renders
-   * each hint on its own line below the label with a blank line between options —
-   * for small action menus whose hints carry current values. "inline" keeps hints
-   * on the label row, suppresses numeric shortcuts, and separates the trailing
-   * completion action (e.g. the `/add` task list).
+   * each hint on its own line below the label with a blank line between options;
+   * it works for both action menus and checklists. "inline" keeps hints on the
+   * label row, suppresses numeric shortcuts, and separates a trailing completion
+   * action.
    */
   hintLayout?: "stacked" | "inline";
   /** Outcome lines from earlier laps of a looping menu. */
   notices?: readonly SelectNotice[];
+  /** Batch-planner checklist navigation: Space toggles, Enter continues, Left/Esc goes back. */
+  plannerNavigation?: true;
+  /** Destination named beside Enter in a batch-planner checklist footer. */
+  plannerContinue?: string;
+  /** Batch-planner review navigation: Enter selects, Left/Esc goes back. */
+  plannerBack?: true;
 }
 
 /** A selectable action appended after local matches for a non-empty query. */


### PR DESCRIPTION
### Summary

PR 2 of 4 in the setup stack; depends on #2763. It hardens the standalone batch planner: selections and notices survive navigation, skipped failures preserve actionable diagnostics and completed results, and structured Vercel failures reach the TUI’s existing recovery routes.

It intentionally does not compose fresh-agent onboarding; that coordinator is isolated in #2765.

### Diff size

Incremental diff against #2763:

- Implementation: **+537 / −308** across 12 files
- Tests: **+543 / −184** across 8 files
- Documentation: **+24 / −18** across 1 file
- Changesets: **+6 / −1** across 2 files
- Total: **+1,110 / −511**

### Validation

- Restacked tip: focused registry and TUI unit tests (198 passing)
- `pnpm --filter eve typecheck`
- `pnpm docs:check`
- Built eve and the official registry, then booted an isolated scaffold against the stack-tip CLI and local registry

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
