### PR TITLE
[3/3] fix(eve): clear suppressed TUI responses

### DIFF
--- a/.changeset/tidy-cats-smile.md
+++ b/.changeset/tidy-cats-smile.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Remove suppressed background-task delivery markers from the terminal UI after streaming completes.

--- a/packages/eve/src/cli/dev/tui/runner.test.ts
+++ b/packages/eve/src/cli/dev/tui/runner.test.ts
@@ -2166,6 +2166,57 @@ describe("EveTUIRunner failure rendering", () => {
   });
 });
 
+describe("EveTUIRunner empty delivery", () => {
+  it("clears streamed sentinel text when completion suppresses delivery", async () => {
+    const prompts: Array<string | undefined> = ["wait for the task", undefined];
+    const emitted: AgentTUIStreamEvent[] = [];
+    const session = sessionYielding([
+      { type: "step.started", data: { sequence: 0, stepIndex: 0, turnId: "t0" } },
+      {
+        type: "message.appended",
+        data: {
+          messageDelta: "<eve-empty-delivery/>",
+          messageSoFar: "<eve-empty-delivery/>",
+          sequence: 0,
+          stepIndex: 0,
+          turnId: "t0",
+        },
+      },
+      {
+        type: "message.completed",
+        data: {
+          finishReason: "stop",
+          message: null,
+          sequence: 0,
+          stepIndex: 0,
+          turnId: "t0",
+        },
+      },
+      { type: "turn.completed", data: { sequence: 0, turnId: "t0" } },
+      {
+        type: "session.waiting",
+        data: { continuationToken: "session-id", wait: "next-user-message" },
+      },
+    ]);
+    const renderer: AgentTUIRenderer = {
+      readPrompt: vi.fn(async () => prompts.shift()),
+      renderStream: vi.fn(async (result) => {
+        for await (const event of result.events as AsyncIterable<AgentTUIStreamEvent>) {
+          emitted.push(event);
+        }
+      }),
+    };
+
+    await new EveTUIRunner({ session, renderer, name: "Weather Agent" }).run();
+
+    expect(emitted).toContainEqual({
+      id: "text:t0:0",
+      text: null,
+      type: "assistant-complete",
+    });
+  });
+});
+
 describe("EveTUIRunner reused step indexes", () => {
   it("renders the post-subagent message that the harness emits under a reused stepIndex", async () => {
     // Mirrors the real parent stream around a subagent dispatch: the second

--- a/packages/eve/src/cli/dev/tui/runner.ts
+++ b/packages/eve/src/cli/dev/tui/runner.ts
@@ -2237,9 +2237,10 @@ async function* eveEventsToTUIStream(
             yield { type: "assistant-complete", id, text: message };
           }
         } else if (state.text.length > 0) {
+          state.text = "";
           state.completed = true;
           state.completedEpoch = stepEpoch;
-          yield { type: "assistant-complete", id };
+          yield { type: "assistant-complete", id, text: null };
         }
         break;
       }

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
@@ -266,6 +266,20 @@ describe("TerminalRenderer (inline scrollback)", () => {
     expect(snapshot.match(/Recovered answer\./gu)).toHaveLength(1);
   });
 
+  it("removes streamed text when completion suppresses delivery", async () => {
+    const { screen, renderer } = makeRenderer();
+    await renderer.renderStream(
+      streamOf([
+        { type: "assistant-delta", id: "empty", delta: "<eve-empty-delivery/>" },
+        { type: "assistant-complete", id: "empty", text: null },
+        { type: "finish" },
+      ]),
+      { continueSession: true },
+    );
+
+    expect(screen.snapshot()).not.toContain("eve-empty-delivery");
+  });
+
   it("renders rejected tools as denied", async () => {
     const { screen, renderer } = makeRenderer();
     await renderer.renderStream(

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.ts
@@ -3518,6 +3518,12 @@ export class TerminalRenderer implements AgentTUIRenderer {
       }
 
       case "assistant-complete": {
+        if (event.text === null) {
+          turnState.text.set(event.id, "");
+          this.#removeBlock(event.id);
+          this.#paint();
+          break;
+        }
         const existing = turnState.text.get(event.id) ?? "";
         const text = typeof event.text === "string" ? stripTerminalControls(event.text) : existing;
         turnState.text.set(event.id, text);


### PR DESCRIPTION
### Summary

Fixes the TUI leaving `<eve-empty-delivery/>` in the transcript when a background-task reporting turn suppresses its final response. A null `message.completed` now clears the streamed assistant block instead of finalizing the sentinel as visible text.

Depends on #2797.

### Validation

Adds runner and terminal renderer tests for streaming the marker before receiving a null completion.

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the patch changeset.

**Implementation** — 2 files · `+9 / -2`

Carries the null completion through the TUI stream and removes the matching transcript block.

**Tests** — 2 files · `+65 / -0`

Covers event translation and terminal rendering.
