### PR TITLE
fix(eve): surface MCP channel invocation failure context

### DIFF
--- a/.changeset/sanitized-mcp-invocation-failures.md
+++ b/.changeset/sanitized-mcp-invocation-failures.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Expose workflow run and Vercel deployment references for failed MCP invocations instead of opaque workflow error payloads.

--- a/packages/eve/src/internal/invocation/workflow-execution.test.ts
+++ b/packages/eve/src/internal/invocation/workflow-execution.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { SessionAuthContext } from "#channel/types.js";
 import { INTERNAL_CHANNEL_DELIVER } from "#channel/channel-operations.js";
@@ -41,6 +41,10 @@ const deliver = vi.fn();
 const from = vi.fn(() => ({ [INTERNAL_CHANNEL_DELIVER]: deliver }) as never);
 
 describe("WorkflowAgentInvocationExecution", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     getReadable.mockReturnValue(eventStream([]));
@@ -421,6 +425,134 @@ describe("WorkflowAgentInvocationExecution", () => {
     expect(getReadable).not.toHaveBeenCalled();
   });
 
+  it("projects the workflow run reference without private error data", async () => {
+    const privateError = Object.assign(new Error("private provider detail"), {
+      apiKey: "secret",
+    });
+    runsGet.mockResolvedValue(run({ error: privateError, status: "failed" }));
+    getReadable.mockReturnValue(
+      eventStream([
+        {
+          type: "session.failed",
+          data: {
+            code: "MODEL_CALL_FAILED",
+            details: {
+              errorId: "err_123",
+              hint: "Try again shortly.",
+              message: "AI Gateway rate-limited the request.",
+              name: "AI Gateway rate limit exceeded",
+              semanticErrorId: "gateway-rate-limited",
+              upstreamMessage: "private provider detail",
+            },
+            message: "AI Gateway rate-limited the request.",
+            sessionId: "wrun_invocation",
+          },
+          meta: { at: "2026-07-20T00:00:00.000Z", id: "event_1" },
+        } as HandleMessageStreamEvent,
+      ]),
+    );
+
+    await expect(execution().read({ auth, invocationId: "wrun_invocation" })).resolves.toEqual({
+      createdAt: "2026-07-20T00:00:00.000Z",
+      error: {
+        code: -32603,
+        data: {
+          errorId: "err_123",
+          eveCode: "MODEL_CALL_FAILED",
+          hint: "Try again shortly.",
+          name: "AI Gateway rate limit exceeded",
+          runId: "wrun_invocation",
+          semanticErrorId: "gateway-rate-limited",
+        },
+        message: "AI Gateway rate-limited the request.",
+      },
+      invocationId: "wrun_invocation",
+      status: "failed",
+    });
+  });
+
+  it("projects a bounded unknown failure message and correlation id", async () => {
+    runsGet.mockResolvedValue(run({ status: "failed" }));
+    getReadable.mockReturnValue(
+      eventStream([
+        {
+          type: "session.failed",
+          data: {
+            code: "MODEL_CALL_FAILED",
+            details: { errorId: "err_unknown", upstreamMessage: "private provider detail" },
+            message: "private provider detail",
+            sessionId: "wrun_invocation",
+          },
+          meta: { at: "2026-07-20T00:00:00.000Z", id: "event_1" },
+        } as HandleMessageStreamEvent,
+      ]),
+    );
+
+    await expect(
+      execution().read({ auth, invocationId: "wrun_invocation" }),
+    ).resolves.toMatchObject({
+      error: {
+        data: {
+          errorId: "err_unknown",
+          eveCode: "MODEL_CALL_FAILED",
+          runId: "wrun_invocation",
+        },
+        message: "private provider detail",
+      },
+      status: "failed",
+    });
+  });
+
+  it("truncates an unknown failure message to Slack's display bound", async () => {
+    const message = "x".repeat(200);
+    runsGet.mockResolvedValue(run({ status: "failed" }));
+    getReadable.mockReturnValue(
+      eventStream([
+        {
+          type: "session.failed",
+          data: { code: "MODEL_CALL_FAILED", message, sessionId: "wrun_invocation" },
+          meta: { at: "2026-07-20T00:00:00.000Z", id: "event_1" },
+        } as HandleMessageStreamEvent,
+      ]),
+    );
+
+    const invocation = await execution().read({ auth, invocationId: "wrun_invocation" });
+    expect(invocation?.status === "failed" ? invocation.error.message : undefined).toBe(
+      `${"x".repeat(159)}…`,
+    );
+  });
+
+  it("includes the Vercel deployment reference only on Vercel", async () => {
+    vi.stubEnv("VERCEL", "1");
+    vi.stubEnv("VERCEL_DEPLOYMENT_ID", "dpl_123");
+    runsGet.mockResolvedValue(run({ status: "failed" }));
+
+    await expect(
+      execution().read({ auth, invocationId: "wrun_invocation" }),
+    ).resolves.toMatchObject({
+      error: {
+        data: { runId: "wrun_invocation", vercelDeploymentId: "dpl_123" },
+        message: "Invocation failed.",
+      },
+      status: "failed",
+    });
+  });
+
+  it("keeps terminal failures generic when no failure event was persisted", async () => {
+    runsGet.mockResolvedValue(run({ status: "failed" }));
+
+    await expect(
+      execution().read({ auth, invocationId: "wrun_invocation" }),
+    ).resolves.toMatchObject({
+      error: {
+        code: -32603,
+        data: { runId: "wrun_invocation" },
+        message: "Invocation failed.",
+      },
+      status: "failed",
+    });
+  });
+
   it("terminally cancels the workflow run", async () => {
     runsGet
       .mockResolvedValueOnce(run({ status: "running" }))
@@ -438,7 +570,7 @@ function execution(): WorkflowAgentInvocationExecution {
   return new WorkflowAgentInvocationExecution({ createSession, from });
 }
 
-function run(input: { ownerKey?: string; status: string }) {
+function run(input: { error?: unknown; ownerKey?: string; status: string }) {
   const attributes: Record<string, string> = {
     "$eve.invocation_owner": input.ownerKey ?? invocationOwnerKey(auth),
     "$eve.invocation_token": "invocation:token",
@@ -446,6 +578,7 @@ function run(input: { ownerKey?: string; status: string }) {
   return {
     attributes,
     createdAt: new Date("2026-07-20T00:00:00.000Z"),
+    error: input.error,
     input: [{ serializedContext: { "eve.initiatorAuth": auth } }],
     runId: "wrun_invocation",
     status: input.status,

--- a/packages/eve/src/internal/invocation/workflow-execution.ts
+++ b/packages/eve/src/internal/invocation/workflow-execution.ts
@@ -73,7 +73,9 @@ export class WorkflowAgentInvocationExecution {
     if (run === undefined) return undefined;
 
     if (isTerminalRunStatus(run.status)) {
-      return await terminalInvocation(run);
+      const events =
+        run.status === "failed" ? await readRecentPersistedEvents(input.invocationId) : [];
+      return await terminalInvocation(run, events);
     }
     const events = await readRecentPersistedEvents(input.invocationId);
     return projectNonterminal(
@@ -289,13 +291,16 @@ function projectNonterminal(
   return { ...base, pollAfterMs: 1_000, status: "working" };
 }
 
-async function terminalInvocation(run: {
-  readonly createdAt: Date;
-  readonly error?: unknown;
-  readonly expiredAt?: Date;
-  readonly runId: string;
-  readonly status: string;
-}): Promise<AgentInvocation> {
+async function terminalInvocation(
+  run: {
+    readonly createdAt: Date;
+    readonly error?: unknown;
+    readonly expiredAt?: Date;
+    readonly runId: string;
+    readonly status: string;
+  },
+  events: readonly HandleMessageStreamEvent[],
+): Promise<AgentInvocation> {
   const base = {
     createdAt: run.createdAt.toISOString(),
     expiresAt: run.expiredAt?.toISOString(),
@@ -305,7 +310,7 @@ async function terminalInvocation(run: {
   if (run.status === "failed") {
     return {
       ...base,
-      error: { code: -32603, data: safeJson(run.error), message: errorMessage(run.error) },
+      error: publicInvocationFailure(run.runId, events),
       status: "failed",
     };
   }
@@ -329,8 +334,99 @@ function safeJson(value: unknown): JsonValue {
   }
 }
 
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : "Session failed.";
+function publicInvocationFailure(
+  runId: string,
+  events: readonly HandleMessageStreamEvent[],
+): Extract<AgentInvocation, { readonly status: "failed" }>["error"] {
+  const event = [...events].reverse().find((candidate) => candidate.type === "session.failed");
+  const data: Record<string, string> = { runId };
+  if (event !== undefined) data.eveCode = event.data.code;
+
+  const deploymentId = vercelDeploymentId();
+  if (deploymentId !== undefined) data.vercelDeploymentId = deploymentId;
+  if (typeof event?.data.details?.errorId === "string") data.errorId = event.data.details.errorId;
+
+  const semantic = event === undefined ? null : semanticFailure(event.data);
+  if (semantic === null) {
+    const fallback = event === undefined ? null : fallbackFailure(event.data);
+    if (fallback === null) return { code: -32603, data, message: "Invocation failed." };
+    if (fallback.name !== undefined) data.name = fallback.name;
+    return { code: -32603, data, message: fallback.message };
+  }
+
+  data.semanticErrorId = semantic.id;
+  data.name = semantic.name;
+  if (semantic.hint !== undefined) data.hint = semantic.hint;
+  return { code: -32603, data, message: semantic.message };
+}
+
+function semanticFailure(
+  event: Extract<HandleMessageStreamEvent, { type: "session.failed" }>["data"],
+): {
+  readonly hint?: string;
+  readonly id: string;
+  readonly message: string;
+  readonly name: string;
+} | null {
+  const details = event.details;
+  if (
+    typeof details?.semanticErrorId !== "string" ||
+    details.semanticErrorId.trim().length === 0 ||
+    typeof details.name !== "string" ||
+    details.name.trim().length === 0
+  ) {
+    return null;
+  }
+
+  const message =
+    typeof details.message === "string" && details.message.trim().length > 0
+      ? details.message.trim()
+      : event.message.trim();
+  if (message.length === 0) return null;
+
+  const hint =
+    typeof details.hint === "string" && details.hint.trim().length > 0
+      ? details.hint.trim()
+      : undefined;
+  const summary: {
+    hint?: string;
+    id: string;
+    message: string;
+    name: string;
+  } = {
+    id: details.semanticErrorId,
+    message,
+    name: details.name,
+  };
+  if (hint !== undefined) summary.hint = hint;
+  return summary;
+}
+
+function fallbackFailure(
+  event: Extract<HandleMessageStreamEvent, { type: "session.failed" }>["data"],
+): {
+  readonly message: string;
+  readonly name?: string;
+} | null {
+  const message = event.message.trim();
+  const name = typeof event.details?.name === "string" ? event.details.name.trim() : "";
+  if (message.length === 0 && name.length === 0) return null;
+  const fallback: { message: string; name?: string } = {
+    message: message.length === 0 ? name : truncateForDisplay(message),
+  };
+  if (name.length > 0) fallback.name = name;
+  return fallback;
+}
+
+function truncateForDisplay(value: string, maxChars = 160): string {
+  if (value.length <= maxChars) return value;
+  return `${value.slice(0, maxChars - 1).trimEnd()}…`;
+}
+
+function vercelDeploymentId(): string | undefined {
+  if (process.env.VERCEL !== "1") return undefined;
+  const deploymentId = process.env.VERCEL_DEPLOYMENT_ID?.trim();
+  return deploymentId && deploymentId.length > 0 ? deploymentId : undefined;
 }
 
 function conflict(message: string): AgentInvocationMutationResult {


### PR DESCRIPTION
### Summary

Mirrors the Slack channel failure policy for durable MCP invocations. `agent_get` now reads the terminal `session.failed` event rather than returning the opaque encrypted workflow error: cataloged failures expose Eve-curated name, message, and remediation; other failures expose only the bounded terminal message and optional name.

All failures include the workflow run ID and correlation ID when available. Vercel deployments additionally report the deployment ID, allowing operators to locate the relevant runtime logs without requiring Eve to construct or expose a dashboard URL. Raw diagnostic details, provider payloads, stack traces, and encrypted workflow data remain private.

### Validation

Focused invocation coverage exercises cataloged failures, unknown failures, message truncation, missing terminal events, and Vercel deployment detection (18 tests). The framework invariant guard and package type checking pass.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the required patch changeset.

**Implementation** — 1 file · `+107 / -11`

Keeps failure projection at the durable-invocation boundary, reusing the terminal failure event that other channels consume while adding MCP run and Vercel deployment references.

**Tests** — 1 file · `+135 / -2`

Covers semantic and unknown failure projections, privacy boundaries, truncation, missing events, and Vercel-only metadata.
