### PR TITLE
test(eve): cover MCP terminal failures and rejected calls

### DIFF
--- a/packages/eve/src/internal/invocation/mcp-agent-channel.scenario.test.ts
+++ b/packages/eve/src/internal/invocation/mcp-agent-channel.scenario.test.ts
@@ -17,6 +17,10 @@ const MCP_AGENT_DESCRIPTOR: ScenarioAppDescriptor = {
 import { mockModel } from "eve/evals";
 
 const model = mockModel((request) => {
+  const prompt = JSON.stringify(request.messages);
+  if (prompt.includes("MCP-FAILURE-PROBE")) {
+    throw new Error("MCP-FAILURE-PROBE: provider rejected the request.");
+  }
   const answered = request.toolResults.some((result) => result.name === "ask_question");
   if (!answered) {
     return {
@@ -107,6 +111,34 @@ describe("MCP agent channel", () => {
         await expect(
           pollInvocation(server.url, "alice", "legacy", legacyInvocationId, ["cancelled"]),
         ).resolves.toMatchObject({ status: "cancelled" });
+
+        const failing = await callTool(server.url, "alice", "modern", "agent_start", {
+          message: "Trigger MCP-FAILURE-PROBE.",
+        });
+        const failingInvocationId = requiredString(failing.invocationId, "invocationId");
+        const failed = await pollInvocation(server.url, "alice", "modern", failingInvocationId, [
+          "failed",
+        ]);
+        const failure = requiredRecord(failed.error, "error");
+        expect(typeof failure.message).toBe("string");
+        expect((failure.message as string).length).toBeGreaterThan(0);
+        expect(requiredRecord(failure.data, "error.data")).toMatchObject({
+          runId: failingInvocationId,
+        });
+        const serialized = JSON.stringify(failed);
+        expect(serialized).not.toMatch(/\n\s+at /);
+        expect(serialized).not.toContain("stack");
+        expect(serialized.length).toBeLessThan(4_096);
+
+        const unknown = await callToolResult(server.url, "alice", "modern", "agent_get", {
+          invocationId: "does-not-exist",
+        });
+        expect(unknown.isError).toBe(true);
+        const notPending = await callToolResult(server.url, "alice", "modern", "agent_update", {
+          invocationId,
+          responses: [{ optionId: "yes", requestId: "stale" }],
+        });
+        expect(notPending.isError).toBe(true);
       } catch (error) {
         throw new Error(
           [`stdout:\n${server.stdout()}`, `stderr:\n${server.stderr()}`].join("\n\n"),


### PR DESCRIPTION
### Summary

The MCP scenario proved the basic input and cancellation lifecycle but not the path a hosted-client demo is most likely to hit: a task that fails. Without coverage, the sanitized terminal `failed` shape from #2893 could regress silently into either an opaque "Invocation failed." or a leaked stack trace. This PR extends the fixture-owned scenario with a deterministic model failure and asserts the terminal error a client actually sees: a non-empty curated `message`, `error.data.runId` equal to the invocation ID, and a compact payload with no stack frames. It also asserts that `agent_get` on an unknown ID and `agent_update` against a stale request are rejected as tool errors rather than surfacing as invocation state.

Scope is deliberately narrow. `authorization_required` → callback → resume needs a connection with an interactive challenge plus a callback round trip, which is not yet deterministic inside the scenario budget; it stays a manual step in the demo checklist added by #2988. Tool-operation error *shape* and request limits are covered by #2991 and #2992's unit tests. The weather-agent MCP fixture you drafted locally is left to the `docs/grok-bot` branch rather than duplicated here.

Retitled from the original "hosted MCP client interactions" to reflect the narrowed scope.

### Validation

- `pnpm build` then `pnpm --filter eve exec vitest run --config vitest.scenario.config.ts src/internal/invocation/mcp-agent-channel.scenario.test.ts` — passed (real `eve dev` process; modern + legacy lifecycle, now including the failure and rejected-call paths).
- `pnpm fmt`, `pnpm lint` — pass. No changeset: test-only.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
