### PR TITLE
perf(eve): turn execution - prototype inline root turns

### DIFF
--- a/.changeset/fast-turns-inline.md
+++ b/.changeset/fast-turns-inline.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Prototype direct execution of simple root conversation turns to measure the latency ceiling from removing the per-turn child Workflow handshake.

--- a/e2e/fixtures/agent-workflow-stress/agent/agent.ts
+++ b/e2e/fixtures/agent-workflow-stress/agent/agent.ts
@@ -8,7 +8,8 @@ export default defineAgent({
   ...e2eAgentConfig(),
   model: mockModel(
     ({ lastUserMessage, userMessageCount }) =>
-      `stress-ack:${userMessageCount}:${lastUserMessage ?? ""}`,
+      // The private experiment marker is rendered as one ephemeral user-context message.
+      `stress-ack:${userMessageCount - 1}:${lastUserMessage ?? ""}`,
   ),
   modelContextWindowTokens: 1_000_000,
 });

--- a/e2e/fixtures/agent-workflow-stress/evals/concurrent-workflow-turns.eval.ts
+++ b/e2e/fixtures/agent-workflow-stress/evals/concurrent-workflow-turns.eval.ts
@@ -5,6 +5,7 @@ const SESSION_COUNT = 50;
 const TURNS_PER_SESSION = 2;
 const TURN_COUNT = SESSION_COUNT * TURNS_PER_SESSION;
 const PERFORMANCE_LOG_PREFIX = "EVE_WORKFLOW_STRESS_METRIC=";
+const INLINE_TURN_EXPERIMENT = "__evePerfInlineTurn";
 
 export default defineEval({
   description: "Workflow stress: 50 durable sessions complete 100 total turns.",
@@ -16,7 +17,9 @@ export default defineEval({
     const firstTurns = await Promise.all(
       sessions.map(async (session, index) => {
         const startedAt = performance.now();
-        const result = await session.send(markerFor(index, 1));
+        const result = await session.send(markerFor(index, 1), {
+          clientContext: INLINE_TURN_EXPERIMENT,
+        });
 
         return {
           durationMs: performance.now() - startedAt,
@@ -33,7 +36,9 @@ export default defineEval({
     const secondTurns = await Promise.all(
       sessions.map(async (session, index) => {
         const startedAt = performance.now();
-        const result = await session.send(markerFor(index, 2));
+        const result = await session.send(markerFor(index, 2), {
+          clientContext: INLINE_TURN_EXPERIMENT,
+        });
 
         return {
           durationMs: performance.now() - startedAt,

--- a/e2e/fixtures/agent-workflow-stress/evals/sequential-workflow-turns.eval.ts
+++ b/e2e/fixtures/agent-workflow-stress/evals/sequential-workflow-turns.eval.ts
@@ -3,6 +3,7 @@ import { equals } from "eve/evals/expect";
 
 const TURN_COUNT = 100;
 const PERFORMANCE_LOG_PREFIX = "EVE_WORKFLOW_STRESS_METRIC=";
+const INLINE_TURN_EXPERIMENT = "__evePerfInlineTurn";
 
 export default defineEval({
   description: "Workflow stress: one durable session completes 100 sequential turns.",
@@ -15,7 +16,7 @@ export default defineEval({
     for (let turnNumber = 1; turnNumber <= TURN_COUNT; turnNumber += 1) {
       const marker = `sequential-turn-${String(turnNumber).padStart(3, "0")}`;
       const startedAt = performance.now();
-      const result = await t.send(marker);
+      const result = await t.send(marker, { clientContext: INLINE_TURN_EXPERIMENT });
       const durationMs = performance.now() - startedAt;
       const elapsedSeconds = durationMs / 1_000;
 

--- a/packages/eve/src/execution/workflow-entry.test.ts
+++ b/packages/eve/src/execution/workflow-entry.test.ts
@@ -26,6 +26,8 @@ import { settleCancelledTurnStep } from "#execution/settle-cancelled-turn-step.j
 import { emitTerminalSessionFailureStep } from "#execution/terminal-session-failure-step.js";
 import type { SessionInboxPayload } from "#execution/session-command-inbox.js";
 import { sessionCommandHookToken } from "#execution/session-command-token.js";
+import { turnStep } from "#execution/workflow-steps.js";
+import { attachClientContext } from "#internal/client-context.js";
 
 vi.mock("#compiled/@workflow/core/index.js", () => ({
   createHook: vi.fn(),
@@ -85,6 +87,10 @@ vi.mock("./terminate-child-sessions-step.js", () => ({
 
 vi.mock("./dispatch-turn-step.js", () => ({
   dispatchTurnStep: vi.fn().mockImplementation(async () => ({ runId: "turn-run" })),
+}));
+
+vi.mock("./workflow-steps.js", () => ({
+  turnStep: vi.fn(),
 }));
 
 vi.mock("./terminal-session-failure-step.js", () => ({
@@ -404,6 +410,56 @@ describe("workflowEntry", () => {
       lifecycle: "terminal",
       sessionId: "wrun_test_123",
       settled: { output: "" },
+    });
+  });
+
+  it("runs marked simple root turns without a child workflow handshake", async () => {
+    const sessionState = createBaseSessionState();
+    const settledState = createBaseSessionState({
+      emissionState: { sequence: 5, sessionStarted: true, stepIndex: 1, turnId: "turn-1" },
+    });
+    vi.mocked(createSessionStep).mockResolvedValue(createSessionStepResultForMock(sessionState));
+    vi.mocked(turnStep).mockResolvedValueOnce({
+      action: "park",
+      hasPendingAuthorization: false,
+      hasPendingInputBatch: false,
+      serializedContext: { "eve.sessionId": "wrun_test_123" },
+      sessionState: settledState,
+      settled: { output: "ok" },
+    });
+    installHookMocks({
+      stableHook: { values: [{ kind: "session-timeout" }] },
+      turnControls: [],
+    });
+
+    await expect(
+      workflowEntry({
+        input: attachClientContext({ message: "hello there" }, [
+          "Client context:\n__evePerfInlineTurn",
+        ]),
+        serializedContext: createSerializedContext(),
+      }),
+    ).resolves.toEqual({ output: "" });
+
+    expect(turnStep).toHaveBeenCalledWith({
+      input: expect.objectContaining({
+        kind: "deliver",
+        payloads: [
+          expect.objectContaining({
+            message: "hello there",
+          }),
+        ],
+      }),
+      parentWritable: expect.any(WritableStream),
+      serializedContext: expect.any(Object),
+      sessionState,
+    });
+    expect(dispatchTurnStep).not.toHaveBeenCalled();
+    expect(notifyTurnCallerStep).toHaveBeenCalledWith({
+      caller: undefined,
+      lifecycle: "parked",
+      sessionId: "wrun_test_123",
+      settled: { output: "ok" },
     });
   });
 

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -25,6 +25,7 @@ import {
 } from "#execution/delegated-parent-result.js";
 import type { DurableSessionState } from "#execution/durable-session-store.js";
 import type { NextDriverAction } from "#execution/next-driver-action.js";
+import type { DurableStepResult } from "#execution/next-driver-action.js";
 import { nextTurnDelivery, type NextTurnInstruction } from "#execution/parked-delivery-wait.js";
 import { SessionStateCursor } from "#execution/session-state-cursor.js";
 import { cancelDescendantTurnsStep } from "#execution/cancel-descendant-turns-step.js";
@@ -48,9 +49,11 @@ import type { DynamicSubagentAgentConfig } from "#runtime/subagents/dynamic-agen
 import type { TokenUsage } from "#shared/token-usage.js";
 import { isTaskOwnedSerializedContext } from "#execution/tasks/child/instructions.js";
 import { attachClientContext, readClientContext } from "#internal/client-context.js";
+import { turnStep } from "#execution/workflow-steps.js";
 
 const SAFE_OUTER_WORKFLOW_FAILURE_MESSAGE =
   "Agent workflow failed. Inspect the private session trace for details.";
+const INLINE_TURN_EXPERIMENT_MARKER = "Client context:\n__evePerfInlineTurn";
 
 // workflow-entry.ts is the durable workflow body — the bundler rejects
 // node built-ins here, so `internal/logging.ts` cannot be imported.
@@ -434,20 +437,27 @@ async function runDriverLoop(input: {
       caller,
       serializedContext: stateCursor.serializedContext,
     });
-    const turn = await dispatchAndAwaitTurn({
-      bufferedDeliveries,
-      bufferedSessionControls,
-      cancelledTaskIds,
-      capabilities: input.capabilities,
-      commandInbox,
-      controlToken: nextTurnControlToken(),
-      delivery,
-      mode: input.mode,
-      parentWritable: input.driverWritable,
-      serializedContext,
-      seenTaskDeliveries,
-      sessionState: stateCursor.sessionState,
-    });
+    const turn = shouldRunInlineTurnExperiment(delivery, input.mode, caller)
+      ? await runInlineTurnExperiment({
+          delivery,
+          parentWritable: input.driverWritable,
+          serializedContext,
+          sessionState: stateCursor.sessionState,
+        })
+      : await dispatchAndAwaitTurn({
+          bufferedDeliveries,
+          bufferedSessionControls,
+          cancelledTaskIds,
+          capabilities: input.capabilities,
+          commandInbox,
+          controlToken: nextTurnControlToken(),
+          delivery,
+          mode: input.mode,
+          parentWritable: input.driverWritable,
+          serializedContext,
+          seenTaskDeliveries,
+          sessionState: stateCursor.sessionState,
+        });
     await disposeSettledTurnControl?.();
     disposeSettledTurnControl = turn.dispose;
     stateCursor.adoptState(turn.action);
@@ -609,6 +619,76 @@ async function runDriverLoop(input: {
     await sessionTimeout?.dispose();
     await commandInbox.dispose();
   }
+}
+
+function shouldRunInlineTurnExperiment(
+  delivery: HookPayload,
+  mode: RunMode,
+  caller: TurnCaller | undefined,
+): boolean {
+  if (mode !== "conversation" || caller !== undefined || delivery.kind !== "deliver") return false;
+  return delivery.payloads.some((payload) =>
+    readClientContext(payload)?.includes(INLINE_TURN_EXPERIMENT_MARKER),
+  );
+}
+
+async function runInlineTurnExperiment(input: {
+  readonly delivery: HookPayload;
+  readonly parentWritable: WritableStream<Uint8Array>;
+  readonly serializedContext: Record<string, unknown>;
+  readonly sessionState: DurableSessionState;
+}): Promise<{ readonly action: TurnDriverAction; dispose(): Promise<void> }> {
+  const result = await turnStep({
+    input: input.delivery,
+    parentWritable: input.parentWritable,
+    serializedContext: input.serializedContext,
+    sessionState: input.sessionState,
+  });
+
+  return {
+    action: inlineDriverAction(result),
+    async dispose() {},
+  };
+}
+
+function inlineDriverAction(result: DurableStepResult): TurnDriverAction {
+  if (
+    result.backgroundTaskState !== undefined ||
+    result.backgroundTasks !== undefined ||
+    ("sleepDurationMs" in result && result.sleepDurationMs !== undefined)
+  ) {
+    throw new Error("Inline turn experiment does not support background or sleeping work.");
+  }
+
+  if (result.action === "done") {
+    return {
+      isError: result.isError,
+      kind: "done",
+      output: result.output ?? "",
+      serializedContext: result.serializedContext,
+      sessionState: result.sessionState,
+      usage: result.usage,
+      usageDelta: result.usageDelta,
+    };
+  }
+
+  if (
+    result.action === "park" &&
+    result.pendingRuntimeActionKeys === undefined &&
+    result.hasPendingAuthorization === false &&
+    result.hasPendingInputBatch === false
+  ) {
+    return {
+      authorizationAttemptIds: result.authorizationAttemptIds,
+      authorizationNames: result.authorizationNames,
+      kind: "park",
+      serializedContext: result.serializedContext,
+      sessionState: result.sessionState,
+      settled: result.settled,
+    };
+  }
+
+  throw new Error(`Inline turn experiment cannot handle action "${result.action}".`);
 }
 
 async function finalizeExpiredSession(input: {


### PR DESCRIPTION
### Summary

Related to #876. This benchmark-only prototype measures the upper-bound latency benefit of executing simple root conversation turns in the session driver, removing the per-turn child Workflow, private inbox/cancellation hooks, and terminal control resume. The stress fixture opts into the path with ephemeral client context; every other session retains the existing topology.

This is not proposed for merge as written: marked turns reject background work, sleeps, runtime actions, and authorization/input waits, and the direct path does not preserve mid-turn cancellation or latest-deployment routing. The result shows that restoring those semantics around a single-run turn architecture has enough payoff to justify the larger design.

### Hosted result

Compared with the exact benchmark base in [run 33468124247](https://github.com/vercel/eve/actions/runs/33468124247), the candidate in [run 33468225787](https://github.com/vercel/eve/actions/runs/33468225787) produced:

| Metric | Base | Inline prototype | Delta |
| --- | ---: | ---: | ---: |
| Sequential mean | 3.042s | 1.170s | -61.6% |
| Sequential p50 | 3.036s | 1.110s | -63.5% |
| Sequential p95 | 3.692s | 1.515s | -59.0% |
| Concurrent second-turn p50 | 1.867s | 0.946s | -49.3% |
| Sequential turn-order slope | 13.31 ms/turn | 0.44 ms/turn | -96.7% |

The hosted Vercel stress job and full Vercel e2e matrix passed. These are contemporaneous but unpaired single runs, so the exact percentages remain directional; the size and consistency across the distribution identify the parent/child turn boundary and replay-growing driver history as the dominant optimization target.

### Validation

The focused workflow-entry suite passes 33 tests and verifies that a marked simple root turn invokes `turnStep` without dispatching a child. The eve package typecheck and JavaScript build pass; the repository lint completes with pre-existing warnings. The hosted Vercel e2e matrix passes.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

The changeset labels the package impact of the experiment.

**Implementation** — 1 file · `+94 / -14`

The opt-in driver path and explicit terminal-action conversion are kept together so the semantic boundary is visible during review.

**Tests** — 4 files · `+67 / -4`

Focused unit coverage proves child dispatch is skipped, while the stress fixture and its two evals apply the private opt-in to sequential and concurrent samples.
