### PR TITLE
fix(eve): diagnose terminal eval stream failures

### DIFF
--- a/.changeset/eval-stream-failure-diagnostics.md
+++ b/.changeset/eval-stream-failure-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Include durable cursor and observed-event context when an eval stream ends before its turn boundary.

--- a/packages/eve/src/evals/runner/execute-task.test.ts
+++ b/packages/eve/src/evals/runner/execute-task.test.ts
@@ -699,6 +699,29 @@ describe("executeTask", () => {
     expect(outcome.assertions.every((assertion) => assertion.passed)).toBe(true);
   });
 
+  it("reports durable stream context when a turn stream fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_request, init) => {
+      if ((init?.method ?? "GET") === "POST") {
+        return Response.json({ ok: true, sessionId: "session_diagnostic" }, { status: 202 });
+      }
+      return new Response('{"type":"turn.started"}\nnot-json\n', {
+        headers: { [EVE_STREAM_VERSION_HEADER]: EVE_MESSAGE_STREAM_VERSION },
+      });
+    });
+
+    const { error } = await executeTask({
+      client: new Client({ host: target.url }),
+      target,
+      evaluation: createTestEval(async (t) => {
+        await t.send("diagnose stream failure");
+      }, "stream-diagnostic"),
+    });
+
+    expect(error).toContain("Eval stream failed for session session_diagnostic");
+    expect(error).toContain("cursor=1, startIndex=0, events=0");
+    expect(error).toContain("lastEvent=none, turnStatus=no turn boundary");
+  });
+
   it("captures a schedule-dispatch capability failure as the task error", async () => {
     // A throwing `test` body is caught by executeTask and surfaced as `error`
     // (executeEval turns it into a failed verdict) rather than rejecting.

--- a/packages/eve/src/evals/session.ts
+++ b/packages/eve/src/evals/session.ts
@@ -212,6 +212,7 @@ export class EvalSessionDriver implements EveEvalSession {
 
   async #start(input: SendTurnPayload): Promise<EveEvalLiveTurn> {
     const turnInput = attachSignal(input, this.#signal);
+    const startIndex = this.#session?.state.streamIndex ?? 0;
     let response;
     if (this.#session === undefined) {
       if (turnInput.message === undefined) {
@@ -236,6 +237,7 @@ export class EvalSessionDriver implements EveEvalSession {
       record: (events) => this.#recordObservedTurn(response.sessionId, events),
       session: this,
       sessionId: response.sessionId,
+      startIndex,
     });
   }
 
@@ -269,6 +271,7 @@ export class EvalSessionDriver implements EveEvalSession {
       record: (events) => this.#recordObservedTurn(sessionId, events),
       session: this,
       sessionId,
+      startIndex: options?.startIndex ?? this.#session.state.streamIndex,
     });
   }
 
@@ -372,6 +375,7 @@ class EvalLiveTurn implements EveEvalLiveTurn {
   readonly #completion: Promise<EveEvalTurn>;
   readonly #events: MessageStreamEvent[] = [];
   readonly #waiters = new Set<LiveEventWaiter>();
+  readonly #startIndex: number;
   #waitError: Error | undefined;
 
   constructor(input: {
@@ -380,9 +384,11 @@ class EvalLiveTurn implements EveEvalLiveTurn {
     readonly record: (events: readonly MessageStreamEvent[]) => EveEvalTurn;
     readonly session: EveEvalSession;
     readonly sessionId: string;
+    readonly startIndex: number;
   }) {
     this.session = input.session;
     this.sessionId = input.sessionId;
+    this.#startIndex = input.startIndex;
     this.#completion = this.#consume(input.events, input.observe, input.record);
     void this.#completion.catch(() => {});
   }
@@ -451,15 +457,28 @@ class EvalLiveTurn implements EveEvalLiveTurn {
       }
 
       if (!sawBoundary) {
-        throw new Error(`Stream for session "${this.sessionId}" closed before a turn boundary.`);
+        throw new Error("stream closed before a turn boundary");
       }
 
       return record(this.#events);
     } catch (error) {
-      const normalized = error instanceof Error ? error : new Error(String(error));
-      this.#closeWaiters(normalized);
-      throw error;
+      const diagnostic = this.#streamFailureDiagnostic(error);
+      this.#closeWaiters(diagnostic);
+      throw diagnostic;
     }
+  }
+
+  #streamFailureDiagnostic(error: unknown): Error {
+    const cause = error instanceof Error ? error : new Error(String(error));
+    const lastEvent = this.#events.at(-1);
+    const cursor = this.session.state?.streamIndex ?? this.#startIndex + this.#events.length;
+    const status = this.#events.findLast(isCurrentTurnBoundaryEvent)?.type ?? "no turn boundary";
+    return new Error(
+      `Eval stream failed for session ${this.sessionId}: ${cause.message}. ` +
+        `cursor=${cursor}, startIndex=${this.#startIndex}, events=${this.#events.length}, ` +
+        `lastEvent=${lastEvent?.type ?? "none"}, turnStatus=${status}.`,
+      { cause },
+    );
   }
 
   #resolveWaiters(event: MessageStreamEvent): void {


### PR DESCRIPTION
### Summary

This is the second PR in the CI reliability stack and builds on #2969. Eval stream failures now report the durable session cursor, starting index, observed event count, last event, and whether a turn boundary was seen. It does not resend an ambiguously accepted turn or add a broad eval retry.

### Validation

Focused eval-runner unit coverage verifies terminal stream diagnostics include the session and durable-stream context. `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/evals/runner/execute-task.test.ts` and `pnpm --filter eve typecheck` passed.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+5 / -0`

The changeset documents the improved eval failure evidence.

**Implementation** — 1 file · `+25 / -4`

Attaches durable-stream state to an otherwise terminal eval error without changing request semantics.

**Tests** — 1 file · `+21 / -0`

Exercises diagnostic output after an interrupted stream.
