### PR TITLE
[4/5] feat(eve): publish tool rendering state

### DIFF
--- a/.changeset/structured-activity-state.md
+++ b/.changeset/structured-activity-state.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Allow tools to project successful output as renderer-owned structured activity state. The built-in `todo` tool now exposes its current item list through the same generic state projection.

--- a/docs/tools/overview.mdx
+++ b/docs/tools/overview.mdx
@@ -58,7 +58,7 @@ Provided tools define labels for `bash`, `glob`, `grep`, `load_skill`, `read_fil
 
 ### Project structured activity state
 
-Return `renderingState` from `label.complete` when a successful tool result should replace structured state that a channel renderer can present. The state key identifies the renderer contract; eve stores the projected JSON value without interpreting its schema:
+Return `renderingState` from `label.complete` when a successful tool result should replace structured state that a channel renderer can present. eve keys the state by the path-derived tool name and stores the projected JSON value without interpreting its schema:
 
 ```ts title="agent/tools/project_plan.ts"
 import { defineTool } from "eve/tools";
@@ -76,7 +76,7 @@ export default defineTool({
   label: {
     start: () => "Update project plan",
     complete: (_input, output) => ({
-      renderingState: { key: "project-plan", value: output.tasks },
+      renderingState: output.tasks,
     }),
   },
   execute({ tasks }) {

--- a/docs/tools/overview.mdx
+++ b/docs/tools/overview.mdx
@@ -58,7 +58,7 @@ Provided tools define labels for `bash`, `glob`, `grep`, `load_skill`, `read_fil
 
 ### Project structured activity state
 
-Use `activity.state` when a successful tool result should replace structured state that a channel renderer can present. The state key identifies the renderer contract; eve stores the projected JSON value without interpreting its schema:
+Return `renderingState` from `label.complete` when a successful tool result should replace structured state that a channel renderer can present. The state key identifies the renderer contract; eve stores the projected JSON value without interpreting its schema:
 
 ```ts title="agent/tools/project_plan.ts"
 import { defineTool } from "eve/tools";
@@ -73,12 +73,11 @@ export default defineTool({
   description: "Replace the current project plan.",
   inputSchema: z.object({ tasks: z.array(taskSchema) }),
   outputSchema: z.object({ tasks: z.array(taskSchema) }),
-  activity: {
-    label: () => "Update project plan",
-    state: {
-      key: "project-plan",
-      project: (output) => output.tasks,
-    },
+  label: {
+    start: () => "Update project plan",
+    complete: (_input, output) => ({
+      renderingState: { key: "project-plan", value: output.tasks },
+    }),
   },
   execute({ tasks }) {
     return { tasks };
@@ -133,8 +132,7 @@ action complete.
 eve normalizes and bounds projected text before rendering it. If either
 callback throws or returns an empty string, eve keeps the existing activity
 label. `label.complete` does not run for failed or rejected tool calls. The
-full values remain available in `action.partial` and `action.result`; renderers
-receive only the projected text.
+full values remain available in `action.partial` and `action.result`; renderers receive only the projected label and optional rendering state.
 
 ### Background execution
 

--- a/docs/tools/overview.mdx
+++ b/docs/tools/overview.mdx
@@ -54,7 +54,43 @@ export default defineTool({
 
 The label is presentation only. It does not replace the path-derived tool name, enter model input, or change execution. eve records the bounded label on the corresponding public action event so activity renderers and other authorized stream consumers can use it without interpreting raw tool data. Built-in channel activity can show `Deploy storefront to production` instead of `deploy`; if the callback throws or returns an empty label, activity falls back to the tool name.
 
-Provided tools define labels for `bash`, `glob`, `grep`, `load_skill`, `read_file`, `web_fetch`, `web_search`, and `write_file`.
+Provided tools define labels for `bash`, `glob`, `grep`, `load_skill`, `read_file`, `todo`, `web_fetch`, `web_search`, and `write_file`.
+
+### Project structured activity state
+
+Use `activity.state` when a successful tool result should replace structured state that a channel renderer can present. The state key identifies the renderer contract; eve stores the projected JSON value without interpreting its schema:
+
+```ts title="agent/tools/project_plan.ts"
+import { defineTool } from "eve/tools";
+import { z } from "zod";
+
+const taskSchema = z.object({
+  title: z.string(),
+  status: z.enum(["pending", "in_progress", "completed"]),
+});
+
+export default defineTool({
+  description: "Replace the current project plan.",
+  inputSchema: z.object({ tasks: z.array(taskSchema) }),
+  outputSchema: z.object({ tasks: z.array(taskSchema) }),
+  activity: {
+    label: () => "Update project plan",
+    state: {
+      key: "project-plan",
+      project: (output) => output.tasks,
+    },
+  },
+  execute({ tasks }) {
+    return { tasks };
+  },
+});
+```
+
+The projection runs only for successful final results. A later result with the same key from the same work replaces its previous value. Root and delegated work keep separate publications, so renderers can select root state, group state under each work item, or flatten values that share a key. Each `snapshot.states` entry includes the key, projected value, source tool and action, owning work, and update time. A renderer that does not recognize the key can ignore it.
+
+State projections are explicit because tool results may contain sensitive or large data. eve accepts only bounded JSON values and isolates projection failures from tool execution. The projected state does not enter model history or add a new event to the public session stream; it is derived from the existing durable `action.result` event for activity presentation.
+
+The built-in `todo` tool publishes its item list under the `todo` state key. Other planning tools can publish a different schema and key, or adopt a shared key when their renderer expects the same contract.
 
 ### Stream preliminary tool results
 

--- a/packages/eve/extension-contracts/compatibility/channel/v19.ts
+++ b/packages/eve/extension-contracts/compatibility/channel/v19.ts
@@ -1,0 +1,3 @@
+import { disableRoute } from "#public/channels/index.js";
+
+export default disableRoute();

--- a/packages/eve/extension-contracts/compatibility/connection/v15.ts
+++ b/packages/eve/extension-contracts/compatibility/connection/v15.ts
@@ -1,0 +1,6 @@
+import { defineMcpClientConnection } from "#public/connections/index.js";
+
+export default defineMcpClientConnection({
+  description: "Call-aware MCP service",
+  url: "https://example.com/mcp",
+});

--- a/packages/eve/extension-contracts/compatibility/dynamicInstructions/v18.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicInstructions/v18.ts
@@ -1,0 +1,8 @@
+import { defineDynamic, defineInstructions } from "#public/instructions/index.js";
+
+export default defineDynamic({
+  events: {
+    "session.started": (_event, ctx) =>
+      defineInstructions({ markdown: `Use session ${ctx.session.id} for correlation.` }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/dynamicSkill/v17.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicSkill/v17.ts
@@ -1,0 +1,11 @@
+import { defineDynamic, defineSkill } from "#public/skills/index.js";
+
+export default defineDynamic({
+  events: {
+    "turn.started": (_event, ctx) =>
+      defineSkill({
+        description: `Review session ${ctx.session.id}.`,
+        markdown: "# Review\n\nCheck each claim.",
+      }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/dynamicTool/v31.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicTool/v31.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+import { defineDynamic, defineTool } from "#public/tools/index.js";
+
+export default defineDynamic({
+  events: {
+    "session.started": () =>
+      defineTool({
+        description: "Deploy a project.",
+        inputSchema: z.object({ project: z.string() }),
+        label: { start: ({ project }) => `Deploy ${project}` },
+        execute: ({ project }) => ({ project, status: "deployed" }),
+      }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/hook/v22.ts
+++ b/packages/eve/extension-contracts/compatibility/hook/v22.ts
@@ -1,0 +1,9 @@
+import { defineHook } from "#public/hooks/index.js";
+
+export default defineHook({
+  events: {
+    "subagent.completed"(event, ctx) {
+      console.info(event.data.subagentName, ctx.session.id);
+    },
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/schedule/v11.ts
+++ b/packages/eve/extension-contracts/compatibility/schedule/v11.ts
@@ -1,0 +1,8 @@
+import { defineSchedule } from "#public/schedules/index.js";
+
+export default defineSchedule({
+  cron: "0 0 * * *",
+  run({ waitUntil }) {
+    waitUntil(Promise.resolve());
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/subagent/v10.ts
+++ b/packages/eve/extension-contracts/compatibility/subagent/v10.ts
@@ -1,0 +1,6 @@
+import { defineAgent } from "#public/index.js";
+
+export default defineAgent({
+  description: "Delegate research tasks.",
+  model: "anthropic/claude-sonnet-5",
+});

--- a/packages/eve/extension-contracts/compatibility/tool/v32.ts
+++ b/packages/eve/extension-contracts/compatibility/tool/v32.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+import { defineTool } from "#public/tools/index.js";
+
+export default defineTool({
+  description: "Build a report.",
+  inputSchema: z.object({ project: z.string() }),
+  label: {
+    start: ({ project }) => `Build ${project}`,
+    delta: (_input, partial) => JSON.stringify(partial),
+    complete: (_input, output) => JSON.stringify(output),
+  },
+  async *execute({ project }) {
+    yield { phase: "building", project };
+    return { phase: "complete", project };
+  },
+});

--- a/packages/eve/extension-contracts/reports/channel/v20.json
+++ b/packages/eve/extension-contracts/reports/channel/v20.json
@@ -1,0 +1,21 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "channel",
+  "epoch": 20,
+  "sha256": "326560757b549cc2e6da721228be047e811efcc4def0a6548d66bcff690d5c9a",
+  "exports": [
+    "DELETE",
+    "GET",
+    "HEAD",
+    "OPTIONS",
+    "PATCH",
+    "POST",
+    "PUT",
+    "WS",
+    "createWebSocketUpgradeServer",
+    "defineChannel",
+    "disableRoute",
+    "isChannel",
+    "isDisabledRouteSentinel"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/connection/v16.json
+++ b/packages/eve/extension-contracts/reports/connection/v16.json
@@ -1,0 +1,16 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "connection",
+  "epoch": 16,
+  "sha256": "d82a7889578ad87c57fb25540b28f9815d4039a1394d8adf9144c91dc23db0e0",
+  "exports": [
+    "ConnectionAuthorizationFailedError",
+    "ConnectionAuthorizationRequiredError",
+    "defineDynamic",
+    "defineInteractiveAuthorization",
+    "defineMcpClientConnection",
+    "defineOpenAPIConnection",
+    "isConnectionAuthorizationFailedError",
+    "isConnectionAuthorizationRequiredError"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/dynamicInstructions/v19.json
+++ b/packages/eve/extension-contracts/reports/dynamicInstructions/v19.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicInstructions",
+  "epoch": 19,
+  "sha256": "033fa550f2467584f8fca850d0f04d9bf0d0f73e37c08a602a30eb38816219d2",
+  "exports": ["defineDynamic"]
+}

--- a/packages/eve/extension-contracts/reports/dynamicSkill/v18.json
+++ b/packages/eve/extension-contracts/reports/dynamicSkill/v18.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicSkill",
+  "epoch": 18,
+  "sha256": "a60aeeae29de562680fa0ba45949753b5705635758add2d35ce4fae51aae662d",
+  "exports": ["defineDynamic"]
+}

--- a/packages/eve/extension-contracts/reports/dynamicTool/v32.json
+++ b/packages/eve/extension-contracts/reports/dynamicTool/v32.json
@@ -1,0 +1,13 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicTool",
+  "epoch": 32,
+  "sha256": "4d1f99c7a37c6908cd17a3bf245e10c52f216c1d715a28bbc975e23ec99dcdd2",
+  "exports": [
+    "DynamicToolEntry",
+    "DynamicToolEvents",
+    "DynamicToolResult",
+    "DynamicToolSet",
+    "defineDynamic"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/hook/v23.json
+++ b/packages/eve/extension-contracts/reports/hook/v23.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "hook",
+  "epoch": 23,
+  "sha256": "13d38dbd34808124330d8056091fc20ef0bb2494735bbf60a8984435287dee86",
+  "exports": ["defineHook"]
+}

--- a/packages/eve/extension-contracts/reports/schedule/v12.json
+++ b/packages/eve/extension-contracts/reports/schedule/v12.json
@@ -1,0 +1,14 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "schedule",
+  "epoch": 12,
+  "sha256": "4cec25f5ff07551ba246939229e0bbb1e2c95fda7e83918c05542b53e505a63b",
+  "exports": [
+    "ScheduleDefinition",
+    "ScheduleHandlerArgs",
+    "ScheduleRunHandler",
+    "ScheduleToFn",
+    "TypedReceiveTarget",
+    "defineSchedule"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/subagent/v11.json
+++ b/packages/eve/extension-contracts/reports/subagent/v11.json
@@ -1,0 +1,20 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "subagent",
+  "epoch": 11,
+  "sha256": "5d1b03ea373200ba48695efcbefb9097a70fd7d4779b5d9c4247c75b465a9c0a",
+  "exports": [
+    "AgentCompactionDefinition",
+    "AgentDefinition",
+    "AgentModelDefinition",
+    "AgentStaticModelDefinition",
+    "DefinedAgent",
+    "DynamicLocalSubagentDefinition",
+    "DynamicSubagentDefinition",
+    "RemoteAgentDefinition",
+    "RemoteAgentDefinitionInput",
+    "defineAgent",
+    "defineDynamic",
+    "defineRemoteAgent"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/tool/v33.json
+++ b/packages/eve/extension-contracts/reports/tool/v33.json
@@ -1,0 +1,20 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "tool",
+  "epoch": 33,
+  "sha256": "57033b3a0752beb16caf593f418681556dbd3baf88a5dc42a34cfd36f8012901",
+  "exports": [
+    "defaultWebSearch",
+    "defineTool",
+    "defineWorkflowTool",
+    "disableTool",
+    "experimental_workflow",
+    "isDisabledToolSentinel",
+    "isExperimentalWorkflowToolDefinition",
+    "isWebSearchToolDefinition",
+    "toolOutput",
+    "toolOutputPart",
+    "toolResultFrom",
+    "webSearch"
+  ]
+}

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -79,8 +79,8 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     },
   },
   connection: {
-    current: 15,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 13, 14, 15],
+    current: 16,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 13, 14, 15, 16],
     dropped: {
       9: "Dynamic connection resolvers no longer receive conversation or channel continuation data",
       10: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",
@@ -104,16 +104,16 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
   },
   skill: { current: 1, supported: [1], dropped: {} },
   dynamicSkill: {
-    current: 17,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 15, 16, 17],
+    current: 18,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 15, 16, 17, 18],
     dropped: {
       13: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",
     },
   },
   instructions: { current: 2, supported: [1, 2], dropped: {} },
   dynamicInstructions: {
-    current: 18,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 16, 17, 18],
+    current: 19,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 16, 17, 18, 19],
     dropped: {
       14: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",
     },

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -22,8 +22,8 @@ interface ExtensionCapabilityContract {
 const EXTENSION_CAPABILITY_CONTRACTS = {
   extension: { current: 1, supported: [1], dropped: {} },
   tool: {
-    current: 32,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 28, 29, 30, 31, 32],
+    current: 33,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 28, 29, 30, 31, 32, 33],
     dropped: {
       14: "TaskExec.delegated was removed; migrate to workflow-backed background tools",
       15: "TaskExec replaces stageEffect with send",
@@ -42,9 +42,9 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     },
   },
   dynamicTool: {
-    current: 31,
+    current: 32,
     supported: [
-      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 28, 29, 30, 31,
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 28, 29, 30, 31, 32,
     ],
     dropped: {
       21: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",
@@ -56,22 +56,22 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     },
   },
   channel: {
-    current: 19,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19],
+    current: 20,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19, 20],
     dropped: {
       12: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",
     },
   },
   schedule: {
-    current: 11,
-    supported: [1, 2, 3, 4, 6, 7, 8, 9, 10, 11],
+    current: 12,
+    supported: [1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12],
     dropped: {
       5: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",
     },
   },
   subagent: {
-    current: 10,
-    supported: [3, 4, 6, 7, 8, 9, 10],
+    current: 11,
+    supported: [3, 4, 6, 7, 8, 9, 10, 11],
     dropped: {
       1: "Persistent subagent sessions are now the default and the experimental opt-in was removed",
       2: "Persistent subagent sessions are now the default and the experimental opt-in was removed",
@@ -87,8 +87,8 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     },
   },
   hook: {
-    current: 22,
-    supported: [10, 11, 12, 13, 14, 15, 17, 18, 19, 20, 21, 22],
+    current: 23,
+    supported: [10, 11, 12, 13, 14, 15, 17, 18, 19, 20, 21, 22, 23],
     dropped: {
       1: "Model identity moved from session.started runtime metadata to step.started call attribution.",
       2: "Model identity moved from session.started runtime metadata to step.started call attribution.",

--- a/packages/eve/src/execution/activity-events.test.ts
+++ b/packages/eve/src/execution/activity-events.test.ts
@@ -153,7 +153,12 @@ describe("projectActivityEvents", () => {
         at: "2026-01-01T00:00:02Z",
         event: {
           data: {
-            presentation: { "tool-1": { label: "Report ready" } },
+            presentation: {
+              "tool-1": {
+                label: "Report ready",
+                state: { key: "build_report", value: { sections: 3 } },
+              },
+            },
             result: {
               callId: "tool-1",
               kind: "tool-result",
@@ -176,6 +181,20 @@ describe("projectActivityEvents", () => {
         eventId: "action:work:root:turn:tool-1:result:result-1",
         kind: "action.label.updated",
         label: "Report ready",
+      },
+      {
+        eventId: "action:work:root:turn:tool-1:state:result-1",
+        kind: "state.replaced",
+        state: {
+          key: "build_report",
+          parentWorkId: "work:root:turn",
+          replacedAt: "2026-01-01T00:00:02Z",
+          rootTurnId: "turn",
+          sourceActionId: "action:work:root:turn:tool-1",
+          sourceEventId: "result-1",
+          sourceToolName: "build_report",
+          value: { sections: 3 },
+        },
       },
       {
         actionId: "action:work:root:turn:tool-1",

--- a/packages/eve/src/execution/activity-events.ts
+++ b/packages/eve/src/execution/activity-events.ts
@@ -87,7 +87,8 @@ export function projectActivityEvents(input: {
       ];
     }
     const id = actionId(lineage.id, result.callId);
-    const label = activityLabel(event.data.presentation?.[result.callId]?.label);
+    const presentation = event.data.presentation?.[result.callId];
+    const label = activityLabel(presentation?.label);
     return [
       ...(label === undefined
         ? []
@@ -97,6 +98,24 @@ export function projectActivityEvents(input: {
               eventId: `${id}:result:${input.eventId ?? input.at}`,
               kind: "action.label.updated" as const,
               label,
+            },
+          ]),
+      ...(presentation?.state === undefined
+        ? []
+        : [
+            {
+              eventId: `${id}:state:${input.eventId ?? input.at}`,
+              kind: "state.replaced" as const,
+              state: {
+                key: presentation.state.key,
+                parentWorkId: lineage.id,
+                replacedAt: input.at,
+                rootTurnId: lineage.rootTurnId,
+                sourceActionId: id,
+                sourceEventId: input.eventId ?? input.at,
+                sourceToolName: result.kind === "tool-result" ? result.toolName : "load_skill",
+                value: presentation.state.value,
+              },
             },
           ]),
       {

--- a/packages/eve/src/execution/node-step.test.ts
+++ b/packages/eve/src/execution/node-step.test.ts
@@ -221,9 +221,7 @@ describe("createNodeHarnessTools", () => {
     const node = await createNodeWithSourceOwnedTools({ names: ["web_search"] });
     const tool = createNodeHarnessTools({ node }).get("web_search");
 
-    expect(tool?.activity?.start?.({ query: "Slack plan blocks" })).toBe(
-      "Search Slack plan blocks",
-    );
+    expect(tool?.label?.start?.({ query: "Slack plan blocks" })).toBe("Search Slack plan blocks");
   });
 
   it("does not add the framework label to an authored web_search override", async () => {
@@ -232,7 +230,7 @@ describe("createNodeHarnessTools", () => {
       owner: { kind: "application" },
     });
 
-    expect(createNodeHarnessTools({ node }).get("web_search")?.activity).toBeUndefined();
+    expect(createNodeHarnessTools({ node }).get("web_search")?.label).toBeUndefined();
   });
 
   it("keeps the compiled framework question tool client-side", async () => {

--- a/packages/eve/src/execution/node-step.test.ts
+++ b/packages/eve/src/execution/node-step.test.ts
@@ -219,9 +219,9 @@ function createNoopRuntime(): Runtime {
 describe("createNodeHarnessTools", () => {
   it("adds the framework label start callback to provider-managed web search", async () => {
     const node = await createNodeWithSourceOwnedTools({ names: ["web_search"] });
-    const label = createNodeHarnessTools({ node }).get("web_search")?.label?.start;
+    const tool = createNodeHarnessTools({ node }).get("web_search");
 
-    expect(label?.({ query: "Slack plan blocks" })).toBe("Search Slack plan blocks");
+    expect(tool?.activityLabel?.({ query: "Slack plan blocks" })).toBe("Search Slack plan blocks");
   });
 
   it("does not add the framework label to an authored web_search override", async () => {
@@ -230,7 +230,7 @@ describe("createNodeHarnessTools", () => {
       owner: { kind: "application" },
     });
 
-    expect(createNodeHarnessTools({ node }).get("web_search")?.label?.start).toBeUndefined();
+    expect(createNodeHarnessTools({ node }).get("web_search")?.activityLabel).toBeUndefined();
   });
 
   it("keeps the compiled framework question tool client-side", async () => {

--- a/packages/eve/src/execution/node-step.test.ts
+++ b/packages/eve/src/execution/node-step.test.ts
@@ -221,7 +221,9 @@ describe("createNodeHarnessTools", () => {
     const node = await createNodeWithSourceOwnedTools({ names: ["web_search"] });
     const tool = createNodeHarnessTools({ node }).get("web_search");
 
-    expect(tool?.activityLabel?.({ query: "Slack plan blocks" })).toBe("Search Slack plan blocks");
+    expect(tool?.activity?.start?.({ query: "Slack plan blocks" })).toBe(
+      "Search Slack plan blocks",
+    );
   });
 
   it("does not add the framework label to an authored web_search override", async () => {
@@ -230,7 +232,7 @@ describe("createNodeHarnessTools", () => {
       owner: { kind: "application" },
     });
 
-    expect(createNodeHarnessTools({ node }).get("web_search")?.activityLabel).toBeUndefined();
+    expect(createNodeHarnessTools({ node }).get("web_search")?.activity).toBeUndefined();
   });
 
   it("keeps the compiled framework question tool client-side", async () => {

--- a/packages/eve/src/execution/session-activity.test.ts
+++ b/packages/eve/src/execution/session-activity.test.ts
@@ -68,10 +68,68 @@ describe("activity protocol and reducer", () => {
     );
   });
 
+  it("replaces structured state per work and converges out-of-order delivery", () => {
+    const replacement = (
+      eventId: string,
+      replacedAt: string,
+      value: string,
+      parentWorkId = work.id,
+    ): ActivityEventV1 => ({
+      eventId,
+      kind: "state.replaced",
+      state: {
+        key: "project-plan",
+        parentWorkId,
+        replacedAt,
+        rootTurnId: work.rootTurnId,
+        sourceActionId: `action:${eventId}`,
+        sourceEventId: eventId,
+        sourceToolName: "project_plan",
+        value: { current: value },
+      },
+    });
+    const root = replacement("result-2", "2026-01-01T00:00:02Z", "implement");
+    const child = replacement("child-result", "2026-01-01T00:00:03Z", "research", "work:child");
+    const snapshot = reduce([
+      root,
+      replacement("result-1", "2026-01-01T00:00:01Z", "design"),
+      child,
+    ]);
+
+    expect(snapshot.states).toEqual({
+      "root:session:turn:project-plan": expect.objectContaining({
+        value: { current: "implement" },
+      }),
+      "work:child:project-plan": expect.objectContaining({ value: { current: "research" } }),
+    });
+    expect(snapshot.revision).toBe(1);
+  });
+
   it("rejects malformed known events", () => {
     expect(
       parseActivityBatchV1({
         events: [{ eventId: "started", kind: "work.started", work }],
+        version: 1,
+      }),
+    ).toBeUndefined();
+    expect(
+      parseActivityBatchV1({
+        events: [
+          {
+            eventId: "state",
+            kind: "state.replaced",
+            state: {
+              key: "project plan",
+              parentWorkId: work.id,
+              replacedAt: "now",
+              rootTurnId: "turn",
+              sourceActionId: "action",
+              sourceEventId: "result",
+              sourceToolName: "project_plan",
+              value: "x".repeat(33 * 1024),
+            },
+          },
+        ],
         version: 1,
       }),
     ).toBeUndefined();

--- a/packages/eve/src/execution/session-activity.ts
+++ b/packages/eve/src/execution/session-activity.ts
@@ -21,6 +21,7 @@ export function createActivitySnapshot(): ActivitySnapshotV1 {
     pendingSettlements: {},
     revision: 0,
     seenEventIds: [],
+    states: {},
     version: 1,
     work: {},
   };
@@ -52,7 +53,10 @@ export function reduceActivityBatch(
 
 function presentationDiffers(left: ActivitySnapshotV1, right: ActivitySnapshotV1): boolean {
   return (
-    left.actions !== right.actions || left.blockers !== right.blockers || left.work !== right.work
+    left.actions !== right.actions ||
+    left.blockers !== right.blockers ||
+    left.states !== right.states ||
+    left.work !== right.work
   );
 }
 
@@ -72,6 +76,8 @@ function reduceEvent(snapshot: ActivitySnapshotV1, event: ActivityEventV1): Acti
       return startBlocker(snapshot, event);
     case "blocker.settled":
       return settleBlocker(snapshot, event);
+    case "state.replaced":
+      return replaceStructuredState(snapshot, event);
   }
 }
 
@@ -225,6 +231,25 @@ function settleBlocker(
       phase: event.outcome,
       settledAt: event.settledAt,
     }),
+  };
+}
+
+function replaceStructuredState(
+  snapshot: ActivitySnapshotV1,
+  event: Extract<ActivityEventV1, { readonly kind: "state.replaced" }>,
+): ActivitySnapshotV1 {
+  const id = `${event.state.parentWorkId}:${event.state.key}`;
+  const current = snapshot.states[id];
+  if (
+    current !== undefined &&
+    (current.replacedAt > event.state.replacedAt ||
+      (current.replacedAt === event.state.replacedAt &&
+        current.sourceEventId >= event.state.sourceEventId))
+  )
+    return snapshot;
+  return {
+    ...snapshot,
+    states: replaceBounded(snapshot.states, id, event.state),
   };
 }
 

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -111,7 +111,6 @@ function channelDeliveryErrorCode(error: unknown): string {
 }
 
 export type { TurnStepInput };
-
 /** Runs one atomic harness step inside a durable `"use step"` boundary. */
 export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResult> {
   "use step";

--- a/packages/eve/src/harness/tool-presentation.ts
+++ b/packages/eve/src/harness/tool-presentation.ts
@@ -1,7 +1,12 @@
-import type { ActionPresentationByCallId } from "#protocol/message.js";
+import type {
+  ActionPresentation,
+  ActionPresentationByCallId,
+  ActionPresentationState,
+} from "#protocol/message.js";
 import type { HarnessToolDefinition } from "#harness/execute-tool.js";
 import { normalizePresentationText } from "#shared/presentation-text.js";
-import { parseJsonObject, type JsonObject } from "#shared/json.js";
+import { isPresentationStateKey, isPresentationStateValue } from "#shared/presentation-state.js";
+import { parseJsonValue, parseJsonObject, type JsonObject } from "#shared/json.js";
 
 export function projectResultPresentation(
   definition: HarnessToolDefinition | undefined,
@@ -9,7 +14,23 @@ export function projectResultPresentation(
   input: JsonObject | undefined,
   output: unknown,
 ): ActionPresentationByCallId | undefined {
-  return projectPresentationText(definition?.label?.complete, callId, input, output);
+  if (definition?.label?.complete === undefined || input === undefined) return undefined;
+  try {
+    const complete = definition.label.complete(parseJsonObject(input), output);
+    const presentation =
+      typeof complete === "string"
+        ? { label: normalizePresentationText(complete) || undefined }
+        : {
+            label:
+              complete.label === undefined
+                ? undefined
+                : normalizePresentationText(complete.label) || undefined,
+            state: projectRenderingState(definition.name, complete.renderingState),
+          };
+    return hasPresentation(presentation) ? { [callId]: presentation } : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 export function projectDeltaPresentation(
@@ -18,20 +39,25 @@ export function projectDeltaPresentation(
   input: JsonObject | undefined,
   output: unknown,
 ): ActionPresentationByCallId | undefined {
-  return projectPresentationText(definition?.label?.delta, callId, input, output);
-}
-
-function projectPresentationText(
-  project: ((input: unknown, value: unknown) => string) | undefined,
-  callId: string,
-  input: JsonObject | undefined,
-  value: unknown,
-): ActionPresentationByCallId | undefined {
-  if (project === undefined || input === undefined) return undefined;
+  if (definition?.label?.delta === undefined || input === undefined) return undefined;
   try {
-    const text = normalizePresentationText(project(parseJsonObject(input), value));
-    return text === "" ? undefined : { [callId]: { label: text } };
+    const label = normalizePresentationText(definition.label.delta(parseJsonObject(input), output));
+    return label === "" ? undefined : { [callId]: { label } };
   } catch {
     return undefined;
   }
+}
+
+function projectRenderingState(key: string, state: unknown): ActionPresentationState | undefined {
+  if (state === undefined || !isPresentationStateKey(key)) return undefined;
+  try {
+    const value = parseJsonValue(state);
+    return isPresentationStateValue(value) ? { key, value } : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function hasPresentation(presentation: ActionPresentation): boolean {
+  return presentation.label !== undefined || presentation.state !== undefined;
 }

--- a/packages/eve/src/internal/authored-definition/schema-backed.test.ts
+++ b/packages/eve/src/internal/authored-definition/schema-backed.test.ts
@@ -16,7 +16,7 @@ describe("normalizeToolDefinition", () => {
     const tool = defineTool({
       label: {
         start: () => "Echo input",
-        complete: (_input, output) => ({ renderingState: { key: "echo", value: output } }),
+        complete: (_input, output) => ({ renderingState: output }),
       },
       description: "Echoes the input back to the caller.",
       inputSchema: z.object({}),

--- a/packages/eve/src/internal/authored-definition/schema-backed.test.ts
+++ b/packages/eve/src/internal/authored-definition/schema-backed.test.ts
@@ -14,6 +14,10 @@ const FAILURE_MESSAGE = "Expected the tool export to match the public eve shape.
 describe("normalizeToolDefinition", () => {
   it("returns a tool entry for a real defineTool default export", () => {
     const tool = defineTool({
+      activity: {
+        label: () => "Echo input",
+        state: { key: "echo", project: (output) => output },
+      },
       description: "Echoes the input back to the caller.",
       inputSchema: z.object({}),
       execute(input) {

--- a/packages/eve/src/internal/authored-definition/schema-backed.test.ts
+++ b/packages/eve/src/internal/authored-definition/schema-backed.test.ts
@@ -14,9 +14,9 @@ const FAILURE_MESSAGE = "Expected the tool export to match the public eve shape.
 describe("normalizeToolDefinition", () => {
   it("returns a tool entry for a real defineTool default export", () => {
     const tool = defineTool({
-      activity: {
-        label: () => "Echo input",
-        state: { key: "echo", project: (output) => output },
+      label: {
+        start: () => "Echo input",
+        complete: (_input, output) => ({ renderingState: { key: "echo", value: output } }),
       },
       description: "Echoes the input back to the caller.",
       inputSchema: z.object({}),

--- a/packages/eve/src/internal/authored-definition/schema-backed.ts
+++ b/packages/eve/src/internal/authored-definition/schema-backed.ts
@@ -118,7 +118,7 @@ export function normalizeToolDefinition(value: unknown, message: string): Normal
   expectOnlyKnownKeys(
     record,
     [
-      "label",
+      "activity",
       "auth",
       "description",
       "execute",
@@ -178,12 +178,18 @@ export function normalizeToolDefinition(value: unknown, message: string): Normal
    * references are captured later by `resolve-agent.ts` when it materializes
    * the module export and attaches them to the ResolvedToolDefinition.
    */
-  if (record.label !== undefined) {
-    const label = expectObjectRecord(record.label, message);
-    expectOnlyKnownKeys(label, ["start", "complete", "delta"], message);
-    expectFunction(label.start, message);
-    if (label.complete !== undefined) expectFunction(label.complete, message);
-    if (label.delta !== undefined) expectFunction(label.delta, message);
+  if (record.activity !== undefined) {
+    const activity = expectObjectRecord(record.activity, message);
+    expectOnlyKnownKeys(activity, ["label", "result", "state", "update"], message);
+    expectFunction(activity.label, message);
+    if (activity.result !== undefined) expectFunction(activity.result, message);
+    if (activity.state !== undefined) {
+      const state = expectObjectRecord(activity.state, message);
+      expectOnlyKnownKeys(state, ["key", "project"], message);
+      expectString(state.key, message);
+      expectFunction(state.project, message);
+    }
+    if (activity.update !== undefined) expectFunction(activity.update, message);
   }
 
   if (record.approval !== undefined) {

--- a/packages/eve/src/internal/authored-definition/schema-backed.ts
+++ b/packages/eve/src/internal/authored-definition/schema-backed.ts
@@ -118,7 +118,7 @@ export function normalizeToolDefinition(value: unknown, message: string): Normal
   expectOnlyKnownKeys(
     record,
     [
-      "activity",
+      "label",
       "auth",
       "description",
       "execute",
@@ -178,18 +178,12 @@ export function normalizeToolDefinition(value: unknown, message: string): Normal
    * references are captured later by `resolve-agent.ts` when it materializes
    * the module export and attaches them to the ResolvedToolDefinition.
    */
-  if (record.activity !== undefined) {
-    const activity = expectObjectRecord(record.activity, message);
-    expectOnlyKnownKeys(activity, ["label", "result", "state", "update"], message);
-    expectFunction(activity.label, message);
-    if (activity.result !== undefined) expectFunction(activity.result, message);
-    if (activity.state !== undefined) {
-      const state = expectObjectRecord(activity.state, message);
-      expectOnlyKnownKeys(state, ["key", "project"], message);
-      expectString(state.key, message);
-      expectFunction(state.project, message);
-    }
-    if (activity.update !== undefined) expectFunction(activity.update, message);
+  if (record.label !== undefined) {
+    const label = expectObjectRecord(record.label, message);
+    expectOnlyKnownKeys(label, ["start", "complete", "delta"], message);
+    expectFunction(label.start, message);
+    if (label.complete !== undefined) expectFunction(label.complete, message);
+    if (label.delta !== undefined) expectFunction(label.delta, message);
   }
 
   if (record.approval !== undefined) {

--- a/packages/eve/src/protocol/activity.ts
+++ b/packages/eve/src/protocol/activity.ts
@@ -390,14 +390,14 @@ function parseStructuredState(value: unknown): ActivityStructuredStateV1 | undef
       "sourceToolName",
       "value",
     ]) ||
-    !isStateKey(value.key) ||
+    !isPresentationStateKey(value.key) ||
     !isIdentity(value.parentWorkId) ||
     !isBoundedString(value.replacedAt) ||
     !isIdentity(value.rootTurnId) ||
     !isIdentity(value.sourceActionId) ||
     !isIdentity(value.sourceEventId) ||
     !isBoundedString(value.sourceToolName) ||
-    !isBoundedJsonValue(value.value)
+    !isPresentationStateValue(value.value)
   )
     return undefined;
   return {

--- a/packages/eve/src/protocol/activity.ts
+++ b/packages/eve/src/protocol/activity.ts
@@ -1,9 +1,16 @@
 import type { JsonValue } from "#shared/json.js";
+import {
+  isPresentationStateKey,
+  isPresentationStateValue,
+  MAX_PRESENTATION_STATE_BYTES,
+  MAX_PRESENTATION_STATE_DEPTH,
+  MAX_PRESENTATION_STATE_ENTRIES,
+} from "#shared/presentation-state.js";
 
 export const MAX_ACTIVITY_EVENTS_PER_BATCH = 100;
-export const MAX_ACTIVITY_STATE_BYTES = 32 * 1024;
-export const MAX_ACTIVITY_STATE_DEPTH = 10;
-export const MAX_ACTIVITY_STATE_ENTRIES = 500;
+export const MAX_ACTIVITY_STATE_BYTES = MAX_PRESENTATION_STATE_BYTES;
+export const MAX_ACTIVITY_STATE_DEPTH = MAX_PRESENTATION_STATE_DEPTH;
+export const MAX_ACTIVITY_STATE_ENTRIES = MAX_PRESENTATION_STATE_ENTRIES;
 
 export type ActivityWorkKind = "root-turn" | "subagent" | "remote-agent" | "task";
 export type ActivityWorkPhase = "running" | "completed" | "failed" | "cancelled";
@@ -406,45 +413,11 @@ function parseStructuredState(value: unknown): ActivityStructuredStateV1 | undef
 }
 
 export function isActivityStateKey(value: unknown): value is string {
-  return isStateKey(value);
+  return isPresentationStateKey(value);
 }
 
 export function isActivityStateValue(value: unknown): value is JsonValue {
-  return isBoundedJsonValue(value);
-}
-
-function isStateKey(value: unknown): value is string {
-  return typeof value === "string" && /^[a-zA-Z0-9][a-zA-Z0-9._/-]{0,127}$/u.test(value);
-}
-
-function isBoundedJsonValue(value: unknown): value is JsonValue {
-  try {
-    if (new TextEncoder().encode(JSON.stringify(value)).byteLength > MAX_ACTIVITY_STATE_BYTES) {
-      return false;
-    }
-  } catch {
-    return false;
-  }
-  let entries = 0;
-  const visit = (candidate: unknown, depth: number): boolean => {
-    if (depth > MAX_ACTIVITY_STATE_DEPTH || entries > MAX_ACTIVITY_STATE_ENTRIES) return false;
-    if (
-      candidate === null ||
-      typeof candidate === "string" ||
-      typeof candidate === "boolean" ||
-      (typeof candidate === "number" && Number.isFinite(candidate))
-    )
-      return true;
-    if (Array.isArray(candidate)) {
-      entries += candidate.length;
-      return candidate.every((item) => visit(item, depth + 1));
-    }
-    if (!isRecord(candidate)) return false;
-    const values = Object.values(candidate);
-    entries += values.length;
-    return values.every((item) => visit(item, depth + 1));
-  };
-  return visit(value, 0);
+  return isPresentationStateValue(value);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/eve/src/protocol/activity.ts
+++ b/packages/eve/src/protocol/activity.ts
@@ -1,4 +1,9 @@
+import type { JsonValue } from "#shared/json.js";
+
 export const MAX_ACTIVITY_EVENTS_PER_BATCH = 100;
+export const MAX_ACTIVITY_STATE_BYTES = 32 * 1024;
+export const MAX_ACTIVITY_STATE_DEPTH = 10;
+export const MAX_ACTIVITY_STATE_ENTRIES = 500;
 
 export type ActivityWorkKind = "root-turn" | "subagent" | "remote-agent" | "task";
 export type ActivityWorkPhase = "running" | "completed" | "failed" | "cancelled";
@@ -63,6 +68,17 @@ export interface ActivityBlockerStateV1 extends ActivityBlockerIdentityV1 {
   readonly startedAt: string;
 }
 
+export interface ActivityStructuredStateV1 {
+  readonly key: string;
+  readonly parentWorkId: string;
+  readonly replacedAt: string;
+  readonly rootTurnId: string;
+  readonly sourceActionId: string;
+  readonly sourceEventId: string;
+  readonly sourceToolName: string;
+  readonly value: JsonValue;
+}
+
 export type ActivityEventV1 =
   | {
       readonly eventId: string;
@@ -108,6 +124,11 @@ export type ActivityEventV1 =
       readonly kind: "blocker.settled";
       readonly outcome: Exclude<ActivityBlockerPhase, "blocked">;
       readonly settledAt: string;
+    }
+  | {
+      readonly eventId: string;
+      readonly kind: "state.replaced";
+      readonly state: ActivityStructuredStateV1;
     };
 
 export interface ActivityBatchV1 {
@@ -121,6 +142,7 @@ export interface ActivitySnapshotV1 {
   readonly pendingSettlements: Readonly<Record<string, PendingActivitySettlementV1>>;
   readonly revision: number;
   readonly seenEventIds: readonly string[];
+  readonly states: Readonly<Record<string, ActivityStructuredStateV1>>;
   readonly version: 1;
   readonly work: Readonly<Record<string, ActivityWorkStateV1>>;
 }
@@ -286,6 +308,12 @@ function parseKnownEvent(value: Record<string, unknown>): ActivityEventV1 | null
         settledAt: value.settledAt,
       };
     }
+    case "state.replaced": {
+      if (!hasOnlyKeys(value, ["eventId", "kind", "state"])) return undefined;
+      const state = parseStructuredState(value.state);
+      if (!isIdentity(value.eventId) || state === undefined) return undefined;
+      return { eventId: value.eventId, kind: "state.replaced", state };
+    }
     default:
       return null;
   }
@@ -340,6 +368,83 @@ function parseBlockerIdentity(value: unknown): ActivityBlockerIdentityV1 | undef
     parentWorkId: value.parentWorkId,
     rootTurnId: value.rootTurnId,
   };
+}
+
+function parseStructuredState(value: unknown): ActivityStructuredStateV1 | undefined {
+  if (
+    !isRecord(value) ||
+    !hasOnlyKeys(value, [
+      "key",
+      "parentWorkId",
+      "replacedAt",
+      "rootTurnId",
+      "sourceActionId",
+      "sourceEventId",
+      "sourceToolName",
+      "value",
+    ]) ||
+    !isStateKey(value.key) ||
+    !isIdentity(value.parentWorkId) ||
+    !isBoundedString(value.replacedAt) ||
+    !isIdentity(value.rootTurnId) ||
+    !isIdentity(value.sourceActionId) ||
+    !isIdentity(value.sourceEventId) ||
+    !isBoundedString(value.sourceToolName) ||
+    !isBoundedJsonValue(value.value)
+  )
+    return undefined;
+  return {
+    key: value.key,
+    parentWorkId: value.parentWorkId,
+    replacedAt: value.replacedAt,
+    rootTurnId: value.rootTurnId,
+    sourceActionId: value.sourceActionId,
+    sourceEventId: value.sourceEventId,
+    sourceToolName: value.sourceToolName,
+    value: value.value,
+  };
+}
+
+export function isActivityStateKey(value: unknown): value is string {
+  return isStateKey(value);
+}
+
+export function isActivityStateValue(value: unknown): value is JsonValue {
+  return isBoundedJsonValue(value);
+}
+
+function isStateKey(value: unknown): value is string {
+  return typeof value === "string" && /^[a-zA-Z0-9][a-zA-Z0-9._/-]{0,127}$/u.test(value);
+}
+
+function isBoundedJsonValue(value: unknown): value is JsonValue {
+  try {
+    if (new TextEncoder().encode(JSON.stringify(value)).byteLength > MAX_ACTIVITY_STATE_BYTES) {
+      return false;
+    }
+  } catch {
+    return false;
+  }
+  let entries = 0;
+  const visit = (candidate: unknown, depth: number): boolean => {
+    if (depth > MAX_ACTIVITY_STATE_DEPTH || entries > MAX_ACTIVITY_STATE_ENTRIES) return false;
+    if (
+      candidate === null ||
+      typeof candidate === "string" ||
+      typeof candidate === "boolean" ||
+      (typeof candidate === "number" && Number.isFinite(candidate))
+    )
+      return true;
+    if (Array.isArray(candidate)) {
+      entries += candidate.length;
+      return candidate.every((item) => visit(item, depth + 1));
+    }
+    if (!isRecord(candidate)) return false;
+    const values = Object.values(candidate);
+    entries += values.length;
+    return values.every((item) => visit(item, depth + 1));
+  };
+  return visit(value, 0);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/eve/src/protocol/message.ts
+++ b/packages/eve/src/protocol/message.ts
@@ -224,8 +224,14 @@ export type MessageReceivedPart =
  * action lifecycles by call ID rather than assume one event contains every call
  * from an assistant step.
  */
+export interface ActionPresentationState {
+  readonly key: string;
+  readonly value: JsonValue;
+}
+
 export interface ActionPresentation {
   readonly label?: string;
+  readonly state?: ActionPresentationState;
 }
 
 export type ActionPresentationByCallId = Readonly<Record<string, ActionPresentation>>;

--- a/packages/eve/src/public/definitions/exact.test.ts
+++ b/packages/eve/src/public/definitions/exact.test.ts
@@ -68,7 +68,7 @@ describe("definition helper exact inputs", () => {
           expectTypeOf(output.phase).toEqualTypeOf<string>();
           return {
             label: `Report ${output.phase}`,
-            renderingState: { key: "report", value: { phase: output.phase } },
+            renderingState: { phase: output.phase },
           };
         },
         delta(_input, partial) {

--- a/packages/eve/src/public/definitions/exact.test.ts
+++ b/packages/eve/src/public/definitions/exact.test.ts
@@ -66,7 +66,10 @@ describe("definition helper exact inputs", () => {
         start: () => "Build report",
         complete(_input, output) {
           expectTypeOf(output.phase).toEqualTypeOf<string>();
-          return `Report ${output.phase}`;
+          return {
+            label: `Report ${output.phase}`,
+            renderingState: { key: "report", value: { phase: output.phase } },
+          };
         },
         delta(_input, partial) {
           expectTypeOf(partial.phase).toEqualTypeOf<string>();

--- a/packages/eve/src/public/tools/index.ts
+++ b/packages/eve/src/public/tools/index.ts
@@ -10,6 +10,7 @@ export {
   isDisabledToolSentinel,
   type TaskExec,
   type TaskReceipt,
+  type ToolLabelComplete,
   type ToolLabelDefinition,
   type ToolAuthOptions,
   type ToolAuthProvider,

--- a/packages/eve/src/shared/presentation-state.ts
+++ b/packages/eve/src/shared/presentation-state.ts
@@ -1,0 +1,42 @@
+import type { JsonValue } from "#shared/json.js";
+
+export const MAX_PRESENTATION_STATE_BYTES = 32 * 1024;
+export const MAX_PRESENTATION_STATE_DEPTH = 10;
+export const MAX_PRESENTATION_STATE_ENTRIES = 500;
+
+export function isPresentationStateKey(value: unknown): value is string {
+  return typeof value === "string" && /^[a-zA-Z0-9][a-zA-Z0-9._/-]{0,127}$/u.test(value);
+}
+
+export function isPresentationStateValue(value: unknown): value is JsonValue {
+  try {
+    if (new TextEncoder().encode(JSON.stringify(value)).byteLength > MAX_PRESENTATION_STATE_BYTES) {
+      return false;
+    }
+  } catch {
+    return false;
+  }
+  let entries = 0;
+  const visit = (candidate: unknown, depth: number): boolean => {
+    if (depth > MAX_PRESENTATION_STATE_DEPTH || entries > MAX_PRESENTATION_STATE_ENTRIES) {
+      return false;
+    }
+    if (
+      candidate === null ||
+      typeof candidate === "string" ||
+      typeof candidate === "boolean" ||
+      (typeof candidate === "number" && Number.isFinite(candidate))
+    ) {
+      return true;
+    }
+    if (Array.isArray(candidate)) {
+      entries += candidate.length;
+      return candidate.every((item) => visit(item, depth + 1));
+    }
+    if (typeof candidate !== "object" || candidate === null) return false;
+    const values = Object.values(candidate);
+    entries += values.length;
+    return values.every((item) => visit(item, depth + 1));
+  };
+  return visit(value, 0);
+}

--- a/packages/eve/src/tools/definition.ts
+++ b/packages/eve/src/tools/definition.ts
@@ -7,7 +7,7 @@ import type {
 import type { Approval } from "#approval/definition.js";
 import type { SessionContext } from "#context/session-context.js";
 import { stampDefinitionKey } from "#internal/authored-definition/source-identity.js";
-import type { JsonObject } from "#shared/json.js";
+import type { JsonObject, JsonValue } from "#shared/json.js";
 import type { TokenResult } from "#shared/connection-types.js";
 import type { ToolAuthOptions, ToolAuthProvider } from "#tools/auth.js";
 import type { InputOption } from "#shared/input.js";
@@ -40,13 +40,18 @@ interface ToolDefinitionBase {
   readonly execution?: ToolExecution;
 }
 
+export interface ToolLabelComplete {
+  readonly label?: string;
+  readonly renderingState?: JsonValue;
+}
+
 export interface ToolLabelDefinition<TInput = unknown, TOutput = unknown> {
   /** Returns the presentation-safe label when one action invocation starts. */
   start(input: Readonly<TInput>): string;
   /** Projects one preliminary output snapshot into presentation-safe label text. */
   delta?(input: Readonly<TInput>, partial: Readonly<TOutput>): string;
-  /** Projects a successful final output into presentation-safe settlement text. */
-  complete?(input: Readonly<TInput>, output: Readonly<TOutput>): string;
+  /** Projects successful settlement into text and optional renderer-consumable state. */
+  complete?(input: Readonly<TInput>, output: Readonly<TOutput>): string | ToolLabelComplete;
 }
 
 /**
@@ -57,7 +62,7 @@ export interface ToolLabelDefinition<TInput = unknown, TOutput = unknown> {
  * carry `name`; identity comes from the file path.
  */
 export interface InternalToolLabelDefinition {
-  readonly complete?: (input: unknown, output: unknown) => string;
+  readonly complete?: (input: unknown, output: unknown) => string | ToolLabelComplete;
   readonly delta?: (input: unknown, partial: unknown) => string;
   readonly start?: (input: unknown) => string;
 }

--- a/packages/eve/src/tools/provided/todo.ts
+++ b/packages/eve/src/tools/provided/todo.ts
@@ -28,9 +28,11 @@ export const todo = defineTool({
     "- Mark tasks in_progress when you start, completed when done",
     "- Only have ONE task in_progress at a time",
   ].join("\n"),
-  activity: {
-    label: (input) => (input.todos === undefined ? "Read todo list" : "Update todo list"),
-    state: { key: "todo", project: (output) => output.todos },
+  label: {
+    start: (input) => (input.todos === undefined ? "Read todo list" : "Update todo list"),
+    complete: (_input, output) => ({
+      renderingState: { key: "todo", value: output.todos },
+    }),
   },
   execute: async (input) => executeTodoTool((input ?? {}) as TodoToolInput),
   inputSchema: TODO_INPUT_SCHEMA,

--- a/packages/eve/src/tools/provided/todo.ts
+++ b/packages/eve/src/tools/provided/todo.ts
@@ -28,6 +28,10 @@ export const todo = defineTool({
     "- Mark tasks in_progress when you start, completed when done",
     "- Only have ONE task in_progress at a time",
   ].join("\n"),
+  activity: {
+    label: (input) => (input.todos === undefined ? "Read todo list" : "Update todo list"),
+    state: { key: "todo", project: (output) => output.todos },
+  },
   execute: async (input) => executeTodoTool((input ?? {}) as TodoToolInput),
   inputSchema: TODO_INPUT_SCHEMA,
   outputSchema: TODO_OUTPUT_SCHEMA,

--- a/packages/eve/src/tools/provided/todo.ts
+++ b/packages/eve/src/tools/provided/todo.ts
@@ -31,7 +31,7 @@ export const todo = defineTool({
   label: {
     start: (input) => (input.todos === undefined ? "Read todo list" : "Update todo list"),
     complete: (_input, output) => ({
-      renderingState: { key: "todo", value: output.todos },
+      renderingState: output.todos,
     }),
   },
   execute: async (input) => executeTodoTool((input ?? {}) as TodoToolInput),

--- a/packages/eve/test/scenarios/mounted-extension-installed.scenario.test.ts
+++ b/packages/eve/test/scenarios/mounted-extension-installed.scenario.test.ts
@@ -249,7 +249,7 @@ describe("mounted extension installed under node_modules", () => {
     );
     expect(
       JSON.parse(extensionFiles[`node_modules/${PACKAGE_NAME}/dist/extension/_manifest.json`]!),
-    ).toMatchObject({ requires: { channel: 19, schedule: 11, subagent: 10 } });
+    ).toMatchObject({ requires: { channel: 20, schedule: 12, subagent: 11 } });
     const app = await scenarioApp({
       name: "mounted-extension-installed",
       installDependencies: true,

--- a/research/tool-structured-activity-state.md
+++ b/research/tool-structured-activity-state.md
@@ -20,7 +20,7 @@ export default defineTool({
   label: {
     start: () => "Update project plan",
     complete: (_input, output) => ({
-      renderingState: { key: "project-plan", value: output.tasks },
+      renderingState: output.tasks,
     }),
   },
 });
@@ -42,11 +42,11 @@ model tool call
 
 ## Semantics
 
-- The state key identifies a contract between the tool and renderer. eve does not assign meaning to keys or inspect projected schemas.
+- The path-derived tool name identifies the contract between the tool and renderer. eve does not inspect projected schemas.
 - A successful final result replaces the previous value for `(owning work, key)`. Failed and rejected calls do not change state.
 - The snapshot records the projected value with its source tool, action, event, owning work, root turn, and replacement time.
 - A renderer receives every work-scoped publication and ignores keys it does not understand. It may show only root state, nest state under its owning work, or flatten publications that share a key. Multiple renderers may interpret the same state differently.
-- Custom tools can use their own keys and schemas. Tools may share a key only when they intentionally implement the same renderer contract.
+- Custom tools use their own path-derived names and schemas.
 - Structured state is separate from observed `work`, `actions`, and `blockers`. A renderer may combine them visually, but eve infers no ownership relation beyond the recorded source action and work.
 
 ## Boundaries

--- a/research/tool-structured-activity-state.md
+++ b/research/tool-structured-activity-state.md
@@ -31,14 +31,14 @@ The data path remains a projection of the durable session event log:
 ```text
 model tool call
   -> validated tool execution
-  -> durable action.result
   -> authored completion projection
-  -> internal state.replaced activity event
+  -> durable action.result.data.presentation
+  -> observer-derived state.replaced activity event
   -> activity snapshot.states[key]
   -> channel renderer
 ```
 
-`action.result` remains the source event. `state.replaced` is internal reducer input rather than a new public session event or duplicated result payload.
+`action.result` remains the source event and carries the bounded presentation projection. `state.replaced` is derived observer output for the private activity reducer rather than a second public session event.
 
 ## Semantics
 
@@ -55,7 +55,7 @@ Projection is opt-in. Automatically forwarding tool results would disclose value
 
 Projection callbacks follow the existing activity failure boundary: an invalid key, callback exception, non-JSON result, or over-limit value drops the state update without changing tool execution, model output, or final-response delivery.
 
-The collector uses replacement time and source event identity to converge duplicate or out-of-order deliveries. Activity remains best-effort presentation; the public event stream remains the durable record available for replay and inspection.
+The collector uses replacement time and source event identity to converge duplicate or out-of-order deliveries. Activity remains best-effort presentation; the self-contained public event stream is the durable record available for replay and inspection.
 
 ## Built-in `todo`
 

--- a/research/tool-structured-activity-state.md
+++ b/research/tool-structured-activity-state.md
@@ -17,12 +17,11 @@ Add an explicit tool projection that maps successful output to bounded JSON unde
 ```ts
 export default defineTool({
   // description, schemas, and execute omitted
-  activity: {
-    label: () => "Update project plan",
-    state: {
-      key: "project-plan",
-      project: (output) => output.tasks,
-    },
+  label: {
+    start: () => "Update project plan",
+    complete: (_input, output) => ({
+      renderingState: { key: "project-plan", value: output.tasks },
+    }),
   },
 });
 ```
@@ -33,7 +32,7 @@ The data path remains a projection of the durable session event log:
 model tool call
   -> validated tool execution
   -> durable action.result
-  -> authored state projection
+  -> authored completion projection
   -> internal state.replaced activity event
   -> activity snapshot.states[key]
   -> channel renderer

--- a/research/tool-structured-activity-state.md
+++ b/research/tool-structured-activity-state.md
@@ -1,0 +1,63 @@
+---
+issue: https://app.notion.com/p/vercel/9-1-26-Activity-rendering-overview-3cfe06b059c4814f8625e5238264af9b
+status: implemented
+last_updated: "2026-09-02"
+---
+
+# Project structured tool state into activity
+
+> **AI status:** Written entirely by AI; human review pending.
+
+## Strategy
+
+Tools sometimes produce model-authored state that a channel may want to render separately from the action lifecycle. The built-in `todo` tool is one example, but plans are not a framework-level activity concept: an authored tool may expose a different planning schema or an unrelated stateful artifact.
+
+Add an explicit tool projection that maps successful output to bounded JSON under a renderer-owned key:
+
+```ts
+export default defineTool({
+  // description, schemas, and execute omitted
+  activity: {
+    label: () => "Update project plan",
+    state: {
+      key: "project-plan",
+      project: (output) => output.tasks,
+    },
+  },
+});
+```
+
+The data path remains a projection of the durable session event log:
+
+```text
+model tool call
+  -> validated tool execution
+  -> durable action.result
+  -> authored state projection
+  -> internal state.replaced activity event
+  -> activity snapshot.states[key]
+  -> channel renderer
+```
+
+`action.result` remains the source event. `state.replaced` is internal reducer input rather than a new public session event or duplicated result payload.
+
+## Semantics
+
+- The state key identifies a contract between the tool and renderer. eve does not assign meaning to keys or inspect projected schemas.
+- A successful final result replaces the previous value for `(owning work, key)`. Failed and rejected calls do not change state.
+- The snapshot records the projected value with its source tool, action, event, owning work, root turn, and replacement time.
+- A renderer receives every work-scoped publication and ignores keys it does not understand. It may show only root state, nest state under its owning work, or flatten publications that share a key. Multiple renderers may interpret the same state differently.
+- Custom tools can use their own keys and schemas. Tools may share a key only when they intentionally implement the same renderer contract.
+- Structured state is separate from observed `work`, `actions`, and `blockers`. A renderer may combine them visually, but eve infers no ownership relation beyond the recorded source action and work.
+
+## Boundaries
+
+Projection is opt-in. Automatically forwarding tool results would disclose values that were not authored for presentation and could impose unbounded work on the collector or provider renderer. Projected values must therefore be JSON-serializable and pass explicit byte, depth, and entry limits before they enter the activity protocol.
+
+Projection callbacks follow the existing activity failure boundary: an invalid key, callback exception, non-JSON result, or over-limit value drops the state update without changing tool execution, model output, or final-response delivery.
+
+The collector uses replacement time and source event identity to converge duplicate or out-of-order deliveries. Activity remains best-effort presentation; the public event stream remains the durable record available for replay and inspection.
+
+## Built-in `todo`
+
+The built-in `todo` tool adopts the same authored surface as any other tool and projects its current item list under the `todo` key. Root and nested subagent todo lists remain separate publications; a Slack or other channel renderer decides whether to show the root list, render one list per work item, or combine them. This exposes todo status without adding a `plan` lane or todo-specific parsing to the activity protocol.


### PR DESCRIPTION
### Summary

Allows `label.complete` to return structured state alongside its label. This can be used by renderers to display richer information than just a plain label.

Before:

```ts
label: {
  start: () => "Update project plan",
  complete: (_input, output) => `Updated ${output.tasks.length} tasks`
},
```

After:
```ts
label: {
  start: () => "Update project plan",
  complete: (_input, output) => ({
    label: `Updated ${output.tasks.length} tasks`,
    renderingState: output.tasks,
  }),
},
```

This is  used by the native `todo` tool, and can be used to e.g. natively render todos in Slack as part of the overall renderer system, see #2916 for the implementation.

### Long-running agent example

A long-running agent could use structured rendering state to publish cumulative progress:

```ts
// agent/tools/record_progress.ts
import { defineTool } from "eve/tools";
import { z } from "zod";

const stage = z.string().trim().min(1).max(80);

const progress = z.object({
  completed: z.array(stage).max(12),
  current: stage,
  remaining: z.array(stage).max(12),
  estimatedMinutesRemaining: z.number().int().min(0).max(1440),
});

export default defineTool({
  description: "Record progress for a multi-stage task.",
  inputSchema: progress,
  outputSchema: progress,
  label: {
    start: () => "Record progress",
    complete: (_input, output) => ({
      label: output.current,
      renderingState: output,
    }),
  },
  execute(input) {
    return input;
  },
  toModelOutput() {
    return { type: "text", value: "Progress recorded." };
  },
});
```

Each successful `action.result` records the bounded projection, and the activity observer derives work-scoped replacement state from that durable event. Each call replaces the previous `record_progress` state from the same work item. A channel renderer could present it as an update-in-place progress card showing completed stages, the current stage, what remains, and the estimated time remaining. Other renderers could present the same state differently or ignore it.

### Validation

Adds coverage for typed static and durable dynamic completion results, bounded rendering state, work-scoped replacement, out-of-order reduction, failure isolation, and the built-in `todo` definition.

### Diff size

**Docs** — 4 files · `+109 / -8`

Documents the completion result, records the rendering-state design, and includes its release note.

**Implementation** — 22 files · `+327 / -81`

Records optional bounded rendering state on successful `action.result` events and derives work-scoped activity state from them.

**Tests** — 14 files · `+213 / -34`

Covers authoring and replay, projection validation, reducer ordering and replacement, and compatibility contracts.




