### PR TITLE
feat(eve): isolate local delegated traces

### DIFF
--- a/.changeset/trace-local-delegated-sessions.md
+++ b/.changeset/trace-local-delegated-sessions.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Give local delegated sessions replay-stable child traces and record only trace coordinates acknowledged by the child runtime.

--- a/packages/eve/src/channel/session-trace-state.ts
+++ b/packages/eve/src/channel/session-trace-state.ts
@@ -1,0 +1,15 @@
+import type { TraceCoordinates } from "#protocol/agent-invocation-trace.js";
+
+const acceptedTraceCoordinates = new WeakMap<object, TraceCoordinates>();
+
+export function attachAcceptedTraceCoordinates<T extends object>(
+  target: T,
+  trace: TraceCoordinates | undefined,
+): T {
+  if (trace !== undefined) acceptedTraceCoordinates.set(target, trace);
+  return target;
+}
+
+export function readAcceptedTraceCoordinates(target: object): TraceCoordinates | undefined {
+  return acceptedTraceCoordinates.get(target);
+}

--- a/packages/eve/src/execution/internal-run-input.ts
+++ b/packages/eve/src/execution/internal-run-input.ts
@@ -1,0 +1,9 @@
+import type { RunInput, SessionTraceContext } from "#channel/types.js";
+
+export interface InternalRunInput extends RunInput {
+  readonly traceSeed?: SessionTraceContext;
+}
+
+export function readInternalTraceSeed(input: RunInput): SessionTraceContext | undefined {
+  return (input as InternalRunInput).traceSeed;
+}

--- a/packages/eve/src/execution/route-child-delivery.test.ts
+++ b/packages/eve/src/execution/route-child-delivery.test.ts
@@ -187,6 +187,7 @@ describe("task HITL delivery routing", () => {
     vi.mocked(dispatchTaskAgentInvocationStep).mockResolvedValue({
       kind: "failed",
       result,
+      serializedContext: { source: "parent" },
       sessionState: nextState,
     });
 

--- a/packages/eve/src/execution/runtime-context.ts
+++ b/packages/eve/src/execution/runtime-context.ts
@@ -1,4 +1,4 @@
-import type { RunInput, SessionAuthContext } from "#channel/types.js";
+import type { SessionAuthContext } from "#channel/types.js";
 import { ContextContainer, contextStorage } from "#context/container.js";
 import { setChannelContext } from "#execution/channel-context.js";
 import {
@@ -16,9 +16,11 @@ import {
   ActivityObserverKey,
   ScheduleIdKey,
   SessionCallbackKey,
+  SessionTraceSeedKey,
 } from "#context/keys.js";
 import { BundleKey, type CompiledBundle } from "#runtime/sessions/runtime-context-keys.js";
 import type { DynamicSubagentAgentConfig } from "#runtime/subagents/dynamic-agent-config.js";
+import type { InternalRunInput } from "#execution/internal-run-input.js";
 
 /**
  * Builds the bootstrap {@link ContextContainer} for one run.
@@ -26,7 +28,7 @@ import type { DynamicSubagentAgentConfig } from "#runtime/subagents/dynamic-agen
 export function buildRunContext(input: {
   readonly bundle: CompiledBundle;
   readonly dynamicSubagentAgentConfig?: DynamicSubagentAgentConfig;
-  readonly run: RunInput;
+  readonly run: InternalRunInput;
 }): ContextContainer {
   const { bundle, run } = input;
   const ctx = new ContextContainer();
@@ -85,6 +87,9 @@ export function buildRunContext(input: {
 
   if (run.parentTraceContext !== undefined) {
     ctx.set(ParentTraceContextKey, run.parentTraceContext);
+  }
+  if (run.traceSeed !== undefined) {
+    ctx.set(SessionTraceSeedKey, run.traceSeed);
   }
 
   // `run.limits` deliberately never enters the context: inherited limits ride

--- a/packages/eve/src/execution/tools/subagent/invoke-step.test.ts
+++ b/packages/eve/src/execution/tools/subagent/invoke-step.test.ts
@@ -236,6 +236,72 @@ describe("owner agent invocation dispatch", () => {
       expect.arrayContaining([expect.objectContaining({ ownerId: "task-1", phase: "claimed" })]),
     );
   });
+
+  it("records only the child trace confirmed by the returned address", async () => {
+    const childTraceId = "4".repeat(32);
+    const serializedContext = {
+      "eve.harness.agentTrace": {
+        actions: {
+          action: {
+            attemptIndex: 0,
+            callId: "call-1",
+            kind: "subagent-call",
+            name: "research",
+            parent: {
+              spanId: "2".repeat(16),
+              traceFlags: 1,
+              traceId: "1".repeat(32),
+            },
+            rootSessionId: "parent",
+            sessionId: "parent",
+            spanId: "3".repeat(16),
+            startTimeMs: 1,
+            stepIndex: 2,
+            turnId: "turn-1",
+          },
+        },
+        sessions: {},
+        turns: {},
+      },
+    };
+    vi.mocked(prepareOwnerAgentInvocation).mockResolvedValue({
+      ...prepared,
+      plan: [
+        {
+          kind: "start",
+          target: { action, kind: "local", source: { type: "runtime" } },
+        },
+      ],
+      serializedContext,
+    } as never);
+    vi.mocked(startSubagent).mockResolvedValue({
+      ...called,
+      address: { ...called.address, traceId: childTraceId },
+    });
+
+    const dispatched = await dispatch();
+
+    expect(dispatched.kind).toBe("dispatched");
+    if (dispatched.kind !== "dispatched") throw new Error("Expected dispatch.");
+    expect(
+      (
+        dispatched.serializedContext["eve.harness.agentTrace"] as {
+          actions: Record<string, { childTraceId?: string }>;
+        }
+      ).actions.action,
+    ).toMatchObject({ childTraceId });
+    expect(
+      getAgentHandleStore(dispatched.sessionState.snapshot?.session.state)?.handles.find(
+        (handle) =>
+          "address" in handle &&
+          "traceId" in handle.address &&
+          handle.address.traceId === childTraceId,
+      ),
+    ).toMatchObject({
+      address: { traceId: childTraceId },
+      phase: "claimed",
+    });
+  });
 });
 
 describe("task-owned agent settlement", () => {

--- a/packages/eve/src/execution/tools/subagent/invoke-step.ts
+++ b/packages/eve/src/execution/tools/subagent/invoke-step.ts
@@ -50,17 +50,20 @@ import {
   getTurnUsageState,
   setTurnUsageState,
 } from "#harness/turn-tag-state.js";
+import { recordActionChildTraceId } from "#tracing/agent-trace-context-store.js";
 
 export type AgentInvocationDispatchResult =
   | {
       readonly kind: "dispatched";
       readonly agentId: string;
       readonly event: SubagentCalledStreamEvent;
+      readonly serializedContext: Record<string, unknown>;
       readonly sessionState: DurableSessionState;
     }
   | {
       readonly kind: "failed";
       readonly result: RuntimeSubagentResult;
+      readonly serializedContext: Record<string, unknown>;
       readonly sessionState: DurableSessionState;
     };
 
@@ -106,7 +109,12 @@ export async function dispatchAgentInvocation(input: {
     return applied.result;
   };
   if (entry.kind === "reject") {
-    return { kind: "failed", result: entry.result, sessionState: sessionState() };
+    return {
+      kind: "failed",
+      result: entry.result,
+      serializedContext: prepared.serializedContext,
+      sessionState: sessionState(),
+    };
   }
 
   let outcome: DispatchOutcome;
@@ -148,6 +156,7 @@ export async function dispatchAgentInvocation(input: {
         return {
           kind: "failed",
           result: createTaskClaimError(entry.action, entry.agentId, claim),
+          serializedContext: prepared.serializedContext,
           sessionState: sessionState(),
         };
       }
@@ -246,8 +255,23 @@ export async function dispatchAgentInvocation(input: {
   }
 
   if (outcome.kind === "error") {
-    return { kind: "failed", result: outcome.result, sessionState: sessionState() };
+    return {
+      kind: "failed",
+      result: outcome.result,
+      serializedContext: prepared.serializedContext,
+      sessionState: sessionState(),
+    };
   }
+  const serializedContext =
+    "traceId" in outcome.address && outcome.address.traceId
+      ? recordActionChildTraceId(
+          prepared.serializedContext,
+          prepared.session.sessionId,
+          prepared.batch.event.turnId,
+          outcome.callId,
+          outcome.address.traceId,
+        )
+      : prepared.serializedContext;
 
   const action = entry.kind === "resume" ? entry.action : entry.target.action;
   const dynamicRemoteAgent =
@@ -280,7 +304,13 @@ export async function dispatchAgentInvocation(input: {
   if (input.emit !== undefined) {
     await input.emit(event);
   }
-  return { kind: "dispatched", agentId, event, sessionState: sessionState() };
+  return {
+    kind: "dispatched",
+    agentId,
+    event,
+    serializedContext,
+    sessionState: sessionState(),
+  };
 }
 
 /**

--- a/packages/eve/src/execution/tools/subagent/start.ts
+++ b/packages/eve/src/execution/tools/subagent/start.ts
@@ -18,6 +18,7 @@ import { startLocalSubagent } from "#subagents/start-local.js";
 import { startRemoteSubagent } from "#subagents/start-remote.js";
 import { buildSubagentRunInput, type SubagentInputSource } from "#subagents/tool.js";
 import { readActionTraceContext } from "#tracing/agent-trace-context-store.js";
+import { allocateChildSessionTraceSeed } from "#tracing/agent-child-trace-seed.js";
 
 export type SubagentStartTarget =
   | {
@@ -77,6 +78,15 @@ export async function startSubagent(input: {
             forwardedTracePolicy,
           ),
         };
+  const traceSeed =
+    input.target.kind === "local"
+      ? allocateChildSessionTraceSeed({
+          callId: input.target.action.callId,
+          parentTraceContext,
+          sessionId: input.session.sessionId,
+          turnId: input.batchEvent.turnId,
+        })
+      : undefined;
 
   switch (input.target.kind) {
     case "local":
@@ -94,6 +104,7 @@ export async function startSubagent(input: {
         localDevRequest: input.localDevRequest,
         parentContinuationToken: input.parentContinuationToken,
         parentTraceContext,
+        traceSeed,
         activityObserver: input.activityObserver,
         sandboxSessionId: input.sandboxSessionId,
         session: input.session,

--- a/packages/eve/src/execution/tools/subagent/task-agent-requests.ts
+++ b/packages/eve/src/execution/tools/subagent/task-agent-requests.ts
@@ -61,7 +61,7 @@ export async function applyTaskAgentRequest(
           const emitted = await emitTaskSubagentCalledStep({
             event: dispatched.event,
             parentWritable: ctx.parentWritable,
-            serializedContext: ctx.serializedContext,
+            serializedContext: dispatched.serializedContext,
           });
           return {
             serializedContext: emitted.serializedContext,
@@ -74,7 +74,7 @@ export async function applyTaskAgentRequest(
             results: [dispatched.result],
           });
           return {
-            serializedContext: ctx.serializedContext,
+            serializedContext: dispatched.serializedContext,
             sessionState: dispatched.sessionState,
           };
         case "not-admitted":

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -21,6 +21,8 @@ import type {
   SessionCommand,
   SessionCommandResult,
 } from "#channel/types.js";
+import { readInternalTraceSeed, type InternalRunInput } from "#execution/internal-run-input.js";
+import { attachAcceptedTraceCoordinates } from "#channel/session-trace-state.js";
 import { ActivityObserverKey } from "#context/keys.js";
 import { serializeContext } from "#context/serialize.js";
 import {
@@ -139,6 +141,7 @@ export function createWorkflowRuntime(config: {
 }): Runtime {
   return {
     async createSession(input: RunInput): Promise<RunHandle> {
+      const internalInput = input as InternalRunInput;
       const bundle = await getCompiledRuntimeAgentBundle({
         compiledArtifactsSource: config.compiledArtifactsSource,
         nodeId: config.nodeId,
@@ -146,13 +149,14 @@ export function createWorkflowRuntime(config: {
       const ctx = buildRunContext({
         bundle,
         dynamicSubagentAgentConfig: config.dynamicSubagentAgentConfig,
-        run: input,
+        run: internalInput,
       });
       const effectiveAgent = resolveEffectiveAgentRuntime(bundle, ctx);
       initializeSessionInstrumentation({
         agentName: effectiveAgent.turnAgent.id,
         ctx,
         parentTraceContext: input.parentTraceContext,
+        traceSeed: readInternalTraceSeed(input),
       });
       const sessionTimeoutMs = effectiveAgent.limits?.sessionTimeoutMs;
       let collectorRunId: string | undefined;
@@ -261,12 +265,15 @@ export function createWorkflowRuntime(config: {
         return events;
       };
 
-      return {
-        get events() {
-          return getEvents();
+      return attachAcceptedTraceCoordinates(
+        {
+          get events() {
+            return getEvents();
+          },
+          sessionId: run.runId,
         },
-        sessionId: run.runId,
-      };
+        internalInput.traceSeed,
+      );
     },
 
     async dispatchContinuation<TCommand extends SessionCommand>(

--- a/packages/eve/src/instrumentation/runtime.test.ts
+++ b/packages/eve/src/instrumentation/runtime.test.ts
@@ -799,4 +799,39 @@ describe("initializeSessionInstrumentation", () => {
     expect(first?.traceId).not.toBe(parentTraceContext.traceId);
     expect(sibling?.traceId).not.toBe(first?.traceId);
   });
+
+  it("evaluates a preallocated child trace with the child policy and sampler", () => {
+    const tracePolicy = vi.fn(() => ({
+      emit: true,
+      recordInputs: false,
+      recordOutputs: true,
+    }));
+    const samplesTrace = vi.fn(() => true);
+    registerSeedRuntime({ samplesTrace, tracePolicy });
+    const ctx = createContext();
+    const traceSeed = {
+      spanId: "4".repeat(16),
+      traceFlags: 0,
+      traceId: "3".repeat(32),
+    };
+
+    initializeSessionInstrumentation({
+      agentName: "child-agent",
+      ctx,
+      traceSeed,
+    });
+
+    expect(ctx.get(SessionTraceSeedKey)).toEqual({
+      ...traceSeed,
+      decision: {
+        action: "record",
+        recordInputs: false,
+        recordOutputs: true,
+      },
+      forwardedTracePolicy: undefined,
+      traceFlags: 1,
+    });
+    expect(tracePolicy).toHaveBeenCalledOnce();
+    expect(samplesTrace).toHaveBeenCalledExactlyOnceWith(traceSeed.traceId);
+  });
 });

--- a/packages/eve/src/instrumentation/runtime.ts
+++ b/packages/eve/src/instrumentation/runtime.ts
@@ -63,18 +63,14 @@ import {
 import { resolveParentLineage } from "#instrumentation/parent-lineage.js";
 import type { ChannelInstrumentationProjection, SessionTraceContext } from "#channel/types.js";
 import { readSessionTraceDecision } from "#tracing/agent-trace-context-store.js";
-import {
-  intersectInstrumentationDecisions,
-  readInstrumentationDecision,
-} from "#shared/instrumentation-decision.js";
+import { readInstrumentationDecision } from "#shared/instrumentation-decision.js";
 import {
   applyLiveDeliveryAudienceCeiling,
-  type ForwardedTraceAssertion,
   formatTraceContentCeiling,
   readForwardedTraceAssertion,
   resolveForwardedTraceSeed,
-  traceContentCeilingToDecision,
 } from "#shared/forwarded-trace-policy.js";
+import { resolveInitialSessionTraceSeed } from "#instrumentation/session-trace-seed.js";
 
 const INSTRUMENTATION_RUNTIME_KEY = Symbol.for("eve.instrumentation-runtime");
 const TURN_TRACE_STATE_KEY = "eve.harness.turnTrace";
@@ -525,6 +521,7 @@ export function initializeSessionInstrumentation(input: {
   readonly agentName: string;
   readonly ctx: ContextContainer;
   readonly parentTraceContext?: SessionTraceContext;
+  readonly traceSeed?: SessionTraceSeed;
 }): void {
   const runtime = getInstrumentationRuntime();
   const channel = input.ctx.get(ChannelInstrumentationKey);
@@ -533,13 +530,14 @@ export function initializeSessionInstrumentation(input: {
   );
   const audience =
     forwardedTracePolicy?.originAudience ?? normalizeChannelAudience(channel?.metadata.audience);
-  const traceSeed = allocateSessionTraceSeed({
+  const traceSeed = resolveInitialSessionTraceSeed({
     agentName: input.agentName,
     audience,
     channelType: channel?.channelType,
     forwardedTracePolicy,
     parentTraceContext: input.parentTraceContext,
     runtime,
+    seed: input.traceSeed,
   });
   if (traceSeed !== undefined) {
     input.ctx.set(SessionTraceSeedKey, traceSeed);
@@ -560,63 +558,6 @@ export function initializeSessionInstrumentation(input: {
     }
   }
   input.ctx.set(OtelTraceEnabledKey, runtime?.prepareSessionTrace !== undefined);
-}
-
-function allocateSessionTraceSeed(input: {
-  readonly agentName: string;
-  readonly audience: ReturnType<typeof normalizeChannelAudience>;
-  readonly channelType?: string;
-  readonly forwardedTracePolicy: ForwardedTraceAssertion | undefined;
-  readonly parentTraceContext?: SessionTraceContext;
-  readonly runtime: InstrumentationRuntime | undefined;
-}): SessionTraceSeed | undefined {
-  if (input.parentTraceContext !== undefined) {
-    const forwardedCeiling = input.forwardedTracePolicy
-      ? traceContentCeilingToDecision(input.forwardedTracePolicy.ceiling)
-      : undefined;
-    const inheritedDecision = readInstrumentationDecision(input.parentTraceContext.decision);
-    const parentDecision = forwardedCeiling
-      ? inheritedDecision === undefined
-        ? forwardedCeiling
-        : intersectInstrumentationDecisions(forwardedCeiling, inheritedDecision)
-      : (inheritedDecision ??
-        resolveTracePolicyDecision(isSampledTrace(input.parentTraceContext), input.audience));
-    const decision = input.forwardedTracePolicy
-      ? intersectInstrumentationDecisions(
-          parentDecision,
-          resolveTracePolicy(input.runtime?.otelSettings?.tracePolicy, {
-            agentName: input.agentName,
-            audience: input.audience,
-            channelType: input.channelType,
-          }),
-        )
-      : parentDecision;
-    return {
-      decision,
-      forwardedTracePolicy: input.forwardedTracePolicy,
-      spanId: input.parentTraceContext.spanId,
-      traceFlags:
-        input.forwardedTracePolicy !== undefined && decision.action === "drop"
-          ? input.parentTraceContext.traceFlags & ~1
-          : input.parentTraceContext.traceFlags,
-      traceId: input.parentTraceContext.traceId,
-    };
-  }
-  if (input.runtime?.prepareSessionTrace === undefined) return undefined;
-  if (input.runtime.idGenerator === undefined) return undefined;
-  const decision = resolveTracePolicy(input.runtime.otelSettings?.tracePolicy, {
-    agentName: input.agentName,
-    audience: input.audience,
-    channelType: input.channelType,
-  });
-  const traceId = input.runtime.idGenerator.generateTraceId();
-  const sampled = decision.action === "record" && (input.runtime.samplesTrace?.(traceId) ?? true);
-  return {
-    decision,
-    spanId: input.runtime.idGenerator.allocateSpanId(),
-    traceFlags: sampled ? 1 : 0,
-    traceId,
-  };
 }
 
 function resolveStepInstrumentationDecision(

--- a/packages/eve/src/instrumentation/session-trace-seed.ts
+++ b/packages/eve/src/instrumentation/session-trace-seed.ts
@@ -1,0 +1,112 @@
+import type { SessionTraceContext } from "#channel/types.js";
+import type { SessionTraceSeed } from "#context/keys.js";
+import type { InstrumentationRuntime } from "#instrumentation/runtime.js";
+import { normalizeChannelAudience } from "#shared/channel-audience.js";
+import {
+  intersectInstrumentationDecisions,
+  readInstrumentationDecision,
+} from "#shared/instrumentation-decision.js";
+import {
+  type ForwardedTraceAssertion,
+  traceContentCeilingToDecision,
+} from "#shared/forwarded-trace-policy.js";
+import {
+  isSampledTrace,
+  resolveTracePolicy,
+  resolveTracePolicyDecision,
+} from "#tracing/sampled-trace.js";
+
+export function resolveInitialSessionTraceSeed(input: {
+  readonly agentName: string;
+  readonly audience: ReturnType<typeof normalizeChannelAudience>;
+  readonly channelType?: string;
+  readonly forwardedTracePolicy: ForwardedTraceAssertion | undefined;
+  readonly parentTraceContext?: SessionTraceContext;
+  readonly runtime: InstrumentationRuntime | undefined;
+  readonly seed?: SessionTraceSeed;
+}): SessionTraceSeed | undefined {
+  return input.seed === undefined
+    ? allocateSessionTraceSeed(input)
+    : evaluatePreallocatedSessionTraceSeed({ ...input, seed: input.seed });
+}
+
+function evaluatePreallocatedSessionTraceSeed(
+  input: Parameters<typeof resolveInitialSessionTraceSeed>[0] & {
+    readonly seed: SessionTraceSeed;
+  },
+): SessionTraceSeed {
+  const localDecision = resolveTracePolicy(input.runtime?.otelSettings?.tracePolicy, {
+    agentName: input.agentName,
+    audience: input.audience,
+    channelType: input.channelType,
+  });
+  const decision =
+    input.forwardedTracePolicy === undefined
+      ? localDecision
+      : intersectInstrumentationDecisions(
+          localDecision,
+          traceContentCeilingToDecision(input.forwardedTracePolicy.ceiling),
+        );
+  const sampled =
+    decision.action === "record" && (input.runtime?.samplesTrace?.(input.seed.traceId) ?? true);
+  return {
+    decision,
+    forwardedTracePolicy: input.forwardedTracePolicy,
+    spanId: input.seed.spanId,
+    traceFlags: sampled ? input.seed.traceFlags | 1 : input.seed.traceFlags & ~1,
+    traceId: input.seed.traceId,
+  };
+}
+
+function allocateSessionTraceSeed(
+  input: Parameters<typeof resolveInitialSessionTraceSeed>[0],
+): SessionTraceSeed | undefined {
+  if (input.parentTraceContext !== undefined) {
+    const forwardedCeiling = input.forwardedTracePolicy
+      ? traceContentCeilingToDecision(input.forwardedTracePolicy.ceiling)
+      : undefined;
+    const inheritedDecision = readInstrumentationDecision(input.parentTraceContext.decision);
+    const parentDecision = forwardedCeiling
+      ? inheritedDecision === undefined
+        ? forwardedCeiling
+        : intersectInstrumentationDecisions(forwardedCeiling, inheritedDecision)
+      : (inheritedDecision ??
+        resolveTracePolicyDecision(isSampledTrace(input.parentTraceContext), input.audience));
+    const decision = input.forwardedTracePolicy
+      ? intersectInstrumentationDecisions(
+          parentDecision,
+          resolveTracePolicy(input.runtime?.otelSettings?.tracePolicy, {
+            agentName: input.agentName,
+            audience: input.audience,
+            channelType: input.channelType,
+          }),
+        )
+      : parentDecision;
+    return {
+      decision,
+      forwardedTracePolicy: input.forwardedTracePolicy,
+      spanId: input.parentTraceContext.spanId,
+      traceFlags:
+        input.forwardedTracePolicy !== undefined && decision.action === "drop"
+          ? input.parentTraceContext.traceFlags & ~1
+          : input.parentTraceContext.traceFlags,
+      traceId: input.parentTraceContext.traceId,
+    };
+  }
+  if (input.runtime?.prepareSessionTrace === undefined || input.runtime.idGenerator === undefined) {
+    return undefined;
+  }
+  const decision = resolveTracePolicy(input.runtime.otelSettings?.tracePolicy, {
+    agentName: input.agentName,
+    audience: input.audience,
+    channelType: input.channelType,
+  });
+  const traceId = input.runtime.idGenerator.generateTraceId();
+  const sampled = decision.action === "record" && (input.runtime.samplesTrace?.(traceId) ?? true);
+  return {
+    decision,
+    spanId: input.runtime.idGenerator.allocateSpanId(),
+    traceFlags: sampled ? 1 : 0,
+    traceId,
+  };
+}

--- a/packages/eve/src/subagents/handles/store.ts
+++ b/packages/eve/src/subagents/handles/store.ts
@@ -78,11 +78,13 @@ export type AgentAddress =
       readonly kind: "agent/local";
       readonly sessionId: string;
       readonly continuationToken: string;
+      readonly traceId?: string;
     }
   | {
       readonly kind: "agent/self";
       readonly sessionId: string;
       readonly continuationToken: string;
+      readonly traceId?: string;
     }
   | {
       readonly kind: "agent/remote";
@@ -245,11 +247,19 @@ const addressSchema: z.ZodType<AgentAddress> = z.discriminatedUnion("kind", [
     continuationToken: nonEmptyString,
     kind: z.literal("agent/local"),
     sessionId: nonEmptyString,
+    traceId: z
+      .string()
+      .regex(/^[0-9a-f]{32}$/u)
+      .optional(),
   }),
   z.strictObject({
     continuationToken: nonEmptyString,
     kind: z.literal("agent/self"),
     sessionId: nonEmptyString,
+    traceId: z
+      .string()
+      .regex(/^[0-9a-f]{32}$/u)
+      .optional(),
   }),
   z.strictObject({
     callbackBaseUrl: z.url(),

--- a/packages/eve/src/subagents/start-local.ts
+++ b/packages/eve/src/subagents/start-local.ts
@@ -8,6 +8,7 @@ import { createLogger, logError } from "#internal/logging.js";
 import type { RuntimeSubagentDispatchRequest } from "#shared/action-types.js";
 import type { CompiledBundle } from "#runtime/sessions/runtime-context-keys.js";
 import { toErrorMessage } from "#shared/errors.js";
+import { readAcceptedTraceCoordinates } from "#channel/session-trace-state.js";
 
 const log = createLogger("execution.subagent-start-local");
 
@@ -30,6 +31,7 @@ export async function startLocalSubagent(input: {
   readonly localDevRequest?: LocalDevRequestProvenance;
   readonly parentContinuationToken: string | undefined;
   readonly parentTraceContext: Parameters<typeof buildSubagentRunInput>[0]["parentTraceContext"];
+  readonly traceSeed: Parameters<typeof buildSubagentRunInput>[0]["traceSeed"];
   readonly activityObserver?: Parameters<typeof buildSubagentRunInput>[0]["activityObserver"];
   readonly sandboxSessionId: string;
   readonly session: RuntimeSession;
@@ -53,6 +55,7 @@ export async function startLocalSubagent(input: {
     graph: input.bundle.graph,
     parentContinuationToken: input.parentContinuationToken,
     parentTraceContext: input.parentTraceContext,
+    traceSeed: input.traceSeed,
     activityObserver: input.activityObserver,
     sandboxSessionId: input.sandboxSessionId,
     session: input.session,
@@ -63,11 +66,15 @@ export async function startLocalSubagent(input: {
 
   const targetKind = source.type === "runtime" ? ("agent/self" as const) : ("agent/local" as const);
   let childSessionId: string;
+  let confirmedTraceId: string | undefined;
   try {
-    await contextStorage.run(new ContextContainer({ localDevRequest: input.localDevRequest }), () =>
-      childRuntime.createSession(runInput),
+    const created = await contextStorage.run(
+      new ContextContainer({ localDevRequest: input.localDevRequest }),
+      () => childRuntime.createSession(runInput),
     );
+    confirmedTraceId = readAcceptedTraceCoordinates(created)?.traceId;
     childSessionId = (await waitForCommandHookOwner(childContinuationToken)).runId;
+    if (created.sessionId !== childSessionId) confirmedTraceId = undefined;
   } catch (error) {
     logError(log, "local subagent start failed", error, {
       callId: action.callId,
@@ -91,11 +98,17 @@ export async function startLocalSubagent(input: {
     };
   }
 
-  const address = {
+  const address: {
+    continuationToken: string;
+    kind: typeof targetKind;
+    sessionId: string;
+    traceId?: string;
+  } = {
     continuationToken: childContinuationToken,
     kind: targetKind,
     sessionId: childSessionId,
-  } as const;
+  };
+  if (confirmedTraceId !== undefined) address.traceId = confirmedTraceId;
   return {
     address,
     callId: action.callId,

--- a/packages/eve/src/subagents/tool.test.ts
+++ b/packages/eve/src/subagents/tool.test.ts
@@ -300,6 +300,31 @@ describe("buildSubagentRunInput", () => {
     expect(untraced.runInput.parentTraceContext).toBeUndefined();
   });
 
+  it("carries a preallocated child trace separately from the parent context", () => {
+    const parentTraceContext = {
+      spanId: "2".repeat(16),
+      traceFlags: 1,
+      traceId: "1".repeat(32),
+    };
+    const traceSeed = {
+      spanId: "4".repeat(16),
+      traceFlags: 0,
+      traceId: "3".repeat(32),
+    };
+    const { runInput } = buildRuntimeSubagentRunInput({
+      action: makeAction(),
+      auth: null,
+      batchEvent: { sequence: 0, turnId: "turn-0" },
+      initiatorAuth: null,
+      parentTraceContext,
+      session: makeSession(),
+      traceSeed,
+    });
+
+    expect(runInput.parentTraceContext).toEqual(parentTraceContext);
+    expect(runInput.traceSeed).toEqual(traceSeed);
+  });
+
   it("passes a resolved local subagent description into the child message", () => {
     const { runInput } = buildSubagentRunInput({
       action: {

--- a/packages/eve/src/subagents/tool.ts
+++ b/packages/eve/src/subagents/tool.ts
@@ -3,7 +3,6 @@ import { formatSubagentInput, normalizeRequestedOutputSchema } from "#subagents/
 import type {
   ActivityObserverConfig,
   ChannelInstrumentationProjection,
-  RunInput,
   RunSessionLimits,
   SessionAuthContext,
   SessionCapabilities,
@@ -14,6 +13,7 @@ import type { RuntimeSubagentDispatchRequest } from "#shared/action-types.js";
 import { mintSubagentContinuationToken } from "#execution/session.js";
 import { resolveRemainingSessionTokenLimits } from "#subagents/token-budget.js";
 import type { JsonObject } from "#shared/json.js";
+import type { InternalRunInput } from "#execution/internal-run-input.js";
 
 /**
  * Pending task batch event metadata needed for child run lineage.
@@ -43,7 +43,7 @@ export type SubagentInputSource =
  */
 export interface SubagentRunInputBuild {
   readonly childContinuationToken: string;
-  readonly runInput: RunInput;
+  readonly runInput: InternalRunInput;
 }
 
 /**
@@ -96,6 +96,7 @@ export function buildSubagentRunInput(input: {
   /** Hook token owned by the workflow currently waiting for this child. */
   readonly parentContinuationToken?: string;
   readonly parentTraceContext?: SessionTraceContext;
+  readonly traceSeed?: SessionTraceContext;
   readonly activityObserver?: ActivityObserverConfig;
   readonly session: HarnessSession;
   readonly source: SubagentInputSource;
@@ -147,7 +148,7 @@ export function buildSubagentRunInput(input: {
   }
 
   const runInput: {
-    -readonly [K in keyof RunInput]: RunInput[K];
+    -readonly [K in keyof InternalRunInput]: InternalRunInput[K];
   } = {
     adapter: {
       kind: SUBAGENT_ADAPTER_KIND,
@@ -177,6 +178,7 @@ export function buildSubagentRunInput(input: {
       },
     },
     parentTraceContext: input.parentTraceContext,
+    traceSeed: input.traceSeed,
     activityObserver: input.activityObserver,
   };
   if (input.taskId !== undefined) runInput.taskId = input.taskId;


### PR DESCRIPTION
### Summary

Gives local delegated sessions replay-stable child traces before dispatch and records a child trace on the parent caller only after the local runtime acknowledges the same coordinates. The child evaluates its own trace policy and sampler while retaining a separate parent link context.

This is the local dispatch layer. Remote and channel transport of the strict trace extension remains in the next stacked PR.

Depends on #2957.

### Validation

Focused local dispatch coverage passed with 78 tests. The full workspace typecheck passed all 44 tasks, the `eve` package typecheck passed, and `pnpm guard:invariants` passed.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the required patch changeset.

**Implementation** — 12 files · `+239 / -84`

Moves session seed evaluation into a dedicated helper, threads internal child seeds through local workflow creation, stores confirmed local trace IDs on handles, and persists acknowledged coordinates on caller state.

**Tests** — 4 files · `+127 / -0`

Covers child policy evaluation, trace-seed propagation, local acknowledgement, handle persistence, and context flow.
