### PR TITLE
fix(eve): install addressed registry items directly

### DIFF
--- a/.changeset/direct-add-address.md
+++ b/.changeset/direct-add-address.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Make `/add <item>` confirm and install the requested registry address directly instead of expanding it into planner selections.

--- a/.changeset/scoped-registry-cancellation.md
+++ b/.changeset/scoped-registry-cancellation.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Cancel only the active registry item when setup is interrupted, then report installed, failed, and cancelled selections in order.

--- a/docs/guides/dev-tui.md
+++ b/docs/guides/dev-tui.md
@@ -13,22 +13,22 @@ The transcript remains in your terminal scrollback after you exit. Run `/help` i
 
 ## Commands
 
-| Command       | Description                                                                                                                                           |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `/model`      | Configure the model and its provider. Pass a model ID to set it directly: `/model provider/model-id`.                                                 |
-| `/add`        | Select and install channels, MCP connections, extensions, and observability integrations. Pass an item address to preselect it: `/add channel/slack`. |
-| `/deploy`     | Deploy the agent to Vercel production. Links the directory first if needed.                                                                           |
-| `/vc:install` | Install the Vercel CLI.                                                                                                                               |
-| `/vc:login`   | Log in to Vercel or restore access to a remote deployment.                                                                                            |
-| `/info`       | Show the resolved application, compiled artifacts, discovery diagnostics, and messaging routes.                                                       |
-| `/loglevel`   | Choose which server and agent logs appear in the transcript.                                                                                          |
-| `/traces`     | Open the local trace viewer. Pass a trace ID prefix to open a specific trace.                                                                         |
-| `/reset`      | Start a fresh session.                                                                                                                                |
-| `/cancel`     | Cancel the current turn without discarding settled context.                                                                                           |
-| `/clear`      | Clear the session's model-message history. `/new` is an alias.                                                                                        |
-| `/compact`    | Compact the current session's context.                                                                                                                |
-| `/exit`       | Quit the UI.                                                                                                                                          |
-| `/help`       | List available commands.                                                                                                                              |
+| Command       | Description                                                                                                                                                              |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `/model`      | Configure the model and its provider. Pass a model ID to set it directly: `/model provider/model-id`.                                                                    |
+| `/add`        | Select and install channels, MCP connections, extensions, and observability integrations. Pass an item address to confirm and install it directly: `/add channel/slack`. |
+| `/deploy`     | Deploy the agent to Vercel production. Links the directory first if needed.                                                                                              |
+| `/vc:install` | Install the Vercel CLI.                                                                                                                                                  |
+| `/vc:login`   | Log in to Vercel or restore access to a remote deployment.                                                                                                               |
+| `/info`       | Show the resolved application, compiled artifacts, discovery diagnostics, and messaging routes.                                                                          |
+| `/loglevel`   | Choose which server and agent logs appear in the transcript.                                                                                                             |
+| `/traces`     | Open the local trace viewer. Pass a trace ID prefix to open a specific trace.                                                                                            |
+| `/reset`      | Start a fresh session.                                                                                                                                                   |
+| `/cancel`     | Cancel the current turn without discarding settled context.                                                                                                              |
+| `/clear`      | Clear the session's model-message history. `/new` is an alias.                                                                                                           |
+| `/compact`    | Compact the current session's context.                                                                                                                                   |
+| `/exit`       | Quit the UI.                                                                                                                                                             |
+| `/help`       | List available commands.                                                                                                                                                 |
 
 `/model`, `/add`, `/deploy`, `/info`, and `/traces` are available when `eve dev` runs locally. They are unavailable when the UI connects to a server with `--url`.
 
@@ -40,11 +40,11 @@ Model and Vercel changes take effect when you complete the Model step. Channel a
 
 ## Add an integration
 
-Bare `/add` opens the standalone planner on **Integrations**. It does not include model configuration. `/add <item>` preselects the requested item and opens **Review**. The progress rail shows selection counts as you move between **Channels**, **Integrations**, and **Review**.
+Bare `/add` opens the standalone planner on **Integrations**. It does not include model configuration. The progress rail shows selection counts as you move between **Channels**, **Integrations**, and **Review**.
 
 Press `Right Arrow` or `Enter` to preserve the current selections and continue. Press `Left Arrow` to preserve them and go back, or `Esc` to cancel. Installation still requires `Enter` on **Install and set up** from Review. During installation, `Esc` cancels only the active item and continues with the remaining selections. The final summary reports installed, cancelled, and failed items separately.
 
-Pass an official item address — `<category>/<name>`, where category is `channel`, `connection`, `extension`, or `instrumentation` — to preselect it in the planner. Product presets and configured registry addresses are also supported:
+Pass an item address to `/add` to confirm and install that exact address without opening the planner:
 
 ```text
 /add channel/slack
@@ -53,7 +53,7 @@ Pass an official item address — `<category>/<name>`, where category is `channe
 /add @acme/analytics
 ```
 
-Product presets expand into their individual channels and integrations on Review. The UI installs selected items in order and offers deployment once after the batch when an installed item requires it.
+The UI installs planner selections in order and offers deployment once after the batch when an installed item requires it.
 
 ## Work with the agent
 

--- a/docs/guides/dev-tui.md
+++ b/docs/guides/dev-tui.md
@@ -42,7 +42,7 @@ Model and Vercel changes take effect when you complete the Model step. Channel a
 
 Bare `/add` opens the standalone planner on **Integrations**. It does not include model configuration. `/add <item>` preselects the requested item and opens **Review**. The progress rail shows selection counts as you move between **Channels**, **Integrations**, and **Review**.
 
-Press `Right Arrow` or `Enter` to preserve the current selections and continue. Press `Left Arrow` to preserve them and go back, or `Esc` to cancel. Installation still requires `Enter` on **Install and set up** from Review.
+Press `Right Arrow` or `Enter` to preserve the current selections and continue. Press `Left Arrow` to preserve them and go back, or `Esc` to cancel. Installation still requires `Enter` on **Install and set up** from Review. During installation, `Esc` cancels only the active item and continues with the remaining selections. The final summary reports installed, cancelled, and failed items separately.
 
 Pass an official item address — `<category>/<name>`, where category is `channel`, `connection`, `extension`, or `instrumentation` — to preselect it in the planner. Product presets and configured registry addresses are also supported:
 

--- a/packages/eve/src/cli/commands/init.integration.test.ts
+++ b/packages/eve/src/cli/commands/init.integration.test.ts
@@ -176,8 +176,7 @@ describe("runInitCommand", () => {
       "exec",
       "eve",
       "dev",
-      "--input",
-      "/model",
+      "--onboard",
     ]);
     // Substring assertions keep the expectations color-agnostic; picocolors
     // decides at import time whether the strings carry escape codes. The boot
@@ -370,8 +369,7 @@ describe("runInitCommand", () => {
         "exec",
         "eve",
         "dev",
-        "--input",
-        "/model",
+        "--onboard",
       ]);
       expect(output.messages[1]).toContain("Created an eve agent in ");
       expect(output.messages[1]).toContain(projectPath);
@@ -396,9 +394,9 @@ describe("runInitCommand", () => {
   });
 
   it.each([
-    ["npm", ["exec", "--", "eve", "dev", "--input", "/model"]],
-    ["yarn", ["eve", "dev", "--input", "/model"]],
-    ["bun", ["x", "eve", "dev", "--input", "/model"]],
+    ["npm", ["exec", "--", "eve", "dev", "--onboard"]],
+    ["yarn", ["eve", "dev", "--onboard"]],
+    ["bun", ["x", "eve", "dev", "--onboard"]],
   ] as const)(
     "scaffolds a fresh project owned by the invoking manager %s without package-manager pins",
     async (kind, devArguments) => {
@@ -459,16 +457,15 @@ describe("runInitCommand", () => {
       "x",
       "eve",
       "dev",
-      "--input",
-      "/model",
+      "--onboard",
     ]);
   });
 
   it.each([
-    ["npm", "package-lock.json", "bun", ["exec", "--", "eve", "dev", "--input", "/model"]],
-    ["yarn", "yarn.lock", "npm", ["eve", "dev", "--input", "/model"]],
-    ["bun", "bun.lock", "npm", ["x", "eve", "dev", "--input", "/model"]],
-    ["pnpm", "pnpm-lock.yaml", "npm", ["exec", "eve", "dev", "--input", "/model"]],
+    ["npm", "package-lock.json", "bun", ["exec", "--", "eve", "dev", "--onboard"]],
+    ["yarn", "yarn.lock", "npm", ["eve", "dev", "--onboard"]],
+    ["bun", "bun.lock", "npm", ["x", "eve", "dev", "--onboard"]],
+    ["pnpm", "pnpm-lock.yaml", "npm", ["exec", "eve", "dev", "--onboard"]],
   ] as const)(
     "scaffolds a fresh named project with the ancestor %s lockfile before the launcher",
     async (kind, lockfile, invokingManager, devArguments) => {
@@ -640,8 +637,8 @@ describe("runInitCommand", () => {
   });
 
   it.each([
-    ["yarn", "yarn.lock", ["eve", "dev", "--input", "/model"]],
-    ["bun", "bun.lock", ["x", "eve", "dev", "--input", "/model"]],
+    ["yarn", "yarn.lock", ["eve", "dev", "--onboard"]],
+    ["bun", "bun.lock", ["x", "eve", "dev", "--onboard"]],
   ] as const)(
     "scaffolds a fresh %s workspace member without nested root-only package fields",
     async (kind, lockfile, devArguments) => {
@@ -719,8 +716,7 @@ describe("runInitCommand", () => {
       "--",
       "eve",
       "dev",
-      "--input",
-      "/model",
+      "--onboard",
     ]);
   });
 
@@ -744,8 +740,7 @@ describe("runInitCommand", () => {
       "exec",
       "eve",
       "dev",
-      "--input",
-      "/model",
+      "--onboard",
     ]);
   });
 
@@ -772,8 +767,7 @@ describe("runInitCommand", () => {
       "exec",
       "eve",
       "dev",
-      "--input",
-      "/model",
+      "--onboard",
     ]);
   });
 
@@ -1206,7 +1200,7 @@ describe("runInitCommand", () => {
     expect(deps.spawnPackageManager).toHaveBeenCalledWith(
       "pnpm",
       join(parentDirectory, "my-agent"),
-      ["exec", "eve", "dev", "--input", "/model"],
+      ["exec", "eve", "dev", "--onboard"],
     );
   });
 

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -658,11 +658,8 @@ export async function runInitCommand(
   // existing app may start unrelated processes. Exec-style runs do not echo
   // the command the way run-scripts do, so the handoff line is printed here.
   const freshScaffold = result.kind === "created";
-  const devArguments = freshScaffold
-    ? [...baseDevArguments, "--input", "/model"]
-    : baseDevArguments;
-  logger.log(pc.dim(freshScaffold ? "$ eve dev --input /model" : "$ eve dev"));
-
+  const devArguments = freshScaffold ? [...baseDevArguments, "--onboard"] : baseDevArguments;
+  logger.log(pc.dim("$ eve dev"));
   if (
     !resultSucceeded(
       await dependencies.spawnPackageManager(

--- a/packages/eve/src/cli/dev/command-options.ts
+++ b/packages/eve/src/cli/dev/command-options.ts
@@ -12,6 +12,8 @@ export interface DevelopmentCliOptions {
   header?: DevelopmentRequestHeaders;
   host?: string;
   input?: string;
+  /** Internal fresh-agent handoff from `eve init`. */
+  onboard?: boolean;
   logs?: LogDisplayMode;
   name?: string;
   port?: number;

--- a/packages/eve/src/cli/dev/run-interactive-ui.ts
+++ b/packages/eve/src/cli/dev/run-interactive-ui.ts
@@ -46,6 +46,7 @@ export async function runInteractiveDevelopmentUi(input: {
   const tuiInput: RunDevelopmentTuiInput = {
     target,
     initialInput: input.options.input,
+    onboard: input.options.onboard,
     onBootProgress: input.report,
     lifecycle: input.lifecycle,
     ...display,

--- a/packages/eve/src/cli/dev/tui/blocks.test.ts
+++ b/packages/eve/src/cli/dev/tui/blocks.test.ts
@@ -22,6 +22,22 @@ describe("renderBlockLines", () => {
     expect(lines[0]).toBe("▲ all done");
   });
 
+  it("colors per-item status markers in a mixed command result", () => {
+    const colored = createTheme({ color: true, unicode: true });
+    const lines = renderBlockLines(
+      {
+        kind: "result",
+        body: "Added Web Chat\n\n✓ Web Chat\n  Installed.\n\n⨯ Slack\n  Cancelled.",
+      },
+      80,
+      colored,
+      ctx,
+    );
+
+    expect(lines.join("\n")).toContain(colored.colors.green("✓"));
+    expect(lines.join("\n")).toContain(colored.colors.red("⨯"));
+  });
+
   it("summarizes a completed tool with a result line", () => {
     const lines = render({
       kind: "tool",

--- a/packages/eve/src/cli/dev/tui/blocks.ts
+++ b/packages/eve/src/cli/dev/tui/blocks.ts
@@ -493,8 +493,16 @@ function renderResult(block: Block, width: number, theme: Theme): string[] {
   // SGR 22 closes bold and dim together, so a result that bolds a span (the
   // /model reply's model name) would drop the rest of the line out of dim;
   // re-open dim after each close so the whole line stays quiet.
-  const dim = (line: string): string =>
-    theme.colors.dim(line.replaceAll("\x1b[22m", "\x1b[22m\x1b[2m"));
+  const dim = (line: string): string => {
+    const body = theme.colors.dim(line.replaceAll("\x1b[22m", "\x1b[22m\x1b[2m"));
+    if (line.startsWith(`${theme.glyph.success} `)) {
+      return body.replace(theme.glyph.success, theme.colors.green(theme.glyph.success));
+    }
+    if (line.startsWith(`${theme.glyph.error} `)) {
+      return body.replace(theme.glyph.error, theme.colors.red(theme.glyph.error));
+    }
+    return body;
+  };
   return lines.map((line, index) =>
     index === 0 ? `   ${marker}  ${dim(line)}` : `      ${dim(line)}`,
   );

--- a/packages/eve/src/cli/dev/tui/prompt-command-handler.ts
+++ b/packages/eve/src/cli/dev/tui/prompt-command-handler.ts
@@ -138,7 +138,7 @@ export function createPromptCommandHandler(
         if (context.registryPlannerContext !== undefined) {
           commandInput.registryPlannerContext = context.registryPlannerContext;
         }
-        // `/add <item>` preselects that registry item; bare `/add` starts empty.
+        // `/add <item>` confirms and installs that address; bare `/add` opens the planner.
         if (command.name === "add" && command.argument.length > 0) {
           commandInput.initialRegistryAddress = command.argument;
         }

--- a/packages/eve/src/cli/dev/tui/registry-item-interrupt.ts
+++ b/packages/eve/src/cli/dev/tui/registry-item-interrupt.ts
@@ -1,0 +1,31 @@
+import { WizardCancelledError } from "#setup/step.js";
+
+interface InterruptSource {
+  waitForInterrupt(): { promise: Promise<void>; dispose(): void };
+}
+
+/** Runs one registry item behind an Esc trap that does not abort the surrounding batch. */
+export async function runInterruptibleRegistryItem<T>(input: {
+  parentSignal: AbortSignal;
+  source: InterruptSource;
+  task(signal: AbortSignal): Promise<T>;
+}): Promise<T> {
+  const controller = new AbortController();
+  const signal = AbortSignal.any([input.parentSignal, controller.signal]);
+  const interrupt = input.source.waitForInterrupt();
+  const interrupted = Symbol("item-interrupted");
+  const execution = input.task(signal);
+  try {
+    const result = await Promise.race([execution, interrupt.promise.then(() => interrupted)]);
+    if (result !== interrupted) return result as T;
+    controller.abort(new WizardCancelledError());
+    try {
+      await execution;
+    } catch {
+      // The item cancellation is represented by the wizard error below.
+    }
+    throw new WizardCancelledError();
+  } finally {
+    interrupt.dispose();
+  }
+}

--- a/packages/eve/src/cli/dev/tui/registry-result-message.test.ts
+++ b/packages/eve/src/cli/dev/tui/registry-result-message.test.ts
@@ -23,14 +23,42 @@ describe("formatRegistrySessionResult", () => {
       }),
     ).toBe(
       "Added Web Chat and Photon iMessage\n\n" +
-        "Web Chat\n" +
+        "✓ Web Chat\n" +
         "  Installed.\n\n" +
-        "Photon iMessage\n" +
+        "✓ Photon iMessage\n" +
         "  Agent phone number  +15551234567\n" +
         "  Configured MCP connection.\n\n" +
-        "Couldn't add Slack\n" +
+        "⨯ Slack\n" +
         "  Vercel CLI is not authenticated.\n" +
         "  Run /vc:login, then try again.",
+    );
+  });
+
+  it("reports every installed, cancelled, and failed selection in order", () => {
+    expect(
+      formatRegistrySessionResult({
+        items: [
+          { title: "Web Chat", facts: [], output: [] },
+          { title: "Notion", facts: [], output: [] },
+        ],
+        failures: [{ title: "GitHub", message: "Installation failed." }],
+        outcomes: [
+          { kind: "installed", title: "Web Chat", facts: [], output: [] },
+          { kind: "cancelled", title: "Slack" },
+          { kind: "failed", title: "GitHub", message: "Installation failed." },
+          { kind: "installed", title: "Notion", facts: [], output: [] },
+        ],
+      }),
+    ).toBe(
+      "Added Web Chat and Notion\n\n" +
+        "✓ Web Chat\n" +
+        "  Installed.\n\n" +
+        "⨯ Slack\n" +
+        "  Cancelled.\n\n" +
+        "⨯ GitHub\n" +
+        "  Installation failed.\n\n" +
+        "✓ Notion\n" +
+        "  Installed.",
     );
   });
 });

--- a/packages/eve/src/cli/dev/tui/registry-result-message.ts
+++ b/packages/eve/src/cli/dev/tui/registry-result-message.ts
@@ -19,7 +19,8 @@ export function registryItemProgress(renderer: {
 }
 
 export function registryResultTone(result: RegistrySessionResult): "success" | "error" | undefined {
-  if (result.failures.length > 0) return "error";
+  if (result.failures.length > 0 && result.items.length === 0) return "error";
+  if (result.outcomes?.some((outcome) => outcome.kind === "cancelled")) return undefined;
   return result.items.length > 0 ? "success" : undefined;
 }
 
@@ -33,24 +34,30 @@ function joinedTitles(titles: readonly string[]): string {
 /** Formats structured registry setup results after their temporary panel closes. */
 export function formatRegistrySessionResult(result: RegistrySessionResult): string {
   const lines: string[] = [];
-  if (result.items.length > 0)
+  const outcomes = result.outcomes ?? [
+    ...result.items.map((item) => ({ kind: "installed" as const, ...item })),
+    ...result.failures.map((failure) => ({ kind: "failed" as const, ...failure })),
+  ];
+  if (result.items.length > 0) {
     lines.push(`Added ${joinedTitles(result.items.map((item) => item.title))}`);
-  for (const item of result.items) {
-    lines.push("", item.title);
-    if (item.facts.length === 0 && item.output.length === 0) {
+  }
+  for (const outcome of outcomes) {
+    lines.push("", `${outcome.kind === "installed" ? "✓" : "⨯"} ${outcome.title}`);
+    if (outcome.kind === "cancelled") {
+      lines.push("  Cancelled.");
+      continue;
+    }
+    if (outcome.kind === "failed") {
+      lines.push(...outcome.message.split("\n").map((line) => `  ${line}`));
+      continue;
+    }
+    if (outcome.facts.length === 0 && outcome.output.length === 0) {
       lines.push("  Installed.");
       continue;
     }
-    const width = Math.max(0, ...item.facts.map((fact) => fact.label.length));
-    for (const fact of item.facts) lines.push(`  ${fact.label.padEnd(width)}  ${fact.value}`);
-    for (const output of item.output) lines.push(`  ${output}`);
-  }
-  for (const failure of result.failures) {
-    lines.push(
-      "",
-      `Couldn't add ${failure.title}`,
-      ...failure.message.split("\n").map((line) => `  ${line}`),
-    );
+    const width = Math.max(0, ...outcome.facts.map((fact) => fact.label.length));
+    for (const fact of outcome.facts) lines.push(`  ${fact.label.padEnd(width)}  ${fact.value}`);
+    for (const output of outcome.output) lines.push(`  ${output}`);
   }
   if (result.cancelled === true) {
     lines.push("", "Setup cancelled before the remaining selections were added.");

--- a/packages/eve/src/cli/dev/tui/setup-commands.test.ts
+++ b/packages/eve/src/cli/dev/tui/setup-commands.test.ts
@@ -4,6 +4,7 @@ import { createFakePrompter } from "#internal/testing/fake-prompter.js";
 import { RegistryFlowFailedError } from "#setup/flows/registry.js";
 import type { RegistrySessionResult } from "#setup/flows/registry-session.js";
 import { HumanActionRequiredError } from "#setup/human-action.js";
+import { WizardCancelledError } from "#setup/step.js";
 
 import {
   runTuiSetupCommand,
@@ -436,7 +437,7 @@ describe("runTuiSetupCommand", () => {
       registryResult({
         items: [{ title: "Agent Browser", facts: [], output: [] }],
       }),
-      "Added Agent Browser\n\nAgent Browser\n  Installed.",
+      "Added Agent Browser\n\n✓ Agent Browser\n  Installed.",
     ],
     ["empty", registryResult(), "No integrations selected."],
     ["deployed", registryResult({ deployed: "production" }), "No integrations selected."],
@@ -476,7 +477,7 @@ describe("runTuiSetupCommand", () => {
     });
 
     await expect(run({ command: "add", flows })).resolves.toMatchObject({
-      message: expect.stringContaining("Couldn't add GitHub"),
+      message: expect.stringContaining("⨯ GitHub"),
       preserveFlowDiagnostics: true,
     });
   });
@@ -491,6 +492,46 @@ describe("runTuiSetupCommand", () => {
     expect(flows.runDeployFlow).toHaveBeenCalledWith(
       expect.objectContaining({ interactive: true }),
     );
+  });
+
+  it("limits an installation interrupt to the active registry item", async () => {
+    const renderer = fakePanelRenderer();
+    const flows = fakeFlows({
+      runRegistryFlow: vi.fn<TuiSetupFlows["runRegistryFlow"]>(
+        async ({ initialScreen, runItem }) => {
+          expect(initialScreen).toBe("integrations");
+          await expect(
+            runItem?.(
+              (signal) =>
+                new Promise((_resolve, reject) => {
+                  signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+                }),
+            ),
+          ).rejects.toBeInstanceOf(WizardCancelledError);
+          return registryResult({
+            items: [
+              { title: "Web Chat", facts: [], output: [] },
+              { title: "Notion", facts: [], output: [] },
+            ],
+            outcomes: [
+              { kind: "installed", title: "Web Chat", facts: [], output: [] },
+              { kind: "cancelled", title: "Slack" },
+              { kind: "installed", title: "Notion", facts: [], output: [] },
+            ],
+          });
+        },
+      ),
+    });
+
+    const result = run({ command: "add", flows, renderer });
+    renderer.fireInterrupt();
+
+    await expect(result).resolves.toEqual({
+      message:
+        "Added Web Chat and Notion\n\n✓ Web Chat\n  Installed.\n\n" +
+        "⨯ Slack\n  Cancelled.\n\n✓ Notion\n  Installed.",
+      preserveFlowDiagnostics: true,
+    });
   });
 
   it("preserves model access refreshes when provider setup is interrupted", async () => {

--- a/packages/eve/src/cli/dev/tui/setup-commands.ts
+++ b/packages/eve/src/cli/dev/tui/setup-commands.ts
@@ -17,6 +17,7 @@ import {
 import type { PlannerNavigation, Prompter } from "#setup/prompter.js";
 import { WizardCancelledError } from "#setup/step.js";
 
+import { runInterruptibleRegistryItem } from "./registry-item-interrupt.js";
 import {
   formatRegistrySessionResult,
   registryItemProgress,
@@ -171,6 +172,14 @@ export async function runTuiSetupCommand(
   const prompter = (input.createPrompter ?? createTuiPrompter)(renderer);
 
   const execution = executeSetupCommand(input, prompter, renderer, controller.signal);
+  if (command === "add") {
+    try {
+      return await execution;
+    } finally {
+      input.renderer.setStatus(undefined);
+    }
+  }
+
   const interrupt = input.renderer.waitForInterrupt();
   const INTERRUPTED = Symbol("interrupted");
   try {
@@ -302,6 +311,12 @@ async function executeSetupCommand(
           recoverHumanAction: (error) =>
             recoverVercelHumanAction(error, flows, { appRoot, prompter, signal }),
           onItemStart: registryItemProgress(renderer),
+          runItem: (task) =>
+            runInterruptibleRegistryItem({
+              parentSignal: signal,
+              source: input.renderer,
+              task: (itemSignal) => task(itemSignal),
+            }),
         });
         if (flow.kind === "cancelled") {
           return { message: "/add dismissed.", cancelled: true, preserveFlowDiagnostics: true };
@@ -319,7 +334,7 @@ async function executeSetupCommand(
         const result = flow.result;
         const outcome: TuiSetupCommandResult = {
           message:
-            result.items.length > 0 || result.failures.length > 0
+            result.items.length > 0 || result.failures.length > 0 || result.outcomes !== undefined
               ? formatRegistrySessionResult(result)
               : "No integrations selected.",
           preserveFlowDiagnostics: true,

--- a/packages/eve/src/cli/dev/tui/setup-commands.ts
+++ b/packages/eve/src/cli/dev/tui/setup-commands.ts
@@ -64,7 +64,7 @@ export interface TuiSetupCommandInput {
   modelNavigation?: PlannerNavigation;
   /** First registry planner section for an unaddressed setup flow. */
   initialRegistryScreen?: RegistryPlannerSection;
-  /** Registry address supplied by `/add <item>`, preselected in the batch planner. */
+  /** Registry address supplied by `/add <item>`, confirmed and installed directly. */
   initialRegistryAddress?: string;
   /** Selections restored when an enclosing onboarding journey returns to the planner. */
   initialRegistryAddresses?: readonly string[];

--- a/packages/eve/src/cli/dev/tui/tui.ts
+++ b/packages/eve/src/cli/dev/tui/tui.ts
@@ -34,11 +34,10 @@ export interface RunDevelopmentTuiInput extends TuiDisplayOptions {
   readonly target: DevelopmentTuiTarget;
   /** Additional request headers sent by this TUI client. */
   readonly headers?: Readonly<Record<string, string>>;
-  /**
-   * Text to seed the prompt input with after the UI launches. A bare local
-   * `/model` starts fresh-agent onboarding. Applies to the first prompt only.
-   */
+  /** Text to seed the prompt input with after the UI launches. Applies to the first prompt only. */
   readonly initialInput?: string;
+  /** Explicit fresh-agent onboarding handoff from `eve init`. */
+  readonly onboard?: boolean;
   /** Reports local CLI boot phases. Omitted for remote and programmatic TUI runs. */
   readonly onBootProgress?: DevBootProgressReporter;
   /** Gives setup subprocesses exclusive terminal and development-host ownership. */
@@ -141,6 +140,7 @@ export async function runDevelopmentTui(input: RunDevelopmentTuiInput): Promise<
     target,
     headers,
     initialInput,
+    onboard,
     onBootProgress,
     lifecycle,
     startup,
@@ -187,6 +187,7 @@ export async function runDevelopmentTui(input: RunDevelopmentTuiInput): Promise<
     options.renderer = startup.renderer;
     options.startup = startup;
   }
+  if (onboard !== undefined) options.onboard = onboard;
   if (onBootProgress !== undefined) options.onBootProgress = onBootProgress;
   if (lifecycle !== undefined) options.lifecycle = lifecycle;
   if (withExclusiveTerminal !== undefined) options.withExclusiveTerminal = withExclusiveTerminal;

--- a/packages/eve/src/cli/run.test.ts
+++ b/packages/eve/src/cli/run.test.ts
@@ -418,6 +418,20 @@ describe("eve dev --input", () => {
     ).rejects.toThrow("--input requires the interactive UI");
   });
 
+  it("forwards the internal init onboarding handoff to the local TUI", async () => {
+    const startHost = vi.fn(() => ({
+      start: async () => ({
+        kind: "existing" as const,
+        appRoot: "/canonical/app",
+        url: "http://127.0.0.1:4321/",
+      }),
+      close: async () => {},
+    }));
+    const runDevelopmentTui = await runInteractiveDev(["dev", "--onboard"], { startHost });
+
+    expect(runDevelopmentTui).toHaveBeenCalledWith(expect.objectContaining({ onboard: true }));
+  });
+
   it("rejects the option with explicit --no-ui", async () => {
     await expect(
       runCli(["dev", "--input", "/model", "--no-ui"], {

--- a/packages/eve/src/setup/flows/registry-session.ts
+++ b/packages/eve/src/setup/flows/registry-session.ts
@@ -22,11 +22,18 @@ export interface RegistrySessionItemFailure {
   message: string;
 }
 
+export type RegistrySessionOutcome =
+  | ({ kind: "installed" } & RegistrySessionItemResult)
+  | ({ kind: "failed" } & RegistrySessionItemFailure)
+  | { kind: "cancelled"; title: string };
+
 export interface RegistrySessionResult {
   items: readonly RegistrySessionItemResult[];
   /** Installation failures retained when a user skips an item. */
   failures: readonly RegistrySessionItemFailure[];
-  /** Setup stopped after preserving already-settled item results. */
+  /** Every item outcome in installation order. */
+  outcomes?: readonly RegistrySessionOutcome[];
+  /** Setup stopped outside an individual item after preserving settled results. */
   cancelled?: true;
   deployed?: "production";
 }
@@ -34,6 +41,7 @@ export interface RegistrySessionResult {
 export interface RegistrySession {
   add(title: string, output: readonly string[], setup?: RegistrySetupCompletion): void;
   addFailure(title: string, message: string): void;
+  addCancellation(title: string): void;
   result(deployed?: "production"): RegistrySessionResult;
   continueAfterInstall(input: {
     appRoot: string;
@@ -44,24 +52,36 @@ export interface RegistrySession {
 
 /** Owns the accumulated output and deployment decision for one `/add` session. */
 export function createRegistrySession(deps: RegistrySessionDeps): RegistrySession {
-  const items: RegistrySessionItemResult[] = [];
-  const failures: RegistrySessionItemFailure[] = [];
+  const outcomes: RegistrySessionOutcome[] = [];
   let deploymentRequired = false;
 
   function result(deployed?: "production"): RegistrySessionResult {
+    const items = outcomes.flatMap((outcome) =>
+      outcome.kind === "installed"
+        ? [{ title: outcome.title, facts: outcome.facts, output: outcome.output }]
+        : [],
+    );
+    const failures = outcomes.flatMap((outcome) =>
+      outcome.kind === "failed" ? [{ title: outcome.title, message: outcome.message }] : [],
+    );
     const session: RegistrySessionResult = { items, failures };
+    if (outcomes.some((outcome) => outcome.kind !== "installed")) session.outcomes = outcomes;
     if (deployed !== undefined) session.deployed = deployed;
     return session;
   }
 
   return {
     add(title, itemOutput, setup = { facts: [] }) {
-      items.push({ title, facts: setup.facts, output: itemOutput });
+      outcomes.push({ kind: "installed", title, facts: setup.facts, output: itemOutput });
       deploymentRequired ||= setup.deploymentRequired === true;
     },
 
     addFailure(title, message) {
-      failures.push({ title, message });
+      outcomes.push({ kind: "failed", title, message });
+    },
+
+    addCancellation(title) {
+      outcomes.push({ kind: "cancelled", title });
     },
 
     result,

--- a/packages/eve/src/setup/flows/registry.test.ts
+++ b/packages/eve/src/setup/flows/registry.test.ts
@@ -600,6 +600,68 @@ describe("runRegistryFlow", () => {
     });
   });
 
+  it("continues with later selections after one item is cancelled", async () => {
+    const answers = ["install"];
+    const selections = [["channel/web", "channel/slack"], ["connection/linear"]];
+    const fake = createFakePrompter({
+      single: () => answers.shift()!,
+      multiple: () => selections.shift()!,
+    });
+    const installRegistryItem = vi
+      .fn<RegistryFlowDeps["installRegistryItem"]>()
+      .mockResolvedValueOnce({ output: [] })
+      .mockRejectedValueOnce(new WizardCancelledError())
+      .mockResolvedValueOnce({ output: [] });
+    const flowDeps = deps({ installRegistryItem });
+    flowDeps.browseRegistryCatalog = vi.fn(async () => ({
+      items: [
+        {
+          address: "channel/web",
+          name: "channel/web",
+          title: "Web Chat",
+          source: "Vercel",
+        },
+        {
+          address: "channel/slack",
+          name: "channel/slack",
+          title: "Slack",
+          source: "Vercel",
+        },
+        {
+          address: "connection/linear",
+          name: "connection/linear",
+          title: "Linear",
+          source: "Vercel",
+        },
+      ],
+      total: 3,
+      errors: [],
+    }));
+
+    await expect(
+      runRegistryFlow({
+        appRoot: APP_ROOT,
+        prompter: fake.prompter,
+        deps: flowDeps,
+      }),
+    ).resolves.toMatchObject({
+      kind: "done",
+      result: {
+        items: [
+          expect.objectContaining({ title: "Web Chat" }),
+          expect.objectContaining({ title: "Linear" }),
+        ],
+        outcomes: [
+          { kind: "installed", title: "Web Chat" },
+          { kind: "cancelled", title: "Slack" },
+          { kind: "installed", title: "Linear" },
+        ],
+      },
+    });
+    expect(installRegistryItem).toHaveBeenCalledTimes(3);
+    expect(fake.selectMessages).not.toContain("Couldn't add Slack");
+  });
+
   it("lets structured setup failures reach the command boundary", async () => {
     const answers = ["install"];
     const selections = [["channel/web"], []];

--- a/packages/eve/src/setup/flows/registry.test.ts
+++ b/packages/eve/src/setup/flows/registry.test.ts
@@ -31,7 +31,6 @@ function deps(overrides: Partial<RegistryFlowDeps> = {}): RegistryFlowDeps {
       total: 2,
       errors: [],
     })),
-    getRegistryItemManifest: vi.fn(async (_appRoot, item) => ({ name: item })),
     installRegistryItem: vi.fn(async () => ({ output: [] })),
     detectDeployment: vi.fn(async () => ({ state: "unlinked" as const })),
     runDeployFlow: vi.fn(async () => ({ kind: "deployed" as const })),
@@ -344,7 +343,7 @@ describe("runRegistryFlow", () => {
     ]);
   });
 
-  it("expands an explicitly requested product preset into its reviewable components", async () => {
+  it("confirms and installs an explicitly requested address without opening the planner", async () => {
     const prompts: unknown[] = [];
     const fake = createFakePrompter({
       single: (options) => {
@@ -360,83 +359,21 @@ describe("runRegistryFlow", () => {
       appRoot: APP_ROOT,
       prompter: fake.prompter,
       initialAddress: "linear",
-      deps: deps({
-        browseRegistryCatalog: vi.fn(async () => ({
-          items: [
-            { address: "linear", name: "linear", title: "Linear", source: "Vercel" },
-            {
-              address: "channel/linear-agent",
-              name: "channel/linear-agent",
-              title: "Linear Agent",
-              source: "Vercel",
-            },
-            {
-              address: "connection/linear",
-              name: "connection/linear",
-              title: "Linear",
-              source: "Vercel",
-            },
-          ],
-          total: 3,
-          errors: [],
-        })),
-        getRegistryItemManifest: vi.fn(async () => ({
-          name: "linear",
-          meta: {
-            eve: {
-              components: [{ item: "channel/linear-agent" }, { item: "connection/linear" }],
-            },
-          },
-        })),
-        installRegistryItem,
-      }),
+      deps: deps({ installRegistryItem }),
     });
 
-    expect(prompts[0]).toMatchObject({
-      message: "Review additions",
-      metadata: [
-        { label: "Channels", value: "Linear Agent" },
-        { label: "Integrations", value: "Linear" },
-      ],
-    });
-    expect(installRegistryItem).toHaveBeenNthCalledWith(
-      1,
-      APP_ROOT,
-      "channel/linear-agent",
-      expect.objectContaining({ silent: true }),
-    );
-    expect(installRegistryItem).toHaveBeenNthCalledWith(
-      2,
-      APP_ROOT,
-      "connection/linear",
-      expect.objectContaining({ silent: true }),
-    );
-  });
-
-  it("resolves an explicitly requested external address that is not in the catalog", async () => {
-    const fake = createFakePrompter({
-      single: () => "install",
-      multiple: (options) => options.initialValues ?? [],
-    });
-    const getRegistryItemManifest = vi.fn(async () => ({
-      name: "extension/analytics",
-      title: "Analytics",
-    }));
-    const installRegistryItem = vi.fn<RegistryFlowDeps["installRegistryItem"]>(async () => ({
-      output: [],
-    }));
-
-    await runRegistryFlow({
-      appRoot: APP_ROOT,
-      prompter: fake.prompter,
-      initialAddress: "@acme/analytics",
-      deps: deps({ getRegistryItemManifest, installRegistryItem }),
-    });
-
-    expect(getRegistryItemManifest).toHaveBeenCalledWith(APP_ROOT, "@acme/analytics");
+    expect(prompts).toMatchObject([
+      {
+        message: "Add linear?",
+        options: [
+          { value: "install", label: "Install and set up" },
+          { value: "cancel", label: "Cancel" },
+        ],
+      },
+    ]);
     expect(installRegistryItem).toHaveBeenCalledWith(
       APP_ROOT,
-      "@acme/analytics",
+      "linear",
       expect.objectContaining({ silent: true }),
     );
   });
@@ -470,23 +407,6 @@ describe("runRegistryFlow", () => {
 
     expect(recoverHumanAction).toHaveBeenCalledOnce();
     expect(installRegistryItem).toHaveBeenCalledTimes(2);
-  });
-
-  it("reports an explicitly requested address that cannot be resolved", async () => {
-    const fake = createFakePrompter();
-    const getRegistryItemManifest = vi.fn(async () => {
-      throw new Error('Registry item "channel/slak" was not found.');
-    });
-
-    await expect(
-      runRegistryFlow({
-        appRoot: APP_ROOT,
-        prompter: fake.prompter,
-        initialAddress: "channel/slak",
-        deps: deps({ getRegistryItemManifest }),
-      }),
-    ).rejects.toThrow('Registry item "channel/slak" was not found.');
-    expect(fake.selectMessages).toEqual([]);
   });
 
   it("surfaces registry source failures on the planner", async () => {
@@ -594,7 +514,7 @@ describe("runRegistryFlow", () => {
       }),
     ).resolves.toMatchObject({
       result: {
-        failures: [{ title: "Web Chat", message: expect.stringContaining("WEB_TOKEN") }],
+        failures: [{ title: "web", message: expect.stringContaining("WEB_TOKEN") }],
         cancelled: true,
       },
     });

--- a/packages/eve/src/setup/flows/registry.ts
+++ b/packages/eve/src/setup/flows/registry.ts
@@ -38,7 +38,6 @@ export type RegistryHumanActionRecovery = (
 
 export interface RegistryFlowDeps {
   browseRegistryCatalog: (typeof import("#cli/commands/registry.js"))["browseRegistryCatalog"];
-  getRegistryItemManifest: (typeof import("#cli/commands/registry.js"))["getRegistryItemManifest"];
   installRegistryItem: (typeof import("#cli/commands/registry.js"))["installRegistryItem"];
   detectDeployment: (typeof import("#setup/project-resolution.js"))["detectDeployment"];
   runDeployFlow: (typeof import("./deploy.js"))["runDeployFlow"];
@@ -90,8 +89,6 @@ function isPlannerItem(section: Section, item: Item): boolean {
 }
 
 function orderedSectionItems(section: Section, catalog: readonly Item[]): Item[] {
-  // Product-level presets are installed as one item when explicitly requested;
-  // the bare planner presents their independently installable components.
   const matching = catalog.filter((item) => isPlannerItem(section, item));
   const featured = SECTIONS[section].featured
     .map((name) => matching.find((item) => item.name === name))
@@ -280,82 +277,6 @@ async function editPlan(input: {
   }
 }
 
-function itemSource(address: string): string {
-  if (address.startsWith("@")) return address.split("/")[0] ?? address;
-  if (/^https?:\/\//u.test(address)) {
-    try {
-      return new URL(address).host;
-    } catch {
-      return address;
-    }
-  }
-  return "Vercel";
-}
-
-function manifestRecord(manifest: unknown): Record<string, unknown> {
-  return typeof manifest === "object" && manifest !== null && !Array.isArray(manifest)
-    ? (manifest as Record<string, unknown>)
-    : {};
-}
-
-function manifestComponents(manifest: Record<string, unknown>): string[] {
-  const meta = manifest.meta;
-  if (typeof meta !== "object" || meta === null || Array.isArray(meta)) return [];
-  const eve = (meta as Record<string, unknown>).eve;
-  if (typeof eve !== "object" || eve === null || Array.isArray(eve)) return [];
-  const components = (eve as Record<string, unknown>).components;
-  if (!Array.isArray(components)) return [];
-  return components.flatMap((component) => {
-    if (typeof component !== "object" || component === null || Array.isArray(component)) return [];
-    const item = (component as Record<string, unknown>).item;
-    return typeof item === "string" ? [item] : [];
-  });
-}
-
-async function resolveInitialItems(input: {
-  appRoot: string;
-  address: string;
-  catalog: readonly Item[];
-  prompter: Prompter;
-  getRegistryItemManifest: RegistryFlowDeps["getRegistryItemManifest"];
-}): Promise<Item[]> {
-  const known = input.catalog.find(
-    (item) => item.address === input.address || item.name === input.address,
-  );
-  if (known !== undefined && known.name.includes("/")) return [known];
-
-  const manifest = manifestRecord(
-    await withSpinner(input.prompter, "Loading registry item…", () =>
-      input.getRegistryItemManifest(input.appRoot, input.address),
-    ),
-  );
-  const components = manifestComponents(manifest);
-  if (components.length > 0) {
-    return components.map((address) => {
-      const component = input.catalog.find(
-        (item) => item.address === address || item.name === address,
-      );
-      if (component === undefined) {
-        throw new Error(
-          `Registry package "${input.address}" references unavailable item "${address}".`,
-        );
-      }
-      return component;
-    });
-  }
-  if (known !== undefined) return [known];
-
-  const item: Item = {
-    address: input.address,
-    name: typeof manifest.name === "string" ? manifest.name : input.address,
-    source: itemSource(input.address),
-  };
-  if (typeof manifest.title === "string") item.title = manifest.title;
-  if (typeof manifest.type === "string") item.type = manifest.type;
-  if (typeof manifest.description === "string") item.description = manifest.description;
-  return [item];
-}
-
 async function recoverHumanAction<T>(
   task: () => Promise<T>,
   recover: RegistryHumanActionRecovery | undefined,
@@ -375,7 +296,7 @@ export async function runRegistryFlow(input: {
   appRoot: string;
   prompter: Prompter;
   signal?: AbortSignal;
-  /** Registry item supplied by `/add <item>`, preselected before the planner opens. */
+  /** Registry item supplied by `/add <item>`, confirmed and installed directly. */
   initialAddress?: string;
   /** First screen for an unaddressed flow; onboarding defaults to channels. */
   initialScreen?: RegistryPlannerSection;
@@ -393,69 +314,62 @@ export async function runRegistryFlow(input: {
 > {
   let session: ReturnType<typeof createRegistrySession> | undefined;
   try {
-    const registry =
-      input.deps?.browseRegistryCatalog === undefined ||
-      input.deps?.getRegistryItemManifest === undefined ||
-      input.deps?.installRegistryItem === undefined
-        ? await import("#cli/commands/registry.js")
-        : undefined;
-    const browseRegistryCatalog =
-      input.deps?.browseRegistryCatalog ?? registry!.browseRegistryCatalog;
-    const getRegistryItemManifest =
-      input.deps?.getRegistryItemManifest ?? registry!.getRegistryItemManifest;
-    const installRegistryItem = input.deps?.installRegistryItem ?? registry!.installRegistryItem;
-    const catalogResult = await withSpinner(input.prompter, "Loading registry…", () =>
-      browseRegistryCatalog(input.appRoot),
-    );
-    const catalog = [...catalogResult.items];
-    const selected = new Set<string>(input.initialAddresses);
     const initialAddress = input.initialAddress?.trim();
+    let items: Item[];
     if (initialAddress !== undefined && initialAddress !== "") {
-      const items = await resolveInitialItems({
-        appRoot: input.appRoot,
-        address: initialAddress,
-        catalog,
-        prompter: input.prompter,
-        getRegistryItemManifest,
+      const confirmed = await input.prompter.select({
+        message: `Add ${initialAddress}?`,
+        options: [
+          { value: "install" as const, label: "Install and set up" },
+          { value: "cancel" as const, label: "Cancel" },
+        ],
       });
-      for (const item of items) {
-        if (!catalog.some((candidate) => candidate.address === item.address)) catalog.push(item);
-        selected.add(item.address);
+      if (confirmed === "cancel") return { kind: "cancelled" };
+      items = [{ address: initialAddress, name: initialAddress, source: "Registry" }];
+    } else {
+      const browseRegistryCatalog =
+        input.deps?.browseRegistryCatalog ??
+        (await import("#cli/commands/registry.js")).browseRegistryCatalog;
+      const catalogResult = await withSpinner(input.prompter, "Loading registry…", () =>
+        browseRegistryCatalog(input.appRoot),
+      );
+      const catalog = [...catalogResult.items];
+      const selected = new Set<string>(input.initialAddresses);
+      const notices = catalogResult.errors.map((error) => ({
+        tone: "warning" as const,
+        text: `${error.registry}: ${error.message}`,
+      }));
+      const itemsByAddress = new Map(catalog.map((item) => [item.address, item]));
+      const plan = await editPlan({
+        prompter: input.prompter,
+        catalog,
+        itemsByAddress,
+        selected,
+        notices,
+        initialScreen: input.initialScreen ?? "channels",
+        plannerContext: input.plannerContext,
+      });
+      if (plan === "back-before-channels") {
+        return { kind: "navigate-back", selectedAddresses: [...selected] };
       }
+      if (plan !== "install") return { kind: "cancelled" };
+      items = [...selected].map((address) => {
+        const item = itemsByAddress.get(address);
+        if (item === undefined)
+          throw new Error(`Registry item "${address}" is no longer available.`);
+        return item;
+      });
     }
-    const notices = catalogResult.errors.map((error) => ({
-      tone: "warning" as const,
-      text: `${error.registry}: ${error.message}`,
-    }));
-    const itemsByAddress = new Map(catalog.map((item) => [item.address, item]));
-    const plan = await editPlan({
-      prompter: input.prompter,
-      catalog,
-      itemsByAddress,
-      selected,
-      notices,
-      initialScreen:
-        initialAddress !== undefined && initialAddress !== ""
-          ? "review"
-          : (input.initialScreen ?? "channels"),
-      plannerContext: input.plannerContext,
-    });
-    if (plan === "back-before-channels") {
-      return { kind: "navigate-back", selectedAddresses: [...selected] };
-    }
-    if (plan !== "install") return { kind: "cancelled" };
 
+    const installRegistryItem =
+      input.deps?.installRegistryItem ??
+      (await import("#cli/commands/registry.js")).installRegistryItem;
     const detectDeployment =
       input.deps?.detectDeployment ??
       (await import("#setup/project-resolution.js")).detectDeployment;
     const runDeployFlow = input.deps?.runDeployFlow ?? (await import("./deploy.js")).runDeployFlow;
     session = createRegistrySession({ detectDeployment, runDeployFlow });
     const activeSession = session;
-    const items = [...selected].map((address) => {
-      const item = itemsByAddress.get(address);
-      if (item === undefined) throw new Error(`Registry item "${address}" is no longer available.`);
-      return item;
-    });
     for (const [index, item] of items.entries()) {
       input.signal?.throwIfAborted();
       input.onItemStart?.(item, index, items.length);

--- a/packages/eve/src/setup/flows/registry.ts
+++ b/packages/eve/src/setup/flows/registry.ts
@@ -383,6 +383,8 @@ export async function runRegistryFlow(input: {
   plannerContext?: RegistryPlannerContext;
   recoverHumanAction?: RegistryHumanActionRecovery;
   onItemStart?: (item: Item, index: number, total: number) => void;
+  /** Gives each installation its own cancellation boundary without ending the batch. */
+  runItem?<T>(task: (signal?: AbortSignal) => Promise<T>): Promise<T>;
   deps?: Partial<RegistryFlowDeps>;
 }): Promise<
   | { kind: "done"; result: RegistrySessionResult }
@@ -458,23 +460,26 @@ export async function runRegistryFlow(input: {
       input.signal?.throwIfAborted();
       input.onItemStart?.(item, index, items.length);
       try {
-        const install = () =>
+        const install = (signal = input.signal) =>
           installRegistryItem(input.appRoot, item.address, {
             silent: true,
             prompter: input.prompter,
-            signal: input.signal,
+            signal,
           });
+        const run = () => (input.runItem === undefined ? install() : input.runItem(install));
         const installed = await recoverHumanAction(
-          () => input.prompter.withExclusiveTerminal?.(install) ?? install(),
+          () => input.prompter.withExclusiveTerminal?.(run) ?? run(),
           input.recoverHumanAction,
         );
         if (installed === undefined) throw new WizardCancelledError();
         activeSession.add(label(item), installed.output, installed.setup);
       } catch (error) {
         input.signal?.throwIfAborted();
-        if (error instanceof WizardCancelledError || error instanceof HumanActionRequiredError) {
-          throw error;
+        if (error instanceof WizardCancelledError) {
+          activeSession.addCancellation(label(item));
+          continue;
         }
+        if (error instanceof HumanActionRequiredError) throw error;
         const message = error instanceof Error ? error.message : String(error);
         const failureMessage = message.trim() || "Installation failed.";
         const summary = failureMessage.split("\n").find((line) => line.trim() !== "");
@@ -509,7 +514,8 @@ export async function runRegistryFlow(input: {
   } catch (error) {
     if (error instanceof WizardCancelledError) {
       const settled = session?.result();
-      return settled !== undefined && (settled.items.length > 0 || settled.failures.length > 0)
+      return settled !== undefined &&
+        (settled.items.length > 0 || settled.failures.length > 0 || settled.outcomes !== undefined)
         ? { kind: "done", result: { ...settled, cancelled: true } }
         : { kind: "cancelled" };
     }


### PR DESCRIPTION
### Summary

Follow-up to #2766. `/add <item>` now asks for confirmation and installs the exact requested registry address directly. It no longer loads registry manifests, expands product presets, synthesizes planner entries, or exposes planner navigation for the addressed path.

Bare `/add` and fresh-agent onboarding retain the existing planner behavior.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/setup/flows/registry.test.ts src/cli/dev/tui/setup-commands.test.ts src/cli/dev/tui/runner.test.ts src/cli/dev/tui/prompt-command-handler.test.ts src/cli/dev/tui/registry-result-message.test.ts` (167 passing)
- `pnpm --filter eve typecheck`
- `pnpm docs:check`

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
