### PR TITLE
fix(eve): make repeated MCP input updates idempotent

### DIFF
--- a/.changeset/mcp-idempotent-input-updates.md
+++ b/.changeset/mcp-idempotent-input-updates.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+MCP `agent_update` now acknowledges a repeated answer that eve already accepted for the same input batch instead of returning a conflict, so a client that retries after a lost response converges on the current invocation state. `agent_get` also stops reporting `input_required` as soon as the answer is resolved rather than waiting for the next turn event.

--- a/packages/eve/src/internal/invocation/workflow-execution.test.ts
+++ b/packages/eve/src/internal/invocation/workflow-execution.test.ts
@@ -306,6 +306,80 @@ describe("WorkflowAgentInvocationExecution", () => {
     expect(deliver).toHaveBeenCalledTimes(2);
   });
 
+  it("stops reporting input_required once the answer is resolved", async () => {
+    runsGet.mockResolvedValue(run({ status: "running" }));
+    getReadable.mockReturnValue(
+      eventStream([
+        inputRequestedEvent("event_1", ["question"]),
+        inputResolvedEvent("event_2", [{ optionId: "yes", requestId: "question" }]),
+      ]),
+    );
+
+    await expect(
+      execution().read({ auth, invocationId: "wrun_invocation" }),
+    ).resolves.toMatchObject({ status: "working" });
+  });
+
+  it("acknowledges a repeated answer that eve already accepted", async () => {
+    runsGet.mockResolvedValue(run({ status: "running" }));
+    const requestId = invocationInputRequestId("event_1", "question");
+    getReadable.mockImplementation(() =>
+      eventStream([
+        inputRequestedEvent("event_1", ["question"]),
+        inputResolvedEvent("event_2", [{ optionId: "yes", requestId: "question" }]),
+      ]),
+    );
+
+    await expect(
+      execution().update({
+        auth,
+        invocationId: "wrun_invocation",
+        responses: [{ optionId: "yes", requestId }],
+      }),
+    ).resolves.toMatchObject({ invocation: { status: "working" }, type: "success" });
+    expect(deliver).not.toHaveBeenCalled();
+
+    await expect(
+      execution().update({
+        auth,
+        invocationId: "wrun_invocation",
+        responses: [{ optionId: "no", requestId }],
+      }),
+    ).resolves.toEqual({ message: "Invocation is not waiting for input.", type: "conflict" });
+    await expect(
+      execution().update({
+        auth,
+        invocationId: "wrun_invocation",
+        responses: [{ requestId, text: "yes" }],
+      }),
+    ).resolves.toMatchObject({ type: "conflict" });
+    expect(deliver).not.toHaveBeenCalled();
+  });
+
+  it("acknowledges a repeated answer after the run completes", async () => {
+    runsGet.mockResolvedValue(run({ status: "completed" }));
+    returnValue.mockResolvedValue({ output: "done" });
+    const requestId = invocationInputRequestId("event_1", "question");
+    getReadable.mockImplementation(() =>
+      eventStream([
+        inputRequestedEvent("event_1", ["question"]),
+        inputResolvedEvent("event_2", [{ requestId: "question", text: "go" }]),
+      ]),
+    );
+
+    await expect(
+      execution().update({
+        auth,
+        invocationId: "wrun_invocation",
+        responses: [{ requestId, text: "go" }],
+      }),
+    ).resolves.toMatchObject({
+      invocation: { result: "done", status: "completed" },
+      type: "success",
+    });
+    expect(deliver).not.toHaveBeenCalled();
+  });
+
   it("projects and clears pending connection authorization", async () => {
     runsGet.mockResolvedValue(run({ status: "running" }));
     const required = {
@@ -605,6 +679,27 @@ function inputRequestedEvent(id: string, requestIds: readonly string[]): HandleM
     },
     meta: { at: "2026-07-20T00:00:00.000Z", id },
     type: "input.requested",
+  };
+}
+
+function inputResolvedEvent(
+  id: string,
+  responses: readonly { optionId?: string; requestId: string; text?: string }[],
+): HandleMessageStreamEvent {
+  return {
+    data: {
+      resolutions: responses.map((response) => ({
+        kind: "question" as const,
+        outcome: "answered" as const,
+        requestId: response.requestId,
+        response,
+      })),
+      sequence: 0,
+      stepIndex: 0,
+      turnId: "turn_1",
+    },
+    meta: { at: "2026-07-20T00:00:01.000Z", id },
+    type: "input.resolved",
   };
 }
 

--- a/packages/eve/src/internal/invocation/workflow-execution.ts
+++ b/packages/eve/src/internal/invocation/workflow-execution.ts
@@ -22,7 +22,7 @@ import {
 } from "#internal/invocation/metadata.js";
 import type { RouteSessionCreator } from "#internal/nitro/routes/channel-route-context.js";
 import { getRun, getWorld } from "#internal/workflow/runtime.js";
-import type { HandleMessageStreamEvent } from "#protocol/message.js";
+import type { HandleMessageStreamEvent, InputResolution } from "#protocol/message.js";
 import type { InputRequest, InputResponse } from "#shared/input.js";
 import type { JsonObject, JsonValue } from "#shared/json.js";
 import { parseJsonValue } from "#shared/json.js";
@@ -94,6 +94,12 @@ export class WorkflowAgentInvocationExecution {
     const current = await this.read(input);
     if (current === undefined) return { type: "not_found" };
     if (current.status !== "input_required") {
+      // A retry after a lost response is the common case here: the answer
+      // already landed, so acknowledge it instead of demanding a new one.
+      const events = await readRecentPersistedEvents(input.invocationId);
+      if (replaysResolvedBatch(events, input.responses)) {
+        return { invocation: current, type: "success" };
+      }
       return conflict("Invocation is not waiting for input.");
     }
     const run = await this.#readInvocationRun(input.invocationId, input.auth);
@@ -218,15 +224,90 @@ function pendingInputBatch(
   return { id: event.meta.id, rawRequestIds, requests };
 }
 
+/**
+ * Removes resolved requests from a batch. The harness resolves a batch as a
+ * whole today, but request-level bookkeeping keeps this correct if it ever
+ * resolves them separately.
+ */
+function withoutResolved(
+  batch: PendingInputBatch,
+  resolutions: readonly InputResolution[],
+): PendingInputBatch | undefined {
+  const resolvedRawIds = new Set(resolutions.map((resolution) => resolution.requestId));
+  const rawRequestIds: Record<string, string> = {};
+  const requests: Record<string, InputRequest> = {};
+  for (const [requestId, rawRequestId] of Object.entries(batch.rawRequestIds)) {
+    if (resolvedRawIds.has(rawRequestId)) continue;
+    rawRequestIds[requestId] = rawRequestId;
+    const request = batch.requests[requestId];
+    if (request !== undefined) requests[requestId] = request;
+  }
+  return Object.keys(rawRequestIds).length === 0
+    ? undefined
+    : { id: batch.id, rawRequestIds, requests };
+}
+
+interface ResolvedInputBatch {
+  readonly batch: PendingInputBatch;
+  readonly responses: ReadonlyMap<string, InputResponse | undefined>;
+}
+
+/**
+ * Folds the event window into the currently pending batch and the most
+ * recently resolved batch. Both are needed: the first to accept an answer,
+ * the second to recognize a client re-sending an answer that already landed.
+ */
+function foldInputBatches(events: readonly HandleMessageStreamEvent[]): {
+  readonly pending: PendingInputBatch | undefined;
+  readonly resolved: ResolvedInputBatch | undefined;
+} {
+  let pending: PendingInputBatch | undefined;
+  let requested: PendingInputBatch | undefined;
+  let resolved: ResolvedInputBatch | undefined;
+  for (const event of events) {
+    if (event.type === "input.requested") {
+      requested = pendingInputBatch(event);
+      pending = requested;
+    } else if (event.type === "input.resolved") {
+      if (requested === undefined) continue;
+      const responses = new Map<string, InputResponse | undefined>();
+      for (const resolution of event.data.resolutions) {
+        responses.set(resolution.requestId, resolution.response);
+      }
+      resolved = { batch: requested, responses };
+      if (pending !== undefined) pending = withoutResolved(pending, event.data.resolutions);
+    } else if (event.type === "turn.started") {
+      pending = undefined;
+    }
+  }
+  return { pending, resolved };
+}
+
 function latestPendingInputBatch(
   events: readonly HandleMessageStreamEvent[],
 ): PendingInputBatch | undefined {
-  let batch: PendingInputBatch | undefined;
-  for (const event of events) {
-    if (event.type === "input.requested") batch = pendingInputBatch(event);
-    else if (event.type === "turn.started") batch = undefined;
+  return foldInputBatches(events).pending;
+}
+
+/** True when `responses` exactly repeats the answers eve already accepted for the last batch. */
+function replaysResolvedBatch(
+  events: readonly HandleMessageStreamEvent[],
+  responses: readonly InputResponse[],
+): boolean {
+  const resolved = foldInputBatches(events).resolved;
+  if (resolved === undefined || responses.length !== resolved.responses.size) return false;
+  const seen = new Set<string>();
+  for (const response of responses) {
+    const rawRequestId = resolved.batch.rawRequestIds[response.requestId];
+    if (rawRequestId === undefined || seen.has(rawRequestId)) return false;
+    seen.add(rawRequestId);
+    if (!resolved.responses.has(rawRequestId)) return false;
+    const accepted = resolved.responses.get(rawRequestId);
+    if (accepted?.optionId !== response.optionId || accepted?.text !== response.text) {
+      return false;
+    }
   }
-  return batch;
+  return true;
 }
 
 function projectNonterminal(
@@ -241,6 +322,10 @@ function projectNonterminal(
   for (const event of events) {
     if (event.type === "input.requested") {
       inputBatch = pendingInputBatch(event);
+    } else if (event.type === "input.resolved") {
+      if (inputBatch !== undefined) {
+        inputBatch = withoutResolved(inputBatch, event.data.resolutions);
+      }
     } else if (event.type === "turn.started") {
       authorizations.clear();
       inputBatch = undefined;


### PR DESCRIPTION
### Summary

A client that retried `agent_update` after a lost response got a confusing "not waiting for input" conflict even though its answer had been applied, and `agent_get` kept reporting `input_required` after the harness had already accepted the answer, because the MCP projection ignored `input.resolved` events. That stale window is also where a second `agent_update` could deliver the same batch twice.

Stale-batch protection already existed — request IDs are `sha256(batchId, requestId)` so an old batch cannot answer a newer request — so this PR targets only the remaining gap and adds no new storage. The projection now folds `input.resolved` into the pending batch, so `agent_get` reports `working` as soon as eve accepts the answer. When an invocation is not `input_required`, `agent_update` compares the submitted responses against the most recently resolved batch in the event stream: an exact repeat returns the current invocation state as success (including a terminal `completed` state), while a different answer for an already-answered batch remains a `conflict`.

The residual race between two concurrent first deliveries, before `input.resolved` is persisted, is not addressed here; durable single-acceptance belongs to the in-flight HITL ledger work (#2822, #2863). The earlier idea of exposing an `inputBatchId` field is dropped as unnecessary.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/internal/invocation/workflow-execution.test.ts` — 21 passed. New tests cover the projection clearing `input_required` on resolution, an identical repeat acknowledged without redelivery (`optionId` and `text` variants), a different answer still conflicting, and a repeat after the run completed returning the completed state.
- `pnpm build` then `pnpm --filter eve exec vitest run --config vitest.scenario.config.ts src/internal/invocation/mcp-agent-channel.scenario.test.ts` — passed, since projection over the live stream changed.
- `pnpm fmt`, `pnpm lint`, `pnpm --filter eve typecheck`, `pnpm guard:invariants`, `pnpm docs:check` — all pass.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
