### PR TITLE
fix(selfmod): loosen registry search

### DIFF
--- a/packages/eve-self-modification/extension/tools/search_registry.ts
+++ b/packages/eve-self-modification/extension/tools/search_registry.ts
@@ -9,6 +9,7 @@ const DEFAULT_REGISTRY_BASE = "https://eve.dev/r";
 const INDEX_PATH = "/registry.json";
 const DEFAULT_LIMIT = 10;
 const MAX_LIMIT = 25;
+const MIN_RELATIVE_SCORE = 0.4;
 const FETCH_TIMEOUT_MS = 10_000;
 /**
  * The catalog changes when eve releases, not between turns, so one fetch can
@@ -283,21 +284,49 @@ export function selectIntegrationPage(input: {
     .split(/\s+/u)
     .filter((term) => term.length > 0);
 
-  const matches = input.entries.filter((entry) => {
-    if (input.category !== undefined && !matchesCategory(entry, input.category)) return false;
-    if (terms.length === 0) return true;
-    const haystack = [
-      entry.address,
-      entry.title,
-      entry.description ?? "",
-      ...(entry.componentSearchTerms ?? entry.components ?? []),
-    ]
-      .join(" ")
-      .toLowerCase();
-    return terms.every((term) => haystack.includes(term));
+  const searchableEntries = input.entries.map((entry, index) => {
+    const primaryTerms = `${entry.address} ${entry.title}`.toLowerCase();
+    return {
+      entry,
+      haystack: [
+        primaryTerms,
+        entry.description ?? "",
+        ...(entry.componentSearchTerms ?? entry.components ?? []),
+      ]
+        .join(" ")
+        .toLowerCase(),
+      index,
+      primaryTerms,
+    };
   });
+  const termWeights = new Map(
+    terms.map((term) => {
+      const documentFrequency = searchableEntries.filter(({ haystack }) =>
+        haystack.includes(term),
+      ).length;
+      return [term, Math.log((searchableEntries.length + 1) / (documentFrequency + 1)) + 1];
+    }),
+  );
+  const rankedMatches = searchableEntries
+    .map(({ entry, haystack, index, primaryTerms }) => {
+      if (input.category !== undefined && !matchesCategory(entry, input.category)) return undefined;
+      if (terms.length === 0) return { entry, index, score: 0 };
+      const score = terms.reduce((total, term) => {
+        const weight = termWeights.get(term) ?? 0;
+        if (primaryTerms.includes(term)) return total + 2 * weight;
+        return haystack.includes(term) ? total + weight : total;
+      }, 0);
+      return score > 0 ? { entry, index, score } : undefined;
+    })
+    .filter(
+      (match): match is { entry: CatalogEntry; index: number; score: number } =>
+        match !== undefined,
+    )
+    .sort((left, right) => right.score - left.score || left.index - right.index);
+  const minimumScore = (rankedMatches[0]?.score ?? 0) * MIN_RELATIVE_SCORE;
+  const matches = rankedMatches.filter(({ score }) => score >= minimumScore);
 
-  const items = matches.slice(offset, offset + limit).map((entry) => {
+  const items = matches.slice(offset, offset + limit).map(({ entry }) => {
     const row: {
       address: string;
       category?: Category;

--- a/packages/eve-self-modification/src/search-registry.test.ts
+++ b/packages/eve-self-modification/src/search-registry.test.ts
@@ -103,14 +103,23 @@ describe("parseRegistryIndex", () => {
 });
 
 describe("selectIntegrations", () => {
-  it("matches every query term across address, title, and description", () => {
+  it("returns entries that match any query term and ranks stronger matches first", () => {
     expect(
       selectIntegrations({ entries: catalog(), query: "notion pages" }).map((row) => row.address),
     ).toEqual(["connection/notion"]);
-    expect(selectIntegrations({ entries: catalog(), query: "slack" })).toHaveLength(1);
+    expect(
+      selectIntegrations({
+        category: "channel",
+        entries: catalog(),
+        query: "Slack channel integration",
+      }).map((row) => row.address),
+    ).toEqual(["channel/slack", "channel/discord"]);
     expect(
       selectIntegrations({ entries: catalog(), query: "linear agent" }).map((row) => row.address),
     ).toEqual(["linear"]);
+    expect(
+      selectIntegrations({ entries: catalog(), query: "agent notion" }).map((row) => row.address),
+    ).toEqual(["connection/notion"]);
     expect(selectIntegrations({ entries: catalog(), query: "nothing here" })).toEqual([]);
   });
 


### PR DESCRIPTION
### Summary

Registry searches no longer require every word in a natural-language query to match an integration. Matches are ranked by term specificity and name/title matches, while results substantially weaker than the best match remain excluded.

### Validation

Confirmed the ranking, category filtering, bundle matching, and no-match behavior with `pnpm --filter @eve/self-modification exec vitest run src/search-registry.test.ts` (17 tests).

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 1 file · `+43 / -14`

Keeps fuzzy matching and ranking local to registry search selection.

**Tests** — 1 file · `+11 / -2`

Covers partial query matches and ranking alongside existing registry-search coverage.
