### PR TITLE
feat(eve): incorporate /model and /add into a unified initial onboarding flow

### DIFF
--- a/.changeset/resumable-agent-onboarding.md
+++ b/.changeset/resumable-agent-onboarding.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Present model, channel, integration, and review setup as one cohesive fresh-agent onboarding journey.

--- a/docs/guides/dev-tui.md
+++ b/docs/guides/dev-tui.md
@@ -13,30 +13,36 @@ The transcript remains in your terminal scrollback after you exit. Run `/help` i
 
 ## Commands
 
-| Command       | Description                                                                                                                                                              |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `/model`      | Configure the model and its provider. Pass a model ID to set it directly: `/model provider/model-id`.                                                                    |
-| `/add`        | Select and install channels, MCP connections, extensions, and observability integrations. Pass an item address to confirm and install it directly: `/add channel/slack`. |
-| `/deploy`     | Deploy the agent to Vercel production. Links the directory first if needed.                                                                                              |
-| `/vc:install` | Install the Vercel CLI.                                                                                                                                                  |
-| `/vc:login`   | Log in to Vercel or restore access to a remote deployment.                                                                                                               |
-| `/info`       | Show the resolved application, compiled artifacts, discovery diagnostics, and messaging routes.                                                                          |
-| `/loglevel`   | Choose which server and agent logs appear in the transcript.                                                                                                             |
-| `/traces`     | Open the local trace viewer. Pass a trace ID prefix to open a specific trace.                                                                                            |
-| `/reset`      | Start a fresh session.                                                                                                                                                   |
-| `/cancel`     | Cancel the current turn without discarding settled context.                                                                                                              |
-| `/clear`      | Clear the session's model-message history. `/new` is an alias.                                                                                                           |
-| `/compact`    | Compact the current session's context.                                                                                                                                   |
-| `/exit`       | Quit the UI.                                                                                                                                                             |
-| `/help`       | List available commands.                                                                                                                                                 |
+| Command       | Description                                                                                                                                           |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/model`      | Configure the model and its provider. Pass a model ID to set it directly: `/model provider/model-id`.                                                 |
+| `/add`        | Select and install channels, MCP connections, extensions, and observability integrations. Pass an item address to preselect it: `/add channel/slack`. |
+| `/deploy`     | Deploy the agent to Vercel production. Links the directory first if needed.                                                                           |
+| `/vc:install` | Install the Vercel CLI.                                                                                                                               |
+| `/vc:login`   | Log in to Vercel or restore access to a remote deployment.                                                                                            |
+| `/info`       | Show the resolved application, compiled artifacts, discovery diagnostics, and messaging routes.                                                       |
+| `/loglevel`   | Choose which server and agent logs appear in the transcript.                                                                                          |
+| `/traces`     | Open the local trace viewer. Pass a trace ID prefix to open a specific trace.                                                                         |
+| `/reset`      | Start a fresh session.                                                                                                                                |
+| `/cancel`     | Cancel the current turn without discarding settled context.                                                                                           |
+| `/clear`      | Clear the session's model-message history. `/new` is an alias.                                                                                        |
+| `/compact`    | Compact the current session's context.                                                                                                                |
+| `/exit`       | Quit the UI.                                                                                                                                          |
+| `/help`       | List available commands.                                                                                                                              |
 
 `/model`, `/add`, `/deploy`, `/info`, and `/traces` are available when `eve dev` runs locally. They are unavailable when the UI connects to a server with `--url`.
 
+## Set up a new agent
+
+After `eve init`, the terminal UI guides you through **Model**, **Channels**, **Integrations**, and **Review** before the first chat prompt. The progress rail keeps the four steps visible throughout onboarding. Model setup can install or upgrade the Vercel CLI, open Vercel login, and resume project linking without leaving the flow.
+
+Model and Vercel changes take effect when you complete Model, then onboarding continues to Channels. Channel and integration selections remain drafts until you finish Review. You can move back and forth between Channels, Integrations, and Review; use `/model` after onboarding to change the committed model configuration.
+
 ## Add an integration
 
-Bare `/add` opens the planner on **Channels**. The tab rail shows selection counts as you move between **Channels**, **Integrations**, and **Review**.
+Bare `/add` opens the standalone planner on **Channels**. It does not include model configuration. The progress rail shows selection counts as you move between **Channels**, **Integrations**, and **Review**.
 
-Press `Space` or `Enter` to toggle the highlighted item. Press `Right Arrow` to preserve the current selections and continue, `Left Arrow` to preserve them and go back, or `Esc` to cancel. Installation requires `Enter` on **Install and set up** from the Review tab. If an item fails, you can skip it and continue with the remaining items.
+Press `Space` or `Enter` to toggle the highlighted item. Press `Right Arrow` to preserve the current selections and continue, `Left Arrow` to preserve them and go back, or `Esc` to cancel. Installation requires `Enter` on **Install and set up** from Review. If an item fails, you can skip it and continue with the remaining items.
 
 Pass an item address to `/add` to confirm and install that exact address without opening the planner:
 

--- a/packages/eve/src/cli/commands/init.integration.test.ts
+++ b/packages/eve/src/cli/commands/init.integration.test.ts
@@ -176,8 +176,7 @@ describe("runInitCommand", () => {
       "exec",
       "eve",
       "dev",
-      "--input",
-      "/model",
+      "--onboard",
     ]);
     // Substring assertions keep the expectations color-agnostic; picocolors
     // decides at import time whether the strings carry escape codes. The boot
@@ -370,8 +369,7 @@ describe("runInitCommand", () => {
         "exec",
         "eve",
         "dev",
-        "--input",
-        "/model",
+        "--onboard",
       ]);
       expect(output.messages[1]).toContain("Created an eve agent in ");
       expect(output.messages[1]).toContain(projectPath);
@@ -396,9 +394,9 @@ describe("runInitCommand", () => {
   });
 
   it.each([
-    ["npm", ["exec", "--", "eve", "dev", "--input", "/model"]],
-    ["yarn", ["eve", "dev", "--input", "/model"]],
-    ["bun", ["x", "eve", "dev", "--input", "/model"]],
+    ["npm", ["exec", "--", "eve", "dev", "--onboard"]],
+    ["yarn", ["eve", "dev", "--onboard"]],
+    ["bun", ["x", "eve", "dev", "--onboard"]],
   ] as const)(
     "scaffolds a fresh project owned by the invoking manager %s without package-manager pins",
     async (kind, devArguments) => {
@@ -459,16 +457,15 @@ describe("runInitCommand", () => {
       "x",
       "eve",
       "dev",
-      "--input",
-      "/model",
+      "--onboard",
     ]);
   });
 
   it.each([
-    ["npm", "package-lock.json", "bun", ["exec", "--", "eve", "dev", "--input", "/model"]],
-    ["yarn", "yarn.lock", "npm", ["eve", "dev", "--input", "/model"]],
-    ["bun", "bun.lock", "npm", ["x", "eve", "dev", "--input", "/model"]],
-    ["pnpm", "pnpm-lock.yaml", "npm", ["exec", "eve", "dev", "--input", "/model"]],
+    ["npm", "package-lock.json", "bun", ["exec", "--", "eve", "dev", "--onboard"]],
+    ["yarn", "yarn.lock", "npm", ["eve", "dev", "--onboard"]],
+    ["bun", "bun.lock", "npm", ["x", "eve", "dev", "--onboard"]],
+    ["pnpm", "pnpm-lock.yaml", "npm", ["exec", "eve", "dev", "--onboard"]],
   ] as const)(
     "scaffolds a fresh named project with the ancestor %s lockfile before the launcher",
     async (kind, lockfile, invokingManager, devArguments) => {
@@ -640,8 +637,8 @@ describe("runInitCommand", () => {
   });
 
   it.each([
-    ["yarn", "yarn.lock", ["eve", "dev", "--input", "/model"]],
-    ["bun", "bun.lock", ["x", "eve", "dev", "--input", "/model"]],
+    ["yarn", "yarn.lock", ["eve", "dev", "--onboard"]],
+    ["bun", "bun.lock", ["x", "eve", "dev", "--onboard"]],
   ] as const)(
     "scaffolds a fresh %s workspace member without nested root-only package fields",
     async (kind, lockfile, devArguments) => {
@@ -719,8 +716,7 @@ describe("runInitCommand", () => {
       "--",
       "eve",
       "dev",
-      "--input",
-      "/model",
+      "--onboard",
     ]);
   });
 
@@ -744,8 +740,7 @@ describe("runInitCommand", () => {
       "exec",
       "eve",
       "dev",
-      "--input",
-      "/model",
+      "--onboard",
     ]);
   });
 
@@ -772,8 +767,7 @@ describe("runInitCommand", () => {
       "exec",
       "eve",
       "dev",
-      "--input",
-      "/model",
+      "--onboard",
     ]);
   });
 
@@ -1206,7 +1200,7 @@ describe("runInitCommand", () => {
     expect(deps.spawnPackageManager).toHaveBeenCalledWith(
       "pnpm",
       join(parentDirectory, "my-agent"),
-      ["exec", "eve", "dev", "--input", "/model"],
+      ["exec", "eve", "dev", "--onboard"],
     );
   });
 

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -658,11 +658,8 @@ export async function runInitCommand(
   // existing app may start unrelated processes. Exec-style runs do not echo
   // the command the way run-scripts do, so the handoff line is printed here.
   const freshScaffold = result.kind === "created";
-  const devArguments = freshScaffold
-    ? [...baseDevArguments, "--input", "/model"]
-    : baseDevArguments;
-  logger.log(pc.dim(freshScaffold ? "$ eve dev --input /model" : "$ eve dev"));
-
+  const devArguments = freshScaffold ? [...baseDevArguments, "--onboard"] : baseDevArguments;
+  logger.log(pc.dim("$ eve dev"));
   if (
     !resultSucceeded(
       await dependencies.spawnPackageManager(

--- a/packages/eve/src/cli/dev/command-options.ts
+++ b/packages/eve/src/cli/dev/command-options.ts
@@ -12,6 +12,8 @@ export interface DevelopmentCliOptions {
   header?: DevelopmentRequestHeaders;
   host?: string;
   input?: string;
+  /** Internal fresh-agent handoff from `eve init`. */
+  onboard?: boolean;
   logs?: LogDisplayMode;
   name?: string;
   port?: number;

--- a/packages/eve/src/cli/dev/run-interactive-ui.ts
+++ b/packages/eve/src/cli/dev/run-interactive-ui.ts
@@ -46,6 +46,7 @@ export async function runInteractiveDevelopmentUi(input: {
   const tuiInput: RunDevelopmentTuiInput = {
     target,
     initialInput: input.options.input,
+    onboard: input.options.onboard,
     onBootProgress: input.report,
     lifecycle: input.lifecycle,
     ...display,

--- a/packages/eve/src/cli/dev/tui/prompt-command-handler.ts
+++ b/packages/eve/src/cli/dev/tui/prompt-command-handler.ts
@@ -109,7 +109,8 @@ export function createPromptCommandHandler(
       }
       const { runTuiSetupCommand, SETUP_FLOW_CONFIG } = setupCommands;
       const flowConfig = SETUP_FLOW_CONFIG[command.name];
-      flow.begin(flowConfig.title, flowConfig.indicator);
+      flow.begin(context.setupFlowTitle ?? flowConfig.title, flowConfig.indicator);
+      flow.setNavigation?.(context.setupFlowNavigation);
       let preserveFlowDiagnostics = true;
       try {
         const commandInput: TuiSetupCommandInput = {
@@ -122,16 +123,17 @@ export function createPromptCommandHandler(
         if (context.initialModelStep !== undefined) {
           commandInput.initialModelStep = context.initialModelStep;
         }
-        // `/add <item>` confirms and installs that address; bare `/add` opens the planner.
+        if (context.registryPlannerContext !== undefined) {
+          commandInput.registryPlannerContext = context.registryPlannerContext;
+        }
+        // `/add <item>` preselects that registry item; bare `/add` starts empty.
         if (command.name === "add" && command.argument.length > 0) {
           commandInput.initialRegistryAddress = command.argument;
         }
         if (options.flows !== undefined) commandInput.flows = options.flows;
         const result = await runTuiSetupCommand(commandInput);
         preserveFlowDiagnostics = result.preserveFlowDiagnostics;
-        const outcome: PromptCommandOutcome = { message: result.message };
-        if (result.tone !== undefined) outcome.tone = result.tone;
-        if (result.effect !== undefined) outcome.effect = result.effect;
+        const { preserveFlowDiagnostics: _preserve, partial: _partial, ...outcome } = result;
         return outcome;
       } finally {
         if (context.keepSetupFlowOpen !== true) {

--- a/packages/eve/src/cli/dev/tui/registry-result-message.ts
+++ b/packages/eve/src/cli/dev/tui/registry-result-message.ts
@@ -7,14 +7,13 @@ export function registryItemProgress(renderer: {
     headline: string;
     facts: readonly { label: string; value: string }[];
   }): void;
+  setNavigation?(navigation: undefined): void;
   setStatus(status: string | undefined): void;
 }): (item: RegistryCatalogItem, index: number, total: number) => void {
   return (item, index, total) => {
-    renderer.replaceContent?.({
-      headline: `Adding ${item.title ?? item.name} · ${index + 1} of ${total}`,
-      facts: [],
-    });
-    renderer.setStatus("Installing files and dependencies…");
+    renderer.setNavigation?.(undefined);
+    renderer.replaceContent?.();
+    renderer.setStatus(`Adding ${item.title ?? item.name} · ${index + 1} of ${total}`);
   };
 }
 

--- a/packages/eve/src/cli/dev/tui/runner.test.ts
+++ b/packages/eve/src/cli/dev/tui/runner.test.ts
@@ -502,7 +502,7 @@ describe("EveTUIRunner idle session follow", () => {
       }),
       name: "Weather Agent",
       appRoot: "/tmp/weather-agent",
-      initialInput: "/model",
+      onboard: true,
       bootDetections: [],
       getVercelAuthStatus: vi.fn(async (): Promise<"authenticated"> => "authenticated"),
       promptCommandHandler: { handle },
@@ -3141,7 +3141,7 @@ describe("EveTUIRunner boot setup detection", () => {
       serverUrl: "http://localhost:3000",
       name: "Weather Agent",
       appRoot: "/tmp/weather-agent",
-      initialInput: "/model",
+      onboard: true,
       bootDetections: input.bootDetections ?? [
         {
           id: "test",
@@ -3180,16 +3180,14 @@ describe("EveTUIRunner boot setup detection", () => {
     expect(warnings).toEqual(["1 setup issue: AI Gateway credentials · /model"]);
   });
 
-  it("runs the initial model onboarding prerequisites before opening /model", async () => {
+  it("runs initial onboarding as one-way model and registry phases", async () => {
     const order: string[] = [];
-    const authStatuses: Array<"cli-missing" | "logged-out" | "authenticated"> = [
-      "cli-missing",
-      "logged-out",
-      "authenticated",
-    ];
+    const results: string[] = [];
     const handle = vi.fn(async (command: { name: string }) => {
       order.push(command.name);
-      return { message: "/model dismissed." };
+      return command.name === "model"
+        ? { message: "/model failed: provider unavailable", tone: "error" as const }
+        : { message: `/${command.name} dismissed.` };
     });
     const renderer = fakeRenderer({
       readPrompt: vi.fn(async (options?: AgentTUISessionOptions) => {
@@ -3197,6 +3195,7 @@ describe("EveTUIRunner boot setup detection", () => {
         expect(options?.initialDraft).toBeUndefined();
         return undefined;
       }),
+      renderCommandResult: (message) => results.push(message),
       setupFlow: createFakeSetupFlowRenderer(),
     });
     const runner = new EveTUIRunner({
@@ -3204,82 +3203,145 @@ describe("EveTUIRunner boot setup detection", () => {
       renderer,
       name: "Weather Agent",
       appRoot: "/tmp/weather-agent",
-      initialInput: "/model",
-      bootDetections: [
-        {
-          id: "test",
-          detect: () => [
-            {
-              kind: "attention",
-              label: "model provider not linked",
-              command: "/model",
-            },
-          ],
-        },
-      ],
-      getVercelAuthStatus: vi.fn(async () => authStatuses.shift() ?? "authenticated"),
+      onboard: true,
+      bootDetections: [],
       promptCommandHandler: { handle },
     });
 
     await runner.run();
 
-    expect(order).toEqual(["vc:install", "vc:login", "model", "add", "prompt"]);
-    expect(handle).toHaveBeenNthCalledWith(
-      1,
-      { type: "extension", name: "vc:install", argument: "" },
-      expect.objectContaining({ keepSetupFlowOpen: true }),
-    );
-    expect(handle).toHaveBeenNthCalledWith(
-      2,
-      { type: "extension", name: "vc:login", argument: "" },
-      expect.objectContaining({ keepSetupFlowOpen: true }),
-    );
+    expect(order).toEqual(["model", "prompt"]);
+    expect(results).toContain("/model failed: provider unavailable");
     expect(handle).toHaveBeenCalledWith(
       { type: "extension", name: "model", argument: "" },
-      { renderer, title: "Weather Agent", initialModelStep: "provider" },
+      expect.objectContaining({
+        renderer,
+        title: "Weather Agent",
+        initialModelStep: "provider",
+        keepSetupFlowOpen: true,
+        setupFlowNavigation: {
+          kind: "planner",
+          activeStep: 0,
+          firstNavigableStep: 1,
+          steps: [
+            { label: "Model", complete: false },
+            { label: "Channels" },
+            { label: "Integrations" },
+            { label: "Review" },
+          ],
+        },
+      }),
     );
-    expect(handle).toHaveBeenCalledWith(
+    expect(handle).not.toHaveBeenCalledWith(
       { type: "extension", name: "add", argument: "" },
-      { renderer, title: "Weather Agent" },
+      expect.anything(),
     );
   });
 
-  it("stops onboarding when Vercel CLI installation leaves the CLI unavailable", async () => {
+  it("moves from Model to Channels and preserves diagnostics after a failed registry phase", async () => {
     const order: string[] = [];
-    const authStatuses: Array<"cli-missing"> = ["cli-missing", "cli-missing"];
-    const end = vi.fn();
-    const setupFlow = createFakeSetupFlowRenderer({ end });
+    const end = vi.fn(() => order.push("end"));
+    const handle = vi.fn(async (command: { name: string }) => {
+      order.push(command.name);
+      return command.name === "add"
+        ? { message: "/add failed", tone: "error" as const }
+        : { message: "model ready" };
+    });
+    const renderer = fakeRenderer({
+      readPrompt: vi.fn(async () => {
+        order.push("prompt");
+        return undefined;
+      }),
+      setupFlow: createFakeSetupFlowRenderer({ end }),
+    });
     const runner = new EveTUIRunner({
       session: sessionYielding([]),
-      renderer: fakeRenderer({ setupFlow }),
+      renderer,
       name: "Weather Agent",
       appRoot: "/tmp/weather-agent",
-      initialInput: "/model",
-      bootDetections: [
-        {
-          id: "test",
-          detect: () => [
-            {
-              kind: "attention",
-              label: "model provider not linked",
-              command: "/model",
-            },
-          ],
+      onboard: true,
+      bootDetections: [],
+      promptCommandHandler: { handle },
+    });
+
+    await runner.run();
+
+    expect(order).toEqual(["model", "add", "end", "prompt"]);
+    expect(end).toHaveBeenCalledWith({ preserveDiagnostics: true });
+    expect(handle).toHaveBeenNthCalledWith(
+      2,
+      { type: "extension", name: "add", argument: "" },
+      expect.not.objectContaining({ setupFlowNavigation: expect.anything() }),
+    );
+    expect(handle).toHaveBeenNthCalledWith(
+      2,
+      { type: "extension", name: "add", argument: "" },
+      expect.objectContaining({
+        registryPlannerContext: {
+          prefixSteps: [{ label: "Model", complete: true }],
+          reviewMessage: "Review your agent",
+          primaryActionLabel: "Install and finish setup",
+          emptyActionLabel: "Finish setup",
         },
-      ],
-      getVercelAuthStatus: vi.fn(async () => authStatuses.shift() ?? "cli-missing"),
+      }),
+    );
+  });
+
+  it("keeps the completed /add result after onboarding", async () => {
+    const renderCommandInvocation = vi.fn();
+    const renderCommandResult = vi.fn();
+    const runner = new EveTUIRunner({
+      session: sessionYielding([]),
+      renderer: fakeRenderer({
+        readPrompt: vi.fn(async () => undefined),
+        renderCommandInvocation,
+        renderCommandResult,
+        setupFlow: createFakeSetupFlowRenderer(),
+      }),
+      name: "Weather Agent",
+      appRoot: "/tmp/weather-agent",
+      onboard: true,
+      bootDetections: [],
       promptCommandHandler: {
-        handle: async (command) => {
-          order.push(command.name);
-          return { message: "/vc:install dismissed." };
-        },
+        handle: async (command) =>
+          command.name === "model"
+            ? { message: "Model ready" }
+            : { message: "Added Web Chat", tone: "success" as const },
       },
     });
 
     await runner.run();
 
-    expect(order).toEqual(["vc:install"]);
-    expect(end).toHaveBeenCalledOnce();
+    expect(renderCommandInvocation).toHaveBeenCalledWith("/add", undefined);
+    expect(renderCommandResult).toHaveBeenCalledWith("Added Web Chat", "success");
+  });
+
+  it("does not render a detached /add dismissed result when onboarding is cancelled", async () => {
+    const renderCommandResult = vi.fn();
+    const renderer = fakeRenderer({
+      readPrompt: vi.fn(async () => undefined),
+      renderCommandResult,
+      setupFlow: createFakeSetupFlowRenderer(),
+    });
+    const runner = new EveTUIRunner({
+      session: sessionYielding([]),
+      renderer,
+      name: "Weather Agent",
+      appRoot: "/tmp/weather-agent",
+      onboard: true,
+      bootDetections: [],
+      getVercelAuthStatus: vi.fn(async () => "authenticated" as const),
+      promptCommandHandler: {
+        handle: async (command) =>
+          command.name === "model"
+            ? { message: "Model ready" }
+            : { message: "/add dismissed.", cancelled: true as const },
+      },
+    });
+
+    await runner.run();
+
+    expect(renderCommandResult).not.toHaveBeenCalledWith("/add dismissed.", expect.anything());
   });
 
   it("does not auto-open /model outside the prefilled onboarding launch", async () => {
@@ -3365,7 +3427,6 @@ describe("EveTUIRunner boot setup detection", () => {
     });
     expect(headers.map((header) => header.info?.agent.model.endpoint)).toEqual([
       { kind: "gateway", connected: false },
-      { kind: "gateway", connected: true, credential: "api-key" },
     ]);
   });
 
@@ -3399,7 +3460,7 @@ describe("EveTUIRunner boot setup detection", () => {
 
     expect(client.info).toHaveBeenCalledTimes(2);
     expect(detect.mock.calls.at(-1)?.[0].info).toBeUndefined();
-    expect(headers.at(-1)?.info).toBeUndefined();
+    expect(headers.at(-1)?.info).toBe(disconnectedGatewayInfo);
   });
 
   it("stays quiet without a local setup context, even with issues", async () => {

--- a/packages/eve/src/cli/dev/tui/runner.ts
+++ b/packages/eve/src/cli/dev/tui/runner.ts
@@ -78,6 +78,8 @@ import {
   type BootDetectionContext,
   type SetupIssue,
 } from "./setup-issues.js";
+import type { RegistryPlannerContext } from "#setup/flows/registry.js";
+import type { PlannerNavigation } from "#setup/prompter.js";
 import type { SetupFlowRenderer } from "./setup-flow.js";
 import type { TraceViewerRenderer } from "./traces/trace-viewer-session.js";
 import type { RemoteDevelopmentTarget } from "./target.js";
@@ -373,6 +375,11 @@ export interface PromptCommandHandlerContext {
   readonly title: string;
   /** Provider entry authorized by confirmed boot-time model-access evidence. */
   readonly initialModelStep?: "provider";
+  readonly registryPlannerContext?: RegistryPlannerContext;
+  /** Overrides the standalone command title inside a composed setup journey. */
+  readonly setupFlowTitle?: string;
+  /** Progress owned by an enclosing journey while this command runs. */
+  readonly setupFlowNavigation?: PlannerNavigation;
   /** Live ChatGPT identity shown only inside model configuration UI. */
   readonly chatGptAccountLabel?: string;
   /**
@@ -393,6 +400,7 @@ export interface PromptCommandOutcome {
   tone?: "success" | "error";
   /** Post-command work after setup settles. */
   effect?: VercelStatusEffect | { kind: "model-access-changed" };
+  cancelled?: true;
 }
 
 export interface PromptCommandHandler {
@@ -439,11 +447,10 @@ export type EveTUIRunnerOptions = TuiDisplayOptions & {
   serverUrl?: string;
   /** Absolute local application root; omitted for remote `--url` sessions. */
   appRoot?: string;
-  /**
-   * Seeds the editable prompt buffer for the first prompt. A bare local
-   * `/model` starts initial model onboarding.
-   */
+  /** Seeds the editable prompt buffer for the first prompt. */
   initialInput?: string;
+  /** Explicit fresh-agent onboarding handoff from `eve init`. */
+  onboard?: boolean;
   /** Handles non-core slash commands without adding feature branches to the runner. */
   promptCommandHandler?: PromptCommandHandler;
   /** Commands shown in discovery for this local or remote session. */
@@ -496,12 +503,12 @@ export class EveTUIRunner {
   readonly #runtimeArtifacts?: DevelopmentRuntimeArtifactRefresher;
   readonly #serverUrl?: string;
   readonly #appRoot?: string;
-  /**
-   * Seeds the first prompt's editable buffer. A bare local `/model` starts
-   * fresh-agent onboarding.
-   */
+  /** Seeds the first prompt's editable buffer. */
   readonly #initialInput?: string;
   readonly #startup?: TuiStartup;
+  /** Explicit fresh-agent onboarding handoff from `eve init`. */
+  readonly #onboard: boolean;
+  #initialOnboardingActive = false;
   readonly #promptCommandHandler?: PromptCommandHandler;
   readonly #availablePromptCommands: readonly PromptCommandSpec[];
   readonly #withExclusiveTerminal?: <T>(task: () => Promise<T>) => Promise<T>;
@@ -604,6 +611,7 @@ export class EveTUIRunner {
     this.#formatTransportError = options.formatTransportError ?? toErrorMessage;
     if (options.initialInput !== undefined) this.#initialInput = options.initialInput;
     if (options.startup !== undefined) this.#startup = options.startup;
+    this.#onboard = options.onboard === true;
     if (options.appRoot !== undefined) {
       this.#appRoot = options.appRoot;
       const trackerOptions: VercelStatusTrackerOptions = {
@@ -659,7 +667,7 @@ export class EveTUIRunner {
     const serverUrl = this.#serverUrl;
     if (serverUrl === undefined) {
       this.#reportBeforeFirstPaint();
-      await this.#renderSetupIssues(undefined);
+      if (!this.#onboard) await this.#renderSetupIssues(undefined);
       return this.#startup?.finish() ?? this.#initialInput;
     }
 
@@ -685,7 +693,7 @@ export class EveTUIRunner {
     const initialDraft = this.#startup?.finish() ?? this.#initialInput;
     this.#reportBeforeFirstPaint();
     const headerInfo = this.#replaceAgentInfo(info);
-    await this.#renderSetupIssues(headerInfo);
+    if (!this.#onboard) await this.#renderSetupIssues(headerInfo);
     return initialDraft;
   }
 
@@ -694,7 +702,7 @@ export class EveTUIRunner {
       this.#appRoot === undefined ? info : normalizeLocalModelEndpoint(info, process.env);
     this.#agentInfo = headerInfo;
     const serverUrl = this.#serverUrl;
-    if (serverUrl === undefined) return headerInfo;
+    if (serverUrl === undefined || this.#initialOnboardingActive) return headerInfo;
 
     const header: AgentTUIAgentHeader = {
       name: this.#name,
@@ -756,18 +764,19 @@ export class EveTUIRunner {
     this.#vercelStatus?.refreshIdentity();
     this.#mcpConnectionStatus?.refresh();
 
-    const initialCommand =
-      this.#initialInput === undefined ? undefined : parsePromptCommand(this.#initialInput);
-    const initialModelOnboarding =
-      initialCommand?.type === "extension" &&
-      initialCommand.name === "model" &&
-      initialCommand.argument === "" &&
+    const initialAgentOnboarding =
+      this.#onboard &&
       this.#appRoot !== undefined &&
       this.#promptCommandHandler !== undefined &&
       this.#renderer.setupFlow !== undefined;
-    if (initialModelOnboarding) {
+    if (initialAgentOnboarding) {
       initialDraft = undefined;
-      await this.#runInitialModelOnboarding(title);
+      this.#initialOnboardingActive = true;
+      try {
+        await this.#runInitialAgentOnboarding(title);
+      } finally {
+        this.#initialOnboardingActive = false;
+      }
     }
 
     while (true) {
@@ -1611,7 +1620,15 @@ export class EveTUIRunner {
 
   async #handleExtensionCommand(
     command: Extract<PromptCommand, { type: "extension" }>,
-    input: Pick<PromptCommandHandlerContext, "initialModelStep" | "keepSetupFlowOpen" | "title">,
+    input: Pick<
+      PromptCommandHandlerContext,
+      | "initialModelStep"
+      | "registryPlannerContext"
+      | "setupFlowTitle"
+      | "setupFlowNavigation"
+      | "keepSetupFlowOpen"
+      | "title"
+    >,
   ): Promise<PromptCommandOutcome | undefined> {
     const handler = this.#promptCommandHandler;
     if (handler === undefined)
@@ -1619,9 +1636,8 @@ export class EveTUIRunner {
 
     const endpoint = this.#agentInfo?.agent.model.endpoint;
     const baseContext: PromptCommandHandlerContext = {
+      ...input,
       renderer: this.#renderer,
-      title: input.title,
-      initialModelStep: input.initialModelStep,
       chatGptAccountLabel:
         endpoint?.kind === "chatgpt" && endpoint.state === "ready"
           ? endpoint.accountLabel
@@ -1643,11 +1659,13 @@ export class EveTUIRunner {
   #renderStartupCommandInvocation(
     command: Extract<PromptCommand, { type: "extension" }>,
     trigger: "startup" | "command",
+    tone?: "success" | "error",
   ): void {
     if (trigger !== "startup") return;
 
     const state = this.#remoteConnection?.current().connection.state;
-    const status = state === "auth-failed" || state === "unavailable" ? "failed" : undefined;
+    const status =
+      tone === "error" || state === "auth-failed" || state === "unavailable" ? "failed" : undefined;
     const argument = command.argument.length === 0 ? "" : ` ${command.argument}`;
     this.#renderer.renderCommandInvocation?.(`/${command.name}${argument}`, status);
   }
@@ -1672,77 +1690,88 @@ export class EveTUIRunner {
     input: {
       readonly trigger: "startup" | "command";
       readonly initialModelStep?: "provider";
+      readonly registryPlannerContext?: RegistryPlannerContext;
+      readonly setupFlowTitle?: string;
+      readonly setupFlowNavigation?: PlannerNavigation;
       readonly keepSetupFlowOpen?: true;
+      readonly suppressSuccessfulTranscript?: true;
+      readonly suppressCancelledTranscript?: true;
     },
-  ): Promise<void> {
-    const outcome = await this.#handleExtensionCommand(command, {
-      initialModelStep: input.initialModelStep,
-      keepSetupFlowOpen: input.keepSetupFlowOpen,
-      title,
-    });
-    this.#renderStartupCommandInvocation(command, input.trigger);
-    this.#renderCommandOutcome(outcome?.message, outcome?.tone);
+  ): Promise<PromptCommandOutcome | undefined> {
+    const outcome = await this.#handleExtensionCommand(command, { ...input, title });
+    const suppressTranscript =
+      (input.suppressSuccessfulTranscript === true && outcome?.tone !== "error") ||
+      (input.suppressCancelledTranscript === true && outcome?.cancelled === true);
+    if (!suppressTranscript) {
+      this.#renderStartupCommandInvocation(command, input.trigger, outcome?.tone);
+    }
+    if (!suppressTranscript) this.#renderCommandOutcome(outcome?.message, outcome?.tone);
     await this.#applyCommandEffect(outcome?.effect);
     this.#refreshHeaderFromRemoteConnection();
+    return outcome;
   }
 
-  /**
-   * Fresh `eve init` launches the TUI with `/model` prefilled. Project-backed
-   * model access depends on the Vercel CLI and a Vercel session, so resolve
-   * only those missing prerequisites before entering the model picker. A probe
-   * failure still opens `/model`: its API-key and external-provider paths do
-   * not require Vercel. After model setup, open the categorized registry hub so
-   * a new user has concrete next steps before reaching the chat prompt.
-   */
-  async #runInitialModelOnboarding(title: string): Promise<void> {
-    const appRoot = this.#appRoot;
-    if (appRoot === undefined) return;
+  #onboardingNavigation(activeStep: number): PlannerNavigation {
+    return {
+      kind: "planner",
+      activeStep,
+      firstNavigableStep: 1,
+      steps: [
+        { label: "Model", complete: activeStep > 0 },
+        { label: "Channels" },
+        { label: "Integrations" },
+        { label: "Review" },
+      ],
+    };
+  }
 
-    const authStatus = async (): Promise<VercelAuthStatus | undefined> => {
-      try {
-        return await this.#getVercelAuthStatus(appRoot, { signal: this.#authProbeAbort.signal });
-      } catch {
-        return undefined;
-      }
+  /** Runs fresh-agent setup as two cohesive, one-way phases. */
+  async #runInitialAgentOnboarding(title: string): Promise<void> {
+    const journey = {
+      keepSetupFlowOpen: true as const,
+      setupFlowTitle: `Set up ${title}`,
+      trigger: "startup" as const,
     };
 
-    let status = await authStatus();
-    if (status === "cli-missing") {
-      await this.#executeExtensionCommand(
-        { type: "extension", name: "vc:install", argument: "" },
-        title,
-        { trigger: "startup", keepSetupFlowOpen: true },
-      );
-      status = await authStatus();
-      if (status === "cli-missing") {
-        this.#renderer.setupFlow?.end();
-        return;
-      }
+    const modelOutcome = await this.#executeExtensionCommand(
+      { type: "extension", name: "model", argument: "" },
+      title,
+      {
+        ...journey,
+        suppressSuccessfulTranscript: true,
+        initialModelStep: "provider",
+        setupFlowNavigation: this.#onboardingNavigation(0),
+      },
+    );
+    if (modelOutcome?.tone === "error" || modelOutcome?.cancelled === true) {
+      this.#renderer.setupFlow?.end({ preserveDiagnostics: modelOutcome.tone === "error" });
+      return;
     }
 
-    if (status === "logged-out") {
-      await this.#executeExtensionCommand(
-        { type: "extension", name: "vc:login", argument: "" },
+    let addOutcome: PromptCommandOutcome | undefined;
+    try {
+      addOutcome = await this.#executeExtensionCommand(
+        { type: "extension", name: "add", argument: "" },
         title,
-        { trigger: "startup", keepSetupFlowOpen: true },
+        {
+          ...journey,
+          registryPlannerContext: {
+            prefixSteps: [{ label: "Model", complete: true }],
+            reviewMessage: "Review your agent",
+            primaryActionLabel: "Install and finish setup",
+            emptyActionLabel: "Finish setup",
+          },
+        },
       );
-      status = await authStatus();
-      if (status === "cli-missing" || status === "logged-out") {
-        this.#renderer.setupFlow?.end();
-        return;
-      }
+    } finally {
+      // `/add` is the final onboarding phase. Release the shared panel so the
+      // ordinary chat prompt can own input, retaining deploy/setup evidence on failure.
+      this.#renderer.setupFlow?.end({ preserveDiagnostics: addOutcome?.tone === "error" });
     }
-
-    await this.#executeExtensionCommand({ type: "extension", name: "model", argument: "" }, title, {
-      trigger: "startup",
-      initialModelStep: "provider",
-    });
-    await this.#executeExtensionCommand({ type: "extension", name: "add", argument: "" }, title, {
-      trigger: "startup",
-    });
   }
 
   #refreshHeaderFromRemoteConnection(): void {
+    if (this.#initialOnboardingActive) return;
     const connection = this.#remoteConnection?.current().connection;
     if (connection?.state !== "ready" || connection.info === this.#agentInfo) return;
     this.#agentInfo = connection.info;

--- a/packages/eve/src/cli/dev/tui/setup-commands.test.ts
+++ b/packages/eve/src/cli/dev/tui/setup-commands.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { createFakePrompter } from "#internal/testing/fake-prompter.js";
 import { RegistryFlowFailedError } from "#setup/flows/registry.js";
+import type { RegistrySessionResult } from "#setup/flows/registry-session.js";
 import { HumanActionRequiredError } from "#setup/human-action.js";
 
 import {
@@ -28,6 +29,7 @@ function fakePanelRenderer(): TuiSetupCommandRenderer & {
     readText: vi.fn(async () => ""),
     readAcknowledge: vi.fn(async () => {}),
     readChoice: vi.fn(() => ({ choice: Promise.resolve(undefined), close: vi.fn() })),
+    setNavigation: vi.fn(),
     setStatus: vi.fn(),
     renderLine: vi.fn(),
     replaceContent: vi.fn(),
@@ -46,18 +48,7 @@ function fakePanelRenderer(): TuiSetupCommandRenderer & {
   };
 }
 
-function registryResult(
-  overrides: Partial<{
-    items: readonly {
-      title: string;
-      facts: readonly never[];
-      output: readonly string[];
-    }[];
-    failures: readonly never[];
-    cancelled: true;
-    deployed: "production";
-  }> = {},
-) {
+function registryResult(overrides: Partial<RegistrySessionResult> = {}) {
   return {
     kind: "done" as const,
     result: { items: [], failures: [], ...overrides },
@@ -114,18 +105,6 @@ function run(input: {
 }
 
 describe("runTuiSetupCommand", () => {
-  it("keeps registry setup interruptible through the parent drawer", async () => {
-    const renderer = fakePanelRenderer();
-    const runRegistryFlow = vi.fn<TuiSetupFlows["runRegistryFlow"]>(async () => registryResult());
-
-    await run({ command: "add", flows: fakeFlows({ runRegistryFlow }), renderer });
-
-    expect(runRegistryFlow).toHaveBeenCalledWith(
-      expect.not.objectContaining({ initialScreen: expect.anything() }),
-    );
-    expect(renderer.waitForInterrupt).toHaveBeenCalledWith();
-  });
-
   it("suspends the runtime during registry installation", async () => {
     const calls: string[] = [];
     const runRegistryFlow = vi.fn<TuiSetupFlows["runRegistryFlow"]>(async (input) => {
@@ -148,6 +127,9 @@ describe("runTuiSetupCommand", () => {
       withExclusiveTerminal,
     });
 
+    expect(runRegistryFlow).toHaveBeenCalledWith(
+      expect.not.objectContaining({ initialScreen: expect.anything() }),
+    );
     expect(calls).toEqual(["suspend", "install", "resume"]);
   });
 
@@ -164,11 +146,9 @@ describe("runTuiSetupCommand", () => {
 
     await run({ command: "add", flows: fakeFlows({ runRegistryFlow }), renderer });
 
-    expect(renderer.replaceContent).toHaveBeenCalledWith({
-      headline: "Adding Web Chat · 1 of 4",
-      facts: [],
-    });
-    expect(renderer.setStatus).toHaveBeenCalledWith("Installing files and dependencies…");
+    expect(renderer.setNavigation).toHaveBeenCalledWith(undefined);
+    expect(renderer.replaceContent).toHaveBeenCalledWith(undefined);
+    expect(renderer.setStatus).toHaveBeenCalledWith("Adding Web Chat · 1 of 4");
   });
 
   it("uses the build pulse for every setup command except deploy", () => {
@@ -329,6 +309,7 @@ describe("runTuiSetupCommand", () => {
     });
     await expect(run({ command: "model", flows })).resolves.toEqual({
       message: "/model dismissed.",
+      cancelled: true,
       preserveFlowDiagnostics: false,
     });
   });
@@ -471,7 +452,6 @@ describe("runTuiSetupCommand", () => {
 
     await expect(run({ command: "add", flows })).resolves.toMatchObject({
       message: expect.stringContaining("Couldn't add GitHub"),
-      tone: "error",
       preserveFlowDiagnostics: true,
     });
   });
@@ -486,40 +466,6 @@ describe("runTuiSetupCommand", () => {
     expect(flows.runDeployFlow).toHaveBeenCalledWith(
       expect.objectContaining({ interactive: true }),
     );
-  });
-
-  it("preserves settled registry results when batch setup is interrupted", async () => {
-    const renderer = fakePanelRenderer();
-    const flows = fakeFlows({
-      runRegistryFlow: vi.fn<TuiSetupFlows["runRegistryFlow"]>(
-        ({ signal }) =>
-          new Promise((resolve) => {
-            signal?.addEventListener(
-              "abort",
-              () =>
-                resolve(
-                  registryResult({
-                    items: [{ title: "Web Chat", facts: [], output: [] }],
-                    cancelled: true,
-                  }),
-                ),
-              { once: true },
-            );
-          }),
-      ),
-    });
-
-    const result = run({ command: "add", flows, renderer });
-    renderer.fireInterrupt();
-
-    await expect(result).resolves.toEqual({
-      message:
-        "Added Web Chat\n\nWeb Chat\n  Installed.\n\n" +
-        "Setup cancelled before the remaining selections were added.",
-      partial: true,
-      tone: "error",
-      preserveFlowDiagnostics: true,
-    });
   });
 
   it("preserves model access refreshes when provider setup is interrupted", async () => {

--- a/packages/eve/src/cli/dev/tui/setup-commands.ts
+++ b/packages/eve/src/cli/dev/tui/setup-commands.ts
@@ -8,7 +8,11 @@ import { runLoginFlow, type LoginFlowResult } from "#setup/flows/login.js";
 import { runModelFlow } from "#setup/flows/model.js";
 import type { ProviderSelection } from "#setup/provider-settings.js";
 import { runProviderFlow, type ProviderPicker } from "#setup/flows/provider.js";
-import { RegistryFlowFailedError, runRegistryFlow } from "#setup/flows/registry.js";
+import {
+  RegistryFlowFailedError,
+  runRegistryFlow,
+  type RegistryPlannerContext,
+} from "#setup/flows/registry.js";
 import type { Prompter } from "#setup/prompter.js";
 import { WizardCancelledError } from "#setup/step.js";
 
@@ -39,10 +43,13 @@ export const SETUP_FLOW_CONFIG = {
 
 /** The prompter surface plus the working-state interrupt trap a command races against. */
 export type TuiSetupCommandRenderer = TuiPrompterRenderer &
-  Pick<SetupFlowRenderer, "readProviderPicker" | "readModelEditor" | "waitForInterrupt">;
+  Pick<
+    SetupFlowRenderer,
+    "readProviderPicker" | "readModelEditor" | "setNavigation" | "waitForInterrupt"
+  >;
 
 type MuteableSetupRenderer = TuiPrompterRenderer &
-  Pick<SetupFlowRenderer, "readProviderPicker" | "readModelEditor">;
+  Pick<SetupFlowRenderer, "readProviderPicker" | "readModelEditor" | "setNavigation">;
 
 export interface TuiSetupCommandInput {
   command: TuiSetupCommand;
@@ -54,6 +61,8 @@ export interface TuiSetupCommandInput {
   initialModelStep?: "provider";
   /** Registry address supplied by `/add <item>`, confirmed and installed directly. */
   initialRegistryAddress?: string;
+  /** Presentation and navigation supplied by an enclosing setup journey. */
+  registryPlannerContext?: RegistryPlannerContext;
   /** Live ChatGPT identity shown only inside model configuration UI. */
   chatGptAccountLabel?: string;
   /** Suspends development runtime artifacts while registry installation and setup mutate them. */
@@ -75,6 +84,8 @@ export interface TuiSetupFlows {
 
 export interface TuiSetupCommandResult {
   message: string;
+  /** The user dismissed this setup step without completing it. */
+  cancelled?: true;
   /** Keep settled batch results instead of replacing them with an interrupt notice. */
   partial?: true;
   /** Promotes an outcome to a top-level status. */
@@ -111,6 +122,9 @@ function muteableRenderer(
       isMuted()
         ? { choice: Promise.resolve(undefined), close: () => {} }
         : renderer.readChoice(options),
+    setNavigation: (navigation) => {
+      if (!isMuted()) renderer.setNavigation?.(navigation);
+    },
     setStatus: (text) => {
       if (!isMuted()) renderer.setStatus(text);
     },
@@ -149,9 +163,9 @@ export async function runTuiSetupCommand(
   const renderer = muteableRenderer(input.renderer, () => interrupted, input.withExclusiveTerminal);
   const prompter = (input.createPrompter ?? createTuiPrompter)(renderer);
 
+  const execution = executeSetupCommand(input, prompter, renderer, controller.signal);
   const interrupt = input.renderer.waitForInterrupt();
   const INTERRUPTED = Symbol("interrupted");
-  const execution = executeSetupCommand(input, prompter, renderer, controller.signal);
   try {
     const outcome = await Promise.race([execution, interrupt.promise.then(() => INTERRUPTED)]);
     if (outcome !== INTERRUPTED) return outcome as TuiSetupCommandResult;
@@ -210,7 +224,16 @@ async function executeSetupCommand(
           deps: {
             pickModelSettings: (request) => renderer.readModelEditor(request),
             runProviderFlow: (providerInput) =>
-              runProviderFlow({ ...providerInput, picker: pickProvider }),
+              runProviderFlow({
+                ...providerInput,
+                picker: pickProvider,
+                recoverHumanAction: (error) =>
+                  recoverVercelHumanAction(error, flows, {
+                    appRoot,
+                    prompter,
+                    signal,
+                  }),
+              }),
           },
         };
         if (input.initialModelStep !== undefined) {
@@ -225,6 +248,7 @@ async function executeSetupCommand(
               result.discardedDraft === true
                 ? "/model dismissed. Drafted changes were discarded; Done commits them."
                 : "/model dismissed.",
+            cancelled: true,
             preserveFlowDiagnostics: false,
           };
         }
@@ -253,10 +277,11 @@ async function executeSetupCommand(
           prompter,
           signal,
           initialAddress: input.initialRegistryAddress,
+          plannerContext: input.registryPlannerContext,
           onItemStart: registryItemProgress(renderer),
         });
         if (flow.kind === "cancelled") {
-          return { message: "/add dismissed.", preserveFlowDiagnostics: true };
+          return { message: "/add dismissed.", cancelled: true, preserveFlowDiagnostics: true };
         }
         const result = flow.result;
         const outcome: TuiSetupCommandResult = {
@@ -304,6 +329,7 @@ async function executeSetupCommand(
     if (error instanceof WizardCancelledError) {
       return {
         message: `/${command} dismissed.`,
+        cancelled: true,
         preserveFlowDiagnostics: command !== "model",
       };
     }
@@ -333,6 +359,81 @@ async function executeSetupCommand(
       preserveFlowDiagnostics: true,
     };
   }
+}
+
+async function recoverVercelHumanAction(
+  error: HumanActionRequiredError,
+  flows: TuiSetupFlows,
+  input: { appRoot: string; prompter: Prompter; signal: AbortSignal },
+): Promise<"retry" | "cancel"> {
+  const action = error.action.kind;
+  if (
+    action !== "vercel-cli-missing" &&
+    action !== "vercel-cli-upgrade" &&
+    action !== "vercel-login" &&
+    action !== "vercel-forbidden"
+  ) {
+    throw error;
+  }
+
+  const repair =
+    action === "vercel-cli-missing"
+      ? { label: "Install Vercel CLI", message: "The Vercel CLI is required. Install it now?" }
+      : action === "vercel-cli-upgrade"
+        ? {
+            label: "Upgrade Vercel CLI",
+            message: "Your Vercel CLI needs an update. Upgrade it now?",
+          }
+        : {
+            label:
+              action === "vercel-forbidden" ? "Re-authenticate with Vercel" : "Log in to Vercel",
+            message:
+              action === "vercel-forbidden"
+                ? "Vercel denied access to that team. Re-authenticate and continue?"
+                : "You need to log in to Vercel to continue.",
+          };
+
+  let choice: "repair" | "cancel";
+  try {
+    choice = await input.prompter.select({
+      message: repair.message,
+      options: [
+        { value: "repair", label: `${repair.label} and continue` },
+        { value: "cancel", label: "Choose another option" },
+      ],
+      initialValue: "repair",
+    });
+  } catch {
+    return "cancel";
+  }
+  if (choice === "cancel") return "cancel";
+
+  if (action === "vercel-cli-missing" || action === "vercel-cli-upgrade") {
+    const result = await flows.runInstallVercelCliFlow({
+      appRoot: input.appRoot,
+      prompter: input.prompter,
+      signal: input.signal,
+      upgrade: action === "vercel-cli-upgrade",
+    });
+    if (result.kind === "installed" || result.kind === "already") return "retry";
+    input.prompter.log.warning(
+      result.kind === "failed" && result.reason !== undefined
+        ? `Couldn't ${action === "vercel-cli-upgrade" ? "upgrade" : "install"} the Vercel CLI: ${result.reason}`
+        : `Couldn't ${action === "vercel-cli-upgrade" ? "upgrade" : "install"} the Vercel CLI.`,
+    );
+    return "cancel";
+  }
+
+  const login = await flows.runLoginFlow({
+    appRoot: input.appRoot,
+    prompter: input.prompter,
+    signal: input.signal,
+    force: action === "vercel-forbidden",
+  });
+  // Device-login output belongs only to the login attempt. Clear it before
+  // either linking or the provider picker resumes.
+  input.prompter.replaceContent?.();
+  return login.kind === "logged-in" || login.kind === "already" ? "retry" : "cancel";
 }
 
 function withRegistryResults(

--- a/packages/eve/src/cli/dev/tui/setup-flow.ts
+++ b/packages/eve/src/cli/dev/tui/setup-flow.ts
@@ -74,6 +74,8 @@ export type SetupSelectResult =
 
 export interface SetupFlowRenderer {
   begin(title: string, indicator?: SetupFlowIndicator): void;
+  /** Sets progress owned by an enclosing setup journey, independent of its active question. */
+  setNavigation?(navigation: PlannerNavigation | undefined): void;
   end(options?: { preserveDiagnostics?: boolean }): void;
   readSelect(options: SetupSelectRequest): Promise<SetupSelectResult>;
   readEditableSelect(options: {

--- a/packages/eve/src/cli/dev/tui/setup-issues.integration.test.ts
+++ b/packages/eve/src/cli/dev/tui/setup-issues.integration.test.ts
@@ -107,7 +107,7 @@ describe("BOOT_DETECTIONS against a real directory", () => {
       renderer,
       serverUrl: "http://localhost:3000",
       session: client.sessions.attach("session_test"),
-      initialInput: "/model",
+      onboard: true,
     });
 
     await runner.run();
@@ -115,12 +115,40 @@ describe("BOOT_DETECTIONS against a real directory", () => {
     expect(handle).toHaveBeenNthCalledWith(
       1,
       { type: "extension", name: "model", argument: "" },
-      { renderer, title: "eve", initialModelStep: "provider" },
+      expect.objectContaining({
+        renderer,
+        title: "eve",
+        initialModelStep: "provider",
+        keepSetupFlowOpen: true,
+        setupFlowTitle: "Set up eve",
+        setupFlowNavigation: {
+          kind: "planner",
+          activeStep: 0,
+          firstNavigableStep: 1,
+          steps: [
+            { label: "Model", complete: false },
+            { label: "Channels" },
+            { label: "Integrations" },
+            { label: "Review" },
+          ],
+        },
+      }),
     );
     expect(handle).toHaveBeenNthCalledWith(
       2,
       { type: "extension", name: "add", argument: "" },
-      { renderer, title: "eve" },
+      expect.objectContaining({
+        renderer,
+        title: "eve",
+        keepSetupFlowOpen: true,
+        setupFlowTitle: "Set up eve",
+        registryPlannerContext: {
+          prefixSteps: [{ label: "Model", complete: true }],
+          reviewMessage: "Review your agent",
+          primaryActionLabel: "Install and finish setup",
+          emptyActionLabel: "Finish setup",
+        },
+      }),
     );
     expect(readPrompt).toHaveBeenCalledOnce();
     expect(order).toEqual(["model", "add", "prompt"]);

--- a/packages/eve/src/cli/dev/tui/setup-panel.ts
+++ b/packages/eve/src/cli/dev/tui/setup-panel.ts
@@ -202,6 +202,8 @@ export type FlowPanelContent =
 export interface FlowPanelState {
   /** The invoked command, e.g. "/deploy". Empty renders no title row. */
   title: string;
+  /** Progress owned by an enclosing journey, visible through nested questions and waits. */
+  navigation?: PlannerNavigation;
   lines: readonly FlowPanelLine[];
   content: FlowPanelContent;
 }
@@ -310,6 +312,9 @@ export function renderFlowPanel(state: FlowPanelState, theme: Theme, width: numb
     rows.push(`  ${c.bold(state.title)}`);
   }
   rows.push("");
+  if (state.navigation?.kind === "planner") {
+    rows.push(...plannerStepRows(state.navigation, undefined, theme));
+  }
 
   const recent = state.lines.slice(-FLOW_PANEL_LINE_CAP);
   for (const line of recent) {
@@ -450,10 +455,13 @@ function plannerStepRows(
   const labels = navigation.steps.map((step, index) => {
     const resolvedCount = index === navigation.activeStep ? activeCount : step.count;
     const count = resolvedCount === undefined || resolvedCount === 0 ? "" : ` (${resolvedCount})`;
-    const text = `${step.label}${count}`;
+    const complete = step.complete === true ? `${theme.glyph.success} ` : "";
+    const text = `${complete}${step.label}${count}`;
     return index === navigation.activeStep
       ? theme.colors.inverse(theme.colors.blue(theme.colors.bold(` ${text} `)))
-      : theme.colors.dim(text);
+      : step.complete === true
+        ? theme.colors.green(text)
+        : theme.colors.dim(text);
   });
   const progress = labels.flatMap((label, index) => {
     if (index === labels.length - 1) return [label];

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.ts
@@ -62,7 +62,7 @@ import type {
   SetupSelectRequest,
   SetupSelectResult,
 } from "./setup-flow.js";
-import type { SelectNotice } from "#setup/prompter.js";
+import type { PlannerNavigation, SelectNotice } from "#setup/prompter.js";
 import type { ModelSettingsRequest, ModelSettingsResult } from "#setup/flows/model.js";
 import type { ProviderPickerChoice, ProviderPickerRequest } from "#setup/flows/provider.js";
 import {
@@ -242,6 +242,7 @@ type TurnIndicatorState = { kind: "idle" } | { kind: "waiting"; startedAtMs: num
 
 type SetupFlowState = {
   title: string;
+  navigation?: PlannerNavigation;
   indicator: SetupFlowIndicatorState;
   lines: FlowPanelLine[];
   summary?: { headline: string; facts: readonly { label: string; value: string }[] };
@@ -589,6 +590,7 @@ export class TerminalRenderer implements AgentTUIRenderer {
   #terminalBackground?: RgbColor;
   readonly setupFlow: SetupFlowRenderer = {
     begin: (title, indicator) => this.#beginSetupFlow(title, indicator),
+    setNavigation: (navigation) => this.#setSetupFlowNavigation(navigation),
     end: (options) => this.#endSetupFlow(options?.preserveDiagnostics ?? true),
     readSelect: (options) => this.#readSetupSelect(options),
     readEditableSelect: (options) => this.#readSetupEditableSelect(options),
@@ -1824,6 +1826,12 @@ export class TerminalRenderer implements AgentTUIRenderer {
     // The ticker runs for the whole flow: the idle pulse, the status indicator,
     // and the output preview all animate through it.
     this.#startTicker();
+    this.#paint();
+  }
+
+  #setSetupFlowNavigation(navigation: PlannerNavigation | undefined): void {
+    if (this.#setupFlow === undefined) return;
+    this.#setupFlow.navigation = navigation;
     this.#paint();
   }
 
@@ -4163,6 +4171,7 @@ export class TerminalRenderer implements AgentTUIRenderer {
       }
       const state: Parameters<typeof renderFlowPanel>[0] = {
         title: flow.title,
+        navigation: flow.navigation,
         lines:
           flow.summary === undefined
             ? flow.hideLinesWhileQuestion === true

--- a/packages/eve/src/cli/dev/tui/tui.ts
+++ b/packages/eve/src/cli/dev/tui/tui.ts
@@ -34,11 +34,10 @@ export interface RunDevelopmentTuiInput extends TuiDisplayOptions {
   readonly target: DevelopmentTuiTarget;
   /** Additional request headers sent by this TUI client. */
   readonly headers?: Readonly<Record<string, string>>;
-  /**
-   * Text to seed the prompt input with after the UI launches. A bare local
-   * `/model` starts fresh-agent onboarding. Applies to the first prompt only.
-   */
+  /** Text to seed the prompt input with after the UI launches. Applies to the first prompt only. */
   readonly initialInput?: string;
+  /** Explicit fresh-agent onboarding handoff from `eve init`. */
+  readonly onboard?: boolean;
   /** Reports local CLI boot phases. Omitted for remote and programmatic TUI runs. */
   readonly onBootProgress?: DevBootProgressReporter;
   /** Gives setup subprocesses exclusive terminal and development-host ownership. */
@@ -141,6 +140,7 @@ export async function runDevelopmentTui(input: RunDevelopmentTuiInput): Promise<
     target,
     headers,
     initialInput,
+    onboard,
     onBootProgress,
     lifecycle,
     startup,
@@ -187,6 +187,7 @@ export async function runDevelopmentTui(input: RunDevelopmentTuiInput): Promise<
     options.renderer = startup.renderer;
     options.startup = startup;
   }
+  if (onboard !== undefined) options.onboard = onboard;
   if (onBootProgress !== undefined) options.onBootProgress = onBootProgress;
   if (lifecycle !== undefined) options.lifecycle = lifecycle;
   if (withExclusiveTerminal !== undefined) options.withExclusiveTerminal = withExclusiveTerminal;

--- a/packages/eve/src/cli/run.test.ts
+++ b/packages/eve/src/cli/run.test.ts
@@ -418,6 +418,20 @@ describe("eve dev --input", () => {
     ).rejects.toThrow("--input requires the interactive UI");
   });
 
+  it("forwards the internal init onboarding handoff to the local TUI", async () => {
+    const startHost = vi.fn(() => ({
+      start: async () => ({
+        kind: "existing" as const,
+        appRoot: "/canonical/app",
+        url: "http://127.0.0.1:4321/",
+      }),
+      close: async () => {},
+    }));
+    const runDevelopmentTui = await runInteractiveDev(["dev", "--onboard"], { startHost });
+
+    expect(runDevelopmentTui).toHaveBeenCalledWith(expect.objectContaining({ onboard: true }));
+  });
+
   it("rejects the option with explicit --no-ui", async () => {
     await expect(
       runCli(["dev", "--input", "/model", "--no-ui"], {

--- a/packages/eve/src/cli/run.ts
+++ b/packages/eve/src/cli/run.ts
@@ -1,4 +1,9 @@
-import { Command, CommanderError, InvalidArgumentError } from "#compiled/commander/index.js";
+import {
+  Command,
+  CommanderError,
+  InvalidArgumentError,
+  Option,
+} from "#compiled/commander/index.js";
 import { registerBuildCommand, type BuildHost } from "#cli/commands/build.js";
 import type { DevBootProgressReporter } from "#internal/dev-boot-progress.js";
 import { resolveApplicationRoot } from "#internal/application/paths.js";
@@ -335,7 +340,8 @@ function createCliProgram(
     )
     .option("--no-ui", "Start the server without an interactive UI")
     .option("--name <name>", "Title shown in the terminal UI (defaults to the app folder name)")
-    .option("--input <text>", "Pre-fill the prompt input, or start onboarding with /model")
+    .option("--input <text>", "Pre-fill the prompt input")
+    .addOption(new Option("--onboard", "Start fresh-agent onboarding").hideHelp())
     .option(
       "--tools <mode>",
       "How tool calls render: full | collapsed | auto-collapsed | hidden",
@@ -449,7 +455,7 @@ function createCliProgram(
 
       let tuiStartup: DevelopmentTuiStartup | undefined;
       const tuiStartupPromise =
-        mode === "tui" && runtime.runDevelopmentTui === undefined
+        mode === "tui" && options.onboard !== true && runtime.runDevelopmentTui === undefined
           ? loadDevelopmentTuiModule().then((module) => {
               onBootProgress({ type: "before-first-paint" });
               return module.startDevelopmentTuiStartup({

--- a/packages/eve/src/setup/flows/login.test.ts
+++ b/packages/eve/src/setup/flows/login.test.ts
@@ -58,6 +58,31 @@ describe("runLoginFlow", () => {
     expect(runVercelLogin).toHaveBeenCalledWith(expect.objectContaining({ cwd: APP_ROOT }));
   });
 
+  it("keeps the Vercel device-login URL visible", async () => {
+    const { prompter } = createFakePrompter({});
+    const runVercelLogin = vi.fn<LoginFlowDeps["runVercelLogin"]>(async ({ onOutput }) => {
+      onOutput({
+        stream: "stdout",
+        text: "Visit https://vercel.com/oauth/device?user_code=MDXV-HSVH",
+      });
+      onOutput({ stream: "stdout", text: "Waiting for authentication..." });
+      return false;
+    });
+
+    await expect(
+      runLoginFlow({
+        appRoot: APP_ROOT,
+        prompter,
+        deps: { getVercelAuthStatus: authProbe("logged-out"), runVercelLogin },
+      }),
+    ).resolves.toEqual({ kind: "failed" });
+
+    expect(prompter.log.info).toHaveBeenCalledExactlyOnceWith(
+      "Open https://vercel.com/oauth/device?user_code=MDXV-HSVH",
+    );
+    expect(prompter.log.commandOutput).toHaveBeenCalledTimes(2);
+  });
+
   it("reports failed when vercel login exits non-zero", async () => {
     const runVercelLogin = vi.fn<LoginFlowDeps["runVercelLogin"]>(async () => false);
     await expect(

--- a/packages/eve/src/setup/flows/login.ts
+++ b/packages/eve/src/setup/flows/login.ts
@@ -26,6 +26,10 @@ export type LoginFlowResult =
  */
 const LOGIN_TIMEOUT_MS = 5 * 60_000;
 
+function vercelLoginUrl(text: string): string | undefined {
+  return text.match(/https:\/\/vercel\.com\/oauth\/device\?[^\s]+/u)?.[0];
+}
+
 /** Injected for tests; defaults to the real auth probe and `vercel login`. */
 export interface LoginFlowDeps {
   getVercelAuthStatus: typeof getVercelAuthStatus;
@@ -114,7 +118,16 @@ export async function runLoginFlow(input: {
 }): Promise<LoginFlowResult> {
   const { appRoot, prompter, signal } = input;
   const deps: LoginFlowDeps = { ...defaultDeps, ...input.deps };
-  const onOutput = createPromptCommandOutput(prompter.log);
+  const commandOutput = createPromptCommandOutput(prompter.log);
+  let shownLoginUrl: string | undefined;
+  const onOutput: ReturnType<typeof createPromptCommandOutput> = (line) => {
+    commandOutput(line);
+    const url = vercelLoginUrl(line.text);
+    if (url !== undefined && url !== shownLoginUrl) {
+      shownLoginUrl = url;
+      prompter.log.info(`Open ${url}`);
+    }
+  };
 
   const probeAuth = (): Promise<VercelAuthStatus> => deps.getVercelAuthStatus(appRoot, { signal });
 

--- a/packages/eve/src/setup/flows/model.test.ts
+++ b/packages/eve/src/setup/flows/model.test.ts
@@ -487,11 +487,12 @@ describe("runModelFlow", () => {
     expect(menuPaints[0]?.notices).toEqual([]);
   });
 
-  it("leaves via the Done row exactly like Esc", async () => {
+  it("completes via Done without requiring a model change", async () => {
     const { prompter, menuPaints } = scriptedPrompter({ menu: ["done"] });
 
     await expect(runModelFlow({ appRoot: APP_ROOT, prompter, deps: flowDeps() })).resolves.toEqual({
-      kind: "cancelled",
+      kind: "done",
+      accessChanged: false,
     });
     expect(menuPaints).toHaveLength(1);
   });
@@ -709,12 +710,13 @@ describe("runModelFlow", () => {
     expect(menuPaints[0]?.options[0]?.hint).toBe("anthropic/claude-sonnet-5@medium");
   });
 
-  it("folds an unchanged screen and a Done exit into a cancel", async () => {
+  it("completes after confirming unchanged model settings", async () => {
     const { prompter } = scriptedPrompter({ menu: ["model", "done"] });
     const deps = flowDeps({ pickModelSettings: vi.fn(async () => ({})) });
 
     await expect(runModelFlow({ appRoot: APP_ROOT, prompter, deps })).resolves.toEqual({
-      kind: "cancelled",
+      kind: "done",
+      accessChanged: false,
     });
     expect(deps.applySettings).not.toHaveBeenCalled();
   });
@@ -805,19 +807,19 @@ describe("runModelFlow", () => {
     expect(resolveAvailableProviders).toHaveBeenCalledTimes(1);
   });
 
-  it("treats the external-provider branch as informational — no notice, no outcome", async () => {
-    const { prompter, menuPaints } = scriptedPrompter({ menu: ["provider", "esc"] });
+  it("completes without persisted changes after direct-provider instructions", async () => {
+    const { prompter, menuPaints } = scriptedPrompter({ menu: ["provider", "done"] });
     const deps = flowDeps({
       runProviderFlow: vi.fn(async () => ({ kind: "external-provider" }) as const),
     });
 
-    // Nothing changed on disk (any existing gateway link is untouched), so
-    // the lap leaves no trace and the empty exit folds to cancelled.
     await expect(runModelFlow({ appRoot: APP_ROOT, prompter, deps })).resolves.toEqual({
-      kind: "cancelled",
+      kind: "done",
+      accessChanged: false,
     });
 
     expect(deps.resolveAvailableProviders).toHaveBeenCalledTimes(1);
+    expect(deps.writeProviderSelection).not.toHaveBeenCalled();
     expect(menuPaints[1]?.notices).toEqual([]);
   });
 

--- a/packages/eve/src/setup/flows/model.ts
+++ b/packages/eve/src/setup/flows/model.ts
@@ -347,6 +347,7 @@ export async function runModelFlow(input: {
   let lastApply: ApplyModelSettingsOutcome | undefined;
   let committedProviderSelection: ProviderSelection | undefined;
   let shouldAuthenticateChatGpt = false;
+  let completed = false;
   let commitDraft = false;
   const sourceOwnedExternalRouting =
     routing?.kind === "external" && !isChatGptModelRouting(routing);
@@ -403,6 +404,7 @@ export async function runModelFlow(input: {
     }
 
     if (pick === "done") {
+      completed = true;
       commitDraft = true;
       break;
     }
@@ -468,7 +470,9 @@ export async function runModelFlow(input: {
       nextSelection = "provider";
       continue;
     }
-    // External-provider setup only shows instructions, so keep the menu open.
+    // Direct-provider setup remains source-owned. Acknowledging the instructions
+    // returns to Done so the user can explicitly continue without persisting a
+    // misleading eve provider selection.
     if (result.kind === "external-provider") {
       if (signal?.aborted) return { kind: "cancelled" };
       nextSelection = "done";
@@ -514,7 +518,7 @@ export async function runModelFlow(input: {
     committedProviderSelection === undefined &&
     !shouldAuthenticateChatGpt
   ) {
-    return { kind: "cancelled" };
+    return completed ? { kind: "done", accessChanged: false } : { kind: "cancelled" };
   }
   const done: Extract<ModelFlowResult, { kind: "done" }> = {
     kind: "done",

--- a/packages/eve/src/setup/flows/provider.test.ts
+++ b/packages/eve/src/setup/flows/provider.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { createFakePrompter } from "#internal/testing/fake-prompter.js";
 import type { VercelAuthStatus } from "#setup/vercel-project.js";
+import { HumanActionRequiredError } from "#setup/human-action.js";
 
 import {
   EXTERNAL_PROVIDER_INSTRUCTIONS,
@@ -163,6 +164,26 @@ describe("runProviderFlow", () => {
     });
   });
 
+  it("does not mark an inferred provider as current during onboarding", async () => {
+    const fake = createFakePrompter();
+    const deps = createDeps();
+    const picker: ProviderPicker = async (request) => {
+      expect(request.initialValue).toBe("ai-gateway-project");
+      expect(request.options.every((option) => option.checked !== true)).toBe(true);
+      expect(request.options.every((option) => option.hint !== "Current")).toBe(true);
+      return undefined;
+    };
+
+    await runTestProviderFlow({
+      appRoot: APP_ROOT,
+      prompter: fake.prompter,
+      picker,
+      selectedProvider: "ai-gateway-project",
+      selectionExplicit: false,
+      deps,
+    });
+  });
+
   it("uses the stored selection when multiple providers are available", async () => {
     const fake = createFakePrompter();
     const deps = createDeps();
@@ -184,6 +205,122 @@ describe("runProviderFlow", () => {
       selectedProvider: "ai-gateway-project",
       deps,
     });
+  });
+
+  it("keeps a transiently unavailable project selectable for retry", async () => {
+    const fake = createFakePrompter();
+    const deps = createDeps();
+    deps.getVercelAuthStatus
+      .mockResolvedValueOnce("unavailable")
+      .mockResolvedValueOnce("authenticated");
+    let pick = 0;
+
+    await expect(
+      runTestProviderFlow({
+        appRoot: APP_ROOT,
+        prompter: fake.prompter,
+        picker: async (request) => {
+          if (pick++ === 1) {
+            expect(request.initialValue).toBe("ai-gateway-project");
+            expect(request.options[0]).toMatchObject({
+              value: "ai-gateway-project",
+              hint: "Couldn't reach Vercel — select to retry",
+            });
+            expect(request.options[0]?.disabled).not.toBe(true);
+          }
+          return { kind: "ai-gateway-project" };
+        },
+        deps,
+      }),
+    ).resolves.toEqual({ kind: "ai-gateway-project" });
+
+    expect(deps.getVercelAuthStatus).toHaveBeenCalledTimes(2);
+    expect(deps.runLinkFlow).toHaveBeenCalledOnce();
+  });
+
+  it("keeps a declined login recoverable from the project row", async () => {
+    const fake = createFakePrompter();
+    const deps = createDeps();
+    deps.getVercelAuthStatus.mockResolvedValue("logged-out");
+    const recoverHumanAction = vi.fn(async () => "cancel" as const);
+    let pick = 0;
+
+    await expect(
+      runTestProviderFlow({
+        appRoot: APP_ROOT,
+        prompter: fake.prompter,
+        picker: async (request) => {
+          if (pick++ === 1) {
+            expect(request.initialValue).toBe("ai-gateway-project");
+            expect(request.options[0]).toMatchObject({
+              value: "ai-gateway-project",
+              hint: "Log in to Vercel — select to retry",
+            });
+            expect(request.options[0]?.disabled).not.toBe(true);
+            return undefined;
+          }
+          return { kind: "ai-gateway-project" };
+        },
+        recoverHumanAction,
+        deps,
+      }),
+    ).resolves.toEqual({ kind: "cancelled" });
+
+    expect(recoverHumanAction).toHaveBeenCalledOnce();
+  });
+
+  it("repairs a missing CLI and login in place before linking", async () => {
+    const fake = createFakePrompter();
+    const deps = createDeps();
+    deps.getVercelAuthStatus
+      .mockResolvedValueOnce("cli-missing")
+      .mockResolvedValueOnce("logged-out")
+      .mockResolvedValueOnce("authenticated");
+    const actions: string[] = [];
+
+    await expect(
+      runTestProviderFlow({
+        appRoot: APP_ROOT,
+        prompter: fake.prompter,
+        picker: async () => ({ kind: "ai-gateway-project" }),
+        recoverHumanAction: async (error) => {
+          actions.push(error.action.kind);
+          return "retry";
+        },
+        deps,
+      }),
+    ).resolves.toEqual({ kind: "ai-gateway-project" });
+
+    expect(actions).toEqual(["vercel-cli-missing", "vercel-login"]);
+    expect(deps.runLinkFlow).toHaveBeenCalledOnce();
+  });
+
+  it("repairs a link-time Vercel capability and resumes the same link", async () => {
+    const fake = createFakePrompter();
+    const deps = createDeps();
+    deps.runLinkFlow
+      .mockRejectedValueOnce(
+        new HumanActionRequiredError({
+          kind: "vercel-cli-upgrade",
+          command: "vercel upgrade",
+          reason: "The CLI cannot list teams.",
+        }),
+      )
+      .mockResolvedValueOnce({ kind: "done" });
+    const recoverHumanAction = vi.fn(async () => "retry" as const);
+
+    await expect(
+      runTestProviderFlow({
+        appRoot: APP_ROOT,
+        prompter: fake.prompter,
+        picker: async () => ({ kind: "ai-gateway-project" }),
+        recoverHumanAction,
+        deps,
+      }),
+    ).resolves.toEqual({ kind: "ai-gateway-project" });
+
+    expect(recoverHumanAction).toHaveBeenCalledOnce();
+    expect(deps.runLinkFlow).toHaveBeenCalledTimes(2);
   });
 
   it("preserves cancellation from the project link flow", async () => {

--- a/packages/eve/src/setup/flows/provider.ts
+++ b/packages/eve/src/setup/flows/provider.ts
@@ -15,6 +15,7 @@ import {
 import { withSpinner } from "../with-spinner.js";
 
 import type { ProviderSelection } from "#setup/provider-settings.js";
+import { HumanActionRequiredError } from "#setup/human-action.js";
 
 import { runLinkFlow } from "./link.js";
 
@@ -70,12 +71,22 @@ export type ProviderPicker = (
 
 function projectConnectionOption(
   authStatus: VercelAuthStatus | undefined,
+  recoverable: boolean,
 ): SelectOption<ProviderConnection> {
   const option: SelectOption<ProviderConnection> = {
     value: "ai-gateway-project",
     label: "AI Gateway via Project",
     hint: "Authenticates with AI Gateway automatically\nin a new or existing project. No keys to manage.",
   };
+  if (authStatus === "unavailable") {
+    return { ...option, hint: "Couldn't reach Vercel — select to retry" };
+  }
+  if (recoverable && authStatus === "logged-out") {
+    return { ...option, hint: "Log in to Vercel — select to retry" };
+  }
+  if (recoverable && authStatus === "cli-missing") {
+    return { ...option, hint: "Install the Vercel CLI — select to retry" };
+  }
   const disabledReason = authStatus === undefined ? undefined : vercelAuthBlockerReason(authStatus);
   return disabledReason === undefined
     ? option
@@ -85,9 +96,16 @@ function projectConnectionOption(
 function providerOptions(
   authStatus: VercelAuthStatus | undefined,
   selectedProvider: ProviderSelection,
+  selectionExplicit: boolean,
+  recoverable: boolean,
 ): SelectOption<ProviderConnection>[] {
-  let project = projectConnectionOption(authStatus);
-  if (selectedProvider === "ai-gateway-project") {
+  let project = projectConnectionOption(authStatus, recoverable);
+  if (
+    selectionExplicit &&
+    selectedProvider === "ai-gateway-project" &&
+    authStatus !== "unavailable" &&
+    !(recoverable && (authStatus === "logged-out" || authStatus === "cli-missing"))
+  ) {
     project = { ...project, checked: true, hint: "Current" };
   }
 
@@ -96,7 +114,7 @@ function providerOptions(
     label: `AI Gateway via ${AI_GATEWAY_API_KEY_ENV_VAR}`,
     hint: "⎿ type your key",
   };
-  if (selectedProvider === "ai-gateway-key") {
+  if (selectionExplicit && selectedProvider === "ai-gateway-key") {
     gatewayKey = { ...gatewayKey, checked: true, hint: "Current" };
   }
 
@@ -106,8 +124,11 @@ function providerOptions(
     {
       value: "chatgpt",
       label: "ChatGPT subscription",
-      hint: selectedProvider === "chatgpt" ? "Current" : "Authenticate through the Codex CLI",
-      checked: selectedProvider === "chatgpt" || undefined,
+      hint:
+        selectionExplicit && selectedProvider === "chatgpt"
+          ? "Current"
+          : "Authenticate through the Codex CLI",
+      checked: (selectionExplicit && selectedProvider === "chatgpt") || undefined,
     },
     {
       value: "external",
@@ -155,6 +176,10 @@ export async function runProviderFlow(input: {
   availableProviders: readonly ProviderSelection[];
   /** The current provider selection. */
   selectedProvider: ProviderSelection;
+  /** Whether that selection was explicitly persisted rather than inferred from available access. */
+  selectionExplicit?: boolean;
+  /** Interactive caller recovery that resumes project linking after Vercel repair. */
+  recoverHumanAction?: (error: HumanActionRequiredError) => Promise<"retry" | "cancel">;
   deps?: Partial<ProviderFlowDeps>;
 }): Promise<ProviderFlowResult> {
   const { appRoot, prompter, signal } = input;
@@ -177,7 +202,12 @@ export async function runProviderFlow(input: {
     while (true) {
       const choice = await selectProvider({
         picker: input.picker,
-        options: providerOptions(authStatus, selectedProvider),
+        options: providerOptions(
+          authStatus,
+          selectedProvider,
+          input.selectionExplicit !== false,
+          input.recoverHumanAction !== undefined,
+        ),
         initialValue,
         validateInlineKey: (key, validationSignal) =>
           deps.validateGatewayApiKey(
@@ -215,23 +245,62 @@ export async function runProviderFlow(input: {
         return choice;
       }
 
-      const auth = await withSpinner(prompter, "Checking your Vercel login…", () =>
-        deps.getVercelAuthStatus(appRoot, { signal }),
-      );
-      signal?.throwIfAborted();
-      authStatus = auth;
-      if (vercelAuthBlockerReason(authStatus) !== undefined) {
-        initialValue = "ai-gateway-key";
-        continue;
+      while (true) {
+        const auth = await withSpinner(prompter, "Checking your Vercel login…", () =>
+          deps.getVercelAuthStatus(appRoot, { signal }),
+        );
+        signal?.throwIfAborted();
+        authStatus = auth;
+        if (auth === "authenticated") break;
+        const actionKind =
+          auth === "cli-missing"
+            ? "vercel-cli-missing"
+            : auth === "logged-out"
+              ? "vercel-login"
+              : undefined;
+        if (actionKind === undefined || input.recoverHumanAction === undefined) {
+          initialValue = auth === "unavailable" ? "ai-gateway-project" : "ai-gateway-key";
+          break;
+        }
+        const recovery = await input.recoverHumanAction(
+          new HumanActionRequiredError({
+            kind: actionKind,
+            command: auth === "cli-missing" ? "npm i -g vercel@latest" : "vercel login",
+            reason:
+              auth === "cli-missing"
+                ? "AI Gateway via Project requires the Vercel CLI."
+                : "AI Gateway via Project requires a Vercel login.",
+          }),
+        );
+        if (recovery === "cancel") {
+          initialValue = "ai-gateway-project";
+          break;
+        }
       }
-      const result = await deps.runLinkFlow({
-        appRoot,
-        prompter,
-        signal,
-        projectSelection: "create-or-link",
-      });
-      if (result.kind === "cancelled") return result;
-      return { kind: "ai-gateway-project" };
+      if (authStatus !== "authenticated") continue;
+      while (true) {
+        try {
+          const result = await deps.runLinkFlow({
+            appRoot,
+            prompter,
+            signal,
+            projectSelection: "create-or-link",
+          });
+          if (result.kind === "cancelled") return result;
+          return { kind: "ai-gateway-project" };
+        } catch (error) {
+          if (
+            !(error instanceof HumanActionRequiredError) ||
+            input.recoverHumanAction === undefined
+          ) {
+            throw error;
+          }
+          if ((await input.recoverHumanAction(error)) === "cancel") {
+            initialValue = "ai-gateway-key";
+            break;
+          }
+        }
+      }
     }
   } catch (error) {
     if (error instanceof WizardCancelledError) return { kind: "cancelled" };

--- a/packages/eve/src/setup/flows/registry.test.ts
+++ b/packages/eve/src/setup/flows/registry.test.ts
@@ -82,6 +82,38 @@ describe("runRegistryFlow", () => {
     );
   });
 
+  it("orders first-party Photon before non-featured channel providers", async () => {
+    const channelLabels: string[] = [];
+    const fake = createFakePrompter({
+      multiple: (options) => {
+        if (options.message === "Where should people reach your agent?") {
+          channelLabels.push(...options.options.map((option) => option.label));
+        }
+        return [];
+      },
+      single: () => "install",
+    });
+    const flowDeps = deps({
+      browseRegistryCatalog: vi.fn(async () => ({
+        items: [
+          { address: "channel/blooio", name: "channel/blooio", title: "Blooio", source: "Vercel" },
+          {
+            address: "channel/photon-imessage",
+            name: "channel/photon-imessage",
+            title: "Photon iMessage",
+            source: "Vercel",
+          },
+        ],
+        total: 2,
+        errors: [],
+      })),
+    });
+
+    await runRegistryFlow({ appRoot: APP_ROOT, prompter: fake.prompter, deps: flowDeps });
+
+    expect(channelLabels).toEqual(["Photon iMessage", "Blooio"]);
+  });
+
   it("lets the user browse, retain selections, and review the plan before installing", async () => {
     const answers = ["install"];
     const prompts: unknown[] = [];
@@ -114,15 +146,59 @@ describe("runRegistryFlow", () => {
       placeholder: "Search integrations",
     });
     expect(prompts[2]).toMatchObject({
-      message: "Review your agent",
+      message: "Review additions",
       navigation: {
         kind: "planner",
         activeStep: 2,
         steps: [{ label: "Channels" }, { label: "Integrations", count: 1 }, { label: "Review" }],
       },
-      metadata: [{ label: "Integration", value: "Linear" }],
+      metadata: [{ label: "Integrations", value: "Linear" }],
       options: [
         { value: "install", label: "Install and set up" },
+        { value: "back", label: "Back" },
+      ],
+    });
+  });
+
+  it("prefixes onboarding progress without changing standalone review", async () => {
+    const prompts: unknown[] = [];
+    const fake = createFakePrompter({
+      single: (options) => {
+        prompts.push(options);
+        return "install";
+      },
+      multiple: (options) => {
+        prompts.push(options);
+        return [];
+      },
+    });
+
+    await runRegistryFlow({
+      appRoot: APP_ROOT,
+      prompter: fake.prompter,
+      deps: deps(),
+      plannerContext: {
+        prefixSteps: [{ label: "Model", complete: true }],
+        reviewMessage: "Review your agent",
+        emptyActionLabel: "Finish setup",
+      },
+    });
+
+    expect(prompts[0]).toMatchObject({
+      navigation: {
+        activeStep: 1,
+        steps: [
+          { label: "Model", complete: true },
+          { label: "Channels" },
+          { label: "Integrations" },
+          { label: "Review" },
+        ],
+      },
+    });
+    expect(prompts[2]).toMatchObject({
+      metadata: [],
+      options: [
+        { value: "install", label: "Finish setup" },
         { value: "back", label: "Back" },
       ],
     });
@@ -151,7 +227,7 @@ describe("runRegistryFlow", () => {
       { message: "Where should people reach your agent?" },
       { message: "What should your agent be able to work with?" },
       {
-        message: "Review your agent",
+        message: "Review additions",
         description: "No channels or integrations selected.",
         options: [
           { value: "install", label: "Finish without adding" },
@@ -251,6 +327,7 @@ describe("runRegistryFlow", () => {
         return "install";
       },
     });
+    const browseRegistryCatalog = vi.fn<RegistryFlowDeps["browseRegistryCatalog"]>();
     const installRegistryItem = vi.fn<RegistryFlowDeps["installRegistryItem"]>(async () => ({
       output: [],
     }));
@@ -258,22 +335,23 @@ describe("runRegistryFlow", () => {
     await runRegistryFlow({
       appRoot: APP_ROOT,
       prompter: fake.prompter,
-      initialAddress: "linear",
-      deps: deps({ installRegistryItem }),
+      initialAddress: "@acme/analytics",
+      deps: deps({ browseRegistryCatalog, installRegistryItem }),
     });
 
     expect(prompts).toMatchObject([
       {
-        message: "Add linear?",
+        message: "Add @acme/analytics?",
         options: [
           { value: "install", label: "Install and set up" },
           { value: "cancel", label: "Cancel" },
         ],
       },
     ]);
+    expect(browseRegistryCatalog).not.toHaveBeenCalled();
     expect(installRegistryItem).toHaveBeenCalledWith(
       APP_ROOT,
-      "linear",
+      "@acme/analytics",
       expect.objectContaining({ silent: true }),
     );
   });
@@ -330,28 +408,6 @@ describe("runRegistryFlow", () => {
     expect(fake.selectMessages).not.toContain("Couldn't add Web Chat");
   });
 
-  it("treats setup-prompt cancellation as a dismissed flow, not an installation failure", async () => {
-    const answers = ["install"];
-    const selections = [["channel/web"], []];
-    const fake = createFakePrompter({
-      single: () => answers.shift()!,
-      multiple: () => selections.shift()!,
-    });
-
-    await expect(
-      runRegistryFlow({
-        appRoot: APP_ROOT,
-        prompter: fake.prompter,
-        deps: deps({
-          installRegistryItem: vi.fn(async () => {
-            throw new WizardCancelledError();
-          }),
-        }),
-      }),
-    ).resolves.toEqual({ kind: "cancelled" });
-    expect(fake.selectMessages).not.toContain("Couldn't add Web Chat");
-  });
-
   it("keeps a skipped installation failure in the result and proceeds with later items", async () => {
     const answers = ["install", "skip"];
     const selections = [["channel/web"], ["connection/linear"]];
@@ -405,34 +461,6 @@ describe("runRegistryFlow", () => {
     ).resolves.toMatchObject({
       result: {
         failures: [{ title: "web", message: expect.stringContaining("WEB_TOKEN") }],
-        cancelled: true,
-      },
-    });
-  });
-
-  it("preserves settled items when a later installation is cancelled", async () => {
-    const answers = ["install"];
-    const selections = [["channel/web"], ["connection/linear"]];
-    const fake = createFakePrompter({
-      single: () => answers.shift()!,
-      multiple: () => selections.shift()!,
-    });
-    const installRegistryItem = vi
-      .fn<RegistryFlowDeps["installRegistryItem"]>()
-      .mockResolvedValueOnce({ output: [] })
-      .mockRejectedValueOnce(new WizardCancelledError());
-
-    await expect(
-      runRegistryFlow({
-        appRoot: APP_ROOT,
-        prompter: fake.prompter,
-        deps: deps({ installRegistryItem }),
-      }),
-    ).resolves.toEqual({
-      kind: "done",
-      result: {
-        items: [{ title: "Web Chat", facts: [], output: [] }],
-        failures: [],
         cancelled: true,
       },
     });

--- a/packages/eve/src/setup/flows/registry.ts
+++ b/packages/eve/src/setup/flows/registry.ts
@@ -19,6 +19,14 @@ type PlannerScreen = Section | "review";
 
 const PLANNER_STEPS = ["Channels", "Integrations", "Review"] as const;
 
+export interface RegistryPlannerContext {
+  /** Steps owned by an enclosing journey, rendered before the registry steps. */
+  prefixSteps?: readonly { label: string; complete?: boolean }[];
+  reviewMessage?: string;
+  primaryActionLabel?: string;
+  emptyActionLabel?: string;
+}
+
 export interface RegistryFlowDeps {
   browseRegistryCatalog: (typeof import("#cli/commands/registry.js"))["browseRegistryCatalog"];
   installRegistryItem: (typeof import("#cli/commands/registry.js"))["installRegistryItem"];
@@ -40,7 +48,13 @@ const SECTIONS = {
   channels: {
     title: "Where should people reach your agent?",
     description: "You can add more later with /add.",
-    featured: ["channel/web", "channel/slack", "channel/github", "channel/linear-agent"],
+    featured: [
+      "channel/web",
+      "channel/slack",
+      "channel/github",
+      "channel/linear-agent",
+      "channel/photon-imessage",
+    ],
     includes: (item: Item) => item.name.startsWith("channel/"),
   },
   integrations: {
@@ -66,6 +80,8 @@ function isPlannerItem(section: Section, item: Item): boolean {
 }
 
 function orderedSectionItems(section: Section, catalog: readonly Item[]): Item[] {
+  // Product-level presets are installed as one item when explicitly requested;
+  // the bare planner presents their independently installable components.
   const matching = catalog.filter((item) => isPlannerItem(section, item));
   const featured = SECTIONS[section].featured
     .map((name) => matching.find((item) => item.name === name))
@@ -101,17 +117,26 @@ function plannerNavigation(
   input: {
     catalog: readonly Item[];
     selected: ReadonlySet<string>;
+    plannerContext?: RegistryPlannerContext;
   },
 ): NonNullable<MultiSelectOptions<string>["navigation"]> {
+  const prefix = (input.plannerContext?.prefixSteps ?? []).map((step) => ({
+    label: step.label,
+    complete: step.complete,
+  }));
   return {
     kind: "planner",
-    activeStep,
-    steps: PLANNER_STEPS.map((label, index) => {
-      if (index === 2) return { label };
-      const section = index === 0 ? "channels" : "integrations";
-      const count = selectedInSection(section, input.catalog, input.selected).length;
-      return count === 0 ? { label } : { label, count };
-    }),
+    activeStep: prefix.length + activeStep,
+    firstNavigableStep: prefix.length,
+    steps: [
+      ...prefix,
+      ...PLANNER_STEPS.map((label, index) => {
+        if (index === 2) return { label };
+        const section = index === 0 ? "channels" : "integrations";
+        const count = selectedInSection(section, input.catalog, input.selected).length;
+        return count === 0 ? { label } : { label, count };
+      }),
+    ],
   };
 }
 
@@ -168,6 +193,7 @@ async function editPlan(input: {
   itemsByAddress: ReadonlyMap<string, Item>;
   selected: Set<string>;
   notices?: readonly SelectNotice[];
+  plannerContext?: RegistryPlannerContext;
 }): Promise<"install" | "cancelled"> {
   let screen: PlannerScreen = "channels";
   let notices = input.notices;
@@ -194,22 +220,32 @@ async function editPlan(input: {
 
     try {
       const hasSelections = input.selected.size > 0;
+      const selectedItems = [...input.selected].map((address) => {
+        const item = input.itemsByAddress.get(address);
+        if (item === undefined)
+          throw new Error(`Registry item "${address}" is no longer available.`);
+        return item;
+      });
+      const channels = selectedItems.filter((item) => item.name.startsWith("channel/"));
+      const integrations = selectedItems.filter((item) => !item.name.startsWith("channel/"));
+      const selectionMetadata = [
+        ...(channels.length === 0
+          ? []
+          : [{ label: "Channels", value: channels.map(label).join(", ") }]),
+        ...(integrations.length === 0
+          ? []
+          : [{ label: "Integrations", value: integrations.map(label).join(", ") }]),
+      ];
       const request: SingleSelectOptions<"install" | "back"> = {
-        message: "Review your agent",
-        metadata: [...input.selected].map((address) => {
-          const item = input.itemsByAddress.get(address);
-          if (item === undefined)
-            throw new Error(`Registry item "${address}" is no longer available.`);
-          return {
-            label: item.name.startsWith("channel/") ? "Channel" : "Integration",
-            value: label(item),
-          };
-        }),
+        message: input.plannerContext?.reviewMessage ?? "Review additions",
+        metadata: selectionMetadata,
         navigation: plannerNavigation(2, input),
         options: [
           {
             value: "install",
-            label: hasSelections ? "Install and set up" : "Finish without adding",
+            label: hasSelections
+              ? (input.plannerContext?.primaryActionLabel ?? "Install and set up")
+              : (input.plannerContext?.emptyActionLabel ?? "Finish without adding"),
           },
           { value: "back", label: "Back" },
         ],
@@ -238,6 +274,7 @@ export async function runRegistryFlow(input: {
   signal?: AbortSignal;
   /** Registry item supplied by `/add <item>`, confirmed and installed directly. */
   initialAddress?: string;
+  plannerContext?: RegistryPlannerContext;
   onItemStart?: (item: Item, index: number, total: number) => void;
   deps?: Partial<RegistryFlowDeps>;
 }): Promise<{ kind: "done"; result: RegistrySessionResult } | { kind: "cancelled" }> {
@@ -269,17 +306,15 @@ export async function runRegistryFlow(input: {
         text: `${error.registry}: ${error.message}`,
       }));
       const itemsByAddress = new Map(catalog.map((item) => [item.address, item]));
-      if (
-        (await editPlan({
-          prompter: input.prompter,
-          catalog,
-          itemsByAddress,
-          selected,
-          notices,
-        })) !== "install"
-      ) {
-        return { kind: "cancelled" };
-      }
+      const plan = await editPlan({
+        prompter: input.prompter,
+        catalog,
+        itemsByAddress,
+        selected,
+        notices,
+        plannerContext: input.plannerContext,
+      });
+      if (plan !== "install") return { kind: "cancelled" };
       items = [...selected].map((address) => {
         const item = itemsByAddress.get(address);
         if (item === undefined)
@@ -296,6 +331,7 @@ export async function runRegistryFlow(input: {
       (await import("#setup/project-resolution.js")).detectDeployment;
     const runDeployFlow = input.deps?.runDeployFlow ?? (await import("./deploy.js")).runDeployFlow;
     session = createRegistrySession({ detectDeployment, runDeployFlow });
+    const activeSession = session;
     for (const [index, item] of items.entries()) {
       input.signal?.throwIfAborted();
       input.onItemStart?.(item, index, items.length);
@@ -307,7 +343,7 @@ export async function runRegistryFlow(input: {
             signal: input.signal,
           });
         const installed = await (input.prompter.withExclusiveTerminal?.(install) ?? install());
-        session.add(label(item), installed.output, installed.setup);
+        activeSession.add(label(item), installed.output, installed.setup);
       } catch (error) {
         input.signal?.throwIfAborted();
         if (error instanceof WizardCancelledError || error instanceof HumanActionRequiredError) {
@@ -316,7 +352,7 @@ export async function runRegistryFlow(input: {
         const message = error instanceof Error ? error.message : String(error);
         const failureMessage = message.trim() || "Installation failed.";
         const summary = failureMessage.split("\n").find((line) => line.trim() !== "");
-        session.addFailure(label(item), failureMessage);
+        activeSession.addFailure(label(item), failureMessage);
         const request: SingleSelectOptions<"skip" | "cancel"> = {
           message: `Couldn't add ${label(item)}`,
           options: [
@@ -327,13 +363,13 @@ export async function runRegistryFlow(input: {
         if (summary !== undefined) request.description = summary;
         const action = await input.prompter.select(request);
         if (action === "cancel") {
-          return { kind: "done", result: { ...session.result(), cancelled: true } };
+          return { kind: "done", result: { ...activeSession.result(), cancelled: true } };
         }
       }
     }
     return {
       kind: "done",
-      result: await session.continueAfterInstall({
+      result: await activeSession.continueAfterInstall({
         appRoot: input.appRoot,
         prompter: input.prompter,
         signal: input.signal,

--- a/packages/eve/src/setup/prompter.ts
+++ b/packages/eve/src/setup/prompter.ts
@@ -115,7 +115,7 @@ export interface PlannerNavigation {
   activeStep: number;
   /** Earliest step reachable with Left Arrow; defaults to the first step. */
   firstNavigableStep?: number;
-  steps: readonly { label: string; count?: number }[];
+  steps: readonly { label: string; count?: number; complete?: boolean }[];
 }
 
 /** Options common to every {@link Prompter.select} call. */

--- a/packages/eve/src/setup/vercel-project.test.ts
+++ b/packages/eve/src/setup/vercel-project.test.ts
@@ -112,8 +112,12 @@ describe("getVercelAuthStatus", () => {
     );
   });
 
-  it("reports logged-out when whoami ran but exited non-zero", async () => {
-    mockedCaptureVercel.mockResolvedValueOnce(failedCapture("", "Error: Not authenticated"));
+  it.each([
+    "Error: Not authenticated",
+    "Error: The specified token is not valid. Use `vercel login` to generate a new token.",
+    "Error: You do not have access to the specified account\nLearn More: https://err.sh/vercel/scope-not-accessible",
+  ])("reports logged-out for an authentication-recovery diagnostic: %s", async (stderr) => {
+    mockedCaptureVercel.mockResolvedValueOnce(failedCapture("", stderr));
     await expect(getVercelAuthStatus("/tmp/eve-agent")).resolves.toBe("logged-out");
   });
 

--- a/packages/eve/src/setup/vercel-project.ts
+++ b/packages/eve/src/setup/vercel-project.ts
@@ -187,18 +187,20 @@ async function probeWhoami(projectRoot: string, options: VercelProjectOperationO
 }
 
 /**
- * Whether a failed `whoami` is the explicit not-authenticated diagnostic ("No
- * existing credentials found" / "not authenticated") rather than a transient
- * fault (DNS, network, API error, timeout). Only the former is a genuine
- * logged-out state; classifying any non-zero exit as logged-out would route a
- * network blip to `/vc:login`.
+ * Whether a failed `whoami` explicitly calls for authentication recovery
+ * rather than reporting a transient fault (DNS, network, API error, timeout).
+ * Vercel reports an invalid stored token directly, but a linked team can mask
+ * that diagnostic with `scope-not-accessible`; both require a fresh login.
  */
 function isLoggedOutFailure(failure: VercelCaptureFailure): boolean {
   const text = `${failure.stdout} ${failure.stderr}`.toLowerCase();
   return (
     text.includes("credentials") ||
     text.includes("not authenticated") ||
-    text.includes("not logged in")
+    text.includes("not logged in") ||
+    text.includes("specified token is not valid") ||
+    text.includes("scope-not-accessible") ||
+    text.includes("do not have access to the specified account")
   );
 }
 

--- a/packages/eve/test/scenarios/eve-init.scenario.test.ts
+++ b/packages/eve/test/scenarios/eve-init.scenario.test.ts
@@ -234,7 +234,7 @@ describe("eve init smoke", () => {
         cwd: canonicalProjectDir,
       },
       {
-        args: ["--dir", canonicalProjectDir, "exec", "eve", "dev", "--input", "/model"],
+        args: ["--dir", canonicalProjectDir, "exec", "eve", "dev", "--onboard"],
         cwd: canonicalProjectDir,
       },
     ]);
@@ -273,7 +273,7 @@ describe("eve init smoke", () => {
     );
     const [installCall, devCall] = await fakePnpm.readCalls();
     expect(installCall?.args.slice(-2)).toEqual(["install", "--no-frozen-lockfile"]);
-    expect(devCall?.args.slice(-5)).toEqual(["exec", "eve", "dev", "--input", "/model"]);
+    expect(devCall?.args.slice(-4)).toEqual(["exec", "eve", "dev", "--onboard"]);
   });
 
   it("adds Web Chat through npm without writing pnpm configuration", async () => {
@@ -298,7 +298,7 @@ describe("eve init smoke", () => {
         cwd: canonicalProjectDir,
       },
       {
-        args: ["exec", "--", "eve", "dev", "--input", "/model"],
+        args: ["exec", "--", "eve", "dev", "--onboard"],
         cwd: canonicalProjectDir,
       },
     ]);
@@ -399,7 +399,7 @@ describe("eve init smoke", () => {
         cwd: canonicalProjectDir,
       },
       {
-        args: ["--dir", canonicalProjectDir, "exec", "eve", "dev", "--input", "/model"],
+        args: ["--dir", canonicalProjectDir, "exec", "eve", "dev", "--onboard"],
         cwd: canonicalProjectDir,
       },
     ]);

--- a/packages/eve/test/tui-client/tui-packed-install-model.ts
+++ b/packages/eve/test/tui-client/tui-packed-install-model.ts
@@ -138,8 +138,8 @@ void (async () => {
       input.send("\x1b");
       await screen.waitForText("Change model", 5_000);
       input.send("\x1b");
-      await screen.waitForText("/model dismissed.", 5_000);
-      // Cancelling the required model phase exits onboarding and returns to chat.
+      // Initial onboarding suppresses the standalone command transcript; cancelling
+      // the required model phase returns directly to chat.
       await screen.waitForIdlePrompt(5_000);
 
       input.type("/exit");

--- a/packages/eve/test/tui-client/tui-packed-install-model.ts
+++ b/packages/eve/test/tui-client/tui-packed-install-model.ts
@@ -7,7 +7,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { theme } from "./lib/theme.ts";
 
 /**
- * End-to-end proof that the *packed* eve artifact can open onboarding `/model`
+ * End-to-end proof that the *packed* eve artifact can open initial onboarding
  * after a consumer-shaped install.
  *
  * Every other smoke test resolves eve's modules inside the workspace, where
@@ -103,7 +103,7 @@ void (async () => {
       userInput: input,
       name: "Packed install model command",
       appRoot: consumerRoot,
-      initialInput: "/model",
+      onboard: true,
       getVercelAuthStatus: async () => "authenticated",
       promptCommandHandler: createPromptCommandHandler({
         target: {
@@ -128,9 +128,9 @@ void (async () => {
     const runPromise = runner.run();
 
     try {
-      // The provider picker paints before the first prompt only when the
-      // prefilled onboarding `/model` flow and its module graph load — the
-      // exact surface the oxc-parser regression crashed.
+      // The provider picker paints before the first prompt only when initial
+      // onboarding and its module graph load — the exact surface the
+      // oxc-parser regression crashed.
       await screen.waitForText("Configure the agent model", 15_000);
       await screen.waitForText("Which model provider do you want to use?", 15_000);
       console.log(theme.muted("[tui-packed-install] /model opened provider setup"));
@@ -139,15 +139,7 @@ void (async () => {
       await screen.waitForText("Change model", 5_000);
       input.send("\x1b");
       await screen.waitForText("/model dismissed.", 5_000);
-      // Fresh-model onboarding now follows the picker with the registry hub.
-      // Dismiss it too before asserting that the runner returns to chat.
-      await screen.waitForText("Add to your agent", 5_000);
-      // The title paints before registry loading necessarily yields to the
-      // category picker. Wait for a real option so Escape belongs to the
-      // question rather than the setup flow's between-questions interrupt trap.
-      await screen.waitForText("Channels", 5_000);
-      input.send("\x1b");
-      await screen.waitForText("/add dismissed.", 5_000);
+      // Cancelling the required model phase exits onboarding and returns to chat.
       await screen.waitForIdlePrompt(5_000);
 
       input.type("/exit");

--- a/packages/eve/test/tui-client/tui-packed-install-model.ts
+++ b/packages/eve/test/tui-client/tui-packed-install-model.ts
@@ -128,10 +128,10 @@ void (async () => {
     const runPromise = runner.run();
 
     try {
-      // The provider picker paints before the first prompt only when initial
-      // onboarding and its module graph load — the exact surface the
-      // oxc-parser regression crashed.
-      await screen.waitForText("Configure the agent model", 15_000);
+      // The provider picker paints inside the shared onboarding journey before
+      // the first prompt only when its module graph loads — the exact surface
+      // the oxc-parser regression crashed.
+      await screen.waitForText("Set up Packed install model command", 15_000);
       await screen.waitForText("Which model provider do you want to use?", 15_000);
       console.log(theme.muted("[tui-packed-install] /model opened provider setup"));
 


### PR DESCRIPTION
### Summary

Prior to this PR, the initial onboarding was a bit disorienting in tw ways:

1. the way you entered the flow was somewhat hardcoded: if you ran `eve dev --input /model`, this was essentially a secret handshake indicating that you were in the onboarding flow (and therefore `/add` would be executed after completing the `/model` flow).
2. Along those same lines, the model and add flows were completely disjoint, and didn't feel like a single cohesive onboarding experience.

This PR now a) adds a hidden flag `eve dev --onboard` that is invoked by `eve init` b) in this onboarding flow, adds the model selection to a more overarching tabbed interface that is in line with the experience provided by `/add`.

I also added in some logic so that we can handle common vercel onboarding issues (old vc CLI version, vercel auth issues, etc.) within the context of the onboarding flow, replacing the old behavior that ejected you from that flow and told you to run e.g. `/vc:login`.

<img width="747" height="471" alt="Screenshot 2026-08-31 at 2 57 57 PM" src="https://github.com/user-attachments/assets/a41ecca8-6f44-43e6-923d-ee2ad1d98ba7" />

<img width="1075" height="408" alt="Screenshot 2026-08-31 at 2 57 40 PM" src="https://github.com/user-attachments/assets/56fe5ec0-6fc8-4163-9fea-cdee7bc3d349" />


### Validation

- Focused registry, setup-command, runner, provider, and login unit tests: 175 passing
- `pnpm lint`
- `pnpm --filter eve typecheck` (on the stack tip)
- `pnpm docs:check` (on the stack tip)
- `pnpm guard:invariants` (on the stack tip)

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
