### PR TITLE
fix: build eve before self-modification tests

### DIFF
--- a/packages/eve-self-modification/turbo.json
+++ b/packages/eve-self-modification/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "test:unit": {
+      "dependsOn": ["^build"]
+    }
+  }
+}


### PR DESCRIPTION
### Summary

Follow-up to #2787. Moving `@eve/self-modification` from `prepare` to `prepack` stopped installs from incidentally building `eve` before unit tests. On clean CI runners, Turbo could start the self-modification tests concurrently with `eve#build`, causing imports from `eve` and `eve/tools` to fail. This adds a package-local dependency so those tests wait for workspace dependency builds while preserving fast warm installs.

### Validation

Removed `packages/eve/dist` and ran `pnpm turbo run test:unit --filter=@eve/self-modification --force`; Turbo built `eve` first and all 29 self-modification tests passed. The full `pnpm test:unit` suite also passed.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 1 file · `+8 / -0`

Keeps the ordering fix local to the affected package's Turbo task graph.

**Tests** — 0 files · `+0 / -0`

The existing self-modification unit suite directly covers the imports that failed under the incorrect build order.
