### PR TITLE
fix(execution): run the cancelled-turn epilogue inside the eve context

### DIFF
--- a/.changeset/olive-moons-cancel.md
+++ b/.changeset/olive-moons-cancel.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Keep the cancelled-turn epilogue inside the eve context. Cancelling a turn whose message carried an attachment failed `turnStep` with "No active eve context" — the harness step's ALS scope had already closed, so staging the preserved message's file parts threw, and the retries made it a terminal session failure.

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -191,6 +191,22 @@ const threadContextAdapter: ChannelAdapter = {
     const thread = adapterCtx.ctx.ensure(ThreadKey, () => "unset");
     const message = payload.message ?? "";
 
+    // `attach:` delivers structured UserContent carrying a FilePart, the
+    // shape real channels produce for an uploaded image or document.
+    if (typeof message === "string" && message.startsWith("attach:")) {
+      return {
+        message: [
+          { text: `thread=${thread}; user=${message.slice("attach:".length)}`, type: "text" },
+          {
+            data: new URL("https://files.example/diagram.png"),
+            filename: "diagram.png",
+            mediaType: "image/png",
+            type: "file",
+          },
+        ],
+      };
+    }
+
     return { message: `thread=${thread}; user=${message}` };
   },
 };
@@ -1539,6 +1555,56 @@ describe("turnStep", () => {
     expect(result.serializedContext).not.toHaveProperty(ThreadKey.name);
     expect(result.sessionState.snapshot?.session.history).toEqual([
       { content: "thread=unset; user=cancel this turn", role: "user" },
+    ]);
+  });
+
+  it("preserves a cancelled turn message that carries an attachment", async () => {
+    const session = createStubSession();
+    installSessionStoreMocks([session]);
+    vi.mocked(getCompiledRuntimeAgentBundle).mockResolvedValue({
+      adapterRegistry: {
+        adaptersByKind: new Map([[threadContextAdapter.kind, threadContextAdapter]]),
+      },
+      compiledArtifactsSource: {},
+      graph: {
+        nodesByNodeId: new Map(),
+        root: {
+          sandboxRegistry: { sandbox: null },
+          turnAgent: TestTurnAgent,
+        },
+      },
+      moduleMap: { nodes: {} },
+      hookRegistry: createEmptyHookRegistry(),
+      resolvedAgent: { config: {} },
+      subagentRegistry: {},
+      toolRegistry: {},
+      turnAgent: TestTurnAgent,
+    } as never);
+    vi.mocked(createExecutionNodeStep).mockImplementation(() => {
+      return async (): Promise<StepResult> => {
+        throw new TurnCancelledError();
+      };
+    });
+
+    const result = await turnStep({
+      input: {
+        kind: "deliver",
+        payloads: [{ message: "attach:look at this" }],
+      },
+      parentWritable: createTestWritable(),
+      serializedContext: createSerializedContext(),
+      sessionState: createStubSessionState(),
+    });
+
+    expect(result).toMatchObject({ action: "cancelled" });
+    expect(result.sessionState.snapshot?.session.history).toEqual([
+      {
+        content: [
+          { text: "thread=unset; user=look at this", type: "text" },
+          expect.objectContaining({ filename: "diagram.png", type: "file" }),
+        ],
+        role: "user",
+      },
     ]);
   });
 

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -553,9 +553,13 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
     // again after this cancellation settles.
     const interrupted = serializeContext(ctx);
     const retained = readRetainedBackgroundToolResult(ctx);
-    const cancelledSession = await preserveCancelledTurnMessage(
-      retained?.backgroundTaskSession ?? initialSession,
-      resolved,
+    // Runs inside the ALS scope: preserving the message stages its
+    // attachments, and `stageAttachmentsToSandbox` reads the sandbox off the
+    // active context. The harness step's own scope closed when it threw, so
+    // without this the cancellation epilogue fails with "No active eve
+    // context" whenever the discarded turn carried a file part.
+    const cancelledSession = await contextStorage.run(ctx, () =>
+      preserveCancelledTurnMessage(retained?.backgroundTaskSession ?? initialSession, resolved),
     );
     return {
       action: "cancelled",


### PR DESCRIPTION
## Problem

Cancelling a turn whose message carried an attachment kills the session:

```
FatalError: Step "step//eve@0.47.3//turnStep" failed after 3 retries:
No active eve context. Call this function only from authored runtime code
such as tools, steps, and model callbacks.
```

Hit in production on eve 0.47.3 — two root sessions ended terminal within 40 minutes of each other, both cancelled under a second after dispatch when a second Slack event arrived ~40ms behind the first. The throw is deterministic, so all three retries fail identically and the session is unrecoverable ("Start a new thread to continue").

## Root cause

`runStep` → `withContextScope` (`context/run-step.ts`) holds the only `contextStorage.run(...)` for a harness step, and it has already unwound by the time `turnStep`'s cancellation catch executes. That epilogue calls `preserveCancelledTurnMessage`, which stages the discarded message's attachments through `stageAttachmentsToSandbox`, which calls `loadContext()`:

```
❯ loadContext src/context/container.ts:147:11
❯ stageAttachmentsToSandbox src/harness/attachment-staging.ts:100:21
❯ preserveCancelledTurnMessage src/execution/cancelled-turn-message.ts:11:25
❯ Module.turnStep src/execution/workflow-steps.ts:556:36
```

`stageAttachmentsToSandbox` returns early for string content and for part arrays with no `type: "file"` part, so only a cancelled turn carrying an attachment reaches the throw. That matches the incident: text-only cancellations in the same sessions settled normally.

Still present on `main` — 0.51.0 moved the function into `execution/cancelled-turn-message.ts` but kept the same call placement.

## Fix

Wrap the epilogue in `contextStorage.run(ctx, ...)`, the same scoping `turnStep` already applies to `instrumentChannelDelivery`. `sandboxProvider` declares no `rollback`, so the sandbox access is still live at that point and staging behaves as it does mid-turn.

## Test

`turnStep > preserves a cancelled turn message that carries an attachment` in `workflow-steps.test.ts`. The stub channel adapter gained an `attach:` prefix that delivers `UserContent` with a `FilePart` — the shape real channels produce for an uploaded image. Without the fix the test fails with the exact production stack above; with it the turn settles `action: "cancelled"` and the file part survives into history.

## Checks

`pnpm fmt`, `pnpm lint`, `pnpm guard:invariants`, `tsc --noEmit`, and `vitest run --config vitest.unit.config.ts` (7937 passed) all clean. The 4 failing files under `src/self-modification/` fail identically on an unmodified checkout — they resolve `eve/tools` from the package's built `dist`, which `test:unit` does not build.

## Note

Per CONTRIBUTING, external contributors are asked to open an issue rather than a PR. Opening this as a draft with the reproduction and a suggested implementation attached — happy to convert it to an issue instead if that is the preferred path.
