### PR TITLE
fix(eve): preserve completed /add results

### DIFF
--- a/.changeset/honest-add-cancellation.md
+++ b/.changeset/honest-add-cancellation.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Keep `/add` results successful when setup is dismissed after every selected integration has finished installing.

--- a/packages/eve/src/setup/flows/registry.test.ts
+++ b/packages/eve/src/setup/flows/registry.test.ts
@@ -524,6 +524,34 @@ describe("runRegistryFlow", () => {
     expect(fake.selectMessages).not.toContain("Couldn't add Web Chat");
   });
 
+  it("keeps completed installations successful when the post-install prompt is dismissed", async () => {
+    let prompt = 0;
+    const fake = createFakePrompter({
+      single: () => (++prompt === 1 ? "install" : Promise.reject(new WizardCancelledError())),
+    });
+
+    await expect(
+      runRegistryFlow({
+        appRoot: APP_ROOT,
+        prompter: fake.prompter,
+        initialAddress: "connection/notion",
+        deps: deps({
+          detectDeployment: vi.fn(async () => ({ state: "linked" as const, projectId: "prj_1" })),
+          installRegistryItem: vi.fn(async () => ({
+            output: [],
+            setup: { facts: [], deploymentRequired: true as const },
+          })),
+        }),
+      }),
+    ).resolves.toEqual({
+      kind: "done",
+      result: {
+        items: [{ title: "notion", facts: [], output: [] }],
+        failures: [],
+      },
+    });
+  });
+
   it("offers deployment once after the selected batch completes", async () => {
     const answers = ["install", "deploy", "yes"];
     const fake = createFakePrompter({

--- a/packages/eve/src/setup/flows/registry.ts
+++ b/packages/eve/src/setup/flows/registry.ts
@@ -290,6 +290,7 @@ export async function runRegistryFlow(input: {
   deps?: Partial<RegistryFlowDeps>;
 }): Promise<{ kind: "done"; result: RegistrySessionResult } | { kind: "cancelled" }> {
   let session: ReturnType<typeof createRegistrySession> | undefined;
+  let installationsComplete = false;
   try {
     const initialAddress = input.initialAddress?.trim();
     let items: Item[];
@@ -381,6 +382,7 @@ export async function runRegistryFlow(input: {
         }
       }
     }
+    installationsComplete = true;
     return {
       kind: "done",
       result: await activeSession.continueAfterInstall({
@@ -392,9 +394,11 @@ export async function runRegistryFlow(input: {
   } catch (error) {
     if (error instanceof WizardCancelledError) {
       const settled = session?.result();
-      return hasSettledOutcomes(settled)
-        ? { kind: "done", result: { ...settled, cancelled: true } }
-        : { kind: "cancelled" };
+      if (!hasSettledOutcomes(settled)) return { kind: "cancelled" };
+
+      return installationsComplete
+        ? { kind: "done", result: settled }
+        : { kind: "done", result: { ...settled, cancelled: true } };
     }
     const settled = session?.result();
     if (hasSettledOutcomes(settled)) {


### PR DESCRIPTION
### Summary

Dismissing `/add` after every selected integration finished could render a contradictory error result: each item appeared installed, while the command was marked failed and claimed selections remained. This keeps the settled installation result successful when only the optional post-install prompt is dismissed, while preserving partial cancellation reporting when setup stops during the installation batch.

### Validation

- `pnpm --filter eve build:compiled`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/setup/flows/registry.test.ts` (16 tests passed; the initial run before `build:compiled` could not resolve the generated catalog artifact)
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/cli/dev/tui/setup-commands.test.ts` (39 tests passed)
- `pnpm --filter eve exec tsc --noEmit --pretty false -p tsconfig.json`
- `pnpm exec oxfmt --check packages/eve/src/setup/flows/registry.ts packages/eve/src/setup/flows/registry.test.ts`
- `pnpm exec oxlint packages/eve/src/setup/flows/registry.ts packages/eve/src/setup/flows/registry.test.ts`
- `git diff --check`

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
