### PR TITLE
fix: polish multi-agent project setup

### DIFF
--- a/.changeset/polish-multi-agent-setup.md
+++ b/.changeset/polish-multi-agent-setup.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix multi-agent setup flows so `eve init --agents` asks which agent to run, while shared AI Gateway, integration, and deployment setup uses the project root.

--- a/packages/eve/src/cli/commands/agent-instructions.test.ts
+++ b/packages/eve/src/cli/commands/agent-instructions.test.ts
@@ -65,6 +65,12 @@ describe("initAgentReadySummary", () => {
       "✓ Model openai/gpt-5.5\n",
     );
   });
+
+  it("reports the agents directory for a workspace", () => {
+    expect(stripAnsi(initAgentReadySummary(undefined, "/app", { workspace: true }))).toBe(
+      "✓ Model openai/gpt-5.6-luna-fast (eve default)\n✓ Agents /app/agents",
+    );
+  });
 });
 
 describe("initAgentDevHandoff", () => {

--- a/packages/eve/src/cli/commands/agent-instructions.ts
+++ b/packages/eve/src/cli/commands/agent-instructions.ts
@@ -61,13 +61,19 @@ export function initAgentInstructions(): string {
 }
 
 /** Concise scaffold facts printed only when a coding agent launched `eve init`. */
-export function initAgentReadySummary(model: string | undefined, projectPath: string): string {
+export function initAgentReadySummary(
+  model: string | undefined,
+  projectPath: string,
+  options: { workspace?: boolean } = {},
+): string {
   const selectedModel = model ?? DEFAULT_AGENT_MODEL_ID;
   const defaultLabel = model === undefined ? pc.dim(" (eve default)") : "";
-  return [
-    `${pc.green("✓")} Model ${pc.bold(selectedModel)}${defaultLabel}`,
-    `${pc.green("✓")} Instructions ${pc.bold(join(projectPath, "agent/instructions.md"))}`,
-  ].join("\n");
+  const authoredFiles = options.workspace
+    ? `${pc.green("✓")} Agents ${pc.bold(join(projectPath, "agents"))}`
+    : `${pc.green("✓")} Instructions ${pc.bold(join(projectPath, "agent/instructions.md"))}`;
+  return [`${pc.green("✓")} Model ${pc.bold(selectedModel)}${defaultLabel}`, authoredFiles].join(
+    "\n",
+  );
 }
 
 /** The post-scaffold handoff printed after a coding agent runs `eve init`. */

--- a/packages/eve/src/cli/commands/init.integration.test.ts
+++ b/packages/eve/src/cli/commands/init.integration.test.ts
@@ -166,6 +166,13 @@ describe("runInitCommand", () => {
     await expect(readFile(join(projectRoot, "tsconfig.json"), "utf8")).resolves.toContain(
       '"agents/**/*.ts"',
     );
+    expect(deps.selectInitHandoff).toHaveBeenCalledWith({ agentName: "operations" });
+    expect(deps.spawnPackageManager).toHaveBeenCalledWith("pnpm", projectRoot, [
+      "exec",
+      "eve",
+      "dev",
+      "--onboard",
+    ]);
   });
 
   it("adds only agent files to an existing workspace", async () => {

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -618,8 +618,9 @@ export async function runInitCommand(
     }
   }
 
-  const selectedAgentArguments = options.agents?.[0] ? ["--agent", options.agents[0]] : [];
-  const baseDevArguments = [...eveDevArguments(result.packageManager), ...selectedAgentArguments];
+  // A workspace has no implicit primary agent. Let `eve dev` ask the person
+  // which member to run, rather than silently selecting the first --agents value.
+  const baseDevArguments = eveDevArguments(result.packageManager);
   const agentDevCommand = [result.packageManager, ...baseDevArguments].join(" ");
   const agentHandoff = initAgentDevHandoff({
     projectPath: result.projectPath,
@@ -627,7 +628,11 @@ export async function runInitCommand(
   });
 
   if (result.agentLaunched) {
-    logger.log(initAgentReadySummary(options.model, result.projectPath));
+    logger.log(
+      initAgentReadySummary(options.model, result.projectPath, {
+        workspace: options.agents !== undefined,
+      }),
+    );
     logger.log(agentHandoff);
     return;
   }
@@ -667,11 +672,7 @@ export async function runInitCommand(
   // the command the way run-scripts do, so the handoff line is printed here.
   const freshScaffold = result.kind === "created";
   const devArguments = freshScaffold ? [...baseDevArguments, "--onboard"] : baseDevArguments;
-  logger.log(
-    pc.dim(
-      `$ eve dev${selectedAgentArguments.length > 0 ? ` --agent ${selectedAgentArguments[1]}` : ""}`,
-    ),
-  );
+  logger.log(pc.dim("$ eve dev"));
   if (
     !resultSucceeded(
       await dependencies.spawnPackageManager(

--- a/packages/eve/src/cli/commands/register-project-commands.ts
+++ b/packages/eve/src/cli/commands/register-project-commands.ts
@@ -1,9 +1,23 @@
 import type { Command } from "#compiled/commander/index.js";
-import { applicationCommand, type CliApplicationContext } from "#cli/application-command.js";
+import type { CliApplicationContext } from "#cli/application-command.js";
+import { findEveProjectContext } from "#internal/project-context.js";
 
 interface ProjectCommandLogger {
   error(message: string): void;
   log(message: string): void;
+}
+
+/**
+ * Resolves standalone projects without using application discovery, which
+ * deliberately selects an individual agent and cannot represent a workspace
+ * root. Workspace members remain unchanged so the command can explain that
+ * deployment and linking belong at the workspace root.
+ */
+function projectCommand(command: Command, applicationContext: CliApplicationContext): Command {
+  return command.hook("preAction", async () => {
+    const context = await findEveProjectContext(applicationContext.root);
+    if (context?.kind === "standalone") applicationContext.root = context.appRoot;
+  });
 }
 
 /** Registers project-level Vercel commands without eagerly loading their flows. */
@@ -12,7 +26,7 @@ export function registerProjectCommands(input: {
   logger: ProjectCommandLogger;
   applicationContext: CliApplicationContext;
 }): void {
-  applicationCommand(input.program.command("link"), input.applicationContext)
+  projectCommand(input.program.command("link"), input.applicationContext)
     .description("Link this directory to a Vercel project and pull AI Gateway credentials.")
     .option("--non-interactive", "Run without interactive prompts")
     .option("--project <name-or-id>", "Vercel project name or ID")
@@ -22,7 +36,7 @@ export function registerProjectCommands(input: {
       await runLinkCommand(input.logger, input.applicationContext.root, undefined, options);
     });
 
-  applicationCommand(input.program.command("deploy"), input.applicationContext)
+  projectCommand(input.program.command("deploy"), input.applicationContext)
     .description("Deploy the agent to Vercel production (links first if needed).")
     .option("--non-interactive", "Run without interactive prompts")
     .option("--project <name-or-id>", "Vercel project name or ID")

--- a/packages/eve/src/cli/dev/run-interactive-ui.ts
+++ b/packages/eve/src/cli/dev/run-interactive-ui.ts
@@ -37,18 +37,8 @@ export async function runInteractiveDevelopmentUi(input: {
     projectContext?.kind === "workspace-member" ? projectContext.member.appRoot : undefined;
   const target =
     input.remoteTarget === undefined || input.existingLocalServer
-      ? {
-          kind: "local" as const,
-          serverUrl: input.server.serverUrl,
-          workspaceRoot,
-          ...(agentRoot === undefined ? {} : { agentRoot }),
-        }
-      : {
-          kind: "remote" as const,
-          serverUrl: input.server.serverUrl,
-          workspaceRoot,
-          ...(agentRoot === undefined ? {} : { agentRoot }),
-        };
+      ? { kind: "local" as const, serverUrl: input.server.serverUrl, workspaceRoot, agentRoot }
+      : { kind: "remote" as const, serverUrl: input.server.serverUrl, workspaceRoot, agentRoot };
   const display = resolveTuiDisplayOptions(input.options);
   const name = resolveTuiTitle({ name: input.options.name, target });
   if (name !== undefined) display.name = name;

--- a/packages/eve/src/cli/dev/run-interactive-ui.ts
+++ b/packages/eve/src/cli/dev/run-interactive-ui.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import { devBootPhase, type DevBootProgressReporter } from "#internal/dev-boot-progress.js";
+import { findEveProjectContext } from "#internal/project-context.js";
 import {
   resumeDevelopmentRuntimeArtifacts,
   suspendDevelopmentRuntimeArtifacts,
@@ -29,17 +30,24 @@ export async function runInteractiveDevelopmentUi(input: {
     async () => input.runDevelopmentTui ?? (await import("#cli/dev/tui/tui.js")).runDevelopmentTui,
     input.report,
   );
+  const applicationRoot = input.server.appRoot ?? input.applicationRoot;
+  const projectContext = await findEveProjectContext(applicationRoot);
+  const workspaceRoot = projectContext?.environmentRoot ?? applicationRoot;
+  const agentRoot =
+    projectContext?.kind === "workspace-member" ? projectContext.member.appRoot : undefined;
   const target =
     input.remoteTarget === undefined || input.existingLocalServer
       ? {
           kind: "local" as const,
           serverUrl: input.server.serverUrl,
-          workspaceRoot: input.server.appRoot ?? input.applicationRoot,
+          workspaceRoot,
+          ...(agentRoot === undefined ? {} : { agentRoot }),
         }
       : {
           kind: "remote" as const,
           serverUrl: input.server.serverUrl,
-          workspaceRoot: input.applicationRoot,
+          workspaceRoot,
+          ...(agentRoot === undefined ? {} : { agentRoot }),
         };
   const display = resolveTuiDisplayOptions(input.options);
   const name = resolveTuiTitle({ name: input.options.name, target });

--- a/packages/eve/src/cli/dev/tui/prompt-command-handler.ts
+++ b/packages/eve/src/cli/dev/tui/prompt-command-handler.ts
@@ -116,11 +116,11 @@ export function createPromptCommandHandler(
         const commandInput: TuiSetupCommandInput = {
           command: command.name,
           appRoot: target.workspaceRoot,
-          ...(target.agentRoot === undefined ? {} : { agentRoot: target.agentRoot }),
           renderer: flow,
           withExclusiveTerminal: context.withExclusiveTerminal,
           chatGptAccountLabel: context.chatGptAccountLabel,
         };
+        if (target.agentRoot !== undefined) commandInput.agentRoot = target.agentRoot;
         if (context.initialModelStep !== undefined) {
           commandInput.initialModelStep = context.initialModelStep;
         }

--- a/packages/eve/src/cli/dev/tui/prompt-command-handler.ts
+++ b/packages/eve/src/cli/dev/tui/prompt-command-handler.ts
@@ -52,7 +52,7 @@ export function createPromptCommandHandler(
               "/model needs eve dev running the local server (it is not available with --url).",
           };
         }
-        const appRoot = target.workspaceRoot;
+        const appRoot = target.agentRoot ?? target.workspaceRoot;
         // Package-loading failures are command outcomes at this CLI boundary.
         try {
           const { modelChangeRefusalForUneditableModel } = await import("#setup/flows/model.js");
@@ -116,6 +116,7 @@ export function createPromptCommandHandler(
         const commandInput: TuiSetupCommandInput = {
           command: command.name,
           appRoot: target.workspaceRoot,
+          ...(target.agentRoot === undefined ? {} : { agentRoot: target.agentRoot }),
           renderer: flow,
           withExclusiveTerminal: context.withExclusiveTerminal,
           chatGptAccountLabel: context.chatGptAccountLabel,

--- a/packages/eve/src/cli/dev/tui/setup-commands.test.ts
+++ b/packages/eve/src/cli/dev/tui/setup-commands.test.ts
@@ -81,6 +81,7 @@ function run(input: {
   flows: TuiSetupFlows;
   renderer?: TuiSetupCommandRenderer;
   initialModelStep?: "provider";
+  agentRoot?: string;
   useDefaultPrompter?: boolean;
   upgradeChoice?: "upgrade" | "later";
   withExclusiveTerminal?: TuiSetupCommandInput["withExclusiveTerminal"];
@@ -95,6 +96,7 @@ function run(input: {
     renderer: input.renderer ?? fakePanelRenderer(),
     flows: input.flows,
   };
+  if (input.agentRoot !== undefined) commandInput.agentRoot = input.agentRoot;
   if (input.useDefaultPrompter !== true) commandInput.createPrompter = () => fake.prompter;
   if (input.initialModelStep !== undefined) {
     commandInput.initialModelStep = input.initialModelStep;
@@ -203,6 +205,23 @@ describe("runTuiSetupCommand", () => {
       expect.objectContaining({
         appRoot: APP_ROOT,
         deps: expect.objectContaining({ runProviderFlow: expect.any(Function) }),
+      }),
+    );
+  });
+
+  it("edits the selected workspace agent while configuring project-level provider access", async () => {
+    const flows = fakeFlows();
+
+    await run({
+      command: "model",
+      flows,
+      agentRoot: "/tmp/project/agents/researcher",
+    });
+
+    expect(flows.runModelFlow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appRoot: "/tmp/project/agents/researcher",
+        environmentRoot: APP_ROOT,
       }),
     );
   });

--- a/packages/eve/src/cli/dev/tui/setup-commands.ts
+++ b/packages/eve/src/cli/dev/tui/setup-commands.ts
@@ -53,8 +53,10 @@ type MuteableSetupRenderer = TuiPrompterRenderer &
 
 export interface TuiSetupCommandInput {
   command: TuiSetupCommand;
-  /** The local project the in-process dev server is running. */
+  /** Project root for setup that changes shared dependencies, links, or environment files. */
   appRoot: string;
+  /** Selected agent root whose authored settings are changed by `/model`. */
+  agentRoot?: string;
   /** The renderer surface the TUI-native prompter drives. */
   renderer: TuiSetupCommandRenderer;
   /** Initial model-flow step authorized by the runner's boot evidence. */
@@ -256,7 +258,8 @@ async function executeSetupCommand(
       case "model": {
         const pickProvider: ProviderPicker = (request) => renderer.readProviderPicker(request);
         const modelInput: Parameters<TuiSetupFlows["runModelFlow"]>[0] = {
-          appRoot,
+          appRoot: input.agentRoot ?? appRoot,
+          environmentRoot: appRoot,
           prompter,
           signal,
           chatGptAccountLabel: input.chatGptAccountLabel,

--- a/packages/eve/src/cli/run.test.ts
+++ b/packages/eve/src/cli/run.test.ts
@@ -11,7 +11,8 @@ function resolvedProject(appRoot: string) {
   return { agentRoot: `${appRoot}/agent`, appRoot, layout: "nested" as const };
 }
 
-const { runInitCommand, runSetCommand } = vi.hoisted(() => ({
+const { runDeployCommand, runInitCommand, runSetCommand } = vi.hoisted(() => ({
+  runDeployCommand: vi.fn(async () => {}),
   runInitCommand: vi.fn(async () => {}),
   runSetCommand: vi.fn(async () => {}),
 }));
@@ -20,6 +21,7 @@ vi.mock("#cli/application-root.js", () => ({
   findCliApplicationRoot: vi.fn(async () => undefined),
   resolveCliApplicationProject: vi.fn(async (cwd: string) => resolvedProject(cwd)),
 }));
+vi.mock("#cli/commands/deploy.js", () => ({ runDeployCommand }));
 vi.mock("#cli/commands/init.js", () => ({ runInitCommand }));
 vi.mock("#cli/commands/set.js", () => ({ runSetCommand }));
 vi.mock("#internal/project-context.js", () => ({
@@ -90,6 +92,24 @@ describe("CLI command registration", () => {
     expect(runSetCommand).toHaveBeenCalledWith(logger, resolve(process.cwd()), {
       model: "openai/gpt-5.6-sol",
       reasoning: "high",
+    });
+  });
+
+  it("runs deploy from a workspace root without application discovery", async () => {
+    const logger = { error: vi.fn(), log: vi.fn() };
+    const resolveProject = vi.fn(async () => {
+      throw new Error("application discovery must not run for a workspace root");
+    });
+    runDeployCommand.mockClear();
+
+    await runCli(["deploy"], logger, { resolveApplicationProject: resolveProject });
+
+    expect(resolveProject).not.toHaveBeenCalled();
+    expect(runDeployCommand).toHaveBeenCalledWith(logger, resolve(process.cwd()), undefined, {
+      nonInteractive: undefined,
+      project: undefined,
+      team: undefined,
+      yes: undefined,
     });
   });
 

--- a/packages/eve/src/services/dev-client/target.ts
+++ b/packages/eve/src/services/dev-client/target.ts
@@ -1,8 +1,10 @@
 /** Server target used by development clients. */
 interface DevelopmentTargetBase {
   readonly serverUrl: string;
-  /** Local workspace root for app files and the fallback Vercel project link. */
+  /** Project root for shared dependencies, Vercel links, and environment files. */
   readonly workspaceRoot: string;
+  /** The selected agent's root when it is a member of a multi-agent project. */
+  readonly agentRoot?: string;
 }
 
 /** A development client backed by a local `eve dev` server. */

--- a/packages/eve/src/setup/flows/model.ts
+++ b/packages/eve/src/setup/flows/model.ts
@@ -282,7 +282,10 @@ function modelMenuRows(
  * external-provider instructions return to the menu.
  */
 export async function runModelFlow(input: {
+  /** Selected agent root whose authored model settings are edited. */
   appRoot: string;
+  /** Project root for shared provider configuration and Vercel credentials. */
+  environmentRoot?: string;
   prompter: Prompter;
   /** Opens provider setup before the root menu when runtime evidence requires it. */
   initialStep?: "provider";
@@ -294,6 +297,7 @@ export async function runModelFlow(input: {
   deps?: Partial<ModelFlowDeps>;
 }): Promise<ModelFlowResult> {
   const { appRoot, prompter, signal } = input;
+  const environmentRoot = input.environmentRoot ?? appRoot;
   const deps: ModelFlowDeps = {
     readCurrentModel: readCurrentAgentModel,
     applySettings: changeAgentModelSettings,
@@ -316,10 +320,10 @@ export async function runModelFlow(input: {
       Promise.all([
         deps.readCurrentModel(appRoot),
         deps.resolveAvailableProviders(
-          appRoot,
+          environmentRoot,
           signal === undefined ? { env: process.env } : { signal, env: process.env },
         ),
-        deps.readProviderSelection(appRoot),
+        deps.readProviderSelection(environmentRoot),
         fetchCatalog(signal).catch((): GatewayCatalogModel[] | undefined => undefined),
       ]),
   );
@@ -457,7 +461,7 @@ export async function runModelFlow(input: {
     }
 
     const result = await deps.runProviderFlow({
-      appRoot,
+      appRoot: environmentRoot,
       prompter,
       signal,
       availableProviders,
@@ -506,7 +510,7 @@ export async function runModelFlow(input: {
     lastApply = await deps.applySettings({ appRoot, patch });
   }
   if (commitDraft && nextProviderSelection !== undefined && lastApply?.kind !== "rejected") {
-    await deps.writeProviderSelection(appRoot, nextProviderSelection);
+    await deps.writeProviderSelection(environmentRoot, nextProviderSelection);
     committedProviderSelection = nextProviderSelection;
   }
   if (lastApply !== undefined && committedProviderSelection === undefined) {

--- a/scripts/repro-multi-agent-init.mjs
+++ b/scripts/repro-multi-agent-init.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const evePackageRoot = join(repositoryRoot, "packages", "eve");
+const projectName = process.argv[2] ?? "my-project";
+
+if (process.argv.length > 3 || projectName.startsWith("-")) {
+  console.error("Usage: node scripts/repro-multi-agent-init.mjs [project-name]");
+  process.exitCode = 1;
+} else {
+  const packageJson = JSON.parse(await readFile(join(evePackageRoot, "package.json"), "utf8"));
+  const packageVersion = packageJson.version;
+  if (typeof packageVersion !== "string")
+    throw new Error("packages/eve/package.json has no version.");
+
+  const tempRoot = await mkdtemp(join(tmpdir(), "eve-multi-agent-init-"));
+  const packDirectory = await mkdtemp(join(tmpdir(), "eve-multi-agent-pack-"));
+  const homeDirectory = await mkdtemp(join(tmpdir(), "eve-multi-agent-home-"));
+  const target = join(tempRoot, projectName);
+  await writeFile(join(homeDirectory, ".npmrc"), "registry=https://registry.npmjs.org/\n");
+
+  try {
+    await run("pnpm", ["pack", "--pack-destination", packDirectory], { cwd: evePackageRoot });
+    const environment = {
+      ...process.env,
+      EVE_INIT_PACKAGE_SPEC: `file:${join(packDirectory, `eve-${packageVersion}.tgz`)}`,
+      HOME: homeDirectory,
+      npm_config_globalconfig: "/dev/null",
+      npm_config_registry: "https://registry.npmjs.org",
+      npm_config_userconfig: join(homeDirectory, ".npmrc"),
+    };
+    await run(
+      process.execPath,
+      [join(evePackageRoot, "bin", "eve.js"), "init", target, "--agents", "researcher,bug-finder"],
+      {
+        cwd: tempRoot,
+        env: environment,
+      },
+    );
+    console.log(`\nCreated test workspace: ${target}`);
+  } finally {
+    await Promise.all([
+      rm(packDirectory, { force: true, recursive: true }),
+      rm(homeDirectory, { force: true, recursive: true }),
+    ]);
+  }
+}
+
+function run(command, args, options) {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(command, args, { ...options, stdio: "inherit" });
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (code === 0) return resolvePromise();
+      reject(new Error(`${command} ${args.join(" ")} exited with ${signal ?? `code ${code}`}.`));
+    });
+  });
+}


### PR DESCRIPTION
### Summary

Fixes a set of polish issues for multi-agent projects:

- when you initialize a multi-agent project and proceed to the dev TUI, it asks you to select which agent to use rather than defaulting to the first one
- when you first are prompted to link a project, the default name is now the name of the enclosing eve project folder rather than the name of the currently-selected agent
- `/deploy` now properly runs the root deployment flow rather than failing

### Validation

- `pnpm fmt`
- `pnpm lint` (passes with existing unrelated warnings in `apps/benchmarks/run.mjs` and `packages/eve/src/public/channels/teams/teamsChannel.test.ts`)
- `pnpm typecheck`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/cli/run.test.ts`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/cli/commands/agent-instructions.test.ts src/setup/flows/model.test.ts src/cli/dev/tui/setup-commands.test.ts src/cli/dev/tui/prompt-command-handler.test.ts`
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/cli/commands/deploy.integration.test.ts src/cli/commands/link.integration.test.ts src/cli/commands/init.integration.test.ts`

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
