### PR TITLE
Shorten main package artifact versions

### DIFF
--- a/apps/package-artifacts/lib/package.mjs
+++ b/apps/package-artifacts/lib/package.mjs
@@ -1,4 +1,5 @@
 export const SHA_PATTERN = /^[0-9a-f]{40}$/i;
+const PACKAGE_VERSION_SHA_LENGTH = 16;
 
 export function packageArtifactPath(sourceSha) {
   return `packages/${sourceSha}/eve.tgz`;
@@ -18,7 +19,7 @@ export function packageDependencyUrl(baseUrl, sourceSha) {
 export function packageVersion(stableVersion, sourceSha) {
   const match = stableVersion.match(/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/);
   if (match === null) throw new Error(`Expected a stable eve version, received ${stableVersion}.`);
-  return `${stableVersion}+main.${sourceSha}`;
+  return `${stableVersion}+main.${sourceSha.slice(0, PACKAGE_VERSION_SHA_LENGTH)}`;
 }
 
 export function preparePackageJson(packageJson, sourceSha) {

--- a/apps/package-artifacts/lib/package.test.mjs
+++ b/apps/package-artifacts/lib/package.test.mjs
@@ -12,7 +12,7 @@ const sha = "a".repeat(40);
 
 describe("package artifacts", () => {
   test("derives a main build version", () => {
-    expect(packageVersion("0.33.0", sha)).toBe(`0.33.0+main.${sha}`);
+    expect(packageVersion("0.33.0", sha)).toBe("0.33.0+main.aaaaaaaaaaaaaaaa");
   });
 
   test("derives immutable artifact and dependency URLs", () => {
@@ -33,7 +33,7 @@ describe("package artifacts", () => {
     const source = { name: "eve", version: "0.33.0" };
     expect(preparePackageJson(source, sha)).toEqual({
       name: "eve",
-      version: `0.33.0+main.${sha}`,
+      version: "0.33.0+main.aaaaaaaaaaaaaaaa",
     });
     expect(source.version).toBe("0.33.0");
   });


### PR DESCRIPTION
### Summary

Main package artifacts embedded the full 40-character commit SHA in the eve package version, causing Vercel to reject the generated Build Output API config because `framework.version` exceeded 50 characters. Package artifact versions now use the first 16 SHA characters while immutable artifact paths and manifests continue to retain the full source SHA.

### Validation

Confirmed the shortened package version and preserved full-SHA artifact addressing with all 10 `eve-package-artifacts` tests.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 1 file · `+2 / -1`

Keeps the shorter package identity at its source without adding Vercel-specific parsing or truncation.

**Tests** — 1 file · `+2 / -2`

Updates focused expectations for generated package metadata while retaining coverage for full-SHA artifact paths.
