### PR TITLE
fix(eve): preserve GenAI span identity and redacted error context

### DIFF
--- a/.changeset/tidy-cats-observe.md
+++ b/.changeset/tidy-cats-observe.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Preserve agent invocation and tool execution names when exporting GenAI spans to Datadog instead of displaying them as `otel.span`.
+Preserve GenAI operation and resource names when exporting spans to Datadog instead of displaying them as `otel.span`, and retain generic error details when private output is redacted.

--- a/.changeset/tidy-cats-observe.md
+++ b/.changeset/tidy-cats-observe.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Preserve agent invocation and tool execution names when exporting GenAI spans to Datadog instead of displaying them as `otel.span`.

--- a/.changeset/tidy-cats-observe.md
+++ b/.changeset/tidy-cats-observe.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Preserve GenAI operation and resource names when exporting spans to Datadog instead of displaying them as `otel.span`, and retain generic error details when private output is redacted.
+Preserve GenAI operation and resource identity for OTLP consumers, and retain generic error details when private output is redacted.

--- a/packages/eve/src/instrumentation/ai-sdk-telemetry.test.ts
+++ b/packages/eve/src/instrumentation/ai-sdk-telemetry.test.ts
@@ -13,10 +13,32 @@ vi.mock("#internal/logging.js", () => ({
 }));
 
 import {
+  datadogGenAiSpanNames,
   ensureOtelIntegration,
   getRegisteredTelemetryIntegrations,
   telemetryWithoutErrorContent,
 } from "#instrumentation/ai-sdk-telemetry.js";
+
+describe("datadogGenAiSpanNames", () => {
+  it("preserves the detailed resource for AI SDK GenAI spans", async () => {
+    const exporter = new InMemorySpanExporter();
+    const provider = new BasicTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    const tracer = datadogGenAiSpanNames(provider.getTracer("test"));
+
+    tracer.startSpan("step 1", { attributes: { "gen_ai.operation.name": "agent_step" } }).end();
+    tracer.startSpan("plain span").end();
+    await provider.forceFlush();
+
+    expect(exporter.getFinishedSpans()[0]?.attributes).toMatchObject({
+      "operation.name": "agent_step",
+      "resource.name": "step 1",
+    });
+    expect(exporter.getFinishedSpans()[1]?.attributes).not.toHaveProperty("operation.name");
+    await provider.shutdown();
+  });
+});
 
 describe("getRegisteredTelemetryIntegrations", () => {
   const original = globalThis.AI_SDK_TELEMETRY_INTEGRATIONS;

--- a/packages/eve/src/instrumentation/ai-sdk-telemetry.test.ts
+++ b/packages/eve/src/instrumentation/ai-sdk-telemetry.test.ts
@@ -13,19 +13,19 @@ vi.mock("#internal/logging.js", () => ({
 }));
 
 import {
-  datadogGenAiSpanNames,
+  genAiSpanIdentityTracer,
   ensureOtelIntegration,
   getRegisteredTelemetryIntegrations,
   telemetryWithoutErrorContent,
 } from "#instrumentation/ai-sdk-telemetry.js";
 
-describe("datadogGenAiSpanNames", () => {
-  it("preserves the detailed resource for AI SDK GenAI spans", async () => {
+describe("genAiSpanIdentityTracer", () => {
+  it("adds operation and resource compatibility aliases to GenAI spans", async () => {
     const exporter = new InMemorySpanExporter();
     const provider = new BasicTracerProvider({
       spanProcessors: [new SimpleSpanProcessor(exporter)],
     });
-    const tracer = datadogGenAiSpanNames(provider.getTracer("test"));
+    const tracer = genAiSpanIdentityTracer(provider.getTracer("test"));
 
     tracer.startSpan("step 1", { attributes: { "gen_ai.operation.name": "agent_step" } }).end();
     tracer.startSpan("plain span").end();

--- a/packages/eve/src/instrumentation/ai-sdk-telemetry.ts
+++ b/packages/eve/src/instrumentation/ai-sdk-telemetry.ts
@@ -1,4 +1,5 @@
 import { OpenTelemetry } from "#compiled/@ai-sdk/otel/index.js";
+import { trace, type Tracer } from "#compiled/@opentelemetry/api/index.js";
 import { registerTelemetry, type Telemetry } from "ai";
 import { createLogger } from "#internal/logging.js";
 
@@ -21,9 +22,43 @@ export function ensureOtelIntegration(): void {
     return;
   }
   registered = true;
-  eveOtelIntegration = new OpenTelemetry({ runtimeContext: true });
+  eveOtelIntegration = new OpenTelemetry({
+    runtimeContext: true,
+    tracer: datadogGenAiSpanNames(trace.getTracer("gen_ai")),
+  });
   errorSafeEveOtelIntegration = telemetryWithoutErrorContent(eveOtelIntegration);
   registerTelemetry(eveOtelIntegration);
+}
+
+/** Adds Datadog's operation/resource overrides without changing GenAI semantics. @internal */
+export function datadogGenAiSpanNames(tracer: Tracer): Tracer {
+  return new Proxy(tracer, {
+    get(target, property) {
+      if (property !== "startSpan") {
+        const value = Reflect.get(target, property, target) as unknown;
+        return typeof value === "function" ? value.bind(target) : value;
+      }
+      const startSpan: Tracer["startSpan"] = (name, options, parentContext) => {
+        const operationName = options?.attributes?.["gen_ai.operation.name"];
+        if (typeof operationName !== "string") {
+          return target.startSpan(name, options, parentContext);
+        }
+        return target.startSpan(
+          name,
+          {
+            ...options,
+            attributes: {
+              ...options?.attributes,
+              "operation.name": operationName,
+              "resource.name": name,
+            },
+          },
+          parentContext,
+        );
+      };
+      return startSpan;
+    },
+  });
 }
 
 /**

--- a/packages/eve/src/instrumentation/ai-sdk-telemetry.ts
+++ b/packages/eve/src/instrumentation/ai-sdk-telemetry.ts
@@ -24,14 +24,14 @@ export function ensureOtelIntegration(): void {
   registered = true;
   eveOtelIntegration = new OpenTelemetry({
     runtimeContext: true,
-    tracer: datadogGenAiSpanNames(trace.getTracer("gen_ai")),
+    tracer: genAiSpanIdentityTracer(trace.getTracer("gen_ai")),
   });
   errorSafeEveOtelIntegration = telemetryWithoutErrorContent(eveOtelIntegration);
   registerTelemetry(eveOtelIntegration);
 }
 
-/** Adds Datadog's operation/resource overrides without changing GenAI semantics. @internal */
-export function datadogGenAiSpanNames(tracer: Tracer): Tracer {
+/** Adds operation/resource compatibility aliases without changing GenAI semantics. @internal */
+export function genAiSpanIdentityTracer(tracer: Tracer): Tracer {
   return new Proxy(tracer, {
     get(target, property) {
       if (property !== "startSpan") {

--- a/packages/eve/src/tracing/agent-otel-provider.test.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.test.ts
@@ -740,6 +740,8 @@ describe("createAgentOtelInstrumentation", () => {
     expect(turn.attributes).toMatchObject({
       "gen_ai.conversation.id": "remote-session",
       "gen_ai.operation.name": "invoke_agent",
+      "operation.name": "invoke_agent",
+      "resource.name": "invoke_agent",
     });
     expect(turn.attributes).not.toHaveProperty("gen_ai.agent.name");
   });
@@ -820,6 +822,8 @@ describe("createAgentOtelInstrumentation", () => {
       "gen_ai.operation.name": "invoke_agent",
       "gen_ai.usage.input_tokens": 10,
       "gen_ai.usage.output_tokens": 5,
+      "operation.name": "invoke_agent",
+      "resource.name": "invoke_agent weather",
     });
     expect(nanos(turn.startTime)).toBeLessThanOrEqual(nanos(step.startTime));
     expect(nanos(turn.endTime)).toBeGreaterThanOrEqual(nanos(step.endTime) - 1_000_000n);
@@ -843,6 +847,8 @@ describe("createAgentOtelInstrumentation", () => {
       "gen_ai.tool.call.id": "tool-1",
       "gen_ai.tool.name": "weather",
       "gen_ai.tool.type": "function",
+      "operation.name": "execute_tool",
+      "resource.name": "execute_tool weather",
     });
     expect(tool.attributes).not.toHaveProperty("gen_ai.agent.name");
   });

--- a/packages/eve/src/tracing/agent-otel-provider.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.ts
@@ -267,9 +267,10 @@ export function createAgentOtelInstrumentation(
         const session = await input.stateStore.getSession(event.sessionId);
         if (isSampledTrace(turn.context)) {
           const agentName = session?.agentName ?? turn.subagentName;
+          const spanName = agentSpanName(agentName);
           const span = input.idGenerator.withSpanId(turn.context.spanId, () =>
             input.tracer.startSpan(
-              agentSpanName(agentName),
+              spanName,
               {
                 attributes: {
                   "agent.framework.name": "eve",
@@ -282,6 +283,8 @@ export function createAgentOtelInstrumentation(
                   "gen_ai.agent.name": agentName,
                   "gen_ai.conversation.id": event.sessionId,
                   "gen_ai.operation.name": "invoke_agent",
+                  "operation.name": "invoke_agent",
+                  "resource.name": spanName,
                 },
                 kind: SpanKind.INTERNAL,
                 startTime: turn.startTimeMs,

--- a/packages/eve/src/tracing/agent-tool-instrumentation.ts
+++ b/packages/eve/src/tracing/agent-tool-instrumentation.ts
@@ -214,6 +214,8 @@ function toolAttributes(event: InstrumentationToolCallStartedEvent): Record<stri
     "gen_ai.tool.call.id": event.callId,
     "gen_ai.tool.name": event.toolName,
     "gen_ai.tool.type": "function",
+    "operation.name": "execute_tool",
+    "resource.name": `execute_tool ${event.toolName}`,
   };
 }
 

--- a/packages/eve/src/tracing/content-span-processor.test.ts
+++ b/packages/eve/src/tracing/content-span-processor.test.ts
@@ -96,7 +96,7 @@ describe("contentFilteringProcessor", () => {
     });
   });
 
-  it("withholds exception details when outputs are declined", () => {
+  it("replaces exception details when outputs are declined", () => {
     const downstream = recordingProcessor();
     const original = {
       ...(span({ "service.name": "weather" }) as object),
@@ -113,8 +113,14 @@ describe("contentFilteringProcessor", () => {
       events: unknown[];
       status: unknown;
     };
-    expect(visible.events).toEqual([{ attributes: undefined, name: "turn.completed" }]);
-    expect(visible.status).toEqual({ code: 2 });
+    expect(visible.events).toEqual([
+      {
+        attributes: { "exception.message": "Operation failed", "exception.type": "Error" },
+        name: "exception",
+      },
+      { attributes: undefined, name: "turn.completed" },
+    ]);
+    expect(visible.status).toEqual({ code: 2, message: "Operation failed" });
     expect(original.events).toHaveLength(2);
     expect(original.status).toEqual({ code: 2, message: "private failure detail" });
   });

--- a/packages/eve/src/tracing/content-span-processor.ts
+++ b/packages/eve/src/tracing/content-span-processor.ts
@@ -1,4 +1,5 @@
 import type { SpanProcessor } from "#compiled/@vercel/otel/index.js";
+import { SpanStatusCode } from "#compiled/@opentelemetry/api/index.js";
 
 import {
   withoutDeclinedContent,
@@ -14,6 +15,8 @@ import {
   type SpanExportPolicy,
 } from "#tracing/span-export-policy.js";
 import { channelAudienceFromContext } from "#tracing/channel-audience-context.js";
+
+const REDACTED_ERROR_MESSAGE = "Operation failed";
 
 /**
  * Puts one destination's content policy in front of it.
@@ -283,7 +286,16 @@ function refreshEvents(
   for (const event of source) {
     if (typeof event !== "object" || event === null) continue;
     const record = event as Readonly<Record<string, unknown>>;
-    if (record["name"] === "exception") continue;
+    if (record["name"] === "exception") {
+      destination.push({
+        ...record,
+        attributes: {
+          "exception.message": REDACTED_ERROR_MESSAGE,
+          "exception.type": "Error",
+        },
+      });
+      continue;
+    }
     destination.push({ ...record, attributes: undefined });
   }
 }
@@ -300,5 +312,7 @@ function refreshStatus(
   if (record["code"] !== undefined) destination["code"] = record["code"];
   if (content.recordOutputs && record["message"] !== undefined) {
     destination["message"] = record["message"];
+  } else if (!content.recordOutputs && record["code"] === SpanStatusCode.ERROR) {
+    destination["message"] = REDACTED_ERROR_MESSAGE;
   }
 }


### PR DESCRIPTION
### Summary

Follow-up to #2706. Some OTLP ingestion pipelines do not derive operation and resource identity from the emerging GenAI semantic conventions, which can collapse correctly named agent, step, and tool spans into generic backend entries even though their OTel span names and `gen_ai.operation.name` attributes are present. eve now supplies compatibility `operation.name` and `resource.name` aliases for framework and AI SDK GenAI spans while keeping the standard GenAI attributes authoritative and unchanged. Output-redacted destinations also retain a generic `Operation failed` status and exception event instead of presenting an error with no message; private error content remains redacted. Datadog's managed OTLP intake is the observed reproducer.

### Validation

The focused agent provider, AI SDK telemetry, and destination content-filter suites passed all 75 tests, covering structural and AI SDK span names plus safe redacted errors.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the patch release note for preserved OTLP span identity and safe redacted errors.

**Implementation** — 4 files · `+57 / -3`

Adds compatibility aliases at the existing structural boundaries, wraps eve's AI SDK tracer for dependency-owned GenAI spans, and substitutes safe generic error details during destination redaction.

**Tests** — 3 files · `+37 / -3`

Extends the existing trace hierarchy, AI SDK telemetry, and content-redaction coverage.
