### PR TITLE
[2/3] fix(eve): resume approved background tools

### DIFF
--- a/.changeset/silly-waves-smile.md
+++ b/.changeset/silly-waves-smile.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Run approved background tool calls even when the AI SDK skips its input callback during resume.

--- a/packages/eve/src/harness/tools.test.ts
+++ b/packages/eve/src/harness/tools.test.ts
@@ -16,6 +16,7 @@ import {
 } from "#harness/provider-tool-schemas.js";
 import type { JsonObject } from "#shared/json.js";
 import { isAsyncIterable } from "#shared/async-iterable.js";
+import { BackgroundToolExecutorKey } from "#harness/background-tools.js";
 import type { HarnessToolDefinition } from "#harness/execute-tool.js";
 import { buildToolApproval, buildToolSet, buildToolSetWithProviderTools } from "#harness/tools.js";
 import type { HarnessToolMap } from "#harness/types.js";
@@ -129,6 +130,56 @@ describe("buildToolSet", () => {
 
     expect(receivedOptions?.abortSignal).toBe(abortController.signal);
     expect(receivedOptions?.toolCallId).toBe("call_observe");
+  });
+
+  it("registers background calls at execution when input callbacks are skipped or repeated", async () => {
+    const observedBatches: string[][] = [];
+    const ctx = new ContextContainer();
+    ctx.set(BackgroundToolExecutorKey, {
+      async execute({ batch }) {
+        observedBatches.push(batch.calls.map((call) => call.callId));
+        return { status: "working" };
+      },
+    });
+    const tools: HarnessToolMap = new Map([
+      [
+        "background_work",
+        {
+          description: "Start background work.",
+          execute: async () => ({ status: "working" }),
+          execution: "background",
+          inputSchema: jsonSchema({ type: "object" }),
+          name: "background_work",
+        },
+      ],
+    ]);
+
+    const result = buildToolSet({ tools });
+    const backgroundTool = result.background_work as typeof result.background_work & {
+      readonly onInputAvailable: (input: {
+        readonly input: unknown;
+        readonly toolCallId: string;
+      }) => void;
+    };
+    await contextStorage.run(ctx, async () => {
+      await executeSdkTool({
+        tool: backgroundTool,
+        toolCallId: "approved-call",
+        toolInput: { task: "resume" },
+      });
+
+      backgroundTool.onInputAvailable({
+        input: { task: "new" },
+        toolCallId: "new-call",
+      });
+      await executeSdkTool({
+        tool: backgroundTool,
+        toolCallId: "new-call",
+        toolInput: { task: "new" },
+      });
+    });
+
+    expect(observedBatches).toEqual([["approved-call"], ["approved-call", "new-call"]]);
   });
 
   it("passes the AI SDK abort signal to the authored tool context", async () => {

--- a/packages/eve/src/harness/tools.ts
+++ b/packages/eve/src/harness/tools.ts
@@ -216,15 +216,21 @@ export function wrapToolExecute(
   return (input, options) => {
     let output: unknown;
     try {
-      output =
-        definition.execution === "background"
-          ? executeBackgroundToolCall({
-              batch: backgroundBatch,
-              definition: definition as BackgroundExecutableTool,
-              options,
-              toolInput: input,
-            })
-          : execute(input, options);
+      if (definition.execution === "background") {
+        backgroundBatch.register({
+          callId: options.toolCallId,
+          input,
+          toolName: definition.name,
+        });
+        output = executeBackgroundToolCall({
+          batch: backgroundBatch,
+          definition: definition as BackgroundExecutableTool,
+          options,
+          toolInput: input,
+        });
+      } else {
+        output = execute(input, options);
+      }
     } catch (error) {
       return Promise.reject(error);
     }


### PR DESCRIPTION
### Summary

Fixes approved background tool calls failing on resume because the AI SDK does not repeat `onInputAvailable`. Execution now performs the same idempotent batch registration as a fallback before starting the task.

Depends on #2796.

### Validation

Adds a regression test for executing without the input callback, plus the normal path where both registrations occur.

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the patch changeset.

**Implementation** — 1 file · `+15 / -9`

Keeps the fallback local to background tool execution.

**Tests** — 1 file · `+51 / -0`

Covers skipped and repeated input callback registration.
