### PR TITLE
fix: speed up workspace installs

### DIFF
--- a/.changeset/quick-installs-rest.md
+++ b/.changeset/quick-installs-rest.md
@@ -1,5 +1,0 @@
----
-"@eve/self-modification": patch
----
-
-Build the self-modification extension when packing it for publication instead of rebuilding it during every workspace install.

--- a/.changeset/quick-installs-rest.md
+++ b/.changeset/quick-installs-rest.md
@@ -1,0 +1,5 @@
+---
+"@eve/self-modification": patch
+---
+
+Build the self-modification extension when packing it for publication instead of rebuilding it during every workspace install.

--- a/package.json
+++ b/package.json
@@ -4,12 +4,6 @@
   "private": true,
   "description": "Monorepo for eve, a filesystem-first framework for durable backend agents on Vercel.",
   "homepage": "https://eve.dev/",
-  "workspaces": [
-    "apps/*",
-    "apps/*/*",
-    "e2e/fixtures/*",
-    "packages/*"
-  ],
   "type": "module",
   "scripts": {
     "benchmark": "pnpm --filter @eve-internal/benchmarks benchmark",

--- a/packages/eve-self-modification/package.json
+++ b/packages/eve-self-modification/package.json
@@ -58,7 +58,7 @@
   "scripts": {
     "build": "eve extension build && pnpm run build:scaffold",
     "build:scaffold": "node -e \"require('node:fs').rmSync('scaffold', { force: true, recursive: true })\" && tsc -p tsconfig.scaffold.json",
-    "prepare": "pnpm run build",
+    "prepack": "pnpm run build",
     "test:scenario": "vitest run src/*.scenario.test.ts",
     "test:unit": "vitest run src --exclude src/**/*.scenario.test.ts",
     "typecheck": "tsc -p tsconfig.json && tsc -p tsconfig.scaffold.json --noEmit"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - apps/*
-  - apps/*/*
+  - apps/fixtures/*
+  - apps/frameworks/*
   - e2e/fixtures/*
   - packages/*
 


### PR DESCRIPTION
### Summary

Warm `pnpm install` runs unnecessarily rebuilt `@eve/self-modification` through its `prepare` lifecycle and traversed generated directories through the broad `apps/*/*` workspace glob. This moves the package build to `prepack`, narrows nested app workspaces to the fixture and framework directories that actually contain projects, and removes duplicate workspace metadata from the root manifest. The workspace still contains all 46 projects.

### Validation

A warm `pnpm install --frozen-lockfile --reporter=append-only` improved from 10.31s to 2.33s and 2.66s on consecutive runs. `pnpm pack --dry-run` confirmed that `@eve/self-modification` still builds its published artifacts, and `pnpm list --recursive --depth -1 --parseable` confirmed all 46 workspace projects remain included.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 3 files · `+3 / -8`

Keeps the install optimization limited to package lifecycle and workspace configuration.

**Tests** — 0 files · `+0 / -0`

Not applicable; the behavior was verified directly with warm installs, workspace enumeration, and a package dry run.
