### PR TITLE
feat(extensions): support built-in extension mounts

### DIFF
--- a/.changeset/built-in-extension-mounts.md
+++ b/.changeset/built-in-extension-mounts.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Extension packages can expose built-in extension distributions from package export subpaths.

--- a/packages/eve/src/discover/extensions.test.ts
+++ b/packages/eve/src/discover/extensions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  locateExtensionMount,
   locateExtensionMountPackage,
   mountNamespace,
   packageStateNamespace,
@@ -34,6 +35,42 @@ describe("packageStateNamespace", () => {
 });
 
 describe("locateExtensionMountPackage", () => {
+  it("resolves a package-local built-in extension without a compatibility manifest", async () => {
+    const appRoot = "/repo/apps/agent";
+    const agentRoot = `${appRoot}/agent`;
+    const packageRoot = `${appRoot}/node_modules/eve`;
+    const source = createMemoryProjectSource({
+      files: {
+        [`${agentRoot}/extensions/selfmod.ts`]:
+          'export { default } from "eve/self-modification";\n',
+        [`${packageRoot}/package.json`]: JSON.stringify({
+          name: "eve",
+          eve: {
+            builtInExtensions: {
+              "./self-modification": { dist: "dist/src/self-modification/extension" },
+            },
+          },
+        }),
+      },
+    });
+
+    const result = await locateExtensionMount({
+      source,
+      agentRoot,
+      appRoot,
+      mount: createModuleSourceRef({ logicalPath: "extensions/selfmod.ts" }),
+      namespace: "selfmod",
+    });
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.location).toMatchObject({
+      packageName: "eve",
+      packageRoot,
+      sourceRoot: `${packageRoot}/dist/src/self-modification/extension`,
+      specifier: "eve/self-modification",
+    });
+  });
+
   it("resolves source and dist roots before the distribution exists", async () => {
     const appRoot = "/repo/apps/agent";
     const agentRoot = `${appRoot}/agent`;

--- a/packages/eve/src/discover/extensions.ts
+++ b/packages/eve/src/discover/extensions.ts
@@ -396,15 +396,16 @@ async function resolvePackageRoot(input: {
   }
 }
 
-/**
- * Returns the package portion of a bare specifier, dropping any deep subpath.
- * `@acme/crm/mount` → `@acme/crm`; `gizmo/mount` → `gizmo`.
- */
+/** Returns the export subpath of a bare package specifier. */
 function packageSpecifierSubpath(specifier: string): string {
   const subpath = specifier.slice(bareSpecifierPackagePath(specifier).length);
   return subpath.length === 0 ? "." : `.${subpath}`;
 }
 
+/**
+ * Returns the package portion of a bare specifier, dropping any deep subpath.
+ * `@acme/crm/mount` → `@acme/crm`; `gizmo/mount` → `gizmo`.
+ */
 function bareSpecifierPackagePath(specifier: string): string {
   const segments = specifier.split("/");
   if (specifier.startsWith("@")) {

--- a/packages/eve/src/discover/extensions.ts
+++ b/packages/eve/src/discover/extensions.ts
@@ -10,7 +10,10 @@ import { parseExtensionMountSpecifier } from "#discover/extension-specifier.js";
 import { SUPPORTED_AUTHORED_MODULE_FILE_EXTENSIONS } from "#discover/filesystem.js";
 import type { ExtensionSourceRef } from "#discover/manifest.js";
 import type { ProjectSource } from "#discover/project-source.js";
-import { parseExtensionPackageRoots } from "#shared/extension-package-contract.js";
+import {
+  parseBuiltInExtensionPackageRoots,
+  parseExtensionPackageRoots,
+} from "#shared/extension-package-contract.js";
 
 /**
  * Emitted when a mount file cannot be resolved to an extension package.
@@ -113,6 +116,8 @@ export interface ExtensionMountPackageLocation {
   readonly authoredSourceRoot?: string;
   /** Absolute path to the agent-shaped distribution root. */
   readonly distRoot: string;
+  /** The distribution is shipped by the resolved eve package itself. */
+  readonly builtIn: boolean;
 }
 
 /**
@@ -180,6 +185,20 @@ export async function locateExtensionMount(input: {
   }
 
   const { location } = locatedPackage;
+  if (location.builtIn) {
+    return {
+      location: {
+        namespace: location.namespace,
+        specifier: location.specifier,
+        packageName: location.packageName,
+        packageRoot: location.packageRoot,
+        sourceRoot: location.distRoot,
+        externalDependencies: [],
+      },
+      diagnostics: [],
+    };
+  }
+
   const compatibilityPath = join(location.distRoot, EXTENSION_COMPATIBILITY_MANIFEST_FILENAME);
   let compatibility;
   try {
@@ -291,7 +310,7 @@ export async function locateExtensionMountPackage(input: {
   }
 
   const manifestPath = join(packageRoot, "package.json");
-  let pkg: { name?: unknown; eve?: { extension?: unknown } };
+  let pkg: { name?: unknown; eve?: { extension?: unknown; builtInExtensions?: unknown } };
   try {
     pkg = JSON.parse(await input.source.readTextFile(manifestPath)) as typeof pkg;
   } catch {
@@ -306,7 +325,11 @@ export async function locateExtensionMountPackage(input: {
     };
   }
 
-  const extension = parseExtensionPackageRoots(pkg.eve?.extension);
+  const builtInExtension = parseBuiltInExtensionPackageRoots(
+    pkg.eve?.builtInExtensions,
+    packageSpecifierSubpath(specifier),
+  );
+  const extension = builtInExtension ?? parseExtensionPackageRoots(pkg.eve?.extension);
   if (extension === null) {
     return {
       diagnostics: [
@@ -330,6 +353,7 @@ export async function locateExtensionMountPackage(input: {
       ...(extension.source === undefined
         ? {}
         : { authoredSourceRoot: resolve(packageRoot, extension.source) }),
+      builtIn: builtInExtension !== null,
       distRoot: resolve(packageRoot, extension.dist),
     },
     diagnostics: [],
@@ -376,6 +400,11 @@ async function resolvePackageRoot(input: {
  * Returns the package portion of a bare specifier, dropping any deep subpath.
  * `@acme/crm/mount` → `@acme/crm`; `gizmo/mount` → `gizmo`.
  */
+function packageSpecifierSubpath(specifier: string): string {
+  const subpath = specifier.slice(bareSpecifierPackagePath(specifier).length);
+  return subpath.length === 0 ? "." : `.${subpath}`;
+}
+
 function bareSpecifierPackagePath(specifier: string): string {
   const segments = specifier.split("/");
   if (specifier.startsWith("@")) {

--- a/packages/eve/src/shared/extension-package-contract.ts
+++ b/packages/eve/src/shared/extension-package-contract.ts
@@ -29,6 +29,15 @@ export function parseExtensionPackageRoots(value: unknown): ExtensionPackageRoot
     : null;
 }
 
+/** Parses package-local extension distributions keyed by their export subpath. */
+export function parseBuiltInExtensionPackageRoots(
+  value: unknown,
+  subpath: string,
+): ExtensionPackageRoots | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return parseExtensionPackageRoots((value as Record<string, unknown>)[subpath]);
+}
+
 function parseExternalDependencies(value: unknown): readonly string[] | undefined | null {
   if (value === undefined) return undefined;
   if (!Array.isArray(value)) return null;


### PR DESCRIPTION
### Summary

Add package-local built-in extension mounts. An installed package can expose an extension distribution from one of its export subpaths without requiring a separate extension package or compatibility manifest.

### Validation

Added focused discovery coverage for a built-in extension mount.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 2 files · `+41 / -3`

Keeps built-in mount resolution local to extension discovery and its package contract.

**Tests** — 1 file · `+37 / -0`

Covers discovery without a compatibility manifest.
