### PR TITLE
fix(eve): preserve local subagent trace content

### DIFF
--- a/.changeset/preserve-subagent-trace-content.md
+++ b/.changeset/preserve-subagent-trace-content.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Preserve inherited channel audience metadata when local subagents persist adapter state. Public parent traces now continue capturing local child inputs and outputs while destination-specific redaction remains independent.

--- a/packages/eve/src/execution/channel-context.ts
+++ b/packages/eve/src/execution/channel-context.ts
@@ -11,13 +11,18 @@ export function setChannelContext(
     readonly channelName?: string;
   } = {},
 ): void {
+  const existing = ctx.get(ChannelInstrumentationKey);
+  const projection = buildChannelInstrumentationProjection({
+    adapter,
+    channelName: options.channelName,
+    existingKind: existing?.kind,
+  });
   ctx.set(ChannelKey, adapter);
-  ctx.set(
-    ChannelInstrumentationKey,
-    buildChannelInstrumentationProjection({
-      adapter,
-      channelName: options.channelName,
-      existingKind: ctx.get(ChannelInstrumentationKey)?.kind,
-    }),
-  );
+  ctx.set(ChannelInstrumentationKey, {
+    ...projection,
+    metadata:
+      adapter.instrumentation?.metadata === undefined && existing !== undefined
+        ? existing.metadata
+        : projection.metadata,
+  });
 }

--- a/packages/eve/src/execution/runtime-context.test.ts
+++ b/packages/eve/src/execution/runtime-context.test.ts
@@ -12,6 +12,7 @@ import {
   SessionKey,
   ScheduleIdKey,
 } from "#context/keys.js";
+import { setChannelContext } from "#execution/channel-context.js";
 import { buildRunContext } from "#execution/runtime-context.js";
 
 function createTestSession(
@@ -274,7 +275,7 @@ describe("buildRunContext", () => {
   it("grafts parent metadata onto the child's own kind", () => {
     const parentProjection = {
       kind: "channel:slack",
-      metadata: { threadTs: "1234.5678", userId: "U123" },
+      metadata: { audience: "public" as const, threadTs: "1234.5678", userId: "U123" },
     };
     const ctx = buildRunContext({
       bundle: createMinimalBundle(),
@@ -290,7 +291,18 @@ describe("buildRunContext", () => {
 
     const result = ctx.get(ChannelInstrumentationKey)!;
     expect(result.kind).toBe("subagent");
-    expect(result.metadata).toEqual({ threadTs: "1234.5678", userId: "U123" });
+    expect(result.metadata).toEqual({
+      audience: "public",
+      threadTs: "1234.5678",
+      userId: "U123",
+    });
+
+    setChannelContext(ctx, { kind: "subagent", state: { persisted: true } });
+    expect(ctx.get(ChannelInstrumentationKey)?.metadata).toEqual({
+      audience: "public",
+      threadTs: "1234.5678",
+      userId: "U123",
+    });
   });
 
   it("uses the adapter's own projection when channelMetadata is not provided", () => {

--- a/packages/eve/src/instrumentation/runtime.test.ts
+++ b/packages/eve/src/instrumentation/runtime.test.ts
@@ -7,6 +7,7 @@ import {
   ParentTraceContextKey,
   SessionTraceSeedKey,
 } from "#context/keys.js";
+import { setChannelContext } from "#execution/channel-context.js";
 import type { InstrumentationHooks } from "#instrumentation/lifecycle.js";
 import {
   bindInstrumentationRuntime,
@@ -591,6 +592,29 @@ describe("bindInstrumentationRuntime", () => {
       recordInputs: false,
       recordOutputs: false,
     });
+  });
+
+  it("retains content after a local subagent adapter refresh", async () => {
+    const ctx = createContext("public");
+    ctx.set(SessionTraceSeedKey, {
+      decision: { action: "record", recordInputs: true, recordOutputs: true },
+      spanId: "1".repeat(16),
+      traceFlags: 1,
+      traceId: "2".repeat(32),
+    });
+
+    setChannelContext(ctx, { kind: "subagent", state: { persisted: true } });
+
+    expect(ctx.get(ChannelInstrumentationKey)?.metadata.audience).toBe("public");
+    expect(
+      await readTelemetry(
+        bindInstrumentationRuntime(
+          createRuntime({ capturesContent: true, publish: vi.fn() }),
+          ctx,
+          boundSession,
+        ),
+      ),
+    ).toMatchObject({ recordInputs: true, recordOutputs: true });
   });
 
   it("derives a legacy seed decision from trace flags", async () => {


### PR DESCRIPTION
### Summary

Related to #2331. Local subagents initially inherit their parent channel audience, but persisting synthetic adapter state replaced that metadata with an `unknown` projection and narrowed otherwise public child traces to metadata-only. Adapter refreshes without a metadata projector now preserve the inherited projection, while real projectors still recompute from live state and genuinely unknown channels remain fail-closed.

### Validation

Focused regression coverage confirms inherited Slack metadata and content capture survive a local subagent adapter refresh. `pnpm --filter eve test:unit` passed 7,831 tests with 1 skipped.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the patch changeset describing the corrected trace behavior.

**Implementation** — 1 file · `+13 / -8`

Keeps the fix within channel-context refresh rather than weakening audience ceilings.

**Tests** — 2 files · `+38 / -2`

Covers preservation of inherited channel metadata and the resulting public-trace content decision.
