### PR TITLE
fix(eve): memory - request identity-encoded Blob reads

### DIFF
--- a/.changeset/fix-file-memory-identity-encoding.md
+++ b/.changeset/fix-file-memory-identity-encoding.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Prevent Vercel Blob file memory from receiving compressed responses with weak ETags that cannot be used for conditional writes. Blob reads now request identity encoding so memory documents continue saving as they grow.

--- a/packages/eve/src/public/memory/file/backends/vercel-blob.test.ts
+++ b/packages/eve/src/public/memory/file/backends/vercel-blob.test.ts
@@ -64,6 +64,7 @@ describe("Vercel Blob file-memory backend", () => {
     expect(get).toHaveBeenCalledWith("custom/memory/mem_scope/MEMORY.md", {
       abortSignal: signal,
       access: "private",
+      headers: { "accept-encoding": "identity" },
       oidcToken: "oidc",
       storeId: "store",
       token: "rw",

--- a/packages/eve/src/public/memory/file/backends/vercel-blob.ts
+++ b/packages/eve/src/public/memory/file/backends/vercel-blob.ts
@@ -34,6 +34,7 @@ export function vercelBlob(options: VercelBlobBackendOptions = {}): MemoryDocume
       ...credentials,
       abortSignal: input.signal,
       access: "private",
+      headers: { "accept-encoding": "identity" },
       useCache: false,
     });
     if (result === null) return null;


### PR DESCRIPTION
### Summary

Follow-up to #2934 after its revert in #2935. Vercel Blob reads inherited the HTTP client's default compression negotiation, allowing the CDN to return a weak ETag that cannot satisfy Blob's conditional writes. File memory now explicitly requests identity encoding, preserving Blob's strong object ETag without rewriting the opaque validator or changing conflict semantics.

### Validation

Confirmed the Blob read request contract and the full file-memory unit suite with `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/memory/file` (36 tests passed).

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds release metadata for the recovered Vercel Blob file-memory saves.

**Implementation** — 1 file · `+1 / -0`

Requests identity encoding for Vercel Blob reads so the CDN does not weaken the object ETag.

**Tests** — 1 file · `+1 / -0`

Locks the identity-encoding header into the existing Blob read request contract.
