### PR TITLE
feat(eve): support readline cursor movement

### DIFF
--- a/.changeset/tidy-terminals-move.md
+++ b/.changeset/tidy-terminals-move.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add readline-style Ctrl+B/F and Alt+B/F cursor movement to editable fields in the eve TUI, including common modified-arrow terminal sequences.

--- a/packages/eve/src/cli/dev/tui/line-editor.test.ts
+++ b/packages/eve/src/cli/dev/tui/line-editor.test.ts
@@ -16,6 +16,8 @@ import {
   moveLeft,
   movePromptLine,
   moveRight,
+  moveWordBackward,
+  moveWordForward,
   visibleLine,
 } from "./line-editor.js";
 
@@ -84,6 +86,22 @@ describe("line editing", () => {
     expect(moveRight({ text: "ab", cursor: 1 })).toEqual({ text: "ab", cursor: 2 });
   });
 
+  it("moves backward and forward by readline-style words", () => {
+    const text = "one,  two_three 世界";
+    expect(moveWordForward({ text, cursor: 0 })).toEqual({ text, cursor: 3 });
+    expect(moveWordForward({ text, cursor: 3 })).toEqual({ text, cursor: 15 });
+    expect(moveWordForward({ text, cursor: 15 })).toEqual({ text, cursor: text.length });
+    expect(moveWordBackward({ text, cursor: text.length })).toEqual({ text, cursor: 16 });
+    expect(moveWordBackward({ text, cursor: 16 })).toEqual({ text, cursor: 6 });
+    expect(moveWordBackward({ text, cursor: 6 })).toEqual({ text, cursor: 0 });
+  });
+
+  it("moves by whole graphemes when words contain combining characters", () => {
+    const text = "e\u0301lan vital";
+    expect(moveWordForward({ text, cursor: 0 })).toEqual({ text, cursor: 5 });
+    expect(moveWordBackward({ text, cursor: 5 })).toEqual({ text, cursor: 0 });
+  });
+
   it("jumps home and end", () => {
     expect(moveHome({ text: "abc", cursor: 2 })).toEqual({ text: "abc", cursor: 0 });
     expect(moveEnd({ text: "abc", cursor: 0 })).toEqual({ text: "abc", cursor: 3 });
@@ -125,6 +143,22 @@ describe("line editing", () => {
     });
     expect(applyLineEditorKey(line, { type: "ctrl-e" })).toEqual({
       text: "abc",
+      cursor: 3,
+    });
+    expect(applyLineEditorKey(line, { type: "ctrl-f" })).toEqual({
+      text: "abc",
+      cursor: 2,
+    });
+    expect(applyLineEditorKey(line, { type: "ctrl-b" })).toEqual({
+      text: "abc",
+      cursor: 0,
+    });
+    expect(applyLineEditorKey(lineOf("one two"), { type: "alt-b" })).toEqual({
+      text: "one two",
+      cursor: 4,
+    });
+    expect(applyLineEditorKey({ text: "one two", cursor: 0 }, { type: "alt-f" })).toEqual({
+      text: "one two",
       cursor: 3,
     });
     expect(applyLineEditorKey(line, { type: "enter" })).toBeUndefined();

--- a/packages/eve/src/cli/dev/tui/line-editor.ts
+++ b/packages/eve/src/cli/dev/tui/line-editor.ts
@@ -82,6 +82,38 @@ export function moveRight(state: LineState): LineState {
     : { text: state.text, cursor: nextGraphemeBoundary(state.text, state.cursor) };
 }
 
+/** Moves to the beginning of the current or previous word (Alt+B). */
+export function moveWordBackward(state: LineState): LineState {
+  let cursor = state.cursor;
+  while (cursor > 0) {
+    const previous = previousGraphemeBoundary(state.text, cursor);
+    if (isWordCharacter(state.text.slice(previous, cursor))) break;
+    cursor = previous;
+  }
+  while (cursor > 0) {
+    const previous = previousGraphemeBoundary(state.text, cursor);
+    if (!isWordCharacter(state.text.slice(previous, cursor))) break;
+    cursor = previous;
+  }
+  return cursor === state.cursor ? state : { text: state.text, cursor };
+}
+
+/** Moves to the end of the current or next word (Alt+F). */
+export function moveWordForward(state: LineState): LineState {
+  let cursor = state.cursor;
+  while (cursor < state.text.length) {
+    const next = nextGraphemeBoundary(state.text, cursor);
+    if (isWordCharacter(state.text.slice(cursor, next))) break;
+    cursor = next;
+  }
+  while (cursor < state.text.length) {
+    const next = nextGraphemeBoundary(state.text, cursor);
+    if (!isWordCharacter(state.text.slice(cursor, next))) break;
+    cursor = next;
+  }
+  return cursor === state.cursor ? state : { text: state.text, cursor };
+}
+
 /** Moves the caret to the start of the line (Home / Ctrl+A). */
 export function moveHome(state: LineState): LineState {
   const cursor = logicalLineStart(state.text, state.cursor);
@@ -172,9 +204,15 @@ export function applyLineEditorKey(
     case "delete":
       return deleteForward(state);
     case "left":
+    case "ctrl-b":
       return moveLeft(state);
     case "right":
+    case "ctrl-f":
       return moveRight(state);
+    case "alt-b":
+      return moveWordBackward(state);
+    case "alt-f":
+      return moveWordForward(state);
     case "home":
     case "ctrl-a":
       return moveHome(state);
@@ -194,6 +232,10 @@ export function applyLineEditorKey(
 
 function isWhitespace(text: string): boolean {
   return /^\s+$/u.test(text);
+}
+
+function isWordCharacter(text: string): boolean {
+  return /^[\p{L}\p{M}\p{N}_]/u.test(text);
 }
 
 /**

--- a/packages/eve/src/cli/dev/tui/stream-format.test.ts
+++ b/packages/eve/src/cli/dev/tui/stream-format.test.ts
@@ -112,6 +112,11 @@ describe("nextKey", () => {
     expect(nextKey("\x1bO")).toEqual({ consumed: 0, incomplete: true });
   });
 
+  it("decodes Alt+B/F as complete readline word-movement chords", () => {
+    expect(nextKey("\x1bb")).toEqual({ key: { type: "alt-b" }, consumed: 2 });
+    expect(nextKey("\x1bF")).toEqual({ key: { type: "alt-f" }, consumed: 2 });
+  });
+
   it("takes a printable run as a single character token", () => {
     expect(nextKey("hello")).toEqual({
       key: { type: "text", value: "hello", framing: "unframed" },
@@ -205,9 +210,17 @@ describe("parseKey", () => {
     expect(parseKey(Buffer.from("\r"))).toEqual({ type: "enter" });
   });
 
-  it("decodes ctrl-n and ctrl-p for emacs-style navigation", () => {
-    expect(parseKey(Buffer.from(""))).toEqual({ type: "ctrl-n" });
-    expect(parseKey(Buffer.from(""))).toEqual({ type: "ctrl-p" });
+  it("decodes ctrl-b/f/n/p for emacs-style navigation", () => {
+    expect(parseKey(Buffer.from("\u0002"))).toEqual({ type: "ctrl-b" });
+    expect(parseKey(Buffer.from("\u0006"))).toEqual({ type: "ctrl-f" });
+    expect(parseKey(Buffer.from("\u000e"))).toEqual({ type: "ctrl-n" });
+    expect(parseKey(Buffer.from("\u0010"))).toEqual({ type: "ctrl-p" });
+  });
+
+  it("decodes common modified-arrow word-movement sequences", () => {
+    expect(parseKey(Buffer.from("\x1b[1;3D"))).toEqual({ type: "alt-b" });
+    expect(parseKey(Buffer.from("\x1b[1;5C"))).toEqual({ type: "alt-f" });
+    expect(parseKey(Buffer.from("\x1b[5D"))).toEqual({ type: "alt-b" });
   });
 
   it("decodes SGR mouse press and release with cell coordinates", () => {

--- a/packages/eve/src/cli/dev/tui/stream-format.ts
+++ b/packages/eve/src/cli/dev/tui/stream-format.ts
@@ -35,8 +35,12 @@ export type TerminalKey =
       y: number;
     }
   | { type: "ctrl-a" }
+  | { type: "ctrl-b" }
   | { type: "ctrl-e" }
+  | { type: "ctrl-f" }
   | { type: "ctrl-d" }
+  | { type: "alt-b" }
+  | { type: "alt-f" }
   | { type: "ctrl-k" }
   | { type: "ctrl-n" }
   | { type: "ctrl-p" }
@@ -182,7 +186,15 @@ export function nextKey(buffer: string): KeyToken {
         consumed: end + (end === bel ? 1 : 2),
       };
     }
-    // `ESC` + another byte (e.g. Alt+key): surface the Escape and re-tokenize.
+    // Alt/Meta letter chords arrive as ESC followed by the letter. Decode the
+    // readline word-movement chords together instead of surfacing Escape first.
+    if (second === "b" || second === "B") {
+      return { key: { type: "alt-b" }, consumed: 2 };
+    }
+    if (second === "f" || second === "F") {
+      return { key: { type: "alt-f" }, consumed: 2 };
+    }
+    // Other `ESC` + byte chords surface Escape and then re-tokenize the byte.
     return { key: { type: "escape" }, consumed: 1 };
   }
 
@@ -224,8 +236,12 @@ export function parseKey(chunk: Buffer): TerminalKey {
   switch (value) {
     case "\u0001":
       return { type: "ctrl-a" };
+    case "\u0002":
+      return { type: "ctrl-b" };
     case "\u0005":
       return { type: "ctrl-e" };
+    case "\u0006":
+      return { type: "ctrl-f" };
     case "\u0004":
       return { type: "ctrl-d" };
     case "\u000b":
@@ -267,6 +283,14 @@ export function parseKey(chunk: Buffer): TerminalKey {
     case "\x1B[D":
     case "\x1BOD":
       return { type: "left" };
+    case "\x1B[1;3C":
+    case "\x1B[1;5C":
+    case "\x1B[5C":
+      return { type: "alt-f" };
+    case "\x1B[1;3D":
+    case "\x1B[1;5D":
+    case "\x1B[5D":
+      return { type: "alt-b" };
     case "\x1B[H":
     case "\x1BOH":
     case "\x1B[1~":


### PR DESCRIPTION
### Summary

Adds readline-style cursor movement to eve TUI inputs: Ctrl+B/F moves by character, while Alt+B/F and common modified-arrow sequences move by word. This stays within the existing terminal decoder and line editor, with no new dependency.

### Validation

Adds unit coverage for decoding the terminal sequences and moving across words, Unicode text, and grapheme clusters.

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the required release changeset.

**Implementation** — 2 files · `+67 / -1`

Extends the existing key decoder and line editor without adding dependencies.

**Tests** — 2 files · `+50 / -3`

Covers key decoding and readline-style cursor behavior.
