### PR TITLE
fix(eve): sandbox - enforce non-root runtime user

### DIFF
--- a/.changeset/fix-sandbox-runtime-user.md
+++ b/.changeset/fix-sandbox-runtime-user.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Run authored Vercel Sandbox commands and file operations as `vercel-sandbox`, matching local backends, and keep system toolchain paths root-owned across image architectures. Sandbox image tag overrides now invalidate cached templates and live session sandboxes.

--- a/.github/workflows/docker-image-size-analysis.yml
+++ b/.github/workflows/docker-image-size-analysis.yml
@@ -99,8 +99,13 @@ jobs:
             set -euo pipefail
             test "$(id -un)" = vercel-sandbox
             test "$(stat -c %U /workspace)" = vercel-sandbox
+            test "$(stat -c %U /usr/local/bin/node)" = root
+            test ! -w /usr/local/bin
             test "$(npm prefix -g)" = "$HOME/.local"
             test "$(pnpm bin -g)" = "$PNPM_HOME/bin"
+            printf "%s\n" "#!/bin/sh" "printf sandbox-user-path-ok" > "$HOME/.local/bin/eve-image-smoke"
+            chmod +x "$HOME/.local/bin/eve-image-smoke"
+            test "$(eve-image-smoke)" = sandbox-user-path-ok
             git init --quiet /workspace
             git -C /workspace remote add origin https://github.com/vercel/eve.git
             sudo -n true

--- a/docs/sandbox.mdx
+++ b/docs/sandbox.mdx
@@ -158,6 +158,10 @@ With `backend` omitted, eve uses `defaultBackend()`, which resolves on first use
 
 By default, Docker and microsandbox pull `ghcr.io/vercel/eve` while Vercel Sandbox pulls `vcr.vercel.com/vercel/eve/base`. Each image tag matches the installed eve version. Set `EVE_SANDBOX_IMAGE_TAG` to replace the version-derived tag for these default images. An explicit `image` passed to `docker()` or `microsandbox()` still takes precedence.
 
+Authored commands and file operations run as the non-root `vercel-sandbox` user on Docker, microsandbox, and Vercel Sandbox. `/workspace` and `$HOME` are writable; system paths such as `/usr/local` remain root-owned. Install user-scoped executables under `$HOME/.local/bin`, which is already on `PATH`, or use `sudo` explicitly when setup genuinely needs system-wide changes.
+
+Changing `EVE_SANDBOX_IMAGE_TAG` replaces reusable templates and live session sandboxes on the next use. Prefer immutable tags: cache keys include the tag string, not the registry digest, so moving an existing tag does not by itself invalidate a cached template. If you select a mutable tag such as `latest`, update the sandbox `revalidationKey` when that tag moves.
+
 `defaultBackend()` also accepts a keyed bag so each inner backend gets its own typed create options:
 
 ```ts
@@ -273,7 +277,7 @@ Only the session that owns a shared sandbox can delete it. Deleting the owner's 
 
 Custom backend handles implement the same boundary in `delete()`: remove the session runtime and disposable persisted state without deleting reusable templates.
 
-Session sandboxes are keyed per durable session, not per deployment, so redeploying your app does not by itself discard them. A definition change to the authored sandbox source, workspace seed content, or `revalidationKey` replaces the sandbox on the next turn and runs `onSession` again.
+Session sandboxes are keyed per durable session, not per deployment, so redeploying your app does not by itself discard them. A definition change to the authored sandbox source, workspace seed content, `revalidationKey`, or `EVE_SANDBOX_IMAGE_TAG` replaces the sandbox on the next turn and runs `onSession` again.
 
 Reattachment still depends on the backend retaining its physical sandbox state. If a persisted Vercel sandbox is no longer available, eve creates a replacement, using the current template when one is configured. Files and other changes made after the original sandbox was created are not restored automatically. Because the durable session still has the same sandbox key, `onSession` does not run again for this replacement. Persist important artifacts outside the sandbox, and do not rely on `onSession` as the only place that applies security-critical configuration.
 

--- a/e2e/fixtures/agent-tools-sandbox/agent/sandbox/sandbox.ts
+++ b/e2e/fixtures/agent-tools-sandbox/agent/sandbox/sandbox.ts
@@ -18,9 +18,9 @@ import { vercel } from "eve/sandbox/vercel";
  * Backend is left as the framework default so this fixture works both
  * locally (where `defaultBackend()` resolves to `docker()`) and on Vercel
  * deployments (where it resolves to `vercel()`). Both run the published eve
- * base image: GHCR locally and VCR on Vercel. CI sets `EVE_SANDBOX_IMAGE_TAG`
- * to `latest` so release PRs can run before their versioned image exists. The
- * image ships Python, Node, and git; the bootstrap below assumes
+ * base image: GHCR locally and VCR on Vercel. CI sets
+ * `EVE_SANDBOX_IMAGE_TAG` to `latest` so release PRs can run before their
+ * versioned image exists. The image ships Python, Node, and git; the bootstrap below assumes
  * that real-binary environment and is not meant to run against the
  * dependency-free `just-bash` fallback.
  *
@@ -34,8 +34,9 @@ export const SANDBOX_MARKER_PATH = "/workspace/smoke-marker.txt";
 export const SANDBOX_MARKER_TOKEN = "sandbox-bootstrap-ok-J3Q";
 
 /**
- * Custom CLI installed during bootstrap. The base image puts the sandbox
- * user's npm global prefix on PATH, so the same install works across backends.
+ * Custom CLI installed during bootstrap. The image's user-local bin directory
+ * is on PATH and writable by `vercel-sandbox` on every backend; system paths
+ * such as `/usr/local/bin` intentionally remain root-owned.
  */
 const SANDBOX_CLI_DIRECTORY_PATH = "/home/vercel-sandbox/.local/bin";
 export const SANDBOX_CLI_PATH = `${SANDBOX_CLI_DIRECTORY_PATH}/eve-greet`;

--- a/e2e/fixtures/agent-tools-sandbox/evals/sandbox/user.eval.ts
+++ b/e2e/fixtures/agent-tools-sandbox/evals/sandbox/user.eval.ts
@@ -1,0 +1,17 @@
+import { defineEval } from "eve/evals";
+
+const SANDBOX_USER = "vercel-sandbox";
+
+// This runs in the deterministic world suites as well as the real-model suite.
+// It protects parity between Docker and hosted Vercel Sandbox, whose custom
+// image execution default is otherwise root even when the Dockerfile has USER.
+export default defineEval({
+  description: "Sandbox: authored commands run as the non-root sandbox user.",
+  async test(t) {
+    await t.send("Run the bash command `whoami` and reply with its output verbatim.");
+
+    t.succeeded();
+    t.calledTool("bash", { output: new RegExp(SANDBOX_USER) });
+    t.messageIncludes(SANDBOX_USER);
+  },
+});

--- a/packages/eve/Dockerfile
+++ b/packages/eve/Dockerfile
@@ -46,7 +46,7 @@ RUN set -eux; \
   test -n "${node_file}"; \
   curl -fsSLO "${base_url}/${node_file}"; \
   grep " ${node_file}$" "${shasums}" | sha256sum -c -; \
-  tar -xJf "${node_file}" -C /usr/local --strip-components=1; \
+  tar -xJf "${node_file}" -C /usr/local --strip-components=1 --no-same-owner; \
   rm "${node_file}" "${shasums}"; \
   rm -rf /usr/local/include/node /usr/local/share/doc /usr/local/share/man; \
   npm install -g "pnpm@${PNPM_VERSION}"; \
@@ -77,6 +77,7 @@ RUN set -eux; \
   # them into another image layer. A small user-owned prefix retains global installs.
   install -d --owner=vercel-sandbox --group=vercel-sandbox \
     /home/vercel-sandbox/.local \
+    /home/vercel-sandbox/.local/bin \
     /home/vercel-sandbox/.local/share/pnpm; \
   mkdir -p /workspace; \
   chown vercel-sandbox:vercel-sandbox /workspace; \

--- a/packages/eve/src/execution/sandbox/bindings/vercel-sdk-types.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel-sdk-types.ts
@@ -9,6 +9,8 @@ export type VercelModule = typeof Vercel;
 
 export type VercelSandbox = Vercel.Sandbox;
 
+export type VercelSandboxUser = ReturnType<VercelSandbox["asUser"]>;
+
 export type VercelDeleteGetOptions = Parameters<typeof VercelDelete.Sandbox.get>[0];
 
 export type VercelDeleteModule = typeof VercelDelete;

--- a/packages/eve/src/execution/sandbox/bindings/vercel-user-session.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel-user-session.ts
@@ -1,0 +1,112 @@
+import { adaptMultiplexedCommandToSandboxProcess } from "#execution/sandbox/multiplexed-command.js";
+import { streamToBuffer } from "#execution/sandbox/stream-utils.js";
+import { normalizeVercelReadStream } from "#execution/sandbox/bindings/vercel-read-stream.js";
+import type {
+  VercelSandbox,
+  VercelSandboxUser,
+} from "#execution/sandbox/bindings/vercel-sdk-types.js";
+import type { SandboxSeedFile } from "#public/definitions/sandbox-backend.js";
+import { WORKSPACE_ROOT } from "#runtime/workspace/types.js";
+import { resolveSandboxModelPath } from "#shared/skill-paths.js";
+import type {
+  InternalSandboxSession,
+  SandboxProcess,
+  SandboxReadFileOptions,
+  SandboxRemovePathOptions,
+  SandboxSession,
+  SandboxSpawnOptions,
+  SandboxWriteFileOptions,
+} from "#shared/sandbox-session.js";
+
+const VERCEL_SANDBOX_USER = "vercel-sandbox";
+
+export function createVercelInternalSandboxSession(
+  sandbox: VercelSandbox,
+  id: string,
+): InternalSandboxSession {
+  const user = getVercelSandboxUser(sandbox);
+  return {
+    id,
+    resolvePath: resolveVercelSandboxPath,
+    async spawn(options: SandboxSpawnOptions): Promise<SandboxProcess> {
+      const command = await user.runCommand({
+        args: ["-lc", options.command],
+        cmd: "bash",
+        cwd: options.workingDirectory ?? WORKSPACE_ROOT,
+        detached: true,
+        env: options.env,
+        signal: options.abortSignal,
+      });
+      return adaptMultiplexedCommandToSandboxProcess({
+        command,
+        getOutput: (log) => log.stream,
+      });
+    },
+    async readFile(options: SandboxReadFileOptions) {
+      return normalizeVercelReadStream(
+        await user.readFile({ path: options.path }, { signal: options.abortSignal }),
+      );
+    },
+    async writeFile(options: SandboxWriteFileOptions) {
+      const bytes = await streamToBuffer(options.content);
+      await user.writeFiles([{ content: bytes, path: options.path }], {
+        signal: options.abortSignal,
+      });
+    },
+    async removePath(options: SandboxRemovePathOptions) {
+      const flags = `${options.recursive === true ? "r" : ""}${options.force === true ? "f" : ""}`;
+      const result = await user.runCommand({
+        args: [...(flags.length > 0 ? [`-${flags}`] : []), "--", options.path],
+        cmd: "rm",
+        signal: options.abortSignal,
+      });
+      await expectVercelCommandSuccess(result, `remove "${options.path}" from sandbox`);
+    },
+  };
+}
+
+export async function writeVercelSandboxSeedFiles(input: {
+  readonly sandbox: VercelSandbox;
+  readonly seedFiles: ReadonlyArray<SandboxSeedFile>;
+  readonly session: SandboxSession;
+}): Promise<void> {
+  if (input.seedFiles.length === 0) {
+    return;
+  }
+
+  const files = await Promise.all(
+    input.seedFiles.map(async (file) => ({
+      content: typeof file.content === "string" ? Buffer.from(file.content) : file.content,
+      path: await resolveSandboxModelPath({
+        path: file.path,
+        sandbox: input.session,
+      }),
+    })),
+  );
+
+  await getVercelSandboxUser(input.sandbox).writeFiles(files);
+}
+
+function getVercelSandboxUser(sandbox: VercelSandbox): VercelSandboxUser {
+  return sandbox.asUser(VERCEL_SANDBOX_USER);
+}
+
+async function expectVercelCommandSuccess(
+  result: Awaited<ReturnType<VercelSandboxUser["runCommand"]>>,
+  description: string,
+): Promise<void> {
+  if (result.exitCode === 0) {
+    return;
+  }
+
+  const [stdout, stderr] = await Promise.all([result.stdout(), result.stderr()]);
+  const output = [stdout.trim(), stderr.trim()].filter(Boolean).join("\n");
+  throw new Error(`Failed to ${description}.${output ? `\n${output}` : ""}`);
+}
+
+function resolveVercelSandboxPath(path: string): string {
+  if (path.startsWith("/")) {
+    return path;
+  }
+  return `${WORKSPACE_ROOT}/${path}`;
+}

--- a/packages/eve/src/execution/sandbox/bindings/vercel.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel.test.ts
@@ -52,7 +52,27 @@ function createMockSandbox(input: {
 }) {
   const files = new Map<string, Buffer>();
   let tags = input.tags;
+  const sandboxUser = {
+    readFile: vi.fn(async (file: { path: string }): Promise<object | null> => {
+      const content = files.get(file.path);
+      return content === undefined ? null : Readable.from([content]);
+    }),
+    runCommand: vi.fn().mockResolvedValue(createMockCommandResult()),
+    writeFiles: vi.fn(
+      async (nextFiles: ReadonlyArray<{ readonly content: Uint8Array; readonly path: string }>) => {
+        for (const file of nextFiles) {
+          files.set(file.path, Buffer.from(file.content));
+        }
+      },
+    ),
+  };
   return {
+    asUser: vi.fn((username: string) => {
+      if (username !== "vercel-sandbox") {
+        throw new Error(`Unexpected sandbox user: ${username}`);
+      }
+      return sandboxUser;
+    }),
     currentSnapshotId: input.snapshotId ?? "",
     delete: vi.fn().mockResolvedValue(undefined),
     fs: {
@@ -65,6 +85,7 @@ function createMockSandbox(input: {
       return content === undefined ? null : Readable.from([content]);
     }),
     runCommand: vi.fn().mockResolvedValue(createMockCommandResult()),
+    sandboxUser,
     snapshot: vi.fn().mockResolvedValue({ snapshotId: `${input.name}-snapshot` }),
     status: input.status ?? "running",
     stop: vi.fn().mockResolvedValue(undefined),
@@ -300,7 +321,7 @@ describe("createVercelSandbox", () => {
   it("resolves and writes all seed paths to the sandbox filesystem in one batch", async () => {
     const templateSandbox = createMockSandbox({ name: "template" });
     const sessionSandbox = createMockSandbox({ name: "session" });
-    vi.mocked(templateSandbox.runCommand).mockImplementation(
+    vi.mocked(templateSandbox.sandboxUser.runCommand).mockImplementation(
       async (options: { readonly detached?: boolean }) =>
         options.detached === true
           ? (createMockDetachedCommand([
@@ -357,9 +378,9 @@ describe("createVercelSandbox", () => {
       templateKey: "template-key",
     });
 
-    expect(templateSandbox.writeFiles).toHaveBeenCalledTimes(1);
+    expect(templateSandbox.sandboxUser.writeFiles).toHaveBeenCalledTimes(1);
 
-    const files = vi.mocked(templateSandbox.writeFiles).mock.calls[0]?.[0];
+    const files = vi.mocked(templateSandbox.sandboxUser.writeFiles).mock.calls[0]?.[0];
     expect(files?.map((file) => file.path)).toEqual([
       "/workspace/skills/weather/SKILL.md",
       "/workspace/assets/fixture.bin",
@@ -368,6 +389,8 @@ describe("createVercelSandbox", () => {
     expect(files?.[0]?.content).toEqual(Buffer.from("skill body"));
     expect(files?.[1]?.content).toEqual(Buffer.from([0, 1, 2, 3]));
     expect(files?.[2]?.content).toEqual(Buffer.from("model skill body"));
+    expect(templateSandbox.asUser).toHaveBeenCalledWith("vercel-sandbox");
+    expect(templateSandbox.writeFiles).not.toHaveBeenCalled();
   });
 
   it("writes seed files before bootstrap and snapshots bootstrap outputs", async () => {
@@ -401,7 +424,7 @@ describe("createVercelSandbox", () => {
       templateKey: "template-key",
     });
 
-    const writes = vi.mocked(templateSandbox.writeFiles);
+    const writes = vi.mocked(templateSandbox.sandboxUser.writeFiles);
     expect(writes).toHaveBeenCalledTimes(2);
     expect(writes.mock.calls[0]?.[0].map((file) => file.path)).toEqual([
       "/workspace/seed.txt",
@@ -501,7 +524,7 @@ describe("createVercelSandbox", () => {
     expect(sandboxModule.Sandbox.create).not.toHaveBeenCalled();
   });
 
-  it("removes paths through the sandbox filesystem API", async () => {
+  it("removes paths as the sandbox user", async () => {
     const templateSandbox = createMockSandbox({ name: "template" });
     const sessionSandbox = createMockSandbox({ name: "session" });
     const sandboxModule = {
@@ -528,16 +551,16 @@ describe("createVercelSandbox", () => {
       sessionKey: "session-key",
       templateKey: "template-key",
     });
-    vi.mocked(sessionSandbox.runCommand).mockClear();
+    vi.mocked(sessionSandbox.sandboxUser.runCommand).mockClear();
 
     await handle.session.removePath({ force: true, path: "skills/tenant", recursive: true });
 
-    expect(sessionSandbox.fs.rm).toHaveBeenCalledWith("/workspace/skills/tenant", {
-      force: true,
-      recursive: true,
+    expect(sessionSandbox.sandboxUser.runCommand).toHaveBeenCalledWith({
+      args: ["-rf", "--", "/workspace/skills/tenant"],
+      cmd: "rm",
       signal: undefined,
     });
-    expect(sessionSandbox.runCommand).not.toHaveBeenCalled();
+    expect(sessionSandbox.fs.rm).not.toHaveBeenCalled();
   });
 
   it("applies a 30-minute default timeout to Sandbox.create", async () => {
@@ -1091,14 +1114,16 @@ describe("createVercelSandbox", () => {
 
   it("stops authored compute and keeps the Vercel session handle usable", async () => {
     const { handle, sessionSandbox } = await createTestVercelSession();
-    vi.mocked(sessionSandbox.runCommand).mockResolvedValue(createMockDetachedCommand() as never);
-    vi.mocked(sessionSandbox.runCommand).mockClear();
+    vi.mocked(sessionSandbox.sandboxUser.runCommand).mockResolvedValue(
+      createMockDetachedCommand() as never,
+    );
+    vi.mocked(sessionSandbox.sandboxUser.runCommand).mockClear();
 
     await handle.stop();
     await handle.session.run({ command: "printf resumed" });
 
     expect(sessionSandbox.stop).toHaveBeenCalledTimes(1);
-    expect(sessionSandbox.runCommand).toHaveBeenCalledWith(
+    expect(sessionSandbox.sandboxUser.runCommand).toHaveBeenCalledWith(
       expect.objectContaining({ args: ["-lc", "printf resumed"], cmd: "bash" }),
     );
   });
@@ -1635,7 +1660,7 @@ describe("createVercelSandbox", () => {
 
   it("converts Vercel Node file streams to the public Web stream contract", async () => {
     const { handle, sessionSandbox } = await createTestVercelSession();
-    sessionSandbox.readFile.mockResolvedValueOnce(
+    sessionSandbox.sandboxUser.readFile.mockResolvedValueOnce(
       Readable.from([Buffer.from("hello "), Buffer.from("sandbox")]),
     );
 
@@ -1643,7 +1668,10 @@ describe("createVercelSandbox", () => {
 
     expect(stream).not.toBeNull();
     expect(await consumeWebStream(stream!)).toBe("hello sandbox");
-    expect(sessionSandbox.readFile).toHaveBeenCalledWith({ path: "/workspace/message.txt" });
+    expect(sessionSandbox.sandboxUser.readFile).toHaveBeenCalledWith(
+      { path: "/workspace/message.txt" },
+      { signal: undefined },
+    );
   });
 
   it("passes existing Web file streams through unchanged", async () => {
@@ -1654,7 +1682,7 @@ describe("createVercelSandbox", () => {
         controller.close();
       },
     });
-    sessionSandbox.readFile.mockResolvedValueOnce(providerStream);
+    sessionSandbox.sandboxUser.readFile.mockResolvedValueOnce(providerStream);
 
     const stream = await handle.session.readFile({ path: "/workspace/message.txt" });
 
@@ -1671,7 +1699,7 @@ describe("createVercelSandbox", () => {
   it("propagates Vercel file-read errors unchanged", async () => {
     const { handle, sessionSandbox } = await createTestVercelSession();
     const providerError = new Error("provider read failed");
-    sessionSandbox.readFile.mockRejectedValueOnce(providerError);
+    sessionSandbox.sandboxUser.readFile.mockRejectedValueOnce(providerError);
 
     await expect(handle.session.readFile({ path: "/workspace/message.txt" })).rejects.toBe(
       providerError,
@@ -1680,7 +1708,7 @@ describe("createVercelSandbox", () => {
 
   it("rejects unsupported Vercel file-stream values", async () => {
     const { handle, sessionSandbox } = await createTestVercelSession();
-    sessionSandbox.readFile.mockResolvedValueOnce({ readable: true });
+    sessionSandbox.sandboxUser.readFile.mockResolvedValueOnce({ readable: true });
 
     await expect(handle.session.readFile({ path: "/workspace/message.txt" })).rejects.toThrow(
       "Vercel Sandbox returned an unsupported file stream.",
@@ -1715,16 +1743,18 @@ describe("createVercelSandbox", () => {
       templateKey: "template-key",
     });
 
-    vi.mocked(sessionSandbox.runCommand).mockResolvedValue(createMockDetachedCommand() as never);
-    vi.mocked(sessionSandbox.runCommand).mockClear();
+    vi.mocked(sessionSandbox.sandboxUser.runCommand).mockResolvedValue(
+      createMockDetachedCommand() as never,
+    );
+    vi.mocked(sessionSandbox.sandboxUser.runCommand).mockClear();
 
     await handle.session.spawn({
       command: "printenv DEPLOY_ENV",
       env: { DEPLOY_ENV: "staging" },
     });
 
-    expect(sessionSandbox.runCommand).toHaveBeenCalledTimes(1);
-    expect(sessionSandbox.runCommand).toHaveBeenCalledWith(
+    expect(sessionSandbox.sandboxUser.runCommand).toHaveBeenCalledTimes(1);
+    expect(sessionSandbox.sandboxUser.runCommand).toHaveBeenCalledWith(
       expect.objectContaining({
         args: ["-lc", "printenv DEPLOY_ENV"],
         cmd: "bash",
@@ -1761,16 +1791,19 @@ describe("createVercelSandbox", () => {
       templateKey: "template-key",
     });
 
-    vi.mocked(sessionSandbox.runCommand).mockResolvedValue(createMockDetachedCommand() as never);
-    vi.mocked(sessionSandbox.runCommand).mockClear();
+    vi.mocked(sessionSandbox.sandboxUser.runCommand).mockResolvedValue(
+      createMockDetachedCommand() as never,
+    );
+    vi.mocked(sessionSandbox.sandboxUser.runCommand).mockClear();
 
     await handle.session.run({
       command: "printenv DEPLOY_ENV",
       env: { DEPLOY_ENV: "production" },
     });
 
-    expect(sessionSandbox.runCommand).toHaveBeenCalledTimes(1);
-    expect(sessionSandbox.runCommand).toHaveBeenCalledWith(
+    expect(sessionSandbox.asUser).toHaveBeenCalledWith("vercel-sandbox");
+    expect(sessionSandbox.sandboxUser.runCommand).toHaveBeenCalledTimes(1);
+    expect(sessionSandbox.sandboxUser.runCommand).toHaveBeenCalledWith(
       expect.objectContaining({
         args: ["-lc", "printenv DEPLOY_ENV"],
         cmd: "bash",

--- a/packages/eve/src/execution/sandbox/bindings/vercel.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel.ts
@@ -6,15 +6,6 @@ import {
 } from "#execution/sandbox/bindings/vercel-base-runtime.js";
 import type { SandboxBootstrapContext } from "#public/definitions/sandbox.js";
 import type {
-  InternalSandboxSession,
-  SandboxProcess,
-  SandboxReadFileOptions,
-  SandboxRemovePathOptions,
-  SandboxSession,
-  SandboxSpawnOptions,
-  SandboxWriteFileOptions,
-} from "#shared/sandbox-session.js";
-import type {
   SandboxBackend,
   SandboxBackendCreateInput,
   SandboxBackendHandle,
@@ -30,11 +21,8 @@ import type {
   VercelSandboxSessionCreateOptions,
   VercelSandboxSessionUseOptions,
 } from "#public/sandbox/vercel-sandbox.js";
-import { WORKSPACE_ROOT } from "#runtime/workspace/types.js";
 import { createLoggingSandboxSession } from "#execution/sandbox/logging-session.js";
-import { adaptMultiplexedCommandToSandboxProcess } from "#execution/sandbox/multiplexed-command.js";
 import { buildSandboxSession } from "#execution/sandbox/session.js";
-import { streamToBuffer } from "#execution/sandbox/stream-utils.js";
 import {
   createVercelEveImageSandbox,
   type CreateVercelSandbox,
@@ -49,8 +37,10 @@ import {
   deleteVercelSandbox,
   stopVercelSandbox,
 } from "#execution/sandbox/bindings/vercel-lifecycle.js";
-import { normalizeVercelReadStream } from "#execution/sandbox/bindings/vercel-read-stream.js";
-import { resolveSandboxModelPath } from "#shared/skill-paths.js";
+import {
+  createVercelInternalSandboxSession,
+  writeVercelSandboxSeedFiles,
+} from "#execution/sandbox/bindings/vercel-user-session.js";
 import type {
   VercelCreateOptions,
   VercelDeleteModule,
@@ -505,73 +495,6 @@ function createHandle(input: {
       }
     },
   };
-}
-
-function createVercelInternalSandboxSession(
-  sandbox: VercelSandbox,
-  id: string,
-): InternalSandboxSession {
-  return {
-    id,
-    resolvePath: resolveVercelSandboxPath,
-    async spawn(options: SandboxSpawnOptions): Promise<SandboxProcess> {
-      const command = await sandbox.runCommand({
-        args: ["-lc", options.command],
-        cmd: "bash",
-        cwd: options.workingDirectory ?? WORKSPACE_ROOT,
-        detached: true,
-        env: options.env,
-        signal: options.abortSignal,
-      });
-      return adaptMultiplexedCommandToSandboxProcess({
-        command,
-        getOutput: (log) => log.stream,
-      });
-    },
-    async readFile(options: SandboxReadFileOptions) {
-      return normalizeVercelReadStream(await sandbox.readFile({ path: options.path }));
-    },
-    async writeFile(options: SandboxWriteFileOptions) {
-      const bytes = await streamToBuffer(options.content);
-      await sandbox.writeFiles([{ content: bytes, path: options.path }]);
-    },
-    async removePath(options: SandboxRemovePathOptions) {
-      await sandbox.fs.rm(options.path, {
-        force: options.force,
-        recursive: options.recursive,
-        signal: options.abortSignal,
-      });
-    },
-  };
-}
-
-async function writeVercelSandboxSeedFiles(input: {
-  readonly sandbox: VercelSandbox;
-  readonly seedFiles: ReadonlyArray<SandboxSeedFile>;
-  readonly session: SandboxSession;
-}): Promise<void> {
-  if (input.seedFiles.length === 0) {
-    return;
-  }
-
-  const files = await Promise.all(
-    input.seedFiles.map(async (file) => ({
-      content: typeof file.content === "string" ? Buffer.from(file.content) : file.content,
-      path: await resolveSandboxModelPath({
-        path: file.path,
-        sandbox: input.session,
-      }),
-    })),
-  );
-
-  await input.sandbox.writeFiles(files);
-}
-
-function resolveVercelSandboxPath(path: string): string {
-  if (path.startsWith("/")) {
-    return path;
-  }
-  return `${WORKSPACE_ROOT}/${path}`;
 }
 
 function isUnprovisionedTerminalTemplateSandbox(

--- a/packages/eve/src/runtime/sandbox/keys.test.ts
+++ b/packages/eve/src/runtime/sandbox/keys.test.ts
@@ -16,7 +16,7 @@ import {
   createRuntimeSandboxTemplateKey,
 } from "#runtime/sandbox/keys.js";
 
-const RUNTIME_SANDBOX_CONTRACT_VERSION = 7;
+const RUNTIME_SANDBOX_CONTRACT_VERSION = 8;
 
 const CONTENT_HASH = "a".repeat(64);
 
@@ -47,14 +47,14 @@ function expectedTemplateKey(input: { scopeSource: string; version: string }): s
   const scope = sha256(input.scopeSource).slice(0, 16);
   const versionHash = sha256(`workspace-content:${CONTENT_HASH}:__root__:eve:default-sandbox`);
   const templateHash = sha256(
-    `${input.version}:${RUNTIME_SANDBOX_CONTRACT_VERSION}:${versionHash}`,
+    `${input.version}:${RUNTIME_SANDBOX_CONTRACT_VERSION}:${versionHash}:default`,
   ).slice(0, 20);
   return `eve-sbx-tpl-local-${scope}-${templateHash}`;
 }
 
-async function deriveTemplateKey(): Promise<string | null> {
+async function deriveTemplateKey(backendName = "local"): Promise<string | null> {
   return await createRuntimeSandboxTemplateKey({
-    backendName: "local",
+    backendName,
     compiledArtifactsSource: createBundledRuntimeCompiledArtifactsSource(),
     nodeId: "__root__",
     sourceId: "eve:default-sandbox",
@@ -177,6 +177,29 @@ describe("createRuntimeSandboxKeys", () => {
     );
 
     expect(first).not.toBe(second);
+  });
+
+  it("rotates template and session keys when the default image tag override changes", async () => {
+    vi.stubEnv("EVE_SANDBOX_IMAGE_TAG", "candidate-a");
+    const firstTemplate = await deriveTemplateKey("docker");
+    const firstSession = await deriveSessionKey({ backendName: "docker" });
+
+    vi.stubEnv("EVE_SANDBOX_IMAGE_TAG", "candidate-b");
+    const secondTemplate = await deriveTemplateKey("docker");
+    const secondSession = await deriveSessionKey({ backendName: "docker" });
+
+    expect(firstTemplate).not.toBe(secondTemplate);
+    expect(firstSession).not.toBe(secondSession);
+  });
+
+  it("does not let the default image tag override perturb custom backends", async () => {
+    vi.stubEnv("EVE_SANDBOX_IMAGE_TAG", "candidate-a");
+    const first = await deriveSessionKey({ backendName: "custom" });
+
+    vi.stubEnv("EVE_SANDBOX_IMAGE_TAG", "candidate-b");
+    const second = await deriveSessionKey({ backendName: "custom" });
+
+    expect(first).toBe(second);
   });
 });
 

--- a/packages/eve/src/runtime/sandbox/keys.ts
+++ b/packages/eve/src/runtime/sandbox/keys.ts
@@ -13,10 +13,10 @@ import type { RuntimeSandboxTemplatePlan } from "#runtime/sandbox/template-plan.
 
 /*
  * Template keys include this version for sandbox runtime contract changes
- * that are not captured by source or resource hashes. Version 7 writes static
- * skill seed files to the sandbox user's $HOME/.agents/skills directory.
+ * that are not captured by source or resource hashes. Version 8 guarantees
+ * that authored Vercel sandbox operations run as the `vercel-sandbox` user.
  */
-const RUNTIME_SANDBOX_CONTRACT_VERSION = 7;
+const RUNTIME_SANDBOX_CONTRACT_VERSION = 8;
 
 /**
  * Input for deriving the stable runtime keys used for one sandbox definition.
@@ -110,7 +110,7 @@ function buildRuntimeSandboxTemplateKey(
   }
 
   const templateHash = createStableHash(
-    `${resolvePackageVersionForTemplateKey(parts.metadata)}:${RUNTIME_SANDBOX_CONTRACT_VERSION}:${parts.versionHash}`,
+    `${resolvePackageVersionForTemplateKey(parts.metadata)}:${RUNTIME_SANDBOX_CONTRACT_VERSION}:${parts.versionHash}:${resolveSandboxImageTagKey(input.backendName)}`,
   ).slice(0, 20);
 
   return sanitizeRuntimeSandboxKey(
@@ -127,6 +127,8 @@ function buildRuntimeSandboxTemplateKey(
  * definition's version hash, so changing the sandbox itself (bootstrap
  * source, `revalidationKey`, or workspace seed content) rotates the
  * session sandbox onto the new template — unrelated source changes do not.
+ * An explicit default-image tag override also rotates the session so a
+ * changed image selection cannot reattach to a sandbox from another image.
  * The eve package version deliberately does not participate: upgrading
  * eve must not discard session sandbox state.
  */
@@ -135,13 +137,22 @@ function buildRuntimeSandboxSessionKey(
   parts: RuntimeSandboxKeyParts,
 ): string {
   const version = createStableHash(
-    `${RUNTIME_SANDBOX_CONTRACT_VERSION}:${parts.versionHash ?? "none"}`,
+    `${RUNTIME_SANDBOX_CONTRACT_VERSION}:${parts.versionHash ?? "none"}:${resolveSandboxImageTagKey(input.backendName)}`,
   ).slice(0, 12);
   const nodeScope = sanitizeRuntimeSandboxKey(input.nodeId);
 
   return sanitizeRuntimeSandboxKey(
     `eve-sbx-ses-${input.backendName}-${parts.scope}-${version}-${input.sessionId}-${nodeScope}`,
   );
+}
+
+function resolveSandboxImageTagKey(backendName: string): string {
+  if (backendName !== "docker" && backendName !== "microsandbox" && backendName !== "vercel") {
+    return "default";
+  }
+
+  const override = process.env.EVE_SANDBOX_IMAGE_TAG?.trim();
+  return override === undefined || override.length === 0 ? "default" : override;
 }
 
 /**


### PR DESCRIPTION
### Summary

Follow-up to #1893 and #2906. The image declares `USER vercel-sandbox`, but Vercel Sandbox SDK command and file operations still default to root for the custom Ubuntu image. The latest image change also preserved Node archive owners, making `/usr/local` ownership depend on the archive's architecture-specific UID.

eve now selects `sandbox.asUser("vercel-sandbox")` for authored Vercel commands, reads, writes, removals, and seed files. The image keeps system tooling root-owned while providing a writable user-local install prefix. The runtime contract version rotates existing template and session keys once so old root-owned state is not reattached, and an explicit `EVE_SANDBOX_IMAGE_TAG` participates in subsequent template and session keys.

### Validation

Rebuilt the Docker image on arm64 and verified the runtime identity, root-owned Node installation, non-writable `/usr/local/bin`, writable user-local executable path, workspace ownership, and passwordless sudo. The complete unit suite passed with 734 files and 7,830 tests (one existing skip). Focused coverage verifies hosted user-scoped commands, reads, writes, removals, seed files, and image-tag key rotation. All 117 CI checks pass, including the deterministic `whoami` regression in local, Postgres, and Vercel E2E.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+10 / -1`

Documents the cross-backend user, installation-path, and mutable-tag revalidation contracts and includes the release note.

**Implementation** — 6 files · `+142 / -92`

Keeps hosted user-scoped I/O in a focused adapter, normalizes image ownership, invalidates stale sandbox identities, and incorporates the selected default-image tag in template and session keys.

**Tests** — 4 files · `+108 / -30`

Updates the image smoke coverage and adds unit, fixture, and deterministic E2E regressions for the corrected identity and cache-key behavior.
