### PR TITLE
fix(eve): emit one managed agent trace tree

### DIFF
--- a/.changeset/single-agent-trace-tree.md
+++ b/.changeset/single-agent-trace-tree.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Emit one framework-owned agent trace tree from managed OpenTelemetry runtimes. Legacy instrumentation keeps its existing span hierarchy, and authored AI SDK telemetry integrations continue to compose with eve's structural spans.

--- a/packages/eve/src/instrumentation/ai-sdk-telemetry.test.ts
+++ b/packages/eve/src/instrumentation/ai-sdk-telemetry.test.ts
@@ -56,9 +56,13 @@ describe("getRegisteredTelemetryIntegrations", () => {
 
     const registered = getRegisteredTelemetryIntegrations();
     const errorSafe = getRegisteredTelemetryIntegrations({ sanitizeEveOtelErrors: true });
+    const authoredOnly = getRegisteredTelemetryIntegrations({
+      excludeEveOtelIntegration: true,
+    });
     expect(errorSafe).toHaveLength(2);
     expect(errorSafe[0]).not.toBe(registered[0]);
     expect(errorSafe[1]).toBe(authored);
+    expect(authoredOnly).toEqual([authored]);
   });
 });
 

--- a/packages/eve/src/instrumentation/ai-sdk-telemetry.ts
+++ b/packages/eve/src/instrumentation/ai-sdk-telemetry.ts
@@ -35,9 +35,14 @@ export function ensureOtelIntegration(): void {
  * these forward or they stop receiving events.
  */
 export function getRegisteredTelemetryIntegrations(options?: {
+  readonly excludeEveOtelIntegration?: boolean;
   readonly sanitizeEveOtelErrors?: boolean;
 }): readonly Telemetry[] {
-  const integrations = globalThis.AI_SDK_TELEMETRY_INTEGRATIONS ?? [];
+  const registered = globalThis.AI_SDK_TELEMETRY_INTEGRATIONS ?? [];
+  const integrations =
+    options?.excludeEveOtelIntegration === true
+      ? registered.filter((integration) => integration !== eveOtelIntegration)
+      : registered;
   if (options?.sanitizeEveOtelErrors !== true) return integrations;
   let matched = false;
   const sanitized = integrations.map((integration) => {
@@ -47,7 +52,7 @@ export function getRegisteredTelemetryIntegrations(options?: {
     matched = true;
     return errorSafeEveOtelIntegration;
   });
-  if (!matched && !warnedMissingEveOtelIntegration) {
+  if (!matched && options.excludeEveOtelIntegration !== true && !warnedMissingEveOtelIntegration) {
     warnedMissingEveOtelIntegration = true;
     log.warn("could not sanitize eve's AI SDK OpenTelemetry integration", {
       reason:

--- a/packages/eve/src/instrumentation/runtime.test.ts
+++ b/packages/eve/src/instrumentation/runtime.test.ts
@@ -151,6 +151,45 @@ describe("bindInstrumentationRuntime", () => {
     expect(telemetry).toMatchObject({ recordInputs: false, recordOutputs: false });
   });
 
+  it("uses one framework-owned span tree when the runtime owns agent spans", async () => {
+    const originalIntegrations = globalThis.AI_SDK_TELEMETRY_INTEGRATIONS;
+    const authoredIntegration = { onStart: vi.fn() };
+    globalThis.AI_SDK_TELEMETRY_INTEGRATIONS = [authoredIntegration];
+    const runtime = {
+      ...createRuntime({ capturesContent: true, publish: vi.fn() }),
+      ownsAgentSpans: true,
+    };
+    const instrumentation = bindInstrumentationRuntime(runtime, createContext(), boundSession);
+
+    try {
+      const result = await instrumentation?.prepareExecution().runStep(
+        {
+          environment: "test",
+          eveVersion: "0.0.0",
+          hasInput: true,
+          session: { sessionId: "session-1", state: {} as Record<string, unknown> },
+        },
+        async (scope) => ({
+          integrations: scope.prepareAttempt({
+            attemptIndex: 0,
+            stepIndex: 0,
+            turnId: "turn-1",
+          }).telemetry?.integrations,
+          session: scope.session,
+        }),
+      );
+
+      expect(result?.session.state?.["eve.harness.turnTrace"]).toBeUndefined();
+      expect(result?.integrations).toEqual([
+        expect.objectContaining({ onStart: expect.any(Function) }),
+        authoredIntegration,
+      ]);
+      expect(globalThis.AI_SDK_TELEMETRY_INTEGRATIONS).toEqual([authoredIntegration]);
+    } finally {
+      globalThis.AI_SDK_TELEMETRY_INTEGRATIONS = originalIntegrations;
+    }
+  });
+
   it("isolates concurrent step decisions and audiences", async () => {
     const ctx = createContext("private");
     const runtime = createRuntime({ capturesContent: true, publish: vi.fn() });

--- a/packages/eve/src/instrumentation/runtime.ts
+++ b/packages/eve/src/instrumentation/runtime.ts
@@ -147,6 +147,7 @@ export interface InstrumentationRuntime {
   readonly hooks: InstrumentationHooks;
   readonly idGenerator?: AgentSpanIdGenerator;
   readonly instrumentationProviders?: boolean;
+  readonly ownsAgentSpans?: boolean;
   readonly prepareSessionTrace?: (
     event: InstrumentationSessionStartedEvent,
   ) => Promise<InstrumentationTraceSeed>;
@@ -218,8 +219,10 @@ export function bindInstrumentationRuntime(
   };
   const captureExecutionRuntime = () => {
     const otelSettings = runtime.otelSettings;
-    if (otelSettings !== undefined) ensureOtelIntegration();
+    const ownsAgentSpans = runtime.ownsAgentSpans === true;
+    if (otelSettings !== undefined && !ownsAgentSpans) ensureOtelIntegration();
     return {
+      ownsAgentSpans,
       otelSettings,
       runtimeContextResolvers: runtime.runtimeContextResolvers,
       stepStartedRuntimeContextResolver: runtime.stepStartedRuntimeContextResolver,
@@ -268,7 +271,10 @@ export function bindInstrumentationRuntime(
         const functionId = settings?.functionId ?? boundSession.agentName;
         if (functionId) attributes["ai.telemetry.functionId"] = functionId;
         let turnSpan =
-          tracer !== undefined && decision?.action !== "drop" && input.hasInput
+          tracer !== undefined &&
+          !executionRuntime.ownsAgentSpans &&
+          decision?.action !== "drop" &&
+          input.hasInput
             ? tracer.startSpan("ai.eve.turn", { attributes })
             : undefined;
         const spanContext = turnSpan?.spanContext();
@@ -337,7 +343,13 @@ export function bindInstrumentationRuntime(
           }
           const sanitizeEveOtelErrors =
             settings !== undefined && !(content.recordInputs && content.recordOutputs);
-          const integrations = () => getRegisteredTelemetryIntegrations({ sanitizeEveOtelErrors });
+          const integrations = () =>
+            getRegisteredTelemetryIntegrations({
+              ...(executionRuntime.ownsAgentSpans
+                ? { excludeEveOtelIntegration: true }
+                : undefined),
+              sanitizeEveOtelErrors,
+            });
           return {
             functionId: settings?.functionId ?? boundSession.agentName,
             includeRuntimeContext,

--- a/packages/eve/src/tracing/install-instrumentation-runtime.test.ts
+++ b/packages/eve/src/tracing/install-instrumentation-runtime.test.ts
@@ -71,6 +71,7 @@ describe("installInstrumentationRuntime", () => {
     expect(forceFlush).toHaveBeenCalledOnce();
     expect(providerFlush).toHaveBeenCalledOnce();
     expect(runtime.instrumentationProviders).toBe(true);
+    expect(runtime.ownsAgentSpans).toBe(true);
     expect(runtime.otelSettings).toEqual({
       functionId: undefined,
       recordInputs: true,

--- a/packages/eve/src/tracing/install-instrumentation-runtime.ts
+++ b/packages/eve/src/tracing/install-instrumentation-runtime.ts
@@ -86,6 +86,7 @@ export function installInstrumentationRuntime(input: {
     idGenerator: otelRuntime?.idGenerator ?? new AgentSpanIdGenerator(),
     instrumentationProviders: input.instrumentationProviders,
     otelSettings: input.collected.declared ? input.collected.settings : undefined,
+    ownsAgentSpans: otelRuntime !== undefined,
     prepareSessionTrace,
     prepareTurnTrace,
     runtimeContextResolvers: input.runtimeContextResolvers,


### PR DESCRIPTION
### Summary

With instrumentation providers enabled, eve sent each AI SDK telemetry event through both its structural lifecycle bridge and the framework-registered `@ai-sdk/otel` integration. Agent Runs and authored span processors could therefore receive duplicate model and tool spans under a second legacy `ai.eve.turn` tree. Managed tracing runtimes now identify eve's structural bridge as the span owner and skip the framework generic integration and turn wrapper.

Legacy `agent/instrumentation.ts` tracing and user-authored AI SDK telemetry integrations remain unchanged. Zero-config local tracing also stops creating generic spans that its exporter already discarded.

### Validation

Coverage verifies that managed runtimes omit the legacy turn state and framework AI SDK wrapper while preserving authored integrations. The affected suites pass with 291 unit tests and 3 local tracing scenarios.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the patch changeset for a single framework-owned agent trace tree.

**Implementation** — 3 files · `+23 / -5`

Keeps span ownership and integration filtering within the existing instrumentation runtime and telemetry composition paths.

**Tests** — 3 files · `+44 / -0`

Covers managed ownership, legacy-wrapper removal, authored integration preservation, and runtime installation.
