### PR TITLE
fix(eve): release stopped stream response bodies

### DIFF
--- a/.changeset/release-stream-follower-response-bodies.md
+++ b/.changeset/release-stream-follower-response-bodies.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Release response bodies when a client stops following a session stream, preventing retained stream listeners during repeated reconnects.

--- a/packages/eve/src/client/open-stream.test.ts
+++ b/packages/eve/src/client/open-stream.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { EVE_MESSAGE_STREAM_VERSION, EVE_STREAM_VERSION_HEADER } from "#protocol/message.js";
+
+import { openStreamBody } from "./open-stream.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("openStreamBody", () => {
+  it("cancels an opened response body and aborts its request exactly once when closed", async () => {
+    const cancel = vi.fn();
+    const body = new ReadableStream<Uint8Array>({ cancel });
+    let signal: AbortSignal | undefined;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_request, init) => {
+      signal = init?.signal ?? undefined;
+      return new Response(body, {
+        headers: { [EVE_STREAM_VERSION_HEADER]: EVE_MESSAGE_STREAM_VERSION },
+      });
+    });
+
+    const connection = await openStreamBody({
+      host: "https://eve.test",
+      resolveHeaders: async () => new Headers(),
+      sessionId: "session_1",
+      startIndex: 0,
+    });
+    connection.close();
+    connection.close();
+    await Promise.resolve();
+
+    expect(signal?.aborted).toBe(true);
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/eve/src/client/open-stream.ts
+++ b/packages/eve/src/client/open-stream.ts
@@ -274,9 +274,16 @@ export async function openStreamBody(
       if (!response.body) {
         throw new ClientError(response.status, "Response body is null.", response.headers);
       }
+      const body = response.body;
+      let closed = false;
       return {
-        body: response.body,
-        close: () => connectionController.abort(),
+        body,
+        close: () => {
+          if (closed) return;
+          closed = true;
+          connectionController.abort();
+          void body.cancel().catch(() => {});
+        },
         streamVersion: readMessageStreamVersion(response.headers),
         tailIndex: parseTailIndexHeader(response.headers),
       };


### PR DESCRIPTION
### Summary

This is the first PR in a four-layer CI reliability stack. Closing a client stream now also cancels its opened response body, so reconnecting or stopped consumers do not retain server-side stream listeners. The cleanup remains idempotent and preserves existing abort behavior.

### Validation

Focused unit coverage verifies the body is cancelled and the request signal is aborted exactly once. `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/client/open-stream.test.ts` and `pnpm --filter eve typecheck` passed. The stream-follow integration suite could not start because its Vitest config cannot resolve the pre-existing `#internal/workflow-bundle/workflow-builders.js` import.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

The changeset records the observable resource-lifecycle fix for release notes.

**Implementation** — 1 file · `+9 / -2`

Keeps cleanup at the shared stream connection boundary.

**Tests** — 1 file · `+36 / -0`

Covers body cancellation and request abort idempotence.
