### PR TITLE
fix(eve): allow sandbox image tag override

### DIFF
--- a/.changeset/sandbox-image-tag.md
+++ b/.changeset/sandbox-image-tag.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Allow `EVE_SANDBOX_IMAGE_TAG` to override the version-derived tag used for eve's default sandbox images.

--- a/.github/workflows/e2e-local.yml
+++ b/.github/workflows/e2e-local.yml
@@ -78,6 +78,7 @@ jobs:
       AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
       EVE_E2E_MODEL: ${{ matrix.model_id }}
       EVE_EVAL_JUNIT_DIR: ${{ github.workspace }}/.junit
+      EVE_SANDBOX_IMAGE_TAG: latest
 
     steps:
       - name: Checkout code

--- a/.github/workflows/e2e-postgres.yml
+++ b/.github/workflows/e2e-postgres.yml
@@ -92,6 +92,7 @@ jobs:
       # The world package comes from this world's e2e/matrix.json entry.
       EVE_E2E_WORKFLOW_WORLD: ${{ matrix.world_package }}
       EVE_EVAL_JUNIT_DIR: ${{ github.workspace }}/.junit
+      EVE_SANDBOX_IMAGE_TAG: latest
       WORKFLOW_POSTGRES_MAX_POOL_SIZE: "52"
       WORKFLOW_POSTGRES_URL: postgres://world:world@127.0.0.1:5432/world
       WORKFLOW_POSTGRES_WORKER_CONCURRENCY: "50"

--- a/.github/workflows/e2e-vercel.yml
+++ b/.github/workflows/e2e-vercel.yml
@@ -77,6 +77,7 @@ jobs:
     env:
       EVE_E2E_MODEL: mock
       EVE_EVAL_JUNIT_DIR: ${{ github.workspace }}/.junit
+      EVE_SANDBOX_IMAGE_TAG: latest
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
@@ -165,7 +166,9 @@ jobs:
             VERCEL_PROJECT_ID="$VERCEL_PROJECT_ID" \
             pnpm exec eve build --profile "$EVE_BUILD_PROFILE"
           DEPLOYMENT_URL="$(pnpm exec vc deploy --prebuilt --yes --target=preview \
-            --env "EVE_E2E_MODEL=$EVE_E2E_MODEL" "${token_args[@]}" | tail -n 1)"
+            --env "EVE_E2E_MODEL=$EVE_E2E_MODEL" \
+            --env "EVE_SANDBOX_IMAGE_TAG=$EVE_SANDBOX_IMAGE_TAG" \
+            "${token_args[@]}" | tail -n 1)"
 
           npx eve eval --strict --verbose --exclude-tag real-model \
             --url "$DEPLOYMENT_URL" \

--- a/docs/sandbox.mdx
+++ b/docs/sandbox.mdx
@@ -156,7 +156,7 @@ With `backend` omitted, eve uses `defaultBackend()`, which resolves on first use
 3. **microsandbox** when the host supports it: macOS on Apple Silicon, or glibc Linux with KVM enabled.
 4. **just-bash** as the dependency-free fallback.
 
-By default, Docker and microsandbox pull `ghcr.io/vercel/eve` while Vercel Sandbox pulls `vcr.vercel.com/vercel/eve/base`. Each image tag matches the installed eve version.
+By default, Docker and microsandbox pull `ghcr.io/vercel/eve` while Vercel Sandbox pulls `vcr.vercel.com/vercel/eve/base`. Each image tag matches the installed eve version. Set `EVE_SANDBOX_IMAGE_TAG` to replace the version-derived tag for these default images. An explicit `image` passed to `docker()` or `microsandbox()` still takes precedence.
 
 `defaultBackend()` also accepts a keyed bag so each inner backend gets its own typed create options:
 

--- a/e2e/fixtures/agent-tools-sandbox/agent/sandbox/sandbox.ts
+++ b/e2e/fixtures/agent-tools-sandbox/agent/sandbox/sandbox.ts
@@ -18,8 +18,9 @@ import { vercel } from "eve/sandbox/vercel";
  * Backend is left as the framework default so this fixture works both
  * locally (where `defaultBackend()` resolves to `docker()`) and on Vercel
  * deployments (where it resolves to `vercel()`). Both run the published eve
- * base image tagged with the installed eve version: GHCR locally and VCR on
- * Vercel. The image ships Python, Node, and git; the bootstrap below assumes
+ * base image: GHCR locally and VCR on Vercel. CI sets `EVE_SANDBOX_IMAGE_TAG`
+ * to `latest` so release PRs can run before their versioned image exists. The
+ * image ships Python, Node, and git; the bootstrap below assumes
  * that real-binary environment and is not meant to run against the
  * dependency-free `just-bash` fallback.
  *

--- a/e2e/fixtures/agent-tools-sandbox/evals/sandbox/redeploy.eval.ts
+++ b/e2e/fixtures/agent-tools-sandbox/evals/sandbox/redeploy.eval.ts
@@ -155,17 +155,30 @@ async function deployToAlias(t: EveEvalContext, alias: string, phase: string): P
 
   const tokenArgs =
     process.env.VERCEL_TOKEN === undefined ? [] : ["--token", process.env.VERCEL_TOKEN];
-  const modelArgs =
-    process.env.EVE_E2E_MODEL === undefined
+  const deploymentEnvArgs = [
+    ...(process.env.EVE_E2E_MODEL === undefined
       ? []
-      : ["--env", `EVE_E2E_MODEL=${process.env.EVE_E2E_MODEL}`];
+      : ["--env", `EVE_E2E_MODEL=${process.env.EVE_E2E_MODEL}`]),
+    ...(process.env.EVE_SANDBOX_IMAGE_TAG === undefined
+      ? []
+      : ["--env", `EVE_SANDBOX_IMAGE_TAG=${process.env.EVE_SANDBOX_IMAGE_TAG}`]),
+  ];
   // vc alias does not infer the team from the project link the way deploy
   // does, so pass the scope explicitly.
   const scopeArgs =
     process.env.VERCEL_ORG_ID === undefined ? [] : ["--scope", process.env.VERCEL_ORG_ID];
   const deploy = await execFileAsync(
     "pnpm",
-    ["exec", "vc", "deploy", "--prebuilt", "--yes", "--target=preview", ...modelArgs, ...tokenArgs],
+    [
+      "exec",
+      "vc",
+      "deploy",
+      "--prebuilt",
+      "--yes",
+      "--target=preview",
+      ...deploymentEnvArgs,
+      ...tokenArgs,
+    ],
     EXEC_OPTIONS,
   );
   const deploymentUrl = deploy.stdout.trim().split("\n").at(-1)?.trim();

--- a/packages/eve/src/execution/sandbox/bindings/eve-image.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/eve-image.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("#internal/application/package.js", () => ({
   resolveInstalledPackageInfo: () => ({ name: "eve", version: "1.2.3" }),
@@ -12,6 +12,11 @@ import {
 } from "#execution/sandbox/bindings/eve-image.js";
 
 describe("eve sandbox image", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
   it("uses the versioned GHCR image outside Vercel Sandbox", () => {
     expect(resolveEveSandboxImage()).toBe("ghcr.io/vercel/eve:1.2.3");
     expect(DEFAULT_EVE_SANDBOX_IMAGE).toBe("ghcr.io/vercel/eve:1.2.3");
@@ -20,5 +25,16 @@ describe("eve sandbox image", () => {
   it("uses the versioned VCR image for Vercel Sandbox", () => {
     expect(resolveVercelEveSandboxImage()).toBe("vcr.vercel.com/vercel/eve/base:1.2.3");
     expect(VERCEL_EVE_SANDBOX_IMAGE).toBe("vcr.vercel.com/vercel/eve/base:1.2.3");
+  });
+
+  it("uses EVE_SANDBOX_IMAGE_TAG for both registries", async () => {
+    vi.stubEnv("EVE_SANDBOX_IMAGE_TAG", "latest");
+    vi.resetModules();
+
+    const images = await import("#execution/sandbox/bindings/eve-image.js");
+    expect(images.resolveEveSandboxImage()).toBe("ghcr.io/vercel/eve:latest");
+    expect(images.DEFAULT_EVE_SANDBOX_IMAGE).toBe("ghcr.io/vercel/eve:latest");
+    expect(images.resolveVercelEveSandboxImage()).toBe("vcr.vercel.com/vercel/eve/base:latest");
+    expect(images.VERCEL_EVE_SANDBOX_IMAGE).toBe("vcr.vercel.com/vercel/eve/base:latest");
   });
 });

--- a/packages/eve/src/execution/sandbox/bindings/eve-image.ts
+++ b/packages/eve/src/execution/sandbox/bindings/eve-image.ts
@@ -4,11 +4,18 @@ const GHCR_EVE_SANDBOX_IMAGE_REPOSITORY = "ghcr.io/vercel/eve";
 const VERCEL_EVE_SANDBOX_IMAGE_REPOSITORY = "vcr.vercel.com/vercel/eve/base";
 
 export function resolveEveSandboxImage(): string {
-  return `${GHCR_EVE_SANDBOX_IMAGE_REPOSITORY}:${resolveInstalledPackageInfo().version}`;
+  return `${GHCR_EVE_SANDBOX_IMAGE_REPOSITORY}:${resolveEveSandboxImageTag()}`;
 }
 
 export function resolveVercelEveSandboxImage(): string {
-  return `${VERCEL_EVE_SANDBOX_IMAGE_REPOSITORY}:${resolveInstalledPackageInfo().version}`;
+  return `${VERCEL_EVE_SANDBOX_IMAGE_REPOSITORY}:${resolveEveSandboxImageTag()}`;
+}
+
+function resolveEveSandboxImageTag(): string {
+  const override = process.env.EVE_SANDBOX_IMAGE_TAG?.trim();
+  return override !== undefined && override.length > 0
+    ? override
+    : resolveInstalledPackageInfo().version;
 }
 
 export const DEFAULT_EVE_SANDBOX_IMAGE = resolveEveSandboxImage();

--- a/packages/eve/src/public/sandbox/docker-sandbox.ts
+++ b/packages/eve/src/public/sandbox/docker-sandbox.ts
@@ -25,7 +25,8 @@ export interface DockerSandboxCreateOptions {
   /**
    * Base container image for templates and sessions. Defaults to eve's
    * published `ghcr.io/vercel/eve` image, tagged with the installed eve
-   * version. Framework setup creates `/workspace` and verifies Bash. Install
+   * version or `EVE_SANDBOX_IMAGE_TAG` when set. Framework setup creates
+   * `/workspace` and verifies Bash. Install
    * any authored runtime tools in sandbox bootstrap or provide them through a
    * custom image.
    */

--- a/packages/eve/src/public/sandbox/microsandbox-sandbox.ts
+++ b/packages/eve/src/public/sandbox/microsandbox-sandbox.ts
@@ -17,7 +17,7 @@ export interface MicrosandboxSandboxCreateOptions {
    * Python, or ripgrep in sandbox bootstrap or provide them through a
    * custom image.
    *
-   * @default The `ghcr.io/vercel/eve` tag matching the installed eve version.
+   * @default The `ghcr.io/vercel/eve` tag matching the installed eve version, or `EVE_SANDBOX_IMAGE_TAG` when set.
    */
   readonly image?: string;
   /** Number of virtual CPUs assigned to each sandbox. @default 1 */

--- a/packages/eve/src/public/sandbox/vercel-sandbox.ts
+++ b/packages/eve/src/public/sandbox/vercel-sandbox.ts
@@ -30,8 +30,9 @@ type VercelSandboxAuthorCreateOptions<T> = T extends unknown
  * author-supplied values.
  *
  * `runtime` is excluded as well: eve always boots its sandboxes from the
- * published `vcr.vercel.com/vercel/eve/base` image tag matching the installed
- * eve version, which is mutually exclusive with a stock runtime.
+ * published `vcr.vercel.com/vercel/eve/base` image tagged with the installed
+ * eve version or `EVE_SANDBOX_IMAGE_TAG` when set, which is mutually exclusive
+ * with a stock runtime.
  *
  * `source` is honored only on the template create at prewarm time, so
  * an author-supplied snapshot, git revision, or tarball becomes the


### PR DESCRIPTION
### Summary

Changesets release PRs stamp the next eve package version before its matching sandbox image exists, so sandbox E2E fails while pulling that unpublished tag. This adds `EVE_SANDBOX_IMAGE_TAG` as an override for eve's default GHCR and VCR image tags, then sets it to `latest` across the local, Postgres, and Vercel E2E worlds, including Vercel redeploys. Normal usage remains pinned to the installed eve version unless the environment variable is set, and explicit Docker or microsandbox images still take precedence.

### Validation

`pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/execution/sandbox/bindings/eve-image.test.ts` passed all 3 tests, `pnpm typecheck` passed, and `pnpm docs:check` passed. E2E is CI-only and will validate the workflow propagation.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+6 / -1`

Documents the public override and adds its release-note changeset.

**Implementation** — 7 files · `+21 / -7`

Keeps version-pinned defaults while applying the optional tag override and propagating `latest` through every E2E world.

**Tests** — 3 files · `+37 / -7`

Covers both registries and exported defaults, and preserves the override through the sandbox fixture's Vercel redeploy flow.
