### PR TITLE
feat(selfmod): keep self-modification private

### DIFF
--- a/packages/eve-self-modification/extension/tools/search_models.ts
+++ b/packages/eve-self-modification/extension/tools/search_models.ts
@@ -1,0 +1,108 @@
+import { defineTool } from "eve/tools";
+
+const AI_GATEWAY_MODELS_URL = "https://ai-gateway.vercel.sh/v1/models";
+const DEFAULT_AGENT_MODEL_ID = "openai/gpt-5.6-luna-fast";
+const FETCH_TIMEOUT_MS = 5_000;
+const MAX_RESULTS = 20;
+
+const inputSchema = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    query: {
+      type: "string",
+      minLength: 1,
+      maxLength: 100,
+      description: "A full model ID, model name, or short name such as 'luna'.",
+    },
+  },
+  required: ["query"],
+} as const;
+
+const outputSchema = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    models: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          id: { type: "string" },
+          name: { type: "string" },
+          provider: { type: "string" },
+        },
+        required: ["id", "name", "provider"],
+      },
+    },
+  },
+  required: ["models"],
+} as const;
+
+interface GatewayModel {
+  readonly id: string;
+  readonly name: string;
+  readonly tags: readonly string[];
+  readonly type: string;
+}
+
+export function parseGatewayModels(value: unknown): GatewayModel[] {
+  if (typeof value !== "object" || value === null || !("data" in value)) {
+    throw new Error("AI Gateway returned an invalid model catalog.");
+  }
+  const { data } = value;
+  if (!Array.isArray(data)) throw new Error("AI Gateway returned an invalid model catalog.");
+
+  return data.flatMap((entry) => {
+    if (typeof entry !== "object" || entry === null) return [];
+    const { id, name, tags, type } = entry;
+    if (typeof id !== "string" || typeof name !== "string" || typeof type !== "string") return [];
+    return [{ id, name, tags: Array.isArray(tags) ? tags.filter(isString) : [], type }];
+  });
+}
+
+export function searchGatewayModels(models: readonly GatewayModel[], query: string) {
+  const needle = query.trim().toLowerCase();
+  return models
+    .filter(
+      (model) =>
+        model.type === "language" &&
+        (model.id === DEFAULT_AGENT_MODEL_ID || model.tags.includes("web-search")) &&
+        (model.id.toLowerCase().includes(needle) || model.name.toLowerCase().includes(needle)),
+    )
+    .slice(0, MAX_RESULTS)
+    .map((model) => ({
+      id: model.id,
+      name: model.name,
+      provider: model.id.split("/")[0] ?? "",
+    }));
+}
+
+export default defineTool({
+  description:
+    "Search the Vercel AI Gateway model catalog. Call this to list available AI Gateway models or resolve a model to its exact ID.",
+  inputSchema,
+  outputSchema,
+  async execute(input, ctx) {
+    if (typeof input.query !== "string") throw new Error("Expected a model search query.");
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    try {
+      const signal = AbortSignal.any([ctx.abortSignal, controller.signal]);
+      const response = await fetch(AI_GATEWAY_MODELS_URL, { signal });
+      if (!response.ok) {
+        throw new Error(`AI Gateway model catalog request failed (${response.status}).`);
+      }
+      return {
+        models: searchGatewayModels(parseGatewayModels(await response.json()), input.query),
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  },
+});
+
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}

--- a/packages/eve-self-modification/package.json
+++ b/packages/eve-self-modification/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@eve/self-modification",
   "version": "0.0.8",
+  "private": true,
   "description": "Development-only source editing subagent for eve applications.",
   "keywords": [
     "agents",
@@ -51,9 +52,6 @@
       "types": "./dist/tools/index.d.ts",
       "default": "./dist/tools/index.mjs"
     }
-  },
-  "publishConfig": {
-    "access": "public"
   },
   "scripts": {
     "build": "eve extension build && pnpm run build:scaffold",

--- a/packages/eve-self-modification/src/search-models.test.ts
+++ b/packages/eve-self-modification/src/search-models.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import searchModels, {
+  parseGatewayModels,
+  searchGatewayModels,
+} from "./extension/tools/search_models.js";
+
+const CATALOG = {
+  data: [
+    {
+      id: "openai/gpt-5.6-sol",
+      name: "GPT-5.6 Sol",
+      tags: ["web-search"],
+      type: "language",
+    },
+    {
+      id: "openai/gpt-5.6-terra",
+      name: "GPT-5.6 Terra",
+      tags: ["web-search"],
+      type: "language",
+    },
+    {
+      id: "openai/gpt-5.6-luna-fast",
+      name: "GPT-5.6 Luna Fast",
+      tags: [],
+      type: "language",
+    },
+    {
+      id: "openai/gpt-image-1",
+      name: "GPT Image",
+      tags: ["web-search"],
+      type: "image",
+    },
+  ],
+};
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("searchGatewayModels", () => {
+  it("matches abbreviated model IDs from the /model catalog", () => {
+    expect(searchGatewayModels(parseGatewayModels(CATALOG), "sol")).toEqual([
+      { id: "openai/gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai" },
+    ]);
+  });
+
+  it("uses the same language-model eligibility as /model", () => {
+    expect(searchGatewayModels(parseGatewayModels(CATALOG), "luna")).toEqual([
+      {
+        id: "openai/gpt-5.6-luna-fast",
+        name: "GPT-5.6 Luna Fast",
+        provider: "openai",
+      },
+    ]);
+    expect(searchGatewayModels(parseGatewayModels(CATALOG), "image")).toEqual([]);
+  });
+
+  it("rejects a malformed catalog", () => {
+    expect(() => parseGatewayModels({ models: [] })).toThrow("invalid model catalog");
+  });
+});
+
+describe("selfmod__search_models", () => {
+  it("queries the live AI Gateway model endpoint", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: async () => CATALOG,
+      ok: true,
+      status: 200,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await searchModels.execute({ query: "sol" }, {
+      abortSignal: new AbortController().signal,
+    } as never);
+    if (Symbol.asyncIterator in result)
+      throw new TypeError("selfmod__search_models must not stream.");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://ai-gateway.vercel.sh/v1/models",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(result).toEqual({
+      models: [{ id: "openai/gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai" }],
+    });
+  });
+});

--- a/packages/eve-self-modification/src/search-models.test.ts
+++ b/packages/eve-self-modification/src/search-models.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import searchModels, {
   parseGatewayModels,
   searchGatewayModels,
-} from "./extension/tools/search_models.js";
+} from "../extension/tools/search_models.js";
 
 const CATALOG = {
   data: [

--- a/scripts/assert-changeset-publish-packages.mjs
+++ b/scripts/assert-changeset-publish-packages.mjs
@@ -1,7 +1,7 @@
 import { access, readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 
-const allowedPublicPackages = new Set(["@eve/buzz-acp-adapter", "eve", "@eve/self-modification"]);
+const allowedPublicPackages = new Set(["@eve/buzz-acp-adapter", "eve"]);
 const workspaceRoots = ["apps", "packages"];
 
 async function readJson(path) {


### PR DESCRIPTION
### Summary

Keep `@eve/self-modification` as a private workspace package rather than shipping it through `eve`. It no longer has publication configuration or a changeset allowlist entry, while retaining the AI Gateway model-search tool for the internal extension.

### Validation

Focused self-modification unit coverage, package type checking, and the invariant guard passed.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 3 files · `+110 / -4`

Keeps the extension private, removes its publishing path, and adds its internal model-catalog lookup.

**Tests** — 1 file · `+85 / -0`

Covers catalog parsing, eligibility filtering, and the model lookup tool.
