### PR TITLE
fix(eve): flush and shut down the registered meter provider

### DIFF
--- a/.changeset/otel-meter-lifecycle.md
+++ b/.changeset/otel-meter-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+eve now owns the full OpenTelemetry lifecycle it registers: declared metric readers are flushed on `forceFlush` and shut down on `shutdown`, and declared auto-instrumentations are disabled at shutdown, so metrics recorded near teardown are exported instead of silently dropped.

--- a/packages/eve/scripts/vendor-compiled/declarations/@opentelemetry/api.d.ts
+++ b/packages/eve/scripts/vendor-compiled/declarations/@opentelemetry/api.d.ts
@@ -130,6 +130,12 @@ export interface Meter {
 
 export declare const metrics: {
   getMeter(name: string, version?: string): Meter;
+  /**
+   * The globally registered meter provider, shared across API copies. The
+   * instance comes from whichever metrics SDK registered it, so callers must
+   * feature-detect lifecycle methods before invoking them.
+   */
+  getMeterProvider(): unknown;
 };
 
 export declare enum SpanKind {

--- a/packages/eve/src/tracing/otel-registration.scenario.test.ts
+++ b/packages/eve/src/tracing/otel-registration.scenario.test.ts
@@ -11,6 +11,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   ROOT_CONTEXT as COMPILED_ROOT_CONTEXT,
   context as runtimeContext,
+  metrics as runtimeMetrics,
   trace as runtimeTrace,
 } from "#compiled/@opentelemetry/api/index.js";
 import { registerOtelPipeline } from "#tracing/otel-registration.js";
@@ -20,12 +21,14 @@ const authoredApi = require("@opentelemetry/api") as typeof import("@opentelemet
 
 afterEach(() => {
   authoredApi.context.disable();
+  authoredApi.metrics.disable();
   authoredApi.propagation.disable();
   authoredApi.trace.disable();
   context.disable();
   propagation.disable();
   trace.disable();
   (runtimeContext as typeof runtimeContext & { disable(): void }).disable();
+  (runtimeMetrics as typeof runtimeMetrics & { disable(): void }).disable();
   (runtimeTrace as typeof runtimeTrace & { disable(): void }).disable();
 });
 
@@ -168,6 +171,44 @@ describe("registerOtelPipeline", () => {
         inject: () => {},
       }),
     ).toBe(true);
+  });
+
+  it("flushes and shuts down the registered meter provider", async () => {
+    const reader = {
+      forceFlush: vi.fn(async () => {}),
+      setMetricProducer: vi.fn(),
+      shutdown: vi.fn(async () => {}),
+    };
+    const runtime = registerOtelPipeline({
+      pipeline: { metricReaders: [reader], spanProcessors: [] },
+      serviceName: "weather",
+    });
+
+    await runtime.forceFlush();
+    expect(reader.forceFlush).toHaveBeenCalledOnce();
+    expect(reader.shutdown).not.toHaveBeenCalled();
+
+    await runtime.shutdown();
+    expect(reader.shutdown).toHaveBeenCalledOnce();
+  });
+
+  it("disables declared instrumentations at shutdown", async () => {
+    const instrumentation = {
+      disable: vi.fn(),
+      enable: vi.fn(),
+      getConfig: () => ({ enabled: false }),
+      setMeterProvider: vi.fn(),
+      setTracerProvider: vi.fn(),
+    };
+    const runtime = registerOtelPipeline({
+      pipeline: { instrumentations: [instrumentation], spanProcessors: [] },
+      serviceName: "weather",
+    });
+    expect(instrumentation.enable).toHaveBeenCalledOnce();
+    expect(instrumentation.disable).not.toHaveBeenCalled();
+
+    await runtime.shutdown();
+    expect(instrumentation.disable).toHaveBeenCalledOnce();
   });
 
   it("does not export the private registration span", async () => {

--- a/packages/eve/src/tracing/otel-registration.ts
+++ b/packages/eve/src/tracing/otel-registration.ts
@@ -1,6 +1,12 @@
 import { createRequire } from "node:module";
 
-import { context, propagation, trace, type Context } from "#compiled/@opentelemetry/api/index.js";
+import {
+  context,
+  metrics,
+  propagation,
+  trace,
+  type Context,
+} from "#compiled/@opentelemetry/api/index.js";
 import {
   registerOTel,
   type Configuration,
@@ -182,15 +188,27 @@ export function registerOtelPipeline(input: {
     throw new Error("The registered OpenTelemetry tracer provider has no lifecycle methods.");
   }
   optionalPeerTracerProxy?.setDelegate(provider);
+  // `registerOTel` also registers a global meter provider when metric readers
+  // are declared, but returns no handle to it. Capture it now so metrics get
+  // the same flush and shutdown coverage as spans; without metric readers the
+  // global is a no-op provider with no lifecycle methods.
+  const meterProvider = runtimeMeterProvider();
   return {
-    forceFlush: () => provider.forceFlush!(),
+    forceFlush: async () => {
+      await Promise.all([provider.forceFlush!(), meterProvider.forceFlush?.()]);
+    },
     idGenerator,
     samplesTrace: (traceId) => samplerAdmitsTrace(idGenerator, traceId),
-    shutdown: () => provider.shutdown!(),
+    shutdown: async () => {
+      // Stop auto-instrumentations first so nothing records into providers
+      // that are about to shut down.
+      disableInstrumentations(pipeline.instrumentations);
+      await Promise.all([provider.shutdown!(), meterProvider.shutdown?.()]);
+    },
   };
 }
 
-/** Lifecycle retained from the tracer provider that owns every destination. */
+/** Lifecycle retained from the providers that own every destination. */
 export interface RegisteredOtelPipeline {
   readonly forceFlush: () => Promise<void>;
   readonly idGenerator: AgentSpanIdGenerator;
@@ -207,6 +225,11 @@ function samplerAdmitsTrace(idGenerator: AgentSpanIdGenerator, traceId: string):
 }
 
 interface RuntimeTracerProvider {
+  forceFlush(): Promise<void>;
+  shutdown(): Promise<void>;
+}
+
+interface RuntimeMeterProvider {
   forceFlush(): Promise<void>;
   shutdown(): Promise<void>;
 }
@@ -249,6 +272,33 @@ function rollbackRegistration(input: {
 function runtimeTracerProvider(): Partial<RuntimeTracerProvider> {
   const globalProvider = trace.getTracerProvider() as Partial<ProxyTracerProvider>;
   return (globalProvider.getDelegate?.() ?? globalProvider) as Partial<RuntimeTracerProvider>;
+}
+
+function runtimeMeterProvider(): Partial<RuntimeMeterProvider> {
+  const globalProvider = metrics.getMeterProvider() as {
+    forceFlush?: unknown;
+    shutdown?: unknown;
+  } | null;
+  return {
+    forceFlush:
+      typeof globalProvider?.forceFlush === "function"
+        ? () => (globalProvider as RuntimeMeterProvider).forceFlush()
+        : undefined,
+    shutdown:
+      typeof globalProvider?.shutdown === "function"
+        ? () => (globalProvider as RuntimeMeterProvider).shutdown()
+        : undefined,
+  };
+}
+
+function disableInstrumentations(instrumentations: readonly unknown[] | undefined): void {
+  for (const instrumentation of instrumentations ?? []) {
+    const disable = (instrumentation as { disable?: unknown } | null)?.disable;
+    if (typeof disable !== "function") continue;
+    try {
+      disable.call(instrumentation);
+    } catch {}
+  }
 }
 
 function globalTracerUses(idGenerator: AgentSpanIdGenerator): boolean {


### PR DESCRIPTION
### Summary

`registerOTel` creates a global meter provider and enables declared instrumentations, but eve previously retained lifecycle control only for the tracer provider. Buffered metrics could therefore be lost at teardown, while instrumentations could continue recording into providers that had already shut down. Registration now captures the global meter provider so `forceFlush` includes metrics, and `shutdown` disables declared instrumentations before shutting down both providers. Without metric readers the meter lifecycle remains a no-op; shutdown still leaves the global context manager untouched, and failed-registration rollback is unchanged.

### Validation

Scenario coverage registers real metric and instrumentation pipelines and verifies metric flush and shutdown plus instrumentation enable and disable behavior. Both regressions fail without the fix; the full `otel-registration` scenario and unit suites pass.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the patch changeset for complete OpenTelemetry lifecycle handling.

**Implementation** — 2 files · `+60 / -4`

Captures the feature-detected meter lifecycle, sequences instrumentation shutdown, and adds the matching vendored API declaration.

**Tests** — 1 file · `+41 / -0`

Adds focused scenarios for metric-reader lifecycle and instrumentation cleanup.
