### PR TITLE
fix(eve): keep approval responses at the history tail on resume

### DIFF
--- a/.changeset/approval-resume-tail-context.md
+++ b/.changeset/approval-resume-tail-context.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix approved tool calls silently not executing when task state or a dynamic skill announcement was injected on the resume step. The runtime context was appended after the approval response, so the AI SDK skipped the approved tool and providers rejected the prompt with errors like `No tool output found for function call`.

--- a/packages/eve/src/harness/current-messages.test.ts
+++ b/packages/eve/src/harness/current-messages.test.ts
@@ -59,6 +59,35 @@ describe("createCurrentMessages", () => {
     ]);
   });
 
+  it("keeps later context out of the tail when history ends with an approval response", () => {
+    const approvalTail = {
+      role: "tool" as const,
+      content: [
+        {
+          approvalId: "approval-1",
+          approved: true,
+          type: "tool-approval-response" as const,
+        },
+      ],
+    };
+    const current = createCurrentMessages([
+      { role: "user", content: "history" },
+      {
+        role: "assistant",
+        content: [
+          { type: "tool-call", toolCallId: "call-1", toolName: "bash", input: {} },
+          { type: "tool-approval-request", approvalId: "approval-1", toolCallId: "call-1" },
+        ],
+      },
+      approvalTail,
+    ]);
+
+    current.add(1, "task state");
+
+    expect(current.systemMessages).toEqual([{ role: "system", content: "task state" }]);
+    expect(current.nonSystemMessages.at(-1)).toBe(approvalTail);
+  });
+
   it("keeps hierarchy-sensitive context in instructions when requested", () => {
     const current = createCurrentMessages([]);
 

--- a/packages/eve/src/harness/current-messages.ts
+++ b/packages/eve/src/harness/current-messages.ts
@@ -34,10 +34,15 @@ export function createCurrentMessages(
     }
   }
   let userInsertionIndex = currentTurnInsertionIndex ?? nonSystemMessages.length;
+  // The AI SDK collects approval responses only from the tail tool message.
+  // Appending user-role context there would skip the approved tool's
+  // execution and send the provider a tool call with no result.
+  const canAppendUserMessages =
+    currentTurnInsertionIndex !== undefined || !hasTailApprovalResponse(nonSystemMessages);
 
   return {
     add(turnSequence, message, { cacheFriendly = true } = {}) {
-      if (turnSequence > 0 && cacheFriendly === true) {
+      if (turnSequence > 0 && cacheFriendly === true && canAppendUserMessages) {
         nonSystemMessages.splice(userInsertionIndex, 0, { role: "user", content: message });
         userInsertionIndex += 1;
       } else {
@@ -54,4 +59,12 @@ export function createCurrentMessages(
       return [...systemMessages];
     },
   };
+}
+
+/** True when the history ends with a tool message carrying a tool-approval-response. */
+export function hasTailApprovalResponse(messages: readonly ModelMessage[]): boolean {
+  const tail = messages.at(-1);
+  return (
+    tail?.role === "tool" && tail.content.some((part) => part.type === "tool-approval-response")
+  );
 }

--- a/packages/eve/src/harness/input-requests.ts
+++ b/packages/eve/src/harness/input-requests.ts
@@ -3,6 +3,7 @@ import type { ModelMessage } from "ai";
 import type { RuntimeToolCallActionRequest } from "#shared/action-types.js";
 import type { InputRequest, InputResponse } from "#shared/input.js";
 import { resolveTextToResponses } from "#channel/resolve-text.js";
+import { hasTailApprovalResponse } from "#harness/current-messages.js";
 import {
   getApprovedTools,
   hasAnsweredApprovalBatch,
@@ -182,13 +183,6 @@ function canonicalizeInputResponses(responses: readonly InputResponse[]): readon
   const byRequestId = new Map<string, InputResponse>();
   for (const response of responses) byRequestId.set(response.requestId, response);
   return [...byRequestId.values()];
-}
-
-function hasTailApprovalResponse(messages: readonly ModelMessage[]): boolean {
-  const tail = messages.at(-1);
-  return (
-    tail?.role === "tool" && tail.content.some((part) => part.type === "tool-approval-response")
-  );
 }
 
 function resolveTextMessageInput(

--- a/packages/eve/src/harness/tool-loop-generate-approval-resume.integration.test.ts
+++ b/packages/eve/src/harness/tool-loop-generate-approval-resume.integration.test.ts
@@ -8,8 +8,15 @@ import {
   preparePersistedStepDynamicToolMetadata,
 } from "#context/dynamic-tool-lifecycle.js";
 import type { OldSourceOffsetDynamicToolMetadata } from "#context/dynamic-tool-metadata.js";
-import { AuthKey, SessionKey, StepDynamicToolMetadataKey } from "#context/keys.js";
+import { PendingSkillAnnouncementKey } from "#context/dynamic-skill-lifecycle.js";
+import {
+  AuthKey,
+  SessionKey,
+  StepDynamicToolMetadataKey,
+  TurnTaskStateKey,
+} from "#context/keys.js";
 import { setHarnessEmissionState } from "#harness/emission.js";
+import type { InputRequest } from "#shared/input.js";
 import { appendPendingInputBatch } from "#harness/input-requests.js";
 import { createToolLoopHarness } from "#harness/tool-loop.js";
 import { setTurnUsageState } from "#harness/turn-tag-state.js";
@@ -78,11 +85,8 @@ const secondApprovalRequest = {
   type: "tool-approval-request" as const,
 };
 
-function createPendingApprovalSession(
-  history?: readonly ModelMessage[],
-  responseAuthorization = false,
-): HarnessSession {
-  const session: HarnessSession = {
+function createBaseSession(history?: readonly ModelMessage[]): HarnessSession {
+  return {
     agent: {
       modelReference: { id: "generate-approval-resume-model" },
       system: "You are a test assistant.",
@@ -99,27 +103,32 @@ function createPendingApprovalSession(
     history: [...(history ?? [{ content: "Run pwd.", role: "user" }])],
     sessionId: "generate-approval-resume-session",
   };
+}
 
+const pendingApprovalInputRequest: InputRequest = {
+  action: {
+    callId: toolCall.toolCallId,
+    input: toolCall.input,
+    kind: "tool-call",
+    toolName: toolCall.toolName,
+  },
+  allowFreeform: false,
+  display: "confirmation",
+  kind: "tool-approval",
+  options: [
+    { id: "approve", label: "Yes" },
+    { id: "cancel", label: "No" },
+  ],
+  prompt: "Approve tool call: bash",
+  requestId: approvalRequest.approvalId,
+};
+
+function createPendingApprovalSession(
+  history?: readonly ModelMessage[],
+  responseAuthorization = false,
+): HarnessSession {
   return appendPendingInputBatch({
-    requests: [
-      {
-        action: {
-          callId: toolCall.toolCallId,
-          input: toolCall.input,
-          kind: "tool-call",
-          toolName: toolCall.toolName,
-        },
-        allowFreeform: false,
-        display: "confirmation",
-        kind: "tool-approval",
-        options: [
-          { id: "approve", label: "Yes" },
-          { id: "cancel", label: "No" },
-        ],
-        prompt: "Approve tool call: bash",
-        requestId: approvalRequest.approvalId,
-      },
-    ],
+    requests: [pendingApprovalInputRequest],
     responseAuthRequiredRequestIds: responseAuthorization
       ? [approvalRequest.approvalId]
       : undefined,
@@ -129,7 +138,7 @@ function createPendingApprovalSession(
         role: "assistant",
       },
     ],
-    session,
+    session: createBaseSession(history),
   });
 }
 
@@ -597,6 +606,76 @@ describe("tool loop generate approval resume (real AI SDK)", () => {
       toolCallId: toolCall.toolCallId,
       toolName: toolCall.toolName,
     });
+    expect(result.session.history.at(-1)).toMatchObject({
+      content: [{ text: "The command returned /workspace.", type: "text" }],
+      role: "assistant",
+    });
+  });
+
+  // Regression: turn-local context (task state, dynamic skill announcement) was
+  // appended as a user message after the approval response. The AI SDK reads
+  // approvals only from the tail tool message, so the approved tool never ran
+  // and the provider rejected the prompt with a tool call that had no output.
+  it.each([
+    { key: PendingSkillAnnouncementKey, label: "dynamic skill announcement" },
+    { key: TurnTaskStateKey, label: "task state" },
+  ])("executes the approved tool when $label is injected on the resume step", async ({ key }) => {
+    const siblingCall = {
+      input: { command: "whoami" },
+      toolCallId: "call-sibling",
+      toolName: "bash",
+      type: "tool-call" as const,
+    };
+    const siblingResult = {
+      output: { type: "text" as const, value: "eve" },
+      toolCallId: siblingCall.toolCallId,
+      toolName: "bash",
+      type: "tool-result" as const,
+    };
+    const session = appendPendingInputBatch({
+      requests: [pendingApprovalInputRequest],
+      // The parked shape when a gated call shares a step with an ungated one.
+      responseMessages: [
+        { content: [toolCall, approvalRequest, siblingCall], role: "assistant" },
+        { content: [siblingResult], role: "tool" },
+      ],
+      session: createBaseSession(),
+    });
+    const ctx = new ContextContainer();
+    ctx.set(key, "[Runtime context]\nInjected on the resume step.");
+    const execute = vi.fn(async () => "/workspace");
+    const model = createModel();
+
+    const result = await contextStorage.run(ctx, () =>
+      createToolLoopHarness(createConfig(model, execute))(
+        setHarnessEmissionState(session, {
+          sequence: 1,
+          sessionStarted: true,
+          stepIndex: 1,
+          turnId: "turn-1",
+        }),
+        { inputResponses: [{ optionId: "approve", requestId: approvalRequest.approvalId }] },
+      ),
+    );
+
+    expect(execute).toHaveBeenCalledExactlyOnceWith(
+      toolCall.input,
+      expect.objectContaining({ toolCallId: toolCall.toolCallId }),
+    );
+
+    const providerPrompt = model.doGenerateCalls[0]?.prompt ?? [];
+    const answered = new Set<string>();
+    const called: string[] = [];
+    for (const message of providerPrompt) {
+      if (!Array.isArray(message.content)) continue;
+      for (const part of message.content) {
+        if (part.type === "tool-call") called.push(part.toolCallId);
+        if (part.type === "tool-result") answered.add(part.toolCallId);
+      }
+    }
+    expect(called).toEqual([toolCall.toolCallId, siblingCall.toolCallId]);
+    expect(called.filter((id) => !answered.has(id))).toEqual([]);
+    expect(providerPrompt.at(-1)?.role).toBe("tool");
     expect(result.session.history.at(-1)).toMatchObject({
       content: [{ text: "The command returned /workspace.", type: "text" }],
       role: "assistant",


### PR DESCRIPTION
### Summary

Approving a gated tool call was failing with `AI Gateway model request rejected: No tool output found for function call call_…` (reported in SRE and v). The failure is not specific to OpenAI or to multi-tool steps; it happens whenever the approval-resume step also injects turn-local runtime context.

Since #2648, `createCurrentMessages` routes later-turn context (task state, dynamic skill announcements, delivery guidance) as a trailing user message for prompt-cache friendliness. On an approval-resume step there is no current-turn user input (it is deferred), so that context landed *after* the `tool-approval-response`. The AI SDK collects approvals only from the tail `tool` message, so the approved tool never executed and the provider received an assistant tool call with no output. Any agent with a running background task or a dynamic skill manifest hit this on every approval.

`createCurrentMessages` now keeps cache-friendly context in the system prompt when the history tail carries an approval response and there is no current-turn insertion point — the same path the pending-approvals instruction already takes. The duplicated `hasTailApprovalResponse` helper in `input-requests.ts` is consolidated into `current-messages.ts`.

### Validation

Reproduced against the real AI SDK with a parked approval batch (gated call plus an ungated sibling with its result) and either `TurnTaskStateKey` or `PendingSkillAnnouncementKey` set on the resume step: the approved tool's `execute` was never called and the provider prompt ended in a `user` message with a dangling tool call. With the fix, the tool runs and the prompt ends in the `tool` message with both results. The new integration cases fail on `main` and pass here; the existing approval-resume, `input-requests`, and `tool-loop` suites still pass.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Changeset only; no public API or documented behavior changes.

**Implementation** — 2 files · `+15 / -8`

A single guard in `createCurrentMessages` plus moving the shared tail-approval helper out of `input-requests.ts`.

**Tests** — 2 files · `+134 / -26`

A unit case for the placement rule and two real-AI-SDK regression cases covering task state and skill announcement injection. Part of the integration diff is factoring the existing fixture builder so the new cases can reuse the pending-approval request without duplicating it.
