### PR TITLE
feat(eve): sandbox - use versioned VCR image

### DIFF
--- a/.changeset/tidy-owls-build.md
+++ b/.changeset/tidy-owls-build.md
@@ -1,0 +1,5 @@
+---
+"eve": minor
+---
+
+Use the version-matched Vercel Container Registry image as the default base for Docker, microsandbox, and Vercel sandboxes. The backend environment must have pull access to the `vercel/eve` VCR project.

--- a/.changeset/tidy-owls-build.md
+++ b/.changeset/tidy-owls-build.md
@@ -2,4 +2,4 @@
 "eve": minor
 ---
 
-Use the version-matched Vercel Container Registry image as the default base for Docker, microsandbox, and Vercel sandboxes. The backend environment must have pull access to the `vercel/eve` VCR project.
+Use the version-matched public Vercel Container Registry image as the default base for Docker, microsandbox, and Vercel sandboxes.

--- a/docs/sandbox.mdx
+++ b/docs/sandbox.mdx
@@ -156,7 +156,7 @@ With `backend` omitted, eve uses `defaultBackend()`, which resolves on first use
 3. **microsandbox** when the host supports it: macOS on Apple Silicon, or glibc Linux with KVM enabled.
 4. **just-bash** as the dependency-free fallback.
 
-The Docker, microsandbox, and Vercel backends use the published `vcr.vercel.com/vercel/eve/base` image tag matching the installed eve version by default. The backend environment must have VCR pull access to the `vercel/eve` project; eve does not log local Docker or microsandbox hosts in to VCR automatically.
+The Docker, microsandbox, and Vercel backends use the public `vcr.vercel.com/vercel/eve/base` image tag matching the installed eve version by default. Docker and microsandbox can pull it without registry credentials.
 
 `defaultBackend()` also accepts a keyed bag so each inner backend gets its own typed create options:
 

--- a/docs/sandbox.mdx
+++ b/docs/sandbox.mdx
@@ -156,6 +156,8 @@ With `backend` omitted, eve uses `defaultBackend()`, which resolves on first use
 3. **microsandbox** when the host supports it: macOS on Apple Silicon, or glibc Linux with KVM enabled.
 4. **just-bash** as the dependency-free fallback.
 
+The Docker, microsandbox, and Vercel backends use the published `vcr.vercel.com/vercel/eve/base` image tag matching the installed eve version by default. The backend environment must have VCR pull access to the `vercel/eve` project; eve does not log local Docker or microsandbox hosts in to VCR automatically.
+
 `defaultBackend()` also accepts a keyed bag so each inner backend gets its own typed create options:
 
 ```ts
@@ -164,7 +166,7 @@ import { defaultBackend, defineSandbox } from "eve/sandbox";
 export default defineSandbox({
   backend: defaultBackend({
     vercel: { networkPolicy: "deny-all", resources: { vcpus: 4 } },
-    docker: { image: "ghcr.io/vercel/eve:latest" },
+    docker: { networkPolicy: "deny-all" },
     microsandbox: { memoryMiB: 2048 },
   }),
 });
@@ -172,11 +174,11 @@ export default defineSandbox({
 
 ### Docker
 
-`docker()` drives the Docker CLI directly. The default base image is `ghcr.io/vercel/eve:latest`, eve's published sandbox runtime image. eve creates `/workspace` and verifies Bash during framework setup, before authored bootstrap code runs. Configure it through `docker({ image, env, pullPolicy, networkPolicy })`, and install authored runtime tools in sandbox bootstrap or provide them through a custom image. Templates are committed as local Docker images and reused across sessions when the sandbox source, seed files, `revalidationKey`, and Docker backend options still match. Sessions run as long-lived containers whose filesystems persist `/workspace` changes across turns for the same durable session. `eve dev` prunes stale template images in the background.
+`docker()` drives the Docker CLI directly. By default, it uses eve's published sandbox runtime image at `vcr.vercel.com/vercel/eve/base:<eve-version>`, with the tag resolved from the installed eve version. eve creates `/workspace` and verifies Bash during framework setup, before authored bootstrap code runs. Configure it through `docker({ image, env, pullPolicy, networkPolicy })`, and install authored runtime tools in sandbox bootstrap or provide them through a custom image. Templates are committed as local Docker images and reused across sessions when the sandbox source, seed files, `revalidationKey`, and Docker backend options still match. Sessions run as long-lived containers whose filesystems persist `/workspace` changes across turns for the same durable session. `eve dev` prunes stale template images in the background.
 
 ### microsandbox
 
-`microsandbox()` runs each sandbox in a lightweight local VM with snapshot-backed templates, a `vercel-sandbox` user, and a firewall capable of domain-level network policies and credential brokering. It is the closest local match to hosted Vercel Sandbox. The default base image is `ghcr.io/vercel/eve:latest`, eve's published sandbox runtime image. During framework setup, before authored bootstrap code runs, eve verifies Bash and creates `/workspace` and the sandbox user. Install authored runtime tools in sandbox bootstrap or provide them through a custom image. Supported hosts are macOS on Apple Silicon, or Linux (glibc) with KVM. The `microsandbox` npm package and its VM runtime are not bundled with eve, so `eve dev` installs both automatically when missing (disable with `setup: { autoInstall: false }`); production processes fail with actionable install errors instead.
+`microsandbox()` runs each sandbox in a lightweight local VM with snapshot-backed templates, a `vercel-sandbox` user, and a firewall capable of domain-level network policies and credential brokering. It is the closest local match to hosted Vercel Sandbox. By default, it uses eve's published sandbox runtime image at `vcr.vercel.com/vercel/eve/base:<eve-version>`, with the tag resolved from the installed eve version. During framework setup, before authored bootstrap code runs, eve verifies Bash and creates `/workspace` and the sandbox user. Install authored runtime tools in sandbox bootstrap or provide them through a custom image. Supported hosts are macOS on Apple Silicon, or Linux (glibc) with KVM. The `microsandbox` npm package and its VM runtime are not bundled with eve, so `eve dev` installs both automatically when missing (disable with `setup: { autoInstall: false }`); production processes fail with actionable install errors instead.
 
 ### just-bash
 

--- a/e2e/fixtures/agent-tools-sandbox/agent/sandbox/sandbox.ts
+++ b/e2e/fixtures/agent-tools-sandbox/agent/sandbox/sandbox.ts
@@ -18,9 +18,10 @@ import { vercel } from "eve/sandbox/vercel";
  * Backend is left as the framework default so this fixture works both
  * locally (where `defaultBackend()` resolves to `docker()`) and on Vercel
  * deployments (where it resolves to `vercel()`). Both run the published
- * `ghcr.io/vercel/eve:latest` base image, which ships Python, Node, and git;
- * the bootstrap below assumes that real-binary environment and is not meant
- * to run against the dependency-free `just-bash` fallback.
+ * `vcr.vercel.com/vercel/eve/base` image tagged with the installed eve version,
+ * which ships Python, Node, and git; the bootstrap below assumes that
+ * real-binary environment and is not meant to run against the dependency-free
+ * `just-bash` fallback.
  *
  * `EVE_TEST_AUTHOR_SNAPSHOT_ID`, when set, overrides the backend with
  * `vercel({ source: { type: "snapshot", snapshotId } })` so the

--- a/packages/eve/src/execution/sandbox/bindings/eve-image.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/eve-image.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from "vitest";
+
+const packageMocks = vi.hoisted(() => ({
+  resolveInstalledPackageInfo: vi.fn(() => ({ name: "eve", version: "1.2.3" })),
+}));
+
+vi.mock("#internal/application/package.js", () => packageMocks);
+
+import {
+  DEFAULT_EVE_SANDBOX_IMAGE,
+  resolveEveSandboxImage,
+} from "#execution/sandbox/bindings/eve-image.js";
+
+describe("eve sandbox image", () => {
+  it("uses the VCR image tagged with the installed eve version", () => {
+    expect(resolveEveSandboxImage()).toBe("vcr.vercel.com/vercel/eve/base:1.2.3");
+    expect(DEFAULT_EVE_SANDBOX_IMAGE).toBe("vcr.vercel.com/vercel/eve/base:1.2.3");
+  });
+});

--- a/packages/eve/src/execution/sandbox/bindings/eve-image.ts
+++ b/packages/eve/src/execution/sandbox/bindings/eve-image.ts
@@ -2,9 +2,8 @@ import { resolveInstalledPackageInfo } from "#internal/application/package.js";
 
 const EVE_SANDBOX_IMAGE_REPOSITORY = "vcr.vercel.com/vercel/eve/base";
 
-// TODO: Replace with resolveEveSandboxImage() after the release workflow publishes its first VCR image.
-export const DEFAULT_EVE_SANDBOX_IMAGE = "ghcr.io/vercel/eve:latest";
-
 export function resolveEveSandboxImage(): string {
   return `${EVE_SANDBOX_IMAGE_REPOSITORY}:${resolveInstalledPackageInfo().version}`;
 }
+
+export const DEFAULT_EVE_SANDBOX_IMAGE = resolveEveSandboxImage();

--- a/packages/eve/src/public/sandbox/docker-sandbox.ts
+++ b/packages/eve/src/public/sandbox/docker-sandbox.ts
@@ -23,11 +23,11 @@ export type DockerSandboxNetworkPolicy = "allow-all" | "deny-all";
  */
 export interface DockerSandboxCreateOptions {
   /**
-   * Base container image for templates and sessions. Defaults to
-   * `ghcr.io/vercel/eve:latest` — eve's published sandbox runtime image.
-   * Framework setup creates `/workspace` and verifies Bash. Install any
-   * authored runtime tools in sandbox bootstrap or provide them through a
-   * custom image.
+   * Base container image for templates and sessions. Defaults to eve's
+   * published `vcr.vercel.com/vercel/eve/base` image, tagged with the installed
+   * eve version. Framework setup creates `/workspace` and verifies Bash.
+   * Install any authored runtime tools in sandbox bootstrap or provide them
+   * through a custom image.
    */
   readonly image?: string;
   /**

--- a/packages/eve/src/public/sandbox/microsandbox-sandbox.ts
+++ b/packages/eve/src/public/sandbox/microsandbox-sandbox.ts
@@ -17,7 +17,7 @@ export interface MicrosandboxSandboxCreateOptions {
    * Python, or ripgrep in sandbox bootstrap or provide them through a
    * custom image.
    *
-   * @default "ghcr.io/vercel/eve:latest"
+   * @default The `vcr.vercel.com/vercel/eve/base` tag matching the installed eve version.
    */
   readonly image?: string;
   /** Number of virtual CPUs assigned to each sandbox. @default 1 */

--- a/packages/eve/src/public/sandbox/vercel-sandbox.ts
+++ b/packages/eve/src/public/sandbox/vercel-sandbox.ts
@@ -30,7 +30,8 @@ type VercelSandboxAuthorCreateOptions<T> = T extends unknown
  * author-supplied values.
  *
  * `runtime` is excluded as well: eve always boots its sandboxes from the
- * published eve image, which is mutually exclusive with a stock runtime.
+ * published eve image tag matching the installed eve version, which is
+ * mutually exclusive with a stock runtime.
  *
  * `source` is honored only on the template create at prewarm time, so
  * an author-supplied snapshot, git revision, or tarball becomes the

--- a/packages/eve/test/scenarios/public-api-portability.scenario.test.ts
+++ b/packages/eve/test/scenarios/public-api-portability.scenario.test.ts
@@ -49,7 +49,7 @@ import { microsandbox } from "eve/sandbox/microsandbox";
 import { Drive, vercel } from "eve/sandbox/vercel";
 
 const fallback = defaultBackend({
-  docker: { image: "ghcr.io/vercel/eve:latest" },
+  docker: { image: "ubuntu:24.04" },
   justBash: {},
   microsandbox: {},
   vercel: { resources: { vcpus: 2 } },


### PR DESCRIPTION
### Summary

The sandbox default still points at the temporary `ghcr.io/vercel/eve:latest` fallback even though the first VCR image has been published. Docker, microsandbox, and Vercel sandboxes now share `vcr.vercel.com/vercel/eve/base:<eve-version>`, resolved from the installed eve version. The minor changeset will produce 0.50.0, whose release workflow publishes the matching VCR image before npm. This depends on [vercel/api#89572](https://github.com/vercel/api/pull/89572) being deployed so local runtimes can pull the public image without credentials; keep this PR in draft until then.

### Validation

The four focused sandbox suites pass with 64 tests, including coverage that the resolver and exported default use the installed package version. The docs compile and workspace typechecking passes. Anonymous registry access is covered by the dependent API PR and must be verified against production after that change deploys.

### Checklist

- [x] Tests added or updated for behavior changes
- [x] Documentation updated for user-facing changes
- [x] Changeset added for the published `eve` package

### Diff size

Docs — 5 files · +18 / -10
Implementation — 1 file · +2 / -3
Tests — 3 files · +24 / -4

Total — 9 files · +44 / -17