### PR TITLE
feat(eve): define delegated trace contract

### DIFF
--- a/.changeset/isolate-delegated-trace-contract.md
+++ b/.changeset/isolate-delegated-trace-contract.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Emit schema 4 agent traces with explicit caller and execution roles, durable lineage, and validated child trace coordinates.

--- a/packages/eve/src/instrumentation/lifecycle.ts
+++ b/packages/eve/src/instrumentation/lifecycle.ts
@@ -264,6 +264,10 @@ export function actionIdempotencyKey(sessionId: string, turnId: string, callId: 
   return `action:${sessionId}:${turnId}:${callId}`;
 }
 
+export function childSessionTraceKey(sessionId: string, turnId: string, callId: string): string {
+  return `child-session:${sessionId}:${turnId}:${callId}`;
+}
+
 export interface InstrumentationStepAttemptStartedEvent {
   readonly type: "step.attempt.started";
   readonly idempotencyKey: string;
@@ -279,6 +283,7 @@ export interface InstrumentationSessionStartedEvent {
   readonly channelType?: string;
   readonly channelAudience?: ChannelAudience;
   readonly idempotencyKey: string;
+  readonly parentLineage?: InstrumentationParentLineage;
   readonly parentTraceContext?: InstrumentationTraceContext;
   readonly rootSessionId: string;
   readonly sessionId: string;

--- a/packages/eve/src/instrumentation/prepare-trace-context.ts
+++ b/packages/eve/src/instrumentation/prepare-trace-context.ts
@@ -49,6 +49,7 @@ export async function prepareTurnTraceContext(
         channelAudience: input.channelAudience,
         channelType: input.channelType,
         idempotencyKey: sessionIdempotencyKey(input.sessionId),
+        parentLineage: input.parentLineage,
         parentTraceContext: input.parentTraceContext,
         rootSessionId: input.rootSessionId,
         sessionId: input.sessionId,

--- a/packages/eve/src/instrumentation/runtime.test.ts
+++ b/packages/eve/src/instrumentation/runtime.test.ts
@@ -19,6 +19,7 @@ import {
   type InstrumentationStepScope,
 } from "#instrumentation/runtime.js";
 import { AgentSpanIdGenerator } from "#tracing/agent-span-id-generator.js";
+import { allocateChildSessionTraceSeed } from "#tracing/agent-child-trace-seed.js";
 import { ContextAgentTraceStateStore } from "#tracing/agent-trace-context-store.js";
 import type { TraceCapturePolicy } from "#tracing/otel-declaration.js";
 import { readForwardedAudienceBaggage, writeForwardedAudienceBaggage } from "#protocol/baggage.js";
@@ -770,5 +771,32 @@ describe("initializeSessionInstrumentation", () => {
 
     expect(ctx.get(SessionTraceSeedKey)?.traceFlags).toBe(0);
     expect(samplesTrace).not.toHaveBeenCalled();
+  });
+
+  it("preallocates distinct replay-stable child trace coordinates", () => {
+    registerSeedRuntime({});
+    const parentTraceContext = {
+      spanId: "2".repeat(16),
+      traceFlags: 1,
+      traceId: "1".repeat(32),
+    };
+    const input = {
+      callId: "call-1",
+      parentTraceContext,
+      sessionId: "parent-session",
+      turnId: "turn-1",
+    };
+
+    const first = allocateChildSessionTraceSeed(input);
+    const replay = allocateChildSessionTraceSeed(input);
+    const sibling = allocateChildSessionTraceSeed({
+      ...input,
+      callId: "call-2",
+    });
+
+    expect(first).toEqual(replay);
+    expect(first).toMatchObject({ traceFlags: 0 });
+    expect(first?.traceId).not.toBe(parentTraceContext.traceId);
+    expect(sibling?.traceId).not.toBe(first?.traceId);
   });
 });

--- a/packages/eve/src/protocol/agent-invocation-trace.test.ts
+++ b/packages/eve/src/protocol/agent-invocation-trace.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AGENT_INVOCATION_ROLES,
+  AGENT_INVOCATION_TRACE_WIRE_VERSION,
+  AGENT_SESSION_KINDS,
+  AGENT_TRACE_ATTRIBUTES,
+  AGENT_TRACE_SCHEMA_VERSION,
+  agentInvocationTraceSchema,
+  buildAgentInvocationTrace,
+  validateAgentInvocationBinding,
+} from "#protocol/agent-invocation-trace.js";
+
+const parent = {
+  spanId: "2".repeat(16),
+  traceFlags: 1,
+  traceId: "1".repeat(32),
+};
+const seed = {
+  spanId: "4".repeat(16),
+  traceFlags: 0,
+  traceId: "3".repeat(32),
+};
+
+describe("agent invocation trace protocol", () => {
+  it("defines the closed emitted trace contract", () => {
+    expect(AGENT_TRACE_SCHEMA_VERSION).toBe(4);
+    expect(AGENT_INVOCATION_ROLES).toEqual({
+      caller: "caller",
+      execution: "execution",
+    });
+    expect(AGENT_SESSION_KINDS).toEqual({
+      delegated: "delegated",
+      root: "root",
+    });
+    expect(AGENT_TRACE_ATTRIBUTES).toEqual({
+      childTraceId: "agent.child.trace.id",
+      invocationRole: "agent.invocation.role",
+      schemaVersion: "agent.trace.schema.version",
+      sessionKind: "agent.session.kind",
+    });
+  });
+
+  it("serializes only parent and child coordinates", () => {
+    expect(buildAgentInvocationTrace({ parent, seed })).toEqual({
+      parent,
+      seed,
+      version: AGENT_INVOCATION_TRACE_WIRE_VERSION,
+    });
+  });
+
+  it("rejects policy fields and invalid identifiers", () => {
+    expect(
+      agentInvocationTraceSchema.safeParse({
+        parent,
+        seed: { ...seed, decision: { action: "drop" } },
+        version: AGENT_INVOCATION_TRACE_WIRE_VERSION,
+      }).success,
+    ).toBe(false);
+    expect(
+      agentInvocationTraceSchema.safeParse({
+        parent,
+        seed: {
+          spanId: "0".repeat(16),
+          traceFlags: 0,
+          traceId: "0".repeat(32),
+        },
+        version: AGENT_INVOCATION_TRACE_WIRE_VERSION,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("cross-validates callback, parent, and distinct child traces", () => {
+    const invocation = {
+      callId: "call-1",
+      rootSessionId: "root-session",
+      sessionId: "parent-session",
+      turn: { id: "parent-turn", sequence: 0 },
+    };
+    const trace = buildAgentInvocationTrace({ parent, seed });
+
+    expect(
+      validateAgentInvocationBinding({
+        callbackCallId: "call-1",
+        invocation,
+        trace,
+        traceparent: parent,
+      }),
+    ).toBeUndefined();
+    expect(
+      validateAgentInvocationBinding({
+        callbackCallId: "call-2",
+        invocation,
+        trace,
+      }),
+    ).toBe("call-id-mismatch");
+    expect(
+      validateAgentInvocationBinding({
+        callbackCallId: "call-1",
+        invocation,
+        trace: { ...trace, seed: { ...trace.seed, traceId: parent.traceId } },
+        traceparent: parent,
+      }),
+    ).toBe("trace-context-mismatch");
+  });
+});

--- a/packages/eve/src/protocol/agent-invocation-trace.ts
+++ b/packages/eve/src/protocol/agent-invocation-trace.ts
@@ -1,0 +1,118 @@
+import { z } from "#compiled/zod/index.js";
+
+import type { SessionParent, SessionTraceContext } from "#channel/types.js";
+
+export const AGENT_TRACE_SCHEMA_VERSION = 4 as const;
+export const AGENT_INVOCATION_TRACE_WIRE_VERSION = 1 as const;
+export const AGENT_INVOCATION_ROLES = {
+  caller: "caller",
+  execution: "execution",
+} as const;
+export const AGENT_SESSION_KINDS = {
+  delegated: "delegated",
+  root: "root",
+} as const;
+export const AGENT_TRACE_ATTRIBUTES = {
+  childTraceId: "agent.child.trace.id",
+  invocationRole: "agent.invocation.role",
+  schemaVersion: "agent.trace.schema.version",
+  sessionKind: "agent.session.kind",
+} as const;
+
+export const traceIdSchema = z
+  .string()
+  .regex(/^[0-9a-f]{32}$/u)
+  .refine((value) => !/^0+$/u.test(value));
+export const spanIdSchema = z
+  .string()
+  .regex(/^[0-9a-f]{16}$/u)
+  .refine((value) => !/^0+$/u.test(value));
+
+export const traceCoordinatesSchema = z.strictObject({
+  spanId: spanIdSchema,
+  traceFlags: z.number().int().min(0).max(255),
+  traceId: traceIdSchema,
+});
+
+export const agentInvocationTraceSchema = z.strictObject({
+  parent: traceCoordinatesSchema.optional(),
+  seed: traceCoordinatesSchema,
+  version: z.literal(AGENT_INVOCATION_TRACE_WIRE_VERSION),
+});
+
+export type AgentInvocationTrace = z.infer<typeof agentInvocationTraceSchema>;
+export type TraceCoordinates = z.infer<typeof traceCoordinatesSchema>;
+
+export function buildAgentInvocationParent(input: {
+  readonly callId: string;
+  readonly rootSessionId: string;
+  readonly sessionId: string;
+  readonly turnId: string;
+  readonly turnSequence: number;
+}): SessionParent {
+  return {
+    callId: input.callId,
+    rootSessionId: input.rootSessionId,
+    sessionId: input.sessionId,
+    turn: { id: input.turnId, sequence: input.turnSequence },
+  };
+}
+
+export function buildAgentInvocationTrace(input: {
+  readonly parent?: SessionTraceContext;
+  readonly seed: SessionTraceContext;
+}): AgentInvocationTrace {
+  const trace: AgentInvocationTrace = {
+    seed: traceCoordinates(input.seed),
+    version: AGENT_INVOCATION_TRACE_WIRE_VERSION,
+  };
+  if (input.parent !== undefined) {
+    trace.parent = traceCoordinates(input.parent);
+  }
+  return trace;
+}
+
+export type AgentInvocationBindingError = "call-id-mismatch" | "trace-context-mismatch";
+
+export function validateAgentInvocationBinding(input: {
+  readonly callbackCallId?: string;
+  readonly invocation?: SessionParent;
+  readonly trace?: AgentInvocationTrace;
+  readonly traceparent?: SessionTraceContext;
+}): AgentInvocationBindingError | undefined {
+  if (
+    input.invocation !== undefined &&
+    (input.callbackCallId === undefined || input.invocation.callId !== input.callbackCallId)
+  ) {
+    return "call-id-mismatch";
+  }
+  if (input.trace === undefined) return undefined;
+  if (input.callbackCallId === undefined || input.invocation === undefined) {
+    return "trace-context-mismatch";
+  }
+  const parent = input.trace.parent;
+  if (
+    (input.traceparent !== undefined &&
+      (parent === undefined || !traceCoordinatesEqual(input.traceparent, parent))) ||
+    (parent !== undefined && input.trace.seed.traceId === parent.traceId)
+  ) {
+    return "trace-context-mismatch";
+  }
+  return undefined;
+}
+
+export function traceCoordinatesEqual(left: TraceCoordinates, right: TraceCoordinates): boolean {
+  return (
+    left.traceId === right.traceId &&
+    left.spanId === right.spanId &&
+    left.traceFlags === right.traceFlags
+  );
+}
+
+function traceCoordinates(context: SessionTraceContext): TraceCoordinates {
+  return {
+    spanId: context.spanId,
+    traceFlags: context.traceFlags,
+    traceId: context.traceId,
+  };
+}

--- a/packages/eve/src/tracing/agent-action-instrumentation.ts
+++ b/packages/eve/src/tracing/agent-action-instrumentation.ts
@@ -1,5 +1,6 @@
 import {
   ROOT_CONTEXT,
+  SpanKind,
   SpanStatusCode,
   type Context,
   type Span,
@@ -9,6 +10,7 @@ import {
 } from "#compiled/@opentelemetry/api/index.js";
 
 import type {
+  InstrumentationActionKind,
   InstrumentationActionStartedEvent,
   InstrumentationActionTerminalEvent,
   InstrumentationAttemptScope,
@@ -22,6 +24,10 @@ import type { AgentActionTraceState, AgentTraceStateStore } from "#tracing/agent
 import { normalizeChannelAudience } from "#shared/channel-audience.js";
 import { isSampledTrace } from "#tracing/sampled-trace.js";
 import { withChannelAudience } from "#tracing/channel-audience-context.js";
+import {
+  AGENT_INVOCATION_ROLES,
+  AGENT_TRACE_ATTRIBUTES,
+} from "#protocol/agent-invocation-trace.js";
 
 export interface AgentActionInstrumentation {
   readonly events: Pick<
@@ -40,6 +46,7 @@ export interface AgentActionInstrumentation {
 
 export interface AgentActionContext {
   readonly context: Context;
+  readonly kind: InstrumentationActionKind;
   readonly spanContext: SpanContext;
 }
 
@@ -92,6 +99,7 @@ export function createAgentActionInstrumentation(input: {
     if (state === undefined) return;
     try {
       const span = startSpan(state);
+      setChildTraceId(span, state);
       span.setAttribute("agent.action.outcome", event.outcome);
       if (event.type === "action.failed") {
         if (event.errorCode !== undefined) {
@@ -118,9 +126,10 @@ export function createAgentActionInstrumentation(input: {
   };
 
   const startSpan = (state: AgentActionTraceState): Span => {
+    const invocation = isAgentInvocation(state.kind);
     const span = input.idGenerator.withSpanId(state.spanId, () =>
       input.tracer.startSpan(
-        "agent.action",
+        invocation ? `invoke_agent ${state.name}` : "agent.action",
         {
           attributes: {
             "agent.action.call_id": state.callId,
@@ -132,7 +141,15 @@ export function createAgentActionInstrumentation(input: {
             "agent.step.attempt": state.attemptIndex,
             "agent.step.index": state.stepIndex,
             "agent.turn.id": state.turnId,
+            ...(invocation
+              ? {
+                  "gen_ai.agent.name": state.name,
+                  "gen_ai.operation.name": "invoke_agent",
+                  [AGENT_TRACE_ATTRIBUTES.invocationRole]: AGENT_INVOCATION_ROLES.caller,
+                }
+              : undefined),
           },
+          kind: state.kind === "remote-agent-call" ? SpanKind.CLIENT : SpanKind.INTERNAL,
           startTime: state.startTimeMs,
         },
         contextFromActionState(state),
@@ -162,6 +179,7 @@ export function createAgentActionInstrumentation(input: {
         const state = await input.stateStore.getAction(key);
         if (state === undefined) continue;
         const span = startSpan(state);
+        setChildTraceId(span, state);
         recordError(span, error);
         span.end();
         await input.stateStore.deleteAction(key);
@@ -180,6 +198,12 @@ export function createAgentActionInstrumentation(input: {
       if (keys.size === 0) byAttempt.delete(attemptId);
     }
   }
+
+  function setChildTraceId(span: Span, state: AgentActionTraceState): void {
+    if (state.childTraceId !== undefined) {
+      span.setAttribute(AGENT_TRACE_ATTRIBUTES.childTraceId, state.childTraceId);
+    }
+  }
 }
 
 function actionContext(state: AgentActionTraceState): AgentActionContext {
@@ -194,8 +218,13 @@ function actionContext(state: AgentActionTraceState): AgentActionContext {
       trace.setSpan(ROOT_CONTEXT, trace.wrapSpanContext(spanContext)),
       state.channelAudience,
     ),
+    kind: state.kind,
     spanContext,
   };
+}
+
+function isAgentInvocation(kind: InstrumentationActionKind): boolean {
+  return kind === "subagent-call" || kind === "remote-agent-call";
 }
 
 function contextFromActionState(state: AgentActionTraceState): Context {

--- a/packages/eve/src/tracing/agent-child-trace-seed.ts
+++ b/packages/eve/src/tracing/agent-child-trace-seed.ts
@@ -1,0 +1,33 @@
+import type { SessionTraceContext } from "#channel/types.js";
+import type { SessionTraceSeed } from "#context/keys.js";
+import { childSessionTraceKey } from "#instrumentation/lifecycle.js";
+import { getInstrumentationRuntime } from "#instrumentation/runtime.js";
+
+export function allocateChildSessionTraceSeed(input: {
+  readonly callId: string;
+  readonly parentTraceContext?: SessionTraceContext;
+  readonly sessionId: string;
+  readonly turnId: string;
+}): SessionTraceSeed | undefined {
+  const runtime = getInstrumentationRuntime();
+  if (runtime?.prepareSessionTrace === undefined || runtime.idGenerator === undefined) {
+    return undefined;
+  }
+  const key = childSessionTraceKey(input.sessionId, input.turnId, input.callId);
+  const derivedTraceId = runtime.idGenerator.deriveTraceId(key);
+  const traceId =
+    input.parentTraceContext === undefined
+      ? derivedTraceId
+      : distinctChildTraceId(derivedTraceId, input.parentTraceContext.traceId);
+  return {
+    spanId: runtime.idGenerator.deriveSpanId(`${key}:root`),
+    traceFlags: 0,
+    traceId,
+  };
+}
+
+function distinctChildTraceId(traceId: string, parentTraceId: string): string {
+  if (traceId !== parentTraceId) return traceId;
+  const lastDigit = traceId.at(-1);
+  return `${traceId.slice(0, -1)}${lastDigit === "f" ? "e" : "f"}`;
+}

--- a/packages/eve/src/tracing/agent-otel-provider.test.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.test.ts
@@ -36,6 +36,7 @@ import {
   type InstrumentationHooks,
   type InstrumentationParentLineage,
   type InstrumentationTraceContext,
+  type InstrumentationTraceSeed,
   type InstrumentationUsage,
 } from "#instrumentation/lifecycle.js";
 import type { ChannelAudience } from "#shared/channel-audience.js";
@@ -62,6 +63,7 @@ interface TestRuntime {
     ReturnType<typeof createAgentOtelInstrumentation>["hook"]["projectEvent"]
   >;
   readonly runInContext: InstrumentationContextRunner;
+  readonly stateStore: AgentTraceStateStore;
   readonly tracer: ReturnType<BasicTracerProvider["getTracer"]>;
 }
 
@@ -105,12 +107,14 @@ function createRuntime(
     projectEvent: agentOtel.hook.projectEvent!,
     provider,
     runInContext: agentOtel.runInContext,
+    stateStore,
     tracer,
   };
 }
 
 async function emitAttempt(input: {
   readonly actionUsage?: InstrumentationUsage;
+  readonly childTraceId?: string;
   readonly attemptIndex?: number;
   readonly attemptError?: Error;
   readonly channelAudience?: ChannelAudience;
@@ -122,6 +126,7 @@ async function emitAttempt(input: {
   readonly actionKind?: InstrumentationActionKind;
   readonly runtimeContext?: Readonly<Record<string, unknown>>;
   readonly sessionId: string;
+  readonly stateStore?: AgentTraceStateStore;
   readonly skipModelTerminal?: boolean;
   readonly skipToolTerminal?: boolean;
   readonly toolError?: Error;
@@ -219,6 +224,15 @@ async function emitAttempt(input: {
     scope,
     type: "action.started",
   });
+  if (input.childTraceId !== undefined && input.stateStore !== undefined) {
+    const action = await input.stateStore.getAction(actionKey);
+    if (action !== undefined) {
+      await input.stateStore.setAction(actionKey, {
+        ...action,
+        childTraceId: input.childTraceId,
+      });
+    }
+  }
   await Reflect.apply(bridge.onToolExecutionStart!, bridge, [
     {
       callId: "call-1",
@@ -310,6 +324,7 @@ async function publishTurnStarted(input: {
   readonly sessionId: string;
   readonly turnId: string;
   readonly turnSequence: number;
+  readonly traceSeed?: InstrumentationTraceSeed;
 }): Promise<void> {
   const rootSessionId = input.rootSessionId ?? input.sessionId;
   await input.hooks.publish({
@@ -317,9 +332,11 @@ async function publishTurnStarted(input: {
     channelAudience: input.channelAudience ?? "public",
     channelKind: "http",
     idempotencyKey: sessionIdempotencyKey(input.sessionId),
+    parentLineage: input.parentLineage,
     parentTraceContext: input.parentTraceContext,
     rootSessionId,
     sessionId: input.sessionId,
+    traceSeed: input.traceSeed,
     type: "session.started",
   });
   await input.hooks.publish({
@@ -427,6 +444,67 @@ describe("createAgentOtelInstrumentation", () => {
     const session = byName(spans, "agent.session")[0]!;
     expect(session.spanContext().traceId).toBe(seed.traceId);
     expect(session.spanContext().spanId).toBe(seed.spanId);
+  });
+
+  it("roots a delegated session in its child trace and links the parent", async () => {
+    const runtime = createRuntime();
+    const parent = {
+      spanId: "c".repeat(16),
+      traceFlags: 1,
+      traceId: "d".repeat(32),
+    };
+    const seed = {
+      spanId: "a".repeat(16),
+      traceFlags: 1,
+      traceId: "b".repeat(32),
+    };
+    const parentLineage = {
+      callId: "call-child",
+      sessionId: "parent-session",
+      subagentName: "researcher",
+      turnId: "parent-turn",
+    };
+
+    await publishTurnStarted({
+      hooks: runtime.hooks,
+      parentLineage,
+      parentTraceContext: parent,
+      rootSessionId: "root-session",
+      sessionId: "child-session",
+      traceSeed: seed,
+      turnId: "child-turn",
+      turnSequence: 0,
+    });
+    await completeTurn(runtime.hooks, "child-session", "child-turn");
+    await runtime.provider.forceFlush();
+
+    const spans = runtime.exporter.getFinishedSpans();
+    const session = byName(spans, "agent.session")[0]!;
+    const execution = byName(spans, "invoke_agent weather")[0]!;
+    expect(session.spanContext()).toMatchObject(seed);
+    expect(session.parentSpanContext).toBeUndefined();
+    expect(session.links).toEqual([
+      expect.objectContaining({
+        attributes: { "eve.link.type": "agent.dispatch" },
+        context: expect.objectContaining(parent),
+      }),
+    ]);
+    expect(session.attributes).toMatchObject({
+      "agent.session.kind": "delegated",
+      "agent.trace.schema.version": 4,
+    });
+    expect(execution.spanContext().traceId).toBe(seed.traceId);
+    expect(execution.parentSpanContext?.spanId).toBe(seed.spanId);
+    expect(execution.attributes).toMatchObject({
+      "agent.invocation.role": "execution",
+      "agent.parent_call.id": "call-child",
+      "agent.parent_run.id": "parent-session",
+      "agent.root_run.id": "root-session",
+      "agent.session.kind": "delegated",
+      "agent.trace.schema.version": 4,
+      "gen_ai.conversation.id": "child-session",
+      "gen_ai.operation.name": "invoke_agent",
+    });
   });
 
   it("falls back to fresh ids when no trace seed is present", async () => {
@@ -783,7 +861,15 @@ describe("createAgentOtelInstrumentation", () => {
     expect(session.attributes).toMatchObject({
       "agent.channel.audience": "public",
       "agent.session.id": "session-1",
-      "agent.trace.schema.version": 3,
+      "agent.session.kind": "root",
+      "agent.trace.schema.version": 4,
+    });
+    expect(turn.attributes).toMatchObject({
+      "agent.invocation.role": "execution",
+      "agent.root_run.id": "session-1",
+      "agent.session.kind": "root",
+      "agent.trace.schema.version": 4,
+      "gen_ai.conversation.id": "session-1",
     });
     expect(turn.parentSpanContext?.spanId).toBe(session.spanContext().spanId);
     expect(step.parentSpanContext?.spanId).toBe(turn.spanContext().spanId);
@@ -1696,8 +1782,9 @@ describe("createAgentOtelInstrumentation", () => {
     }
   });
 
-  it("labels a subagent action by its kind, not as a plain tool", async () => {
+  it("emits a subagent action as a caller invocation", async () => {
     const runtime = createRuntime();
+    const childTraceId = "e".repeat(32);
     await emitAttempt({
       actionUsage: {
         inputTokenDetails: { cacheReadTokens: 3, cacheWriteTokens: 4 },
@@ -1706,23 +1793,32 @@ describe("createAgentOtelInstrumentation", () => {
       },
       hooks: runtime.hooks,
       actionKind: "subagent-call",
+      childTraceId,
       runInContext: runtime.runInContext,
       sessionId: "session-1",
+      stateStore: runtime.stateStore,
       turnId: "turn-1",
       turnSequence: 0,
     });
     await runtime.provider.forceFlush();
 
-    const action = runtime.exporter.getFinishedSpans().find((span) => span.name === "agent.action");
+    const spans = runtime.exporter.getFinishedSpans();
+    const action = byName(spans, "invoke_agent weather")[0];
     expect(action?.attributes).toMatchObject({
       "agent.action.kind": "subagent-call",
       "agent.action.name": "weather",
       "agent.action.outcome": "completed",
+      "agent.child.trace.id": childTraceId,
+      "agent.invocation.role": "caller",
       "agent.usage.cache_read_tokens": 3,
       "agent.usage.cache_write_tokens": 4,
       "agent.usage.input_tokens": 10,
       "agent.usage.output_tokens": 5,
+      "gen_ai.agent.name": "weather",
+      "gen_ai.operation.name": "invoke_agent",
     });
+    expect(byName(spans, "agent.action")).toHaveLength(0);
+    expect(byName(spans, "execute_tool weather")).toHaveLength(0);
     expect(
       Object.keys(action?.attributes ?? {}).some((key) => key.startsWith("gen_ai.usage.")),
     ).toBe(false);

--- a/packages/eve/src/tracing/agent-otel-provider.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.ts
@@ -61,6 +61,12 @@ import type {
   InstrumentationTurnTerminalEvent,
 } from "#instrumentation/lifecycle.js";
 import { attemptIdempotencyKey } from "#instrumentation/lifecycle.js";
+import {
+  AGENT_INVOCATION_ROLES,
+  AGENT_SESSION_KINDS,
+  AGENT_TRACE_ATTRIBUTES,
+  AGENT_TRACE_SCHEMA_VERSION,
+} from "#protocol/agent-invocation-trace.js";
 
 interface SpanState {
   readonly context: Context;
@@ -305,7 +311,16 @@ export function createAgentOtelInstrumentation(
                   "agent.framework.name": "eve",
                   "agent.framework.version": input.frameworkVersion,
                   "agent.name": agentName,
+                  "agent.parent_call.id": turn.parentLineage?.callId,
+                  "agent.parent_run.id": turn.parentLineage?.sessionId,
+                  "agent.root_run.id": turn.rootSessionId,
                   "agent.session.id": event.sessionId,
+                  [AGENT_TRACE_ATTRIBUTES.invocationRole]: AGENT_INVOCATION_ROLES.execution,
+                  [AGENT_TRACE_ATTRIBUTES.schemaVersion]: AGENT_TRACE_SCHEMA_VERSION,
+                  [AGENT_TRACE_ATTRIBUTES.sessionKind]:
+                    turn.parentLineage === undefined
+                      ? AGENT_SESSION_KINDS.root
+                      : AGENT_SESSION_KINDS.delegated,
                   "agent.subagent.name": turn.subagentName,
                   "agent.turn.id": event.turnId,
                   "agent.turn.sequence": turn.sequence,

--- a/packages/eve/src/tracing/agent-otel-session-context.ts
+++ b/packages/eve/src/tracing/agent-otel-session-context.ts
@@ -2,6 +2,7 @@ import type { SpanContext, Tracer } from "#compiled/@opentelemetry/api/index.js"
 
 import {
   sessionIdempotencyKey,
+  type InstrumentationParentLineage,
   type InstrumentationSessionStartedEvent,
   type InstrumentationTraceContext,
   type InstrumentationTraceSeed,
@@ -18,6 +19,11 @@ import {
 } from "#tracing/sampled-trace.js";
 import type { AgentSessionTraceState, AgentTraceStateStore } from "#tracing/agent-trace-state.js";
 import { readInstrumentationDecision } from "#shared/instrumentation-decision.js";
+import {
+  AGENT_SESSION_KINDS,
+  AGENT_TRACE_ATTRIBUTES,
+  AGENT_TRACE_SCHEMA_VERSION,
+} from "#protocol/agent-invocation-trace.js";
 
 interface AgentOtelSessionContextInput {
   readonly frameworkVersion: string;
@@ -48,7 +54,9 @@ export function createAgentOtelSessionContext(
     readonly channelType?: string;
     readonly rootSessionId: string;
     readonly sessionId: string;
+    readonly parentLineage?: InstrumentationParentLineage;
     readonly traceDecision: ReturnType<typeof resolveTracePolicy>;
+    readonly parentTraceContext?: InstrumentationTraceContext;
     readonly traceSeed?: InstrumentationTraceContext;
   }): SpanContext => {
     if (session.traceSeed !== undefined) {
@@ -68,8 +76,21 @@ export function createAgentOtelSessionContext(
             "agent.channel.audience": session.channelAudience,
             "agent.name": session.agentName,
             "agent.session.id": session.sessionId,
-            "agent.trace.schema.version": 3,
+            [AGENT_TRACE_ATTRIBUTES.sessionKind]:
+              session.parentLineage === undefined
+                ? AGENT_SESSION_KINDS.root
+                : AGENT_SESSION_KINDS.delegated,
+            [AGENT_TRACE_ATTRIBUTES.schemaVersion]: AGENT_TRACE_SCHEMA_VERSION,
           },
+          links:
+            session.parentTraceContext === undefined
+              ? undefined
+              : [
+                  {
+                    attributes: { "eve.link.type": "agent.dispatch" },
+                    context: adoptedSpanContext(session.parentTraceContext),
+                  },
+                ],
           root: true,
         });
       const span = input.idGenerator.withSpanId(session.traceSeed.spanId, () =>
@@ -95,8 +116,21 @@ export function createAgentOtelSessionContext(
         "agent.channel.audience": session.channelAudience,
         "agent.name": session.agentName,
         "agent.session.id": session.sessionId,
-        "agent.trace.schema.version": 3,
+        [AGENT_TRACE_ATTRIBUTES.sessionKind]:
+          session.parentLineage === undefined
+            ? AGENT_SESSION_KINDS.root
+            : AGENT_SESSION_KINDS.delegated,
+        [AGENT_TRACE_ATTRIBUTES.schemaVersion]: AGENT_TRACE_SCHEMA_VERSION,
       },
+      links:
+        session.parentTraceContext === undefined
+          ? undefined
+          : [
+              {
+                attributes: { "eve.link.type": "agent.dispatch" },
+                context: adoptedSpanContext(session.parentTraceContext),
+              },
+            ],
       root: true,
     });
     span.addEvent("session.started");
@@ -117,18 +151,21 @@ export function createAgentOtelSessionContext(
         channelKind: event.channelKind,
         decision,
         context:
-          event.parentTraceContext === undefined
+          event.traceSeed !== undefined || event.parentTraceContext === undefined
             ? openSessionTrace({
                 agentName: event.agentName,
                 channelAudience,
                 channelType: event.channelType,
                 rootSessionId: event.rootSessionId,
                 sessionId: event.sessionId,
+                parentLineage: event.parentLineage,
+                parentTraceContext: event.parentTraceContext,
                 traceDecision: decision,
                 traceSeed: event.traceSeed,
               })
             : adoptedSpanContext(event.parentTraceContext),
         rootSessionId: event.rootSessionId,
+        parentLineage: event.parentLineage,
       };
       await input.stateStore.setSession(event.sessionId, state);
     }
@@ -161,6 +198,7 @@ export function createAgentOtelSessionContext(
       channelAudience: "unknown",
       channelKind: undefined,
       idempotencyKey: sessionIdempotencyKey(event.sessionId),
+      parentLineage: event.parentLineage,
       parentTraceContext: event.parentTraceContext,
       rootSessionId: event.rootSessionId,
       sessionId: event.sessionId,
@@ -179,10 +217,11 @@ export function createAgentOtelSessionContext(
       context: turnContext,
       parentIsRemote: session.context.isRemote,
       parentSpanId: session.context.spanId,
+      parentLineage: event.parentLineage ?? session.parentLineage,
       rootSessionId: event.rootSessionId,
       sequence: event.sequence,
       startTimeMs: Date.now(),
-      subagentName: event.parentLineage?.subagentName,
+      subagentName: (event.parentLineage ?? session.parentLineage)?.subagentName,
     });
     return portableSpanContext(session.context, session.decision);
   };

--- a/packages/eve/src/tracing/agent-span-id-generator.ts
+++ b/packages/eve/src/tracing/agent-span-id-generator.ts
@@ -17,8 +17,12 @@ export class AgentSpanIdGenerator {
 
   /** Derives one span id for a replay-stable instrumentation event. */
   deriveSpanId(key: string): string {
-    const spanId = createHash("sha256").update(key).digest("hex").slice(0, 16);
-    return /^0+$/u.test(spanId) ? "0000000000000001" : spanId;
+    return derivedHexId(key, 16);
+  }
+
+  /** Derives one trace id for a replay-stable child dispatch. */
+  deriveTraceId(key: string): string {
+    return derivedHexId(key, 32);
   }
 
   generateSpanId(): string {
@@ -70,4 +74,9 @@ function randomHexId(length: number): string {
     }
   } while (!/[1-9a-f]/u.test(id));
   return id;
+}
+
+function derivedHexId(key: string, length: number): string {
+  const id = createHash("sha256").update(key).digest("hex").slice(0, length);
+  return /^0+$/u.test(id) ? `${"0".repeat(length - 1)}1` : id;
 }

--- a/packages/eve/src/tracing/agent-tool-instrumentation.ts
+++ b/packages/eve/src/tracing/agent-tool-instrumentation.ts
@@ -23,13 +23,15 @@ import type { AgentActionContext } from "#tracing/agent-action-instrumentation.j
 interface ToolSpanState {
   readonly actionKey: string;
   readonly attemptId: string;
-  readonly context: Context;
+  context: Context;
   readonly event: InstrumentationToolCallStartedEvent;
   readonly fallbackParent: Context;
   readonly idempotencyKey: string;
   readonly spanId: string;
   readonly startTimeMs: number;
+  contextConsumed?: true;
   finished?: true;
+  suppressed?: true;
   span?: Span;
   terminal?: InstrumentationToolCallTerminalEvent;
 }
@@ -76,6 +78,10 @@ export function createAgentToolInstrumentation(input: {
       if (actionParent === undefined) return;
       state = reserve(event, actionKey, actionParent);
     }
+    if (actionParent !== undefined && isAgentInvocation(actionParent)) {
+      suppress(state, actionParent);
+      return;
+    }
     if (actionParent !== undefined) startSpan(state, actionParent.context);
   };
 
@@ -84,13 +90,17 @@ export function createAgentToolInstrumentation(input: {
     if (state === undefined) return;
     state.terminal = event;
 
-    if (state.span === undefined) {
+    if (state.span === undefined && state.suppressed !== true) {
       const actionParent = await input.actionContextFor(
         state.event.scope.sessionId,
         state.event.scope.turnId,
         state.event.callId,
       );
-      if (actionParent !== undefined) startSpan(state, actionParent.context);
+      if (actionParent !== undefined && isAgentInvocation(actionParent)) {
+        suppress(state, actionParent);
+      } else if (actionParent !== undefined) {
+        startSpan(state, actionParent.context);
+      }
     }
     finishIfReady(state);
   };
@@ -105,16 +115,24 @@ export function createAgentToolInstrumentation(input: {
         event.callId,
       );
       if (actionParent === undefined) return;
-      startSpan(state, actionParent.context);
+      if (isAgentInvocation(actionParent)) suppress(state, actionParent);
+      else startSpan(state, actionParent.context);
       finishIfReady(state);
     },
-    contextFor: (attemptId, idempotencyKey) =>
-      byAttempt.get(attemptId)?.get(idempotencyKey)?.context,
+    contextFor(attemptId, idempotencyKey) {
+      const state = byAttempt.get(attemptId)?.get(idempotencyKey);
+      if (state !== undefined) state.contextConsumed = true;
+      return state?.context;
+    },
     drain(attemptId, failure) {
       const states = byAttempt.get(attemptId);
       if (states === undefined) return;
       for (const state of states.values()) {
         if (state.finished === true) continue;
+        if (state.suppressed === true) {
+          finish(state);
+          continue;
+        }
         if (state.span === undefined) startSpan(state, state.fallbackParent);
         finish(state, failure);
       }
@@ -166,7 +184,9 @@ export function createAgentToolInstrumentation(input: {
   }
 
   function startSpan(state: ToolSpanState, parent: Context): void {
-    if (state.span !== undefined || state.finished === true) return;
+    if (state.span !== undefined || state.finished === true || state.suppressed === true) {
+      return;
+    }
     state.span = input.idGenerator.withSpanId(state.spanId, () =>
       input.tracer.startSpan(
         `execute_tool ${state.event.toolName}`,
@@ -185,15 +205,23 @@ export function createAgentToolInstrumentation(input: {
   }
 
   function finishIfReady(state: ToolSpanState): void {
-    if (state.span === undefined || state.terminal === undefined) return;
+    if ((state.span === undefined && state.suppressed !== true) || state.terminal === undefined) {
+      return;
+    }
     finish(state);
   }
 
   function finish(state: ToolSpanState, failure?: { readonly error: unknown }): void {
     const span = state.span;
-    if (span === undefined || state.finished === true) return;
+    if ((span === undefined && state.suppressed !== true) || state.finished === true) {
+      return;
+    }
     state.finished = true;
     const terminal = state.terminal;
+    if (span === undefined) {
+      cleanup(state);
+      return;
+    }
     if (failure !== undefined) {
       recordError(span, failure.error);
     } else if (terminal?.type === "tool.call.failed") {
@@ -205,11 +233,29 @@ export function createAgentToolInstrumentation(input: {
       if (result !== undefined) span.setAttribute("gen_ai.tool.call.result", result);
     }
     span.end();
+    cleanup(state);
+  }
+
+  function suppress(state: ToolSpanState, action: AgentActionContext): void {
+    if (state.contextConsumed === true || state.span !== undefined) {
+      state.suppressed = undefined;
+      startSpan(state, action.context);
+      return;
+    }
+    state.context = action.context;
+    state.suppressed = true;
+  }
+
+  function cleanup(state: ToolSpanState): void {
     byAction.delete(state.actionKey);
     const states = byAttempt.get(state.attemptId);
     states?.delete(state.idempotencyKey);
     if (states?.size === 0) byAttempt.delete(state.attemptId);
   }
+}
+
+function isAgentInvocation(action: AgentActionContext): boolean {
+  return action.kind === "subagent-call" || action.kind === "remote-agent-call";
 }
 
 function toolAttributes(event: InstrumentationToolCallStartedEvent): Record<string, string> {

--- a/packages/eve/src/tracing/agent-trace-context-store.test.ts
+++ b/packages/eve/src/tracing/agent-trace-context-store.test.ts
@@ -6,6 +6,7 @@ import { deserializeContext, serializeContext } from "#context/serialize.js";
 import {
   ContextAgentTraceStateStore,
   preserveSerializedAgentTraceState,
+  recordActionChildTraceId,
   readActionTraceContext,
   readCurrentSessionTraceDecision,
   readSessionTraceContext,
@@ -125,6 +126,47 @@ describe("ContextAgentTraceStateStore", () => {
 
     expect(preserved.authored).toBe("original");
     expect(preserved["eve.harness.agentTrace"]).toBeDefined();
+  });
+
+  it("persists only valid confirmed child trace ids", async () => {
+    const context = new ContextContainer();
+    await contextStorage.run(context, () => {
+      new ContextAgentTraceStateStore().setAction("action-1", {
+        attemptIndex: 0,
+        callId: "call-1",
+        kind: "subagent-call",
+        name: "researcher",
+        parent: spanContext("1", "2"),
+        rootSessionId: "session-1",
+        sessionId: "session-1",
+        spanId: "3".repeat(16),
+        startTimeMs: 1,
+        stepIndex: 0,
+        turnId: "turn-1",
+      });
+    });
+    const serialized = await serializeContext(context);
+    const invalid = recordActionChildTraceId(
+      serialized,
+      "session-1",
+      "turn-1",
+      "call-1",
+      "0".repeat(32),
+    );
+    const confirmed = recordActionChildTraceId(
+      invalid,
+      "session-1",
+      "turn-1",
+      "call-1",
+      "4".repeat(32),
+    );
+    const restored = await deserializeContext(confirmed);
+
+    await contextStorage.run(restored, () => {
+      expect(new ContextAgentTraceStateStore().getAction("action-1")?.childTraceId).toBe(
+        "4".repeat(32),
+      );
+    });
   });
 });
 

--- a/packages/eve/src/tracing/agent-trace-context-store.ts
+++ b/packages/eve/src/tracing/agent-trace-context-store.ts
@@ -11,6 +11,7 @@ import type {
   AgentTraceStateStore,
   AgentTurnTraceState,
 } from "#tracing/agent-trace-state.js";
+import { traceIdSchema } from "#protocol/agent-invocation-trace.js";
 import { normalizeChannelAudience } from "#shared/channel-audience.js";
 import {
   type InstrumentationDecision,
@@ -101,6 +102,36 @@ export function readActionTraceContext(
     },
     state.sessions[action.sessionId]?.decision,
   );
+}
+
+export function recordActionChildTraceId(
+  serializedContext: Record<string, unknown>,
+  sessionId: string,
+  turnId: string,
+  callId: string,
+  childTraceId: string,
+): Record<string, unknown> {
+  const parsedTraceId = traceIdSchema.safeParse(childTraceId);
+  if (!parsedTraceId.success) return serializedContext;
+  const raw = serializedContext[AgentTraceContextKey.name];
+  if (raw === undefined) return serializedContext;
+  const state = deserializeState(raw);
+  const entry = Object.entries(state.actions).find(
+    ([, action]) =>
+      action.sessionId === sessionId && action.turnId === turnId && action.callId === callId,
+  );
+  if (entry === undefined) return serializedContext;
+  const [key, action] = entry;
+  return {
+    ...serializedContext,
+    [AgentTraceContextKey.name]: serializeState({
+      ...state,
+      actions: {
+        ...state.actions,
+        [key]: { ...action, childTraceId: parsedTraceId.data },
+      },
+    }),
+  };
 }
 
 function withTraceDecision(
@@ -273,6 +304,7 @@ function deserializeState(data: unknown): AgentTraceContextState {
       channelKind: typeof value.channelKind === "string" ? value.channelKind : undefined,
       context: value.context,
       decision: readInstrumentationDecision(value.decision),
+      parentLineage: deserializeParentLineage(value.parentLineage),
       rootSessionId: typeof value.rootSessionId === "string" ? value.rootSessionId : "",
     } satisfies AgentSessionTraceState;
   });
@@ -284,6 +316,7 @@ function deserializeState(data: unknown): AgentTraceContextState {
     return {
       context: value.context,
       modelUsage: deserializeModelUsage(value.modelUsage),
+      parentLineage: deserializeParentLineage(value.parentLineage),
       parentIsRemote: typeof value.parentIsRemote === "boolean" ? value.parentIsRemote : undefined,
       parentSpanId: value.parentSpanId,
       rootSessionId: typeof value.rootSessionId === "string" ? value.rootSessionId : "",
@@ -294,6 +327,25 @@ function deserializeState(data: unknown): AgentTraceContextState {
     } satisfies AgentTurnTraceState;
   });
   return { actions, sessions, turns };
+}
+
+function deserializeParentLineage(
+  value: unknown,
+): AgentTurnTraceState["parentLineage"] | undefined {
+  if (
+    !isRecord(value) ||
+    typeof value.callId !== "string" ||
+    typeof value.sessionId !== "string" ||
+    typeof value.turnId !== "string"
+  ) {
+    return undefined;
+  }
+  return {
+    callId: value.callId,
+    sessionId: value.sessionId,
+    subagentName: typeof value.subagentName === "string" ? value.subagentName : undefined,
+    turnId: value.turnId,
+  };
 }
 
 function deserializeModelUsage(
@@ -328,6 +380,10 @@ function deserializeAction(value: unknown): AgentActionTraceState | undefined {
     attemptIndex: value.attemptIndex,
     callId: value.callId,
     channelAudience: normalizeChannelAudience(value.channelAudience),
+    childTraceId:
+      typeof value.childTraceId === "string" && traceIdSchema.safeParse(value.childTraceId).success
+        ? value.childTraceId
+        : undefined,
     inputAttribute: typeof value.inputAttribute === "string" ? value.inputAttribute : undefined,
     kind: value.kind,
     name: value.name,

--- a/packages/eve/src/tracing/agent-trace-state.ts
+++ b/packages/eve/src/tracing/agent-trace-state.ts
@@ -2,6 +2,7 @@ import type { SpanContext } from "#compiled/@opentelemetry/api/index.js";
 
 import type {
   InstrumentationActionKind,
+  InstrumentationParentLineage,
   InstrumentationTraceContext,
   InstrumentationTurnFailedEvent,
   InstrumentationTurnSettledEvent,
@@ -15,12 +16,14 @@ export interface AgentSessionTraceState {
   readonly channelKind?: string;
   readonly context: SpanContext;
   readonly decision?: InstrumentationDecision;
+  readonly parentLineage?: InstrumentationParentLineage;
   readonly rootSessionId: string;
 }
 
 export interface AgentTurnTraceState {
   readonly context: SpanContext;
   readonly modelUsage?: { readonly inputTokens?: number; readonly outputTokens?: number };
+  readonly parentLineage?: InstrumentationParentLineage;
   readonly parentIsRemote?: boolean;
   readonly parentSpanId: string;
   readonly rootSessionId: string;
@@ -36,6 +39,7 @@ export interface AgentActionTraceState {
   readonly attemptIndex: number;
   readonly callId: string;
   readonly channelAudience?: ChannelAudience;
+  readonly childTraceId?: string;
   readonly inputAttribute?: string;
   readonly kind: InstrumentationActionKind;
   readonly name: string;


### PR DESCRIPTION
### Summary

Defines the schema 4 trace contract for delegated eve sessions. Agent sessions can now root in an explicit child trace while linking the parent dispatch, `invoke_agent` spans distinguish caller and execution roles, and caller state accepts only validated nonzero child trace IDs.

This is the foundational tracing layer only. Local, remote, channel, and workflow-tool dispatch surfaces will adopt the preallocation and acknowledgement helpers in follow-up PRs.

### Validation

Focused unit coverage passed with 102 tests across the invocation protocol, trace seed allocation, durable state, and OTel provider. The full workspace typecheck passed all 44 tasks, and `pnpm guard:invariants` passed.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the required patch changeset for the published `eve` package.

**Implementation** — 11 files · `+371 / -16`

Defines strict trace coordinates, replay-stable child trace allocation, durable lineage and child acknowledgement state, and schema 4 session/caller/execution span emission.

**Tests** — 4 files · `+275 / -3`

Covers protocol validation, stable child coordinates, delegated root/link structure, role attributes, duplicate tool-span suppression, and confirmed child trace IDs.
