### PR TITLE
fix(eve): chatgpt - preserve stateless reasoning replay

### DIFF
--- a/.changeset/quiet-chatgpt-reasoning.md
+++ b/.changeset/quiet-chatgpt-reasoning.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix `chatgpt()` dropping reasoning summaries and emitting unsupported-reasoning warnings after tool calls. Stateless requests now preserve all summaries and their encrypted reasoning payload across model steps.

--- a/docs/reference/typescript-api.md
+++ b/docs/reference/typescript-api.md
@@ -182,6 +182,8 @@ export default defineAgent({
 
 Pass another bare OpenAI model slug to override the default. `experimental_chatgpt()` remains as a deprecated alias.
 
+`chatgpt()` uses stateless requests (`store: false`). eve retains reasoning summaries and encrypted reasoning in session history and replays them after tool calls and on later turns. You do not need to configure `reasoning.encrypted_content` explicitly.
+
 Authentication is delegated entirely to the Codex CLI:
 
 1. Install or upgrade `codex` and run `codex login`.

--- a/packages/eve/src/public/models/openai/chatgpt/model.integration.test.ts
+++ b/packages/eve/src/public/models/openai/chatgpt/model.integration.test.ts
@@ -1,0 +1,217 @@
+import { jsonSchema } from "ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createDurableSessionState } from "#execution/durable-session-store.js";
+import { createToolLoopHarness } from "#harness/tool-loop.js";
+import type { HarnessSession } from "#harness/types.js";
+import { createCodexSubscriptionModel } from "./model.js";
+
+afterEach(() => vi.restoreAllMocks());
+
+interface RecordedRequest {
+  readonly store: boolean;
+  readonly include: string[];
+  readonly input: Array<Record<string, unknown>>;
+}
+
+describe("ChatGPT streamed reasoning replay", () => {
+  it("preserves all summaries and encrypted reasoning through a tool and durable history", async () => {
+    const warnings = vi.spyOn(process, "emitWarning").mockImplementation(() => {});
+    const requests: RecordedRequest[] = [];
+    const model = createCodexSubscriptionModel(
+      { model: "gpt-5.6-luna" },
+      {
+        broker: {
+          getToken: async () => ({ token: "test-token" }),
+          refreshState: async () => ({ kind: "ready" }),
+          state: () => ({ kind: "ready" }),
+        },
+        fetch: async (_input, init) => {
+          requests.push(JSON.parse(String(init?.body)));
+          return sseResponse(requests.length === 1 ? reasoningAndToolEvents() : answerEvents());
+        },
+      },
+    );
+    const execute = vi.fn(async () => ({ id: "invoice-1", total: 42 }));
+    const runStep = createToolLoopHarness({
+      handleEvent: async () => {},
+      mode: "conversation",
+      resolveModel: async () => model,
+      tools: new Map([
+        [
+          "get_invoice",
+          {
+            name: "get_invoice",
+            description: "Read the invoice.",
+            inputSchema: jsonSchema({ type: "object", properties: {} }),
+            execute,
+          },
+        ],
+      ]),
+    });
+    const session: HarnessSession = {
+      agent: {
+        modelReference: { id: "chatgpt-reasoning-test" },
+        system: "Check the invoice.",
+        tools: [
+          {
+            name: "get_invoice",
+            description: "Read the invoice.",
+            inputSchema: { type: "object", properties: {} },
+          },
+        ],
+      },
+      compaction: { recentWindowSize: 10, threshold: 100_000 },
+      continuationToken: "http:chatgpt-reasoning-test",
+      history: [],
+      sessionId: "chatgpt-reasoning-test",
+    };
+
+    const first = await runStep(session, { message: "Check the invoice total." });
+    expect(execute).toHaveBeenCalledOnce();
+    if (typeof first.next !== "function") throw new Error("Expected a second model step.");
+
+    const stored: ReturnType<typeof createDurableSessionState> = JSON.parse(
+      JSON.stringify(createDurableSessionState({ session: first.session })),
+    );
+    if (stored.snapshot === undefined) throw new Error("Expected a durable snapshot.");
+    const history = stored.snapshot.session.history;
+    const reasoning = history.flatMap((message) =>
+      message.role === "assistant" && Array.isArray(message.content)
+        ? message.content.filter((part) => part.type === "reasoning")
+        : [],
+    );
+    expect(reasoning).toMatchObject([
+      { text: "Checking invoice fields.", providerOptions: { openai: { itemId: "rs_1" } } },
+      {
+        text: "Reading the total.",
+        providerOptions: {
+          openai: { itemId: "rs_1", reasoningEncryptedContent: "encrypted-reasoning" },
+        },
+      },
+    ]);
+
+    const second = await first.next({ ...first.session, history });
+    expect(second.next).toBeNull();
+    expect(JSON.stringify(second.session.history)).toContain("The total is 42.");
+    expect(requests).toHaveLength(2);
+    expect(requests[1]?.input).toEqual(
+      expect.arrayContaining([
+        {
+          type: "reasoning",
+          encrypted_content: "encrypted-reasoning",
+          summary: [
+            { type: "summary_text", text: "Checking invoice fields." },
+            { type: "summary_text", text: "Reading the total." },
+          ],
+        },
+        { type: "function_call", call_id: "call_1", name: "get_invoice", arguments: "{}" },
+        expect.objectContaining({
+          type: "function_call_output",
+          call_id: "call_1",
+          output: expect.stringContaining("invoice-1"),
+        }),
+      ]),
+    );
+
+    const followup = await runStep(
+      { ...second.session, history: JSON.parse(JSON.stringify(second.session.history)) },
+      { message: "Confirm the total." },
+    );
+    expect(followup.next).toBeNull();
+    expect(requests).toHaveLength(3);
+    const replayedReasoning = (request: RecordedRequest | undefined) =>
+      request?.input.filter((item) => item.type === "reasoning");
+    expect(replayedReasoning(requests[2])).toEqual(replayedReasoning(requests[1]));
+
+    for (const request of requests) {
+      expect(request.store).toBe(false);
+      expect(request.include).toContain("reasoning.encrypted_content");
+      expect(request.input).not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ id: expect.anything() })]),
+      );
+      expect(request.input).not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: "item_reference" })]),
+      );
+    }
+    expect(warnings).not.toHaveBeenCalled();
+  });
+});
+
+function sseResponse(events: readonly unknown[]): Response {
+  return new Response(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""), {
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+function reasoningAndToolEvents(): unknown[] {
+  const events: unknown[] = [
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { type: "reasoning", id: "rs_1", encrypted_content: null },
+    },
+  ];
+  for (const [summary_index, delta] of [
+    "Checking invoice fields.",
+    "Reading the total.",
+  ].entries()) {
+    events.push(
+      { type: "response.reasoning_summary_part.added", item_id: "rs_1", summary_index },
+      { type: "response.reasoning_summary_text.delta", item_id: "rs_1", summary_index, delta },
+      { type: "response.reasoning_summary_part.done", item_id: "rs_1", summary_index },
+    );
+  }
+  const tool = {
+    type: "function_call",
+    id: "fc_1",
+    call_id: "call_1",
+    name: "get_invoice",
+    arguments: "{}",
+  };
+  return [
+    ...events,
+    {
+      type: "response.output_item.done",
+      output_index: 0,
+      item: { type: "reasoning", id: "rs_1", encrypted_content: "encrypted-reasoning" },
+    },
+    { type: "response.output_item.added", output_index: 1, item: { ...tool, arguments: "" } },
+    {
+      type: "response.function_call_arguments.delta",
+      item_id: "fc_1",
+      output_index: 1,
+      delta: "{}",
+    },
+    { type: "response.output_item.done", output_index: 1, item: { ...tool, status: "completed" } },
+    completedEvent(),
+  ];
+}
+
+function answerEvents(): unknown[] {
+  const item = { type: "message", id: "msg_1", role: "assistant", content: [] };
+  return [
+    { type: "response.output_item.added", output_index: 0, item },
+    {
+      type: "response.output_text.delta",
+      item_id: "msg_1",
+      output_index: 0,
+      delta: "The total is 42.",
+    },
+    { type: "response.output_item.done", output_index: 0, item },
+    completedEvent(),
+  ];
+}
+
+function completedEvent(): unknown {
+  return {
+    type: "response.completed",
+    response: {
+      id: "resp_1",
+      created_at: 0,
+      model: "gpt-5.6-luna",
+      status: "completed",
+      usage: { input_tokens: 10, output_tokens: 10 },
+    },
+  };
+}

--- a/packages/eve/src/public/models/openai/chatgpt/model.test.ts
+++ b/packages/eve/src/public/models/openai/chatgpt/model.test.ts
@@ -122,6 +122,58 @@ describe("Codex model", () => {
     // echoed back, so `include` must carry it whenever reasoning is set.
     expect(body.include).toContain("reasoning.encrypted_content");
   });
+
+  it("groups summaries by reasoning item and preserves encrypted-only items", async () => {
+    const requests: RecordedRequest[] = [];
+    const model = createCodexSubscriptionModel(
+      { model: "gpt-5.6-luna" },
+      {
+        broker: fakeBroker(),
+        fetch: createRecordingFetch(requests),
+      },
+    );
+    const result = await model.doGenerate({
+      prompt: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "reasoning",
+              text: "First summary.",
+              providerOptions: { openai: { itemId: "rs_1" } },
+            },
+            {
+              type: "reasoning",
+              text: "Second summary.",
+              providerOptions: {
+                openai: { itemId: "rs_1", reasoningEncryptedContent: "encrypted-1" },
+              },
+            },
+            {
+              type: "reasoning",
+              text: "",
+              providerOptions: {
+                openai: { itemId: "rs_2", reasoningEncryptedContent: "encrypted-2" },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(JSON.parse(requests[0]?.body ?? "{}").input).toEqual([
+      {
+        type: "reasoning",
+        encrypted_content: "encrypted-1",
+        summary: [
+          { type: "summary_text", text: "First summary." },
+          { type: "summary_text", text: "Second summary." },
+        ],
+      },
+      { type: "reasoning", encrypted_content: "encrypted-2", summary: [] },
+    ]);
+  });
 });
 
 function fakeBroker(): CodexTokenBroker {

--- a/packages/eve/src/public/models/openai/chatgpt/model.ts
+++ b/packages/eve/src/public/models/openai/chatgpt/model.ts
@@ -4,7 +4,6 @@ import type {
   LanguageModelV4CallOptions,
 } from "#compiled/@ai-sdk/provider/index.js";
 import { createCodexFetch, type CodexTransportOptions } from "./transport.js";
-import { isObject } from "#shared/guards.js";
 
 const CODEX_LOCAL_AUTH_API_KEY = "codex-local-auth";
 
@@ -30,8 +29,8 @@ export function createCodexSubscriptionModel(
     name: "codex",
   }).responses(model);
 
-  // The Codex backend rejects stored responses and server-side item ids, so
-  // every call goes through normalizeCodexCallOptions before delegation.
+  // Keep item IDs until the provider has grouped streamed reasoning summaries.
+  // The transport removes them from the stateless request sent to Codex.
   return {
     specificationVersion: openaiModel.specificationVersion,
     provider: openaiModel.provider,
@@ -64,7 +63,7 @@ function normalizeCodexCallOptions(
 
   return {
     ...rest,
-    prompt: stripOpenAIItemIdsFromPrompt(prompt),
+    prompt,
     providerOptions: {
       ...providerOptions,
       openai: {
@@ -90,66 +89,4 @@ function hoistSystemInstructions(prompt: LanguageModelV4CallOptions["prompt"]): 
     instructions: systemContent.join("\n\n"),
     prompt: prompt.filter((message) => message.role !== "system"),
   };
-}
-
-function stripOpenAIItemIdsFromPrompt(
-  prompt: LanguageModelV4CallOptions["prompt"],
-): LanguageModelV4CallOptions["prompt"] {
-  return stripOpenAIItemIds(prompt, new WeakMap()) as LanguageModelV4CallOptions["prompt"];
-}
-
-/**
- * Copy-on-write: rebuilds only the spine of paths that actually carry an
- * OpenAI `itemId`, so untouched prompt content — the bulk of a long
- * conversation, tool outputs, file parts — is shared, not cloned, on every
- * model call.
- */
-function stripOpenAIItemIds(value: unknown, memo: WeakMap<object, unknown>): unknown {
-  if (typeof value !== "object" || value === null) {
-    return value;
-  }
-  const memoized = memo.get(value);
-  if (memoized !== undefined) {
-    return memoized;
-  }
-  // In-progress marker: a cycle resolves to the original reference.
-  memo.set(value, value);
-
-  if (Array.isArray(value)) {
-    let changed = false;
-    const next = value.map((item) => {
-      const stripped = stripOpenAIItemIds(item, memo);
-      if (stripped !== item) changed = true;
-      return stripped;
-    });
-    const result = changed ? next : value;
-    memo.set(value, result);
-    return result;
-  }
-
-  if (!isObject(value)) {
-    return value;
-  }
-
-  let changed = false;
-  const next: Record<string, unknown> = {};
-  for (const [key, entryValue] of Object.entries(value)) {
-    let stripped = stripOpenAIItemIds(entryValue, memo);
-    if (key === "providerOptions" || key === "providerMetadata") {
-      stripped = withoutOpenAIItemId(stripped);
-    }
-    if (stripped !== entryValue) changed = true;
-    next[key] = stripped;
-  }
-  const result = changed ? next : value;
-  memo.set(value, result);
-  return result;
-}
-
-function withoutOpenAIItemId(value: unknown): unknown {
-  if (!isObject(value) || !isObject(value.openai) || !("itemId" in value.openai)) {
-    return value;
-  }
-  const { itemId: _itemId, ...openaiOptions } = value.openai;
-  return { ...value, openai: openaiOptions };
 }

--- a/packages/eve/src/public/models/openai/chatgpt/transport.test.ts
+++ b/packages/eve/src/public/models/openai/chatgpt/transport.test.ts
@@ -44,8 +44,45 @@ describe("Codex direct transport", () => {
       ),
     });
 
+    const body = {
+      stream: true,
+      store: false,
+      input: [
+        {
+          type: "reasoning",
+          id: "rs_1",
+          encrypted_content: "encrypted",
+          summary: [{ type: "summary_text", text: "Checking." }],
+        },
+        {
+          type: "message",
+          id: "msg_1",
+          role: "assistant",
+          content: [{ type: "output_text", text: "Checking." }],
+        },
+        {
+          type: "function_call",
+          id: "fc_1",
+          call_id: "call_1",
+          name: "read",
+          arguments: '{"id":"invoice-1","providerOptions":{"openai":{"itemId":"user-data"}}}',
+        },
+        {
+          type: "function_call_output",
+          call_id: "call_1",
+          output: [
+            {
+              type: "input_image",
+              image_url: "https://example.com/invoice.png",
+              detail: "auto",
+              id: "nested-id",
+            },
+          ],
+        },
+      ],
+    };
     const response = await codexFetch("https://api.openai.com/v1/responses", {
-      body: '{"stream":true}',
+      body: JSON.stringify(body),
       method: "POST",
     });
 
@@ -56,7 +93,15 @@ describe("Codex direct transport", () => {
       "Bearer stale-token",
       "Bearer fresh-token",
     ]);
-    expect(requests.map((request) => request.body)).toEqual(['{"stream":true}', '{"stream":true}']);
+    const expectedBody = {
+      ...body,
+      input: body.input.map(({ id: _id, ...item }) => item),
+    };
+    expect(requests.map((request) => JSON.parse(request.body ?? "{}"))).toEqual([
+      expectedBody,
+      expectedBody,
+    ]);
+    expect(requests[0]?.body).toBe(requests[1]?.body);
   });
 
   it("does not replay a Request body after 401", async () => {

--- a/packages/eve/src/public/models/openai/chatgpt/transport.ts
+++ b/packages/eve/src/public/models/openai/chatgpt/transport.ts
@@ -1,3 +1,4 @@
+import { isObject } from "#shared/guards.js";
 import { getDefaultCodexTokenBroker, type CodexTokenBroker } from "./token-broker.js";
 
 const CODEX_API_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses";
@@ -23,14 +24,38 @@ export function createCodexFetch(options: CodexTransportOptions = {}): Fetch {
 
   return async (input: FetchInput, init?: RequestInit): Promise<Response> => {
     const url = rewriteCodexEndpoint(requestUrl(input), codexApiEndpoint);
+    const requestInit = stripInputItemIds(init);
     const token = await broker.getToken({ reason: "request" });
-    const first = await httpFetch(url, authenticatedInit(input, init, token));
+    const first = await httpFetch(url, authenticatedInit(input, requestInit, token));
     if (first.status !== 401 || !isReplayable(input, init)) return first;
 
     await first.body?.cancel();
     const refreshed = await broker.getToken({ reason: "rejected" });
-    return httpFetch(url, authenticatedInit(input, init, refreshed));
+    return httpFetch(url, authenticatedInit(input, requestInit, refreshed));
   };
+}
+
+function stripInputItemIds(init: RequestInit | undefined): RequestInit | undefined {
+  if (typeof init?.body !== "string") return init;
+
+  let body: unknown;
+  try {
+    body = JSON.parse(init.body);
+  } catch {
+    return init;
+  }
+  if (!isObject(body) || !Array.isArray(body.input)) return init;
+
+  // Only response item IDs are forbidden; tool call IDs and IDs inside tool
+  // inputs or outputs belong to the conversation and must survive replay.
+  let changed = false;
+  for (const item of body.input) {
+    if (isObject(item) && "id" in item) {
+      delete item.id;
+      changed = true;
+    }
+  }
+  return changed ? { ...init, body: JSON.stringify(body) } : init;
 }
 
 export function rewriteCodexEndpoint(input: string, codexApiEndpoint = CODEX_API_ENDPOINT): string {


### PR DESCRIPTION
### Summary

After a streamed ChatGPT tool call, eve removed the shared reasoning item ID before the OpenAI provider could combine its summaries with the encrypted payload. Preserve IDs through provider conversion, then remove only top-level input item IDs at the Codex transport boundary. This preserves all reasoning summaries and encrypted content with `store: false`, while keeping authentication retries and tool call IDs intact.

Closes #2749. Related to the unmerged draft #2750, which proposed the same boundary fix; this PR adds streaming and durable-history regression coverage against current main.

### Validation

- Reproduced the unsupported-reasoning warning with the new unit test before the fix. The streaming integration regression also fails against the original adapter because the first summary is missing.
- `pnpm test:unit` — passed across the workspace; eve passed 7,988 tests with 1 skipped.
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/models/openai/chatgpt` — 22 passed, including authentication, request normalization, encrypted-only reasoning, and 401 replay coverage.
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/public/models/openai/chatgpt/model.integration.test.ts src/harness/tool-loop-stream-retry.integration.test.ts src/harness/tool-loop-generate-approval-resume.integration.test.ts` — 14 passed. The new regression exercises the real Responses stream parser, authored tool execution, serialized durable history, and a later turn using a mocked HTTP endpoint and token broker.
- `pnpm --filter eve typecheck`, `pnpm fmt`, `pnpm lint`, `pnpm guard:invariants`, `pnpm docs:check`, and `git diff --check` — passed. Subsequent test edits also passed scoped formatting, lint, and TypeScript checks.
- `pnpm typecheck` — blocked in the unrelated `agent-tools` fixture build by an internal module-export error for `buildChannelInstrumentationProjection`. An isolated `pnpm --filter agent-tools typecheck` also failed, reporting a missing `isNonEmptyString` export.
- No live ChatGPT subscription request or local e2e run; e2e suites run in CI.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
