### PR TITLE
feat(eve): compose workspace services in vercel.ts

### DIFF
--- a/.changeset/compose-workspace-services.md
+++ b/.changeset/compose-workspace-services.md
@@ -1,5 +1,5 @@
 ---
-"eve": minor
+"eve": patch
 ---
 
 Add `withEve` from `eve/vercel` for composing native workspace agents with authored services in `vercel.ts`. Vercel resolves the generated agent services and transport routes before independently building each service.

--- a/.changeset/compose-workspace-services.md
+++ b/.changeset/compose-workspace-services.md
@@ -1,0 +1,5 @@
+---
+"eve": minor
+---
+
+Add `withEve` from `eve/vercel` for composing native workspace agents with authored services in `vercel.ts`. Vercel resolves the generated agent services and transport routes before independently building each service.

--- a/.changeset/compose-workspace-services.md
+++ b/.changeset/compose-workspace-services.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Add `withEve` from `eve/vercel` for composing native workspace agents with authored services in `vercel.ts`. Vercel resolves the generated agent services and transport routes before independently building each service.
+Add `withEveServices` from `eve/vercel` for composing native workspace agents with authored services in `vercel.ts`. Vercel resolves the generated agent services and transport routes before independently building each service.

--- a/.changeset/compose-workspace-services.md
+++ b/.changeset/compose-workspace-services.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Add `withEveServices` from `eve/vercel` for composing native workspace agents with authored services in `vercel.ts`. Vercel resolves the generated agent services and transport routes before independently building each service.
+Add `withEve` from `eve/vercel` for composing native workspace agents with authored services in `vercel.ts`. Vercel resolves the generated agent services and transport routes before independently building each service.

--- a/docs/guides/deployment/vercel.mdx
+++ b/docs/guides/deployment/vercel.mdx
@@ -94,7 +94,7 @@ export default await withEve({
 
 Vercel evaluates `vercel.ts` before resolving the service graph. `withEve` discovers direct workspace members, adds their services and transport routes, and returns a plain Vercel configuration. Vercel can then build `web` and every eve agent independently. The frontend does not need `withEve` in its framework configuration or a build script that builds the agents.
 
-Generated transport routes are inserted before a filesystem handler or an authored catch-all route. eve reserves each generated `eve-<agent>` service name and exact `/<agent>/eve/v1/*` transport route; other service names, routes, bindings, and Cron Jobs remain authored in `vercel.ts`.
+Generated transport routes are inserted before a filesystem handler or, when no filesystem handler exists, before authored routes. `withEve` throws instead of overwriting an authored service key or exact transport route that belongs to a generated agent. Remove the authored route, and remove or rename the authored service; `withEve` adds both automatically. Names in the array form of `services` must also be unique. Other service names, routes, bindings, and Cron Jobs remain authored in `vercel.ts`.
 
 Custom agent channel endpoints are not published automatically. Expose one explicitly by routing it to the generated service:
 

--- a/docs/guides/deployment/vercel.mdx
+++ b/docs/guides/deployment/vercel.mdx
@@ -67,7 +67,58 @@ In an eve workspace, eve discovers direct `agents/<name>/` children that contain
 
 Create this layout with `eve init my-project --agents support,research`, or add one agent to an existing workspace with `eve init billing`.
 
-With no authored `vercel.json#services`, `eve build` derives the complete Vercel Services graph on every build. If `vercel.json` declares `services`, that authored graph is authoritative instead; use `vercel build` to build and validate the complete project. This supports heterogeneous projects with frontends, private APIs, bindings, and other non-eve services without generated configuration files.
+For an agent-only workspace, run `eve build`. eve owns the Vercel Build Output and generates one independently built service and a `/<name>/eve/v1/*` transport route for each workspace member.
+
+### Compose agents with other Vercel services
+
+Use Vercel's programmatic configuration when a workspace also deploys a frontend, private API, or another non-eve service. Replace `vercel.json` with a root `vercel.ts` and compose the authored graph with `withEve`:
+
+```typescript title="vercel.ts"
+import { withEve } from "eve/vercel";
+
+export default await withEve({
+  services: {
+    web: {
+      framework: "nextjs",
+      root: "apps/web",
+    },
+  },
+  routes: [
+    {
+      src: "^(.*)$",
+      destination: { type: "service", service: "web" },
+    },
+  ],
+});
+```
+
+Vercel evaluates `vercel.ts` before resolving the service graph. `withEve` discovers direct workspace members, adds their services and transport routes, and returns a plain Vercel configuration. Vercel can then build `web` and every eve agent independently. The frontend does not need `withEve` in its framework configuration or a build script that builds the agents.
+
+Generated transport routes are inserted before a filesystem handler or an authored catch-all route. eve reserves each generated `eve-<agent>` service name and exact `/<agent>/eve/v1/*` transport route; other service names, routes, bindings, and Cron Jobs remain authored in `vercel.ts`.
+
+Custom agent channel endpoints are not published automatically. Expose one explicitly by routing it to the generated service:
+
+```typescript title="vercel.ts"
+import { withEve } from "eve/vercel";
+
+export default await withEve({
+  services: {
+    web: { framework: "nextjs", root: "apps/web" },
+  },
+  routes: [
+    {
+      src: "^/webhooks/github$",
+      destination: { type: "service", service: "eve-triage" },
+    },
+    {
+      src: "^(.*)$",
+      destination: { type: "service", service: "web" },
+    },
+  ],
+});
+```
+
+A Vercel project can use only one configuration source, so remove `vercel.json` when adopting `vercel.ts`. Keep `eve` in the root package dependencies so Vercel can import `eve/vercel` while evaluating the configuration. Pass `{ root: "/absolute/workspace/path" }` as the second argument only when `vercel.ts` is evaluated from somewhere other than the workspace root.
 
 An authored eve service routed at `/eve/v1` already uses the protocol path; callbacks remain at `/eve/v1/callback/*`. A named mount such as `/support` adds that mount before the protocol path, giving `/support/eve/v1/callback/*`.
 

--- a/docs/guides/deployment/vercel.mdx
+++ b/docs/guides/deployment/vercel.mdx
@@ -71,12 +71,12 @@ For an agent-only workspace, run `eve build`. eve owns the Vercel Build Output a
 
 ### Compose agents with other Vercel services
 
-Use Vercel's programmatic configuration when a workspace also deploys a frontend, private API, or another non-eve service. Replace `vercel.json` with a root `vercel.ts` and compose the authored graph with `withEveServices`:
+Use Vercel's programmatic configuration when a workspace also deploys a frontend, private API, or another non-eve service. Replace `vercel.json` with a root `vercel.ts` and compose the authored graph with `withEve`:
 
 ```typescript title="vercel.ts"
-import { withEveServices } from "eve/vercel";
+import { withEve } from "eve/vercel";
 
-export default await withEveServices({
+export default await withEve({
   services: {
     web: {
       framework: "nextjs",
@@ -92,16 +92,16 @@ export default await withEveServices({
 });
 ```
 
-Vercel evaluates `vercel.ts` before resolving the service graph. `withEveServices` discovers direct workspace members, adds their services and transport routes, and returns a plain Vercel configuration. Vercel can then build `web` and every eve agent independently. The frontend does not need `withEveServices` in its framework configuration or a build script that builds the agents.
+Vercel evaluates `vercel.ts` before resolving the service graph. `withEve` discovers direct workspace members, adds their services and transport routes, and returns a plain Vercel configuration. Vercel can then build `web` and every eve agent independently. The frontend does not need `withEve` in its framework configuration or a build script that builds the agents.
 
-Generated transport routes are inserted before a filesystem handler or, when no filesystem handler exists, before authored routes. `withEveServices` throws instead of overwriting an authored service key or exact transport route that belongs to a generated agent. Remove the authored route, and remove or rename the authored service; `withEveServices` adds both automatically. Names in the array form of `services` must also be unique. Other service names, routes, bindings, and Cron Jobs remain authored in `vercel.ts`.
+Generated transport routes are inserted before a filesystem handler or, when no filesystem handler exists, before authored routes. `withEve` throws instead of overwriting an authored service key or exact transport route that belongs to a generated agent. Remove the authored route, and remove or rename the authored service; `withEve` adds both automatically. Names in the array form of `services` must also be unique. Other service names, routes, bindings, and Cron Jobs remain authored in `vercel.ts`.
 
 Custom agent channel endpoints are not published automatically. Expose one explicitly by routing it to the generated service:
 
 ```typescript title="vercel.ts"
-import { withEveServices } from "eve/vercel";
+import { withEve } from "eve/vercel";
 
-export default await withEveServices({
+export default await withEve({
   services: {
     web: { framework: "nextjs", root: "apps/web" },
   },

--- a/docs/guides/deployment/vercel.mdx
+++ b/docs/guides/deployment/vercel.mdx
@@ -71,12 +71,12 @@ For an agent-only workspace, run `eve build`. eve owns the Vercel Build Output a
 
 ### Compose agents with other Vercel services
 
-Use Vercel's programmatic configuration when a workspace also deploys a frontend, private API, or another non-eve service. Replace `vercel.json` with a root `vercel.ts` and compose the authored graph with `withEve`:
+Use Vercel's programmatic configuration when a workspace also deploys a frontend, private API, or another non-eve service. Replace `vercel.json` with a root `vercel.ts` and compose the authored graph with `withEveServices`:
 
 ```typescript title="vercel.ts"
-import { withEve } from "eve/vercel";
+import { withEveServices } from "eve/vercel";
 
-export default await withEve({
+export default await withEveServices({
   services: {
     web: {
       framework: "nextjs",
@@ -92,16 +92,16 @@ export default await withEve({
 });
 ```
 
-Vercel evaluates `vercel.ts` before resolving the service graph. `withEve` discovers direct workspace members, adds their services and transport routes, and returns a plain Vercel configuration. Vercel can then build `web` and every eve agent independently. The frontend does not need `withEve` in its framework configuration or a build script that builds the agents.
+Vercel evaluates `vercel.ts` before resolving the service graph. `withEveServices` discovers direct workspace members, adds their services and transport routes, and returns a plain Vercel configuration. Vercel can then build `web` and every eve agent independently. The frontend does not need `withEveServices` in its framework configuration or a build script that builds the agents.
 
-Generated transport routes are inserted before a filesystem handler or, when no filesystem handler exists, before authored routes. `withEve` throws instead of overwriting an authored service key or exact transport route that belongs to a generated agent. Remove the authored route, and remove or rename the authored service; `withEve` adds both automatically. Names in the array form of `services` must also be unique. Other service names, routes, bindings, and Cron Jobs remain authored in `vercel.ts`.
+Generated transport routes are inserted before a filesystem handler or, when no filesystem handler exists, before authored routes. `withEveServices` throws instead of overwriting an authored service key or exact transport route that belongs to a generated agent. Remove the authored route, and remove or rename the authored service; `withEveServices` adds both automatically. Names in the array form of `services` must also be unique. Other service names, routes, bindings, and Cron Jobs remain authored in `vercel.ts`.
 
 Custom agent channel endpoints are not published automatically. Expose one explicitly by routing it to the generated service:
 
 ```typescript title="vercel.ts"
-import { withEve } from "eve/vercel";
+import { withEveServices } from "eve/vercel";
 
-export default await withEve({
+export default await withEveServices({
   services: {
     web: { framework: "nextjs", root: "apps/web" },
   },

--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -86,6 +86,12 @@
       "import": "./dist/src/public/next/index.js",
       "default": "./dist/src/public/next/index.js"
     },
+    "./vercel": {
+      "eve-source": "./src/public/vercel/index.ts",
+      "types": "./dist/src/public/vercel/index.d.ts",
+      "import": "./dist/src/public/vercel/index.js",
+      "default": "./dist/src/public/vercel/index.js"
+    },
     "./nuxt": {
       "types": "./dist/src/public/nuxt/index.d.ts",
       "import": "./dist/src/public/nuxt/index.js",

--- a/packages/eve/src/internal/vercel/build-agent-workspace.integration.test.ts
+++ b/packages/eve/src/internal/vercel/build-agent-workspace.integration.test.ts
@@ -129,6 +129,6 @@ describe("buildAgentWorkspace", () => {
     const root = await createWorkspace();
     await writeFile(join(root, "vercel.json"), JSON.stringify({ services: {} }));
     const workspace = await resolveWorkspace(root);
-    await expect(buildAgentWorkspace(workspace)).rejects.toThrow(/Run `vercel build`/);
+    await expect(buildAgentWorkspace(workspace)).rejects.toThrow(/vercel\.ts.*eve\/vercel/);
   });
 });

--- a/packages/eve/src/internal/vercel/build-agent-workspace.ts
+++ b/packages/eve/src/internal/vercel/build-agent-workspace.ts
@@ -42,7 +42,7 @@ export async function buildAgentWorkspace(workspace: AgentWorkspace): Promise<st
     config.experimentalServicesV2 !== undefined
   ) {
     throw new Error(
-      "This project defines its Vercel service graph in vercel.json. Run `vercel build` to build the complete project, or run `eve build` from an individual agent directory.",
+      "This project defines its Vercel service graph in vercel.json. Compose generated workspace agents from a programmatic vercel.ts with `withEve` from `eve/vercel`, manually define every service and run `vercel build`, or run `eve build` from an individual agent directory.",
     );
   }
 

--- a/packages/eve/src/internal/vercel/build-agent-workspace.ts
+++ b/packages/eve/src/internal/vercel/build-agent-workspace.ts
@@ -42,7 +42,7 @@ export async function buildAgentWorkspace(workspace: AgentWorkspace): Promise<st
     config.experimentalServicesV2 !== undefined
   ) {
     throw new Error(
-      "This project defines its Vercel service graph in vercel.json. Compose generated workspace agents from a programmatic vercel.ts with `withEve` from `eve/vercel`, manually define every service and run `vercel build`, or run `eve build` from an individual agent directory.",
+      "This project defines its Vercel service graph in vercel.json. Compose generated workspace agents from a programmatic vercel.ts with `withEveServices` from `eve/vercel`, manually define every service and run `vercel build`, or run `eve build` from an individual agent directory.",
     );
   }
 

--- a/packages/eve/src/internal/vercel/build-agent-workspace.ts
+++ b/packages/eve/src/internal/vercel/build-agent-workspace.ts
@@ -42,7 +42,7 @@ export async function buildAgentWorkspace(workspace: AgentWorkspace): Promise<st
     config.experimentalServicesV2 !== undefined
   ) {
     throw new Error(
-      "This project defines its Vercel service graph in vercel.json. Compose generated workspace agents from a programmatic vercel.ts with `withEveServices` from `eve/vercel`, manually define every service and run `vercel build`, or run `eve build` from an individual agent directory.",
+      "This project defines its Vercel service graph in vercel.json. Compose generated workspace agents from a programmatic vercel.ts with `withEve` from `eve/vercel`, manually define every service and run `vercel build`, or run `eve build` from an individual agent directory.",
     );
   }
 

--- a/packages/eve/src/internal/vercel/vercel-services-config.test.ts
+++ b/packages/eve/src/internal/vercel/vercel-services-config.test.ts
@@ -16,6 +16,15 @@ describe("parseVercelServicesConfig", () => {
     });
   });
 
+  it("rejects duplicate names in service arrays", () => {
+    expect(() =>
+      createServiceConfigRecord([
+        { framework: "nextjs", name: "web" },
+        { framework: "nuxtjs", name: "web" },
+      ]),
+    ).toThrow('Duplicate Vercel service name "web".');
+  });
+
   it.each([
     [null, /must contain a JSON object/],
     [{ services: null }, /services must be a JSON object or named service array/],

--- a/packages/eve/src/internal/vercel/vercel-services-config.ts
+++ b/packages/eve/src/internal/vercel/vercel-services-config.ts
@@ -201,7 +201,15 @@ export function createServiceConfigRecord(
 ): Record<string, VercelServiceConfig> {
   if (services === undefined) return {};
   if (!isNamedServiceArray(services)) return services;
-  return Object.fromEntries(services.map(({ name, ...service }) => [name, service]));
+
+  const record: Record<string, VercelServiceConfig> = {};
+  for (const { name, ...service } of services) {
+    if (Object.hasOwn(record, name)) {
+      throw new Error(`Duplicate Vercel service name ${JSON.stringify(name)}.`);
+    }
+    record[name] = service;
+  }
+  return record;
 }
 
 export function hasServices(

--- a/packages/eve/src/public/vercel/index.integration.test.ts
+++ b/packages/eve/src/public/vercel/index.integration.test.ts
@@ -1,0 +1,101 @@
+import { access, mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("#shared/resolve-eve-binary.js", () => ({
+  resolveEveBinaryPath: (root: string) => join(root, "node_modules", "eve", "bin", "eve.js"),
+}));
+
+import { withEve } from "./index.js";
+
+async function createWorkspace(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "eve-vercel-config-"));
+  await writeFile(
+    join(root, "package.json"),
+    JSON.stringify({ dependencies: { eve: "*" }, packageManager: "pnpm@10.0.0", private: true }),
+  );
+  await Promise.all([
+    mkdir(join(root, "agents", "support", "agent"), { recursive: true }),
+    mkdir(join(root, "agents", "research", "agent"), { recursive: true }),
+  ]);
+  return root;
+}
+
+describe("withEve", () => {
+  it("composes workspace agents with authored Vercel services and routes", async () => {
+    const root = await createWorkspace();
+    const config = await withEve(
+      {
+        crons: [{ path: "/api/dispatch", schedule: "* * * * *" }],
+        routes: [
+          { destination: { service: "web", type: "service" }, src: "^/api/(.*)$" },
+          { handle: "filesystem" },
+        ],
+        services: { web: { framework: "nextjs", root: "apps/web" } },
+      },
+      { root },
+    );
+
+    expect(config.crons).toEqual([{ path: "/api/dispatch", schedule: "* * * * *" }]);
+    expect(config.routes).toEqual([
+      { destination: { service: "web", type: "service" }, src: "^/api/(.*)$" },
+      {
+        destination: { service: "eve-research", type: "service" },
+        src: "^/research/eve/v1/(.*)$",
+      },
+      {
+        destination: { service: "eve-support", type: "service" },
+        src: "^/support/eve/v1/(.*)$",
+      },
+      { handle: "filesystem" },
+    ]);
+    expect(config.services.web).toEqual({ framework: "nextjs", root: "apps/web" });
+    expect(config.services["eve-support"]).toEqual({
+      buildCommand:
+        "cd '../../../agents/support' && export EVE_INTERNAL_BUILD_OUTPUT_DIRECTORY='../../.eve/vercel-services/eve-support/.vercel/output' && export EVE_INTERNAL_HOST_BUILD_OUTPUT_DIRECTORY='../../.vercel/output' && export EVE_PUBLIC_ROUTE_PREFIX='/support' && export EVE_INTERNAL_AGENT_WORKSPACE_MEMBER=1 && node 'node_modules/eve/bin/eve.js' build",
+      framework: "eve",
+      root: ".eve/vercel-services/eve-support",
+      routes: [
+        {
+          src: "^/support/eve/v1/(.*)$",
+          transforms: [{ args: "/eve/v1/$1", op: "set", type: "request.path" }],
+        },
+      ],
+    });
+    await expect(
+      access(join(root, ".eve", "vercel-services", "eve-support")),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not modify the root Build Output", async () => {
+    const root = await createWorkspace();
+    const marker = join(root, ".vercel", "output", "services", "web", "config.json");
+    await mkdir(join(marker, ".."), { recursive: true });
+    await writeFile(marker, "web output");
+
+    await withEve({}, { root });
+
+    await expect(access(marker)).resolves.toBeUndefined();
+  });
+
+  it("reserves generated service names and transport routes", async () => {
+    const root = await createWorkspace();
+
+    await expect(
+      withEve({ services: { "eve-support": { framework: "nextjs" } } }, { root }),
+    ).rejects.toThrow(/eve-support.*reserved/);
+    await expect(
+      withEve({ routes: [{ src: "^/support/eve/v1/(.*)$" }] }, { root }),
+    ).rejects.toThrow(/route.*support.*reserved/);
+  });
+
+  it("requires an eve workspace root", async () => {
+    const root = await mkdtemp(join(tmpdir(), "eve-vercel-config-standalone-"));
+    await writeFile(join(root, "package.json"), JSON.stringify({ dependencies: { eve: "*" } }));
+    await mkdir(join(root, "agent"), { recursive: true });
+
+    await expect(withEve({}, { root })).rejects.toThrow(/workspace root/);
+  });
+});

--- a/packages/eve/src/public/vercel/index.integration.test.ts
+++ b/packages/eve/src/public/vercel/index.integration.test.ts
@@ -80,15 +80,60 @@ describe("withEve", () => {
     await expect(access(marker)).resolves.toBeUndefined();
   });
 
-  it("reserves generated service names and transport routes", async () => {
+  it("rejects authored service keys owned by generated agents", async () => {
     const root = await createWorkspace();
 
     await expect(
       withEve({ services: { "eve-support": { framework: "nextjs" } } }, { root }),
-    ).rejects.toThrow(/eve-support.*reserved/);
+    ).rejects.toThrow(
+      'Vercel service key "eve-support" conflicts with the service generated for eve workspace agent "support". Remove or rename the authored service; withEve owns this key.',
+    );
+  });
+
+  it("rejects authored routes owned by generated agents", async () => {
+    const root = await createWorkspace();
+
     await expect(
       withEve({ routes: [{ src: "^/support/eve/v1/(.*)$" }] }, { root }),
-    ).rejects.toThrow(/route.*support.*reserved/);
+    ).rejects.toThrow(
+      'Vercel route "^/support/eve/v1/(.*)$" conflicts with the transport route generated for eve workspace agent "support". Remove the authored route; withEve adds it automatically.',
+    );
+  });
+
+  it("rejects duplicate names in a service array", async () => {
+    const root = await createWorkspace();
+
+    await expect(
+      withEve(
+        {
+          services: [
+            { framework: "nextjs", name: "web", root: "apps/first" },
+            { framework: "nuxtjs", name: "web", root: "apps/second" },
+          ],
+        },
+        { root },
+      ),
+    ).rejects.toThrow(
+      'withEve received duplicate Vercel service name "web". Give every entry in the services array a unique name.',
+    );
+  });
+
+  it("rejects obsolete service fields", async () => {
+    const root = await createWorkspace();
+
+    await expect(withEve({ experimentalServicesV2: {} }, { root })).rejects.toThrow(
+      "withEve cannot compose experimentalServices or experimentalServicesV2. Remove the obsolete field and define authored services under services.",
+    );
+  });
+
+  it("requires at least one workspace agent", async () => {
+    const root = await mkdtemp(join(tmpdir(), "eve-vercel-config-empty-workspace-"));
+    await writeFile(join(root, "package.json"), JSON.stringify({ dependencies: { eve: "*" } }));
+    await mkdir(join(root, "agents"));
+
+    await expect(withEve({}, { root })).rejects.toThrow(
+      `withEve found no workspace agents under ${join(root, "agents")}. Add an agent or remove withEve from vercel.ts.`,
+    );
   });
 
   it("requires an eve workspace root", async () => {

--- a/packages/eve/src/public/vercel/index.integration.test.ts
+++ b/packages/eve/src/public/vercel/index.integration.test.ts
@@ -113,9 +113,7 @@ describe("withEve", () => {
         },
         { root },
       ),
-    ).rejects.toThrow(
-      'withEve received duplicate Vercel service name "web". Give every entry in the services array a unique name.',
-    );
+    ).rejects.toThrow('Duplicate Vercel service name "web".');
   });
 
   it("rejects obsolete service fields", async () => {

--- a/packages/eve/src/public/vercel/index.integration.test.ts
+++ b/packages/eve/src/public/vercel/index.integration.test.ts
@@ -45,10 +45,12 @@ describe("withEveServices", () => {
         destination: { service: "eve-research", type: "service" },
         src: "^/research/eve/v1/(.*)$",
       },
+      { destination: { service: "eve-research", type: "service" }, src: "^/research/?$" },
       {
         destination: { service: "eve-support", type: "service" },
         src: "^/support/eve/v1/(.*)$",
       },
+      { destination: { service: "eve-support", type: "service" }, src: "^/support/?$" },
       { handle: "filesystem" },
     ]);
     expect(config.services.web).toEqual({ framework: "nextjs", root: "apps/web" });
@@ -58,6 +60,10 @@ describe("withEveServices", () => {
       framework: "eve",
       root: ".eve/vercel-services/eve-support",
       routes: [
+        {
+          src: "^/support/?$",
+          transforms: [{ args: "/", op: "set", type: "request.path" }],
+        },
         {
           src: "^/support/eve/v1/(.*)$",
           transforms: [{ args: "/eve/v1/$1", op: "set", type: "request.path" }],

--- a/packages/eve/src/public/vercel/index.integration.test.ts
+++ b/packages/eve/src/public/vercel/index.integration.test.ts
@@ -8,7 +8,7 @@ vi.mock("#shared/resolve-eve-binary.js", () => ({
   resolveEveBinaryPath: (root: string) => join(root, "node_modules", "eve", "bin", "eve.js"),
 }));
 
-import { withEve } from "./index.js";
+import { withEveServices } from "./index.js";
 
 async function createWorkspace(): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), "eve-vercel-config-"));
@@ -23,10 +23,10 @@ async function createWorkspace(): Promise<string> {
   return root;
 }
 
-describe("withEve", () => {
+describe("withEveServices", () => {
   it("composes workspace agents with authored Vercel services and routes", async () => {
     const root = await createWorkspace();
-    const config = await withEve(
+    const config = await withEveServices(
       {
         crons: [{ path: "/api/dispatch", schedule: "* * * * *" }],
         routes: [
@@ -75,7 +75,7 @@ describe("withEve", () => {
     await mkdir(join(marker, ".."), { recursive: true });
     await writeFile(marker, "web output");
 
-    await withEve({}, { root });
+    await withEveServices({}, { root });
 
     await expect(access(marker)).resolves.toBeUndefined();
   });
@@ -84,9 +84,9 @@ describe("withEve", () => {
     const root = await createWorkspace();
 
     await expect(
-      withEve({ services: { "eve-support": { framework: "nextjs" } } }, { root }),
+      withEveServices({ services: { "eve-support": { framework: "nextjs" } } }, { root }),
     ).rejects.toThrow(
-      'Vercel service key "eve-support" conflicts with the service generated for eve workspace agent "support". Remove or rename the authored service; withEve owns this key.',
+      'Vercel service key "eve-support" conflicts with the service generated for eve workspace agent "support". Remove or rename the authored service; withEveServices owns this key.',
     );
   });
 
@@ -94,9 +94,9 @@ describe("withEve", () => {
     const root = await createWorkspace();
 
     await expect(
-      withEve({ routes: [{ src: "^/support/eve/v1/(.*)$" }] }, { root }),
+      withEveServices({ routes: [{ src: "^/support/eve/v1/(.*)$" }] }, { root }),
     ).rejects.toThrow(
-      'Vercel route "^/support/eve/v1/(.*)$" conflicts with the transport route generated for eve workspace agent "support". Remove the authored route; withEve adds it automatically.',
+      'Vercel route "^/support/eve/v1/(.*)$" conflicts with the transport route generated for eve workspace agent "support". Remove the authored route; withEveServices adds it automatically.',
     );
   });
 
@@ -104,7 +104,7 @@ describe("withEve", () => {
     const root = await createWorkspace();
 
     await expect(
-      withEve(
+      withEveServices(
         {
           services: [
             { framework: "nextjs", name: "web", root: "apps/first" },
@@ -119,8 +119,8 @@ describe("withEve", () => {
   it("rejects obsolete service fields", async () => {
     const root = await createWorkspace();
 
-    await expect(withEve({ experimentalServicesV2: {} }, { root })).rejects.toThrow(
-      "withEve cannot compose experimentalServices or experimentalServicesV2. Remove the obsolete field and define authored services under services.",
+    await expect(withEveServices({ experimentalServicesV2: {} }, { root })).rejects.toThrow(
+      "withEveServices cannot compose experimentalServices or experimentalServicesV2. Remove the obsolete field and define authored services under services.",
     );
   });
 
@@ -129,8 +129,8 @@ describe("withEve", () => {
     await writeFile(join(root, "package.json"), JSON.stringify({ dependencies: { eve: "*" } }));
     await mkdir(join(root, "agents"));
 
-    await expect(withEve({}, { root })).rejects.toThrow(
-      `withEve found no workspace agents under ${join(root, "agents")}. Add an agent or remove withEve from vercel.ts.`,
+    await expect(withEveServices({}, { root })).rejects.toThrow(
+      `withEveServices found no workspace agents under ${join(root, "agents")}. Add an agent or remove withEveServices from vercel.ts.`,
     );
   });
 
@@ -139,6 +139,6 @@ describe("withEve", () => {
     await writeFile(join(root, "package.json"), JSON.stringify({ dependencies: { eve: "*" } }));
     await mkdir(join(root, "agent"), { recursive: true });
 
-    await expect(withEve({}, { root })).rejects.toThrow(/workspace root/);
+    await expect(withEveServices({}, { root })).rejects.toThrow(/workspace root/);
   });
 });

--- a/packages/eve/src/public/vercel/index.integration.test.ts
+++ b/packages/eve/src/public/vercel/index.integration.test.ts
@@ -8,7 +8,7 @@ vi.mock("#shared/resolve-eve-binary.js", () => ({
   resolveEveBinaryPath: (root: string) => join(root, "node_modules", "eve", "bin", "eve.js"),
 }));
 
-import { withEveServices } from "./index.js";
+import { withEve } from "./index.js";
 
 async function createWorkspace(): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), "eve-vercel-config-"));
@@ -23,10 +23,10 @@ async function createWorkspace(): Promise<string> {
   return root;
 }
 
-describe("withEveServices", () => {
+describe("withEve", () => {
   it("composes workspace agents with authored Vercel services and routes", async () => {
     const root = await createWorkspace();
-    const config = await withEveServices(
+    const config = await withEve(
       {
         crons: [{ path: "/api/dispatch", schedule: "* * * * *" }],
         routes: [
@@ -81,7 +81,7 @@ describe("withEveServices", () => {
     await mkdir(join(marker, ".."), { recursive: true });
     await writeFile(marker, "web output");
 
-    await withEveServices({}, { root });
+    await withEve({}, { root });
 
     await expect(access(marker)).resolves.toBeUndefined();
   });
@@ -90,9 +90,9 @@ describe("withEveServices", () => {
     const root = await createWorkspace();
 
     await expect(
-      withEveServices({ services: { "eve-support": { framework: "nextjs" } } }, { root }),
+      withEve({ services: { "eve-support": { framework: "nextjs" } } }, { root }),
     ).rejects.toThrow(
-      'Vercel service key "eve-support" conflicts with the service generated for eve workspace agent "support". Remove or rename the authored service; withEveServices owns this key.',
+      'Vercel service key "eve-support" conflicts with the service generated for eve workspace agent "support". Remove or rename the authored service; withEve owns this key.',
     );
   });
 
@@ -100,9 +100,9 @@ describe("withEveServices", () => {
     const root = await createWorkspace();
 
     await expect(
-      withEveServices({ routes: [{ src: "^/support/eve/v1/(.*)$" }] }, { root }),
+      withEve({ routes: [{ src: "^/support/eve/v1/(.*)$" }] }, { root }),
     ).rejects.toThrow(
-      'Vercel route "^/support/eve/v1/(.*)$" conflicts with the transport route generated for eve workspace agent "support". Remove the authored route; withEveServices adds it automatically.',
+      'Vercel route "^/support/eve/v1/(.*)$" conflicts with the transport route generated for eve workspace agent "support". Remove the authored route; withEve adds it automatically.',
     );
   });
 
@@ -110,7 +110,7 @@ describe("withEveServices", () => {
     const root = await createWorkspace();
 
     await expect(
-      withEveServices(
+      withEve(
         {
           services: [
             { framework: "nextjs", name: "web", root: "apps/first" },
@@ -125,8 +125,8 @@ describe("withEveServices", () => {
   it("rejects obsolete service fields", async () => {
     const root = await createWorkspace();
 
-    await expect(withEveServices({ experimentalServicesV2: {} }, { root })).rejects.toThrow(
-      "withEveServices cannot compose experimentalServices or experimentalServicesV2. Remove the obsolete field and define authored services under services.",
+    await expect(withEve({ experimentalServicesV2: {} }, { root })).rejects.toThrow(
+      "withEve cannot compose experimentalServices or experimentalServicesV2. Remove the obsolete field and define authored services under services.",
     );
   });
 
@@ -135,8 +135,8 @@ describe("withEveServices", () => {
     await writeFile(join(root, "package.json"), JSON.stringify({ dependencies: { eve: "*" } }));
     await mkdir(join(root, "agents"));
 
-    await expect(withEveServices({}, { root })).rejects.toThrow(
-      `withEveServices found no workspace agents under ${join(root, "agents")}. Add an agent or remove withEveServices from vercel.ts.`,
+    await expect(withEve({}, { root })).rejects.toThrow(
+      `withEve found no workspace agents under ${join(root, "agents")}. Add an agent or remove withEve from vercel.ts.`,
     );
   });
 
@@ -145,6 +145,6 @@ describe("withEveServices", () => {
     await writeFile(join(root, "package.json"), JSON.stringify({ dependencies: { eve: "*" } }));
     await mkdir(join(root, "agent"), { recursive: true });
 
-    await expect(withEveServices({}, { root })).rejects.toThrow(/workspace root/);
+    await expect(withEve({}, { root })).rejects.toThrow(/workspace root/);
   });
 });

--- a/packages/eve/src/public/vercel/index.ts
+++ b/packages/eve/src/public/vercel/index.ts
@@ -1,0 +1,152 @@
+import { mkdir } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+import { resolveEveProjectContext } from "#internal/project-context.js";
+import { assembleEveVercelServices } from "#internal/vercel/assemble-eve-services.js";
+import { quoteVercelShellArgument, toVercelRelativePath } from "#internal/vercel/build-command.js";
+import {
+  createEveServiceName,
+  createEveServiceRouteSrc,
+} from "#internal/vercel/eve-service-contribution.js";
+import {
+  createServiceConfigRecord,
+  type VercelServicesConfig,
+} from "#internal/vercel/vercel-services-config.js";
+import { resolveEveBinaryPath } from "#shared/resolve-eve-binary.js";
+
+/** A route accepted by eve's Vercel configuration composer. */
+export interface EveVercelRouteConfig {
+  readonly destination?: string | { readonly service?: string; readonly type?: string };
+  readonly handle?: string;
+  readonly src?: string;
+  readonly transforms?: readonly Record<string, unknown>[];
+  readonly [key: string]: unknown;
+}
+
+/** A service accepted by eve's Vercel configuration composer. */
+export interface EveVercelServiceConfig {
+  readonly buildCommand?: string;
+  readonly entrypoint?: string;
+  readonly framework?: string;
+  readonly mount?: string | { readonly path?: string; readonly subdomain?: string };
+  readonly routes?: readonly EveVercelRouteConfig[];
+  readonly root?: string;
+  readonly type?: string;
+  readonly [key: string]: unknown;
+}
+
+/** The portion of a programmatic Vercel configuration composed by eve. */
+export interface EveVercelConfig {
+  readonly experimentalServices?: unknown;
+  readonly experimentalServicesV2?: unknown;
+  readonly routes?: readonly EveVercelRouteConfig[];
+  readonly services?:
+    | Readonly<Record<string, EveVercelServiceConfig>>
+    | readonly (EveVercelServiceConfig & { readonly name: string })[];
+  readonly [key: string]: unknown;
+}
+
+/** Options for composing an eve workspace into a programmatic Vercel configuration. */
+export interface WithEveOptions {
+  /** Eve workspace root. Defaults to the directory evaluating `vercel.ts`. */
+  readonly root?: string;
+}
+
+function toInternalConfig(config: EveVercelConfig): VercelServicesConfig {
+  return config as unknown as VercelServicesConfig;
+}
+
+function assertComposableConfig(config: EveVercelConfig, agentNames: readonly string[]): void {
+  if (config.experimentalServices !== undefined || config.experimentalServicesV2 !== undefined) {
+    throw new Error(
+      "withEve does not support experimentalServices. Use services or remove the obsolete configuration.",
+    );
+  }
+
+  const internalConfig = toInternalConfig(config);
+  const services = createServiceConfigRecord(internalConfig.services);
+  for (const name of agentNames) {
+    const serviceName = createEveServiceName(name);
+    if (services[serviceName] !== undefined) {
+      throw new Error(
+        `Vercel service ${JSON.stringify(serviceName)} is reserved for eve workspace agent ${JSON.stringify(name)}.`,
+      );
+    }
+
+    const routeSrc = createEveServiceRouteSrc(`/${name}`);
+    if (config.routes?.some((route) => route.src === routeSrc)) {
+      throw new Error(
+        `Vercel route ${JSON.stringify(routeSrc)} is reserved for eve workspace agent ${JSON.stringify(name)}.`,
+      );
+    }
+  }
+}
+
+/**
+ * Add a hostless eve workspace's generated agent services and transport routes to `vercel.ts`.
+ *
+ * The returned object is a plain Vercel configuration. Vercel resolves it before independently
+ * building the authored services and each generated eve agent service.
+ */
+export async function withEve<TConfig extends EveVercelConfig>(
+  config: TConfig,
+  options: WithEveOptions = {},
+): Promise<
+  Omit<TConfig, "routes" | "services"> & {
+    readonly routes: readonly EveVercelRouteConfig[];
+    readonly services: Readonly<Record<string, EveVercelServiceConfig>>;
+  }
+> {
+  const root = resolve(options.root ?? process.cwd());
+  const context = await resolveEveProjectContext(root);
+  if (context.kind !== "workspace" || context.workspace.root !== root) {
+    throw new Error(`withEve must run at an eve workspace root; received ${root}.`);
+  }
+
+  const { workspace } = context;
+  const agentNames = workspace.members.map((member) => member.name);
+  const generatedServiceNames = new Set(agentNames.map(createEveServiceName));
+  assertComposableConfig(config, agentNames);
+
+  const outputDirectory = join(root, ".vercel", "output");
+  const internalConfig = toInternalConfig(config);
+  const assembled = assembleEveVercelServices({
+    agents: workspace.members.map((member) => ({
+      agent: {
+        appRoot: member.appRoot,
+        buildCommand: `node ${quoteVercelShellArgument(
+          toVercelRelativePath(member.appRoot, resolveEveBinaryPath(member.appRoot)),
+        )} build`,
+        name: member.name,
+        publicRoutePrefix: `/${member.name}`,
+        workspaceMember: true,
+      },
+      target: {
+        hostOutputDirectory: outputDirectory,
+        projectRoot: root,
+      },
+    })),
+    routes: internalConfig.routes,
+    services: createServiceConfigRecord(internalConfig.services),
+  });
+
+  await Promise.all(
+    assembled.rootDirectories.map((directory) => mkdir(directory, { recursive: true })),
+  );
+
+  const services = Object.fromEntries(
+    Object.entries(assembled.services).map(([name, service]) => {
+      if (!generatedServiceNames.has(name)) {
+        return [name, service];
+      }
+      const { routePrefix: _routePrefix, ...vercelSourceService } = service;
+      return [name, vercelSourceService];
+    }),
+  );
+
+  return {
+    ...config,
+    routes: assembled.routes as readonly EveVercelRouteConfig[],
+    services: services as Readonly<Record<string, EveVercelServiceConfig>>,
+  };
+}

--- a/packages/eve/src/public/vercel/index.ts
+++ b/packages/eve/src/public/vercel/index.ts
@@ -53,30 +53,45 @@ export interface WithEveOptions {
 }
 
 function toInternalConfig(config: EveVercelConfig): VercelServicesConfig {
-  return config as unknown as VercelServicesConfig;
+  return config as VercelServicesConfig;
+}
+
+function assertUniqueNamedServices(services: EveVercelConfig["services"]): void {
+  if (!Array.isArray(services)) return;
+
+  const seen = new Set<string>();
+  for (const service of services) {
+    if (seen.has(service.name)) {
+      throw new Error(
+        `withEve received duplicate Vercel service name ${JSON.stringify(service.name)}. Give every entry in the services array a unique name.`,
+      );
+    }
+    seen.add(service.name);
+  }
 }
 
 function assertComposableConfig(config: EveVercelConfig, agentNames: readonly string[]): void {
   if (config.experimentalServices !== undefined || config.experimentalServicesV2 !== undefined) {
     throw new Error(
-      "withEve does not support experimentalServices. Use services or remove the obsolete configuration.",
+      "withEve cannot compose experimentalServices or experimentalServicesV2. Remove the obsolete field and define authored services under services.",
     );
   }
 
+  assertUniqueNamedServices(config.services);
   const internalConfig = toInternalConfig(config);
   const services = createServiceConfigRecord(internalConfig.services);
   for (const name of agentNames) {
     const serviceName = createEveServiceName(name);
-    if (services[serviceName] !== undefined) {
+    if (Object.hasOwn(services, serviceName)) {
       throw new Error(
-        `Vercel service ${JSON.stringify(serviceName)} is reserved for eve workspace agent ${JSON.stringify(name)}.`,
+        `Vercel service key ${JSON.stringify(serviceName)} conflicts with the service generated for eve workspace agent ${JSON.stringify(name)}. Remove or rename the authored service; withEve owns this key.`,
       );
     }
 
     const routeSrc = createEveServiceRouteSrc(`/${name}`);
     if (config.routes?.some((route) => route.src === routeSrc)) {
       throw new Error(
-        `Vercel route ${JSON.stringify(routeSrc)} is reserved for eve workspace agent ${JSON.stringify(name)}.`,
+        `Vercel route ${JSON.stringify(routeSrc)} conflicts with the transport route generated for eve workspace agent ${JSON.stringify(name)}. Remove the authored route; withEve adds it automatically.`,
       );
     }
   }
@@ -104,6 +119,12 @@ export async function withEve<TConfig extends EveVercelConfig>(
   }
 
   const { workspace } = context;
+  if (workspace.members.length === 0) {
+    throw new Error(
+      `withEve found no workspace agents under ${join(root, "agents")}. Add an agent or remove withEve from vercel.ts.`,
+    );
+  }
+
   const agentNames = workspace.members.map((member) => member.name);
   const generatedServiceNames = new Set(agentNames.map(createEveServiceName));
   assertComposableConfig(config, agentNames);

--- a/packages/eve/src/public/vercel/index.ts
+++ b/packages/eve/src/public/vercel/index.ts
@@ -59,7 +59,7 @@ function toInternalConfig(config: EveVercelConfig): VercelServicesConfig {
 function assertComposableConfig(config: EveVercelConfig, agentNames: readonly string[]): void {
   if (config.experimentalServices !== undefined || config.experimentalServicesV2 !== undefined) {
     throw new Error(
-      "withEve cannot compose experimentalServices or experimentalServicesV2. Remove the obsolete field and define authored services under services.",
+      "withEveServices cannot compose experimentalServices or experimentalServicesV2. Remove the obsolete field and define authored services under services.",
     );
   }
 
@@ -69,14 +69,14 @@ function assertComposableConfig(config: EveVercelConfig, agentNames: readonly st
     const serviceName = createEveServiceName(name);
     if (Object.hasOwn(services, serviceName)) {
       throw new Error(
-        `Vercel service key ${JSON.stringify(serviceName)} conflicts with the service generated for eve workspace agent ${JSON.stringify(name)}. Remove or rename the authored service; withEve owns this key.`,
+        `Vercel service key ${JSON.stringify(serviceName)} conflicts with the service generated for eve workspace agent ${JSON.stringify(name)}. Remove or rename the authored service; withEveServices owns this key.`,
       );
     }
 
     const routeSrc = createEveServiceRouteSrc(`/${name}`);
     if (config.routes?.some((route) => route.src === routeSrc)) {
       throw new Error(
-        `Vercel route ${JSON.stringify(routeSrc)} conflicts with the transport route generated for eve workspace agent ${JSON.stringify(name)}. Remove the authored route; withEve adds it automatically.`,
+        `Vercel route ${JSON.stringify(routeSrc)} conflicts with the transport route generated for eve workspace agent ${JSON.stringify(name)}. Remove the authored route; withEveServices adds it automatically.`,
       );
     }
   }
@@ -88,7 +88,7 @@ function assertComposableConfig(config: EveVercelConfig, agentNames: readonly st
  * The returned object is a plain Vercel configuration. Vercel resolves it before independently
  * building the authored services and each generated eve agent service.
  */
-export async function withEve<TConfig extends EveVercelConfig>(
+export async function withEveServices<TConfig extends EveVercelConfig>(
   config: TConfig,
   options: WithEveOptions = {},
 ): Promise<
@@ -100,13 +100,13 @@ export async function withEve<TConfig extends EveVercelConfig>(
   const root = resolve(options.root ?? process.cwd());
   const context = await resolveEveProjectContext(root);
   if (context.kind !== "workspace" || context.workspace.root !== root) {
-    throw new Error(`withEve must run at an eve workspace root; received ${root}.`);
+    throw new Error(`withEveServices must run at an eve workspace root; received ${root}.`);
   }
 
   const { workspace } = context;
   if (workspace.members.length === 0) {
     throw new Error(
-      `withEve found no workspace agents under ${join(root, "agents")}. Add an agent or remove withEve from vercel.ts.`,
+      `withEveServices found no workspace agents under ${join(root, "agents")}. Add an agent or remove withEveServices from vercel.ts.`,
     );
   }
 

--- a/packages/eve/src/public/vercel/index.ts
+++ b/packages/eve/src/public/vercel/index.ts
@@ -56,20 +56,6 @@ function toInternalConfig(config: EveVercelConfig): VercelServicesConfig {
   return config as VercelServicesConfig;
 }
 
-function assertUniqueNamedServices(services: EveVercelConfig["services"]): void {
-  if (!Array.isArray(services)) return;
-
-  const seen = new Set<string>();
-  for (const service of services) {
-    if (seen.has(service.name)) {
-      throw new Error(
-        `withEve received duplicate Vercel service name ${JSON.stringify(service.name)}. Give every entry in the services array a unique name.`,
-      );
-    }
-    seen.add(service.name);
-  }
-}
-
 function assertComposableConfig(config: EveVercelConfig, agentNames: readonly string[]): void {
   if (config.experimentalServices !== undefined || config.experimentalServicesV2 !== undefined) {
     throw new Error(
@@ -77,7 +63,6 @@ function assertComposableConfig(config: EveVercelConfig, agentNames: readonly st
     );
   }
 
-  assertUniqueNamedServices(config.services);
   const internalConfig = toInternalConfig(config);
   const services = createServiceConfigRecord(internalConfig.services);
   for (const name of agentNames) {

--- a/packages/eve/src/public/vercel/index.ts
+++ b/packages/eve/src/public/vercel/index.ts
@@ -59,7 +59,7 @@ function toInternalConfig(config: EveVercelConfig): VercelServicesConfig {
 function assertComposableConfig(config: EveVercelConfig, agentNames: readonly string[]): void {
   if (config.experimentalServices !== undefined || config.experimentalServicesV2 !== undefined) {
     throw new Error(
-      "withEveServices cannot compose experimentalServices or experimentalServicesV2. Remove the obsolete field and define authored services under services.",
+      "withEve cannot compose experimentalServices or experimentalServicesV2. Remove the obsolete field and define authored services under services.",
     );
   }
 
@@ -69,14 +69,14 @@ function assertComposableConfig(config: EveVercelConfig, agentNames: readonly st
     const serviceName = createEveServiceName(name);
     if (Object.hasOwn(services, serviceName)) {
       throw new Error(
-        `Vercel service key ${JSON.stringify(serviceName)} conflicts with the service generated for eve workspace agent ${JSON.stringify(name)}. Remove or rename the authored service; withEveServices owns this key.`,
+        `Vercel service key ${JSON.stringify(serviceName)} conflicts with the service generated for eve workspace agent ${JSON.stringify(name)}. Remove or rename the authored service; withEve owns this key.`,
       );
     }
 
     const routeSrc = createEveServiceRouteSrc(`/${name}`);
     if (config.routes?.some((route) => route.src === routeSrc)) {
       throw new Error(
-        `Vercel route ${JSON.stringify(routeSrc)} conflicts with the transport route generated for eve workspace agent ${JSON.stringify(name)}. Remove the authored route; withEveServices adds it automatically.`,
+        `Vercel route ${JSON.stringify(routeSrc)} conflicts with the transport route generated for eve workspace agent ${JSON.stringify(name)}. Remove the authored route; withEve adds it automatically.`,
       );
     }
   }
@@ -88,7 +88,7 @@ function assertComposableConfig(config: EveVercelConfig, agentNames: readonly st
  * The returned object is a plain Vercel configuration. Vercel resolves it before independently
  * building the authored services and each generated eve agent service.
  */
-export async function withEveServices<TConfig extends EveVercelConfig>(
+export async function withEve<TConfig extends EveVercelConfig>(
   config: TConfig,
   options: WithEveOptions = {},
 ): Promise<
@@ -100,13 +100,13 @@ export async function withEveServices<TConfig extends EveVercelConfig>(
   const root = resolve(options.root ?? process.cwd());
   const context = await resolveEveProjectContext(root);
   if (context.kind !== "workspace" || context.workspace.root !== root) {
-    throw new Error(`withEveServices must run at an eve workspace root; received ${root}.`);
+    throw new Error(`withEve must run at an eve workspace root; received ${root}.`);
   }
 
   const { workspace } = context;
   if (workspace.members.length === 0) {
     throw new Error(
-      `withEveServices found no workspace agents under ${join(root, "agents")}. Add an agent or remove withEveServices from vercel.ts.`,
+      `withEve found no workspace agents under ${join(root, "agents")}. Add an agent or remove withEve from vercel.ts.`,
     );
   }
 

--- a/packages/eve/test/scenarios/public-api-portability.scenario.test.ts
+++ b/packages/eve/test/scenarios/public-api-portability.scenario.test.ts
@@ -42,6 +42,29 @@ const PORTABILITY_CASES: readonly PortabilityCase[] = [
   {
     descriptor: {
       files: {
+        "agent/vercel.ts": `import { withEve, type EveVercelConfig } from "eve/vercel";
+
+const config = {
+  routes: [{ destination: { service: "web", type: "service" }, src: "^(.*)$" }],
+  services: { web: { framework: "nextjs", root: "apps/web" } },
+} satisfies EveVercelConfig;
+
+export default withEve(config);
+`,
+      },
+      name: "vercel-composer-public-api-portability",
+    },
+    include: ["src/public/vercel/index.ts"],
+    name: "lets tsc typecheck withEve from the public Vercel subpath",
+    packageExports: {
+      "./vercel": {
+        types: "./dist/src/public/vercel/index.d.ts",
+      },
+    },
+  },
+  {
+    descriptor: {
+      files: {
         "agent/sandbox.ts": `import { defaultBackend, defineSandbox } from "eve/sandbox";
 import { docker } from "eve/sandbox/docker";
 import { justbash } from "eve/sandbox/just-bash";

--- a/packages/eve/test/scenarios/public-api-portability.scenario.test.ts
+++ b/packages/eve/test/scenarios/public-api-portability.scenario.test.ts
@@ -42,20 +42,20 @@ const PORTABILITY_CASES: readonly PortabilityCase[] = [
   {
     descriptor: {
       files: {
-        "agent/vercel.ts": `import { withEveServices, type EveVercelConfig } from "eve/vercel";
+        "agent/vercel.ts": `import { withEve, type EveVercelConfig } from "eve/vercel";
 
 const config = {
   routes: [{ destination: { service: "web", type: "service" }, src: "^(.*)$" }],
   services: { web: { framework: "nextjs", root: "apps/web" } },
 } satisfies EveVercelConfig;
 
-export default withEveServices(config);
+export default withEve(config);
 `,
       },
       name: "vercel-composer-public-api-portability",
     },
     include: ["src/public/vercel/index.ts"],
-    name: "lets tsc typecheck withEveServices from the public Vercel subpath",
+    name: "lets tsc typecheck withEve from the public Vercel subpath",
     packageExports: {
       "./vercel": {
         types: "./dist/src/public/vercel/index.d.ts",

--- a/packages/eve/test/scenarios/public-api-portability.scenario.test.ts
+++ b/packages/eve/test/scenarios/public-api-portability.scenario.test.ts
@@ -42,20 +42,20 @@ const PORTABILITY_CASES: readonly PortabilityCase[] = [
   {
     descriptor: {
       files: {
-        "agent/vercel.ts": `import { withEve, type EveVercelConfig } from "eve/vercel";
+        "agent/vercel.ts": `import { withEveServices, type EveVercelConfig } from "eve/vercel";
 
 const config = {
   routes: [{ destination: { service: "web", type: "service" }, src: "^(.*)$" }],
   services: { web: { framework: "nextjs", root: "apps/web" } },
 } satisfies EveVercelConfig;
 
-export default withEve(config);
+export default withEveServices(config);
 `,
       },
       name: "vercel-composer-public-api-portability",
     },
     include: ["src/public/vercel/index.ts"],
-    name: "lets tsc typecheck withEve from the public Vercel subpath",
+    name: "lets tsc typecheck withEveServices from the public Vercel subpath",
     packageExports: {
       "./vercel": {
         types: "./dist/src/public/vercel/index.d.ts",


### PR DESCRIPTION
### Summary

`withEve` from `eve/vercel` composes generated eve workspace services and transport routes with authored Vercel services in a root `vercel.ts`. This lets Vercel resolve the complete service graph before it independently builds a frontend and each workspace agent.

The helper rejects conflicting generated service keys and transport routes, preserves authored routes, bindings, and Cron Jobs, and shares named-service validation with the existing Vercel service configuration normalizer.

### Validation

- `pnpm --filter eve typecheck`
- `pnpm exec oxlint packages/eve/src/internal/vercel/build-agent-workspace.ts packages/eve/src/public/vercel/index.ts packages/eve/src/public/vercel/index.integration.test.ts packages/eve/test/scenarios/public-api-portability.scenario.test.ts`
- `pnpm docs:check`

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
