### PR TITLE
fix(eve): release stream bodies when followers stop

### DIFF
--- a/.changeset/calm-workflow-stream-followers.md
+++ b/.changeset/calm-workflow-stream-followers.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Release local Workflow stream listeners when client stream followers reconnect or stop.

--- a/packages/eve/src/client/open-stream.test.ts
+++ b/packages/eve/src/client/open-stream.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { openStreamBody } from "./open-stream.js";
+import { EVE_MESSAGE_STREAM_VERSION, EVE_STREAM_VERSION_HEADER } from "#protocol/message.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("openStreamBody", () => {
+  it("cancels an opened response body when the stream follower closes", async () => {
+    const cancel = vi.fn();
+    const body = new ReadableStream<Uint8Array>({ cancel });
+    let signal: AbortSignal | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+        signal = init?.signal ?? undefined;
+        return new Response(body, {
+          headers: { [EVE_STREAM_VERSION_HEADER]: EVE_MESSAGE_STREAM_VERSION },
+          status: 200,
+        });
+      }),
+    );
+
+    const connection = await openStreamBody({
+      host: "https://agent.example",
+      resolveHeaders: () => Promise.resolve(new Headers()),
+      sessionId: "session_1",
+      startIndex: 0,
+    });
+    connection.close();
+    connection.close();
+    await Promise.resolve();
+
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(signal?.aborted).toBe(true);
+  });
+});

--- a/packages/eve/src/client/open-stream.ts
+++ b/packages/eve/src/client/open-stream.ts
@@ -274,9 +274,19 @@ export async function openStreamBody(
       if (!response.body) {
         throw new ClientError(response.status, "Response body is null.", response.headers);
       }
+      let closed = false;
       return {
         body: response.body,
-        close: () => connectionController.abort(),
+        close: () => {
+          if (closed) return;
+          closed = true;
+          // Aborting a fetch after its response has resolved does not reliably
+          // propagate cancellation through every local HTTP transport. Cancel
+          // the body as well so its server-side Workflow stream releases its
+          // live chunk and close listeners before a reconnect opens another.
+          response.body?.cancel().catch(() => {});
+          connectionController.abort();
+        },
         streamVersion: readMessageStreamVersion(response.headers),
         tailIndex: parseTailIndexHeader(response.headers),
       };


### PR DESCRIPTION
### Summary

`eve dev` could retain local Workflow stream listeners when a TUI session follower stopped or reconnected after its HTTP response had already opened. Repeated follows of one pending parent session then emitted `MaxListenersExceededWarning` for both the stream's `chunk:` and `close:` events.

Close now cancels the response body as well as aborting its fetch controller, ensuring the local Workflow stream subscription is released before a later follow opens another reader. The public client API and durable reconnect behavior are unchanged.

### Validation

`pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/client/open-stream.test.ts` and `pnpm --filter eve exec tsc --noEmit --pretty false` pass. `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/client/stream-follow.integration.test.ts` could not start because this checkout's integration Vitest config imports a missing generated `#internal/workflow-bundle/workflow-builders.js` module.

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Patch changeset describing the local Workflow stream cleanup.

**Implementation** — 1 file · `+11 / -1`

Keeps cancellation at the client stream connection boundary so every caller benefits without changing the public API.

**Tests** — 1 file · `+39 / -0`

Verifies that closing an already-open stream cancels the response body exactly once and aborts the underlying request.
