### PR TITLE
fix(eve): harden legacy inbox caller projection

### DIFF
--- a/.changeset/fix-legacy-subagent-inboxes.md
+++ b/.changeset/fix-legacy-subagent-inboxes.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix deliveries to persistent subagent inboxes by projecting current caller metadata through the destination wire schema.

--- a/packages/eve/src/execution/wire/session-inbox-encoder.test.ts
+++ b/packages/eve/src/execution/wire/session-inbox-encoder.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import type { SessionInboxWireTarget } from "#execution/wire/session-inbox-contract.js";
+import { sessionInboxWire } from "#execution/wire/session-inbox-encoder.js";
+
+const legacyTargets = [
+  { variant: "deliver", version: 0 },
+  { variant: "send", version: 0 },
+  { version: 1 },
+] satisfies readonly SessionInboxWireTarget[];
+const activityObserver = {
+  sink: { url: "https://example.com/activity", version: 1 as const },
+};
+
+describe("session inbox encoder", () => {
+  it.each(
+    legacyTargets.flatMap(
+      (target) =>
+        [
+          [target, undefined],
+          [target, activityObserver],
+        ] as const,
+    ),
+  )("projects caller fields for target %o with activity observer %o", (target, observer) => {
+    const caller = {
+      activityObserver: observer,
+      callId: "call-1",
+      futureCallerField: "future-value",
+      replyTo: { kind: "hook" as const, token: "callback-token" },
+      subagentName: "researcher",
+    };
+
+    const wire = sessionInboxWire.encode(
+      { caller, kind: "send", payload: { message: "legacy" } },
+      target,
+    );
+
+    expect(wire).toHaveProperty("caller", {
+      callId: "call-1",
+      replyTo: { kind: "hook", token: "callback-token" },
+      subagentName: "researcher",
+    });
+  });
+});

--- a/packages/eve/src/execution/wire/session-inbox-encoder.ts
+++ b/packages/eve/src/execution/wire/session-inbox-encoder.ts
@@ -2,10 +2,12 @@ import type {
   DeliverHookPayload,
   SessionCommand,
   SessionTimeoutHookPayload,
+  TurnCaller,
 } from "#channel/types.js";
 import {
   encodeSessionCommandV1,
   type SessionInboxWireV1,
+  sessionInboxWireV1Schema,
 } from "#execution/wire/session-inbox-wire.v1.js";
 import {
   encodeSessionCommandV2,
@@ -28,7 +30,7 @@ type LegacySessionInboxWireTarget = Extract<SessionInboxWireTarget, { readonly v
 type VersionedSessionInboxEncoder = (command: SessionInboxCommand) => unknown;
 
 const versionedEncoders = {
-  1: (command: SessionInboxCommand) => encodeSessionCommandV1(withoutActivityObserver(command)),
+  1: (command: SessionInboxCommand) => encodeSessionCommandV1(toV1Command(command)),
   2: encodeSessionCommandV2,
 } satisfies Record<SessionInboxWireVersion, VersionedSessionInboxEncoder>;
 
@@ -52,10 +54,7 @@ function encode(
   target: SessionInboxWireTarget,
 ): SessionInboxWireV1 | SessionInboxWireV2 | Record<string, unknown> {
   if (target.version === 0) {
-    return encodeSessionCommandV0(
-      encodeSessionCommandV1(withoutActivityObserver(command)),
-      target.variant,
-    );
+    return encodeSessionCommandV0(encodeSessionCommandV1(toV1Command(command)), target.variant);
   }
   if (isSessionInboxWireVersion(target.version)) {
     return versionedEncoders[target.version](command) as SessionInboxWireV1 | SessionInboxWireV2;
@@ -65,10 +64,17 @@ function encode(
   );
 }
 
-function withoutActivityObserver(command: SessionInboxCommand): SessionInboxCommand {
-  if (!("caller" in command) || command.caller?.activityObserver === undefined) return command;
-  const { activityObserver: _activityObserver, ...caller } = command.caller;
-  return { ...command, caller };
+const sessionInboxWireV1CallerProjection = sessionInboxWireV1Schema.options[0].shape.caller
+  .unwrap()
+  .strip();
+
+function toV1Command(command: SessionInboxCommand): SessionInboxCommand {
+  if (!("caller" in command) || command.caller === undefined) return command;
+  return { ...command, caller: toV1Caller(command.caller) };
+}
+
+function toV1Caller(caller: TurnCaller) {
+  return sessionInboxWireV1CallerProjection.parse(caller);
 }
 
 /** Server/step-safe producer facade. */


### PR DESCRIPTION
### Summary

Hardens encoding for persistent subagent inboxes created by older eve versions. Instead of removing the known `activityObserver` field ad hoc, legacy targets now project caller metadata through a stripping schema derived from the immutable v1 caller schema, preventing current or future caller fields from leaking into v0/v1 payloads.

### Validation

Adds a unit matrix covering both legacy v0 variants and v1 with omitted and populated activity observers, plus a simulated future caller field. The original encoder rejects the undefined case and would reject the future field; the schema projection emits only v1 caller fields.

### Diff size

**Docs** — 1 file · `+5 / -0`

Patch changeset for the published `eve` package.

**Implementation** — 1 file · `+15 / -9`

Replaces the field-specific downgrade shim with a projection derived from the existing v1 schema.

**Tests** — 1 file · `+44 / -0`

Focused matrix for all legacy targets and both current and prospective caller fields.
