### PR TITLE
fix(channels): preserve built-in audience evidence

### DIFF
--- a/.changeset/complete-channel-audiences.md
+++ b/.changeset/complete-channel-audiences.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Preserve or fail-close audience evidence across built-in channel webhooks and proactive sends, including GitHub and Telegram visibility, restricted phone conversations, Chat SDK targets, imperative Slack sends, and explicit Discord or Teams handoffs.

--- a/docs/guides/instrumentation.md
+++ b/docs/guides/instrumentation.md
@@ -60,7 +60,7 @@ You are responsible for ensuring any observability or eval provider is approved 
 
 The third configurable surface, [runtime context events](#runtime-context), attaches per-model-call values to these spans.
 
-Built-in messaging channels classify their instrumentation metadata with an `audience`: `public`, `private`, or `unknown`. Slack public channels and Chat SDK workspace-visible threads are public; direct and private conversations are private; platform surfaces without enough visibility evidence remain unknown. Proactive Slack `receive` / `ctx.send` handoffs stay `unknown` unless the caller passes `audience` on the target, for example when a webhook or schedule already knows the destination channel is public.
+Built-in messaging channels classify their instrumentation metadata with an `audience`: `public`, `private`, or `unknown`. Slack public channels, Chat SDK workspace-visible threads, public GitHub repositories, and username-addressable Telegram channels and supergroups are public. Direct, private, externally shared, ephemeral, and participant-restricted phone conversations are private; platform surfaces without enough visibility evidence remain unknown. Generic Chat SDK, Discord, Slack, and Teams handoffs stay `unknown` unless the caller passes `audience` on the target, for example when a webhook or schedule already knows the destination is public. Discord and Teams inbound hooks can return the same evidence; platform-derived private evidence takes precedence. The Photon and Linq wrappers classify all iMessage and SMS conversations as private.
 
 ## Channel delivery traces
 

--- a/packages/eve/src/public/channels/chat-sdk/audience.ts
+++ b/packages/eve/src/public/channels/chat-sdk/audience.ts
@@ -1,5 +1,5 @@
 import type { SerializedThread } from "#compiled/chat/index.js";
-import type { ChannelAudience } from "#shared/channel-audience.js";
+import { normalizeChannelAudience, type ChannelAudience } from "#shared/channel-audience.js";
 import type {
   ChatSdkChannelState,
   ChatSdkInstrumentationMetadata,
@@ -10,18 +10,32 @@ export function chatSdkInstrumentationMetadata(
 ): ChatSdkInstrumentationMetadata {
   return {
     adapterName: state.thread?.adapterName ?? null,
-    audience: chatSdkAudience(state.thread),
+    audience: chatSdkAudience(state.thread, state.audience),
     channelId: state.thread?.channelId ?? null,
     isDM: state.thread?.isDM ?? null,
     threadId: state.thread?.id ?? null,
   };
 }
 
-function chatSdkAudience(thread: SerializedThread | null): ChannelAudience {
+export function combineChatSdkAudienceEvidence(
+  defaultAudience: ChannelAudience | undefined,
+  operationAudience: ChannelAudience | undefined,
+): ChannelAudience {
+  const defaultValue = normalizeChannelAudience(defaultAudience);
+  const operationValue = normalizeChannelAudience(operationAudience);
+  if (defaultValue === "private" || operationValue === "private") return "private";
+  return operationAudience === undefined ? defaultValue : operationValue;
+}
+
+function chatSdkAudience(
+  thread: SerializedThread | null,
+  explicitAudience: ChannelAudience | undefined,
+): ChannelAudience {
   if (thread?.isDM === true) return "private";
-  if (thread?.channelVisibility === "workspace") return "public";
   if (thread?.channelVisibility === "private" || thread?.channelVisibility === "external") {
     return "private";
   }
+  if (explicitAudience !== undefined) return normalizeChannelAudience(explicitAudience);
+  if (thread?.channelVisibility === "workspace") return "public";
   return "unknown";
 }

--- a/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.test.ts
+++ b/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.test.ts
@@ -160,6 +160,35 @@ describe("chatSdkChannel", () => {
     expect(adapter.instrumentation?.metadata?.(adapter.state)).toMatchObject({ audience });
   });
 
+  it.each([
+    [{ isDM: false, channelVisibility: "unknown" }, "public", "public"],
+    [{ isDM: false, channelVisibility: "workspace" }, "private", "private"],
+    [{ isDM: true, channelVisibility: "workspace" }, "public", "private"],
+  ] as const)(
+    "combines $audience evidence with thread privacy as $expected",
+    (thread, audience, expected) => {
+      const bridge = chatSdkChannel({
+        adapters: { test: testAdapter() },
+        state: memoryState(),
+        userName: "bot",
+      });
+      const adapter = getAdapter(bridge.channel);
+      if (!adapter.state) throw new Error("Expected Chat SDK state.");
+      adapter.state.audience = audience;
+      adapter.state.thread = {
+        _type: "chat:Thread",
+        adapterName: "test",
+        channelId: CHANNEL_ID,
+        id: THREAD_ID,
+        ...thread,
+      };
+
+      expect(adapter.instrumentation?.metadata?.(adapter.state)).toMatchObject({
+        audience: expected,
+      });
+    },
+  );
+
   it("mounts GET and POST webhook routes per Chat SDK adapter", () => {
     const bridge = chatSdkChannel({
       adapters: {
@@ -240,6 +269,27 @@ describe("chatSdkChannel", () => {
         },
       },
       title: "mention",
+    });
+  });
+
+  it("applies the channel default audience to bridge.send", async () => {
+    const bridge = chatSdkChannel({
+      adapters: { test: testAdapter() },
+      audience: "private",
+      state: memoryState(),
+      userName: "bot",
+    });
+
+    bridge.bot.onNewMention(async (thread: Thread, message: Message) => {
+      await bridge.send(message.text, { auth: AUTH, thread });
+    });
+
+    const { send } = await firePost(bridge.channel, "/eve/v1/test", {
+      text: "@bot hello",
+    });
+
+    expect(send.mock.calls[0]?.[1]).toMatchObject({
+      state: { audience: "private" },
     });
   });
 
@@ -353,6 +403,143 @@ describe("chatSdkChannel", () => {
           isDM: false,
         },
       },
+    });
+  });
+
+  it("projects private audience for proactive receive with a DM thread id", async () => {
+    const adapter = testAdapter();
+    vi.spyOn(adapter, "isDM").mockReturnValue(true);
+    const bridge = chatSdkChannel({
+      adapters: { test: adapter },
+      state: memoryState(),
+      userName: "bot",
+    });
+    const send = vi.fn().mockResolvedValue({ id: "session-1" });
+
+    await bridge.channel.receive?.(
+      {
+        auth: AUTH,
+        message: "proactive DM",
+        target: { adapterName: "test", threadId: THREAD_ID },
+      },
+      mockChannelContext(send),
+    );
+
+    expect(adapter.isDM).toHaveBeenCalledWith(THREAD_ID);
+    const state = send.mock.calls[0]?.[1].state as ChatSdkChannelState;
+    expect(state.thread).toMatchObject({
+      channelVisibility: "workspace",
+      isDM: true,
+    });
+    expect(getAdapter(bridge.channel).instrumentation?.metadata?.(state)).toMatchObject({
+      audience: "private",
+    });
+  });
+
+  it("persists explicit audience evidence for proactive receive", async () => {
+    const bridge = chatSdkChannel({
+      adapters: { test: testAdapter() },
+      state: memoryState(),
+      userName: "bot",
+    });
+    const send = vi.fn().mockResolvedValue({ id: "session-1" });
+
+    await bridge.channel.receive?.(
+      {
+        auth: AUTH,
+        message: "proactive",
+        target: {
+          adapterName: "test",
+          audience: "private",
+          threadId: THREAD_ID,
+        },
+      },
+      mockChannelContext(send),
+    );
+
+    const state = send.mock.calls[0]?.[1].state as ChatSdkChannelState;
+    expect(state.audience).toBe("private");
+    expect(getAdapter(bridge.channel).instrumentation?.metadata?.(state)).toMatchObject({
+      audience: "private",
+    });
+  });
+
+  it("applies a default audience to proactive receive", async () => {
+    const bridge = chatSdkChannel({
+      adapters: { test: testAdapter() },
+      audience: "private",
+      state: memoryState(),
+      userName: "bot",
+    });
+    const send = vi.fn().mockResolvedValue({ id: "session-1" });
+
+    await bridge.channel.receive?.(
+      {
+        auth: AUTH,
+        message: "proactive",
+        target: { adapterName: "test", threadId: THREAD_ID },
+      },
+      mockChannelContext(send),
+    );
+
+    expect(send.mock.calls[0]?.[1]).toMatchObject({
+      state: { audience: "private" },
+    });
+  });
+
+  it("does not let proactive evidence widen a private default audience", async () => {
+    const bridge = chatSdkChannel({
+      adapters: { test: testAdapter() },
+      audience: "private",
+      state: memoryState(),
+      userName: "bot",
+    });
+    const send = vi.fn().mockResolvedValue({ id: "session-1" });
+
+    await bridge.channel.receive?.(
+      {
+        auth: AUTH,
+        message: "proactive",
+        target: {
+          adapterName: "test",
+          audience: "public",
+          threadId: THREAD_ID,
+        },
+      },
+      mockChannelContext(send),
+    );
+
+    expect(send.mock.calls[0]?.[1]).toMatchObject({
+      state: { audience: "private" },
+    });
+  });
+
+  it("lets explicit unknown evidence narrow a public default audience", async () => {
+    const bridge = chatSdkChannel({
+      adapters: { test: testAdapter() },
+      audience: "public",
+      state: memoryState(),
+      userName: "bot",
+    });
+    const send = vi.fn().mockResolvedValue({ id: "session-1" });
+
+    await bridge.channel.receive?.(
+      {
+        auth: AUTH,
+        message: "proactive",
+        target: {
+          adapterName: "test",
+          audience: "unknown",
+          threadId: "opaque-thread",
+        },
+      },
+      mockChannelContext(send),
+    );
+
+    const state = send.mock.calls[0]?.[1].state as ChatSdkChannelState;
+    expect(state.audience).toBe("unknown");
+    expect(getAdapter(bridge.channel).instrumentation?.metadata?.(state)).toMatchObject({
+      audience: "unknown",
     });
   });
 
@@ -937,7 +1124,7 @@ class TestAdapter {
     return "workspace";
   }
 
-  isDM(): boolean {
+  isDM(_threadId: string): boolean {
     return false;
   }
 

--- a/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.ts
+++ b/packages/eve/src/public/channels/chat-sdk/chatSdkChannel.ts
@@ -44,7 +44,14 @@ import {
   type RouteHandlerArgs,
   type Session,
 } from "#public/definitions/channel.js";
-import { chatSdkInstrumentationMetadata } from "#public/channels/chat-sdk/audience.js";
+import {
+  chatSdkInstrumentationMetadata,
+  combineChatSdkAudienceEvidence,
+} from "#public/channels/chat-sdk/audience.js";
+import {
+  serializeChatSdkReceiveTarget,
+  serializeChatSdkThread,
+} from "#public/channels/chat-sdk/thread.js";
 import type { ChannelAudience } from "#shared/channel-audience.js";
 
 const log = createLogger("chat-sdk.channel");
@@ -72,6 +79,8 @@ const ActiveWebhookKey = new ContextKey<ActiveWebhookContext>("chat-sdk.active-w
 
 /** Durable Chat SDK thread state plus default-handler streaming bookkeeping. */
 export interface ChatSdkChannelState extends Record<string, unknown> {
+  /** Explicit audience evidence supplied before dispatch, when known. */
+  audience?: ChannelAudience;
   thread: SerializedThread | null;
   /** Message id of the in-flight streamed assistant post (edit fallback). */
   anchorMessageId?: string | null;
@@ -97,6 +106,8 @@ export interface ChatSdkChannelState extends Record<string, unknown> {
  */
 export interface ChatSdkReceiveTarget {
   readonly adapterName?: string;
+  /** Optional audience evidence for proactive receives. Omit to infer from the thread. */
+  readonly audience?: ChannelAudience;
   readonly thread?: SerializedThread;
   readonly threadId?: string;
 }
@@ -143,6 +154,8 @@ export type ChatSdkChannelEvents<TAdapters extends ChatSdkAdapters = ChatSdkAdap
  * determines the eve continuation token and the persisted channel state.
  */
 export interface ChatSdkSendOptions {
+  /** Optional audience evidence from the active webhook. */
+  readonly audience?: ChannelAudience;
   readonly auth?: SessionAuthContext | null;
   readonly callback?: ChannelAddressDeliveryOptions<ChatSdkChannelState>["callback"];
   readonly mode?: ChannelAddressDeliveryOptions<ChatSdkChannelState>["mode"];
@@ -170,6 +183,8 @@ export interface ChatSdkChannelConfig<
 > extends Omit<ChatConfig<TAdapters>, "adapters"> {
   /** Map of Chat SDK adapter name to adapter instance. */
   readonly adapters: TAdapters;
+  /** Default audience evidence for every thread handled by this channel. */
+  readonly audience?: ChannelAudience;
   /**
    * Base route for generated adapter webhooks. Defaults to `/eve/v1`, so an
    * adapter named `slack` mounts at `/eve/v1/slack`.
@@ -284,6 +299,7 @@ export function chatSdkChannel<TAdapters extends ChatSdkAdapters>(
         auth: config.resolveInputAuth ? await config.resolveInputAuth(event) : null,
         thread: event.thread,
       },
+      config.audience,
     );
   });
 
@@ -330,10 +346,15 @@ export function chatSdkChannel<TAdapters extends ChatSdkAdapters>(
       return [GET<ChatSdkChannelState>(path, handler), POST<ChatSdkChannelState>(path, handler)];
     }),
     async receive(input, { from }) {
-      const thread = serializeReceiveTarget(bot, input.target);
+      const thread = serializeChatSdkReceiveTarget(bot, input.target);
+      const state: ChatSdkChannelState = { thread };
+      const audience = combineChatSdkAudienceEvidence(config.audience, input.target.audience);
+      if (config.audience !== undefined || input.target.audience !== undefined) {
+        state.audience = audience;
+      }
       return from(thread.id).send(input.message, {
         auth: input.auth,
-        state: { thread },
+        state,
       });
     },
     events: mergedEvents,
@@ -343,7 +364,7 @@ export function chatSdkChannel<TAdapters extends ChatSdkAdapters>(
     bot,
     channel,
     send(input, options) {
-      return bridgeSend(bot, input, options);
+      return bridgeSend(bot, input, options, config.audience);
     },
   };
 }
@@ -567,6 +588,7 @@ async function bridgeSend<TAdapters extends ChatSdkAdapters>(
   bot: Chat<TAdapters>,
   input: ChatSdkSendInput,
   options: ChatSdkSendOptions,
+  defaultAudience: ChannelAudience | undefined,
 ): Promise<Session> {
   const active = contextStorage.getStore()?.get(ActiveWebhookKey);
   if (!active) {
@@ -574,11 +596,16 @@ async function bridgeSend<TAdapters extends ChatSdkAdapters>(
       "chatSdkChannel().send can only run during a Chat SDK webhook handler for this bridge.",
     );
   }
-  const thread = serializeThread(bot, options.thread, options.adapterName);
+  const thread = serializeChatSdkThread(bot, options.thread, options.adapterName);
   const payload = normalizeSendInput(input);
+  const state: ChatSdkChannelState = { thread };
+  const audience = combineChatSdkAudienceEvidence(defaultAudience, options.audience);
+  if (defaultAudience !== undefined || options.audience !== undefined) {
+    state.audience = audience;
+  }
   const deliveryOptions: MutableDeliveryOptions<ChatSdkChannelState> = {
     auth: options.auth ?? null,
-    state: { thread },
+    state,
   };
   if (options.callback !== undefined) deliveryOptions.callback = options.callback;
   if (options.mode !== undefined) deliveryOptions.mode = options.mode;
@@ -614,50 +641,6 @@ function threadFromState<TAdapters extends ChatSdkAdapters>(
     log.warn("failed to rebuild Chat SDK thread from channel state", { error });
     return null;
   }
-}
-
-function serializeReceiveTarget<TAdapters extends ChatSdkAdapters>(
-  bot: Chat<TAdapters>,
-  target: ChatSdkReceiveTarget,
-): SerializedThread {
-  if (target.thread) return target.thread;
-  if (!target.threadId) {
-    throw new Error("chatSdkChannel().receive requires target.thread or target.threadId.");
-  }
-  return serializeThread(bot, target.threadId, target.adapterName);
-}
-
-function serializeThread<TAdapters extends ChatSdkAdapters>(
-  bot: Chat<TAdapters>,
-  thread: SerializedThread | Thread | string,
-  adapterName?: string,
-): SerializedThread {
-  if (typeof thread === "string") {
-    const resolvedAdapterName = adapterName ?? inferAdapterName(thread);
-    const adapter = bot.getAdapter(resolvedAdapterName);
-    return {
-      _type: "chat:Thread",
-      adapterName: resolvedAdapterName,
-      channelId: adapter.channelIdFromThreadId(thread),
-      channelVisibility: adapter.getChannelVisibility?.(thread),
-      id: thread,
-      isDM: false,
-    };
-  }
-  if (isSerializedThread(thread)) return thread;
-  return thread.toJSON();
-}
-
-function isSerializedThread(value: SerializedThread | Thread): value is SerializedThread {
-  return "_type" in value && value._type === "chat:Thread";
-}
-
-function inferAdapterName(threadId: string): string {
-  const separator = threadId.indexOf(":");
-  if (separator <= 0) {
-    throw new Error("chatSdkChannel string thread references require options.adapterName.");
-  }
-  return threadId.slice(0, separator);
 }
 
 function adapterNames<TAdapters extends ChatSdkAdapters>(

--- a/packages/eve/src/public/channels/chat-sdk/thread.ts
+++ b/packages/eve/src/public/channels/chat-sdk/thread.ts
@@ -1,0 +1,47 @@
+import type { Adapter, Chat, SerializedThread, Thread } from "#compiled/chat/index.js";
+
+type ChatSdkAdapters = Record<string, Adapter>;
+
+export function serializeChatSdkReceiveTarget<TAdapters extends ChatSdkAdapters>(
+  bot: Chat<TAdapters>,
+  target: {
+    readonly adapterName?: string;
+    readonly thread?: SerializedThread;
+    readonly threadId?: string;
+  },
+): SerializedThread {
+  if (target.thread) return target.thread;
+  if (!target.threadId) {
+    throw new Error("chatSdkChannel().receive requires target.thread or target.threadId.");
+  }
+  return serializeChatSdkThread(bot, target.threadId, target.adapterName);
+}
+
+export function serializeChatSdkThread<TAdapters extends ChatSdkAdapters>(
+  bot: Chat<TAdapters>,
+  thread: SerializedThread | Thread | string,
+  adapterName?: string,
+): SerializedThread {
+  if (typeof thread === "string") {
+    const resolvedAdapterName = adapterName ?? inferAdapterName(thread);
+    const adapter = bot.getAdapter(resolvedAdapterName);
+    return {
+      _type: "chat:Thread",
+      adapterName: resolvedAdapterName,
+      channelId: adapter.channelIdFromThreadId(thread),
+      channelVisibility: adapter.getChannelVisibility?.(thread),
+      id: thread,
+      isDM: adapter.isDM?.(thread) ?? false,
+    };
+  }
+  if ("_type" in thread && thread._type === "chat:Thread") return thread;
+  return thread.toJSON();
+}
+
+function inferAdapterName(threadId: string): string {
+  const separator = threadId.indexOf(":");
+  if (separator <= 0) {
+    throw new Error("chatSdkChannel string thread references require options.adapterName.");
+  }
+  return threadId.slice(0, separator);
+}

--- a/packages/eve/src/public/channels/discord/audience.ts
+++ b/packages/eve/src/public/channels/discord/audience.ts
@@ -1,8 +1,16 @@
-import type { ChannelAudience } from "#shared/channel-audience.js";
-import type { DiscordChannelState } from "#public/channels/discord/discordChannel.js";
+import { normalizeChannelAudience, type ChannelAudience } from "#shared/channel-audience.js";
+import type {
+  DiscordChannelState,
+  DiscordCommandResult,
+} from "#public/channels/discord/discordChannel.js";
 import type { DiscordInstrumentationMetadata } from "#public/channels/discord/index.js";
+import type { DiscordInteraction } from "#public/channels/discord/inbound.js";
 
-export function discordAudience(channelType: number | undefined): ChannelAudience {
+export function discordAudience(
+  channelType: number | undefined,
+  guildId: string | undefined,
+): ChannelAudience {
+  if (guildId === undefined) return "private";
   if (channelType === 1 || channelType === 3 || channelType === 12) return "private";
   return "unknown";
 }
@@ -14,5 +22,47 @@ export function discordInstrumentationMetadata(
     audience: state.audience ?? "unknown",
     channelId: state.channelId,
     guildId: state.guildId,
+  };
+}
+
+export function discordStateFromInteraction(
+  interaction: DiscordInteraction,
+  options: {
+    readonly conversationId: string;
+    readonly hasMessageAnchor: boolean;
+    readonly initialResponseSent: boolean;
+  },
+): DiscordChannelState {
+  return {
+    audience: discordAudience(interaction.channelType, interaction.guildId),
+    applicationId: interaction.applicationId,
+    channelId: interaction.channelId,
+    conversationId: options.conversationId,
+    guildId: interaction.guildId ?? null,
+    hasMessageAnchor: options.hasMessageAnchor,
+    initialResponseSent: options.initialResponseSent,
+    interactionToken: interaction.token,
+  };
+}
+
+export function discordCommandAudience(
+  platformAudience: ChannelAudience | undefined,
+  result: Exclude<DiscordCommandResult, null>,
+): ChannelAudience {
+  if (platformAudience === "private" || result.ephemeral === true) return "private";
+  const explicitAudience = normalizeChannelAudience(result.audience);
+  return explicitAudience === "unknown" ? (platformAudience ?? "unknown") : explicitAudience;
+}
+
+export function initialDiscordState(): DiscordChannelState {
+  return {
+    audience: "unknown",
+    applicationId: null,
+    channelId: null,
+    conversationId: null,
+    guildId: null,
+    hasMessageAnchor: false,
+    initialResponseSent: false,
+    interactionToken: null,
   };
 }

--- a/packages/eve/src/public/channels/discord/discordChannel.test.ts
+++ b/packages/eve/src/public/channels/discord/discordChannel.test.ts
@@ -239,6 +239,72 @@ describe("discordChannel() inbound route", () => {
     });
   });
 
+  it.each([
+    {
+      audience: "public",
+      channel: { type: 0 },
+      ephemeral: false,
+      expected: "public",
+      guildId: "G01",
+    },
+    {
+      audience: "public",
+      channel: { type: 0 },
+      ephemeral: true,
+      expected: "private",
+      guildId: "G01",
+    },
+    {
+      audience: "public",
+      channel: { type: 1 },
+      ephemeral: false,
+      expected: "private",
+      guildId: "G01",
+    },
+    {
+      audience: "public",
+      channel: { type: 0 },
+      ephemeral: false,
+      expected: "private",
+      guildId: undefined,
+    },
+    {
+      audience: "everyone",
+      channel: { type: 0 },
+      ephemeral: false,
+      expected: "unknown",
+      guildId: "G01",
+    },
+  ] as const)(
+    "projects command audience evidence as $expected",
+    async ({ audience, channel: interactionChannel, ephemeral, expected, guildId }) => {
+      const { privateKey, publicKeyHex } = testKeys();
+      const channel = discordChannel({
+        credentials: { publicKey: publicKeyHex },
+        onCommand: () => ({
+          audience: audience as "public",
+          auth: null,
+          ephemeral,
+        }),
+      });
+
+      const { send } = await firePost(
+        channel,
+        signedRequest({
+          body: commandBody({
+            channel: interactionChannel,
+            guild_id: guildId,
+          }),
+          privateKey,
+        }),
+      );
+
+      expect(send.mock.calls[0]?.[1]).toMatchObject({
+        state: { audience: expected },
+      });
+    },
+  );
+
   it("acknowledges commands without dispatch when onCommand returns null", async () => {
     const { privateKey, publicKeyHex } = testKeys();
     const channel = discordChannel({
@@ -561,6 +627,28 @@ describe("discordChannel() default event handlers", () => {
         initialResponseSent: true,
         interactionToken: null,
       },
+    });
+  });
+
+  it.each([
+    ["public", "public"],
+    ["private", "private"],
+    ["everyone", "unknown"],
+  ] as const)("projects proactive audience %s as %s", async (audience, expected) => {
+    const channel = discordChannel({ credentials: { botToken: "bot-token" } });
+    const send = vi.fn().mockResolvedValue({ id: "s1" });
+
+    await channel.receive!(
+      {
+        target: { audience: audience as "public", channelId: "C01" },
+        auth: null,
+        message: "start",
+      },
+      mockChannelContext(send),
+    );
+
+    expect(send.mock.calls[0]?.[1]).toMatchObject({
+      state: { audience: expected },
     });
   });
 });

--- a/packages/eve/src/public/channels/discord/discordChannel.ts
+++ b/packages/eve/src/public/channels/discord/discordChannel.ts
@@ -51,8 +51,13 @@ import { readNonEmptyString } from "#shared/guards.js";
 import { parseJsonObject, type JsonObject } from "#shared/json.js";
 import { defineChannel, POST, type Channel } from "#public/definitions/channel.js";
 import type { ValidatedInputResponse } from "#shared/input.js";
-import type { ChannelAudience } from "#shared/channel-audience.js";
-import { discordAudience, discordInstrumentationMetadata } from "./audience.js";
+import { normalizeChannelAudience, type ChannelAudience } from "#shared/channel-audience.js";
+import {
+  discordCommandAudience,
+  discordInstrumentationMetadata,
+  discordStateFromInteraction,
+  initialDiscordState,
+} from "./audience.js";
 
 const log = createLogger("discord.channel");
 
@@ -97,6 +102,8 @@ export interface DiscordChannelCredentials extends DiscordCredentials {
 
 /** Target accepted by `receive(discord, { target })` for proactive sessions. */
 export interface DiscordReceiveTarget {
+  /** Optional audience evidence for proactive receives. Omit to leave `unknown`. */
+  readonly audience?: ChannelAudience;
   readonly channelId: string;
   readonly conversationId?: string;
   readonly initialMessage?: string | DiscordMessageBody;
@@ -105,12 +112,15 @@ export interface DiscordReceiveTarget {
 /**
  * Result of an inbound Discord command hook. Return `null` to acknowledge the
  * interaction without dispatching the agent.
+ * - `audience`: optional visibility evidence already known by the handler.
  * - `auth`: session auth context for the dispatched turn, or `null` for anonymous.
  * - `ephemeral`: when `true`, the deferred reply is visible only to the invoking user.
  * - `context`: model-visible context lines appended after the Discord context block.
  * - `title`: workflow run title override that does not change model input.
  */
 export type DiscordCommandResult = {
+  /** Optional audience evidence from the command handler. */
+  readonly audience?: ChannelAudience;
   readonly auth: SessionAuthContext | null;
   readonly ephemeral?: boolean;
   readonly context?: readonly string[];
@@ -300,7 +310,7 @@ export function discordChannel(config: DiscordChannelConfig = {}): DiscordChanne
       return from(discordContinuationToken(channelId, conversationId)).send(input.message, {
         auth: input.auth,
         state: {
-          audience: "unknown",
+          audience: normalizeChannelAudience(receiveTarget.audience),
           applicationId: null,
           channelId,
           conversationId: conversationId || null,
@@ -506,7 +516,7 @@ async function handleCommandInteraction(input: {
   readonly from: ChannelFrom<DiscordChannelState>;
   readonly waitUntil: (task: Promise<unknown>) => void;
 }): Promise<Response> {
-  const state = stateFromInteraction(input.interaction, {
+  const state = discordStateFromInteraction(input.interaction, {
     conversationId: input.interaction.id,
     hasMessageAnchor: false,
     initialResponseSent: false,
@@ -525,6 +535,7 @@ async function handleCommandInteraction(input: {
   if (result === null || result === undefined) {
     return discordJson({ content: "Command ignored.", ephemeral: true });
   }
+  state.audience = discordCommandAudience(state.audience, result);
 
   input.waitUntil(
     dispatchCommand({
@@ -632,39 +643,6 @@ async function dispatchInputResponses(input: {
   } catch (error) {
     log.error("interaction response delivery failed", { error });
   }
-}
-
-function stateFromInteraction(
-  interaction: DiscordInteraction,
-  options: {
-    readonly conversationId: string;
-    readonly hasMessageAnchor: boolean;
-    readonly initialResponseSent: boolean;
-  },
-): DiscordChannelState {
-  return {
-    audience: discordAudience(interaction.channelType),
-    applicationId: interaction.applicationId,
-    channelId: interaction.channelId,
-    conversationId: options.conversationId,
-    guildId: interaction.guildId ?? null,
-    hasMessageAnchor: options.hasMessageAnchor,
-    initialResponseSent: options.initialResponseSent,
-    interactionToken: interaction.token,
-  };
-}
-
-function initialDiscordState(): DiscordChannelState {
-  return {
-    audience: "unknown",
-    applicationId: null,
-    channelId: null,
-    conversationId: null,
-    guildId: null,
-    hasMessageAnchor: false,
-    initialResponseSent: false,
-    interactionToken: null,
-  };
 }
 
 function mergeCredentials(

--- a/packages/eve/src/public/channels/github/api.ts
+++ b/packages/eve/src/public/channels/github/api.ts
@@ -10,6 +10,8 @@ import {
   type GitHubAuthApiOptions,
   type GitHubChannelCredentials,
 } from "#public/channels/github/auth.js";
+import { githubRepositoryAudience } from "#public/channels/github/privacy.js";
+import type { ChannelAudience } from "#shared/channel-audience.js";
 import { isObject } from "#shared/guards.js";
 import { parseJsonObject, type JsonObject } from "#shared/json.js";
 
@@ -398,7 +400,11 @@ export function createGitHubReaction(
 /** Fetches repository metadata, primarily to resolve `repository.id` for receive(). */
 export async function getGitHubRepository(
   input: GitHubResourceInput & { readonly auth?: boolean },
-): Promise<{ readonly id: number; readonly defaultBranch: string | undefined }> {
+): Promise<{
+  readonly audience: ChannelAudience;
+  readonly id: number;
+  readonly defaultBranch: string | undefined;
+}> {
   const response = await callGitHubApi({
     api: input.api,
     credentials: input.credentials,
@@ -410,7 +416,7 @@ export async function getGitHubRepository(
   const body = isObject(response.body) ? response.body : {};
   const id = typeof body.id === "number" ? body.id : 0;
   const defaultBranch = typeof body.default_branch === "string" ? body.default_branch : undefined;
-  return { defaultBranch, id };
+  return { audience: githubRepositoryAudience(body), defaultBranch, id };
 }
 
 function normalizeCommentBody(body: string | GitHubCommentBody): GitHubJsonObject {

--- a/packages/eve/src/public/channels/github/githubChannel.test.ts
+++ b/packages/eve/src/public/channels/github/githubChannel.test.ts
@@ -199,6 +199,61 @@ describe("githubChannel", () => {
     }
   });
 
+  it.each([
+    { audience: "public", repositoryFields: { visibility: "public" } },
+    { audience: "unknown", repositoryFields: { private: false } },
+    { audience: "private", repositoryFields: { visibility: "private" } },
+    { audience: "private", repositoryFields: { visibility: "internal" } },
+    { audience: "private", repositoryFields: { private: true } },
+    {
+      audience: "private",
+      repositoryFields: { private: true, visibility: "public" },
+    },
+    {
+      audience: "unknown",
+      repositoryFields: { private: "false", visibility: "PUBLIC" },
+    },
+    {
+      audience: "unknown",
+      repositoryFields: { private: "false", visibility: "public" },
+    },
+  ] as const)(
+    "projects explicit repository visibility as $audience for verified webhooks",
+    async ({ audience, repositoryFields }) => {
+      const channel = githubChannel({
+        botName: "testbot",
+        credentials: { webhookSecret: SECRET },
+        onComment: () => ({ auth: null }),
+      });
+      const { send } = await firePost(
+        channel,
+        signedRequest(
+          "issue_comment",
+          basePayload({
+            action: "created",
+            comment: {
+              body: "@testbot help me",
+              id: 10,
+              user: { id: 1, login: "octocat", type: "User" },
+            },
+            issue: { number: 5 },
+            repository: {
+              full_name: "vercel/eve",
+              id: 123,
+              name: "eve",
+              owner: { login: "vercel" },
+              ...repositoryFields,
+            },
+          }),
+        ),
+      );
+
+      const state = send.mock.calls[0]![1].state as GitHubChannelState;
+      expect(state.audience).toBe(audience);
+      expect(getAdapter(channel).instrumentation?.metadata?.({ ...state })).toEqual({ audience });
+    },
+  );
+
   it("acks ping deliveries without dispatching", async () => {
     const channel = githubChannel({ credentials: { webhookSecret: SECRET } });
     const { response, send } = await firePost(channel, signedRequest("ping", basePayload({})));
@@ -1187,5 +1242,58 @@ describe("githubChannel", () => {
     expect(sandbox.commandLog).toContain(
       `cd '/workspace' && GIT_TERMINAL_PROMPT=0 git fetch --depth 1 origin '${headSha}'`,
     );
+  });
+
+  it("reuses repository API metadata to seed proactive receive visibility", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: 123, visibility: "private" }), {
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const channel = asCompiled<GitHubChannelState>(
+      githubChannel({ api: { apiBaseUrl: "https://github.test", fetch: fetchMock } }),
+    );
+    const send = vi.fn().mockResolvedValue({ id: "s1" });
+
+    await channel.receive!(
+      {
+        auth: null,
+        message: "run",
+        target: { issueNumber: 5, owner: "vercel", repo: "eve" },
+      },
+      mockChannelContext(send),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://github.test/repos/vercel/eve");
+    const state = send.mock.calls[0]![1].state as GitHubChannelState;
+    expect(state).toMatchObject({ audience: "private", repositoryId: 123 });
+    expect(channel.adapter.instrumentation?.metadata?.({ ...state })).toEqual({
+      audience: "private",
+    });
+  });
+
+  it("keeps proactive receive visibility unknown when repositoryId skips metadata lookup", async () => {
+    const fetchMock = vi.fn();
+    const channel = asCompiled<GitHubChannelState>(
+      githubChannel({ api: { apiBaseUrl: "https://github.test", fetch: fetchMock } }),
+    );
+    const send = vi.fn().mockResolvedValue({ id: "s1" });
+
+    await channel.receive!(
+      {
+        auth: null,
+        message: "run",
+        target: { issueNumber: 5, owner: "vercel", repo: "eve", repositoryId: 123 },
+      },
+      mockChannelContext(send),
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    const state = send.mock.calls[0]![1].state as GitHubChannelState;
+    expect(state).toMatchObject({ audience: "unknown", repositoryId: 123 });
+    expect(channel.adapter.instrumentation?.metadata?.({ ...state })).toEqual({
+      audience: "unknown",
+    });
   });
 });

--- a/packages/eve/src/public/channels/github/githubChannel.ts
+++ b/packages/eve/src/public/channels/github/githubChannel.ts
@@ -51,6 +51,7 @@ import {
 import type { GitHubPullRequestContextConfig } from "#public/channels/github/pr-context.js";
 import { verifyGitHubRequest } from "#public/channels/github/verify.js";
 import { defineChannel, POST, type Channel } from "#public/definitions/channel.js";
+import type { ChannelAudience } from "#shared/channel-audience.js";
 import { readNonEmptyString } from "#shared/guards.js";
 
 const log = createLogger("github.channel");
@@ -96,6 +97,11 @@ export interface GitHubChannelContext {
   readonly repository: GitHubRepositoryRef;
   readonly thread: GitHubThread;
   state: GitHubChannelState;
+}
+
+/** GitHub channel metadata exposed to instrumentation callbacks. */
+export interface GitHubInstrumentationMetadata extends Record<string, unknown> {
+  readonly audience: ChannelAudience;
 }
 
 /** Event-handler GitHub context, including continuation routing. */
@@ -227,7 +233,11 @@ export interface GitHubChannelConfig {
 }
 
 /** Concrete return type of {@link githubChannel}. */
-export interface GitHubChannel extends Channel<GitHubChannelState, GitHubReceiveTarget> {}
+export interface GitHubChannel extends Channel<
+  GitHubChannelState,
+  GitHubReceiveTarget,
+  GitHubInstrumentationMetadata
+> {}
 
 /** GitHub channel factory for GitHub App webhooks and proactive comments. */
 export function githubChannel(config: GitHubChannelConfig = {}): GitHubChannel {
@@ -246,10 +256,19 @@ export function githubChannel(config: GitHubChannelConfig = {}): GitHubChannel {
     ...config.events,
   };
 
-  const channel = defineChannel<GitHubChannelState, GitHubChannelContext, GitHubReceiveTarget>({
+  const channel = defineChannel<
+    GitHubChannelState,
+    GitHubChannelContext,
+    GitHubReceiveTarget,
+    GitHubInstrumentationMetadata
+  >({
     kindHint: "github",
     turnPolicy: config.turnPolicy,
     state: initialGitHubState(),
+
+    metadata(state): GitHubInstrumentationMetadata {
+      return { audience: state.audience ?? "unknown" };
+    },
 
     context(state, session) {
       return rebuildGitHubContext(state, session, config);
@@ -411,23 +430,23 @@ export function githubChannel(config: GitHubChannelConfig = {}): GitHubChannel {
         );
       }
 
-      const repositoryId =
-        target.repositoryId ??
-        (
-          await getGitHubRepository({
-            api: config.api,
-            credentials: config.credentials,
-            installationId: target.installationId,
-            owner,
-            repo,
-          })
-        ).id;
+      const repository =
+        target.repositoryId === undefined
+          ? await getGitHubRepository({
+              api: config.api,
+              credentials: config.credentials,
+              installationId: target.installationId,
+              owner,
+              repo,
+            })
+          : { audience: "unknown" as const, id: target.repositoryId };
 
       const state = stateFromReceiveTarget({
+        audience: repository.audience,
         target,
         owner,
         repo,
-        repositoryId,
+        repositoryId: repository.id,
       });
 
       if (target.initialMessage !== undefined) {

--- a/packages/eve/src/public/channels/github/inbound-types.ts
+++ b/packages/eve/src/public/channels/github/inbound-types.ts
@@ -1,10 +1,12 @@
 import type { JsonObject } from "#shared/json.js";
+import type { ChannelAudience } from "#shared/channel-audience.js";
 
 /** GitHub conversation kinds represented by the channel state. */
 export type GitHubConversationKind = "issue" | "pull_request" | "review_thread";
 
 /** Stable repository identity normalized from webhook payloads. */
 export interface GitHubRepositoryRef {
+  readonly audience?: ChannelAudience;
   readonly fullName: string;
   readonly id: number;
   readonly name: string;

--- a/packages/eve/src/public/channels/github/inbound.ts
+++ b/packages/eve/src/public/channels/github/inbound.ts
@@ -1,5 +1,6 @@
 import { isObject } from "#shared/guards.js";
 import { parseJsonObject, type JsonObject } from "#shared/json.js";
+import { githubRepositoryAudience } from "#public/channels/github/privacy.js";
 import type {
   GitHubAppRef,
   GitHubCheckRunWebhookEvent,
@@ -446,7 +447,9 @@ function normalizeRepository(value: unknown): GitHubRepositoryRef | null {
   const name = typeof value.name === "string" ? value.name : fallbackName;
   const id = typeof value.id === "number" ? value.id : 0;
   if (!owner || !name) return null;
+  const audience = githubRepositoryAudience(value);
   return {
+    audience,
     fullName: fullName || `${owner}/${name}`,
     id,
     name,

--- a/packages/eve/src/public/channels/github/index.ts
+++ b/packages/eve/src/public/channels/github/index.ts
@@ -44,6 +44,7 @@ export {
   type GitHubInboundContext,
   type GitHubInboundResult,
   type GitHubInboundResultOrPromise,
+  type GitHubInstrumentationMetadata,
   type GitHubProgressConfig,
   type GitHubReceiveTarget,
 } from "#public/channels/github/githubChannel.js";

--- a/packages/eve/src/public/channels/github/privacy.ts
+++ b/packages/eve/src/public/channels/github/privacy.ts
@@ -1,0 +1,20 @@
+import type { ChannelAudience } from "#shared/channel-audience.js";
+import { isObject } from "#shared/guards.js";
+
+/** Resolves repository visibility without treating missing or malformed fields as public. */
+export function githubRepositoryAudience(value: unknown): ChannelAudience {
+  if (!isObject(value)) return "unknown";
+  if (value.private === true) return "private";
+  if (value.visibility === "private" || value.visibility === "internal") return "private";
+  if ("private" in value && typeof value.private !== "boolean") return "unknown";
+  if (
+    "visibility" in value &&
+    value.visibility !== "public" &&
+    value.visibility !== "private" &&
+    value.visibility !== "internal"
+  ) {
+    return "unknown";
+  }
+  if (value.visibility === "public") return "public";
+  return "unknown";
+}

--- a/packages/eve/src/public/channels/github/state.ts
+++ b/packages/eve/src/public/channels/github/state.ts
@@ -9,6 +9,7 @@ import {
   type GitHubPullRequestReviewCommentEvent,
   type GitHubPullRequestWebhookEvent,
 } from "#public/channels/github/inbound.js";
+import type { ChannelAudience } from "#shared/channel-audience.js";
 
 /**
  * Durable, mutable per-conversation GitHub channel state, persisted as JSON.
@@ -24,6 +25,7 @@ import {
  * the repository, which is why the fields are mutable.
  */
 export interface GitHubChannelState {
+  audience?: ChannelAudience;
   baseRef: string | null;
   baseSha: string | null;
   checkoutPath: string | null;
@@ -53,6 +55,7 @@ export interface GitHubReceiveStateTarget {
 /** Initial empty GitHub channel state. */
 export function initialGitHubState(): GitHubChannelState {
   return {
+    audience: "unknown",
     baseRef: null,
     baseSha: null,
     checkoutPath: null,
@@ -77,6 +80,7 @@ export function initialGitHubState(): GitHubChannelState {
 export function stateFromIssueCommentEvent(event: GitHubIssueCommentEvent): GitHubChannelState {
   return {
     ...initialGitHubState(),
+    audience: event.repository.audience ?? "unknown",
     baseRef: event.baseRef,
     baseSha: event.baseSha,
     conversationKind: event.conversation.kind,
@@ -100,6 +104,7 @@ export function stateFromPullRequestReviewCommentEvent(
 ): GitHubChannelState {
   return {
     ...initialGitHubState(),
+    audience: event.repository.audience ?? "unknown",
     baseRef: event.baseRef,
     baseSha: event.baseSha,
     conversationKind: "review_thread",
@@ -122,6 +127,7 @@ export function stateFromPullRequestReviewCommentEvent(
 export function stateFromIssueEvent(event: GitHubIssueWebhookEvent): GitHubChannelState {
   return {
     ...initialGitHubState(),
+    audience: event.repository.audience ?? "unknown",
     conversationKind: "issue",
     installationId: event.installationId ?? null,
     issueNumber: event.issue.issueNumber,
@@ -138,6 +144,7 @@ export function stateFromPullRequestEvent(
 ): GitHubChannelState {
   return {
     ...initialGitHubState(),
+    audience: event.repository.audience ?? "unknown",
     baseRef: event.baseRef,
     baseSha: event.baseSha,
     conversationKind: "pull_request",
@@ -160,6 +167,7 @@ export function stateFromCiEvent(event: GitHubCiWebhookEvent): GitHubChannelStat
   const pullRequestNumber = ci.pullRequests[0] ?? null;
   return {
     ...initialGitHubState(),
+    audience: event.repository.audience ?? "unknown",
     conversationKind: "pull_request",
     headSha: ci.headSha,
     installationId: event.installationId ?? null,
@@ -174,6 +182,7 @@ export function stateFromCiEvent(event: GitHubCiWebhookEvent): GitHubChannelStat
 
 /** Builds state for proactive `receive()` calls. */
 export function stateFromReceiveTarget(input: {
+  readonly audience: ChannelAudience;
   readonly target: GitHubReceiveStateTarget;
   readonly owner: string;
   readonly repo: string;
@@ -184,6 +193,7 @@ export function stateFromReceiveTarget(input: {
     target.pullRequestNumber !== undefined ? "pull_request" : "issue";
   return {
     ...initialGitHubState(),
+    audience: input.audience,
     conversationKind,
     installationId: target.installationId ?? null,
     issueNumber:

--- a/packages/eve/src/public/channels/linear/linearChannel.test.ts
+++ b/packages/eve/src/public/channels/linear/linearChannel.test.ts
@@ -158,6 +158,14 @@ function makeRequest(overrides: Partial<InputRequest> = {}): InputRequest {
 }
 
 describe("linearChannel inbound Agent Session events", () => {
+  it("projects an explicit unknown audience into instrumentation metadata", () => {
+    const adapter = getAdapter(linearChannel());
+
+    expect(adapter.instrumentation?.metadata?.(adapter.state)).toMatchObject({
+      audience: "unknown",
+    });
+  });
+
   it("dispatches created events with auth, context, token, and state", async () => {
     const channel = linearChannel({
       credentials: { webhookSecret: SECRET },

--- a/packages/eve/src/public/channels/linear/linearChannel.ts
+++ b/packages/eve/src/public/channels/linear/linearChannel.ts
@@ -34,6 +34,7 @@ import {
   type Channel,
   type ChannelContinuationOps,
 } from "#public/definitions/channel.js";
+import type { ChannelAudience } from "#shared/channel-audience.js";
 import { isObject, readNonEmptyString } from "#shared/guards.js";
 import type { JsonObject } from "#shared/json.js";
 
@@ -63,6 +64,7 @@ export interface LinearChannelState {
 
 /** Per-session instrumentation snapshot for Linear runtime telemetry. */
 export interface LinearInstrumentationMetadata extends Record<string, unknown> {
+  readonly audience?: ChannelAudience;
   readonly agentSessionId: string | null;
   readonly commentId: string | null;
   readonly issueId: string | null;
@@ -216,6 +218,7 @@ export function linearChannel(config: LinearChannelConfig = {}): LinearChannel {
     state: initialLinearState(),
     metadata(state): LinearInstrumentationMetadata {
       return {
+        audience: "unknown",
         agentSessionId: state.agentSessionId,
         commentId: state.commentId ?? null,
         issueId: state.issueId ?? null,

--- a/packages/eve/src/public/channels/linq/linqChannel.test.ts
+++ b/packages/eve/src/public/channels/linq/linqChannel.test.ts
@@ -1,25 +1,28 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { createLinqAdapter, directMessage, markRead, newMessage, send } = vi.hoisted(() => ({
-  createLinqAdapter: vi.fn((_config: { credentials?: () => unknown | Promise<unknown> }) => ({
-    name: "linq",
-  })),
-  directMessage: vi.fn(),
-  markRead: vi.fn(),
-  newMessage: vi.fn(),
-  send: vi.fn(),
-}));
+const { chatSdkChannel, createLinqAdapter, directMessage, markRead, newMessage, send } = vi.hoisted(
+  () => ({
+    chatSdkChannel: vi.fn(() => ({
+      bot: {
+        getAdapter: () => ({ markRead }),
+        onDirectMessage: directMessage,
+        onNewMessage: newMessage,
+      },
+      channel: { routes: [] },
+      send,
+    })),
+    createLinqAdapter: vi.fn((_config: { credentials?: () => unknown | Promise<unknown> }) => ({
+      name: "linq",
+    })),
+    directMessage: vi.fn(),
+    markRead: vi.fn(),
+    newMessage: vi.fn(),
+    send: vi.fn(),
+  }),
+);
 
 vi.mock("#public/channels/chat-sdk/index.js", () => ({
-  chatSdkChannel: () => ({
-    bot: {
-      getAdapter: () => ({ markRead }),
-      onDirectMessage: directMessage,
-      onNewMessage: newMessage,
-    },
-    channel: { routes: [] },
-    send,
-  }),
+  chatSdkChannel,
   messageToUserContent: (message: Message) => message.text,
 }));
 vi.mock("#compiled/@chat-adapter/state-memory/index.js", () => ({
@@ -71,6 +74,7 @@ describe("linqChannel", () => {
         title: undefined,
       },
     );
+    expect(chatSdkChannel).toHaveBeenCalledWith(expect.objectContaining({ audience: "private" }));
   });
 
   it("uses lazy credentials and the managed credential verifier", async () => {

--- a/packages/eve/src/public/channels/linq/linqChannel.ts
+++ b/packages/eve/src/public/channels/linq/linqChannel.ts
@@ -97,6 +97,7 @@ export function linqChannel(config: LinqChannelConfig): LinqChannel {
   const linq = createLinqAdapter(adapterConfig);
   const bridge = chatSdkChannel({
     adapters: { linq },
+    audience: "private",
     concurrency: "concurrent",
     events: config.events,
     routes: { linq: config.route ?? "/eve/v1/linq" },

--- a/packages/eve/src/public/channels/photon/photonIMessageChannel.test.ts
+++ b/packages/eve/src/public/channels/photon/photonIMessageChannel.test.ts
@@ -1,13 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { directMessage, newMessage, send } = vi.hoisted(() => ({
-  directMessage: vi.fn(),
-  newMessage: vi.fn(),
-  send: vi.fn(),
-}));
-
-vi.mock("#public/channels/chat-sdk/index.js", () => ({
-  chatSdkChannel: () => ({
+const { chatSdkChannel, directMessage, newMessage, send } = vi.hoisted(() => ({
+  chatSdkChannel: vi.fn(() => ({
     bot: {
       getAdapter: () => ({ markRead: vi.fn() }),
       onDirectMessage: directMessage,
@@ -15,7 +9,14 @@ vi.mock("#public/channels/chat-sdk/index.js", () => ({
     },
     channel: { routes: [] },
     send,
-  }),
+  })),
+  directMessage: vi.fn(),
+  newMessage: vi.fn(),
+  send: vi.fn(),
+}));
+
+vi.mock("#public/channels/chat-sdk/index.js", () => ({
+  chatSdkChannel,
   messageToUserContent: (message: Message) => message.text,
 }));
 vi.mock("#compiled/@chat-adapter/state-memory/index.js", () => ({
@@ -56,6 +57,7 @@ describe("photonIMessageChannel", () => {
       { context: [], message: "Steer this response" },
       { auth: null, thread, title: "Photon run" },
     );
+    expect(chatSdkChannel).toHaveBeenCalledWith(expect.objectContaining({ audience: "private" }));
   });
 
   it("derives user auth for default direct-message dispatch", async () => {

--- a/packages/eve/src/public/channels/photon/photonIMessageChannel.ts
+++ b/packages/eve/src/public/channels/photon/photonIMessageChannel.ts
@@ -87,6 +87,7 @@ export function photonIMessageChannel(config: PhotonIMessageChannelConfig): Phot
   });
   const bridge = chatSdkChannel({
     adapters: { imessage },
+    audience: "private",
     concurrency: "concurrent",
     events: config.events,
     routes: { imessage: config.route ?? "/eve/v1/photon" },

--- a/packages/eve/src/public/channels/slack/inbound.ts
+++ b/packages/eve/src/public/channels/slack/inbound.ts
@@ -73,6 +73,8 @@ export interface SlackMessage {
   readonly channelId: string;
   /** Slack team id, when the envelope carried one. */
   readonly teamId: string | undefined;
+  /** Whether Slack identified the conversation as externally shared. */
+  readonly isExtSharedChannel?: boolean;
   /** Author of the message. May be `undefined` for system events. */
   readonly author: SlackAuthor | undefined;
   /** File / image attachments on the inbound message. */
@@ -135,6 +137,7 @@ interface SlackMessageEvent {
  */
 export interface SlackEventCallback {
   readonly type: "event_callback";
+  readonly is_ext_shared_channel?: boolean;
   readonly team_id?: string;
   readonly authorizations?: readonly {
     readonly is_bot?: boolean;
@@ -181,7 +184,11 @@ export function parseAppMentionEvent(envelope: SlackEventCallback): SlackMessage
   if (envelope.type !== "event_callback") return null;
   const event = envelope.event;
   if (!event || event.type !== "app_mention") return null;
-  return buildSlackMessage(event as SlackAppMentionEvent, envelope.team_id);
+  return buildSlackMessage(
+    event as SlackAppMentionEvent,
+    envelope.team_id,
+    envelope.is_ext_shared_channel,
+  );
 }
 
 /**
@@ -245,7 +252,11 @@ export function parseMessageEvent(envelope: SlackEventCallback): SlackMessage | 
   if (envelope.type !== "event_callback") return null;
   const event = envelope.event;
   if (!event || event.type !== "message") return null;
-  return buildSlackMessage(event as SlackMessageEvent, envelope.team_id);
+  return buildSlackMessage(
+    event as SlackMessageEvent,
+    envelope.team_id,
+    envelope.is_ext_shared_channel,
+  );
 }
 
 export function parseDirectMessageEvent(envelope: SlackEventCallback): SlackMessage | null {
@@ -257,7 +268,7 @@ export function parseDirectMessageEvent(envelope: SlackEventCallback): SlackMess
   if (message.channel_type !== "im") return null;
   if (!isHumanMessage(message)) return null;
 
-  return buildSlackMessage(message, envelope.team_id);
+  return buildSlackMessage(message, envelope.team_id, envelope.is_ext_shared_channel);
 }
 
 function isHumanMessage(message: SlackMessageEvent): boolean {
@@ -293,6 +304,7 @@ export function slackMessageFromWebhookPayload(
     ts: payload.ts,
     threadTs: payload.threadTs,
     channelId: payload.channelId,
+    isExtSharedChannel: payload.isExtSharedChannel,
     teamId: payload.teamId,
     author: parsePayloadAuthor(payload),
     attachments: parsePayloadAttachments(payload.files),
@@ -303,6 +315,7 @@ export function slackMessageFromWebhookPayload(
 function buildSlackMessage(
   event: SlackAppMentionEvent | SlackMessageEvent,
   envelopeTeamId: string | undefined,
+  isExtSharedChannel?: boolean,
 ): SlackMessage | null {
   const channelId = typeof event.channel === "string" ? event.channel : "";
   const ts = typeof event.ts === "string" ? event.ts : "";
@@ -319,6 +332,7 @@ function buildSlackMessage(
     ts,
     threadTs,
     channelId,
+    isExtSharedChannel,
     teamId,
     author: parseAuthor(event),
     attachments: parseAttachments(event.files),

--- a/packages/eve/src/public/channels/slack/privacy.test.ts
+++ b/packages/eve/src/public/channels/slack/privacy.test.ts
@@ -13,6 +13,9 @@ describe("Slack conversation privacy", () => {
     expect(readSlackConversationPrivacy({ channel_type: "im" })).toBe("private");
     expect(readSlackConversationPrivacy({ channel_type: "mpim" })).toBe("private");
     expect(readSlackConversationPrivacy({ channel_type: "group" })).toBe("private");
+    expect(readSlackConversationPrivacy({ channel_type: "channel", is_ext_shared: true })).toBe(
+      "private",
+    );
     expect(readSlackConversationPrivacy({})).toBe("unknown");
     await expect(
       isPrivateSlackConversation({
@@ -49,6 +52,14 @@ describe("Slack conversation privacy", () => {
     { response: { ok: true, channel: { is_private: true } }, label: "private channel" },
     { response: { ok: true, channel: { is_im: true } }, label: "DM" },
     { response: { ok: true, channel: { is_mpim: true } }, label: "group DM" },
+    {
+      response: { ok: true, channel: { is_ext_shared: true, is_private: false } },
+      label: "Slack Connect channel",
+    },
+    {
+      response: { ok: true, channel: { is_private: false, is_shared: true } },
+      label: "shared channel",
+    },
     { response: { ok: true, channel: {} }, label: "ambiguous response" },
     { response: { ok: false, error: "missing_scope" }, label: "failed response" },
   ])("treats a $label lookup as private", async ({ response }) => {

--- a/packages/eve/src/public/channels/slack/privacy.ts
+++ b/packages/eve/src/public/channels/slack/privacy.ts
@@ -5,6 +5,7 @@ export type SlackConversationPrivacy = "private" | "public" | "unknown";
 export function readSlackConversationPrivacy(
   raw: Readonly<Record<string, unknown>> | undefined,
 ): SlackConversationPrivacy {
+  if (raw?.is_ext_shared === true || raw?.is_shared === true) return "private";
   switch (raw?.channel_type) {
     case "im":
     case "mpim":
@@ -19,9 +20,11 @@ export function readSlackConversationPrivacy(
 
 export async function isPrivateSlackConversation(input: {
   readonly channelId: string;
+  readonly isExtSharedChannel?: boolean;
   readonly raw: Readonly<Record<string, unknown>> | undefined;
   readonly request: (operation: string, body: unknown) => Promise<SlackApiResponse>;
 }): Promise<boolean> {
+  if (input.isExtSharedChannel === true) return true;
   const eventPrivacy = readSlackConversationPrivacy(input.raw);
   if (eventPrivacy !== "unknown") return eventPrivacy === "private";
 
@@ -39,7 +42,13 @@ function readConversationInfoPrivacy(response: SlackApiResponse): SlackConversat
   if (response.ok !== true || !isRecord(response.channel)) return "unknown";
 
   const channel = response.channel;
-  if (channel.is_im === true || channel.is_mpim === true || channel.is_private === true) {
+  if (
+    channel.is_im === true ||
+    channel.is_mpim === true ||
+    channel.is_private === true ||
+    channel.is_ext_shared === true ||
+    channel.is_shared === true
+  ) {
     return "private";
   }
   return channel.is_private === false ? "public" : "unknown";

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -217,6 +217,7 @@ let mentionCounter = 0;
 
 function buildMentionBody(overrides?: {
   channel?: string;
+  isExtSharedChannel?: boolean;
   threadTs?: string;
   ts?: string;
   text?: string;
@@ -237,6 +238,7 @@ function buildMentionBody(overrides?: {
   if (overrides?.threadTs) event.thread_ts = overrides.threadTs;
   const body = JSON.stringify({
     type: "event_callback",
+    is_ext_shared_channel: overrides?.isExtSharedChannel,
     team_id: overrides?.teamId ?? "T01",
     event_id: `Ev${mentionCounter}`,
     event,
@@ -1623,6 +1625,72 @@ describe("slackChannel() inbound mention pipeline", () => {
         triggeringUserId: "U01",
       },
     });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("marks imperative direct-message sends as private before the handler returns", async () => {
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-test" },
+      async onDirectMessage(ctx) {
+        await ctx.send("Imperative DM follow-up");
+        return null;
+      },
+    });
+    const { body } = buildDirectMessageBody();
+
+    const { send } = await firePost(channel, buildSignedRequest({ body }));
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0]?.[1]).toMatchObject({
+      message: "Imperative DM follow-up",
+      state: { audience: "private" },
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("applies an explicit app mention visibility lookup to an imperative send", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, channel: { is_private: true } }), {
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-test" },
+      async onAppMention(ctx) {
+        expect(await ctx.isDMOrPrivateChannel()).toBe(true);
+        await ctx.send("Imperative private follow-up");
+        return null;
+      },
+    });
+    const { body } = buildMentionBody({ channel: "C_PRIVATE" });
+
+    const { send } = await firePost(channel, buildSignedRequest({ body }));
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0]?.[1]).toMatchObject({
+      message: "Imperative private follow-up",
+      state: { audience: "private" },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("conversations.info");
+  });
+
+  it("marks imperative Slack Connect sends private without an API lookup", async () => {
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-test" },
+      async onAppMention(ctx) {
+        await ctx.send("Imperative shared-channel follow-up");
+        return null;
+      },
+    });
+    const { body } = buildMentionBody({ channel: "C_SHARED", isExtSharedChannel: true });
+
+    const { send } = await firePost(channel, buildSignedRequest({ body }));
+
+    expect(send.mock.calls[0]?.[1]).toMatchObject({
+      state: { audience: "private" },
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("lets onAppMention cancel the active turn before dispatching its replacement", async () => {
@@ -2016,6 +2084,7 @@ describe("slackChannel() inbound mention pipeline", () => {
     const { send } = await firePost(channel, buildSignedRequest({ body }));
 
     expect(send).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("awaits an async onAppMention before deciding whether to dispatch", async () => {

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -1308,7 +1308,10 @@ async function dispatchSlackMessage(input: {
   });
   const author = input.message.author;
   const channelState: SlackChannelState = {
-    audience: "unknown",
+    audience:
+      input.kind === "direct_message" || input.message.isExtSharedChannel === true
+        ? "private"
+        : "unknown",
     channelId: input.message.channelId,
     installationTeamId: input.installationTeamId ?? null,
     teamId: input.message.teamId ?? null,
@@ -1334,12 +1337,16 @@ async function dispatchSlackMessage(input: {
     state: channelState,
   });
   let privateConversation: Promise<boolean> | undefined;
-  const isDMOrPrivateChannel = () =>
-    (privateConversation ??= isPrivateSlackConversation({
+  const isDMOrPrivateChannel = async () => {
+    const isPrivate = await (privateConversation ??= isPrivateSlackConversation({
       channelId: input.message.channelId,
+      isExtSharedChannel: input.message.isExtSharedChannel,
       raw: input.message.raw,
       request: slack.request,
     }));
+    channelState.audience = isPrivate ? "private" : "public";
+    return isPrivate;
+  };
   const isBotMentioned =
     input.kind === "app_mention" ||
     (input.botUserId !== undefined && input.message.text.includes(`<@${input.botUserId}`));

--- a/packages/eve/src/public/channels/teams/teamsChannel.test.ts
+++ b/packages/eve/src/public/channels/teams/teamsChannel.test.ts
@@ -136,6 +136,31 @@ describe("teamsChannel", () => {
     });
   });
 
+  it.each([
+    ["channel", "public", "public"],
+    ["channel", "private", "private"],
+    ["channel", "everyone", "unknown"],
+    ["personal", "public", "private"],
+    ["groupChat", "public", "private"],
+  ] as const)(
+    "projects %s handler audience %s as %s",
+    async (conversationType, audience, expected) => {
+      const channel = teamsChannel({
+        credentials: { webhookVerifier: () => true },
+        onMessage: () => ({
+          audience: audience as "public",
+          auth: null,
+        }),
+      });
+
+      const { send } = await firePost(channel, messageActivity({ conversationType }));
+
+      expect(send.mock.calls[0]?.[1]).toMatchObject({
+        state: { audience: expected },
+      });
+    },
+  );
+
   it("dispatches verified personal messages with Teams state", async () => {
     const channel = teamsChannel({
       credentials: { webhookVerifier: () => true },
@@ -556,6 +581,38 @@ describe("teamsChannel", () => {
       state: { replyToActivityId: "ANCHOR" },
     });
   });
+
+  it.each([
+    ["channel", "public", "public"],
+    ["channel", "private", "private"],
+    ["channel", "everyone", "unknown"],
+    ["personal", "public", "private"],
+    ["groupChat", "public", "private"],
+  ] as const)(
+    "projects proactive %s audience %s as %s",
+    async (conversationType, audience, expected) => {
+      const channel = teamsChannel();
+      const send = vi.fn().mockResolvedValue({ id: "s1" });
+
+      await channel.receive!(
+        {
+          target: {
+            audience: audience as "public",
+            conversationId: "CONV",
+            conversationType,
+            serviceUrl: "https://service.example/teams",
+          },
+          auth: null,
+          message: "Begin",
+        },
+        mockChannelContext(send),
+      );
+
+      expect(send.mock.calls[0]?.[1]).toMatchObject({
+        state: { audience: expected },
+      });
+    },
+  );
 });
 
 function messageActivity(input: { readonly conversationType: string }): Record<string, unknown> {

--- a/packages/eve/src/public/channels/teams/teamsChannel.ts
+++ b/packages/eve/src/public/channels/teams/teamsChannel.ts
@@ -61,7 +61,7 @@ import { verifyTeamsRequest, type TeamsWebhookVerifier } from "#public/channels/
 import { readNonEmptyString } from "#shared/guards.js";
 import { parseJsonObject, type JsonObject } from "#shared/json.js";
 import { defineChannel, POST, type Channel } from "#public/definitions/channel.js";
-import type { ChannelAudience } from "#shared/channel-audience.js";
+import { normalizeChannelAudience, type ChannelAudience } from "#shared/channel-audience.js";
 
 const log = createLogger("teams.channel");
 
@@ -96,6 +96,8 @@ export interface TeamsPendingApprovalCard {
 }
 
 export interface TeamsChannelState {
+  /** Audience evidence captured before the session is dispatched. */
+  audience?: ChannelAudience;
   /** Bot account captured from the inbound activity recipient. */
   bot: TeamsChannelAccount | null;
   channelId: string | null;
@@ -128,6 +130,8 @@ export interface TeamsChannelCredentials extends TeamsCredentials {
  * a new root that anchors non-personal threads.
  */
 export interface TeamsReceiveTarget {
+  /** Optional audience evidence for proactive receives. Omit to infer from conversation type. */
+  readonly audience?: ChannelAudience;
   /** Teams team/channel id, for channel conversations. */
   readonly channelId?: string;
   readonly conversationId: string;
@@ -146,6 +150,8 @@ export interface TeamsReceiveTarget {
 
 /** Result of an inbound Teams message hook. Return `null` to acknowledge without dispatching. */
 export type TeamsInboundResult = {
+  /** Optional audience evidence from the inbound message handler. */
+  readonly audience?: ChannelAudience;
   readonly auth: SessionAuthContext | null;
   readonly context?: readonly string[];
   /** Overrides the workflow run title without changing the message sent to the model. */
@@ -307,7 +313,7 @@ export function teamsChannel(config: TeamsChannelConfig = {}): TeamsChannel {
       credentials: config.credentials,
     }),
     metadata: (state) => ({
-      audience: teamsAudience(state.conversationType),
+      audience: teamsEffectiveAudience(teamsAudience(state.conversationType), state.audience),
       channelId: state.channelId,
       conversationType: state.conversationType,
       teamId: state.teamId,
@@ -406,6 +412,7 @@ export function teamsChannel(config: TeamsChannelConfig = {}): TeamsChannel {
 
       const state: TeamsChannelState = {
         ...initialTeamsState(),
+        audience: teamsEffectiveAudience(teamsAudience(conversationType), receiveTarget.audience),
         channelId: readNonEmptyString(receiveTarget.channelId) ?? null,
         conversationId,
         conversationType,
@@ -440,6 +447,15 @@ export function teamsChannel(config: TeamsChannelConfig = {}): TeamsChannel {
 function teamsAudience(conversationType: string | null): ChannelAudience {
   if (conversationType === "personal" || conversationType === "groupChat") return "private";
   return "unknown";
+}
+
+function teamsEffectiveAudience(
+  platformAudience: ChannelAudience,
+  explicitAudience: unknown,
+): ChannelAudience {
+  if (platformAudience === "private") return "private";
+  const normalized = normalizeChannelAudience(explicitAudience);
+  return normalized === "unknown" ? platformAudience : normalized;
 }
 
 function rebuildTeamsContext(
@@ -636,6 +652,7 @@ async function dispatchMessage(input: {
     return;
   }
   if (result === null || result === undefined) return;
+  state.audience = teamsEffectiveAudience(teamsAudience(state.conversationType), result.audience);
 
   const fileParts = collectTeamsFileParts(input.activity.attachments, input.filesPolicy);
   const turnMessage = buildTeamsTurnMessage(input.activity.text, fileParts);
@@ -729,6 +746,7 @@ function stateFromActivity(
     replyToActivityId: teamsThreadRootActivityId(activity),
   });
   return {
+    audience: teamsAudience(activity.conversationType ?? activity.scope),
     bot: activity.recipient,
     channelId: activity.teamsChannelId ?? null,
     conversationId: activity.conversation.id,
@@ -791,6 +809,7 @@ function rejectInput(): null {
 
 function initialTeamsState(): TeamsChannelState {
   return {
+    audience: "unknown",
     bot: null,
     channelId: null,
     conversationId: null,

--- a/packages/eve/src/public/channels/telegram/api.test.ts
+++ b/packages/eve/src/public/channels/telegram/api.test.ts
@@ -62,12 +62,15 @@ describe("callTelegramApi", () => {
 });
 
 describe("sendTelegramMessage", () => {
-  it("extracts the posted message id and chat id from Telegram's response", async () => {
+  it("extracts the posted message id and chat metadata from Telegram's response", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(
         JSON.stringify({
           ok: true,
-          result: { message_id: 42, chat: { id: -1001 } },
+          result: {
+            message_id: 42,
+            chat: { id: -1001, type: "supergroup", username: "public_ops" },
+          },
         }),
       ),
     );
@@ -79,7 +82,12 @@ describe("sendTelegramMessage", () => {
       fetch: fetchMock,
     });
 
-    expect(posted).toMatchObject({ chatId: "-1001", id: "42" });
+    expect(posted).toMatchObject({
+      chatId: "-1001",
+      chatType: "supergroup",
+      chatUsername: "public_ops",
+      id: "42",
+    });
   });
 
   it("includes Telegram's error description when delivery fails", async () => {

--- a/packages/eve/src/public/channels/telegram/api.ts
+++ b/packages/eve/src/public/channels/telegram/api.ts
@@ -50,6 +50,8 @@ export interface TelegramMessageResult {
   readonly chatId?: string;
   /** Recognized Telegram chat type associated with the message, when returned. */
   readonly chatType?: TelegramChatType;
+  /** Telegram chat username, when returned. */
+  readonly chatUsername?: string;
   /** Telegram's raw JSON response. */
   readonly raw: unknown;
 }
@@ -322,6 +324,8 @@ function toTelegramMessageResult(body: unknown): TelegramMessageResult {
     chatId:
       typeof chat.id === "number" || typeof chat.id === "string" ? String(chat.id) : undefined,
     chatType: parseTelegramChatType(chat.type) ?? undefined,
+    chatUsername:
+      typeof chat.username === "string" && chat.username.length > 0 ? chat.username : undefined,
     id:
       typeof result.message_id === "number" || typeof result.message_id === "string"
         ? String(result.message_id)

--- a/packages/eve/src/public/channels/telegram/audience.ts
+++ b/packages/eve/src/public/channels/telegram/audience.ts
@@ -6,21 +6,24 @@ export function telegramInstrumentationMetadata(
   state: TelegramChannelState,
 ): TelegramInstrumentationMetadata {
   return {
-    audience: telegramAudience(state.chatType),
+    audience: telegramAudience(state.chatType, state.chatUsername),
     chatId: state.chatId,
     chatType: state.chatType,
     triggeringUserId: state.triggeringUserId ?? null,
   };
 }
 
-function telegramAudience(chatType: TelegramChannelState["chatType"]): ChannelAudience {
+function telegramAudience(
+  chatType: TelegramChannelState["chatType"],
+  chatUsername: TelegramChannelState["chatUsername"],
+): ChannelAudience {
+  if (chatType === null) return "unknown";
   if (
-    chatType === "private" ||
-    chatType === "group" ||
-    chatType === "supergroup" ||
-    chatType === "channel"
+    (chatType === "supergroup" || chatType === "channel") &&
+    typeof chatUsername === "string" &&
+    chatUsername.length > 0
   ) {
-    return "private";
+    return "public";
   }
-  return "unknown";
+  return "private";
 }

--- a/packages/eve/src/public/channels/telegram/inbound.ts
+++ b/packages/eve/src/public/channels/telegram/inbound.ts
@@ -200,7 +200,7 @@ function parseTelegramChat(value: unknown): TelegramChat | null {
     id,
     title: typeof value.title === "string" ? value.title : undefined,
     type,
-    username: typeof value.username === "string" ? value.username : undefined,
+    username: isNonEmptyString(value.username) ? value.username : undefined,
   };
 }
 

--- a/packages/eve/src/public/channels/telegram/state.ts
+++ b/packages/eve/src/public/channels/telegram/state.ts
@@ -1,4 +1,7 @@
-import { telegramContinuationToken } from "#public/channels/telegram/api.js";
+import {
+  telegramContinuationToken,
+  type TelegramMessageResult,
+} from "#public/channels/telegram/api.js";
 import type { TelegramCallbackQuery, TelegramMessage } from "#public/channels/telegram/inbound.js";
 import type { TelegramChannelState } from "#public/channels/telegram/telegramChannel.js";
 
@@ -11,6 +14,7 @@ export function stateFromTelegramMessage(
     ...initialTelegramState(botUsername),
     chatId: message.chat.id,
     chatType: message.chat.type,
+    chatUsername: message.chat.username ?? null,
     conversationId: privateChat ? null : conversationIdForMessage(message),
     messageThreadId: message.messageThreadId ?? null,
     triggeringUserId: message.from?.id ?? null,
@@ -30,6 +34,7 @@ export function stateFromTelegramCallbackQuery(
     ...initialTelegramState(botUsername),
     chatId: message.chat.id,
     chatType: message.chat.type,
+    chatUsername: message.chat.username ?? null,
     conversationId: privateChat ? null : message.messageId,
     messageThreadId: message.messageThreadId ?? null,
     triggeringUserId: query.from.id,
@@ -49,6 +54,7 @@ export function initialTelegramState(botUsername: string | undefined): TelegramC
     botUsername: botUsername ?? null,
     chatId: null,
     chatType: null,
+    chatUsername: null,
     conversationId: null,
     hitlCallbacks: {},
     messageThreadId: null,
@@ -57,6 +63,18 @@ export function initialTelegramState(botUsername: string | undefined): TelegramC
     pendingFreeformReplies: {},
     triggeringUserId: null,
   };
+}
+
+export function updateTelegramChatMetadata(
+  state: TelegramChannelState,
+  posted: TelegramMessageResult,
+): void {
+  if (state.chatType === null && posted.chatType !== undefined) state.chatType = posted.chatType;
+  if (posted.chatUsername !== undefined) {
+    state.chatUsername = posted.chatUsername;
+  } else if (posted.chatType === "supergroup" || posted.chatType === "channel") {
+    state.chatUsername = null;
+  }
 }
 
 function conversationIdForMessage(message: TelegramMessage): string {

--- a/packages/eve/src/public/channels/telegram/telegramChannel.test.ts
+++ b/packages/eve/src/public/channels/telegram/telegramChannel.test.ts
@@ -146,15 +146,21 @@ describe("telegramChannel() inbound route", () => {
   });
 
   it.each([
-    ["private", "private"],
-    ["group", "private"],
-    ["supergroup", "private"],
-    [null, "unknown"],
-  ] as const)("maps %s chats to the %s audience", (chatType, audience) => {
-    const adapter = withState(getAdapter(telegramChannel()), { chatType });
+    ["private", "named_private", "private"],
+    ["group", "named_group", "private"],
+    ["supergroup", "public_ops", "public"],
+    ["channel", "public_news", "public"],
+    ["supergroup", null, "private"],
+    ["channel", undefined, "private"],
+    [null, "public_but_unknown_type", "unknown"],
+  ] as const)(
+    "maps %s chats with username %s to the %s audience",
+    (chatType, chatUsername, audience) => {
+      const adapter = withState(getAdapter(telegramChannel()), { chatType, chatUsername });
 
-    expect(adapter.instrumentation?.metadata?.(adapter.state)).toMatchObject({ audience });
-  });
+      expect(adapter.instrumentation?.metadata?.(adapter.state)).toMatchObject({ audience });
+    },
+  );
 
   it("dispatches verified private messages with Telegram auth and chat-wide token", async () => {
     const channel = telegramChannel({
@@ -193,6 +199,7 @@ describe("telegramChannel() inbound route", () => {
       state: {
         chatId: "42",
         chatType: "private",
+        chatUsername: null,
         conversationId: null,
       },
       title: "Telegram run",
@@ -229,12 +236,15 @@ describe("telegramChannel() inbound route", () => {
       message: {
         message_id: 11,
         from: { id: 42, is_bot: false },
-        chat: { id: -1001, type: "supergroup" },
+        chat: { id: -1001, type: "supergroup", username: "public_ops" },
         text: "/ask@testbot hello",
       },
     });
     expect(mentioned.send).toHaveBeenCalledTimes(1);
     expect(mentioned.send.mock.calls[0]![0]).toBe("-1001::11");
+    expect(mentioned.send.mock.calls[0]![1]).toMatchObject({
+      state: { chatType: "supergroup", chatUsername: "public_ops" },
+    });
     expect((mentioned.send.mock.calls[0]![1] as { context: string[] }).context[0]).toContain(
       "is_mentioned: true",
     );
@@ -740,7 +750,7 @@ describe("telegramChannel() default event handlers", () => {
     expect(ctx.state.conversationId).toBeNull();
   });
 
-  it("hydrates unknown group message posts and re-keys to the posted message id", async () => {
+  it("clears a stale public username when Telegram returns a restricted supergroup", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -752,7 +762,12 @@ describe("telegramChannel() default event handlers", () => {
     vi.stubGlobal("fetch", fetchMock);
     const adapter = withState(
       getAdapter(telegramChannel({ credentials: { botToken: "bot-token" } })),
-      { chatId: "-1001", chatType: null, conversationId: null },
+      {
+        chatId: "-1001",
+        chatType: "supergroup",
+        chatUsername: "public_ops",
+        conversationId: null,
+      },
     );
     const { accessor, writes } = captureAccessor("telegram:-1001::");
     const ctx = buildAdapterContext(adapter, accessor);
@@ -771,7 +786,9 @@ describe("telegramChannel() default event handlers", () => {
 
     expect(writes).toContainEqual(["eve.continuationToken", "telegram:-1001::77"]);
     expect(ctx.state.chatType).toBe("supergroup");
+    expect(ctx.state.chatUsername).toBeNull();
     expect(ctx.state.conversationId).toBe("77");
+    expect(adapter.instrumentation?.metadata?.(ctx.state)).toMatchObject({ audience: "private" });
   });
 
   it("preserves explicit conversation ids after Telegram identifies a private chat", async () => {
@@ -953,11 +970,52 @@ describe("telegramChannel().receive", () => {
           state: expect.objectContaining({
             chatId: "-1001",
             chatType,
+            chatUsername: null,
             conversationId: "88",
           }),
         }),
       );
     }
+  });
+
+  it("preserves a public username returned for a proactive initialMessage", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          result: {
+            message_id: 88,
+            chat: { id: -1001, type: "supergroup", username: "public_ops" },
+          },
+        }),
+      ),
+    );
+    const channel = asCompiled<TelegramChannelState>(
+      telegramChannel({
+        api: { apiBaseUrl: "https://telegram.example", fetch: fetchMock },
+        credentials: { botToken: "bot-token" },
+      }),
+    );
+    const send = vi.fn().mockResolvedValue({ id: "s1" });
+
+    await channel.receive!(
+      {
+        target: { chatId: -1001, initialMessage: "Starting" },
+        auth: null,
+        message: "run",
+      },
+      mockChannelContext(send),
+    );
+
+    expect(send).toHaveBeenCalledWith(
+      "-1001::88",
+      expect.objectContaining({
+        state: expect.objectContaining({
+          chatType: "supergroup",
+          chatUsername: "public_ops",
+        }),
+      }),
+    );
   });
 
   it("leaves initialMessage sessions unanchored when Telegram omits the chat type", async () => {

--- a/packages/eve/src/public/channels/telegram/telegramChannel.ts
+++ b/packages/eve/src/public/channels/telegram/telegramChannel.ts
@@ -60,6 +60,7 @@ import {
   stateFromTelegramCallbackQuery,
   stateFromTelegramMessage,
   telegramContinuationTokenFromState,
+  updateTelegramChatMetadata,
 } from "#public/channels/telegram/state.js";
 import {
   verifyTelegramRequest,
@@ -96,6 +97,7 @@ export interface TelegramChannelState extends TelegramHitlState {
   chatId: string | null;
   /** Telegram chat type, when known from an inbound update. */
   chatType: TelegramChatType | null;
+  chatUsername?: string | null;
   /** Group/supergroup conversation anchor message id. */
   conversationId: string | null;
   /** Forum topic id, when known. */
@@ -363,15 +365,12 @@ function buildTelegramHandle(input: {
   readonly session?: SessionHandle;
   readonly state: TelegramChannelState;
 }): TelegramHandle {
-  const api = input.config.api;
-  const state = input.state;
-  const credentials = input.config.credentials;
+  const { api, credentials } = input.config;
+  const { state } = input;
 
   function anchor(posted: TelegramMessageResult): void {
     const chatType = state.chatType ?? posted.chatType ?? null;
-    if (state.chatType === null && posted.chatType !== undefined) {
-      state.chatType = posted.chatType;
-    }
+    updateTelegramChatMetadata(state, posted);
     if (!posted.id || !shouldAnchorTelegramConversation(chatType)) return;
     state.conversationId = posted.id;
     if (state.chatId) {

--- a/research/channel-audience-content-policy.md
+++ b/research/channel-audience-content-policy.md
@@ -1,7 +1,7 @@
 ---
 issue: https://github.com/vercel/eve/issues/2331
 status: proposed
-last_updated: "2026-09-01"
+last_updated: "2026-09-03"
 ---
 
 # Audience-aware trace content policy
@@ -20,7 +20,7 @@ Channels may project one of three values from their existing synchronous `metada
 type ChannelAudience = "public" | "private" | "unknown";
 ```
 
-The field is optional for authored channels. Eve normalizes absent, malformed, and unsupported values to `unknown`. Built-in channel metadata interfaces require the field and classify only from platform evidence already captured during dispatch; ambiguous and proactive destinations remain `unknown` rather than performing observability-only network requests. Proactive Slack `receive` / `ctx.send` targets may optionally supply `audience` when the caller already knows channel visibility, for example a webhook that classified the Slack destination before handoff.
+The field is optional for authored channels. eve normalizes absent, malformed, and unsupported values to `unknown`. Built-in channel metadata interfaces require the field and classify only from platform evidence already captured during dispatch; ambiguous and proactive destinations remain `unknown` rather than performing observability-only network requests. Proactive Chat SDK, Discord, Slack, and Teams targets may optionally supply `audience` when the caller already knows destination visibility. Discord and Teams inbound hooks may supply the same evidence, while platform-derived private classifications always take precedence.
 
 The normalized audience is persisted with session trace state and exported as `agent.channel.audience` only on each `agent.session` window. Durable Eve state and an internal OpenTelemetry context key make the same value available to descendant export policies without duplicating a public attribute onto every span. Local subagents inherit the parent audience. A remote agent with principal forwarding propagates the immutable origin audience and the current hop's effective directional ceiling through one `eve.audience` W3C Baggage member. The receiver accepts it only with the same `trustedForwarders` decision that admitted the principal, then intersects it with its own process policy. Every later hop forwards that intersection; malformed and mixed-version assertions become metadata-only.
 


### PR DESCRIPTION
### Summary

Related to #2331 and complements #2842.

Built-in channels now preserve visibility evidence already available during webhook parsing or proactive setup, while malformed, conflicting, incomplete, and restricted evidence remains fail-closed. The policy covers GitHub, Slack, Telegram, Discord, Teams, generic Chat SDK adapters, fixed-private Photon and Linq conversations, Twilio, and currently unclassifiable Linear sessions.

### Validation

Confirmed the completed channel policy with 341 focused tests, 7,878 passing unit tests with one skip, and 706 passing integration tests. Workspace type checking, formatting, linting, invariant checks, extension contract checks, dependency consistency, and docs validation also passed; lint reported two existing warnings outside this diff.

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 3 files · `+8 / -3`

Updates the observability guidance and research contract for the complete built-in channel policy, plus the release changeset.

**Implementation** — 24 files · `+346 / -135`

Projects platform evidence and explicit handoff evidence into durable audience state across every built-in channel path. The Chat SDK and Discord helpers are split by concern to keep the primary channel modules within repository size limits.

**Tests** — 11 files · `+643 / -43`

Covers inbound and proactive classification, private-evidence precedence, malformed evidence, imperative sends, stale visibility, restricted phone conversations, and all newly exposed evidence boundaries.
