### PR TITLE
fix(eve): preserve client context for its entire turn

### DIFF
--- a/.changeset/steady-client-context.md
+++ b/.changeset/steady-client-context.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Keep client context available across every model step in its turn while excluding it from later turns and durable conversation history.

--- a/docs/guides/client/messages.mdx
+++ b/docs/guides/client/messages.mdx
@@ -59,7 +59,7 @@ const { session, response } = await client.sessions.create({
 await response.result();
 ```
 
-`clientContext` is one-turn context for the next model call. Strings become user-role context messages, arrays of strings become multiple context messages, and objects are JSON-serialized into one context message. It isn't persisted to durable session history and doesn't dispatch a turn by itself.
+`clientContext` is ephemeral context for the current turn. Strings become user-role context messages, arrays of strings become multiple context messages, and objects are JSON-serialized into one context message. The context remains available to every model call in the turn, then disappears before the next turn. It isn't persisted to durable session history and doesn't dispatch a turn by itself.
 
 ## Send attachments
 

--- a/docs/guides/frontend/overview.mdx
+++ b/docs/guides/frontend/overview.mdx
@@ -201,7 +201,7 @@ For fully custom state machines, `authorization.required` and `authorization.com
 
 ## Attach page context per turn
 
-`clientContext` adds ephemeral context for the next model call only. Strings (or an array of strings) become user-role context messages; an object is JSON-serialized into one. It rides along with a message or HITL response, so it never dispatches a turn on its own and never lands in durable session history. Pass it in the second argument to `send()` or `respond()`:
+`clientContext` adds ephemeral context for the current turn. Strings (or an array of strings) become user-role context messages; an object is JSON-serialized into one. The context remains available to every model call in the turn, then disappears before the next turn. It rides along with a message or HITL response, so it never dispatches a turn on its own and never lands in durable session history. Pass it in the second argument to `send()` or `respond()`:
 
 ```tsx
 await agent.send("What should I do on this screen?", {

--- a/packages/eve/src/client/types.ts
+++ b/packages/eve/src/client/types.ts
@@ -114,12 +114,13 @@ export interface SendTurnOptions<TOutput = unknown> {
   readonly turnPolicy?: TurnPolicy;
 
   /**
-   * Ephemeral client/page context for the next model call only.
+   * Ephemeral client/page context for the current turn.
    *
    * Strings are rendered as user-role model context messages. Objects are
    * JSON-serialized into one user-role model context message. Client context
    * rides along with a message or HITL response; it does not dispatch a turn by
-   * itself and is never persisted to durable session history.
+   * itself, remains available to every model call in the turn, and is never
+   * persisted to durable session history or exposed to later turns.
    */
   readonly clientContext?: string | readonly string[] | JsonObject;
 

--- a/packages/eve/src/harness/emission-state.ts
+++ b/packages/eve/src/harness/emission-state.ts
@@ -1,4 +1,5 @@
 import type { HarnessSession, SessionStateMap } from "#harness/types.js";
+import { clearTurnClientContextState } from "#harness/turn-client-context.js";
 
 /**
  * Tracks emission lifecycle state across harness step invocations.
@@ -44,10 +45,11 @@ export function setHarnessEmissionState(
   session: HarnessSession,
   state: HarnessEmissionState,
 ): HarnessSession {
+  const scopedSession = state.turnId === "" ? clearTurnClientContextState(session) : session;
   return {
-    ...session,
+    ...scopedSession,
     state: {
-      ...session.state,
+      ...scopedSession.state,
       [HARNESS_EMISSION_STATE_KEY]: state,
     },
   };

--- a/packages/eve/src/harness/emission.test.ts
+++ b/packages/eve/src/harness/emission.test.ts
@@ -9,6 +9,10 @@ import {
   setHarnessEmissionState,
 } from "#harness/emission.js";
 import type { HarnessToolDefinition } from "#harness/execute-tool.js";
+import {
+  getTurnClientContextState,
+  setTurnClientContextState,
+} from "#harness/turn-client-context.js";
 import type { HarnessEmitFn, HarnessSession } from "#harness/types.js";
 import { EMPTY_DELIVERY_SENTINEL } from "#shared/empty-delivery.js";
 
@@ -124,6 +128,24 @@ describe("setHarnessEmissionState", () => {
     const retrieved = getHarnessEmissionState(session.state);
 
     expect(retrieved).toEqual(state);
+  });
+
+  it("clears client context when the emission state moves between turns", () => {
+    const turnId = "turn_5";
+    const session = setTurnClientContextState(createSession(), {
+      insertionIndex: 0,
+      messages: ["current page"],
+      turnId,
+    });
+
+    const updated = setHarnessEmissionState(session, {
+      sequence: 6,
+      sessionStarted: true,
+      stepIndex: 0,
+      turnId: "",
+    });
+
+    expect(getTurnClientContextState(updated.state, turnId)).toBeUndefined();
   });
 });
 

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -12172,6 +12172,81 @@ describe("createToolLoopHarness", () => {
       }
     });
 
+    it("keeps client context at a stable prompt position through every step of its turn", async () => {
+      const toolCallMessage = {
+        content: [
+          {
+            input: { a: 20, b: 22 },
+            toolCallId: "call-1",
+            toolName: "add",
+            type: "tool-call",
+          },
+        ],
+        role: "assistant",
+      } as const;
+      const toolResultMessage = {
+        content: [
+          {
+            output: "42",
+            toolCallId: "call-1",
+            toolName: "add",
+            type: "tool-result",
+          },
+        ],
+        role: "tool",
+      } as const;
+      setupMockAgent({
+        finishReason: "tool-calls",
+        response: { messages: [toolCallMessage, toolResultMessage] },
+        text: "",
+        toolCalls: toolCallMessage.content,
+        toolResults: [
+          {
+            input: { a: 20, b: 22 },
+            output: "42",
+            toolCallId: "call-1",
+            toolName: "add",
+            type: "tool-result",
+          },
+        ],
+      });
+      const runStep = createToolLoopHarness(createTestConfig("conversation"));
+      const clientContext = "Client context:\nroute=/billing";
+
+      const firstStep = await runStep(
+        createTestSession(),
+        attachClientContext({ message: "Add 20 and 22." }, [clientContext]),
+      );
+      expect(firstStep.next).toBe(runStep);
+      const firstPrompt = structuredClone(getLastAgentSettings().messages);
+
+      setupMockAgent(defaultModelResult());
+      const serializedSession = JSON.parse(JSON.stringify(firstStep.session)) as HarnessSession;
+      const secondStep = await runStep(serializedSession);
+      expect(secondStep.next).toBeNull();
+      const secondPrompt = getLastAgentSettings().messages;
+
+      expect(secondPrompt.slice(0, firstPrompt.length)).toEqual(firstPrompt);
+      expect(secondPrompt).toEqual([
+        { content: clientContext, role: "user" },
+        { content: "Add 20 and 22.", role: "user" },
+        toolCallMessage,
+        toolResultMessage,
+      ]);
+      expect(secondStep.session.history).not.toContainEqual({
+        content: clientContext,
+        role: "user",
+      });
+      expect(JSON.stringify(secondStep.session.state)).not.toContain(clientContext);
+
+      setupMockAgent(defaultModelResult());
+      await runStep(secondStep.session, { message: "Start another turn." });
+      expect(getLastAgentSettings().messages).not.toContainEqual({
+        content: clientContext,
+        role: "user",
+      });
+    });
+
     it("keeps ephemeral client context out of compaction and its token baseline", async () => {
       vi.mocked(shouldCompact).mockReturnValueOnce(true);
       vi.mocked(compactMessages).mockImplementationOnce(async (messages) => [...messages]);

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -132,6 +132,11 @@ import {
 import { createToolResultMessagePartFromToolError } from "#harness/action-result-helpers.js";
 import { activeTurnId } from "#harness/active-turn-id.js";
 import {
+  clearTurnClientContextState,
+  getTurnClientContextState,
+  setTurnClientContextState,
+} from "#harness/turn-client-context.js";
+import {
   getApprovalAuditState,
   markApprovalCandidateHistoryEventEmitted,
   markApprovalCandidatePendingEventEmitted,
@@ -933,11 +938,13 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
 
     // --- Turn preamble ------------------------------------------------------
 
-    const clientContext = readClientContext(effectiveStepInput);
+    const turnId = activeTurnId(emissionState);
+    const storedClientContext = getTurnClientContextState(pending.session.state, turnId);
+    const clientContext =
+      pending.deferredContext === true ? undefined : readClientContext(effectiveStepInput);
+    const activeClientContext = clientContext ?? storedClientContext?.messages;
     const ephemeralContextMessages: ModelMessage[] =
-      clientContext === undefined || pending.deferredContext === true
-        ? []
-        : clientContext.map((content) => ({ content, role: "user" }));
+      activeClientContext?.map((content) => ({ content, role: "user" })) ?? [];
     const preparedTurnInput: ModelMessage[] = [];
     if (effectiveStepInput?.context !== undefined && pending.deferredContext !== true) {
       for (const entry of effectiveStepInput.context) {
@@ -1059,15 +1066,34 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       }
     }
 
+    // Keep the insertion point stable when a later durable step reconstructs
+    // the model-only prompt, preserving the full prompt prefix within the turn.
+    let turnClientContext = storedClientContext;
+    if (clientContext !== undefined) {
+      turnClientContext = {
+        insertionIndex: storedClientContext?.insertionIndex ?? messages.length,
+        messages: [...clientContext],
+        turnId,
+      };
+    }
+    if (turnClientContext !== undefined) {
+      session = setTurnClientContextState(session, turnClientContext);
+    }
+
     messages = [...messages, ...preparedTurnInput];
 
     const createModelMessages = (durableMessages: readonly ModelMessage[]): ModelMessage[] => {
-      if (ephemeralContextMessages.length === 0) return [...durableMessages];
+      if (turnClientContext === undefined || turnClientContext.messages.length === 0) {
+        return [...durableMessages];
+      }
 
-      const insertionIndex = Math.max(0, durableMessages.length - preparedTurnInput.length);
+      const insertionIndex = Math.min(
+        Math.max(0, turnClientContext.insertionIndex),
+        durableMessages.length,
+      );
       return [
         ...durableMessages.slice(0, insertionIndex),
-        ...ephemeralContextMessages,
+        ...turnClientContext.messages.map((content) => ({ content, role: "user" as const })),
         ...durableMessages.slice(insertionIndex),
       ];
     };
@@ -1113,6 +1139,10 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     // `messages` (which the harness uses to rebuild session history).
     const attributionHeaders = buildGatewayAttributionHeaders(model, config.runtimeIdentity);
 
+    const clientContextTailLength =
+      turnClientContext === undefined
+        ? undefined
+        : Math.max(0, messages.length - turnClientContext.insertionIndex);
     const compaction = await maybeCompact({
       abortSignal: config.abortSignal,
       auth: ctx?.get(AuthKey) ?? null,
@@ -1131,6 +1161,13 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     session = compaction.session;
     if (compaction.compacted) {
       messages = compaction.messages;
+      if (turnClientContext !== undefined && clientContextTailLength !== undefined) {
+        turnClientContext = {
+          ...turnClientContext,
+          insertionIndex: Math.max(0, messages.length - clientContextTailLength),
+        };
+        session = setTurnClientContextState(session, turnClientContext);
+      }
     }
     projectedMessages = normalizeModelMessages(
       projectHistory(createModelMessages(messages), session.state),
@@ -1779,7 +1816,9 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       emit,
       emissionState,
       durableModelPromptMessageCount:
-        ephemeralContextMessages.length === 0 ? projectedMessages.length : undefined,
+        turnClientContext === undefined || turnClientContext.messages.length === 0
+          ? projectedMessages.length
+          : undefined,
       promptMessages: messages,
       result,
       runStep,
@@ -2764,6 +2803,7 @@ async function finishTaskTurn(input: {
 }): Promise<StepResult> {
   const { emit, history, result, schema, stepOutput } = input;
   let { emissionState, session } = input;
+  session = clearTurnClientContextState(session);
 
   if (schema === undefined) {
     if (emit) {
@@ -2813,6 +2853,7 @@ async function finishConversationTurn(input: {
 }): Promise<StepResult> {
   const { emit, history, result, schema, stepOutput } = input;
   let { emissionState, session } = input;
+  session = clearTurnClientContextState(session);
 
   if (schema === undefined) {
     if (emit) {

--- a/packages/eve/src/harness/turn-client-context.ts
+++ b/packages/eve/src/harness/turn-client-context.ts
@@ -1,0 +1,39 @@
+import type { HarnessSession, SessionStateMap } from "#harness/types.js";
+
+const TURN_CLIENT_CONTEXT_STATE_KEY = "eve.harness.turnClientContext";
+
+export interface TurnClientContextState {
+  readonly insertionIndex: number;
+  readonly messages: readonly string[];
+  readonly turnId: string;
+}
+
+export function getTurnClientContextState(
+  state: SessionStateMap | undefined,
+  turnId: string,
+): TurnClientContextState | undefined {
+  const clientContext = state?.[TURN_CLIENT_CONTEXT_STATE_KEY] as
+    | TurnClientContextState
+    | undefined;
+  return clientContext?.turnId === turnId ? clientContext : undefined;
+}
+
+export function setTurnClientContextState(
+  session: HarnessSession,
+  clientContext: TurnClientContextState,
+): HarnessSession {
+  return {
+    ...session,
+    state: {
+      ...session.state,
+      [TURN_CLIENT_CONTEXT_STATE_KEY]: clientContext,
+    },
+  };
+}
+
+export function clearTurnClientContextState(session: HarnessSession): HarnessSession {
+  if (session.state?.[TURN_CLIENT_CONTEXT_STATE_KEY] === undefined) return session;
+
+  const { [TURN_CLIENT_CONTEXT_STATE_KEY]: _clientContext, ...state } = session.state;
+  return { ...session, state };
+}

--- a/packages/eve/src/protocol/message.ts
+++ b/packages/eve/src/protocol/message.ts
@@ -140,8 +140,9 @@ export interface RuntimeTraceContext {
  * `message` is either a plain text string or an AI SDK `UserContent`
  * array (mixing `text`, `image`, and `file` parts). Clients pass
  * multimodal attachments with the same shape AI SDK's `useChat`
- * `sendMessage({ files })` produces. `clientContext` is one-turn
- * client/page context; the channel converts it into internal model context.
+ * `sendMessage({ files })` produces. `clientContext` is turn-scoped
+ * client/page context; the channel converts it into internal model context
+ * for every model call in that turn.
  */
 export type HandleMessageRequestBody =
   | {


### PR DESCRIPTION
### Summary

Client context currently reaches only the first model call, so later tool-loop steps lose turn-local page context and the reusable prompt prefix changes. This keeps client context and its insertion point in serialized turn state, re-injects it into every model-only prompt, and removes it at the turn boundary; it never enters durable history or later turns. This replaces the cross-turn persistence approach closed in #3029.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/harness/tool-loop.test.ts` — 222 passed
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/harness/emission.test.ts` — 27 passed
- `pnpm typecheck` — 43 workspace tasks passed
- `pnpm fmt`
- `pnpm lint`
- `pnpm guard:invariants`
- `pnpm docs:check`

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
