### PR TITLE
fix(e2e): stabilize model-sensitive evals

### DIFF
--- a/e2e/fixtures/agent-tools/evals/static-tools/web-search-parallel.eval.ts
+++ b/e2e/fixtures/agent-tools/evals/static-tools/web-search-parallel.eval.ts
@@ -4,10 +4,16 @@ import { defineEval } from "eve/evals";
 const TOOL_NAME = "web_search";
 const MIN_COMPLETED_SEARCHES = 8;
 
-const EXPECTED_WINNERS =
-  "2026 New York Knicks; 2025 Oklahoma City Thunder; 2024 Boston Celtics; " +
-  "2023 Denver Nuggets; 2022 Golden State Warriors; 2021 Milwaukee Bucks; " +
-  "2020 Los Angeles Lakers; 2019 Toronto Raptors.";
+const EXPECTED_WINNERS = [
+  /Knicks/iu,
+  /Thunder/iu,
+  /Celtics/iu,
+  /Nuggets/iu,
+  /Warriors/iu,
+  /Bucks/iu,
+  /Lakers/iu,
+  /Raptors/iu,
+];
 
 function completedToolResultCount(events: readonly MessageStreamEvent[], toolName: string) {
   const callIds = new Set<string>();
@@ -42,6 +48,8 @@ export default defineEval({
       (events) => completedToolResultCount(events, TOOL_NAME) >= MIN_COMPLETED_SEARCHES,
     );
     t.noFailedActions();
-    t.judge.autoevals.factuality(EXPECTED_WINNERS, { on: turn.message }).atLeast(0.5);
+    for (const winner of EXPECTED_WINNERS) {
+      turn.messageIncludes(winner);
+    }
   },
 });

--- a/e2e/fixtures/agent-tools/evals/static-tools/web-search.eval.ts
+++ b/e2e/fixtures/agent-tools/evals/static-tools/web-search.eval.ts
@@ -61,10 +61,5 @@ export default defineEval({
       (events) => providerRequestsPrecedeResults(events),
     );
     t.messageIncludes(/New York Knicks/iu);
-    t.judge.autoevals
-      .factuality("The New York Knicks won the 2026 NBA Finals.", {
-        on: turn.message,
-      })
-      .atLeast(0.5);
   },
 });


### PR DESCRIPTION
### Summary

Recent `e2e-local` runs failed after successful web-search execution because the Autoevals factuality judge returned `Unknown score choice undefined`. Before → after: the model answer went through another model judge; it now goes directly through deterministic expected-winner checks.

The single-search eval still checks the exact winning team. The parallel eval checks all eight winners, at least eight completed searches, and no failed actions. The prompt-cache fixture was removed upstream in #2924, so the rebase dropped that obsolete branch commit.

No runtime behavior, public API, documentation, or release metadata changes.

### Validation

The [exact-patch E2E workflow](https://github.com/vercel/eve/actions/runs/33692204576) passed all 40 jobs; `agent-tools / anthropic-opus` passed 27/27 evals and 102/102 gates, including 5/5 for the single search and 11/11 for the parallel search. After rebasing, the focused fixture build/typecheck and invariant guard also passed.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 0 files · `+0 / -0`

Not applicable.

**Tests** — 2 files · `+13 / -10`

Replaces the two model-judge gates with deterministic answer assertions while preserving the tool execution and failure checks.
