### PR TITLE
feat(eve): support agent workspace member packages

### DIFF
--- a/docs/guides/deployment/vercel.mdx
+++ b/docs/guides/deployment/vercel.mdx
@@ -67,7 +67,19 @@ my-project/
         └── agent/
 ```
 
-The `eve.agents` declaration marks the project as a workspace. eve then validates and discovers only direct `agents/<name>/agent/` children. Their directory names become their public identities, exposed at `/eve/agents/<name>/eve/v1/*`. Run `eve dev`, `eve info`, and `eve eval` from an individual child directory; run project-level build, link, and deploy commands from the workspace root. The workspace root is the project package; child agent directories do not define packages or build scripts.
+The `eve.agents` declaration marks the project as a workspace. eve then validates and discovers only direct `agents/<name>/agent/` children. Their directory names become their public identities, exposed at `/eve/agents/<name>/eve/v1/*`. Run `eve dev`, `eve info`, and `eve eval` from an individual child directory; run project-level build, link, and deploy commands from the workspace root.
+
+An agent may have its own `package.json` when the root package-manager workspace claims `agents/*` (for example, with `packages: ["agents/*"]` in `pnpm-workspace.yaml`). A member package's `build` script runs for its service; otherwise eve runs `eve build` from that agent directory. Member packages can therefore use their own dependencies and build steps while sharing the root workspace installation.
+
+### Choose a workspace or independent packages
+
+Use an agent workspace when several agents form one operational unit. The root owns the shared environment and validates the agent set, while member packages can still own dependencies and build scripts. On Vercel, the root also owns the link and deployment, and peer services serve their agents at `/eve/agents/support/eve/v1/*` and `/eve/agents/research/eve/v1/*`.
+
+Keep agents as independent packages when they need separate Vercel projects or deployment lifecycles. A repository can still be a pnpm, npm, Yarn, or Bun workspace with `agents/*` package members without adding `eve.agents`; run `eve link`, `eve deploy`, and `eve build` from each agent package instead. This is the better structure for a mixed monorepo, such as one that contains agents with their own `vercel.json`, framework applications, or non-agent packages.
+
+`eve.agents` is not a generic monorepo marker. It matches every direct `agents/*` directory, and each matched directory must contain `agent/`. Do not use it for a tree that includes non-agent packages under `agents/` or for agents that must retain separate Vercel service graphs.
+
+Outside Vercel, `eve build` from the workspace root builds each member sequentially. Each member publishes its normal `.output/` directory; your process manager and reverse proxy decide how to run and route them.
 
 With no authored `vercel.json#services`, `eve build` derives the complete Vercel Services graph on every build. If `vercel.json` declares `services`, that authored graph is authoritative instead; use `vercel build` to build and validate the complete project. This supports heterogeneous projects with frontends, private APIs, bindings, and other non-eve services without generated configuration files.
 

--- a/docs/guides/deployment/vercel.mdx
+++ b/docs/guides/deployment/vercel.mdx
@@ -67,9 +67,19 @@ my-project/
         └── agent/
 ```
 
-The `eve.agents` declaration marks the project as a workspace. eve then validates and discovers only direct `agents/<name>/agent/` children. Their directory names become their public identities, exposed at `/eve/agents/<name>/eve/v1/*`. Run `eve dev`, `eve info`, and `eve eval` from an individual child directory; run project-level build, link, and deploy commands from the workspace root.
+The `eve.agents` declaration marks the project as a workspace. Each entry is a workspace-relative directory path or glob pattern. Every matched directory must contain `agent/`; its final directory name becomes the public identity, exposed at `/eve/agents/<name>/eve/v1/*`. Names must be unique across all entries. Run `eve dev`, `eve info`, and `eve eval` from an individual child directory; run project-level build, link, and deploy commands from the workspace root.
 
-An agent may have its own `package.json` when the root package-manager workspace claims `agents/*` (for example, with `packages: ["agents/*"]` in `pnpm-workspace.yaml`). A member package's `build` script runs for its service; otherwise eve runs `eve build` from that agent directory. Member packages can therefore use their own dependencies and build steps while sharing the root workspace installation.
+For example, a workspace can combine a conventional group and an exact path:
+
+```json title="package.json"
+{
+  "eve": {
+    "agents": ["agents/*", "products/escalation"]
+  }
+}
+```
+
+An agent may have its own `package.json` when the root package-manager workspace claims its path (for example, with `packages: ["agents/*", "products/*"]` in `pnpm-workspace.yaml`). A member package's `build` script runs for its service; otherwise eve runs `eve build` from that agent directory. Member packages can therefore use their own dependencies and build steps while sharing the root workspace installation.
 
 ### Choose a workspace or independent packages
 
@@ -77,7 +87,7 @@ Use an agent workspace when several agents form one operational unit. The root o
 
 Keep agents as independent packages when they need separate Vercel projects or deployment lifecycles. A repository can still be a pnpm, npm, Yarn, or Bun workspace with `agents/*` package members without adding `eve.agents`; run `eve link`, `eve deploy`, and `eve build` from each agent package instead. This is the better structure for a mixed monorepo, such as one that contains agents with their own `vercel.json`, framework applications, or non-agent packages.
 
-`eve.agents` is not a generic monorepo marker. It matches every direct `agents/*` directory, and each matched directory must contain `agent/`. Do not use it for a tree that includes non-agent packages under `agents/` or for agents that must retain separate Vercel service graphs.
+`eve.agents` is not a generic monorepo marker. Every configured path or glob match must contain `agent/`. Do not include non-agent packages or agents that must retain separate Vercel service graphs.
 
 Outside Vercel, `eve build` from the workspace root builds each member sequentially. Each member publishes its normal `.output/` directory; your process manager and reverse proxy decide how to run and route them.
 

--- a/packages/eve/src/cli/commands/build.ts
+++ b/packages/eve/src/cli/commands/build.ts
@@ -50,15 +50,38 @@ export function registerBuildCommand(input: {
             "Workspace builds do not support --profile or --skip-sandbox-prewarm. Run those options from an individual agent directory.",
           );
         }
-        const { buildAgentWorkspace } = await import("#internal/vercel/build-agent-workspace.js");
-        const outputDir = await buildAgentWorkspace(projectContext.workspace);
-        input.logger.log(
-          renderCliTaggedLine(theme, {
-            message: `built output at ${outputDir}`,
-            tag: "build",
-            tone: "success",
-          }),
+        if (process.env.VERCEL) {
+          const { buildAgentWorkspace } = await import("#internal/vercel/build-agent-workspace.js");
+          const outputDir = await buildAgentWorkspace(projectContext.workspace);
+          input.logger.log(
+            renderCliTaggedLine(theme, {
+              message: `built output at ${outputDir}`,
+              tag: "build",
+              tone: "success",
+            }),
+          );
+          return;
+        }
+
+        const buildApplication =
+          input.buildHost ?? (await import("#internal/nitro/host.js")).buildApplication;
+        const { buildAgentWorkspaceMembers } = await import("#internal/agent-workspace-build.js");
+        const members = await buildAgentWorkspaceMembers(
+          projectContext.workspace,
+          buildApplication,
         );
+        for (const member of members) {
+          input.logger.log(
+            renderCliTaggedLine(theme, {
+              message:
+                member.outputDir === undefined
+                  ? `built agent ${member.name} at ${member.appRoot}`
+                  : `built agent ${member.name} at ${member.outputDir}`,
+              tag: "build",
+              tone: "success",
+            }),
+          );
+        }
         return;
       }
 

--- a/packages/eve/src/internal/agent-workspace-build.ts
+++ b/packages/eve/src/internal/agent-workspace-build.ts
@@ -1,0 +1,58 @@
+import { readFile } from "node:fs/promises";
+
+import type { AgentWorkspace, AgentWorkspaceMember } from "#internal/agent-workspace.js";
+import type { ApplicationBuildOptions } from "#internal/nitro/host/types.js";
+import { detectPackageManager } from "#setup/package-manager.js";
+import { spawnPackageManager } from "#setup/primitives/pm/run.js";
+import { parseJsonObject } from "#shared/json.js";
+
+export type AgentWorkspaceBuildApplication = (
+  appRoot: string,
+  options: ApplicationBuildOptions,
+) => Promise<string>;
+
+async function hasBuildScript(member: AgentWorkspaceMember): Promise<boolean> {
+  if (member.packageJsonPath === undefined) return false;
+
+  const packageJson = parseJsonObject(JSON.parse(await readFile(member.packageJsonPath, "utf8")));
+  if (packageJson.scripts === undefined) return false;
+  const scripts = parseJsonObject(packageJson.scripts);
+  return typeof scripts.build === "string";
+}
+
+/** Builds every agent in a workspace for a host that runs members independently. */
+export async function buildAgentWorkspaceMembers(
+  workspace: AgentWorkspace,
+  buildApplication: AgentWorkspaceBuildApplication,
+): Promise<
+  readonly { readonly appRoot: string; readonly name: string; readonly outputDir?: string }[]
+> {
+  const packageManager = await detectPackageManager(workspace.root);
+  const results: { appRoot: string; name: string; outputDir?: string }[] = [];
+
+  for (const member of workspace.members) {
+    if (await hasBuildScript(member)) {
+      const built = await spawnPackageManager(packageManager.kind, member.appRoot, [
+        "run",
+        "build",
+      ]);
+      if (!built) {
+        throw new Error(`Failed to build workspace agent "${member.name}" at ${member.appRoot}.`);
+      }
+      results.push({ appRoot: member.appRoot, name: member.name });
+      continue;
+    }
+
+    results.push({
+      appRoot: member.appRoot,
+      name: member.name,
+      outputDir: await buildApplication(member.appRoot, {
+        publicRoutePrefix: undefined,
+        skipVercelSandboxPrewarm: false,
+        vercelServiceOutput: undefined,
+      }),
+    });
+  }
+
+  return results;
+}

--- a/packages/eve/src/internal/agent-workspace.integration.test.ts
+++ b/packages/eve/src/internal/agent-workspace.integration.test.ts
@@ -108,6 +108,32 @@ describe("resolveAgentWorkspace", () => {
     );
   });
 
+  it("allows a custom-path member package claimed by the root workspace", async () => {
+    const root = await createWorkspace(["products/support"]);
+    const supportRoot = join(root, "products", "support");
+    const packageJsonPath = join(supportRoot, "package.json");
+    await mkdir(join(supportRoot, "agent"), { recursive: true });
+    await Promise.all([
+      writeFile(join(root, "pnpm-workspace.yaml"), 'packages:\n  - "products/*"\n'),
+      writeFile(packageJsonPath, "{}\n"),
+    ]);
+
+    await expect(resolveAgentWorkspace(root)).resolves.toMatchObject({
+      members: [{ name: "support", packageJsonPath }],
+    });
+  });
+
+  it("rejects an unclaimed custom-path member package", async () => {
+    const root = await createWorkspace(["products/support"]);
+    const supportRoot = join(root, "products", "support");
+    await mkdir(join(supportRoot, "agent"), { recursive: true });
+    await writeFile(join(supportRoot, "package.json"), "{}\n");
+
+    await expect(resolveAgentWorkspace(root)).rejects.toThrow(
+      /not a member of the root pnpm workspace/,
+    );
+  });
+
   it("does not recognize the retired collection declaration", async () => {
     const root = await mkdtemp(join(tmpdir(), "eve-retired-collection-"));
     await writeFile(join(root, "package.json"), JSON.stringify({ eve: { collection: true } }));

--- a/packages/eve/src/internal/agent-workspace.ts
+++ b/packages/eve/src/internal/agent-workspace.ts
@@ -3,10 +3,13 @@ import { basename, isAbsolute, join, relative, resolve } from "node:path";
 import { createDiskProjectSource, type ProjectSource } from "#discover/project-source.js";
 import { assertValidPublicAgentName } from "#internal/agent-name.js";
 import { parseJsonObject } from "#shared/json.js";
+import { detectPackageManager } from "#setup/package-manager.js";
+import { packageManagerWorkspaceClaimsProject } from "#setup/workspace-membership.js";
 
 export interface AgentWorkspaceMember {
   readonly appRoot: string;
   readonly name: string;
+  readonly packageJsonPath?: string;
 }
 
 export interface AgentWorkspace {
@@ -150,6 +153,8 @@ export async function resolveAgentWorkspace(
     }
   }
 
+  const packageManager =
+    source.kind === "disk" ? await detectPackageManager(workspaceRoot) : undefined;
   const members: AgentWorkspaceMember[] = [];
   const names = new Set<string>();
   for (const appRoot of [...appRoots].sort((left, right) =>
@@ -157,11 +162,12 @@ export async function resolveAgentWorkspace(
   )) {
     const name = basename(appRoot);
     assertValidPublicAgentName(name, "Agent workspace member");
-    if (!names.add(name)) {
+    if (names.has(name)) {
       throw new Error(
         `eve.agents resolves multiple agent directories named ${JSON.stringify(name)}. Use paths with distinct final directory names.`,
       );
     }
+    names.add(name);
 
     if ((await source.stat(join(appRoot, "agent"))) !== "directory") {
       const relativeAppRoot = relative(workspaceRoot, appRoot);
@@ -174,7 +180,19 @@ export async function resolveAgentWorkspace(
       );
     }
 
-    members.push({ appRoot, name });
+    const packageJsonPath = join(appRoot, "package.json");
+    const hasPackageJson = (await source.stat(packageJsonPath)) === "file";
+    if (
+      source.kind === "disk" &&
+      hasPackageJson &&
+      !packageManagerWorkspaceClaimsProject(packageManager!.kind, workspaceRoot, appRoot)
+    ) {
+      throw new Error(
+        `${join(relative(workspaceRoot, appRoot), "package.json")} defines a child package that is not a member of the root ${packageManager!.kind} workspace. Add a matching workspace pattern to the workspace configuration.`,
+      );
+    }
+
+    members.push(hasPackageJson ? { appRoot, name, packageJsonPath } : { appRoot, name });
   }
 
   return { members, root: workspaceRoot };
@@ -184,7 +202,7 @@ export async function resolveAgentWorkspace(
 export async function loadAgentWorkspace(root: string): Promise<AgentWorkspace> {
   const workspace = await resolveAgentWorkspace(root);
   if (workspace === undefined) {
-    throw new Error("An eve agent workspace requires an agents/ directory.");
+    throw new Error("An eve agent workspace requires package.json eve.agents.");
   }
   return workspace;
 }

--- a/packages/eve/src/setup/primitives/pm/pnpm.ts
+++ b/packages/eve/src/setup/primitives/pm/pnpm.ts
@@ -173,9 +173,9 @@ function parsePnpmWorkspacePackagePatterns(source: string): string[] | undefined
   const patterns: string[] = [];
   for (const line of lines.slice(packagesIndex + 1)) {
     if (/^\S/u.test(line)) break;
-    const match = /^\s*-\s*(.+?)\s*$/u.exec(line);
+    const match = /^\s*-\s*(.+?)(?:\s+#.*)?\s*$/u.exec(line);
     if (match === null) continue;
-    patterns.push(match[1]!.replace(/^['"]|['"]$/gu, ""));
+    patterns.push(match[1]!.trim().replace(/^['"]|['"]$/gu, ""));
   }
   return patterns;
 }

--- a/packages/eve/test/scenarios/hostless-agent-workspace.scenario.test.ts
+++ b/packages/eve/test/scenarios/hostless-agent-workspace.scenario.test.ts
@@ -2,7 +2,7 @@ import { access, readFile, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { join } from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { useScenarioApp } from "../../src/internal/testing/scenario-app.js";
 import { runPnpmCommand } from "../../src/internal/testing/run-pnpm-command.js";
@@ -15,10 +15,29 @@ describe("hostless agent workspace", () => {
   it("assembles every direct child as a peer Vercel service", async () => {
     const app = await scenarioApp({
       files: {
+        "agents/research/package.json": JSON.stringify({
+          name: "@fixture/research",
+          private: true,
+          scripts: { build: "eve build" },
+        }),
         "agents/research/agent/agent.mjs": `import { defineAgent } from "eve";\nexport default defineAgent({ model: "openai/gpt-5.4" });\n`,
         "agents/research/agent/instructions.md": "You are the research agent.\n",
-        "agents/support/agent/agent.mjs": `import { defineAgent } from "eve";\nexport default defineAgent({ model: "openai/gpt-5.4" });\n`,
+        "agents/support/package.json": JSON.stringify({
+          name: "@fixture/support",
+          private: true,
+          dependencies: { "@fixture/shared": "workspace:*" },
+          scripts: { build: "node scripts/generate.mjs && eve build" },
+        }),
+        "agents/support/scripts/generate.mjs": `import { writeFile } from "node:fs/promises";\nawait writeFile(new URL("../agent/generated.mjs", import.meta.url), "export default 'generated';\\n");\n`,
+        "agents/support/agent/agent.mjs": `import generated from "./generated.mjs";\nimport shared from "@fixture/shared";\nif (generated + shared !== "generated shared") throw new Error("member build did not generate or resolve shared code");\nexport default { model: "openai/gpt-5.4" };\n`,
         "agents/support/agent/instructions.md": "You are the support agent.\n",
+        "packages/shared/package.json": JSON.stringify({
+          name: "@fixture/shared",
+          private: true,
+          type: "module",
+          exports: "./index.mjs",
+        }),
+        "packages/shared/index.mjs": "export default ' shared';\n",
         ".vercel/project.json": `${JSON.stringify(
           {
             orgId: "team_eve_scenario",
@@ -34,7 +53,8 @@ describe("hostless agent workspace", () => {
           null,
           2,
         )}\n`,
-        "pnpm-workspace.yaml": "minimumReleaseAge: 0\n",
+        "pnpm-workspace.yaml":
+          'packages:\n  - "agents/*"\n  - "packages/*"\nminimumReleaseAge: 0\n',
       },
       dependencies: { vercel: vercelManifest.version },
       installDependencies: true,
@@ -45,6 +65,19 @@ describe("hostless agent workspace", () => {
     packageJson.eve = { agents: ["agents/*"] };
     packageJson.scripts = { build: "eve build" };
     await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+
+    vi.stubEnv("VERCEL", "");
+    try {
+      await runPnpmCommand({ args: ["exec", "eve", "build"], cwd: app.appRoot });
+      await expect(
+        access(join(app.appRoot, "agents", "support", ".output", "server", "index.mjs")),
+      ).resolves.toBeUndefined();
+      await expect(
+        access(join(app.appRoot, "agents", "research", ".output", "server", "index.mjs")),
+      ).resolves.toBeUndefined();
+    } finally {
+      vi.unstubAllEnvs();
+    }
 
     await runPnpmCommand({ args: ["exec", "vercel", "build", "--yes"], cwd: app.appRoot });
 


### PR DESCRIPTION
### Summary

Replaces #2043 after its branch was accidentally reset while importing the existing workspace PR chain into `gh stack`; the implementation and prior review fixes are preserved. Related to #2588. Agent workspace members may own `package.json` files when the root package-manager workspace claims them, and workspace-root builds run member build scripts or fall back to `eve build` while preserving each member's output.

This also broadens `eve.agents` from the original fixed direct-child layout to validated workspace-relative paths and glob patterns, with globally unique path-derived member names.

### Validation

Focused workspace discovery and build integration coverage passes, including pnpm inline comments, workspace dependencies, custom member build scripts, generated imports, and a real hostless workspace build scenario.

### Checklist

- [x] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+23 / -1`

Documents member packages, build ownership, custom paths, and workspace boundaries.

**Implementation** — 4 files · `+112 / -13`

Adds workspace-member build orchestration and package-manager membership validation while generalizing workspace discovery paths.

**Tests** — 2 files · `+62 / -3`

Covers custom and recursive paths, package membership, inline pnpm comments, and a real member-package build with generated and workspace-linked imports.
