### PR TITLE
feat(eve): support dynamic remote subagent maps

### DIFF
--- a/.changeset/dynamic-remote-subagent-maps.md
+++ b/.changeset/dynamic-remote-subagent-maps.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Dynamic subagent resolvers can now return a named map of remote agents. Each map entry is exposed as an independently callable subagent with its own child session.

--- a/docs/guides/dynamic-capabilities.md
+++ b/docs/guides/dynamic-capabilities.md
@@ -119,6 +119,35 @@ principal forwarding, and output schema. Function-valued URLs resolve when the
 dynamic event runs. Auth and headers remain lazy and resolve before each
 outbound request without entering durable workflow state.
 
+A dynamic remote subagent can also return a record of `defineRemoteAgent()`
+definitions. eve exposes one subagent tool for each record entry, named after
+the subagent file and entry key. For example, `specialists.ts` exposes
+`specialists__triage` and `specialists__review`:
+
+```ts title="agent/subagents/specialists.ts"
+import { defineDynamic, defineRemoteAgent } from "eve";
+
+export default defineDynamic({
+  events: {
+    "session.started": () => ({
+      triage: defineRemoteAgent({
+        description: "Classify and route the request.",
+        url: "https://triage.example.com",
+      }),
+      review: defineRemoteAgent({
+        description: "Review the proposed response.",
+        url: "https://review.example.com",
+      }),
+    }),
+  },
+});
+```
+
+Map entries must be remote agents; local `defineAgent()` subagents remain
+one-per-directory. Each entry has an independent child session. A turn map
+replaces the resolver's complete session map for that turn, so an empty record
+hides every session-level entry from that resolver.
+
 Dynamic subagents support `session.started` and `turn.started`. A turn selection
 shadows the session selection for that turn, including when the turn handler
 returns `null`. If a resolver throws or returns an invalid definition, eve logs the

--- a/packages/eve/extension-contracts/compatibility/subagent/v9.ts
+++ b/packages/eve/extension-contracts/compatibility/subagent/v9.ts
@@ -1,0 +1,16 @@
+import { defineAgent, defineDynamic, defineRemoteAgent } from "#public/index.js";
+
+export const dynamic = defineDynamic({
+  events: {
+    "session.started": () =>
+      defineRemoteAgent({
+        description: "Handle requests remotely.",
+        url: "https://agent.example.com",
+      }),
+  },
+});
+
+export default defineAgent({
+  description: "Delegate research tasks.",
+  model: "anthropic/claude-sonnet-5",
+});

--- a/packages/eve/extension-contracts/reports/subagent/v10.json
+++ b/packages/eve/extension-contracts/reports/subagent/v10.json
@@ -1,0 +1,20 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "subagent",
+  "epoch": 10,
+  "sha256": "da896c41ef82a6dc892e567ae0b4e6e36f756f075dad9ae74a96735f437e5f18",
+  "exports": [
+    "AgentCompactionDefinition",
+    "AgentDefinition",
+    "AgentModelDefinition",
+    "AgentStaticModelDefinition",
+    "DefinedAgent",
+    "DynamicLocalSubagentDefinition",
+    "DynamicSubagentDefinition",
+    "RemoteAgentDefinition",
+    "RemoteAgentDefinitionInput",
+    "defineAgent",
+    "defineDynamic",
+    "defineRemoteAgent"
+  ]
+}

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -68,8 +68,8 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     },
   },
   subagent: {
-    current: 9,
-    supported: [3, 4, 6, 7, 8, 9],
+    current: 10,
+    supported: [3, 4, 6, 7, 8, 9, 10],
     dropped: {
       1: "Persistent subagent sessions are now the default and the experimental opt-in was removed",
       2: "Persistent subagent sessions are now the default and the experimental opt-in was removed",

--- a/packages/eve/src/context/dynamic-subagent-lifecycle.test.ts
+++ b/packages/eve/src/context/dynamic-subagent-lifecycle.test.ts
@@ -352,6 +352,44 @@ describe("dynamic subagent lifecycle", () => {
     expect(getDynamicSubagentSelection(ctx, resolver.nodeId)).toBeUndefined();
   });
 
+  it('supports a dynamic subagent map entry named "kind"', async () => {
+    const ctx = createContext();
+    const created = createResolver();
+    const resolver: ResolvedDynamicSubagentResolver = {
+      ...created.resolver,
+      events: {
+        "session.started": () => ({
+          kind: defineRemoteAgent({
+            description: "Classifies the request kind.",
+            url: "https://kind.example.com",
+          }),
+        }),
+      },
+    };
+
+    await dispatchDynamicSubagentEvent({
+      ctx,
+      event: createSessionStartedEvent(),
+      messages: [],
+      persistentSessions: false,
+      resolvers: [resolver],
+    });
+
+    expect(buildDynamicSubagentTools(ctx)).toMatchObject([
+      {
+        name: "researcher__kind",
+        runtimeAction: {
+          nodeId: "subagents/researcher#kind",
+          remoteAgentName: "researcher__kind",
+        },
+      },
+    ]);
+    expect(getDynamicSubagentSelection(ctx, "subagents/researcher#kind")).toMatchObject({
+      kind: "remote",
+      remoteAgent: { url: "https://kind.example.com" },
+    });
+  });
+
   it("lets a turn map replace every session entry from the same resolver", async () => {
     const ctx = createContext();
     const created = createResolver({ eventNames: ["session.started", "turn.started"] });

--- a/packages/eve/src/context/dynamic-subagent-lifecycle.test.ts
+++ b/packages/eve/src/context/dynamic-subagent-lifecycle.test.ts
@@ -7,7 +7,11 @@ import {
   getDynamicSubagentSelection,
   refreshDynamicSessionSubagentsForRuntimeRevision,
 } from "#context/dynamic-subagent-lifecycle.js";
-import { SessionDynamicSubagentRuntimeRevisionKey, SessionIdKey } from "#context/keys.js";
+import {
+  SessionDynamicSubagentRuntimeRevisionKey,
+  SessionIdKey,
+  TurnDynamicSubagentSelectionsKey,
+} from "#context/keys.js";
 import { defineAgent } from "#public/definitions/agent.js";
 import { defineRemoteAgent } from "#public/definitions/remote-agent.js";
 import { createSessionStartedEvent, createTurnStartedEvent } from "#protocol/message.js";
@@ -295,6 +299,98 @@ describe("dynamic subagent lifecycle", () => {
     });
 
     expect(buildDynamicSubagentTools(ctx)[0]?.execution).toBe("background");
+  });
+
+  it("exposes every remote entry in a dynamic subagent map with a keyed identity", async () => {
+    const ctx = createContext();
+    const created = createResolver();
+    const resolver: ResolvedDynamicSubagentResolver = {
+      ...created.resolver,
+      events: {
+        "session.started": () => ({
+          review: defineRemoteAgent({
+            description: "Reviews the request.",
+            url: "https://review.example.com",
+          }),
+          triage: defineRemoteAgent({
+            description: "Classifies the request.",
+            url: "https://triage.example.com",
+          }),
+        }),
+      },
+    };
+
+    await dispatchDynamicSubagentEvent({
+      ctx,
+      event: createSessionStartedEvent(),
+      messages: [],
+      resolvers: [resolver],
+    });
+
+    expect(buildDynamicSubagentTools(ctx)).toMatchObject([
+      {
+        name: "researcher__review",
+        runtimeAction: {
+          kind: "remote-agent-call",
+          nodeId: "subagents/researcher#review",
+          remoteAgentName: "researcher__review",
+        },
+      },
+      {
+        name: "researcher__triage",
+        runtimeAction: {
+          kind: "remote-agent-call",
+          nodeId: "subagents/researcher#triage",
+          remoteAgentName: "researcher__triage",
+        },
+      },
+    ]);
+    expect(getDynamicSubagentSelection(ctx, "subagents/researcher#triage")).toMatchObject({
+      kind: "remote",
+      remoteAgent: { url: "https://triage.example.com" },
+    });
+    expect(getDynamicSubagentSelection(ctx, resolver.nodeId)).toBeUndefined();
+  });
+
+  it("lets a turn map replace every session entry from the same resolver", async () => {
+    const ctx = createContext();
+    const created = createResolver({ eventNames: ["session.started", "turn.started"] });
+    const resolver: ResolvedDynamicSubagentResolver = {
+      ...created.resolver,
+      events: {
+        "session.started": () => ({
+          triage: defineRemoteAgent({
+            description: "Classifies.",
+            url: "https://triage.example.com",
+          }),
+          review: defineRemoteAgent({ description: "Reviews.", url: "https://review.example.com" }),
+        }),
+        "turn.started": () => ({
+          review: defineRemoteAgent({
+            description: "Reviews deeply.",
+            url: "https://deep-review.example.com",
+          }),
+        }),
+      },
+    };
+
+    await dispatchDynamicSubagentEvent({
+      ctx,
+      event: createSessionStartedEvent(),
+      messages: [],
+      resolvers: [resolver],
+    });
+    await dispatchDynamicSubagentEvent({
+      ctx,
+      event: createTurnStartedEvent({ sequence: 0, turnId: "turn-1" }),
+      messages: [],
+      resolvers: [resolver],
+    });
+
+    expect(ctx.get(TurnDynamicSubagentSelectionsKey)).toBeDefined();
+    expect(buildDynamicSubagentTools(ctx).map((tool) => tool.name)).toEqual(["researcher__review"]);
+    expect(getDynamicSubagentSelection(ctx, "subagents/researcher#triage")).toBeUndefined();
+    expect(getDynamicSubagentSelection(ctx, "subagents/researcher#review")?.kind).toBe("remote");
   });
 
   it("omits an invalid non-null result", async () => {

--- a/packages/eve/src/context/dynamic-subagent-lifecycle.test.ts
+++ b/packages/eve/src/context/dynamic-subagent-lifecycle.test.ts
@@ -330,19 +330,11 @@ describe("dynamic subagent lifecycle", () => {
     expect(buildDynamicSubagentTools(ctx)).toMatchObject([
       {
         name: "researcher__review",
-        runtimeAction: {
-          kind: "remote-agent-call",
-          nodeId: "subagents/researcher#review",
-          remoteAgentName: "researcher__review",
-        },
+        nodeId: "subagents/researcher#review",
       },
       {
         name: "researcher__triage",
-        runtimeAction: {
-          kind: "remote-agent-call",
-          nodeId: "subagents/researcher#triage",
-          remoteAgentName: "researcher__triage",
-        },
+        nodeId: "subagents/researcher#triage",
       },
     ]);
     expect(getDynamicSubagentSelection(ctx, "subagents/researcher#triage")).toMatchObject({
@@ -371,17 +363,13 @@ describe("dynamic subagent lifecycle", () => {
       ctx,
       event: createSessionStartedEvent(),
       messages: [],
-      persistentSessions: false,
       resolvers: [resolver],
     });
 
     expect(buildDynamicSubagentTools(ctx)).toMatchObject([
       {
         name: "researcher__kind",
-        runtimeAction: {
-          nodeId: "subagents/researcher#kind",
-          remoteAgentName: "researcher__kind",
-        },
+        nodeId: "subagents/researcher#kind",
       },
     ]);
     expect(getDynamicSubagentSelection(ctx, "subagents/researcher#kind")).toMatchObject({

--- a/packages/eve/src/context/dynamic-subagent-lifecycle.ts
+++ b/packages/eve/src/context/dynamic-subagent-lifecycle.ts
@@ -7,6 +7,7 @@ import {
   SessionDynamicSubagentRuntimeRevisionKey,
   SessionDynamicSubagentSelectionsKey,
   TurnDynamicSubagentSelectionsKey,
+  type DurableDynamicSubagentResolverSelection,
   type DurableDynamicSubagentSelection,
 } from "#context/keys.js";
 import { createPreparedWorkflowToolHarnessDefinition } from "#execution/tools/workflow/background.js";
@@ -22,7 +23,62 @@ import { toErrorMessage } from "#shared/errors.js";
 const log = createLogger("dynamic-subagents");
 const ALLOWED_DYNAMIC_SUBAGENT_EVENTS = new Set(["session.started", "turn.started"]);
 
-type DynamicSubagentSelections = Readonly<Record<string, DurableDynamicSubagentSelection>>;
+type DynamicSubagentSelections = Readonly<Record<string, DurableDynamicSubagentResolverSelection>>;
+
+function dynamicSubagentEntryNodeId(resolverNodeId: string, entryKey: string): string {
+  return `${resolverNodeId}#${entryKey}`;
+}
+
+function dynamicSubagentResolverNodeId(nodeId: string): string {
+  return nodeId.split("#", 1)[0]!;
+}
+
+function isRemoteAgentMap(value: unknown): value is Readonly<Record<string, unknown>> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.values(value).every(isRemoteAgentDefinition)
+  );
+}
+
+function isDynamicSubagentMapSelection(
+  value: DurableDynamicSubagentResolverSelection,
+): value is Readonly<Record<string, DurableDynamicSubagentSelection>> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Object.hasOwn(value, "kind") &&
+    Object.values(value).every(
+      (entry) => entry === null || (typeof entry === "object" && entry.kind === "remote"),
+    )
+  );
+}
+
+async function resolveRemoteSelection(input: {
+  readonly name: string;
+  readonly nodeId: string;
+  readonly resolver: ResolvedDynamicSubagentResolver;
+  readonly value: unknown;
+}): Promise<Exclude<DurableDynamicSubagentSelection, null>> {
+  const remoteAgent = await normalizeDynamicRemoteAgentConfig({
+    name: input.name,
+    value: input.value,
+  });
+  const prepared = createPreparedRuntimeSubagentTool({
+    description: remoteAgent.description,
+    kind: "remote",
+    logicalPath: input.resolver.logicalPath,
+    name: input.name,
+    nodeId: input.nodeId,
+    outputSchema: remoteAgent.outputSchema,
+    path: remoteAgent.path,
+    sourceId: input.resolver.sourceId,
+    sourceKind: input.resolver.sourceKind,
+    url: remoteAgent.url,
+  });
+  return { kind: "remote", prepared, remoteAgent };
+}
 
 async function resolveSelections(input: {
   readonly ctx: ContextContainer;
@@ -33,33 +89,38 @@ async function resolveSelections(input: {
   const outcomes = await Promise.allSettled(
     input.resolvers.map(async (resolver) => {
       const handler = resolver.events[input.event.type];
-      if (handler === undefined) {
-        return [resolver.nodeId, null] as const;
-      }
+      if (handler === undefined) return [resolver.nodeId, null] as const;
 
       const result = await handler(input.event, buildResolveContext(input.ctx, input.messages));
-      if (result === null || result === undefined) {
-        return [resolver.nodeId, null] as const;
-      }
+      if (result === null || result === undefined) return [resolver.nodeId, null] as const;
       if (isRemoteAgentDefinition(result)) {
-        const remoteAgent = await normalizeDynamicRemoteAgentConfig({
-          name: resolver.name,
-          value: result,
-        });
-        const prepared = createPreparedRuntimeSubagentTool({
-          description: remoteAgent.description,
-          kind: "remote",
-          logicalPath: resolver.logicalPath,
-          name: resolver.name,
-          nodeId: resolver.nodeId,
-          outputSchema: remoteAgent.outputSchema,
-          path: remoteAgent.path,
-          sourceId: resolver.sourceId,
-          sourceKind: resolver.sourceKind,
-          url: remoteAgent.url,
-        });
+        return [
+          resolver.nodeId,
+          await resolveRemoteSelection({
+            name: resolver.name,
+            nodeId: resolver.nodeId,
+            resolver,
+            value: result,
+          }),
+        ] as const;
+      }
 
-        return [resolver.nodeId, { kind: "remote", prepared, remoteAgent }] as const;
+      if (isRemoteAgentMap(result)) {
+        const entries: Record<string, DurableDynamicSubagentSelection> = {};
+        for (const [entryKey, value] of Object.entries(result)) {
+          if (!isRemoteAgentDefinition(value)) {
+            throw new Error(
+              `Dynamic subagent resolver "${resolver.logicalPath}" returned "${entryKey}" without defineRemoteAgent(). Dynamic subagent maps may contain only defineRemoteAgent() values.`,
+            );
+          }
+          entries[entryKey] = await resolveRemoteSelection({
+            name: `${resolver.name}__${entryKey}`,
+            nodeId: dynamicSubagentEntryNodeId(resolver.nodeId, entryKey),
+            resolver,
+            value,
+          });
+        }
+        return [resolver.nodeId, entries] as const;
       }
 
       const agentConfig = normalizeDynamicSubagentAgentConfig({
@@ -77,14 +138,13 @@ async function resolveSelections(input: {
         sourceId: resolver.sourceId,
         sourceKind: resolver.sourceKind,
       });
-
       return [
         resolver.nodeId,
         { agentConfig: resolvedAgentConfig, kind: "subagent", prepared },
       ] as const;
     }),
   );
-  const selections: Record<string, DurableDynamicSubagentSelection> = {};
+  const selections: Record<string, DurableDynamicSubagentResolverSelection> = {};
 
   for (let index = 0; index < outcomes.length; index += 1) {
     const outcome = outcomes[index]!;
@@ -117,20 +177,18 @@ export async function dispatchDynamicSubagentEvent(input: {
   readonly messages: readonly ModelMessage[];
   readonly resolvers: readonly ResolvedDynamicSubagentResolver[];
 }): Promise<void> {
-  if (!ALLOWED_DYNAMIC_SUBAGENT_EVENTS.has(input.event.type)) {
-    return;
-  }
+  if (!ALLOWED_DYNAMIC_SUBAGENT_EVENTS.has(input.event.type)) return;
 
-  const matching = input.resolvers.filter((resolver) =>
+  const resolvers = input.resolvers.filter((resolver) =>
     resolver.eventNames.includes(input.event.type),
   );
-  const selections = await resolveSelections({ ...input, resolvers: matching });
-
-  if (input.event.type === "session.started") {
-    input.ctx.set(SessionDynamicSubagentSelectionsKey, selections);
-  } else {
-    input.ctx.set(TurnDynamicSubagentSelectionsKey, selections);
-  }
+  const selections = await resolveSelections({ ...input, resolvers });
+  input.ctx.set(
+    input.event.type === "session.started"
+      ? SessionDynamicSubagentSelectionsKey
+      : TurnDynamicSubagentSelectionsKey,
+    selections,
+  );
 }
 
 export async function refreshDynamicSessionSubagentsForRuntimeRevision(input: {
@@ -140,36 +198,39 @@ export async function refreshDynamicSessionSubagentsForRuntimeRevision(input: {
   readonly resolvers: readonly ResolvedDynamicSubagentResolver[];
   readonly runtimeRevision: string;
 }): Promise<void> {
-  if (input.ctx.get(SessionDynamicSubagentRuntimeRevisionKey) === input.runtimeRevision) {
-    return;
-  }
+  if (input.ctx.get(SessionDynamicSubagentRuntimeRevisionKey) === input.runtimeRevision) return;
 
-  const matching = input.resolvers.filter((resolver) =>
+  const resolvers = input.resolvers.filter((resolver) =>
     resolver.eventNames.includes("session.started"),
   );
-  const selections = await resolveSelections({ ...input, resolvers: matching });
+  const selections = await resolveSelections({ ...input, resolvers });
   input.ctx.set(SessionDynamicSubagentSelectionsKey, selections);
   input.ctx.set(SessionDynamicSubagentRuntimeRevisionKey, input.runtimeRevision);
 }
 
 export function buildDynamicSubagentTools(input: ContextReader): readonly HarnessToolDefinition[] {
-  const session = input.get(SessionDynamicSubagentSelectionsKey) ?? {};
-  const turn = input.get(TurnDynamicSubagentSelectionsKey) ?? {};
-  const effective = { ...session, ...turn };
+  const effective = {
+    ...input.get(SessionDynamicSubagentSelectionsKey),
+    ...input.get(TurnDynamicSubagentSelectionsKey),
+  };
   const tools: HarnessToolDefinition[] = [];
   const names = new Set<string>();
 
-  for (const selection of Object.values(effective)) {
-    if (selection === null) {
-      continue;
+  for (const resolverSelection of Object.values(effective)) {
+    const selections =
+      resolverSelection !== null && isDynamicSubagentMapSelection(resolverSelection)
+        ? Object.values(resolverSelection)
+        : [resolverSelection];
+    for (const selection of selections) {
+      if (selection === null) continue;
+      if (names.has(selection.prepared.name)) {
+        throw new Error(
+          `Found multiple active dynamic subagents named "${selection.prepared.name}". Subagent names must be unique at runtime.`,
+        );
+      }
+      names.add(selection.prepared.name);
+      tools.push(createPreparedWorkflowToolHarnessDefinition(selection.prepared));
     }
-    if (names.has(selection.prepared.name)) {
-      throw new Error(
-        `Found multiple active dynamic subagents named "${selection.prepared.name}". Subagent names must be unique at runtime.`,
-      );
-    }
-    names.add(selection.prepared.name);
-    tools.push(createPreparedWorkflowToolHarnessDefinition(selection.prepared));
   }
 
   return tools;
@@ -179,11 +240,22 @@ export function getDynamicSubagentSelection(
   input: ContextReader,
   nodeId: string,
 ): Exclude<DurableDynamicSubagentSelection, null> | undefined {
+  const resolverNodeId = dynamicSubagentResolverNodeId(nodeId);
+  const entryKey = nodeId.slice(resolverNodeId.length + 1);
   const turn = input.get(TurnDynamicSubagentSelectionsKey) ?? {};
-  if (Object.hasOwn(turn, nodeId)) {
-    return turn[nodeId] ?? undefined;
+  const resolverSelection = Object.hasOwn(turn, resolverNodeId)
+    ? turn[resolverNodeId]
+    : (input.get(SessionDynamicSubagentSelectionsKey) ?? {})[resolverNodeId];
+  if (resolverSelection === undefined || resolverSelection === null) return undefined;
+  if (isDynamicSubagentMapSelection(resolverSelection)) {
+    return entryKey === "" ? undefined : (resolverSelection[entryKey] ?? undefined);
   }
+  return entryKey === "" ? resolverSelection : undefined;
+}
 
-  const session = input.get(SessionDynamicSubagentSelectionsKey) ?? {};
-  return session[nodeId] ?? undefined;
+export function isDynamicSubagentNodeId(
+  dynamicResolverNodeIds: ReadonlySet<string>,
+  nodeId: string,
+): boolean {
+  return dynamicResolverNodeIds.has(dynamicSubagentResolverNodeId(nodeId));
 }

--- a/packages/eve/src/context/dynamic-subagent-lifecycle.ts
+++ b/packages/eve/src/context/dynamic-subagent-lifecycle.ts
@@ -45,13 +45,10 @@ function isRemoteAgentMap(value: unknown): value is Readonly<Record<string, unkn
 function isDynamicSubagentMapSelection(
   value: DurableDynamicSubagentResolverSelection,
 ): value is Readonly<Record<string, DurableDynamicSubagentSelection>> {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    !Object.hasOwn(value, "kind") &&
-    Object.values(value).every(
-      (entry) => entry === null || (typeof entry === "object" && entry.kind === "remote"),
-    )
+  if (typeof value !== "object" || value === null) return false;
+  if (value.kind === "remote" || value.kind === "subagent") return false;
+  return Object.values(value).every(
+    (entry) => entry === null || (typeof entry === "object" && entry.kind === "remote"),
   );
 }
 

--- a/packages/eve/src/context/dynamic-subagent-lifecycle.ts
+++ b/packages/eve/src/context/dynamic-subagent-lifecycle.ts
@@ -233,6 +233,27 @@ export function buildDynamicSubagentTools(input: ContextReader): readonly Harnes
   return tools;
 }
 
+export function getDynamicSubagentSelectionByName(
+  input: ContextReader,
+  name: string,
+): Exclude<DurableDynamicSubagentSelection, null> | undefined {
+  const effective = {
+    ...input.get(SessionDynamicSubagentSelectionsKey),
+    ...input.get(TurnDynamicSubagentSelectionsKey),
+  };
+  for (const resolverSelection of Object.values(effective)) {
+    const selections =
+      resolverSelection !== null && isDynamicSubagentMapSelection(resolverSelection)
+        ? Object.values(resolverSelection)
+        : [resolverSelection];
+    const match = selections.find(
+      (selection) => selection !== null && selection.prepared.name === name,
+    );
+    if (match !== undefined && match !== null) return match;
+  }
+  return undefined;
+}
+
 export function getDynamicSubagentSelection(
   input: ContextReader,
   nodeId: string,

--- a/packages/eve/src/context/keys.ts
+++ b/packages/eve/src/context/keys.ts
@@ -270,12 +270,16 @@ export type DurableDynamicSubagentSelection =
     }
   | null;
 
+export type DurableDynamicSubagentResolverSelection =
+  | DurableDynamicSubagentSelection
+  | Readonly<Record<string, DurableDynamicSubagentSelection>>;
+
 export const SessionDynamicSubagentSelectionsKey = new ContextKey<
-  Readonly<Record<string, DurableDynamicSubagentSelection>>
+  Readonly<Record<string, DurableDynamicSubagentResolverSelection>>
 >("eve.sessionDynamicSubagentSelections");
 
 export const TurnDynamicSubagentSelectionsKey = new ContextKey<
-  Readonly<Record<string, DurableDynamicSubagentSelection>>
+  Readonly<Record<string, DurableDynamicSubagentResolverSelection>>
 >("eve.turnDynamicSubagentSelections");
 
 export const SessionDynamicSubagentRuntimeRevisionKey = new ContextKey<string>(

--- a/packages/eve/src/execution/tools/subagent/invoke-preparation.ts
+++ b/packages/eve/src/execution/tools/subagent/invoke-preparation.ts
@@ -17,11 +17,6 @@ import type { AgentInvocationRequest } from "#execution/tools/subagent/invoke-ag
 import { BundleKey, type CompiledBundle } from "#runtime/sessions/runtime-context-keys.js";
 import { ROOT_RUNTIME_AGENT_NODE_ID } from "#runtime/graph.js";
 import { AGENT_TOOL_DESCRIPTION, AGENT_TOOL_NAME } from "#tools/framework/agent-contract.js";
-import {
-  SessionDynamicSubagentSelectionsKey,
-  TurnDynamicSubagentSelectionsKey,
-  type DurableDynamicSubagentSelection,
-} from "#context/keys.js";
 import type { DynamicRemoteAgentConfig } from "#runtime/subagents/dynamic-remote-agent-config.js";
 import {
   isAgentHandleAction,
@@ -29,7 +24,11 @@ import {
   type RuntimeSession,
 } from "#subagents/handle-dispatch.js";
 import { getAgentHandleStore } from "#subagents/handles/store.js";
-import { getDynamicSubagentSelection } from "#context/dynamic-subagent-lifecycle.js";
+import {
+  getDynamicSubagentSelection,
+  getDynamicSubagentSelectionByName,
+  isDynamicSubagentNodeId,
+} from "#context/dynamic-subagent-lifecycle.js";
 import {
   createRecursiveAgentRootOnlyResult,
   createUnavailableDynamicSubagentResult,
@@ -105,10 +104,12 @@ export function planAgentDispatch(input: {
     typeof rawAgentId === "string" && rawAgentId.trim() !== "" ? rawAgentId : undefined;
   if (agentId !== undefined && isAgentHandleAction(input.action)) {
     if (knownAgentIds.has(agentId)) {
-      const dynamicSubagentSelection =
-        input.bundle.subagentRegistry.dynamicNodeIds?.has(input.action.nodeId) === true
-          ? getDynamicSubagentSelection(input.ctx, input.action.nodeId)
-          : undefined;
+      const dynamicSubagentSelection = isDynamicSubagentNodeId(
+        input.bundle.subagentRegistry.dynamicNodeIds ?? new Set(),
+        input.action.nodeId,
+      )
+        ? getDynamicSubagentSelection(input.ctx, input.action.nodeId)
+        : undefined;
       return {
         action: input.action,
         agentId,
@@ -135,8 +136,10 @@ function classifyFreshStart(input: {
 }): Extract<OwnerAgentDispatchPlanEntry, { kind: "reject" | "start" }> {
   const { action } = input;
   const registry = input.bundle.subagentRegistry.subagentsByNodeId;
-  const isDynamicSubagent =
-    input.bundle.subagentRegistry.dynamicNodeIds?.has(action.nodeId) === true;
+  const isDynamicSubagent = isDynamicSubagentNodeId(
+    input.bundle.subagentRegistry.dynamicNodeIds ?? new Set(),
+    action.nodeId,
+  );
   const dynamicSubagentSelection = isDynamicSubagent
     ? getDynamicSubagentSelection(input.ctx, action.nodeId)
     : undefined;
@@ -237,13 +240,7 @@ function resolveAgentInvocationAction(input: {
   const registered = bundle.subagentRegistry.subagentsByName.get(input.input.target);
   const dynamicSelection =
     registered === undefined
-      ? Object.values({
-          ...input.ctx.get(SessionDynamicSubagentSelectionsKey),
-          ...input.ctx.get(TurnDynamicSubagentSelectionsKey),
-        }).find(
-          (selection: DurableDynamicSubagentSelection) =>
-            selection !== null && selection.prepared?.name === input.input.target,
-        )
+      ? getDynamicSubagentSelectionByName(input.ctx, input.input.target)
       : undefined;
   const definition =
     registered?.definition ??

--- a/packages/eve/src/public/definitions/agent.ts
+++ b/packages/eve/src/public/definitions/agent.ts
@@ -55,7 +55,13 @@ export type DynamicLocalSubagentDefinition = Extract<
 > & { readonly description: string };
 
 /** Definition a dynamic subagent resolver may select at runtime. */
-export type DynamicSubagentDefinition = DynamicLocalSubagentDefinition | RemoteAgentDefinition;
+export type DynamicRemoteSubagentMap = Readonly<Record<string, RemoteAgentDefinition>>;
+
+/** Definition a dynamic subagent resolver may select at runtime. */
+export type DynamicSubagentDefinition =
+  | DynamicLocalSubagentDefinition
+  | RemoteAgentDefinition
+  | DynamicRemoteSubagentMap;
 
 type DynamicEventHandler<TEvents extends DynamicEvents> = Extract<
   NonNullable<TEvents[keyof TEvents]>,

--- a/packages/eve/src/public/definitions/exact.test.ts
+++ b/packages/eve/src/public/definitions/exact.test.ts
@@ -195,6 +195,21 @@ function typeOnlyFixtures(): void {
     },
   });
 
+  defineDynamic({
+    events: {
+      "session.started": () => ({
+        review: defineRemoteAgent({
+          description: "Delegate response review.",
+          url: "https://review.example.com",
+        }),
+        triage: defineRemoteAgent({
+          description: "Delegate request triage.",
+          url: "https://triage.example.com",
+        }),
+      }),
+    },
+  });
+
   // @ts-expect-error A dynamic local-subagent selection must use a static model.
   defineDynamic({
     events: {

--- a/packages/eve/src/public/index.ts
+++ b/packages/eve/src/public/index.ts
@@ -16,6 +16,7 @@ export {
   type DefinedAgent,
   type DynamicSubagentDefinition,
   type DynamicLocalSubagentDefinition,
+  type DynamicRemoteSubagentMap,
   defineAgent,
   defineDynamic,
 } from "#public/definitions/agent.js";

--- a/packages/eve/src/subagents/remote-dispatch.test.ts
+++ b/packages/eve/src/subagents/remote-dispatch.test.ts
@@ -72,6 +72,43 @@ describe("resolveRemoteAgentForAction", () => {
       headers: { authorization: "Bearer selected" },
     });
   });
+
+  it("finds the owning resolver for a keyed dynamic map entry", async () => {
+    const definition = {
+      dynamic: {
+        eventNames: ["session.started"],
+        events: { "session.started": () => null },
+        logicalPath: "subagents/specialists.ts",
+        sourceId: "subagents/specialists.ts",
+        sourceKind: "module",
+      },
+      kind: "subagent",
+      logicalPath: "subagents/specialists.ts",
+      name: "specialists",
+      nodeId: "subagents/specialists",
+      sourceId: "subagents/specialists.ts",
+      sourceKind: "module",
+    } as const;
+
+    const resolved = await resolveRemoteAgentForAction({
+      dynamicRemoteAgent: {
+        description: "Selected remote triage.",
+        path: "/eve/v1/session",
+        url: "https://triage.example.com",
+      },
+      nodeId: "subagents/specialists#triage",
+      registry: new Map([[definition.nodeId, { definition }]]),
+      remoteAgentName: "specialists__triage",
+    });
+
+    expect(resolved).toMatchObject({
+      logicalPath: "subagents/specialists.ts",
+      name: "specialists__triage",
+      nodeId: "subagents/specialists#triage",
+      sourceId: "subagents/specialists.ts",
+      url: "https://triage.example.com",
+    });
+  });
 });
 
 describe("resolveRemoteAgentStreamHeaders", () => {

--- a/packages/eve/src/subagents/remote-dispatch.ts
+++ b/packages/eve/src/subagents/remote-dispatch.ts
@@ -443,7 +443,9 @@ export function resolveRemoteAgentForAction(input: {
   const registered = input.registry.get(input.nodeId);
   const definition = registered?.definition;
   if (input.dynamicRemoteAgent !== undefined) {
-    if (definition === undefined) {
+    const dynamicResolverDefinition =
+      definition ?? input.registry.get(input.nodeId.split("#", 1)[0]!)?.definition;
+    if (dynamicResolverDefinition === undefined) {
       throw new Error(`Missing remote agent "${input.remoteAgentName}" in runtime registry.`);
     }
     const credentials = resolveDynamicRemoteAgentCredentials(input.dynamicRemoteAgent);
@@ -465,12 +467,12 @@ export function resolveRemoteAgentForAction(input: {
     } = {
       description: config.description,
       kind: "remote",
-      logicalPath: definition.logicalPath,
+      logicalPath: dynamicResolverDefinition.logicalPath,
       name: input.remoteAgentName,
       nodeId: input.nodeId,
       outputSchema: config.outputSchema,
       path: config.path,
-      sourceId: definition.sourceId,
+      sourceId: dynamicResolverDefinition.sourceId,
       sourceKind: "module",
       url: config.url,
     };


### PR DESCRIPTION
### Summary

Dynamic subagent resolvers can now return a named map of `defineRemoteAgent()` definitions, exposing independently callable `<resolver>__<key>` tools. This provides a good foundation for the subsequent PR, but also would be conceptually useful for other sorts of remote agent registries.

### Validation

Focused dynamic-subagent, remote dispatch, cancellation, and public-definition coverage passed, including a regression for an entry named `kind`; `pnpm typecheck`, `pnpm docs:check`, and `pnpm guard:invariants` also passed.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+34 / -0`

Documents the new map return form and records its patch release note.

**Implementation** — 8 files · `+186 / -73`

Extends the dynamic-subagent selection model and lifecycle lookup, plus the required retained public capability metadata.

**Tests** — 4 files · `+196 / -1`

Covers map naming and identity, including the `kind` key edge case, turn-level replacement, remote resolver lookup, public typing, and the retained extension API example.
