### PR TITLE
refactor(eve): share Gateway model catalog parsing

### DIFF
--- a/.changeset/shared-gateway-model-catalog.md
+++ b/.changeset/shared-gateway-model-catalog.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+`eve/self-modification` now uses the same AI Gateway model catalog validation as `/model`.

--- a/packages/eve/src/self-modification/extension/tools/search_models.ts
+++ b/packages/eve/src/self-modification/extension/tools/search_models.ts
@@ -1,7 +1,11 @@
 import { defineTool } from "eve/tools";
 
-const AI_GATEWAY_MODELS_URL = "https://ai-gateway.vercel.sh/v1/models";
-const DEFAULT_AGENT_MODEL_ID = "openai/gpt-5.6-luna-fast";
+import { AI_GATEWAY_MODELS_URL } from "#internal/gateway.js";
+import { DEFAULT_AGENT_MODEL_ID } from "#shared/default-agent-model.js";
+import {
+  parseGatewayModelCatalog,
+  type GatewayCatalogModel,
+} from "#shared/gateway-model-catalog.js";
 const FETCH_TIMEOUT_MS = 5_000;
 const MAX_RESULTS = 20;
 
@@ -40,35 +44,13 @@ const outputSchema = {
   required: ["models"],
 } as const;
 
-interface GatewayModel {
-  readonly id: string;
-  readonly name: string;
-  readonly tags: readonly string[];
-  readonly type: string;
-}
-
-export function parseGatewayModels(value: unknown): GatewayModel[] {
-  if (typeof value !== "object" || value === null || !("data" in value)) {
-    throw new Error("AI Gateway returned an invalid model catalog.");
-  }
-  const { data } = value;
-  if (!Array.isArray(data)) throw new Error("AI Gateway returned an invalid model catalog.");
-
-  return data.flatMap((entry) => {
-    if (typeof entry !== "object" || entry === null) return [];
-    const { id, name, tags, type } = entry;
-    if (typeof id !== "string" || typeof name !== "string" || typeof type !== "string") return [];
-    return [{ id, name, tags: Array.isArray(tags) ? tags.filter(isString) : [], type }];
-  });
-}
-
-export function searchGatewayModels(models: readonly GatewayModel[], query: string) {
+export function searchGatewayModels(models: readonly GatewayCatalogModel[], query: string) {
   const needle = query.trim().toLowerCase();
   return models
     .filter(
       (model) =>
         model.type === "language" &&
-        (model.id === DEFAULT_AGENT_MODEL_ID || model.tags.includes("web-search")) &&
+        (model.id === DEFAULT_AGENT_MODEL_ID || model.tags?.includes("web-search")) &&
         (model.id.toLowerCase().includes(needle) || model.name.toLowerCase().includes(needle)),
     )
     .slice(0, MAX_RESULTS)
@@ -95,14 +77,10 @@ export default defineTool({
         throw new Error(`AI Gateway model catalog request failed (${response.status}).`);
       }
       return {
-        models: searchGatewayModels(parseGatewayModels(await response.json()), input.query),
+        models: searchGatewayModels(parseGatewayModelCatalog(await response.json()), input.query),
       };
     } finally {
       clearTimeout(timeout);
     }
   },
 });
-
-function isString(value: unknown): value is string {
-  return typeof value === "string";
-}

--- a/packages/eve/src/self-modification/search-models.test.ts
+++ b/packages/eve/src/self-modification/search-models.test.ts
@@ -1,33 +1,36 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import searchModels, {
-  parseGatewayModels,
-  searchGatewayModels,
-} from "./extension/tools/search_models.js";
+import { parseGatewayModelCatalog } from "#shared/gateway-model-catalog.js";
+
+import searchModels, { searchGatewayModels } from "./extension/tools/search_models.js";
 
 const CATALOG = {
   data: [
     {
       id: "openai/gpt-5.6-sol",
       name: "GPT-5.6 Sol",
+      owned_by: "openai",
       tags: ["web-search"],
       type: "language",
     },
     {
       id: "openai/gpt-5.6-terra",
       name: "GPT-5.6 Terra",
+      owned_by: "openai",
       tags: ["web-search"],
       type: "language",
     },
     {
       id: "openai/gpt-5.6-luna-fast",
       name: "GPT-5.6 Luna Fast",
+      owned_by: "openai",
       tags: [],
       type: "language",
     },
     {
       id: "openai/gpt-image-1",
       name: "GPT Image",
+      owned_by: "openai",
       tags: ["web-search"],
       type: "image",
     },
@@ -38,24 +41,24 @@ afterEach(() => vi.unstubAllGlobals());
 
 describe("searchGatewayModels", () => {
   it("matches abbreviated model IDs from the /model catalog", () => {
-    expect(searchGatewayModels(parseGatewayModels(CATALOG), "sol")).toEqual([
+    expect(searchGatewayModels(parseGatewayModelCatalog(CATALOG), "sol")).toEqual([
       { id: "openai/gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai" },
     ]);
   });
 
   it("uses the same language-model eligibility as /model", () => {
-    expect(searchGatewayModels(parseGatewayModels(CATALOG), "luna")).toEqual([
+    expect(searchGatewayModels(parseGatewayModelCatalog(CATALOG), "luna")).toEqual([
       {
         id: "openai/gpt-5.6-luna-fast",
         name: "GPT-5.6 Luna Fast",
         provider: "openai",
       },
     ]);
-    expect(searchGatewayModels(parseGatewayModels(CATALOG), "image")).toEqual([]);
+    expect(searchGatewayModels(parseGatewayModelCatalog(CATALOG), "image")).toEqual([]);
   });
 
   it("rejects a malformed catalog", () => {
-    expect(() => parseGatewayModels({ models: [] })).toThrow("invalid model catalog");
+    expect(() => parseGatewayModelCatalog({ models: [] })).toThrow("invalid model catalog");
   });
 });
 

--- a/packages/eve/src/setup/boxes/select-model.ts
+++ b/packages/eve/src/setup/boxes/select-model.ts
@@ -1,6 +1,9 @@
-import { z } from "#compiled/zod/index.js";
 import { AI_GATEWAY_MODELS_URL, vercelGatewayFetch } from "#internal/gateway.js";
 import { DEFAULT_AGENT_MODEL_ID } from "#shared/default-agent-model.js";
+import {
+  parseGatewayModelCatalog,
+  type GatewayCatalogModel,
+} from "#shared/gateway-model-catalog.js";
 
 import { select, type Asker, type SelectOption } from "../ask.js";
 import type { SetupState } from "../state.js";
@@ -9,30 +12,7 @@ const FETCH_TIMEOUT_MS = 5000;
 const WEB_SEARCH_TAG = "web-search";
 const MODEL_PROMPT_MESSAGE = "Which model should your agent use?";
 
-const gatewayCatalogModelSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  type: z.string(),
-  owned_by: z.string(),
-  /** Public release timestamp in Unix seconds. Missing values sort last. */
-  released: z.number().finite().optional().catch(undefined),
-  tags: z.array(z.string()).optional().catch(undefined),
-  /** Per-tier pricing; the `service_tiers` keys reveal Fast mode (priority) support. */
-  pricing: z
-    .object({ service_tiers: z.record(z.string(), z.unknown()).optional().catch(undefined) })
-    .optional()
-    .catch(undefined),
-});
-
-const gatewayCatalogSchema = z.object({ data: z.array(z.unknown()) }).transform(({ data }) =>
-  data.flatMap((entry) => {
-    const result = gatewayCatalogModelSchema.safeParse(entry);
-    return result.success ? [result.data] : [];
-  }),
-);
-
-/** One model entry from the AI Gateway catalog response. */
-export type GatewayCatalogModel = z.infer<typeof gatewayCatalogModelSchema>;
+export type { GatewayCatalogModel } from "#shared/gateway-model-catalog.js";
 
 function modelOption(
   value: string,
@@ -85,24 +65,13 @@ export async function fetchGatewayCatalog(signal?: AbortSignal): Promise<Gateway
       signal === undefined ? controller.signal : AbortSignal.any([signal, controller.signal]);
     const res = await vercelGatewayFetch(AI_GATEWAY_MODELS_URL, { signal: requestSignal });
     if (!res.ok) throw new Error(`AI Gateway model catalog request failed (${res.status}).`);
-    return parseGatewayCatalog(await res.json());
+    return parseGatewayModelCatalog(await res.json());
   } finally {
     clearTimeout(timeout);
   }
 }
 
-/**
- * Validates a Gateway catalog response. A malformed payload throws (the
- * picker then falls back to the static shortlist), but a malformed entry is
- * skipped: one experimental entry shape must not take down the whole catalog.
- */
-export function parseGatewayCatalog(input: unknown): GatewayCatalogModel[] {
-  const result = gatewayCatalogSchema.safeParse(input);
-  if (!result.success) {
-    throw new Error("AI Gateway returned an invalid model catalog.");
-  }
-  return result.data;
-}
+export { parseGatewayModelCatalog as parseGatewayCatalog } from "#shared/gateway-model-catalog.js";
 
 /** Position in the curated shortlist, or its length for everything else. */
 function featuredPriority(id: string): number {

--- a/packages/eve/src/shared/gateway-model-catalog.ts
+++ b/packages/eve/src/shared/gateway-model-catalog.ts
@@ -1,0 +1,37 @@
+import { z } from "#compiled/zod/index.js";
+
+const gatewayCatalogModelSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  type: z.string(),
+  owned_by: z.string(),
+  released: z.number().finite().optional().catch(undefined),
+  tags: z.array(z.string()).optional().catch(undefined),
+  pricing: z
+    .object({ service_tiers: z.record(z.string(), z.unknown()).optional().catch(undefined) })
+    .optional()
+    .catch(undefined),
+});
+
+const gatewayCatalogSchema = z.object({ data: z.array(z.unknown()) }).transform(({ data }) =>
+  data.flatMap((entry) => {
+    const result = gatewayCatalogModelSchema.safeParse(entry);
+    return result.success ? [result.data] : [];
+  }),
+);
+
+/** One model entry from the AI Gateway catalog response. */
+export type GatewayCatalogModel = z.infer<typeof gatewayCatalogModelSchema>;
+
+/**
+ * Validates a Gateway catalog response. A malformed payload throws, but a
+ * malformed entry is skipped so one experimental entry shape cannot discard
+ * the rest of the catalog.
+ */
+export function parseGatewayModelCatalog(input: unknown): GatewayCatalogModel[] {
+  const result = gatewayCatalogSchema.safeParse(input);
+  if (!result.success) {
+    throw new Error("AI Gateway returned an invalid model catalog.");
+  }
+  return result.data;
+}


### PR DESCRIPTION
### Summary

The self-modification model-search tool is already on `main` after the package move. This PR now shares its AI Gateway model-listing parser with `/model`, so both surfaces validate catalog entries and derive their model shape consistently.

### Validation

Focused `/model` and self-modification model-search coverage passed (18 tests), along with `pnpm --filter eve typecheck` and `pnpm --filter eve build`.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Records the patch release note for the shared catalog validation.

**Implementation** — 3 files · `+53 / -69`

A small shared parser replaces duplicate catalog-validation code in the setup picker and bundled self-modification tool.

**Tests** — 1 file · `+11 / -8`

Updates self-modification coverage to exercise the shared parser while preserving model-search behavior.
