### PR TITLE
research: tool suspendability and lifetime as explicit axes

### DIFF
--- a/research/tool-suspendability-and-lifetime.md
+++ b/research/tool-suspendability-and-lifetime.md
@@ -8,243 +8,124 @@ last_updated: 2026-09-03
 
 ## 1. Summary
 
-An authored tool has two independent properties that eve currently encodes as
-two unrelated flags and re-derives with `if` chains at every consumer:
+An authored tool has two independent properties that eve encodes as two
+unrelated flags and re-derives with `if` chains at every consumer:
 
-- **Suspendability** — can the body park without holding compute? Today this
-  is implied by the `"use workflow"` directive and surfaces as
-  `handling.kind === "workflow-tool"` on `CompiledToolBehavior`.
-- **Lifetime** — does the call end with the harness step, or does it outlive
-  it as a durable task? Today this is `execution: "background"`.
+- **Suspendability** — can the body park without holding compute? Implied by
+  the `"use workflow"` directive; surfaces as `handling.kind === "workflow-tool"`.
+- **Lifetime** — does the call end with the harness step, or outlive it as a
+  durable task? Declared by `execution: "background"`.
 
-This document makes both axes explicit in the compiled tool shape, gives each
-of the four resulting cells a distinct `execute` contract, and replaces the
-task-side authoring API. `execution: "background"` stays as the way to declare
-a task lifetime. The third `task` argument stays, but `task.delegated`,
-`task.send`, and `task.binding` are removed from it; in their place, a
-background body communicates with its task only through `yield`, in three
-forms:
-
-```ts
-yield { progress: 0.4 }; // progress: transient, never persisted
-yield task.setState({ devboxTaskId, taskUrl }); // durable state; silent
-yield task.postMessage("Devbox needs input"); // one message; wakes the parent with it
-```
-
-Author-supplied task data becomes durable, model-visible state on the task
-view (`view.state`) rather than a one-shot tool result, and the first set
-value is the receipt the launching turn returns.
-
-`yield` is one-way. Anything that needs a reply is a separate primitive that
-already exists for waiting workflow tools and is made to work for background
-bodies: `ask` from `eve/workflow` for human input, and `ctx.getToken` /
-`ctx.requireAuth` inside a `"use step"` for provider authorization under the
-requester's identity. The latter is a blocker today and is in scope.
+This document makes the pair explicit in the compiled tool shape and gives
+each of the four cells one `execute` contract. The authoring surface keeps
+`execution: "background"` and the third `task` argument, but `task` loses
+`delegated`, `send`, and `binding`. In their place a background body has one
+one-way channel to its task (`yield`) and two round-trip primitives that
+already exist for waiting workflow tools: `ask` for the human, and
+`ctx.getToken`/`ctx.requireAuth` inside a step for the provider. The latter is
+a blocker today for any Connect-backed workflow tool and is in scope.
 
 Motivating case: [vercel/internal-agents#2173](https://github.com/vercel/internal-agents/pull/2173)
 runs Devbox as a background tool and had to build a relay workflow, a webhook
 route, and a `session.completed` adapter because a background `execute()`
-cannot park on an external webhook, and a background workflow tool cannot put
-author data in its receipt.
+cannot park on an external webhook, cannot resolve the requester's token, and
+cannot put author data in its receipt.
 
 ## 2. The four cells
 
-|                       | `lifetime: "step"`                                                                | `lifetime: "task"`                                                                                                              |
-| --------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `suspend: "none"`     | Ordinary tool. Runs inside the step; generator yields stream as `action.partial`. | Task tool. Task created; body runs inside the step and must return; `yield task.setState()` annotates before returning.         |
-| `suspend: "workflow"` | Waiting durable tool. Turn parks on the run; return value is the tool result.     | Background durable tool. Model gets a receipt; run outlives the step; `yield` sets state, posts a message, or reports progress. |
+|                       | `lifetime: "step"`                                                              | `lifetime: "task"`                                                                                                          |
+| --------------------- | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `suspend: "none"`     | `execute(input, ctx)`. Runs in the step; generator yields are `action.partial`. | `execute(input, ctx, task)`. Runs in the step; `yield task.setState()` then `return` completes. No `postMessage`, no `ask`. |
+| `suspend: "workflow"` | `execute(input, ctx)` with `"use workflow"`. Turn parks on the run.             | `execute(input, ctx, task)` with `"use workflow"`. Receipt to the model; run outlives the step; all of §3.                  |
 
-Every cell exists today. What changes is that the pair is data the compiler
-writes once and consumers switch on, and that `yield` is the only channel from
-a body to its task in both task cells, instead of `delegated()`/`send` in one
-and nothing in the other.
-
-```
-                suspend: none                suspend: workflow
-              ┌──────────────────────┐    ┌──────────────────────────┐
-lifetime:step │ execute() in step    │    │ run; turn parks on it    │
-              └──────────────────────┘    └──────────────────────────┘
-              ┌──────────────────────┐    ┌──────────────────────────┐
-lifetime:task │ execute() in step,   │    │ run; receipt to model;   │
-              │ setState then return │    │ setState / post / yield  │
-              └──────────────────────┘    └──────────────────────────┘
-```
+Every cell exists today. What changes: the pair is data the compiler writes
+once (§5), the same `task` capability means the same thing in both task cells,
+and a background workflow body receives `task` at all — today it is silently
+absent. `execution: "background"` selects the task row; the directive selects
+the workflow column; there is no combined enum.
 
 ## 3. Authoring API
 
-### 3.1 Declaring the axes
-
-`execution: "background"` selects `lifetime: "task"`; its absence selects
-`lifetime: "step"`. Suspendability is not declared: the compiler reads the
-`"use workflow"` directive from the body, as it does today. The two never
-collapse into one enum (`"background-workflow"` is rejected).
-
-```ts
-export default defineTool({
-  execution: "background",
-  inputSchema,
-  async *execute(input, ctx, task) {
-    "use workflow";
-    // …
-  },
-});
-```
-
-A background tool whose body is a workflow now receives the third `task`
-argument too. Today it is silently absent there.
-
-### 3.2 The `task` argument
+### 3.1 The `task` argument and `yield`
 
 `TaskExec` shrinks to identity plus two descriptor constructors. Both return
-plain tagged JSON and perform no I/O, so they are replay-safe inside a workflow
-body.
+tagged JSON and do no I/O, so they are replay-safe in a workflow body.
 
 ```ts
 interface TaskExec {
   readonly taskId: string;
   readonly batch: readonly BackgroundToolCall[];
   setState(state: JsonObject): TaskSetState;
-  postMessage(message: string | JsonObject): TaskMessage;
+  postMessage(message: string): TaskMessage;
 }
 ```
 
-`setState` writes a durable snapshot the parent can read on any later turn.
-`postMessage` delivers one message to the parent as input for a new turn, like
-`postMessage` between windows: it is not stored on the task, and it does not
-change `view.state`. The two are independent; a body that wants both sets state
-and then posts.
-
-Removed: `delegated()`, `send()`, `binding`, `session`. `delegated` and the
-executor binding survive as the internal seam subagent dispatch and the
-tool-run return through; they are no longer exported.
-
-### 3.3 Four directions of communication
-
-A background body talks to four parties. Each has one primitive; none overlap.
-
-| direction                   | primitive                                    | shape                                 | durable                                          |
-| --------------------------- | -------------------------------------------- | ------------------------------------- | ------------------------------------------------ |
-| body → parent, one-way      | `yield` (progress / setState / postMessage)  | JSON snapshot, or a message           | setState yes; postMessage and progress no        |
-| body ↔ human, round trip    | `ask(ctx, request)` from `eve/workflow`      | structured request → structured reply | yes: run-owned, answerable after the turn ends   |
-| body ↔ provider, round trip | `ctx.getToken` / `ctx.requireAuth` in a step | token, or an authorization park       | yes: same `authorization.required` wire as today |
-| body → parent, terminal     | `return` / `throw`                           | tool output / error                   | yes                                              |
-
-The parent reaches the body only through `ctx.abortSignal`.
-
-`yield` is fire-and-forget state. It never carries a question. Anything that
-needs a reply from a human is `ask`; anything that needs a reply from an
-identity provider is `requireAuth`. Both are suspension points with typed
-replies and already exist for waiting workflow tools; §3.5 and §3.6 make them
-available to background bodies.
-
-### 3.4 The three `yield` forms
-
-A background body may `yield` three kinds of value. They differ in whether the
-value is persisted as task state and whether the parent is woken.
+A background body may `yield` three kinds of value:
 
 | form                          | `view.state`          | parent                               | use                                         |
 | ----------------------------- | --------------------- | ------------------------------------ | ------------------------------------------- |
-| `yield value` (untagged)      | untouched             | note, under pending-cohort policy    | transient progress                          |
+| `yield value` (untagged)      | untouched             | progress note (today's behaviour)    | transient progress                          |
 | `yield task.setState(state)`  | replaced with `state` | not woken                            | receipt, identifiers, state for later turns |
 | `yield task.postMessage(msg)` | untouched             | woken with `msg` as the turn's input | something the parent should act on now      |
 
-- **Progress** is today's generator semantics, unchanged: `action.partial`
-  for a waiting tool, the existing `Background task … update: <json>` note for
-  a background one. It is never persisted.
-- **setState** is the only way to write `view.state`. Replace, not merge.
-  Silent: no parent turn is started.
-- **postMessage** wakes the parent with the message as input, attributed to
-  the task. The message is not stored; if the parent needs to recall it later
-  it reads `view.state`, which the body sets separately. Runs under the
-  pending-cohort delivery policy like any other task-triggered turn.
+`setState` is the only writer of `view.state` (§4.1): replace, not merge,
+silent. `postMessage` is one delivery to the parent, like `postMessage`
+between windows: not stored, attributed to the task, run under the existing
+task-delivery policy. A body that wants both sets state and then posts.
 
-The first `setState` observed by the launching turn is the receipt:
+The first `setState` observed by the launching turn is the receipt,
 `{ status: "working", taskId, ...view.state }`. Progress and messages yielded
-before it are buffered and delivered after the receipt.
+before it are delivered after it.
 
-### 3.5 Human input: `ask`
+### 3.2 Replies: `ask` and provider authorization
 
-Unchanged from the waiting-tool contract in `docs/tools/workflows.mdx`. The
-request travels over the run's `request` channel; the owning task moves to
-`input_required`; the channel renders it the way it renders `ask_question`;
-the answer resumes the hook and the task returns to `working`. The reply is the
-existing static shape `{ optionId?, text? }`. Richer response schemas are out
-of scope here.
+`yield` never asks. Anything that needs a reply is a suspension point with a
+typed reply, disjoint from `yield`:
 
-What this document adds is only the statement that `ask` is the HITL channel
-for background bodies too, and that it is disjoint from `yield`: a
-`postMessage` tells the parent agent something; an `ask` asks the human
-something. A body that needs the user's input does not post a message to the
-parent and have it relay a question.
+| direction                | primitive                                    | reply                         |
+| ------------------------ | -------------------------------------------- | ----------------------------- |
+| body ↔ human             | `ask(ctx, request)` from `eve/workflow`      | `{ optionId?, text? }`        |
+| body ↔ identity provider | `ctx.getToken` / `ctx.requireAuth` in a step | a token, or a park on sign-in |
 
-### 3.6 Provider authorization in a workflow body
+The parent reaches the body only through `ctx.abortSignal`.
 
-Today `ctx.getToken` and `ctx.requireAuth` throw inside a workflow body
-(`tool-run/workflow.ts`), and a `"use step"` only sees `process.env`. A tool
-that must act under the requester's grant — every Connect-backed tool — cannot
-be written as a workflow. This is the blocker for Devbox and has to be fixed
-here, not deferred.
+**`ask`** is unchanged from the waiting-tool contract in
+`docs/tools/workflows.mdx`: the request travels over the run's `request`
+channel, the task moves to `input_required`, the channel renders it like
+`ask_question`, the answer resumes the hook. Richer response schemas are
+deferred. `postMessage` tells the agent something; `ask` asks the human
+something. A body never posts a question for the parent to relay.
 
-Contract:
+**Provider authorization** is the change. Today `getToken`/`requireAuth`
+throw in a workflow body and a step sees only `process.env`, so no
+Connect-backed tool can be a workflow. Contract:
 
-- `ctx.getToken(provider)` and `ctx.requireAuth(provider)` are callable inside
-  a `"use step"` function that received `ctx`. They resolve against the
-  session identity carried in the run's serialized context, through the same
+- Both are callable inside a `"use step"` that received `ctx`. They resolve
+  under the session identity in the run's serialized context, through the
   scoped-authorization path a step tool uses (`execution/tool-auth.ts`).
-- A resolved token is returned to the step and never enters the workflow
-  body's replay log. Steps that hold a token are ordinary steps: retried on
-  failure, not journaled.
-- When the provider requires interactive authorization, the step does not
-  return an `AuthorizationSignal` to the model. Instead the run parks the way
-  `ask` parks: the challenge travels over the run's `request` channel, the
-  owning task moves to `input_required` with an authorization request, the
-  parent channel renders the sign-in the way it renders a subagent's
-  `authorization.required` today (`tasks/child/steps.ts`), and the callback
-  resumes the hook. The step then re-resolves and continues. To the body this
-  is one `await`.
+- A token is returned to the step and never enters the body's replay log.
+- Interactive authorization does not return an `AuthorizationSignal` to the
+  model. The run parks the way `ask` parks: the challenge is a `RunRequestMessage`
+  with a new `authorization` variant next to `question`; the task moves to
+  `input_required`; the parent channel renders it like a subagent's
+  `authorization.required` today (`tasks/child/steps.ts`); the callback resumes
+  the step's hook and it re-resolves. To the body this is one `await`.
 - The loop guard is unchanged: a token rejected immediately after
-  authorization fails the run with `ConnectionAuthorizationFailedError`.
-- In the body itself (outside a step) both methods keep throwing with the
-  current message. Credentials never touch deterministic code.
+  authorization fails the run.
+- In the body itself both methods keep throwing.
 
-This reuses two existing wires — the scoped-authorization resolver and the
-task-owned authorization event — and adds one mapping: a step-raised
-authorization requirement becomes a run request, alongside `ask`.
+### 3.3 Example: Devbox as a background durable tool
 
-### 3.7 Per-cell `execute` contract
+Against the api-devbox contract the v PR already codes to: one webhook URL at
+`createTask`; `taskStateChange` posts with
+`state ∈ { pending, running, attention-required, complete, errored }`; a
+`prompt` endpoint for follow-ups; a result `{ summary, exitStatus, error?, prs? }`
+from `getTask`. `Hook` is an `AsyncIterable`, so one webhook receives every
+state change for the task's lifetime.
 
-- **`step` / `none`** — `execute(input, ctx)`. Unchanged.
-- **`step` / `workflow`** — `execute(input, ctx)` with `"use workflow"`.
-  Unchanged. `yield` remains `action.partial`; no `task` argument.
-- **`task` / `workflow`** — `execute(input, ctx, task)` with
-  `"use workflow"`. All three `yield` forms, `ask`, and step-scoped auth.
-  `return` completes the task with the return value; `throw` fails it;
-  `ctx.abortSignal` is the cancel path.
-- **`task` / `none`** — `execute(input, ctx, task)`. `yield task.setState()` and
-  progress before `return`; `return` completes. `task.postMessage()` and `ask`
-  are unavailable: the body cannot outlive the step, so there is no later turn
-  to message and no gap for anyone to answer into. Auth is today's step-tool
-  path (an `AuthorizationSignal` parks the turn). A body that must outlive the
-  step is a workflow.
-
-`defineTool` overloads keep the wrong capability unreachable: `task` is absent
-on a `lifetime: "step"` call; `postMessage` is absent from the `TaskExec` a
-non-workflow body receives.
-
-### 3.8 Example: Devbox as a background durable tool
-
-Written against the api-devbox contract the v PR already codes to: one
-webhook URL registered at `createTask`, `taskStateChange` posts with
-`state ∈ { pending, running, attention-required, complete, errored }`, a
-`prompt` endpoint for follow-ups, and a result of
-`{ summary, exitStatus, error?, prs? }` read from `getTask`. `Hook` is an
-`AsyncIterable`, so one webhook receives every state change for the task's
-lifetime.
-
-One run owns the whole api-devbox task. The user's follow-ups — an answer to
-an attention-required prompt, or "now fix the review findings" after a
-completed review — all go through `ask`, so there is no continuation
-argument, no "one active binding" constraint, and no second tool.
+One run owns the whole api-devbox task. Every follow-up — an
+attention-required answer, or "now fix the review findings" — goes through
+`ask`, so there is no continuation argument and no second tool.
 
 ```ts
 export default defineTool({
@@ -255,13 +136,13 @@ export default defineTool({
     "use workflow";
 
     const events = createWebhook(); // registered before the task exists
-    const devbox = await createDevboxTask(input, events.url, ctx); // step: requester's Connect token
+    const devbox = await createDevboxTask(input, events.url, ctx); // step
     yield task.setState({ devboxTaskId: devbox.taskId, taskUrl: devbox.taskUrl, state: "pending" });
 
     try {
       for await (const request of events) {
-        const change = parseTaskStateChange(await request.json()); // { taskId, state } or null
-        if (change === null || change.taskId !== devbox.taskId) continue; // unrelated or malformed post
+        const change = parseTaskStateChange(await request.json());
+        if (change === null || change.taskId !== devbox.taskId) continue;
         yield task.setState({
           devboxTaskId: devbox.taskId,
           taskUrl: devbox.taskUrl,
@@ -289,7 +170,6 @@ export default defineTool({
           case "complete": {
             const result = await readDevboxTask(devbox.taskId, ctx); // step: authoritative
             if (input.pr === false) {
-              // A review has no PR; the requester may want the findings acted on.
               const next = await ask(ctx, {
                 prompt: `Review finished:\n\n${result.summary}\n\nApply these findings?`,
                 display: "confirmation",
@@ -300,7 +180,7 @@ export default defineTool({
               });
               if (next.optionId === "apply") {
                 await promptDevbox(devbox.taskId, "Apply the review findings and open a PR.", ctx);
-                continue; // back to waiting on the same webhook
+                continue;
               }
             }
             return { summary: result.summary, prs: result.prs ?? [], taskUrl: devbox.taskUrl };
@@ -323,7 +203,11 @@ export default defineTool({
 
 async function createDevboxTask(input: DevboxInput, webhookUrl: string, ctx: ToolContext) {
   "use step";
-  const client = await devboxClient(ctx);
+  const { token } = await ctx.getToken(devboxUserAuth); // parks the run on sign-in (§3.2)
+  const client = createDevboxClient({
+    token,
+    onUnauthorized: () => ctx.requireAuth(devboxUserAuth),
+  });
   const snapshot = await selectSnapshot(client, input.repos);
   const set = await client.createTaskSet(input.title ?? deriveTitle(input.prompt));
   const created = await client.createTask({
@@ -341,148 +225,73 @@ async function createDevboxTask(input: DevboxInput, webhookUrl: string, ctx: Too
     taskUrl: devboxTaskUrl(created.task_id),
   };
 }
-
-async function devboxClient(ctx: ToolContext) {
-  "use step";
-  const { token } = await ctx.getToken(devboxUserAuth); // parks the run on sign-in (§3.6)
-  return createDevboxClient({ token, onUnauthorized: () => ctx.requireAuth(devboxUserAuth) });
-}
 ```
 
-`promptDevbox`, `readDevboxTask`, and `stopDevbox` are one-call steps over
-the same client. Snapshot selection, title derivation, and the deliverable
-prompt are the PR's existing helpers, unchanged.
+`promptDevbox`, `readDevboxTask`, and `stopDevbox` are one-call steps over the
+same client; snapshot selection and prompt construction are the PR's helpers.
 
-How each constraint from the integration doc is met:
+What this buys over the bridge:
 
-- **v owns every user-facing message.** The `ask` prompts are rendered on v's
-  channel as v's questions; the model never sees a Devbox turn. Devbox is not
-  a subagent.
-- **attention-required is not terminal.** The run parks on `ask`; the task is
-  `input_required` until the requester answers, then `working` again. The
-  answer is posted to api-devbox from the same run. api-devbox does not put
-  the question text in the webhook, so the prompt links the task page rather
-  than pretending to know what was asked.
-- **Only the requester answers.** `ask` already enforces this on Slack: another
-  user's click is rejected without resolving the request.
-- **Sign-in is not a state the tool returns.** `getToken` in a step parks the
-  run on `authorization.required` under the requester's identity; a later
-  401 is `requireAuth` on the same path.
-- **The callback is a signal.** Terminal states re-read the task; the webhook
-  body is never reported as the result.
-- **A review can be followed by a fix without a second launch.** The
-  `complete` branch of a `pr: false` task offers to apply the findings, which
-  is another prompt to the same api-devbox task on the same webhook.
-- **Cancellation reaches the sandbox.** `finally` stops the Devbox when
-  `ctx.abortSignal` fired (§7). `stop_devbox_task` goes away.
-- **Duplicate and out-of-order webhooks are harmless.** State posts for other
-  tasks are skipped; a repeated `attention-required` re-asks, which is the
-  right behaviour when the sandbox asked again; a repeated terminal state
-  after `return` is a post to a hook the run no longer reads.
+- attention-required is not terminal. The run parks on `ask`, the requester
+  answers on v's channel (only the requester — `ask` already enforces that on
+  Slack), and the answer is posted from the same run.
+- A review can be followed by a fix without a second launch.
+- Sign-in is not a state the tool returns; `getToken` parks the run under the
+  requester's identity.
+- Cancellation stops the sandbox from `finally` (§7).
+- Duplicate or out-of-order webhooks are harmless: other tasks' posts are
+  skipped, a repeated `attention-required` re-asks, and a post after `return`
+  hits a hook nobody reads.
 
-Deleted from the PR: the relay workflow, the relay route, the
-`session.completed`/`subagentName` adapter, the launch and follow-up
-fingerprint guards (step replay is the idempotency mechanism), the `task`
-continuation argument, `stop_devbox_task`, and `get_devbox_task` except as an
-ad hoc status tool.
-
-What the model sees, in order: the receipt
-`{ status: "working", taskId, devboxTaskId, taskUrl, state: "pending" }`; a
-`[Task state]` entry whose `state` tracks api-devbox; an `input.requested` on
-the channel whenever the body asks; and one terminal result. Nothing in
-between requires v to act.
+Deleted: the relay workflow and route, the `session.completed`/`subagentName`
+adapter, the launch and follow-up fingerprint guards (replay is the idempotency
+mechanism), the `task` continuation argument, and `stop_devbox_task`.
 
 ## 4. Task state and messages
 
-### 4.1 Task view
+### 4.1 `view.state`
 
-`TaskView` gains an author-owned, model-visible field:
-
-```ts
-readonly state?: JsonObject;
-```
-
-`state` is distinct from the existing `status`. `status` is the framework's
-lifecycle verdict (`working`, `input_required`, `completed`, …) and is written
-only by lifecycle commands. `state` is whatever the body last set, opaque to
-the framework, and is written only by `setState`.
-
-It is present on `working` and `input_required` views and retained unchanged
-on terminal views. It is included in model-visible task JSON, in the
-`[Task state]` cohort projection, and in `task_status`/TUI rendering. It never
-carries routing credentials; those stay on the private `executor` binding.
+`TaskView` gains an author-owned, model-visible `state?: JsonObject`. It is
+distinct from `status`, the framework's lifecycle verdict: `state` is whatever
+the body last set, opaque to the framework. Present on `working` and
+`input_required` views, retained on terminal ones, included in model-visible
+task JSON and the `[Task state]` projection. Never carries credentials; those
+stay on the private `executor` binding.
 
 ### 4.2 The `set-state` command
 
-The task run accepts one new command through its existing single-writer inbox:
-
-```ts
-{
-  kind: "set-state";
-  state: JsonObject;
-}
-```
-
-- Accepted only while the view is `working` or `input_required`; rejected
-  (not failed) on a terminal view.
-- `state` **replaces** `view.state`. Last-write-wins. No merge.
-- Silent: no parent turn is started.
-- Idempotency comes from the existing hook cursor plus the run's
-  `(epoch, index, callId)` delivery id. Replayed reports are no-ops.
+One new task command through the existing single-writer inbox:
+`{ kind: "set-state", state: JsonObject }`. Accepted while `working` or
+`input_required`, rejected on a terminal view. Replaces `view.state`. Starts no
+turn. Idempotent under the existing hook cursor and the run's
+`(epoch, index, callId)` delivery id.
 
 ### 4.3 Messages
 
-`postMessage` is not a task command. It does not pass through the task run's
-transition function and does not touch the view. It is a delivery to the
-parent session, the same kind of `send` command the child workflow already
-issues for updates (`wakeTaskUpdateParentStep`), with two differences:
-
-- The payload is the author's message, attributed to the task
-  (`taskId`, tool name), rather than the framework's
-  `Background task … update:` prose. A string is delivered as text; an object
-  is delivered as JSON.
-- Delivery is deduplicated by the run's `(epoch, index, callId)` id, so a
-  replayed yield does not start a second turn.
-
-The receiving turn runs under the existing task-delivery policy: while the
-cohort is pending the model is told to act only if the message requires it and
-otherwise stay silent. `postMessage` is how a body tells the agent to act; it
-is not a way to talk to the user.
-
-Progress yields keep today's report path unchanged.
+`postMessage` is not a task command and does not touch the view. It is the
+parent-session `send` the child workflow already issues for updates
+(`wakeTaskUpdateParentStep`), carrying the author's message attributed to the
+task instead of the framework's `Background task … update:` prose, deduplicated
+by the same delivery id. The receiving turn runs under the existing
+task-delivery policy.
 
 ### 4.4 Wiring
 
-- **Workflow run → task.** `runBody` already sends each yield as a
-  `RunReport` through `resumeHookStep(owner.report)`. The owner
-  (`runReportToTaskUpdate`) maps a `TaskSetState` to the `set-state` command,
-  a `TaskMessage` to a parent `send`, and an untagged value to today's progress
-  note.
-- **Receipt.** `createWorkflowToolBackgroundExecute` waits on the owner's
-  report channel for the first `setState`, raced against the run's outcome so
-  a body that returns or throws first still settles the call. The receipt is
-  `{ status: "working", taskId, ...view.state }`. A body that never sets state
-  keeps `{ status: "working", taskId }`.
-- **Step-lifetime task tool.** The `"Background tools cannot return
-AsyncIterable"` guard is removed; the executor iterates the body, sends each
-  `setState` as a `set-state`, and completes with the return value. All sets
-  precede completion by construction.
-- **Waiting workflow tool.** Unchanged: yields stream as `action.partial`.
-  `TaskSetState`/`TaskMessage` cannot be constructed there because there is no
-  `task` argument.
-- **Subagents and the tool-run.** Continue to bind an executor through the
-  internal `delegated` seam. Unchanged behaviour; no public surface.
-- **Step-scoped auth (§3.6).** `ToolRunWorkflowInput` carries the session
-  identity the scoped-authorization resolver needs (it already carries
-  `session`). `createWorkflowToolContext` builds `getToken`/`requireAuth` that
-  work when invoked from a step and throw when invoked from the body; the
-  distinction is the ambient step context the Workflow SDK exposes. A
-  step-raised authorization requirement is sent as a `RunRequestMessage` on the
-  existing `request` channel with a new `authorization` variant next to
-  `question`; `runRequestToInputRequestPayload` maps it to the
-  `authorization.required` task event the child workflow already forwards
-  (`wakeTaskAuthorizationParentStep`). The callback resumes the same
-  `answerToken` hook the step is parked on.
+- `runBody` already sends each yield as a `RunReport`. The owner maps
+  `TaskSetState` → `set-state`, `TaskMessage` → parent `send`, untagged →
+  today's progress note.
+- `createWorkflowToolBackgroundExecute` waits on the report channel for the
+  first `setState`, raced against the run's outcome, and merges it into the
+  receipt. No `setState` → `{ status: "working", taskId }`.
+- The `"Background tools cannot return AsyncIterable"` guard goes; the
+  step-lifetime executor iterates the body and sends each `setState` before
+  completing with the return value.
+- Step-scoped auth: `createWorkflowToolContext` builds `getToken`/`requireAuth`
+  that work under ambient step context and throw otherwise;
+  `runRequestToInputRequestPayload` maps the `authorization` request variant to
+  the `authorization.required` task event the child workflow already forwards.
+- Subagents and the tool-run keep binding executors through the internal
+  `delegated` seam. No public surface.
 
 ## 5. Compiled shape
 
@@ -496,111 +305,74 @@ readonly shape: {
 ```
 
 `handling.kind === "workflow-tool"` collapses into `suspend: "workflow"` plus
-its `workflowId`. Consumers that currently re-derive the combination switch on
-`shape` instead:
-
-- `prepareToolBehavior` (`runtime/tools/registry.ts`)
-- the background-call filter in `harness/tool-loop.ts`
-- `dispatchTaskStep`'s `entry.kind === "workflow-tool"` branch
-- `createWorkflowToolBackgroundExecute` / `BackgroundToolExecutionScope`
+its `workflowId`. `prepareToolBehavior`, the background-call filter in
+`tool-loop.ts`, `dispatchTaskStep`, and `createWorkflowToolBackgroundExecute`
+switch on `shape` instead of re-deriving it. `defineTool` overloads gate the
+capabilities by cell: no `task` on a step-lifetime call; no `postMessage` on a
+non-workflow `TaskExec`.
 
 ## 6. Removed
 
-From the public `TaskExec`:
+From the public `TaskExec`: `delegated()` and `TaskExecutorBinding` (a tool
+parks on the external system from a workflow body instead of handing off by
+sentinel; the seam stays internal), `send()` (not restart-safe by its own
+contract; dominated by `yield`), `binding` (the framework callback wire stops
+being reachable from authored code), and `session` (use `ctx.session`).
 
-- `delegated()` and `TaskExecutorBinding`. An authored tool no longer hands a
-  task to an external executor by returning a sentinel; it parks on the
-  external system from a workflow body. The seam remains internal for
-  subagent dispatch and the tool-run.
-- `send()`. Not restart-safe by its own contract; strictly dominated by
-  `yield` in a workflow body and by `yield task.setState()` before `return` in a
-  step body.
-- `binding`. The framework-owned callback wire (`session.completed` /
-  `session.failed`) stops being reachable from authored code.
-- `session`. Read session context through `ctx.session`, as every other tool
-  does.
-
-Pre-1.0: no compatibility shim. The only known external consumer of the
-removed surface is the internal-agents Devbox bridge, whose replacement is
-§3.8. The `agent-background-tools/export.ts` fixture is rewritten as a workflow
-body.
+Pre-1.0: no shim. The only known external consumer is the Devbox bridge; §3.3
+is its replacement. The `agent-background-tools/export.ts` fixture is rewritten
+as a workflow body.
 
 ## 7. Cancellation
 
-Unchanged in mechanism, but two behaviours become load-bearing once there is
-no executor binding for an authored tool to hang a cancel handler on:
+`task_cancel` aborts `ctx.abortSignal` in the run and waits the existing grace
+period — unchanged. What changes: a body parked on a hook, webhook, `ask`, or
+authorization does not observe the signal today and is abandoned after the
+grace period without running `finally`. The tool-run must race the parked
+await against its control inbox so `finally` runs before the run ends;
+otherwise external cleanup has no home and authors reach for a second tool.
 
-- `task_cancel` on a background workflow tool aborts `ctx.abortSignal` in the
-  run and waits the existing grace period.
-- A body parked on a hook, webhook, `ask`, or authorization does not observe
-  the signal today and is abandoned after the grace period without running
-  `finally`. The tool-run should race the parked await against its control
-  inbox so `finally` runs before the run ends. Without this, external cleanup
-  (`stopDevbox` above) has no home and authors reach for a second tool.
-
-Together with §3.6 these are the two `execution/` changes beyond wiring, and
-both are required for the Devbox migration to be complete.
+With §3.2's auth change, this is one of two `execution/` changes beyond wiring.
+Both are required for the Devbox migration.
 
 ## 8. Invariants
 
-- A tool's cell is fixed at compile time and visible in the manifest.
-- The `task` argument exists iff `execution === "background"`.
-- `yield` is the only one-way channel from a body to its task. There is no
-  post-return path.
-- `yield` never asks. Human input is `ask`; provider authorization is
-  `getToken`/`requireAuth` in a step. Neither is expressible as a yield.
-- `view.state` is written only by `setState`; progress yields never touch
-  it; it is never derived from the tool result or the executor binding.
-- `postMessage` and `ask` exist only for a workflow body.
-- A token never enters a workflow body's replay log. Credentials are resolved
-  and consumed inside steps.
-- The task run remains the single writer of task lifecycle and `state`.
-- A receipt is observed by the launching turn exactly once, from the first
-  `setState`; later sets arrive as task state and messages as input, never as a tool
-  result.
-- Subagent task behaviour is unchanged; it uses the internal seam.
+- A tool's cell is fixed at compile time and visible in the manifest; `task`
+  exists iff `execution === "background"`.
+- `yield` is the only one-way channel from a body to its task, and it never
+  asks. There is no post-return path.
+- `view.state` is written only by `setState`; never derived from the tool
+  result or the executor binding. The task run stays the single writer.
+- A receipt is observed exactly once, from the first `setState`.
+- A token never enters a workflow body's replay log.
+- Subagent task behaviour is unchanged.
 
 ## 9. Open decisions
 
-- Whether `setState`/`postMessage` should also be importable from `eve/tools` as
-  standalone descriptor constructors (matches `ask` from `eve/workflow`), or
-  stay on `task` for type gating only. Leaning `task` only.
-- Whether progress yields in a background body should keep waking the parent
-  with the framework's note (today's behaviour) or become stream-only now that
-  `postMessage` exists for deliberate wakes. Leaning stream-only: two ways to
-  wake the parent is one too many, and a body that wants a wake can say so.
-- Whether `postMessage` should accept only strings. An object is convenient
-  but blurs the line with `setState`; a body that wants the parent to read
-  structured data can set state and post a short pointer. Leaning string only.
+- Progress yields in a background body currently wake the parent with the
+  framework's note. With `postMessage` available, they should probably become
+  stream-only so there is one way to wake the parent. Leaning stream-only.
+- Whether `setState`/`postMessage` should also be importable from `eve/tools`
+  (matches `ask` from `eve/workflow`) or stay on `task` for type gating.
+  Leaning `task` only.
 - Whether `view.state` should be size-bounded, given it is projected into model
   context on every task-triggered turn.
-- Structured `ask` responses (a response schema instead of
-  `{ optionId?, text? }`). Deferred; the static shape is sufficient for the
-  cases in scope.
-- How a step detects it is running inside a step versus the body, for the
-  `getToken` gate in §3.6. The Workflow SDK exposes step context; whether eve
-  should also mark it explicitly is an implementation detail to settle in the
-  PR.
+- How a step detects ambient step context for the `getToken` gate. The Workflow
+  SDK exposes it; whether eve marks it explicitly is for the PR.
+- Structured `ask` responses. Deferred.
 
 ## 10. Testing
 
-- Unit: `applyTaskTransition` for `update` with and without `state` on each
-  status; descriptor construction and tagging; `defineTool` overload typing via
-  `expectTypeOf` (no `postMessage` on a non-workflow `TaskExec`, no `delegated`/`send`
-  anywhere).
-- Integration: `setState` → `update` → `view.state`, no parent delivery;
-  `postMessage` → parent `send` carrying the message, `view.state` untouched; untagged yield →
-  progress note, `view.state` untouched; receipt taken from the first
-  `setState` and the race against early return/throw; `getToken` in a step
-  of a background run resolves under the session identity; a step-raised
-  authorization requirement moves the task to `input_required`, renders on the
-  parent channel, and resumes the step on callback; `getToken` in the body
-  still throws.
-- Scenario: compile-time `shape` for each cell; `execution: "background"` step
-  body with `setState` before `return`.
-- E2E: rewrite `agent-background-tools/export.ts` as a workflow body that
-  sets a receipt, yields progress, parks on `createWebhook`, posts a message on the
-  callback, and completes; assert the receipt, the silent setState, the message, and
-  the terminal result. Add a second body that parks on `ask` from a background
-  run and resumes with the answer. Authorization parking from a step is
-  covered at integration tier; e2e cannot drive a real sign-in.
+- Unit: `applyTaskTransition` for `set-state` on each status; descriptor
+  tagging; `defineTool` overload typing via `expectTypeOf`.
+- Integration: `setState` → `view.state` with no parent delivery;
+  `postMessage` → parent `send` with `view.state` untouched; receipt from the
+  first `setState` and the race against early return/throw; `getToken` in a
+  step of a background run resolves under the session identity; a step-raised
+  authorization requirement parks the task `input_required` and resumes on
+  callback; `getToken` in the body still throws.
+- Scenario: compiled `shape` for each cell.
+- E2E: rewrite `agent-background-tools/export.ts` as a workflow body that sets
+  a receipt, parks on `createWebhook`, posts a message on callback, and
+  completes. Add a body that parks on `ask` from a background run. Sign-in
+  cannot be driven in e2e; it stays at integration tier.

--- a/research/tool-suspendability-and-lifetime.md
+++ b/research/tool-suspendability-and-lifetime.md
@@ -62,20 +62,24 @@ interface TaskExec {
 
 A background body may `yield` three kinds of value:
 
-| form                          | `view.state`          | parent                               | use                                         |
-| ----------------------------- | --------------------- | ------------------------------------ | ------------------------------------------- |
-| `yield value` (untagged)      | untouched             | progress note (today's behaviour)    | transient progress                          |
-| `yield task.setState(state)`  | replaced with `state` | not woken                            | receipt, identifiers, state for later turns |
-| `yield task.postMessage(msg)` | untouched             | woken with `msg` as the turn's input | something the parent should act on now      |
+| form                          | `view.state`          | parent                                  | use                                         |
+| ----------------------------- | --------------------- | --------------------------------------- | ------------------------------------------- |
+| `yield value` (untagged)      | untouched             | not woken; streamed as `action.partial` | transient progress                          |
+| `yield task.setState(state)`  | replaced with `state` | not woken                               | receipt, identifiers, state for later turns |
+| `yield task.postMessage(msg)` | untouched             | woken with `msg` as the turn's input    | something the parent should act on now      |
 
-`setState` is the only writer of `view.state` (§4.1): replace, not merge,
-silent. `postMessage` is one delivery to the parent, like `postMessage`
-between windows: not stored, attributed to the task, run under the existing
-task-delivery policy. A body that wants both sets state and then posts.
+Progress is stream-only. Today an untagged yield from a background body wakes
+the parent with a framework-authored note; that goes away, so `postMessage` is
+the one way to wake the parent. `setState` is the only writer of `view.state`
+(§4.1): replace, not merge, silent. `postMessage` is one delivery to the
+parent, like `postMessage` between windows: not stored, attributed to the
+task, run under the existing task-delivery policy. A body that wants both sets
+state and then posts. Neither constructor is importable elsewhere; they live on
+`task` so the type system can withhold them by cell.
 
 The first `setState` observed by the launching turn is the receipt,
-`{ status: "working", taskId, ...view.state }`. Progress and messages yielded
-before it are delivered after it.
+`{ status: "working", taskId, ...view.state }`. Messages yielded before it are
+delivered after it.
 
 ### 3.2 Replies: `ask` and provider authorization
 
@@ -102,7 +106,9 @@ Connect-backed tool can be a workflow. Contract:
 
 - Both are callable inside a `"use step"` that received `ctx`. They resolve
   under the session identity in the run's serialized context, through the
-  scoped-authorization path a step tool uses (`execution/tool-auth.ts`).
+  scoped-authorization path a step tool uses (`execution/tool-auth.ts`). The
+  gate is the Workflow SDK's ambient step context: the same `ctx` method
+  succeeds when that context is present and throws when it is not.
 - A token is returned to the step and never enters the body's replay log.
 - Interactive authorization does not return an `AuthorizationSignal` to the
   model. The run parks the way `ask` parks: the challenge is a `RunRequestMessage`
@@ -279,7 +285,8 @@ task-delivery policy.
 
 - `runBody` already sends each yield as a `RunReport`. The owner maps
   `TaskSetState` → `set-state`, `TaskMessage` → parent `send`, untagged →
-  today's progress note.
+  `action.partial` on the stream. The `wakeTaskUpdateParentStep` path for
+  untagged reports is removed.
 - `createWorkflowToolBackgroundExecute` waits on the report channel for the
   first `setState`, raced against the run's outcome, and merges it into the
   receipt. No `setState` → `{ status: "working", taskId }`.
@@ -347,19 +354,12 @@ Both are required for the Devbox migration.
 - A token never enters a workflow body's replay log.
 - Subagent task behaviour is unchanged.
 
-## 9. Open decisions
+## 9. Deferred
 
-- Progress yields in a background body currently wake the parent with the
-  framework's note. With `postMessage` available, they should probably become
-  stream-only so there is one way to wake the parent. Leaning stream-only.
-- Whether `setState`/`postMessage` should also be importable from `eve/tools`
-  (matches `ask` from `eve/workflow`) or stay on `task` for type gating.
-  Leaning `task` only.
-- Whether `view.state` should be size-bounded, given it is projected into model
-  context on every task-triggered turn.
-- How a step detects ambient step context for the `getToken` gate. The Workflow
-  SDK exposes it; whether eve marks it explicitly is for the PR.
-- Structured `ask` responses. Deferred.
+- Structured `ask` responses (a response schema instead of
+  `{ optionId?, text? }`).
+- A size bound on `view.state`. It is projected into model context on every
+  task-triggered turn; revisit if it becomes a problem in practice.
 
 ## 10. Testing
 

--- a/research/tool-suspendability-and-lifetime.md
+++ b/research/tool-suspendability-and-lifetime.md
@@ -1,0 +1,311 @@
+---
+issue: TBD
+status: draft
+last_updated: 2026-09-03
+---
+
+# Tools: suspendability and lifetime as two explicit axes
+
+## 1. Summary
+
+An authored tool has two independent properties that eve currently encodes as
+two unrelated flags and re-derives with `if` chains at every consumer:
+
+- **Suspendability** — can the body park without holding compute? Today this
+  is implied by the `"use workflow"` directive and surfaces as
+  `handling.kind === "workflow-tool"` on `CompiledToolBehavior`.
+- **Lifetime** — does the call end with the harness step, or does it outlive
+  it as a durable task? Today this is `execution: "background"`.
+
+This document makes both axes explicit in the compiled tool shape and gives
+each of the four resulting cells a distinct `execute` contract, without
+changing the authoring surface: `execution: "background"` and the third `task`
+argument stay as they are and lower onto the new model. One addition,
+`task.update(data, { wake })`, is a pure descriptor a body can `yield`; the
+existing `task.delegated` and `task.send` are re-implemented on top of the same
+task command. Author-supplied task data becomes durable, model-visible state on
+the task view rather than a one-shot tool result.
+
+Motivating case: [vercel/internal-agents#2173](https://github.com/vercel/internal-agents/pull/2173)
+runs Devbox as a background tool and had to build a relay workflow, a webhook
+route, and a `session.completed` adapter because a background `execute()`
+cannot park on an external webhook, and a background workflow tool cannot put
+author data in its receipt.
+
+## 2. The four cells
+
+|                       | `lifetime: "step"`                                                                | `lifetime: "task"`                                                                                                                         |
+| --------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `suspend: "none"`     | Ordinary tool. Runs inside the step; generator yields stream as `action.partial`. | Task tool. Task created; body runs inside the step and must return or `delegated()`; `task.update()` annotates the task before completion. |
+| `suspend: "workflow"` | Waiting durable tool. Turn parks on the run; return value is the tool result.     | Background durable tool. Model gets a receipt; run outlives the step; `yield` updates the task and may wake the parent.                    |
+
+Every cell exists today. What changes is that the pair is data the compiler
+writes once and consumers switch on, and that the same `task` capability means
+the same thing in both task cells, instead of `delegated()`/`send` in one and
+nothing in the other.
+
+```
+                suspend: none                suspend: workflow
+              ┌──────────────────────┐    ┌──────────────────────────┐
+lifetime:step │ execute() in step    │    │ run; turn parks on it    │
+              └──────────────────────┘    └──────────────────────────┘
+              ┌──────────────────────┐    ┌──────────────────────────┐
+lifetime:task │ execute() in step,   │    │ run; receipt to model;   │
+              │ return completes     │    │ yield → task.update      │
+              └──────────────────────┘    └──────────────────────────┘
+```
+
+## 3. Authoring API
+
+### 3.1 Declaring the axes
+
+The authoring surface is unchanged. `execution: "background"` selects
+`lifetime: "task"`; its absence selects `lifetime: "step"`. Suspendability is
+not declared: the compiler reads the `"use workflow"` directive from the body,
+as it does today. The two never collapse into one enum
+(`"background-workflow"` is rejected).
+
+```ts
+export default defineTool({
+  execution: "background",
+  inputSchema,
+  async *execute(input, ctx, task) {
+    "use workflow";
+    // …
+  },
+});
+```
+
+The only new thing is that a background tool whose body is a workflow now
+receives the third `task` argument too. Today it is silently absent there.
+
+### 3.2 `task.update`
+
+`TaskExec` gains one method. It returns a pure descriptor and performs no I/O,
+so it is replay-safe inside a workflow body.
+
+```ts
+interface TaskExec {
+  // existing: batch, binding, session, task, delegated(), send()
+  update(data: JsonObject, options?: { wake?: boolean }): TaskUpdate;
+}
+```
+
+`TaskUpdate` is a tagged JSON object. Yielding an untagged value in a
+background body is sugar for `task.update(value)`.
+
+The existing members lower onto the same primitive (§4.2):
+
+- `task.delegated({ executor, receipt })` — unchanged signature. The
+  `receipt` is written as the task's first `update` (so it lands on
+  `view.data`, not only in the tool result) and the `executor` is written as
+  the `bind` it is today.
+- `task.send({ kind: "update", message })` — becomes
+  `update({ message }, { wake: true })`. Its restart-safety caveat stands; the
+  durable path is `yield` from a workflow body.
+- `task.send({ kind: "complete" | "fail" | "cancel" })` — unchanged.
+
+### 3.3 Per-cell `execute` contract
+
+- **`step` / `none`** — `execute(input, ctx)`. Unchanged.
+- **`step` / `workflow`** — `execute(input, ctx)` with `"use workflow"`.
+  Unchanged. `yield` remains `action.partial`; no `task` argument.
+- **`task` / `workflow`** — `execute(input, ctx, task)` with
+  `"use workflow"`. Each `yield` is a task update (§4). The first update
+  observed by the launching turn is merged into the receipt. `return`
+  completes the task; `throw` fails it; `ctx.abortSignal` is the cancel path.
+  `task.delegated()` and `task.send()` are not callable here: a workflow body
+  is its own executor, and the run already owns the durable report path.
+- **`task` / `none`** — `execute(input, ctx, task)`. Unchanged contract; the
+  body may additionally `yield task.update(...)` before returning. `return`
+  completes; `task.delegated()` hands off to an external executor as today.
+
+`defineTool` overloads keep the wrong capability unreachable: `task` is absent
+on a `lifetime: "step"` call, and `delegated`/`send` are absent from the
+`TaskExec` a workflow body receives.
+
+### 3.4 Example: Devbox as a background durable tool
+
+```ts
+export default defineTool({
+  execution: "background",
+  inputSchema: devboxInputSchema,
+  async *execute(input, ctx, task) {
+    "use workflow";
+
+    const done = createWebhook();
+    const run = await startOrContinueDevbox({ input, callbackUrl: done.url, callId: ctx.callId });
+    yield task.update({ devboxTaskId: run.taskId, taskUrl: run.taskUrl }); // receipt
+
+    try {
+      const event = await (await done).json();
+      if (event.state === "attention-required") {
+        return { state: "attention-required", devboxTaskId: run.taskId, taskUrl: run.taskUrl };
+      }
+      if (event.state === "errored") throw new FatalError(`Devbox task ${run.taskId} failed`);
+      return await readDevboxResult(run.taskId);
+    } finally {
+      if (ctx.abortSignal.aborted) await stopDevbox(run.taskId);
+    }
+  },
+});
+```
+
+`startOrContinueDevbox`, `readDevboxResult`, and `stopDevbox` are
+`"use step"` functions. The relay workflow, relay route, and subagent-protocol
+adapter from the PR are deleted.
+
+## 4. Task data and the `update` command
+
+### 4.1 Task view
+
+`TaskView` gains an author-owned, model-visible field:
+
+```ts
+readonly data?: JsonObject;
+```
+
+It is present on `working` and `input_required` views and retained unchanged
+on terminal views. It is included in model-visible task JSON, in the
+`[Task state]` cohort projection, and in `task_status`/TUI rendering. It never
+carries routing credentials; those stay on the private `executor` binding.
+
+### 4.2 Command
+
+The task run accepts one new command through its existing single-writer inbox:
+
+```ts
+{
+  kind: "update";
+  data: JsonObject;
+  wake: boolean;
+}
+```
+
+Semantics:
+
+- Accepted only while the view is `working` or `input_required`; rejected
+  (not failed) on a terminal view.
+- `data` **replaces** `view.data`. Last-write-wins, the same rule the docs
+  already state for generator snapshots. No merge.
+- `wake: true` delivers the parent the existing
+  `Background task <id> (<name>) update: <json>` message under the existing
+  pending-cohort policy. `wake: false` stores only.
+- Idempotency comes from the existing hook cursor plus the run's
+  `(epoch, index, callId)` delivery id. Replayed reports are no-ops.
+
+### 4.3 Wiring
+
+- **Workflow run → task.** `runBody` already sends each yield as a
+  `RunReport` through `resumeHookStep(owner.report)`. The owner
+  (`runReportToTaskUpdate`) maps a `TaskUpdate` descriptor to the `update`
+  command; an untagged value maps to `{ data: value, wake: true }`.
+- **Receipt.** `createWorkflowToolBackgroundExecute` waits on the owner's
+  report channel for the first report, raced against the run's outcome so a
+  body that returns or throws before yielding still settles the call. The
+  receipt is `{ status: "working", taskId, ...data }`. A body that never
+  yields keeps `{ status: "working", taskId }`.
+- **Step-lifetime task tool.** The `"Background tools cannot return
+AsyncIterable"` guard is removed; the executor iterates the body, sends each
+  update, and completes with the return value (or binds the executor when the
+  return is `delegated()`). All updates precede completion by construction.
+- **`delegated()` receipt.** `BackgroundToolExecutionScope` sends
+  `{ kind: "update", data: receipt, wake: false }` before `bind`, so the
+  receipt data the model already sees is also on `view.data` for later turns.
+- **Waiting workflow tool.** Unchanged: yields stream as `action.partial`. A
+  `TaskUpdate` descriptor cannot be constructed there because there is no
+  `task` argument.
+
+## 5. Compiled shape
+
+`CompiledToolBehavior` carries the pair as data:
+
+```ts
+readonly shape: {
+  readonly lifetime: "step" | "task";
+  readonly suspend: "none" | "workflow";
+};
+```
+
+`handling.kind === "workflow-tool"` collapses into `suspend: "workflow"` plus
+its `workflowId`. Consumers that currently re-derive the combination switch on
+`shape` instead:
+
+- `prepareToolBehavior` (`runtime/tools/registry.ts`)
+- the background-call filter in `harness/tool-loop.ts`
+- `dispatchTaskStep`'s `entry.kind === "workflow-tool"` branch
+- `createWorkflowToolBackgroundExecute` / `BackgroundToolExecutionScope`
+
+## 6. What is kept, what is narrowed
+
+Nothing is removed from `defineTool` or `TaskExec`. Two members are narrowed
+by cell:
+
+- `task.delegated()` and `task.send()` are absent from the `TaskExec` passed to
+  a workflow body (`task` / `workflow`). A workflow body is its own durable
+  executor; `return`/`throw`/`yield` are the complete surface.
+- `task.send({ kind: "update" })` in a step body keeps its documented
+  restart-safety caveat and now lowers onto the same `update` command as
+  `yield`. It is not deprecated; it is the escape hatch for in-process
+  executors that are not workflows.
+
+The internal-agents Devbox bridge keeps working unchanged on this design; §3.4
+is the version that no longer needs the relay, not a forced migration.
+
+## 7. Cancellation
+
+Unchanged in mechanism, but two behaviours become load-bearing for a workflow
+body, which has no executor binding of its own to hang a cancel handler on:
+
+- `task_cancel` on a background workflow tool aborts `ctx.abortSignal` in the
+  run and waits the existing grace period.
+- A body parked on a hook or webhook does not observe the signal today and is
+  abandoned after the grace period without running `finally`. The tool-run
+  should race the parked await against its control inbox so `finally` runs
+  before the run ends. Without this, external cleanup (`stopDevbox` above) has
+  no home and authors reach for a second tool. This is the one `execution/`
+  change beyond wiring and is required for the migration to be complete.
+
+## 8. Invariants
+
+- A tool's cell is fixed at compile time and visible in the manifest.
+- The `task` argument exists iff `execution === "background"`.
+- `wake` is only meaningful when the body is a workflow; a step body's
+  `update` before `return` never wakes anyone (there is no gap to wake into).
+- `view.data` is written only by `update` commands — from `yield`,
+  `task.update`, `task.send({ kind: "update" })`, or a `delegated()` receipt —
+  never derived from the tool result or the executor binding.
+- The task run remains the single writer of task lifecycle and `data`.
+- A receipt is observed by the launching turn exactly once; later updates
+  arrive as session input, never as a tool result.
+- Existing `delegated()`/`send` callers observe identical model-visible
+  behaviour; the only new observable is `view.data`.
+
+## 9. Open decisions
+
+- Whether `task.update` should also be importable from `eve/tools` as a
+  standalone descriptor constructor (matches `ask` from `eve/workflow`), or
+  stay on `task` for type gating only. Leaning `task` only.
+- Whether `wake` defaults to `true` (matches today's generator-in-background
+  behaviour) or `false` (cheaper; no silent turn). Leaning `true` for
+  continuity, revisit with usage.
+- Whether `task.send({ kind: "update" })` should be deprecated once `yield`
+  covers every in-tree use (`agent-background-tools/export.ts` is the only
+  one). Not in scope here.
+- Whether `view.data` should be size-bounded, given it is projected into model
+  context on every task-triggered turn.
+
+## 10. Testing
+
+- Unit: `applyTaskTransition` for `update` on each status; descriptor
+  construction and tagging; `defineTool` overload typing via `expectTypeOf`
+  (no `delegated`/`send` on the workflow-body `TaskExec`).
+- Integration: report → `update` command → `view.data`; receipt merge and
+  the race against early return/throw; `wake: false` producing no parent
+  delivery; `delegated()` receipt appearing on `view.data`; `send({ kind:
+"update" })` and `yield` producing the same task command.
+- Scenario: compile-time `shape` for each cell; `execution: "background"` step
+  body with yields.
+- E2E: extend `agent-background-tools` with a workflow body that yields a
+  receipt, parks on `createWebhook`, and completes; keep the `send`-based
+  `export.ts` fixture as the regression for the lowered path.

--- a/research/tool-suspendability-and-lifetime.md
+++ b/research/tool-suspendability-and-lifetime.md
@@ -1,7 +1,7 @@
 ---
 issue: TBD
 status: draft
-last_updated: 2026-09-03
+last_updated: "2026-09-03"
 ---
 
 # Tools: suspendability and lifetime as two explicit axes

--- a/research/tool-suspendability-and-lifetime.md
+++ b/research/tool-suspendability-and-lifetime.md
@@ -35,6 +35,12 @@ Author-supplied task data becomes durable, model-visible state on the task
 view (`view.data`) rather than a one-shot tool result, and the first stored
 value is the receipt the launching turn returns.
 
+`yield` is one-way. Anything that needs a reply is a separate primitive that
+already exists for waiting workflow tools and is made to work for background
+bodies: `ask` from `eve/workflow` for human input, and `ctx.getToken` /
+`ctx.requireAuth` inside a `"use step"` for provider authorization under the
+requester's identity. The latter is a blocker today and is in scope.
+
 Motivating case: [vercel/internal-agents#2173](https://github.com/vercel/internal-agents/pull/2173)
 runs Devbox as a background tool and had to build a relay workflow, a webhook
 route, and a `session.completed` adapter because a background `execute()`
@@ -106,7 +112,26 @@ Removed: `delegated()`, `send()`, `binding`, `session`. `delegated` and the
 executor binding survive as the internal seam subagent dispatch and the
 tool-run return through; they are no longer exported.
 
-### 3.3 The three `yield` forms
+### 3.3 Four directions of communication
+
+A background body talks to four parties. Each has one primitive; none overlap.
+
+| direction                   | primitive                                    | shape                                 | durable                                          |
+| --------------------------- | -------------------------------------------- | ------------------------------------- | ------------------------------------------------ |
+| body → parent, one-way      | `yield` (progress / store / wake)            | JSON snapshot                         | store and wake yes; progress no                  |
+| body ↔ human, round trip    | `ask(ctx, request)` from `eve/workflow`      | structured request → structured reply | yes: run-owned, answerable after the turn ends   |
+| body ↔ provider, round trip | `ctx.getToken` / `ctx.requireAuth` in a step | token, or an authorization park       | yes: same `authorization.required` wire as today |
+| body → parent, terminal     | `return` / `throw`                           | tool output / error                   | yes                                              |
+
+The parent reaches the body only through `ctx.abortSignal`.
+
+`yield` is fire-and-forget state. It never carries a question. Anything that
+needs a reply from a human is `ask`; anything that needs a reply from an
+identity provider is `requireAuth`. Both are suspension points with typed
+replies and already exist for waiting workflow tools; §3.5 and §3.6 make them
+available to background bodies.
+
+### 3.4 The three `yield` forms
 
 A background body may `yield` three kinds of value. They differ in whether the
 value is stored on the task and whether the parent is woken.
@@ -128,24 +153,78 @@ The first `store` or `wake` observed by the launching turn is the receipt:
 `{ status: "working", taskId, ...view.data }`. Progress yields before it are
 buffered and delivered after the receipt.
 
-### 3.4 Per-cell `execute` contract
+### 3.5 Human input: `ask`
+
+Unchanged from the waiting-tool contract in `docs/tools/workflows.mdx`. The
+request travels over the run's `request` channel; the owning task moves to
+`input_required`; the channel renders it the way it renders `ask_question`;
+the answer resumes the hook and the task returns to `working`. The reply is the
+existing static shape `{ optionId?, text? }`. Richer response schemas are out
+of scope here.
+
+What this document adds is only the statement that `ask` is the HITL channel
+for background bodies too, and that it is disjoint from `yield`: a `wake` tells
+the parent agent to act; an `ask` tells the human to answer. A body that needs
+the user's input does not wake the parent and have it relay a question.
+
+### 3.6 Provider authorization in a workflow body
+
+Today `ctx.getToken` and `ctx.requireAuth` throw inside a workflow body
+(`tool-run/workflow.ts`), and a `"use step"` only sees `process.env`. A tool
+that must act under the requester's grant — every Connect-backed tool — cannot
+be written as a workflow. This is the blocker for Devbox and has to be fixed
+here, not deferred.
+
+Contract:
+
+- `ctx.getToken(provider)` and `ctx.requireAuth(provider)` are callable inside
+  a `"use step"` function that received `ctx`. They resolve against the
+  session identity carried in the run's serialized context, through the same
+  scoped-authorization path a step tool uses (`execution/tool-auth.ts`).
+- A resolved token is returned to the step and never enters the workflow
+  body's replay log. Steps that hold a token are ordinary steps: retried on
+  failure, not journaled.
+- When the provider requires interactive authorization, the step does not
+  return an `AuthorizationSignal` to the model. Instead the run parks the way
+  `ask` parks: the challenge travels over the run's `request` channel, the
+  owning task moves to `input_required` with an authorization request, the
+  parent channel renders the sign-in the way it renders a subagent's
+  `authorization.required` today (`tasks/child/steps.ts`), and the callback
+  resumes the hook. The step then re-resolves and continues. To the body this
+  is one `await`.
+- The loop guard is unchanged: a token rejected immediately after
+  authorization fails the run with `ConnectionAuthorizationFailedError`.
+- In the body itself (outside a step) both methods keep throwing with the
+  current message. Credentials never touch deterministic code.
+
+This reuses two existing wires — the scoped-authorization resolver and the
+task-owned authorization event — and adds one mapping: a step-raised
+authorization requirement becomes a run request, alongside `ask`.
+
+### 3.7 Per-cell `execute` contract
 
 - **`step` / `none`** — `execute(input, ctx)`. Unchanged.
 - **`step` / `workflow`** — `execute(input, ctx)` with `"use workflow"`.
   Unchanged. `yield` remains `action.partial`; no `task` argument.
 - **`task` / `workflow`** — `execute(input, ctx, task)` with
-  `"use workflow"`. All three `yield` forms. `return` completes the task with
-  the return value; `throw` fails it; `ctx.abortSignal` is the cancel path.
+  `"use workflow"`. All three `yield` forms, `ask`, and step-scoped auth.
+  `return` completes the task with the return value; `throw` fails it;
+  `ctx.abortSignal` is the cancel path.
 - **`task` / `none`** — `execute(input, ctx, task)`. `yield task.store()` and
-  progress before `return`; `return` completes. `task.wake()` is a type error:
-  the body cannot outlive the step, so there is no gap for the parent to be
-  woken into. A body that must outlive the step is a workflow.
+  progress before `return`; `return` completes. `task.wake()` and `ask` are
+  unavailable: the body cannot outlive the step, so there is no gap for anyone
+  to answer into. Auth is today's step-tool path (an `AuthorizationSignal`
+  parks the turn). A body that must outlive the step is a workflow.
 
 `defineTool` overloads keep the wrong capability unreachable: `task` is absent
 on a `lifetime: "step"` call; `wake` is absent from the `TaskExec` a
 non-workflow body receives.
 
-### 3.5 Example: Devbox as a background durable tool
+### 3.8 Example: Devbox as a background durable tool
+
+One invocation owns the whole api-devbox task, including every
+attention-required round trip. There is no continuation argument and no
+"one active binding per api-devbox task" constraint: the run is the binding.
 
 ```ts
 export default defineTool({
@@ -154,33 +233,60 @@ export default defineTool({
   async *execute(input, ctx, task) {
     "use workflow";
 
-    const done = createWebhook();
-    const run = await startOrContinueDevbox({ input, callbackUrl: done.url, callId: ctx.callId });
+    const run = await startDevbox(input, ctx); // step: resolves the requester's Connect token
     yield task.store({ devboxTaskId: run.taskId, taskUrl: run.taskUrl }); // receipt
 
     try {
-      const event = await (await done).json();
-      if (event.state === "attention-required") {
-        yield task.wake({
-          devboxTaskId: run.taskId,
-          taskUrl: run.taskUrl,
-          state: "attention-required",
+      while (true) {
+        const done = createWebhook();
+        await subscribeDevbox(run.taskId, done.url, ctx); // step
+        const event = await (await done).json();
+
+        if (event.state === "completed") return await readDevboxResult(run.taskId, ctx);
+        if (event.state === "errored") throw new FatalError(`Devbox task ${run.taskId} failed`);
+
+        // attention-required: the human answers, in the same run.
+        const answer = await ask(ctx, {
+          prompt: event.message,
+          display: "text",
+          allowFreeform: true,
         });
-        return { devboxTaskId: run.taskId, state: "attention-required" };
+        yield { state: "resuming", devboxTaskId: run.taskId }; // progress
+        await continueDevbox(run.taskId, answer.text, ctx); // step
       }
-      if (event.state === "errored") throw new FatalError(`Devbox task ${run.taskId} failed`);
-      return await readDevboxResult(run.taskId);
     } finally {
-      if (ctx.abortSignal.aborted) await stopDevbox(run.taskId);
+      if (ctx.abortSignal.aborted) await stopDevbox(run.taskId, ctx);
     }
   },
 });
+
+async function startDevbox(input: DevboxInput, ctx: ToolContext) {
+  "use step";
+  const { token } = await ctx.getToken(devboxUserAuth); // may park the run on sign-in (§3.6)
+  return createDevboxClient({
+    token,
+    onUnauthorized: () => ctx.requireAuth(devboxUserAuth),
+  }).createTask(input);
+}
 ```
 
-`startOrContinueDevbox`, `readDevboxResult`, and `stopDevbox` are
-`"use step"` functions. The relay workflow, relay route, and subagent-protocol
-adapter from the PR are deleted. A later v turn reads `devboxTaskId` from the
-task's `view.data` in `[Task state]` to continue the same api-devbox task.
+Every HITL constraint the integration doc lists holds:
+
+- v owns every user-facing message. `ask` renders the question on v's channel;
+  Devbox is never a model-visible subagent.
+- attention-required does not complete the task. It parks the run on `ask`;
+  the task is `input_required` while the human answers and `working` again
+  after. No `input.requested` is authored by v; the framework owns it.
+- Sign-in is not a special state the tool returns. `getToken` in a step parks
+  the run the same way, under the requester's identity.
+- The callback is a signal; `readDevboxResult` reads authoritative state.
+- Cancellation stops the sandbox from `finally` (§7); `stop_devbox_task` goes.
+- Duplicate webhooks are harmless: each iteration mints a fresh webhook URL,
+  and a late post to a consumed one is rejected by the SDK.
+
+The relay workflow, relay route, `session.completed` adapter, `task`
+continuation argument, and `get_devbox_task` (for anything other than ad hoc
+status) are deleted.
 
 ## 4. Task data and the `update` command
 
@@ -244,6 +350,17 @@ AsyncIterable"` guard is removed; the executor iterates the body, sends each
   `task` argument.
 - **Subagents and the tool-run.** Continue to bind an executor through the
   internal `delegated` seam. Unchanged behaviour; no public surface.
+- **Step-scoped auth (§3.6).** `ToolRunWorkflowInput` carries the session
+  identity the scoped-authorization resolver needs (it already carries
+  `session`). `createWorkflowToolContext` builds `getToken`/`requireAuth` that
+  work when invoked from a step and throw when invoked from the body; the
+  distinction is the ambient step context the Workflow SDK exposes. A
+  step-raised authorization requirement is sent as a `RunRequestMessage` on the
+  existing `request` channel with a new `authorization` variant next to
+  `question`; `runRequestToInputRequestPayload` maps it to the
+  `authorization.required` task event the child workflow already forwards
+  (`wakeTaskAuthorizationParentStep`). The callback resumes the same
+  `answerToken` hook the step is parked on.
 
 ## 5. Compiled shape
 
@@ -283,7 +400,7 @@ From the public `TaskExec`:
 
 Pre-1.0: no compatibility shim. The only known external consumer of the
 removed surface is the internal-agents Devbox bridge, whose replacement is
-§3.5. The `agent-background-tools/export.ts` fixture is rewritten as a workflow
+§3.8. The `agent-background-tools/export.ts` fixture is rewritten as a workflow
 body.
 
 ## 7. Cancellation
@@ -293,22 +410,28 @@ no executor binding for an authored tool to hang a cancel handler on:
 
 - `task_cancel` on a background workflow tool aborts `ctx.abortSignal` in the
   run and waits the existing grace period.
-- A body parked on a hook or webhook does not observe the signal today and is
-  abandoned after the grace period without running `finally`. The tool-run
-  should race the parked await against its control inbox so `finally` runs
-  before the run ends. Without this, external cleanup (`stopDevbox` above) has
-  no home and authors reach for a second tool. This is the one `execution/`
-  change beyond wiring and is required for the migration to be complete.
+- A body parked on a hook, webhook, `ask`, or authorization does not observe
+  the signal today and is abandoned after the grace period without running
+  `finally`. The tool-run should race the parked await against its control
+  inbox so `finally` runs before the run ends. Without this, external cleanup
+  (`stopDevbox` above) has no home and authors reach for a second tool.
+
+Together with §3.6 these are the two `execution/` changes beyond wiring, and
+both are required for the Devbox migration to be complete.
 
 ## 8. Invariants
 
 - A tool's cell is fixed at compile time and visible in the manifest.
 - The `task` argument exists iff `execution === "background"`.
-- `yield` is the only channel from a body to its task. There is no
+- `yield` is the only one-way channel from a body to its task. There is no
   post-return path.
+- `yield` never asks. Human input is `ask`; provider authorization is
+  `getToken`/`requireAuth` in a step. Neither is expressible as a yield.
 - `view.data` is written only by `store`/`wake`; progress yields never touch
   it; it is never derived from the tool result or the executor binding.
-- `wake` exists only on a workflow body's `TaskExec`.
+- `wake` and `ask` exist only for a workflow body.
+- A token never enters a workflow body's replay log. Credentials are resolved
+  and consumed inside steps.
 - The task run remains the single writer of task lifecycle and `data`.
 - A receipt is observed by the launching turn exactly once, from the first
   `store`/`wake`; later stores and wakes arrive as task state, never as a tool
@@ -327,6 +450,13 @@ no executor binding for an authored tool to hang a cancel handler on:
   exists. Leaning keep, revisit with usage.
 - Whether `view.data` should be size-bounded, given it is projected into model
   context on every task-triggered turn.
+- Structured `ask` responses (a response schema instead of
+  `{ optionId?, text? }`). Deferred; the static shape is sufficient for the
+  cases in scope.
+- How a step detects it is running inside a step versus the body, for the
+  `getToken` gate in §3.6. The Workflow SDK exposes step context; whether eve
+  should also mark it explicitly is an implementation detail to settle in the
+  PR.
 
 ## 10. Testing
 
@@ -337,10 +467,16 @@ no executor binding for an authored tool to hang a cancel handler on:
 - Integration: `store` → `update` → `view.data`, no parent delivery;
   `wake` → `update` → parent delivery carrying `view.data`; untagged yield →
   progress note, `view.data` untouched; receipt taken from the first
-  `store`/`wake` and the race against early return/throw.
+  `store`/`wake` and the race against early return/throw; `getToken` in a step
+  of a background run resolves under the session identity; a step-raised
+  authorization requirement moves the task to `input_required`, renders on the
+  parent channel, and resumes the step on callback; `getToken` in the body
+  still throws.
 - Scenario: compile-time `shape` for each cell; `execution: "background"` step
   body with `store` before `return`.
 - E2E: rewrite `agent-background-tools/export.ts` as a workflow body that
   stores a receipt, yields progress, parks on `createWebhook`, wakes on the
   callback, and completes; assert the receipt, the silent store, the wake, and
-  the terminal result.
+  the terminal result. Add a second body that parks on `ask` from a background
+  run and resumes with the answer. Authorization parking from a step is
+  covered at integration tier; e2e cannot drive a real sign-in.

--- a/research/tool-suspendability-and-lifetime.md
+++ b/research/tool-suspendability-and-lifetime.md
@@ -27,8 +27,8 @@ forms:
 
 ```ts
 yield { progress: 0.4 }; // progress: transient, never persisted
-yield task.setState({ devboxTaskId, taskUrl }); // set task state, do not wake the parent
-yield task.wake({ state: "attention-required" }); // set task state and wake the parent
+yield task.setState({ devboxTaskId, taskUrl }); // durable state; silent
+yield task.postMessage("Devbox needs input"); // one message; wakes the parent with it
 ```
 
 Author-supplied task data becomes durable, model-visible state on the task
@@ -49,10 +49,10 @@ author data in its receipt.
 
 ## 2. The four cells
 
-|                       | `lifetime: "step"`                                                                | `lifetime: "task"`                                                                                                      |
-| --------------------- | --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `suspend: "none"`     | Ordinary tool. Runs inside the step; generator yields stream as `action.partial`. | Task tool. Task created; body runs inside the step and must return; `yield task.setState()` annotates before returning. |
-| `suspend: "workflow"` | Waiting durable tool. Turn parks on the run; return value is the tool result.     | Background durable tool. Model gets a receipt; run outlives the step; `yield` sets state, wakes, or reports progress.   |
+|                       | `lifetime: "step"`                                                                | `lifetime: "task"`                                                                                                              |
+| --------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `suspend: "none"`     | Ordinary tool. Runs inside the step; generator yields stream as `action.partial`. | Task tool. Task created; body runs inside the step and must return; `yield task.setState()` annotates before returning.         |
+| `suspend: "workflow"` | Waiting durable tool. Turn parks on the run; return value is the tool result.     | Background durable tool. Model gets a receipt; run outlives the step; `yield` sets state, posts a message, or reports progress. |
 
 Every cell exists today. What changes is that the pair is data the compiler
 writes once and consumers switch on, and that `yield` is the only channel from
@@ -66,7 +66,7 @@ lifetime:step │ execute() in step    │    │ run; turn parks on it    │
               └──────────────────────┘    └──────────────────────────┘
               ┌──────────────────────┐    ┌──────────────────────────┐
 lifetime:task │ execute() in step,   │    │ run; receipt to model;   │
-              │ setState then return │    │ setState / wake / yield  │
+              │ setState then return │    │ setState / post / yield  │
               └──────────────────────┘    └──────────────────────────┘
 ```
 
@@ -104,9 +104,15 @@ interface TaskExec {
   readonly taskId: string;
   readonly batch: readonly BackgroundToolCall[];
   setState(state: JsonObject): TaskSetState;
-  wake(state?: JsonObject): TaskWake;
+  postMessage(message: string | JsonObject): TaskMessage;
 }
 ```
+
+`setState` writes a durable snapshot the parent can read on any later turn.
+`postMessage` delivers one message to the parent as input for a new turn, like
+`postMessage` between windows: it is not stored on the task, and it does not
+change `view.state`. The two are independent; a body that wants both sets state
+and then posts.
 
 Removed: `delegated()`, `send()`, `binding`, `session`. `delegated` and the
 executor binding survive as the internal seam subagent dispatch and the
@@ -118,7 +124,7 @@ A background body talks to four parties. Each has one primitive; none overlap.
 
 | direction                   | primitive                                    | shape                                 | durable                                          |
 | --------------------------- | -------------------------------------------- | ------------------------------------- | ------------------------------------------------ |
-| body → parent, one-way      | `yield` (progress / setState / wake)         | JSON snapshot                         | setState and wake yes; progress no               |
+| body → parent, one-way      | `yield` (progress / setState / postMessage)  | JSON snapshot, or a message           | setState yes; postMessage and progress no        |
 | body ↔ human, round trip    | `ask(ctx, request)` from `eve/workflow`      | structured request → structured reply | yes: run-owned, answerable after the turn ends   |
 | body ↔ provider, round trip | `ctx.getToken` / `ctx.requireAuth` in a step | token, or an authorization park       | yes: same `authorization.required` wire as today |
 | body → parent, terminal     | `return` / `throw`                           | tool output / error                   | yes                                              |
@@ -136,22 +142,25 @@ available to background bodies.
 A background body may `yield` three kinds of value. They differ in whether the
 value is persisted as task state and whether the parent is woken.
 
-| form                         | `view.state`          | parent                            | use                                         |
-| ---------------------------- | --------------------- | --------------------------------- | ------------------------------------------- |
-| `yield value` (untagged)     | untouched             | note, under pending-cohort policy | transient progress                          |
-| `yield task.setState(state)` | replaced with `state` | not woken                         | receipt, identifiers, state for later turns |
-| `yield task.wake(state?)`    | replaced if `state`   | woken with `view.state`           | a state change the parent should act on     |
+| form                          | `view.state`          | parent                               | use                                         |
+| ----------------------------- | --------------------- | ------------------------------------ | ------------------------------------------- |
+| `yield value` (untagged)      | untouched             | note, under pending-cohort policy    | transient progress                          |
+| `yield task.setState(state)`  | replaced with `state` | not woken                            | receipt, identifiers, state for later turns |
+| `yield task.postMessage(msg)` | untouched             | woken with `msg` as the turn's input | something the parent should act on now      |
 
 - **Progress** is today's generator semantics, unchanged: `action.partial`
   for a waiting tool, the existing `Background task … update: <json>` note for
   a background one. It is never persisted.
 - **setState** is the only way to write `view.state`. Replace, not merge.
-- **wake** is setState followed by a wake. The wake carries the task's current
-  `view.state`, not a free-text note, so the parent turn reads structured state.
+  Silent: no parent turn is started.
+- **postMessage** wakes the parent with the message as input, attributed to
+  the task. The message is not stored; if the parent needs to recall it later
+  it reads `view.state`, which the body sets separately. Runs under the
+  pending-cohort delivery policy like any other task-triggered turn.
 
-The first `setState` or `wake` observed by the launching turn is the receipt:
-`{ status: "working", taskId, ...view.state }`. Progress yields before it are
-buffered and delivered after the receipt.
+The first `setState` observed by the launching turn is the receipt:
+`{ status: "working", taskId, ...view.state }`. Progress and messages yielded
+before it are buffered and delivered after the receipt.
 
 ### 3.5 Human input: `ask`
 
@@ -163,9 +172,10 @@ existing static shape `{ optionId?, text? }`. Richer response schemas are out
 of scope here.
 
 What this document adds is only the statement that `ask` is the HITL channel
-for background bodies too, and that it is disjoint from `yield`: a `wake` tells
-the parent agent to act; an `ask` tells the human to answer. A body that needs
-the user's input does not wake the parent and have it relay a question.
+for background bodies too, and that it is disjoint from `yield`: a
+`postMessage` tells the parent agent something; an `ask` asks the human
+something. A body that needs the user's input does not post a message to the
+parent and have it relay a question.
 
 ### 3.6 Provider authorization in a workflow body
 
@@ -211,13 +221,14 @@ authorization requirement becomes a run request, alongside `ask`.
   `return` completes the task with the return value; `throw` fails it;
   `ctx.abortSignal` is the cancel path.
 - **`task` / `none`** — `execute(input, ctx, task)`. `yield task.setState()` and
-  progress before `return`; `return` completes. `task.wake()` and `ask` are
-  unavailable: the body cannot outlive the step, so there is no gap for anyone
-  to answer into. Auth is today's step-tool path (an `AuthorizationSignal`
-  parks the turn). A body that must outlive the step is a workflow.
+  progress before `return`; `return` completes. `task.postMessage()` and `ask`
+  are unavailable: the body cannot outlive the step, so there is no later turn
+  to message and no gap for anyone to answer into. Auth is today's step-tool
+  path (an `AuthorizationSignal` parks the turn). A body that must outlive the
+  step is a workflow.
 
 `defineTool` overloads keep the wrong capability unreachable: `task` is absent
-on a `lifetime: "step"` call; `wake` is absent from the `TaskExec` a
+on a `lifetime: "step"` call; `postMessage` is absent from the `TaskExec` a
 non-workflow body receives.
 
 ### 3.8 Example: Devbox as a background durable tool
@@ -288,7 +299,7 @@ The relay workflow, relay route, `session.completed` adapter, `task`
 continuation argument, and `get_devbox_task` (for anything other than ad hoc
 status) are deleted.
 
-## 4. Task state and the `update` command
+## 4. Task state and messages
 
 ### 4.1 Task view
 
@@ -301,57 +312,70 @@ readonly state?: JsonObject;
 `state` is distinct from the existing `status`. `status` is the framework's
 lifecycle verdict (`working`, `input_required`, `completed`, …) and is written
 only by lifecycle commands. `state` is whatever the body last set, opaque to
-the framework, and is written only by `setState`/`wake`.
+the framework, and is written only by `setState`.
 
 It is present on `working` and `input_required` views and retained unchanged
 on terminal views. It is included in model-visible task JSON, in the
 `[Task state]` cohort projection, and in `task_status`/TUI rendering. It never
 carries routing credentials; those stay on the private `executor` binding.
 
-### 4.2 Command
+### 4.2 The `set-state` command
 
 The task run accepts one new command through its existing single-writer inbox:
 
 ```ts
 {
-  kind: "update";
-  state?: JsonObject;
-  wake: boolean;
+  kind: "set-state";
+  state: JsonObject;
 }
 ```
 
-Semantics:
-
 - Accepted only while the view is `working` or `input_required`; rejected
   (not failed) on a terminal view.
-- When `state` is present it **replaces** `view.state`. Last-write-wins. No
-  merge.
-- `wake: true` delivers the parent a wake carrying `view.state` under the
-  existing pending-cohort policy. `wake: false` sets state only.
+- `state` **replaces** `view.state`. Last-write-wins. No merge.
+- Silent: no parent turn is started.
 - Idempotency comes from the existing hook cursor plus the run's
   `(epoch, index, callId)` delivery id. Replayed reports are no-ops.
 
-Progress yields do not use this command; they keep today's report path.
+### 4.3 Messages
 
-### 4.3 Wiring
+`postMessage` is not a task command. It does not pass through the task run's
+transition function and does not touch the view. It is a delivery to the
+parent session, the same kind of `send` command the child workflow already
+issues for updates (`wakeTaskUpdateParentStep`), with two differences:
+
+- The payload is the author's message, attributed to the task
+  (`taskId`, tool name), rather than the framework's
+  `Background task … update:` prose. A string is delivered as text; an object
+  is delivered as JSON.
+- Delivery is deduplicated by the run's `(epoch, index, callId)` id, so a
+  replayed yield does not start a second turn.
+
+The receiving turn runs under the existing task-delivery policy: while the
+cohort is pending the model is told to act only if the message requires it and
+otherwise stay silent. `postMessage` is how a body tells the agent to act; it
+is not a way to talk to the user.
+
+Progress yields keep today's report path unchanged.
+
+### 4.4 Wiring
 
 - **Workflow run → task.** `runBody` already sends each yield as a
   `RunReport` through `resumeHookStep(owner.report)`. The owner
-  (`runReportToTaskUpdate`) maps a `TaskSetState` to
-  `{ kind: "update", state, wake: false }`, a `TaskWake` to
-  `{ kind: "update", state?, wake: true }`, and an untagged value to today's
-  progress note.
+  (`runReportToTaskUpdate`) maps a `TaskSetState` to the `set-state` command,
+  a `TaskMessage` to a parent `send`, and an untagged value to today's progress
+  note.
 - **Receipt.** `createWorkflowToolBackgroundExecute` waits on the owner's
-  report channel for the first `setState`/`wake`, raced against the run's outcome
-  so a body that returns or throws first still settles the call. The receipt
-  is `{ status: "working", taskId, ...view.state }`. A body that never sets state
+  report channel for the first `setState`, raced against the run's outcome so
+  a body that returns or throws first still settles the call. The receipt is
+  `{ status: "working", taskId, ...view.state }`. A body that never sets state
   keeps `{ status: "working", taskId }`.
 - **Step-lifetime task tool.** The `"Background tools cannot return
 AsyncIterable"` guard is removed; the executor iterates the body, sends each
-  `setState` as an `update`, and completes with the return value. All sets
+  `setState` as a `set-state`, and completes with the return value. All sets
   precede completion by construction.
 - **Waiting workflow tool.** Unchanged: yields stream as `action.partial`.
-  `TaskSetState`/`TaskWake` cannot be constructed there because there is no
+  `TaskSetState`/`TaskMessage` cannot be constructed there because there is no
   `task` argument.
 - **Subagents and the tool-run.** Continue to bind an executor through the
   internal `delegated` seam. Unchanged behaviour; no public surface.
@@ -432,27 +456,29 @@ both are required for the Devbox migration to be complete.
   post-return path.
 - `yield` never asks. Human input is `ask`; provider authorization is
   `getToken`/`requireAuth` in a step. Neither is expressible as a yield.
-- `view.state` is written only by `setState`/`wake`; progress yields never touch
+- `view.state` is written only by `setState`; progress yields never touch
   it; it is never derived from the tool result or the executor binding.
-- `wake` and `ask` exist only for a workflow body.
+- `postMessage` and `ask` exist only for a workflow body.
 - A token never enters a workflow body's replay log. Credentials are resolved
   and consumed inside steps.
 - The task run remains the single writer of task lifecycle and `state`.
 - A receipt is observed by the launching turn exactly once, from the first
-  `setState`/`wake`; later sets and wakes arrive as task state, never as a tool
+  `setState`; later sets arrive as task state and messages as input, never as a tool
   result.
 - Subagent task behaviour is unchanged; it uses the internal seam.
 
 ## 9. Open decisions
 
-- Whether `setState`/`wake` should also be importable from `eve/tools` as
+- Whether `setState`/`postMessage` should also be importable from `eve/tools` as
   standalone descriptor constructors (matches `ask` from `eve/workflow`), or
   stay on `task` for type gating only. Leaning `task` only.
-- Whether `wake()` with no `state` is worth keeping, or every wake must carry
-  the state it wants the parent to see. Leaning required `state`.
 - Whether progress yields in a background body should keep waking the parent
-  with a note (today's behaviour) or become persistence-free no-ops now that `wake`
-  exists. Leaning keep, revisit with usage.
+  with the framework's note (today's behaviour) or become stream-only now that
+  `postMessage` exists for deliberate wakes. Leaning stream-only: two ways to
+  wake the parent is one too many, and a body that wants a wake can say so.
+- Whether `postMessage` should accept only strings. An object is convenient
+  but blurs the line with `setState`; a body that wants the parent to read
+  structured data can set state and post a short pointer. Leaning string only.
 - Whether `view.state` should be size-bounded, given it is projected into model
   context on every task-triggered turn.
 - Structured `ask` responses (a response schema instead of
@@ -467,12 +493,12 @@ both are required for the Devbox migration to be complete.
 
 - Unit: `applyTaskTransition` for `update` with and without `state` on each
   status; descriptor construction and tagging; `defineTool` overload typing via
-  `expectTypeOf` (no `wake` on a non-workflow `TaskExec`, no `delegated`/`send`
+  `expectTypeOf` (no `postMessage` on a non-workflow `TaskExec`, no `delegated`/`send`
   anywhere).
 - Integration: `setState` → `update` → `view.state`, no parent delivery;
-  `wake` → `update` → parent delivery carrying `view.state`; untagged yield →
+  `postMessage` → parent `send` carrying the message, `view.state` untouched; untagged yield →
   progress note, `view.state` untouched; receipt taken from the first
-  `setState`/`wake` and the race against early return/throw; `getToken` in a step
+  `setState` and the race against early return/throw; `getToken` in a step
   of a background run resolves under the session identity; a step-raised
   authorization requirement moves the task to `input_required`, renders on the
   parent channel, and resumes the step on callback; `getToken` in the body
@@ -480,8 +506,8 @@ both are required for the Devbox migration to be complete.
 - Scenario: compile-time `shape` for each cell; `execution: "background"` step
   body with `setState` before `return`.
 - E2E: rewrite `agent-background-tools/export.ts` as a workflow body that
-  sets a receipt, yields progress, parks on `createWebhook`, wakes on the
-  callback, and completes; assert the receipt, the silent setState, the wake, and
+  sets a receipt, yields progress, parks on `createWebhook`, posts a message on the
+  callback, and completes; assert the receipt, the silent setState, the message, and
   the terminal result. Add a second body that parks on `ask` from a background
   run and resumes with the answer. Authorization parking from a step is
   covered at integration tier; e2e cannot drive a real sign-in.

--- a/research/tool-suspendability-and-lifetime.md
+++ b/research/tool-suspendability-and-lifetime.md
@@ -77,9 +77,7 @@ task, run under the existing task-delivery policy. A body that wants both sets
 state and then posts. Neither constructor is importable elsewhere; they live on
 `task` so the type system can withhold them by cell.
 
-The first `setState` observed by the launching turn is the receipt,
-`{ status: "working", taskId, ...view.state }`. Messages yielded before it are
-delivered after it.
+The model receives `{ status: "working", taskId }` as soon as the task is admitted. The receipt is independent of state: a body may set state later, park before setting it, or never set it. `taskId` and the task's private run addresses—not `view.state`—are what resume parked work.
 
 ### 3.2 Replies: `ask` and provider authorization
 
@@ -287,9 +285,7 @@ task-delivery policy.
   `TaskSetState` → `set-state`, `TaskMessage` → parent `send`, untagged →
   `action.partial` on the stream. The `wakeTaskUpdateParentStep` path for
   untagged reports is removed.
-- `createWorkflowToolBackgroundExecute` waits on the report channel for the
-  first `setState`, raced against the run's outcome, and merges it into the
-  receipt. No `setState` → `{ status: "working", taskId }`.
+- `createWorkflowToolBackgroundExecute` returns `{ status: "working", taskId }` after task admission. It never waits for a body yield.
 - The `"Background tools cannot return AsyncIterable"` guard goes; the
   step-lifetime executor iterates the body and sends each `setState` before
   completing with the return value.
@@ -350,7 +346,7 @@ Both are required for the Devbox migration.
   asks. There is no post-return path.
 - `view.state` is written only by `setState`; never derived from the tool
   result or the executor binding. The task run stays the single writer.
-- A receipt is observed exactly once, from the first `setState`.
+- A fixed `{ status: "working", taskId }` receipt is observed exactly once and never depends on `view.state`.
 - A token never enters a workflow body's replay log.
 - Subagent task behaviour is unchanged.
 
@@ -366,8 +362,7 @@ Both are required for the Devbox migration.
 - Unit: `applyTaskTransition` for `set-state` on each status; descriptor
   tagging; `defineTool` overload typing via `expectTypeOf`.
 - Integration: `setState` → `view.state` with no parent delivery;
-  `postMessage` → parent `send` with `view.state` untouched; receipt from the
-  first `setState` and the race against early return/throw; `getToken` in a
+  `postMessage` → parent `send` with `view.state` untouched; immediate receipt independent of state; `getToken` in a
   step of a background run resolves under the session identity; a step-raised
   authorization requirement parks the task `input_required` and resumes on
   callback; `getToken` in the body still throws.

--- a/research/tool-suspendability-and-lifetime.md
+++ b/research/tool-suspendability-and-lifetime.md
@@ -8,6 +8,10 @@ last_updated: "2026-09-03"
 
 ## 1. Summary
 
+The proposal uses workflow-local bindings for execution data, ordinary yields
+for silent progress, and `yield task.postMessage(...)` for parent messages.
+There is no `task.setState()` or authored `TaskView.state`.
+
 An authored tool has two independent properties that eve encodes as two
 unrelated flags and re-derives with `if` chains at every consumer:
 
@@ -25,58 +29,60 @@ already exist for waiting workflow tools: `ask` for the human, and
 `ctx.getToken`/`ctx.requireAuth` inside a step for the provider. The latter is
 a blocker today for any Connect-backed workflow tool and is in scope.
 
+[Implementation PR #2997](https://github.com/vercel/eve/pull/2997) implements
+the compiled shape, fixed receipt, progress and message yields, and removal of
+`task.delegated()`. Step-scoped provider authorization (§3.2), cancellation of
+parked bodies (§7), consolidation of inbound messages (§4.1), and removal of
+the remaining deprecated `TaskExec` fields (§6) are still proposed work. The
+Devbox example below depends on the authorization and cancellation work.
+
 Motivating case: [vercel/internal-agents#2173](https://github.com/vercel/internal-agents/pull/2173)
 runs Devbox as a background tool and had to build a relay workflow, a webhook
 route, and a `session.completed` adapter because a background `execute()`
-cannot park on an external webhook, cannot resolve the requester's token, and
-cannot put author data in its receipt.
+cannot park on an external webhook or resolve the requester's token.
 
 ## 2. The four cells
 
 |                       | `lifetime: "step"`                                                              | `lifetime: "task"`                                                                                                          |
 | --------------------- | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `suspend: "none"`     | `execute(input, ctx)`. Runs in the step; generator yields are `action.partial`. | `execute(input, ctx, task)`. Runs in the step; `yield task.setState()` then `return` completes. No `postMessage`, no `ask`. |
+| `suspend: "none"`     | `execute(input, ctx)`. Runs in the step; generator yields are `action.partial`. | `execute(input, ctx, task)`. Runs in the step; yields report progress or parent messages, and `return` completes. No `ask`. |
 | `suspend: "workflow"` | `execute(input, ctx)` with `"use workflow"`. Turn parks on the run.             | `execute(input, ctx, task)` with `"use workflow"`. Receipt to the model; run outlives the step; all of §3.                  |
 
 Every cell exists today. What changes: the pair is data the compiler writes
 once (§5), the same `task` capability means the same thing in both task cells,
 and a background workflow body receives `task` at all — today it is silently
-absent. `execution: "background"` selects the task row; the directive selects
-the workflow column; there is no combined enum.
+absent. `execution: "background"` selects the task column; the directive selects
+the workflow row; there is no combined enum.
 
 ## 3. Authoring API
 
 ### 3.1 The `task` argument and `yield`
 
-`TaskExec` shrinks to identity plus two descriptor constructors. Both return
-tagged JSON and do no I/O, so they are replay-safe in a workflow body.
+`TaskExec` shrinks to identity plus one message constructor. It returns tagged
+JSON and does no I/O, so it is replay-safe in a workflow body.
 
 ```ts
 interface TaskExec {
   readonly taskId: string;
-  setState(state: JsonObject): TaskSetState;
   postMessage(message: string): TaskMessage;
 }
 ```
 
-A background body may `yield` three kinds of value:
+A background body may `yield` two kinds of value:
 
-| form                          | `view.state`          | parent                                  | use                                         |
-| ----------------------------- | --------------------- | --------------------------------------- | ------------------------------------------- |
-| `yield value` (untagged)      | untouched             | not woken; streamed as `action.partial` | transient progress                          |
-| `yield task.setState(state)`  | replaced with `state` | not woken                               | receipt, identifiers, state for later turns |
-| `yield task.postMessage(msg)` | untouched             | woken with `msg` as the turn's input    | something the parent should act on now      |
+| form                          | parent                               | use                                    |
+| ----------------------------- | ------------------------------------ | -------------------------------------- |
+| `yield value` (untagged)      | not woken; streamed as progress      | transient progress                     |
+| `yield task.postMessage(msg)` | woken with `msg` as the turn's input | something the parent should act on now |
 
-Progress is stream-only. Today an untagged yield from a background body wakes
-the parent with a framework-authored note; that goes away, so `postMessage` is
-the one way to wake the parent. `setState` is the only writer of `view.state`
-(§4.1): replace, not merge, silent. `postMessage` is one delivery to the
-parent, like `postMessage` between windows: not stored, attributed to the
-task, run under the existing task-delivery policy. A body that wants both sets
-state and then posts. Neither constructor is importable elsewhere; they live on
-`task` so the type system can withhold them by cell.
+Ordinary yields from authored background tools become stream-only progress.
+Subagent update delivery stays unchanged. `postMessage` sends one message
+attributed to the task under the existing task-delivery policy.
 
-The model receives `{ status: "working", taskId }` as soon as the task is admitted. The receipt is independent of state: a body may set state later, park before setting it, or never set it. `taskId` and the task's private run addresses—not `view.state`—are what resume parked work.
+The model receives `{ status: "working", taskId }` after task admission.
+Workflow-local bindings carry the data needed after a durable wait; replay
+reconstructs them from recorded steps and events. No separate authored task
+snapshot is needed to resume the body.
 
 ### 3.2 Replies: `ask` and provider authorization
 
@@ -135,22 +141,16 @@ export default defineTool({
   execution: "background",
   description: "Start repository work in api-devbox and see it through. Use once per task.",
   inputSchema: devboxInputSchema, // repos, prompt, title?, assistant?, model?, pr?
-  async *execute(input, ctx, task) {
+  async execute(input, ctx) {
     "use workflow";
 
     const events = createWebhook(); // registered before the task exists
     const devbox = await createDevboxTask(input, events.url, ctx); // step
-    yield task.setState({ devboxTaskId: devbox.taskId, taskUrl: devbox.taskUrl, state: "pending" });
 
     try {
       for await (const request of events) {
         const change = parseTaskStateChange(await request.json());
         if (change === null || change.taskId !== devbox.taskId) continue;
-        yield task.setState({
-          devboxTaskId: devbox.taskId,
-          taskUrl: devbox.taskUrl,
-          state: change.state,
-        });
 
         switch (change.state) {
           case "pending":
@@ -250,26 +250,9 @@ Deleted: the relay workflow and route, the `session.completed`/`subagentName`
 adapter, the launch and follow-up fingerprint guards (replay is the idempotency
 mechanism), the `task` continuation argument, and `stop_devbox_task`.
 
-## 4. Task state and messages
+## 4. Task messages
 
-### 4.1 `view.state`
-
-`TaskView` gains an author-owned, model-visible `state?: JsonObject`. It is
-distinct from `status`, the framework's lifecycle verdict: `state` is whatever
-the body last set, opaque to the framework. Present on `working` and
-`input_required` views, retained on terminal ones, included in model-visible
-task JSON and the `[Task state]` projection. Never carries credentials; those
-stay on the private `executor` binding.
-
-### 4.2 The `set-state` command
-
-One new task command through the existing single-writer inbox:
-`{ kind: "set-state", state: JsonObject }`. Accepted while `working` or
-`input_required`, rejected on a terminal view. Replaces `view.state`. Starts no
-turn. Idempotent under the existing hook cursor and the run's
-`(epoch, index, callId)` delivery id.
-
-### 4.3 Messages
+### 4.1 Delivery
 
 `postMessage` is not a task command and does not touch the view. It is the
 parent-session `send` the child workflow already issues for updates
@@ -278,16 +261,22 @@ task instead of the framework's `Background task … update:` prose, deduplicate
 by the same delivery id. The receiving turn runs under the existing
 task-delivery policy.
 
-### 4.4 Wiring
+Use one `TaskInboundMessage` contract for parent-bound traffic, subsuming
+`TaskInboundUpdate` rather than keeping separate message and update queues.
+Subagent updates retain their formatting and delivery policy. `TaskProgress`
+remains the stream-only contract. The shared delivery path must preserve
+deduplication ids, buffer messages until dispatch acknowledgement, and drain
+persisted reports before task completion.
+
+### 4.2 Wiring
 
 - `runBody` already sends each yield as a `RunReport`. The owner maps
-  `TaskSetState` → `set-state`, `TaskMessage` → parent `send`, untagged →
-  `action.partial` on the stream. The `wakeTaskUpdateParentStep` path for
-  untagged reports is removed.
+  `TaskMessage` → parent `send`, untagged → progress on the stream. Subagent
+  reports retain their parent wakes through the shared message path.
 - `createWorkflowToolBackgroundExecute` returns `{ status: "working", taskId }` after task admission. It never waits for a body yield.
 - The `"Background tools cannot return AsyncIterable"` guard goes; the
-  step-lifetime executor iterates the body and sends each `setState` before
-  completing with the return value.
+  ordinary background executor iterates the body, routes progress and messages,
+  and completes with the return value.
 - Step-scoped auth: `createWorkflowToolContext` builds `getToken`/`requireAuth`
   that work under ambient step context and throw otherwise;
   `runRequestToInputRequestPayload` maps the `authorization` request variant to
@@ -310,8 +299,8 @@ readonly shape: {
 its `workflowId`. `prepareToolBehavior`, the background-call filter in
 `tool-loop.ts`, `dispatchTaskStep`, and `createWorkflowToolBackgroundExecute`
 switch on `shape` instead of re-deriving it. `defineTool` overloads gate the
-capabilities by cell: no `task` on a step-lifetime call; no `postMessage` on a
-non-workflow `TaskExec`.
+capabilities by cell: `task` is available only for background execution, and
+`ask` requires a workflow body.
 
 ## 6. Removed
 
@@ -319,11 +308,16 @@ From the public `TaskExec`: `delegated()` and `TaskExecutorBinding` (a tool
 parks on the external system from a workflow body instead of handing off by
 sentinel; the seam stays internal), `send()` (not restart-safe by its own
 contract; dominated by `yield`), `binding` (the framework callback wire stops
-being reachable from authored code), and `session` (use `ctx.session`).
+being reachable from authored code), `session` (use `ctx.session`), and `task`
+(the durable task internals remain framework-owned).
 
 Pre-1.0: no shim. The only known external consumer is the Devbox bridge; §3.3
 is its replacement. The `agent-background-tools/export.ts` fixture is rewritten
 as a workflow body.
+
+Extension manifests requiring removed delegation contracts are rejected before
+their code runs. Keep the historical contract fixtures immutable, but compile
+only the versions still declared supported.
 
 ## 7. Cancellation
 
@@ -343,9 +337,10 @@ Both are required for the Devbox migration.
   exists iff `execution === "background"`.
 - `yield` is the only one-way channel from a body to its task, and it never
   asks. There is no post-return path.
-- `view.state` is written only by `setState`; never derived from the tool
-  result or the executor binding. The task run stays the single writer.
-- A fixed `{ status: "working", taskId }` receipt is observed exactly once and never depends on `view.state`.
+- Workflow-local values survive durable waits through replay; there is no
+  authored `TaskView.state` snapshot.
+- A fixed `{ status: "working", taskId }` receipt is observed exactly once and
+  never depends on a body yield.
 - A token never enters a workflow body's replay log.
 - Subagent task behaviour is unchanged.
 
@@ -353,20 +348,20 @@ Both are required for the Devbox migration.
 
 - Structured `ask` responses (a response schema instead of
   `{ optionId?, text? }`).
-- A size bound on `view.state`. It is projected into model context on every
-  task-triggered turn; revisit if it becomes a problem in practice.
+- Externally readable authored task snapshots, pending a concrete consumer.
 
 ## 10. Testing
 
-- Unit: `applyTaskTransition` for `set-state` on each status; descriptor
-  tagging; `defineTool` overload typing via `expectTypeOf`.
-- Integration: `setState` → `view.state` with no parent delivery;
-  `postMessage` → parent `send` with `view.state` untouched; immediate receipt independent of state; `getToken` in a
+- Unit: message descriptor tagging; `defineTool` overload typing via
+  `expectTypeOf`.
+- Integration: ordinary yields remain silent; `postMessage` → parent `send`;
+  receipt independent of body yields; local values remain usable after a
+  durable wait; `getToken` in a
   step of a background run resolves under the session identity; a step-raised
   authorization requirement parks the task `input_required` and resumes on
   callback; `getToken` in the body still throws.
 - Scenario: compiled `shape` for each cell.
-- E2E: rewrite `agent-background-tools/export.ts` as a workflow body that sets
-  a receipt, parks on `createWebhook`, posts a message on callback, and
+- E2E: rewrite `agent-background-tools/export.ts` as a workflow body that
+  parks on `createWebhook`, posts a message on callback, and
   completes. Add a body that parks on `ask` from a background run. Sign-in
   cannot be driven in e2e; it stays at integration tier.

--- a/research/tool-suspendability-and-lifetime.md
+++ b/research/tool-suspendability-and-lifetime.md
@@ -19,7 +19,7 @@ unrelated flags and re-derives with `if` chains at every consumer:
 This document makes the pair explicit in the compiled tool shape and gives
 each of the four cells one `execute` contract. The authoring surface keeps
 `execution: "background"` and the third `task` argument, but `task` loses
-`delegated`, `send`, and `binding`. In their place a background body has one
+`delegated`, `send`, `binding`, and the non-serializable `batch`. In their place a background body has one
 one-way channel to its task (`yield`) and two round-trip primitives that
 already exist for waiting workflow tools: `ask` for the human, and
 `ctx.getToken`/`ctx.requireAuth` inside a step for the provider. The latter is
@@ -54,7 +54,6 @@ tagged JSON and do no I/O, so they are replay-safe in a workflow body.
 ```ts
 interface TaskExec {
   readonly taskId: string;
-  readonly batch: readonly BackgroundToolCall[];
   setState(state: JsonObject): TaskSetState;
   postMessage(message: string): TaskMessage;
 }

--- a/research/tool-suspendability-and-lifetime.md
+++ b/research/tool-suspendability-and-lifetime.md
@@ -26,13 +26,13 @@ background body communicates with its task only through `yield`, in three
 forms:
 
 ```ts
-yield { progress: 0.4 }; // progress: transient, never stored
-yield task.store({ devboxTaskId, taskUrl }); // store on the task, do not wake the parent
-yield task.wake({ state: "attention-required" }); // store on the task and wake the parent
+yield { progress: 0.4 }; // progress: transient, never persisted
+yield task.setState({ devboxTaskId, taskUrl }); // set task state, do not wake the parent
+yield task.wake({ state: "attention-required" }); // set task state and wake the parent
 ```
 
 Author-supplied task data becomes durable, model-visible state on the task
-view (`view.data`) rather than a one-shot tool result, and the first stored
+view (`view.state`) rather than a one-shot tool result, and the first set
 value is the receipt the launching turn returns.
 
 `yield` is one-way. Anything that needs a reply is a separate primitive that
@@ -49,10 +49,10 @@ author data in its receipt.
 
 ## 2. The four cells
 
-|                       | `lifetime: "step"`                                                                | `lifetime: "task"`                                                                                                   |
-| --------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `suspend: "none"`     | Ordinary tool. Runs inside the step; generator yields stream as `action.partial`. | Task tool. Task created; body runs inside the step and must return; `yield task.store()` annotates before returning. |
-| `suspend: "workflow"` | Waiting durable tool. Turn parks on the run; return value is the tool result.     | Background durable tool. Model gets a receipt; run outlives the step; `yield` stores, wakes, or reports progress.    |
+|                       | `lifetime: "step"`                                                                | `lifetime: "task"`                                                                                                      |
+| --------------------- | --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `suspend: "none"`     | Ordinary tool. Runs inside the step; generator yields stream as `action.partial`. | Task tool. Task created; body runs inside the step and must return; `yield task.setState()` annotates before returning. |
+| `suspend: "workflow"` | Waiting durable tool. Turn parks on the run; return value is the tool result.     | Background durable tool. Model gets a receipt; run outlives the step; `yield` sets state, wakes, or reports progress.   |
 
 Every cell exists today. What changes is that the pair is data the compiler
 writes once and consumers switch on, and that `yield` is the only channel from
@@ -66,7 +66,7 @@ lifetime:step │ execute() in step    │    │ run; turn parks on it    │
               └──────────────────────┘    └──────────────────────────┘
               ┌──────────────────────┐    ┌──────────────────────────┐
 lifetime:task │ execute() in step,   │    │ run; receipt to model;   │
-              │ yield store → return │    │ yield store/wake/progress│
+              │ setState then return │    │ setState / wake / yield  │
               └──────────────────────┘    └──────────────────────────┘
 ```
 
@@ -103,8 +103,8 @@ body.
 interface TaskExec {
   readonly taskId: string;
   readonly batch: readonly BackgroundToolCall[];
-  store(data: JsonObject): TaskStore;
-  wake(data?: JsonObject): TaskWake;
+  setState(state: JsonObject): TaskSetState;
+  wake(state?: JsonObject): TaskWake;
 }
 ```
 
@@ -118,7 +118,7 @@ A background body talks to four parties. Each has one primitive; none overlap.
 
 | direction                   | primitive                                    | shape                                 | durable                                          |
 | --------------------------- | -------------------------------------------- | ------------------------------------- | ------------------------------------------------ |
-| body → parent, one-way      | `yield` (progress / store / wake)            | JSON snapshot                         | store and wake yes; progress no                  |
+| body → parent, one-way      | `yield` (progress / setState / wake)         | JSON snapshot                         | setState and wake yes; progress no               |
 | body ↔ human, round trip    | `ask(ctx, request)` from `eve/workflow`      | structured request → structured reply | yes: run-owned, answerable after the turn ends   |
 | body ↔ provider, round trip | `ctx.getToken` / `ctx.requireAuth` in a step | token, or an authorization park       | yes: same `authorization.required` wire as today |
 | body → parent, terminal     | `return` / `throw`                           | tool output / error                   | yes                                              |
@@ -134,23 +134,23 @@ available to background bodies.
 ### 3.4 The three `yield` forms
 
 A background body may `yield` three kinds of value. They differ in whether the
-value is stored on the task and whether the parent is woken.
+value is persisted as task state and whether the parent is woken.
 
-| form                     | `view.data`          | parent                            | use                                         |
-| ------------------------ | -------------------- | --------------------------------- | ------------------------------------------- |
-| `yield value` (untagged) | untouched            | note, under pending-cohort policy | transient progress                          |
-| `yield task.store(data)` | replaced with `data` | not woken                         | receipt, identifiers, state for later turns |
-| `yield task.wake(data?)` | replaced if `data`   | woken with `view.data`            | a state change the parent should act on     |
+| form                         | `view.state`          | parent                            | use                                         |
+| ---------------------------- | --------------------- | --------------------------------- | ------------------------------------------- |
+| `yield value` (untagged)     | untouched             | note, under pending-cohort policy | transient progress                          |
+| `yield task.setState(state)` | replaced with `state` | not woken                         | receipt, identifiers, state for later turns |
+| `yield task.wake(state?)`    | replaced if `state`   | woken with `view.state`           | a state change the parent should act on     |
 
 - **Progress** is today's generator semantics, unchanged: `action.partial`
   for a waiting tool, the existing `Background task … update: <json>` note for
   a background one. It is never persisted.
-- **Store** is the only way to write `view.data`. Replace, not merge.
-- **Wake** is store followed by a wake. The wake carries the task's current
-  `view.data`, not a free-text note, so the parent turn reads structured state.
+- **setState** is the only way to write `view.state`. Replace, not merge.
+- **wake** is setState followed by a wake. The wake carries the task's current
+  `view.state`, not a free-text note, so the parent turn reads structured state.
 
-The first `store` or `wake` observed by the launching turn is the receipt:
-`{ status: "working", taskId, ...view.data }`. Progress yields before it are
+The first `setState` or `wake` observed by the launching turn is the receipt:
+`{ status: "working", taskId, ...view.state }`. Progress yields before it are
 buffered and delivered after the receipt.
 
 ### 3.5 Human input: `ask`
@@ -210,7 +210,7 @@ authorization requirement becomes a run request, alongside `ask`.
   `"use workflow"`. All three `yield` forms, `ask`, and step-scoped auth.
   `return` completes the task with the return value; `throw` fails it;
   `ctx.abortSignal` is the cancel path.
-- **`task` / `none`** — `execute(input, ctx, task)`. `yield task.store()` and
+- **`task` / `none`** — `execute(input, ctx, task)`. `yield task.setState()` and
   progress before `return`; `return` completes. `task.wake()` and `ask` are
   unavailable: the body cannot outlive the step, so there is no gap for anyone
   to answer into. Auth is today's step-tool path (an `AuthorizationSignal`
@@ -234,7 +234,7 @@ export default defineTool({
     "use workflow";
 
     const run = await startDevbox(input, ctx); // step: resolves the requester's Connect token
-    yield task.store({ devboxTaskId: run.taskId, taskUrl: run.taskUrl }); // receipt
+    yield task.setState({ devboxTaskId: run.taskId, taskUrl: run.taskUrl }); // receipt
 
     try {
       while (true) {
@@ -288,15 +288,20 @@ The relay workflow, relay route, `session.completed` adapter, `task`
 continuation argument, and `get_devbox_task` (for anything other than ad hoc
 status) are deleted.
 
-## 4. Task data and the `update` command
+## 4. Task state and the `update` command
 
 ### 4.1 Task view
 
 `TaskView` gains an author-owned, model-visible field:
 
 ```ts
-readonly data?: JsonObject;
+readonly state?: JsonObject;
 ```
+
+`state` is distinct from the existing `status`. `status` is the framework's
+lifecycle verdict (`working`, `input_required`, `completed`, …) and is written
+only by lifecycle commands. `state` is whatever the body last set, opaque to
+the framework, and is written only by `setState`/`wake`.
 
 It is present on `working` and `input_required` views and retained unchanged
 on terminal views. It is included in model-visible task JSON, in the
@@ -310,7 +315,7 @@ The task run accepts one new command through its existing single-writer inbox:
 ```ts
 {
   kind: "update";
-  data?: JsonObject;
+  state?: JsonObject;
   wake: boolean;
 }
 ```
@@ -319,10 +324,10 @@ Semantics:
 
 - Accepted only while the view is `working` or `input_required`; rejected
   (not failed) on a terminal view.
-- When `data` is present it **replaces** `view.data`. Last-write-wins. No
+- When `state` is present it **replaces** `view.state`. Last-write-wins. No
   merge.
-- `wake: true` delivers the parent a wake carrying `view.data` under the
-  existing pending-cohort policy. `wake: false` stores only.
+- `wake: true` delivers the parent a wake carrying `view.state` under the
+  existing pending-cohort policy. `wake: false` sets state only.
 - Idempotency comes from the existing hook cursor plus the run's
   `(epoch, index, callId)` delivery id. Replayed reports are no-ops.
 
@@ -332,21 +337,21 @@ Progress yields do not use this command; they keep today's report path.
 
 - **Workflow run → task.** `runBody` already sends each yield as a
   `RunReport` through `resumeHookStep(owner.report)`. The owner
-  (`runReportToTaskUpdate`) maps a `TaskStore` to
-  `{ kind: "update", data, wake: false }`, a `TaskWake` to
-  `{ kind: "update", data?, wake: true }`, and an untagged value to today's
+  (`runReportToTaskUpdate`) maps a `TaskSetState` to
+  `{ kind: "update", state, wake: false }`, a `TaskWake` to
+  `{ kind: "update", state?, wake: true }`, and an untagged value to today's
   progress note.
 - **Receipt.** `createWorkflowToolBackgroundExecute` waits on the owner's
-  report channel for the first `store`/`wake`, raced against the run's outcome
+  report channel for the first `setState`/`wake`, raced against the run's outcome
   so a body that returns or throws first still settles the call. The receipt
-  is `{ status: "working", taskId, ...view.data }`. A body that never stores
+  is `{ status: "working", taskId, ...view.state }`. A body that never sets state
   keeps `{ status: "working", taskId }`.
 - **Step-lifetime task tool.** The `"Background tools cannot return
 AsyncIterable"` guard is removed; the executor iterates the body, sends each
-  `store` as an `update`, and completes with the return value. All stores
+  `setState` as an `update`, and completes with the return value. All sets
   precede completion by construction.
 - **Waiting workflow tool.** Unchanged: yields stream as `action.partial`.
-  `TaskStore`/`TaskWake` cannot be constructed there because there is no
+  `TaskSetState`/`TaskWake` cannot be constructed there because there is no
   `task` argument.
 - **Subagents and the tool-run.** Continue to bind an executor through the
   internal `delegated` seam. Unchanged behaviour; no public surface.
@@ -391,7 +396,7 @@ From the public `TaskExec`:
   external system from a workflow body. The seam remains internal for
   subagent dispatch and the tool-run.
 - `send()`. Not restart-safe by its own contract; strictly dominated by
-  `yield` in a workflow body and by `yield task.store()` before `return` in a
+  `yield` in a workflow body and by `yield task.setState()` before `return` in a
   step body.
 - `binding`. The framework-owned callback wire (`session.completed` /
   `session.failed`) stops being reachable from authored code.
@@ -427,28 +432,28 @@ both are required for the Devbox migration to be complete.
   post-return path.
 - `yield` never asks. Human input is `ask`; provider authorization is
   `getToken`/`requireAuth` in a step. Neither is expressible as a yield.
-- `view.data` is written only by `store`/`wake`; progress yields never touch
+- `view.state` is written only by `setState`/`wake`; progress yields never touch
   it; it is never derived from the tool result or the executor binding.
 - `wake` and `ask` exist only for a workflow body.
 - A token never enters a workflow body's replay log. Credentials are resolved
   and consumed inside steps.
-- The task run remains the single writer of task lifecycle and `data`.
+- The task run remains the single writer of task lifecycle and `state`.
 - A receipt is observed by the launching turn exactly once, from the first
-  `store`/`wake`; later stores and wakes arrive as task state, never as a tool
+  `setState`/`wake`; later sets and wakes arrive as task state, never as a tool
   result.
 - Subagent task behaviour is unchanged; it uses the internal seam.
 
 ## 9. Open decisions
 
-- Whether `store`/`wake` should also be importable from `eve/tools` as
+- Whether `setState`/`wake` should also be importable from `eve/tools` as
   standalone descriptor constructors (matches `ask` from `eve/workflow`), or
   stay on `task` for type gating only. Leaning `task` only.
-- Whether `wake()` with no `data` is worth keeping, or every wake must carry
-  the state it wants the parent to see. Leaning required `data`.
+- Whether `wake()` with no `state` is worth keeping, or every wake must carry
+  the state it wants the parent to see. Leaning required `state`.
 - Whether progress yields in a background body should keep waking the parent
-  with a note (today's behaviour) or become store-free no-ops now that `wake`
+  with a note (today's behaviour) or become persistence-free no-ops now that `wake`
   exists. Leaning keep, revisit with usage.
-- Whether `view.data` should be size-bounded, given it is projected into model
+- Whether `view.state` should be size-bounded, given it is projected into model
   context on every task-triggered turn.
 - Structured `ask` responses (a response schema instead of
   `{ optionId?, text? }`). Deferred; the static shape is sufficient for the
@@ -460,23 +465,23 @@ both are required for the Devbox migration to be complete.
 
 ## 10. Testing
 
-- Unit: `applyTaskTransition` for `update` with and without `data` on each
+- Unit: `applyTaskTransition` for `update` with and without `state` on each
   status; descriptor construction and tagging; `defineTool` overload typing via
   `expectTypeOf` (no `wake` on a non-workflow `TaskExec`, no `delegated`/`send`
   anywhere).
-- Integration: `store` → `update` → `view.data`, no parent delivery;
-  `wake` → `update` → parent delivery carrying `view.data`; untagged yield →
-  progress note, `view.data` untouched; receipt taken from the first
-  `store`/`wake` and the race against early return/throw; `getToken` in a step
+- Integration: `setState` → `update` → `view.state`, no parent delivery;
+  `wake` → `update` → parent delivery carrying `view.state`; untagged yield →
+  progress note, `view.state` untouched; receipt taken from the first
+  `setState`/`wake` and the race against early return/throw; `getToken` in a step
   of a background run resolves under the session identity; a step-raised
   authorization requirement moves the task to `input_required`, renders on the
   parent channel, and resumes the step on callback; `getToken` in the body
   still throws.
 - Scenario: compile-time `shape` for each cell; `execution: "background"` step
-  body with `store` before `return`.
+  body with `setState` before `return`.
 - E2E: rewrite `agent-background-tools/export.ts` as a workflow body that
-  stores a receipt, yields progress, parks on `createWebhook`, wakes on the
-  callback, and completes; assert the receipt, the silent store, the wake, and
+  sets a receipt, yields progress, parks on `createWebhook`, wakes on the
+  callback, and completes; assert the receipt, the silent setState, the wake, and
   the terminal result. Add a second body that parks on `ask` from a background
   run and resumes with the answer. Authorization parking from a step is
   covered at integration tier; e2e cannot drive a real sign-in.

--- a/research/tool-suspendability-and-lifetime.md
+++ b/research/tool-suspendability-and-lifetime.md
@@ -17,14 +17,23 @@ two unrelated flags and re-derives with `if` chains at every consumer:
 - **Lifetime** — does the call end with the harness step, or does it outlive
   it as a durable task? Today this is `execution: "background"`.
 
-This document makes both axes explicit in the compiled tool shape and gives
-each of the four resulting cells a distinct `execute` contract, without
-changing the authoring surface: `execution: "background"` and the third `task`
-argument stay as they are and lower onto the new model. One addition,
-`task.update(data, { wake })`, is a pure descriptor a body can `yield`; the
-existing `task.delegated` and `task.send` are re-implemented on top of the same
-task command. Author-supplied task data becomes durable, model-visible state on
-the task view rather than a one-shot tool result.
+This document makes both axes explicit in the compiled tool shape, gives each
+of the four resulting cells a distinct `execute` contract, and replaces the
+task-side authoring API. `execution: "background"` stays as the way to declare
+a task lifetime. The third `task` argument stays, but `task.delegated`,
+`task.send`, and `task.binding` are removed from it; in their place, a
+background body communicates with its task only through `yield`, in three
+forms:
+
+```ts
+yield { progress: 0.4 }; // progress: transient, never stored
+yield task.store({ devboxTaskId, taskUrl }); // store on the task, do not wake the parent
+yield task.wake({ state: "attention-required" }); // store on the task and wake the parent
+```
+
+Author-supplied task data becomes durable, model-visible state on the task
+view (`view.data`) rather than a one-shot tool result, and the first stored
+value is the receipt the launching turn returns.
 
 Motivating case: [vercel/internal-agents#2173](https://github.com/vercel/internal-agents/pull/2173)
 runs Devbox as a background tool and had to build a relay workflow, a webhook
@@ -34,15 +43,15 @@ author data in its receipt.
 
 ## 2. The four cells
 
-|                       | `lifetime: "step"`                                                                | `lifetime: "task"`                                                                                                                         |
-| --------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `suspend: "none"`     | Ordinary tool. Runs inside the step; generator yields stream as `action.partial`. | Task tool. Task created; body runs inside the step and must return or `delegated()`; `task.update()` annotates the task before completion. |
-| `suspend: "workflow"` | Waiting durable tool. Turn parks on the run; return value is the tool result.     | Background durable tool. Model gets a receipt; run outlives the step; `yield` updates the task and may wake the parent.                    |
+|                       | `lifetime: "step"`                                                                | `lifetime: "task"`                                                                                                   |
+| --------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `suspend: "none"`     | Ordinary tool. Runs inside the step; generator yields stream as `action.partial`. | Task tool. Task created; body runs inside the step and must return; `yield task.store()` annotates before returning. |
+| `suspend: "workflow"` | Waiting durable tool. Turn parks on the run; return value is the tool result.     | Background durable tool. Model gets a receipt; run outlives the step; `yield` stores, wakes, or reports progress.    |
 
 Every cell exists today. What changes is that the pair is data the compiler
-writes once and consumers switch on, and that the same `task` capability means
-the same thing in both task cells, instead of `delegated()`/`send` in one and
-nothing in the other.
+writes once and consumers switch on, and that `yield` is the only channel from
+a body to its task in both task cells, instead of `delegated()`/`send` in one
+and nothing in the other.
 
 ```
                 suspend: none                suspend: workflow
@@ -51,7 +60,7 @@ lifetime:step │ execute() in step    │    │ run; turn parks on it    │
               └──────────────────────┘    └──────────────────────────┘
               ┌──────────────────────┐    ┌──────────────────────────┐
 lifetime:task │ execute() in step,   │    │ run; receipt to model;   │
-              │ return completes     │    │ yield → task.update      │
+              │ yield store → return │    │ yield store/wake/progress│
               └──────────────────────┘    └──────────────────────────┘
 ```
 
@@ -59,11 +68,10 @@ lifetime:task │ execute() in step,   │    │ run; receipt to model;   │
 
 ### 3.1 Declaring the axes
 
-The authoring surface is unchanged. `execution: "background"` selects
-`lifetime: "task"`; its absence selects `lifetime: "step"`. Suspendability is
-not declared: the compiler reads the `"use workflow"` directive from the body,
-as it does today. The two never collapse into one enum
-(`"background-workflow"` is rejected).
+`execution: "background"` selects `lifetime: "task"`; its absence selects
+`lifetime: "step"`. Suspendability is not declared: the compiler reads the
+`"use workflow"` directive from the body, as it does today. The two never
+collapse into one enum (`"background-workflow"` is rejected).
 
 ```ts
 export default defineTool({
@@ -76,55 +84,68 @@ export default defineTool({
 });
 ```
 
-The only new thing is that a background tool whose body is a workflow now
-receives the third `task` argument too. Today it is silently absent there.
+A background tool whose body is a workflow now receives the third `task`
+argument too. Today it is silently absent there.
 
-### 3.2 `task.update`
+### 3.2 The `task` argument
 
-`TaskExec` gains one method. It returns a pure descriptor and performs no I/O,
-so it is replay-safe inside a workflow body.
+`TaskExec` shrinks to identity plus two descriptor constructors. Both return
+plain tagged JSON and perform no I/O, so they are replay-safe inside a workflow
+body.
 
 ```ts
 interface TaskExec {
-  // existing: batch, binding, session, task, delegated(), send()
-  update(data: JsonObject, options?: { wake?: boolean }): TaskUpdate;
+  readonly taskId: string;
+  readonly batch: readonly BackgroundToolCall[];
+  store(data: JsonObject): TaskStore;
+  wake(data?: JsonObject): TaskWake;
 }
 ```
 
-`TaskUpdate` is a tagged JSON object. Yielding an untagged value in a
-background body is sugar for `task.update(value)`.
+Removed: `delegated()`, `send()`, `binding`, `session`. `delegated` and the
+executor binding survive as the internal seam subagent dispatch and the
+tool-run return through; they are no longer exported.
 
-The existing members lower onto the same primitive (§4.2):
+### 3.3 The three `yield` forms
 
-- `task.delegated({ executor, receipt })` — unchanged signature. The
-  `receipt` is written as the task's first `update` (so it lands on
-  `view.data`, not only in the tool result) and the `executor` is written as
-  the `bind` it is today.
-- `task.send({ kind: "update", message })` — becomes
-  `update({ message }, { wake: true })`. Its restart-safety caveat stands; the
-  durable path is `yield` from a workflow body.
-- `task.send({ kind: "complete" | "fail" | "cancel" })` — unchanged.
+A background body may `yield` three kinds of value. They differ in whether the
+value is stored on the task and whether the parent is woken.
 
-### 3.3 Per-cell `execute` contract
+| form                     | `view.data`          | parent                            | use                                         |
+| ------------------------ | -------------------- | --------------------------------- | ------------------------------------------- |
+| `yield value` (untagged) | untouched            | note, under pending-cohort policy | transient progress                          |
+| `yield task.store(data)` | replaced with `data` | not woken                         | receipt, identifiers, state for later turns |
+| `yield task.wake(data?)` | replaced if `data`   | woken with `view.data`            | a state change the parent should act on     |
+
+- **Progress** is today's generator semantics, unchanged: `action.partial`
+  for a waiting tool, the existing `Background task … update: <json>` note for
+  a background one. It is never persisted.
+- **Store** is the only way to write `view.data`. Replace, not merge.
+- **Wake** is store followed by a wake. The wake carries the task's current
+  `view.data`, not a free-text note, so the parent turn reads structured state.
+
+The first `store` or `wake` observed by the launching turn is the receipt:
+`{ status: "working", taskId, ...view.data }`. Progress yields before it are
+buffered and delivered after the receipt.
+
+### 3.4 Per-cell `execute` contract
 
 - **`step` / `none`** — `execute(input, ctx)`. Unchanged.
 - **`step` / `workflow`** — `execute(input, ctx)` with `"use workflow"`.
   Unchanged. `yield` remains `action.partial`; no `task` argument.
 - **`task` / `workflow`** — `execute(input, ctx, task)` with
-  `"use workflow"`. Each `yield` is a task update (§4). The first update
-  observed by the launching turn is merged into the receipt. `return`
-  completes the task; `throw` fails it; `ctx.abortSignal` is the cancel path.
-  `task.delegated()` and `task.send()` are not callable here: a workflow body
-  is its own executor, and the run already owns the durable report path.
-- **`task` / `none`** — `execute(input, ctx, task)`. Unchanged contract; the
-  body may additionally `yield task.update(...)` before returning. `return`
-  completes; `task.delegated()` hands off to an external executor as today.
+  `"use workflow"`. All three `yield` forms. `return` completes the task with
+  the return value; `throw` fails it; `ctx.abortSignal` is the cancel path.
+- **`task` / `none`** — `execute(input, ctx, task)`. `yield task.store()` and
+  progress before `return`; `return` completes. `task.wake()` is a type error:
+  the body cannot outlive the step, so there is no gap for the parent to be
+  woken into. A body that must outlive the step is a workflow.
 
 `defineTool` overloads keep the wrong capability unreachable: `task` is absent
-on a `lifetime: "step"` call, and `delegated`/`send` are absent from the
-`TaskExec` a workflow body receives.
+on a `lifetime: "step"` call; `wake` is absent from the `TaskExec` a
+non-workflow body receives.
 
-### 3.4 Example: Devbox as a background durable tool
+### 3.5 Example: Devbox as a background durable tool
 
 ```ts
 export default defineTool({
@@ -135,12 +156,17 @@ export default defineTool({
 
     const done = createWebhook();
     const run = await startOrContinueDevbox({ input, callbackUrl: done.url, callId: ctx.callId });
-    yield task.update({ devboxTaskId: run.taskId, taskUrl: run.taskUrl }); // receipt
+    yield task.store({ devboxTaskId: run.taskId, taskUrl: run.taskUrl }); // receipt
 
     try {
       const event = await (await done).json();
       if (event.state === "attention-required") {
-        return { state: "attention-required", devboxTaskId: run.taskId, taskUrl: run.taskUrl };
+        yield task.wake({
+          devboxTaskId: run.taskId,
+          taskUrl: run.taskUrl,
+          state: "attention-required",
+        });
+        return { devboxTaskId: run.taskId, state: "attention-required" };
       }
       if (event.state === "errored") throw new FatalError(`Devbox task ${run.taskId} failed`);
       return await readDevboxResult(run.taskId);
@@ -153,7 +179,8 @@ export default defineTool({
 
 `startOrContinueDevbox`, `readDevboxResult`, and `stopDevbox` are
 `"use step"` functions. The relay workflow, relay route, and subagent-protocol
-adapter from the PR are deleted.
+adapter from the PR are deleted. A later v turn reads `devboxTaskId` from the
+task's `view.data` in `[Task state]` to continue the same api-devbox task.
 
 ## 4. Task data and the `update` command
 
@@ -177,7 +204,7 @@ The task run accepts one new command through its existing single-writer inbox:
 ```ts
 {
   kind: "update";
-  data: JsonObject;
+  data?: JsonObject;
   wake: boolean;
 }
 ```
@@ -186,35 +213,37 @@ Semantics:
 
 - Accepted only while the view is `working` or `input_required`; rejected
   (not failed) on a terminal view.
-- `data` **replaces** `view.data`. Last-write-wins, the same rule the docs
-  already state for generator snapshots. No merge.
-- `wake: true` delivers the parent the existing
-  `Background task <id> (<name>) update: <json>` message under the existing
-  pending-cohort policy. `wake: false` stores only.
+- When `data` is present it **replaces** `view.data`. Last-write-wins. No
+  merge.
+- `wake: true` delivers the parent a wake carrying `view.data` under the
+  existing pending-cohort policy. `wake: false` stores only.
 - Idempotency comes from the existing hook cursor plus the run's
   `(epoch, index, callId)` delivery id. Replayed reports are no-ops.
+
+Progress yields do not use this command; they keep today's report path.
 
 ### 4.3 Wiring
 
 - **Workflow run → task.** `runBody` already sends each yield as a
   `RunReport` through `resumeHookStep(owner.report)`. The owner
-  (`runReportToTaskUpdate`) maps a `TaskUpdate` descriptor to the `update`
-  command; an untagged value maps to `{ data: value, wake: true }`.
+  (`runReportToTaskUpdate`) maps a `TaskStore` to
+  `{ kind: "update", data, wake: false }`, a `TaskWake` to
+  `{ kind: "update", data?, wake: true }`, and an untagged value to today's
+  progress note.
 - **Receipt.** `createWorkflowToolBackgroundExecute` waits on the owner's
-  report channel for the first report, raced against the run's outcome so a
-  body that returns or throws before yielding still settles the call. The
-  receipt is `{ status: "working", taskId, ...data }`. A body that never
-  yields keeps `{ status: "working", taskId }`.
+  report channel for the first `store`/`wake`, raced against the run's outcome
+  so a body that returns or throws first still settles the call. The receipt
+  is `{ status: "working", taskId, ...view.data }`. A body that never stores
+  keeps `{ status: "working", taskId }`.
 - **Step-lifetime task tool.** The `"Background tools cannot return
 AsyncIterable"` guard is removed; the executor iterates the body, sends each
-  update, and completes with the return value (or binds the executor when the
-  return is `delegated()`). All updates precede completion by construction.
-- **`delegated()` receipt.** `BackgroundToolExecutionScope` sends
-  `{ kind: "update", data: receipt, wake: false }` before `bind`, so the
-  receipt data the model already sees is also on `view.data` for later turns.
-- **Waiting workflow tool.** Unchanged: yields stream as `action.partial`. A
-  `TaskUpdate` descriptor cannot be constructed there because there is no
+  `store` as an `update`, and completes with the return value. All stores
+  precede completion by construction.
+- **Waiting workflow tool.** Unchanged: yields stream as `action.partial`.
+  `TaskStore`/`TaskWake` cannot be constructed there because there is no
   `task` argument.
+- **Subagents and the tool-run.** Continue to bind an executor through the
+  internal `delegated` seam. Unchanged behaviour; no public surface.
 
 ## 5. Compiled shape
 
@@ -236,26 +265,31 @@ its `workflowId`. Consumers that currently re-derive the combination switch on
 - `dispatchTaskStep`'s `entry.kind === "workflow-tool"` branch
 - `createWorkflowToolBackgroundExecute` / `BackgroundToolExecutionScope`
 
-## 6. What is kept, what is narrowed
+## 6. Removed
 
-Nothing is removed from `defineTool` or `TaskExec`. Two members are narrowed
-by cell:
+From the public `TaskExec`:
 
-- `task.delegated()` and `task.send()` are absent from the `TaskExec` passed to
-  a workflow body (`task` / `workflow`). A workflow body is its own durable
-  executor; `return`/`throw`/`yield` are the complete surface.
-- `task.send({ kind: "update" })` in a step body keeps its documented
-  restart-safety caveat and now lowers onto the same `update` command as
-  `yield`. It is not deprecated; it is the escape hatch for in-process
-  executors that are not workflows.
+- `delegated()` and `TaskExecutorBinding`. An authored tool no longer hands a
+  task to an external executor by returning a sentinel; it parks on the
+  external system from a workflow body. The seam remains internal for
+  subagent dispatch and the tool-run.
+- `send()`. Not restart-safe by its own contract; strictly dominated by
+  `yield` in a workflow body and by `yield task.store()` before `return` in a
+  step body.
+- `binding`. The framework-owned callback wire (`session.completed` /
+  `session.failed`) stops being reachable from authored code.
+- `session`. Read session context through `ctx.session`, as every other tool
+  does.
 
-The internal-agents Devbox bridge keeps working unchanged on this design; §3.4
-is the version that no longer needs the relay, not a forced migration.
+Pre-1.0: no compatibility shim. The only known external consumer of the
+removed surface is the internal-agents Devbox bridge, whose replacement is
+§3.5. The `agent-background-tools/export.ts` fixture is rewritten as a workflow
+body.
 
 ## 7. Cancellation
 
-Unchanged in mechanism, but two behaviours become load-bearing for a workflow
-body, which has no executor binding of its own to hang a cancel handler on:
+Unchanged in mechanism, but two behaviours become load-bearing once there is
+no executor binding for an authored tool to hang a cancel handler on:
 
 - `task_cancel` on a background workflow tool aborts `ctx.abortSignal` in the
   run and waits the existing grace period.
@@ -270,42 +304,43 @@ body, which has no executor binding of its own to hang a cancel handler on:
 
 - A tool's cell is fixed at compile time and visible in the manifest.
 - The `task` argument exists iff `execution === "background"`.
-- `wake` is only meaningful when the body is a workflow; a step body's
-  `update` before `return` never wakes anyone (there is no gap to wake into).
-- `view.data` is written only by `update` commands — from `yield`,
-  `task.update`, `task.send({ kind: "update" })`, or a `delegated()` receipt —
-  never derived from the tool result or the executor binding.
+- `yield` is the only channel from a body to its task. There is no
+  post-return path.
+- `view.data` is written only by `store`/`wake`; progress yields never touch
+  it; it is never derived from the tool result or the executor binding.
+- `wake` exists only on a workflow body's `TaskExec`.
 - The task run remains the single writer of task lifecycle and `data`.
-- A receipt is observed by the launching turn exactly once; later updates
-  arrive as session input, never as a tool result.
-- Existing `delegated()`/`send` callers observe identical model-visible
-  behaviour; the only new observable is `view.data`.
+- A receipt is observed by the launching turn exactly once, from the first
+  `store`/`wake`; later stores and wakes arrive as task state, never as a tool
+  result.
+- Subagent task behaviour is unchanged; it uses the internal seam.
 
 ## 9. Open decisions
 
-- Whether `task.update` should also be importable from `eve/tools` as a
-  standalone descriptor constructor (matches `ask` from `eve/workflow`), or
+- Whether `store`/`wake` should also be importable from `eve/tools` as
+  standalone descriptor constructors (matches `ask` from `eve/workflow`), or
   stay on `task` for type gating only. Leaning `task` only.
-- Whether `wake` defaults to `true` (matches today's generator-in-background
-  behaviour) or `false` (cheaper; no silent turn). Leaning `true` for
-  continuity, revisit with usage.
-- Whether `task.send({ kind: "update" })` should be deprecated once `yield`
-  covers every in-tree use (`agent-background-tools/export.ts` is the only
-  one). Not in scope here.
+- Whether `wake()` with no `data` is worth keeping, or every wake must carry
+  the state it wants the parent to see. Leaning required `data`.
+- Whether progress yields in a background body should keep waking the parent
+  with a note (today's behaviour) or become store-free no-ops now that `wake`
+  exists. Leaning keep, revisit with usage.
 - Whether `view.data` should be size-bounded, given it is projected into model
   context on every task-triggered turn.
 
 ## 10. Testing
 
-- Unit: `applyTaskTransition` for `update` on each status; descriptor
-  construction and tagging; `defineTool` overload typing via `expectTypeOf`
-  (no `delegated`/`send` on the workflow-body `TaskExec`).
-- Integration: report → `update` command → `view.data`; receipt merge and
-  the race against early return/throw; `wake: false` producing no parent
-  delivery; `delegated()` receipt appearing on `view.data`; `send({ kind:
-"update" })` and `yield` producing the same task command.
+- Unit: `applyTaskTransition` for `update` with and without `data` on each
+  status; descriptor construction and tagging; `defineTool` overload typing via
+  `expectTypeOf` (no `wake` on a non-workflow `TaskExec`, no `delegated`/`send`
+  anywhere).
+- Integration: `store` → `update` → `view.data`, no parent delivery;
+  `wake` → `update` → parent delivery carrying `view.data`; untagged yield →
+  progress note, `view.data` untouched; receipt taken from the first
+  `store`/`wake` and the race against early return/throw.
 - Scenario: compile-time `shape` for each cell; `execution: "background"` step
-  body with yields.
-- E2E: extend `agent-background-tools` with a workflow body that yields a
-  receipt, parks on `createWebhook`, and completes; keep the `send`-based
-  `export.ts` fixture as the regression for the lowered path.
+  body with `store` before `return`.
+- E2E: rewrite `agent-background-tools/export.ts` as a workflow body that
+  stores a receipt, yields progress, parks on `createWebhook`, wakes on the
+  callback, and completes; assert the receipt, the silent store, the wake, and
+  the terminal result.

--- a/research/tool-suspendability-and-lifetime.md
+++ b/research/tool-suspendability-and-lifetime.md
@@ -233,71 +233,164 @@ non-workflow body receives.
 
 ### 3.8 Example: Devbox as a background durable tool
 
-One invocation owns the whole api-devbox task, including every
-attention-required round trip. There is no continuation argument and no
-"one active binding per api-devbox task" constraint: the run is the binding.
+Written against the api-devbox contract the v PR already codes to: one
+webhook URL registered at `createTask`, `taskStateChange` posts with
+`state ∈ { pending, running, attention-required, complete, errored }`, a
+`prompt` endpoint for follow-ups, and a result of
+`{ summary, exitStatus, error?, prs? }` read from `getTask`. `Hook` is an
+`AsyncIterable`, so one webhook receives every state change for the task's
+lifetime.
+
+One run owns the whole api-devbox task. The user's follow-ups — an answer to
+an attention-required prompt, or "now fix the review findings" after a
+completed review — all go through `ask`, so there is no continuation
+argument, no "one active binding" constraint, and no second tool.
 
 ```ts
 export default defineTool({
   execution: "background",
-  inputSchema: devboxInputSchema,
+  description: "Start repository work in api-devbox and see it through. Use once per task.",
+  inputSchema: devboxInputSchema, // repos, prompt, title?, assistant?, model?, pr?
   async *execute(input, ctx, task) {
     "use workflow";
 
-    const run = await startDevbox(input, ctx); // step: resolves the requester's Connect token
-    yield task.setState({ devboxTaskId: run.taskId, taskUrl: run.taskUrl }); // receipt
+    const events = createWebhook(); // registered before the task exists
+    const devbox = await createDevboxTask(input, events.url, ctx); // step: requester's Connect token
+    yield task.setState({ devboxTaskId: devbox.taskId, taskUrl: devbox.taskUrl, state: "pending" });
 
     try {
-      while (true) {
-        const done = createWebhook();
-        await subscribeDevbox(run.taskId, done.url, ctx); // step
-        const event = await (await done).json();
-
-        if (event.state === "completed") return await readDevboxResult(run.taskId, ctx);
-        if (event.state === "errored") throw new FatalError(`Devbox task ${run.taskId} failed`);
-
-        // attention-required: the human answers, in the same run.
-        const answer = await ask(ctx, {
-          prompt: event.message,
-          display: "text",
-          allowFreeform: true,
+      for await (const request of events) {
+        const change = parseTaskStateChange(await request.json()); // { taskId, state } or null
+        if (change === null || change.taskId !== devbox.taskId) continue; // unrelated or malformed post
+        yield task.setState({
+          devboxTaskId: devbox.taskId,
+          taskUrl: devbox.taskUrl,
+          state: change.state,
         });
-        yield { state: "resuming", devboxTaskId: run.taskId }; // progress
-        await continueDevbox(run.taskId, answer.text, ctx); // step
+
+        switch (change.state) {
+          case "pending":
+          case "running":
+            continue;
+
+          case "attention-required": {
+            // api-devbox does not carry the question in the webhook; the task page does.
+            const answer = await ask(ctx, {
+              prompt:
+                `Devbox needs your input to continue "${devbox.title}".\n` +
+                `Open ${devbox.taskUrl} to see what it is asking, then reply here.`,
+              display: "text",
+              allowFreeform: true,
+            });
+            await promptDevbox(devbox.taskId, answer.text ?? "", ctx); // step
+            continue;
+          }
+
+          case "complete": {
+            const result = await readDevboxTask(devbox.taskId, ctx); // step: authoritative
+            if (input.pr === false) {
+              // A review has no PR; the requester may want the findings acted on.
+              const next = await ask(ctx, {
+                prompt: `Review finished:\n\n${result.summary}\n\nApply these findings?`,
+                display: "confirmation",
+                options: [
+                  { id: "apply", label: "Apply the findings", style: "primary" },
+                  { id: "done", label: "Done" },
+                ],
+              });
+              if (next.optionId === "apply") {
+                await promptDevbox(devbox.taskId, "Apply the review findings and open a PR.", ctx);
+                continue; // back to waiting on the same webhook
+              }
+            }
+            return { summary: result.summary, prs: result.prs ?? [], taskUrl: devbox.taskUrl };
+          }
+
+          case "errored": {
+            const result = await readDevboxTask(devbox.taskId, ctx);
+            throw new FatalError(result.error ?? `Devbox task ${devbox.taskId} errored`);
+          }
+        }
       }
+      throw new FatalError(
+        `Webhook for Devbox task ${devbox.taskId} closed before a terminal state`,
+      );
     } finally {
-      if (ctx.abortSignal.aborted) await stopDevbox(run.taskId, ctx);
+      if (ctx.abortSignal.aborted) await stopDevbox(devbox.devboxId, ctx); // step
     }
   },
 });
 
-async function startDevbox(input: DevboxInput, ctx: ToolContext) {
+async function createDevboxTask(input: DevboxInput, webhookUrl: string, ctx: ToolContext) {
   "use step";
-  const { token } = await ctx.getToken(devboxUserAuth); // may park the run on sign-in (§3.6)
-  return createDevboxClient({
-    token,
-    onUnauthorized: () => ctx.requireAuth(devboxUserAuth),
-  }).createTask(input);
+  const client = await devboxClient(ctx);
+  const snapshot = await selectSnapshot(client, input.repos);
+  const set = await client.createTaskSet(input.title ?? deriveTitle(input.prompt));
+  const created = await client.createTask({
+    setId: set.set_id,
+    snapshotId: snapshot.id,
+    prompt: promptWithDeliverable(input),
+    assistant: input.assistant,
+    model: input.model,
+    webhookUrl,
+  });
+  return {
+    taskId: created.task_id,
+    devboxId: created.devbox_id,
+    title: input.title ?? deriveTitle(input.prompt),
+    taskUrl: devboxTaskUrl(created.task_id),
+  };
+}
+
+async function devboxClient(ctx: ToolContext) {
+  "use step";
+  const { token } = await ctx.getToken(devboxUserAuth); // parks the run on sign-in (§3.6)
+  return createDevboxClient({ token, onUnauthorized: () => ctx.requireAuth(devboxUserAuth) });
 }
 ```
 
-Every HITL constraint the integration doc lists holds:
+`promptDevbox`, `readDevboxTask`, and `stopDevbox` are one-call steps over
+the same client. Snapshot selection, title derivation, and the deliverable
+prompt are the PR's existing helpers, unchanged.
 
-- v owns every user-facing message. `ask` renders the question on v's channel;
-  Devbox is never a model-visible subagent.
-- attention-required does not complete the task. It parks the run on `ask`;
-  the task is `input_required` while the human answers and `working` again
-  after. No `input.requested` is authored by v; the framework owns it.
-- Sign-in is not a special state the tool returns. `getToken` in a step parks
-  the run the same way, under the requester's identity.
-- The callback is a signal; `readDevboxResult` reads authoritative state.
-- Cancellation stops the sandbox from `finally` (§7); `stop_devbox_task` goes.
-- Duplicate webhooks are harmless: each iteration mints a fresh webhook URL,
-  and a late post to a consumed one is rejected by the SDK.
+How each constraint from the integration doc is met:
 
-The relay workflow, relay route, `session.completed` adapter, `task`
-continuation argument, and `get_devbox_task` (for anything other than ad hoc
-status) are deleted.
+- **v owns every user-facing message.** The `ask` prompts are rendered on v's
+  channel as v's questions; the model never sees a Devbox turn. Devbox is not
+  a subagent.
+- **attention-required is not terminal.** The run parks on `ask`; the task is
+  `input_required` until the requester answers, then `working` again. The
+  answer is posted to api-devbox from the same run. api-devbox does not put
+  the question text in the webhook, so the prompt links the task page rather
+  than pretending to know what was asked.
+- **Only the requester answers.** `ask` already enforces this on Slack: another
+  user's click is rejected without resolving the request.
+- **Sign-in is not a state the tool returns.** `getToken` in a step parks the
+  run on `authorization.required` under the requester's identity; a later
+  401 is `requireAuth` on the same path.
+- **The callback is a signal.** Terminal states re-read the task; the webhook
+  body is never reported as the result.
+- **A review can be followed by a fix without a second launch.** The
+  `complete` branch of a `pr: false` task offers to apply the findings, which
+  is another prompt to the same api-devbox task on the same webhook.
+- **Cancellation reaches the sandbox.** `finally` stops the Devbox when
+  `ctx.abortSignal` fired (§7). `stop_devbox_task` goes away.
+- **Duplicate and out-of-order webhooks are harmless.** State posts for other
+  tasks are skipped; a repeated `attention-required` re-asks, which is the
+  right behaviour when the sandbox asked again; a repeated terminal state
+  after `return` is a post to a hook the run no longer reads.
+
+Deleted from the PR: the relay workflow, the relay route, the
+`session.completed`/`subagentName` adapter, the launch and follow-up
+fingerprint guards (step replay is the idempotency mechanism), the `task`
+continuation argument, `stop_devbox_task`, and `get_devbox_task` except as an
+ad hoc status tool.
+
+What the model sees, in order: the receipt
+`{ status: "working", taskId, devboxTaskId, taskUrl, state: "pending" }`; a
+`[Task state]` entry whose `state` tracks api-devbox; an `input.requested` on
+the channel whenever the body asks; and one terminal result. Nothing in
+between requires v to act.
 
 ## 4. Task state and messages
 


### PR DESCRIPTION
### Summary

Background tools use workflow-local bindings for execution data, ordinary yields for silent progress, and `yield task.postMessage(...)` for parent messages. This research proposal removes `task.setState()` and authored task snapshots; the fixed `{ status: "working", taskId }` receipt depends only on task admission.

- Keep suspendability and lifetime as two compiled properties, with the existing `"use workflow"` and `execution: "background"` authoring syntax.
- Remove `task.delegated()` and the other callback-era task fields without compatibility shims. Reject extension contracts requiring removed APIs before executing them.
- Consolidate parent-bound traffic under `TaskInboundMessage`, subsuming `TaskInboundUpdate`; keep `TaskProgress` stream-only.
- Rewrite the Devbox example as one async workflow using local bindings across webhook waits, `ask` for human replies, and a final return for the result.

#2997 implements the compiled shape, fixed receipt, progress and message yields, and removal of `task.delegated()`. Provider authorization inside steps, cancellation cleanup for parked bodies, inbound-message consolidation, and removal of the remaining deprecated task fields are still proposed work. The complete Devbox migration depends on the authorization and cancellation work. Motivating integration: [vercel/internal-agents#2173](https://github.com/vercel/internal-agents/pull/2173).

### Validation

Checked the implementation boundary against #2997's task types, workflow body, and delivery paths. Documentation checks pass. This PR changes only the research proposal; runtime code is unchanged.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package — not applicable, research only
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 1 file · `+367 / -0`

One proposal covers the authoring contract, Devbox example, delivery, compatibility, and the remaining authorization and cancellation work.

**Implementation** — 0 files · `+0 / -0`

Not applicable.

**Tests** — 0 files · `+0 / -0`

Not applicable.
