### PR TITLE
fix(eve): memory - normalize weak Blob ETags

### DIFF
--- a/.changeset/fix-file-memory-weak-etags.md
+++ b/.changeset/fix-file-memory-weak-etags.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix Vercel Blob file memory getting stuck in conflict retries after CDN compression returns a weak ETag. File memory now uses the underlying Blob object ETag for conditional writes, so documents continue saving as they grow.

--- a/packages/eve/src/public/memory/file/backends/vercel-blob.test.ts
+++ b/packages/eve/src/public/memory/file/backends/vercel-blob.test.ts
@@ -104,6 +104,31 @@ describe("Vercel Blob file-memory backend", () => {
     });
   });
 
+  it("uses the underlying Blob ETag when CDN compression weakens the response validator", async () => {
+    const content = "x".repeat(1_025);
+    vi.mocked(get).mockResolvedValue(getBlobResult(content, 'W/"etag-current"'));
+    vi.mocked(put).mockResolvedValue(putBlobResult('"etag-next"'));
+    const backend = vercelBlob();
+
+    const document = await backend.read({ key: "mem_a", signal });
+    expect(document).toEqual({ content, version: '"etag-current"' });
+    if (document === null) throw new Error("Expected a memory document.");
+
+    await expect(
+      backend.write({
+        content: `${content} next`,
+        expectedVersion: document.version,
+        key: "mem_a",
+        signal,
+      }),
+    ).resolves.toEqual({ content: `${content} next`, version: '"etag-next"' });
+    expect(put).toHaveBeenCalledWith(
+      "eve/memory/file/mem_a/MEMORY.md",
+      `${content} next`,
+      expect.objectContaining({ ifMatch: '"etag-current"' }),
+    );
+  });
+
   it("normalizes conditional and duplicate-create failures", async () => {
     const backend = vercelBlob();
     vi.mocked(put).mockRejectedValueOnce(new BlobPreconditionFailedError());

--- a/packages/eve/src/public/memory/file/backends/vercel-blob.ts
+++ b/packages/eve/src/public/memory/file/backends/vercel-blob.ts
@@ -40,7 +40,10 @@ export function vercelBlob(options: VercelBlobBackendOptions = {}): MemoryDocume
     if (result.statusCode !== 200 || result.stream === null) {
       throw new Error(`Vercel Blob returned ${result.statusCode} without a memory document.`);
     }
-    return { content: await new Response(result.stream).text(), version: result.blob.etag };
+    return {
+      content: await new Response(result.stream).text(),
+      version: normalizeBlobEtag(result.blob.etag),
+    };
   };
 
   return {
@@ -80,6 +83,12 @@ function normalizePrefix(value: string): string {
   const prefix = value.replace(/^\/+|\/+$/g, "");
   if (prefix.length === 0) throw new TypeError("Vercel Blob memory prefix cannot be empty.");
   return prefix;
+}
+
+function normalizeBlobEtag(etag: string): string {
+  // The CDN weakens the same object ETag when it compresses a response, but
+  // Blob conditional writes require the underlying strong validator.
+  return etag.startsWith("W/") ? etag.slice(2) : etag;
 }
 
 function pathname(prefix: string, key: string): string {


### PR DESCRIPTION
### Summary

`fileMemory()` on Vercel could stop saving once Blob CDN compression weakened a document ETag from `"…"` to `W/"…"`, because Blob conditional writes require the underlying strong validator. The backend now removes only the weak marker at the read boundary while preserving the opaque ETag, so genuinely stale writes still conflict and retry normally.

### Validation

Reproduced the failure with a 1,025-byte document and a weak CDN ETag, then confirmed the fix with `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/memory/file` (37 tests passed) and the built `src/execution/file-memory.integration.test.ts` integration test (1 test passed).

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds release metadata describing the recovered Blob write behavior.

**Implementation** — 1 file · `+10 / -1`

Normalizes weak CDN validators at the Blob backend boundary without changing the memory provider contract or retry policy.

**Tests** — 1 file · `+25 / -0`

Covers reading and conditionally replacing a document above the compression threshold with a `W/` ETag.
