### PR TITLE
fix(eve): require exact Zod peer version

### DIFF
--- a/.changeset/tidy-zod-peers.md
+++ b/.changeset/tidy-zod-peers.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Require projects to install the exact Zod version used by eve so live schemas cannot cross incompatible Zod conversion contexts.

--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -480,7 +480,8 @@
     "ai": "catalog:",
     "braintrust": "^3.0.0",
     "just-bash": "^3.1.0",
-    "microsandbox": "^0.5.0"
+    "microsandbox": "^0.5.0",
+    "zod": "catalog:"
   },
   "peerDependenciesMeta": {
     "@opentelemetry/api": {

--- a/packages/eve/src/setup/scaffold/version-tokens.test.ts
+++ b/packages/eve/src/setup/scaffold/version-tokens.test.ts
@@ -25,6 +25,16 @@ describe("resolveVersionToken", () => {
     expect(manifest).toContain(`"@vercel/connect": "${resolved}"`);
   });
 
+  it("keeps the required Zod peer on the exact vendored catalog version", () => {
+    const resolved = resolveVersionToken("zodPackageVersion", "__ZOD_VERSION__");
+    const packageJson = JSON.parse(readFileSync(fileURLToPath(EVE_PACKAGE_JSON_URL), "utf8")) as {
+      peerDependencies?: { zod?: string };
+    };
+
+    expect(resolved).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(packageJson.peerDependencies?.zod).toBe("catalog:");
+  });
+
   it("resolves eve runtime and dependency version tokens from eve's own package.json", () => {
     const runtimeVersion = resolveVersionToken(
       "evePackage.runtimeVersion",


### PR DESCRIPTION
### Summary

eve vendors Zod for schema conversion but previously allowed consumer projects to provide live schemas from any Zod version, which can cross incompatible private conversion contexts and crash before a model call. This makes Zod a required exact peer sourced from the same catalog entry as the vendored bundle, so incompatible installs are caught during dependency resolution. No runtime schema behavior changes for projects already on Zod 4.5.4.

### Validation

The focused version-token suite passes all 6 tests, including new coverage that the Zod catalog entry is exact and eve's peer consumes it. The eve package typecheck and dependency-policy check also pass.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Patch changeset describing the new install-time compatibility contract.

**Implementation** — 1 file · `+2 / -1`

Declares Zod as a required catalog-backed peer without changing runtime code.

**Tests** — 1 file · `+10 / -0`

Regression coverage keeps the peer declaration and exact vendored catalog version aligned.
