### PR TITLE
fix(eve): containers - preserve published VCR tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,8 +66,26 @@ jobs:
         with:
           team: ${{ secrets.VCR_TEAM_ID }}
 
-      - name: Publish eve image to Vercel Container Registry
+      - name: Check whether the eve image version is already published
         if: github.ref == 'refs/heads/main'
+        id: vcr-image
+        env:
+          VCR_TAG: ${{ steps.vcr-tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          if inspect_output="$(docker buildx imagetools inspect --raw "$VCR_TAG" 2>&1)"; then
+            echo "publish=false" >>"$GITHUB_OUTPUT"
+            echo "$VCR_TAG is already published; skipping the image build."
+          elif grep -Eq ': not found|manifest unknown' <<<"$inspect_output"; then
+            echo "publish=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "$inspect_output" >&2
+            exit 1
+          fi
+
+      - name: Publish eve image to Vercel Container Registry
+        if: github.ref == 'refs/heads/main' && steps.vcr-image.outputs.publish == 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./packages/eve


### PR DESCRIPTION
### Summary

The initial VCR bootstrap succeeded, but the release workflow would currently overwrite the same version tag on every subsequent commit to `main`. The workflow now inspects the authenticated version manifest before building: an existing tag skips both the version and `latest` pushes, an explicit missing-manifest response permits publication, and any other registry error fails closed. Image publication remains before the Changesets npm step, and the existing workflow concurrency prevents two queued releases from racing this check.

### Validation

Exercised the guard against an existing public image, a missing public image, and an unauthenticated VCR request, confirming skip, publish, and fail-closed behavior respectively. The successful bootstrap release confirmed the OIDC login and first VCR push; the authenticated existing-tag path can only run from `main` after merge.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 1 file · `+19 / -1`

Keeps the immutable-tag decision inside the release workflow immediately before the existing build-and-push step.

**Tests** — 0 files · `+0 / -0`

No committed test files; the workflow guard was exercised directly against representative registry outcomes.
