### PR TITLE
fix(eve): harness - preserve Claude Gateway prompt caching

### DIFF
--- a/.changeset/stable-gateway-prompt-cache.md
+++ b/.changeset/stable-gateway-prompt-cache.md
@@ -1,0 +1,5 @@
+---
+"eve": minor
+---
+
+Client context now persists in conversation history across tool steps and later turns, following the normal compaction and clear lifecycle instead of disappearing after one model call. Claude requests through AI Gateway now use explicit prompt-cache breakpoints by default, and dynamic skill announcements keep a stable system-prompt position.

--- a/docs/agent-config.md
+++ b/docs/agent-config.md
@@ -112,6 +112,21 @@ The `session.started` runtime identity does not include a model id for a
 dynamic agent. Each public `step.started` event reports the concrete `modelId`
 selected for that model call.
 
+## Prompt caching
+
+For `anthropic/claude-*` models through AI Gateway, eve adds explicit cache
+breakpoints to the tools, system prompt, and conversation. Direct Anthropic
+models use the same breakpoints. Dynamic skill announcements stay in system
+context across steps and turns; changing the announcement still changes that
+prefix.
+
+Other Gateway models use `gateway.caching: "auto"` by default. An explicit
+`modelOptions.providerOptions.gateway.caching` value takes precedence for
+Gateway models: `"auto"` delegates marker placement to Gateway, and `false`
+disables eve's injected markers and automatic caching. Cache hits still depend
+on the provider's minimum prompt length, cache lifetime, and unchanged prompt
+prefixes.
+
 ## Reasoning effort
 
 Set `reasoning` to control the model's reasoning effort through AI SDK's

--- a/docs/guides/client/messages.mdx
+++ b/docs/guides/client/messages.mdx
@@ -59,7 +59,7 @@ const { session, response } = await client.sessions.create({
 await response.result();
 ```
 
-`clientContext` is one-turn context for the next model call. Strings become user-role context messages, arrays of strings become multiple context messages, and objects are JSON-serialized into one context message. It isn't persisted to durable session history and doesn't dispatch a turn by itself.
+`clientContext` adds context before the delivery message. Strings become user-role context messages, arrays of strings become multiple context messages, and objects are JSON-serialized into one context message. These messages persist in session history across tool steps and later turns, until compaction summarizes them or clear removes them. New client context appends to the conversation; it does not replace earlier context or dispatch a turn by itself.
 
 ## Send attachments
 

--- a/docs/guides/frontend/overview.mdx
+++ b/docs/guides/frontend/overview.mdx
@@ -201,7 +201,7 @@ For fully custom state machines, `authorization.required` and `authorization.com
 
 ## Attach page context per turn
 
-`clientContext` adds ephemeral context for the next model call only. Strings (or an array of strings) become user-role context messages; an object is JSON-serialized into one. It rides along with a message or HITL response, so it never dispatches a turn on its own and never lands in durable session history. Pass it in the second argument to `send()` or `respond()`:
+`clientContext` adds client/page context to session history. Strings (or an array of strings) become user-role context messages; an object is JSON-serialized into one. It rides along with a message or HITL response and persists across tool steps and later turns, until compaction summarizes it or clear removes it. New context appends to the conversation without replacing earlier context. It does not dispatch a turn on its own. Pass it in the second argument to `send()` or `respond()`:
 
 ```tsx
 await agent.send("What should I do on this screen?", {

--- a/e2e/fixtures/agent-basic-runtime/evals/runtime/client-context.eval.ts
+++ b/e2e/fixtures/agent-basic-runtime/evals/runtime/client-context.eval.ts
@@ -5,21 +5,28 @@ const SECOND_CLIENT_CONTEXT_TOKEN = "clientctx-second-P9K4";
 const CLIENT_CONTEXT_TOKEN_PATTERN = /\bclientctx-[A-Za-z0-9-]+\b/g;
 
 /**
- * Core session-route runtime behavior: per-turn client context delivery.
+ * Core session-route runtime behavior: durable client context delivery.
  *
  * The first reply omits its context token. The second turn then asks the model
- * to enumerate the token currently visible, proving that only fresh context
- * reaches the model while ordinary session history remains durable.
+ * to enumerate the visible tokens, proving that earlier client context survives
+ * even when the assistant never repeated it in its reply.
  */
 export default defineEval({
   tags: ["real-model"],
-  description: "Session runtime smoke: client context stays turn-local.",
+  description: "Session runtime smoke: client context persists across turns.",
 
   async test(t) {
     const first = await t.send('Acknowledge this context with exactly "READY".', {
       clientContext: [`The client context token is ${FIRST_CLIENT_CONTEXT_TOKEN}.`],
     });
     first.messageIncludes("READY");
+    await t.require(
+      first.message ?? "",
+      satisfies<string>(
+        (message) => !message.includes(FIRST_CLIENT_CONTEXT_TOKEN),
+        "does not repeat the client context token in assistant history",
+      ),
+    );
 
     const second = await t.send(
       "Reply with every token beginning with clientctx- that is visible anywhere in your model input, one per line, and nothing else.",
@@ -41,8 +48,8 @@ export default defineEval({
     await t.require(
       tokens,
       satisfies<readonly string[]>(
-        (observed) => !observed.includes(FIRST_CLIENT_CONTEXT_TOKEN),
-        "does not contain the first turn's client context token",
+        (observed) => observed.filter((token) => token === FIRST_CLIENT_CONTEXT_TOKEN).length === 1,
+        "contains the first turn's client context token exactly once",
       ),
     );
   },

--- a/e2e/fixtures/agent-skills/evals/skills/dynamic-skill.eval.ts
+++ b/e2e/fixtures/agent-skills/evals/skills/dynamic-skill.eval.ts
@@ -12,6 +12,7 @@ export default defineEval({
   tags: ["real-model"],
   description: "Skills smoke: dynamic single-skill resolution.",
   async test(t) {
+    await t.send('Reply with exactly "READY".');
     await t.send("Please use the dynamic tenant policy skill and follow its instructions exactly.");
 
     t.succeeded();

--- a/packages/eve/src/client/eve-agent-store.ts
+++ b/packages/eve/src/client/eve-agent-store.ts
@@ -59,7 +59,7 @@ export interface EveAgentStoreSnapshot<TData> {
  *
  * `onEvent`, `onError`, `onFinish`, and `onSessionChange` are observe-only.
  * `prepareSend` runs before each turn is sent and may return a modified
- * {@link SendTurnPayload} (for example to attach one-turn client context).
+ * {@link SendTurnPayload} (for example to attach client context).
  */
 export interface EveAgentStoreCallbacks<TData> {
   readonly onError?: (error: Error) => void;

--- a/packages/eve/src/client/types.ts
+++ b/packages/eve/src/client/types.ts
@@ -114,12 +114,13 @@ export interface SendTurnOptions<TOutput = unknown> {
   readonly turnPolicy?: TurnPolicy;
 
   /**
-   * Ephemeral client/page context for the next model call only.
+   * Client/page context appended to the conversation before this delivery.
    *
    * Strings are rendered as user-role model context messages. Objects are
    * JSON-serialized into one user-role model context message. Client context
    * rides along with a message or HITL response; it does not dispatch a turn by
-   * itself and is never persisted to durable session history.
+   * itself. It persists in session history across tool steps and later turns,
+   * following the same compaction and clear lifecycle as other user messages.
    */
   readonly clientContext?: string | readonly string[] | JsonObject;
 

--- a/packages/eve/src/harness/prompt-cache.integration.test.ts
+++ b/packages/eve/src/harness/prompt-cache.integration.test.ts
@@ -1,0 +1,138 @@
+import { createGateway, jsonSchema } from "ai";
+import { describe, expect, it, vi } from "vitest";
+
+import { ContextContainer, contextStorage } from "#context/container.js";
+import { PendingSkillAnnouncementKey } from "#context/dynamic-skill-lifecycle.js";
+import { createToolLoopHarness } from "#harness/tool-loop.js";
+import type { HarnessSession, StepInput, ToolLoopHarnessConfig } from "#harness/types.js";
+import { attachClientContext } from "#internal/client-context.js";
+
+interface GatewayRequest {
+  prompt: Array<{ role: string; content: unknown; providerOptions?: unknown }>;
+  tools: Array<{ name: string; providerOptions?: unknown }>;
+  providerOptions?: { gateway?: { caching?: unknown } };
+}
+
+const marker = {
+  anthropic: { cacheControl: { type: "ephemeral" } },
+  bedrock: { cachePoint: { type: "default" } },
+};
+const usage = {
+  inputTokens: { total: 100, noCache: 100, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 5, text: 5, reasoning: 0 },
+};
+
+describe("Gateway prompt cache requests", () => {
+  it.each(["generate", "stream"])(
+    "preserves the prefix across durable %s steps and turns",
+    async (mode) => {
+      const requests: GatewayRequest[] = [];
+      const model = createGateway({
+        apiKey: "test-key",
+        fetch: async (_url, init) => {
+          requests.push(JSON.parse(String(init?.body)) as GatewayRequest);
+          const first = requests.length === 1;
+          const content = first
+            ? [{ type: "tool-call", toolCallId: "call-1", toolName: "add", input: "{}" }]
+            : [{ type: "text", text: "Done." }];
+          const finishReason = { unified: first ? "tool-calls" : "stop", raw: undefined };
+          if (mode === "generate") {
+            return Response.json({ content, finishReason, usage, warnings: [] });
+          }
+          const parts = [
+            { type: "stream-start", warnings: [] },
+            ...(first
+              ? content
+              : [
+                  { type: "text-start", id: "answer" },
+                  { type: "text-delta", id: "answer", delta: "Done." },
+                  { type: "text-end", id: "answer" },
+                ]),
+            { type: "finish", finishReason, usage },
+          ];
+          return new Response(parts.map((part) => `data: ${JSON.stringify(part)}\n\n`).join(""), {
+            headers: { "content-type": "text/event-stream" },
+          });
+        },
+      })("anthropic/claude-sonnet-4.6");
+      const execute = vi.fn(async () => "3");
+      const config: ToolLoopHarnessConfig = {
+        handleEvent: mode === "stream" ? async () => {} : undefined,
+        mode: "conversation",
+        resolveModel: async () => model,
+        tools: new Map([
+          [
+            "add",
+            {
+              name: "add",
+              description: "Add numbers",
+              inputSchema: jsonSchema({ type: "object" }),
+              execute,
+            },
+          ],
+        ]),
+      };
+      const run = (session: HarnessSession, input?: StepInput) => {
+        const ctx = new ContextContainer();
+        ctx.setVirtualContext(
+          PendingSkillAnnouncementKey,
+          "Available skills\n- receipts: Process receipts.",
+        );
+        return contextStorage.run(ctx, () => createToolLoopHarness(config)(session, input));
+      };
+      const session: HarnessSession = {
+        agent: {
+          modelReference: { id: "anthropic/claude-sonnet-4.6" },
+          system: "You are a test assistant.",
+          tools: [{ name: "add", description: "Add numbers", inputSchema: { type: "object" } }],
+        },
+        compaction: { recentWindowSize: 10, threshold: 100_000 },
+        continuationToken: "http:cache-test",
+        history: [],
+        sessionId: "cache-test",
+      };
+
+      const first = await run(
+        session,
+        attachClientContext({ message: "Add the selected numbers." }, ["Client context:\n1 and 2"]),
+      );
+      expect(typeof first.next).toBe("function");
+      const second = await run(JSON.parse(JSON.stringify(first.session)));
+      expect(second.next).toBeNull();
+      await run(
+        JSON.parse(JSON.stringify(second.session)),
+        attachClientContext({ message: "Confirm." }, ["Client context:\n3 and 4"]),
+      );
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(requests).toHaveLength(3);
+
+      // Cache markers advance; the content they delimit must remain identical.
+      const prompts = requests.map(({ prompt }) =>
+        prompt.map(({ role, content }) => ({ role, content })),
+      );
+      expect(prompts[1]!.slice(0, prompts[0]!.length)).toEqual(prompts[0]);
+      expect(prompts[2]!.slice(0, prompts[1]!.length)).toEqual(prompts[1]);
+      for (const request of requests) {
+        expect(request.prompt[0]).toEqual({
+          role: "system",
+          content: "You are a test assistant.\n\nAvailable skills\n- receipts: Process receipts.",
+          providerOptions: marker,
+        });
+        expect(request.prompt.at(-1)?.providerOptions).toEqual(marker);
+        expect(request.tools.at(-1)?.providerOptions).toEqual(marker);
+        expect(request.providerOptions?.gateway?.caching).toBeUndefined();
+        expect(
+          request.prompt.filter((message) =>
+            JSON.stringify(message.content).includes("Client context:\\n1 and 2"),
+          ),
+        ).toHaveLength(1);
+      }
+      expect(requests[1]!.prompt.at(-1)?.role).toBe("tool");
+      expect(requests[1]!.prompt.at(-2)?.providerOptions).toEqual(marker);
+      expect(second.session.history).toContainEqual({
+        role: "user",
+        content: "Client context:\n1 and 2",
+      });
+    },
+  );
+});

--- a/packages/eve/src/harness/prompt-cache.test.ts
+++ b/packages/eve/src/harness/prompt-cache.test.ts
@@ -18,10 +18,26 @@ function makeObjectModel(provider: string, modelId = "test-model"): LanguageMode
 }
 
 describe("detectPromptCachePath", () => {
-  it("returns gateway-auto for any string model id", () => {
+  it("returns gateway-anthropic for Claude gateway model ids", () => {
     expect(detectPromptCachePath("anthropic/claude-sonnet-4-5")).toEqual({
+      kind: "gateway-anthropic",
+    });
+  });
+
+  it("recognizes resolved gateway models", () => {
+    expect(
+      detectPromptCachePath(makeObjectModel("gateway", "anthropic/claude-sonnet-4.6")),
+    ).toEqual({
+      kind: "gateway-anthropic",
+    });
+    expect(
+      detectPromptCachePath(makeObjectModel("gateway.language-model", "openai/gpt-5")),
+    ).toEqual({
       kind: "gateway-auto",
     });
+  });
+
+  it("returns gateway-auto for other string model ids", () => {
     expect(detectPromptCachePath("bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0")).toEqual({
       kind: "gateway-auto",
     });
@@ -29,6 +45,23 @@ describe("detectPromptCachePath", () => {
       kind: "gateway-auto",
     });
     expect(detectPromptCachePath("openai/gpt-5")).toEqual({ kind: "gateway-auto" });
+  });
+
+  it.each([false, "auto"])("respects explicit gateway caching %j", (caching) => {
+    for (const model of [
+      "anthropic/claude-sonnet-4.6",
+      makeObjectModel("gateway", "anthropic/claude-sonnet-4.6"),
+    ]) {
+      expect(detectPromptCachePath(model, { gateway: { caching } })).toEqual({
+        kind: "gateway-auto",
+      });
+    }
+  });
+
+  it("does not infer Anthropic from another provider's model name", () => {
+    expect(
+      detectPromptCachePath(makeObjectModel("openai-compatible", "anthropic/claude-sonnet-4.6")),
+    ).toEqual({ kind: "none" });
   });
 
   it("returns anthropic-direct for a direct Anthropic provider instance", () => {

--- a/packages/eve/src/harness/prompt-cache.ts
+++ b/packages/eve/src/harness/prompt-cache.ts
@@ -5,11 +5,12 @@ import type { LanguageModel, ModelMessage, SystemModelMessage, ToolSet } from "a
  */
 export type PromptCachePath =
   | { readonly kind: "gateway-auto" }
+  | { readonly kind: "gateway-anthropic" }
   | { readonly kind: "anthropic-direct" }
   | { readonly kind: "none" };
 
 /**
- * Cache marker injected on the Anthropic-direct path.
+ * Cache marker injected for Anthropic models, including AI Gateway.
  *
  * The marker carries two provider namespaces because Anthropic models are
  * reachable through providers that read different provider-options keys:
@@ -21,7 +22,7 @@ export type PromptCachePath =
  *   Converse provider, which does not understand `anthropic.cacheControl`.
  *
  * A provider ignores namespaces it does not own, so carrying both is safe on
- * every Anthropic-direct request regardless of which provider serves it.
+ * every Anthropic request regardless of which provider serves it.
  */
 export interface AnthropicCacheMarker {
   readonly anthropic: {
@@ -33,7 +34,7 @@ export interface AnthropicCacheMarker {
 }
 
 /**
- * Shared frozen marker. All direct-Anthropic breakpoints in the harness share
+ * Shared frozen marker. All Anthropic breakpoints in the harness share
  * this instance to avoid allocating per-message.
  */
 const ANTHROPIC_CACHE_MARKER: AnthropicCacheMarker = Object.freeze({
@@ -50,12 +51,30 @@ const ANTHROPIC_CACHE_MARKER: AnthropicCacheMarker = Object.freeze({
  *
  * Runs once per harness step right after `resolveModel()`.
  */
-export function detectPromptCachePath(model: LanguageModel): PromptCachePath {
-  if (typeof model === "string") {
+export function detectPromptCachePath(
+  model: LanguageModel,
+  providerOptions?: Readonly<Record<string, unknown>>,
+): PromptCachePath {
+  const providerName =
+    typeof model !== "string" && typeof model.provider === "string"
+      ? model.provider.toLowerCase()
+      : "";
+  const modelId =
+    typeof model === "string"
+      ? model.toLowerCase()
+      : typeof model.modelId === "string"
+        ? model.modelId.toLowerCase()
+        : "";
+  if (typeof model === "string" || providerName.split(".")[0] === "gateway") {
+    // An explicit gateway strategy (including opt-out) takes precedence over
+    // eve's breakpoints. Do not combine automatic and manual cache markers.
+    const gateway = providerOptions?.gateway as Record<string, unknown> | undefined;
+    if (modelId.startsWith("anthropic/claude-") && gateway?.caching == null) {
+      return { kind: "gateway-anthropic" };
+    }
     return { kind: "gateway-auto" };
   }
 
-  const providerName = typeof model.provider === "string" ? model.provider.toLowerCase() : "";
   if (providerName.includes("anthropic")) {
     return { kind: "anthropic-direct" };
   }
@@ -64,7 +83,6 @@ export function detectPromptCachePath(model: LanguageModel): PromptCachePath {
   // provider as `amazon-bedrock` and carries the Anthropic identity in the
   // model id (e.g. `anthropic.claude-3-5-sonnet-20241022-v2:0`), so it must be
   // matched on the model id rather than the provider name.
-  const modelId = typeof model.modelId === "string" ? model.modelId.toLowerCase() : "";
   if (providerName.includes("bedrock") && modelId.includes("anthropic")) {
     return { kind: "anthropic-direct" };
   }
@@ -73,8 +91,7 @@ export function detectPromptCachePath(model: LanguageModel): PromptCachePath {
 }
 
 /**
- * Returns the shared Anthropic cache marker used on the `anthropic-direct`
- * path. Exposed for unit tests and for the harness wiring layer.
+ * Returns the shared Anthropic cache marker for direct and Gateway requests.
  */
 export function getAnthropicCacheMarker(): AnthropicCacheMarker {
   return ANTHROPIC_CACHE_MARKER;
@@ -111,7 +128,7 @@ export function mergeGatewayAutoCaching(
 
 /**
  * Returns a new ToolSet where the last tool entry carries the Anthropic
- * cache marker on `providerOptions`. Used on the `anthropic-direct` path
+ * cache marker on `providerOptions`. Used for direct and Gateway requests
  * to place a stable breakpoint at the end of the tools block, caching the
  * full tool definitions across every turn.
  *
@@ -153,11 +170,7 @@ export function applyLastToolCacheBreakpoint(
 /**
  * Marks the last system message in an instructions array with the Anthropic
  * cache marker. This creates a cache breakpoint at the end of the system
- * prompt, preserving the system prefix when tools change between steps.
- *
- * When `instructions` is a string or undefined, returns it unchanged —
- * single-string system prompts don't support per-message providerOptions.
- * No-op when the array is empty.
+ * prompt. No-op when the array is empty.
  */
 export function applySystemCacheBreakpoint(
   instructions: readonly SystemModelMessage[],

--- a/packages/eve/src/harness/step-hooks.ts
+++ b/packages/eve/src/harness/step-hooks.ts
@@ -174,7 +174,7 @@ export function buildStepHooks(input: StepHooksInput): StepHooks {
       );
     }
 
-    if (input.cachePath.kind === "anthropic-direct" && input.marker) {
+    if (input.marker) {
       processed = applyConversationCacheControl([...messages], input.marker);
     }
 

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -14,6 +14,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { ContextContainer, contextStorage } from "#context/container.js";
 import { DynamicModelSelectionError } from "#context/dynamic-model-lifecycle.js";
 import { dispatchDynamicInstructionEvent } from "#context/dynamic-instruction-lifecycle.js";
+import { PendingSkillAnnouncementKey } from "#context/dynamic-skill-lifecycle.js";
 import {
   AuthKey,
   ChannelInstrumentationKey,
@@ -1166,7 +1167,7 @@ describe("createToolLoopHarness", () => {
     const messages = agent.generate.mock.calls[0]?.[0].messages as ModelMessage[];
     // The volatile listing stays out of the system prompt (prompt cache) and
     // rides history as a labeled, framework-injected user message.
-    expect(instructions).toBe("You are a test assistant.");
+    expect(instructions).toMatchObject({ role: "system", content: "You are a test assistant." });
     expect(messages).toContainEqual({
       content: expect.stringContaining(
         '<agent id="ag_research:123456789012" name="research">waiting</agent>',
@@ -5054,7 +5055,9 @@ describe("createToolLoopHarness", () => {
     it("retries with the offending tool dropped and a one-shot system note", async () => {
       const resolveRuntimeContext = vi.fn((input: InstrumentationStepStartedEventInput) => ({
         runtimeContext: {
-          "test.attempt": typeof input.modelInput.instructions === "string" ? "original" : "retry",
+          "test.attempt": JSON.stringify(input.modelInput.instructions).includes("has been removed")
+            ? "retry"
+            : "original",
         },
       }));
       declareTelemetry(
@@ -5671,7 +5674,7 @@ describe("createToolLoopHarness", () => {
       model: null,
       context: undefined,
     });
-    expect(stepResult.providerOptions).toEqual({ gateway: { caching: "auto" } });
+    expect(stepResult.providerOptions).toBeUndefined();
   });
 
   it("emits assistant/tool events in response order when a step completes after tool work", async () => {
@@ -8710,7 +8713,7 @@ describe("createToolLoopHarness", () => {
       },
       role: "user",
     });
-    expect(secondResult.session.history).not.toContainEqual({
+    expect(secondResult.session.history).toContainEqual({
       content: ephemeralContext,
       role: "user",
     });
@@ -10143,7 +10146,7 @@ describe("createToolLoopHarness", () => {
 
         return {
           instructions: structuredClone(settings.instructions),
-          messages: structuredClone(prepared.messages ?? call.messages),
+          messages: structuredClone(call.messages),
           providerOptions: structuredClone(prepared.providerOptions),
           tools: Object.entries(settings.tools ?? {}).map(([name, tool]) => ({
             description: structuredClone(tool.description),
@@ -10254,14 +10257,23 @@ describe("createToolLoopHarness", () => {
           ],
         },
       });
-      const runStep = createToolLoopHarness(config);
+      const ctx = new ContextContainer();
+      const announcement = "Available skills\n- receipts: Process receipts.";
+      ctx.setVirtualContext(PendingSkillAnnouncementKey, announcement);
+      const runStep = (
+        session: HarnessSession,
+        input?: Parameters<ReturnType<typeof createToolLoopHarness>>[1],
+      ) => contextStorage.run(ctx, () => createToolLoopHarness(config)(session, input));
 
       setupMockAgent(modelResults[0]!);
-      const firstStep = await runStep(session, { message: "Add 1 and 2." });
-      expect(firstStep.next).toBe(runStep);
+      const firstStep = await runStep(
+        session,
+        attachClientContext({ message: "Add 1 and 2." }, ["Client context:\nselected numbers"]),
+      );
+      expect(typeof firstStep.next).toBe("function");
 
       setupMockAgent(modelResults[1]!);
-      const secondStep = await runStep(firstStep.session);
+      const secondStep = await runStep(JSON.parse(JSON.stringify(firstStep.session)));
       expect(secondStep.next).toBeNull();
 
       setupMockAgent(modelResults[2]!);
@@ -10280,11 +10292,16 @@ describe("createToolLoopHarness", () => {
       expect(nextTurnPrompt.messages.slice(0, secondPrompt.messages.length)).toEqual(
         secondPrompt.messages,
       );
-      expect(modelCalls.map((call) => call.instructions)).toEqual([
-        "You are a test assistant.",
-        "You are a test assistant.",
-        "You are a test assistant.",
-      ]);
+      expect(modelCalls.map((call) => call.instructions)).toEqual(
+        Array.from({ length: 3 }, () => ({
+          role: "system",
+          content: `You are a test assistant.\n\n${announcement}`,
+          providerOptions: {
+            anthropic: { cacheControl: { type: "ephemeral" } },
+            bedrock: { cachePoint: { type: "default" } },
+          },
+        })),
+      );
       expect(firstPrompt.tools).toEqual([
         {
           description: "Adds numbers",
@@ -10296,7 +10313,10 @@ describe("createToolLoopHarness", () => {
           description: "Looks up a saved result",
           inputSchema: { type: "object" },
           name: "lookup",
-          providerOptions: undefined,
+          providerOptions: {
+            anthropic: { cacheControl: { type: "ephemeral" } },
+            bedrock: { cachePoint: { type: "default" } },
+          },
         },
       ]);
       expect(modelCalls.map((call) => call.tools)).toEqual([
@@ -10305,14 +10325,23 @@ describe("createToolLoopHarness", () => {
         firstPrompt.tools,
       ]);
       expect(modelCalls.map((call) => call.providerOptions)).toEqual([
-        { gateway: { caching: "auto" } },
-        { gateway: { caching: "auto" } },
-        { gateway: { caching: "auto" } },
+        undefined,
+        undefined,
+        undefined,
       ]);
       expect(modelCalls.map((call) => call.messages)).toEqual([
-        [{ content: "Add 1 and 2.", role: "user" }],
-        [{ content: "Add 1 and 2.", role: "user" }, toolCallMessage, toolResultMessage],
         [
+          { content: "Client context:\nselected numbers", role: "user" },
+          { content: "Add 1 and 2.", role: "user" },
+        ],
+        [
+          { content: "Client context:\nselected numbers", role: "user" },
+          { content: "Add 1 and 2.", role: "user" },
+          toolCallMessage,
+          toolResultMessage,
+        ],
+        [
+          { content: "Client context:\nselected numbers", role: "user" },
           { content: "Add 1 and 2.", role: "user" },
           toolCallMessage,
           toolResultMessage,
@@ -10381,11 +10410,11 @@ describe("createToolLoopHarness", () => {
       });
     });
 
-    it("gateway-auto path: merges gateway.caching='auto' into providerOptions for string model ids", async () => {
+    it("gateway-auto path: merges gateway.caching='auto' into providerOptions for other model ids", async () => {
       setupStopResult();
       const config: ToolLoopHarnessConfig = {
         mode: "conversation",
-        resolveModel: vi.fn().mockResolvedValue("anthropic/claude-sonnet-4-5"),
+        resolveModel: vi.fn().mockResolvedValue("openai/gpt-5"),
         tools: new Map([
           [
             "add",
@@ -10461,66 +10490,73 @@ describe("createToolLoopHarness", () => {
         context: undefined,
       });
       expect(stepResult.providerOptions).toEqual({
-        gateway: { order: ["anthropic", "bedrock"], caching: "auto" },
+        gateway: { order: ["anthropic", "bedrock"] },
       });
     });
 
-    it("gateway-auto path: respects author override of gateway.caching", async () => {
-      setupStopResult();
-      const session = createTestSession({
-        agent: {
-          modelReference: {
-            id: "anthropic/claude-sonnet-4-5",
-            providerOptions: { gateway: { caching: false } },
-          },
-          system: "",
-          tools: [{ description: "Adds numbers", name: "add", inputSchema: { type: "object" } }],
-        },
-      });
-      const config: ToolLoopHarnessConfig = {
-        mode: "conversation",
-        resolveModel: vi.fn().mockResolvedValue("anthropic/claude-sonnet-4-5"),
-        tools: new Map([
-          [
-            "add",
-            {
-              description: "Adds numbers",
-              execute: vi.fn(),
-              inputSchema: jsonSchema({ type: "object" }),
-              name: "add",
+    it.each([false, "auto"])(
+      "gateway-auto path: respects author override of gateway.caching=%j",
+      async (caching) => {
+        setupStopResult();
+        const session = createTestSession({
+          agent: {
+            modelReference: {
+              id: "anthropic/claude-sonnet-4-5",
+              providerOptions: { gateway: { caching } },
             },
-          ],
-        ]),
-      };
-      const runStep = createToolLoopHarness(config);
-      await runStep(session, { message: "hi" });
+            system: "",
+            tools: [{ description: "Adds numbers", name: "add", inputSchema: { type: "object" } }],
+          },
+        });
+        const config: ToolLoopHarnessConfig = {
+          mode: "conversation",
+          resolveModel: vi.fn().mockResolvedValue("anthropic/claude-sonnet-4-5"),
+          tools: new Map([
+            [
+              "add",
+              {
+                description: "Adds numbers",
+                execute: vi.fn(),
+                inputSchema: jsonSchema({ type: "object" }),
+                name: "add",
+              },
+            ],
+          ]),
+        };
+        const runStep = createToolLoopHarness(config);
+        await runStep(session, { message: "hi" });
 
-      const agentCall = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0];
-      // providerOptions is now returned by prepareStep, not set on the constructor
-      const prepareStep = getPrepareStep<unknown[], { providerOptions?: unknown }>(
-        agentCall?.prepareStep,
-      );
-      const stepResult = await prepareStep({
-        messages: [],
-        stepNumber: 0,
-        steps: [],
-        model: null,
-        context: undefined,
-      });
-      expect(stepResult.providerOptions).toEqual({
-        gateway: { caching: false },
-      });
-    });
+        const agentCall = vi.mocked(ToolLoopAgent).mock.calls[0]?.[0];
+        // providerOptions is now returned by prepareStep, not set on the constructor
+        const prepareStep = getPrepareStep<unknown[], { providerOptions?: unknown }>(
+          agentCall?.prepareStep,
+        );
+        const stepResult = await prepareStep({
+          messages: [],
+          stepNumber: 0,
+          steps: [],
+          model: null,
+          context: undefined,
+        });
+        expect(stepResult.providerOptions).toEqual({
+          gateway: { caching },
+        });
+        expect(agentCall?.instructions).toBe("");
+        expect(
+          Object.values(agentCall?.tools ?? {}).every((tool) => tool.providerOptions === undefined),
+        ).toBe(true);
+      },
+    );
 
-    it("anthropic-direct path: adds prepareStep and marks the last tool", async () => {
+    it.each([
+      "anthropic/claude-sonnet-4-5",
+      { provider: "gateway", modelId: "anthropic/claude-sonnet-4-5", specificationVersion: "v3" },
+      { provider: "anthropic.messages", modelId: "claude-sonnet-4-5", specificationVersion: "v3" },
+    ])("marks system, tools, and conversation for %j", async (model) => {
       setupStopResult();
       const config: ToolLoopHarnessConfig = {
         mode: "conversation",
-        resolveModel: vi.fn().mockResolvedValue({
-          provider: "anthropic.messages",
-          modelId: "claude-sonnet-4-5",
-          specificationVersion: "v3",
-        } as unknown as LanguageModel),
+        resolveModel: vi.fn().mockResolvedValue(model),
         tools: new Map([
           [
             "add",
@@ -10549,6 +10585,41 @@ describe("createToolLoopHarness", () => {
         anthropic: { cacheControl: { type: "ephemeral" } },
         bedrock: { cachePoint: { type: "default" } },
       });
+      expect(agentCall?.instructions).toEqual({
+        role: "system",
+        content: "You are a test assistant.",
+        providerOptions: lastTool?.providerOptions,
+      });
+      const prepareStep = getPrepareStep<
+        ModelMessage[],
+        { messages: ModelMessage[]; providerOptions?: unknown }
+      >(agentCall?.prepareStep);
+      const messages: ModelMessage[] = [
+        { role: "user", content: "hi" },
+        { role: "assistant", content: "working" },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call-1",
+              toolName: "add",
+              output: { type: "text", value: "42" },
+            },
+          ],
+        },
+      ];
+      const prepared = await prepareStep({
+        messages,
+        stepNumber: 0,
+        steps: [],
+        model: null,
+        context: undefined,
+      });
+      expect(prepared.messages[0]?.providerOptions).toBeUndefined();
+      expect(prepared.messages[1]?.providerOptions).toEqual(lastTool?.providerOptions);
+      expect(prepared.messages[2]?.providerOptions).toEqual(lastTool?.providerOptions);
+      expect(prepared.providerOptions).toBeUndefined();
     });
 
     it("anthropic-direct path: prepareStep marks last user and last assistant messages", async () => {
@@ -12130,6 +12201,36 @@ describe("createToolLoopHarness", () => {
       expect(messages.at(-1)).toEqual({ role: "user", content: "Hi" });
     });
 
+    it.each([0, 1])(
+      "keeps dynamic skill announcements in system context throughout turn %i",
+      async (sequence) => {
+        setupMockAgent(defaultModelResult());
+        const config = createTestConfig("conversation");
+        const ctx = new ContextContainer();
+        const announcement = "Available skills\n- receipts: Process receipts.";
+        ctx.setVirtualContext(PendingSkillAnnouncementKey, announcement);
+        let session = setHarnessEmissionState(createTestSession(), {
+          sequence,
+          sessionStarted: true,
+          stepIndex: 0,
+          turnId: `turn_${sequence}`,
+        });
+
+        for (const input of [{ message: "Hi" }, undefined, { message: "Again" }]) {
+          const result = await contextStorage.run(ctx, () =>
+            createToolLoopHarness(config)(session, input),
+          );
+          const { instructions, messages } = getLastAgentSettings();
+          expect(instructions).toEqual({
+            role: "system",
+            content: `You are a test assistant.\n\n${announcement}`,
+          });
+          expect(messages).not.toContainEqual({ role: "user", content: announcement });
+          session = result.session;
+        }
+      },
+    );
+
     it("persists context strings in session history as user messages", async () => {
       setupMockAgent(defaultModelResult());
       const runStep = createToolLoopHarness(createTestConfig("conversation"));
@@ -12147,11 +12248,12 @@ describe("createToolLoopHarness", () => {
       ]);
     });
 
-    it("does not replay ephemeral client context on later turns", async () => {
+    it("retains client context in the conversation prefix on later turns", async () => {
       setupMockAgent(defaultModelResult());
       const runStep = createToolLoopHarness(createTestConfig("conversation"));
       let session = createTestSession();
 
+      const expectedContext: ModelMessage[] = [];
       for (const token of ["CTX-A", "CTX-B", "CTX-C"]) {
         const clientContext = `Client context:\n${token}`;
         const result = await runStep(
@@ -12163,8 +12265,9 @@ describe("createToolLoopHarness", () => {
             typeof message.content === "string" && message.content.startsWith("Client context:"),
         );
 
-        expect(visibleClientContext).toEqual([{ content: clientContext, role: "user" }]);
-        expect(result.session.history).not.toContainEqual({
+        expectedContext.push({ content: clientContext, role: "user" });
+        expect(visibleClientContext).toEqual(expectedContext);
+        expect(result.session.history).toContainEqual({
           content: clientContext,
           role: "user",
         });
@@ -12172,7 +12275,7 @@ describe("createToolLoopHarness", () => {
       }
     });
 
-    it("keeps ephemeral client context out of compaction and its token baseline", async () => {
+    it("includes client context in compaction and its token baseline", async () => {
       vi.mocked(shouldCompact).mockReturnValueOnce(true);
       vi.mocked(compactMessages).mockImplementationOnce(async (messages) => [...messages]);
       setupMockAgent({
@@ -12199,14 +12302,17 @@ describe("createToolLoopHarness", () => {
       );
       expect(vi.mocked(compactMessages).mock.calls[0]?.[0]).toEqual([
         { content: "earlier", role: "user" },
+        { content: "Client context:\ncurrent", role: "user" },
         { content: "Hi", role: "user" },
       ]);
-      expect(result.session.history).not.toContainEqual({
+      expect(result.session.history).toContainEqual({
         content: "Client context:\ncurrent",
         role: "user",
       });
-      expect(result.session.compaction).not.toHaveProperty("lastKnownInputTokens");
-      expect(result.session.compaction).not.toHaveProperty("lastKnownPromptMessageCount");
+      expect(result.session.compaction).toMatchObject({
+        lastKnownInputTokens: 321,
+        lastKnownPromptMessageCount: 3,
+      });
     });
 
     it("leaves instructions unchanged when no context is provided", async () => {

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -934,11 +934,10 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     // --- Turn preamble ------------------------------------------------------
 
     const clientContext = readClientContext(effectiveStepInput);
-    const ephemeralContextMessages: ModelMessage[] =
+    const preparedTurnInput: ModelMessage[] =
       clientContext === undefined || pending.deferredContext === true
         ? []
         : clientContext.map((content) => ({ content, role: "user" }));
-    const preparedTurnInput: ModelMessage[] = [];
     if (effectiveStepInput?.context !== undefined && pending.deferredContext !== true) {
       for (const entry of effectiveStepInput.context) {
         preparedTurnInput.push({ content: entry, role: "user" });
@@ -963,7 +962,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         );
         prepareMemoryPreamble(store, {
           history: pending.messages,
-          input: [...ephemeralContextMessages, ...preparedTurnInput],
+          input: preparedTurnInput,
           state: pending.session.state,
         });
       }
@@ -1061,17 +1060,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
 
     messages = [...messages, ...preparedTurnInput];
 
-    const createModelMessages = (durableMessages: readonly ModelMessage[]): ModelMessage[] => {
-      if (ephemeralContextMessages.length === 0) return [...durableMessages];
-
-      const insertionIndex = Math.max(0, durableMessages.length - preparedTurnInput.length);
-      return [
-        ...durableMessages.slice(0, insertionIndex),
-        ...ephemeralContextMessages,
-        ...durableMessages.slice(insertionIndex),
-      ];
-    };
-    let projectedMessages = projectHistory(createModelMessages(messages), session.state);
+    let projectedMessages = projectHistory(messages, session.state);
 
     // --- Model + tools ------------------------------------------------------
 
@@ -1104,8 +1093,14 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     session = resolvedModel.session;
     const model = resolvedModel.model;
 
-    const cachePath = detectPromptCachePath(model);
-    const marker = cachePath.kind === "anthropic-direct" ? getAnthropicCacheMarker() : undefined;
+    const cachePath = detectPromptCachePath(
+      model,
+      requireSessionModelReference(session).providerOptions,
+    );
+    const marker =
+      cachePath.kind === "anthropic-direct" || cachePath.kind === "gateway-anthropic"
+        ? getAnthropicCacheMarker()
+        : undefined;
 
     // --- Compaction ---------------------------------------------------------
     //
@@ -1122,7 +1117,6 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       messages: [...messages],
       model,
       onCompaction: config.onCompaction,
-      promptMessages: createModelMessages(messages),
       resolveModel: config.resolveModel,
       runtimeIdentity: config.runtimeIdentity,
       session,
@@ -1132,9 +1126,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     if (compaction.compacted) {
       messages = compaction.messages;
     }
-    projectedMessages = normalizeModelMessages(
-      projectHistory(createModelMessages(messages), session.state),
-    );
+    projectedMessages = normalizeModelMessages(projectHistory(messages, session.state));
 
     if (emit) {
       await emitStepStarted(
@@ -1174,7 +1166,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       currentMessages.addSystem(buildDynamicInstructionMessages(ctx));
       const skillAnnouncement = ctx.get(PendingSkillAnnouncementKey);
       if (skillAnnouncement !== undefined && skillAnnouncement.length > 0) {
-        currentMessages.add(emissionState.sequence, skillAnnouncement);
+        currentMessages.addSystem({ role: "system", content: skillAnnouncement });
       }
       const taskState = ctx.get(TurnTaskStateKey);
       if (taskState !== undefined) {
@@ -1203,7 +1195,9 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         ? [{ role: "system" as const, content: session.agent.system }]
         : [];
       const rawInstructions =
-        currentMessages.systemMessages.length > 0 || extraSystemEntry.length > 0
+        marker !== undefined ||
+        currentMessages.systemMessages.length > 0 ||
+        extraSystemEntry.length > 0
           ? [...extraSystemEntry, ...baseSystemEntry, ...currentMessages.systemMessages]
           : undefined;
       const markedInstructions =
@@ -1778,8 +1772,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       config,
       emit,
       emissionState,
-      durableModelPromptMessageCount:
-        ephemeralContextMessages.length === 0 ? projectedMessages.length : undefined,
+      durableModelPromptMessageCount: projectedMessages.length,
       promptMessages: messages,
       result,
       runStep,
@@ -3069,8 +3062,6 @@ async function maybeCompact(input: {
   readonly messages: ModelMessage[];
   readonly model: LanguageModel;
   readonly onCompaction?: ToolLoopHarnessConfig["onCompaction"];
-  /** Model-visible prompt used only to decide whether durable history needs compaction. */
-  readonly promptMessages?: readonly ModelMessage[];
   readonly resolveModel: ToolLoopHarnessConfig["resolveModel"];
   readonly runtimeIdentity?: ToolLoopHarnessConfig["runtimeIdentity"];
   readonly session: HarnessSession;
@@ -3083,9 +3074,8 @@ async function maybeCompact(input: {
   const { emit, emissionState } = input;
   let messages = input.messages;
   let session = input.session;
-  const promptMessages = input.promptMessages ?? messages;
   const projectedPromptMessages =
-    input.historyProjector?.({ messages: promptMessages, state: session.state }) ?? promptMessages;
+    input.historyProjector?.({ messages, state: session.state }) ?? messages;
   const needsSummary =
     input.force === true || shouldCompact(projectedPromptMessages, session.compaction);
   const needsMemoryCanonicalization = shouldCanonicalizeMemory(messages);

--- a/packages/eve/src/protocol/message.ts
+++ b/packages/eve/src/protocol/message.ts
@@ -140,8 +140,8 @@ export interface RuntimeTraceContext {
  * `message` is either a plain text string or an AI SDK `UserContent`
  * array (mixing `text`, `image`, and `file` parts). Clients pass
  * multimodal attachments with the same shape AI SDK's `useChat`
- * `sendMessage({ files })` produces. `clientContext` is one-turn
- * client/page context; the channel converts it into internal model context.
+ * `sendMessage({ files })` produces. `clientContext` is
+ * client/page context appended to durable conversation history as user messages.
  */
 export type HandleMessageRequestBody =
   | {


### PR DESCRIPTION
### Summary

Claude tool loops through AI Gateway lose reusable prompt prefixes when client context disappears after the first call and dynamic skill announcements move through the conversation. Persist client context as user history, keep skill announcements in system context, and apply explicit cache breakpoints to Claude Gateway requests, including resolved Gateway model objects. Plain-string system prompts now receive a breakpoint too; explicit Gateway caching overrides still take precedence.

The client-context lifetime change is breaking: earlier context remains available across tool steps and later turns, following normal compaction and clear behavior. The docs and minor changeset describe this change. Related to #2841, which overlaps the dynamic-skill announcement placement fix.

### Validation

- `pnpm build`
- `pnpm fmt` and `pnpm lint`
- `pnpm typecheck` — all 43 workspace tasks passed
- `pnpm test:unit` — all workspace unit tasks passed; eve: 7,997 passed, 1 skipped
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/harness/prompt-cache.test.ts src/harness/tool-loop.test.ts src/harness/prompt-cache-accounting.test.ts` — 275 passed
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/harness/prompt-cache.integration.test.ts src/harness/tool-loop-generate-approval-resume.integration.test.ts` — 13 passed
- `pnpm docs:check` and `pnpm guard:invariants`

The new integration test captures serialized requests from the real AI SDK Gateway provider with a stubbed transport, covering streaming, generation, tool continuation, and a later user turn. It verifies stable prompt content and system/tool/conversation cache markers. Regressions failed before the corresponding fixes. Live provider cache-hit rates were not measured. Updated client-context and dynamic-skill evals run only in CI.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
