### PR TITLE
fix(eve): workspace discovery - ignore unrelated ancestor agents directories

### DIFF
--- a/.changeset/fix-unrelated-agents-workspace-detection.md
+++ b/.changeset/fix-unrelated-agents-workspace-detection.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Ignore unrelated ancestor `agents/` directories when resolving standalone projects so local CLI commands do not misclassify neighboring repositories as agent workspaces.

--- a/packages/eve/src/internal/agent-workspace.integration.test.ts
+++ b/packages/eve/src/internal/agent-workspace.integration.test.ts
@@ -103,4 +103,34 @@ describe("resolveAgentWorkspace", () => {
       member: { appRoot: supportRoot, name: "support" },
     });
   });
+
+  it("ignores unrelated agents directories above a standalone project", async () => {
+    const root = await mkdtemp(join(tmpdir(), "eve-standalone-unrelated-agents-"));
+    const appRoot = join(root, "eve", "apps", "fixtures", "weather-agent");
+    await Promise.all([
+      mkdir(join(appRoot, "agent"), { recursive: true }),
+      mkdir(join(root, "agents", "apps"), { recursive: true }),
+    ]);
+
+    await expect(resolveEveProjectContext(appRoot)).resolves.toEqual({
+      appRoot,
+      environmentRoot: appRoot,
+      kind: "standalone",
+    });
+  });
+
+  it("preserves a standalone project boundary above an agents directory", async () => {
+    const root = await mkdtemp(join(tmpdir(), "eve-standalone-boundary-"));
+    const appRoot = join(root, "agents", "support");
+    await Promise.all([
+      mkdir(join(root, "agent"), { recursive: true }),
+      mkdir(join(appRoot, "agent"), { recursive: true }),
+    ]);
+
+    await expect(resolveEveProjectContext(appRoot)).resolves.toEqual({
+      appRoot,
+      environmentRoot: appRoot,
+      kind: "standalone",
+    });
+  });
 });

--- a/packages/eve/src/internal/project-context.ts
+++ b/packages/eve/src/internal/project-context.ts
@@ -1,4 +1,4 @@
-import { join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 
 import { createDiskProjectSource, type ProjectSource } from "#discover/project-source.js";
 import {
@@ -36,30 +36,22 @@ export async function resolveNamedAgentProjectContext(
 ): Promise<Extract<EveProjectContext, { kind: "workspace-member" | "standalone" }> | undefined> {
   const resolvedAppRoot = resolve(appRoot);
   const source = options.source ?? createDiskProjectSource();
-  let workspaceRoot = resolvedAppRoot;
+  const agentsRoot = dirname(resolvedAppRoot);
+  if (basename(agentsRoot) !== "agents") return undefined;
 
-  while (true) {
-    if (
-      workspaceRoot !== resolvedAppRoot &&
-      (await source.stat(join(workspaceRoot, "agent"))) === "directory"
-    ) {
-      return undefined;
-    }
-    const workspace = await resolveAgentWorkspace(workspaceRoot, { source });
-    const member = workspace?.members.find((candidate) => candidate.appRoot === resolvedAppRoot);
-    if (workspace !== undefined && member !== undefined) {
-      return {
-        workspace,
-        environmentRoot: workspace.root,
-        kind: "workspace-member",
-        member,
-      };
-    }
+  const workspaceRoot = dirname(agentsRoot);
+  if ((await source.stat(join(workspaceRoot, "agent"))) === "directory") return undefined;
 
-    const parent = resolve(workspaceRoot, "..");
-    if (parent === workspaceRoot) return undefined;
-    workspaceRoot = parent;
-  }
+  const workspace = await resolveAgentWorkspace(workspaceRoot, { source });
+  const member = workspace?.members.find((candidate) => candidate.appRoot === resolvedAppRoot);
+  if (workspace === undefined || member === undefined) return undefined;
+
+  return {
+    workspace,
+    environmentRoot: workspace.root,
+    kind: "workspace-member",
+    member,
+  };
 }
 
 /** Classify the current filesystem scope before command-specific policy runs. */


### PR DESCRIPTION
### Summary

`eve dev` could exit before opening the TUI when a standalone agent lived below any ancestor containing an unrelated `agents/` directory. Workspace detection scanned every ancestor and validated that directory before establishing that the current app was one of its members. Workspace-member classification now considers only the direct `<workspace>/agents/<name>` shape, while workspace-root discovery and standalone application boundaries remain unchanged.

### Validation

The focused agent-workspace integration suite passes all 11 tests, including coverage for an unrelated ancestor `agents/apps`, a valid direct workspace member, and the existing standalone boundary.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

The changeset records the observable local CLI fix for the next release.

**Implementation** — 1 file · `+15 / -23`

Replaces recursive ancestor scanning with a direct structural workspace-membership check.

**Tests** — 1 file · `+30 / -0`

Covers the reported false positive and preserves both valid member resolution and standalone boundaries.
