### PR TITLE
fix(eve): better handling of cancellation / failure when installing multiple registry items

### DIFF
--- a/.changeset/scoped-registry-cancellation.md
+++ b/.changeset/scoped-registry-cancellation.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Cancel only the active registry item when setup is interrupted, then report installed, failed, and cancelled selections in order.

--- a/docs/guides/dev-tui.md
+++ b/docs/guides/dev-tui.md
@@ -13,22 +13,22 @@ The transcript remains in your terminal scrollback after you exit. Run `/help` i
 
 ## Commands
 
-| Command       | Description                                                                                                                                           |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `/model`      | Configure the model and its provider. Pass a model ID to set it directly: `/model provider/model-id`.                                                 |
-| `/add`        | Select and install channels, MCP connections, extensions, and observability integrations. Pass an item address to preselect it: `/add channel/slack`. |
-| `/deploy`     | Deploy the agent to Vercel production. Links the directory first if needed.                                                                           |
-| `/vc:install` | Install the Vercel CLI.                                                                                                                               |
-| `/vc:login`   | Log in to Vercel or restore access to a remote deployment.                                                                                            |
-| `/info`       | Show the resolved application, compiled artifacts, discovery diagnostics, and messaging routes.                                                       |
-| `/loglevel`   | Choose which server and agent logs appear in the transcript.                                                                                          |
-| `/traces`     | Open the local trace viewer. Pass a trace ID prefix to open a specific trace.                                                                         |
-| `/reset`      | Start a fresh session.                                                                                                                                |
-| `/cancel`     | Cancel the current turn without discarding settled context.                                                                                           |
-| `/clear`      | Clear the session's model-message history. `/new` is an alias.                                                                                        |
-| `/compact`    | Compact the current session's context.                                                                                                                |
-| `/exit`       | Quit the UI.                                                                                                                                          |
-| `/help`       | List available commands.                                                                                                                              |
+| Command       | Description                                                                                                                                                              |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `/model`      | Configure the model and its provider. Pass a model ID to set it directly: `/model provider/model-id`.                                                                    |
+| `/add`        | Select and install channels, MCP connections, extensions, and observability integrations. Pass an item address to confirm and install it directly: `/add channel/slack`. |
+| `/deploy`     | Deploy the agent to Vercel production. Links the directory first if needed.                                                                                              |
+| `/vc:install` | Install the Vercel CLI.                                                                                                                                                  |
+| `/vc:login`   | Log in to Vercel or restore access to a remote deployment.                                                                                                               |
+| `/info`       | Show the resolved application, compiled artifacts, discovery diagnostics, and messaging routes.                                                                          |
+| `/loglevel`   | Choose which server and agent logs appear in the transcript.                                                                                                             |
+| `/traces`     | Open the local trace viewer. Pass a trace ID prefix to open a specific trace.                                                                                            |
+| `/reset`      | Start a fresh session.                                                                                                                                                   |
+| `/cancel`     | Cancel the current turn without discarding settled context.                                                                                                              |
+| `/clear`      | Clear the session's model-message history. `/new` is an alias.                                                                                                           |
+| `/compact`    | Compact the current session's context.                                                                                                                                   |
+| `/exit`       | Quit the UI.                                                                                                                                                             |
+| `/help`       | List available commands.                                                                                                                                                 |
 
 `/model`, `/add`, `/deploy`, `/info`, and `/traces` are available when `eve dev` runs locally. They are unavailable when the UI connects to a server with `--url`.
 
@@ -42,7 +42,7 @@ Model and Vercel changes take effect when you complete Model, then onboarding co
 
 Bare `/add` opens the standalone planner on **Channels**. It does not include model configuration. The progress rail shows selection counts as you move between **Channels**, **Integrations**, and **Review**.
 
-Press `Space` or `Enter` to toggle the highlighted item. Press `Right Arrow` to preserve the current selections and continue, `Left Arrow` to preserve them and go back, or `Esc` to cancel. Installation requires `Enter` on **Install and set up** from Review. If an item fails, you can skip it and continue with the remaining items.
+Press `Space` or `Enter` to toggle the highlighted item. Press `Right Arrow` to preserve the current selections and continue, `Left Arrow` to preserve them and go back, or `Esc` to cancel. Installation requires `Enter` on **Install and set up** from Review. During installation, `Esc` cancels only the active item and continues with the remaining selections. The final summary reports installed, cancelled, and failed items separately.
 
 Pass an item address to `/add` to confirm and install that exact address without opening the planner:
 

--- a/packages/eve/src/cli/dev/tui/blocks.test.ts
+++ b/packages/eve/src/cli/dev/tui/blocks.test.ts
@@ -22,6 +22,41 @@ describe("renderBlockLines", () => {
     expect(lines[0]).toBe("▲ all done");
   });
 
+  it("colors per-item status markers in a mixed command result", () => {
+    const colored = createTheme({ color: true, unicode: true });
+    const lines = renderBlockLines(
+      {
+        kind: "result",
+        body: "2 additions: 1 added, 1 failed\n\n  ✓ Web Chat\n    Installed.\n\n  ⨯ Slack\n    Installation failed.",
+      },
+      80,
+      colored,
+      ctx,
+    );
+
+    expect(lines.join("\n")).toContain(colored.colors.green("✓"));
+    expect(lines[0]).toContain("2 additions: 1 added, 1 failed");
+    expect(lines.join("\n")).toContain(colored.colors.red("⨯"));
+  });
+
+  it("uses ASCII status markers when Unicode is unavailable", () => {
+    const ascii = createTheme({ color: false, unicode: false });
+    const lines = renderBlockLines(
+      {
+        kind: "result",
+        body: "3 additions: 1 added, 1 failed, 1 cancelled\n\n  ✓ Web Chat\n\n  ⨯ Slack\n\n  – Notion",
+      },
+      80,
+      ascii,
+      ctx,
+    );
+
+    expect(lines.join("\n")).toContain("+ Web Chat");
+    expect(lines.join("\n")).toContain("x Slack");
+    expect(lines.join("\n")).toContain("- Notion");
+    expect(lines.join("\n")).not.toMatch(/[✓⨯–]/u);
+  });
+
   it("summarizes a completed tool with a result line", () => {
     const lines = render({
       kind: "tool",

--- a/packages/eve/src/cli/dev/tui/blocks.ts
+++ b/packages/eve/src/cli/dev/tui/blocks.ts
@@ -452,6 +452,14 @@ function renderCommand(block: Block, theme: Theme): string[] {
  * Connect URL, a written env file). The tone travels in `title`; info dims,
  * the other tones keep the body at full intensity behind their glyph.
  */
+function paintOutcomeMarker(line: string, theme: Theme, source = line): string {
+  const marker = source.trimStart().slice(0, 1);
+  if (marker === "✓") return line.replace(marker, theme.colors.green(theme.glyph.success));
+  if (marker === "⨯") return line.replace(marker, theme.colors.red(theme.glyph.error));
+  if (marker === "–") return line.replace(marker, theme.colors.yellow(theme.glyph.dash));
+  return line;
+}
+
 function renderFlow(block: Block, width: number, theme: Theme): string[] {
   const c = theme.colors;
   const tone = block.title ?? "info";
@@ -464,7 +472,8 @@ function renderFlow(block: Block, width: number, theme: Theme): string[] {
           ? c.red(theme.glyph.error)
           : c.dim(theme.glyph.dot);
   const lines = wrap(block.body ?? "", width - 2);
-  const paint = (line: string): string => (tone === "info" ? c.dim(line) : line);
+  const paint = (line: string): string =>
+    tone === "info" ? c.dim(line) : paintOutcomeMarker(line, theme);
   return lines.map((line, index) => `${index === 0 ? glyph : " "} ${paint(line)}`);
 }
 
@@ -493,8 +502,10 @@ function renderResult(block: Block, width: number, theme: Theme): string[] {
   // SGR 22 closes bold and dim together, so a result that bolds a span (the
   // /model reply's model name) would drop the rest of the line out of dim;
   // re-open dim after each close so the whole line stays quiet.
-  const dim = (line: string): string =>
-    theme.colors.dim(line.replaceAll("\x1b[22m", "\x1b[22m\x1b[2m"));
+  const dim = (line: string): string => {
+    const body = theme.colors.dim(line.replaceAll("\x1b[22m", "\x1b[22m\x1b[2m"));
+    return paintOutcomeMarker(body, theme, line);
+  };
   return lines.map((line, index) =>
     index === 0 ? `   ${marker}  ${dim(line)}` : `      ${dim(line)}`,
   );

--- a/packages/eve/src/cli/dev/tui/prompt-command-handler.test.ts
+++ b/packages/eve/src/cli/dev/tui/prompt-command-handler.test.ts
@@ -44,7 +44,7 @@ function setupFlowRenderer() {
     renderOutput: vi.fn(),
     withInheritedStdio: (task) => task(),
     waitForInterrupt: () => ({
-      promise: new Promise<void>(() => {}),
+      promise: new Promise<"escape" | "ctrl-c">(() => {}),
       dispose: vi.fn(),
     }),
   } satisfies SetupFlowRenderer;
@@ -276,7 +276,7 @@ describe("createPromptCommandHandler", () => {
   it("reports mutations that completed before remote /vc:login was interrupted", async () => {
     const setupFlow = {
       ...setupFlowRenderer(),
-      waitForInterrupt: () => ({ promise: Promise.resolve(), dispose: vi.fn() }),
+      waitForInterrupt: () => ({ promise: Promise.resolve("ctrl-c" as const), dispose: vi.fn() }),
     } satisfies SetupFlowRenderer;
     const runLoginFlow = vi.fn(async () => ({ kind: "cancelled" as const }));
     const remoteConnection: RemoteConnectionController = {

--- a/packages/eve/src/cli/dev/tui/prompt-command-handler.ts
+++ b/packages/eve/src/cli/dev/tui/prompt-command-handler.ts
@@ -126,7 +126,7 @@ export function createPromptCommandHandler(
         if (context.registryPlannerContext !== undefined) {
           commandInput.registryPlannerContext = context.registryPlannerContext;
         }
-        // `/add <item>` preselects that registry item; bare `/add` starts empty.
+        // `/add <item>` confirms and installs that address; bare `/add` opens the planner.
         if (command.name === "add" && command.argument.length > 0) {
           commandInput.initialRegistryAddress = command.argument;
         }

--- a/packages/eve/src/cli/dev/tui/registry-result-message.test.ts
+++ b/packages/eve/src/cli/dev/tui/registry-result-message.test.ts
@@ -22,15 +22,61 @@ describe("formatRegistrySessionResult", () => {
         ],
       }),
     ).toBe(
-      "Added Web Chat and Photon iMessage\n\n" +
-        "Web Chat\n" +
-        "  Installed.\n\n" +
-        "Photon iMessage\n" +
-        "  Agent phone number  +15551234567\n" +
-        "  Configured MCP connection.\n\n" +
-        "Couldn't add Slack\n" +
-        "  Vercel CLI is not authenticated.\n" +
-        "  Run /vc:login, then try again.",
+      "3 additions: 2 added, 1 failed\n\n" +
+        "  ✓ Web Chat\n" +
+        "    Installed.\n\n" +
+        "  ✓ Photon iMessage\n" +
+        "    Agent phone number  +15551234567\n" +
+        "    Configured MCP connection.\n\n" +
+        "  ⨯ Slack\n" +
+        "    Vercel CLI is not authenticated.\n" +
+        "    Run /vc:login, then try again.",
+    );
+  });
+
+  it("gives an all-failed report a meaningful headline", () => {
+    expect(
+      formatRegistrySessionResult({
+        items: [],
+        failures: [
+          { title: "Web Chat", message: "Dependency installation failed." },
+          { title: "Notion", message: "Vercel Connect setup failed." },
+        ],
+      }),
+    ).toBe(
+      "2 additions: 2 failed\n\n" +
+        "  ⨯ Web Chat\n" +
+        "    Dependency installation failed.\n\n" +
+        "  ⨯ Notion\n" +
+        "    Vercel Connect setup failed.",
+    );
+  });
+
+  it("reports every installed, cancelled, and failed selection in order", () => {
+    expect(
+      formatRegistrySessionResult({
+        items: [
+          { title: "Web Chat", facts: [], output: [] },
+          { title: "Notion", facts: [], output: [] },
+        ],
+        failures: [{ title: "GitHub", message: "Installation failed." }],
+        outcomes: [
+          { kind: "installed", title: "Web Chat", facts: [], output: [] },
+          { kind: "cancelled", title: "Slack" },
+          { kind: "failed", title: "GitHub", message: "Installation failed." },
+          { kind: "installed", title: "Notion", facts: [], output: [] },
+        ],
+      }),
+    ).toBe(
+      "4 additions: 2 added, 1 failed, 1 cancelled\n\n" +
+        "  ✓ Web Chat\n" +
+        "    Installed.\n\n" +
+        "  – Slack\n" +
+        "    Cancelled.\n\n" +
+        "  ⨯ GitHub\n" +
+        "    Installation failed.\n\n" +
+        "  ✓ Notion\n" +
+        "    Installed.",
     );
   });
 });

--- a/packages/eve/src/cli/dev/tui/registry-result-message.ts
+++ b/packages/eve/src/cli/dev/tui/registry-result-message.ts
@@ -18,7 +18,8 @@ export function registryItemProgress(renderer: {
 }
 
 export function registryResultTone(result: RegistrySessionResult): "success" | "error" | undefined {
-  if (result.failures.length > 0) return "error";
+  if (result.failures.length > 0 && result.items.length === 0) return "error";
+  if (result.outcomes?.some((outcome) => outcome.kind === "cancelled")) return undefined;
   return result.items.length > 0 ? "success" : undefined;
 }
 
@@ -29,30 +30,56 @@ function joinedTitles(titles: readonly string[]): string {
   return `${titles.slice(0, -1).join(", ")}, and ${titles.at(-1)}`;
 }
 
+function resultHeadline(
+  outcomes: readonly { kind: "installed" | "failed" | "cancelled" }[],
+  installedTitles: readonly string[],
+): string {
+  const failed = outcomes.filter((outcome) => outcome.kind === "failed").length;
+  const cancelled = outcomes.filter((outcome) => outcome.kind === "cancelled").length;
+  if (failed === 0 && cancelled === 0) return `Added ${joinedTitles(installedTitles)}`;
+
+  const installed = outcomes.length - failed - cancelled;
+  const parts = [
+    installed > 0 ? `${installed} added` : undefined,
+    failed > 0 ? `${failed} failed` : undefined,
+    cancelled > 0 ? `${cancelled} cancelled` : undefined,
+  ].filter((part): part is string => part !== undefined);
+  return `${outcomes.length} ${outcomes.length === 1 ? "addition" : "additions"}: ${parts.join(", ")}`;
+}
+
 /** Formats structured registry setup results after their temporary panel closes. */
 export function formatRegistrySessionResult(result: RegistrySessionResult): string {
-  const lines: string[] = [];
-  if (result.items.length > 0)
-    lines.push(`Added ${joinedTitles(result.items.map((item) => item.title))}`);
-  for (const item of result.items) {
-    lines.push("", item.title);
-    if (item.facts.length === 0 && item.output.length === 0) {
-      lines.push("  Installed.");
+  const outcomes = result.outcomes ?? [
+    ...result.items.map((item) => ({ kind: "installed" as const, ...item })),
+    ...result.failures.map((failure) => ({ kind: "failed" as const, ...failure })),
+  ];
+  const lines = [
+    resultHeadline(
+      outcomes,
+      result.items.map((item) => item.title),
+    ),
+  ];
+  for (const outcome of outcomes) {
+    const marker = outcome.kind === "installed" ? "✓" : outcome.kind === "failed" ? "⨯" : "–";
+    lines.push("", `  ${marker} ${outcome.title}`);
+    if (outcome.kind === "cancelled") {
+      lines.push("    Cancelled.");
       continue;
     }
-    const width = Math.max(0, ...item.facts.map((fact) => fact.label.length));
-    for (const fact of item.facts) lines.push(`  ${fact.label.padEnd(width)}  ${fact.value}`);
-    for (const output of item.output) lines.push(`  ${output}`);
-  }
-  for (const failure of result.failures) {
-    lines.push(
-      "",
-      `Couldn't add ${failure.title}`,
-      ...failure.message.split("\n").map((line) => `  ${line}`),
-    );
+    if (outcome.kind === "failed") {
+      lines.push(...outcome.message.split("\n").map((line) => `    ${line}`));
+      continue;
+    }
+    if (outcome.facts.length === 0 && outcome.output.length === 0) {
+      lines.push("    Installed.");
+      continue;
+    }
+    const width = Math.max(0, ...outcome.facts.map((fact) => fact.label.length));
+    for (const fact of outcome.facts) lines.push(`    ${fact.label.padEnd(width)}  ${fact.value}`);
+    for (const output of outcome.output) lines.push(`    ${output}`);
   }
   if (result.cancelled === true) {
-    lines.push("", "Setup cancelled before the remaining selections were added.");
+    lines.push("", "Setup stopped before the remaining selections were added.");
   }
   return lines.join("\n");
 }

--- a/packages/eve/src/cli/dev/tui/runner.test.ts
+++ b/packages/eve/src/cli/dev/tui/runner.test.ts
@@ -186,7 +186,7 @@ function idleSetupFlow(): SetupFlowRenderer {
     renderOutput: vi.fn(),
     withInheritedStdio: (task) => task(),
     waitForInterrupt: () => ({
-      promise: new Promise<void>(() => {}),
+      promise: new Promise<"escape" | "ctrl-c">(() => {}),
       dispose: vi.fn(),
     }),
   };

--- a/packages/eve/src/cli/dev/tui/setup-commands.test.ts
+++ b/packages/eve/src/cli/dev/tui/setup-commands.test.ts
@@ -4,6 +4,7 @@ import { createFakePrompter } from "#internal/testing/fake-prompter.js";
 import { RegistryFlowFailedError } from "#setup/flows/registry.js";
 import type { RegistrySessionResult } from "#setup/flows/registry-session.js";
 import { HumanActionRequiredError } from "#setup/human-action.js";
+import { WizardCancelledError } from "#setup/step.js";
 
 import {
   runTuiSetupCommand,
@@ -16,10 +17,10 @@ import {
 const APP_ROOT = "/tmp/weather-agent";
 
 function fakePanelRenderer(): TuiSetupCommandRenderer & {
-  fireInterrupt: () => void;
+  fireInterrupt: (kind?: "escape" | "ctrl-c") => void;
   interruptDisposed: () => boolean;
 } {
-  let fire: () => void = () => {};
+  let fire: (kind: "escape" | "ctrl-c") => void = () => {};
   let disposed = false;
   return {
     readSelect: vi.fn(async () => []),
@@ -36,14 +37,14 @@ function fakePanelRenderer(): TuiSetupCommandRenderer & {
     renderOutput: vi.fn(),
     withInheritedStdio: (task) => task(),
     waitForInterrupt: vi.fn(() => ({
-      promise: new Promise<void>((resolve) => {
+      promise: new Promise<"escape" | "ctrl-c">((resolve) => {
         fire = resolve;
       }),
       dispose: () => {
         disposed = true;
       },
     })),
-    fireInterrupt: () => fire(),
+    fireInterrupt: (kind = "escape") => fire(kind),
     interruptDisposed: () => disposed,
   };
 }
@@ -411,7 +412,7 @@ describe("runTuiSetupCommand", () => {
       registryResult({
         items: [{ title: "Agent Browser", facts: [], output: [] }],
       }),
-      "Added Agent Browser\n\nAgent Browser\n  Installed.",
+      "Added Agent Browser\n\n  ✓ Agent Browser\n    Installed.",
     ],
     ["empty", registryResult(), "No integrations selected."],
     ["deployed", registryResult({ deployed: "production" }), "No integrations selected."],
@@ -451,7 +452,28 @@ describe("runTuiSetupCommand", () => {
     });
 
     await expect(run({ command: "add", flows })).resolves.toMatchObject({
-      message: expect.stringContaining("Couldn't add GitHub"),
+      message: expect.stringContaining("⨯ GitHub"),
+      preserveFlowDiagnostics: true,
+    });
+  });
+
+  it("headlines a completely failed registry batch", async () => {
+    const flows = fakeFlows({
+      runRegistryFlow: vi.fn<TuiSetupFlows["runRegistryFlow"]>(async () => ({
+        kind: "done",
+        result: {
+          items: [],
+          failures: [
+            { title: "Web Chat", message: "Dependency installation failed." },
+            { title: "Vercel", message: "Connector setup failed." },
+          ],
+        },
+      })),
+    });
+
+    await expect(run({ command: "add", flows })).resolves.toMatchObject({
+      message: expect.stringMatching(/^\/add failed — 2 additions: 2 failed/),
+      tone: "error",
       preserveFlowDiagnostics: true,
     });
   });
@@ -466,6 +488,95 @@ describe("runTuiSetupCommand", () => {
     expect(flows.runDeployFlow).toHaveBeenCalledWith(
       expect.objectContaining({ interactive: true }),
     );
+  });
+
+  it("limits an installation interrupt to the active registry item", async () => {
+    const renderer = fakePanelRenderer();
+    const flows = fakeFlows({
+      runRegistryFlow: vi.fn<TuiSetupFlows["runRegistryFlow"]>(async ({ runItem }) => {
+        await expect(
+          runItem?.(
+            (signal) =>
+              new Promise((_resolve, reject) => {
+                signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+              }),
+          ),
+        ).rejects.toBeInstanceOf(WizardCancelledError);
+        return registryResult({
+          items: [
+            { title: "Web Chat", facts: [], output: [] },
+            { title: "Notion", facts: [], output: [] },
+          ],
+          outcomes: [
+            { kind: "installed", title: "Web Chat", facts: [], output: [] },
+            { kind: "cancelled", title: "Slack" },
+            { kind: "installed", title: "Notion", facts: [], output: [] },
+          ],
+        });
+      }),
+    });
+
+    const result = run({ command: "add", flows, renderer });
+    renderer.fireInterrupt();
+
+    await expect(result).resolves.toEqual({
+      message:
+        "3 additions: 2 added, 1 cancelled\n\n  ✓ Web Chat\n    Installed.\n\n" +
+        "  – Slack\n    Cancelled.\n\n  ✓ Notion\n    Installed.",
+      preserveFlowDiagnostics: true,
+    });
+  });
+
+  it("interrupts the whole add command on Ctrl-C during an installation", async () => {
+    const renderer = fakePanelRenderer();
+    const flows = fakeFlows({
+      runRegistryFlow: vi.fn<TuiSetupFlows["runRegistryFlow"]>(async ({ runItem, signal }) => {
+        await expect(
+          runItem?.(
+            (itemSignal) =>
+              new Promise((_resolve, reject) => {
+                itemSignal?.addEventListener("abort", () => reject(itemSignal.reason), {
+                  once: true,
+                });
+              }),
+          ),
+        ).rejects.toBeInstanceOf(WizardCancelledError);
+        signal?.throwIfAborted();
+        return registryResult();
+      }),
+    });
+
+    const result = run({ command: "add", flows, renderer });
+    renderer.fireInterrupt("ctrl-c");
+
+    await expect(result).resolves.toEqual({
+      message: "/add interrupted.",
+      cancelled: true,
+      tone: "error",
+      preserveFlowDiagnostics: true,
+    });
+  });
+
+  it("interrupts add while non-item work is in progress", async () => {
+    const renderer = fakePanelRenderer();
+    const flows = fakeFlows({
+      runRegistryFlow: vi.fn<TuiSetupFlows["runRegistryFlow"]>(
+        ({ signal }) =>
+          new Promise((_resolve, reject) => {
+            signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+          }),
+      ),
+    });
+
+    const result = run({ command: "add", flows, renderer });
+    renderer.fireInterrupt();
+
+    await expect(result).resolves.toEqual({
+      message: "/add interrupted.",
+      cancelled: true,
+      tone: "error",
+      preserveFlowDiagnostics: true,
+    });
   });
 
   it("preserves model access refreshes when provider setup is interrupted", async () => {

--- a/packages/eve/src/cli/dev/tui/setup-commands.ts
+++ b/packages/eve/src/cli/dev/tui/setup-commands.ts
@@ -163,25 +163,57 @@ export async function runTuiSetupCommand(
   const renderer = muteableRenderer(input.renderer, () => interrupted, input.withExclusiveTerminal);
   const prompter = (input.createPrompter ?? createTuiPrompter)(renderer);
 
-  const execution = executeSetupCommand(input, prompter, renderer, controller.signal);
-  const interrupt = input.renderer.waitForInterrupt();
-  const INTERRUPTED = Symbol("interrupted");
+  let cancelActiveRegistryItem: (() => void) | undefined;
+  const runRegistryItem = async <T>(task: (signal?: AbortSignal) => Promise<T>): Promise<T> => {
+    const itemController = new AbortController();
+    cancelActiveRegistryItem = () => itemController.abort(new WizardCancelledError());
+    try {
+      return await task(AbortSignal.any([controller.signal, itemController.signal]));
+    } finally {
+      cancelActiveRegistryItem = undefined;
+    }
+  };
+  const execution = executeSetupCommand(
+    input,
+    prompter,
+    renderer,
+    controller.signal,
+    runRegistryItem,
+  );
+  const outcomePromise = execution.then((value) => ({ kind: "outcome" as const, value }));
   try {
-    const outcome = await Promise.race([execution, interrupt.promise.then(() => INTERRUPTED)]);
-    if (outcome !== INTERRUPTED) return outcome as TuiSetupCommandResult;
-    interrupted = true;
-    controller.abort(new WizardCancelledError());
-    const settled = await execution;
-    return settled.partial === true
-      ? settled
-      : {
-          ...settled,
-          message: `/${command} interrupted.`,
-          tone: "error",
-          preserveFlowDiagnostics: true,
-        };
+    while (true) {
+      const interrupt = input.renderer.waitForInterrupt();
+      try {
+        const settled = await Promise.race([
+          outcomePromise,
+          interrupt.promise.then((interrupt) => ({ kind: "interrupt" as const, interrupt })),
+        ]);
+        if (settled.kind === "outcome") return settled.value;
+        if (
+          command === "add" &&
+          settled.interrupt === "escape" &&
+          cancelActiveRegistryItem !== undefined
+        ) {
+          cancelActiveRegistryItem();
+          continue;
+        }
+        interrupted = true;
+        controller.abort(new WizardCancelledError());
+        const outcome = await execution;
+        return outcome.partial === true
+          ? outcome
+          : {
+              ...outcome,
+              message: `/${command} interrupted.`,
+              tone: "error",
+              preserveFlowDiagnostics: true,
+            };
+      } finally {
+        interrupt.dispose();
+      }
+    }
   } finally {
-    interrupt.dispose();
     // A flow that threw or was abandoned mid-wait must not leave the footer spinning.
     input.renderer.setStatus(undefined);
   }
@@ -193,6 +225,7 @@ async function executeSetupCommand(
   prompter: Prompter,
   renderer: MuteableSetupRenderer,
   signal: AbortSignal,
+  runRegistryItem: <T>(task: (signal?: AbortSignal) => Promise<T>) => Promise<T>,
 ): Promise<TuiSetupCommandResult> {
   const { command, appRoot } = input;
   const flows: TuiSetupFlows = {
@@ -279,19 +312,21 @@ async function executeSetupCommand(
           initialAddress: input.initialRegistryAddress,
           plannerContext: input.registryPlannerContext,
           onItemStart: registryItemProgress(renderer),
+          runItem: runRegistryItem,
         });
         if (flow.kind === "cancelled") {
           return { message: "/add dismissed.", cancelled: true, preserveFlowDiagnostics: true };
         }
         const result = flow.result;
+        const tone = registryResultTone(result);
+        const report =
+          result.items.length > 0 || result.failures.length > 0 || result.outcomes !== undefined
+            ? formatRegistrySessionResult(result)
+            : "No integrations selected.";
         const outcome: TuiSetupCommandResult = {
-          message:
-            result.items.length > 0 || result.failures.length > 0
-              ? formatRegistrySessionResult(result)
-              : "No integrations selected.",
+          message: tone === "error" ? `/add failed — ${report}` : report,
           preserveFlowDiagnostics: true,
         };
-        const tone = registryResultTone(result);
         if (result.cancelled === true) {
           outcome.partial = true;
           outcome.tone = "error";

--- a/packages/eve/src/cli/dev/tui/setup-flow.ts
+++ b/packages/eve/src/cli/dev/tui/setup-flow.ts
@@ -72,6 +72,8 @@ export type SetupSelectResult =
   | { kind: "navigate"; direction: "back" | "forward"; values: readonly string[] }
   | undefined;
 
+export type SetupFlowInterrupt = "escape" | "ctrl-c";
+
 export interface SetupFlowRenderer {
   begin(title: string, indicator?: SetupFlowIndicator): void;
   /** Sets progress owned by an enclosing setup journey, independent of its active question. */
@@ -131,7 +133,7 @@ export interface SetupFlowRenderer {
    * the trap; the promise then never resolves.
    */
   waitForInterrupt(options?: { interruptible?: boolean }): {
-    promise: Promise<void>;
+    promise: Promise<SetupFlowInterrupt>;
     dispose(): void;
   };
 }

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
@@ -1657,6 +1657,7 @@ describe("TerminalRenderer (inline scrollback)", () => {
     renderer.renderCommandResult(
       "Authentication was refreshed, but example.vercel.app is unavailable: Access denied.\n\n" +
         "TRUSTED_SOURCES_ENVIRONMENT_MISMATCH",
+      "error",
     );
     renderer.shutdown();
 
@@ -4606,7 +4607,7 @@ describe("TerminalRenderer setup flow session", () => {
     renderer.setupFlow.setStatus("Creating a Slackbot through Vercel Connect...");
 
     input.ctrlC();
-    await expect(interrupt.promise).resolves.toBeUndefined();
+    await expect(interrupt.promise).resolves.toBe("ctrl-c");
 
     renderer.setupFlow.end();
     renderer.shutdown();

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.ts
@@ -57,6 +57,7 @@ import {
 import type {
   SetupEditableSelectResult,
   SetupFlowIndicator,
+  SetupFlowInterrupt,
   SetupFlowRenderer,
   SetupFlowStatus,
   SetupSelectRequest,
@@ -577,7 +578,7 @@ export class TerminalRenderer implements AgentTUIRenderer {
   /** The prompt submitted for the streaming turn, for external-cancel recovery. */
   #currentSubmittedPrompt?: string;
   /** Armed by {@link SetupFlowRenderer.waitForInterrupt}; fired by the idle key trap. */
-  #flowInterrupt?: () => void;
+  #flowInterrupt?: (interrupt: SetupFlowInterrupt) => void;
   /** The installed working-state key consumer, so re-arming and disposal can recognize it. */
   #flowIdleConsumer?: (key: TerminalKey) => void;
   /** The open `/traces` viewer session, if the alt-screen viewer is active. */
@@ -1795,13 +1796,12 @@ export class TerminalRenderer implements AgentTUIRenderer {
     const content = stripAnsi(text);
     if (content.trim().length === 0) return;
     this.#start();
-    this.#pushBlock(
-      tone === "success"
-        ? { kind: "result", body: content, live: false, status: "done" }
-        : tone === "error"
-          ? { kind: "flow", title: tone, body: content, live: false }
-          : { kind: "result", body: content, live: false },
-    );
+    this.#pushBlock({
+      kind: "result",
+      body: content,
+      live: false,
+      status: tone === "success" ? "done" : undefined,
+    });
     this.#paint();
   }
 
@@ -2647,11 +2647,11 @@ export class TerminalRenderer implements AgentTUIRenderer {
 
   /** See {@link SetupFlowRenderer.waitForInterrupt}. */
   #waitForFlowInterrupt(options?: { interruptible?: boolean }): {
-    promise: Promise<void>;
+    promise: Promise<SetupFlowInterrupt>;
     dispose(): void;
   } {
-    let fire!: () => void;
-    const promise = new Promise<void>((resolve) => {
+    let fire!: (interrupt: SetupFlowInterrupt) => void;
+    const promise = new Promise<SetupFlowInterrupt>((resolve) => {
       fire = resolve;
     });
     this.#flowInterrupt = fire;
@@ -2684,7 +2684,7 @@ export class TerminalRenderer implements AgentTUIRenderer {
         const fire = this.#flowInterrupt;
         this.#flowInterrupt = undefined;
         this.#disarmFlowIdleTrap();
-        fire?.();
+        fire?.(key.type === "ctrl-c" ? "ctrl-c" : "escape");
         return;
       }
       if (key.type === "ctrl-r") this.#paint();

--- a/packages/eve/src/cli/dev/tui/test/fake-setup-flow-renderer.ts
+++ b/packages/eve/src/cli/dev/tui/test/fake-setup-flow-renderer.ts
@@ -23,7 +23,7 @@ export function createFakeSetupFlowRenderer(
     renderOutput: () => {},
     withInheritedStdio: (task) => task(),
     waitForInterrupt: () => ({
-      promise: new Promise<void>(() => {}),
+      promise: new Promise<"escape" | "ctrl-c">(() => {}),
       dispose: () => {},
     }),
     ...rest,

--- a/packages/eve/src/setup/flows/registry-session.ts
+++ b/packages/eve/src/setup/flows/registry-session.ts
@@ -22,11 +22,18 @@ export interface RegistrySessionItemFailure {
   message: string;
 }
 
+export type RegistrySessionOutcome =
+  | ({ kind: "installed" } & RegistrySessionItemResult)
+  | ({ kind: "failed" } & RegistrySessionItemFailure)
+  | { kind: "cancelled"; title: string };
+
 export interface RegistrySessionResult {
   items: readonly RegistrySessionItemResult[];
   /** Installation failures retained when a user skips an item. */
   failures: readonly RegistrySessionItemFailure[];
-  /** Setup stopped after preserving already-settled item results. */
+  /** Every item outcome in installation order. */
+  outcomes?: readonly RegistrySessionOutcome[];
+  /** Setup stopped outside an individual item after preserving settled results. */
   cancelled?: true;
   deployed?: "production";
 }
@@ -34,6 +41,7 @@ export interface RegistrySessionResult {
 export interface RegistrySession {
   add(title: string, output: readonly string[], setup?: RegistrySetupCompletion): void;
   addFailure(title: string, message: string): void;
+  addCancellation(title: string): void;
   result(deployed?: "production"): RegistrySessionResult;
   continueAfterInstall(input: {
     appRoot: string;
@@ -44,24 +52,36 @@ export interface RegistrySession {
 
 /** Owns the accumulated output and deployment decision for one `/add` session. */
 export function createRegistrySession(deps: RegistrySessionDeps): RegistrySession {
-  const items: RegistrySessionItemResult[] = [];
-  const failures: RegistrySessionItemFailure[] = [];
+  const outcomes: RegistrySessionOutcome[] = [];
   let deploymentRequired = false;
 
   function result(deployed?: "production"): RegistrySessionResult {
+    const items = outcomes.flatMap((outcome) =>
+      outcome.kind === "installed"
+        ? [{ title: outcome.title, facts: outcome.facts, output: outcome.output }]
+        : [],
+    );
+    const failures = outcomes.flatMap((outcome) =>
+      outcome.kind === "failed" ? [{ title: outcome.title, message: outcome.message }] : [],
+    );
     const session: RegistrySessionResult = { items, failures };
+    if (outcomes.some((outcome) => outcome.kind !== "installed")) session.outcomes = outcomes;
     if (deployed !== undefined) session.deployed = deployed;
     return session;
   }
 
   return {
     add(title, itemOutput, setup = { facts: [] }) {
-      items.push({ title, facts: setup.facts, output: itemOutput });
+      outcomes.push({ kind: "installed", title, facts: setup.facts, output: itemOutput });
       deploymentRequired ||= setup.deploymentRequired === true;
     },
 
     addFailure(title, message) {
-      failures.push({ title, message });
+      outcomes.push({ kind: "failed", title, message });
+    },
+
+    addCancellation(title) {
+      outcomes.push({ kind: "cancelled", title });
     },
 
     result,

--- a/packages/eve/src/setup/flows/registry.test.ts
+++ b/packages/eve/src/setup/flows/registry.test.ts
@@ -466,6 +466,37 @@ describe("runRegistryFlow", () => {
     });
   });
 
+  it("preserves a cancelled item when a later item fails fatally", async () => {
+    const answers = ["install"];
+    const selections = [["channel/web"], ["connection/linear"]];
+    const fake = createFakePrompter({
+      single: () => answers.shift()!,
+      multiple: () => selections.shift()!,
+    });
+    const cause = new HumanActionRequiredError({
+      kind: "vercel-login",
+      command: "vercel login",
+      reason: "Authentication required.",
+    });
+    const installRegistryItem = vi
+      .fn<RegistryFlowDeps["installRegistryItem"]>()
+      .mockRejectedValueOnce(new WizardCancelledError())
+      .mockRejectedValueOnce(cause);
+
+    await expect(
+      runRegistryFlow({
+        appRoot: APP_ROOT,
+        prompter: fake.prompter,
+        deps: deps({ installRegistryItem }),
+      }),
+    ).rejects.toMatchObject({
+      cause,
+      completed: {
+        outcomes: [{ kind: "cancelled", title: "Web Chat" }],
+      },
+    });
+  });
+
   it("lets structured setup failures reach the command boundary", async () => {
     const answers = ["install"];
     const selections = [["channel/web"], []];

--- a/packages/eve/src/setup/flows/registry.ts
+++ b/packages/eve/src/setup/flows/registry.ts
@@ -22,6 +22,8 @@ const PLANNER_STEPS = ["Channels", "Integrations", "Review"] as const;
 export interface RegistryPlannerContext {
   /** Steps owned by an enclosing journey, rendered before the registry steps. */
   prefixSteps?: readonly { label: string; complete?: boolean }[];
+  /** Facts owned by the enclosing journey, rendered before registry selections. */
+  reviewMetadata?: readonly { label: string; value: string }[];
   reviewMessage?: string;
   primaryActionLabel?: string;
   emptyActionLabel?: string;
@@ -80,8 +82,6 @@ function isPlannerItem(section: Section, item: Item): boolean {
 }
 
 function orderedSectionItems(section: Section, catalog: readonly Item[]): Item[] {
-  // Product-level presets are installed as one item when explicitly requested;
-  // the bare planner presents their independently installable components.
   const matching = catalog.filter((item) => isPlannerItem(section, item));
   const featured = SECTIONS[section].featured
     .map((name) => matching.find((item) => item.name === name))
@@ -238,7 +238,7 @@ async function editPlan(input: {
       ];
       const request: SingleSelectOptions<"install" | "back"> = {
         message: input.plannerContext?.reviewMessage ?? "Review additions",
-        metadata: selectionMetadata,
+        metadata: [...(input.plannerContext?.reviewMetadata ?? []), ...selectionMetadata],
         navigation: plannerNavigation(2, input),
         options: [
           {
@@ -267,6 +267,15 @@ async function editPlan(input: {
   }
 }
 
+function hasSettledOutcomes(
+  result: RegistrySessionResult | undefined,
+): result is RegistrySessionResult {
+  return (
+    result !== undefined &&
+    (result.items.length > 0 || result.failures.length > 0 || result.outcomes !== undefined)
+  );
+}
+
 /** Collects a channel and integration plan, then installs every chosen item in order. */
 export async function runRegistryFlow(input: {
   appRoot: string;
@@ -276,6 +285,8 @@ export async function runRegistryFlow(input: {
   initialAddress?: string;
   plannerContext?: RegistryPlannerContext;
   onItemStart?: (item: Item, index: number, total: number) => void;
+  /** Gives each installation its own cancellation boundary without ending the batch. */
+  runItem?<T>(task: (signal?: AbortSignal) => Promise<T>): Promise<T>;
   deps?: Partial<RegistryFlowDeps>;
 }): Promise<{ kind: "done"; result: RegistrySessionResult } | { kind: "cancelled" }> {
   let session: ReturnType<typeof createRegistrySession> | undefined;
@@ -336,19 +347,22 @@ export async function runRegistryFlow(input: {
       input.signal?.throwIfAborted();
       input.onItemStart?.(item, index, items.length);
       try {
-        const install = () =>
+        const install = (signal = input.signal) =>
           installRegistryItem(input.appRoot, item.address, {
             silent: true,
             prompter: input.prompter,
-            signal: input.signal,
+            signal,
           });
-        const installed = await (input.prompter.withExclusiveTerminal?.(install) ?? install());
+        const run = () => (input.runItem === undefined ? install() : input.runItem(install));
+        const installed = await (input.prompter.withExclusiveTerminal?.(run) ?? run());
         activeSession.add(label(item), installed.output, installed.setup);
       } catch (error) {
         input.signal?.throwIfAborted();
-        if (error instanceof WizardCancelledError || error instanceof HumanActionRequiredError) {
-          throw error;
+        if (error instanceof WizardCancelledError) {
+          activeSession.addCancellation(label(item));
+          continue;
         }
+        if (error instanceof HumanActionRequiredError) throw error;
         const message = error instanceof Error ? error.message : String(error);
         const failureMessage = message.trim() || "Installation failed.";
         const summary = failureMessage.split("\n").find((line) => line.trim() !== "");
@@ -378,12 +392,12 @@ export async function runRegistryFlow(input: {
   } catch (error) {
     if (error instanceof WizardCancelledError) {
       const settled = session?.result();
-      return settled !== undefined && (settled.items.length > 0 || settled.failures.length > 0)
+      return hasSettledOutcomes(settled)
         ? { kind: "done", result: { ...settled, cancelled: true } }
         : { kind: "cancelled" };
     }
     const settled = session?.result();
-    if (settled !== undefined && (settled.items.length > 0 || settled.failures.length > 0)) {
+    if (hasSettledOutcomes(settled)) {
       throw new RegistryFlowFailedError(error, settled);
     }
     throw error;


### PR DESCRIPTION
### Summary

During registry installation, `Esc` now cancels only the active item and continues the remaining batch, while `Ctrl+C` cancels the whole command. Interrupts outside an active item—such as catalog loading or post-install work—also cancel the command instead of becoming inert.

The final report preserves installed, failed, and cancelled outcomes in selection order, including a cancelled-only partial result when a later item fails.

### Validation

- Focused registry, setup-command, terminal-renderer, command-handler, and runner unit tests: 353 passing
- `pnpm lint`
- `pnpm --filter eve typecheck`
- `pnpm docs:check`
- `pnpm guard:invariants`

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
