### PR TITLE
fix(eve): keep addressed add confirmations responsive

### DIFF
--- a/.changeset/brave-panthers-rest.md
+++ b/.changeset/brave-panthers-rest.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Addressed `/add <item>` confirmations now remain responsive in the dev TUI.

--- a/packages/eve/src/cli/dev/tui/setup-commands.test.ts
+++ b/packages/eve/src/cli/dev/tui/setup-commands.test.ts
@@ -106,6 +106,32 @@ function run(input: {
 }
 
 describe("runTuiSetupCommand", () => {
+  it("arms the interrupt trap before an addressed add opens its confirmation", async () => {
+    const calls: string[] = [];
+    const renderer = fakePanelRenderer();
+    renderer.waitForInterrupt = vi.fn(() => {
+      calls.push("interrupt");
+      return { promise: new Promise<"escape" | "ctrl-c">(() => {}), dispose: vi.fn() };
+    });
+    renderer.readSelect = vi.fn(async () => {
+      calls.push("select");
+      return ["install"];
+    });
+    const flows = fakeFlows({
+      runRegistryFlow: vi.fn<TuiSetupFlows["runRegistryFlow"]>(async ({ prompter }) => {
+        await prompter.select({
+          message: "Add experimental/self-modification?",
+          options: [{ value: "install", label: "Install and set up" }],
+        });
+        return registryResult();
+      }),
+    });
+
+    await run({ command: "add", flows, renderer, useDefaultPrompter: true });
+
+    expect(calls).toEqual(["interrupt", "select"]);
+  });
+
   it("suspends the runtime during registry installation", async () => {
     const calls: string[] = [];
     const runRegistryFlow = vi.fn<TuiSetupFlows["runRegistryFlow"]>(async (input) => {

--- a/packages/eve/src/cli/dev/tui/setup-commands.ts
+++ b/packages/eve/src/cli/dev/tui/setup-commands.ts
@@ -173,6 +173,10 @@ export async function runTuiSetupCommand(
       cancelActiveRegistryItem = undefined;
     }
   };
+  // Arm the idle trap before a flow can synchronously open its first question.
+  // Otherwise it replaces the question's key consumer, leaving addressed `/add`
+  // confirmations visible but unresponsive.
+  let interrupt = input.renderer.waitForInterrupt();
   const execution = executeSetupCommand(
     input,
     prompter,
@@ -183,7 +187,7 @@ export async function runTuiSetupCommand(
   const outcomePromise = execution.then((value) => ({ kind: "outcome" as const, value }));
   try {
     while (true) {
-      const interrupt = input.renderer.waitForInterrupt();
+      let rearm = false;
       try {
         const settled = await Promise.race([
           outcomePromise,
@@ -196,22 +200,24 @@ export async function runTuiSetupCommand(
           cancelActiveRegistryItem !== undefined
         ) {
           cancelActiveRegistryItem();
-          continue;
+          rearm = true;
+        } else {
+          interrupted = true;
+          controller.abort(new WizardCancelledError());
+          const outcome = await execution;
+          return outcome.partial === true
+            ? outcome
+            : {
+                ...outcome,
+                message: `/${command} interrupted.`,
+                tone: "error",
+                preserveFlowDiagnostics: true,
+              };
         }
-        interrupted = true;
-        controller.abort(new WizardCancelledError());
-        const outcome = await execution;
-        return outcome.partial === true
-          ? outcome
-          : {
-              ...outcome,
-              message: `/${command} interrupted.`,
-              tone: "error",
-              preserveFlowDiagnostics: true,
-            };
       } finally {
         interrupt.dispose();
       }
+      if (rearm) interrupt = input.renderer.waitForInterrupt();
     }
   } finally {
     // A flow that threw or was abandoned mid-wait must not leave the footer spinning.


### PR DESCRIPTION
### Summary

Addressed `/add <item>` confirmations could become unresponsive because the TUI armed its idle interrupt handler after the confirmation had claimed keyboard input. Arm the handler first so an addressed add prompt retains its key consumer.

### Validation

Focused TUI setup-command coverage passes, including a regression assertion that the interrupt handler is armed before an addressed add confirmation opens.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Records the patch release note.

**Implementation** — 1 file · `+19 / -13`

Keeps interrupt ownership from replacing a synchronously opened setup question.

**Tests** — 1 file · `+26 / -0`

Adds focused coverage for the registration order that caused the input deadlock.
