### PR TITLE
fix(eve): mcp connections - accept structured-only tool results

### DIFF
--- a/.changeset/calm-catalogs-listen.md
+++ b/.changeset/calm-catalogs-listen.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Accept MCP tool results that return only structured content by synthesizing the protocol's text fallback before strict validation.

--- a/packages/eve/src/runtime/connections/mcp-client.integration.test.ts
+++ b/packages/eve/src/runtime/connections/mcp-client.integration.test.ts
@@ -1,0 +1,69 @@
+import { createMCPClient } from "#compiled/@ai-sdk/mcp/index.js";
+import { describe, expect, it, vi } from "vitest";
+
+import { withMcpToolResultCompatibility } from "#runtime/connections/mcp-client.js";
+
+describe("MCP client tool result compatibility", () => {
+  it("accepts structured tool results that omit content", async () => {
+    const structuredContent = { products: [{ id: "gid://shopify/Product/1", title: "Boots" }] };
+    const inner = vi.fn<typeof globalThis.fetch>(async (_input, init) => {
+      const request = JSON.parse(String(init?.body)) as { method: string; id?: number };
+      if (request.method === "initialize") {
+        return jsonRpcResponse(request.id, {
+          capabilities: { tools: {} },
+          protocolVersion: "2025-11-25",
+          serverInfo: { name: "catalog", version: "1.0.0" },
+        });
+      }
+      if (request.method === "notifications/initialized") {
+        return new Response(null, { status: 202 });
+      }
+      if (request.method === "tools/call") {
+        return jsonRpcResponse(request.id, { structuredContent });
+      }
+      throw new Error(`Unexpected MCP method: ${request.method}`);
+    });
+    const client = await createMCPClient({
+      transport: {
+        fetch: withMcpToolResultCompatibility(inner),
+        type: "http",
+        url: "https://catalog.example.com/mcp",
+      },
+    });
+
+    try {
+      await expect(client.callTool({ arguments: {}, name: "search_catalog" })).resolves.toEqual({
+        content: [{ text: JSON.stringify(structuredContent), type: "text" }],
+        isError: false,
+        structuredContent,
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  it("preserves an existing content field", async () => {
+    const body = JSON.stringify({
+      id: 1,
+      jsonrpc: "2.0",
+      result: {
+        content: [{ text: "Already projected", type: "text" }],
+        structuredContent: { value: 1 },
+      },
+    });
+    const wrapped = withMcpToolResultCompatibility(
+      vi.fn(async () => new Response(body, { headers: { "content-type": "application/json" } })),
+    );
+
+    const response = await wrapped("https://catalog.example.com/mcp", {
+      body: JSON.stringify({ id: 1, jsonrpc: "2.0", method: "tools/call" }),
+      method: "POST",
+    });
+
+    await expect(response.text()).resolves.toBe(body);
+  });
+});
+
+function jsonRpcResponse(id: number | undefined, result: unknown): Response {
+  return Response.json({ id, jsonrpc: "2.0", result });
+}

--- a/packages/eve/src/runtime/connections/mcp-client.test.ts
+++ b/packages/eve/src/runtime/connections/mcp-client.test.ts
@@ -172,6 +172,7 @@ describe("McpConnectionClient", () => {
     expect(createMCPClient).toHaveBeenCalledTimes(1);
     expect(createMCPClient).toHaveBeenCalledWith({
       transport: {
+        fetch: expect.any(Function),
         headers: {
           Authorization: "Bearer test-token",
           "X-Api-Key": "key123",
@@ -198,6 +199,7 @@ describe("McpConnectionClient", () => {
     await expect(mcpClient.connect()).resolves.toBe(client);
     expect(createMCPClient).toHaveBeenNthCalledWith(1, {
       transport: {
+        fetch: expect.any(Function),
         headers: { Authorization: "Bearer test-token" },
         type: "http",
         url: "https://mcp.example.com",
@@ -205,6 +207,7 @@ describe("McpConnectionClient", () => {
     });
     expect(createMCPClient).toHaveBeenNthCalledWith(2, {
       transport: {
+        fetch: expect.any(Function),
         headers: { Authorization: "Bearer test-token" },
         type: "sse",
         url: "https://mcp.example.com",
@@ -229,6 +232,7 @@ describe("McpConnectionClient", () => {
     expect(createMCPClient).toHaveBeenCalledTimes(2);
     expect(createMCPClient).toHaveBeenNthCalledWith(2, {
       transport: {
+        fetch: expect.any(Function),
         headers: { Authorization: "Bearer test-token" },
         type: "sse",
         url: "https://mcp.example.com",
@@ -251,6 +255,7 @@ describe("McpConnectionClient", () => {
     expect(createMCPClient).toHaveBeenCalledTimes(2);
     expect(createMCPClient).toHaveBeenNthCalledWith(2, {
       transport: {
+        fetch: expect.any(Function),
         headers: { Authorization: "Bearer test-token" },
         type: "sse",
         url: "https://mcp.example.com",
@@ -275,6 +280,7 @@ describe("McpConnectionClient", () => {
     expect(createMCPClient).toHaveBeenCalledTimes(2);
     expect(createMCPClient).toHaveBeenNthCalledWith(2, {
       transport: {
+        fetch: expect.any(Function),
         headers: { Authorization: "Bearer test-token" },
         type: "sse",
         url: "https://mcp.example.com",
@@ -294,6 +300,7 @@ describe("McpConnectionClient", () => {
     expect(createMCPClient).toHaveBeenCalledTimes(1);
     expect(createMCPClient).toHaveBeenCalledWith({
       transport: {
+        fetch: expect.any(Function),
         headers: { Authorization: "Bearer test-token" },
         type: "http",
         url: "https://mcp.example.com",

--- a/packages/eve/src/runtime/connections/mcp-client.ts
+++ b/packages/eve/src/runtime/connections/mcp-client.ts
@@ -73,17 +73,18 @@ export class McpConnectionClient implements ConnectionClient {
   async #createClient(): Promise<MCPClient> {
     const headers = await resolveHeaders(this.#connection);
     const url = this.#connection.url;
+    const fetch = withMcpToolResultCompatibility();
 
     try {
       return await createMCPClient({
-        transport: { type: "http", url, headers },
+        transport: { type: "http", url, headers, fetch },
       });
     } catch (error) {
       if (!isMcpHttpFallbackRetryableError(error)) {
         throw error;
       }
       return await createMCPClient({
-        transport: { type: "sse", url, headers },
+        transport: { type: "sse", url, headers, fetch },
       });
     }
   }
@@ -262,6 +263,101 @@ export class McpConnectionClient implements ConnectionClient {
       scope: this.#connection.connectionName,
     });
   }
+}
+
+/**
+ * Some MCP servers omit the required `content` field when they return
+ * `structuredContent`. The AI SDK rejects that result before eve can use it,
+ * so mirror the structured value into the protocol's recommended text fallback
+ * at the transport boundary.
+ */
+export function withMcpToolResultCompatibility(
+  inner?: typeof globalThis.fetch,
+): typeof globalThis.fetch {
+  return async (input, init) => {
+    const response = await (inner ?? globalThis.fetch)(input, init);
+    if (!isToolCallRequest(init?.body) || !isJsonResponse(response)) {
+      return response;
+    }
+
+    const responseText = await response.text();
+    let payload: unknown;
+    try {
+      payload = JSON.parse(responseText);
+    } catch {
+      return rebuildResponse(response, responseText);
+    }
+
+    const normalized = normalizeToolCallResponsePayload(payload);
+    return rebuildResponse(
+      response,
+      normalized.changed ? JSON.stringify(normalized.value) : responseText,
+    );
+  };
+}
+
+function isToolCallRequest(body: unknown): boolean {
+  if (typeof body !== "string") return false;
+  try {
+    const payload: unknown = JSON.parse(body);
+    return Array.isArray(payload)
+      ? payload.some((message) => isObject(message) && message.method === "tools/call")
+      : isObject(payload) && payload.method === "tools/call";
+  } catch {
+    return false;
+  }
+}
+
+function isJsonResponse(response: Response): boolean {
+  return (
+    response.ok &&
+    response.headers.get("content-type")?.toLowerCase().includes("application/json") === true
+  );
+}
+
+function normalizeToolCallResponsePayload(payload: unknown): {
+  readonly changed: boolean;
+  readonly value: unknown;
+} {
+  if (Array.isArray(payload)) {
+    let changed = false;
+    const value = payload.map((message) => {
+      const normalized = normalizeToolCallResponsePayload(message);
+      changed ||= normalized.changed;
+      return normalized.value;
+    });
+    return { changed, value: changed ? value : payload };
+  }
+
+  if (!isObject(payload) || !isObject(payload.result)) {
+    return { changed: false, value: payload };
+  }
+
+  const result = payload.result;
+  if (!("structuredContent" in result) || "content" in result) {
+    return { changed: false, value: payload };
+  }
+
+  return {
+    changed: true,
+    value: {
+      ...payload,
+      result: {
+        ...result,
+        content: [{ text: JSON.stringify(result.structuredContent), type: "text" }],
+      },
+    },
+  };
+}
+
+function rebuildResponse(response: Response, body: string): Response {
+  const headers = new Headers(response.headers);
+  headers.delete("content-length");
+  return new Response(body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
 }
 
 /**


### PR DESCRIPTION
### Summary

Shopify's catalog MCP returns tool results with `structuredContent` but no `content`, which causes the strict MCP result parser to reject otherwise usable output. MCP connections now recognize that shape in successful JSON `tools/call` responses and synthesize the spec-recommended text fallback before validation. Existing content remains untouched, and the compatibility behavior stays inside eve's MCP transport boundary without changing the public connection API.

### Validation

Reproduced the failure through the real vendored MCP client with an in-memory Streamable HTTP response containing only `structuredContent`. The focused integration confirms that result now parses with mirrored text, the compliant-result case confirms existing content is preserved, and the full unit suite passed with 7,718 tests and 1 skip.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the patch changeset for the published `eve` package.

**Implementation** — 1 file · `+98 / -2`

Keeps the compatibility normalization at the MCP fetch boundary and scopes it to matching JSON-RPC tool results while preserving response metadata.

**Tests** — 2 files · `+76 / -0`

Covers the regression through the real MCP client, preserves compliant results, and verifies both transports receive the compatibility fetch.
