### PR TITLE
fix(eve): only discover workspace-owned agents

### DIFF
--- a/.changeset/calm-agent-command-prompt.md
+++ b/.changeset/calm-agent-command-prompt.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Avoid loading interactive prompt dependencies when running non-interactive CLI commands such as `eve build` in an agent workspace.

--- a/.changeset/filter-agent-workspace-members.md
+++ b/.changeset/filter-agent-workspace-members.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Only classify agent-shaped, package-less `agents/` children as eve workspace members. Independently packaged agents remain standalone, while unrelated `agents/` directories no longer override flat standalone projects.

--- a/docs/guides/deployment/vercel.mdx
+++ b/docs/guides/deployment/vercel.mdx
@@ -63,7 +63,7 @@ my-project/
         └── agent/
 ```
 
-An `agents/` directory marks the project as a workspace. eve validates and discovers only direct `agents/<name>/agent/` children. Their directory names become their public identities, exposed at `/<name>/eve/v1/*`. Run an agent-specific command from a child directory or pass `--agent <name>` at the workspace root; interactive commands open a picker when the name is omitted. Run project-level build, link, and deploy commands from the workspace root. The workspace root owns the project package, dependencies, and build scripts.
+In an eve workspace, eve discovers direct `agents/<name>/` children that contain nested or flat agent files and do not have their own `package.json`. Their directory names become their public identities, exposed at `/<name>/eve/v1/*`. A child with its own `package.json` is a separate package rather than a member of the parent eve workspace. Run an agent-specific command from a member directory or pass `--agent <name>` at the workspace root; interactive commands open a picker when the name is omitted. Run project-level build, link, and deploy commands from the workspace root. Workspace members share the root package, dependencies, and build scripts.
 
 Create this layout with `eve init my-project --agents support,research`, or add one agent to an existing workspace with `eve init billing`.
 

--- a/packages/eve/src/cli/agent-command.ts
+++ b/packages/eve/src/cli/agent-command.ts
@@ -1,6 +1,5 @@
 import type { Command } from "#compiled/commander/index.js";
 import type { AgentWorkspace } from "#internal/project-context.js";
-import { createPrompter } from "#setup/prompter.js";
 
 import type { CliApplicationContext } from "./application-command.js";
 
@@ -26,6 +25,7 @@ async function selectWorkspaceAgent(
       `This command requires a specific agent. Pass --agent <name>. Available agents: ${names.join(", ")}.`,
     );
   }
+  const { createPrompter } = await import("#setup/prompter.js");
   const name = await createPrompter().select({
     message: "Select an agent",
     options: workspace.members.map((member) => ({ label: member.name, value: member.name })),

--- a/packages/eve/src/internal/agent-workspace.integration.test.ts
+++ b/packages/eve/src/internal/agent-workspace.integration.test.ts
@@ -84,7 +84,7 @@ describe("resolveEveProjectContext", () => {
     });
   });
 
-  it("does not validate member authoring layout while resolving a workspace", async () => {
+  it("discovers flat workspace members", async () => {
     const root = await createWorkspace();
     const appRoot = join(root, "agents", "flat");
     await mkdir(appRoot);
@@ -93,6 +93,66 @@ describe("resolveEveProjectContext", () => {
     await expect(resolveEveProjectContext(appRoot)).resolves.toMatchObject({
       kind: "workspace-member",
       member: { appRoot, name: "flat" },
+    });
+  });
+
+  it("excludes independently packaged eve projects from a workspace", async () => {
+    const root = await createWorkspace();
+    const appRoot = join(root, "agents", "billing");
+    await mkdir(join(appRoot, "agent"), { recursive: true });
+    await writeFile(
+      join(appRoot, "package.json"),
+      JSON.stringify({ dependencies: { eve: "*" }, name: "billing" }),
+    );
+
+    await expect(resolveEveProjectContext(root)).resolves.toMatchObject({
+      kind: "workspace",
+      workspace: {
+        members: [
+          { name: "research", appRoot: join(root, "agents", "research") },
+          { name: "support", appRoot: join(root, "agents", "support") },
+        ],
+      },
+    });
+    await expect(resolveEveProjectContext(appRoot)).resolves.toEqual({
+      appRoot,
+      environmentRoot: appRoot,
+      kind: "standalone",
+    });
+  });
+
+  it("excludes packaged non-eve directories from a workspace", async () => {
+    const root = await createWorkspace();
+    const appRoot = join(root, "agents", "utilities");
+    await mkdir(join(appRoot, "src"), { recursive: true });
+    await writeFile(join(appRoot, "package.json"), JSON.stringify({ name: "utilities" }));
+
+    await expect(resolveEveProjectContext(root)).resolves.toMatchObject({
+      kind: "workspace",
+      workspace: {
+        members: [
+          { name: "research", appRoot: join(root, "agents", "research") },
+          { name: "support", appRoot: join(root, "agents", "support") },
+        ],
+      },
+    });
+    await expect(findEveProjectContext(appRoot)).resolves.toBeUndefined();
+  });
+
+  it("excludes package-less directories without agent files from a workspace", async () => {
+    const root = await createWorkspace();
+    const sharedRoot = join(root, "agents", "Internal Helpers");
+    await mkdir(sharedRoot);
+    await writeFile(join(sharedRoot, "helpers.ts"), "export {};\n");
+
+    await expect(resolveEveProjectContext(root)).resolves.toMatchObject({
+      kind: "workspace",
+      workspace: {
+        members: [
+          { name: "research", appRoot: join(root, "agents", "research") },
+          { name: "support", appRoot: join(root, "agents", "support") },
+        ],
+      },
     });
   });
 
@@ -171,6 +231,22 @@ describe("resolveEveProjectContext", () => {
     await Promise.all([
       writeFile(join(root, "package.json"), JSON.stringify({ dependencies: { eve: "*" } })),
       writeFile(join(root, "agent.ts"), "export default {};\n"),
+    ]);
+
+    await expect(resolveEveProjectContext(root)).resolves.toEqual({
+      appRoot: root,
+      environmentRoot: root,
+      kind: "standalone",
+    });
+  });
+
+  it("keeps a flat standalone agent above an unrelated agents directory", async () => {
+    const root = await mkdtemp(join(tmpdir(), "eve-flat-agent-unrelated-agents-"));
+    await mkdir(join(root, "agents", "customer-support"), { recursive: true });
+    await Promise.all([
+      writeFile(join(root, "package.json"), JSON.stringify({ dependencies: { eve: "*" } })),
+      writeFile(join(root, "agent.ts"), "export default {};\n"),
+      writeFile(join(root, "agents", "customer-support", "index.ts"), "export {};\n"),
     ]);
 
     await expect(resolveEveProjectContext(root)).resolves.toEqual({

--- a/packages/eve/src/internal/project-context.ts
+++ b/packages/eve/src/internal/project-context.ts
@@ -45,15 +45,24 @@ async function hasFlatAgentRoot(root: string, source: ProjectSource): Promise<bo
   );
 }
 
+async function isWorkspaceOwnedAgentRoot(appRoot: string, source: ProjectSource): Promise<boolean> {
+  if ((await source.stat(join(appRoot, "package.json"))) === "file") return false;
+  if ((await source.stat(join(appRoot, "agent"))) === "directory") return true;
+  return hasFlatAgentRoot(appRoot, source);
+}
+
 async function resolveWorkspace(root: string, source: ProjectSource): Promise<AgentWorkspace> {
   const agentsRoot = join(root, "agents");
   const entries = (await source.readDirectory(agentsRoot))
     .filter((entry) => entry.isDirectory() && !entry.name.startsWith("."))
     .sort((left, right) => left.name.localeCompare(right.name));
-  const members = entries.map((entry) => {
+  const members: AgentWorkspaceMember[] = [];
+  for (const entry of entries) {
+    const appRoot = join(agentsRoot, entry.name);
+    if (!(await isWorkspaceOwnedAgentRoot(appRoot, source))) continue;
     assertValidPublicAgentName(entry.name, "Agent workspace member");
-    return { appRoot: join(agentsRoot, entry.name), name: entry.name };
-  });
+    members.push({ appRoot, name: entry.name });
+  }
   return { members, root };
 }
 
@@ -77,27 +86,36 @@ export async function findEveProjectContext(
     return { appRoot: projectRoot, environmentRoot: projectRoot, kind: "standalone" };
   }
 
-  if (!hasAgents) {
-    if (await hasFlatAgentRoot(projectRoot, source)) {
-      return { appRoot: projectRoot, environmentRoot: projectRoot, kind: "standalone" };
+  if (hasAgents) {
+    const workspace = await resolveWorkspace(projectRoot, source);
+    if (workspace.members.length > 0) {
+      const member = workspace.members.find((candidate) =>
+        containsPath(candidate.appRoot, searchDirectory),
+      );
+      if (member !== undefined) {
+        return {
+          workspace,
+          environmentRoot: workspace.root,
+          kind: "workspace-member",
+          member,
+        };
+      }
+
+      return { workspace, environmentRoot: workspace.root, kind: "workspace" };
     }
-    throw new Error(`Invalid eve project at ${projectRoot}: found no agent files.`);
   }
 
-  const workspace = await resolveWorkspace(projectRoot, source);
-  const member = workspace.members.find((candidate) =>
-    containsPath(candidate.appRoot, searchDirectory),
-  );
-  if (member !== undefined) {
+  if (await hasFlatAgentRoot(projectRoot, source)) {
+    return { appRoot: projectRoot, environmentRoot: projectRoot, kind: "standalone" };
+  }
+  if (hasAgents) {
     return {
-      workspace,
-      environmentRoot: workspace.root,
-      kind: "workspace-member",
-      member,
+      workspace: { members: [], root: projectRoot },
+      environmentRoot: projectRoot,
+      kind: "workspace",
     };
   }
-
-  return { workspace, environmentRoot: workspace.root, kind: "workspace" };
+  throw new Error(`Invalid eve project at ${projectRoot}: found no agent files.`);
 }
 
 /** Resolve the owning eve project, throwing when the path has no eve package owner. */

--- a/packages/eve/src/internal/testing/scenario-app.ts
+++ b/packages/eve/src/internal/testing/scenario-app.ts
@@ -301,6 +301,10 @@ async function installScenarioDependencies(input: {
     return;
   }
 
+  // Generated scenario apps install public package dependencies. Pinning the
+  // registry keeps their outcome independent of a developer or runner's
+  // private registry configuration.
+  await writeFile(join(input.appRoot, ".npmrc"), "registry=https://registry.npmjs.org/\n");
   await runPnpmCommand({
     args: [
       "install",

--- a/packages/eve/src/setup/scaffold/extension-peer-compatibility.scenario.test.ts
+++ b/packages/eve/src/setup/scaffold/extension-peer-compatibility.scenario.test.ts
@@ -41,6 +41,7 @@ describe("extension eve peer compatibility", () => {
           "install",
           "--strict-peer-deps",
           "--ignore-scripts",
+          "--no-audit",
           "--no-package-lock",
           join(root, `eve-${eveVersion}.tgz`),
           join(root, "acme-extension-peer-test-1.0.0.tgz"),

--- a/packages/eve/test/scenarios/framework-next-build.scenario.test.ts
+++ b/packages/eve/test/scenarios/framework-next-build.scenario.test.ts
@@ -127,6 +127,18 @@ async function readVercelOutputRoutes(outputRoot: string): Promise<readonly unkn
   return config.routes;
 }
 
+async function runVercelBuild(appRoot: string): Promise<void> {
+  await runPnpmCommand({
+    args: ["exec", "vercel", "build", "--yes"],
+    cwd: appRoot,
+    env: {
+      ...process.env,
+      NPM_CONFIG_AUDIT: "false",
+      NPM_CONFIG_REGISTRY: "https://registry.npmjs.org/",
+    },
+  });
+}
+
 describe("framework-next build", () => {
   it("builds the Next.js framework fixture against the workspace eve dist", async () => {
     await runPnpmCommand({
@@ -138,10 +150,7 @@ describe("framework-next build", () => {
   it("preserves Next middleware when Vercel assembles the generated eve service", async () => {
     const app = await scenarioApp(NEXT_EVE_MIDDLEWARE_DESCRIPTOR);
 
-    await runPnpmCommand({
-      args: ["exec", "vercel", "build", "--yes"],
-      cwd: app.appRoot,
-    });
+    await runVercelBuild(app.appRoot);
 
     const outputRoot = join(app.appRoot, ".vercel", "output");
     const routes = await readVercelOutputRoutes(outputRoot);
@@ -171,10 +180,7 @@ describe("framework-next build", () => {
   it("publishes named eve schedules into the assembled host output", async () => {
     const app = await scenarioApp(NEXT_EVE_NAMED_SCHEDULES_DESCRIPTOR);
 
-    await runPnpmCommand({
-      args: ["exec", "vercel", "build", "--yes"],
-      cwd: app.appRoot,
-    });
+    await runVercelBuild(app.appRoot);
 
     const outputRoot = join(app.appRoot, ".vercel", "output");
     const config = await readVercelOutputConfig(outputRoot);

--- a/scripts/package-publish-report.mjs
+++ b/scripts/package-publish-report.mjs
@@ -510,7 +510,14 @@ async function collectInstalledPackageSnapshot(input) {
   );
   await execFile(
     "npm",
-    ["install", "--ignore-scripts", "--no-package-lock", "--no-save", resolve(input.tarballPath)],
+    [
+      "install",
+      "--ignore-scripts",
+      "--no-audit",
+      "--no-package-lock",
+      "--no-save",
+      resolve(input.tarballPath),
+    ],
     {
       cwd: installRoot,
       maxBuffer: 16 * 1024 * 1024,


### PR DESCRIPTION
### Summary

A root-level `agents/` directory currently turns every direct child into an eve workspace member, even when the child is independently packaged or contains no agent. Only package-less children with a nested or flat agent surface are now workspace members, so packaged agents retain standalone ownership and unrelated `agents/` directories no longer override flat standalone projects. Empty workspace behavior remains unchanged.

Also defer the interactive workspace-agent prompt until a multi-agent workspace needs a selection. Generated Next scenarios now isolate their public package installs from ambient registries and skip npm audit while Vercel installs temporary builders, preventing an unrelated network request from holding a scenario subprocess open.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/internal/agent-workspace.integration.test.ts` (19 tests passed)
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/cli/commands/link.integration.test.ts src/cli/commands/deploy.integration.test.ts src/internal/vercel/build-agent-workspace.integration.test.ts` (11 tests passed)
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/cli/agent-command.test.ts src/cli/application-root.test.ts` (11 tests passed)
- `pnpm --filter eve exec vitest run --config vitest.scenario.config.ts test/scenarios/framework-next-build.scenario.test.ts src/internal/testing/scenario-app.scenario.test.ts test/scenarios/nitro-bundle-report.scenario.test.ts` (13 tests passed)
- `pnpm docs:check`
- `pnpm lint` (passed with two pre-existing warnings)
- `pnpm typecheck`
- `pnpm guard:invariants`

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
