### PR TITLE
fix(eve): carry channel audience on reconstructed durable spans

### DIFF
--- a/.changeset/durable-span-audience.md
+++ b/.changeset/durable-span-audience.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Reconstructed durable spans — `invoke_agent`, `agent.channel.delivery`, and `agent.approval` — now carry their channel audience on the parent context, so destination export policies see the real audience instead of `unknown` and apply the correct export and redaction decisions.

--- a/packages/eve/src/tracing/agent-approval-instrumentation.ts
+++ b/packages/eve/src/tracing/agent-approval-instrumentation.ts
@@ -15,6 +15,7 @@ import type {
 } from "#instrumentation/lifecycle.js";
 import type { JsonValue } from "#shared/json.js";
 import { contentAttribute } from "#tracing/agent-otel-content.js";
+import { withChannelAudience } from "#tracing/channel-audience-context.js";
 import type { AgentActionContext } from "#tracing/agent-action-instrumentation.js";
 import type { AgentSpanIdGenerator } from "#tracing/agent-span-id-generator.js";
 import { normalizeChannelAudience, type ChannelAudience } from "#shared/channel-audience.js";
@@ -108,7 +109,13 @@ export function createAgentApprovalInstrumentation(input: {
             },
             startTime: state.startTimeMs,
           },
-          trace.setSpan(ROOT_CONTEXT, trace.wrapSpanContext({ ...state.parent, isRemote: false })),
+          withChannelAudience(
+            trace.setSpan(
+              ROOT_CONTEXT,
+              trace.wrapSpanContext({ ...state.parent, isRemote: false }),
+            ),
+            state.channelAudience,
+          ),
         ),
     );
     if (state.requestAttribute !== undefined) {

--- a/packages/eve/src/tracing/agent-channel-delivery-instrumentation.ts
+++ b/packages/eve/src/tracing/agent-channel-delivery-instrumentation.ts
@@ -19,6 +19,7 @@ import { sessionIdempotencyKey } from "#instrumentation/lifecycle.js";
 import type { JsonValue } from "#shared/json.js";
 import { normalizeChannelAudience, type ChannelAudience } from "#shared/channel-audience.js";
 import { contentAttribute } from "#tracing/agent-otel-content.js";
+import { withChannelAudience } from "#tracing/channel-audience-context.js";
 import type { AgentSpanIdGenerator } from "#tracing/agent-span-id-generator.js";
 import type { AgentSessionTraceState, AgentTraceStateStore } from "#tracing/agent-trace-state.js";
 import { isSampledTrace } from "#tracing/sampled-trace.js";
@@ -130,7 +131,7 @@ export function createAgentChannelDeliveryInstrumentation(input: {
                 ],
           startTime: startTimeMs,
         },
-        contextFromSpanContext(state.parent),
+        withChannelAudience(contextFromSpanContext(state.parent), state.channelAudience),
       ),
     );
     span.addEvent("channel.delivery.started", undefined, startTimeMs);

--- a/packages/eve/src/tracing/agent-otel-provider.test.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.test.ts
@@ -1449,6 +1449,50 @@ describe("createAgentOtelInstrumentation", () => {
     expect(audiences.get("invoke_agent weather")).toBe("private");
   });
 
+  it("carries the channel audience on the tool execution context", async () => {
+    const runtime = createRuntime();
+    const scope: InstrumentationAttemptScope = {
+      attemptId: "session-1:turn-1:0:0",
+      attemptIndex: 0,
+      channelAudience: "private",
+      functionId: "weather",
+      sessionId: "session-1",
+      stepIndex: 0,
+      turnId: "turn-1",
+    };
+    await publishTurnStarted({
+      channelAudience: "private",
+      hooks: runtime.hooks,
+      sessionId: "session-1",
+      turnId: "turn-1",
+      turnSequence: 0,
+    });
+    await runtime.hooks.publish({
+      idempotencyKey: attemptIdempotencyKey(scope),
+      operation: { modelId: "model", operationId: "ai.streamText", provider: "test" },
+      scope,
+      type: "step.attempt.started",
+    });
+    await runtime.hooks.publish({
+      callId: "tool-1",
+      idempotencyKey: "tool:session-1:turn-1:tool-1",
+      input: { city: "SF" },
+      scope,
+      toolName: "weather",
+      type: "tool.call.started",
+    });
+
+    const withSpy = vi.spyOn(context, "with");
+    await runtime.runInContext(
+      { idempotencyKey: "tool:session-1:turn-1:tool-1", scope, type: "tool.call" },
+      async () => undefined,
+    );
+
+    expect(withSpy).toHaveBeenCalledOnce();
+    expect(channelAudienceFromContext(withSpy.mock.calls[0]![0])).toBe("private");
+    withSpy.mockRestore();
+  });
+
   it("does not create approval spans for other input requests", async () => {
     const runtime = createRuntime();
     const scope: InstrumentationAttemptScope = {

--- a/packages/eve/src/tracing/agent-otel-provider.test.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.test.ts
@@ -4,6 +4,7 @@ import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
   type ReadableSpan,
+  type SpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
 import { describe, expect, it, vi } from "vitest";
 
@@ -37,6 +38,7 @@ import {
   type InstrumentationUsage,
 } from "#instrumentation/lifecycle.js";
 import type { ChannelAudience } from "#shared/channel-audience.js";
+import { channelAudienceFromContext } from "#tracing/channel-audience-context.js";
 import type { TraceCapturePolicy } from "#tracing/otel-declaration.js";
 import {
   actionIdempotencyKey,
@@ -69,12 +71,13 @@ function createRuntime(
     recordInputs: true,
     recordOutputs: true,
   }),
+  extraSpanProcessors: readonly SpanProcessor[] = [],
 ): TestRuntime {
   const exporter = new InMemorySpanExporter();
   const idGenerator = new AgentSpanIdGenerator();
   const provider = new BasicTracerProvider({
     idGenerator,
-    spanProcessors: [new SimpleSpanProcessor(exporter)],
+    spanProcessors: [new SimpleSpanProcessor(exporter), ...extraSpanProcessors],
   });
   const tracer = provider.getTracer("eve.agent");
   const agentOtelInput: Omit<AgentOtelInstrumentationInput, "tracePolicy"> & {
@@ -1341,6 +1344,109 @@ describe("createAgentOtelInstrumentation", () => {
       "agent.turn.id": "turn-1",
     });
     expect(nanos(approval.duration)).toBeGreaterThan(0n);
+  });
+
+  it("carries the channel audience on reconstructed durable span contexts", async () => {
+    // Destination export policies read the audience from the parent context at
+    // onStart; a bare wrapped span context would surface "unknown" and let a
+    // policy apply the wrong export or redaction decision.
+    const audiences = new Map<string, ChannelAudience>();
+    const recorder: SpanProcessor = {
+      forceFlush: async () => {},
+      onEnd: () => {},
+      onStart: (span, parentContext) => {
+        audiences.set(span.name, channelAudienceFromContext(parentContext));
+      },
+      shutdown: async () => {},
+    };
+    const runtime = createRuntime(new InMemoryAgentTraceStateStore(), undefined, [recorder]);
+    const ctx = new ContextContainer();
+    const scope: InstrumentationAttemptScope = {
+      attemptId: "session-1:turn-1:0:0",
+      attemptIndex: 0,
+      channelAudience: "private",
+      functionId: "weather",
+      sessionId: "session-1",
+      stepIndex: 0,
+      turnId: "turn-1",
+    };
+    const actionKey = actionIdempotencyKey("session-1", "turn-1", "tool-1");
+    const inputKey = inputIdempotencyKey("session-1", "turn-1", "approval-1");
+    const delivery = {
+      channelAudience: "private" as const,
+      channelKind: "channel:slack",
+      channelName: "slack",
+      deliveryId: "delivery-1",
+      requestId: "iad1::request-1",
+    };
+
+    await contextStorage.run(ctx, async () => {
+      await publishTurnStarted({
+        channelAudience: "private",
+        hooks: runtime.hooks,
+        sessionId: "session-1",
+        turnId: "turn-1",
+        turnSequence: 0,
+      });
+      await runtime.hooks.publish({
+        agentName: "weather",
+        delivery,
+        idempotencyKey: "channel-delivery:session-1:delivery-1",
+        input: { message: "hi" },
+        rootSessionId: "session-1",
+        sessionId: "session-1",
+        type: "channel.delivery.started",
+      });
+      await runtime.hooks.publish({
+        callId: "tool-1",
+        idempotencyKey: actionKey,
+        input: { city: "SF" },
+        kind: "tool-call",
+        name: "weather",
+        scope,
+        type: "action.started",
+      });
+      await runtime.hooks.publish({
+        action: { callId: "tool-1", name: "weather" },
+        idempotencyKey: inputKey,
+        kind: "tool-approval",
+        request: { prompt: "Approve weather?" },
+        requestId: "approval-1",
+        scope,
+        type: "input.requested",
+      });
+      await runtime.hooks.publish({
+        idempotencyKey: inputKey,
+        kind: "tool-approval",
+        outcome: "approved",
+        requestId: "approval-1",
+        scope,
+        type: "input.resolved",
+      });
+      await runtime.hooks.publish({
+        idempotencyKey: actionKey,
+        outcome: "completed",
+        output: { output: { temperature: 72 }, type: "result" },
+        scope,
+        type: "action.completed",
+      });
+      await runtime.hooks.publish({
+        agentName: "weather",
+        delivery,
+        idempotencyKey: "channel-delivery:session-1:delivery-1",
+        outcome: "completed",
+        rootSessionId: "session-1",
+        sequence: 0,
+        sessionId: "session-1",
+        turnId: "turn-1",
+        type: "channel.delivery.completed",
+      });
+      await completeTurn(runtime.hooks, "session-1", "turn-1");
+    });
+
+    expect(audiences.get("agent.approval")).toBe("private");
+    expect(audiences.get("agent.channel.delivery")).toBe("private");
+    expect(audiences.get("invoke_agent weather")).toBe("private");
   });
 
   it("does not create approval spans for other input requests", async () => {

--- a/packages/eve/src/tracing/agent-otel-provider.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.ts
@@ -286,12 +286,15 @@ export function createAgentOtelInstrumentation(
                 kind: SpanKind.INTERNAL,
                 startTime: turn.startTimeMs,
               },
-              contextFromSpanContext({
-                isRemote: turn.parentIsRemote ?? false,
-                spanId: turn.parentSpanId,
-                traceFlags: turn.context.traceFlags,
-                traceId: turn.context.traceId,
-              }),
+              withChannelAudience(
+                contextFromSpanContext({
+                  isRemote: turn.parentIsRemote ?? false,
+                  spanId: turn.parentSpanId,
+                  traceFlags: turn.context.traceFlags,
+                  traceId: turn.context.traceId,
+                }),
+                session?.channelAudience,
+              ),
             ),
           );
           setAgentInvocationUsage(span, turn.modelUsage);

--- a/packages/eve/src/tracing/agent-tool-instrumentation.ts
+++ b/packages/eve/src/tracing/agent-tool-instrumentation.ts
@@ -16,6 +16,7 @@ import type {
 } from "#instrumentation/lifecycle.js";
 import { actionIdempotencyKey } from "#instrumentation/lifecycle.js";
 import { contentAttribute } from "#tracing/agent-otel-content.js";
+import { withChannelAudience } from "#tracing/channel-audience-context.js";
 import type { AgentSpanIdGenerator } from "#tracing/agent-span-id-generator.js";
 import type { AgentActionContext } from "#tracing/agent-action-instrumentation.js";
 
@@ -144,12 +145,15 @@ export function createAgentToolInstrumentation(input: {
     const state: ToolSpanState = {
       actionKey,
       attemptId: event.scope.attemptId,
-      context: contextFromSpanContext({
-        isRemote: false,
-        spanId,
-        traceFlags: parent.spanContext.traceFlags,
-        traceId: parent.spanContext.traceId,
-      }),
+      context: withChannelAudience(
+        contextFromSpanContext({
+          isRemote: false,
+          spanId,
+          traceFlags: parent.spanContext.traceFlags,
+          traceId: parent.spanContext.traceId,
+        }),
+        event.scope.channelAudience,
+      ),
       event,
       fallbackParent: parent.context,
       idempotencyKey: event.idempotencyKey,


### PR DESCRIPTION
### Summary

Spans reconstructed from durable state (`invoke_agent`, `agent.channel.delivery`, and `agent.approval`) and spans started inside tool execution lost the channel audience from their OTel parent context. Destination policies therefore saw `unknown` and could apply the wrong export or redaction behavior. These contexts now restore the audience already held in durable state or the execution scope with `withChannelAudience`; an absent audience still normalizes to `unknown`, preserving the existing fallback.

### Validation

Regression coverage verifies that all three reconstructed durable spans and the tool execution context expose a private audience to destination policies. Both tests fail with `unknown` before the fix; the full `agent-otel-provider` unit suite passes.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the patch changeset for corrected audience-aware export policy.

**Implementation** — 4 files · `+29 / -14`

Restores the existing audience value at each durable or tool-context reconstruction boundary.

**Tests** — 1 file · `+151 / -1`

Exercises a complete private-audience session, delivery, approval, invocation, and tool execution through the instrumentation hooks.
