### PR TITLE
fix(selfmod): retain compatibility package

### DIFF
--- a/.changeset/green-model-search.md
+++ b/.changeset/green-model-search.md
@@ -1,0 +1,5 @@
+---
+"@eve/self-modification": patch
+---
+
+Publish a compatibility package that forwards existing `@eve/self-modification` imports to the implementation bundled with eve.

--- a/.syncpackrc.json
+++ b/.syncpackrc.json
@@ -25,6 +25,13 @@
       "pinVersion": "workspace:^"
     },
     {
+      "label": "Compatibility shim accepts compatible eve patch releases",
+      "dependencies": ["eve"],
+      "packages": ["@eve/self-modification"],
+      "dependencyTypes": ["peer"],
+      "pinVersion": "workspace:^"
+    },
+    {
       "label": "Blooio is an externally published integration",
       "dependencies": ["eve-channel-blooio"],
       "packages": ["eve-docs"],

--- a/packages/eve-self-modification/.gitignore
+++ b/packages/eve-self-modification/.gitignore
@@ -1,0 +1,3 @@
+dist
+scaffold
+*.tsbuildinfo

--- a/packages/eve-self-modification/CHANGELOG.md
+++ b/packages/eve-self-modification/CHANGELOG.md
@@ -1,0 +1,142 @@
+# @eve/self-modification
+
+## 0.0.8
+
+### Patch Changes
+
+- Updated dependencies [fc123f4]
+- Updated dependencies [b03290a]
+- Updated dependencies [6e630b4]
+- Updated dependencies [ecf0b6a]
+- Updated dependencies [4c45d2f]
+- Updated dependencies [bad0813]
+- Updated dependencies [f9b760a]
+- Updated dependencies [aae2631]
+- Updated dependencies [3cccd71]
+- Updated dependencies [29b9056]
+  - eve@0.51.0
+
+## 0.0.7
+
+### Patch Changes
+
+- Updated dependencies [5b90f3d]
+- Updated dependencies [884cba8]
+- Updated dependencies [2b52714]
+- Updated dependencies [70c8a2e]
+- Updated dependencies [ffcd817]
+  - eve@0.50.0
+
+## 0.0.6
+
+### Patch Changes
+
+- Updated dependencies [68d44b5]
+- Updated dependencies [b20c2aa]
+- Updated dependencies [0172af9]
+- Updated dependencies [fbc89e5]
+- Updated dependencies [3f20c80]
+- Updated dependencies [1ee8fa9]
+- Updated dependencies [a40ebb0]
+  - eve@0.49.0
+
+## 0.0.5
+
+### Patch Changes
+
+- Updated dependencies [62546ab]
+- Updated dependencies [f43525a]
+- Updated dependencies [b7321c9]
+- Updated dependencies [3e2abe5]
+- Updated dependencies [453d194]
+- Updated dependencies [1d78323]
+- Updated dependencies [e219a6a]
+- Updated dependencies [d1b3439]
+- Updated dependencies [9ed9d29]
+- Updated dependencies [1d74287]
+- Updated dependencies [859151e]
+- Updated dependencies [3c16df6]
+  - eve@0.48.0
+
+## 0.0.4
+
+### Patch Changes
+
+- b7ac284: The self-modification subagent can now install items from the configured eve
+  registry. A new `selfmod__registry_add` tool runs `eve add <address>
+--non-interactive --skip-setup` in the application root under `eve dev`,
+  pausing the authored-source watcher for the whole install and reporting the
+  item's declared environment variables that are still unset. Failed dependency
+  installs restore tracked project files and return a sanitized, structured reason
+  instead of implying the project was untouched. Items that declare a setup flow
+  or multiple components are never partially installed: the local dev TUI now
+  opens their existing setup panel automatically, while headless development
+  reports the command that finishes them, so no setup question is answered by the
+  model.
+- Updated dependencies [b0799b3]
+- Updated dependencies [b9eb1b2]
+- Updated dependencies [0a1ad48]
+- Updated dependencies [aafcb34]
+- Updated dependencies [f2c96a1]
+- Updated dependencies [7a7da6d]
+- Updated dependencies [6a8340f]
+- Updated dependencies [ee5e4c7]
+- Updated dependencies [c72dc2e]
+- Updated dependencies [6a8340f]
+- Updated dependencies [1982202]
+- Updated dependencies [b7ac284]
+- Updated dependencies [7a415bf]
+- Updated dependencies [bc2a1f6]
+  - eve@0.47.7
+
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies [a3b23c0]
+- Updated dependencies [52e89ef]
+- Updated dependencies [56514d9]
+- Updated dependencies [41c8286]
+- Updated dependencies [bdb3973]
+- Updated dependencies [fccbf2b]
+  - eve@0.47.0
+
+## 0.0.2
+
+### Patch Changes
+
+- Updated dependencies [47b3e48]
+- Updated dependencies [9c0a138]
+- Updated dependencies [7acb4ec]
+- Updated dependencies [1d79217]
+  - eve@0.46.0
+
+## 0.0.1
+
+### Patch Changes
+
+- 91700b0: Keep self-modification on the pre-1.0 version line by versioning its eve runtime dependency like other separately published eve packages.
+- b595a70: When a self-modification registry search finds an exact item in a local `eve dev` session, the subagent now directs you to install it with `/add <address>` instead of attempting the installation itself.
+- Updated dependencies [4a18994]
+- Updated dependencies [d2995e1]
+- Updated dependencies [dfe0d18]
+- Updated dependencies [b3cf8ee]
+- Updated dependencies [6252784]
+- Updated dependencies [659774f]
+- Updated dependencies [fc52796]
+- Updated dependencies [2be67fa]
+- Updated dependencies [7ed4fb1]
+- Updated dependencies [0bc8432]
+- Updated dependencies [3274eee]
+- Updated dependencies [ae83a08]
+- Updated dependencies [f439e3d]
+- Updated dependencies [80571ee]
+- Updated dependencies [7c5a69e]
+- Updated dependencies [f38eaf1]
+- Updated dependencies [cfa90d6]
+- Updated dependencies [d79de0b]
+- Updated dependencies [687c371]
+- Updated dependencies [8e5d9b2]
+- Updated dependencies [7eae011]
+- Updated dependencies [c6f9c85]
+  - eve@0.45.0

--- a/packages/eve-self-modification/README.md
+++ b/packages/eve-self-modification/README.md
@@ -1,0 +1,19 @@
+# @eve/self-modification
+
+`@eve/self-modification` is a compatibility package. It forwards its entrypoints to the implementation included with `eve`.
+
+Update imports to use `eve` directly:
+
+```ts
+import { defineSelfModificationAgent } from "eve/self-modification/agent";
+
+export default defineSelfModificationAgent();
+```
+
+```ts
+export { default } from "eve/self-modification/sandbox";
+```
+
+```ts
+export { default } from "eve/self-modification";
+```

--- a/packages/eve-self-modification/extension/extension.ts
+++ b/packages/eve-self-modification/extension/extension.ts
@@ -1,0 +1,1 @@
+export { default } from "eve/self-modification";

--- a/packages/eve-self-modification/package.json
+++ b/packages/eve-self-modification/package.json
@@ -66,7 +66,7 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "eve": "workspace:*"
+    "eve": "workspace:^"
   },
   "engines": {
     "node": ">=24"

--- a/packages/eve-self-modification/package.json
+++ b/packages/eve-self-modification/package.json
@@ -66,7 +66,7 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "eve": ">=0.50.1 <1.0.0"
+    "eve": ">=0.52.0 <1.0.0"
   },
   "engines": {
     "node": ">=24"

--- a/packages/eve-self-modification/package.json
+++ b/packages/eve-self-modification/package.json
@@ -1,0 +1,80 @@
+{
+  "name": "@eve/self-modification",
+  "version": "0.0.8",
+  "description": "Compatibility entrypoints for eve self-modification.",
+  "keywords": [
+    "agents",
+    "eve",
+    "extension",
+    "self-modifying"
+  ],
+  "homepage": "https://github.com/vercel/eve#readme",
+  "bugs": {
+    "url": "https://github.com/vercel/eve/issues"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vercel/eve.git",
+    "directory": "packages/eve-self-modification"
+  },
+  "files": [
+    "dist",
+    "scaffold",
+    "src/*.ts",
+    "!src/*.test.ts",
+    "README.md"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.mjs"
+    },
+    "./extension": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.mjs"
+    },
+    "./agent": {
+      "eve-source": "./src/agent.ts",
+      "types": "./scaffold/agent.d.ts",
+      "import": "./scaffold/agent.js",
+      "default": "./scaffold/agent.js"
+    },
+    "./sandbox": {
+      "eve-source": "./src/sandbox.ts",
+      "types": "./scaffold/sandbox.d.ts",
+      "import": "./scaffold/sandbox.js",
+      "default": "./scaffold/sandbox.js"
+    },
+    "./tools": {
+      "types": "./dist/tools/index.d.ts",
+      "default": "./dist/tools/index.mjs"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "eve extension build && pnpm run build:scaffold",
+    "build:scaffold": "node -e \"require('node:fs').rmSync('scaffold', { force: true, recursive: true })\" && tsc -p tsconfig.scaffold.json",
+    "prepack": "pnpm run build",
+    "typecheck": "tsc -p tsconfig.json && tsc -p tsconfig.scaffold.json --noEmit"
+  },
+  "devDependencies": {
+    "eve": "workspace:^",
+    "typescript": "catalog:"
+  },
+  "peerDependencies": {
+    "eve": ">=0.50.1 <1.0.0"
+  },
+  "engines": {
+    "node": ">=24"
+  },
+  "eve": {
+    "extension": {
+      "source": "./extension",
+      "dist": "./dist/extension"
+    }
+  }
+}

--- a/packages/eve-self-modification/package.json
+++ b/packages/eve-self-modification/package.json
@@ -62,11 +62,11 @@
     "typecheck": "tsc -p tsconfig.json && tsc -p tsconfig.scaffold.json --noEmit"
   },
   "devDependencies": {
-    "eve": "workspace:^",
+    "eve": "workspace:*",
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "eve": ">=0.52.0 <1.0.0"
+    "eve": "workspace:*"
   },
   "engines": {
     "node": ">=24"

--- a/packages/eve-self-modification/src/agent.ts
+++ b/packages/eve-self-modification/src/agent.ts
@@ -1,0 +1,2 @@
+export * from "eve/self-modification/agent";
+export { default } from "eve/self-modification/agent";

--- a/packages/eve-self-modification/src/sandbox.ts
+++ b/packages/eve-self-modification/src/sandbox.ts
@@ -1,0 +1,1 @@
+export { default } from "eve/self-modification/sandbox";

--- a/packages/eve-self-modification/tsconfig.json
+++ b/packages/eve-self-modification/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "customConditions": ["eve-source"]
+  },
+  "include": ["extension/**/*.ts", "src/**/*.ts"]
+}

--- a/packages/eve-self-modification/tsconfig.scaffold.json
+++ b/packages/eve-self-modification/tsconfig.scaffold.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "noEmit": false,
+    "outDir": "./scaffold",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/eve-self-modification/turbo.json
+++ b/packages/eve-self-modification/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "test:unit": {
+      "dependsOn": ["^build"]
+    }
+  }
+}

--- a/packages/eve/src/self-modification/package-consumption.scenario.test.ts
+++ b/packages/eve/src/self-modification/package-consumption.scenario.test.ts
@@ -9,6 +9,7 @@ import { afterEach, describe, it } from "vitest";
 
 const runFile = promisify(execFile);
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const compatibilityPackageRoot = resolve(packageRoot, "../eve-self-modification");
 const temporaryRoots: string[] = [];
 
 async function run(command: string, args: string[], cwd: string): Promise<void> {
@@ -81,7 +82,13 @@ describe("packed package consumption", () => {
     await mkdir(tarballsRoot, { recursive: true });
     await mkdir(appRoot, { recursive: true });
 
+    await run("pnpm", ["run", "build"], compatibilityPackageRoot);
     const eveTarball = await pack(packageRoot, tarballsRoot, "eve");
+    const compatibilityTarball = await pack(
+      compatibilityPackageRoot,
+      tarballsRoot,
+      "eve-self-modification",
+    );
     await writeAppFile(
       appRoot,
       "package.json",
@@ -92,6 +99,7 @@ describe("packed package consumption", () => {
           type: "module",
           scripts: { build: "eve build" },
           dependencies: {
+            "@eve/self-modification": `file:${compatibilityTarball}`,
             eve: `file:${eveTarball}`,
             "just-bash": "3.1.0",
           },
@@ -114,17 +122,17 @@ describe("packed package consumption", () => {
     await writeAppFile(
       appRoot,
       "agent/subagents/self-modification/agent.ts",
-      'import { defineSelfModificationAgent } from "eve/self-modification/agent";\n\nexport default defineSelfModificationAgent();\n',
+      'import { defineSelfModificationAgent } from "@eve/self-modification/agent";\n\nexport default defineSelfModificationAgent();\n',
     );
     await writeAppFile(
       appRoot,
       "agent/subagents/self-modification/sandbox.ts",
-      'export { default } from "eve/self-modification/sandbox";\n',
+      'export { default } from "@eve/self-modification/sandbox";\n',
     );
     await writeAppFile(
       appRoot,
       "agent/subagents/self-modification/extensions/selfmod.ts",
-      'export { default } from "eve/self-modification";\n',
+      'export { default } from "@eve/self-modification";\n',
     );
 
     await run(
@@ -139,6 +147,7 @@ describe("packed package consumption", () => {
       appRoot,
     );
     await access(join(appRoot, "node_modules/eve/dist/src/self-modification/agent.js"));
+    await access(join(appRoot, "node_modules/@eve/self-modification/scaffold/agent.js"));
     await run("pnpm", ["build"], appRoot);
   }, 120_000);
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1507,7 +1507,7 @@ importers:
   packages/eve-self-modification:
     devDependencies:
       eve:
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../eve
       typescript:
         specifier: 'catalog:'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1504,6 +1504,15 @@ importers:
         specifier: 'catalog:'
         version: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(vite@8.1.5(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/eve-self-modification:
+    devDependencies:
+      eve:
+        specifier: workspace:^
+        version: link:../eve
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+
 packages:
 
   '@agent-browser/eve@0.33.0':

--- a/scripts/assert-changeset-publish-packages.mjs
+++ b/scripts/assert-changeset-publish-packages.mjs
@@ -1,7 +1,7 @@
 import { access, readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 
-const allowedPublicPackages = new Set(["@eve/buzz-acp-adapter", "eve"]);
+const allowedPublicPackages = new Set(["@eve/buzz-acp-adapter", "@eve/self-modification", "eve"]);
 const workspaceRoots = ["apps", "packages"];
 
 async function readJson(path) {


### PR DESCRIPTION
### Summary

Restore `@eve/self-modification` as a one-time compatibility package for existing imports. Its three entrypoints forward to the implementation bundled with eve and require eve 0.52.0 or a compatible patch release.

### Validation

The focused packed-install scenario builds an app through all compatibility entrypoints, and the shim typechecks successfully.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 3 files · `+166 / -0`

Records the compatibility release and preserves its package documentation and history.

**Implementation** — 11 files · `+134 / -1`

Adds the forwarding package, its compatible `eve` peer contract, and the release configuration needed to publish it once.

**Tests** — 1 file · `+12 / -3`

Exercises all legacy entrypoints from packed package contents.
