### PR TITLE
test(e2e): relax client context model text assertion

### DIFF
--- a/e2e/fixtures/agent-basic-runtime/evals/runtime/client-context.eval.ts
+++ b/e2e/fixtures/agent-basic-runtime/evals/runtime/client-context.eval.ts
@@ -1,8 +1,8 @@
 import { defineEval } from "eve/evals";
-import { equals } from "eve/evals/expect";
-
+import { satisfies } from "eve/evals/expect";
 const FIRST_CLIENT_CONTEXT_TOKEN = "clientctx-first-W7R2";
 const SECOND_CLIENT_CONTEXT_TOKEN = "clientctx-second-P9K4";
+const CLIENT_CONTEXT_TOKEN_PATTERN = /\bclientctx-[A-Za-z0-9-]+\b/g;
 
 /**
  * Core session-route runtime behavior: per-turn client context delivery.
@@ -29,6 +29,21 @@ export default defineEval({
     );
 
     t.succeeded();
-    t.check(second.message?.trim(), equals(SECOND_CLIENT_CONTEXT_TOKEN));
+    const tokens = second.message?.match(CLIENT_CONTEXT_TOKEN_PATTERN) ?? [];
+    await t.require(
+      tokens,
+      satisfies<readonly string[]>(
+        (observed) =>
+          observed.filter((token) => token === SECOND_CLIENT_CONTEXT_TOKEN).length === 1,
+        "contains the fresh client context token exactly once",
+      ),
+    );
+    await t.require(
+      tokens,
+      satisfies<readonly string[]>(
+        (observed) => !observed.includes(FIRST_CLIENT_CONTEXT_TOKEN),
+        "does not contain the first turn's client context token",
+      ),
+    );
   },
 });


### PR DESCRIPTION
### Summary

Real models may include harmless surrounding text when reporting client context. This keeps the isolation check strict about the two meaningful properties: the current token appears exactly once and the previous turn's token does not appear.

### Validation

Confirmed with `pnpm --filter agent-basic-runtime typecheck`. The real-model behavior runs in the Local E2E suite.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

No changeset is needed: this changes an E2E assertion only.

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 0 files · `+0 / -0`

Not applicable.

**Tests** — 1 file · `+18 / -3`

A focused assertion keeps the client-context isolation contract while accepting valid free-form model output.
