### PR TITLE
[5/5] feat(slack): render todo state as native plans

### DIFF
--- a/.changeset/fresh-slack-plans.md
+++ b/.changeset/fresh-slack-plans.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Render the built-in todo list as native Slack plan tasks, with live agent activity attached to the current task.

--- a/packages/eve/src/public/channels/slack/activity-plan.test.ts
+++ b/packages/eve/src/public/channels/slack/activity-plan.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { createActivitySnapshot, reduceActivityBatch } from "#execution/session-activity.js";
 import {
   buildSlackActivityRenderers,
@@ -11,42 +12,59 @@ const root = {
   rootSessionId: "session",
   rootTurnId: "turn",
 };
-const verifier = {
-  id: "verifier",
+const worker = {
+  id: "worker",
   kind: "subagent" as const,
-  name: "verifier",
+  name: "researcher",
   parentId: root.id,
   rootSessionId: "session",
   rootTurnId: "turn",
 };
-const stage = {
-  id: "stage",
-  kind: "task" as const,
-  name: "verify_stage",
-  parentId: verifier.id,
-  rootSessionId: "session",
+const todoAction = {
+  id: "todo-action",
+  kind: "tool" as const,
+  name: "todo",
+  parentWorkId: root.id,
   rootTurnId: "turn",
+  stepIndex: 0,
 };
-const reviewer = {
-  id: "reviewer",
-  kind: "subagent" as const,
-  name: "reviewer",
-  parentId: root.id,
-  rootSessionId: "session",
+const searchAction = {
+  id: "search-action",
+  kind: "tool" as const,
+  name: "web_search",
+  parentWorkId: worker.id,
   rootTurnId: "turn",
+  stepIndex: 1,
 };
-const reviewStage = {
-  id: "review-stage",
-  kind: "task" as const,
-  name: "review_stage",
-  parentId: reviewer.id,
-  rootSessionId: "session",
-  rootTurnId: "turn",
-};
+
+function todoState(
+  sourceEventId: string,
+  replacedAt: string,
+  value: unknown,
+): Extract<
+  Parameters<typeof reduceActivityBatch>[1]["events"][number],
+  { readonly kind: "state.replaced" }
+> {
+  return {
+    eventId: sourceEventId,
+    kind: "state.replaced",
+    state: {
+      key: "todo",
+      parentWorkId: root.id,
+      replacedAt,
+      rootTurnId: "turn",
+      sourceActionId: todoAction.id,
+      sourceEventId,
+      sourceToolName: "todo",
+      value: value as never,
+    },
+  };
+}
 
 describe("Slack activity plan", () => {
   afterEach(() => vi.unstubAllGlobals());
-  it("streams descendant lifecycle once, then replaces the final plan with top-level work", async () => {
+
+  it("renders todo state as plan tasks and streams activity under the active task", async () => {
     const requests: Array<{ operation: string; body: URLSearchParams }> = [];
     vi.stubGlobal(
       "fetch",
@@ -61,127 +79,152 @@ describe("Slack activity plan", () => {
       renderers: [experimental_slackActivityPlan()],
     })[0]!;
     const started = reduceActivityBatch(createActivitySnapshot(), {
-      version: 1,
       events: [
         { eventId: "root", kind: "work.started", startedAt: "1", work: root },
-        { eventId: "verifier", kind: "work.started", startedAt: "2", work: verifier },
-        { eventId: "stage", kind: "work.started", startedAt: "3", work: stage },
+        { eventId: "worker", kind: "work.started", startedAt: "2", work: worker },
+        { action: todoAction, eventId: "todo-started", kind: "action.started", startedAt: "3" },
         {
-          action: {
-            id: "verify-action",
-            kind: "tool",
-            name: "verify",
-            parentWorkId: verifier.id,
-            rootTurnId: "turn",
-            stepIndex: 0,
-          },
-          eventId: "verify-action",
-          kind: "action.started",
-          startedAt: "3",
+          actionId: todoAction.id,
+          eventId: "todo-settled",
+          kind: "action.settled",
+          outcome: "completed",
+          settledAt: "4",
         },
+        todoState("todo-state-1", "4", [
+          { content: "Inspect the renderer", priority: "high", status: "completed" },
+          {
+            content: "Implement Slack plan\nwith extra detail",
+            priority: "high",
+            status: "in_progress",
+          },
+          { content: "Run checks", priority: "medium", status: "pending" },
+        ]),
+        { action: searchAction, eventId: "search-started", kind: "action.started", startedAt: "5" },
         {
-          actionId: "verify-action",
-          eventId: "verify-action-label",
+          actionId: searchAction.id,
+          eventId: "search-label",
           kind: "action.label.updated",
-          label: "Verify release",
+          label: "Review Slack plan API",
         },
       ],
+      version: 1,
     });
+
     const state = await renderer.render({
-      destination: { channelId: "C1", threadTs: "T1", teamId: "TEAM", triggeringUserId: "USER" },
+      destination: {
+        channelId: "C1",
+        installationTeamId: "INSTALL",
+        teamId: "TEAM",
+        threadTs: "T1",
+        triggeringUserId: "USER",
+      },
       snapshot: started,
       state: undefined,
     });
+
     const updated = reduceActivityBatch(started, {
-      version: 1,
       events: [
+        todoState("todo-state-2", "6", [
+          { content: "Inspect the renderer", priority: "high", status: "completed" },
+          { content: "Implement Slack plan", priority: "high", status: "completed" },
+          { content: "Run checks", priority: "medium", status: "in_progress" },
+        ]),
         {
-          actionId: "verify-action",
-          eventId: "verify-action-delta",
-          kind: "action.label.updated",
-          label: "Verifying tests",
+          actionId: searchAction.id,
+          eventId: "search-done",
+          kind: "action.settled",
+          outcome: "completed",
+          settledAt: "6",
+        },
+        {
+          eventId: "worker-done",
+          kind: "work.settled",
+          outcome: "completed",
+          settledAt: "7",
+          workId: worker.id,
         },
       ],
+      version: 1,
     });
     const updatedState = await renderer.render({
-      destination: { channelId: "C1", threadTs: "T1", teamId: "TEAM", triggeringUserId: "USER" },
+      destination: {
+        channelId: "C1",
+        installationTeamId: "INSTALL",
+        teamId: "TEAM",
+        threadTs: "T1",
+        triggeringUserId: "USER",
+      },
       snapshot: updated,
       state,
     });
-    const expanded = reduceActivityBatch(updated, {
-      version: 1,
+
+    const settled = reduceActivityBatch(updated, {
       events: [
-        { eventId: "reviewer", kind: "work.started", startedAt: "3", work: reviewer },
-        { eventId: "review-stage", kind: "work.started", startedAt: "3", work: reviewStage },
-      ],
-    });
-    const expandedState = await renderer.render({
-      destination: { channelId: "C1", threadTs: "T1", teamId: "TEAM", triggeringUserId: "USER" },
-      snapshot: expanded,
-      state: updatedState,
-    });
-    const settled = reduceActivityBatch(expanded, {
-      version: 1,
-      events: [
-        {
-          eventId: "stage-done",
-          kind: "work.settled",
-          outcome: "completed",
-          settledAt: "4",
-          workId: stage.id,
-        },
-        {
-          eventId: "review-stage-done",
-          kind: "work.settled",
-          outcome: "completed",
-          settledAt: "4",
-          workId: reviewStage.id,
-        },
-        {
-          eventId: "verifier-done",
-          kind: "work.settled",
-          outcome: "completed",
-          settledAt: "5",
-          workId: verifier.id,
-        },
-        {
-          eventId: "reviewer-done",
-          kind: "work.settled",
-          outcome: "completed",
-          settledAt: "5",
-          workId: reviewer.id,
-        },
+        todoState("todo-state-3", "8", [
+          { content: "Inspect the renderer", priority: "high", status: "completed" },
+          { content: "Implement Slack plan", priority: "high", status: "completed" },
+          { content: "Run checks", priority: "medium", status: "completed" },
+        ]),
         {
           eventId: "root-done",
           kind: "work.settled",
           outcome: "completed",
-          settledAt: "6",
+          settledAt: "9",
           workId: root.id,
         },
       ],
+      version: 1,
     });
     await renderer.render({
-      destination: { channelId: "C1", threadTs: "T1", teamId: "TEAM", triggeringUserId: "USER" },
+      destination: {
+        channelId: "C1",
+        installationTeamId: "INSTALL",
+        teamId: "TEAM",
+        threadTs: "T1",
+        triggeringUserId: "USER",
+      },
       snapshot: settled,
-      state: expandedState,
+      state: updatedState,
     });
-    expect(requests.map((r) => r.operation)).toEqual([
+
+    expect(requests.map((request) => request.operation)).toEqual([
       "chat.startStream",
-      "chat.appendStream",
       "chat.appendStream",
       "chat.appendStream",
       "chat.appendStream",
       "chat.stopStream",
       "chat.update",
     ]);
-    expect(requests[1]!.body.get("chunks")).toContain("• verify_stage\\n");
-    expect(requests[1]!.body.get("chunks")).toContain("• Verify release\\n");
-    expect(requests[2]!.body.get("chunks")).toContain("• Verifying tests\\n");
-    expect(requests[3]!.body.get("chunks")).toContain('"id":"reviewer"');
-    expect(requests[3]!.body.get("chunks")).toContain("• review_stage\\n");
-    expect(requests[4]!.body.get("chunks")).toContain("✓ verify_stage\\n");
-    expect(requests[4]!.body.get("chunks")).toContain("✓ review_stage\\n");
-    expect(requests[6]!.body.get("blocks")).not.toContain("verify_stage");
-    expect(requests[6]!.body.get("blocks")).toContain("verifier");
+    expect(requests[0]!.body.get("chunks")).toContain("Inspect the renderer");
+    expect(requests[0]!.body.get("chunks")).toContain('"status":"in_progress"');
+    expect(requests[0]!.body.get("chunks")).not.toContain("with extra detail");
+    expect(requests[1]!.body.get("chunks")).toContain("• researcher\\n");
+    expect(requests[1]!.body.get("chunks")).toContain("• Review Slack plan API\\n");
+    expect(requests[2]!.body.get("chunks")).toContain("Run checks");
+    expect(requests[2]!.body.get("chunks")).toContain("✓ Review Slack plan API\\n");
+    expect(requests[5]!.body.get("blocks")).toContain('"title":"Agent plan"');
+    expect(requests[5]!.body.get("blocks")).toContain('"status":"complete"');
+  });
+
+  it("waits for a valid todo projection before starting a stream", async () => {
+    const fetch = vi.fn(async () => Response.json({ ok: true, ts: "1700.1" }));
+    vi.stubGlobal("fetch", fetch);
+    const renderer = buildSlackActivityRenderers({
+      botToken: "xoxb-test",
+      renderers: [experimental_slackActivityPlan()],
+    })[0]!;
+    const snapshot = reduceActivityBatch(createActivitySnapshot(), {
+      events: [{ eventId: "root", kind: "work.started", startedAt: "1", work: root }],
+      version: 1,
+    });
+
+    const state = await renderer.render({
+      destination: { channelId: "C1", teamId: "TEAM", threadTs: "T1", triggeringUserId: "USER" },
+      snapshot,
+      state: undefined,
+    });
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(state).toEqual({ streams: {} });
   });
 });

--- a/packages/eve/src/public/channels/slack/activity-plan.test.ts
+++ b/packages/eve/src/public/channels/slack/activity-plan.test.ts
@@ -20,13 +20,18 @@ const worker = {
   rootSessionId: "session",
   rootTurnId: "turn",
 };
-const todoAction = {
-  id: "todo-action",
+const previousTodoAction = {
+  id: "previous-todo-action",
   kind: "tool" as const,
   name: "todo",
   parentWorkId: root.id,
   rootTurnId: "turn",
   stepIndex: 0,
+};
+const todoAction = {
+  ...previousTodoAction,
+  id: "todo-action",
+  stepIndex: 1,
 };
 const searchAction = {
   id: "search-action",
@@ -82,6 +87,25 @@ describe("Slack activity plan", () => {
       events: [
         { eventId: "root", kind: "work.started", startedAt: "1", work: root },
         { eventId: "worker", kind: "work.started", startedAt: "2", work: worker },
+        {
+          action: previousTodoAction,
+          eventId: "previous-todo-started",
+          kind: "action.started",
+          startedAt: "2",
+        },
+        {
+          actionId: previousTodoAction.id,
+          eventId: "previous-todo-label",
+          kind: "action.label.updated",
+          label: "Update todo list",
+        },
+        {
+          actionId: previousTodoAction.id,
+          eventId: "previous-todo-settled",
+          kind: "action.settled",
+          outcome: "completed",
+          settledAt: "3",
+        },
         { action: todoAction, eventId: "todo-started", kind: "action.started", startedAt: "3" },
         {
           actionId: todoAction.id,
@@ -200,6 +224,7 @@ describe("Slack activity plan", () => {
     expect(requests[0]!.body.get("chunks")).not.toContain("with extra detail");
     expect(requests[1]!.body.get("chunks")).toContain("• researcher\\n");
     expect(requests[1]!.body.get("chunks")).toContain("• Review Slack plan API\\n");
+    expect(requests[1]!.body.get("chunks")).not.toContain("Update todo list");
     expect(requests[2]!.body.get("chunks")).toContain("Run checks");
     expect(requests[2]!.body.get("chunks")).toContain("✓ Review Slack plan API\\n");
     expect(requests[5]!.body.get("blocks")).toContain('"title":"Agent plan"');

--- a/packages/eve/src/public/channels/slack/activity-plan.test.ts
+++ b/packages/eve/src/public/channels/slack/activity-plan.test.ts
@@ -206,25 +206,79 @@ describe("Slack activity plan", () => {
     expect(requests[5]!.body.get("blocks")).toContain('"status":"complete"');
   });
 
-  it("waits for a valid todo projection before starting a stream", async () => {
-    const fetch = vi.fn(async () => Response.json({ ok: true, ts: "1700.1" }));
-    vi.stubGlobal("fetch", fetch);
+  it("falls back to the activity hierarchy when no todo state is available", async () => {
+    const requests: Array<{ operation: string; body: URLSearchParams }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+        requests.push({
+          body: new URLSearchParams(String(init?.body ?? "")),
+          operation: String(url).split("/").at(-1)!,
+        });
+        return Response.json({ ok: true, ts: "1700.1" });
+      }),
+    );
     const renderer = buildSlackActivityRenderers({
       botToken: "xoxb-test",
       renderers: [experimental_slackActivityPlan()],
     })[0]!;
-    const snapshot = reduceActivityBatch(createActivitySnapshot(), {
-      events: [{ eventId: "root", kind: "work.started", startedAt: "1", work: root }],
+    const started = reduceActivityBatch(createActivitySnapshot(), {
+      events: [
+        { eventId: "root", kind: "work.started", startedAt: "1", work: root },
+        { eventId: "worker", kind: "work.started", startedAt: "2", work: worker },
+        { action: searchAction, eventId: "search-started", kind: "action.started", startedAt: "3" },
+      ],
       version: 1,
     });
-
     const state = await renderer.render({
       destination: { channelId: "C1", teamId: "TEAM", threadTs: "T1", triggeringUserId: "USER" },
-      snapshot,
+      snapshot: started,
       state: undefined,
     });
+    const settled = reduceActivityBatch(started, {
+      events: [
+        {
+          actionId: searchAction.id,
+          eventId: "search-done",
+          kind: "action.settled",
+          outcome: "completed",
+          settledAt: "4",
+        },
+        {
+          eventId: "worker-done",
+          kind: "work.settled",
+          outcome: "completed",
+          settledAt: "5",
+          workId: worker.id,
+        },
+        {
+          eventId: "root-done",
+          kind: "work.settled",
+          outcome: "completed",
+          settledAt: "6",
+          workId: root.id,
+        },
+      ],
+      version: 1,
+    });
+    await renderer.render({
+      destination: { channelId: "C1", teamId: "TEAM", threadTs: "T1", triggeringUserId: "USER" },
+      snapshot: settled,
+      state,
+    });
 
-    expect(fetch).not.toHaveBeenCalled();
-    expect(state).toEqual({ streams: {} });
+    expect(requests.map((request) => request.operation)).toEqual([
+      "chat.startStream",
+      "chat.appendStream",
+      "chat.appendStream",
+      "chat.stopStream",
+      "chat.update",
+    ]);
+    expect(requests[0]!.body.get("chunks")).toContain("Agent activity");
+    expect(requests[0]!.body.get("chunks")).toContain("researcher");
+    expect(requests[1]!.body.get("chunks")).toContain("• web_search\\n");
+    expect(requests[2]!.body.get("chunks")).toContain("✓ web_search\\n");
+    expect(requests[4]!.body.get("blocks")).toContain('"title":"Agent activity"');
+    expect(requests[4]!.body.get("blocks")).toContain('"title":"researcher"');
   });
 });

--- a/packages/eve/src/public/channels/slack/activity-plan.ts
+++ b/packages/eve/src/public/channels/slack/activity-plan.ts
@@ -1,5 +1,5 @@
 import type { ChannelActivityRenderer } from "#channel/activity-renderer.js";
-import type { ActivitySnapshotV1 } from "#protocol/activity.js";
+import type { ActivitySnapshotV1, ActivityWorkStateV1 } from "#protocol/activity.js";
 import { callSlackApi, type SlackBotToken } from "#public/channels/slack/api.js";
 
 export const SLACK_ACTIVITY_PLAN_RENDERER_ID = "slack.experimental.plan.v1";
@@ -22,7 +22,7 @@ interface PlanState {
 
 interface PlanTask {
   readonly id: string;
-  readonly status: TodoStatus;
+  readonly status: TodoStatus | ActivityPhase;
   readonly title: string;
 }
 
@@ -30,15 +30,17 @@ interface ActivityDetail {
   readonly id: string;
   readonly name: string;
   readonly phase: ActivityPhase;
+  readonly taskId?: string;
 }
 
 interface PlanView {
   readonly details: readonly ActivityDetail[];
   readonly settled: boolean;
   readonly tasks: readonly PlanTask[];
+  readonly title: string;
 }
 
-/** Creates a native Slack plan backed by the built-in todo tool's projected state. */
+/** Creates a native Slack plan from todo state, falling back to the activity hierarchy. */
 export function createSlackPlanRenderer(
   botToken: SlackBotToken | undefined,
 ): ChannelActivityRenderer {
@@ -77,7 +79,7 @@ export function createSlackPlanRenderer(
             "chat.startStream",
             {
               channel,
-              chunks: [{ type: "plan_update", title: "Agent plan" }, ...view.tasks.map(taskChunk)],
+              chunks: [{ type: "plan_update", title: view.title }, ...view.tasks.map(taskChunk)],
               recipient_team_id: team,
               recipient_user_id: user,
               task_display_mode: "plan",
@@ -128,7 +130,7 @@ export function createSlackPlanRenderer(
                     title: task.title,
                     type: "task_card",
                   })),
-                  title: "Agent plan",
+                  title: view.title,
                   type: "plan",
                 },
               ],
@@ -166,10 +168,11 @@ function projectPlan(snapshot: ActivitySnapshotV1, rootTurnId: string): PlanView
         : left.replacedAt.localeCompare(right.replacedAt),
     )
     .at(-1);
-  if (planState === undefined) return undefined;
+  const todos = planState === undefined ? undefined : parseTodos(planState.value);
+  if (planState === undefined || todos === undefined) {
+    return projectActivityPlan(snapshot, rootTurnId);
+  }
 
-  const todos = parseTodos(planState.value);
-  if (todos === undefined) return undefined;
   const tasks = todos.map((todo, index) => ({
     id: `${planState.parentWorkId}:todo:${index}`,
     status: todo.status,
@@ -204,7 +207,81 @@ function projectPlan(snapshot: ActivitySnapshotV1, rootTurnId: string): PlanView
   const settled = [...work, ...actions, ...blockers].every(
     (entity) => entity.phase !== "running" && entity.phase !== "blocked",
   );
-  return { details, settled, tasks };
+  return { details, settled, tasks, title: "Agent plan" };
+}
+
+function projectActivityPlan(
+  snapshot: ActivitySnapshotV1,
+  rootTurnId: string,
+): PlanView | undefined {
+  const work = Object.values(snapshot.work).filter((item) => item.rootTurnId === rootTurnId);
+  if (work.length === 0) return undefined;
+  const roots = work.filter((item) => item.kind === "root-turn");
+  const rootIds = new Set(roots.map((item) => item.id));
+  let parents = work.filter((item) => item.parentId && rootIds.has(item.parentId));
+  if (parents.length === 0) parents = roots;
+
+  const owner = (workId: string): ActivityWorkStateV1 | undefined => {
+    let item = work.find((candidate) => candidate.id === workId);
+    while (item?.parentId && !parents.some((parent) => parent.id === item!.id)) {
+      item = work.find((candidate) => candidate.id === item!.parentId);
+    }
+    return item && parents.find((parent) => parent.id === item!.id);
+  };
+  const details: ActivityDetail[] = [];
+  for (const child of work) {
+    if (parents.some((parent) => parent.id === child.id) || rootIds.has(child.id)) continue;
+    const parent = owner(child.id);
+    if (parent !== undefined) {
+      details.push({
+        id: child.id,
+        name: child.name ?? "Agent work",
+        phase: child.phase,
+        taskId: parent.id,
+      });
+    }
+  }
+  const actions = Object.values(snapshot.actions).filter(
+    (action) => action.rootTurnId === rootTurnId,
+  );
+  for (const action of actions) {
+    const parent = owner(action.parentWorkId);
+    if (parent !== undefined) {
+      details.push({
+        id: action.id,
+        name: action.label ?? action.name,
+        phase: action.phase,
+        taskId: parent.id,
+      });
+    }
+  }
+  const blockers = Object.values(snapshot.blockers).filter(
+    (blocker) => blocker.rootTurnId === rootTurnId,
+  );
+  for (const blocker of blockers) {
+    const parent = owner(blocker.parentWorkId);
+    if (parent !== undefined) {
+      details.push({
+        id: blocker.id,
+        name: blocker.label ?? blockerLabel(blocker.kind),
+        phase: blocker.phase,
+        taskId: parent.id,
+      });
+    }
+  }
+  const settled = [...work, ...actions, ...blockers].every(
+    (entity) => entity.phase !== "running" && entity.phase !== "blocked",
+  );
+  return {
+    details,
+    settled,
+    tasks: parents.map((parent) => ({
+      id: parent.id,
+      status: parent.phase,
+      title: parent.kind === "root-turn" ? "Agent turn" : (parent.name ?? "Agent work"),
+    })),
+    title: "Agent activity",
+  };
 }
 
 function parseTodos(
@@ -236,20 +313,26 @@ function planUpdates(view: PlanView, seen: Readonly<Record<string, string>>) {
   const taskUpdates = view.tasks
     .filter((task) => seen[task.id] !== taskVersion(task))
     .map(taskChunk);
-  const detailTask =
-    view.tasks.find((task) => task.status === "in_progress") ??
+  const activeTask =
+    view.tasks.find((task) => task.status === "in_progress" || task.status === "running") ??
     view.tasks.find((task) => task.status === "pending") ??
     view.tasks.at(-1);
-  if (detailTask === undefined) return taskUpdates;
   const detailUpdates = view.details
     .filter((detail) => seen[detail.id] !== detailVersion(detail))
-    .map((detail) => ({
-      details: `${phaseIcon(detail.phase)} ${detail.name}\n`,
-      id: safeId(detailTask.id),
-      status: slackTaskStatus(detailTask.status),
-      title: detailTask.title,
-      type: "task_update",
-    }));
+    .flatMap((detail) => {
+      const detailTask = view.tasks.find((task) => task.id === detail.taskId) ?? activeTask;
+      return detailTask === undefined
+        ? []
+        : [
+            {
+              details: `${phaseIcon(detail.phase)} ${detail.name}\n`,
+              id: safeId(detailTask.id),
+              status: slackTaskStatus(detailTask.status),
+              title: detailTask.title,
+              type: "task_update",
+            },
+          ];
+    });
   return [...taskUpdates, ...detailUpdates];
 }
 
@@ -270,15 +353,21 @@ function detailVersion(detail: ActivityDetail): string {
   return `${detail.phase}:${detail.name}`;
 }
 
-function slackTaskStatus(status: TodoStatus): "pending" | "in_progress" | "complete" | "error" {
+function slackTaskStatus(
+  status: TodoStatus | ActivityPhase,
+): "pending" | "in_progress" | "complete" | "error" {
   switch (status) {
     case "pending":
       return "pending";
     case "in_progress":
+    case "running":
+    case "blocked":
       return "in_progress";
     case "completed":
       return "complete";
     case "cancelled":
+    case "failed":
+    case "rejected":
       return "error";
   }
 }

--- a/packages/eve/src/public/channels/slack/activity-plan.ts
+++ b/packages/eve/src/public/channels/slack/activity-plan.ts
@@ -179,7 +179,10 @@ function projectPlan(snapshot: ActivitySnapshotV1, rootTurnId: string): PlanView
     title: todo.content,
   }));
   const actions = Object.values(snapshot.actions).filter(
-    (action) => action.rootTurnId === rootTurnId && action.id !== planState.sourceActionId,
+    (action) =>
+      action.rootTurnId === rootTurnId &&
+      action.name !== planState.sourceToolName &&
+      action.id !== planState.sourceActionId,
   );
   const blockers = Object.values(snapshot.blockers).filter(
     (blocker) => blocker.rootTurnId === rootTurnId,

--- a/packages/eve/src/public/channels/slack/activity-plan.ts
+++ b/packages/eve/src/public/channels/slack/activity-plan.ts
@@ -1,22 +1,44 @@
 import type { ChannelActivityRenderer } from "#channel/activity-renderer.js";
-import type { ActivitySnapshotV1, ActivityWorkStateV1 } from "#protocol/activity.js";
+import type { ActivitySnapshotV1 } from "#protocol/activity.js";
 import { callSlackApi, type SlackBotToken } from "#public/channels/slack/api.js";
 
 export const SLACK_ACTIVITY_PLAN_RENDERER_ID = "slack.experimental.plan.v1";
-type Phase = "running" | "completed" | "failed" | "rejected" | "cancelled" | "blocked";
+
+type ActivityPhase = "running" | "completed" | "failed" | "rejected" | "cancelled" | "blocked";
+type TodoStatus = "pending" | "in_progress" | "completed" | "cancelled";
+
 interface PlanState {
   readonly streams: Readonly<
     Record<
       string,
       {
-        readonly ts: string;
         readonly seen: Readonly<Record<string, string>>;
         readonly stopped: boolean;
+        readonly ts: string;
       }
     >
   >;
 }
 
+interface PlanTask {
+  readonly id: string;
+  readonly status: TodoStatus;
+  readonly title: string;
+}
+
+interface ActivityDetail {
+  readonly id: string;
+  readonly name: string;
+  readonly phase: ActivityPhase;
+}
+
+interface PlanView {
+  readonly details: readonly ActivityDetail[];
+  readonly settled: boolean;
+  readonly tasks: readonly PlanTask[];
+}
+
+/** Creates a native Slack plan backed by the built-in todo tool's projected state. */
 export function createSlackPlanRenderer(
   botToken: SlackBotToken | undefined,
 ): ChannelActivityRenderer {
@@ -24,209 +46,274 @@ export function createSlackPlanRenderer(
     id: SLACK_ACTIVITY_PLAN_RENDERER_ID,
     async dispose() {},
     async render({ destination, snapshot, state }) {
-      const channel = destination["channelId"],
-        thread = destination["threadTs"],
-        team = destination["teamId"],
-        user = destination["triggeringUserId"],
-        installation = destination["installationTeamId"];
+      const channel = destination["channelId"];
+      const installation = destination["installationTeamId"];
+      const team = destination["teamId"];
+      const thread = destination["threadTs"];
+      const user = destination["triggeringUserId"];
       if (
         typeof channel !== "string" ||
         typeof thread !== "string" ||
-        !thread ||
+        thread === "" ||
         typeof team !== "string" ||
         typeof user !== "string"
-      )
+      ) {
         return state;
+      }
+
       const previous = isState(state) ? state.streams : {};
       const streams: Record<
         string,
-        { ts: string; seen: Readonly<Record<string, string>>; stopped: boolean }
+        { seen: Readonly<Record<string, string>>; stopped: boolean; ts: string }
       > = { ...previous };
-      for (const rootTurnId of new Set(
-        Object.values(snapshot.work).map((work) => work.rootTurnId),
-      )) {
-        const view = project(snapshot, rootTurnId);
+
+      for (const rootTurnId of rootTurnIds(snapshot)) {
+        const view = projectPlan(snapshot, rootTurnId);
+        if (view === undefined) continue;
+
         let current = previous[rootTurnId];
-        if (!current) {
+        if (current === undefined) {
           const response = await api(
             "chat.startStream",
             {
               channel,
-              thread_ts: thread,
+              chunks: [{ type: "plan_update", title: "Agent plan" }, ...view.tasks.map(taskChunk)],
               recipient_team_id: team,
               recipient_user_id: user,
               task_display_mode: "plan",
-              chunks: [
-                { type: "plan_update", title: "Agent activity" },
-                ...view.parents.map(taskChunk),
-              ],
+              thread_ts: thread,
             },
             botToken,
             installation,
           );
-          if (!response.ok || typeof response.ts !== "string")
+          if (!response.ok || typeof response.ts !== "string") {
             throw new Error(`Slack activity plan failed: ${response.error ?? "missing ts"}`);
+          }
           current = {
-            ts: response.ts,
-            seen: Object.fromEntries(view.parents.map((parent) => [parent.id, parent.phase])),
+            seen: Object.fromEntries(view.tasks.map((task) => [task.id, taskVersion(task)])),
             stopped: false,
+            ts: response.ts,
           };
         }
+
         if (current.stopped) {
           streams[rootTurnId] = current;
           continue;
         }
-        const updates = detailUpdates(view, current.seen);
-        if (updates.length)
+
+        const updates = planUpdates(view, current.seen);
+        if (updates.length > 0) {
           await checked(
             "chat.appendStream",
-            { channel, ts: current.ts, chunks: updates },
+            { channel, chunks: updates, ts: current.ts },
             botToken,
             installation,
           );
+        }
+
         const seen = Object.fromEntries([
-          ...view.parents.map((parent) => [parent.id, parent.phase]),
-          ...view.entities.map((entity) => [entity.id, entityVersion(entity)]),
+          ...view.tasks.map((task) => [task.id, taskVersion(task)]),
+          ...view.details.map((detail) => [detail.id, detailVersion(detail)]),
         ]);
         if (view.settled) {
           await checked("chat.stopStream", { channel, ts: current.ts }, botToken, installation);
-          const blocks = [
-            {
-              type: "plan",
-              title: "Agent activity",
-              tasks: view.parents.map((parent) => ({
-                type: "task_card",
-                task_id: safeId(parent.id),
-                title: parent.name,
-                status: status(parent.phase),
-              })),
-            },
-          ];
           await checked(
             "chat.update",
-            { channel, ts: current.ts, text: view.parents.map((p) => p.name).join(", "), blocks },
+            {
+              blocks: [
+                {
+                  tasks: view.tasks.map((task) => ({
+                    status: slackTaskStatus(task.status),
+                    task_id: safeId(task.id),
+                    title: task.title,
+                    type: "task_card",
+                  })),
+                  title: "Agent plan",
+                  type: "plan",
+                },
+              ],
+              channel,
+              text: view.tasks.map((task) => task.title).join(", "),
+              ts: current.ts,
+            },
             botToken,
             installation,
           );
-          streams[rootTurnId] = { ts: current.ts, seen, stopped: true };
-        } else streams[rootTurnId] = { ts: current.ts, seen, stopped: false };
+          streams[rootTurnId] = { seen, stopped: true, ts: current.ts };
+        } else {
+          streams[rootTurnId] = { seen, stopped: false, ts: current.ts };
+        }
       }
+
       return { streams } satisfies PlanState;
     },
   };
 }
 
-interface Entity {
-  id: string;
-  name: string;
-  phase: Phase;
-  parent: string;
+function rootTurnIds(snapshot: ActivitySnapshotV1): ReadonlySet<string> {
+  return new Set([
+    ...Object.values(snapshot.work).map((work) => work.rootTurnId),
+    ...Object.values(snapshot.states).map((state) => state.rootTurnId),
+  ]);
 }
-interface View {
-  parents: ActivityWorkStateV1[];
-  entities: Entity[];
-  settled: boolean;
+
+function projectPlan(snapshot: ActivitySnapshotV1, rootTurnId: string): PlanView | undefined {
+  const planState = Object.values(snapshot.states)
+    .filter((state) => state.rootTurnId === rootTurnId && state.key === "todo")
+    .sort((left, right) =>
+      left.replacedAt === right.replacedAt
+        ? left.sourceEventId.localeCompare(right.sourceEventId)
+        : left.replacedAt.localeCompare(right.replacedAt),
+    )
+    .at(-1);
+  if (planState === undefined) return undefined;
+
+  const todos = parseTodos(planState.value);
+  if (todos === undefined) return undefined;
+  const tasks = todos.map((todo, index) => ({
+    id: `${planState.parentWorkId}:todo:${index}`,
+    status: todo.status,
+    title: todo.content,
+  }));
+  const actions = Object.values(snapshot.actions).filter(
+    (action) => action.rootTurnId === rootTurnId && action.id !== planState.sourceActionId,
+  );
+  const blockers = Object.values(snapshot.blockers).filter(
+    (blocker) => blocker.rootTurnId === rootTurnId,
+  );
+  const work = Object.values(snapshot.work).filter((item) => item.rootTurnId === rootTurnId);
+  const details: ActivityDetail[] = [
+    ...work
+      .filter((item) => item.kind !== "root-turn")
+      .map((item) => ({
+        id: item.id,
+        name: item.name ?? "Agent work",
+        phase: item.phase,
+      })),
+    ...actions.map((action) => ({
+      id: action.id,
+      name: action.label ?? action.name,
+      phase: action.phase,
+    })),
+    ...blockers.map((blocker) => ({
+      id: blocker.id,
+      name: blocker.label ?? blockerLabel(blocker.kind),
+      phase: blocker.phase,
+    })),
+  ];
+  const settled = [...work, ...actions, ...blockers].every(
+    (entity) => entity.phase !== "running" && entity.phase !== "blocked",
+  );
+  return { details, settled, tasks };
 }
-function project(snapshot: ActivitySnapshotV1, rootTurnId: string): View {
-  const work = Object.values(snapshot.work).filter((w) => w.rootTurnId === rootTurnId);
-  const roots = work.filter((w) => w.kind === "root-turn");
-  const rootIds = new Set(roots.map((w) => w.id));
-  let parents = work.filter((w) => w.parentId && rootIds.has(w.parentId));
-  if (!parents.length) parents = roots;
-  const owner = (workId: string): ActivityWorkStateV1 | undefined => {
-    let item = work.find((w) => w.id === workId);
-    while (item?.parentId && !parents.some((p) => p.id === item!.id))
-      item = work.find((w) => w.id === item!.parentId);
-    return item && parents.find((p) => p.id === item!.id);
-  };
-  const entities: Entity[] = [];
-  for (const child of work)
-    if (!parents.some((p) => p.id === child.id) && !rootIds.has(child.id)) {
-      const p = owner(child.id);
-      if (p)
-        entities.push({
-          id: child.id,
-          name: child.name ?? "Agent work",
-          phase: child.phase,
-          parent: p.id,
-        });
-    }
-  for (const action of Object.values(snapshot.actions).filter((a) => a.rootTurnId === rootTurnId)) {
-    const p = owner(action.parentWorkId);
-    if (p)
-      entities.push({
-        id: action.id,
-        name: action.label ?? action.name,
-        phase: action.phase,
-        parent: p.id,
-      });
+
+function parseTodos(
+  value: unknown,
+): readonly { content: string; status: TodoStatus }[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const todos: { content: string; status: TodoStatus }[] = [];
+  for (const item of value) {
+    if (item === null || typeof item !== "object" || Array.isArray(item)) return undefined;
+    const content = Reflect.get(item, "content");
+    const status = Reflect.get(item, "status");
+    if (typeof content !== "string" || !isTodoStatus(status)) return undefined;
+    todos.push({ content: firstLine(content), status });
   }
-  for (const blocker of Object.values(snapshot.blockers).filter(
-    (b) => b.rootTurnId === rootTurnId,
-  )) {
-    const p = owner(blocker.parentWorkId);
-    if (p)
-      entities.push({
-        id: blocker.id,
-        name: blocker.label ?? "Waiting",
-        phase: blocker.phase,
-        parent: p.id,
-      });
-  }
-  const settled = [
-    ...work,
-    ...Object.values(snapshot.actions).filter((a) => a.rootTurnId === rootTurnId),
-    ...Object.values(snapshot.blockers).filter((b) => b.rootTurnId === rootTurnId),
-  ].every((e) => e.phase !== "running" && e.phase !== "blocked");
-  return { parents, entities, settled };
+  return todos;
 }
-function detailUpdates(view: View, seen: Readonly<Record<string, string>>) {
-  const parentUpdates = view.parents
-    .filter((parent) => seen[parent.id] !== parent.phase)
+
+function isTodoStatus(value: unknown): value is TodoStatus {
+  return (
+    value === "pending" || value === "in_progress" || value === "completed" || value === "cancelled"
+  );
+}
+
+function firstLine(value: string): string {
+  return value.split(/\r?\n/u, 1)[0] ?? "";
+}
+
+function planUpdates(view: PlanView, seen: Readonly<Record<string, string>>) {
+  const taskUpdates = view.tasks
+    .filter((task) => seen[task.id] !== taskVersion(task))
     .map(taskChunk);
-  const descendantUpdates = view.entities
-    .filter((entity) => seen[entity.id] !== entityVersion(entity))
-    .map((entity) => ({
+  const detailTask =
+    view.tasks.find((task) => task.status === "in_progress") ??
+    view.tasks.find((task) => task.status === "pending") ??
+    view.tasks.at(-1);
+  if (detailTask === undefined) return taskUpdates;
+  const detailUpdates = view.details
+    .filter((detail) => seen[detail.id] !== detailVersion(detail))
+    .map((detail) => ({
+      details: `${phaseIcon(detail.phase)} ${detail.name}\n`,
+      id: safeId(detailTask.id),
+      status: slackTaskStatus(detailTask.status),
+      title: detailTask.title,
       type: "task_update",
-      id: safeId(entity.parent),
-      title: view.parents.find((parent) => parent.id === entity.parent)?.name ?? "Agent work",
-      status: status(
-        view.parents.find((parent) => parent.id === entity.parent)?.phase ?? "running",
-      ),
-      details: `${icon(entity.phase)} ${entity.name}\n`,
     }));
-  return [...parentUpdates, ...descendantUpdates];
+  return [...taskUpdates, ...detailUpdates];
 }
-function entityVersion(entity: Entity): string {
-  return `${entity.phase}:${entity.name}`;
-}
-function taskChunk(work: ActivityWorkStateV1) {
+
+function taskChunk(task: PlanTask) {
   return {
+    id: safeId(task.id),
+    status: slackTaskStatus(task.status),
+    title: task.title,
     type: "task_update",
-    id: safeId(work.id),
-    title: work.kind === "root-turn" ? "Agent turn" : (work.name ?? "Agent work"),
-    status: status(work.phase),
   };
 }
-function status(phase: Phase) {
-  return phase === "running" || phase === "blocked"
-    ? "in_progress"
-    : phase === "completed"
-      ? "complete"
-      : "error";
+
+function taskVersion(task: PlanTask): string {
+  return `${task.status}:${task.title}`;
 }
-function icon(phase: Phase) {
-  return phase === "running" || phase === "blocked"
-    ? "•"
-    : phase === "completed"
-      ? "✓"
-      : phase === "cancelled"
-        ? "–"
-        : "✗";
+
+function detailVersion(detail: ActivityDetail): string {
+  return `${detail.phase}:${detail.name}`;
 }
-function safeId(id: string) {
+
+function slackTaskStatus(status: TodoStatus): "pending" | "in_progress" | "complete" | "error" {
+  switch (status) {
+    case "pending":
+      return "pending";
+    case "in_progress":
+      return "in_progress";
+    case "completed":
+      return "complete";
+    case "cancelled":
+      return "error";
+  }
+}
+
+function phaseIcon(phase: ActivityPhase): string {
+  switch (phase) {
+    case "running":
+      return "•";
+    case "blocked":
+      return "◌";
+    case "completed":
+      return "✓";
+    case "cancelled":
+      return "–";
+    case "failed":
+    case "rejected":
+      return "✗";
+  }
+}
+
+function blockerLabel(kind: "approval" | "authorization" | "input"): string {
+  switch (kind) {
+    case "approval":
+      return "Waiting for approval…";
+    case "authorization":
+      return "Waiting for sign-in…";
+    case "input":
+      return "Waiting for input…";
+  }
+}
+
+function safeId(id: string): string {
   return id.replace(/[^a-zA-Z0-9_-]/g, "_").slice(-200);
 }
+
 async function api(
   operation: string,
   body: unknown,
@@ -234,22 +321,25 @@ async function api(
   installation: unknown,
 ) {
   return callSlackApi({
-    operation,
     body,
     botToken,
     context: { teamId: typeof installation === "string" ? installation : undefined },
+    operation,
   });
 }
+
 async function checked(
   operation: string,
   body: unknown,
   token: SlackBotToken | undefined,
   installation: unknown,
-) {
+): Promise<void> {
   const response = await api(operation, body, token, installation);
-  if (!response.ok)
+  if (!response.ok) {
     throw new Error(`Slack ${operation} failed: ${response.error ?? "unknown_error"}`);
+  }
 }
+
 function isState(value: unknown): value is PlanState {
   return (
     typeof value === "object" && value !== null && typeof Reflect.get(value, "streams") === "object"


### PR DESCRIPTION
### Summary

Renders the built-in `todo` state from #2896 as native Slack plan tasks. Todo statuses drive the plan cards, while the existing work, action, and blocker activity is appended under the current task using the same progress markers as the activity renderers.

When an agent does not use `todo`, the renderer keeps its existing activity-hierarchy plan behavior. Built on #2896.

### Validation

Adds focused coverage for todo-backed task updates, repeated todo writes, labeled activity details, final plan compaction, and the activity-only fallback.

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the required patch changeset for the Slack behavior change.

**Implementation** — 1 file · `+314 / -132`

Adds todo-backed projection to the experimental native plan renderer while preserving its previous activity projection as the fallback.

**Tests** — 1 file · `+209 / -87`

Covers todo-backed rendering, repeated todo writes, and the full no-todo stream lifecycle.

🤖
