### PR TITLE
fix(eve): secure interactive OAuth callbacks

### DIFF
--- a/.changeset/secure-oauth-callbacks.md
+++ b/.changeset/secure-oauth-callbacks.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Interactive OAuth callbacks now require a route reachable without Protection Bypass for Automation, and successful callbacks redirect to a clean completion URL without OAuth parameters.

--- a/docs/connections/overview.mdx
+++ b/docs/connections/overview.mdx
@@ -206,6 +206,8 @@ When a local subagent needs interactive authorization, eve surfaces the authoriz
 
 That means the channel that creates or continues the session must authenticate a real user. For a web app, configure `agent/channels/eve.ts` so your app session maps to `principalType: "user"`; for platform channels, use the built-in channel auth that maps the sender to a user principal. If no authenticated user is attached to the session, the first user-scoped connection call fails with `reason: "principal_required"`.
 
+The OAuth provider must be able to reach eve's `/eve/v1/connections/*/callback/*` routes without an interactive Vercel Deployment Protection challenge. If Deployment Protection covers the callback deployment, use a [Deployment Protection Exception](https://vercel.com/docs/deployment-protection/methods-to-bypass-deployment-protection/deployment-protection-exceptions) or an unprotected callback domain instead.
+
 If the remote service should act as the agent itself instead of the end-user, make the Connect connection app-scoped:
 
 ```ts title="agent/connections/linear.ts"
@@ -223,16 +225,19 @@ App-scoped Connect auth is non-interactive. eve asks Vercel Connect for an app t
 
 ### Troubleshooting Vercel Connect auth
 
-| Symptom                                      | What it means                                                                                                                     | Fix                                                                                                                                       |
-| -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `reason: "principal_required"`               | A user-scoped connection ran without an authenticated user on the active session.                                                 | Return `principalType: "user"` from the channel's route auth, or change the connection to `principalType: "app"` if it should be shared.  |
-| `authorization.required` appears but no UI   | eve parked the turn for OAuth, but the channel or frontend is not rendering the challenge.                                        | Render the challenge from the stream event and continue the same session after the callback.                                              |
-| OAuth works locally but fails after deploy   | The project may not be linked to the Connect client, or the deployed runtime may not have the expected Vercel OIDC/project scope. | Run Connect setup from the consuming project directory, link the project, deploy again, and verify the connector UID in `connect("...")`. |
-| A scheduled or internal run needs user OAuth | Schedules and runtime callers do not automatically carry an end-user principal.                                                   | Dispatch through a user-authenticated channel when work is user-owned, or use app-scoped auth for agent-owned background work.            |
+| Symptom                                             | What it means                                                                                                                     | Fix                                                                                                                                                                                              |
+| --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `reason: "principal_required"`                      | A user-scoped connection ran without an authenticated user on the active session.                                                 | Return `principalType: "user"` from the channel's route auth, or change the connection to `principalType: "app"` if it should be shared.                                                         |
+| `authorization.required` appears but no UI          | eve parked the turn for OAuth, but the channel or frontend is not rendering the challenge.                                        | Render the challenge from the stream event and continue the same session after the callback.                                                                                                     |
+| OAuth works locally but fails after deploy          | The project may not be linked to the Connect client, or the deployed runtime may not have the expected Vercel OIDC/project scope. | Run Connect setup from the consuming project directory, link the project, deploy again, and verify the connector UID in `connect("...")`.                                                        |
+| OAuth opens a Vercel access page or never completes | Deployment Protection is blocking the callback domain.                                                                            | In the Vercel dashboard, open **Project → Settings → Deployment Protection → Deployment Protection Exceptions**, then add the preview domain. Alternatively, use an unprotected callback domain. |
+| A scheduled or internal run needs user OAuth        | Schedules and runtime callers do not automatically carry an end-user principal.                                                   | Dispatch through a user-authenticated channel when work is user-owned, or use app-scoped auth for agent-owned background work.                                                                   |
 
 ## Self-hosted interactive OAuth
 
 To run your own OAuth, use `defineInteractiveAuthorization` from `eve/connections`, which takes a three-method form and needs no Vercel Connect. eve mints a callback URL, parks (durably suspends) the turn on a framework-owned webhook, and resumes once the token comes back. Interactive auth is always `principalType: "user"`, and the factory pins that for you.
+
+The OAuth provider must be able to reach eve's `/eve/v1/connections/*/callback/*` routes without an interactive deployment-protection challenge. Exempt the callback deployment or use an unprotected callback domain instead.
 
 ```ts title="agent/connections/linear.ts"
 import {

--- a/e2e/fixtures/agent-workflow-tools/evals/agent-probe.shared.ts
+++ b/e2e/fixtures/agent-workflow-tools/evals/agent-probe.shared.ts
@@ -21,8 +21,16 @@ export async function runProbe(t: EveEvalContext, probe: ProbeCase): Promise<voi
     const required = await waitForEvent(t, t, started, "authorization.required");
     const url = required.event.data.authorization?.url;
     if (url === undefined) throw new Error("Authorization probe produced no callback URL.");
-    const response = await fetch(url);
-    if (!response.ok) throw new Error(`Authorization callback failed (${response.status}).`);
+    // Callback URLs no longer carry a deployment-protection bypass, so the
+    // request goes through the authenticated target client instead of a bare
+    // fetch that a protected deployment would redirect to SSO.
+    const callback = new URL(url);
+    const response = await t.target.fetch(`${callback.pathname}${callback.search}`, {
+      redirect: "manual",
+    });
+    if (response.status !== 303) {
+      throw new Error(`Authorization callback failed (${response.status}).`);
+    }
     await waitForEvent(t, required.session, undefined, "authorization.completed");
     await waitForMarker(t, required.session, undefined, "WORKFLOW-AUTH:authorized");
   }

--- a/e2e/fixtures/fixture-tasks/evals/task.authorization.callback.accepted-current-attempt.eval.ts
+++ b/e2e/fixtures/fixture-tasks/evals/task.authorization.callback.accepted-current-attempt.eval.ts
@@ -47,10 +47,17 @@ export default defineTaskEval({
     if (webhookUrl === undefined) throw new Error("C7 authorization.required had no webhook URL.");
     const callback = new URL(webhookUrl);
     callback.searchParams.set("code", AUTHORIZATION_CODE);
-    const callbackResponse = await fetch(callback, {
-      method: "GET",
+    // Callback URLs no longer carry a deployment-protection bypass, so the
+    // request goes through the authenticated target client instead of a bare
+    // fetch that a protected deployment would redirect to SSO.
+    const callbackResponse = await t.target.fetch(`${callback.pathname}${callback.search}`, {
+      redirect: "manual",
     });
-    await t.require(callbackResponse.status, equals(200));
+    await t.require(callbackResponse.status, equals(303));
+    await t.require(
+      callbackResponse.headers.get("location"),
+      equals("/eve/v1/connections/authorization-complete"),
+    );
 
     const completed = await waitForAuthorizationEvent(
       t,

--- a/packages/eve/src/eve-channel/index.ts
+++ b/packages/eve/src/eve-channel/index.ts
@@ -2,6 +2,7 @@ import type { SessionAuthContext, SessionTraceContext } from "#channel/types.js"
 import type { Session } from "#channel/session.js";
 import { resolveForwardedPrincipal } from "#channel/forwarded-principal.js";
 import {
+  handleAuthorizationCompleteRequest,
   handleConnectionCallbackRequest,
   handleLegacyConnectionCallbackRequest,
 } from "#execution/connections/callback-route.js";
@@ -27,6 +28,7 @@ import {
 } from "#protocol/message.js";
 import {
   EVE_ACTIVITY_ROUTE_PATTERN,
+  EVE_AUTHORIZATION_COMPLETE_ROUTE_PATH,
   EVE_CALLBACK_ROUTE_PATTERN,
   EVE_CONNECTION_CALLBACK_ROUTE_PATTERN,
   EVE_HEALTH_ROUTE_PATH,
@@ -119,6 +121,7 @@ export function eveChannel(input: EveChannelInput): EveChannel {
         return await respond();
       }),
 
+      GET(EVE_AUTHORIZATION_COMPLETE_ROUTE_PATH, handleAuthorizationCompleteRequest),
       GET(EVE_CONNECTION_CALLBACK_ROUTE_PATTERN, handleConnectionCallbackRequest),
       POST(EVE_CONNECTION_CALLBACK_ROUTE_PATTERN, handleConnectionCallbackRequest),
       GET(EVE_LEGACY_CONNECTION_CALLBACK_ROUTE_PATTERN, handleLegacyConnectionCallbackRequest),

--- a/packages/eve/src/execution/connections/callback-route.ts
+++ b/packages/eve/src/execution/connections/callback-route.ts
@@ -11,8 +11,8 @@
  * 1. Parses the inbound request into a JSON-serializable
  *    {@link AuthorizationCallback} (params only — never request headers).
  * 2. Calls `resumeHook(token, payload)` to wake the suspended workflow.
- * 3. Renders the standard "Authorization complete" landing page so the
- *    user sees a friendly UI instead of an empty `202 Accepted`.
+ * 3. Redirects to the standard "Authorization complete" landing page at a
+ *    clean URL so callback parameters do not remain in the address bar.
  *
  * Owning this route in the framework - instead of routing the IdP at the
  * workflow runtime's raw `/.well-known/workflow/v1/webhook/:token` -
@@ -26,6 +26,8 @@ import { resumeHook } from "#internal/workflow/runtime.js";
 import type { RouteContext } from "#public/definitions/channel.js";
 import { buildAuthorizationCompletePage } from "#runtime/connections/authorization-complete-page.js";
 import type { AuthorizationCallback } from "#shared/connection-types.js";
+
+const VERCEL_PROTECTION_BYPASS_QUERY = "x-vercel-protection-bypass";
 
 /**
  * Logical name prefix of the framework-shipped connection callback
@@ -50,6 +52,11 @@ export async function handleLegacyConnectionCallbackRequest(
   ctx: RouteContext,
 ): Promise<Response> {
   return handleCallbackRequest(request, ctx, true);
+}
+
+/** Renders the completion page at a stable URL without OAuth callback parameters. */
+export async function handleAuthorizationCompleteRequest(): Promise<Response> {
+  return buildAuthorizationCompletePage();
 }
 
 async function handleCallbackRequest(
@@ -91,7 +98,16 @@ async function handleCallbackRequest(
     return Response.json({ error: "Connection callback not pending.", ok: false }, { status: 404 });
   }
 
-  return buildAuthorizationCompletePage();
+  const requestPath = new URL(request.url).pathname;
+  const connectionsIndex = requestPath.lastIndexOf("/connections/");
+  const completionPath = `${requestPath.slice(0, connectionsIndex)}/connections/authorization-complete`;
+  return new Response(null, {
+    headers: {
+      "cache-control": "no-store",
+      location: completionPath,
+    },
+    status: 303,
+  });
 }
 
 /**
@@ -99,7 +115,8 @@ async function handleCallbackRequest(
  * {@link AuthorizationCallback} handed to `completeAuthorization`.
  *
  * Only the IdP-returned params (query string, plus a form-encoded body
- * for `form_post` response modes) and the method are captured. Request
+ * for `form_post` response modes) and the method are captured. Vercel's
+ * deployment-protection bypass parameter is explicitly excluded. Request
  * headers — including any inbound `Cookie`/`Authorization` — are
  * deliberately dropped so they never cross a step boundary; no shipped
  * strategy reads them.
@@ -107,7 +124,9 @@ async function handleCallbackRequest(
 async function projectAuthorizationCallback(request: Request): Promise<AuthorizationCallback> {
   const params: Record<string, string> = {};
   for (const [key, value] of new URL(request.url).searchParams) {
-    params[key] = value;
+    if (key !== VERCEL_PROTECTION_BYPASS_QUERY) {
+      params[key] = value;
+    }
   }
 
   let body: string | undefined;
@@ -120,7 +139,9 @@ async function projectAuthorizationCallback(request: Request): Promise<Authoriza
     const contentType = request.headers.get("content-type") ?? "";
     if (body && contentType.includes("application/x-www-form-urlencoded")) {
       for (const [key, value] of new URLSearchParams(body)) {
-        params[key] = value;
+        if (key !== VERCEL_PROTECTION_BYPASS_QUERY) {
+          params[key] = value;
+        }
       }
     }
   }

--- a/packages/eve/src/harness/authorization.test.ts
+++ b/packages/eve/src/harness/authorization.test.ts
@@ -19,14 +19,24 @@ afterEach(() => {
 });
 
 describe("authorization callback URLs", () => {
-  it("includes the Vercel automation bypass query when configured", () => {
+  it("does not disclose the Vercel automation bypass secret", () => {
     vi.stubEnv("VERCEL_AUTOMATION_BYPASS_SECRET", "secret value");
     const ctx = new ContextContainer();
     ctx.set(CallbackBaseUrlKey, "https://agent.example.com");
     ctx.set(SessionIdKey, "session-1");
 
     expect(contextStorage.run(ctx, () => getHookUrl("linear", "attempt-1"))).toBe(
-      "https://agent.example.com/eve/v1/connections/linear/callback/attempt-1/session-1%3Aauth?x-vercel-protection-bypass=secret+value",
+      "https://agent.example.com/eve/v1/connections/linear/callback/attempt-1/session-1%3Aauth",
+    );
+  });
+
+  it("preserves a public route prefix", () => {
+    const ctx = new ContextContainer();
+    ctx.set(CallbackBaseUrlKey, "https://agent.example.com/eve/agents/support");
+    ctx.set(SessionIdKey, "session-1");
+
+    expect(contextStorage.run(ctx, () => getHookUrl("linear", "attempt-1"))).toBe(
+      "https://agent.example.com/eve/agents/support/eve/v1/connections/linear/callback/attempt-1/session-1%3Aauth",
     );
   });
 });

--- a/packages/eve/src/harness/authorization.ts
+++ b/packages/eve/src/harness/authorization.ts
@@ -34,7 +34,6 @@
 import { loadContext } from "#context/container.js";
 import { ContextKey } from "#context/key.js";
 import { SessionIdKey } from "#context/keys.js";
-import { createWorkflowCallbackUrl } from "#execution/workflow-callback-url.js";
 import type { ConnectionAuthorizationChallenge } from "#connections/errors.js";
 import type { AuthorizationCallback, ConnectionPrincipal } from "#shared/connection-types.js";
 import type { JsonValue } from "#shared/json.js";
@@ -199,10 +198,8 @@ export function getHookUrl(name: string, attemptId: string): string | undefined 
   const baseUrl = ctx.get(CallbackBaseUrlKey);
   if (!sessionId || !baseUrl) return undefined;
   const token = authHookToken(sessionId);
-  return createWorkflowCallbackUrl(
-    baseUrl,
-    createEveConnectionCallbackRoutePath(name, attemptId, token),
-  );
+  const callbackPath = createEveConnectionCallbackRoutePath(name, attemptId, token);
+  return new URL(`${baseUrl.replace(/\/$/, "")}${callbackPath}`).toString();
 }
 
 /** Mints the identity and callback URL for one interactive authorization attempt. */

--- a/packages/eve/src/protocol/routes.ts
+++ b/packages/eve/src/protocol/routes.ts
@@ -107,6 +107,9 @@ export function createEveDevDispatchSchedulePath(scheduleId: string): string {
  */
 export const EVE_CONNECTION_CALLBACK_ROUTE_PATTERN = `${EVE_ROUTE_PREFIX}/connections/:name/callback/:attemptId/:token`;
 
+/** Static landing page shown after an interactive authorization callback completes. */
+export const EVE_AUTHORIZATION_COMPLETE_ROUTE_PATH = `${EVE_ROUTE_PREFIX}/connections/authorization-complete`;
+
 /** Callback shape minted by deployments before authorization attempt IDs. */
 export const EVE_LEGACY_CONNECTION_CALLBACK_ROUTE_PATTERN = `${EVE_ROUTE_PREFIX}/connections/:name/callback/:token`;
 

--- a/packages/eve/src/runtime/connections/callback-route.test.ts
+++ b/packages/eve/src/runtime/connections/callback-route.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createEveConnectionCallbackRoutePath } from "#protocol/routes.js";
 import type { RouteContext } from "#public/definitions/channel.js";
 import {
+  handleAuthorizationCompleteRequest,
   handleConnectionCallbackRequest,
   handleLegacyConnectionCallbackRequest,
 } from "#execution/connections/callback-route.js";
@@ -55,7 +56,7 @@ describe("handleConnectionCallbackRequest", () => {
 
   it("forwards a GET callback into resumeHook as parsed params with no request headers", async () => {
     resumeHookMock.mockResolvedValueOnce(undefined);
-    const url = `https://app.example.com${createEveConnectionCallbackRoutePath("linear", "attempt-1", "tok123")}?code=abc&state=xyz`;
+    const url = `https://app.example.com${createEveConnectionCallbackRoutePath("linear", "attempt-1", "tok123")}?code=abc&state=xyz&x-vercel-protection-bypass=secret`;
     const response = await handleConnectionCallbackRequest(
       new Request(url, {
         headers: { "x-probe": "1" },
@@ -64,13 +65,9 @@ describe("handleConnectionCallbackRequest", () => {
       buildRouteContext({ attemptId: "attempt-1", name: "linear", token: "tok123" }),
     );
 
-    expect(response.status).toBe(200);
-    expect(response.headers.get("content-type")).toContain("text/html");
-    const body = await response.text();
-    expect(body).toContain("Authorization complete");
-    expect(body).toContain("You can close this tab and return to your app.");
-    expect(body).toContain('aria-labelledby="authorization-title"');
-    expect(body).toContain('class="icon" aria-hidden="true"');
+    expect(response.status).toBe(303);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("location")).toBe("/eve/v1/connections/authorization-complete");
 
     expect(resumeHookMock).toHaveBeenCalledTimes(1);
     const [token, payload] = resumeHookMock.mock.calls[0] ?? [];
@@ -101,7 +98,8 @@ describe("handleConnectionCallbackRequest", () => {
       buildRouteContext({ name: "linear", token: "tok123" }),
     );
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe("/eve/v1/connections/authorization-complete");
     expect(resumeHookMock).toHaveBeenCalledWith("tok123", {
       kind: "deliver",
       payloads: [
@@ -116,12 +114,36 @@ describe("handleConnectionCallbackRequest", () => {
     });
   });
 
+  it("preserves a public route prefix in the clean completion redirect", async () => {
+    resumeHookMock.mockResolvedValueOnce(undefined);
+    const callbackPath = createEveConnectionCallbackRoutePath("linear", "attempt-1", "tok123");
+    const response = await handleConnectionCallbackRequest(
+      new Request(`https://app.example.com/eve/agents/support${callbackPath}?code=abc`),
+      buildRouteContext({ attemptId: "attempt-1", name: "linear", token: "tok123" }),
+    );
+
+    expect(response.headers.get("location")).toBe(
+      "/eve/agents/support/eve/v1/connections/authorization-complete",
+    );
+  });
+
+  it("renders the completion page at a clean stable route", async () => {
+    const response = await handleAuthorizationCompleteRequest();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("content-type")).toContain("text/html");
+    const body = await response.text();
+    expect(body).toContain("Authorization complete");
+    expect(body).toContain("You can close this tab and return to your app.");
+  });
+
   it("captures form-encoded POST bodies before resuming the hook", async () => {
     resumeHookMock.mockResolvedValueOnce(undefined);
     const url = `https://app.example.com${createEveConnectionCallbackRoutePath("linear", "attempt-1", "tok123")}`;
     await handleConnectionCallbackRequest(
       new Request(url, {
-        body: "code=abc&state=xyz",
+        body: "code=abc&state=xyz&x-vercel-protection-bypass=secret",
         headers: { "content-type": "application/x-www-form-urlencoded" },
         method: "POST",
       }),
@@ -139,7 +161,7 @@ describe("handleConnectionCallbackRequest", () => {
             callback: {
               params: { code: "abc", state: "xyz" },
               method: "POST",
-              body: "code=abc&state=xyz",
+              body: "code=abc&state=xyz&x-vercel-protection-bypass=secret",
             },
           },
         },


### PR DESCRIPTION
### Summary

Interactive OAuth callback URLs exposed `VERCEL_AUTOMATION_BYPASS_SECRET` to identity providers, browser history, and referrers. This removes the bypass from those URLs, strips it before callback data crosses a step boundary, and redirects completed callbacks to a clean completion page. Protected deployments now need a Deployment Protection Exception or an unprotected callback domain; other eve-to-eve workflow callbacks retain the bypass.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/harness/authorization.test.ts src/runtime/connections/callback-route.test.ts`
- `pnpm typecheck`, `pnpm docs:check`, `pnpm guard:invariants`, `pnpm fmt`, and `pnpm lint`
- `pnpm --filter fixture-tasks --filter agent-workflow-tools run typecheck`
- CI passed, including unit, integration, scenario, Local E2E, Postgres E2E, and Vercel E2E.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
