### PR TITLE
fix(eve): scaffold Browser Use connections

### DIFF
--- a/.changeset/bright-bats-connect.md
+++ b/.changeset/bright-bats-connect.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add Browser Use to the `eve connections add` picker. The generated MCP connection reads `BROWSER_USE_API_KEY` into Browser Use's required API-key header without adding Vercel Connect.

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -354,7 +354,7 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     name: "Browser Use",
     kind: "connection",
     tagline: "Run managed browser automation tasks through Browser Use's MCP server.",
-    surfaces: { scaffoldable: false, registry: true, gallery: true },
+    surfaces: { scaffoldable: true, registry: true, gallery: true },
     connection: {
       description:
         "Browser Use: run browser automation tasks, inspect sessions, and manage browser profiles.",

--- a/packages/eve/src/setup/scaffold/connections/catalog.test.ts
+++ b/packages/eve/src/setup/scaffold/connections/catalog.test.ts
@@ -34,10 +34,13 @@ describe("catalog integrity", () => {
     expect(new Set(slugs).size).toBe(slugs.length);
   });
 
-  test("every curated entry authenticates via Connect", () => {
-    for (const entry of CONNECTION_CATALOG) {
-      expect(entry.auth.kind).toBe("connect");
-    }
+  test("includes Browser Use with static API-key authentication", () => {
+    expect(getCatalogEntry("browser-use")).toMatchObject({
+      auth: {
+        kind: "header",
+        headers: [{ header: "x-browser-use-api-key", envVar: "BROWSER_USE_API_KEY" }],
+      },
+    });
   });
 
   test("gallery-only connections stay out of the scaffolder catalog", () => {
@@ -49,7 +52,7 @@ describe("catalog integrity", () => {
   });
 
   test("every Connect entry resolves a `vercel connect create` service", () => {
-    for (const entry of CONNECTION_CATALOG) {
+    for (const entry of CONNECTION_CATALOG.filter((entry) => entry.auth.kind === "connect")) {
       expect(connectorServiceForEntry(entry)).toBeTruthy();
       expect(canonicalConnectorNameForEntry(entry)).toBeTruthy();
     }

--- a/packages/eve/src/setup/scaffold/connections/catalog.ts
+++ b/packages/eve/src/setup/scaffold/connections/catalog.ts
@@ -107,6 +107,10 @@ export const CUSTOM_CONNECTION_SLUG = "custom";
 // URL. Keep these provider-owned keys explicit instead of deriving them from
 // the endpoint path.
 const CONNECTION_AUTH: Readonly<Record<string, ConnectionAuthSpec>> = {
+  "browser-use": {
+    kind: "header",
+    headers: [{ header: "x-browser-use-api-key", envVar: "BROWSER_USE_API_KEY" }],
+  },
   linear: { kind: "connect", connector: "linear", service: "mcp.linear.app" },
   notion: { kind: "connect", connector: "notion", service: "mcp.notion.com" },
   datadog: { kind: "connect", connector: "datadog", service: "mcp.datadoghq.com" },

--- a/packages/eve/src/setup/scaffold/update/connections.integration.test.ts
+++ b/packages/eve/src/setup/scaffold/update/connections.integration.test.ts
@@ -47,6 +47,35 @@ describe("ensureConnection", () => {
     );
   });
 
+  test("scaffolds Browser Use with its API key", async () => {
+    const projectRoot = await createTempDir();
+    await writeFile(
+      join(projectRoot, "package.json"),
+      `${JSON.stringify({ name: "demo", type: "module" }, null, 2)}\n`,
+      "utf8",
+    );
+
+    const result = await ensureConnection({
+      projectRoot,
+      protocol: "mcp",
+      entry: entry("browser-use"),
+    });
+
+    expect(result.envKeysRequired).toEqual(["BROWSER_USE_API_KEY"]);
+    expect(result.envKeysAdded).toEqual(["BROWSER_USE_API_KEY"]);
+    expect(result.packageJsonUpdated).toEqual([]);
+
+    await expect(readFile(result.filePath, "utf8")).resolves.toContain(
+      '"x-browser-use-api-key": process.env.BROWSER_USE_API_KEY!',
+    );
+    await expect(readFile(join(projectRoot, ".env.local"), "utf8")).resolves.toContain(
+      "BROWSER_USE_API_KEY=",
+    );
+    await expect(readFile(join(projectRoot, "package.json"), "utf8")).resolves.not.toContain(
+      "@vercel/connect",
+    );
+  });
+
   test("seeds .env.local placeholders for a bearer-env connection", async () => {
     const projectRoot = await createTempDir();
 


### PR DESCRIPTION
### Summary

Closes #2746. Browser Use is now available in `eve connections add`; it scaffolds the existing MCP endpoint with `x-browser-use-api-key` from `BROWSER_USE_API_KEY`, seeds `.env.local`, and does not install Vercel Connect.

### Validation

Focused integration coverage verifies the generated Browser Use header, environment placeholder, and absence of an `@vercel/connect` dependency. The focused catalog unit suite verifies Browser Use’s static-header recipe and preserves validation for Connect-backed entries. Catalog unit tests, package type checks, formatting, lint, and the invariant guard also pass.

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the patch-release note for the newly available CLI setup path.

**Implementation** — 2 files · `+5 / -1`

Marks Browser Use as scaffoldable and supplies its existing API-key header recipe to the curated connection catalog.

**Tests** — 2 files · `+37 / -4`

Replaces the Connect-only assumption and covers the generated Browser Use connection, environment setup, and dependency behavior.
