### PR TITLE
feat(eve): deliver HITL group completion durably

### DIFF
--- a/.changeset/tidy-pears-wait.md
+++ b/.changeset/tidy-pears-wait.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Persist completed HITL Groups before owner effects, retry unacknowledged delivery, and close pending Groups, Authorization requests, and response attempts when a turn is cancelled.

--- a/packages/eve/src/execution/node-step.ts
+++ b/packages/eve/src/execution/node-step.ts
@@ -106,6 +106,7 @@ export function createExecutionNodeStep(input: CreateExecutionNodeStepInput): St
     capabilities: input.capabilities,
     clearOnly: input.clearOnly,
     compactOnly: input.compactOnly,
+    durableGroupCompletionDelivery: true,
     workflow: input.node.agent.workflowTool !== undefined,
     workflowMaxSubagents: input.workflowMaxSubagents,
     webSearchProvider: input.node.agent.webSearchProvider,

--- a/packages/eve/src/execution/settle-cancelled-turn-step.ts
+++ b/packages/eve/src/execution/settle-cancelled-turn-step.ts
@@ -15,6 +15,8 @@ import { reconcileSessionContinuationToken } from "#execution/reconcile-session-
 import { activeTurnId } from "#harness/active-turn-id.js";
 import { emitCancelledTurn } from "#harness/cancelled-turn-emission.js";
 import { clearPendingSessionLimitPrompt } from "#harness/input-requests.js";
+import { cancelIncompleteRequestGroups } from "#harness/hitl/request-ledger.js";
+import { cancelActiveApprovalResponseAttempts } from "#harness/hitl/approval-response-attempts.js";
 import {
   getHarnessEmissionState,
   isHarnessBetweenTurns,
@@ -138,6 +140,13 @@ export async function settleCancelledTurnStep(input: {
   // the cancelled turn's inbox is gone, so a child settlement can never
   // reach this store again. This is the last write that can move those
   // handles out of `running`.
+  const closedSession = cancelIncompleteRequestGroups({
+    ...session,
+    state: cancelActiveApprovalResponseAttempts({
+      completedAt: Date.now(),
+      state: session.state,
+    }),
+  });
   const cancelledSession = reconcileSessionContinuationToken(
     ctx,
     setHarnessEmissionState(
@@ -145,7 +154,7 @@ export async function settleCancelledTurnStep(input: {
         clearAllProxyInputRequests(
           clearPendingWorkflowInterrupt(
             clearPendingRuntimeActionBatch(
-              abandonRunningAgentTurns({ ...session, outputSchema: undefined }),
+              abandonRunningAgentTurns({ ...closedSession, outputSchema: undefined }),
             ),
           ),
         ),

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -34,6 +34,7 @@ import { TurnCancelledError } from "#harness/turn-cancellation.js";
 import { getPendingAuthorization, setPendingAuthorization } from "#harness/authorization.js";
 import { getProxyInputRequests, upsertProxyInputRequests } from "#harness/proxy-input-requests.js";
 import { appendPendingInputBatch } from "#harness/input-requests.js";
+import { readRequestLedger } from "#harness/hitl/request-ledger.js";
 import type { HarnessSession, StepResult } from "#harness/types.js";
 import { createEmptyHookRegistry } from "#runtime/hooks/registry.js";
 import { createInputRequestedEvent } from "#protocol/message.js";
@@ -1791,8 +1792,24 @@ describe("turnStep", () => {
     );
   });
 
-  it("keeps a session-scoped dynamic model selection when the first turn is cancelled", async () => {
-    const session = createStubSession();
+  it("keeps session model selection and force-closes HITL when the first turn is cancelled", async () => {
+    const session = appendPendingInputBatch({
+      requests: [
+        {
+          action: {
+            callId: "call-question",
+            input: {},
+            kind: "tool-call",
+            toolName: "ask_question",
+          },
+          kind: "question",
+          prompt: "Continue?",
+          requestId: "question-1",
+        },
+      ],
+      responseMessages: [],
+      session: createStubSession(),
+    });
     installSessionStoreMocks([session]);
     vi.mocked(getCompiledRuntimeAgentBundle).mockResolvedValue({
       adapterRegistry: {
@@ -1848,6 +1865,9 @@ describe("turnStep", () => {
     expect(result.sessionState.snapshot?.session.history).toEqual([
       { content: "thread=unset; user=cancel this turn", role: "user" },
     ]);
+    expect(
+      readRequestLedger(result.sessionState.snapshot?.session.state).groups[0]?.completion,
+    ).toBe("cancelled");
   });
 
   it("rejects task completion while input requests remain pending", async () => {

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -104,6 +104,8 @@ import { resolveRuntimeCompiledArtifactsVersionedCacheKey } from "#runtime/cache
 import { createWorkflowRuntime } from "#execution/workflow-runtime.js";
 import { bindDynamicConnections } from "#execution/dynamic-connections.js";
 import { preserveCancelledTurnMessage } from "#execution/cancelled-turn-message.js";
+import { cancelIncompleteRequestGroups } from "#harness/hitl/request-ledger.js";
+import { cancelActiveApprovalResponseAttempts } from "#harness/hitl/approval-response-attempts.js";
 import { TASK_UPDATE_TOOL_NAME } from "#tools/framework/task-contract.js";
 
 const TASK_DONE_WITH_PENDING_INPUT_ERROR_MESSAGE =
@@ -583,10 +585,17 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
     // again after this cancellation settles.
     const interrupted = serializeContext(ctx);
     const retained = readRetainedBackgroundToolResult(ctx);
-    const cancelledSession = await preserveCancelledTurnMessage(
+    const preservedSession = await preserveCancelledTurnMessage(
       retained?.backgroundTaskSession ?? initialSession,
       resolved,
     );
+    const cancelledSession = cancelIncompleteRequestGroups({
+      ...preservedSession,
+      state: cancelActiveApprovalResponseAttempts({
+        completedAt: Date.now(),
+        state: preservedSession.state,
+      }),
+    });
     return {
       action: "cancelled",
       ...(retained === undefined

--- a/packages/eve/src/harness/hitl/approval-response-attempts.test.ts
+++ b/packages/eve/src/harness/hitl/approval-response-attempts.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { SessionAuthContext } from "#channel/types.js";
 import {
+  cancelActiveApprovalResponseAttempts,
   createApprovalCandidate,
   expireApprovalCandidates,
   finishApprovalCandidate,
@@ -198,6 +199,27 @@ describe("approval candidate state", () => {
       }),
     ]);
     expect(retry.changed).toBe(true);
+  });
+
+  it("force-closes every active response attempt", () => {
+    const first = create({ candidateId: "candidate-1", deliveryId: "d1", principalId: "U1" });
+    const second = create({
+      candidateId: "candidate-2",
+      deliveryId: "d2",
+      principalId: "U2",
+      state: first.state,
+    });
+
+    const state = cancelActiveApprovalResponseAttempts({ completedAt: 300, state: second.state });
+    const audit = getApprovalAuditState(state);
+
+    expect(audit.activeCandidates).toEqual([]);
+    expect(audit.candidateHistory).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ candidateId: "candidate-1", status: "stale" }),
+        expect.objectContaining({ candidateId: "candidate-2", status: "stale" }),
+      ]),
+    );
   });
 
   it("expires stale candidates intrinsically before creating another candidate", () => {

--- a/packages/eve/src/harness/hitl/approval-response-attempts.ts
+++ b/packages/eve/src/harness/hitl/approval-response-attempts.ts
@@ -240,6 +240,23 @@ export function finishApprovalCandidate(input: {
   );
 }
 
+export function cancelActiveApprovalResponseAttempts(input: {
+  readonly completedAt: number;
+  readonly state: SessionStateMap | undefined;
+}): SessionStateMap | undefined {
+  let state = input.state;
+  for (const attempt of Object.values(readApprovalState(state).activeResponseAttempts)) {
+    state = finishApprovalCandidate({
+      candidateId: attempt.candidateId,
+      completedAt: input.completedAt,
+      reason: "The waiting request was cancelled.",
+      state,
+      status: "stale",
+    });
+  }
+  return state;
+}
+
 export function expireApprovalCandidates(input: {
   readonly now: number;
   readonly state: SessionStateMap | undefined;

--- a/packages/eve/src/harness/hitl/pending-input-resolution.ts
+++ b/packages/eve/src/harness/hitl/pending-input-resolution.ts
@@ -21,11 +21,13 @@ export type InputDomainResolverInput = {
 
 export type ResolvePendingInputResult = {
   readonly consumedMessage?: boolean;
+  /** Ready Group delivery being applied by the harness owner. */
+  readonly groupCompletionDeliveryKey?: string;
   readonly deferredContext?: boolean;
   readonly deferredMessage?: boolean;
   /** Present when a session-limit continuation prompt was resolved. */
   readonly limitContinuation?: { readonly granted: boolean };
-  readonly outcome: "resolved" | "continue" | "unresolved";
+  readonly outcome: "resolved" | "continue" | "ready" | "unresolved";
   readonly messages: ModelMessage[];
   readonly rejectedActions?: readonly ResolvedInputActionBatch[];
   readonly resolvedInputs?: readonly ResolvedInputBatch[];

--- a/packages/eve/src/harness/hitl/request-interpreter.ts
+++ b/packages/eve/src/harness/hitl/request-interpreter.ts
@@ -37,6 +37,11 @@ import {
   queueDeferredStepInput,
   removePendingInputBatches,
 } from "#harness/pending-input-batches.js";
+import {
+  listReadyRequestGroupDeliveries,
+  prepareReadyRequestGroupDeliveries,
+  readRequestLedger,
+} from "#harness/hitl/request-ledger.js";
 import type { HarnessSession, StepInput } from "#harness/types.js";
 import { readClientContext } from "#internal/client-context.js";
 import type { InputRequest, InputResponse } from "#shared/input.js";
@@ -50,12 +55,24 @@ import type { InputRequest, InputResponse } from "#shared/input.js";
  */
 export function interpretRequestDelivery(input: {
   readonly deferMessagesWhileApprovalsPending?: boolean;
+  readonly durableGroupCompletionDelivery?: boolean;
   readonly history?: readonly ModelMessage[];
   readonly resolveApprovalKey?: (request: InputRequest) => string | undefined;
   readonly session: HarnessSession;
   readonly stepInput?: StepInput;
 }): ResolvePendingInputResult {
   const baseHistory = [...(input.history ?? input.session.history)];
+  const readyDelivery =
+    input.durableGroupCompletionDelivery === true
+      ? listReadyRequestGroupDeliveries(input.session.state)[0]
+      : undefined;
+  if (readyDelivery !== undefined) {
+    return {
+      ...(readyDelivery.ownerCompletion as StoredRequestGroupCompletion),
+      groupCompletionDeliveryKey: readyDelivery.deliveryKey,
+      session: input.session,
+    };
+  }
   const batches = getPendingInputBatches(input.session.state);
   if (batches.length === 0) {
     return { outcome: "continue", messages: baseHistory, session: input.session };
@@ -98,6 +115,7 @@ export function interpretRequestDelivery(input: {
 
   const resolverInput = {
     baseHistory,
+    durableGroupCompletionDelivery: input.durableGroupCompletionDelivery,
     batches,
     deferTurnInput,
     resolvedStepInput,
@@ -173,6 +191,7 @@ function resolveApprovalRoute(input: {
   readonly baseHistory: ModelMessage[];
   readonly batches: readonly PendingInputBatch[];
   readonly deferTurnInput: boolean;
+  readonly durableGroupCompletionDelivery?: boolean;
   readonly questionBatches: readonly PendingInputBatch[];
   readonly resolveApprovalKey?: (request: InputRequest) => string | undefined;
   readonly resolvedStepInput: ResolvedStepInput | undefined;
@@ -237,22 +256,24 @@ function resolveApprovalRoute(input: {
           }),
   );
 
-  const session = removePendingInputBatches(verdict.session, resolvedBatches);
-
-  return finishResolvedInput({
-    deferTurnInput:
-      resolvedBatches.some((batch) =>
-        batch.requests.some((request) => isApprovalRequest(request)),
-      ) || input.deferTurnInput,
-    leftoverResponses,
-    messages: verdict.messages,
-    rejectedActions: verdict.rejectedActions,
-    resolvedInputs: resolvedBatches.flatMap((batch) => {
-      const resolved = buildResolvedInputBatch(batch, input.responses);
-      return resolved === undefined ? [] : [resolved];
+  return prepareResolvedGroupDelivery({
+    enabled: input.durableGroupCompletionDelivery === true,
+    batches: resolvedBatches,
+    result: finishResolvedInput({
+      deferTurnInput:
+        resolvedBatches.some((batch) =>
+          batch.requests.some((request) => isApprovalRequest(request)),
+        ) || input.deferTurnInput,
+      leftoverResponses,
+      messages: verdict.messages,
+      rejectedActions: verdict.rejectedActions,
+      resolvedInputs: resolvedBatches.flatMap((batch) => {
+        const resolved = buildResolvedInputBatch(batch, input.responses);
+        return resolved === undefined ? [] : [resolved];
+      }),
+      resolvedStepInput: input.resolvedStepInput,
+      session: verdict.session,
     }),
-    resolvedStepInput: input.resolvedStepInput,
-    session,
   });
 }
 
@@ -260,6 +281,7 @@ function resolveQuestionRoute(input: {
   readonly baseHistory: ModelMessage[];
   readonly batches: readonly PendingInputBatch[];
   readonly deferTurnInput: boolean;
+  readonly durableGroupCompletionDelivery?: boolean;
   readonly resolvedStepInput: ResolvedStepInput | undefined;
   readonly responses: readonly InputResponse[];
   readonly session: HarnessSession;
@@ -297,16 +319,19 @@ function resolveQuestionRoute(input: {
       responses: [],
       session: input.session,
     });
-    const session = removePendingInputBatches(verdict.session, [sole]);
-    return {
-      consumedMessage: input.resolvedStepInput.messageConsumed,
-      outcome: "resolved",
-      messages: verdict.messages,
-      resolvedInputs: [buildResolvedInputBatch(sole, [])].filter(
-        (batch): batch is NonNullable<typeof batch> => batch !== undefined,
-      ),
-      session,
-    };
+    return prepareResolvedGroupDelivery({
+      enabled: input.durableGroupCompletionDelivery === true,
+      batches: [sole],
+      result: {
+        consumedMessage: input.resolvedStepInput.messageConsumed,
+        outcome: "resolved",
+        messages: verdict.messages,
+        resolvedInputs: [buildResolvedInputBatch(sole, [])].filter(
+          (batch): batch is NonNullable<typeof batch> => batch !== undefined,
+        ),
+        session: verdict.session,
+      },
+    });
   }
 
   const verdict = reduceRequestVerdicts(
@@ -323,18 +348,20 @@ function resolveQuestionRoute(input: {
         session: state.session,
       }),
   );
-  const session = removePendingInputBatches(verdict.session, resolvedBatches);
-
-  return finishResolvedInput({
-    deferTurnInput: input.deferTurnInput,
-    leftoverResponses,
-    messages: verdict.messages,
-    resolvedInputs: resolvedBatches.flatMap((batch) => {
-      const resolved = buildResolvedInputBatch(batch, input.responses);
-      return resolved === undefined ? [] : [resolved];
+  return prepareResolvedGroupDelivery({
+    enabled: input.durableGroupCompletionDelivery === true,
+    batches: resolvedBatches,
+    result: finishResolvedInput({
+      deferTurnInput: input.deferTurnInput,
+      leftoverResponses,
+      messages: verdict.messages,
+      resolvedInputs: resolvedBatches.flatMap((batch) => {
+        const resolved = buildResolvedInputBatch(batch, input.responses);
+        return resolved === undefined ? [] : [resolved];
+      }),
+      resolvedStepInput: input.resolvedStepInput,
+      session: verdict.session,
     }),
-    resolvedStepInput: input.resolvedStepInput,
-    session,
   });
 }
 
@@ -342,6 +369,7 @@ function resolveSessionLimitRoute(input: {
   readonly baseHistory: ModelMessage[];
   readonly batches: readonly PendingInputBatch[];
   readonly deferTurnInput: boolean;
+  readonly durableGroupCompletionDelivery?: boolean;
   readonly pendingBatch: PendingInputBatch;
   readonly resolvedStepInput: ResolvedStepInput | undefined;
   readonly responses: readonly InputResponse[];
@@ -367,19 +395,63 @@ function resolveSessionLimitRoute(input: {
     responses: input.responses,
     session: input.session,
   });
-  const session = removePendingInputBatches(verdict.session, [input.pendingBatch]);
-
-  return finishResolvedInput({
-    deferTurnInput: input.deferTurnInput || limitBlocked,
-    leftoverResponses,
-    limitContinuation: verdict.limitContinuation,
-    messages: verdict.messages,
-    resolvedInputs: [buildResolvedInputBatch(input.pendingBatch, input.responses)].filter(
-      (batch): batch is NonNullable<typeof batch> => batch !== undefined,
-    ),
-    resolvedStepInput: input.resolvedStepInput,
-    session,
+  return prepareResolvedGroupDelivery({
+    enabled: input.durableGroupCompletionDelivery === true,
+    batches: [input.pendingBatch],
+    result: finishResolvedInput({
+      deferTurnInput: input.deferTurnInput || limitBlocked,
+      leftoverResponses,
+      limitContinuation: verdict.limitContinuation,
+      messages: verdict.messages,
+      resolvedInputs: [buildResolvedInputBatch(input.pendingBatch, input.responses)].filter(
+        (batch): batch is NonNullable<typeof batch> => batch !== undefined,
+      ),
+      resolvedStepInput: input.resolvedStepInput,
+      session: verdict.session,
+    }),
   });
+}
+
+type StoredRequestGroupCompletion = Omit<ResolvePendingInputResult, "session"> & {
+  readonly outcome: "resolved";
+};
+
+function prepareResolvedGroupDelivery(input: {
+  readonly batches: readonly PendingInputBatch[];
+  readonly enabled: boolean;
+  readonly result: ResolvePendingInputResult;
+}): ResolvePendingInputResult {
+  if (input.result.outcome !== "resolved") return input.result;
+  if (!input.enabled) {
+    return {
+      ...input.result,
+      session: removePendingInputBatches(input.result.session, input.batches),
+    };
+  }
+  const requestIds = new Set(
+    input.batches.flatMap((batch) => batch.requests.map((request) => request.requestId)),
+  );
+  const ledger = readRequestLedger(input.result.session.state);
+  const groupIds = ledger.groups
+    .filter(
+      (group) =>
+        group.completion === "waiting" && group.requestIds.some((id) => requestIds.has(id)),
+    )
+    .map((group) => group.id);
+  if (groupIds.length === 0) return input.result;
+  const deliveryKey = `request-group-completion:${JSON.stringify(groupIds)}`;
+  const { session: _session, ...ownerCompletion } = input.result;
+  const session = prepareReadyRequestGroupDeliveries({
+    ownerCompletions: new Map(
+      groupIds.map((groupId) => [groupId, { deliveryKey, ownerCompletion }]),
+    ),
+    session: input.result.session,
+  });
+  return {
+    messages: input.result.messages,
+    outcome: "ready",
+    session,
+  };
 }
 
 function reduceRequestVerdicts(

--- a/packages/eve/src/harness/hitl/request-ledger.test.ts
+++ b/packages/eve/src/harness/hitl/request-ledger.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  acknowledgeReadyRequestGroupDelivery,
+  cancelIncompleteRequestGroups,
   classifyRequestResponse,
   createRequestGroup,
+  listReadyRequestGroupDeliveries,
   openRequestGroups,
+  prepareReadyRequestGroupDeliveries,
   readRequestLedger,
   RequestLedgerConflictError,
+  writePendingAuthorizationState,
   writeRequestLedger,
 } from "#harness/hitl/request-ledger.js";
 import {
@@ -108,7 +113,7 @@ describe("request ledger", () => {
 
     expect(openRequestGroups(delivered.state)).toEqual([]);
     expect(readRequestLedger(delivered.state)).toMatchObject({
-      groups: [{ completion: "delivered" }],
+      groups: [{ completion: { deliveryKey: "legacy:session-turn:0", status: "delivered" } }],
       requests: [{ id: "request-1", state: "terminal" }],
     });
   });
@@ -218,5 +223,123 @@ describe("request group owners", () => {
     });
 
     expect(readRequestLedger(created.state).groups[0]?.owner).toBe("session-turn");
+  });
+});
+
+describe("request group completion delivery", () => {
+  it("prepares resolved groups as ready, terminalizes their public requests, and lists deliveries in group order", () => {
+    const request2: InputRequest = {
+      action: { callId: "call-2", input: {}, kind: "tool-call", toolName: "ask_question" },
+      kind: "question",
+      prompt: "Second?",
+      requestId: "request-2",
+    };
+    const created = createRequestGroup({
+      requests: [request],
+      responseMessages: [],
+      session: createRequestGroup({
+        owner: "framework-approval-gate",
+        requests: [request2],
+        responseMessages: [],
+        session: session(),
+      }),
+    });
+
+    const prepared = prepareReadyRequestGroupDeliveries({
+      ownerCompletions: new Map([
+        ["session-turn:0", { deliveryKey: "delivery-1", ownerCompletion: { ok: 1 } }],
+        ["session-turn:1", { deliveryKey: "delivery-2", ownerCompletion: ["opaque"] }],
+      ]),
+      session: created,
+    });
+
+    expect(listReadyRequestGroupDeliveries(prepared.state)).toEqual([
+      {
+        deliveryKey: "delivery-1",
+        groupId: "session-turn:0",
+        owner: "framework-approval-gate",
+        ownerCompletion: { ok: 1 },
+      },
+      {
+        deliveryKey: "delivery-2",
+        groupId: "session-turn:1",
+        owner: "session-turn",
+        ownerCompletion: ["opaque"],
+      },
+    ]);
+    expect(openRequestGroups(prepared.state)).toEqual([]);
+    expect(readRequestLedger(prepared.state).requests).toEqual([
+      expect.objectContaining({ id: "request-2", state: "terminal" }),
+      expect.objectContaining({ id: "request-1", state: "terminal" }),
+    ]);
+  });
+
+  it("acknowledges one ready delivery idempotently", () => {
+    const created = createRequestGroup({
+      requests: [request],
+      responseMessages: [],
+      session: session(),
+    });
+    const prepared = prepareReadyRequestGroupDeliveries({
+      ownerCompletions: new Map([
+        ["session-turn:0", { deliveryKey: "delivery-1", ownerCompletion: { ok: true } }],
+      ]),
+      session: created,
+    });
+
+    const acknowledged = acknowledgeReadyRequestGroupDelivery({
+      deliveryKey: "delivery-1",
+      session: prepared,
+    });
+    const idempotent = acknowledgeReadyRequestGroupDelivery({
+      deliveryKey: "delivery-1",
+      session: acknowledged,
+    });
+
+    expect(readRequestLedger(acknowledged.state).groups[0]?.completion).toEqual({
+      deliveryKey: "delivery-1",
+      status: "delivered",
+    });
+    expect(idempotent).toBe(acknowledged);
+  });
+
+  it("force-closes waiting and ready groups to cancelled and terminalizes open requests including internal authorization", () => {
+    const challenge = {
+      attemptId: "authorization-1",
+      challenge: { url: "https://example.com" },
+      hookUrl: "https://example.com/callback",
+      name: "linear",
+    } as const;
+    const waiting = createRequestGroup({
+      requests: [request],
+      responseMessages: [],
+      session: session(),
+    });
+    const withAuthorization = {
+      ...waiting,
+      state: writePendingAuthorizationState(waiting.state, [
+        { challenge, responseAttemptId: "authorization-1" },
+      ]),
+    };
+    const ready = prepareReadyRequestGroupDeliveries({
+      ownerCompletions: new Map([
+        ["session-turn:0", { deliveryKey: "delivery-1", ownerCompletion: { ok: true } }],
+      ]),
+      session: withAuthorization,
+    });
+
+    const cancelled = cancelIncompleteRequestGroups(ready);
+
+    expect(readRequestLedger(cancelled.state)).toMatchObject({
+      groups: [{ completion: "cancelled" }],
+      requests: [
+        { id: "request-1", state: "terminal" },
+        {
+          request: { kind: "authorization", requestId: expect.stringContaining("authorization:") },
+          state: "terminal",
+        },
+      ],
+    });
+    expect(listReadyRequestGroupDeliveries(cancelled.state)).toEqual([]);
   });
 });

--- a/packages/eve/src/harness/hitl/request-ledger.ts
+++ b/packages/eve/src/harness/hitl/request-ledger.ts
@@ -30,14 +30,36 @@ export interface RequestRecord {
 
 export type RequestGroupOwner = "framework-approval-gate" | "session-turn";
 
+export interface RequestGroupCompletionReady {
+  readonly deliveryKey: string;
+  readonly ownerCompletion: unknown;
+  readonly status: "ready";
+}
+
+export interface RequestGroupCompletionDelivered {
+  readonly deliveryKey: string;
+  readonly status: "delivered";
+}
+
 export interface RequestGroup {
-  readonly completion: "waiting" | "delivered" | "cancelled";
+  readonly completion:
+    | "waiting"
+    | "cancelled"
+    | RequestGroupCompletionReady
+    | RequestGroupCompletionDelivered;
   readonly event?: PendingInputBatchEvent;
   readonly id: string;
   readonly owner: RequestGroupOwner;
   readonly requestIds: readonly string[];
   readonly responseAuthRequiredRequestIds?: readonly string[];
   readonly responseMessages: readonly ModelMessage[];
+}
+
+export interface ReadyRequestGroupDelivery {
+  readonly deliveryKey: string;
+  readonly groupId: string;
+  readonly owner: RequestGroupOwner;
+  readonly ownerCompletion: unknown;
 }
 
 export interface RequestLedgerAuthorizationRecord {
@@ -259,6 +281,115 @@ export function openRequestGroups(
   });
 }
 
+export function prepareReadyRequestGroupDeliveries(input: {
+  readonly ownerCompletions: ReadonlyMap<
+    string,
+    {
+      readonly deliveryKey: string;
+      readonly ownerCompletion: unknown;
+    }
+  >;
+  readonly session: HarnessSession;
+}): HarnessSession {
+  const ledger = readRequestLedger(input.session.state);
+  if (input.ownerCompletions.size === 0) return input.session;
+  const readyGroupIds = new Set(input.ownerCompletions.keys());
+  let changed = false;
+  const groups = ledger.groups.map((group) => {
+    const ready = input.ownerCompletions.get(group.id);
+    if (ready === undefined || group.completion !== "waiting") return group;
+    changed = true;
+    return {
+      ...group,
+      completion: {
+        deliveryKey: ready.deliveryKey,
+        ownerCompletion: ready.ownerCompletion,
+        status: "ready",
+      },
+    } satisfies RequestGroup;
+  });
+  if (!changed) return input.session;
+  const requests = ledger.requests.map((request) =>
+    request.groupId !== undefined && readyGroupIds.has(request.groupId) && request.state === "open"
+      ? { ...request, state: "terminal" as const }
+      : request,
+  );
+  return writeRequestLedger({
+    expectedVersion: ledger.version,
+    groups,
+    requests,
+    session: input.session,
+  });
+}
+
+export function listReadyRequestGroupDeliveries(
+  state: SessionStateMap | undefined,
+): readonly ReadyRequestGroupDelivery[] {
+  return readRequestLedger(state).groups.flatMap((group) => {
+    if (typeof group.completion !== "object" || group.completion.status !== "ready") return [];
+    return [
+      {
+        deliveryKey: group.completion.deliveryKey,
+        groupId: group.id,
+        owner: group.owner,
+        ownerCompletion: group.completion.ownerCompletion,
+      },
+    ];
+  });
+}
+
+export function acknowledgeReadyRequestGroupDelivery(input: {
+  readonly deliveryKey: string;
+  readonly session: HarnessSession;
+}): HarnessSession {
+  const ledger = readRequestLedger(input.session.state);
+  let changed = false;
+  const groups = ledger.groups.map((group) => {
+    if (
+      typeof group.completion !== "object" ||
+      group.completion.status !== "ready" ||
+      group.completion.deliveryKey !== input.deliveryKey
+    ) {
+      return group;
+    }
+    changed = true;
+    return {
+      ...group,
+      completion: { deliveryKey: group.completion.deliveryKey, status: "delivered" as const },
+    };
+  });
+  if (!changed) return input.session;
+  return writeRequestLedger({
+    expectedVersion: ledger.version,
+    groups,
+    requests: ledger.requests,
+    session: input.session,
+  });
+}
+
+export function cancelIncompleteRequestGroups(session: HarnessSession): HarnessSession {
+  const ledger = readRequestLedger(session.state);
+  const groupIds = new Set(
+    ledger.groups
+      .filter((group) => group.completion === "waiting" || typeof group.completion === "object")
+      .map((group) => group.id),
+  );
+  if (groupIds.size === 0) return session;
+  return writeRequestLedger({
+    expectedVersion: ledger.version,
+    groups: ledger.groups.map((group) =>
+      groupIds.has(group.id) ? { ...group, completion: "cancelled" as const } : group,
+    ),
+    requests: ledger.requests.map((request) =>
+      request.state === "open" &&
+      (groupIds.has(request.groupId ?? "") || request.request.kind === "authorization")
+        ? { ...request, state: "terminal" as const }
+        : request,
+    ),
+    session,
+  });
+}
+
 export function completeRequestGroups(
   session: HarnessSession,
   batches: readonly PendingInputBatch[],
@@ -276,7 +407,12 @@ export function completeRequestGroups(
   return writeRequestLedger({
     expectedVersion: ledger.version,
     groups: ledger.groups.map((group) =>
-      groupIds.has(group.id) ? { ...group, completion: "delivered" } : group,
+      groupIds.has(group.id)
+        ? {
+            ...group,
+            completion: { deliveryKey: `legacy:${group.id}`, status: "delivered" as const },
+          }
+        : group,
     ),
     requests: ledger.requests.map((request) =>
       request.groupId !== undefined && groupIds.has(request.groupId)

--- a/packages/eve/src/harness/hitl/request-ledger.ts
+++ b/packages/eve/src/harness/hitl/request-ledger.ts
@@ -374,7 +374,10 @@ export function cancelIncompleteRequestGroups(session: HarnessSession): HarnessS
       .filter((group) => group.completion === "waiting" || typeof group.completion === "object")
       .map((group) => group.id),
   );
-  if (groupIds.size === 0) return session;
+  const hasOpenAuthorization = ledger.requests.some(
+    (request) => request.state === "open" && request.request.kind === "authorization",
+  );
+  if (groupIds.size === 0 && !hasOpenAuthorization) return session;
   return writeRequestLedger({
     expectedVersion: ledger.version,
     groups: ledger.groups.map((group) =>

--- a/packages/eve/src/harness/hitl/request-lifecycle.conformance.test.ts
+++ b/packages/eve/src/harness/hitl/request-lifecycle.conformance.test.ts
@@ -8,6 +8,10 @@ import {
   resolvePendingInput,
 } from "#harness/input-requests.js";
 import { createSessionLimitContinuationRequest } from "#harness/session-limit-continuation.js";
+import {
+  listReadyRequestGroupDeliveries,
+  readRequestLedger,
+} from "#harness/hitl/request-ledger.js";
 import type { HarnessSession } from "#harness/types.js";
 import type { InputRequest } from "#shared/input.js";
 
@@ -157,6 +161,38 @@ describe("current HITL lifecycle conformance", () => {
       ],
       role: "tool",
     });
+  });
+
+  it("checkpoints ready completion before replaying and acknowledging owner delivery", () => {
+    const parked = appendGroup(session(), [question("question-1")]);
+    const input = {
+      durableGroupCompletionDelivery: true,
+      session: parked,
+      stepInput: { inputResponses: [{ text: "later", requestId: "question-1" }] },
+    } as const;
+
+    const prepared = resolvePendingInput(input);
+    expect(prepared.outcome).toBe("ready");
+    expect(listReadyRequestGroupDeliveries(prepared.session.state)).toHaveLength(1);
+    expect(readRequestLedger(prepared.session.state).groups[0]?.completion).toEqual(
+      expect.objectContaining({ status: "ready" }),
+    );
+
+    const delivered = resolvePendingInput({
+      durableGroupCompletionDelivery: true,
+      session: prepared.session,
+    });
+    const retried = resolvePendingInput({
+      durableGroupCompletionDelivery: true,
+      session: prepared.session,
+    });
+
+    expect(delivered.outcome).toBe("resolved");
+    expect(delivered.groupCompletionDeliveryKey).toBeDefined();
+    expect(retried.messages).toEqual(delivered.messages);
+    expect(readRequestLedger(delivered.session.state).groups[0]?.completion).toEqual(
+      expect.objectContaining({ status: "ready" }),
+    );
   });
 
   it("gives an open limit group priority over responses for another group", () => {

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -155,6 +155,7 @@ import {
   appendPendingInputBatch,
 } from "#harness/input-requests.js";
 import { getPendingInputBatches, queueDeferredStepInput } from "#harness/pending-input-batches.js";
+import { acknowledgeReadyRequestGroupDelivery } from "#harness/hitl/request-ledger.js";
 import {
   convertStaleResponsesToUserMessage,
   dropStaleSessionLimitContinuationResponses,
@@ -800,12 +801,16 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     }
 
     const pending = resolvePendingInput({
+      durableGroupCompletionDelivery: config.durableGroupCompletionDelivery,
       deferMessagesWhileApprovalsPending: config.mode !== "conversation",
       history: resolvedRuntimeActions.messages,
       resolveApprovalKey: resolveApprovalKeyFromTools(config.tools),
       session,
       stepInput: coordinated.stepInput,
     });
+    if (pending.outcome === "ready") {
+      return { next: runStep, session: pending.session };
+    }
     if (pending.outcome === "unresolved") {
       // The runtime-action batch owns the assistant messages. Once that batch
       // resolves, commit its results before the still-pending HITL batch parks.
@@ -878,6 +883,8 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       return { next: null, session: pending.session };
     }
 
+    session = pending.session;
+
     if (pending.resolvedInputs !== undefined) {
       for (const batch of pending.resolvedInputs) {
         await stepInstrumentation?.publishInputResolutions({
@@ -925,6 +932,13 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       }
     }
 
+    if (pending.groupCompletionDeliveryKey !== undefined) {
+      session = acknowledgeReadyRequestGroupDelivery({
+        deliveryKey: pending.groupCompletionDeliveryKey,
+        session,
+      });
+    }
+
     // --- Turn preamble ------------------------------------------------------
 
     const clientContext = readClientContext(effectiveStepInput);
@@ -951,14 +965,11 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     let memoryCommit: ReturnType<typeof drainMemoryCommit> = undefined;
     if (emit && hasStepInput(input)) {
       if (store !== undefined) {
-        prepareDynamicInstructionPreamble(
-          store,
-          projectHistory(pending.session.history, pending.session.state),
-        );
+        prepareDynamicInstructionPreamble(store, projectHistory(session.history, session.state));
         prepareMemoryPreamble(store, {
           history: pending.messages,
           input: [...ephemeralContextMessages, ...preparedTurnInput],
-          state: pending.session.state,
+          state: session.state,
         });
       }
       try {
@@ -974,9 +985,9 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         instructionMessages = store === undefined ? [] : drainDynamicInstructionUserMessages(store);
         memoryCommit = store === undefined ? undefined : drainMemoryCommit(store);
         session = {
-          ...pending.session,
-          history: [...(memoryCommit?.history ?? pending.session.history), ...instructionMessages],
-          state: memoryCommit?.state ?? pending.session.state,
+          ...session,
+          history: [...(memoryCommit?.history ?? session.history), ...instructionMessages],
+          state: memoryCommit?.state ?? session.state,
         };
         if (!isDynamicModelSelectionError(error)) throw error;
         return failModelSelection(error, {
@@ -992,13 +1003,13 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       stepInstrumentation?.setTurnId(emissionState.turnId);
     }
 
-    const committedHistory = memoryCommit?.history ?? pending.session.history;
-    const historyLength = pending.session.history.length;
+    const committedHistory = memoryCommit?.history ?? session.history;
+    const historyLength = session.history.length;
     session = setHarnessEmissionState(
       {
-        ...pending.session,
+        ...session,
         history: [...committedHistory, ...instructionMessages],
-        state: memoryCommit?.state ?? pending.session.state,
+        state: memoryCommit?.state ?? session.state,
       },
       emissionState,
     );

--- a/packages/eve/src/harness/types.ts
+++ b/packages/eve/src/harness/types.ts
@@ -286,6 +286,8 @@ export interface ToolLoopHarnessConfig {
   readonly clearOnly?: boolean;
   /** Forces one context-compaction pass without running a model turn. */
   readonly compactOnly?: boolean;
+  /** Checkpoints resolved HITL Groups before delivering their owner completion. */
+  readonly durableGroupCompletionDelivery?: boolean;
   /**
    * Exposes the `Workflow` orchestration tool — an isolated JavaScript sandbox
    * whose only callable operations are this agent's subagents and remote


### PR DESCRIPTION
### Summary

Stacks on #2822. That PR centralizes durable HITL state, but a resolved Group could still advance directly to delivered while its transcript, lifecycle events, and framework-gate continuation ran in the same step. A process failure between those operations could lose the owner delivery.

Before → after: resolution terminalized Requests and completed the Group in one harness pass → resolution now persists `ready` with an idempotency key and owner payload, returns across the durable step boundary, then replays the payload and acknowledges `delivered` only after owner effects succeed. Retrying from the ready snapshot produces the same delivery.

Turn cancellation now force-closes waiting and ready Groups, internal Authorization Requests, and active approval ResponseAttempts. Direct harness callers keep same-invocation behavior; the checkpoint is enabled by the workflow execution boundary.

### Validation

Package typechecking passed. Seven focused unit files passed with 319 tests, covering the ready/delivered protocol, retry from a ready snapshot, existing HITL behavior, active-attempt closure, and turnStep cancellation persistence. The cancellation-settle integration test could not start because this isolated worktree lacks the generated `#internal/workflow-bundle/workflow-builders.js` module required by the integration config; CI builds that prerequisite normally.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

A separate changeset describes the observable durability and cancellation behavior added by this stacked PR.

**Implementation** — 9 files · `+326 / -64`

Most additions define the explicit Group delivery protocol and adapt the interpreter to store and replay its existing resolution result. Cancellation wiring closes the same ledger state from both in-step and driver-observed cancellation paths.

**Tests** — 4 files · `+204 / -3`

Covers state transitions, idempotent acknowledgement, crash-boundary replay, ResponseAttempt closure, and persisted turnStep cancellation behavior.
