### PR TITLE
feat(eve): emit multi-agent deployment summaries

### DIFF
--- a/packages/eve/src/internal/vercel-agent-summary.ts
+++ b/packages/eve/src/internal/vercel-agent-summary.ts
@@ -53,9 +53,6 @@ export const VERCEL_EVE_AGENT_SUMMARY_VERSION = 5;
  */
 export const VERCEL_EVE_AGENT_SUMMARY_OUTPUT_PATH = ".eve/agent-summary.json";
 
-/** Project-root manifest identifying the independently built agents in a multi-agent deployment. */
-export const VERCEL_EVE_MULTI_AGENT_SUMMARY_OUTPUT_PATH = ".eve/multi-agent-summary.json";
-
 export const VERCEL_EVE_MULTI_AGENT_SUMMARY_KIND = "vercel-eve-multi-agent-summary" as const;
 
 export const VERCEL_EVE_MULTI_AGENT_SUMMARY_VERSION = 1;

--- a/packages/eve/src/internal/vercel-agent-summary.ts
+++ b/packages/eve/src/internal/vercel-agent-summary.ts
@@ -53,6 +53,13 @@ export const VERCEL_EVE_AGENT_SUMMARY_VERSION = 5;
  */
 export const VERCEL_EVE_AGENT_SUMMARY_OUTPUT_PATH = ".eve/agent-summary.json";
 
+/** Project-root manifest identifying the independently built agents in a multi-agent deployment. */
+export const VERCEL_EVE_MULTI_AGENT_SUMMARY_OUTPUT_PATH = ".eve/multi-agent-summary.json";
+
+export const VERCEL_EVE_MULTI_AGENT_SUMMARY_KIND = "vercel-eve-multi-agent-summary" as const;
+
+export const VERCEL_EVE_MULTI_AGENT_SUMMARY_VERSION = 1;
+
 /**
  * Display category eve exposes to the dashboard for one channel chip. Built
  * from the channel's reported {@link CompiledChannelDefinition.adapterKind}.
@@ -195,6 +202,30 @@ export interface VercelEveSubagentEntry {
 export interface VercelEveDiagnosticsSummary {
   readonly errors: number;
   readonly warnings: number;
+}
+
+/** One independently deployed agent declared by a multi-agent project. */
+export interface VercelEveMultiAgentSummaryEntry {
+  /** Stable workspace member name and public URL segment. */
+  readonly name: string;
+  /** Public route prefix for this agent (for example, `/support`). */
+  readonly routePrefix: string;
+  /** Path to the member's existing single-agent summary, relative to project root. */
+  readonly summaryPath: string;
+}
+
+/**
+ * Versioned project-level index for a multi-agent deployment.
+ *
+ * It deliberately references the existing per-agent summaries instead of
+ * flattening them: schedules, tools, and connections may share names across
+ * independently authored agents and must retain their owner.
+ */
+export interface VercelEveMultiAgentSummary {
+  readonly kind: typeof VERCEL_EVE_MULTI_AGENT_SUMMARY_KIND;
+  readonly schemaVersion: typeof VERCEL_EVE_MULTI_AGENT_SUMMARY_VERSION;
+  readonly generatorVersion: string;
+  readonly agents: readonly VercelEveMultiAgentSummaryEntry[];
 }
 
 /**

--- a/packages/eve/src/internal/vercel/build-agent-workspace.integration.test.ts
+++ b/packages/eve/src/internal/vercel/build-agent-workspace.integration.test.ts
@@ -42,6 +42,26 @@ describe("buildAgentWorkspace", () => {
 
     const output = await buildAgentWorkspace(workspace);
     const config = JSON.parse(await readFile(join(output, "config.json"), "utf8"));
+    const multiAgentSummary = JSON.parse(
+      await readFile(join(root, ".eve", "multi-agent-summary.json"), "utf8"),
+    );
+
+    expect(multiAgentSummary).toMatchObject({
+      agents: [
+        {
+          name: "research",
+          routePrefix: "/research",
+          summaryPath: "agents/research/.eve/agent-summary.json",
+        },
+        {
+          name: "support",
+          routePrefix: "/support",
+          summaryPath: "agents/support/.eve/agent-summary.json",
+        },
+      ],
+      kind: "vercel-eve-multi-agent-summary",
+      schemaVersion: 1,
+    });
 
     expect(config.routes).toEqual([
       {

--- a/packages/eve/src/internal/vercel/build-agent-workspace.integration.test.ts
+++ b/packages/eve/src/internal/vercel/build-agent-workspace.integration.test.ts
@@ -43,7 +43,7 @@ describe("buildAgentWorkspace", () => {
     const output = await buildAgentWorkspace(workspace);
     const config = JSON.parse(await readFile(join(output, "config.json"), "utf8"));
     const multiAgentSummary = JSON.parse(
-      await readFile(join(root, ".eve", "multi-agent-summary.json"), "utf8"),
+      await readFile(join(root, ".eve", "agent-summary.json"), "utf8"),
     );
 
     expect(multiAgentSummary).toMatchObject({

--- a/packages/eve/src/internal/vercel/build-agent-workspace.ts
+++ b/packages/eve/src/internal/vercel/build-agent-workspace.ts
@@ -1,6 +1,14 @@
 import { mkdir, rm, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 
+import { resolveInstalledPackageInfo } from "#internal/application/package.js";
+import {
+  VERCEL_EVE_AGENT_SUMMARY_OUTPUT_PATH,
+  VERCEL_EVE_MULTI_AGENT_SUMMARY_KIND,
+  VERCEL_EVE_MULTI_AGENT_SUMMARY_OUTPUT_PATH,
+  VERCEL_EVE_MULTI_AGENT_SUMMARY_VERSION,
+  type VercelEveMultiAgentSummary,
+} from "#internal/vercel-agent-summary.js";
 import type { AgentWorkspace } from "#internal/project-context.js";
 import { assembleEveVercelServices } from "#internal/vercel/assemble-eve-services.js";
 import { quoteVercelShellArgument, toVercelRelativePath } from "#internal/vercel/build-command.js";
@@ -8,6 +16,22 @@ import { readVercelJsonFile } from "#internal/vercel/vercel-services-config.js";
 import { resolveEveBinaryPath } from "#shared/resolve-eve-binary.js";
 
 const VERCEL_BUILD_OUTPUT_VERSION = 3;
+
+function createMultiAgentSummary(workspace: AgentWorkspace): VercelEveMultiAgentSummary {
+  return {
+    agents: workspace.members.map((member) => ({
+      name: member.name,
+      routePrefix: `/${member.name}`,
+      summaryPath: relative(
+        workspace.root,
+        join(member.appRoot, VERCEL_EVE_AGENT_SUMMARY_OUTPUT_PATH),
+      ).replaceAll("\\", "/"),
+    })),
+    generatorVersion: resolveInstalledPackageInfo().version,
+    kind: VERCEL_EVE_MULTI_AGENT_SUMMARY_KIND,
+    schemaVersion: VERCEL_EVE_MULTI_AGENT_SUMMARY_VERSION,
+  };
+}
 
 /** Emit the inferred Vercel Services project for a strict hostless workspace. */
 export async function buildAgentWorkspace(workspace: AgentWorkspace): Promise<string> {
@@ -44,6 +68,11 @@ export async function buildAgentWorkspace(workspace: AgentWorkspace): Promise<st
   await mkdir(outputDirectory, { recursive: true });
   await Promise.all(
     assembled.rootDirectories.map((rootDirectory) => mkdir(rootDirectory, { recursive: true })),
+  );
+  await mkdir(join(workspace.root, ".eve"), { recursive: true });
+  await writeFile(
+    join(workspace.root, VERCEL_EVE_MULTI_AGENT_SUMMARY_OUTPUT_PATH),
+    `${JSON.stringify(createMultiAgentSummary(workspace), null, 2)}\n`,
   );
   await writeFile(
     join(outputDirectory, "config.json"),

--- a/packages/eve/src/internal/vercel/build-agent-workspace.ts
+++ b/packages/eve/src/internal/vercel/build-agent-workspace.ts
@@ -5,7 +5,6 @@ import { resolveInstalledPackageInfo } from "#internal/application/package.js";
 import {
   VERCEL_EVE_AGENT_SUMMARY_OUTPUT_PATH,
   VERCEL_EVE_MULTI_AGENT_SUMMARY_KIND,
-  VERCEL_EVE_MULTI_AGENT_SUMMARY_OUTPUT_PATH,
   VERCEL_EVE_MULTI_AGENT_SUMMARY_VERSION,
   type VercelEveMultiAgentSummary,
 } from "#internal/vercel-agent-summary.js";
@@ -71,7 +70,7 @@ export async function buildAgentWorkspace(workspace: AgentWorkspace): Promise<st
   );
   await mkdir(join(workspace.root, ".eve"), { recursive: true });
   await writeFile(
-    join(workspace.root, VERCEL_EVE_MULTI_AGENT_SUMMARY_OUTPUT_PATH),
+    join(workspace.root, VERCEL_EVE_AGENT_SUMMARY_OUTPUT_PATH),
     `${JSON.stringify(createMultiAgentSummary(workspace), null, 2)}\n`,
   );
   await writeFile(


### PR DESCRIPTION
### Summary

The dashboard has a singular Eve deployment-summary shape, but a multi-agent deployment has independently authored agent surfaces whose names and resources may collide. This extends the canonical `.eve/agent-summary.json` artifact with a new discriminated `vercel-eve-multi-agent-summary` shape. The project-level summary references each existing member summary rather than flattening ownership; API ingestion and dashboard rendering are covered by dependent drafts.

### Validation

- `pnpm --filter eve test:integration -- src/internal/vercel/build-agent-workspace.integration.test.ts` — passed (97 files, 711 tests)

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
