### PR TITLE
feat(eve): support agent workspace CLI flows

### DIFF
--- a/.changeset/agent-workspace-cli.md
+++ b/.changeset/agent-workspace-cli.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Discover multi-agent projects from their `agents/` directory, add consistent `--agent` selection to agent-scoped CLI commands, and let `eve init --agents <name,...>` create or extend an agent workspace.

--- a/docs/guides/deployment/vercel.mdx
+++ b/docs/guides/deployment/vercel.mdx
@@ -63,7 +63,9 @@ my-project/
         └── agent/
 ```
 
-An `agents/` directory marks the project as a workspace. eve validates and discovers only direct `agents/<name>/agent/` children. Their directory names become their public identities, exposed at `/<name>/eve/v1/*`. Run `eve dev`, `eve info`, and `eve eval` from an individual child directory; run project-level build, link, and deploy commands from the workspace root. The workspace root is the project package; child agent directories do not define packages or build scripts.
+An `agents/` directory marks the project as a workspace. eve validates and discovers only direct `agents/<name>/agent/` children. Their directory names become their public identities, exposed at `/<name>/eve/v1/*`. Run an agent-specific command from a child directory or pass `--agent <name>` at the workspace root; interactive commands open a picker when the name is omitted. Run project-level build, link, and deploy commands from the workspace root. The workspace root owns the project package, dependencies, and build scripts.
+
+Create this layout with `eve init my-project --agents support,research`, or add one agent to an existing workspace with `eve init billing`.
 
 With no authored `vercel.json#services`, `eve build` derives the complete Vercel Services graph on every build. If `vercel.json` declares `services`, that authored graph is authoritative instead; use `vercel build` to build and validate the complete project. This supports heterogeneous projects with frontends, private APIs, bindings, and other non-eve services without generated configuration files.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -3,7 +3,7 @@ title: "CLI"
 description: "Reference for every eve CLI command: init, set, info, build, start, dev, logs, trace, link, deploy, eval, channels, and extension."
 ---
 
-Relevant `eve` commands can run from the application root or any directory beneath it. Running `eve` with no command runs `eve init` when the current directory is not an eve project, or `eve dev` when it is.
+Relevant `eve` commands can run from the application root or any directory beneath it. In an `agents/` workspace, agent-specific commands accept `--agent <name>` and otherwise open a picker when more than one agent exists. Non-interactive runs must pass `--agent`. Running `eve` with no command runs `eve init` when the current directory is not an eve project, or `eve dev` when it is.
 
 ## Commands
 
@@ -37,7 +37,7 @@ When `eve build` fails on discovery errors, it prints the full diagnostics repor
 ## `eve init`
 
 ```bash
-eve init [target] [--model <provider/model-id>] [--reasoning <effort>] [--channel-web-nextjs]
+eve init [target] [--agents <name,...>] [--model <provider/model-id>] [--reasoning <effort>] [--channel-web-nextjs]
 ```
 
 Creates a new agent app or adds an agent to an existing app. Always installs dependencies. New directories also initialize Git.
@@ -48,6 +48,8 @@ Creates a new agent app or adds an agent to an existing app. Always installs dep
 | `eve init` or `eve init .` in an empty directory                           | Creates an agent project in the current directory                                                                                                                        |
 | `eve init` or `eve init .` in a non-empty directory without `package.json` | Asks whether to scaffold in the current directory or a named subdirectory. Using the current directory preserves unrelated files but overwrites files at generated paths |
 | `eve init .` in an existing project                                        | Adds `agent/` plus missing `eve`, `ai`, and `zod` dependencies. Requires `package.json` and no existing `agent/` files                                                   |
+| `eve init my-project --agents foreman,researcher`                          | Creates a workspace with `agents/foreman/agent/` and `agents/researcher/agent/`                                                                                          |
+| `eve init billing` from an `agents/` workspace                             | Adds only `agents/billing/agent/`; the workspace keeps its existing package, dependencies, and TypeScript configuration                                                  |
 
 Coding-agent launches and non-interactive terminals cannot answer the location prompt and fail before writing. Pass a new directory name, such as `eve init my-agent`, in those environments.
 
@@ -55,6 +57,7 @@ After scaffolding, a human terminal usually continues into `eve dev`. If a codin
 
 | Flag                   | Type   | Default                    | Description                                                                                                              |
 | ---------------------- | ------ | -------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `--agents <names>`     | list   | unset                      | Create an `agents/` workspace with one or more comma-separated agent names.                                              |
 | `--model <model>`      | string | `openai/gpt-5.6-luna-fast` | Set the root agent's AI Gateway model ID.                                                                                |
 | `--reasoning <effort>` | enum   | provider default           | Set reasoning to `none`, `minimal`, `low`, `medium`, `high`, or `xhigh`. `provider-default` leaves the field unauthored. |
 | `--channel-web-nextjs` | flag   | off                        | Add the Web Chat app (Next.js). Not for existing projects — run `eve add channel/web` there instead.                     |

--- a/packages/eve/src/cli/acp/command.ts
+++ b/packages/eve/src/cli/acp/command.ts
@@ -1,5 +1,6 @@
 import { Command } from "#compiled/commander/index.js";
-import { applicationCommand, type CliApplicationContext } from "#cli/application-command.js";
+import type { CliApplicationContext } from "#cli/application-command.js";
+import { agentCommand } from "#cli/agent-command.js";
 import { loadDevelopmentEnvironmentFiles } from "#cli/dev/environment.js";
 import {
   parseDevelopmentHeaderOption,
@@ -34,7 +35,7 @@ export interface RegisterAcpCommandOptions {
 
 /** Registers the ACP stdio bridge for local and deployed eve agents. */
 export function registerAcpCommand(options: RegisterAcpCommandOptions): void {
-  applicationCommand(options.program.command("acp"), options.applicationContext, (command) => {
+  agentCommand(options.program.command("acp"), options.applicationContext, (command) => {
     const commandOptions = command.opts<AcpCliOptions>();
     return (
       resolveDevelopmentUrlTarget(

--- a/packages/eve/src/cli/agent-command.test.ts
+++ b/packages/eve/src/cli/agent-command.test.ts
@@ -1,0 +1,76 @@
+import { Command } from "#compiled/commander/index.js";
+import { describe, expect, it, vi } from "vitest";
+
+import { agentCommand } from "#cli/agent-command.js";
+import type { CliApplicationContext } from "#cli/application-command.js";
+
+function workspaceContext(): CliApplicationContext {
+  const workspace = {
+    root: "/repo",
+    members: [
+      { appRoot: "/repo/agents/research", name: "research" },
+      { appRoot: "/repo/agents/support", name: "support" },
+    ],
+  };
+  return {
+    root: "/repo",
+    resolve: vi.fn(async () => {}),
+    resolveAgent: vi.fn(async () => ({
+      environmentRoot: "/repo",
+      kind: "workspace" as const,
+      workspace,
+    })),
+  };
+}
+
+describe("agentCommand", () => {
+  it("resolves an explicit workspace agent before the action", async () => {
+    const context = workspaceContext();
+    const action = vi.fn(() => expect(context.root).toBe("/repo/agents/support"));
+    const program = new Command().exitOverride();
+    agentCommand(program.command("info"), context).action(action);
+
+    await program.parseAsync(["info", "--agent", "support"], { from: "user" });
+
+    expect(action).toHaveBeenCalledOnce();
+  });
+
+  it("reports available agents for an unknown name", async () => {
+    const context = workspaceContext();
+    const program = new Command().exitOverride();
+    agentCommand(program.command("info"), context).action(vi.fn());
+
+    await expect(
+      program.parseAsync(["info", "--agent", "missing"], { from: "user" }),
+    ).rejects.toThrow('Unknown agent "missing". Available agents: research, support.');
+  });
+
+  it("requires --agent for a multi-agent workspace without a TTY", async () => {
+    const context = workspaceContext();
+    const program = new Command().exitOverride();
+    agentCommand(program.command("info"), context).action(vi.fn());
+
+    await expect(program.parseAsync(["info"], { from: "user" })).rejects.toThrow(
+      "Pass --agent <name>. Available agents: research, support.",
+    );
+  });
+
+  it("automatically selects the only workspace agent", async () => {
+    const context = workspaceContext();
+    context.resolveAgent = vi.fn(async () => ({
+      environmentRoot: "/repo",
+      kind: "workspace" as const,
+      workspace: {
+        root: "/repo",
+        members: [{ appRoot: "/repo/agents/support", name: "support" }],
+      },
+    }));
+    const action = vi.fn(() => expect(context.root).toBe("/repo/agents/support"));
+    const program = new Command().exitOverride();
+    agentCommand(program.command("info"), context).action(action);
+
+    await program.parseAsync(["info"], { from: "user" });
+
+    expect(action).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/eve/src/cli/agent-command.ts
+++ b/packages/eve/src/cli/agent-command.ts
@@ -2,7 +2,7 @@ import type { Command } from "#compiled/commander/index.js";
 import type { AgentWorkspace } from "#internal/agent-workspace.js";
 import { createPrompter } from "#setup/prompter.js";
 
-import { applicationCommand, type CliApplicationContext } from "./application-command.js";
+import type { CliApplicationContext } from "./application-command.js";
 
 export type AgentCommandRequirement = (command: Command) => boolean;
 
@@ -41,22 +41,34 @@ export function agentCommand(
   requirement: AgentCommandRequirement = () => true,
 ): Command {
   command.option("--agent <name>", "Select an agent from an agents/ workspace");
-  return applicationCommand(command, applicationContext, requirement).hook(
-    "preAction",
-    async (_command, actionCommand) => {
-      const requestedName = actionCommand.opts<{ agent?: string }>().agent;
-      if (!requirement(actionCommand)) {
-        if (requestedName !== undefined) {
-          throw new Error("--agent cannot be combined with a remote URL target.");
-        }
-        return;
+  return command.hook("preAction", async (_command, actionCommand) => {
+    const requestedName = actionCommand.opts<{ agent?: string }>().agent;
+    if (!requirement(actionCommand)) {
+      if (requestedName !== undefined) {
+        throw new Error("--agent cannot be combined with a remote URL target.");
       }
-      const selection = await applicationContext.resolveAgent();
-      if (selection.kind === "workspace") {
-        applicationContext.root = await selectWorkspaceAgent(selection.workspace, requestedName);
-      } else if (requestedName !== undefined) {
-        throw new Error("--agent can only be used from an agents/ workspace.");
+      return;
+    }
+
+    const initialSelection = await applicationContext.resolveAgent();
+    if (initialSelection.kind === "workspace") {
+      applicationContext.root = await selectWorkspaceAgent(
+        initialSelection.workspace,
+        requestedName,
+      );
+      await applicationContext.resolve();
+      return;
+    }
+
+    await applicationContext.resolve();
+    const resolvedSelection = await applicationContext.resolveAgent();
+    if (requestedName !== undefined) {
+      if (
+        resolvedSelection.kind !== "workspace-member" ||
+        resolvedSelection.member.name !== requestedName
+      ) {
+        throw new Error("--agent can only select a member of the enclosing agents/ workspace.");
       }
-    },
-  );
+    }
+  });
 }

--- a/packages/eve/src/cli/agent-command.ts
+++ b/packages/eve/src/cli/agent-command.ts
@@ -1,0 +1,62 @@
+import type { Command } from "#compiled/commander/index.js";
+import type { AgentWorkspace } from "#internal/agent-workspace.js";
+import { createPrompter } from "#setup/prompter.js";
+
+import { applicationCommand, type CliApplicationContext } from "./application-command.js";
+
+export type AgentCommandRequirement = (command: Command) => boolean;
+
+async function selectWorkspaceAgent(
+  workspace: AgentWorkspace,
+  requestedName: string | undefined,
+): Promise<string> {
+  const names = workspace.members.map((member) => member.name);
+  if (requestedName !== undefined) {
+    const member = workspace.members.find((candidate) => candidate.name === requestedName);
+    if (member === undefined) {
+      throw new Error(
+        `Unknown agent ${JSON.stringify(requestedName)}. Available agents: ${names.join(", ")}.`,
+      );
+    }
+    return member.appRoot;
+  }
+  if (workspace.members.length === 1) return workspace.members[0]!.appRoot;
+  if (!(process.stdin.isTTY && process.stdout.isTTY)) {
+    throw new Error(
+      `This command requires a specific agent. Pass --agent <name>. Available agents: ${names.join(", ")}.`,
+    );
+  }
+  const name = await createPrompter().select({
+    message: "Select an agent",
+    options: workspace.members.map((member) => ({ label: member.name, value: member.name })),
+    search: workspace.members.length > 8,
+  });
+  return workspace.members.find((member) => member.name === name)!.appRoot;
+}
+
+/** Adds consistent workspace-agent selection to an agent-scoped command. */
+export function agentCommand(
+  command: Command,
+  applicationContext: CliApplicationContext,
+  requirement: AgentCommandRequirement = () => true,
+): Command {
+  command.option("--agent <name>", "Select an agent from an agents/ workspace");
+  return applicationCommand(command, applicationContext, requirement).hook(
+    "preAction",
+    async (_command, actionCommand) => {
+      const requestedName = actionCommand.opts<{ agent?: string }>().agent;
+      if (!requirement(actionCommand)) {
+        if (requestedName !== undefined) {
+          throw new Error("--agent cannot be combined with a remote URL target.");
+        }
+        return;
+      }
+      const selection = await applicationContext.resolveAgent();
+      if (selection.kind === "workspace") {
+        applicationContext.root = await selectWorkspaceAgent(selection.workspace, requestedName);
+      } else if (requestedName !== undefined) {
+        throw new Error("--agent can only be used from an agents/ workspace.");
+      }
+    },
+  );
+}

--- a/packages/eve/src/cli/application-command.test.ts
+++ b/packages/eve/src/cli/application-command.test.ts
@@ -4,7 +4,15 @@ import { describe, expect, it, vi } from "vitest";
 import { applicationCommand, type CliApplicationContext } from "#cli/application-command.js";
 
 function context(): CliApplicationContext & { resolve: ReturnType<typeof vi.fn> } {
-  return { root: "/workspace", resolve: vi.fn(async () => {}) };
+  return {
+    root: "/workspace",
+    resolve: vi.fn(async () => {}),
+    resolveAgent: vi.fn(async () => ({
+      appRoot: "/workspace",
+      environmentRoot: "/workspace",
+      kind: "standalone" as const,
+    })),
+  };
 }
 
 describe("applicationCommand", () => {

--- a/packages/eve/src/cli/application-command.ts
+++ b/packages/eve/src/cli/application-command.ts
@@ -1,10 +1,12 @@
 import type { Command } from "#compiled/commander/index.js";
 import type { ResolvedDiscoveryProject } from "#discover/project.js";
+import type { EveProjectContext } from "#internal/project-context.js";
 
 export interface CliApplicationContext {
   root: string;
   project?: ResolvedDiscoveryProject;
   resolve(): Promise<void>;
+  resolveAgent(): Promise<EveProjectContext>;
 }
 
 export type CliApplicationRootRequirement = (command: Command) => boolean;

--- a/packages/eve/src/cli/commands/init-agent-workspace.ts
+++ b/packages/eve/src/cli/commands/init-agent-workspace.ts
@@ -1,0 +1,111 @@
+import { mkdir, readFile, rename } from "node:fs/promises";
+import { join } from "node:path";
+
+import pc from "#compiled/picocolors/index.js";
+
+import { assertValidPublicAgentName } from "#internal/agent-name.js";
+import { resolveAgentWorkspace } from "#internal/agent-workspace.js";
+import { DEFAULT_AGENT_MODEL_ID } from "#shared/default-agent-model.js";
+import type { AgentReasoningDefinition } from "#shared/agent-definition.js";
+import { validateModelSlug } from "#setup/flows/model-source-change.js";
+import { pathExists } from "#setup/path-exists.js";
+import { createPrompter } from "#setup/prompter.js";
+import { agentTemplateFiles } from "#setup/scaffold/create/project.js";
+import { writeTextFile } from "#setup/scaffold/files.js";
+
+export interface InitCommandOptions {
+  agents?: readonly string[];
+  channelWebNextjs?: boolean;
+  model?: string;
+  reasoning?: AgentReasoningDefinition;
+}
+
+export interface InitCliLogger {
+  error(message: string): void;
+  log(message: string): void;
+}
+
+function validateAgentNames(names: readonly string[]): void {
+  if (names.length === 0) throw new Error("--agents requires at least one agent name.");
+  const unique = new Set<string>();
+  for (const name of names) {
+    assertValidPublicAgentName(name, "Agent");
+    if (unique.has(name)) throw new Error(`Agent name ${JSON.stringify(name)} is repeated.`);
+    unique.add(name);
+  }
+}
+
+async function writeWorkspaceAgent(
+  workspaceRoot: string,
+  name: string,
+  options: InitCommandOptions,
+): Promise<void> {
+  const appRoot = join(workspaceRoot, "agents", name);
+  if (await pathExists(appRoot)) {
+    throw new Error(
+      `Cannot create agent ${JSON.stringify(name)} because ${appRoot} already exists.`,
+    );
+  }
+  const files = agentTemplateFiles(options.model ?? DEFAULT_AGENT_MODEL_ID, options.reasoning);
+  await Promise.all(
+    Object.entries(files).map(([path, content]) => writeTextFile(join(appRoot, path), content)),
+  );
+}
+
+export async function convertScaffoldToAgentWorkspace(
+  projectRoot: string,
+  names: readonly string[],
+  options: InitCommandOptions,
+): Promise<void> {
+  validateAgentNames(names);
+  if (options.channelWebNextjs === true) {
+    throw new Error("--channel-web-nextjs cannot be combined with --agents.");
+  }
+  const [first, ...remaining] = names;
+  await mkdir(join(projectRoot, "agents", first!), { recursive: true });
+  await rename(join(projectRoot, "agent"), join(projectRoot, "agents", first!, "agent"));
+  const tsconfigPath = join(projectRoot, "tsconfig.json");
+  const tsconfig = await readFile(tsconfigPath, "utf8");
+  await writeTextFile(tsconfigPath, tsconfig.replace('"agent/**/*.ts"', '"agents/**/*.ts"'), {
+    force: true,
+  });
+  for (const name of remaining) await writeWorkspaceAgent(projectRoot, name, options);
+}
+
+export async function addAgentsToWorkspace(
+  logger: InitCliLogger,
+  workspaceRoot: string,
+  target: string | undefined,
+  options: InitCommandOptions,
+  validateModel: typeof validateModelSlug = validateModelSlug,
+): Promise<boolean> {
+  const workspace = await resolveAgentWorkspace(workspaceRoot);
+  if (workspace === undefined) return false;
+  if (options.channelWebNextjs === true) {
+    throw new Error("--channel-web-nextjs is not supported when adding a workspace agent.");
+  }
+  let names = options.agents;
+  if (target !== undefined && names !== undefined) {
+    throw new Error("Pass either an agent name or --agents, not both.");
+  }
+  if (names === undefined && target !== undefined) names = [target];
+  if (names === undefined) {
+    if (!(process.stdin.isTTY && process.stdout.isTTY)) {
+      throw new Error(
+        "This directory is an eve agent workspace. Pass an agent name, for example: eve init billing.",
+      );
+    }
+    names = [await createPrompter().text({ message: "Name the new agent" })];
+  }
+  validateAgentNames(names);
+  if (options.model !== undefined) {
+    const rejection = await validateModel(workspaceRoot, options.model);
+    if (rejection !== null) throw new Error(rejection);
+  }
+  for (const name of names) await writeWorkspaceAgent(workspaceRoot, name, options);
+  logger.log(
+    `${pc.green("✓")} Added ${names.length === 1 ? "agent" : "agents"} ${names.map((name) => pc.bold(name)).join(", ")}`,
+  );
+  logger.log(pc.dim("$ eve dev --agent <name>"));
+  return true;
+}

--- a/packages/eve/src/cli/commands/init.integration.test.ts
+++ b/packages/eve/src/cli/commands/init.integration.test.ts
@@ -140,6 +140,54 @@ afterEach(() => {
 });
 
 describe("runInitCommand", () => {
+  it("creates an agent workspace from comma-separated names", async () => {
+    const parentDirectory = await mkdtemp(join(tmpdir(), "eve-init-agents-"));
+    const output = logger();
+    const deps = dependencies();
+
+    await runInitCommand(
+      output,
+      parentDirectory,
+      "operations",
+      {
+        agents: ["foreman", "researcher"],
+      },
+      deps,
+    );
+
+    const projectRoot = join(parentDirectory, "operations");
+    await expect(
+      pathExists(join(projectRoot, "agents", "foreman", "agent", "agent.ts")),
+    ).resolves.toBe(true);
+    await expect(
+      pathExists(join(projectRoot, "agents", "researcher", "agent", "agent.ts")),
+    ).resolves.toBe(true);
+    await expect(pathExists(join(projectRoot, "agent"))).resolves.toBe(false);
+    await expect(readFile(join(projectRoot, "tsconfig.json"), "utf8")).resolves.toContain(
+      '"agents/**/*.ts"',
+    );
+  });
+
+  it("adds only agent files to an existing workspace", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "eve-init-workspace-agent-"));
+    await mkdir(join(workspaceRoot, "agents", "support", "agent"), { recursive: true });
+    await writeFile(join(workspaceRoot, "package.json"), '{"name":"workspace"}\n');
+    const beforePackageJson = await readFile(join(workspaceRoot, "package.json"), "utf8");
+    const output = logger();
+    const deps = dependencies();
+
+    await runInitCommand(output, workspaceRoot, "billing", {}, deps);
+
+    await expect(
+      pathExists(join(workspaceRoot, "agents", "billing", "agent", "agent.ts")),
+    ).resolves.toBe(true);
+    await expect(readFile(join(workspaceRoot, "package.json"), "utf8")).resolves.toBe(
+      beforePackageJson,
+    );
+    expect(deps.runPackageManagerInstall).not.toHaveBeenCalled();
+    expect(deps.tryInitializeGit).not.toHaveBeenCalled();
+  });
+
   it("creates the base agent with the runtime default model and invoking eve dependency", async () => {
     const parentDirectory = await mkdtemp(join(tmpdir(), "eve-init-base-"));
     const output = logger();

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readdir, rename, rm } from "node:fs/promises";
+import { mkdtemp, readdir, rename, rm } from "node:fs/promises";
 import { basename, join, relative, resolve } from "node:path";
 import { performance } from "node:perf_hooks";
 
@@ -9,10 +9,7 @@ import { EVE_WORDMARK } from "#cli/banner.js";
 import { formatElapsed } from "#cli/format-elapsed.js";
 import { startCliLiveRow } from "#cli/ui/live-row.js";
 import { createLogger, isLogLevelEnabled } from "#internal/logging.js";
-import { assertValidPublicAgentName } from "#internal/agent-name.js";
-import { resolveAgentWorkspace } from "#internal/agent-workspace.js";
 import { DEFAULT_AGENT_MODEL_ID } from "#shared/default-agent-model.js";
-import type { AgentReasoningDefinition } from "#shared/agent-definition.js";
 import { formatNodeEngineOverrideWarning, type NodeEngineOverride } from "#setup/node-engine.js";
 import {
   detectInvokingPackageManager,
@@ -31,7 +28,6 @@ import {
 import type { ProcessOutputLine } from "#setup/primitives/process-output.js";
 import { addAgentToProject } from "#setup/scaffold/create/add-to-project.js";
 import { ensureChannel, scaffoldBaseProject } from "#setup/scaffold/index.js";
-import { createPrompter } from "#setup/prompter.js";
 import { WizardCancelledError } from "#setup/step.js";
 import { validateModelSlug } from "#setup/flows/model-source-change.js";
 import {
@@ -39,13 +35,17 @@ import {
   type WorkspaceRootMutation,
 } from "#setup/scaffold/workspace-root.js";
 import {
-  agentTemplateFiles,
   DEFAULT_EVE_PACKAGE_CONTRACT,
   type EvePackageContract,
 } from "#setup/scaffold/create/project.js";
-import { writeTextFile } from "#setup/scaffold/files.js";
 
 import { initAgentDevHandoff, initAgentReplPrompt } from "./agent-instructions.js";
+import {
+  addAgentsToWorkspace,
+  convertScaffoldToAgentWorkspace,
+  type InitCliLogger,
+  type InitCommandOptions,
+} from "./init-agent-workspace.js";
 import { initAgentReadySummary } from "./agent-instructions.js";
 import { confirmInitInNonEmptyDirectory } from "./init-confirm.js";
 import {
@@ -57,21 +57,7 @@ import { tryInitializeGit, type GitInitResult } from "./init-git.js";
 import { selectInitHandoff, spawnCodingAgentRepl, type InitHandoff } from "./init-repl.js";
 import { resolveInitTarget } from "./init-target.js";
 
-export interface InitCliLogger {
-  error(message: string): void;
-  log(message: string): void;
-}
-
-export interface InitCommandOptions {
-  /** Names used to create or extend an `agents/` workspace. Set by `--agents`. */
-  agents?: readonly string[];
-  /** Add the Web Chat channel (a Next.js app). Set by `--channel-web-nextjs`. */
-  channelWebNextjs?: boolean;
-  /** Model id written to the root agent config. Set by `--model`. */
-  model?: string;
-  /** Reasoning effort written to the root agent config. Set by `--reasoning`. */
-  reasoning?: AgentReasoningDefinition;
-}
+export type { InitCliLogger, InitCommandOptions } from "./init-agent-workspace.js";
 
 export interface InitCommandDependencies {
   addAgentToProject: typeof addAgentToProject;
@@ -111,94 +97,6 @@ const CURRENT_DIRECTORY_PROJECT_NAME = ".";
 export const EVE_INIT_PACKAGE_SPEC_ENV = "EVE_INIT_PACKAGE_SPEC";
 
 const initLog = createLogger("init");
-
-function validateAgentNames(names: readonly string[]): void {
-  if (names.length === 0) throw new Error("--agents requires at least one agent name.");
-  const unique = new Set<string>();
-  for (const name of names) {
-    assertValidPublicAgentName(name, "Agent");
-    if (unique.has(name)) throw new Error(`Agent name ${JSON.stringify(name)} is repeated.`);
-    unique.add(name);
-  }
-}
-
-async function writeWorkspaceAgent(
-  workspaceRoot: string,
-  name: string,
-  options: InitCommandOptions,
-): Promise<void> {
-  const appRoot = join(workspaceRoot, "agents", name);
-  if (await pathExists(appRoot)) {
-    throw new Error(
-      `Cannot create agent ${JSON.stringify(name)} because ${appRoot} already exists.`,
-    );
-  }
-  const files = agentTemplateFiles(options.model ?? DEFAULT_AGENT_MODEL_ID, options.reasoning);
-  await Promise.all(
-    Object.entries(files).map(([path, content]) => writeTextFile(join(appRoot, path), content)),
-  );
-}
-
-async function convertScaffoldToAgentWorkspace(
-  projectRoot: string,
-  names: readonly string[],
-  options: InitCommandOptions,
-): Promise<void> {
-  validateAgentNames(names);
-  if (options.channelWebNextjs === true) {
-    throw new Error("--channel-web-nextjs cannot be combined with --agents.");
-  }
-  const [first, ...remaining] = names;
-  await mkdir(join(projectRoot, "agents", first!), { recursive: true });
-  await rename(join(projectRoot, "agent"), join(projectRoot, "agents", first!, "agent"));
-  const tsconfigPath = join(projectRoot, "tsconfig.json");
-  const tsconfig = await import("node:fs/promises").then(({ readFile }) =>
-    readFile(tsconfigPath, "utf8"),
-  );
-  await writeTextFile(tsconfigPath, tsconfig.replace('"agent/**/*.ts"', '"agents/**/*.ts"'), {
-    force: true,
-  });
-  for (const name of remaining) {
-    await writeWorkspaceAgent(projectRoot, name, options);
-  }
-}
-
-async function addAgentsToWorkspace(
-  logger: InitCliLogger,
-  workspaceRoot: string,
-  target: string | undefined,
-  options: InitCommandOptions,
-): Promise<boolean> {
-  const workspace = await resolveAgentWorkspace(workspaceRoot);
-  if (workspace === undefined) return false;
-  if (options.channelWebNextjs === true) {
-    throw new Error("--channel-web-nextjs is not supported when adding a workspace agent.");
-  }
-  let names = options.agents;
-  if (target !== undefined && names !== undefined) {
-    throw new Error("Pass either an agent name or --agents, not both.");
-  }
-  if (names === undefined && target !== undefined) names = [target];
-  if (names === undefined) {
-    if (!(process.stdin.isTTY && process.stdout.isTTY)) {
-      throw new Error(
-        "This directory is an eve agent workspace. Pass an agent name, for example: eve init billing.",
-      );
-    }
-    names = [await createPrompter().text({ message: "Name the new agent" })];
-  }
-  validateAgentNames(names);
-  if (options.model !== undefined) {
-    const rejection = await validateModelSlug(workspaceRoot, options.model);
-    if (rejection !== null) throw new Error(rejection);
-  }
-  for (const name of names) await writeWorkspaceAgent(workspaceRoot, name, options);
-  logger.log(
-    `${pc.green("✓")} Added ${names.length === 1 ? "agent" : "agents"} ${names.map((name) => pc.bold(name)).join(", ")}`,
-  );
-  logger.log(pc.dim("$ eve dev --agent <name>"));
-  return true;
-}
 
 async function moveDirectoryContents(sourceRoot: string, targetRoot: string): Promise<void> {
   for (const entry of await readdir(sourceRoot)) {
@@ -670,7 +568,16 @@ export async function runInitCommand(
   options: InitCommandOptions,
   dependencies: InitCommandDependencies = defaultDependencies,
 ): Promise<void> {
-  if (await addAgentsToWorkspace(logger, parentDirectory, target, options)) return;
+  if (
+    await addAgentsToWorkspace(
+      logger,
+      parentDirectory,
+      target,
+      options,
+      dependencies.validateModelSlug,
+    )
+  )
+    return;
 
   let result: InitResult;
   try {

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readdir, rename, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, rename, rm } from "node:fs/promises";
 import { basename, join, relative, resolve } from "node:path";
 import { performance } from "node:perf_hooks";
 
@@ -9,6 +9,8 @@ import { EVE_WORDMARK } from "#cli/banner.js";
 import { formatElapsed } from "#cli/format-elapsed.js";
 import { startCliLiveRow } from "#cli/ui/live-row.js";
 import { createLogger, isLogLevelEnabled } from "#internal/logging.js";
+import { assertValidPublicAgentName } from "#internal/agent-name.js";
+import { resolveAgentWorkspace } from "#internal/agent-workspace.js";
 import { DEFAULT_AGENT_MODEL_ID } from "#shared/default-agent-model.js";
 import type { AgentReasoningDefinition } from "#shared/agent-definition.js";
 import { formatNodeEngineOverrideWarning, type NodeEngineOverride } from "#setup/node-engine.js";
@@ -29,6 +31,7 @@ import {
 import type { ProcessOutputLine } from "#setup/primitives/process-output.js";
 import { addAgentToProject } from "#setup/scaffold/create/add-to-project.js";
 import { ensureChannel, scaffoldBaseProject } from "#setup/scaffold/index.js";
+import { createPrompter } from "#setup/prompter.js";
 import { WizardCancelledError } from "#setup/step.js";
 import { validateModelSlug } from "#setup/flows/model-source-change.js";
 import {
@@ -36,9 +39,11 @@ import {
   type WorkspaceRootMutation,
 } from "#setup/scaffold/workspace-root.js";
 import {
+  agentTemplateFiles,
   DEFAULT_EVE_PACKAGE_CONTRACT,
   type EvePackageContract,
 } from "#setup/scaffold/create/project.js";
+import { writeTextFile } from "#setup/scaffold/files.js";
 
 import { initAgentDevHandoff, initAgentReplPrompt } from "./agent-instructions.js";
 import { initAgentReadySummary } from "./agent-instructions.js";
@@ -58,6 +63,8 @@ export interface InitCliLogger {
 }
 
 export interface InitCommandOptions {
+  /** Names used to create or extend an `agents/` workspace. Set by `--agents`. */
+  agents?: readonly string[];
   /** Add the Web Chat channel (a Next.js app). Set by `--channel-web-nextjs`. */
   channelWebNextjs?: boolean;
   /** Model id written to the root agent config. Set by `--model`. */
@@ -104,6 +111,94 @@ const CURRENT_DIRECTORY_PROJECT_NAME = ".";
 export const EVE_INIT_PACKAGE_SPEC_ENV = "EVE_INIT_PACKAGE_SPEC";
 
 const initLog = createLogger("init");
+
+function validateAgentNames(names: readonly string[]): void {
+  if (names.length === 0) throw new Error("--agents requires at least one agent name.");
+  const unique = new Set<string>();
+  for (const name of names) {
+    assertValidPublicAgentName(name, "Agent");
+    if (unique.has(name)) throw new Error(`Agent name ${JSON.stringify(name)} is repeated.`);
+    unique.add(name);
+  }
+}
+
+async function writeWorkspaceAgent(
+  workspaceRoot: string,
+  name: string,
+  options: InitCommandOptions,
+): Promise<void> {
+  const appRoot = join(workspaceRoot, "agents", name);
+  if (await pathExists(appRoot)) {
+    throw new Error(
+      `Cannot create agent ${JSON.stringify(name)} because ${appRoot} already exists.`,
+    );
+  }
+  const files = agentTemplateFiles(options.model ?? DEFAULT_AGENT_MODEL_ID, options.reasoning);
+  await Promise.all(
+    Object.entries(files).map(([path, content]) => writeTextFile(join(appRoot, path), content)),
+  );
+}
+
+async function convertScaffoldToAgentWorkspace(
+  projectRoot: string,
+  names: readonly string[],
+  options: InitCommandOptions,
+): Promise<void> {
+  validateAgentNames(names);
+  if (options.channelWebNextjs === true) {
+    throw new Error("--channel-web-nextjs cannot be combined with --agents.");
+  }
+  const [first, ...remaining] = names;
+  await mkdir(join(projectRoot, "agents", first!), { recursive: true });
+  await rename(join(projectRoot, "agent"), join(projectRoot, "agents", first!, "agent"));
+  const tsconfigPath = join(projectRoot, "tsconfig.json");
+  const tsconfig = await import("node:fs/promises").then(({ readFile }) =>
+    readFile(tsconfigPath, "utf8"),
+  );
+  await writeTextFile(tsconfigPath, tsconfig.replace('"agent/**/*.ts"', '"agents/**/*.ts"'), {
+    force: true,
+  });
+  for (const name of remaining) {
+    await writeWorkspaceAgent(projectRoot, name, options);
+  }
+}
+
+async function addAgentsToWorkspace(
+  logger: InitCliLogger,
+  workspaceRoot: string,
+  target: string | undefined,
+  options: InitCommandOptions,
+): Promise<boolean> {
+  const workspace = await resolveAgentWorkspace(workspaceRoot);
+  if (workspace === undefined) return false;
+  if (options.channelWebNextjs === true) {
+    throw new Error("--channel-web-nextjs is not supported when adding a workspace agent.");
+  }
+  let names = options.agents;
+  if (target !== undefined && names !== undefined) {
+    throw new Error("Pass either an agent name or --agents, not both.");
+  }
+  if (names === undefined && target !== undefined) names = [target];
+  if (names === undefined) {
+    if (!(process.stdin.isTTY && process.stdout.isTTY)) {
+      throw new Error(
+        "This directory is an eve agent workspace. Pass an agent name, for example: eve init billing.",
+      );
+    }
+    names = [await createPrompter().text({ message: "Name the new agent" })];
+  }
+  validateAgentNames(names);
+  if (options.model !== undefined) {
+    const rejection = await validateModelSlug(workspaceRoot, options.model);
+    if (rejection !== null) throw new Error(rejection);
+  }
+  for (const name of names) await writeWorkspaceAgent(workspaceRoot, name, options);
+  logger.log(
+    `${pc.green("✓")} Added ${names.length === 1 ? "agent" : "agents"} ${names.map((name) => pc.bold(name)).join(", ")}`,
+  );
+  logger.log(pc.dim("$ eve dev --agent <name>"));
+  return true;
+}
 
 async function moveDirectoryContents(sourceRoot: string, targetRoot: string): Promise<void> {
   for (const entry of await readdir(sourceRoot)) {
@@ -241,6 +336,9 @@ async function scaffoldProject(
       },
     };
     const stagedProjectPath = await dependencies.scaffoldBaseProject(scaffoldOptions);
+    if (options.agents !== undefined) {
+      await convertScaffoldToAgentWorkspace(stagedProjectPath, options.agents, options);
+    }
 
     if (options.channelWebNextjs === true) {
       await dependencies.ensureChannel({
@@ -572,6 +670,8 @@ export async function runInitCommand(
   options: InitCommandOptions,
   dependencies: InitCommandDependencies = defaultDependencies,
 ): Promise<void> {
+  if (await addAgentsToWorkspace(logger, parentDirectory, target, options)) return;
+
   let result: InitResult;
   try {
     result = await runInitSteps({ dependencies, logger, options, parentDirectory, target });
@@ -611,7 +711,8 @@ export async function runInitCommand(
     }
   }
 
-  const baseDevArguments = [...eveDevArguments(result.packageManager)];
+  const selectedAgentArguments = options.agents?.[0] ? ["--agent", options.agents[0]] : [];
+  const baseDevArguments = [...eveDevArguments(result.packageManager), ...selectedAgentArguments];
   const agentDevCommand = [result.packageManager, ...baseDevArguments].join(" ");
   const agentHandoff = initAgentDevHandoff({
     projectPath: result.projectPath,
@@ -659,7 +760,11 @@ export async function runInitCommand(
   // the command the way run-scripts do, so the handoff line is printed here.
   const freshScaffold = result.kind === "created";
   const devArguments = freshScaffold ? [...baseDevArguments, "--onboard"] : baseDevArguments;
-  logger.log(pc.dim("$ eve dev"));
+  logger.log(
+    pc.dim(
+      `$ eve dev${selectedAgentArguments.length > 0 ? ` --agent ${selectedAgentArguments[1]}` : ""}`,
+    ),
+  );
   if (
     !resultSucceeded(
       await dependencies.spawnPackageManager(

--- a/packages/eve/src/cli/commands/register-integration-commands.test.ts
+++ b/packages/eve/src/cli/commands/register-integration-commands.test.ts
@@ -22,7 +22,11 @@ describe("parseConnectPrincipalType", () => {
     registerIntegrationCommands({
       program,
       logger: { error: vi.fn(), log: vi.fn() },
-      applicationContext: { root: "/workspace", resolve: vi.fn(async () => {}) },
+      applicationContext: {
+        root: "/workspace",
+        resolve: vi.fn(async () => {}),
+        resolveAgent: vi.fn(),
+      },
     });
 
     expect(program.helpInformation()).toContain("integration");

--- a/packages/eve/src/cli/commands/register-integration-commands.ts
+++ b/packages/eve/src/cli/commands/register-integration-commands.ts
@@ -1,5 +1,6 @@
 import { InvalidArgumentError, type Command } from "#compiled/commander/index.js";
-import { applicationCommand, type CliApplicationContext } from "#cli/application-command.js";
+import type { CliApplicationContext } from "#cli/application-command.js";
+import { agentCommand } from "#cli/agent-command.js";
 import type { ConnectPrincipalType } from "#setup/connection-connector.js";
 
 import { parseSetupAnswer } from "./setup-answers.js";
@@ -24,7 +25,7 @@ export function registerIntegrationCommands(input: {
 
   const integration = program.command("integration").description("Set up an eve integration");
 
-  applicationCommand(integration.command("setup <kind>"), applicationContext)
+  agentCommand(integration.command("setup <kind>"), applicationContext)
     .description("Run a built-in integration setup flow")
     .option("-y, --yes")
     .option("--force", "Overwrite files created by setup.")
@@ -58,7 +59,7 @@ export function registerIntegrationCommands(input: {
       },
     );
 
-  applicationCommand(
+  agentCommand(
     integration.command("connect <slug> <service> [canonical-name]", { hidden: true }),
     applicationContext,
   )

--- a/packages/eve/src/cli/commands/register-registry-commands.ts
+++ b/packages/eve/src/cli/commands/register-registry-commands.ts
@@ -1,5 +1,6 @@
 import { InvalidArgumentError, type Command } from "#compiled/commander/index.js";
 import { applicationCommand, type CliApplicationContext } from "#cli/application-command.js";
+import { agentCommand } from "#cli/agent-command.js";
 
 import { parseSetupAnswer } from "./setup-answers.js";
 
@@ -33,7 +34,7 @@ export function registerRegistryCommands(input: {
 }): void {
   const { applicationContext, logger, program } = input;
 
-  const add = applicationCommand(program.command("add [item]"), applicationContext)
+  const add = agentCommand(program.command("add [item]"), applicationContext)
     .description("Install a registry item; relative paths use the official eve registry.")
     .option("-o, --overwrite", "Overwrite existing files.")
     .option("--skip-install", "Run the item's setup flow without installing it.")

--- a/packages/eve/src/cli/invoke/command.ts
+++ b/packages/eve/src/cli/invoke/command.ts
@@ -1,5 +1,6 @@
 import { type Command, InvalidArgumentError } from "#compiled/commander/index.js";
-import { applicationCommand, type CliApplicationContext } from "#cli/application-command.js";
+import type { CliApplicationContext } from "#cli/application-command.js";
+import { agentCommand } from "#cli/agent-command.js";
 import {
   parseDevelopmentHeaderOption,
   resolveDevelopmentUrlTarget,
@@ -66,7 +67,7 @@ export function registerInvokeCommand(input: {
   readonly logger: InvokeCommandLogger;
   readonly program: Command;
 }): void {
-  applicationCommand(input.program.command("invoke"), input.applicationContext, (command) => {
+  agentCommand(input.program.command("invoke"), input.applicationContext, (command) => {
     const options = command.opts<InvokeCliOptions>();
     return options.url === undefined && options.jsonSchema !== true;
   })

--- a/packages/eve/src/cli/option-parsers.ts
+++ b/packages/eve/src/cli/option-parsers.ts
@@ -75,6 +75,16 @@ const REASONING_VALUES: readonly AgentReasoningDefinition[] = [
 ];
 
 /** Parses an authored model reasoning effort. */
+export function parseAgentNamesOption(value: string): string[] {
+  const names = value.split(",").map((name) => name.trim());
+  if (names.length === 0 || names.some((name) => name === "")) {
+    throw new InvalidArgumentError(
+      "--agents requires a comma-separated list of at least one agent name.",
+    );
+  }
+  return names;
+}
+
 export function parseReasoningOption(value: string): AgentReasoningDefinition {
   if (!REASONING_VALUES.some((candidate) => candidate === value)) {
     throw new InvalidArgumentError(

--- a/packages/eve/src/cli/run.ts
+++ b/packages/eve/src/cli/run.ts
@@ -9,7 +9,8 @@ import type { DevBootProgressReporter } from "#internal/dev-boot-progress.js";
 import { resolveApplicationRoot } from "#internal/application/paths.js";
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
 import { isCodingAgentLaunch } from "#cli/agent-detection.js";
-import { applicationCommand, type CliApplicationContext } from "#cli/application-command.js";
+import type { CliApplicationContext } from "#cli/application-command.js";
+import { agentCommand } from "#cli/agent-command.js";
 import { findCliApplicationRoot, resolveCliApplicationProject } from "#cli/application-root.js";
 import { eveCliBanner } from "#cli/banner.js";
 import { registerIntegrationCommands } from "#cli/commands/register-integration-commands.js";
@@ -45,6 +46,12 @@ import {
   parseStatsMode,
 } from "#cli/option-parsers.js";
 import type { AgentReasoningDefinition } from "#shared/agent-definition.js";
+import { resolveTuiTitle, type DevelopmentTuiTarget } from "#cli/dev/tui/target.js";
+import { resolveEveProjectContext } from "#internal/project-context.js";
+import {
+  resumeDevelopmentRuntimeArtifacts,
+  suspendDevelopmentRuntimeArtifacts,
+} from "#services/dev-client/runtime-artifacts.js";
 import { parseDevelopmentServerUrl } from "#cli/dev/url.js";
 import { startCliLiveRow } from "#cli/ui/live-row.js";
 import { createCliTheme, renderCliTaggedLine } from "#cli/ui/output.js";
@@ -150,6 +157,16 @@ function hasInteractiveTerminal(): boolean {
   return Boolean(process.stdin.isTTY && process.stdout.isTTY);
 }
 
+function parseAgentNames(value: string): string[] {
+  const names = value.split(",").map((name) => name.trim());
+  if (names.length === 0 || names.some((name) => name === "")) {
+    throw new InvalidArgumentError(
+      "--agents requires a comma-separated list of at least one agent name.",
+    );
+  }
+  return names;
+}
+
 function createCliProgram(
   logger: CliLogger,
   runtime: CliRuntimeOverrides,
@@ -178,7 +195,7 @@ function createCliProgram(
       },
     });
 
-  applicationCommand(
+  agentCommand(
     program
       .command("channels")
       .description("Manage user-authored channels in the current project.")
@@ -232,6 +249,11 @@ function createCliProgram(
     .command("init [target]")
     .description("Create a new eve agent, or add one to an existing project directory.")
     .option("--channel-web-nextjs", "Add the Web Chat application (Next.js)")
+    .option(
+      "--agents <names>",
+      "Create an agents/ workspace with comma-separated agent names",
+      parseAgentNames,
+    )
     .option("--model <model>", "Set the agent model (provider/model-id)")
     .option(
       "--reasoning <effort>",
@@ -243,6 +265,7 @@ function createCliProgram(
       async (
         target: string | undefined,
         options: {
+          agents?: string[];
           channelWebNextjs?: boolean;
           model?: string;
           reasoning?: AgentReasoningDefinition;
@@ -255,6 +278,7 @@ function createCliProgram(
 
         const { runInitCommand } = await import("#cli/commands/init.js");
         await runInitCommand(logger, applicationContext.root, target, {
+          agents: options.agents,
           channelWebNextjs: options.channelWebNextjs,
           model: options.model,
           reasoning: options.reasoning,
@@ -262,7 +286,7 @@ function createCliProgram(
       },
     );
 
-  applicationCommand(program.command("set"), applicationContext)
+  agentCommand(program.command("set"), applicationContext)
     .description("Change root agent model settings.")
     .option("--model <model>", "Set the agent model (provider/model-id)")
     .option(
@@ -284,7 +308,7 @@ function createCliProgram(
     program,
   });
 
-  applicationCommand(program.command("start"), applicationContext)
+  agentCommand(program.command("start"), applicationContext)
     .description("Start a built eve application.")
     .option("--host <host>", "Host interface to bind")
     .option("--port <port>", "Port to listen on (defaults to $PORT, then 3000)", parsePortOption)
@@ -321,7 +345,7 @@ function createCliProgram(
     startHost: runtime.startHost,
   });
 
-  applicationCommand(program.command("dev"), applicationContext, (command) => {
+  agentCommand(program.command("dev"), applicationContext, (command) => {
     const options = command.opts<DevelopmentCliOptions>();
     return (
       resolveDevelopmentUrlTarget(options, command.processedArgs[0] as string | undefined) ===
@@ -546,7 +570,7 @@ function createCliProgram(
     .command("logs")
     .description("Inspect local `eve dev` diagnostic logs (.eve/logs).");
 
-  applicationCommand(logs.command("show [logid]", { isDefault: true }), applicationContext)
+  agentCommand(logs.command("show [logid]", { isDefault: true }), applicationContext)
     .description("Print a diagnostic log (the most recent when logid is omitted).")
     .option("--dump", "Prepend the log's environment dump (.dump sibling)")
     .option("--events", "Interleave session events from the local workflow store")
@@ -555,7 +579,7 @@ function createCliProgram(
       await runLogsShowCommand(logger, applicationContext.root, logId, options);
     });
 
-  applicationCommand(logs.command("ls"), applicationContext)
+  agentCommand(logs.command("ls"), applicationContext)
     .description("List diagnostic logs, most recent first.")
     .option("--json", "Output as JSON")
     .action(async (options: { json?: boolean }) => {
@@ -563,7 +587,7 @@ function createCliProgram(
       await runLogsListCommand(logger, applicationContext.root, options);
     });
 
-  const traces = applicationCommand(program.command("traces [trace]"), applicationContext)
+  const traces = agentCommand(program.command("traces [trace]"), applicationContext)
     .usage("[options] [trace]\n       eve traces ls [options]")
     .description("Show a local `eve dev` trace (the most recent when trace is omitted).")
     .option("--verbose", "Expand every span with all attributes and events")
@@ -584,7 +608,7 @@ function createCliProgram(
       await runTraceListCommand(logger, applicationContext.root, options);
     });
 
-  applicationCommand(program.command("info"), applicationContext)
+  agentCommand(program.command("info"), applicationContext)
     .description("Print resolved application information.")
     .option("--json", "Output as JSON")
     .action(async (options: { json?: boolean }) => {
@@ -593,7 +617,11 @@ function createCliProgram(
       await printApplicationInfo(logger, applicationContext.root, options);
     });
 
-  applicationCommand(program.command("eval"), applicationContext)
+  agentCommand(
+    program.command("eval"),
+    applicationContext,
+    (command) => command.opts<EvalCliOptions>().url === undefined,
+  )
     .description("Run evals against an eve agent.")
     .argument(
       "[evalIds...]",
@@ -633,6 +661,9 @@ export async function runCli(
       applicationContext.project = project;
       applicationContext.root = project.appRoot;
     },
+    async resolveAgent() {
+      return resolveEveProjectContext(applicationContext.root);
+    },
   };
   const program = createCliProgram(logger, runtime, applicationContext);
   let input = argv;
@@ -640,7 +671,8 @@ export async function runCli(
     const findApplicationRoot = runtime.findApplicationRoot ?? findCliApplicationRoot;
     const appRoot = await findApplicationRoot(applicationContext.root);
     if (appRoot === undefined) {
-      input = ["init"];
+      const projectContext = await resolveEveProjectContext(applicationContext.root);
+      input = projectContext.kind === "workspace" ? ["dev"] : ["init"];
     } else {
       applicationContext.root = appRoot;
       input = ["dev"];

--- a/packages/eve/src/cli/run.ts
+++ b/packages/eve/src/cli/run.ts
@@ -38,6 +38,7 @@ import {
   type InvokeCliRuntimeDependencies,
 } from "#cli/invoke/command.js";
 import {
+  parseAgentNamesOption,
   parseContextSizeOption,
   parseDisplayMode,
   parseLogsMode,
@@ -152,16 +153,6 @@ function hasInteractiveTerminal(): boolean {
   return Boolean(process.stdin.isTTY && process.stdout.isTTY);
 }
 
-function parseAgentNames(value: string): string[] {
-  const names = value.split(",").map((name) => name.trim());
-  if (names.length === 0 || names.some((name) => name === "")) {
-    throw new InvalidArgumentError(
-      "--agents requires a comma-separated list of at least one agent name.",
-    );
-  }
-  return names;
-}
-
 function createCliProgram(
   logger: CliLogger,
   runtime: CliRuntimeOverrides,
@@ -247,7 +238,7 @@ function createCliProgram(
     .option(
       "--agents <names>",
       "Create an agents/ workspace with comma-separated agent names",
-      parseAgentNames,
+      parseAgentNamesOption,
     )
     .option("--model <model>", "Set the agent model (provider/model-id)")
     .option(

--- a/packages/eve/src/cli/run.ts
+++ b/packages/eve/src/cli/run.ts
@@ -46,12 +46,7 @@ import {
   parseStatsMode,
 } from "#cli/option-parsers.js";
 import type { AgentReasoningDefinition } from "#shared/agent-definition.js";
-import { resolveTuiTitle, type DevelopmentTuiTarget } from "#cli/dev/tui/target.js";
 import { resolveEveProjectContext } from "#internal/project-context.js";
-import {
-  resumeDevelopmentRuntimeArtifacts,
-  suspendDevelopmentRuntimeArtifacts,
-} from "#services/dev-client/runtime-artifacts.js";
 import { parseDevelopmentServerUrl } from "#cli/dev/url.js";
 import { startCliLiveRow } from "#cli/ui/live-row.js";
 import { createCliTheme, renderCliTaggedLine } from "#cli/ui/output.js";

--- a/packages/eve/src/internal/vercel/eve-service-contribution.test.ts
+++ b/packages/eve/src/internal/vercel/eve-service-contribution.test.ts
@@ -45,6 +45,22 @@ describe("resolveEveServicePrefixByRoot", () => {
       }),
     ).toBe("/agent");
   });
+
+  it("ignores malformed legacy service collections", () => {
+    expect(
+      resolveCoDeployedEveServicePrefix({
+        appRoots: ["/project/agent"],
+        config: {
+          experimentalServices: null,
+          services: {
+            eve: { framework: "eve", root: "agent", routePrefix: "/agent" },
+            web: { framework: "nextjs" },
+          },
+        },
+        configRoot: "/project",
+      }),
+    ).toBe("/agent");
+  });
 });
 
 describe("createEveServiceName", () => {

--- a/packages/eve/src/internal/vercel/eve-service-contribution.test.ts
+++ b/packages/eve/src/internal/vercel/eve-service-contribution.test.ts
@@ -45,22 +45,6 @@ describe("resolveEveServicePrefixByRoot", () => {
       }),
     ).toBe("/agent");
   });
-
-  it("ignores malformed legacy service collections", () => {
-    expect(
-      resolveCoDeployedEveServicePrefix({
-        appRoots: ["/project/agent"],
-        config: {
-          experimentalServices: null,
-          services: {
-            eve: { framework: "eve", root: "agent", routePrefix: "/agent" },
-            web: { framework: "nextjs" },
-          },
-        },
-        configRoot: "/project",
-      }),
-    ).toBe("/agent");
-  });
 });
 
 describe("createEveServiceName", () => {


### PR DESCRIPTION
### Summary

Agent-scoped CLI commands now share one workspace-selection handler: `--agent <name>` selects a member, interactive runs pick from multiple members, and non-interactive runs receive an actionable list of valid names. `eve init my-project --agents foreman,researcher` creates the conventional workspace layout, while `eve init billing` inside an existing workspace adds only that agent's authored files. Workspace-level build, link, and deploy behavior remains unchanged.

### Validation

Focused CLI unit coverage verifies explicit, automatic, invalid, and non-interactive selection; init integration coverage verifies fresh multi-agent scaffolds and baggage-free additions. The affected integration suites, TypeScript checks, docs checks, lint, and invariant guard pass.

### Checklist

- [ ] I linked an issue with prior discussion confirming this change is wanted
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 3 files · `+13 / -7`

Documents workspace selection and both fresh and incremental init forms, plus the release note.

**Implementation** — 8 files · `+213 / -25`

Centralizes command selection and extends init without adding package metadata or child-project scaffolding.

**Tests** — 3 files · `+133 / -1`

Covers the shared command policy and both workspace initialization paths.
