### PR TITLE
feat(eve): propose subagents on workflow tool context

### DIFF
--- a/research/named-subagent-workflow-bindings.md
+++ b/research/named-subagent-workflow-bindings.md
@@ -4,24 +4,26 @@ status: draft
 last_updated: "2026-09-04"
 ---
 
-# Named subagent bindings in workflows
+# Named subagents on workflow tool context
 
-Expose declared subagents as callable named imports from `eve/workflow`, so workflow
-tools can delegate work and branch on its result.
+Expose self-delegation as `ctx.agent(prompt, options)` and declared subagents as
+`ctx.subagent[name](prompt, options)` on the context supplied by `defineWorkflowTool`.
 
-The proposed call is `await reviewer(message)`. eve supplies the target, invocation
-context, and replay-stable invocation identity currently passed explicitly to
-`agent(ctx, { target, key, message })`. This extends the workflow delegation described
-in [Tools as workflows][tools-as-workflows].
+`ctx.subagent.reviewer` and `ctx.subagent["reviewer"]` address the same declared
+subagent. The context supplies the owning session; eve supplies replay-stable
+invocation identities. This extends the current
+[`defineWorkflowTool` contract][workflow-tool-context], whose `ctx.agent` still takes
+an explicit target and replay key and returns only output.
 
 `defineWorkflow` and workflows started without an owning agent session are deferred
 to a separate change.
 
 ## Proposed authoring API
 
-The following examples describe the requested API, not code supported by the current
-exports. `defineSubagent` retains the name from the initial sketch; its inclusion
-is an open API decision below.
+The callable subagent properties, shorthand `ctx.agent`, and tuple results below
+are proposed. `defineWorkflowTool` and its `execute(input, ctx)` signature already
+exist. `defineSubagent` retains the name from the initial sketch; its inclusion is
+an open API decision below.
 
 ```ts
 // agent/subagents/reviewer.ts
@@ -33,34 +35,34 @@ export default defineSubagent({
 });
 ```
 
-The filename supplies `reviewer`; no separate name or registration is authored.
-Only named subagents receive generated bindings, including named remote subagents.
-The proposed `agent(prompt)` calls
-a copy of itself, matching the built-in
-[`agent` tool][agent-tool]'s target and root-only
-availability. It does not select another named agent.
+The filename supplies the `reviewer` key in `ctx.subagent`; no separate name or
+registration is authored. Only named subagents receive entries, including named
+remote subagents. The proposed `ctx.agent(prompt)` delegates to a copy of itself,
+matching the built-in [`agent` tool][agent-tool]'s target and root-only availability.
+Named targets are selected through `ctx.subagent`.
 
-Importing a binding does not start an agent. Calling it starts a new child or
+Reading a binding from `ctx` does not start an agent. Calling it starts a new child or
 continues the child identified by `agentId`; awaiting it returns `[output, metadata]`
 after that invocation completes.
 
 ```ts
 // agent/tools/orchestration.ts
-import { defineTool } from "eve/tools";
-import { agent, reviewer } from "eve/workflow";
+import { defineWorkflowTool } from "eve/tools";
 import { z } from "zod";
 
 const ReviewSchema = z.object({ successful: z.boolean() });
 
-export default defineTool({
+export default defineWorkflowTool({
   description: "Research and review an issue in parallel.",
   inputSchema: z.object({ issueDescription: z.string() }),
-  async execute(input) {
+  async execute(input, ctx) {
     "use workflow";
 
     const [[research], [review]] = await Promise.all([
-      agent("Research this: " + input.issueDescription),
-      reviewer("Review this: " + input.issueDescription, { outputSchema: ReviewSchema }),
+      ctx.agent("Research this: " + input.issueDescription),
+      ctx.subagent.reviewer("Review this: " + input.issueDescription, {
+        outputSchema: ReviewSchema,
+      }),
     ]);
 
     if (review.successful) return { successful: true, research };
@@ -70,11 +72,38 @@ export default defineTool({
 ```
 
 This example starts research and review independently. To review the research
-itself, await `agent(...)` first and pass its output to `reviewer(...)`.
+itself, await `ctx.agent(...)` first and pass its output to `ctx.subagent.reviewer(...)`.
+
+### Choose a subagent by name
+
+Bracket access supports names selected by application code and names that cannot be
+written with dot access. A shared helper receives the workflow tool's context:
+
+```ts
+import type { WorkflowToolContext } from "eve/tools";
+import { z } from "zod";
+
+const ReviewSchema = z.object({ successful: z.boolean() });
+
+async function reviewWith(
+  ctx: WorkflowToolContext,
+  namedAgent: "reviewer" | "securityReviewer",
+  prompt: string,
+) {
+  const [review] = await ctx.subagent[namedAgent](prompt, { outputSchema: ReviewSchema });
+  return review;
+}
+```
+
+The name selects a declared subagent visible to this context's owning agent. It
+does not look up a global agent or an existing child session. Unknown or currently
+unavailable names must fail with an actionable error before starting a child.
+Bracket access preserves the path-derived name, including extension namespaces;
+it does not bypass availability or authorization checks.
 
 ### Results and continuation
 
-Both `agent` and named bindings accept `prompt` plus optional `outputSchema` and
+Both `ctx.agent` and `ctx.subagent[name]` accept `prompt` plus optional `outputSchema` and
 `agentId`. Without a schema, the result is `[string, metadata]`. With a schema, the
 first tuple element is the validated output value, with its TypeScript type inferred
 from that schema. `review.successful` above is therefore reviewer-authored structured
@@ -85,14 +114,13 @@ The proposed metadata starts with `{ agentId: string }`. Prefer `agentId` over
 [child identity from its session address][child-identity-from-its-session-address].
 
 ```ts
-import { agent } from "eve/workflow";
 import { z } from "zod";
 
 const OutputSchema = z.object({ successful: z.boolean(), reason: z.string() });
 
-// Inside a workflow body:
-const [research, metadata] = await agent("Research the proposed change.");
-const [assessment] = await agent("Assess the change using your research.", {
+// Inside a defineWorkflowTool executor with its ctx argument:
+const [research, metadata] = await ctx.agent("Research the proposed change.");
+const [assessment] = await ctx.agent("Assess the change using your research.", {
   agentId: metadata.agentId,
   outputSchema: OutputSchema,
 });
@@ -102,7 +130,7 @@ Omitting `agentId` starts a fresh child. Supplying the returned `agentId` to the
 binding continues that child's session with its existing history. The schema applies
 to the requested response; a follow-up can choose a different schema or plain text.
 Each follow-up is a new invocation with its own replay identity, even though it uses
-the same child. Named bindings such as `reviewer` use the same continuation contract.
+the same child. `ctx.subagent.reviewer` uses the same continuation contract.
 
 eve must retain a resumable child handle after a successful invocation, including
 when the enclosing workflow tool runs in the background. The handle belongs to the
@@ -118,13 +146,12 @@ between stages.
 Declare `implementer`, `reviewer`, and `securityReviewer` under `agent/subagents/`.
 Give the implementer repository-write tools and an isolated worktree for each issue.
 Give the reviewers read access to commits and diffs. Those capabilities belong in
-the subagent definitions; importing a binding does not provide them. The implementer
+the subagent definitions; accessing `ctx.subagent` does not provide them. The implementer
 must publish its commit to a repository or artifact store the reviewers can read.
 
 ```ts
 // agent/tools/build-issue.ts
-import { defineTool } from "eve/tools";
-import { implementer, reviewer, securityReviewer } from "eve/workflow";
+import { defineWorkflowTool } from "eve/tools";
 import { z } from "zod";
 
 const CommitSha = z.string().regex(/^[0-9a-f]{40}$/);
@@ -135,14 +162,14 @@ const Review = z.object({
   findings: z.array(z.string()),
 });
 
-export default defineTool({
+export default defineWorkflowTool({
   description: "Implement an issue and review the resulting commit.",
   execution: "background",
   inputSchema: z.object({ repository: z.string(), issue: z.string() }),
-  async execute(input) {
+  async execute(input, ctx) {
     "use workflow";
 
-    let [change, implementation] = await implementer(
+    let [change, implementation] = await ctx.subagent.implementer(
       JSON.stringify({ task: "Implement this issue and publish a commit.", ...input }),
       { outputSchema: Change },
     );
@@ -156,8 +183,8 @@ export default defineTool({
         commitSha: change.commitSha,
       });
       const [[review], [security]] = await Promise.all([
-        reviewer(request, { outputSchema: Review }),
-        securityReviewer(request, { outputSchema: Review }),
+        ctx.subagent.reviewer(request, { outputSchema: Review }),
+        ctx.subagent.securityReviewer(request, { outputSchema: Review }),
       ]);
 
       if ([review, security].some((result) => result.commitSha !== change.commitSha)) {
@@ -170,7 +197,7 @@ export default defineTool({
         return { status: "needs_changes", ...change, review, security };
       }
 
-      [change] = await implementer(
+      [change] = await ctx.subagent.implementer(
         JSON.stringify({
           task: "Address these findings and publish the revised commit.",
           commitSha: change.commitSha,
@@ -218,24 +245,25 @@ export default defineRemoteAgent({
 });
 ```
 
-The factory's `securityReviewer(request, { outputSchema: Review })` call stays the
+The factory's `ctx.subagent.securityReviewer(request, { outputSchema: Review })` call stays the
 same. The URL and outbound authentication belong to the declaration. The receiver
 must authorize the calling deployment using the [existing remote auth setup][remote-auth].
 If it needs to act as the parent's end user, configure `forwardPrincipal: true` and
 the receiver's trusted forwarders as described in [identity forwarding][remote-principal].
-The import does not transfer repository credentials or make local files available
+The context binding does not transfer repository credentials or make local files available
 remotely; the receiver needs its own access to the referenced commit.
 
 The result and continuation contract also stays the same:
 
 ```ts
-// Inside the factory's workflow body; Review is the schema above.
-const [review, securityMetadata] = await securityReviewer(request, {
+// Inside the factory's execute(input, ctx); Review is the schema above.
+const [review, securityMetadata] = await ctx.subagent.securityReviewer(request, {
   outputSchema: Review,
 });
-const [clarification] = await securityReviewer("Explain the first finding in more detail.", {
-  agentId: securityMetadata.agentId,
-});
+const [clarification] = await ctx.subagent.securityReviewer(
+  "Explain the first finding in more detail.",
+  { agentId: securityMetadata.agentId },
+);
 ```
 
 The returned `agentId` belongs to the factory's child-handle store. eve uses that
@@ -255,59 +283,67 @@ example, the security-reviewer application could declare `dependencyReviewer` an
 
 ```ts
 // agent/tools/review-commit.ts in the security-reviewer application
-import { defineTool } from "eve/tools";
-import { codeReviewer, dependencyReviewer } from "eve/workflow";
+import { defineWorkflowTool } from "eve/tools";
 import { z } from "zod";
 
 const Finding = z.object({ findings: z.array(z.string()) });
 
-export default defineTool({
+export default defineWorkflowTool({
   description: "Inspect a commit's code and dependencies in parallel.",
   inputSchema: z.object({ repository: z.string(), commitSha: z.string() }),
-  async execute(input) {
+  async execute(input, ctx) {
     "use workflow";
 
     const request = JSON.stringify(input);
     const [[code], [dependencies]] = await Promise.all([
-      codeReviewer(request, { outputSchema: Finding }),
-      dependencyReviewer(request, { outputSchema: Finding }),
+      ctx.subagent.codeReviewer(request, { outputSchema: Finding }),
+      ctx.subagent.dependencyReviewer(request, { outputSchema: Finding }),
     ]);
     return { commitSha: input.commitSha, findings: [...code.findings, ...dependencies.findings] };
   },
 });
 ```
 
-These imports resolve against the receiving application's agent scope. Its session
+These context properties resolve against the receiving application's agent scope. Its session
 owns these children; their handles are not continuation handles for the factory.
 Being invoked remotely does not add the caller's bindings to that scope or change
-the root-only rule for `agent`. The remote agent uses its tool result to produce
+the root-only rule for `ctx.agent`. The remote agent uses its tool result to produce
 the final response required by the factory's `Review` schema.
 
 ## Current behavior and the gap
 
-[`eve/workflow`][eve-workflow] exports `agent` and
-`ask`, with no application-specific named exports. Its current delegation API is:
+Current `main` exposes [`WorkflowToolContext`][workflow-tool-context] from `eve/tools`.
+`defineWorkflowTool` requires a `"use workflow"` executor and supplies `ctx.agent`
+and `ctx.ask`. The `eve/workflow` entry point has been removed, as documented in
+the [workflow-tool migration][workflow-tool-migration]. Its current delegation API is:
 
 ```ts
-const review = await agent(ctx, {
+const review = await ctx.agent({
   key: "review",
   target: "reviewer",
   message: "Review this: " + input.issueDescription,
 });
 ```
 
-The [implementation][implementation]
-derives the invocation ID from `ctx.callId` and `key`, returns the child's output,
-and throws on an error result. It already accepts per-call `outputSchema` and
+The [implementation][implementation] derives the invocation ID from `ctx.callId`
+and `key`, returns the child's output, and throws on an error result.
+It already accepts per-call `outputSchema` and
 `agentId`, but returns only output. It rejects duplicate keys within a run. The
-proposal adds callable named targets, inferred structured output types, and returned
-continuation metadata, while removing authored replay keys for ordinary calls.
+proposal separates self-delegation from named targets, adds inferred structured
+output types and returned continuation metadata, and removes authored replay keys
+for ordinary calls.
 
-The helper also requires an
-[attached workflow tool context][attached-workflow-tool-context].
-It asks the owning session to perform delegation; the session holds authorization,
-capabilities, admission state, and child handles. The proposed bindings use that
-existing ownership contract and supply the invocation context implicitly.
+The runtime already [binds helpers to the executor context][workflow-tool-body].
+Delegation asks the owning session to act; the session holds authorization,
+capabilities, admission state, and child handles. `ctx.subagent` extends that
+existing ownership contract. Ordinary tools, channels, and schedules do not receive
+this workflow context.
+
+The proposed migration is a breaking change to `ctx.agent`: self-delegation becomes
+`ctx.agent(message, options)`, and named targets become
+`ctx.subagent[target](message, options)`. Callers destructure `[output, metadata]`
+instead of receiving only output. The old target-selecting overload is replaced;
+`ctx.ask` retains its current contract.
 
 Current [agent exports][agent-exports] use `defineAgent` for
 both root agents and local subagents. Single-file subagents are already
@@ -319,22 +355,21 @@ The binding feature does not inherently require a new definition helper.
 
 These are requirements for the proposal, not claims about an implementation.
 
-- **Names and scope.** Generated exports represent only named subagents, not
-  arbitrary tools or agent sessions created at runtime. `reviewer` resolves to a
-  declared subagent in the invoking agent's scope. Generated declarations and
-  runtime resolution must agree on the
-  selected subagent. Missing imports fail with an actionable build error; an import
-  never grants access to a subagent unavailable to the invocation's owner. Reject
-  binding names that conflict with existing exports such as `agent` or `ask`, or
-  cannot be imported as identifiers, with a diagnostic naming the declaration.
-- **Self-delegation.** `agent` preserves the built-in tool's self-delegation target
-  and root-only availability. Generated bindings address named subagents separately.
+- **Names and scope.** `ctx.subagent` contains only declared named subagents visible
+  to the invoking agent. Dot access and bracket access select the same entry.
+  Name lookup must use declared entries, not inherited object properties. Unknown,
+  disabled, or out-of-scope names fail before dispatch. Types and runtime lookup
+  must agree on path-derived names; bracket access supports names that cannot be
+  written as JavaScript identifiers. Existing subagent naming rules still apply.
+  Nesting under `ctx.subagent` keeps these keys separate from `ctx.agent` and `ctx.ask`.
+- **Self-delegation.** `ctx.agent` preserves the built-in tool's self-delegation
+  target and root-only availability. `ctx.subagent` addresses named subagents.
 - **Remote parity.** A named `defineRemoteAgent` declaration produces the same
-  callable binding and continuation metadata as a local declaration. Dispatch uses
+  callable entry in `ctx.subagent` and continuation metadata as a local declaration. Dispatch uses
   its configured endpoint and auth, and `agentId` resolves through the owning
   session's handle store. A receiving agent may use its own named bindings under
   the same scope and lifecycle rules.
-- **Invocation identity.** Two calls to `reviewer`, including calls from the same
+- **Invocation identity.** Two calls to `ctx.subagent.reviewer`, including calls from the same
   loop or helper or with the same `agentId`, represent distinct invocations.
   Replaying either call resumes its original invocation. eve must supply identities
   without a process-global
@@ -346,24 +381,22 @@ These are requirements for the proposal, not claims about an implementation.
   responsible for authorization, child handles, human-input routing, usage, and
   cancellation. The binding must use that authority rather than start a separate
   unowned agent loop.
-- **Runtime placement.** Generated code binds names to eve runtime functions. Agent
-  execution and lifecycle behavior remain in the `eve` package.
+- **Runtime placement.** eve creates bindings for the run's executor context.
+  Any generated types describe the names; agent execution and lifecycle behavior
+  remain in the `eve` package. Shared helpers use the supplied context rather than
+  selecting an owner through module-level imports.
 
 ## Decisions to settle
 
 1. **Is `defineSubagent` needed?** It is absent from the current exports;
    `defineAgent` already defines local subagents. Prefer the existing helper unless
    the new helper introduces necessary semantics.
-2. **Does the explicit helper remain?** The proposed `agent(prompt, options)` is
-   strictly self-delegation. Decide whether the current target-selecting
-   `agent(ctx, input)` is removed or moved to a separate API; it should not give the
-   self-delegation binding a second target-selection meaning.
-3. **What happens to an invalid continuation?** Preserve existing busy-child and
+2. **What happens to an invalid continuation?** Preserve existing busy-child and
    target-mismatch checks. Decide whether an unknown or expired `agentId` rejects
    or retains the [current fallback to a fresh child][current-fallback-to-a-fresh-child].
    Rejection would make an
    explicit request to resume fail visibly instead of silently losing history.
-4. **How do remote schema defaults affect the return type?** Remote definitions
+3. **How do remote schema defaults affect the return type?** Remote definitions
    already allow a default `outputSchema` for new sessions. Decide whether a call
    without an explicit schema infers that default or the binding API requires
    per-call schemas. The remote examples above omit a declaration-level default;
@@ -371,8 +404,9 @@ These are requirements for the proposal, not claims about an implementation.
 
 ## Acceptance criteria
 
-- Compile a fixture with `reviewer.ts`, import `reviewer` from `eve/workflow`, and
-  verify its model and configuration are selected when called from a workflow tool.
+- Compile a `defineWorkflowTool` fixture with `reviewer.ts` and verify
+  `ctx.subagent.reviewer` and `ctx.subagent[namedAgent]` select its model and configuration.
+  Verify `ctx.agent` delegates to self and cannot select another target.
 - Run parallel calls, repeated calls to one binding, and calls through a shared
   helper. Resume the workflow after suspension and verify each invocation retains
   its identity without starting duplicate children.
@@ -385,8 +419,10 @@ These are requirements for the proposal, not claims about an implementation.
 - Verify child failure, human-input suspension, cancellation, and owner shutdown.
   Define sibling behavior when one parallel call fails; a rejected aggregate
   promise must not be treated as evidence that sibling work was cancelled.
-- Reject missing, ambiguous, and out-of-scope bindings. Cover reserved names,
-  disabled targets, and confirm arbitrary tools receive no generated bindings.
+- Reject unknown, disabled, and out-of-scope names through both access forms.
+  Cover computed names, names requiring bracket access, and inherited object keys.
+  Confirm arbitrary tools do not appear in `ctx.subagent`, and ordinary tool,
+  channel, and schedule contexts do not expose these delegation methods.
 - Run the factory with a local security reviewer and with a remote one. Verify
   identical tuple shapes, schema validation, continuation history, and repair
   limits. Reject reviews of a different commit and return the final findings when
@@ -395,20 +431,21 @@ These are requirements for the proposal, not claims about an implementation.
   cannot use the specialist's child handles, and cover remote authorization
   rejection, human-input routing, cancellation, and owner cleanup.
 
-Use compiler/scenario coverage for generated imports and fixture-owned CI evals for
-the runtime paths. This draft adds no runtime implementation or published API docs.
+Use compiler/scenario coverage for context types and name resolution, and
+fixture-owned CI evals for the runtime paths. This draft adds no runtime
+implementation or published API docs.
 
-[tools-as-workflows]: ./tools-as-workflows.md
 [agent-tool]: ../packages/eve/src/tools/framework/agent.ts#L25
 [child-identity-from-its-session-address]: ../packages/eve/src/subagents/handles/store.ts#L16
-[eve-workflow]: ../packages/eve/src/public/workflow/index.ts
-[implementation]: ../packages/eve/src/execution/tools/subagent/invoke-agent.ts#L68
-[attached-workflow-tool-context]: ../packages/eve/src/execution/tools/workflow/ask.ts#L40
+[workflow-tool-context]: ../packages/eve/src/tools/workflow-definition.ts#L26
+[workflow-tool-migration]: ../docs/tools/workflows.mdx#migrate-an-existing-workflow-tool
+[workflow-tool-body]: ../packages/eve/src/execution/tools/workflow/body.ts#L128
+[implementation]: ../packages/eve/src/execution/tools/subagent/invoke-agent.ts#L62
 [agent-exports]: ../packages/eve/src/public/index.ts
 [discovered]: ../packages/eve/src/discover/discover-subagent.ts#L119
 [requires-a-description]: ../packages/eve/src/compiler/normalize-manifest-helpers.ts#L107
 [current-fallback-to-a-fresh-child]: ../docs/subagents/index.mdx#agent-messaging
-[workflow-tool-background]: ../research/tools-as-workflows.md#wait-or-run-in-the-background
+[workflow-tool-background]: ../docs/tools/workflows.mdx#wait-or-run-in-the-background
 [remote-auth]: ../docs/guides/remote-agents.md#outbound-auth
 [remote-principal]: ../docs/guides/remote-agents.md#forwarding-the-caller-identity
 [remote-session-address]: ../packages/eve/src/subagents/handles/store.ts#L87

--- a/research/named-subagent-workflow-bindings.md
+++ b/research/named-subagent-workflow-bindings.md
@@ -32,7 +32,8 @@ export default defineSubagent({
 ```
 
 The filename supplies `reviewer`; no separate name or registration is authored.
-Only named subagents receive generated bindings. The proposed `agent(prompt)` calls
+Only named subagents receive generated bindings, including named remote subagents.
+The proposed `agent(prompt)` calls
 a copy of itself, matching the built-in
 [`agent` tool][agent-tool]'s target and root-only
 availability. It does not select another named agent.
@@ -129,6 +130,181 @@ eve must retain a resumable child handle after a successful invocation, includin
 when the enclosing workflow tool runs in the background. The handle belongs to the
 owning session. Completing an invocation does not, by itself, end the child session.
 
+## Example: a software factory
+
+A factory can put implementation, parallel review, and bounded repair in a workflow
+tool using the proposed bindings. The model handling the issue calls this tool once;
+workflow code decides which specialists run next and passes their structured results
+between stages.
+
+Declare `implementer`, `reviewer`, and `securityReviewer` under `agent/subagents/`.
+Give the implementer repository-write tools and an isolated worktree for each issue.
+Give the reviewers read access to commits and diffs. Those capabilities belong in
+the subagent definitions; importing a binding does not provide them. The implementer
+must publish its commit to a repository or artifact store the reviewers can read.
+
+```ts
+// agent/tools/build-issue.ts
+import { defineTool } from "eve/tools";
+import { implementer, reviewer, securityReviewer } from "eve/workflow";
+import { z } from "zod";
+
+const CommitSha = z.string().regex(/^[0-9a-f]{40}$/);
+const Change = z.object({ commitSha: CommitSha, summary: z.string() });
+const Review = z.object({
+  commitSha: CommitSha,
+  approved: z.boolean(),
+  findings: z.array(z.string()),
+});
+
+export default defineTool({
+  description: "Implement an issue and review the resulting commit.",
+  execution: "background",
+  inputSchema: z.object({ repository: z.string(), issue: z.string() }),
+  async execute(input) {
+    "use workflow";
+
+    let [change, implementation] = await implementer(
+      JSON.stringify({ task: "Implement this issue and publish a commit.", ...input }),
+      { outputSchema: Change },
+    );
+    let repairsRemaining = 2;
+
+    while (true) {
+      const request = JSON.stringify({
+        task: "Review this exact commit without modifying it.",
+        repository: input.repository,
+        issue: input.issue,
+        commitSha: change.commitSha,
+      });
+      const [[review], [security]] = await Promise.all([
+        reviewer(request, { outputSchema: Review }),
+        securityReviewer(request, { outputSchema: Review }),
+      ]);
+
+      if ([review, security].some((result) => result.commitSha !== change.commitSha)) {
+        throw new Error("A review returned a different commit than the one requested.");
+      }
+      if (review.approved && security.approved) {
+        return { status: "reviewed", ...change, review, security };
+      }
+      if (repairsRemaining === 0) {
+        return { status: "needs_changes", ...change, review, security };
+      }
+
+      [change] = await implementer(
+        JSON.stringify({
+          task: "Address these findings and publish the revised commit.",
+          commitSha: change.commitSha,
+          findings: [...review.findings, ...security.findings],
+        }),
+        { agentId: implementation.agentId, outputSchema: Change },
+      );
+      repairsRemaining--;
+    }
+  },
+});
+```
+
+The implementer retains its session across repairs. Each review call starts a fresh
+child. The workflow sends both reviewers the same immutable commit reference and
+rejects a different returned reference. The loop permits at most two repair
+invocations and three review rounds. On exhaustion it returns the last commit and
+findings. Execution errors reject the workflow instead of being treated as negative
+reviews.
+
+`execution: "background"` lets the owning agent continue while the factory tool
+runs, following the [existing workflow-tool contract][workflow-tool-background].
+Inside the tool, each binding still waits for its result. A schema validates the
+shape of a review, not whether its conclusions are correct: `reviewed` here means
+both reviewers approved that commit. A merge step must separately check actual CI
+results and that the pull request still points to the reviewed commit. Admission
+across multiple issues also needs an application concurrency limit; `Promise.all`
+only expresses the two reviews within one issue.
+
+## Example: remote specialists
+
+A named remote subagent receives the same proposed binding as a local one. To run
+the factory's security review in another deployment, define its existing name with
+the current [`defineRemoteAgent` API][remote-definition]:
+
+```ts
+// agent/subagents/securityReviewer.ts in the factory application
+import { defineRemoteAgent } from "eve";
+import { vercelOidc } from "eve/agents/auth";
+
+export default defineRemoteAgent({
+  description: "Review an exact repository commit for security issues.",
+  url: "https://security-reviewer.example.com",
+  auth: vercelOidc(),
+});
+```
+
+The factory's `securityReviewer(request, { outputSchema: Review })` call stays the
+same. The URL and outbound authentication belong to the declaration. The receiver
+must authorize the calling deployment using the [existing remote auth setup][remote-auth].
+If it needs to act as the parent's end user, configure `forwardPrincipal: true` and
+the receiver's trusted forwarders as described in [identity forwarding][remote-principal].
+The import does not transfer repository credentials or make local files available
+remotely; the receiver needs its own access to the referenced commit.
+
+The result and continuation contract also stays the same:
+
+```ts
+// Inside the factory's workflow body; Review is the schema above.
+const [review, securityMetadata] = await securityReviewer(request, {
+  outputSchema: Review,
+});
+const [clarification] = await securityReviewer("Explain the first finding in more detail.", {
+  agentId: securityMetadata.agentId,
+});
+```
+
+The returned `agentId` belongs to the factory's child-handle store. eve uses that
+handle's [remote session address][remote-session-address] to continue the same
+session on the receiver. The workflow does not construct HTTP requests or pass a
+remote `sessionId`. Existing [remote dispatch][remote-dispatch] already sends a
+message and output schema with a callback, and supports
+[continuation requests][remote-continuation]. The proposal makes those operations
+available through named calls that resolve to `[output, metadata]`, preserving
+remote failure, human-input, cancellation, and cleanup behavior.
+
+### Inside the remote specialist
+
+The receiving agent can itself use named bindings in its workflow tools. For
+example, the security-reviewer application could declare `dependencyReviewer` and
+`codeReviewer` under its own `agent/subagents/` and combine their results:
+
+```ts
+// agent/tools/review-commit.ts in the security-reviewer application
+import { defineTool } from "eve/tools";
+import { codeReviewer, dependencyReviewer } from "eve/workflow";
+import { z } from "zod";
+
+const Finding = z.object({ findings: z.array(z.string()) });
+
+export default defineTool({
+  description: "Inspect a commit's code and dependencies in parallel.",
+  inputSchema: z.object({ repository: z.string(), commitSha: z.string() }),
+  async execute(input) {
+    "use workflow";
+
+    const request = JSON.stringify(input);
+    const [[code], [dependencies]] = await Promise.all([
+      codeReviewer(request, { outputSchema: Finding }),
+      dependencyReviewer(request, { outputSchema: Finding }),
+    ]);
+    return { commitSha: input.commitSha, findings: [...code.findings, ...dependencies.findings] };
+  },
+});
+```
+
+These imports resolve against the receiving application's agent scope. Its session
+owns these children; their handles are not continuation handles for the factory.
+Being invoked remotely does not add the caller's bindings to that scope or change
+the root-only rule for `agent`. The remote agent uses its tool result to produce
+the final response required by the factory's `Review` schema.
+
 ## Current behavior and the gap
 
 [`eve/workflow`][eve-workflow] exports `agent` and
@@ -178,6 +354,11 @@ These are requirements for the proposal, not claims about an implementation.
   cannot be imported as identifiers, with a diagnostic naming the declaration.
 - **Self-delegation.** `agent` preserves the built-in tool's self-delegation target
   and root-only availability. Generated bindings address named subagents separately.
+- **Remote parity.** A named `defineRemoteAgent` declaration produces the same
+  callable binding and continuation metadata as a local declaration. Dispatch uses
+  its configured endpoint and auth, and `agentId` resolves through the owning
+  session's handle store. A receiving agent may use its own named bindings under
+  the same scope and lifecycle rules.
 - **Invocation identity.** Two calls to `reviewer`, including calls from the same
   loop or helper or with the same `agentId`, represent distinct invocations.
   Replaying either call resumes its original invocation. eve must supply identities
@@ -214,6 +395,11 @@ These are requirements for the proposal, not claims about an implementation.
    or retains the [current fallback to a fresh child][current-fallback-to-a-fresh-child].
    Rejection would make an
    explicit request to resume fail visibly instead of silently losing history.
+5. **How do remote schema defaults affect the return type?** Remote definitions
+   already allow a default `outputSchema` for new sessions. Decide whether a call
+   without an explicit schema infers that default or the binding API requires
+   per-call schemas. The remote examples above omit a declaration-level default;
+   their calls follow the string-or-explicit-schema contract.
 
 ## Acceptance criteria
 
@@ -235,6 +421,13 @@ These are requirements for the proposal, not claims about an implementation.
   promise must not be treated as evidence that sibling work was cancelled.
 - Reject missing, ambiguous, and out-of-scope bindings. Cover reserved names,
   disabled targets, and confirm arbitrary tools receive no generated bindings.
+- Run the factory with a local security reviewer and with a remote one. Verify
+  identical tuple shapes, schema validation, continuation history, and repair
+  limits. Reject reviews of a different commit and return the final findings when
+  repairs are exhausted.
+- Exercise a remote specialist calling its own named subagents. Verify the factory
+  cannot use the specialist's child handles, and cover remote authorization
+  rejection, human-input routing, cancellation, and owner cleanup.
 
 Use compiler/scenario coverage for generated imports and fixture-owned CI evals for
 the runtime paths. This draft adds no runtime implementation or published API docs.
@@ -250,3 +443,10 @@ the runtime paths. This draft adds no runtime implementation or published API do
 [discovered]: ../packages/eve/src/discover/discover-subagent.ts#L119
 [requires-a-description]: ../packages/eve/src/compiler/normalize-manifest-helpers.ts#L107
 [current-fallback-to-a-fresh-child]: ../docs/subagents/index.mdx#agent-messaging
+[workflow-tool-background]: ../research/tools-as-workflows.md#wait-or-run-in-the-background
+[remote-auth]: ../docs/guides/remote-agents.md#outbound-auth
+[remote-principal]: ../docs/guides/remote-agents.md#forwarding-the-caller-identity
+[remote-session-address]: ../packages/eve/src/subagents/handles/store.ts#L87
+[remote-dispatch]: ../packages/eve/src/subagents/remote-dispatch.ts#L56
+[remote-continuation]: ../packages/eve/src/subagents/remote-dispatch.ts#L201
+[remote-definition]: ../packages/eve/src/public/definitions/remote-agent.ts#L83

--- a/research/named-subagent-workflow-bindings.md
+++ b/research/named-subagent-workflow-bindings.md
@@ -1,0 +1,252 @@
+---
+issue: TBD
+status: draft
+last_updated: "2026-09-03"
+---
+
+# Named subagent bindings in workflows
+
+Expose declared subagents as callable named imports from `eve/workflow`, so authored
+code can delegate work and branch on its result in both workflow tools and authored
+workflow functions.
+
+The proposed call is `await reviewer(message)`. eve supplies the target, invocation
+context, and replay-stable invocation identity currently passed explicitly to
+`agent(ctx, { target, key, message })`. This extends the workflow delegation described
+in [Tools as workflows][tools-as-workflows].
+
+## Proposed authoring API
+
+The following examples describe the requested API, not code supported by the current
+exports. `defineSubagent` and `defineWorkflow` retain the names from the initial
+sketch; their inclusion is an open API decision below.
+
+```ts
+// agent/subagents/reviewer.ts
+import { defineSubagent } from "eve";
+
+export default defineSubagent({
+  description: "Review an issue and report whether the review passes.",
+  model: "openai/gpt-5.6-sol",
+});
+```
+
+The filename supplies `reviewer`; no separate name or registration is authored.
+Only named subagents receive generated bindings. The proposed `agent(prompt)` calls
+a copy of itself, matching the built-in
+[`agent` tool][agent-tool]'s target and root-only
+availability. It does not select another named agent.
+
+Importing a binding does not start an agent. Calling it starts a new child or
+continues the child identified by `agentId`; awaiting it returns `[output, metadata]`
+after that invocation completes.
+
+```ts
+// agent/tools/orchestration.ts
+import { defineTool } from "eve/tools";
+import { agent, reviewer } from "eve/workflow";
+import { z } from "zod";
+
+const ReviewSchema = z.object({ successful: z.boolean() });
+
+export default defineTool({
+  description: "Research and review an issue in parallel.",
+  inputSchema: z.object({ issueDescription: z.string() }),
+  async execute(input) {
+    "use workflow";
+
+    const [[research], [review]] = await Promise.all([
+      agent("Research this: " + input.issueDescription),
+      reviewer("Review this: " + input.issueDescription, { outputSchema: ReviewSchema }),
+    ]);
+
+    if (review.successful) return { successful: true, research };
+    return { successful: false };
+  },
+});
+```
+
+The same bindings should be callable from an authored workflow function. The file
+location does not determine how the workflow is started or which session owns it:
+
+```ts
+// workflows/orchestration.ts
+import { defineWorkflow } from "eve";
+import { agent, reviewer } from "eve/workflow";
+import { z } from "zod";
+
+const ReviewSchema = z.object({ successful: z.boolean() });
+
+export default defineWorkflow(async (input: { issueDescription: string }) => {
+  "use workflow";
+
+  const [[research], [review]] = await Promise.all([
+    agent("Research this: " + input.issueDescription),
+    reviewer("Review this: " + input.issueDescription, { outputSchema: ReviewSchema }),
+  ]);
+
+  if (review.successful) return { successful: true, research };
+  return { successful: false };
+});
+```
+
+Both examples start research and review independently. To review the research
+itself, await `agent(...)` first and pass its output to `reviewer(...)`.
+
+### Results and continuation
+
+Both `agent` and named bindings accept `prompt` plus optional `outputSchema` and
+`agentId`. Without a schema, the result is `[string, metadata]`. With a schema, the
+first tuple element is the validated output value, with its TypeScript type inferred
+from that schema. `review.successful` above is therefore reviewer-authored structured
+output. Execution failures reject the promise.
+
+The proposed metadata starts with `{ agentId: string }`. Prefer `agentId` over
+`sessionId` to match the existing continuation input: eve distinguishes the
+[child identity from its session address][child-identity-from-its-session-address].
+
+```ts
+import { agent } from "eve/workflow";
+import { z } from "zod";
+
+const OutputSchema = z.object({ successful: z.boolean(), reason: z.string() });
+
+// Inside a workflow body:
+const [research, metadata] = await agent("Research the proposed change.");
+const [assessment] = await agent("Assess the change using your research.", {
+  agentId: metadata.agentId,
+  outputSchema: OutputSchema,
+});
+```
+
+Omitting `agentId` starts a fresh child. Supplying the returned `agentId` to the same
+binding continues that child's session with its existing history. The schema applies
+to the requested response; a follow-up can choose a different schema or plain text.
+Each follow-up is a new invocation with its own replay identity, even though it uses
+the same child. Named bindings such as `reviewer` use the same continuation contract.
+
+eve must retain a resumable child handle after a successful invocation, including
+when the enclosing workflow tool runs in the background. The handle belongs to the
+owning session. Completing an invocation does not, by itself, end the child session.
+
+## Current behavior and the gap
+
+[`eve/workflow`][eve-workflow] exports `agent` and
+`ask`, with no application-specific named exports. Its current delegation API is:
+
+```ts
+const review = await agent(ctx, {
+  key: "review",
+  target: "reviewer",
+  message: "Review this: " + input.issueDescription,
+});
+```
+
+The [implementation][implementation]
+derives the invocation ID from `ctx.callId` and `key`, returns the child's output,
+and throws on an error result. It already accepts per-call `outputSchema` and
+`agentId`, but returns only output. It rejects duplicate keys within a run. The
+proposal adds callable named targets, inferred structured output types, and returned
+continuation metadata, while removing authored replay keys for ordinary calls.
+
+The helper also requires an
+[attached workflow tool context][attached-workflow-tool-context].
+It asks the owning session to perform delegation; the session holds authorization,
+capabilities, admission state, and child handles. Starting a workflow without an
+existing agent session therefore needs an ownership contract before the shorthand
+can work there. Discovering its source file is insufficient: the
+[workflow scanner][workflow-scanner]
+already scans the application root for workflow directives.
+
+Current [agent exports][agent-exports] use `defineAgent` for
+both root agents and local subagents. Single-file subagents are already
+[discovered][discovered], and the compiler
+[requires a description][requires-a-description].
+The binding feature does not inherently require a new definition helper.
+
+## Required semantics
+
+These are requirements for the proposal, not claims about an implementation.
+
+- **Names and scope.** Generated exports represent only named subagents, not
+  arbitrary tools or agent sessions created at runtime. `reviewer` resolves to a
+  declared subagent in the invoking agent's scope. Generated declarations and
+  runtime resolution must agree on the
+  selected subagent. Missing imports fail with an actionable build error; an import
+  never grants access to a subagent unavailable to the invocation's owner. Reject
+  binding names that conflict with existing exports such as `agent` or `ask`, or
+  cannot be imported as identifiers, with a diagnostic naming the declaration.
+- **Self-delegation.** `agent` preserves the built-in tool's self-delegation target
+  and root-only availability. Generated bindings address named subagents separately.
+- **Invocation identity.** Two calls to `reviewer`, including calls from the same
+  loop or helper or with the same `agentId`, represent distinct invocations.
+  Replaying either call resumes its original invocation. eve must supply identities
+  without a process-global
+  counter or requiring an authored `key` for the examples above.
+- **Awaiting.** A binding returns a promise for `[output, metadata]`, so
+  `Promise.all` can compose calls. Whether the enclosing tool is blocking or
+  background does not turn the binding's result into a background-task receipt.
+- **Execution ownership.** In a workflow tool, the existing owning session remains
+  responsible for authorization, child handles, human-input routing, usage, and
+  cancellation. The binding must use that authority rather than start a separate
+  unowned agent loop. Starting a workflow outside an agent's execution must define
+  equivalent ownership if that entry path is supported.
+- **Runtime placement.** Generated code binds names to eve runtime functions. Agent
+  execution and lifecycle behavior remain in the `eve` package.
+
+## Decisions to settle
+
+1. **How is `workflows/orchestration.ts` started?** If an agent calls it within its
+   execution, that session provides the ownership described above. If a route or
+   cron starts it without an existing agent session, specify how eve establishes
+   agent scope, authorization, child handles, and a destination for human input.
+2. **Are new definition helpers needed?** `defineSubagent` is absent from the
+   current exports; `defineAgent` already defines local subagents. `defineWorkflow`
+   is also absent, while plain functions with `"use workflow"` already have a
+   discovery path. Prefer retaining existing helpers unless a new helper owns
+   necessary semantics, such as establishing ownership when starting a workflow.
+3. **Does the explicit helper remain?** The proposed `agent(prompt, options)` is
+   strictly self-delegation. Decide whether the current target-selecting
+   `agent(ctx, input)` is removed or moved to a separate API; it should not give the
+   self-delegation binding a second target-selection meaning.
+4. **What happens to an invalid continuation?** Preserve existing busy-child and
+   target-mismatch checks. Decide whether an unknown or expired `agentId` rejects
+   or retains the [current fallback to a fresh child][current-fallback-to-a-fresh-child].
+   Rejection would make an
+   explicit request to resume fail visibly instead of silently losing history.
+
+## Acceptance criteria
+
+- Compile a fixture with `reviewer.ts`, import `reviewer` from `eve/workflow`, and
+  verify its model and configuration are selected. Exercise both a workflow tool
+  and an authored workflow function. Cover starting outside an agent session if
+  that entry path is included.
+- Run parallel calls, repeated calls to one binding, and calls through a shared
+  helper. Resume the workflow after suspension and verify each invocation retains
+  its identity without starting duplicate children.
+- Verify a typed structured result supports a branch such as
+  `if (review.successful)`, and distinguish a negative review from execution failure.
+- Verify no schema yields a string and schema input determines the output type.
+  Resume with returned `metadata.agentId`, verify history is retained, and request
+  a different output schema on the follow-up. Cover blocking and background
+  workflow tools, busy or mismatched children, and expired handles.
+- Verify child failure, human-input suspension, cancellation, and owner shutdown.
+  Define sibling behavior when one parallel call fails; a rejected aggregate
+  promise must not be treated as evidence that sibling work was cancelled.
+- Reject missing, ambiguous, and out-of-scope bindings. Cover reserved names,
+  disabled targets, and confirm arbitrary tools receive no generated bindings.
+
+Use compiler/scenario coverage for generated imports and fixture-owned CI evals for
+the runtime paths. This draft adds no runtime implementation or published API docs.
+
+[tools-as-workflows]: ./tools-as-workflows.md
+[agent-tool]: ../packages/eve/src/tools/framework/agent.ts#L25
+[child-identity-from-its-session-address]: ../packages/eve/src/subagents/handles/store.ts#L16
+[eve-workflow]: ../packages/eve/src/public/workflow/index.ts
+[implementation]: ../packages/eve/src/execution/tools/subagent/invoke-agent.ts#L68
+[attached-workflow-tool-context]: ../packages/eve/src/execution/tools/workflow/ask.ts#L40
+[workflow-scanner]: ../packages/eve/src/internal/workflow-bundle/authored-workflow-modules.ts#L45
+[agent-exports]: ../packages/eve/src/public/index.ts
+[discovered]: ../packages/eve/src/discover/discover-subagent.ts#L119
+[requires-a-description]: ../packages/eve/src/compiler/normalize-manifest-helpers.ts#L107
+[current-fallback-to-a-fresh-child]: ../docs/subagents/index.mdx#agent-messaging

--- a/research/named-subagent-workflow-bindings.md
+++ b/research/named-subagent-workflow-bindings.md
@@ -1,25 +1,27 @@
 ---
 issue: TBD
 status: draft
-last_updated: "2026-09-03"
+last_updated: "2026-09-04"
 ---
 
 # Named subagent bindings in workflows
 
-Expose declared subagents as callable named imports from `eve/workflow`, so authored
-code can delegate work and branch on its result in both workflow tools and authored
-workflow functions.
+Expose declared subagents as callable named imports from `eve/workflow`, so workflow
+tools can delegate work and branch on its result.
 
 The proposed call is `await reviewer(message)`. eve supplies the target, invocation
 context, and replay-stable invocation identity currently passed explicitly to
 `agent(ctx, { target, key, message })`. This extends the workflow delegation described
 in [Tools as workflows][tools-as-workflows].
 
+`defineWorkflow` and workflows started without an owning agent session are deferred
+to a separate change.
+
 ## Proposed authoring API
 
 The following examples describe the requested API, not code supported by the current
-exports. `defineSubagent` and `defineWorkflow` retain the names from the initial
-sketch; their inclusion is an open API decision below.
+exports. `defineSubagent` retains the name from the initial sketch; its inclusion
+is an open API decision below.
 
 ```ts
 // agent/subagents/reviewer.ts
@@ -67,31 +69,7 @@ export default defineTool({
 });
 ```
 
-The same bindings should be callable from an authored workflow function. The file
-location does not determine how the workflow is started or which session owns it:
-
-```ts
-// workflows/orchestration.ts
-import { defineWorkflow } from "eve";
-import { agent, reviewer } from "eve/workflow";
-import { z } from "zod";
-
-const ReviewSchema = z.object({ successful: z.boolean() });
-
-export default defineWorkflow(async (input: { issueDescription: string }) => {
-  "use workflow";
-
-  const [[research], [review]] = await Promise.all([
-    agent("Research this: " + input.issueDescription),
-    reviewer("Review this: " + input.issueDescription, { outputSchema: ReviewSchema }),
-  ]);
-
-  if (review.successful) return { successful: true, research };
-  return { successful: false };
-});
-```
-
-Both examples start research and review independently. To review the research
+This example starts research and review independently. To review the research
 itself, await `agent(...)` first and pass its output to `reviewer(...)`.
 
 ### Results and continuation
@@ -328,11 +306,8 @@ continuation metadata, while removing authored replay keys for ordinary calls.
 The helper also requires an
 [attached workflow tool context][attached-workflow-tool-context].
 It asks the owning session to perform delegation; the session holds authorization,
-capabilities, admission state, and child handles. Starting a workflow without an
-existing agent session therefore needs an ownership contract before the shorthand
-can work there. Discovering its source file is insufficient: the
-[workflow scanner][workflow-scanner]
-already scans the application root for workflow directives.
+capabilities, admission state, and child handles. The proposed bindings use that
+existing ownership contract and supply the invocation context implicitly.
 
 Current [agent exports][agent-exports] use `defineAgent` for
 both root agents and local subagents. Single-file subagents are already
@@ -370,32 +345,25 @@ These are requirements for the proposal, not claims about an implementation.
 - **Execution ownership.** In a workflow tool, the existing owning session remains
   responsible for authorization, child handles, human-input routing, usage, and
   cancellation. The binding must use that authority rather than start a separate
-  unowned agent loop. Starting a workflow outside an agent's execution must define
-  equivalent ownership if that entry path is supported.
+  unowned agent loop.
 - **Runtime placement.** Generated code binds names to eve runtime functions. Agent
   execution and lifecycle behavior remain in the `eve` package.
 
 ## Decisions to settle
 
-1. **How is `workflows/orchestration.ts` started?** If an agent calls it within its
-   execution, that session provides the ownership described above. If a route or
-   cron starts it without an existing agent session, specify how eve establishes
-   agent scope, authorization, child handles, and a destination for human input.
-2. **Are new definition helpers needed?** `defineSubagent` is absent from the
-   current exports; `defineAgent` already defines local subagents. `defineWorkflow`
-   is also absent, while plain functions with `"use workflow"` already have a
-   discovery path. Prefer retaining existing helpers unless a new helper owns
-   necessary semantics, such as establishing ownership when starting a workflow.
-3. **Does the explicit helper remain?** The proposed `agent(prompt, options)` is
+1. **Is `defineSubagent` needed?** It is absent from the current exports;
+   `defineAgent` already defines local subagents. Prefer the existing helper unless
+   the new helper introduces necessary semantics.
+2. **Does the explicit helper remain?** The proposed `agent(prompt, options)` is
    strictly self-delegation. Decide whether the current target-selecting
    `agent(ctx, input)` is removed or moved to a separate API; it should not give the
    self-delegation binding a second target-selection meaning.
-4. **What happens to an invalid continuation?** Preserve existing busy-child and
+3. **What happens to an invalid continuation?** Preserve existing busy-child and
    target-mismatch checks. Decide whether an unknown or expired `agentId` rejects
    or retains the [current fallback to a fresh child][current-fallback-to-a-fresh-child].
    Rejection would make an
    explicit request to resume fail visibly instead of silently losing history.
-5. **How do remote schema defaults affect the return type?** Remote definitions
+4. **How do remote schema defaults affect the return type?** Remote definitions
    already allow a default `outputSchema` for new sessions. Decide whether a call
    without an explicit schema infers that default or the binding API requires
    per-call schemas. The remote examples above omit a declaration-level default;
@@ -404,9 +372,7 @@ These are requirements for the proposal, not claims about an implementation.
 ## Acceptance criteria
 
 - Compile a fixture with `reviewer.ts`, import `reviewer` from `eve/workflow`, and
-  verify its model and configuration are selected. Exercise both a workflow tool
-  and an authored workflow function. Cover starting outside an agent session if
-  that entry path is included.
+  verify its model and configuration are selected when called from a workflow tool.
 - Run parallel calls, repeated calls to one binding, and calls through a shared
   helper. Resume the workflow after suspension and verify each invocation retains
   its identity without starting duplicate children.
@@ -438,7 +404,6 @@ the runtime paths. This draft adds no runtime implementation or published API do
 [eve-workflow]: ../packages/eve/src/public/workflow/index.ts
 [implementation]: ../packages/eve/src/execution/tools/subagent/invoke-agent.ts#L68
 [attached-workflow-tool-context]: ../packages/eve/src/execution/tools/workflow/ask.ts#L40
-[workflow-scanner]: ../packages/eve/src/internal/workflow-bundle/authored-workflow-modules.ts#L45
 [agent-exports]: ../packages/eve/src/public/index.ts
 [discovered]: ../packages/eve/src/discover/discover-subagent.ts#L119
 [requires-a-description]: ../packages/eve/src/compiler/normalize-manifest-helpers.ts#L107

--- a/research/named-subagent-workflow-bindings.md
+++ b/research/named-subagent-workflow-bindings.md
@@ -1,7 +1,7 @@
 ---
 issue: TBD
 status: draft
-last_updated: "2026-09-04"
+last_updated: "2026-09-08"
 ---
 
 # Named subagents on workflow tool context
@@ -109,6 +109,11 @@ first tuple element is the validated output value, with its TypeScript type infe
 from that schema. `review.successful` above is therefore reviewer-authored structured
 output. Execution failures reject the promise.
 
+`ctx.agent` accepts an arbitrary caller-supplied output schema for each invocation,
+using the same schema support as tools. The schema does not need to be declared on
+the agent or chosen from a predefined set. It constrains that invocation's response
+without changing the agent definition or fixing the schema for subsequent calls.
+
 The proposed metadata starts with `{ agentId: string }`. Prefer `agentId` over
 `sessionId` to match the existing continuation input: eve distinguishes the
 [child identity from its session address][child-identity-from-its-session-address].
@@ -116,13 +121,16 @@ The proposed metadata starts with `{ agentId: string }`. Prefer `agentId` over
 ```ts
 import { z } from "zod";
 
-const OutputSchema = z.object({ successful: z.boolean(), reason: z.string() });
+const ResearchSchema = z.object({ findings: z.array(z.string()) });
+const AssessmentSchema = z.object({ successful: z.boolean(), reason: z.string() });
 
 // Inside a defineWorkflowTool executor with its ctx argument:
-const [research, metadata] = await ctx.agent("Research the proposed change.");
+const [research, metadata] = await ctx.agent("Research the proposed change.", {
+  outputSchema: ResearchSchema,
+});
 const [assessment] = await ctx.agent("Assess the change using your research.", {
   agentId: metadata.agentId,
-  outputSchema: OutputSchema,
+  outputSchema: AssessmentSchema,
 });
 ```
 
@@ -413,6 +421,8 @@ These are requirements for the proposal, not claims about an implementation.
 - Verify a typed structured result supports a branch such as
   `if (review.successful)`, and distinguish a negative review from execution failure.
 - Verify no schema yields a string and schema input determines the output type.
+  For `ctx.agent`, supply schemas absent from the agent definition and verify each
+  invocation validates against its own schema without changing the definition.
   Resume with returned `metadata.agentId`, verify history is retained, and request
   a different output schema on the follow-up. Cover blocking and background
   workflow tools, busy or mismatched children, and expired handles.


### PR DESCRIPTION
### Summary

Workflow tools on current main already receive delegation through context, but calls still require target strings and replay keys and return no continuation metadata. This draft proposes self-delegation through `ctx.agent(prompt, options)` and named local or remote subagents through `ctx.subagent.reviewer` or `ctx.subagent[namedAgent]`, with inferred structured output and `[output, { agentId }]` results. It replaces the current target-selecting `ctx.agent` contract. Factory and remote-specialist examples use `defineWorkflowTool`. This is research only; `defineWorkflow` and execution without an owning agent session remain deferred.

### Validation

- Rebased onto main at `e6037391160b493e395f46a226878fc81ae1a1c0`; `git range-diff` confirmed all three prior patches were preserved before the context API revision.
- `pnpm docs:check` passed: 88 docs, 302 import paths, and 395 code blocks checked; all 88 docs compile.
- `pnpm guard:invariants`, `pnpm exec oxfmt research/named-subagent-workflow-bindings.md`, and `git diff --cached --check` passed.
- Checked proposal frontmatter and 17 repository references; parsed all nine TypeScript examples with Node's `stripTypeScriptTypes`. The proposed API is not implemented, so these examples have not been typechecked or run end to end.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
