### PR TITLE
fix(eve): structure MCP operation failures

### DIFF
--- a/.changeset/mcp-structured-operation-errors.md
+++ b/.changeset/mcp-structured-operation-errors.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+MCP tool calls that are rejected now return `structuredContent.error` with a stable `code` (`invalid_input`, `not_found`, `conflict`, `internal`), a short `message`, and `retryable`, so clients can act without parsing text. Unexpected server failures no longer forward their raw message; they return an `errorId` that correlates with eve's logs.

--- a/docs/channels/mcp.mdx
+++ b/docs/channels/mcp.mdx
@@ -191,10 +191,14 @@ The invocation response is discriminated by `status`:
 - `failed`: inspect the structured `error`.
 - `cancelled`: cancellation reached a terminal state.
 
-A tool result with `isError: true` means the call itself was rejected (unknown invocation, no input
-pending, incomplete response batch, invalid output schema). A `failed` status means the call
-succeeded and the task itself failed. Handle them differently: correct the call in the first case,
-report the task failure in the second.
+A tool result with `isError: true` means the call itself was rejected. A `failed` status means the call succeeded and the task itself failed. Handle them differently: correct the call in the first case, report the task failure in the second. Rejected calls carry `structuredContent.error` with a stable `code`, a short `message`, and `retryable`:
+
+| `code`          | Meaning                                                                        | `retryable` |
+| --------------- | ------------------------------------------------------------------------------ | ----------- |
+| `invalid_input` | An argument was rejected, for example an oversized or external `outputSchema`. | `false`     |
+| `not_found`     | The invocation does not exist, has expired, or belongs to another caller.      | `false`     |
+| `conflict`      | The invocation is not in the expected state; read it with `agent_get` first.   | `true`      |
+| `internal`      | eve failed; `errorId` correlates with server logs. No details are exposed.     | `false`     |
 
 Cancellation is cooperative, so call `agent_get` after `agent_cancel` until the state becomes terminal.
 

--- a/packages/eve/src/internal/mcp/streamable-http-server.test.ts
+++ b/packages/eve/src/internal/mcp/streamable-http-server.test.ts
@@ -7,6 +7,7 @@ import {
   defineMcpTool,
   MCP_LEGACY_PROTOCOL_VERSION,
   MCP_PROTOCOL_VERSION,
+  McpToolOperationError,
 } from "#internal/mcp/streamable-http-server.js";
 
 const MCP_PROTOCOL_VERSION_META_KEY = "io.modelcontextprotocol/protocolVersion";
@@ -269,6 +270,95 @@ describe("stateless MCP Streamable HTTP server", () => {
       },
     });
     expect(call).not.toHaveBeenCalled();
+  });
+
+  it("returns structured operation errors for expected tool failures", async () => {
+    const handle = createMcpStreamableHttpServer({
+      authenticate: async () => auth,
+      name: "eve-test",
+      tools: [
+        defineMcpTool({
+          call: async () => {
+            throw new McpToolOperationError("conflict", "Invocation is not waiting for input.");
+          },
+          definition: { inputSchema: z.strictObject({}), name: "conflicting" },
+        }),
+      ],
+      version: "0.0.0",
+    });
+
+    for (const request_ of [
+      modernRequest({
+        id: "modern",
+        jsonrpc: "2.0",
+        method: "tools/call",
+        params: { arguments: {}, name: "conflicting" },
+      }),
+      request({
+        id: "legacy",
+        jsonrpc: "2.0",
+        method: "tools/call",
+        params: { arguments: {}, name: "conflicting" },
+      }),
+    ]) {
+      await expect(jsonRpcResponse(await handle(request_))).resolves.toMatchObject({
+        result: {
+          content: [{ text: "Invocation is not waiting for input.", type: "text" }],
+          isError: true,
+          structuredContent: {
+            error: {
+              code: "conflict",
+              message: "Invocation is not waiting for input.",
+              retryable: true,
+            },
+          },
+        },
+      });
+    }
+  });
+
+  it("sanitizes unexpected tool failures behind an error id", async () => {
+    const handle = createMcpStreamableHttpServer({
+      authenticate: async () => auth,
+      name: "eve-test",
+      tools: [
+        defineMcpTool({
+          call: async () => {
+            throw new Error("ECONNREFUSED 10.0.0.7:5432 while reading secret=abc");
+          },
+          definition: { inputSchema: z.strictObject({}), name: "exploding" },
+        }),
+      ],
+      version: "0.0.0",
+    });
+
+    const body = (await jsonRpcResponse(
+      await handle(
+        modernRequest({
+          id: "boom",
+          jsonrpc: "2.0",
+          method: "tools/call",
+          params: { arguments: {}, name: "exploding" },
+        }),
+      ),
+    )) as {
+      result: {
+        content: Array<{ text: string }>;
+        isError: boolean;
+        structuredContent: { error: Record<string, unknown> };
+      };
+    };
+    expect(body.result.isError).toBe(true);
+    expect(body.result.structuredContent.error).toMatchObject({
+      code: "internal",
+      errorId: expect.any(String),
+      retryable: false,
+    });
+    expect(JSON.stringify(body.result)).not.toContain("ECONNREFUSED");
+    expect(JSON.stringify(body.result)).not.toContain("secret=");
+    expect(body.result.content[0]?.text).toContain(
+      String(body.result.structuredContent.error.errorId),
+    );
   });
 
   it("returns JSON-RPC errors and acknowledges notifications", async () => {

--- a/packages/eve/src/internal/mcp/streamable-http-server.ts
+++ b/packages/eve/src/internal/mcp/streamable-http-server.ts
@@ -6,6 +6,9 @@ import {
 } from "#compiled/@modelcontextprotocol/server/index.js";
 
 import type { SessionAuthContext } from "#channel/types.js";
+import { createLogger, logError } from "#internal/logging.js";
+
+const log = createLogger("mcp.server");
 
 export const MCP_PROTOCOL_VERSION = "2026-07-28";
 export const MCP_LEGACY_PROTOCOL_VERSION = "2025-11-25";
@@ -26,12 +29,45 @@ export interface McpCallToolResult<
 > {
   readonly content: readonly McpContent[];
   readonly isError?: boolean;
-  readonly structuredContent?: TStructured;
+  readonly structuredContent?: TStructured | McpToolOperationErrorEnvelope;
+}
+
+export interface McpToolOperationErrorEnvelope {
+  readonly error: McpToolOperationErrorData;
 }
 
 export type McpContent =
   | { readonly type: "text"; readonly text: string }
   | { readonly type: "resource_link"; readonly name: string; readonly uri: string };
+
+/**
+ * Stable, client-actionable reason a tool call was rejected before it could
+ * return a result. `invalid_input` and `conflict` mean the caller should
+ * change or re-read something; `not_found` means stop; `internal` means the
+ * server failed and `errorId` correlates with its logs.
+ */
+export type McpToolOperationErrorCode = "invalid_input" | "not_found" | "conflict" | "internal";
+
+export interface McpToolOperationErrorData {
+  readonly code: McpToolOperationErrorCode;
+  readonly errorId?: string;
+  readonly message: string;
+  readonly retryable: boolean;
+}
+
+/** Thrown by tool handlers to produce a structured `isError` result. */
+export class McpToolOperationError extends Error {
+  readonly code: McpToolOperationErrorCode;
+
+  constructor(code: McpToolOperationErrorCode, message: string) {
+    super(message);
+    this.name = "McpToolOperationError";
+    this.code = code;
+  }
+}
+
+/** Only `conflict` is retryable: the caller re-reads state and tries again. */
+const RETRYABLE_CODES: ReadonlySet<McpToolOperationErrorCode> = new Set(["conflict"]);
 
 export interface McpServerTool {
   readonly name: string;
@@ -327,15 +363,35 @@ async function callTool<TInput, TStructured extends Readonly<Record<string, unkn
   try {
     return await call(input, { auth, signal });
   } catch (error) {
-    return toolError(error instanceof Error ? error.message : "Tool call failed.");
+    if (error instanceof McpToolOperationError) {
+      return toolError({
+        code: error.code,
+        message: error.message,
+        retryable: RETRYABLE_CODES.has(error.code),
+      });
+    }
+    // Unexpected failures never forward their message: it may carry provider
+    // responses, hostnames, or workflow payloads. The errorId is the handle.
+    const errorId = logError(log, "MCP tool call failed", error);
+    return toolError({
+      code: "internal",
+      errorId,
+      message: "The server could not complete this tool call.",
+      retryable: false,
+    });
   }
 }
 
 function toolError<TStructured extends Readonly<Record<string, unknown>>>(
-  message: string,
+  error: McpToolOperationErrorData,
 ): McpCallToolResult<TStructured> {
+  const text =
+    error.errorId === undefined ? error.message : `${error.message} (errorId: ${error.errorId})`;
+  // The SDK skips outputSchema validation when isError is set, so this shape
+  // does not need to appear in each tool's declared output schema.
   return {
-    content: [{ type: "text", text: message }],
+    content: [{ type: "text", text }],
     isError: true,
+    structuredContent: { error },
   };
 }

--- a/packages/eve/src/public/channels/mcp.test.ts
+++ b/packages/eve/src/public/channels/mcp.test.ts
@@ -244,6 +244,13 @@ describe("mcpChannel", () => {
           },
         ],
         isError: true,
+        structuredContent: {
+          error: {
+            code: "invalid_input",
+            message: "outputSchema external $ref values are not supported.",
+            retryable: false,
+          },
+        },
       },
     });
     expect(createSession).not.toHaveBeenCalled();

--- a/packages/eve/src/public/channels/mcp.ts
+++ b/packages/eve/src/public/channels/mcp.ts
@@ -20,6 +20,7 @@ import { validateMcpHttpRequest, validateMcpMetadataRequest } from "#internal/mc
 import {
   createMcpStreamableHttpServer,
   defineMcpTool,
+  McpToolOperationError,
   type McpCallToolResult,
   type McpServerTool,
 } from "#internal/mcp/streamable-http-server.js";
@@ -523,8 +524,15 @@ function createInvocationTools(
   return tools;
 }
 
+// Unknown, expired, and foreign-principal invocations all read as not found
+// so the response never confirms that another caller's invocation exists.
+const INVOCATION_NOT_FOUND =
+  "Invocation not found. It may have expired or belong to another caller.";
+
 function requiredInvocation(invocation: AgentInvocation | undefined): AgentInvocation {
-  if (invocation === undefined) throw new Error("Invocation not found.");
+  if (invocation === undefined) {
+    throw new McpToolOperationError("not_found", INVOCATION_NOT_FOUND);
+  }
   return invocation;
 }
 
@@ -533,9 +541,12 @@ function requiredMutation(result: AgentInvocationMutationResult): AgentInvocatio
     case "success":
       return result.invocation;
     case "conflict":
-      throw new Error(result.message);
+      throw new McpToolOperationError(
+        "conflict",
+        `${result.message} Call agent_get to read the current state before answering again.`,
+      );
     case "not_found":
-      throw new Error("Invocation not found.");
+      throw new McpToolOperationError("not_found", INVOCATION_NOT_FOUND);
   }
 }
 
@@ -549,9 +560,16 @@ function invocationResult(invocation: AgentInvocation): McpCallToolResult {
 
 function asJsonObject(value: unknown): JsonObject | undefined {
   if (value === undefined) return undefined;
-  const schema = parseJsonObject(value);
-  validateOutputSchemaComplexity(schema);
-  return schema;
+  try {
+    const schema = parseJsonObject(value);
+    validateOutputSchemaComplexity(schema);
+    return schema;
+  } catch (error) {
+    throw new McpToolOperationError(
+      "invalid_input",
+      error instanceof Error ? error.message : "outputSchema must be a JSON object.",
+    );
+  }
 }
 
 const AUTHORIZATION_CHALLENGE_SCHEMA = z.strictObject({


### PR DESCRIPTION
### Summary

MCP callers received expected lifecycle-operation failures (unknown or expired invocation, update while no input is pending, incomplete response batch, invalid output schema) only as free text, so a hosted client had to parse wording to decide whether to retry, refresh state, or stop. This PR adds a small stable `structuredContent.error` contract on `isError: true` results from all four tools while leaving the sanitized terminal `status: "failed"` shape from #2893 unchanged.

The code set is deliberately tiny: `invalid_input`, `not_found`, `conflict`, `internal`, each with `retryable` and a short safe `message`. Only `conflict` is retryable (re-read with `agent_get`, then act). There is intentionally no `forbidden` code — a foreign principal's invocation continues to read as `not_found`. The SDK skips output-schema validation when `isError` is set, so the declared `outputSchema` does not need an error alternative; tests confirm `structuredContent` is forwarded on both the 2026 and legacy 2025 paths.

This also closes a disclosure gap in the tool wrapper, which forwarded arbitrary `error.message` text from unexpected exceptions (provider responses, hostnames, workflow payloads) to the client. Unexpected errors now log through `logError` and return `code: "internal"` with the correlating `errorId` and a generic message.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/channels/mcp.test.ts src/internal/mcp` — 32 passed. New tests cover the structured `conflict` result on modern and legacy requests, the `invalid_input` path from `agent_start`, and that an unexpected exception's message never reaches the client while its `errorId` does.
- `pnpm fmt`, `pnpm lint`, `pnpm --filter eve typecheck`, `pnpm guard:invariants`, `pnpm docs:check` — all pass.
- Not run: scenario tier. The existing MCP scenario asserts `isError` for a foreign-principal read and is unaffected.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
