### PR TITLE
fix(eve): memory - support request-scoped Blob OIDC

### DIFF
--- a/.changeset/sweet-lions-smile.md
+++ b/.changeset/sweet-lions-smile.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Allow the default `fileMemory()` backend to use an attached Vercel Blob store when its OIDC token is available from the request context instead of the environment.

--- a/packages/eve/src/public/memory/file/backends/default.test.ts
+++ b/packages/eve/src/public/memory/file/backends/default.test.ts
@@ -89,6 +89,19 @@ describe("default file-memory backend", () => {
     expect(get).toHaveBeenCalledOnce();
   });
 
+  it("uses Vercel Blob with an attached store and request-scoped OIDC", async () => {
+    vi.stubEnv("VERCEL", "1");
+    vi.stubEnv("EVE_DEV", undefined);
+    vi.stubEnv("BLOB_READ_WRITE_TOKEN", undefined);
+    vi.stubEnv("VERCEL_OIDC_TOKEN", undefined);
+    vi.stubEnv("BLOB_STORE_ID", "store_test");
+    vi.mocked(get).mockResolvedValue(null);
+
+    const backend = defaultFileMemoryBackend();
+    await expect(backend.read({ key: "mem_a", signal })).resolves.toBeNull();
+    expect(get).toHaveBeenCalledOnce();
+  });
+
   it("gives Vercel selection precedence over eve dev", async () => {
     vi.stubEnv("VERCEL", "1");
     vi.stubEnv("EVE_DEV", "1");
@@ -105,7 +118,6 @@ describe("default file-memory backend", () => {
   it.each([
     { label: "no Blob environment", oidcToken: undefined, storeId: undefined, token: undefined },
     { label: "OIDC without a store ID", oidcToken: "oidc", storeId: undefined, token: undefined },
-    { label: "store ID without OIDC", oidcToken: undefined, storeId: "store", token: undefined },
     { label: "empty Blob values", oidcToken: " ", storeId: " ", token: " " },
   ])("rejects Vercel without usable Blob credentials: $label", async (environment) => {
     vi.stubEnv("VERCEL", "1");

--- a/packages/eve/src/public/memory/file/backends/default.ts
+++ b/packages/eve/src/public/memory/file/backends/default.ts
@@ -12,9 +12,9 @@ interface DefaultFileMemoryBackendProbes {
 }
 
 const ENVIRONMENT_PROBES: DefaultFileMemoryBackendProbes = {
+  // OIDC is request-scoped on Vercel, so the store ID is the stable attachment signal.
   hasVercelBlobStore: () =>
-    hasEnvironmentValue("BLOB_READ_WRITE_TOKEN") ||
-    (hasEnvironmentValue("BLOB_STORE_ID") && hasEnvironmentValue("VERCEL_OIDC_TOKEN")),
+    hasEnvironmentValue("BLOB_READ_WRITE_TOKEN") || hasEnvironmentValue("BLOB_STORE_ID"),
   isEveDevelopment: isEveDevEnvironment,
   isDeployedOnVercel: () => hasEnvironmentValue("VERCEL"),
 };


### PR DESCRIPTION
### Summary

The default `fileMemory()` backend rejected attached Vercel Blob stores when OIDC was available only through the request context because its preflight required `VERCEL_OIDC_TOKEN` in the process environment. Treat `BLOB_STORE_ID` as the stable attachment signal and let `@vercel/blob` resolve request-scoped OIDC credentials. Read-write token selection and errors for genuinely missing Blob configuration remain unchanged.

### Validation

Added regression coverage for a Vercel deployment with `BLOB_STORE_ID` but no environment OIDC token. `pnpm test` passed with 7,732 unit tests (one skipped) and 711 integration tests.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

The patch changeset records the corrected deployed behavior for release notes; the existing memory documentation already describes request-scoped OIDC as supported.

**Implementation** — 1 file · `+2 / -2`

Keeps the fix local to default backend detection and delegates credential resolution to the existing Blob backend.

**Tests** — 1 file · `+13 / -1`

Covers automatic Blob selection with an attached store and no environment OIDC token while retaining missing-store failure coverage.
