### PR TITLE
fix: avoid duplicate sandbox image layer

### DIFF
--- a/.changeset/slim-sandbox-image-layer.md
+++ b/.changeset/slim-sandbox-image-layer.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Reduce the published sandbox image by avoiding a duplicate ownership-only layer while preserving global npm and pnpm installs for sandbox users.

--- a/.github/workflows/docker-image-size-analysis.yml
+++ b/.github/workflows/docker-image-size-analysis.yml
@@ -99,6 +99,8 @@ jobs:
             set -euo pipefail
             test "$(id -un)" = vercel-sandbox
             test "$(stat -c %U /workspace)" = vercel-sandbox
+            test "$(npm prefix -g)" = "$HOME/.local"
+            test "$(pnpm bin -g)" = "$PNPM_HOME/bin"
             git init --quiet /workspace
             git -C /workspace remote add origin https://github.com/vercel/eve.git
             sudo -n true

--- a/packages/eve/Dockerfile
+++ b/packages/eve/Dockerfile
@@ -73,16 +73,19 @@ RUN set -eux; \
   if ! id -u vercel-sandbox >/dev/null 2>&1; then \
     useradd --create-home --shell /bin/bash vercel-sandbox; \
   fi; \
-  npm_prefix="$(npm prefix -g)"; \
-  mkdir -p "${npm_prefix}/bin" "${npm_prefix}/lib/node_modules" "${npm_prefix}/share"; \
-  chown -R vercel-sandbox:vercel-sandbox \
-    "${npm_prefix}/bin" \
-    "${npm_prefix}/lib/node_modules" \
-    "${npm_prefix}/share"; \
+  # Keep Node and pnpm root-owned: recursively changing their ownership copies
+  # them into another image layer. A small user-owned prefix retains global installs.
+  install -d --owner=vercel-sandbox --group=vercel-sandbox \
+    /home/vercel-sandbox/.local \
+    /home/vercel-sandbox/.local/share/pnpm; \
   mkdir -p /workspace; \
   chown vercel-sandbox:vercel-sandbox /workspace; \
   printf 'vercel-sandbox ALL=(ALL) NOPASSWD:ALL\n' >/etc/sudoers.d/vercel-sandbox; \
   chmod 0440 /etc/sudoers.d/vercel-sandbox
+
+ENV NPM_CONFIG_PREFIX=/home/vercel-sandbox/.local
+ENV PNPM_HOME=/home/vercel-sandbox/.local/share/pnpm
+ENV PATH=/home/vercel-sandbox/.local/share/pnpm/bin:/home/vercel-sandbox/.local/bin:${PATH}
 
 USER vercel-sandbox
 WORKDIR /workspace


### PR DESCRIPTION
### Summary

Avoid the ownership-only image layer created when the sandbox image recursively `chown`s the Node and pnpm global-install tree. Global npm and pnpm installs now use small, user-owned prefixes while Node and the bundled pnpm installation remain root-owned. The prior image analysis showed that ownership-change layer at roughly 53 MB during import; CI will report the actual final image delta.

### Validation

Verified the Docker smoke-test shell syntax and confirmed the npm and pnpm global-prefix assertions with the same isolated environment. The local Docker daemon is unavailable, so CI will build the image and measure its final size.

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

The release note records the smaller published sandbox image.

**Implementation** — 1 file · `+9 / -6`

Replaces the recursive ownership change with the user-owned prefixes that preserve global package installation without copying the installed runtime into another layer.

**Tests** — 1 file · `+2 / -0`

Extends the existing image smoke test with compact npm and pnpm prefix assertions.
