### PR TITLE
fix(eve): consult the OTel sampler for pre-allocated trace seeds

### DIFF
--- a/.changeset/sampler-honest-trace-seed.md
+++ b/.changeset/sampler-honest-trace-seed.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Pre-allocated session trace seeds now consult the configured OTel sampler, so `$eve.trace_id` workflow attributes are only stamped for traces the sampler will actually record. Previously an `always_off`, ratio, or custom sampler could leave links to traces that were never exported.

--- a/packages/eve/src/instrumentation/runtime.test.ts
+++ b/packages/eve/src/instrumentation/runtime.test.ts
@@ -10,11 +10,13 @@ import type { InstrumentationHooks } from "#instrumentation/lifecycle.js";
 import {
   bindInstrumentationRuntime,
   bindSessionInstrumentation,
+  initializeSessionInstrumentation,
   registerInstrumentationRuntime,
   type ExecutionInstrumentation,
   type InstrumentationRuntime,
   type InstrumentationStepScope,
 } from "#instrumentation/runtime.js";
+import { AgentSpanIdGenerator } from "#tracing/agent-span-id-generator.js";
 import { ContextAgentTraceStateStore } from "#tracing/agent-trace-context-store.js";
 import type { TraceCapturePolicy } from "#tracing/otel-declaration.js";
 
@@ -341,5 +343,61 @@ describe("bindSessionInstrumentation", () => {
     });
     expect(policy).toHaveBeenCalledOnce();
     expect(ctx.get(SessionTraceSeedKey)).toBeUndefined();
+  });
+});
+
+describe("initializeSessionInstrumentation", () => {
+  function registerSeedRuntime(input: {
+    readonly samplesTrace?: (traceId: string) => boolean;
+    readonly tracePolicy?: TraceCapturePolicy;
+  }): void {
+    registerInstrumentationRuntime({
+      ...createRuntime({ capturesContent: true, publish: vi.fn() }, input.tracePolicy),
+      idGenerator: new AgentSpanIdGenerator(),
+      prepareSessionTrace: async () => ({ spanId: "", traceFlags: 0, traceId: "" }),
+      ...(input.samplesTrace === undefined ? {} : { samplesTrace: input.samplesTrace }),
+    });
+  }
+
+  it("marks the seed unsampled when the installed sampler drops the trace", () => {
+    const samplesTrace = vi.fn(() => false);
+    registerSeedRuntime({ samplesTrace });
+    const ctx = createContext();
+
+    initializeSessionInstrumentation({ agentName: "test-agent", ctx });
+
+    const seed = ctx.get(SessionTraceSeedKey);
+    expect(seed?.traceFlags).toBe(0);
+    expect(seed?.decision).toMatchObject({ action: "record" });
+    expect(samplesTrace).toHaveBeenCalledExactlyOnceWith(seed?.traceId);
+  });
+
+  it("keeps the seed sampled when the sampler admits the trace", () => {
+    registerSeedRuntime({ samplesTrace: () => true });
+    const ctx = createContext();
+
+    initializeSessionInstrumentation({ agentName: "test-agent", ctx });
+
+    expect(ctx.get(SessionTraceSeedKey)?.traceFlags).toBe(1);
+  });
+
+  it("stays sampled when no sampler capability is installed", () => {
+    registerSeedRuntime({});
+    const ctx = createContext();
+
+    initializeSessionInstrumentation({ agentName: "test-agent", ctx });
+
+    expect(ctx.get(SessionTraceSeedKey)?.traceFlags).toBe(1);
+  });
+
+  it("skips the sampler when policy already drops the trace", () => {
+    const samplesTrace = vi.fn(() => true);
+    registerSeedRuntime({ samplesTrace, tracePolicy: () => false });
+    const ctx = createContext();
+
+    initializeSessionInstrumentation({ agentName: "test-agent", ctx });
+
+    expect(ctx.get(SessionTraceSeedKey)?.traceFlags).toBe(0);
+    expect(samplesTrace).not.toHaveBeenCalled();
   });
 });

--- a/packages/eve/src/instrumentation/runtime.test.ts
+++ b/packages/eve/src/instrumentation/runtime.test.ts
@@ -355,7 +355,7 @@ describe("initializeSessionInstrumentation", () => {
       ...createRuntime({ capturesContent: true, publish: vi.fn() }, input.tracePolicy),
       idGenerator: new AgentSpanIdGenerator(),
       prepareSessionTrace: async () => ({ spanId: "", traceFlags: 0, traceId: "" }),
-      ...(input.samplesTrace === undefined ? {} : { samplesTrace: input.samplesTrace }),
+      samplesTrace: input.samplesTrace,
     });
   }
 

--- a/packages/eve/src/instrumentation/runtime.ts
+++ b/packages/eve/src/instrumentation/runtime.ts
@@ -156,6 +156,8 @@ export interface InstrumentationRuntime {
   otelSettings: OtelHarnessSettings | undefined;
   readonly runtimeContextResolvers?: readonly RuntimeContextResolver[];
   readonly runInContext: InstrumentationContextRunner;
+  /** Whether the installed OTel sampler would record a trace with this id. */
+  readonly samplesTrace?: (traceId: string) => boolean;
   readonly shutdown: () => Promise<void>;
   stepStartedRuntimeContextResolver?: InstrumentationEvents["step.started"];
 }
@@ -526,11 +528,17 @@ function allocateSessionTraceSeed(input: {
     audience: input.audience,
     channelType: input.channelType,
   });
+  const traceId = input.runtime.idGenerator.generateTraceId();
+  // The seed is stamped onto workflow attributes as `$eve.trace_id` before
+  // any span exists, so the configured OTel sampler must agree now: a
+  // policy-sampled seed for a sampler-dropped trace would link to a trace
+  // that is never exported.
+  const sampled = decision.action === "record" && (input.runtime.samplesTrace?.(traceId) ?? true);
   return {
     decision,
     spanId: input.runtime.idGenerator.allocateSpanId(),
-    traceFlags: decision.action === "record" ? 1 : 0,
-    traceId: input.runtime.idGenerator.generateTraceId(),
+    traceFlags: sampled ? 1 : 0,
+    traceId,
   };
 }
 

--- a/packages/eve/src/instrumentation/runtime.ts
+++ b/packages/eve/src/instrumentation/runtime.ts
@@ -529,10 +529,6 @@ function allocateSessionTraceSeed(input: {
     channelType: input.channelType,
   });
   const traceId = input.runtime.idGenerator.generateTraceId();
-  // The seed is stamped onto workflow attributes as `$eve.trace_id` before
-  // any span exists, so the configured OTel sampler must agree now: a
-  // policy-sampled seed for a sampler-dropped trace would link to a trace
-  // that is never exported.
   const sampled = decision.action === "record" && (input.runtime.samplesTrace?.(traceId) ?? true);
   return {
     decision,

--- a/packages/eve/src/tracing/install-instrumentation-runtime.ts
+++ b/packages/eve/src/tracing/install-instrumentation-runtime.ts
@@ -90,6 +90,7 @@ export function installInstrumentationRuntime(input: {
     prepareTurnTrace,
     runtimeContextResolvers: input.runtimeContextResolvers,
     runInContext,
+    samplesTrace: otelRuntime?.samplesTrace,
     shutdown: () => {
       shutdown ??= settleAll([
         ...(otelRuntime === undefined ? [] : [otelRuntime.shutdown]),

--- a/packages/eve/src/tracing/otel-registration.scenario.test.ts
+++ b/packages/eve/src/tracing/otel-registration.scenario.test.ts
@@ -70,6 +70,45 @@ describe("registerOtelPipeline", () => {
     ).not.toThrow();
   });
 
+  it("reports the installed sampler's verdict for pre-allocated trace ids", () => {
+    const runtime = registerOtelPipeline({
+      pipeline: { sampler: "always_off", spanProcessors: [] },
+      serviceName: "weather",
+    });
+
+    expect(runtime.samplesTrace(runtime.idGenerator.generateTraceId())).toBe(false);
+  });
+
+  it("passes the pre-allocated trace id to a custom sampler without exporting the probe", async () => {
+    const seen: string[] = [];
+    const sampler = {
+      shouldSample: (_context: unknown, traceId: string) => {
+        seen.push(traceId);
+        return { decision: traceId.startsWith("a") ? 2 : 0 };
+      },
+      toString: () => "test-sampler",
+    };
+    const exporter = new InMemorySpanExporter();
+    const processor = new SimpleSpanProcessor(exporter);
+    const runtime = registerOtelPipeline({
+      pipeline: {
+        sampler: sampler as unknown as NonNullable<
+          Parameters<typeof registerOtelPipeline>[0]["pipeline"]["sampler"]
+        >,
+        spanProcessors: [processor],
+      },
+      serviceName: "weather",
+    });
+
+    expect(runtime.samplesTrace("a".repeat(32))).toBe(true);
+    expect(runtime.samplesTrace("b".repeat(32))).toBe(false);
+    expect(seen).toContain("a".repeat(32));
+    expect(seen).toContain("b".repeat(32));
+
+    await runtime.forceFlush();
+    expect(exporter.getFinishedSpans()).toEqual([]);
+  });
+
   it("fails without replacing another runtime's global propagator", async () => {
     let foreignInjections = 0;
     const shutdown = vi.fn(async () => undefined);

--- a/packages/eve/src/tracing/otel-registration.scenario.test.ts
+++ b/packages/eve/src/tracing/otel-registration.scenario.test.ts
@@ -81,20 +81,19 @@ describe("registerOtelPipeline", () => {
 
   it("passes the pre-allocated trace id to a custom sampler without exporting the probe", async () => {
     const seen: string[] = [];
-    const sampler = {
-      shouldSample: (_context: unknown, traceId: string) => {
-        seen.push(traceId);
-        return { decision: traceId.startsWith("a") ? 2 : 0 };
-      },
-      toString: () => "test-sampler",
-    };
+    const sampler: NonNullable<Parameters<typeof registerOtelPipeline>[0]["pipeline"]["sampler"]> =
+      {
+        shouldSample: (_context: unknown, traceId: string) => {
+          seen.push(traceId);
+          return { decision: traceId.startsWith("a") ? 2 : 0 };
+        },
+        toString: () => "test-sampler",
+      };
     const exporter = new InMemorySpanExporter();
     const processor = new SimpleSpanProcessor(exporter);
     const runtime = registerOtelPipeline({
       pipeline: {
-        sampler: sampler as unknown as NonNullable<
-          Parameters<typeof registerOtelPipeline>[0]["pipeline"]["sampler"]
-        >,
+        sampler,
         spanProcessors: [processor],
       },
       serviceName: "weather",

--- a/packages/eve/src/tracing/otel-registration.ts
+++ b/packages/eve/src/tracing/otel-registration.ts
@@ -173,16 +173,6 @@ export interface RegisteredOtelPipeline {
   readonly shutdown: () => Promise<void>;
 }
 
-/**
- * Asks the installed sampler whether a trace with this pre-allocated id will
- * exist. eve stamps `$eve.trace_id` onto workflow attributes before any span
- * starts, so the sampler must be consulted at allocation time or an
- * `always_off`, ratio, or custom sampler would leave links to traces that are
- * never exported. The probe roots a span exactly as `agent.session` does and,
- * like the ownership probe above, is deliberately never ended so it cannot
- * export. Trace-id-based and constant samplers are exact; a custom sampler
- * keyed on span name sees the probe's name rather than `agent.session`.
- */
 function samplerAdmitsTrace(idGenerator: AgentSpanIdGenerator, traceId: string): boolean {
   const probe = idGenerator.withTraceId(traceId, () =>
     trace.getTracer("eve.registration").startSpan(REGISTRATION_SPAN_NAME, { root: true }),

--- a/packages/eve/src/tracing/otel-registration.ts
+++ b/packages/eve/src/tracing/otel-registration.ts
@@ -159,6 +159,7 @@ export function registerOtelPipeline(input: {
   return {
     forceFlush: () => provider.forceFlush!(),
     idGenerator,
+    samplesTrace: (traceId) => samplerAdmitsTrace(idGenerator, traceId),
     shutdown: () => provider.shutdown!(),
   };
 }
@@ -167,7 +168,26 @@ export function registerOtelPipeline(input: {
 export interface RegisteredOtelPipeline {
   readonly forceFlush: () => Promise<void>;
   readonly idGenerator: AgentSpanIdGenerator;
+  /** Whether the installed sampler would record a trace with this id. */
+  readonly samplesTrace: (traceId: string) => boolean;
   readonly shutdown: () => Promise<void>;
+}
+
+/**
+ * Asks the installed sampler whether a trace with this pre-allocated id will
+ * exist. eve stamps `$eve.trace_id` onto workflow attributes before any span
+ * starts, so the sampler must be consulted at allocation time or an
+ * `always_off`, ratio, or custom sampler would leave links to traces that are
+ * never exported. The probe roots a span exactly as `agent.session` does and,
+ * like the ownership probe above, is deliberately never ended so it cannot
+ * export. Trace-id-based and constant samplers are exact; a custom sampler
+ * keyed on span name sees the probe's name rather than `agent.session`.
+ */
+function samplerAdmitsTrace(idGenerator: AgentSpanIdGenerator, traceId: string): boolean {
+  const probe = idGenerator.withTraceId(traceId, () =>
+    trace.getTracer("eve.registration").startSpan(REGISTRATION_SPAN_NAME, { root: true }),
+  );
+  return (probe.spanContext().traceFlags & 1) === 1;
 }
 
 interface RuntimeTracerProvider {


### PR DESCRIPTION
### Summary

The pre-allocated session trace seed was marked sampled before OTel's configured sampler ran, so `always_off`, ratio, or custom samplers could drop `agent.session` after eve had stamped a `$eve.trace_id` for a trace that would never be exported. Seed allocation now probes the installed sampler with the pre-allocated trace ID and marks it sampled only when both eve's trace policy and the sampler accept it. The probe is never ended, so it cannot export; existing behavior for non-OTel providers and configurations without a sampler is preserved. Custom samplers receive the trace ID, but the probe does not reproduce `agent.session` metadata.

### Validation

Unit coverage verifies sampler admit, drop, absence, and policy short-circuit behavior. Scenario coverage verifies `always_off`, custom trace-ID sampling, and that probes do not export; the full unit tier and eve integration suite (678 tests) pass.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the patch changeset for sampler-consistent trace links.

**Implementation** — 3 files · `+17 / -2`

Keeps the sampler probe and seed decision within the existing OTel registration and instrumentation runtime boundaries.

**Tests** — 2 files · `+96 / -0`

Covers policy and sampler combinations plus real registered samplers, including the non-exporting probe.
