### PR TITLE
fix(eve): memory - support Vercel CLI 57

### DIFF
--- a/.changeset/fix-file-memory-vercel-57.md
+++ b/.changeset/fix-file-memory-vercel-57.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix file-memory setup failing after it creates a Vercel Blob store when the project uses Vercel CLI 57. Setup now connects the store without passing that release an unsupported output flag, so retrying repairs the partial setup normally.

--- a/packages/eve/src/setup/integrations/file-memory/vercel-client.test.ts
+++ b/packages/eve/src/setup/integrations/file-memory/vercel-client.test.ts
@@ -24,7 +24,7 @@ beforeEach(() => {
 });
 
 describe("file-memory Vercel CLI client", () => {
-  it("uses authenticated API reads and the resource connection command", async () => {
+  it("uses authenticated API reads and a Vercel 57-compatible resource connection command", async () => {
     captureVercel
       .mockResolvedValueOnce({
         ok: true,
@@ -114,7 +114,6 @@ describe("file-memory Vercel CLI client", () => {
         "--environment",
         "development",
         "--yes",
-        "--json",
         "--scope",
         "team_acme",
       ],

--- a/packages/eve/src/setup/integrations/file-memory/vercel.ts
+++ b/packages/eve/src/setup/integrations/file-memory/vercel.ts
@@ -165,7 +165,6 @@ export function createFileMemoryVercelClient(
         prefix,
         ...environments.flatMap((environment) => ["--environment", environment]),
         "--yes",
-        "--json",
         ...scope,
       ];
       await captureMutation(args, "Vercel Blob project connection");


### PR DESCRIPTION
### Summary

`eve add memory/file` could create its private Blob store and then fail to connect it when the project used Vercel CLI 57, because that release rejects `--json` on `integration-resource connect`. The connection mutation now omits the unused output-format flag while store lookups keep their machine-readable output. Retrying `eve integration setup file-memory` continues to reuse and repair the partial store instead of creating another one.

### Validation

Reproduced the CLI mismatch with `pnpm dlx vercel@57.0.0 integration-resource connect --help`, then confirmed the Vercel client and partial-store repair paths with `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/setup/integrations/file-memory/vercel.test.ts src/setup/integrations/file-memory/vercel-client.test.ts` (15 tests passed).

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the release note for the Vercel CLI 57 compatibility fix and partial-store recovery behavior.

**Implementation** — 1 file · `+0 / -1`

Removes the unused structured-output flag from the resource connection mutation.

**Tests** — 1 file · `+1 / -2`

Locks the resource connection arguments to the command surface supported by Vercel CLI 57.
