### PR TITLE
[2/2] test(eve): cover undefined fields across wire targets

### DIFF
--- a/.changeset/fix-legacy-subagent-inboxes.md
+++ b/.changeset/fix-legacy-subagent-inboxes.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix deliveries to persistent subagent inboxes created by older eve versions when no activity observer is configured.

--- a/packages/eve/src/execution/wire/session-inbox-encoder.test.ts
+++ b/packages/eve/src/execution/wire/session-inbox-encoder.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SESSION_INBOX_WIRE_VERSIONS,
+  type SessionInboxWireTarget,
+} from "#execution/wire/session-inbox-contract.js";
+import { sessionInboxWire } from "#execution/wire/session-inbox-encoder.js";
+
+const targets = [
+  { variant: "deliver", version: 0 },
+  { variant: "send", version: 0 },
+  ...SESSION_INBOX_WIRE_VERSIONS.map((version) => ({ version })),
+] satisfies readonly SessionInboxWireTarget[];
+
+const caller = {
+  callId: "call-1",
+  replyTo: { kind: "hook" as const, token: "callback-token" },
+  subagentName: "researcher",
+};
+
+function encodeAsJson(
+  command: Parameters<typeof sessionInboxWire.encode>[0],
+  target: SessionInboxWireTarget,
+): unknown {
+  return JSON.parse(JSON.stringify(sessionInboxWire.encode(command, target)));
+}
+
+describe("session inbox encoder", () => {
+  it.each(targets)("treats undefined fields as omitted for target %o", (target) => {
+    const omitted = { caller, kind: "send" as const, payload: { message: "hello" } };
+    const explicit = { ...omitted, caller: { ...caller, activityObserver: undefined } };
+
+    expect(encodeAsJson(explicit, target)).toStrictEqual(encodeAsJson(omitted, target));
+  });
+});

--- a/packages/eve/src/execution/wire/session-inbox-encoder.ts
+++ b/packages/eve/src/execution/wire/session-inbox-encoder.ts
@@ -66,7 +66,13 @@ function encode(
 }
 
 function withoutActivityObserver(command: SessionInboxCommand): SessionInboxCommand {
-  if (!("caller" in command) || command.caller?.activityObserver === undefined) return command;
+  if (
+    !("caller" in command) ||
+    command.caller === undefined ||
+    !("activityObserver" in command.caller)
+  ) {
+    return command;
+  }
   const { activityObserver: _activityObserver, ...caller } = command.caller;
   return { ...command, caller };
 }


### PR DESCRIPTION
### Summary

Adds a general session-inbox encoder invariant: explicitly `undefined` current fields must encode identically to omitted fields for every supported wire target. The matrix derives versioned targets from `SESSION_INBOX_WIRE_VERSIONS` and also includes both legacy v0 variants, so future wire versions join the test automatically.

Depends on #2802.

### Validation

The test fails for all three legacy targets without #2802 and passes for the complete target matrix with the fix.

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 0 files · `+0 / -0`

Not applicable.

**Tests** — 1 file · `+35 / -0`

One table-driven invariant covers both v0 variants and all declared versioned targets.
