### PR TITLE
feat(eve): transport remote delegated traces

### DIFF
--- a/.changeset/trace-remote-delegated-sessions.md
+++ b/.changeset/trace-remote-delegated-sessions.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Carry delegated trace coordinates across remote eve session creation and acknowledge only exact child traces accepted by the receiver.

--- a/packages/eve/src/channel/channel-address.ts
+++ b/packages/eve/src/channel/channel-address.ts
@@ -9,6 +9,7 @@ import {
 import type { SendPayload } from "#channel/routes.js";
 import { normalizeSendInput, serializeUrlFilePartsInMessage } from "#channel/send-input.js";
 import { createSession, sessionCallbackToTurnCaller, type Session } from "#channel/session.js";
+import { copyAcceptedTraceCoordinates } from "#channel/session-trace-state.js";
 import type {
   CancelTurnResult,
   ClearSessionResult,
@@ -198,12 +199,14 @@ export function createChannelAddress<TState = undefined>(input: {
     },
     async resolveSession() {
       const owner = await input.runtime.resolveContinuation(namespacedToken);
-      return owner === undefined
-        ? undefined
-        : createSession(owner.sessionId, input.runtime, {
-            ...metadata,
-            turnPolicy: input.turnPolicy,
-          });
+      if (owner === undefined) return undefined;
+      return copyAcceptedTraceCoordinates(
+        owner,
+        createSession(owner.sessionId, input.runtime, {
+          ...metadata,
+          turnPolicy: input.turnPolicy,
+        }),
+      );
     },
   };
 }

--- a/packages/eve/src/channel/session-trace-state.ts
+++ b/packages/eve/src/channel/session-trace-state.ts
@@ -13,3 +13,7 @@ export function attachAcceptedTraceCoordinates<T extends object>(
 export function readAcceptedTraceCoordinates(target: object): TraceCoordinates | undefined {
   return acceptedTraceCoordinates.get(target);
 }
+
+export function copyAcceptedTraceCoordinates<T extends object>(source: object, target: T): T {
+  return attachAcceptedTraceCoordinates(target, acceptedTraceCoordinates.get(source));
+}

--- a/packages/eve/src/eve-channel/index.ts
+++ b/packages/eve/src/eve-channel/index.ts
@@ -1,5 +1,6 @@
 import type { SessionAuthContext, SessionTraceContext } from "#channel/types.js";
 import type { Session } from "#channel/session.js";
+import { readAcceptedTraceCoordinates } from "#channel/session-trace-state.js";
 import { resolveForwardedPrincipal } from "#channel/forwarded-principal.js";
 import {
   handleConnectionCallbackRequest,
@@ -54,6 +55,11 @@ import {
   FAIL_CLOSED_FORWARDED_TRACE_ASSERTION,
   formatTraceContentCeiling,
 } from "#shared/forwarded-trace-policy.js";
+import {
+  traceCoordinatesEqual,
+  type TraceCoordinates,
+  validateAgentInvocationBinding,
+} from "#protocol/agent-invocation-trace.js";
 import { routeAuth } from "#public/channels/auth.js";
 import { mergeUploadPolicy } from "#public/channels/upload-policy.js";
 import { defineChannel, DELETE, GET, HEAD, PATCH, POST, PUT } from "#public/definitions/channel.js";
@@ -84,6 +90,23 @@ import type { EveChannel, EveChannelInput, EveEventContext } from "#eve-channel/
 export * from "#eve-channel/types.js";
 
 const log = createLogger("eve.channel");
+
+function acceptedSessionResponse(sessionId: string, traceContext?: TraceCoordinates): Response {
+  const body: {
+    ok: true;
+    sessionId: string;
+    status: "accepted";
+    trace?: TraceCoordinates;
+  } = { ok: true, sessionId, status: "accepted" };
+  if (traceContext !== undefined) body.trace = traceContext;
+  return Response.json(body, {
+    headers: {
+      "cache-control": "no-store",
+      [EVE_SESSION_ID_HEADER]: sessionId,
+    },
+    status: 202,
+  });
+}
 
 /**
  * Builds the default eve HTTP channel: a {@link defineChannel} instance serving the
@@ -150,12 +173,45 @@ export function eveChannel(input: EveChannelInput): EveChannel {
 
         const body = parseCreateBody(payload);
         if (body instanceof Response) return body;
-        // Top-level sessions own their trace. Callback sessions are delegated
-        // remote agents and intentionally continue the dispatching agent trace.
-        const parsedParentTraceContext =
+        const legacyParentTraceContext =
           body.callback === undefined
             ? undefined
             : parseTraceparent(req.headers.get("traceparent"));
+        const invocationBindingError = validateAgentInvocationBinding({
+          callbackCallId: body.callback?.callId,
+          invocation: body.invocation,
+          trace: body.trace,
+          traceparent: legacyParentTraceContext,
+        });
+        if (invocationBindingError === "call-id-mismatch") {
+          return Response.json(
+            {
+              error: "Invocation callId does not match callback callId.",
+              ok: false,
+            },
+            { status: 400 },
+          );
+        }
+        if (invocationBindingError === "trace-context-mismatch") {
+          return Response.json(
+            {
+              error: "Invocation trace context does not match traceparent.",
+              ok: false,
+            },
+            { status: 400 },
+          );
+        }
+        const parsedParentTraceContext: SessionTraceContext | undefined =
+          body.trace?.parent === undefined
+            ? body.trace === undefined
+              ? legacyParentTraceContext
+              : undefined
+            : {
+                isRemote: true,
+                spanId: body.trace.parent.spanId,
+                traceFlags: body.trace.parent.traceFlags,
+                traceId: body.trace.parent.traceId,
+              };
 
         const policyRejection = checkUploadPolicy(body, uploadPolicy);
         if (policyRejection !== null) return policyRejection;
@@ -176,16 +232,14 @@ export function eveChannel(input: EveChannelInput): EveChannel {
         if (operationToken !== undefined) {
           const owner = await args.resolveSession(operationToken);
           if (owner !== undefined) {
-            return Response.json(
-              { ok: true, sessionId: owner.id, status: "accepted" },
-              {
-                headers: {
-                  "cache-control": "no-store",
-                  [EVE_SESSION_ID_HEADER]: owner.id,
-                },
-                status: 202,
-              },
-            );
+            const acceptedTraceCoordinates = readAcceptedTraceCoordinates(owner);
+            const replayedTraceCoordinates =
+              body.trace !== undefined &&
+              acceptedTraceCoordinates !== undefined &&
+              traceCoordinatesEqual(body.trace.seed, acceptedTraceCoordinates)
+                ? acceptedTraceCoordinates
+                : undefined;
+            return acceptedSessionResponse(owner.id, replayedTraceCoordinates);
           }
         }
 
@@ -197,13 +251,16 @@ export function eveChannel(input: EveChannelInput): EveChannel {
           forwarded.accepted &&
           parsedParentTraceContext !== undefined &&
           (parsedParentTraceContext.traceFlags & 1) === 1;
-        const acceptedForwardedTracePolicy = !acceptsForwardedTracePolicy
-          ? undefined
-          : typeof forwardedTraceAssertion === "object"
-            ? forwardedTraceAssertion
-            : forwardedTraceAssertion === "malformed"
-              ? FAIL_CLOSED_FORWARDED_TRACE_ASSERTION
-              : undefined;
+        const acceptedForwardedTracePolicy =
+          forwarded.accepted && body.trace?.forwardedTracePolicy !== undefined
+            ? body.trace.forwardedTracePolicy
+            : !acceptsForwardedTracePolicy
+              ? undefined
+              : typeof forwardedTraceAssertion === "object"
+                ? forwardedTraceAssertion
+                : forwardedTraceAssertion === "malformed"
+                  ? FAIL_CLOSED_FORWARDED_TRACE_ASSERTION
+                  : undefined;
         let parentTraceContext: SessionTraceContext | undefined = parsedParentTraceContext;
         if (acceptedForwardedTracePolicy !== undefined && parsedParentTraceContext !== undefined) {
           parentTraceContext = {
@@ -246,7 +303,11 @@ export function eveChannel(input: EveChannelInput): EveChannel {
 
         let handle: Awaited<ReturnType<typeof createSession>>;
         try {
-          handle = await createSession({
+          const createInput: {
+            -readonly [K in keyof Parameters<typeof createSession>[0]]: Parameters<
+              typeof createSession
+            >[0][K];
+          } = {
             activityObserver: body.activityObserver,
             auth: messageResult.auth,
             capabilities:
@@ -263,9 +324,21 @@ export function eveChannel(input: EveChannelInput): EveChannel {
               body.context,
             ),
             mode: body.mode ?? "conversation",
+            parent: body.invocation,
             parentTraceContext,
             title: messageResult.title,
-          });
+          };
+          if (body.trace !== undefined) {
+            createInput.acceptedTraceCoordinates = body.trace.seed;
+            createInput.traceSeed =
+              acceptedForwardedTracePolicy === undefined
+                ? body.trace.seed
+                : {
+                    ...body.trace.seed,
+                    forwardedTracePolicy: acceptedForwardedTracePolicy,
+                  };
+          }
+          handle = await createSession(createInput);
         } catch (error) {
           const errorId = logError(log, "session-create request failed", error);
           return Response.json(
@@ -274,16 +347,7 @@ export function eveChannel(input: EveChannelInput): EveChannel {
           );
         }
 
-        return Response.json(
-          { ok: true, sessionId: handle.sessionId, status: "accepted" },
-          {
-            headers: {
-              "cache-control": "no-store",
-              [EVE_SESSION_ID_HEADER]: handle.sessionId,
-            },
-            status: 202,
-          },
-        );
+        return acceptedSessionResponse(handle.sessionId, readAcceptedTraceCoordinates(handle));
       }),
 
       POST(EVE_SESSION_ROUTE_PATTERN, async (req, { attachSession, params }) => {

--- a/packages/eve/src/eve-channel/request.ts
+++ b/packages/eve/src/eve-channel/request.ts
@@ -5,8 +5,14 @@ import type {
   SessionAuthContext,
   SessionCallback,
   SessionCapabilities,
+  SessionParent,
   TurnPolicy,
 } from "#channel/types.js";
+import {
+  agentInvocationTraceSchema,
+  type AgentInvocationTrace,
+  sessionParentSchema,
+} from "#protocol/agent-invocation-trace.js";
 import type { Session } from "#channel/session.js";
 import { parseSessionCallback } from "#channel/session-callback.js";
 import {
@@ -41,6 +47,8 @@ interface ParsedCreateBody {
   context?: readonly string[];
   operationId?: string;
   outputSchema?: JsonObject;
+  invocation?: SessionParent;
+  trace?: AgentInvocationTrace;
 }
 
 /** Replay-stable identity for one authenticated create operation. */
@@ -94,6 +102,10 @@ export function parseCreateBody(payload: Record<string, unknown>): ParsedCreateB
 
   const outputSchema = parseOutputSchemaField(payload.outputSchema);
   if (outputSchema instanceof Response) return outputSchema;
+  const invocation = parseInvocationField(payload.invocation);
+  if (invocation instanceof Response) return invocation;
+  const trace = parseInvocationTraceField(payload.trace);
+  if (trace instanceof Response) return trace;
 
   if (message === undefined) {
     return Response.json(
@@ -116,11 +128,29 @@ export function parseCreateBody(payload: Record<string, unknown>): ParsedCreateB
     capabilities,
     message,
     mode,
+    invocation,
     context,
     outputSchema,
+    trace,
   };
   if (typeof rawOperationId === "string") result.operationId = rawOperationId;
   return result;
+}
+
+function parseInvocationTraceField(value: unknown): ParsedCreateBody["trace"] | Response {
+  if (value === undefined) return undefined;
+  const parsed = agentInvocationTraceSchema.safeParse(value);
+  return parsed.success ? parsed.data : invalidCreateField("trace");
+}
+
+function parseInvocationField(value: unknown): SessionParent | undefined | Response {
+  if (value === undefined) return undefined;
+  const parsed = sessionParentSchema.safeParse(value);
+  return parsed.success ? parsed.data : invalidCreateField("invocation");
+}
+
+function invalidCreateField(field: string): Response {
+  return Response.json({ error: `Expected a valid '${field}' field.`, ok: false }, { status: 400 });
 }
 
 interface ParsedSessionMessageBody {

--- a/packages/eve/src/execution/internal-run-input.ts
+++ b/packages/eve/src/execution/internal-run-input.ts
@@ -1,6 +1,8 @@
 import type { RunInput, SessionTraceContext } from "#channel/types.js";
+import type { TraceCoordinates } from "#protocol/agent-invocation-trace.js";
 
 export interface InternalRunInput extends RunInput {
+  readonly acceptedTraceCoordinates?: TraceCoordinates;
   readonly traceSeed?: SessionTraceContext;
 }
 

--- a/packages/eve/src/execution/remote-agent-create-request.ts
+++ b/packages/eve/src/execution/remote-agent-create-request.ts
@@ -1,0 +1,64 @@
+import type { ForwardedPrincipal } from "#channel/forwarded-principal.js";
+import type { SessionParent } from "#channel/types.js";
+import {
+  createSessionAcceptedResponseSchema,
+  traceCoordinatesEqual,
+  type AgentInvocationTrace,
+} from "#protocol/agent-invocation-trace.js";
+
+export interface RemoteAgentCreateRequestBody {
+  readonly forwardedPrincipal?: ForwardedPrincipal;
+  readonly invocation?: SessionParent;
+  readonly trace?: AgentInvocationTrace;
+  readonly [key: string]: unknown;
+}
+
+export async function sendRemoteAgentCreateRequest(input: {
+  readonly body: RemoteAgentCreateRequestBody;
+  readonly headers: Record<string, string>;
+  readonly remoteAgentName: string;
+  readonly url: string;
+}): Promise<{ readonly sessionId: string; readonly traceId?: string }> {
+  const send = (body: RemoteAgentCreateRequestBody) =>
+    fetch(input.url, {
+      body: JSON.stringify(body),
+      headers: { "content-type": "application/json", ...input.headers },
+      method: "POST",
+    });
+  const sentExtension = input.body.invocation !== undefined || input.body.trace !== undefined;
+  let proposedSeed = input.body.trace?.seed;
+  let response = await send(input.body);
+  if (response.status === 400 && sentExtension) {
+    const legacyBody = { ...input.body };
+    delete legacyBody.invocation;
+    delete legacyBody.trace;
+    proposedSeed = undefined;
+    response = await send(legacyBody);
+  }
+  if (!response.ok) {
+    throw new Error(
+      `Remote agent "${input.remoteAgentName}" create-session request failed with HTTP ${response.status}.`,
+    );
+  }
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    throw new Error(
+      `Remote agent "${input.remoteAgentName}" create-session response was not valid JSON.`,
+    );
+  }
+  const parsed = createSessionAcceptedResponseSchema.safeParse(body);
+  if (!parsed.success) {
+    throw new Error(`Remote agent "${input.remoteAgentName}" create-session response was invalid.`);
+  }
+  const acceptedTraceId =
+    proposedSeed !== undefined &&
+    parsed.data.trace !== undefined &&
+    traceCoordinatesEqual(proposedSeed, parsed.data.trace)
+      ? proposedSeed.traceId
+      : undefined;
+  return acceptedTraceId === undefined
+    ? { sessionId: parsed.data.sessionId }
+    : { sessionId: parsed.data.sessionId, traceId: acceptedTraceId };
+}

--- a/packages/eve/src/execution/session-command-inbox.test.ts
+++ b/packages/eve/src/execution/session-command-inbox.test.ts
@@ -129,6 +129,36 @@ describe("createSessionCommandInbox", () => {
     await inbox.dispose();
   });
 
+  it("publishes accepted trace coordinates only on the continuation alias", async () => {
+    const stable = createMockHook({ token: "stable" });
+    const continuation = createMockHook({ token: "channel" });
+    installHooks(stable, continuation);
+    const trace = {
+      spanId: "2".repeat(16),
+      traceFlags: 1,
+      traceId: "1".repeat(32),
+    };
+    const inbox = createSessionCommandInbox({
+      acceptedTraceCoordinates: trace,
+    });
+
+    await inbox.claimStable("stable");
+    await inbox.rekeyContinuation("channel");
+
+    expect(createHookMock).toHaveBeenNthCalledWith(1, {
+      metadata: { sessionInboxWireVersion: 4 },
+      token: "stable",
+    });
+    expect(createHookMock).toHaveBeenNthCalledWith(2, {
+      metadata: {
+        eveAcceptedTraceCoordinates: trace,
+        sessionInboxWireVersion: 4,
+      },
+      token: "channel",
+    });
+    await inbox.dispose();
+  });
+
   it("disposes active hooks without closing pending iterators", async () => {
     const stable = createMockHook({ token: "stable" });
     const alias = createMockHook({ token: "channel" });

--- a/packages/eve/src/execution/session-command-inbox.ts
+++ b/packages/eve/src/execution/session-command-inbox.ts
@@ -1,4 +1,5 @@
 import { createHook, type Hook } from "#compiled/@workflow/core/index.js";
+import type { Serializable } from "#compiled/@workflow/core/schemas.js";
 
 import type {
   DeliverHookPayload,
@@ -11,6 +12,8 @@ import {
   SESSION_INBOX_WIRE_VERSION,
   SESSION_INBOX_WIRE_VERSION_METADATA_KEY,
 } from "#execution/wire/session-inbox-contract.js";
+import { ACCEPTED_TRACE_COORDINATES_METADATA_KEY } from "#execution/session-operation-metadata.js";
+import type { TraceCoordinates } from "#protocol/agent-invocation-trace.js";
 /**
  * Payloads accepted by a session driver's stable and channel aliases.
  *
@@ -85,7 +88,9 @@ export interface SessionCommandInboxHandle extends SessionCommandInbox {
  * only the channel alias. Reads already committed to a retired alias remain in
  * the multiplexed queue and are consumed exactly once.
  */
-export function createSessionCommandInbox(): SessionCommandInboxHandle {
+export function createSessionCommandInbox(
+  input: { readonly acceptedTraceCoordinates?: TraceCoordinates } = {},
+): SessionCommandInboxHandle {
   let stable: SessionCommandHookState | undefined;
   let continuation: SessionCommandHookState | undefined;
   let authorization: SessionCommandHookState | undefined;
@@ -130,15 +135,19 @@ export function createSessionCommandInbox(): SessionCommandInboxHandle {
     if (state.resolved !== undefined) enqueue(state.resolved);
   };
 
-  const createState = (token: string): SessionCommandHookState => {
+  const createState = (token: string, includeAcceptedTrace: boolean): SessionCommandHookState => {
+    const metadata: Record<string, Serializable> = {
+      [SESSION_INBOX_WIRE_VERSION_METADATA_KEY]: SESSION_INBOX_WIRE_VERSION,
+    };
+    if (includeAcceptedTrace && input.acceptedTraceCoordinates !== undefined) {
+      metadata[ACCEPTED_TRACE_COORDINATES_METADATA_KEY] = input.acceptedTraceCoordinates;
+    }
     // Stamp the consumer's wire capability so producers can select an encoder
     // pre-resume. Hooks created before this stamp carry no wire marker:
     // markerless means the consumer predates the capability and accepts a
     // legacy shape.
     const hook = createHook<SessionInboxPayload>({
-      metadata: {
-        [SESSION_INBOX_WIRE_VERSION_METADATA_KEY]: SESSION_INBOX_WIRE_VERSION,
-      },
+      metadata,
       token,
     });
     return {
@@ -197,7 +206,7 @@ export function createSessionCommandInbox(): SessionCommandInboxHandle {
         throw new Error("A session command inbox cannot change its authorization token.");
       }
 
-      const candidate = createState(token);
+      const candidate = createState(token, false);
       await claimHookOwnership(candidate.hook);
       // Stays disabled until the driver opens the authorization window;
       // resolved reads stash on the state and enqueue when it opens.
@@ -210,7 +219,7 @@ export function createSessionCommandInbox(): SessionCommandInboxHandle {
         throw new Error("A session command inbox cannot change its stable token.");
       }
 
-      const candidate = createState(token);
+      const candidate = createState(token, false);
       await claimHookOwnership(candidate.hook);
       enable(candidate);
       stable = candidate;
@@ -296,7 +305,7 @@ export function createSessionCommandInbox(): SessionCommandInboxHandle {
     async rekeyContinuation(token: string): Promise<void> {
       if (!token || continuation?.hook.token === token) return;
 
-      const candidate = createState(token);
+      const candidate = createState(token, true);
       if (continuation === undefined) {
         await claimHookOwnership(candidate.hook);
         enable(candidate);

--- a/packages/eve/src/execution/session-operation-metadata.ts
+++ b/packages/eve/src/execution/session-operation-metadata.ts
@@ -1,0 +1,13 @@
+import { traceCoordinatesSchema, type TraceCoordinates } from "#protocol/agent-invocation-trace.js";
+
+export const ACCEPTED_TRACE_COORDINATES_METADATA_KEY = "eveAcceptedTraceCoordinates";
+
+export function readAcceptedTraceCoordinatesMetadata(value: unknown): TraceCoordinates | undefined {
+  if (value === null || typeof value !== "object") return undefined;
+  const metadata = Reflect.get(value, "metadata");
+  if (metadata === null || typeof metadata !== "object") return undefined;
+  const parsed = traceCoordinatesSchema.safeParse(
+    Reflect.get(metadata, ACCEPTED_TRACE_COORDINATES_METADATA_KEY),
+  );
+  return parsed.success ? parsed.data : undefined;
+}

--- a/packages/eve/src/execution/tools/subagent/start.ts
+++ b/packages/eve/src/execution/tools/subagent/start.ts
@@ -11,6 +11,7 @@ import type {
 import { normalizeChannelAudience } from "#shared/channel-audience.js";
 import {
   applyLiveDeliveryAudienceCeiling,
+  decisionToTraceContentCeiling,
   readForwardedTraceAssertion,
 } from "#shared/forwarded-trace-policy.js";
 import type { DispatchOutcome, RuntimeSession } from "#subagents/handle-dispatch.js";
@@ -78,15 +79,30 @@ export async function startSubagent(input: {
             forwardedTracePolicy,
           ),
         };
-  const traceSeed =
-    input.target.kind === "local"
-      ? allocateChildSessionTraceSeed({
-          callId: input.target.action.callId,
-          parentTraceContext,
-          sessionId: input.session.sessionId,
-          turnId: input.batchEvent.turnId,
-        })
-      : undefined;
+  const decisionCeiling = decisionToTraceContentCeiling(parentTraceContext?.decision);
+  const ceiling =
+    decisionCeiling === undefined
+      ? forwardedTracePolicy?.ceiling
+      : forwardedTracePolicy === undefined
+        ? decisionCeiling
+        : {
+            recordInputs: decisionCeiling.recordInputs && forwardedTracePolicy.ceiling.recordInputs,
+            recordOutputs:
+              decisionCeiling.recordOutputs && forwardedTracePolicy.ceiling.recordOutputs,
+          };
+  const traceSeed = allocateChildSessionTraceSeed({
+    callId: input.target.action.callId,
+    forwardedTracePolicy:
+      ceiling === undefined
+        ? undefined
+        : {
+            ceiling,
+            originAudience: forwardedTracePolicy?.originAudience ?? liveAudience,
+          },
+    parentTraceContext,
+    sessionId: input.session.sessionId,
+    turnId: input.batchEvent.turnId,
+  });
 
   switch (input.target.kind) {
     case "local":
@@ -124,6 +140,7 @@ export async function startSubagent(input: {
         initiatorAuth: input.initiatorAuth,
         parentContinuationToken: input.parentContinuationToken,
         parentTraceContext,
+        traceSeed,
         activityObserver: input.activityObserver,
         session: input.session,
         taskId: input.taskId,

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -45,6 +45,7 @@ import { terminateChildSessionsStep } from "#execution/terminate-child-sessions-
 import type { DynamicSubagentAgentConfig } from "#runtime/subagents/dynamic-agent-config.js";
 import { attachClientContext, readClientContext } from "#internal/client-context.js";
 import { settleContinuationConflictStep } from "#execution/continuation-conflict-step.js";
+import type { TraceCoordinates } from "#protocol/agent-invocation-trace.js";
 
 const SAFE_OUTER_WORKFLOW_FAILURE_MESSAGE =
   "Agent workflow failed. Inspect the private session trace for details.";
@@ -59,6 +60,7 @@ const SAFE_OUTER_WORKFLOW_FAILURE_MESSAGE =
  * and deserialized at each `"use step"` boundary.
  */
 export interface WorkflowEntryInput {
+  readonly acceptedTraceCoordinates?: TraceCoordinates;
   readonly activityCollectorRunId?: string;
   readonly continuationConflictCommand?: Extract<SessionCommand, { readonly kind: "send" }>;
   readonly input: RunInput["input"];
@@ -178,7 +180,7 @@ export async function workflowEntry(input: WorkflowEntryInput): Promise<Workflow
       | DynamicSubagentAgentConfig
       | undefined;
 
-    const commandInbox = createSessionCommandInbox();
+    const commandInbox = createSessionCommandInbox(input);
     const stableCommandToken = sessionCommandHookToken(sessionId);
     const authorizationHookToken = `${sessionId}:auth`;
     let sessionState: DurableSessionState;

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -23,6 +23,8 @@ import type {
 } from "#channel/types.js";
 import { readInternalTraceSeed, type InternalRunInput } from "#execution/internal-run-input.js";
 import { attachAcceptedTraceCoordinates } from "#channel/session-trace-state.js";
+import { traceCoordinatesEqual, type TraceCoordinates } from "#protocol/agent-invocation-trace.js";
+import { readAcceptedTraceCoordinatesMetadata } from "#execution/session-operation-metadata.js";
 import { ActivityObserverKey } from "#context/keys.js";
 import { serializeContext } from "#context/serialize.js";
 import {
@@ -87,6 +89,7 @@ const STABLE_ID_BASE = EVE_PACKAGE_INFO.name;
 const log = createLogger("execution.workflow-runtime");
 
 interface WorkflowHookRecord {
+  readonly acceptedTraceCoordinates?: TraceCoordinates;
   readonly runId: string;
 }
 
@@ -212,6 +215,9 @@ export function createWorkflowRuntime(config: {
       };
       const taskId = input.taskId ?? input.callback?.taskId;
       if (taskId !== undefined) workflowInput.taskId = taskId;
+      if (internalInput.acceptedTraceCoordinates !== undefined) {
+        workflowInput.acceptedTraceCoordinates = internalInput.acceptedTraceCoordinates;
+      }
       if (collectorRunId !== undefined) {
         workflowInput.activityCollectorRunId = collectorRunId;
       }
@@ -265,14 +271,31 @@ export function createWorkflowRuntime(config: {
         return events;
       };
 
+      let acceptedSessionId = run.runId;
+      let acceptedTraceCoordinates = internalInput.acceptedTraceCoordinates;
+      if (
+        internalInput.acceptedTraceCoordinates !== undefined &&
+        input.continuationToken !== undefined
+      ) {
+        const owner = await waitForCommandHookOwner(input.continuationToken);
+        acceptedSessionId = owner.runId;
+        acceptedTraceCoordinates =
+          owner.acceptedTraceCoordinates !== undefined &&
+          traceCoordinatesEqual(
+            internalInput.acceptedTraceCoordinates,
+            owner.acceptedTraceCoordinates,
+          )
+            ? owner.acceptedTraceCoordinates
+            : undefined;
+      }
       return attachAcceptedTraceCoordinates(
         {
           get events() {
             return getEvents();
           },
-          sessionId: run.runId,
+          sessionId: acceptedSessionId,
         },
-        internalInput.traceSeed,
+        acceptedTraceCoordinates ?? internalInput.traceSeed,
       );
     },
 
@@ -313,7 +336,10 @@ export function createWorkflowRuntime(config: {
     ): Promise<{ sessionId: string } | undefined> {
       try {
         const hook = await getHookByToken(continuationToken);
-        return { sessionId: hook.runId };
+        return attachAcceptedTraceCoordinates(
+          { sessionId: hook.runId },
+          readAcceptedTraceCoordinatesMetadata(hook),
+        );
       } catch (error) {
         if (HookNotFoundError.is(error)) {
           return undefined;
@@ -524,6 +550,7 @@ function normalizeWorkflowHook(value: unknown): WorkflowHookRecord {
   }
 
   return {
+    acceptedTraceCoordinates: readAcceptedTraceCoordinatesMetadata(value),
     runId,
   };
 }

--- a/packages/eve/src/internal/nitro/routes/channel-route-context.ts
+++ b/packages/eve/src/internal/nitro/routes/channel-route-context.ts
@@ -1,5 +1,6 @@
 import type { RouteHandlerArgs } from "#channel/routes.js";
-import type { RunHandle, RunInput } from "#channel/types.js";
+import type { RunHandle } from "#channel/types.js";
+import type { InternalRunInput } from "#execution/internal-run-input.js";
 
 type AgentInfoRouteResponse = () => Promise<Response>;
 export interface HomeRouteMetadata {
@@ -11,7 +12,7 @@ export interface HomeRouteMetadata {
  * established here is visible to `resolveSession` on the same channel.
  */
 export type RouteSessionCreator = (
-  input: Omit<RunInput, "adapter" | "channelName" | "requestId">,
+  input: Omit<InternalRunInput, "adapter" | "channelName" | "requestId">,
 ) => Promise<RunHandle>;
 
 export type RemoteAgentStreamHeadersResolver = (input: {

--- a/packages/eve/src/protocol/agent-invocation-trace.test.ts
+++ b/packages/eve/src/protocol/agent-invocation-trace.test.ts
@@ -49,6 +49,20 @@ describe("agent invocation trace protocol", () => {
     });
   });
 
+  it("accepts a bounded forwarded policy without serializing decisions", () => {
+    const forwardedTracePolicy = {
+      ceiling: { recordInputs: false, recordOutputs: true },
+      originAudience: "private" as const,
+    };
+
+    expect(buildAgentInvocationTrace({ forwardedTracePolicy, parent, seed })).toEqual({
+      forwardedTracePolicy,
+      parent,
+      seed,
+      version: AGENT_INVOCATION_TRACE_WIRE_VERSION,
+    });
+  });
+
   it("rejects policy fields and invalid identifiers", () => {
     expect(
       agentInvocationTraceSchema.safeParse({

--- a/packages/eve/src/protocol/agent-invocation-trace.ts
+++ b/packages/eve/src/protocol/agent-invocation-trace.ts
@@ -34,7 +34,38 @@ export const traceCoordinatesSchema = z.strictObject({
   traceId: traceIdSchema,
 });
 
+const instrumentationDecisionSchema = z.discriminatedUnion("action", [
+  z.strictObject({ action: z.literal("drop") }),
+  z.strictObject({
+    action: z.literal("record"),
+    recordInputs: z.boolean(),
+    recordOutputs: z.boolean(),
+  }),
+]);
+export const forwardedTracePolicySchema = z.strictObject({
+  ceiling: z.strictObject({
+    recordInputs: z.boolean(),
+    recordOutputs: z.boolean(),
+  }),
+  originAudience: z.enum(["private", "public", "unknown"]),
+});
+export const sessionTraceContextSchema: z.ZodType<SessionTraceContext> = z.strictObject({
+  decision: instrumentationDecisionSchema.optional(),
+  forwardedTracePolicy: forwardedTracePolicySchema.optional(),
+  ...traceCoordinatesSchema.shape,
+});
+export const sessionParentSchema: z.ZodType<SessionParent> = z.strictObject({
+  callId: z.string().min(1),
+  rootSessionId: z.string().min(1),
+  sessionId: z.string().min(1),
+  turn: z.strictObject({
+    id: z.string().min(1),
+    sequence: z.number().int().min(0),
+  }),
+});
+
 export const agentInvocationTraceSchema = z.strictObject({
+  forwardedTracePolicy: forwardedTracePolicySchema.optional(),
   parent: traceCoordinatesSchema.optional(),
   seed: traceCoordinatesSchema,
   version: z.literal(AGENT_INVOCATION_TRACE_WIRE_VERSION),
@@ -42,6 +73,13 @@ export const agentInvocationTraceSchema = z.strictObject({
 
 export type AgentInvocationTrace = z.infer<typeof agentInvocationTraceSchema>;
 export type TraceCoordinates = z.infer<typeof traceCoordinatesSchema>;
+
+export const createSessionAcceptedResponseSchema = z.object({
+  ok: z.literal(true),
+  sessionId: z.string().min(1),
+  status: z.literal("accepted"),
+  trace: traceCoordinatesSchema.optional(),
+});
 
 export function buildAgentInvocationParent(input: {
   readonly callId: string;
@@ -59,6 +97,7 @@ export function buildAgentInvocationParent(input: {
 }
 
 export function buildAgentInvocationTrace(input: {
+  readonly forwardedTracePolicy?: AgentInvocationTrace["forwardedTracePolicy"];
   readonly parent?: SessionTraceContext;
   readonly seed: SessionTraceContext;
 }): AgentInvocationTrace {
@@ -66,6 +105,9 @@ export function buildAgentInvocationTrace(input: {
     seed: traceCoordinates(input.seed),
     version: AGENT_INVOCATION_TRACE_WIRE_VERSION,
   };
+  if (input.forwardedTracePolicy !== undefined) {
+    trace.forwardedTracePolicy = input.forwardedTracePolicy;
+  }
   if (input.parent !== undefined) {
     trace.parent = traceCoordinates(input.parent);
   }

--- a/packages/eve/src/subagents/handles/store.ts
+++ b/packages/eve/src/subagents/handles/store.ts
@@ -89,6 +89,7 @@ export type AgentAddress =
   | {
       readonly kind: "agent/remote";
       readonly sessionId: string;
+      readonly traceId?: string;
       readonly url: string;
       readonly callbackBaseUrl: string;
       /** Auth/header resolver selected when this child was created; `{}` means none. */
@@ -266,6 +267,10 @@ const addressSchema: z.ZodType<AgentAddress> = z.discriminatedUnion("kind", [
     credentialResolver: z.strictObject({ resolverId: nonEmptyString.optional() }).optional(),
     kind: z.literal("agent/remote"),
     sessionId: nonEmptyString,
+    traceId: z
+      .string()
+      .regex(/^[0-9a-f]{32}$/u)
+      .optional(),
     url: z.url(),
   }),
 ]);

--- a/packages/eve/src/subagents/remote-dispatch.test.ts
+++ b/packages/eve/src/subagents/remote-dispatch.test.ts
@@ -201,6 +201,133 @@ describe("startRemoteAgentSession", () => {
     });
   });
 
+  it("sends distinct child coordinates and records only an exact acknowledgement", async () => {
+    const parentTraceContext = {
+      spanId: "2".repeat(16),
+      traceFlags: 1,
+      traceId: "1".repeat(32),
+    };
+    const traceSeed = {
+      spanId: "4".repeat(16),
+      traceFlags: 0,
+      traceId: "3".repeat(32),
+    };
+    const parent = {
+      callId: "call-remote",
+      rootSessionId: "root-session",
+      sessionId: "parent-session",
+      turn: { id: "parent-turn", sequence: 2 },
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json(
+          {
+            ok: true,
+            sessionId: "accepted-child",
+            status: "accepted",
+            trace: traceSeed,
+          },
+          { status: 202 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        Response.json(
+          {
+            ok: true,
+            sessionId: "mismatched-child",
+            status: "accepted",
+            trace: { ...traceSeed, spanId: "5".repeat(16) },
+          },
+          { status: 202 },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const input = {
+      action: createAction(),
+      callbackBaseUrl: "https://caller.example.com",
+      parent,
+      parentTraceContext,
+      remote: createRemoteAgent(),
+      session: {
+        agent: { modelReference: { id: "mock/test" }, system: "", tools: [] },
+        compaction: { recentWindowSize: 10, threshold: 100000 },
+        continuationToken: "eve:parent-token",
+        history: [],
+        sessionId: "parent-session",
+        state: {},
+      },
+      traceSeed,
+    };
+
+    await expect(startRemoteAgentSession(input)).resolves.toEqual({
+      sessionId: "accepted-child",
+      traceId: traceSeed.traceId,
+    });
+    await expect(startRemoteAgentSession(input)).resolves.toEqual({
+      sessionId: "mismatched-child",
+    });
+    const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(request.headers).not.toHaveProperty("traceparent");
+    expect(JSON.parse(request.body as string)).toMatchObject({
+      invocation: parent,
+      trace: { parent: parentTraceContext, seed: traceSeed, version: 1 },
+    });
+  });
+
+  it("retries an older receiver without joining the parent trace", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json({ ok: false }, { status: 400 }))
+      .mockResolvedValueOnce(
+        Response.json(
+          { ok: true, sessionId: "remote-session", status: "accepted" },
+          { status: 202 },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      startRemoteAgentSession({
+        action: createAction(),
+        callbackBaseUrl: "https://caller.example.com",
+        parent: {
+          callId: "call-remote",
+          rootSessionId: "root-session",
+          sessionId: "parent-session",
+          turn: { id: "parent-turn", sequence: 0 },
+        },
+        parentTraceContext: {
+          spanId: "2".repeat(16),
+          traceFlags: 1,
+          traceId: "1".repeat(32),
+        },
+        remote: createRemoteAgent(),
+        session: {
+          agent: { modelReference: { id: "mock/test" }, system: "", tools: [] },
+          compaction: { recentWindowSize: 10, threshold: 100000 },
+          continuationToken: "eve:parent-token",
+          history: [],
+          sessionId: "parent-session",
+          state: {},
+        },
+        traceSeed: {
+          spanId: "4".repeat(16),
+          traceFlags: 1,
+          traceId: "3".repeat(32),
+        },
+      }),
+    ).resolves.toEqual({ sessionId: "remote-session" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string)).toHaveProperty("trace");
+    expect(JSON.parse(fetchMock.mock.calls[1]?.[1]?.body as string)).not.toHaveProperty("trace");
+    expect(JSON.parse(fetchMock.mock.calls[1]?.[1]?.body as string)).not.toHaveProperty(
+      "invocation",
+    );
+    expect(fetchMock.mock.calls[1]?.[1]?.headers).not.toHaveProperty("traceparent");
+  });
+
   it("posts the formatted subagent message and callback metadata", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(

--- a/packages/eve/src/subagents/remote-dispatch.ts
+++ b/packages/eve/src/subagents/remote-dispatch.ts
@@ -1,4 +1,3 @@
-import { z } from "#compiled/zod/index.js";
 import { CancelTurnResponseSchema } from "#protocol/cancel-turn.js";
 import { ResetResponseSchema, type ResetResponse } from "#protocol/reset-session.js";
 import { AgentHandleError } from "#protocol/agent-handle-error.js";
@@ -12,6 +11,7 @@ import type {
   ActivityObserverConfig,
   CancelTurnResult,
   SessionAuthContext,
+  SessionParent,
   SessionTraceContext,
 } from "#channel/types.js";
 import type { ChannelAudience } from "#shared/channel-audience.js";
@@ -32,15 +32,15 @@ import type { JsonObject } from "#shared/json.js";
 import { readTaskIdFromInboxToken } from "#tasks/task-inbox-token.js";
 import { writeForwardedAudienceBaggage } from "#protocol/baggage.js";
 import { decisionToTraceContentCeiling } from "#shared/forwarded-trace-policy.js";
-
-const CreateSessionResponseSchema = z.object({
-  ok: z.literal(true),
-  sessionId: z.string().min(1),
-  status: z.literal("accepted"),
-});
+import {
+  buildAgentInvocationTrace,
+  type AgentInvocationTrace,
+} from "#protocol/agent-invocation-trace.js";
+import { sendRemoteAgentCreateRequest } from "#execution/remote-agent-create-request.js";
 
 type RemoteAgentSessionCoordinates = {
   readonly sessionId: string;
+  readonly traceId?: string;
 };
 
 class RemoteAgentCancelRequestError extends Error {
@@ -69,10 +69,12 @@ export async function startRemoteAgentSession(input: {
    * created instead of starting a second one.
    */
   readonly operationId?: string;
+  readonly parent?: SessionParent;
   readonly parentTraceContext?: SessionTraceContext;
   readonly remote: ResolvedRuntimeRemoteAgentNode;
   readonly session: HarnessSession;
   readonly taskId?: string;
+  readonly traceSeed?: SessionTraceContext;
 }): Promise<RemoteAgentSessionCoordinates> {
   const callbackToken = input.callbackToken ?? input.session.continuationToken;
   if (!callbackToken) {
@@ -98,6 +100,8 @@ export async function startRemoteAgentSession(input: {
     mode: "conversation" | "task";
     operationId?: string;
     outputSchema?: object;
+    invocation?: SessionParent;
+    trace?: AgentInvocationTrace;
   } = {
     capabilities: {},
     callback: {
@@ -125,12 +129,19 @@ export async function startRemoteAgentSession(input: {
   if (input.operationId !== undefined) {
     requestBody.operationId = input.operationId;
   }
+  if (input.parent !== undefined) requestBody.invocation = input.parent;
+  if (input.traceSeed !== undefined) {
+    requestBody.trace = buildAgentInvocationTrace({
+      forwardedTracePolicy: input.traceSeed.forwardedTracePolicy,
+      parent: input.parentTraceContext,
+      seed: input.traceSeed,
+    });
+  }
 
   const headers = await resolveRemoteAgentRequestHeaders(input.remote);
-  const traceparent = formatTraceparent(input.parentTraceContext);
-  if (traceparent !== undefined) {
-    setHeader(headers, "traceparent", traceparent);
-  }
+  const traceparent =
+    requestBody.trace === undefined ? formatTraceparent(input.parentTraceContext) : undefined;
+  setHeader(headers, "traceparent", traceparent);
   const baggage = writeForwardedAudienceBaggage(
     readHeader(headers, "baggage"),
     buildForwardedTraceAssertion({
@@ -141,38 +152,12 @@ export async function startRemoteAgentSession(input: {
     }),
   );
   setHeader(headers, "baggage", baggage);
-  const response = await fetch(createRemoteAgentSessionUrl(input.remote), {
-    body: JSON.stringify(requestBody),
-    headers: {
-      "content-type": "application/json",
-      ...headers,
-    },
-    method: "POST",
+  return await sendRemoteAgentCreateRequest({
+    body: requestBody,
+    headers,
+    remoteAgentName: input.action.remoteAgentName,
+    url: createRemoteAgentSessionUrl(input.remote),
   });
-
-  if (!response.ok) {
-    throw new Error(
-      `Remote agent "${input.action.remoteAgentName}" create-session request failed with HTTP ${response.status}.`,
-    );
-  }
-
-  let body: unknown;
-  try {
-    body = await response.json();
-  } catch {
-    throw new Error(
-      `Remote agent "${input.action.remoteAgentName}" create-session response was not valid JSON.`,
-    );
-  }
-
-  const parsed = CreateSessionResponseSchema.safeParse(body);
-  if (!parsed.success) {
-    throw new Error(
-      `Remote agent "${input.action.remoteAgentName}" create-session response was invalid.`,
-    );
-  }
-
-  return { sessionId: parsed.data.sessionId };
 }
 
 function buildForwardedTraceAssertion(input: {

--- a/packages/eve/src/subagents/start-remote.ts
+++ b/packages/eve/src/subagents/start-remote.ts
@@ -10,6 +10,7 @@ import { createLogger, logError } from "#internal/logging.js";
 import type { RuntimeRemoteAgentDispatchRequest } from "#shared/action-types.js";
 import type { CompiledBundle } from "#runtime/sessions/runtime-context-keys.js";
 import type { ChannelAudience } from "#shared/channel-audience.js";
+import { buildAgentInvocationParent } from "#protocol/agent-invocation-trace.js";
 
 const log = createLogger("execution.subagent-start-remote");
 
@@ -28,6 +29,7 @@ export async function startRemoteSubagent(input: {
   readonly initiatorAuth: Parameters<typeof startRemoteAgentSession>[0]["initiatorAuth"];
   readonly parentContinuationToken: string | undefined;
   readonly parentTraceContext: Parameters<typeof startRemoteAgentSession>[0]["parentTraceContext"];
+  readonly traceSeed: Parameters<typeof startRemoteAgentSession>[0]["traceSeed"];
   readonly activityObserver?: Parameters<typeof startRemoteAgentSession>[0]["activityObserver"];
   readonly session: RuntimeSession;
   readonly taskId?: string;
@@ -92,19 +94,35 @@ export async function startRemoteSubagent(input: {
       originAudience: input.originAudience,
       initiatorAuth: input.initiatorAuth,
       operationId: operation.id,
+      parent: buildAgentInvocationParent({
+        callId: action.callId,
+        rootSessionId: input.session.rootSessionId ?? input.session.sessionId,
+        sessionId: input.session.sessionId,
+        turnId: input.batchEvent.turnId,
+        turnSequence: input.batchEvent.sequence,
+      }),
       parentTraceContext: input.parentTraceContext,
       activityObserver,
       remote: resolvedRemote,
       session: input.session,
       taskId: input.taskId,
+      traceSeed: input.traceSeed,
     });
-    const address = {
+    const address: {
+      callbackBaseUrl: string;
+      credentialResolver: typeof credentialResolver;
+      kind: "agent/remote";
+      sessionId: string;
+      traceId?: string;
+      url: string;
+    } = {
       callbackBaseUrl,
       credentialResolver,
       kind: "agent/remote",
       sessionId: child.sessionId,
       url: resolvedRemote.url,
-    } as const;
+    };
+    if (child.traceId !== undefined) address.traceId = child.traceId;
     return {
       address,
       callId: action.callId,

--- a/packages/eve/src/tracing/agent-child-trace-seed.ts
+++ b/packages/eve/src/tracing/agent-child-trace-seed.ts
@@ -2,9 +2,11 @@ import type { SessionTraceContext } from "#channel/types.js";
 import type { SessionTraceSeed } from "#context/keys.js";
 import { childSessionTraceKey } from "#instrumentation/lifecycle.js";
 import { getInstrumentationRuntime } from "#instrumentation/runtime.js";
+import type { ForwardedTraceAssertion } from "#shared/forwarded-trace-policy.js";
 
 export function allocateChildSessionTraceSeed(input: {
   readonly callId: string;
+  readonly forwardedTracePolicy?: ForwardedTraceAssertion;
   readonly parentTraceContext?: SessionTraceContext;
   readonly sessionId: string;
   readonly turnId: string;
@@ -19,11 +21,14 @@ export function allocateChildSessionTraceSeed(input: {
     input.parentTraceContext === undefined
       ? derivedTraceId
       : distinctChildTraceId(derivedTraceId, input.parentTraceContext.traceId);
-  return {
+  const seed: SessionTraceSeed = {
     spanId: runtime.idGenerator.deriveSpanId(`${key}:root`),
     traceFlags: 0,
     traceId,
   };
+  return input.forwardedTracePolicy === undefined
+    ? seed
+    : { ...seed, forwardedTracePolicy: input.forwardedTracePolicy };
 }
 
 function distinctChildTraceId(traceId: string, parentTraceId: string): string {


### PR DESCRIPTION
### Summary

Carries schema 4 delegated trace coordinates through remote eve session creation. The sender transmits explicit invocation lineage and a distinct child seed, the receiver validates the binding and echoes only accepted coordinates, and the caller records a trace ID only when the acknowledgement exactly matches.

A 400 response from an older receiver triggers one compatibility retry with the new invocation and trace extension removed; the fallback does not join the child to the parent trace.

Depends on #2959.

### Validation

Focused protocol, remote dispatch, continuation metadata, and session-route coverage passed with 62 tests. The full workspace typecheck passed all 44 tasks, the `eve` package typecheck passed, and `pnpm guard:invariants` passed.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the required patch changeset.

**Implementation** — 17 files · `+397 / -106`

Extends the strict trace protocol, transports it through remote create requests and the Eve channel, persists replay acknowledgements on continuation metadata, and stores confirmed trace IDs on remote handles.

**Tests** — 3 files · `+171 / -0`

Covers forwarded policy validation, exact acknowledgement, mismatched responses, compatibility fallback, and continuation metadata.
