### PR TITLE
fix(eve): align agent traces with current GenAI semantics

### DIFF
--- a/.changeset/calm-otters-trace.md
+++ b/.changeset/calm-otters-trace.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Align model and tool traces with current OpenTelemetry GenAI semantic conventions, including client span kinds, conversation and agent context, response identity, canonical token usage, cache-write naming, and failed-generation finish reasons.

--- a/.changeset/calm-otters-trace.md
+++ b/.changeset/calm-otters-trace.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Align model and tool traces with current OpenTelemetry GenAI semantic conventions, including client span kinds, conversation and agent context, response identity, canonical token usage, cache-write naming, and failed-generation finish reasons.
+Align model and tool traces with current OpenTelemetry GenAI semantic conventions, including client span kinds, conversation and agent context, response identity, canonical token usage, and cache-write naming.

--- a/packages/eve/src/cli/commands/trace-detail.test.ts
+++ b/packages/eve/src/cli/commands/trace-detail.test.ts
@@ -57,9 +57,10 @@ describe("summarizeLocalTrace", () => {
       span({
         attributes: {
           "agent.model.id": "gpt-5",
+          "agent.usage.cache_read_tokens": 800,
+          "agent.usage.cache_write_tokens": 120,
           "agent.usage.input_tokens": 1000,
           "agent.usage.output_tokens": 100,
-          "gen_ai.usage.cache_read.input_tokens": 800,
           "gen_ai.usage.cost": 0.01,
         },
       }),
@@ -84,9 +85,24 @@ describe("summarizeLocalTrace", () => {
     expect(summary.inputTokens).toBe(1500);
     expect(summary.outputTokens).toBe(150);
     expect(summary.cacheReadTokens).toBe(800);
+    expect(summary.cacheWriteTokens).toBe(120);
     expect(summary.costUsd).toBeCloseTo(0.01);
     expect(summary.models).toEqual(["gpt-5", "claude-sonnet-4"]);
     expect(summary.errorCount).toBe(0);
+  });
+
+  it("reads legacy GenAI cache details from persisted step spans", () => {
+    const summary = summarizeLocalTrace([
+      span({
+        attributes: {
+          "gen_ai.usage.cache_creation.input_tokens": 20,
+          "gen_ai.usage.cache_read.input_tokens": 40,
+        },
+      }),
+    ]);
+
+    expect(summary.cacheReadTokens).toBe(40);
+    expect(summary.cacheWriteTokens).toBe(20);
   });
 
   it("reports errors and leaves cost undefined when unreported", () => {

--- a/packages/eve/src/cli/commands/trace-detail.ts
+++ b/packages/eve/src/cli/commands/trace-detail.ts
@@ -65,8 +65,15 @@ export function summarizeLocalTrace(spans: readonly LocalTraceSpan[]): LocalTrac
     if (span.name !== "agent.step") continue;
     inputTokens += numberAttribute(span, "agent.usage.input_tokens") ?? 0;
     outputTokens += numberAttribute(span, "agent.usage.output_tokens") ?? 0;
-    cacheReadTokens += numberAttribute(span, "gen_ai.usage.cache_read.input_tokens") ?? 0;
-    cacheWriteTokens += numberAttribute(span, "gen_ai.usage.cache_creation.input_tokens") ?? 0;
+    cacheReadTokens +=
+      numberAttribute(span, "agent.usage.cache_read_tokens") ??
+      numberAttribute(span, "gen_ai.usage.cache_read.input_tokens") ??
+      0;
+    cacheWriteTokens +=
+      numberAttribute(span, "agent.usage.cache_write_tokens") ??
+      numberAttribute(span, "gen_ai.usage.cache_write.input_tokens") ??
+      numberAttribute(span, "gen_ai.usage.cache_creation.input_tokens") ??
+      0;
     const cost = spanCostUsd(span);
     if (cost !== undefined) costUsd = (costUsd ?? 0) + cost;
   }

--- a/packages/eve/src/instrumentation/ai-sdk-hook-bridge.test.ts
+++ b/packages/eve/src/instrumentation/ai-sdk-hook-bridge.test.ts
@@ -469,6 +469,7 @@ describe("createAiSdkHookBridge", () => {
           { type: "some-future-kind" },
         ],
         finishReason: "tool-calls",
+        modelId: "response-model",
         performance: { responseTimeMs: 1 },
         responseId: "response-1",
         usage: {
@@ -514,6 +515,7 @@ describe("createAiSdkHookBridge", () => {
         ],
         finishReason: "tool-calls",
         idempotencyKey: modelCallIdempotencyKey(scope, 0),
+        response: { id: "response-1", modelId: "response-model" },
         scope,
         type: "model.call.completed",
         usage: {

--- a/packages/eve/src/instrumentation/ai-sdk-hook-bridge.ts
+++ b/packages/eve/src/instrumentation/ai-sdk-hook-bridge.ts
@@ -193,10 +193,12 @@ function toModelCallCompleted(
   idempotencyKey: string,
   source: TelemetryEvent<"onLanguageModelCallEnd">,
 ): InstrumentationModelCallCompletedEvent {
+  const response = Object.freeze({ id: source.responseId, modelId: source.modelId });
   return Object.freeze({
     content: state.capturesOutputs ? toContentParts(source.content) : undefined,
     finishReason: source.finishReason,
     idempotencyKey,
+    response,
     scope: state.scope,
     type: "model.call.completed",
     usage: toUsage(source.usage),

--- a/packages/eve/src/instrumentation/lifecycle.ts
+++ b/packages/eve/src/instrumentation/lifecycle.ts
@@ -41,6 +41,11 @@ export interface InstrumentationModelRef {
   readonly provider: string;
 }
 
+export interface InstrumentationModelResponseRef {
+  readonly id?: string;
+  readonly modelId?: string;
+}
+
 /** Token usage for one model call. A field is absent when the provider omits it. */
 export interface InstrumentationUsage {
   readonly inputTokenDetails?: {
@@ -413,6 +418,7 @@ export interface InstrumentationModelCallCompletedEvent {
   readonly content?: readonly InstrumentationContentPart[];
   readonly finishReason: string;
   readonly idempotencyKey: string;
+  readonly response?: InstrumentationModelResponseRef;
   readonly scope: InstrumentationAttemptScope;
   readonly usage: InstrumentationUsage;
 }

--- a/packages/eve/src/tracing/agent-action-instrumentation.ts
+++ b/packages/eve/src/tracing/agent-action-instrumentation.ts
@@ -16,7 +16,7 @@ import type {
 } from "#instrumentation/lifecycle.js";
 import { actionIdempotencyKey, attemptIdempotencyKey } from "#instrumentation/lifecycle.js";
 import { contentAttribute } from "#tracing/agent-otel-content.js";
-import { setAgentUsage } from "#tracing/agent-otel-usage.js";
+import { setSpanUsage } from "#tracing/agent-otel-usage.js";
 import type { AgentSpanIdGenerator } from "#tracing/agent-span-id-generator.js";
 import type { AgentActionTraceState, AgentTraceStateStore } from "#tracing/agent-trace-state.js";
 import { normalizeChannelAudience } from "#shared/channel-audience.js";
@@ -103,7 +103,7 @@ export function createAgentActionInstrumentation(input: {
         recordError(span, event.output.error);
       } else {
         if (event.usage !== undefined) {
-          setAgentUsage(span, event.usage, { includeGenAiDetails: false });
+          setSpanUsage(span, event.usage, "agent");
         }
         if (input.recordOutputs) {
           const result = contentAttribute(event.output.output, false);

--- a/packages/eve/src/tracing/agent-otel-provider.test.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.test.ts
@@ -195,6 +195,7 @@ async function emitAttempt(input: {
           },
         ],
         finishReason: "tool-calls",
+        modelId: "claude-response",
         performance: { responseTimeMs: 10 },
         responseId: "response-1",
         usage: {
@@ -790,6 +791,7 @@ describe("createAgentOtelInstrumentation", () => {
       }),
     ]);
     expect(model.parentSpanContext?.spanId).toBe(step.spanContext().spanId);
+    expect(model.kind).toBe(SpanKind.CLIENT);
     expect(
       executionParents.some(
         (parent) =>
@@ -827,10 +829,10 @@ describe("createAgentOtelInstrumentation", () => {
       "agent.framework.name": "eve",
       "agent.model.id": "claude-test",
       "agent.model.provider": "anthropic",
+      "agent.usage.cache_read_tokens": 4,
+      "agent.usage.cache_write_tokens": 2,
       "agent.usage.input_tokens": 10,
       "agent.usage.output_tokens": 5,
-      "gen_ai.usage.cache_creation.input_tokens": 2,
-      "gen_ai.usage.cache_read.input_tokens": 4,
     });
     expect(action.attributes).toMatchObject({
       "agent.action.kind": "tool-call",
@@ -839,12 +841,12 @@ describe("createAgentOtelInstrumentation", () => {
     });
     expect(tool.kind).toBe(SpanKind.INTERNAL);
     expect(tool.attributes).toMatchObject({
+      "gen_ai.agent.name": "weather",
       "gen_ai.operation.name": "execute_tool",
       "gen_ai.tool.call.id": "tool-1",
       "gen_ai.tool.name": "weather",
       "gen_ai.tool.type": "function",
     });
-    expect(tool.attributes).not.toHaveProperty("gen_ai.agent.name");
   });
 
   it.each(["private", "unknown"] as const)(
@@ -1414,6 +1416,9 @@ describe("createAgentOtelInstrumentation", () => {
     for (const name of ["chat claude-test", "agent.action", "execute_tool weather"]) {
       const span = byName(spans, name)[0]!;
       expect(span.status).toEqual({ code: SpanStatusCode.ERROR, message: error.message });
+      if (name === "chat claude-test") {
+        expect(span.attributes["gen_ai.response.finish_reasons"]).toEqual(["error"]);
+      }
       if (name !== "agent.action") expect(span.attributes["error.type"]).toBe("Error");
       expect(span.events).toContainEqual(
         expect.objectContaining({
@@ -1482,13 +1487,20 @@ describe("createAgentOtelInstrumentation", () => {
     expect(model.attributes["ai.response.text"]).toBe("Checking the weather.");
     expect(model.attributes).toMatchObject({
       "gen_ai.agent.name": "weather",
+      "gen_ai.conversation.id": "session-1",
       "gen_ai.input.messages":
         '[{"parts":[{"content":"real user text","type":"text"}],"role":"user"}]',
       "gen_ai.operation.name": "chat",
       "gen_ai.output.messages": expect.stringContaining('"finish_reason":"tool_call"'),
+      "gen_ai.response.id": "response-1",
       "gen_ai.response.finish_reasons": ["tool-calls"],
+      "gen_ai.response.model": "claude-response",
       "gen_ai.system_instructions":
         '[{"content":"You are a weather assistant (system prompt).","type":"text"}]',
+      "gen_ai.usage.cache_read.input_tokens": 4,
+      "gen_ai.usage.cache_write.input_tokens": 2,
+      "gen_ai.usage.input_tokens": 10,
+      "gen_ai.usage.output_tokens": 5,
     });
     expect(model.attributes["agent.input.messages.delta"]).toBeUndefined();
     // Provider-executed tools never reach the tool loop; their calls and

--- a/packages/eve/src/tracing/agent-otel-provider.test.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.test.ts
@@ -834,6 +834,7 @@ describe("createAgentOtelInstrumentation", () => {
       "agent.usage.input_tokens": 10,
       "agent.usage.output_tokens": 5,
     });
+    expect(Object.keys(step.attributes).some((key) => key.startsWith("gen_ai.usage."))).toBe(false);
     expect(action.attributes).toMatchObject({
       "agent.action.kind": "tool-call",
       "agent.action.name": "weather",
@@ -1416,9 +1417,6 @@ describe("createAgentOtelInstrumentation", () => {
     for (const name of ["chat claude-test", "agent.action", "execute_tool weather"]) {
       const span = byName(spans, name)[0]!;
       expect(span.status).toEqual({ code: SpanStatusCode.ERROR, message: error.message });
-      if (name === "chat claude-test") {
-        expect(span.attributes["gen_ai.response.finish_reasons"]).toEqual(["error"]);
-      }
       if (name !== "agent.action") expect(span.attributes["error.type"]).toBe("Error");
       expect(span.events).toContainEqual(
         expect.objectContaining({

--- a/packages/eve/src/tracing/agent-otel-provider.test.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.test.ts
@@ -1500,6 +1500,7 @@ describe("createAgentOtelInstrumentation", () => {
       "gen_ai.usage.input_tokens": 10,
       "gen_ai.usage.output_tokens": 5,
     });
+    expect(Object.keys(model.attributes).some((key) => key.startsWith("agent.usage."))).toBe(false);
     expect(model.attributes["agent.input.messages.delta"]).toBeUndefined();
     // Provider-executed tools never reach the tool loop; their calls and
     // results are captured off the model response content.

--- a/packages/eve/src/tracing/agent-otel-provider.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.ts
@@ -326,11 +326,13 @@ export function createAgentOtelInstrumentation(
       {
         attributes: {
           "gen_ai.agent.name": event.scope.functionId,
+          "gen_ai.conversation.id": event.scope.sessionId,
           "gen_ai.operation.name": "chat",
           "gen_ai.provider.name": event.model.provider,
           "gen_ai.request.model": event.model.modelId,
           ...runtimeContextAttributes(event.runtimeContext),
         },
+        kind: SpanKind.CLIENT,
       },
       attempt.context,
     );
@@ -358,13 +360,21 @@ export function createAgentOtelInstrumentation(
     const state = takeSpanState(modelSpans, event.scope, event.idempotencyKey);
     if (state === undefined) return;
     if (event.type === "model.call.failed") {
-      recordError(state.span, event.error);
+      recordModelError(state.span, event.error);
     } else {
       await recordTurnUsage(event);
       setAgentUsage(state.span, event.usage);
       state.span.setAttribute("gen_ai.response.finish_reasons", [event.finishReason]);
+      if (event.response?.id !== undefined) {
+        state.span.setAttribute("gen_ai.response.id", event.response.id);
+      }
+      if (event.response?.modelId !== undefined) {
+        state.span.setAttribute("gen_ai.response.model", event.response.modelId);
+      }
       const attempt = steps.get(event.scope);
-      if (attempt !== undefined) setAgentUsage(attempt.span, event.usage);
+      if (attempt !== undefined) {
+        setAgentUsage(attempt.span, event.usage, { includeGenAiDetails: false });
+      }
       if (recordOutputs) {
         state.span.setAttribute("ai.response.finish_reason", event.finishReason);
         const content = event.content;
@@ -545,7 +555,7 @@ export function createAgentOtelInstrumentation(
 
   function drainOpenSpans(event: InstrumentationStepAttemptTerminalEvent): void {
     for (const state of modelSpans.get(event.scope)?.values() ?? []) {
-      if (event.type === "step.attempt.failed") recordError(state.span, event.error);
+      if (event.type === "step.attempt.failed") recordModelError(state.span, event.error);
       state.span.end();
     }
     modelSpans.delete(event.scope);
@@ -664,4 +674,9 @@ function recordError(span: Span, error: unknown): void {
     span.recordException(error);
     span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
   } else span.setStatus({ code: SpanStatusCode.ERROR });
+}
+
+function recordModelError(span: Span, error: unknown): void {
+  span.setAttribute("gen_ai.response.finish_reasons", ["error"]);
+  recordError(span, error);
 }

--- a/packages/eve/src/tracing/agent-otel-provider.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.ts
@@ -360,7 +360,7 @@ export function createAgentOtelInstrumentation(
     const state = takeSpanState(modelSpans, event.scope, event.idempotencyKey);
     if (state === undefined) return;
     if (event.type === "model.call.failed") {
-      recordModelError(state.span, event.error);
+      recordError(state.span, event.error);
     } else {
       await recordTurnUsage(event);
       setAgentUsage(state.span, event.usage);
@@ -555,7 +555,7 @@ export function createAgentOtelInstrumentation(
 
   function drainOpenSpans(event: InstrumentationStepAttemptTerminalEvent): void {
     for (const state of modelSpans.get(event.scope)?.values() ?? []) {
-      if (event.type === "step.attempt.failed") recordModelError(state.span, event.error);
+      if (event.type === "step.attempt.failed") recordError(state.span, event.error);
       state.span.end();
     }
     modelSpans.delete(event.scope);
@@ -674,9 +674,4 @@ function recordError(span: Span, error: unknown): void {
     span.recordException(error);
     span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
   } else span.setStatus({ code: SpanStatusCode.ERROR });
-}
-
-function recordModelError(span: Span, error: unknown): void {
-  span.setAttribute("gen_ai.response.finish_reasons", ["error"]);
-  recordError(span, error);
 }

--- a/packages/eve/src/tracing/agent-otel-provider.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.ts
@@ -32,7 +32,7 @@ import { createAgentChannelDeliveryInstrumentation } from "#tracing/agent-channe
 import { createAgentToolInstrumentation } from "#tracing/agent-tool-instrumentation.js";
 import { markAgentTraceContext } from "#tracing/agent-trace-context.js";
 import { runtimeContextAttributes } from "#tracing/agent-otel-runtime-context.js";
-import { setAgentUsage } from "#tracing/agent-otel-usage.js";
+import { setSpanUsage } from "#tracing/agent-otel-usage.js";
 import { createAgentOtelSessionContext } from "#tracing/agent-otel-session-context.js";
 import type { TraceCapturePolicy } from "#tracing/otel-declaration.js";
 import { isSampledTrace, resolveTracePolicyDecision } from "#tracing/sampled-trace.js";
@@ -363,7 +363,7 @@ export function createAgentOtelInstrumentation(
       recordError(state.span, event.error);
     } else {
       await recordTurnUsage(event);
-      setAgentUsage(state.span, event.usage);
+      setSpanUsage(state.span, event.usage, "gen_ai");
       state.span.setAttribute("gen_ai.response.finish_reasons", [event.finishReason]);
       if (event.response?.id !== undefined) {
         state.span.setAttribute("gen_ai.response.id", event.response.id);
@@ -373,7 +373,7 @@ export function createAgentOtelInstrumentation(
       }
       const attempt = steps.get(event.scope);
       if (attempt !== undefined) {
-        setAgentUsage(attempt.span, event.usage, { includeGenAiDetails: false });
+        setSpanUsage(attempt.span, event.usage, "agent");
       }
       if (recordOutputs) {
         state.span.setAttribute("ai.response.finish_reason", event.finishReason);

--- a/packages/eve/src/tracing/agent-otel-usage.ts
+++ b/packages/eve/src/tracing/agent-otel-usage.ts
@@ -2,38 +2,26 @@ import type { Span } from "#compiled/@opentelemetry/api/index.js";
 
 import type { InstrumentationUsage } from "#instrumentation/lifecycle.js";
 
-/** Applies eve's structural token usage attributes to an agent span. */
-export function setAgentUsage(
+/** Applies token usage using one structural or GenAI attribute namespace. */
+export function setSpanUsage(
   span: Span,
   usage: InstrumentationUsage,
-  options: { readonly includeGenAiDetails?: boolean } = {},
+  namespace: "agent" | "gen_ai",
 ): void {
-  const includeGenAiDetails = options.includeGenAiDetails !== false;
+  const prefix = `${namespace}.usage`;
   if (usage.inputTokens !== undefined) {
-    span.setAttribute("agent.usage.input_tokens", usage.inputTokens);
-    if (includeGenAiDetails) {
-      span.setAttribute("gen_ai.usage.input_tokens", usage.inputTokens);
-    }
+    span.setAttribute(`${prefix}.input_tokens`, usage.inputTokens);
   }
   if (usage.outputTokens !== undefined) {
-    span.setAttribute("agent.usage.output_tokens", usage.outputTokens);
-    if (includeGenAiDetails) {
-      span.setAttribute("gen_ai.usage.output_tokens", usage.outputTokens);
-    }
+    span.setAttribute(`${prefix}.output_tokens`, usage.outputTokens);
   }
   const details = usage.inputTokenDetails;
   if (details?.cacheReadTokens !== undefined) {
-    if (!includeGenAiDetails) {
-      span.setAttribute("agent.usage.cache_read_tokens", details.cacheReadTokens);
-    } else {
-      span.setAttribute("gen_ai.usage.cache_read.input_tokens", details.cacheReadTokens);
-    }
+    const key = namespace === "agent" ? "cache_read_tokens" : "cache_read.input_tokens";
+    span.setAttribute(`${prefix}.${key}`, details.cacheReadTokens);
   }
   if (details?.cacheWriteTokens !== undefined) {
-    if (!includeGenAiDetails) {
-      span.setAttribute("agent.usage.cache_write_tokens", details.cacheWriteTokens);
-    } else {
-      span.setAttribute("gen_ai.usage.cache_write.input_tokens", details.cacheWriteTokens);
-    }
+    const key = namespace === "agent" ? "cache_write_tokens" : "cache_write.input_tokens";
+    span.setAttribute(`${prefix}.${key}`, details.cacheWriteTokens);
   }
 }

--- a/packages/eve/src/tracing/agent-otel-usage.ts
+++ b/packages/eve/src/tracing/agent-otel-usage.ts
@@ -8,25 +8,32 @@ export function setAgentUsage(
   usage: InstrumentationUsage,
   options: { readonly includeGenAiDetails?: boolean } = {},
 ): void {
+  const includeGenAiDetails = options.includeGenAiDetails !== false;
   if (usage.inputTokens !== undefined) {
     span.setAttribute("agent.usage.input_tokens", usage.inputTokens);
+    if (includeGenAiDetails) {
+      span.setAttribute("gen_ai.usage.input_tokens", usage.inputTokens);
+    }
   }
   if (usage.outputTokens !== undefined) {
     span.setAttribute("agent.usage.output_tokens", usage.outputTokens);
+    if (includeGenAiDetails) {
+      span.setAttribute("gen_ai.usage.output_tokens", usage.outputTokens);
+    }
   }
   const details = usage.inputTokenDetails;
   if (details?.cacheReadTokens !== undefined) {
-    if (options.includeGenAiDetails === false) {
+    if (!includeGenAiDetails) {
       span.setAttribute("agent.usage.cache_read_tokens", details.cacheReadTokens);
     } else {
       span.setAttribute("gen_ai.usage.cache_read.input_tokens", details.cacheReadTokens);
     }
   }
   if (details?.cacheWriteTokens !== undefined) {
-    if (options.includeGenAiDetails === false) {
+    if (!includeGenAiDetails) {
       span.setAttribute("agent.usage.cache_write_tokens", details.cacheWriteTokens);
     } else {
-      span.setAttribute("gen_ai.usage.cache_creation.input_tokens", details.cacheWriteTokens);
+      span.setAttribute("gen_ai.usage.cache_write.input_tokens", details.cacheWriteTokens);
     }
   }
 }

--- a/packages/eve/src/tracing/agent-tool-instrumentation.ts
+++ b/packages/eve/src/tracing/agent-tool-instrumentation.ts
@@ -210,6 +210,9 @@ export function createAgentToolInstrumentation(input: {
 
 function toolAttributes(event: InstrumentationToolCallStartedEvent): Record<string, string> {
   return {
+    ...(event.scope.functionId === undefined
+      ? {}
+      : { "gen_ai.agent.name": event.scope.functionId }),
     "gen_ai.operation.name": "execute_tool",
     "gen_ai.tool.call.id": event.callId,
     "gen_ai.tool.name": event.toolName,


### PR DESCRIPTION
### Summary

Follow-up to #2706. Align eve's model and tool spans with the current [OpenTelemetry GenAI semantic conventions](https://github.com/open-telemetry/semantic-conventions-genai/tree/main/docs/gen-ai): model calls are `CLIENT` spans with real conversation context, canonical-only usage, and response identity, while tool spans identify their executing agent. Cache writes use the renamed `gen_ai.usage.cache_write.input_tokens` attribute, while structural step/action usage remains in eve's `agent.usage.*` namespace and local summaries retain compatibility with persisted traces using the previous key. The zero-duration `agent.session` span remains a structural trace anchor, and caller-side `CLIENT invoke_agent` spans for remote agents remain a separate topology follow-up. Failed model calls retain OTel error status and `error.type`, but do not infer `gen_ai.response.finish_reasons=["error"]` because the bridge cannot establish that a generation choice was observed.

### Validation

The emitted fields were audited against the normative `gen_ai.inference.client`, `gen_ai.execute_tool.internal`, and `gen_ai.invoke_agent.internal` definitions in `semantic-conventions-genai`. The full eve unit suite passed 7,497 tests across 700 files with one skipped. Focused agent OTel, AI SDK bridge, and persisted trace summary coverage passed 84 tests; eve typechecking and invariant checks also passed.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the patch release note for the GenAI semantic alignment.

**Implementation** — 7 files · `+45 / -22`

Carries response metadata through the lifecycle bridge, separates structural from canonical GenAI usage, updates model and tool span attributes and kinds, and keeps local summaries compatible with persisted cache attributes.

**Tests** — 3 files · `+33 / -4`

Covers the updated model and tool semantics, response identity, canonical usage placement, and legacy cache-key reading.
