### PR TITLE
docs: improve memory provider guide

### DIFF
--- a/docs/memory/overview.mdx
+++ b/docs/memory/overview.mdx
@@ -79,15 +79,15 @@ automatically or only through explicit tool calls.
 ### Supermemory
 
 [Supermemory](https://github.com/supermemoryai/eve-supermemory#readme) is a
-hosted memory service with an eve provider. It recalls relevant context before
-each turn, captures completed turns automatically, and gives the model tools to
-search, remember, forget, and extract sources.
+long-term memory platform that adds persistent, self-growing memory to eve
+agents. It automatically captures completed turns and retrieves relevant context
+through semantic search. Add it from the eve registry:
 
 ```bash
 eve add memory/supermemory
 ```
 
-The command installs `@supermemory/eve` and writes a `supermemory` slot:
+This scaffolds a memory slot that you can customize:
 
 ```ts title="agent/memory/supermemory.ts"
 import supermemory from "@supermemory/eve";
@@ -103,10 +103,8 @@ export default defineMemory({
 });
 ```
 
-Set `SUPERMEMORY_API_KEY` in the agent's environment. The provider sends
-conversation content and extracted sources to Supermemory, so review its
-retention and data handling before enabling it for sensitive data. See the
-[Supermemory integration page](/integrations/supermemory) for provider options.
+See the [Supermemory provider documentation](/integrations/supermemory) for
+full setup and configuration.
 
 ### File memory
 


### PR DESCRIPTION
### Summary

Improves the Memory guide’s Supermemory introduction with an actionable registry quick start. Complete installation and configuration guidance remains on the Supermemory integration page.

### Validation

Ran `pnpm docs:check`.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+6 / -8`

Updates the provider overview without changing framework behavior.

**Implementation** — 0 files · `+0 / -0`

Not applicable.

**Tests** — 0 files · `+0 / -0`

Not applicable.
