### PR TITLE
feat(registry): add Supermemory memory provider

### DIFF
--- a/.changeset/add-supermemory-memory-provider.md
+++ b/.changeset/add-supermemory-memory-provider.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add Supermemory as a memory provider in the official registry. Run `eve add memory/supermemory` to install the provider and create a principal-scoped memory slot.

--- a/apps/docs/app/[lang]/integrations/[slug]/page.tsx
+++ b/apps/docs/app/[lang]/integrations/[slug]/page.tsx
@@ -23,6 +23,7 @@ const typeLabel = {
   connection: "Connection",
   extension: "Extension",
   instrumentation: "Instrumentation",
+  memory: "Memory provider",
 } as const;
 
 const languages = Object.keys(translations);

--- a/apps/docs/app/[lang]/integrations/components/gallery.tsx
+++ b/apps/docs/app/[lang]/integrations/components/gallery.tsx
@@ -23,7 +23,7 @@ const FILTERS: { value: GalleryFilter; label: string }[] = [
   { value: "channel", label: "Channels" },
   { value: "connection", label: "Connections" },
   { value: "extension", label: "Extensions" },
-  { value: "memory", label: "Memory" },
+  { value: "memory", label: "Memory providers" },
   { value: "instrumentation", label: "Observability" },
 ];
 
@@ -33,9 +33,9 @@ const FILTER_DESCRIPTIONS: Record<Exclude<GalleryFilter, "all">, string> = {
   connection:
     "Connections are the tools your agent calls during a run: services reached over MCP or OpenAPI.",
   extension: "Extensions are packages that add reusable tools, skills, connections, and hooks.",
+  memory: "Memory providers store and recall context across sessions through eve-managed scopes.",
   instrumentation:
     "Observability providers are OpenTelemetry backends that receive your agent's traces: every model call, tool execution, and turn.",
-  memory: "Memory integrations let your agent store and recall information across sessions.",
 };
 
 interface GalleryProps {

--- a/apps/docs/app/[lang]/integrations/components/integration-card.tsx
+++ b/apps/docs/app/[lang]/integrations/components/integration-card.tsx
@@ -8,6 +8,7 @@ const typeLabel: Record<Integration["type"], string> = {
   connection: "Connection",
   extension: "Extension",
   instrumentation: "Instrumentation",
+  memory: "Memory provider",
 };
 
 interface IntegrationCardProps {

--- a/apps/docs/app/[lang]/integrations/page.tsx
+++ b/apps/docs/app/[lang]/integrations/page.tsx
@@ -9,7 +9,7 @@ import { Gallery, type GalleryFilter } from "./components/gallery";
 
 const title = "Integrations";
 const description =
-  "Browse the channels, connections, extensions, and instrumentation providers available to an eve agent, each with install, quick start, and configuration steps.";
+  "Browse the channels, connections, extensions, memory providers, and instrumentation providers available to an eve agent, each with install, quick start, and configuration steps.";
 const titleMetadata = pageTitleMetadata(title);
 
 export const metadata: Metadata = {
@@ -55,8 +55,8 @@ const IntegrationsPage = ({ searchParams }: PageProps<"/[lang]/integrations">) =
         <h1 className="text-gray-1000 text-heading-48 sm:text-heading-64">Integrations</h1>
         <p className="mt-5 max-w-2xl text-gray-900 text-lg">
           Add the channels where people reach your agent, connections to external services,
-          extensions that package reusable capabilities, and instrumentation providers that receive
-          traces.
+          extensions that package reusable capabilities, memory providers that retain context across
+          sessions, and instrumentation providers that receive traces.
         </p>
       </section>
       <Suspense fallback={<Gallery filter="all" integrations={integrations} />}>

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -6,6 +6,7 @@ import {
   connectionProtocols as protocolsForIdentity,
   extensionEntries,
   instrumentationEntries,
+  memoryEntries,
 } from "@eve/catalog";
 import type { LogoKey } from "./logos";
 
@@ -18,7 +19,7 @@ import type { LogoKey } from "./logos";
  * keyed by slug.
  */
 
-export type IntegrationType = "channel" | "connection" | "extension" | "instrumentation";
+export type IntegrationType = "channel" | "connection" | "extension" | "instrumentation" | "memory";
 
 /** Wire protocol and transport identity types are owned by the shared catalog. */
 export type { ConnectionProtocol, McpTransport, OpenApiTransport } from "@eve/catalog";
@@ -110,12 +111,15 @@ interface ChannelPresentation extends Presentation {
   configure: string;
 }
 
-/** Extension overlay with hand-authored package setup. */
-interface ExtensionPresentation extends Presentation {
+/** Extension and memory overlays with hand-authored package setup. */
+interface PackagePresentation extends Presentation {
   install: string;
   quickStart: string;
   configure: string;
 }
+
+type ExtensionPresentation = PackagePresentation;
+type MemoryPresentation = PackagePresentation;
 
 /** Connection overlay: presentation plus Connect auth/config details. */
 interface ConnectionPresentation extends Presentation {
@@ -1183,7 +1187,7 @@ See the [Email (Resend) adapter documentation](https://chat-sdk.dev/adapters/ven
     configure: `Verify a sending domain in Resend, set \`RESEND_API_KEY\`, \`RESEND_WEBHOOK_SECRET\`, and \`RESEND_FROM_ADDRESS\`, then point the Resend inbound webhook at \`/eve/v1/resend\`. This is a vendor-official Chat SDK adapter. See the [Chat SDK channel docs](/docs/channels/chat-sdk) for eve session dispatch, state, streaming, and human-in-the-loop behavior.`,
   },
 };
-const extensionPresentations: Record<string, ExtensionPresentation> = {
+const baseExtensionPresentations: Record<string, ExtensionPresentation> = {
   blitzreels: {
     logo: "blitzreels",
     docsHref: "https://www.npmjs.com/package/@blitzreels/eve",
@@ -1627,6 +1631,61 @@ For a self-hosted server, set \`HINDSIGHT_API_URL\` and pass \`apiKey: null\` to
 
 A bank is one isolated memory store, and both files must use the same bank. Do not share the default bank across untrusted users; use separate agent deployments with distinct \`HINDSIGHT_BANK_ID\` values for separate users or tenants. See the [Hindsight eve integration guide](https://hindsight.vectorize.io/sdks/integrations/eve) for Cloud, self-hosted, and factory configuration.`,
   },
+};
+
+const memoryPresentations: Record<string, MemoryPresentation> = {
+  supermemory: {
+    logo: "supermemory",
+    docsHref: "https://github.com/supermemoryai/eve-supermemory#readme",
+    keywords: [
+      "memory",
+      "long-term memory",
+      "semantic search",
+      "rag",
+      "conversation history",
+      "retrieval",
+      "Supermemory",
+    ],
+    install: `Install the Supermemory provider for eve:
+
+\`\`\`bash
+eve add memory/supermemory
+\`\`\`
+
+This installs \`@supermemory/eve\` and writes a memory slot. The provider requires Node.js 24 or later and eve 0.47.3 or later.`,
+    quickStart: `Create a Supermemory API key and add it to the agent's environment:
+
+\`\`\`bash title=".env.local"
+SUPERMEMORY_API_KEY=...
+\`\`\`
+
+The registry creates this memory slot:
+
+\`\`\`ts title="agent/memory/supermemory.ts"
+import supermemory from "@supermemory/eve";
+import { defineMemory } from "eve/memory";
+import { byPrincipal } from "eve/memory/scope";
+
+export default defineMemory({
+  description: "Recall and manage durable context for the current user.",
+  provider: supermemory({
+    apiKey: process.env.SUPERMEMORY_API_KEY!,
+  }),
+  scope: byPrincipal,
+});
+\`\`\`
+
+The filename creates the \`supermemory\` memory slot, so the provider's tools are named \`supermemory__search\`, \`supermemory__remember\`, and \`supermemory__forget\`. The provider uses eve's locked scope key to partition all reads and writes.`,
+    configure: `\`byPrincipal\` keeps memory disabled for anonymous and runtime principals, and shares the local-development scope while you run \`eve dev\`. For a multi-tenant agent, replace it with a scope resolver that derives both tenant and caller identity from verified session context. See [Multi-tenant memory](/docs/patterns/multi-tenant-memory).
+
+Supermemory automatically recalls relevant context before a turn and captures completed turns. It also provides tools to search, read sessions and documents, remember context, extract files, URLs, or text, and forget memories. The provider sends stored conversations and extracted sources to Supermemory; configure its retention and data handling for your application before enabling it for sensitive data.
+
+Keep \`SUPERMEMORY_API_KEY\` in the environment rather than prompts or source control. You can change the container-tag prefix, automatic search, capture policy, and profile-context time zone through \`supermemory(...)\`. See the [Supermemory eve provider documentation](https://github.com/supermemoryai/eve-supermemory#readme) for all options and tool behavior.`,
+  },
+};
+
+const extensionPresentations: Record<string, ExtensionPresentation> = {
+  ...baseExtensionPresentations,
   "agent-browser": {
     logo: "agent-browser",
     docsHref:
@@ -2412,6 +2471,27 @@ function buildExtension(entry: IntegrationEntry): Integration {
   };
 }
 
+function buildMemory(entry: IntegrationEntry): Integration {
+  const presentation = memoryPresentations[entry.slug];
+  if (presentation === undefined) {
+    throw new Error(
+      `Memory provider "${entry.slug}" is in the catalog gallery but has no docs presentation.`,
+    );
+  }
+  return {
+    slug: entry.slug,
+    name: entry.name,
+    type: "memory",
+    tagline: entry.tagline,
+    logo: presentation.logo,
+    docsHref: presentation.docsHref,
+    keywords: presentation.keywords,
+    install: presentation.install,
+    quickStart: presentation.quickStart,
+    configure: presentation.configure,
+  };
+}
+
 function buildInstrumentation(entry: IntegrationEntry): Integration {
   const presentation = instrumentationPresentations[entry.slug];
   if (presentation === undefined) {
@@ -2445,6 +2525,10 @@ const extensions: Integration[] = extensionEntries()
   .filter((entry) => entry.surfaces.gallery)
   .map(buildExtension);
 
+const memory: Integration[] = memoryEntries()
+  .filter((entry) => entry.surfaces.gallery)
+  .map(buildMemory);
+
 const instrumentation: Integration[] = instrumentationEntries()
   .filter((entry) => entry.surfaces.gallery)
   .map(buildInstrumentation);
@@ -2472,6 +2556,7 @@ export const authModeLabel: Record<AuthMode, string> = {
 export const integrations: Integration[] = [
   ...channels,
   ...extensions,
+  ...memory,
   ...connections,
   ...instrumentation,
 ];

--- a/apps/docs/lib/integrations/discovery.test.ts
+++ b/apps/docs/lib/integrations/discovery.test.ts
@@ -123,6 +123,18 @@ describe("integration discovery", () => {
     expect(integrationSearchText(arcana!)).toContain("long-term memory");
   });
 
+  it("renders the Supermemory provider setup", () => {
+    const supermemory = getIntegration("supermemory");
+    expect(supermemory).toBeDefined();
+
+    const markdown = integrationMarkdown(supermemory!);
+    expect(markdown).toContain("eve add memory/supermemory");
+    expect(markdown).toContain('import supermemory from "@supermemory/eve"');
+    expect(markdown).toContain("SUPERMEMORY_API_KEY");
+    expect(markdown).toContain("supermemory__search");
+    expect(integrationSearchText(supermemory!)).toContain("Memory provider");
+  });
+
   it("renders the Hindsight memory extension setup", () => {
     const hindsight = getIntegration("hindsight");
     expect(hindsight).toBeDefined();

--- a/apps/docs/lib/integrations/discovery.ts
+++ b/apps/docs/lib/integrations/discovery.ts
@@ -10,6 +10,7 @@ const typeLabel: Record<Integration["type"], string> = {
   connection: "Connection",
   extension: "Extension",
   instrumentation: "Instrumentation",
+  memory: "Memory provider",
 };
 
 const section = (title: string, content: string): string => `## ${title}\n\n${content}`;
@@ -57,7 +58,7 @@ export const integrationMarkdown = (integration: Integration): string => {
 /** Markdown landing page for agent-readable integration discovery. */
 export const integrationsIndexMarkdown = (): string =>
   [
-    "Browse every third-party service eve connects to, including extensions, messaging channels, and tool connections over MCP or OpenAPI.",
+    "Browse eve integrations, including extensions, messaging channels, memory providers, and tool connections over MCP or OpenAPI.",
     ...integrations.map(
       (integration) =>
         `- [${integration.name}](/integrations/${integration.slug}): ${integration.tagline}`,

--- a/apps/docs/lib/integrations/logos.tsx
+++ b/apps/docs/lib/integrations/logos.tsx
@@ -229,6 +229,16 @@ export const arcanaLogo = (props: LogoProps) => (
   </svg>
 );
 
+export const supermemoryLogo = (props: LogoProps) => (
+  <svg fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <rect width="24" height="24" rx="6" fill="#161616" />
+    <path
+      d="M16.8 7.4c-.9-.8-2.1-1.3-3.6-1.3-2.4 0-4.1 1.2-4.1 3.1 0 1.8 1.5 2.4 3.7 2.9 1.5.3 2.1.6 2.1 1.2 0 .7-.7 1.1-1.8 1.1-1.2 0-2.4-.5-3.4-1.4l-1.6 1.8c1.2 1.2 2.9 1.8 4.9 1.8 2.8 0 4.6-1.3 4.6-3.3 0-1.9-1.4-2.6-3.9-3.1-1.4-.3-2-.6-2-1.1 0-.6.6-1 1.5-1 1 0 2 .4 2.8 1.1l1.8-1.8Z"
+      fill="white"
+    />
+  </svg>
+);
+
 export const hindsightLogo = (props: LogoProps) => (
   <svg fill="none" viewBox="0 0 186 139" xmlns="http://www.w3.org/2000/svg" {...props}>
     <g stroke="#078BC2" strokeLinecap="round" strokeLinejoin="round" strokeWidth="8">
@@ -749,6 +759,7 @@ export const logos = {
   kernel: kernelLogo,
   upstash: upstashLogo,
   arcana: arcanaLogo,
+  supermemory: supermemoryLogo,
   hindsight: hindsightLogo,
   airtable: airtableLogo,
   bitly: bitlyLogo,

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -13,11 +13,12 @@
     "test:unit": "vitest run --config vitest.config.ts",
     "render:eve-5": "NODE_OPTIONS=--loader=./scripts/wgsl-node-loader.mjs tsx scripts/render-eve-5.ts",
     "registry:build": "tsx scripts/prepare-registry-output.ts && shadcn build",
-    "registry:check": "node --test ../../scripts/materialize-registry-release-requirements.test.mjs ../../scripts/validate-public-registry-requirements.test.mjs && node ../../scripts/validate-public-registry-requirements.mjs && pnpm run registry:build && pnpm run registry:validate && pnpm run registry:validate:channels && pnpm run registry:validate:instrumentation && tsc --project registry/tsconfig.json",
+    "registry:check": "node --test ../../scripts/materialize-registry-release-requirements.test.mjs ../../scripts/validate-public-registry-requirements.test.mjs && node ../../scripts/validate-public-registry-requirements.mjs && pnpm run registry:build && pnpm run registry:validate && pnpm run registry:validate:channels && pnpm run registry:validate:instrumentation && pnpm run registry:validate:memory && tsc --project registry/tsconfig.json",
     "registry:validate": "tsx scripts/validate-connection-registry.ts",
     "registry:validate:channels": "tsx scripts/validate-channel-registry.ts",
     "registry:validate:instrumentation": "tsx scripts/validate-instrumentation-registry.ts",
-    "templates:sync": "tsx scripts/sync-templates.ts"
+    "templates:sync": "tsx scripts/sync-templates.ts",
+    "registry:validate:memory": "tsx scripts/validate-memory-registry.ts"
   },
   "dependencies": {
     "@eve/catalog": "workspace:*",
@@ -73,6 +74,7 @@
     "@opentelemetry/sdk-trace-base": "catalog:",
     "@posthog/ai": "7.19.6",
     "@resend/chat-sdk-adapter": "0.2.2",
+    "@supermemory/eve": "0.1.0",
     "@tailwindcss/postcss": "4.3.0",
     "@types/mdx": "2.0.13",
     "@types/node": "catalog:",

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -171,6 +171,28 @@
       ]
     },
     {
+      "name": "memory/supermemory",
+      "type": "registry:item",
+      "title": "Supermemory",
+      "description": "Recall relevant context, capture completed turns, and manage durable memory.",
+      "dependencies": ["@supermemory/eve"],
+      "envVars": {
+        "SUPERMEMORY_API_KEY": ""
+      },
+      "meta": {
+        "eve": {
+          "requires": ">=0.47.3"
+        }
+      },
+      "files": [
+        {
+          "path": "registry/memory/supermemory.ts",
+          "type": "registry:file",
+          "target": "agent/memory/supermemory.ts"
+        }
+      ]
+    },
+    {
       "name": "extension/arcana",
       "type": "registry:item",
       "title": "Kybernesis Arcana",

--- a/apps/docs/registry/memory/supermemory.ts
+++ b/apps/docs/registry/memory/supermemory.ts
@@ -1,0 +1,11 @@
+import supermemory from "@supermemory/eve";
+import { defineMemory } from "eve/memory";
+import { byPrincipal } from "eve/memory/scope";
+
+export default defineMemory({
+  description: "Recall and manage durable context for the current user.",
+  provider: supermemory({
+    apiKey: process.env.SUPERMEMORY_API_KEY!,
+  }),
+  scope: byPrincipal,
+});

--- a/apps/docs/registry/tsconfig.json
+++ b/apps/docs/registry/tsconfig.json
@@ -8,7 +8,8 @@
     "channels/**/*.ts",
     "connections/**/*.ts",
     "extensions/**/*.ts",
-    "instrumentation/**/*.ts"
+    "instrumentation/**/*.ts",
+    "memory/**/*.ts"
   ],
   "exclude": ["node_modules"]
 }

--- a/apps/docs/scripts/validate-memory-registry.ts
+++ b/apps/docs/scripts/validate-memory-registry.ts
@@ -1,0 +1,59 @@
+import { access, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { memoryEntries } from "@eve/catalog";
+
+interface RegistryFile {
+  path: string;
+  target?: string;
+}
+
+interface RegistryItem {
+  name: string;
+  dependencies?: string[];
+  envVars?: Record<string, string>;
+  files?: RegistryFile[];
+}
+
+interface Registry {
+  items: RegistryItem[];
+}
+
+const docsRoot = join(import.meta.dirname, "..");
+const registry = JSON.parse(await readFile(join(docsRoot, "registry.json"), "utf8")) as Registry;
+const items = registry.items.filter((item) => item.name.startsWith("memory/"));
+const expectedSlugs = memoryEntries()
+  .filter((entry) => entry.surfaces.registry)
+  .map((entry) => entry.slug);
+const actualSlugs = items.map((item) => item.name.slice("memory/".length));
+
+if (JSON.stringify(actualSlugs) !== JSON.stringify(expectedSlugs)) {
+  throw new Error(
+    `Memory registry entries do not match the catalog.\nExpected: ${expectedSlugs.join(", ")}\nActual: ${actualSlugs.join(", ")}`,
+  );
+}
+
+for (const item of items) {
+  const slug = item.name.slice("memory/".length);
+  const expectedPath = `registry/memory/${slug}.ts`;
+  const expectedTarget = `agent/memory/${slug}.ts`;
+  const file = item.files?.[0];
+
+  if (item.files?.length !== 1 || file?.path !== expectedPath || file.target !== expectedTarget) {
+    throw new Error(
+      `Registry item "${item.name}" must write ${expectedPath} to ${expectedTarget}.`,
+    );
+  }
+  await access(join(docsRoot, expectedPath));
+
+  if (slug === "supermemory") {
+    if (!item.dependencies?.includes("@supermemory/eve")) {
+      throw new Error('Registry item "memory/supermemory" must depend on @supermemory/eve.');
+    }
+    if (!("SUPERMEMORY_API_KEY" in (item.envVars ?? {}))) {
+      throw new Error(
+        'Registry item "memory/supermemory" must declare SUPERMEMORY_API_KEY as an environment variable.',
+      );
+    }
+  }
+}

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -29,12 +29,15 @@ recall and maintain memory:
 | Provider        | Status         | Use it for                                                                |
 | --------------- | -------------- | ------------------------------------------------------------------------- |
 | `fileMemory()`  | Built into eve | A bounded, model-maintained list of durable facts and preferences         |
-| Supermemory     | Coming soon    | The first third-party implementation of the eve provider contract         |
+| Supermemory     | Third-party    | Semantic recall, automatic capture, source extraction, and memory tools   |
 | Custom provider | Supported      | Application-specific retrieval, capture, retention, or model-facing tools |
 
-Supermemory is building the first third-party provider for eve. It is not
-available yet; until it is released, use `fileMemory()` or implement the
-provider contract described below.
+[Supermemory](https://github.com/supermemoryai/eve-supermemory#readme) is a
+third-party provider that recalls relevant context before each turn, captures
+completed turns, and supplies search, memory-management, and source-extraction
+tools. Add it with `eve add memory/supermemory`. It requires a Supermemory API
+key and a memory scope you choose; review its retention and data handling before
+sending sensitive content to the service.
 
 ## Use file memory
 

--- a/packages/eve-catalog/src/index.test.ts
+++ b/packages/eve-catalog/src/index.test.ts
@@ -8,6 +8,7 @@ import {
   extensionEntries,
   getIntegrationEntry,
   instrumentationEntries,
+  memoryEntries,
 } from "./index.js";
 
 describe("integration catalog", () => {
@@ -21,7 +22,8 @@ describe("integration catalog", () => {
       channelEntries().length +
         connectionEntries().length +
         extensionEntries().length +
-        instrumentationEntries().length,
+        instrumentationEntries().length +
+        memoryEntries().length,
     ).toBe(INTEGRATIONS.length);
   });
 
@@ -54,6 +56,13 @@ describe("integration catalog", () => {
   it("keeps instrumentation providers free of connection identity", () => {
     expect(instrumentationEntries().length).toBeGreaterThan(0);
     for (const entry of instrumentationEntries()) {
+      expect(entry.connection).toBeUndefined();
+    }
+  });
+
+  it("keeps memory providers free of connection identity", () => {
+    expect(memoryEntries().length).toBeGreaterThan(0);
+    for (const entry of memoryEntries()) {
       expect(entry.connection).toBeUndefined();
     }
   });
@@ -114,6 +123,11 @@ describe("integration catalog", () => {
   it("exposes Hindsight as an extension", () => {
     expect(getIntegrationEntry("hindsight")?.kind).toBe("extension");
     expect(getIntegrationEntry("hindsight")?.connection).toBeUndefined();
+  });
+
+  it("exposes Supermemory as a memory provider", () => {
+    expect(getIntegrationEntry("supermemory")?.kind).toBe("memory");
+    expect(getIntegrationEntry("supermemory")?.connection).toBeUndefined();
   });
 
   it("exposes Buzz as a gallery-only channel", () => {

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -19,7 +19,7 @@
  */
 
 /** Surface an integration targets. Extend as new kinds are catalogued. */
-export type IntegrationKind = "channel" | "connection" | "extension" | "instrumentation";
+export type IntegrationKind = "channel" | "connection" | "extension" | "instrumentation" | "memory";
 
 /** Wire protocol a connection speaks at runtime. */
 export type ConnectionProtocol = "mcp" | "openapi";
@@ -324,6 +324,13 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     name: "Upstash AgentKit",
     kind: "extension",
     tagline: "Add long-term memory, Redis Search, and durable chat history with Upstash Redis.",
+    surfaces: { scaffoldable: false, registry: true, gallery: true },
+  },
+  {
+    slug: "supermemory",
+    name: "Supermemory",
+    kind: "memory",
+    tagline: "Recall relevant context, capture completed turns, and manage durable memory.",
     surfaces: { scaffoldable: false, registry: true, gallery: true },
   },
   {
@@ -927,4 +934,9 @@ export function extensionEntries(): IntegrationEntry[] {
 /** All instrumentation entries, in catalog order. */
 export function instrumentationEntries(): IntegrationEntry[] {
   return integrationsByKind("instrumentation");
+}
+
+/** All memory provider entries, in catalog order. */
+export function memoryEntries(): IntegrationEntry[] {
+  return integrationsByKind("memory");
 }

--- a/packages/eve/src/setup/flows/registry.test.ts
+++ b/packages/eve/src/setup/flows/registry.test.ts
@@ -90,6 +90,11 @@ describe("runRegistryFlow", () => {
           hint: "Add browser automation, memory, and developer tools",
         }),
         expect.objectContaining({
+          value: "category:memory",
+          label: "Memory providers",
+          hint: "Retain and recall scoped context across sessions",
+        }),
+        expect.objectContaining({
           value: "category:instrumentation",
           label: "Observability",
           hint: "Trace, evaluate, and monitor your agent",
@@ -121,6 +126,41 @@ describe("runRegistryFlow", () => {
         { value: "add", label: "Add to project" },
         { value: "back", label: "Back" },
       ],
+    });
+  });
+
+  it("browses memory providers", async () => {
+    const answers = ["category:memory", "action:back", "action:done"];
+    const prompts: unknown[] = [];
+    const fake = createFakePrompter({
+      single: (options) => {
+        prompts.push(options);
+        return answers.shift()!;
+      },
+    });
+    const flowDeps = deps({
+      browseRegistryCatalog: vi.fn(async () => ({
+        items: [
+          {
+            address: "memory/supermemory",
+            name: "memory/supermemory",
+            type: "registry:item",
+            description: "Durable memory",
+            source: "Vercel",
+          },
+        ],
+        total: 1,
+        errors: [],
+      })),
+    });
+
+    await runRegistryFlow({ appRoot: APP_ROOT, prompter: fake.prompter, deps: flowDeps });
+
+    expect(prompts[1]).toMatchObject({
+      message: "Browse memory providers",
+      options: expect.arrayContaining([
+        expect.objectContaining({ label: "Supermemory", hint: "Durable memory" }),
+      ]),
     });
   });
 

--- a/packages/eve/src/setup/flows/registry.ts
+++ b/packages/eve/src/setup/flows/registry.ts
@@ -21,7 +21,7 @@ const DONE = "action:done";
 const ALL = "category:all";
 
 type RegistryRow = string;
-type RegistryCategory = "channel" | "connection" | "extension" | "instrumentation";
+type RegistryCategory = "channel" | "connection" | "extension" | "instrumentation" | "memory";
 
 const REGISTRY_CATEGORIES: ReadonlyArray<{
   value: `category:${RegistryCategory}`;
@@ -50,6 +50,13 @@ const REGISTRY_CATEGORIES: ReadonlyArray<{
     label: "Extensions",
     hint: "Add browser automation, memory, and developer tools",
     browseLabel: "Browse extensions",
+  },
+  {
+    value: "category:memory",
+    prefix: "memory/",
+    label: "Memory providers",
+    hint: "Retain and recall scoped context across sessions",
+    browseLabel: "Browse memory providers",
   },
   {
     value: "category:instrumentation",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,6 +326,9 @@ importers:
       '@resend/chat-sdk-adapter':
         specifier: 0.2.2
         version: 0.2.2(@chat-adapter/shared@4.34.0(ai@7.0.79(zod@4.4.3))(supports-color@10.2.2)(zod@4.4.3))(@react-email/render@2.1.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(bufferutil@4.1.0)(chat@4.34.0(ai@7.0.79(zod@4.4.3))(supports-color@10.2.2)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@10.2.2)
+      '@supermemory/eve':
+        specifier: 0.1.0
+        version: 0.1.0(eve@packages+eve)
       '@tailwindcss/postcss':
         specifier: 4.3.0
         version: 4.3.0
@@ -6943,6 +6946,12 @@ packages:
     resolution: {integrity: sha512-i7HTNuDgZWb+VdrNVOam9gQhIc5MSSDXKWXgbUrn/4vSRaSMM+Rtl10MQj4wLWPNpF7p80waJsAqFP8HZfb0Jg==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
+
+  '@supermemory/eve@0.1.0':
+    resolution: {integrity: sha512-aIQf+DXHbOCii7/m2NI0rpWMq4q/eKlpfqDL+hB+PA/yUQX+ZqrrgpONLXoMf1+VFofvoVQsto/V1EsEwBp2/w==}
+    engines: {node: '>=24'}
+    peerDependencies:
+      eve: ^0.47.3
 
   '@superradcompany/microsandbox-darwin-arm64@0.5.5':
     resolution: {integrity: sha512-Yy7b2Ak+/WT+Ho3yRrcKclSl+hNVwcEAqtrWFLIQoGIjSCYEsL30r9S21zKFgd7z5o/FMdaGt/sNqWsV47Ar5g==}
@@ -14592,6 +14601,10 @@ packages:
   super-media-element@1.4.2:
     resolution: {integrity: sha512-9pP/CVNp4NF2MNlRzLwQkjiTgKKe9WYXrLh9+8QokWmMxz+zt2mf1utkWLco26IuA3AfVcTb//qtlTIjY3VHxA==}
 
+  supermemory@4.25.4:
+    resolution: {integrity: sha512-97ME3rlmu7OmsXJTb9OgXOD+3VUv4Wej0ZX9xezG+LKkMwrzi4xeeAZaOJFcr0oI/QQjcHG2WOzm+und1e7MFA==}
+    hasBin: true
+
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
@@ -21488,6 +21501,12 @@ snapshots:
     dependencies:
       react: 19.2.6
       shiki: 3.23.0
+
+  '@supermemory/eve@0.1.0(eve@packages+eve)':
+    dependencies:
+      eve: link:packages/eve
+      supermemory: 4.25.4
+      zod: 4.4.3
 
   '@superradcompany/microsandbox-darwin-arm64@0.5.5':
     optional: true
@@ -31819,6 +31838,8 @@ snapshots:
   stylis@4.4.0: {}
 
   super-media-element@1.4.2: {}
+
+  supermemory@4.25.4: {}
 
   supports-color@10.2.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -66,6 +66,7 @@ minimumReleaseAge: 2880 # 2 days
 minimumReleaseAgeExclude:
   - "@linqapp/chat-sdk-adapter"
   - "@linqapp/sdk"
+  - "@supermemory/eve"
   - "@vercel/*"
   - "@workflow/*"
   - nitro


### PR DESCRIPTION
### Summary

Add Supermemory as the first official `memory` registry item. `eve add memory/supermemory` installs the published provider, declares `SUPERMEMORY_API_KEY`, and writes a principal-scoped `agent/memory/supermemory.ts` slot.

The integration catalog, docs gallery, crawler-facing integration pages, and interactive `/add` browser now distinguish memory providers from extensions. Existing memory-capable extensions remain extensions.

### Validation

Confirmed the upstream `@supermemory/eve@0.1.0` package builds, typechecks, lints, and packs; verified the registry source, generated registry artifact, documentation snippets, focused catalog and registry-flow coverage, docs tests, workspace typecheck, and lint. `pnpm guard:invariants` remains blocked by 12 existing benchmark-transcript violations on `main`, outside this diff.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+12 / -4`

Updates the memory guide now that the provider is published and adds the required release-note entry.

**Implementation** — 16 files · `+250 / -15`

Adds the provider kind, official registry item, principal-scoped mount, validation, gallery presentation, and pinned reviewed dependency needed for installation and discovery.

**Tests** — 3 files · `+67 / -1`

Covers catalog partitioning, the Memory providers registry category, and generated integration discovery content.
