### PR TITLE
feat(eve): trace bounded principal metadata

### DIFF
--- a/.changeset/trace-agent-principals.md
+++ b/.changeset/trace-agent-principals.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add bounded pseudonymous current and initiator principal summaries to schema 4 agent execution spans.

--- a/packages/eve/src/instrumentation/lifecycle.ts
+++ b/packages/eve/src/instrumentation/lifecycle.ts
@@ -295,6 +295,20 @@ export interface InstrumentationTraceSeed extends InstrumentationTraceContext {
   readonly decision?: InstrumentationDecision;
 }
 
+export type InstrumentationPrincipalType =
+  | "anonymous"
+  | "app"
+  | "local-dev"
+  | "none"
+  | "other"
+  | "service"
+  | "user";
+
+export interface InstrumentationPrincipalSummary {
+  readonly fingerprint?: string;
+  readonly type: InstrumentationPrincipalType;
+}
+
 /**
  * Which tool call dispatched a subagent child. The trace structure alone
  * cannot say: one turn's children all parent to the same window.
@@ -336,7 +350,9 @@ export type InstrumentationSessionTransitionEvent =
 export interface InstrumentationTurnStartedEvent {
   readonly type: "turn.started";
   readonly agentName?: string;
+  readonly currentPrincipal?: InstrumentationPrincipalSummary;
   readonly idempotencyKey: string;
+  readonly initiatorPrincipal?: InstrumentationPrincipalSummary;
   readonly parentLineage?: InstrumentationParentLineage;
   readonly parentTraceContext?: InstrumentationTraceContext;
   readonly rootSessionId: string;

--- a/packages/eve/src/instrumentation/prepare-trace-context.ts
+++ b/packages/eve/src/instrumentation/prepare-trace-context.ts
@@ -3,6 +3,7 @@ import { contextStorage } from "#context/container.js";
 import type { RuntimeTraceContext } from "#protocol/message.js";
 import type {
   InstrumentationParentLineage,
+  InstrumentationPrincipalSummary,
   InstrumentationSessionStartedEvent,
   InstrumentationTraceSeed,
   InstrumentationTurnStartedEvent,
@@ -26,6 +27,8 @@ export interface PrepareTurnTraceContextInput {
       event: InstrumentationTurnStartedEvent,
     ) => Promise<InstrumentationTraceSeed>;
   };
+  readonly currentPrincipal?: InstrumentationPrincipalSummary;
+  readonly initiatorPrincipal?: InstrumentationPrincipalSummary;
   readonly parentLineage?: InstrumentationParentLineage;
   readonly parentTraceContext?: InstrumentationTraceSeed;
   readonly rootSessionId: string;
@@ -65,7 +68,9 @@ export async function prepareTurnTraceContext(
     try {
       prepared = await input.instrumentation.prepareTurnTrace({
         agentName: input.agentName,
+        currentPrincipal: input.currentPrincipal,
         idempotencyKey: turnIdempotencyKey(input.sessionId, input.turnId),
+        initiatorPrincipal: input.initiatorPrincipal,
         parentLineage: input.parentLineage,
         parentTraceContext: input.parentTraceContext,
         rootSessionId: input.rootSessionId,

--- a/packages/eve/src/instrumentation/principal-summary.test.ts
+++ b/packages/eve/src/instrumentation/principal-summary.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { summarizeInstrumentationPrincipal } from "#instrumentation/principal-summary.js";
+
+describe("summarizeInstrumentationPrincipal", () => {
+  it("preserves explicit null without inventing a fingerprint", () => {
+    expect(summarizeInstrumentationPrincipal(null)).toEqual({ type: "none" });
+    expect(summarizeInstrumentationPrincipal(undefined)).toBeUndefined();
+  });
+
+  it("produces a deterministic bounded pseudonym", () => {
+    const principal = {
+      attributes: {},
+      authenticator: "oidc",
+      issuer: "https://issuer.example",
+      principalId: "secret-user-id",
+      principalType: "tenant-administrator",
+      subject: "secret-subject",
+    };
+    const summary = summarizeInstrumentationPrincipal(principal);
+
+    expect(summary).toEqual(summarizeInstrumentationPrincipal(principal));
+    expect(summary).toMatchObject({ type: "other" });
+    expect(summary?.fingerprint).toMatch(/^[0-9a-f]{32}$/u);
+    expect(JSON.stringify(summary)).not.toContain("secret");
+  });
+});

--- a/packages/eve/src/instrumentation/principal-summary.ts
+++ b/packages/eve/src/instrumentation/principal-summary.ts
@@ -1,0 +1,37 @@
+import { createHash } from "node:crypto";
+
+import type { SessionAuthContext } from "#channel/types.js";
+import type {
+  InstrumentationPrincipalSummary,
+  InstrumentationPrincipalType,
+} from "#instrumentation/lifecycle.js";
+
+const PRINCIPAL_TYPES = new Set<InstrumentationPrincipalType>([
+  "anonymous",
+  "app",
+  "local-dev",
+  "service",
+  "user",
+]);
+
+export function summarizeInstrumentationPrincipal(
+  principal: SessionAuthContext | null | undefined,
+): InstrumentationPrincipalSummary | undefined {
+  if (principal === undefined) return undefined;
+  if (principal === null) return { type: "none" };
+  const type = PRINCIPAL_TYPES.has(principal.principalType as InstrumentationPrincipalType)
+    ? (principal.principalType as InstrumentationPrincipalType)
+    : "other";
+  const identity = JSON.stringify([
+    "eve:instrumentation-principal:v1",
+    principal.authenticator,
+    principal.issuer ?? null,
+    principal.principalType,
+    principal.principalId,
+    principal.subject ?? null,
+  ]);
+  return {
+    fingerprint: createHash("sha256").update(identity).digest("hex").slice(0, 32),
+    type,
+  };
+}

--- a/packages/eve/src/instrumentation/runtime.ts
+++ b/packages/eve/src/instrumentation/runtime.ts
@@ -47,7 +47,9 @@ import type { OtelHarnessSettings, RuntimeContextResolver } from "#tracing/otel-
 import type { SessionTraceSeed } from "#context/keys.js";
 import { contextStorage, type ContextContainer } from "#context/container.js";
 import {
+  AuthKey,
   ChannelInstrumentationKey,
+  InitiatorAuthKey,
   OtelTraceEnabledKey,
   ParentSessionKey,
   ParentTraceContextKey,
@@ -61,6 +63,7 @@ import {
   resolveTracePolicyDecision,
 } from "#tracing/sampled-trace.js";
 import { resolveParentLineage } from "#instrumentation/parent-lineage.js";
+import { summarizeInstrumentationPrincipal } from "#instrumentation/principal-summary.js";
 import type { ChannelInstrumentationProjection, SessionTraceContext } from "#channel/types.js";
 import { readSessionTraceDecision } from "#tracing/agent-trace-context-store.js";
 import { readInstrumentationDecision } from "#shared/instrumentation-decision.js";
@@ -214,12 +217,14 @@ export function bindInstrumentationRuntime(
         : { ...storedTraceSeed, ...resolvedTraceState };
     const parentTraceContext = context.get(ParentTraceContextKey);
     return {
+      currentPrincipal: summarizeInstrumentationPrincipal(context.get(AuthKey)),
       channel: context.get(ChannelKey),
       context,
       instrumentation: context.get(ChannelInstrumentationKey),
       forwardedTracePolicy: readForwardedTraceAssertion(traceSeed?.forwardedTracePolicy),
       parent: context.get(ParentSessionKey),
       parentTraceContext,
+      initiatorPrincipal: summarizeInstrumentationPrincipal(context.get(InitiatorAuthKey)),
       traceSeed,
     };
   };
@@ -256,7 +261,9 @@ export function bindInstrumentationRuntime(
       agentName: boundSession.agentName,
       channelAudience: audience,
       channelType: channel?.channelType,
+      currentPrincipal: sessionContext.currentPrincipal,
       instrumentation: runtime,
+      initiatorPrincipal: sessionContext.initiatorPrincipal,
       parentLineage: resolveParentLineage(sessionContext.parent, sessionContext.channel),
       parentTraceContext: sessionContext.parentTraceContext,
       rootSessionId: sessionContext.parent?.rootSessionId ?? boundSession.rootSessionId,

--- a/packages/eve/src/protocol/agent-invocation-trace.test.ts
+++ b/packages/eve/src/protocol/agent-invocation-trace.test.ts
@@ -36,6 +36,10 @@ describe("agent invocation trace protocol", () => {
     expect(AGENT_TRACE_ATTRIBUTES).toEqual({
       childTraceId: "agent.child.trace.id",
       invocationRole: "agent.invocation.role",
+      principalCurrentFingerprint: "agent.principal.current.fingerprint",
+      principalCurrentType: "agent.principal.current.type",
+      principalInitiatorFingerprint: "agent.principal.initiator.fingerprint",
+      principalInitiatorType: "agent.principal.initiator.type",
       schemaVersion: "agent.trace.schema.version",
       sessionKind: "agent.session.kind",
     });

--- a/packages/eve/src/protocol/agent-invocation-trace.ts
+++ b/packages/eve/src/protocol/agent-invocation-trace.ts
@@ -15,6 +15,10 @@ export const AGENT_SESSION_KINDS = {
 export const AGENT_TRACE_ATTRIBUTES = {
   childTraceId: "agent.child.trace.id",
   invocationRole: "agent.invocation.role",
+  principalCurrentFingerprint: "agent.principal.current.fingerprint",
+  principalCurrentType: "agent.principal.current.type",
+  principalInitiatorFingerprint: "agent.principal.initiator.fingerprint",
+  principalInitiatorType: "agent.principal.initiator.type",
   schemaVersion: "agent.trace.schema.version",
   sessionKind: "agent.session.kind",
 } as const;

--- a/packages/eve/src/tracing/agent-otel-provider.test.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.test.ts
@@ -317,7 +317,15 @@ async function emitAttempt(input: {
 
 async function publishTurnStarted(input: {
   readonly channelAudience?: ChannelAudience;
+  readonly currentPrincipal?: {
+    readonly fingerprint?: string;
+    readonly type: "anonymous" | "app" | "local-dev" | "none" | "other" | "service" | "user";
+  };
   readonly hooks: InstrumentationHooks;
+  readonly initiatorPrincipal?: {
+    readonly fingerprint?: string;
+    readonly type: "anonymous" | "app" | "local-dev" | "none" | "other" | "service" | "user";
+  };
   readonly parentLineage?: InstrumentationParentLineage;
   readonly parentTraceContext?: InstrumentationTraceContext;
   readonly rootSessionId?: string;
@@ -340,7 +348,9 @@ async function publishTurnStarted(input: {
     type: "session.started",
   });
   await input.hooks.publish({
+    currentPrincipal: input.currentPrincipal,
     idempotencyKey: turnIdempotencyKey(input.sessionId, input.turnId),
+    initiatorPrincipal: input.initiatorPrincipal,
     parentLineage: input.parentLineage,
     parentTraceContext: input.parentTraceContext,
     rootSessionId,
@@ -466,7 +476,12 @@ describe("createAgentOtelInstrumentation", () => {
     };
 
     await publishTurnStarted({
+      currentPrincipal: {
+        fingerprint: "c".repeat(32),
+        type: "user",
+      },
       hooks: runtime.hooks,
+      initiatorPrincipal: { type: "none" },
       parentLineage,
       parentTraceContext: parent,
       rootSessionId: "root-session",
@@ -499,12 +514,16 @@ describe("createAgentOtelInstrumentation", () => {
       "agent.invocation.role": "execution",
       "agent.parent_call.id": "call-child",
       "agent.parent_run.id": "parent-session",
+      "agent.principal.current.fingerprint": "c".repeat(32),
+      "agent.principal.current.type": "user",
+      "agent.principal.initiator.type": "none",
       "agent.root_run.id": "root-session",
       "agent.session.kind": "delegated",
       "agent.trace.schema.version": 4,
       "gen_ai.conversation.id": "child-session",
       "gen_ai.operation.name": "invoke_agent",
     });
+    expect(execution.attributes).not.toHaveProperty("agent.principal.initiator.fingerprint");
   });
 
   it("falls back to fresh ids when no trace seed is present", async () => {

--- a/packages/eve/src/tracing/agent-otel-provider.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.ts
@@ -321,6 +321,12 @@ export function createAgentOtelInstrumentation(
                     turn.parentLineage === undefined
                       ? AGENT_SESSION_KINDS.root
                       : AGENT_SESSION_KINDS.delegated,
+                  [AGENT_TRACE_ATTRIBUTES.principalCurrentType]: turn.currentPrincipal?.type,
+                  [AGENT_TRACE_ATTRIBUTES.principalCurrentFingerprint]:
+                    turn.currentPrincipal?.fingerprint,
+                  [AGENT_TRACE_ATTRIBUTES.principalInitiatorType]: turn.initiatorPrincipal?.type,
+                  [AGENT_TRACE_ATTRIBUTES.principalInitiatorFingerprint]:
+                    turn.initiatorPrincipal?.fingerprint,
                   "agent.subagent.name": turn.subagentName,
                   "agent.turn.id": event.turnId,
                   "agent.turn.sequence": turn.sequence,

--- a/packages/eve/src/tracing/agent-otel-session-context.ts
+++ b/packages/eve/src/tracing/agent-otel-session-context.ts
@@ -215,6 +215,8 @@ export function createAgentOtelSessionContext(
     };
     await input.stateStore.setTurn(event.sessionId, event.turnId, {
       context: turnContext,
+      currentPrincipal: event.currentPrincipal,
+      initiatorPrincipal: event.initiatorPrincipal,
       parentIsRemote: session.context.isRemote,
       parentSpanId: session.context.spanId,
       parentLineage: event.parentLineage ?? session.parentLineage,

--- a/packages/eve/src/tracing/agent-trace-context-store.ts
+++ b/packages/eve/src/tracing/agent-trace-context-store.ts
@@ -315,6 +315,8 @@ function deserializeState(data: unknown): AgentTraceContextState {
     }
     return {
       context: value.context,
+      currentPrincipal: deserializePrincipalSummary(value.currentPrincipal),
+      initiatorPrincipal: deserializePrincipalSummary(value.initiatorPrincipal),
       modelUsage: deserializeModelUsage(value.modelUsage),
       parentLineage: deserializeParentLineage(value.parentLineage),
       parentIsRemote: typeof value.parentIsRemote === "boolean" ? value.parentIsRemote : undefined,
@@ -327,6 +329,30 @@ function deserializeState(data: unknown): AgentTraceContextState {
     } satisfies AgentTurnTraceState;
   });
   return { actions, sessions, turns };
+}
+
+function deserializePrincipalSummary(
+  value: unknown,
+): AgentTurnTraceState["currentPrincipal"] | undefined {
+  if (!isRecord(value) || !isPrincipalType(value.type)) return undefined;
+  return {
+    fingerprint: typeof value.fingerprint === "string" ? value.fingerprint : undefined,
+    type: value.type,
+  };
+}
+
+function isPrincipalType(
+  value: unknown,
+): value is NonNullable<AgentTurnTraceState["currentPrincipal"]>["type"] {
+  return (
+    value === "anonymous" ||
+    value === "app" ||
+    value === "local-dev" ||
+    value === "none" ||
+    value === "other" ||
+    value === "service" ||
+    value === "user"
+  );
 }
 
 function deserializeParentLineage(

--- a/packages/eve/src/tracing/agent-trace-state.ts
+++ b/packages/eve/src/tracing/agent-trace-state.ts
@@ -3,6 +3,7 @@ import type { SpanContext } from "#compiled/@opentelemetry/api/index.js";
 import type {
   InstrumentationActionKind,
   InstrumentationParentLineage,
+  InstrumentationPrincipalSummary,
   InstrumentationTraceContext,
   InstrumentationTurnFailedEvent,
   InstrumentationTurnSettledEvent,
@@ -22,6 +23,8 @@ export interface AgentSessionTraceState {
 
 export interface AgentTurnTraceState {
   readonly context: SpanContext;
+  readonly currentPrincipal?: InstrumentationPrincipalSummary;
+  readonly initiatorPrincipal?: InstrumentationPrincipalSummary;
   readonly modelUsage?: { readonly inputTokens?: number; readonly outputTokens?: number };
   readonly parentLineage?: InstrumentationParentLineage;
   readonly parentIsRemote?: boolean;


### PR DESCRIPTION
### Summary

Adds bounded current and initiator principal summaries to schema 4 execution spans. Types are allowlisted, unknown values collapse to `other`, explicit null becomes `none`, and identities are represented only by deterministic 32-character pseudonymous fingerprints.

Principal metadata is display-only and does not participate in authorization or routing.

Depends on #2962.

### Validation

Focused principal, runtime, durable-state, protocol, and OTel provider coverage passed with 106 tests. The full workspace typecheck passed all 44 tasks, the `eve` package typecheck passed, and `pnpm guard:invariants` passed.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

Adds the required patch changeset.

**Implementation** — 10 files · `+110 / -0`

Defines the bounded summary, propagates it through durable turn state, and emits the allowlisted schema 4 attributes.

**Tests** — 2 files · `+46 / -0`

Covers null handling, deterministic pseudonyms, type bounding, emitted attributes, and fingerprint omission.
