### PR TITLE
feat(self-modification): prepare production proposal workspaces

### DIFF
--- a/packages/eve/src/execution/sandbox/shell-quote.ts
+++ b/packages/eve/src/execution/sandbox/shell-quote.ts
@@ -1,14 +1,1 @@
-/**
- * Wraps a value in POSIX single-quotes, escaping any embedded single-quotes.
- *
- * Used by the `glob` and `grep` execution cores to safely embed model-supplied
- * patterns, paths, and globs into shell commands run via `sandbox.run`.
- *
- * The quoting strategy is the standard POSIX approach: wrap the value in
- * single-quotes and replace each embedded `'` with `'\''` (end the
- * single-quoted string, insert an escaped single-quote, re-open
- * single-quoting).
- */
-export function shellQuote(value: string): string {
-  return `'${value.replace(/'/g, "'\\''")}'`;
-}
+export { shellQuote } from "#shared/shell-quote.js";

--- a/packages/eve/src/internal/authored-package-boundary.test.ts
+++ b/packages/eve/src/internal/authored-package-boundary.test.ts
@@ -1,3 +1,6 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { describe, expect, it } from "vitest";
 
 import {
@@ -5,7 +8,38 @@ import {
   type RolldownResolveContext,
 } from "#internal/authored-package-boundary.js";
 
+const PACKAGE_ROOT = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+
 describe("createRuntimeLoaderPackageBoundaryPlugin", () => {
+  it("resolves eve package imports through the published dist mapping", async () => {
+    const plugin = createRuntimeLoaderPackageBoundaryPlugin({
+      externalDependencies: [],
+      packageRoot: PACKAGE_ROOT,
+    });
+    const resolveId = plugin.resolveId as (
+      this: RolldownResolveContext,
+      source: string,
+      importer: string | undefined,
+      options: { kind: string },
+    ) => Promise<unknown>;
+    const context: RolldownResolveContext = {
+      async resolve() {
+        throw new Error("package imports should resolve before delegating");
+      },
+    };
+
+    await expect(
+      resolveId.call(
+        context,
+        "#shared/git.js",
+        join(PACKAGE_ROOT, "dist/src/self-modification/agent.js"),
+        { kind: "import-statement" },
+      ),
+    ).resolves.toEqual({
+      id: join(PACKAGE_ROOT, "dist/src/shared/git.js"),
+    });
+  });
+
   it.each([
     [
       "C:\\workspace\\app\\node_modules\\external-only\\index.js",

--- a/packages/eve/src/internal/authored-package-boundary.ts
+++ b/packages/eve/src/internal/authored-package-boundary.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, realpathSync } from "node:fs";
-import { isBuiltin } from "node:module";
+import { createRequire, isBuiltin } from "node:module";
 import { dirname, join, resolve, sep } from "node:path";
 
 import { normalizeEsmImportSpecifier } from "#internal/application/import-specifier.js";
@@ -92,6 +92,17 @@ export function createRuntimeLoaderPackageBoundaryPlugin(input: {
 
       if (isFrameworkRuntimeImport(source, importer)) {
         return { external: true, id: resolveFrameworkRuntimeImport(source) };
+      }
+
+      // The published package maps #imports to dist, while the eve-source
+      // condition used by the app build maps them to TypeScript source.
+      // Resolve through Node's default package-import conditions here so a
+      // packed eve installation does not leak #shared/* into the bundle.
+      if (source.startsWith("#")) {
+        const resolvedPackageImport = resolvePackageImport(source, input.packageRoot);
+        if (resolvedPackageImport !== undefined) {
+          return { id: resolvedPackageImport };
+        }
       }
 
       const externalModule = await resolveConfiguredExternalModule.call(this, {
@@ -308,6 +319,17 @@ function nearestPackageName(filePath: string): string | undefined {
       return undefined;
     }
     directory = parent;
+  }
+}
+
+function resolvePackageImport(source: string, packageRoot: string): string | undefined {
+  try {
+    const resolved = createRequire(join(packageRoot, "package.json")).resolve(source);
+    return isPathInsideOrEqual(toCanonicalPath(resolved), toCanonicalPath(packageRoot))
+      ? resolved
+      : undefined;
+  } catch {
+    return undefined;
   }
 }
 

--- a/packages/eve/src/internal/vercel/build-command.ts
+++ b/packages/eve/src/internal/vercel/build-command.ts
@@ -1,9 +1,9 @@
 import { relative } from "node:path";
 
+import { shellQuote } from "#shared/shell-quote.js";
+
 /** Quote one argument for Vercel's POSIX build-command shell. */
-export function quoteVercelShellArgument(value: string): string {
-  return `'${value.replaceAll("'", "'\\''")}'`;
-}
+export const quoteVercelShellArgument = shellQuote;
 
 /** Return a portable relative path for a generated Vercel configuration. */
 export function toVercelRelativePath(from: string, to: string): string {

--- a/packages/eve/src/public/channels/github/checkout.ts
+++ b/packages/eve/src/public/channels/github/checkout.ts
@@ -8,7 +8,8 @@ import {
   resolveGitHubInstallationToken,
   type GitHubChannelCredentials,
 } from "#public/channels/github/auth.js";
-import type { SandboxNetworkPolicy } from "#shared/sandbox-network-policy.js";
+import { gitHubGitBrokerNetworkPolicy, gitHubRemoteUrl, isFullGitSha } from "#shared/git.js";
+import { shellQuote } from "#shared/shell-quote.js";
 import type { SandboxSession } from "#shared/sandbox-session.js";
 
 const DEFAULT_CHECKOUT_PATH = "/workspace";
@@ -71,7 +72,7 @@ export async function checkoutGitHubRepository(
   const checkoutPath = sandbox.resolvePath(input.path ?? DEFAULT_CHECKOUT_PATH);
   const checkoutRef = resolveCheckoutRef(input.ref, descriptor);
 
-  if (isFullSha(checkoutRef)) {
+  if (isFullGitSha(checkoutRef)) {
     const currentHead = await readCheckoutHead(sandbox, checkoutPath);
     if (currentHead === checkoutRef) {
       return {
@@ -91,14 +92,14 @@ export async function checkoutGitHubRepository(
     credentials: input.credentials,
     installationId: descriptor.installationId,
   });
-  const remote = publicRemoteUrl({ owner: descriptor.owner, repo: descriptor.repo });
-  const fetchedRef = isFullSha(checkoutRef) ? checkoutRef : "FETCH_HEAD";
+  const remote = gitHubRemoteUrl({ owner: descriptor.owner, repo: descriptor.repo });
+  const fetchedRef = isFullGitSha(checkoutRef) ? checkoutRef : "FETCH_HEAD";
 
   // Broker the installation token at the sandbox firewall: git fetches a clean
   // (token-free) URL and the platform injects `Authorization` on egress to
   // GitHub, so the token never enters the sandbox process. The `"*"` rule keeps
   // the agent's other egress open.
-  await sandbox.setNetworkPolicy(buildBrokerNetworkPolicy(token));
+  await sandbox.setNetworkPolicy(gitHubGitBrokerNetworkPolicy(token));
 
   await runCheckoutCommand({
     command: `mkdir -p ${shellQuote(checkoutPath)}`,
@@ -272,7 +273,7 @@ async function readCheckoutHead(
   });
   if (result.exitCode !== 0) return null;
   const head = String(result.stdout ?? "").trim();
-  return isFullSha(head) ? head : null;
+  return isFullGitSha(head) ? head : null;
 }
 
 async function runCheckoutCommand(input: {
@@ -304,37 +305,6 @@ function normalizeCheckoutDepth(value: number | undefined): number {
   return Math.floor(value);
 }
 
-function publicRemoteUrl(input: { readonly owner: string; readonly repo: string }): string {
-  return `https://github.com/${input.owner}/${input.repo}.git`;
-}
-
-/**
- * Builds the firewall policy that brokers the installation token onto git's
- * HTTPS egress. The header is injected at the fetch boundary (git uses Basic
- * auth with `x-access-token` as the username), so the clean remote URL carries
- * no secret. `codeload.github.com` is included because shallow fetches can
- * redirect there; `"*"` leaves all other egress untouched.
- */
-function buildBrokerNetworkPolicy(token: string): SandboxNetworkPolicy {
-  const authorization = `Basic ${Buffer.from(`x-access-token:${token}`).toString("base64")}`;
-  const rule = [{ transform: [{ headers: { Authorization: authorization } }] }];
-  return {
-    allow: {
-      "github.com": rule,
-      "codeload.github.com": rule,
-      "*": [],
-    },
-  };
-}
-
 function readNonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
-}
-
-function isFullSha(value: string): boolean {
-  return /^[a-f0-9]{40}$/iu.test(value);
-}
-
-function shellQuote(value: string): string {
-  return `'${value.replace(/'/gu, "'\\''")}'`;
 }

--- a/packages/eve/src/self-modification/git-workspace.test.ts
+++ b/packages/eve/src/self-modification/git-workspace.test.ts
@@ -1,0 +1,99 @@
+import type { SandboxNetworkPolicy } from "eve/sandbox";
+import { describe, expect, it } from "vitest";
+
+import { prepareSelfModificationWorkspace } from "./git-workspace.js";
+
+function sandbox(
+  input: { readonly failPolicyAt?: number; readonly failRun?: (command: string) => boolean } = {},
+) {
+  const commands: string[] = [];
+  const policies: SandboxNetworkPolicy[] = [];
+  return {
+    commands,
+    policies,
+    run: async ({ command }: { command: string }) => {
+      commands.push(command);
+      if (input.failRun?.(command)) return { exitCode: 1, stderr: "failed", stdout: "" };
+      if (command.includes("rev-parse")) return { exitCode: 0, stderr: "", stdout: "a".repeat(40) };
+      return { exitCode: 0, stderr: "", stdout: "" };
+    },
+    setNetworkPolicy: async (policy: SandboxNetworkPolicy) => {
+      policies.push(policy);
+      if (policies.length === input.failPolicyAt) throw new Error("policy update failed");
+    },
+  };
+}
+
+const input = {
+  directory: "apps/weather",
+  repository: { owner: "vercel", repo: "eve" },
+  targetBranch: "main",
+  token: "secret-token",
+} as const;
+
+describe("prepareSelfModificationWorkspace", () => {
+  it("fetches the configured target branch through a temporary credential boundary", async () => {
+    const session = sandbox();
+    await expect(
+      prepareSelfModificationWorkspace({ ...input, sandbox: session }),
+    ).resolves.toMatchObject({
+      baseSha: "a".repeat(40),
+      directory: "apps/weather",
+    });
+    expect(session.commands.join("\n")).toContain("refs/heads/main");
+    expect(session.commands.join("\n")).not.toContain("secret-token");
+    expect(session.policies).toEqual([
+      expect.objectContaining({
+        allow: expect.objectContaining({
+          "*": [],
+          "codeload.github.com": expect.any(Array),
+          "github.com": expect.any(Array),
+        }),
+      }),
+      "allow-all",
+    ]);
+  });
+
+  it("revokes credentials after a failed checkout", async () => {
+    const session = sandbox({ failRun: (command) => command.includes(" fetch ") });
+    await expect(prepareSelfModificationWorkspace({ ...input, sandbox: session })).rejects.toThrow(
+      "Git command failed",
+    );
+    expect(session.policies.at(-1)).toBe("allow-all");
+  });
+
+  it("attempts revocation when installing the broker policy fails", async () => {
+    const session = sandbox({ failPolicyAt: 1 });
+    await expect(prepareSelfModificationWorkspace({ ...input, sandbox: session })).rejects.toThrow(
+      "policy update failed",
+    );
+    expect(session.policies).toHaveLength(2);
+    expect(session.policies.at(-1)).toBe("allow-all");
+  });
+
+  it("reports credential revocation failures", async () => {
+    const session = sandbox({ failPolicyAt: 2 });
+    await expect(prepareSelfModificationWorkspace({ ...input, sandbox: session })).rejects.toThrow(
+      "Could not revoke the brokered GitHub credential",
+    );
+  });
+
+  it("rejects invalid branches before brokering credentials", async () => {
+    const session = sandbox();
+    await expect(
+      prepareSelfModificationWorkspace({
+        ...input,
+        sandbox: session,
+        targetBranch: "main; curl bad",
+      }),
+    ).rejects.toThrow("valid Git ref");
+    expect(session.policies).toEqual([]);
+  });
+
+  it("rejects an application root without agent", async () => {
+    const session = sandbox({ failRun: (command) => command.startsWith("test -d") });
+    await expect(prepareSelfModificationWorkspace({ ...input, sandbox: session })).rejects.toThrow(
+      "does not contain agent/",
+    );
+  });
+});

--- a/packages/eve/src/self-modification/git-workspace.ts
+++ b/packages/eve/src/self-modification/git-workspace.ts
@@ -1,0 +1,104 @@
+import type { SandboxSession } from "eve/sandbox";
+
+import { gitHubRemoteUrl } from "#shared/git.js";
+import { shellQuote } from "#shared/shell-quote.js";
+
+import type { GitHubRepository } from "./config.js";
+import { gitOutput, runGitCommand, withBrokeredGitHubCredential } from "./git.js";
+import { assertFullSha, assertGitRef } from "./identifiers.js";
+
+export const SELF_MODIFICATION_CONFIG_PATH = "agent/subagents/self-modification/config.ts";
+export const WORKSPACE_PATH = "/workspace";
+export const REPOSITORY_PATH = `${WORKSPACE_PATH}/repository`;
+export const BASE_REF = "refs/eve-self-modification/base";
+const GIT_FETCH_ENV =
+  "GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null GIT_LFS_SKIP_SMUDGE=1 GIT_TERMINAL_PROMPT=0";
+
+export interface PreparedSelfModificationWorkspace {
+  readonly baseSha: string;
+  readonly directory: string;
+  readonly repository: GitHubRepository;
+  readonly repositoryPath: string;
+  readonly targetBranch: string;
+}
+
+type CheckoutSandbox = Pick<SandboxSession, "run" | "setNetworkPolicy">;
+
+/** Prepares a token-free remote and immutable target-branch checkout for one child session. */
+export async function prepareSelfModificationWorkspace(input: {
+  readonly directory: string;
+  readonly repository: GitHubRepository;
+  readonly sandbox: CheckoutSandbox;
+  readonly targetBranch: string;
+  readonly token: string;
+}): Promise<PreparedSelfModificationWorkspace> {
+  assertGitRef(input.targetBranch, "target branch");
+  const remote = gitHubRemoteUrl(input.repository);
+  await withBrokeredGitHubCredential(input.sandbox, input.token, async () => {
+    await run(
+      input.sandbox,
+      `rm -rf ${quote(REPOSITORY_PATH)} && mkdir -p ${quote(REPOSITORY_PATH)}`,
+    );
+    await run(input.sandbox, `git -C ${quote(REPOSITORY_PATH)} init`);
+    await run(input.sandbox, `git -C ${quote(REPOSITORY_PATH)} remote add origin ${quote(remote)}`);
+    await run(
+      input.sandbox,
+      `${GIT_FETCH_ENV} git -C ${quote(REPOSITORY_PATH)} fetch --no-tags origin ${quote(`refs/heads/${input.targetBranch}`)}`,
+    );
+    await run(input.sandbox, `git -C ${quote(REPOSITORY_PATH)} update-ref ${BASE_REF} FETCH_HEAD`);
+    await run(input.sandbox, `git -C ${quote(REPOSITORY_PATH)} checkout --detach ${BASE_REF}`);
+  });
+  const baseSha = await gitOutput(
+    input.sandbox,
+    `git -C ${quote(REPOSITORY_PATH)} rev-parse ${BASE_REF}`,
+  );
+  assertFullSha(baseSha, "target branch revision");
+  await verifyApplicationRoot(input.sandbox, input.directory);
+  return {
+    baseSha,
+    directory: input.directory,
+    repository: input.repository,
+    repositoryPath: REPOSITORY_PATH,
+    targetBranch: input.targetBranch,
+  };
+}
+
+/** Reconstructs trusted workspace metadata after the session checkout preflight. */
+export async function readPreparedSelfModificationWorkspace(input: {
+  readonly directory: string;
+  readonly repository: GitHubRepository;
+  readonly sandbox: Pick<SandboxSession, "run">;
+  readonly targetBranch: string;
+}): Promise<PreparedSelfModificationWorkspace> {
+  const baseSha = await gitOutput(
+    input.sandbox,
+    `git -C ${quote(REPOSITORY_PATH)} rev-parse ${BASE_REF}`,
+  );
+  assertFullSha(baseSha, "target branch revision");
+  await verifyApplicationRoot(input.sandbox, input.directory);
+  return {
+    baseSha,
+    directory: input.directory,
+    repository: input.repository,
+    repositoryPath: REPOSITORY_PATH,
+    targetBranch: input.targetBranch,
+  };
+}
+
+export async function verifyApplicationRoot(
+  sandbox: Pick<SandboxSession, "run">,
+  directory: string,
+): Promise<void> {
+  const root = directory === "." ? REPOSITORY_PATH : `${REPOSITORY_PATH}/${directory}`;
+  const result = await sandbox.run({ command: `test -d ${quote(`${root}/agent`)}` });
+  if (result.exitCode !== 0) {
+    throw new Error(`Self-modification source directory does not contain agent/: ${directory}`);
+  }
+}
+
+function quote(value: string): string {
+  return shellQuote(value);
+}
+async function run(sandbox: Pick<SandboxSession, "run">, command: string): Promise<void> {
+  await runGitCommand(sandbox, command);
+}

--- a/packages/eve/src/self-modification/git.ts
+++ b/packages/eve/src/self-modification/git.ts
@@ -1,0 +1,72 @@
+import type { SandboxSession } from "eve/sandbox";
+
+import { gitHubGitBrokerNetworkPolicy } from "#shared/git.js";
+
+import { SELF_MODIFICATION_BASELINE_NETWORK_POLICY } from "./network-policy.js";
+
+const MAX_ERROR_OUTPUT = 2_000;
+type CommandSandbox = Pick<SandboxSession, "run">;
+
+export async function withBrokeredGitHubCredential<T>(
+  sandbox: Pick<SandboxSession, "setNetworkPolicy">,
+  token: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  let outcome:
+    | { readonly ok: true; readonly value: T }
+    | { readonly error: unknown; readonly ok: false };
+  try {
+    await sandbox.setNetworkPolicy(gitHubGitBrokerNetworkPolicy(token));
+    outcome = { ok: true, value: await operation() };
+  } catch (error) {
+    outcome = { error, ok: false };
+  }
+
+  try {
+    await sandbox.setNetworkPolicy(SELF_MODIFICATION_BASELINE_NETWORK_POLICY);
+  } catch (revocationError) {
+    throw new Error("Could not revoke the brokered GitHub credential from the sandbox.", {
+      cause: outcome.ok ? revocationError : new AggregateError([outcome.error, revocationError]),
+    });
+  }
+
+  if (!outcome.ok) throw outcome.error;
+  return outcome.value;
+}
+
+export async function gitOutput(
+  sandbox: CommandSandbox,
+  command: string,
+  trim = true,
+): Promise<string> {
+  const result = await sandbox.run({ command });
+  if (result.exitCode !== 0) throw gitCommandError(command, result);
+  const stdout = String(result.stdout ?? "");
+  return trim ? stdout.trim() : stdout;
+}
+
+export async function runGitCommand(sandbox: CommandSandbox, command: string): Promise<void> {
+  const result = await sandbox.run({ command });
+  if (result.exitCode !== 0) throw gitCommandError(command, result);
+}
+
+function gitCommandError(
+  command: string,
+  result: { readonly exitCode: number; readonly stderr?: unknown; readonly stdout?: unknown },
+): Error {
+  const stderr = truncate(String(result.stderr ?? "").trim());
+  const stdout = truncate(String(result.stdout ?? "").trim());
+  return new Error(
+    [
+      `Git command failed with exit ${result.exitCode}: ${command}`,
+      stderr && `stderr: ${stderr}`,
+      stdout && `stdout: ${stdout}`,
+    ]
+      .filter(Boolean)
+      .join("; "),
+  );
+}
+
+function truncate(value: string): string {
+  return value.length <= MAX_ERROR_OUTPUT ? value : `${value.slice(0, MAX_ERROR_OUTPUT)}…`;
+}

--- a/packages/eve/src/self-modification/network-policy.ts
+++ b/packages/eve/src/self-modification/network-policy.ts
@@ -1,0 +1,1 @@
+export const SELF_MODIFICATION_BASELINE_NETWORK_POLICY = "allow-all" as const;

--- a/packages/eve/src/shared/git.test.ts
+++ b/packages/eve/src/shared/git.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  gitHubGitBrokerNetworkPolicy,
+  gitHubRemoteUrl,
+  isFullGitSha,
+  isValidGitRef,
+} from "./git.js";
+
+describe("Git helpers", () => {
+  it("recognizes full object SHAs", () => {
+    expect(isFullGitSha("A".repeat(40))).toBe(true);
+    expect(isFullGitSha("a".repeat(39))).toBe(false);
+  });
+
+  it("rejects unsafe Git refs", () => {
+    expect(isValidGitRef("feature/self-modification")).toBe(true);
+    expect(isValidGitRef("main.lock")).toBe(false);
+    expect(isValidGitRef("main; curl example.com")).toBe(false);
+  });
+
+  it("uses a clean GitHub remote and brokers credentials only at the firewall", () => {
+    expect(gitHubRemoteUrl({ owner: "vercel", repo: "eve" })).toBe(
+      "https://github.com/vercel/eve.git",
+    );
+    const authorization = `Basic ${Buffer.from("x-access-token:secret").toString("base64")}`;
+    expect(gitHubGitBrokerNetworkPolicy("secret")).toEqual({
+      allow: {
+        "*": [],
+        "codeload.github.com": [{ transform: [{ headers: { Authorization: authorization } }] }],
+        "github.com": [{ transform: [{ headers: { Authorization: authorization } }] }],
+      },
+    });
+  });
+});

--- a/packages/eve/src/shared/shell-quote.ts
+++ b/packages/eve/src/shared/shell-quote.ts
@@ -1,0 +1,4 @@
+/** Wraps a value in POSIX single quotes, escaping embedded single quotes. */
+export function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}

--- a/packages/eve/src/shared/vercel-services.ts
+++ b/packages/eve/src/shared/vercel-services.ts
@@ -1,6 +1,8 @@
 import { mkdir, readFile } from "node:fs/promises";
 import { dirname, join, relative } from "node:path";
 
+import { shellQuote } from "#shared/shell-quote.js";
+
 import {
   EVE_INTERNAL_BUILD_OUTPUT_DIRECTORY_ENV,
   EVE_INTERNAL_HOST_BUILD_OUTPUT_DIRECTORY_ENV,
@@ -117,10 +119,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function toPosixRelative(from: string, to: string): string {
   const relativePath = relative(from, to);
   return relativePath.length === 0 ? "." : relativePath.replaceAll("\\", "/");
-}
-
-function quoteShellArgument(value: string): string {
-  return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
 function isNamedServiceConfigArray(
@@ -294,10 +292,10 @@ function createGeneratedServiceBuild(input: {
   const configuredHostOutputDirectory = toPosixRelative(input.appRoot, hostOutputDirectory);
   const buildCommand =
     input.eveBuildCommand ??
-    `node ${quoteShellArgument(toPosixRelative(input.appRoot, resolveEveBinaryPath(input.hostRoot)))} build`;
+    `node ${shellQuote(toPosixRelative(input.appRoot, resolveEveBinaryPath(input.hostRoot)))} build`;
 
   return {
-    buildCommand: `cd ${quoteShellArgument(workingDirectory)} && export ${EVE_INTERNAL_BUILD_OUTPUT_DIRECTORY_ENV}=${quoteShellArgument(configuredOutputDirectory)} && export ${EVE_INTERNAL_HOST_BUILD_OUTPUT_DIRECTORY_ENV}=${quoteShellArgument(configuredHostOutputDirectory)} && ${buildCommand}`,
+    buildCommand: `cd ${shellQuote(workingDirectory)} && export ${EVE_INTERNAL_BUILD_OUTPUT_DIRECTORY_ENV}=${shellQuote(configuredOutputDirectory)} && export ${EVE_INTERNAL_HOST_BUILD_OUTPUT_DIRECTORY_ENV}=${shellQuote(configuredHostOutputDirectory)} && ${buildCommand}`,
     root: toPosixRelative(input.hostRoot, rootDirectory),
     rootDirectory,
   };


### PR DESCRIPTION
### Summary

Production proposals need an isolated checkout without leaving brokered credentials or changing the sandbox's configured egress policy. This PR prepares an immutable target-branch workspace and temporarily injects GitHub credentials through the sandbox firewall. This PR is stacked on #2870.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/self-modification/git-workspace.test.ts src/execution/sandbox/session.test.ts src/execution/sandbox/bindings/vercel.test.ts` (87 tests passed)

### Checklist

- [x] This change was requested or approved by a maintainer
- [ ] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
