### PR TITLE
fix(eve): dual-publish sandbox images

### DIFF
--- a/.changeset/dual-images-publish.md
+++ b/.changeset/dual-images-publish.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Use version-matched GHCR images for Docker and microsandbox while Vercel Sandbox uses VCR. Publish each eve sandbox image version to both registries.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  GHCR_IMAGE: ghcr.io/vercel/eve
   VCR_IMAGE: vcr.vercel.com/vercel/eve/base
 
 jobs:
@@ -19,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: write
       pull-requests: write
       id-token: write
 
@@ -45,15 +47,20 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Prepare VCR tag
+      - name: Prepare image tags
         if: github.ref == 'refs/heads/main'
-        id: vcr-tag
+        id: image-tags
         run: |
           set -euo pipefail
 
           version="$(jq -er '.version | select(type == "string" and length > 0)' packages/eve/package.json)"
           echo "version=${version}" >>"$GITHUB_OUTPUT"
-          echo "tag=${VCR_IMAGE}:${version}" >>"$GITHUB_OUTPUT"
+          echo "ghcr-tag=${GHCR_IMAGE}:${version}" >>"$GITHUB_OUTPUT"
+          echo "vcr-tag=${VCR_IMAGE}:${version}" >>"$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        if: github.ref == 'refs/heads/main'
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
         if: github.ref == 'refs/heads/main'
@@ -66,17 +73,43 @@ jobs:
         with:
           team: ${{ secrets.VCR_TEAM_ID }}
 
-      - name: Check whether the eve image version is already published
+      - name: Log in to GitHub Container Registry
+        if: github.ref == 'refs/heads/main'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check whether the VCR image version is already published
         if: github.ref == 'refs/heads/main'
         id: vcr-image
         env:
-          VCR_TAG: ${{ steps.vcr-tag.outputs.tag }}
+          IMAGE_TAG: ${{ steps.image-tags.outputs.vcr-tag }}
         run: |
           set -euo pipefail
 
-          if inspect_output="$(docker buildx imagetools inspect --raw "$VCR_TAG" 2>&1)"; then
+          if inspect_output="$(docker buildx imagetools inspect --raw "$IMAGE_TAG" 2>&1)"; then
             echo "publish=false" >>"$GITHUB_OUTPUT"
-            echo "$VCR_TAG is already published; skipping the image build."
+            echo "$IMAGE_TAG is already published; skipping the image build."
+          elif grep -Eq ': not found|manifest unknown' <<<"$inspect_output"; then
+            echo "publish=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "$inspect_output" >&2
+            exit 1
+          fi
+
+      - name: Check whether the GHCR image version is already published
+        if: github.ref == 'refs/heads/main'
+        id: ghcr-image
+        env:
+          IMAGE_TAG: ${{ steps.image-tags.outputs.ghcr-tag }}
+        run: |
+          set -euo pipefail
+
+          if inspect_output="$(docker buildx imagetools inspect --raw "$IMAGE_TAG" 2>&1)"; then
+            echo "publish=false" >>"$GITHUB_OUTPUT"
+            echo "$IMAGE_TAG is already published; skipping the image build."
           elif grep -Eq ': not found|manifest unknown' <<<"$inspect_output"; then
             echo "publish=true" >>"$GITHUB_OUTPUT"
           else
@@ -93,14 +126,35 @@ jobs:
           platforms: linux/amd64
           provenance: false
           tags: |
-            ${{ steps.vcr-tag.outputs.tag }}
+            ${{ steps.image-tags.outputs.vcr-tag }}
             ${{ env.VCR_IMAGE }}:latest
           labels: |
             org.opencontainers.image.title=eve Sandbox
             org.opencontainers.image.description=Sandbox base image for eve agents.
             org.opencontainers.image.source=https://github.com/vercel/eve
             org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.version=${{ steps.vcr-tag.outputs.version }}
+            org.opencontainers.image.version=${{ steps.image-tags.outputs.version }}
+          outputs: type=image,push=true,oci-mediatypes=true,compression=zstd,compression-level=3,force-compression=true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Publish eve image to GitHub Container Registry
+        if: github.ref == 'refs/heads/main' && steps.ghcr-image.outputs.publish == 'true'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: ./packages/eve
+          file: ./packages/eve/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          tags: |
+            ${{ steps.image-tags.outputs.ghcr-tag }}
+            ${{ env.GHCR_IMAGE }}:latest
+          labels: |
+            org.opencontainers.image.title=eve Sandbox
+            org.opencontainers.image.description=Sandbox base image for eve agents.
+            org.opencontainers.image.source=https://github.com/vercel/eve
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.image-tags.outputs.version }}
           outputs: type=image,push=true,oci-mediatypes=true,compression=zstd,compression-level=3,force-compression=true
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/docs/sandbox.mdx
+++ b/docs/sandbox.mdx
@@ -156,6 +156,8 @@ With `backend` omitted, eve uses `defaultBackend()`, which resolves on first use
 3. **microsandbox** when the host supports it: macOS on Apple Silicon, or glibc Linux with KVM enabled.
 4. **just-bash** as the dependency-free fallback.
 
+By default, Docker and microsandbox pull `ghcr.io/vercel/eve` while Vercel Sandbox pulls `vcr.vercel.com/vercel/eve/base`. Each image tag matches the installed eve version.
+
 `defaultBackend()` also accepts a keyed bag so each inner backend gets its own typed create options:
 
 ```ts
@@ -164,7 +166,7 @@ import { defaultBackend, defineSandbox } from "eve/sandbox";
 export default defineSandbox({
   backend: defaultBackend({
     vercel: { networkPolicy: "deny-all", resources: { vcpus: 4 } },
-    docker: { image: "ghcr.io/vercel/eve:latest" },
+    docker: { networkPolicy: "deny-all" },
     microsandbox: { memoryMiB: 2048 },
   }),
 });
@@ -172,11 +174,11 @@ export default defineSandbox({
 
 ### Docker
 
-`docker()` drives the Docker CLI directly. The default base image is `ghcr.io/vercel/eve:latest`, eve's published sandbox runtime image. eve creates `/workspace` and verifies Bash during framework setup, before authored bootstrap code runs. Configure it through `docker({ image, env, pullPolicy, networkPolicy })`, and install authored runtime tools in sandbox bootstrap or provide them through a custom image. Templates are committed as local Docker images and reused across sessions when the sandbox source, seed files, `revalidationKey`, and Docker backend options still match. Sessions run as long-lived containers whose filesystems persist `/workspace` changes across turns for the same durable session. `eve dev` prunes stale template images in the background.
+`docker()` drives the Docker CLI directly. By default, it uses the `ghcr.io/vercel/eve` image tag matching the installed eve version. eve creates `/workspace` and verifies Bash during framework setup, before authored bootstrap code runs. Configure it through `docker({ image, env, pullPolicy, networkPolicy })`, and install authored runtime tools in sandbox bootstrap or provide them through a custom image. Templates are committed as local Docker images and reused across sessions when the sandbox source, seed files, `revalidationKey`, and Docker backend options still match. Sessions run as long-lived containers whose filesystems persist `/workspace` changes across turns for the same durable session. `eve dev` prunes stale template images in the background.
 
 ### microsandbox
 
-`microsandbox()` runs each sandbox in a lightweight local VM with snapshot-backed templates, a `vercel-sandbox` user, and a firewall capable of domain-level network policies and credential brokering. It is the closest local match to hosted Vercel Sandbox. The default base image is `ghcr.io/vercel/eve:latest`, eve's published sandbox runtime image. During framework setup, before authored bootstrap code runs, eve verifies Bash and creates `/workspace` and the sandbox user. Install authored runtime tools in sandbox bootstrap or provide them through a custom image. Supported hosts are macOS on Apple Silicon, or Linux (glibc) with KVM. The `microsandbox` npm package and its VM runtime are not bundled with eve, so `eve dev` installs both automatically when missing (disable with `setup: { autoInstall: false }`); production processes fail with actionable install errors instead.
+`microsandbox()` runs each sandbox in a lightweight local VM with snapshot-backed templates, a `vercel-sandbox` user, and a firewall capable of domain-level network policies and credential brokering. It is the closest local match to hosted Vercel Sandbox. By default, it uses the `ghcr.io/vercel/eve` image tag matching the installed eve version. During framework setup, before authored bootstrap code runs, eve verifies Bash and creates `/workspace` and the sandbox user. Install authored runtime tools in sandbox bootstrap or provide them through a custom image. Supported hosts are macOS on Apple Silicon, or Linux (glibc) with KVM. The `microsandbox` npm package and its VM runtime are not bundled with eve, so `eve dev` installs both automatically when missing (disable with `setup: { autoInstall: false }`); production processes fail with actionable install errors instead.
 
 ### just-bash
 

--- a/e2e/fixtures/agent-tools-sandbox/agent/sandbox/sandbox.ts
+++ b/e2e/fixtures/agent-tools-sandbox/agent/sandbox/sandbox.ts
@@ -17,10 +17,11 @@ import { vercel } from "eve/sandbox/vercel";
  *
  * Backend is left as the framework default so this fixture works both
  * locally (where `defaultBackend()` resolves to `docker()`) and on Vercel
- * deployments (where it resolves to `vercel()`). Both run the published
- * `ghcr.io/vercel/eve:latest` base image, which ships Python, Node, and git;
- * the bootstrap below assumes that real-binary environment and is not meant
- * to run against the dependency-free `just-bash` fallback.
+ * deployments (where it resolves to `vercel()`). Both run the published eve
+ * base image tagged with the installed eve version: GHCR locally and VCR on
+ * Vercel. The image ships Python, Node, and git; the bootstrap below assumes
+ * that real-binary environment and is not meant to run against the
+ * dependency-free `just-bash` fallback.
  *
  * `EVE_TEST_AUTHOR_SNAPSHOT_ID`, when set, overrides the backend with
  * `vercel({ source: { type: "snapshot", snapshotId } })` so the

--- a/packages/eve/src/execution/sandbox/bindings/eve-image.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/eve-image.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("#internal/application/package.js", () => ({
+  resolveInstalledPackageInfo: () => ({ name: "eve", version: "1.2.3" }),
+}));
+
+import {
+  DEFAULT_EVE_SANDBOX_IMAGE,
+  resolveEveSandboxImage,
+  resolveVercelEveSandboxImage,
+  VERCEL_EVE_SANDBOX_IMAGE,
+} from "#execution/sandbox/bindings/eve-image.js";
+
+describe("eve sandbox image", () => {
+  it("uses the versioned GHCR image outside Vercel Sandbox", () => {
+    expect(resolveEveSandboxImage()).toBe("ghcr.io/vercel/eve:1.2.3");
+    expect(DEFAULT_EVE_SANDBOX_IMAGE).toBe("ghcr.io/vercel/eve:1.2.3");
+  });
+
+  it("uses the versioned VCR image for Vercel Sandbox", () => {
+    expect(resolveVercelEveSandboxImage()).toBe("vcr.vercel.com/vercel/eve/base:1.2.3");
+    expect(VERCEL_EVE_SANDBOX_IMAGE).toBe("vcr.vercel.com/vercel/eve/base:1.2.3");
+  });
+});

--- a/packages/eve/src/execution/sandbox/bindings/eve-image.ts
+++ b/packages/eve/src/execution/sandbox/bindings/eve-image.ts
@@ -1,10 +1,15 @@
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
 
-const EVE_SANDBOX_IMAGE_REPOSITORY = "vcr.vercel.com/vercel/eve/base";
-
-// TODO: Replace with resolveEveSandboxImage() after the release workflow publishes its first VCR image.
-export const DEFAULT_EVE_SANDBOX_IMAGE = "ghcr.io/vercel/eve:latest";
+const GHCR_EVE_SANDBOX_IMAGE_REPOSITORY = "ghcr.io/vercel/eve";
+const VERCEL_EVE_SANDBOX_IMAGE_REPOSITORY = "vcr.vercel.com/vercel/eve/base";
 
 export function resolveEveSandboxImage(): string {
-  return `${EVE_SANDBOX_IMAGE_REPOSITORY}:${resolveInstalledPackageInfo().version}`;
+  return `${GHCR_EVE_SANDBOX_IMAGE_REPOSITORY}:${resolveInstalledPackageInfo().version}`;
 }
+
+export function resolveVercelEveSandboxImage(): string {
+  return `${VERCEL_EVE_SANDBOX_IMAGE_REPOSITORY}:${resolveInstalledPackageInfo().version}`;
+}
+
+export const DEFAULT_EVE_SANDBOX_IMAGE = resolveEveSandboxImage();
+export const VERCEL_EVE_SANDBOX_IMAGE = resolveVercelEveSandboxImage();

--- a/packages/eve/src/execution/sandbox/bindings/vercel-create-sdk.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel-create-sdk.ts
@@ -1,5 +1,5 @@
 import { getVercelSandboxFetch } from "#execution/sandbox/bindings/vercel-credentials.js";
-import { DEFAULT_EVE_SANDBOX_IMAGE } from "#execution/sandbox/bindings/eve-image.js";
+import { VERCEL_EVE_SANDBOX_IMAGE } from "#execution/sandbox/bindings/eve-image.js";
 import type {
   VercelCreateOptions,
   VercelModule,
@@ -43,7 +43,7 @@ export async function createVercelEveImageSandbox(input: {
   return await input.sandboxModule.Sandbox.create({
     ...createOptions,
     source,
-    image: DEFAULT_EVE_SANDBOX_IMAGE,
+    image: VERCEL_EVE_SANDBOX_IMAGE,
     fetch,
   });
 }

--- a/packages/eve/src/execution/sandbox/bindings/vercel.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SandboxTemplateNotProvisionedError } from "#public/definitions/sandbox-backend.js";
 import { vercel } from "#public/sandbox/backends/vercel.js";
-import { DEFAULT_EVE_SANDBOX_IMAGE } from "#execution/sandbox/bindings/eve-image.js";
+import { VERCEL_EVE_SANDBOX_IMAGE } from "#execution/sandbox/bindings/eve-image.js";
 import { createVercelSandbox } from "#execution/sandbox/bindings/vercel.js";
 
 // The credential fallback consults the developer's Vercel CLI auth and the
@@ -179,7 +179,7 @@ describe("createVercelSandbox", () => {
     expect(sandboxModule.Sandbox.create).toHaveBeenCalledTimes(1);
     expect(sandboxModule.Sandbox.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        image: DEFAULT_EVE_SANDBOX_IMAGE,
+        image: VERCEL_EVE_SANDBOX_IMAGE,
         name: "template-key",
         networkPolicy: "allow-all",
         persistent: false,
@@ -216,7 +216,7 @@ describe("createVercelSandbox", () => {
     expect(sandboxModule.Sandbox.create).toHaveBeenCalledWith(
       expect.objectContaining({
         __experimentalFlag: "enabled",
-        image: DEFAULT_EVE_SANDBOX_IMAGE,
+        image: VERCEL_EVE_SANDBOX_IMAGE,
       }),
     );
   });

--- a/packages/eve/src/public/sandbox/docker-sandbox.ts
+++ b/packages/eve/src/public/sandbox/docker-sandbox.ts
@@ -23,10 +23,10 @@ export type DockerSandboxNetworkPolicy = "allow-all" | "deny-all";
  */
 export interface DockerSandboxCreateOptions {
   /**
-   * Base container image for templates and sessions. Defaults to
-   * `ghcr.io/vercel/eve:latest` — eve's published sandbox runtime image.
-   * Framework setup creates `/workspace` and verifies Bash. Install any
-   * authored runtime tools in sandbox bootstrap or provide them through a
+   * Base container image for templates and sessions. Defaults to eve's
+   * published `ghcr.io/vercel/eve` image, tagged with the installed eve
+   * version. Framework setup creates `/workspace` and verifies Bash. Install
+   * any authored runtime tools in sandbox bootstrap or provide them through a
    * custom image.
    */
   readonly image?: string;

--- a/packages/eve/src/public/sandbox/microsandbox-sandbox.ts
+++ b/packages/eve/src/public/sandbox/microsandbox-sandbox.ts
@@ -17,7 +17,7 @@ export interface MicrosandboxSandboxCreateOptions {
    * Python, or ripgrep in sandbox bootstrap or provide them through a
    * custom image.
    *
-   * @default "ghcr.io/vercel/eve:latest"
+   * @default The `ghcr.io/vercel/eve` tag matching the installed eve version.
    */
   readonly image?: string;
   /** Number of virtual CPUs assigned to each sandbox. @default 1 */

--- a/packages/eve/src/public/sandbox/vercel-sandbox.ts
+++ b/packages/eve/src/public/sandbox/vercel-sandbox.ts
@@ -30,7 +30,8 @@ type VercelSandboxAuthorCreateOptions<T> = T extends unknown
  * author-supplied values.
  *
  * `runtime` is excluded as well: eve always boots its sandboxes from the
- * published eve image, which is mutually exclusive with a stock runtime.
+ * published `vcr.vercel.com/vercel/eve/base` image tag matching the installed
+ * eve version, which is mutually exclusive with a stock runtime.
  *
  * `source` is honored only on the template create at prewarm time, so
  * an author-supplied snapshot, git revision, or tarball becomes the


### PR DESCRIPTION
### Summary

eve sandbox images are currently published only to VCR, which hosted Vercel Sandbox can pull but Docker and microsandbox cannot. This restores dual publishing to VCR and GHCR with immutable version tags and `latest`, while independently preserving tags that are already published. Docker and microsandbox now resolve the version-matched GHCR image; Vercel Sandbox resolves the version-matched VCR image. GHCR remains multi-architecture, while VCR remains `linux/amd64` for Vercel.

### Validation

Focused image resolver, Docker options, microsandbox, and Vercel unit suites passed with 65 tests, and `pnpm --filter eve exec vitest run --config vitest.scenario.config.ts test/scenarios/public-api-portability.scenario.test.ts` passed with 9 tests. Registry pushes require release credentials and remain CI-only.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+10 / -3`

Updates the sandbox guide and release metadata for the registry-specific defaults.

**Implementation** — 6 files · `+82 / -22`

Adds independent VCR and GHCR publishing while keeping the runtime resolver split small and explicit.

**Tests** — 3 files · `+32 / -7`

Covers both versioned image resolvers and verifies that Vercel Sandbox receives the VCR image.
