### PR TITLE
test(eve): characterize HITL request lifecycle

### DIFF
--- a/packages/eve/src/harness/hitl/request-lifecycle.conformance.test.ts
+++ b/packages/eve/src/harness/hitl/request-lifecycle.conformance.test.ts
@@ -1,0 +1,188 @@
+import type { ModelMessage } from "ai";
+import { describe, expect, it } from "vitest";
+
+import {
+  appendPendingInputBatch,
+  consumeDeferredStepInput,
+  getPendingInputRequestIds,
+  resolvePendingInput,
+} from "#harness/input-requests.js";
+import { createSessionLimitContinuationRequest } from "#harness/session-limit-continuation.js";
+import type { HarnessSession } from "#harness/types.js";
+import type { InputRequest } from "#shared/input.js";
+
+function session(): HarnessSession {
+  return {
+    agent: { modelReference: {} as never, system: "", tools: [] },
+    compaction: { recentWindowSize: 10, threshold: 0.8 },
+    continuationToken: "test",
+    history: [],
+    sessionId: "session-1",
+  };
+}
+
+function approval(requestId: string): InputRequest {
+  return {
+    action: { callId: `${requestId}-call`, input: {}, kind: "tool-call", toolName: "bash" },
+    allowFreeform: false,
+    display: "confirmation",
+    kind: "tool-approval",
+    options: [
+      { id: "approve", label: "Approve" },
+      { id: "cancel", label: "Cancel" },
+    ],
+    prompt: "Approve bash",
+    requestId,
+  };
+}
+
+function question(requestId: string): InputRequest {
+  return {
+    action: {
+      callId: `${requestId}-call`,
+      input: {},
+      kind: "tool-call",
+      toolName: "ask_question",
+    },
+    display: "text",
+    kind: "question",
+    prompt: "What next?",
+    requestId,
+  };
+}
+
+function responseMessages(requests: readonly InputRequest[]): ModelMessage[] {
+  return [
+    {
+      content: requests.map((request) => ({
+        input: request.action.input,
+        toolCallId: request.action.callId,
+        toolName: request.action.toolName,
+        type: "tool-call" as const,
+      })),
+      role: "assistant",
+    },
+  ];
+}
+
+function appendGroup(current: HarnessSession, requests: readonly InputRequest[]): HarnessSession {
+  return appendPendingInputBatch({
+    requests,
+    responseMessages: responseMessages(requests),
+    session: current,
+  });
+}
+
+describe("current HITL lifecycle conformance", () => {
+  it("keeps a mixed group open until its approval is answered", () => {
+    const requests = [question("question-1"), approval("approval-1")];
+    const parked = appendGroup(session(), requests);
+
+    const result = resolvePendingInput({
+      session: parked,
+      stepInput: { inputResponses: [{ optionId: "yes", requestId: "question-1" }] },
+    });
+
+    expect(result.outcome).toBe("unresolved");
+    expect(getPendingInputRequestIds(result.session.state)).toEqual(
+      new Set(["question-1", "approval-1"]),
+    );
+    expect(consumeDeferredStepInput({ session: result.session }).input).toEqual({
+      inputResponses: [{ optionId: "yes", requestId: "question-1" }],
+    });
+  });
+
+  it("settles a mixed group when its approval is answered and dismisses an unanswered question", () => {
+    const requests = [question("question-1"), approval("approval-1")];
+    const parked = appendGroup(session(), requests);
+
+    const result = resolvePendingInput({
+      session: parked,
+      stepInput: { inputResponses: [{ optionId: "approve", requestId: "approval-1" }] },
+    });
+
+    expect(result.outcome).toBe("resolved");
+    expect(getPendingInputRequestIds(result.session.state)).toEqual(new Set());
+    expect(result.messages.at(-1)).toEqual({
+      content: expect.arrayContaining([
+        expect.objectContaining({
+          output: { type: "json", value: { status: "ignored" } },
+          toolCallId: "question-1-call",
+          type: "tool-result",
+        }),
+        expect.objectContaining({
+          approvalId: "approval-1",
+          approved: true,
+          type: "tool-approval-response",
+        }),
+      ]),
+      role: "tool",
+    });
+  });
+
+  it("answers an independent question group while an approval group remains open", () => {
+    let parked = appendGroup(session(), [approval("approval-1")]);
+    parked = appendGroup(parked, [question("question-1")]);
+
+    const result = resolvePendingInput({
+      session: parked,
+      stepInput: { inputResponses: [{ text: "later", requestId: "question-1" }] },
+    });
+
+    expect(result.outcome).toBe("resolved");
+    expect(getPendingInputRequestIds(result.session.state)).toEqual(new Set(["approval-1"]));
+  });
+
+  it("uses the last response when one delivery repeats a request id", () => {
+    const parked = appendGroup(session(), [approval("approval-1")]);
+
+    const result = resolvePendingInput({
+      session: parked,
+      stepInput: {
+        inputResponses: [
+          { optionId: "cancel", requestId: "approval-1" },
+          { optionId: "approve", requestId: "approval-1" },
+        ],
+      },
+    });
+
+    expect(result.outcome).toBe("resolved");
+    expect(result.messages.at(-1)).toEqual({
+      content: [
+        expect.objectContaining({
+          approvalId: "approval-1",
+          approved: true,
+          type: "tool-approval-response",
+        }),
+      ],
+      role: "tool",
+    });
+  });
+
+  it("gives an open limit group priority over responses for another group", () => {
+    let parked = appendGroup(session(), [approval("approval-1")]);
+    parked = appendPendingInputBatch({
+      requests: [
+        createSessionLimitContinuationRequest({
+          sessionId: "session-1",
+          violation: { kind: "input", limit: 10, usedTokens: 10 },
+        }),
+      ],
+      responseMessages: [],
+      session: parked,
+    });
+
+    const result = resolvePendingInput({
+      session: parked,
+      stepInput: { inputResponses: [{ optionId: "approve", requestId: "approval-1" }] },
+    });
+
+    expect(result.outcome).toBe("unresolved");
+    expect(getPendingInputRequestIds(result.session.state)).toEqual(
+      new Set(["approval-1", "session-1:limit:input:10"]),
+    );
+    expect(consumeDeferredStepInput({ session: result.session }).input).toEqual({
+      inputResponses: [{ optionId: "approve", requestId: "approval-1" }],
+    });
+  });
+});


### PR DESCRIPTION
## What

Add one conformance suite for the existing Approval, Question, and Limit lifecycle before replacing its implementation.

The suite locks down the cross-kind behavior that is currently spread across the pending-input routers:

- a mixed Question/Approval batch stays parked until its Approval is answered;
- settling that Approval dismisses an unanswered Question in the same batch;
- independent groups remain independently answerable;
- duplicate responses in one delivery use the last response;
- an open Limit prompt takes precedence over responses for other groups.

Before → after: these behaviors were covered indirectly across domain-specific tests → they now have one executable boundary suite that can run unchanged against the request interpreter.

This PR changes no runtime behavior or persisted state. It is the first implementation increment after #2652 and is the base for the authoritative request-ledger PR.
