### PR TITLE
fix(eve): sandbox image - exit login shells cleanly as vercel-sandbox

### DIFF
--- a/.changeset/fix-sandbox-image-login-shell.md
+++ b/.changeset/fix-sandbox-image-login-shell.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix the sandbox base image so a non-interactive `bash -lc` login shell exits cleanly as `vercel-sandbox`. Ubuntu's default `.bash_logout` ran `clear_console` on exit, which wrote `TERM environment variable not set.` to stderr and, under `set -e`, turned a successful `exit 0` into exit 1 on Vercel Sandbox. `sudo` no longer warns about unresolvable sandbox hostnames, `$HOME/.local/bin` exists on `PATH` for user-scoped installs, and Node is root-owned on every architecture.

--- a/.github/workflows/docker-image-size-analysis.yml
+++ b/.github/workflows/docker-image-size-analysis.yml
@@ -99,11 +99,19 @@ jobs:
             set -euo pipefail
             test "$(id -un)" = vercel-sandbox
             test "$(stat -c %U /workspace)" = vercel-sandbox
+            test "$(stat -c %U /usr/local/bin/node)" = root
             test "$(npm prefix -g)" = "$HOME/.local"
             test "$(pnpm bin -g)" = "$PNPM_HOME/bin"
+            test -d "$HOME/.local/bin"
             git init --quiet /workspace
             git -C /workspace remote add origin https://github.com/vercel/eve.git
             sudo -n true
+            # Backends run authored commands through a non-interactive `bash -lc`
+            # login shell. Exiting it must be silent and preserve the exit status.
+            test ! -e "$HOME/.bash_logout"
+            test -z "$(bash -lc "exit 0" 2>&1)"
+            bash -lc "set -euo pipefail; exit 0"
+            bash -lc "exit 3" || test "$?" = 3
           '
 
       - name: Generate Docker image size report

--- a/docs/sandbox.mdx
+++ b/docs/sandbox.mdx
@@ -158,6 +158,8 @@ With `backend` omitted, eve uses `defaultBackend()`, which resolves on first use
 
 By default, Docker and microsandbox pull `ghcr.io/vercel/eve` while Vercel Sandbox pulls `vcr.vercel.com/vercel/eve/base`. Each image tag matches the installed eve version. Set `EVE_SANDBOX_IMAGE_TAG` to replace the version-derived tag for these default images. An explicit `image` passed to `docker()` or `microsandbox()` still takes precedence.
 
+On every backend, authored commands run as the non-root `vercel-sandbox` user through a non-interactive `bash -lc` login shell. `/workspace` and `$HOME` are writable, `$HOME/.local/bin` is on `PATH` for user-scoped executables, and system paths such as `/usr/local` stay root-owned. Use passwordless `sudo` when setup genuinely needs system-wide changes; `sudo` resets the environment, so pass through variables like `NPM_CONFIG_PREFIX` explicitly if a privileged step depends on them.
+
 `defaultBackend()` also accepts a keyed bag so each inner backend gets its own typed create options:
 
 ```ts

--- a/packages/eve/Dockerfile
+++ b/packages/eve/Dockerfile
@@ -46,7 +46,7 @@ RUN set -eux; \
   test -n "${node_file}"; \
   curl -fsSLO "${base_url}/${node_file}"; \
   grep " ${node_file}$" "${shasums}" | sha256sum -c -; \
-  tar -xJf "${node_file}" -C /usr/local --strip-components=1; \
+  tar -xJf "${node_file}" -C /usr/local --strip-components=1 --no-same-owner; \
   rm "${node_file}" "${shasums}"; \
   rm -rf /usr/local/include/node /usr/local/share/doc /usr/local/share/man; \
   npm install -g "pnpm@${PNPM_VERSION}"; \
@@ -73,15 +73,26 @@ RUN set -eux; \
   if ! id -u vercel-sandbox >/dev/null 2>&1; then \
     useradd --create-home --shell /bin/bash vercel-sandbox; \
   fi; \
+  # Ubuntu's skel .bash_logout runs `clear_console` when a login shell exits at
+  # SHLVL=1. Backends run every command through `bash -lc` with no TTY, so it
+  # prints "TERM environment variable not set." and, under `set -e`, turns a
+  # successful `exit 0` into exit 1.
+  rm -f /home/vercel-sandbox/.bash_logout; \
   # Keep Node and pnpm root-owned: recursively changing their ownership copies
   # them into another image layer. A small user-owned prefix retains global installs.
   install -d --owner=vercel-sandbox --group=vercel-sandbox \
     /home/vercel-sandbox/.local \
+    /home/vercel-sandbox/.local/bin \
     /home/vercel-sandbox/.local/share/pnpm; \
   mkdir -p /workspace; \
   chown vercel-sandbox:vercel-sandbox /workspace; \
-  printf 'vercel-sandbox ALL=(ALL) NOPASSWD:ALL\n' >/etc/sudoers.d/vercel-sandbox; \
-  chmod 0440 /etc/sudoers.d/vercel-sandbox
+  # !fqdn: sandbox hostnames are not resolvable, so sudo would otherwise warn on stderr.
+  printf '%s\n' \
+    'Defaults !fqdn' \
+    'vercel-sandbox ALL=(ALL) NOPASSWD:ALL' \
+    >/etc/sudoers.d/vercel-sandbox; \
+  chmod 0440 /etc/sudoers.d/vercel-sandbox; \
+  visudo -cf /etc/sudoers.d/vercel-sandbox
 
 ENV NPM_CONFIG_PREFIX=/home/vercel-sandbox/.local
 ENV PNPM_HOME=/home/vercel-sandbox/.local/share/pnpm


### PR DESCRIPTION
### Summary

Follow-up to #1893, which went live on VCR yesterday. Once the image ran as `vercel-sandbox`, Ubuntu's skel `~/.bash_logout` started firing when eve's non-interactive `bash -lc` login shell exited: it runs `clear_console`, which writes `TERM environment variable not set.` to stderr, `\x1b[3J` to stdout, and returns 1. Under `set -e`, that turns a script's successful `exit 0` into exit 1. This broke e0's `onSession` on Vercel Sandbox (`computer-use Cua driver startup failed (exit 1) ... TERM environment variable not set.`) even though the driver had started. Docker was unaffected only because its binding nests one extra shell, so `SHLVL=2` skips the `.bash_logout` guard.

The image now removes `.bash_logout`, so login shells exit silently with the caller's status on every backend. Alongside it: `sudo` sets `!fqdn` so the unresolvable sandbox hostname no longer warns on every privileged command, `~/.local/bin` is pre-created so Ubuntu's `.profile` keeps it on `PATH`, and the Node tarball extracts with `--no-same-owner` so `/usr/local/bin/node` is root-owned on both architectures instead of inheriting the archive's uid.

No runtime code changes. The Vercel binding already runs commands as `vercel-sandbox`; the earlier attempt in #2937 to wrap commands in `asUser` was based on a stale VCR tag and would have stripped `PATH`, `NPM_CONFIG_PREFIX`, and the proxy CA environment. Existing sandboxes are not rotated; the fix applies when a template is provisioned from the new image.

### Validation

Reproduced `bash -lc 'set -euo pipefail; exit 0'` returning 1 with the `TERM` message on both a live Vercel Sandbox and the published `ghcr.io/vercel/eve:latest`. Rebuilt the image locally and confirmed the same command returns 0 with no output, `bash -lc 'exit 3'` preserves 3, `sudo` is silent with an unresolvable hostname, and nothing under `/usr/local/{bin,lib/node_modules}` is non-root. Ran e0's real `install.sh` → display → driver-start sequence against the rebuilt image; all three exit 0. The new smoke assertions fail on the currently published image and pass on the rebuilt one.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+7 / -0`

Documents the cross-backend contract (user, login shell, writable paths, `sudo` env reset) and the release note.

**Implementation** — 2 files · `+22 / -3`

Four small Dockerfile changes with comments explaining the non-obvious ones, plus the CI smoke assertions that prove each of them against the built image.

**Tests** — 0 files · `+0 / -0`

The image smoke checks live in the size-analysis workflow, counted above.
