### PR TITLE
feat(eve): add multi-agent deployment landing page

### DIFF
--- a/packages/eve/src/internal/nitro/routes/index.ts
+++ b/packages/eve/src/internal/nitro/routes/index.ts
@@ -5,8 +5,9 @@
  */
 const EVE_DOCS_URL = "https://eve.dev/docs";
 
-const DEPLOYMENT_URL_PLACEHOLDER = "{{DEPLOYMENT_URL}}";
 const AGENT_NAME_PLACEHOLDER = "{{AGENT_NAME}}";
+const STATUS_DETAIL_PLACEHOLDER = "{{STATUS_DETAIL}}";
+const TERMINAL_PLACEHOLDER = "{{TERMINAL}}";
 
 const EVE_LOGO_SVG = `<svg aria-hidden="true" class="logo" fill="none" viewBox="0 0 169 53" xmlns="http://www.w3.org/2000/svg">
     <path d="M169 8.47h-51.39L81.73 53H70.36L113 0H169zM169 44.51v8.47h-45.87V44.5zM45.87 52.98H0V44.5h45.87zM38.66 30.55H0v-8.47h38.66z" fill="currentColor"></path>
@@ -202,11 +203,8 @@ const HOME_PAGE_HTML_TEMPLATE = `<!doctype html>
     <div class="agent-row">
       <strong class="agent-name">${AGENT_NAME_PLACEHOLDER}</strong>
     </div>
-    <p class="lede"><span class="status"><span class="status-dot" aria-hidden="true"></span>Ready</span><span class="lede-divider" aria-hidden="true">／</span><span>Agent is up and accepting messages.</span> <a href="${EVE_DOCS_URL}">Docs<span class="lede-arrow" aria-hidden="true">&nbsp;&rarr;</span></a></p>
-    <div class="terminal mono" role="group" aria-label="Send a message from your terminal">
-      <span class="terminal-prompt" aria-hidden="true">$</span>
-      <span class="terminal-cmd">eve dev ${DEPLOYMENT_URL_PLACEHOLDER}</span>
-    </div>
+    <p class="lede"><span class="status"><span class="status-dot" aria-hidden="true"></span>Ready</span><span class="lede-divider" aria-hidden="true">／</span><span>${STATUS_DETAIL_PLACEHOLDER}</span> <a href="${EVE_DOCS_URL}">Docs<span class="lede-arrow" aria-hidden="true">&nbsp;&rarr;</span></a></p>
+    ${TERMINAL_PLACEHOLDER}
   </section>
 </main>
 </body>
@@ -254,6 +252,25 @@ function resolveDeploymentUrl(request: Request): string {
   return `${proto}://${host}`;
 }
 
+/** Render the shared lightweight deployment status page. */
+export function buildHomePageHtml(input: {
+  readonly name: string;
+  readonly statusDetail: string;
+  readonly terminalCommand?: string;
+}): string {
+  const terminal =
+    input.terminalCommand === undefined
+      ? ""
+      : `<div class="terminal mono" role="group" aria-label="Send a message from your terminal">
+      <span class="terminal-prompt" aria-hidden="true">$</span>
+      <span class="terminal-cmd">${escapeHtml(input.terminalCommand)}</span>
+    </div>`;
+
+  return HOME_PAGE_HTML_TEMPLATE.replace(AGENT_NAME_PLACEHOLDER, () => escapeHtml(input.name))
+    .replace(STATUS_DETAIL_PLACEHOLDER, () => escapeHtml(input.statusDetail))
+    .replace(TERMINAL_PLACEHOLDER, () => terminal);
+}
+
 /**
  * Builds the barebones home page response for one request. Exposed
  * for tests so callers can supply a real {@link Request}; production
@@ -266,9 +283,11 @@ export function buildHomePageResponse(
   request: Request,
 ): Response {
   const deploymentUrl = resolveDeploymentUrl(request);
-  const html = HOME_PAGE_HTML_TEMPLATE.replace(AGENT_NAME_PLACEHOLDER, () =>
-    escapeHtml(input.agentName),
-  ).replace(DEPLOYMENT_URL_PLACEHOLDER, () => escapeHtml(deploymentUrl));
+  const html = buildHomePageHtml({
+    name: input.agentName,
+    statusDetail: "Agent is up and accepting messages.",
+    terminalCommand: `eve dev ${deploymentUrl}`,
+  });
 
   return new Response(html, {
     headers: {

--- a/packages/eve/src/internal/vercel/assemble-eve-services.ts
+++ b/packages/eve/src/internal/vercel/assemble-eve-services.ts
@@ -52,6 +52,9 @@ export function assembleEveVercelServices(input: {
             ),
           };
     eveRoutes.push({ routeSrc: contribution.routeSrc, serviceName });
+    if (contribution.homeRouteSrc !== undefined) {
+      eveRoutes.push({ routeSrc: contribution.homeRouteSrc, serviceName });
+    }
   }
 
   return {

--- a/packages/eve/src/internal/vercel/build-agent-workspace.integration.test.ts
+++ b/packages/eve/src/internal/vercel/build-agent-workspace.integration.test.ts
@@ -69,10 +69,22 @@ describe("buildAgentWorkspace", () => {
         src: "^/research/eve/v1/(.*)$",
       },
       {
+        destination: { service: "eve-research", type: "service" },
+        src: "^/research/?$",
+      },
+      {
         destination: { service: "eve-support", type: "service" },
         src: "^/support/eve/v1/(.*)$",
       },
+      {
+        destination: { service: "eve-support", type: "service" },
+        src: "^/support/?$",
+      },
+      { handle: "filesystem" },
     ]);
+    await expect(readFile(join(output, "static", "index.html"), "utf8")).resolves.toContain(
+      '<a href="/research/">research</a>',
+    );
     await expect(
       access(join(root, ".eve", "vercel-services", "eve-support")),
     ).resolves.toBeUndefined();
@@ -84,6 +96,10 @@ describe("buildAgentWorkspace", () => {
       root: ".eve/vercel-services/eve-support",
       routePrefix: "/support",
       routes: [
+        {
+          src: "^/support/?$",
+          transforms: [{ args: "/", op: "set", type: "request.path" }],
+        },
         {
           src: "^/support/eve/v1/(.*)$",
           transforms: [{ args: "/eve/v1/$1", op: "set", type: "request.path" }],

--- a/packages/eve/src/internal/vercel/build-agent-workspace.integration.test.ts
+++ b/packages/eve/src/internal/vercel/build-agent-workspace.integration.test.ts
@@ -83,7 +83,7 @@ describe("buildAgentWorkspace", () => {
       { handle: "filesystem" },
     ]);
     await expect(readFile(join(output, "static", "index.html"), "utf8")).resolves.toContain(
-      '<a href="/research/">research</a>',
+      "2 agents are up and accepting messages.",
     );
     await expect(
       access(join(root, ".eve", "vercel-services", "eve-support")),

--- a/packages/eve/src/internal/vercel/build-agent-workspace.ts
+++ b/packages/eve/src/internal/vercel/build-agent-workspace.ts
@@ -10,6 +10,7 @@ import {
 } from "#internal/vercel-agent-summary.js";
 import type { AgentWorkspace } from "#internal/project-context.js";
 import { assembleEveVercelServices } from "#internal/vercel/assemble-eve-services.js";
+import { buildMultiAgentLandingPage } from "#internal/vercel/build-multi-agent-landing-page.js";
 import { quoteVercelShellArgument, toVercelRelativePath } from "#internal/vercel/build-command.js";
 import { readVercelJsonFile } from "#internal/vercel/vercel-services-config.js";
 import { resolveEveBinaryPath } from "#shared/resolve-eve-binary.js";
@@ -73,12 +74,15 @@ export async function buildAgentWorkspace(workspace: AgentWorkspace): Promise<st
     join(workspace.root, VERCEL_EVE_AGENT_SUMMARY_OUTPUT_PATH),
     `${JSON.stringify(createMultiAgentSummary(workspace), null, 2)}\n`,
   );
+  const staticDirectory = join(outputDirectory, "static");
+  await mkdir(staticDirectory, { recursive: true });
+  await writeFile(join(staticDirectory, "index.html"), buildMultiAgentLandingPage(workspace));
   await writeFile(
     join(outputDirectory, "config.json"),
     `${JSON.stringify(
       {
         version: VERCEL_BUILD_OUTPUT_VERSION,
-        routes: assembled.routes,
+        routes: [...assembled.routes, { handle: "filesystem" }],
         services: assembled.services,
       },
       null,

--- a/packages/eve/src/internal/vercel/build-multi-agent-landing-page.ts
+++ b/packages/eve/src/internal/vercel/build-multi-agent-landing-page.ts
@@ -1,34 +1,11 @@
 import type { AgentWorkspace } from "#internal/project-context.js";
-
-function escapeHtml(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
-}
+import { buildHomePageHtml } from "#internal/nitro/routes/index.js";
 
 /** Build the public root page for a hostless multi-agent deployment. */
 export function buildMultiAgentLandingPage(workspace: AgentWorkspace): string {
-  const agents = workspace.members
-    .map(
-      (member) =>
-        `<li><a href="/${encodeURIComponent(member.name)}/">${escapeHtml(member.name)}</a></li>`,
-    )
-    .join("\n");
-
-  return `<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1">
-<meta name="robots" content="noindex">
-<meta name="referrer" content="no-referrer">
-<title>eve</title>
-<style>body{margin:0;background:#fff;color:#0a0a0a;font-family:ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;display:grid;min-height:100vh;place-items:center;padding:2rem}main{max-width:28rem;width:100%}h1{font-size:1rem;margin:0 0 .5rem}p{color:#6b6b6b;margin:0 0 1.5rem}ul{list-style:none;margin:0;padding:0;border:1px solid rgba(0,0,0,.12);border-radius:.5rem}li+li{border-top:1px solid rgba(0,0,0,.12)}a{color:inherit;display:block;padding:.875rem 1rem;text-decoration:none}a:hover{text-decoration:underline}@media(prefers-color-scheme:dark){body{background:#0a0a0a;color:#f5f5f5}p{color:#a3a3a3}ul,li+li{border-color:rgba(255,255,255,.16)}}</style>
-</head>
-<body><main><h1>eve agents</h1><p>${workspace.members.length} agents are ready.</p><ul>${agents}</ul></main></body>
-</html>
-`;
+  const agentCount = workspace.members.length;
+  return buildHomePageHtml({
+    name: "eve agents",
+    statusDetail: `${agentCount} ${agentCount === 1 ? "agent is" : "agents are"} up and accepting messages.`,
+  });
 }

--- a/packages/eve/src/internal/vercel/build-multi-agent-landing-page.ts
+++ b/packages/eve/src/internal/vercel/build-multi-agent-landing-page.ts
@@ -1,0 +1,34 @@
+import type { AgentWorkspace } from "#internal/project-context.js";
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+/** Build the public root page for a hostless multi-agent deployment. */
+export function buildMultiAgentLandingPage(workspace: AgentWorkspace): string {
+  const agents = workspace.members
+    .map(
+      (member) =>
+        `<li><a href="/${encodeURIComponent(member.name)}/">${escapeHtml(member.name)}</a></li>`,
+    )
+    .join("\n");
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="robots" content="noindex">
+<meta name="referrer" content="no-referrer">
+<title>eve</title>
+<style>body{margin:0;background:#fff;color:#0a0a0a;font-family:ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;display:grid;min-height:100vh;place-items:center;padding:2rem}main{max-width:28rem;width:100%}h1{font-size:1rem;margin:0 0 .5rem}p{color:#6b6b6b;margin:0 0 1.5rem}ul{list-style:none;margin:0;padding:0;border:1px solid rgba(0,0,0,.12);border-radius:.5rem}li+li{border-top:1px solid rgba(0,0,0,.12)}a{color:inherit;display:block;padding:.875rem 1rem;text-decoration:none}a:hover{text-decoration:underline}@media(prefers-color-scheme:dark){body{background:#0a0a0a;color:#f5f5f5}p{color:#a3a3a3}ul,li+li{border-color:rgba(255,255,255,.16)}}</style>
+</head>
+<body><main><h1>eve agents</h1><p>${workspace.members.length} agents are ready.</p><ul>${agents}</ul></main></body>
+</html>
+`;
+}

--- a/packages/eve/src/internal/vercel/eve-service-contribution.ts
+++ b/packages/eve/src/internal/vercel/eve-service-contribution.ts
@@ -38,7 +38,7 @@ export interface EveVercelBuildTarget {
 }
 
 export interface EveVercelServiceContribution {
-  readonly homeRouteSrc?: string;
+  readonly homeRouteSrc: string | undefined;
   readonly rootDirectory: string;
   readonly routeSrc: string;
   readonly service: GeneratedVercelServiceConfig;
@@ -149,7 +149,7 @@ export function compileEveVercelService(input: {
   });
 
   return {
-    ...(homeRouteSrc === undefined ? {} : { homeRouteSrc }),
+    homeRouteSrc,
     rootDirectory: build.rootDirectory,
     routeSrc,
     service: {

--- a/packages/eve/src/internal/vercel/eve-service-contribution.ts
+++ b/packages/eve/src/internal/vercel/eve-service-contribution.ts
@@ -129,8 +129,14 @@ export function compileEveVercelService(input: {
 }): EveVercelServiceContribution {
   const serviceName = createEveServiceName(input.agent.name);
   const routeSrc = createEveServiceRouteSrc(input.agent.publicRoutePrefix);
-  const homeRouteSrc = createEveHomeRouteSrc(input.agent.publicRoutePrefix);
-  const homeRoute = createEveHomePathRoute(input.agent.publicRoutePrefix);
+  const homeRouteSrc =
+    input.agent.workspaceMember === true
+      ? createEveHomeRouteSrc(input.agent.publicRoutePrefix)
+      : undefined;
+  const homeRoute =
+    input.agent.workspaceMember === true
+      ? createEveHomePathRoute(input.agent.publicRoutePrefix)
+      : undefined;
   const build = createIsolatedBuild({
     agent: input.agent,
     hostOutputDirectory: input.target.hostOutputDirectory,

--- a/packages/eve/src/internal/vercel/eve-service-contribution.ts
+++ b/packages/eve/src/internal/vercel/eve-service-contribution.ts
@@ -66,10 +66,14 @@ export function createEveServiceName(name: string | undefined): string {
   return serviceName;
 }
 
+function escapeVercelRouteLiteral(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 export function createEveServiceRouteSrc(publicRoutePrefix: string): string {
   if (publicRoutePrefix.length === 0) return `^${EVE_ROUTE_PREFIX}/(.*)$`;
   const prefix = publicRoutePrefix.startsWith("/") ? publicRoutePrefix : `/${publicRoutePrefix}`;
-  return `^${prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}${EVE_ROUTE_PREFIX}/(.*)$`;
+  return `^${escapeVercelRouteLiteral(prefix)}${EVE_ROUTE_PREFIX}/(.*)$`;
 }
 
 export function createEveRequestPathRoute(routeSrc: string): VercelRouteConfig {
@@ -82,7 +86,7 @@ export function createEveRequestPathRoute(routeSrc: string): VercelRouteConfig {
 export function createEveHomeRouteSrc(publicRoutePrefix: string): string | undefined {
   if (publicRoutePrefix.length === 0) return undefined;
   const prefix = publicRoutePrefix.startsWith("/") ? publicRoutePrefix : `/${publicRoutePrefix}`;
-  return `^${prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/?$`;
+  return `^${escapeVercelRouteLiteral(prefix)}/?$`;
 }
 
 /** Route a member's public base path to its package-owned home channel. */

--- a/packages/eve/src/internal/vercel/eve-service-contribution.ts
+++ b/packages/eve/src/internal/vercel/eve-service-contribution.ts
@@ -38,6 +38,7 @@ export interface EveVercelBuildTarget {
 }
 
 export interface EveVercelServiceContribution {
+  readonly homeRouteSrc?: string;
   readonly rootDirectory: string;
   readonly routeSrc: string;
   readonly service: GeneratedVercelServiceConfig;
@@ -78,6 +79,20 @@ export function createEveRequestPathRoute(routeSrc: string): VercelRouteConfig {
   };
 }
 
+export function createEveHomeRouteSrc(publicRoutePrefix: string): string | undefined {
+  if (publicRoutePrefix.length === 0) return undefined;
+  const prefix = publicRoutePrefix.startsWith("/") ? publicRoutePrefix : `/${publicRoutePrefix}`;
+  return `^${prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/?$`;
+}
+
+/** Route a member's public base path to its package-owned home channel. */
+export function createEveHomePathRoute(publicRoutePrefix: string): VercelRouteConfig | undefined {
+  const src = createEveHomeRouteSrc(publicRoutePrefix);
+  return src === undefined
+    ? undefined
+    : { src, transforms: [{ args: "/", op: "set", type: "request.path" }] };
+}
+
 export function createEvePublicRoute(serviceName: string, routeSrc: string): VercelRouteConfig {
   return { destination: { service: serviceName, type: "service" }, src: routeSrc };
 }
@@ -114,6 +129,8 @@ export function compileEveVercelService(input: {
 }): EveVercelServiceContribution {
   const serviceName = createEveServiceName(input.agent.name);
   const routeSrc = createEveServiceRouteSrc(input.agent.publicRoutePrefix);
+  const homeRouteSrc = createEveHomeRouteSrc(input.agent.publicRoutePrefix);
+  const homeRoute = createEveHomePathRoute(input.agent.publicRoutePrefix);
   const build = createIsolatedBuild({
     agent: input.agent,
     hostOutputDirectory: input.target.hostOutputDirectory,
@@ -122,13 +139,17 @@ export function compileEveVercelService(input: {
   });
 
   return {
+    ...(homeRouteSrc === undefined ? {} : { homeRouteSrc }),
     rootDirectory: build.rootDirectory,
     routeSrc,
     service: {
       buildCommand: build.buildCommand,
       framework: "eve",
       root: build.root,
-      routes: [createEveRequestPathRoute(routeSrc)],
+      routes: [
+        ...(homeRoute === undefined ? [] : [homeRoute]),
+        createEveRequestPathRoute(routeSrc),
+      ],
       ...(input.agent.publicRoutePrefix.length > 0
         ? { routePrefix: input.agent.publicRoutePrefix }
         : {}),


### PR DESCRIPTION
### Summary

Multi-agent Eve deployments currently route only each agent’s API prefix, so the base deployment URL returns Vercel’s 404 while single-agent deployments render Eve’s lightweight status page. This adds a static multi-agent landing page at `/`, and ensures each single agent also has its own standard landing page at `/<agent>/`.

<img width="905" height="522" alt="Screenshot 2026-09-03 at 3 00 41 PM" src="https://github.com/user-attachments/assets/e62308e9-8ff7-4e7e-9913-6e8af8dc368a" />



### Validation

- `pnpm --filter eve test:integration -- src/internal/vercel/build-agent-workspace.integration.test.ts` — passed (97 files, 711 tests)

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
