### PR TITLE
fix(eve): stabilize generated Next scenario builds

### DIFF
--- a/e2e/fixtures/agent-workflow-stress/evals/concurrent-workflow-turns.eval.ts
+++ b/e2e/fixtures/agent-workflow-stress/evals/concurrent-workflow-turns.eval.ts
@@ -13,7 +13,7 @@ export default defineEval({
   async test(t) {
     const sessions = Array.from({ length: SESSION_COUNT }, () => t.newSession());
     const firstBatchStartedAt = performance.now();
-    const firstTurns = await Promise.all(
+    const firstTurns = await Promise.allSettled(
       sessions.map(async (session, index) => {
         const startedAt = performance.now();
         const result = await session.send(markerFor(index, 1));
@@ -26,11 +26,21 @@ export default defineEval({
       }),
     );
     const firstBatchDurationMs = performance.now() - firstBatchStartedAt;
-    firstTurns.forEach((turn, index) => {
+    const failedFirstTurns = firstTurns.flatMap((turn, index) =>
+      turn.status === "rejected" ? [`session ${index + 1}: ${formatErrorChain(turn.reason)}`] : [],
+    );
+    if (failedFirstTurns.length > 0) {
+      throw new Error(`First concurrent turn batch failed: ${failedFirstTurns.join("; ")}`);
+    }
+    const completedFirstTurns = firstTurns.map((turn) => {
+      if (turn.status === "rejected") throw new Error("Unreachable failed first turn.");
+      return turn.value;
+    });
+    completedFirstTurns.forEach((turn, index) => {
       t.log(`workflow run id (${index + 1}/${SESSION_COUNT}): ${turn.result.sessionId}`);
     });
     const secondBatchStartedAt = performance.now();
-    const secondTurns = await Promise.all(
+    const secondTurns = await Promise.allSettled(
       sessions.map(async (session, index) => {
         const startedAt = performance.now();
         const result = await session.send(markerFor(index, 2));
@@ -43,10 +53,20 @@ export default defineEval({
       }),
     );
     const secondBatchDurationMs = performance.now() - secondBatchStartedAt;
+    const failedSecondTurns = secondTurns.flatMap((turn, index) =>
+      turn.status === "rejected" ? [`session ${index + 1}: ${formatErrorChain(turn.reason)}`] : [],
+    );
+    if (failedSecondTurns.length > 0) {
+      throw new Error(`Second concurrent turn batch failed: ${failedSecondTurns.join("; ")}`);
+    }
+    const completedSecondTurns = secondTurns.map((turn) => {
+      if (turn.status === "rejected") throw new Error("Unreachable failed second turn.");
+      return turn.value;
+    });
 
     for (let index = 0; index < SESSION_COUNT; index += 1) {
-      const first = firstTurns[index]!.result.expectOk();
-      const second = secondTurns[index]!.result.expectOk();
+      const first = completedFirstTurns[index]!.result.expectOk();
+      const second = completedSecondTurns[index]!.result.expectOk();
 
       await t.require(first.message, equals(`stress-ack:1:${markerFor(index, 1)}`));
       await t.require(second.message, equals(`stress-ack:2:${markerFor(index, 2)}`));
@@ -54,7 +74,7 @@ export default defineEval({
     }
 
     await t.require(
-      new Set(firstTurns.map((turn) => turn.result.sessionId)).size,
+      new Set(completedFirstTurns.map((turn) => turn.result.sessionId)).size,
       equals(SESSION_COUNT),
     );
 
@@ -63,7 +83,7 @@ export default defineEval({
         batches: [
           {
             batchDurationMs: firstBatchDurationMs,
-            samples: firstTurns.map(({ durationMs, sessionNumber }) => ({
+            samples: completedFirstTurns.map(({ durationMs, sessionNumber }) => ({
               durationMs,
               sessionNumber,
             })),
@@ -71,7 +91,7 @@ export default defineEval({
           },
           {
             batchDurationMs: secondBatchDurationMs,
-            samples: secondTurns.map(({ durationMs, sessionNumber }) => ({
+            samples: completedSecondTurns.map(({ durationMs, sessionNumber }) => ({
               durationMs,
               sessionNumber,
             })),
@@ -92,6 +112,23 @@ export default defineEval({
     t.notEvent("turn.failed");
   },
 });
+
+function formatErrorChain(error: unknown): string {
+  const messages: string[] = [];
+  const seen = new Set<unknown>();
+  let current = error;
+  while (typeof current === "object" && current !== null && !seen.has(current)) {
+    seen.add(current);
+    const name = "name" in current && typeof current.name === "string" ? current.name : "Error";
+    const message =
+      "message" in current && typeof current.message === "string"
+        ? current.message
+        : JSON.stringify(current);
+    messages.push(`${name}: ${message}`);
+    current = "cause" in current ? current.cause : undefined;
+  }
+  return messages.length > 0 ? messages.join(" <- ") : String(error);
+}
 
 function markerFor(sessionIndex: number, turnNumber: number): string {
   return `stress-session-${String(sessionIndex + 1).padStart(2, "0")}-turn-${turnNumber}`;

--- a/packages/eve/src/internal/testing/scenario-app.ts
+++ b/packages/eve/src/internal/testing/scenario-app.ts
@@ -301,6 +301,10 @@ async function installScenarioDependencies(input: {
     return;
   }
 
+  // Generated scenario apps install public package dependencies. Pinning the
+  // registry keeps their outcome independent of a developer or runner's
+  // private registry configuration.
+  await writeFile(join(input.appRoot, ".npmrc"), "registry=https://registry.npmjs.org/\n");
   await runPnpmCommand({
     args: [
       "install",

--- a/packages/eve/test/scenarios/framework-next-build.scenario.test.ts
+++ b/packages/eve/test/scenarios/framework-next-build.scenario.test.ts
@@ -127,6 +127,18 @@ async function readVercelOutputRoutes(outputRoot: string): Promise<readonly unkn
   return config.routes;
 }
 
+async function runVercelBuild(appRoot: string): Promise<void> {
+  await runPnpmCommand({
+    args: ["exec", "vercel", "build", "--yes"],
+    cwd: appRoot,
+    env: {
+      ...process.env,
+      NPM_CONFIG_AUDIT: "false",
+      NPM_CONFIG_REGISTRY: "https://registry.npmjs.org/",
+    },
+  });
+}
+
 describe("framework-next build", () => {
   it("builds the Next.js framework fixture against the workspace eve dist", async () => {
     await runPnpmCommand({
@@ -138,10 +150,7 @@ describe("framework-next build", () => {
   it("preserves Next middleware when Vercel assembles the generated eve service", async () => {
     const app = await scenarioApp(NEXT_EVE_MIDDLEWARE_DESCRIPTOR);
 
-    await runPnpmCommand({
-      args: ["exec", "vercel", "build", "--yes"],
-      cwd: app.appRoot,
-    });
+    await runVercelBuild(app.appRoot);
 
     const outputRoot = join(app.appRoot, ".vercel", "output");
     const routes = await readVercelOutputRoutes(outputRoot);
@@ -171,10 +180,7 @@ describe("framework-next build", () => {
   it("publishes named eve schedules into the assembled host output", async () => {
     const app = await scenarioApp(NEXT_EVE_NAMED_SCHEDULES_DESCRIPTOR);
 
-    await runPnpmCommand({
-      args: ["exec", "vercel", "build", "--yes"],
-      cwd: app.appRoot,
-    });
+    await runVercelBuild(app.appRoot);
 
     const outputRoot = join(app.appRoot, ".vercel", "output");
     const config = await readVercelOutputConfig(outputRoot);


### PR DESCRIPTION
### Summary

Generated Next scenarios let Vercel CLI install builders with ambient npm settings. When npm audit stalled, `vercel build` outlived the scenario timeout and left installers running; the resulting resource pressure caused unrelated scenario timeouts. Run those fixture installs and Vercel’s builder install against npmjs with audit disabled.

The concurrent workflow stress eval also now reports every failed session launch and its transport-cause chain. It keeps all 50 launches concurrent and does not retry failures; the added detail will distinguish an initial connection problem from a workflow behavior failure.

### Validation

`pnpm --filter eve exec vitest run --config vitest.scenario.config.ts test/scenarios/framework-next-build.scenario.test.ts src/internal/testing/scenario-app.scenario.test.ts test/scenarios/nitro-bundle-report.scenario.test.ts` passed (13 tests). `pnpm --filter agent-workflow-stress typecheck` and `EVE_E2E_MODEL=mock pnpm --filter agent-workflow-stress exec eve eval concurrent-workflow-turns --strict --verbose` passed (156 gates). Full CI is running.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

No changeset is needed: this changes scenario and E2E test infrastructure only.
