### PR TITLE
fix(eve): performance - accelerate session inbox resumes

### DIFF
--- a/.changeset/fast-session-resumes.md
+++ b/.changeset/fast-session-resumes.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Reduce durable session wake latency by sending compatible fixed-session commands through Workflow's optimized token-resume path without a metadata lookup.

--- a/packages/eve/src/execution/session-command-token.ts
+++ b/packages/eve/src/execution/session-command-token.ts
@@ -5,6 +5,14 @@ export function isReservedSessionCommandToken(token: string): boolean {
   return token.startsWith(`${SESSION_COMMAND_NAMESPACE}:`);
 }
 
+/** Returns whether a token is the stable command inbox for one workflow run. */
+export function isSessionCommandHookToken(token: string): boolean {
+  const prefix = `${SESSION_COMMAND_NAMESPACE}:`;
+  const suffix = ":inbox";
+  if (!token.startsWith(prefix) || !token.endsWith(suffix)) return false;
+  return !token.slice(prefix.length, -suffix.length).includes(":");
+}
+
 /** Derives the framework-reserved stable command inbox token for a session. */
 export function sessionCommandHookToken(sessionId: string): string {
   return `${SESSION_COMMAND_NAMESPACE}:${sessionId}:inbox`;

--- a/packages/eve/src/execution/wire/session-inbox-encoder.ts
+++ b/packages/eve/src/execution/wire/session-inbox-encoder.ts
@@ -66,7 +66,13 @@ function encode(
 }
 
 function withoutActivityObserver(command: SessionInboxCommand): SessionInboxCommand {
-  if (!("caller" in command) || command.caller?.activityObserver === undefined) return command;
+  if (
+    !("caller" in command) ||
+    command.caller === undefined ||
+    !("activityObserver" in command.caller)
+  ) {
+    return command;
+  }
   const { activityObserver: _activityObserver, ...caller } = command.caller;
   return { ...command, caller };
 }

--- a/packages/eve/src/execution/wire/session-inbox-resume.test.ts
+++ b/packages/eve/src/execution/wire/session-inbox-resume.test.ts
@@ -75,7 +75,30 @@ describe("session inbox target resolution", () => {
 });
 
 describe("resumeSessionInbox", () => {
-  it("encodes for the resolved consumer and resumes the exact inspected hook", async () => {
+  it("resumes a compatible stable inbox by token without inspecting metadata", async () => {
+    const token = sessionCommandHookToken("session-1");
+    const hook = sessionHook("session-1", token, { sessionInboxWireVersion: 2 });
+    resumeHookMock.mockResolvedValue(hook);
+
+    await resumeSessionInbox(token, {
+      kind: "send",
+      payload: { message: "follow-up" },
+    });
+
+    expect(getHookByTokenMock).not.toHaveBeenCalled();
+    expect(resumeHookMock).toHaveBeenCalledWith(token, {
+      auth: undefined,
+      caller: undefined,
+      delivery: undefined,
+      kind: "send",
+      payload: { message: "follow-up" },
+      requestId: undefined,
+      taskDeliveryId: undefined,
+      turnPolicy: undefined,
+    });
+  });
+
+  it("encodes continuation delivery for the resolved consumer and resumes that hook", async () => {
     const hook = sessionHook("session-1", "continuation-1", { sessionInboxWireVersion: 1 });
     getHookByTokenMock.mockResolvedValue(hook);
     resumeHookMock.mockResolvedValue(hook);
@@ -95,6 +118,33 @@ describe("resumeSessionInbox", () => {
       requestId: undefined,
       version: 1,
     });
+  });
+
+  it("retains metadata negotiation when a stable delivery needs the current caller wire", async () => {
+    const token = sessionCommandHookToken("session-1");
+    const hook = sessionHook("session-1", token, { sessionInboxWireVersion: 2 });
+    getHookByTokenMock.mockResolvedValue(hook);
+    resumeHookMock.mockResolvedValue(hook);
+
+    await resumeSessionInbox(token, {
+      caller: {
+        activityObserver: { sink: { url: "https://example.com/activity", version: 1 } },
+        callId: "call-1",
+        replyTo: { kind: "hook", token: "reply-1" },
+        subagentName: "researcher",
+      },
+      kind: "send",
+      payload: { message: "follow-up" },
+    });
+
+    expect(getHookByTokenMock).toHaveBeenCalledWith(token);
+    expect(resumeHookMock).toHaveBeenCalledWith(
+      hook,
+      expect.objectContaining({
+        caller: expect.objectContaining({ activityObserver: expect.any(Object) }),
+        version: 2,
+      }),
+    );
   });
 });
 

--- a/packages/eve/src/execution/wire/session-inbox-resume.test.ts
+++ b/packages/eve/src/execution/wire/session-inbox-resume.test.ts
@@ -120,6 +120,21 @@ describe("resumeSessionInbox", () => {
     });
   });
 
+  it("inspects reserved session aliases outside the stable inbox", async () => {
+    const token = "eve:session:session-1:session-timeout";
+    const hook = sessionHook("session-1", token, { sessionInboxWireVersion: 1 });
+    getHookByTokenMock.mockResolvedValue(hook);
+    resumeHookMock.mockResolvedValue(hook);
+
+    await resumeSessionInbox(token, { kind: "session-timeout" });
+
+    expect(getHookByTokenMock).toHaveBeenCalledWith(token);
+    expect(resumeHookMock).toHaveBeenCalledWith(hook, {
+      kind: "session-timeout",
+      version: 1,
+    });
+  });
+
   it("retains metadata negotiation when a stable delivery needs the current caller wire", async () => {
     const token = sessionCommandHookToken("session-1");
     const hook = sessionHook("session-1", token, { sessionInboxWireVersion: 2 });

--- a/packages/eve/src/execution/wire/session-inbox-resume.test.ts
+++ b/packages/eve/src/execution/wire/session-inbox-resume.test.ts
@@ -98,6 +98,39 @@ describe("resumeSessionInbox", () => {
     });
   });
 
+  it("strips an undefined activity observer from the stable fast path", async () => {
+    const token = sessionCommandHookToken("session-1");
+    const hook = sessionHook("session-1", token, { sessionInboxWireVersion: 2 });
+    resumeHookMock.mockResolvedValue(hook);
+
+    await resumeSessionInbox(token, {
+      caller: {
+        activityObserver: undefined,
+        callId: "call-1",
+        replyTo: { kind: "hook", token: "reply-1" },
+        subagentName: "researcher",
+      },
+      kind: "send",
+      payload: { message: "follow-up" },
+    });
+
+    expect(getHookByTokenMock).not.toHaveBeenCalled();
+    expect(resumeHookMock).toHaveBeenCalledWith(token, {
+      auth: undefined,
+      caller: {
+        callId: "call-1",
+        replyTo: { kind: "hook", token: "reply-1" },
+        subagentName: "researcher",
+      },
+      delivery: undefined,
+      kind: "send",
+      payload: { message: "follow-up" },
+      requestId: undefined,
+      taskDeliveryId: undefined,
+      turnPolicy: undefined,
+    });
+  });
+
   it("encodes continuation delivery for the resolved consumer and resumes that hook", async () => {
     const hook = sessionHook("session-1", "continuation-1", { sessionInboxWireVersion: 1 });
     getHookByTokenMock.mockResolvedValue(hook);

--- a/packages/eve/src/execution/wire/session-inbox-resume.ts
+++ b/packages/eve/src/execution/wire/session-inbox-resume.ts
@@ -5,7 +5,10 @@ import type {
   SessionCommand,
   SessionTimeoutHookPayload,
 } from "#channel/types.js";
-import { sessionCommandHookToken } from "#execution/session-command-token.js";
+import {
+  isReservedSessionCommandToken,
+  sessionCommandHookToken,
+} from "#execution/session-command-token.js";
 import {
   SESSION_INBOX_WIRE_VERSION_METADATA_KEY,
   isSessionInboxWireVersion,
@@ -23,9 +26,24 @@ export async function resumeSessionInbox(
   token: string,
   command: DeliverHookPayload | SessionCommand | SessionTimeoutHookPayload,
 ): Promise<ResumedSessionInboxHook> {
+  if (isStableInboxFastPathCompatible(token, command)) {
+    return await resumeHook(
+      token,
+      sessionInboxWire.encode(command, { variant: "send", version: 0 }),
+    );
+  }
+
   const hook = await getHookByToken(token);
   const target = await resolveSessionInboxWireTarget(hook);
   return await resumeHook(hook, sessionInboxWire.encode(command, target));
+}
+
+function isStableInboxFastPathCompatible(
+  token: string,
+  command: DeliverHookPayload | SessionCommand | SessionTimeoutHookPayload,
+): boolean {
+  if (!isReservedSessionCommandToken(token)) return false;
+  return !("caller" in command && command.caller?.activityObserver !== undefined);
 }
 
 type SessionInboxHook = Awaited<ReturnType<typeof getHookByToken>>;

--- a/packages/eve/src/execution/wire/session-inbox-resume.ts
+++ b/packages/eve/src/execution/wire/session-inbox-resume.ts
@@ -6,7 +6,7 @@ import type {
   SessionTimeoutHookPayload,
 } from "#channel/types.js";
 import {
-  isReservedSessionCommandToken,
+  isSessionCommandHookToken,
   sessionCommandHookToken,
 } from "#execution/session-command-token.js";
 import {
@@ -42,7 +42,7 @@ function isStableInboxFastPathCompatible(
   token: string,
   command: DeliverHookPayload | SessionCommand | SessionTimeoutHookPayload,
 ): boolean {
-  if (!isReservedSessionCommandToken(token)) return false;
+  if (!isSessionCommandHookToken(token)) return false;
   return !("caller" in command && command.caller?.activityObserver !== undefined);
 }
 

--- a/packages/eve/src/execution/workflow-runtime.test.ts
+++ b/packages/eve/src/execution/workflow-runtime.test.ts
@@ -177,11 +177,10 @@ describe("createWorkflowRuntime command dispatch", () => {
       }),
     ).resolves.toEqual({ sessionId: "session-1", status: "accepted" });
 
-    expect(resumeHookMock).toHaveBeenCalledWith(
-      currentSessionHook(sessionCommandHookToken("session-1")),
-      { kind: "clear", version: 1 },
-    );
-    expect(getHookByTokenMock).toHaveBeenCalledWith(sessionCommandHookToken("session-1"));
+    expect(resumeHookMock).toHaveBeenCalledWith(sessionCommandHookToken("session-1"), {
+      kind: "clear",
+    });
+    expect(getHookByTokenMock).not.toHaveBeenCalled();
   });
 
   it("preserves the delivery payload through the stable session inbox", async () => {
@@ -194,18 +193,17 @@ describe("createWorkflowRuntime command dispatch", () => {
       }),
     ).resolves.toEqual({ sessionId: "session-1", status: "accepted" });
 
-    expect(resumeHookMock).toHaveBeenCalledWith(
-      currentSessionHook(sessionCommandHookToken("session-1")),
-      {
-        auth: undefined,
-        caller: undefined,
-        kind: "deliver",
-        payload: { message: "hello" },
-        payloads: [{ message: "hello" }],
-        requestId: undefined,
-        version: 1,
-      },
-    );
+    expect(resumeHookMock).toHaveBeenCalledWith(sessionCommandHookToken("session-1"), {
+      auth: undefined,
+      caller: undefined,
+      delivery: undefined,
+      kind: "send",
+      payload: { message: "hello" },
+      requestId: undefined,
+      taskDeliveryId: undefined,
+      turnPolicy: undefined,
+    });
+    expect(getHookByTokenMock).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -248,10 +246,11 @@ describe("createWorkflowRuntime command dispatch", () => {
         sessionId: "session-1",
       }),
     ).resolves.toEqual({ sessionId: "session-1", status: "accepted" });
-    expect(resumeHookMock).toHaveBeenCalledWith(
-      currentSessionHook(sessionCommandHookToken("session-1")),
-      { kind: "cancel", turnId: "turn-2", version: 1 },
-    );
+    expect(resumeHookMock).toHaveBeenCalledWith(sessionCommandHookToken("session-1"), {
+      kind: "cancel",
+      turnId: "turn-2",
+    });
+    expect(getHookByTokenMock).not.toHaveBeenCalled();
   });
 
   it("maps missing and terminal targets to 'no_active_turn'", async () => {


### PR DESCRIPTION
### Summary

Related to #876. This is PR 1 of 3 in the turn-performance stack.

Fixed-session delivery currently reads and decrypts hook metadata before every command, even though every stable-inbox consumer accepts eve's historical `send` envelope. Compatible fixed-session commands now use that envelope and resume by token, avoiding the metadata lookup while allowing Workflow to select its optimized durable-write and queue-publish path.

Continuation aliases still negotiate the persisted consumer version and resume the exact inspected Hook. Activity-observer deliveries retain that path, and undefined observer keys are stripped before legacy encoding. This layer deliberately preserves child workflows and deployment routing so its hosted result isolates session ingress.

### Hosted timing

Isolated Vercel Workflow stress run: [attempt 2](https://github.com/vercel/eve/actions/runs/33524878948/attempts/2), artifact `workflow-stress-performance`.

| Scenario | Samples | Mean | p50 | p95 |
| --- | ---: | ---: | ---: | ---: |
| Sequential turns | 100 | 2.058s | 2.049s | 2.483s |
| Concurrent first turn | 50 | 4.674s | 4.467s | 5.523s |
| Concurrent second turn | 50 | 1.773s | 1.558s | 2.995s |

The first ten warm turns had a 1.727s p50 and the last ten had a 2.166s p50. This layer does not materially remove eve's approximately two-second sequential turn floor.

The isolated artifact predates the final undefined-observer correction. The stress fixture does not send a delegated caller, so that correction does not touch the measured path. Exact-head Vercel and Postgres E2E matrices passed, and the local prompt-cache retry also passed.

### Validation

- `pnpm guard:invariants`
- `pnpm --filter eve typecheck`
- Focused session-inbox wire suites (28 passed)
- Hosted Workflow stress fixture (100 sequential turns and 50 two-turn concurrent sessions)
- Exact-head Vercel and Postgres E2E matrices

CI note: the required `test-scenario` job remains red because `dev-server-drain.scenario.test.ts` twice observed a new client port across worker replacement ([PR retry](https://github.com/vercel/eve/actions/runs/33529625808/attempts/2)). The same assertion is failing on current `main` ([main run](https://github.com/vercel/eve/actions/runs/33527178967)); this PR does not touch dev-server draining.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

- Docs: 1 file, +5/-0
- Implementation: 3 files, +34/-2
- Tests: 2 files, +119/-22
