### PR TITLE
fix(eve): containers - use local VCR login action

### DIFF
--- a/.github/actions/vcr-login/LICENSE
+++ b/.github/actions/vcr-login/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Vercel, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.github/actions/vcr-login/action.yml
+++ b/.github/actions/vcr-login/action.yml
@@ -1,0 +1,13 @@
+name: "Log in to Vercel Container Registry"
+description: "Log Docker in to VCR with a GitHub Actions OIDC token."
+
+inputs:
+  team:
+    description: "Vercel team ID (team_xxxxxxxx)."
+    required: true
+
+runs:
+  using: "node24"
+  main: "main.mjs"
+  post: "post.mjs"
+  post-if: "always()"

--- a/.github/actions/vcr-login/lib.mjs
+++ b/.github/actions/vcr-login/lib.mjs
@@ -1,0 +1,11 @@
+export const registry = "vcr.vercel.com";
+export const vercelApi = process.env.VERCEL_API_ORIGIN || "https://api.vercel.com";
+export const vcrAppId = "cl_inrfNy8noLlhRrGbPEm0z47woXNcJVZ0";
+
+export function command(name, value) {
+  const escaped = String(value)
+    .replaceAll("%", "%25")
+    .replaceAll("\r", "%0D")
+    .replaceAll("\n", "%0A");
+  process.stdout.write(`::${name}::${escaped}\n`);
+}

--- a/.github/actions/vcr-login/main.mjs
+++ b/.github/actions/vcr-login/main.mjs
@@ -1,0 +1,125 @@
+import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { appendFileSync } from "node:fs";
+import { command, registry, vcrAppId, vercelApi } from "./lib.mjs";
+
+async function main() {
+  const team = getInput("team");
+  if (!team.startsWith("team_")) {
+    command("warning", `The team input ("${team}") does not look like a Vercel team ID.`);
+  }
+
+  const githubOidcToken = await requestGithubOidcToken();
+  const vercelToken = await exchangeToken(team, githubOidcToken);
+  command("add-mask", vercelToken);
+  saveState("accessToken", vercelToken);
+
+  const result = spawnSync("docker", ["login", "--username", team, "--password-stdin", registry], {
+    input: Buffer.from(vercelToken),
+    stdio: ["pipe", "inherit", "inherit"],
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(`docker login exited with status ${result.status}.`);
+  }
+
+  saveState("loggedIn", "true");
+  console.log(`Logged Docker in to ${registry}.`);
+}
+
+function getInput(name) {
+  const value = process.env[`INPUT_${name.toUpperCase()}`]?.trim();
+  if (!value) {
+    throw new Error(`Input required and not supplied: ${name}`);
+  }
+  return value;
+}
+
+async function requestGithubOidcToken() {
+  const requestUrl = process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
+  const requestToken = process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
+  if (!requestUrl || !requestToken) {
+    throw new Error(
+      'Unable to request the GitHub OIDC token. Add "permissions: id-token: write" to the job.',
+    );
+  }
+
+  const response = await fetch(requestUrl, {
+    headers: { Authorization: `bearer ${requestToken}` },
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub OIDC token request failed with HTTP ${response.status}.`);
+  }
+
+  const json = await response.json();
+  if (typeof json.value !== "string" || !json.value) {
+    throw new Error("GitHub OIDC response did not include a token.");
+  }
+  return json.value;
+}
+
+async function exchangeToken(team, githubOidcToken) {
+  const body = new URLSearchParams({
+    grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+    client_id: vcrAppId,
+    subject_token_type: "urn:ietf:params:oauth:token-type:id_token",
+    requested_token_type: "urn:ietf:params:oauth:token-type:access_token",
+    team_id_or_slug: team,
+    subject_token: githubOidcToken,
+  });
+
+  let lastError = "";
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      const response = await fetch(`${vercelApi}/login/oauth/token`, {
+        method: "POST",
+        body,
+        signal: AbortSignal.timeout(30_000),
+      });
+      if (response.ok) {
+        const json = await response.json().catch(() => ({}));
+        if (typeof json.access_token === "string" && json.access_token) {
+          return json.access_token;
+        }
+        lastError = "response did not include an access_token";
+        break;
+      }
+
+      lastError = `HTTP ${response.status}: ${await response.text().catch(() => "")}`;
+      if (response.status !== 429 && response.status < 500) {
+        break;
+      }
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+
+    if (attempt < 3) {
+      await new Promise((resolve) => setTimeout(resolve, 1_000 * attempt));
+    }
+  }
+
+  throw new Error(
+    "Token exchange with Vercel failed. Check that the team's OIDC policy " +
+      `matches this repository and workflow. (${lastError})`,
+  );
+}
+
+function saveState(name, value) {
+  const stateFile = process.env.GITHUB_STATE;
+  if (!stateFile) {
+    throw new Error("GITHUB_STATE is not available.");
+  }
+  const delimiter = `ghadelimiter_${randomUUID()}`;
+  if (String(value).includes(delimiter)) {
+    throw new Error(`State value for ${name} contains the generated delimiter.`);
+  }
+  appendFileSync(stateFile, `${name}<<${delimiter}\n${value}\n${delimiter}\n`, "utf8");
+}
+
+main().catch((error) => {
+  command("error", error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/.github/actions/vcr-login/post.mjs
+++ b/.github/actions/vcr-login/post.mjs
@@ -1,0 +1,46 @@
+import { spawnSync } from "node:child_process";
+import { command, registry, vcrAppId, vercelApi } from "./lib.mjs";
+
+async function post() {
+  if (process.env.STATE_loggedIn === "true") {
+    const result = spawnSync("docker", ["logout", registry], {
+      stdio: "inherit",
+    });
+    if (result.error || result.status !== 0) {
+      command("warning", `Docker logout from ${registry} failed.`);
+    }
+  }
+
+  const token = process.env.STATE_accessToken;
+  if (!token) {
+    return;
+  }
+  command("add-mask", token);
+
+  try {
+    const response = await fetch(`${vercelApi}/login/oauth/token/revoke`, {
+      method: "POST",
+      body: new URLSearchParams({
+        client_id: vcrAppId,
+        token,
+        token_type_hint: "access_token",
+      }),
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!response.ok) {
+      command(
+        "warning",
+        `Failed to revoke the Vercel access token (HTTP ${response.status}). It will remain valid until it expires.`,
+      );
+      return;
+    }
+    console.log("Revoked the Vercel access token.");
+  } catch (error) {
+    command(
+      "warning",
+      `Failed to revoke the Vercel access token (${error instanceof Error ? error.message : error}). It will remain valid until it expires.`,
+    );
+  }
+}
+
+post();

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,8 @@ jobs:
 
       - name: Log in to Vercel Container Registry
         if: github.ref == 'refs/heads/main'
-        uses: vercel/vcr-login-action@9340c52f6b68b4758d9d2eebbd4c52b36e66f7f3 # main
+        # Public workflows cannot resolve the upstream action while its repository is private.
+        uses: ./.github/actions/vcr-login
         with:
           team: ${{ secrets.VCR_TEAM_ID }}
 


### PR DESCRIPTION
### Summary

The release workflow fails during job setup because the public `vercel/eve` repository cannot resolve the private `vercel/vcr-login-action` repository, so neither the image nor npm packages can publish. This adds a Docker-only local adaptation of the action that requests GitHub OIDC, exchanges it for a short-lived VCR token, and logs out and revokes the token after the job. It continues using `VCR_TEAM_ID`, preserves VCR publishing before the Changesets npm step, and can be replaced with the upstream action once that repository is public.

### Validation

Simulated the complete lifecycle against mock GitHub OIDC and Vercel token endpoints plus a fake Docker executable, confirming the exchange request, stdin login, saved cleanup state, logout, and revocation. A real OIDC policy match and VCR push can only execute from the release workflow after merge because publishing is restricted to `main`.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+21 / -0`

Includes the upstream MIT license required by the local adaptation.

**Implementation** — 5 files · `+197 / -1`

Adds the narrowly scoped local OIDC login action and switches the release workflow to invoke it without changing image tags or release ordering.

**Tests** — 0 files · `+0 / -0`

No committed test files; the workflow-specific lifecycle was exercised with local mocks.
