### PR TITLE
fix(eve): dev server - stabilize keep-alive scenario

### DIFF
--- a/packages/eve/test/scenarios/dev-server-drain.scenario.test.ts
+++ b/packages/eve/test/scenarios/dev-server-drain.scenario.test.ts
@@ -68,13 +68,31 @@ const DRAIN_DESCRIPTOR: ScenarioAppDescriptor = {
   name: "weather-agent-drain",
 };
 
-async function triggerWorkerReplacement(server: RunningEveDev, appRoot: string): Promise<void> {
-  const previousWorkerId = await fetchText(server.url, "/drain/worker-id");
+async function readWorkerId(server: RunningEveDev, agent?: Agent): Promise<string> {
+  if (agent === undefined) {
+    return await fetchText(server.url, "/drain/worker-id");
+  }
+
+  const response = await requestWithAgent(new URL("/drain/worker-id", server.url).href, agent);
+  if (response.statusCode < 200 || response.statusCode >= 300) {
+    throw new Error(
+      `Expected /drain/worker-id to succeed, received ${String(response.statusCode)}.`,
+    );
+  }
+  return response.body;
+}
+
+async function triggerWorkerReplacement(
+  server: RunningEveDev,
+  appRoot: string,
+  agent?: Agent,
+): Promise<void> {
+  const previousWorkerId = await readWorkerId(server, agent);
   await writeFile(join(appRoot, ".env.local"), `EVE_DRAIN_RELOAD=${Date.now()}\n`);
   await waitForCondition(
     async () => {
       try {
-        return (await fetchText(server.url, "/drain/worker-id")) !== previousWorkerId;
+        return (await readWorkerId(server, agent)) !== previousWorkerId;
       } catch {
         return false;
       }
@@ -135,7 +153,9 @@ describe("eve dev drained worker replacement", () => {
         const first = await requestWithAgent(new URL("/drain/worker-id", server.url).href, agent);
         expect(first.localPort).toBeDefined();
 
-        await triggerWorkerReplacement(server, app.appRoot);
+        // Keep the asserted socket active while the replacement builds so the
+        // test does not depend on finishing before Node's idle keep-alive timeout.
+        await triggerWorkerReplacement(server, app.appRoot, agent);
 
         const second = await requestWithAgent(new URL("/drain/worker-id", server.url).href, agent);
         expect(second.localPort).toBe(first.localPort);


### PR DESCRIPTION
### Summary

`test-scenario` intermittently failed when a worker reload exceeded Node's idle keep-alive window: the client socket expired before the post-reload port assertion even though the replacement completed correctly. The scenario now polls worker readiness through the same keep-alive agent, keeping the connection active and making the assertion measure worker replacement rather than CI speed. Product behavior is unchanged; this test-only fix needs no documentation or changeset.

### Validation

Confirmed with the focused drain scenario: all five tests pass, including the previously flaky keep-alive case.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

No user-facing behavior changes.

**Implementation** — 0 files · `+0 / -0`

No product, configuration, or dependency changes.

**Tests** — 1 file · `+24 / -4`

Keeps agent-aware worker polling local to the drain scenario so the fix does not alter shared runtime behavior.
