### PR TITLE
fix(eve): inbox upgrades - retain compatible session execution

### DIFF
--- a/.changeset/retained-session-execution.md
+++ b/.changeset/retained-session-execution.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Keep existing Vercel sessions on their original deployment when a newer runtime cannot confirm session-state compatibility. Pending work and later turns continue without a reset; retain the original deployment until those sessions finish.

--- a/docs/guides/deployment/vercel.mdx
+++ b/docs/guides/deployment/vercel.mdx
@@ -92,6 +92,18 @@ Vercel uses the generated output to configure these services:
 
 ## Verify the deployment
 
+### Preserve existing sessions during upgrades
+
+Keep each existing session's original deployment available when you upgrade eve. If the receiving runtime cannot confirm that it understands the session's state and the state its parent can read, it forwards the turn to that original deployment. This includes sessions created before state-compatibility negotiation was introduced.
+
+These sessions keep their IDs, history, pending work, and original agent code. They do not automatically adopt updated instructions or tools. New sessions use the newly deployed agent; sessions with a matching state contract can run later turns on newer deployments.
+
+Retain the original deployment, Workflow data, and credentials needed by its unfinished sessions, tasks, and callbacks. Disabled session expiry can extend this requirement indefinitely. Vercel runtime logs identify forwarded turns with `using retained session code for an incompatible turn state contract` and include the session and execution deployment IDs.
+
+For an agent-code rollback, deploy the earlier authored code with the current eve runtime. Keep the compatibility-capable runtime serving ingress and retain both generations of session executables. Rolling back the eve package itself to a release without this boundary is not a supported downgrade path. This retained-deployment behavior is specific to Vercel; it does not establish compatibility when replacing a self-hosted executable in place.
+
+### Check the deployed agent
+
 Check the health route and connect the development TUI:
 
 ```bash

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -131,7 +131,18 @@ the current producer must choose the old consumer's wire version, and the real
 old consumer must decode and buffer it. The eval then cancels the deliberately
 blocked turn and verifies that the old session runs the buffered follow-up.
 
-The eval redeploys from inside its test body: it mutates the agent source,
+`agent-inbox-upgrade/evals/inbox-upgrade.redeploy.eval.ts` uses published
+`eve@0.49.0`, whose parent dispatches later turns to the accepting deployment.
+It checks idle follow-up, a pending blocking-tool answer, cancellation, a
+background task after its initiating turn completes, and stream resumption.
+Execution markers record the deployment and workflow run: pending bodies must
+finish on their original deployment, while later turns use the checkout with
+the original session ID. A third deployment rolls back agent code while keeping
+the current runtime. Session expiry is disabled throughout the probe. This is
+the compatibility baseline for the unified inbox refactor; it does not exercise
+the proposed new owner topology or self-hosted executable retention.
+
+These evals redeploy from inside their test bodies: they mutate agent source,
 runs `eve build` + `vc deploy`, and repoints a run-scoped Vercel alias at
 each new deployment, polling `/eve/v1/info` until the alias serves it.
 Because immutable deployment URLs never change what they serve, the eval

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -141,6 +141,9 @@ the original session ID. A third deployment rolls back agent code while keeping
 the current runtime. Session expiry is disabled throughout the probe. This is
 the compatibility baseline for the unified inbox refactor; it does not exercise
 the proposed new owner topology or self-hosted executable retention.
+During alias propagation, bounded read-only turns may still reach a prior
+deployment. Every turn must keep the session usable; the probe then requires
+the new deployment and marker before accepting the code transition.
 
 The historical workflow fixture stages a copy of the published package with
 its unusable `eve-source` conditions removed from `package.json`; those point

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -133,25 +133,25 @@ blocked turn and verifies that the old session runs the buffered follow-up.
 
 `agent-inbox-upgrade/evals/inbox-upgrade.redeploy.eval.ts` uses published
 `eve@0.49.0`, whose parent dispatches later turns to the accepting deployment.
-It checks idle follow-up, a pending blocking-tool answer, cancellation, a
-background task after its initiating turn completes, and stream resumption.
-Execution markers record the deployment and workflow run: pending bodies must
-finish on their original deployment, while later turns use the checkout with
-the original session ID. A third deployment rolls back agent code while keeping
-the current runtime. Session expiry is disabled throughout the probe. This is
-the compatibility baseline for the unified inbox refactor; it does not exercise
-the proposed new owner topology or self-hosted executable retention.
-During alias propagation, bounded read-only turns may still reach a prior
-deployment. Every turn must keep the session usable; the probe then requires
-the new deployment and marker before accepting the code transition.
+The current entry forwards incompatible turns back to the retained parent
+executable before claiming hooks or running agent code. The probe requires old
+sessions to preserve their IDs and stream cursors, answer and cancel pending
+work, continue after task completion, and start and finish new blocking and
+background work after the upgrade. Execution markers prove each body uses its
+original deployment. A child run on that deployment distinguishes forwarding
+through current ingress from an old ingress executing the ordinary read inline.
+New sessions use current code and follow an agent-code rollback with the current
+runtime retained. Old sessions continue on their original code through rollback.
+Session expiry is disabled throughout.
 
-The probe currently reproduces a real compatibility failure: after a published
-0.49.0 background task completes, the next user turn fails because the current
-runtime rejects its unversioned `eve.tasks` index. It retains that failure while
-checking rollback on independent sessions, then fails the eval. See the
-[spike findings](../research/discriminated-workflow-inboxes.md#published-consumer-compatibility-spike).
-Do not replace the assertion with an expected error or reset the session to make
-the upgrade pass.
+During alias propagation, bounded read-only turns may still reach a prior
+ingress. Every accepted turn must keep the session usable. The probe requires
+actual deployment and run provenance before accepting each transition.
+The [spike findings](../research/discriminated-workflow-inboxes.md#published-consumer-compatibility-spike)
+record the original fatal task-state failure. The post-task follow-up remains a
+required success assertion; a reset is only used after the probe for cleanup.
+The test does not exercise the proposed new owner topology or self-hosted
+executable retention.
 
 The historical workflow fixture stages a copy of the published package with
 its unusable `eve-source` conditions removed from `package.json`; those point

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -142,6 +142,13 @@ the current runtime. Session expiry is disabled throughout the probe. This is
 the compatibility baseline for the unified inbox refactor; it does not exercise
 the proposed new owner topology or self-hosted executable retention.
 
+The historical workflow fixture stages a copy of the published package with
+its unusable `eve-source` conditions removed from `package.json`; those point
+to source files absent from npm and otherwise leave `eve/workflow` unresolved
+in the Workflow sandbox. Published runtime code is unchanged. This build
+accommodation is specific to the probe; production upgrades must retain their
+old deployment artifacts.
+
 These evals redeploy from inside their test bodies: they mutate agent source,
 runs `eve build` + `vc deploy`, and repoints a run-scoped Vercel alias at
 each new deployment, polling `/eve/v1/info` until the alias serves it.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -145,6 +145,14 @@ During alias propagation, bounded read-only turns may still reach a prior
 deployment. Every turn must keep the session usable; the probe then requires
 the new deployment and marker before accepting the code transition.
 
+The probe currently reproduces a real compatibility failure: after a published
+0.49.0 background task completes, the next user turn fails because the current
+runtime rejects its unversioned `eve.tasks` index. It retains that failure while
+checking rollback on independent sessions, then fails the eval. See the
+[spike findings](../research/discriminated-workflow-inboxes.md#published-consumer-compatibility-spike).
+Do not replace the assertion with an expected error or reset the session to make
+the upgrade pass.
+
 The historical workflow fixture stages a copy of the published package with
 its unusable `eve-source` conditions removed from `package.json`; those point
 to source files absent from npm and otherwise leave `eve/workflow` unresolved

--- a/e2e/fixtures/agent-channels/evals/custom-channels/cross-version-session-inbox.eval.ts
+++ b/e2e/fixtures/agent-channels/evals/custom-channels/cross-version-session-inbox.eval.ts
@@ -1,39 +1,22 @@
-import { execFile } from "node:child_process";
-import { readFile, readlink, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import { realpath } from "node:fs/promises";
 import { resolve } from "node:path";
-import { promisify } from "node:util";
 
+import { createRedeployFixture, readEveVersion } from "@eve-e2e/config/redeploy";
 import { defineEval } from "eve/evals";
-import type { EveEvalContext } from "eve/evals";
 import { satisfies } from "eve/evals/expect";
 
 import { postChannel } from "./shared";
 
-const ALIAS_ENV = "EVE_E2E_REDEPLOY_ALIAS";
 const OLD_EVE_VERSION = "0.30.8";
 const ACTIVE_TURN_MESSAGE = "Please wait for cross-version follow-up.";
 const FOLLOW_UP_TOKEN = "CROSS-VERSION-WIRE-OK";
-
-const INSTRUCTIONS_PATH = resolve("agent", "instructions.md");
-const FIXTURE_EVE_LINK = resolve("node_modules", "eve");
-const CONFIG_EVE_LINK = resolve("..", "e2e-config", "node_modules", "eve");
-const OLD_EVE_PACKAGE = resolve("node_modules", "historical-eve-0-30-8");
-
 const OLD_DEPLOYMENT_MARKER = "cross-version-eve-0-30-8";
 const CURRENT_DEPLOYMENT_MARKER = "cross-version-eve-current";
 const TOOL_NAME = "wait-for-cancellation";
 
-const execFileAsync = promisify(execFile);
-const EXEC_OPTIONS = { maxBuffer: 64 * 1024 * 1024 } as const;
-
 type MessageResponse = { ok: boolean; sessionId?: string };
 
-/**
- * Proves the complete mixed-version codec boundary through the real Workflow
- * hook: the current producer resumes an active turn built and deployed with
- * the published eve@0.30.8 consumer, then the old session accepts the
- * replacement message and completes its next turn.
- */
+/** Exercises the published decoder, not a current decoder receiving an old version number. */
 export default defineEval({
   description:
     "Session inbox: the current producer resumes an active eve@0.30.8 consumer through the durable hook.",
@@ -41,42 +24,13 @@ export default defineEval({
   timeoutMs: 20 * 60_000,
 
   async test(t) {
-    const alias = process.env[ALIAS_ENV];
-    if (alias === undefined || alias.length === 0) {
-      t.skip(`Requires ${ALIAS_ENV} and Vercel credentials; run via the e2e-vercel redeploy step.`);
+    const fixture = await createRedeployFixture(t);
+    const oldEvePackage = await realpath(resolve("node_modules", "historical-eve-0-30-8"));
+    if ((await readEveVersion(oldEvePackage)) !== OLD_EVE_VERSION) {
+      throw new Error(`Expected published eve@${OLD_EVE_VERSION}.`);
     }
-    if (new URL(t.target.url).host !== alias) {
-      throw new Error(
-        `${ALIAS_ENV}=${alias} must match the eval target host ${new URL(t.target.url).host}; ` +
-          "redeploys repoint the alias, so the eval must run against it.",
-      );
-    }
-
-    const originalInstructions = await readFile(INSTRUCTIONS_PATH, "utf8");
-    const links = await Promise.all([
-      snapshotLink(FIXTURE_EVE_LINK),
-      snapshotLink(CONFIG_EVE_LINK),
-    ]);
-    const currentEvePackage = await realpath(FIXTURE_EVE_LINK);
-    const currentEveVersion = await readPackageVersion(currentEvePackage);
-    const oldEvePackage = await realpath(OLD_EVE_PACKAGE);
-    const oldEveVersion = await readPackageVersion(oldEvePackage);
-    if (oldEveVersion !== OLD_EVE_VERSION) {
-      throw new Error(
-        `Expected ${OLD_EVE_PACKAGE} to resolve eve@${OLD_EVE_VERSION}; got eve@${oldEveVersion}.`,
-      );
-    }
-
     try {
-      await replaceLink(FIXTURE_EVE_LINK, oldEvePackage);
-      await replaceLink(CONFIG_EVE_LINK, oldEvePackage);
-      await writeFile(
-        INSTRUCTIONS_PATH,
-        `${originalInstructions}\nDeployment marker: ${OLD_DEPLOYMENT_MARKER}.\n`,
-      );
-      await deployToAlias(t, alias, "eve@0.30.8");
-      await waitForAliasToServe(t, OLD_DEPLOYMENT_MARKER);
-
+      await fixture.deploy(oldEvePackage, OLD_DEPLOYMENT_MARKER);
       const sessionRef = crypto.randomUUID();
       const started = await postChannel<MessageResponse>(t.target, "/cross-version-webhook", {
         message: ACTIVE_TURN_MESSAGE,
@@ -99,13 +53,7 @@ export default defineEval({
         },
       });
 
-      await restoreLinks(links);
-      await writeFile(
-        INSTRUCTIONS_PATH,
-        `${originalInstructions}\nDeployment marker: ${CURRENT_DEPLOYMENT_MARKER}.\n`,
-      );
-      await deployToAlias(t, alias, `eve@${currentEveVersion}`);
-      await waitForAliasToServe(t, CURRENT_DEPLOYMENT_MARKER);
+      await fixture.deploy(fixture.currentPackage, CURRENT_DEPLOYMENT_MARKER);
 
       const replacement = await postChannel<MessageResponse>(t.target, "/cross-version-webhook", {
         message: `Reply with exactly ${FOLLOW_UP_TOKEN}.`,
@@ -151,97 +99,7 @@ export default defineEval({
 
       t.succeeded();
     } finally {
-      await restoreLinks(links);
-      await writeFile(INSTRUCTIONS_PATH, originalInstructions);
+      await fixture.restore();
     }
   },
 });
-
-interface LinkSnapshot {
-  readonly path: string;
-  readonly target: string;
-}
-
-async function snapshotLink(path: string): Promise<LinkSnapshot> {
-  return { path, target: await readlink(path) };
-}
-
-async function replaceLink(path: string, target: string): Promise<void> {
-  await rm(path, { force: true });
-  await symlink(target, path);
-}
-
-async function restoreLinks(links: readonly LinkSnapshot[]): Promise<void> {
-  for (const link of links) {
-    await replaceLink(link.path, link.target);
-  }
-}
-
-async function readPackageVersion(packagePath: string): Promise<string> {
-  const manifest = JSON.parse(await readFile(resolve(packagePath, "package.json"), "utf8")) as {
-    version?: string;
-  };
-  if (manifest.version === undefined) {
-    throw new Error(`Package at ${packagePath} has no version.`);
-  }
-  return manifest.version;
-}
-
-/** Builds the fixture and repoints the run-scoped alias at the fresh deployment. */
-async function deployToAlias(t: EveEvalContext, alias: string, phase: string): Promise<void> {
-  await execFileAsync("pnpm", ["exec", "eve", "build"], {
-    ...EXEC_OPTIONS,
-    env: {
-      ...process.env,
-      VERCEL: "1",
-      VERCEL_ENV: "preview",
-      VERCEL_TARGET_ENV: "preview",
-    },
-  });
-  const tokenArgs =
-    process.env.VERCEL_TOKEN === undefined ? [] : ["--token", process.env.VERCEL_TOKEN];
-  const modelArgs =
-    process.env.EVE_E2E_MODEL === undefined
-      ? []
-      : ["--env", `EVE_E2E_MODEL=${process.env.EVE_E2E_MODEL}`];
-  const scopeArgs =
-    process.env.VERCEL_ORG_ID === undefined ? [] : ["--scope", process.env.VERCEL_ORG_ID];
-  const deploy = await execFileAsync(
-    "pnpm",
-    ["exec", "vc", "deploy", "--prebuilt", "--yes", "--target=preview", ...modelArgs, ...tokenArgs],
-    EXEC_OPTIONS,
-  );
-  const deploymentUrl = deploy.stdout.trim().split("\n").at(-1)?.trim();
-  if (deploymentUrl === undefined || !deploymentUrl.startsWith("https://")) {
-    throw new Error(`vc deploy did not print a deployment URL; got: ${deploy.stdout}`);
-  }
-  t.log(`deployed ${deploymentUrl} (${phase}); aliasing ${alias}`);
-
-  await execFileAsync(
-    "pnpm",
-    ["exec", "vc", "alias", "set", deploymentUrl, alias, ...tokenArgs, ...scopeArgs],
-    EXEC_OPTIONS,
-  );
-}
-
-/** Waits until the alias exposes the marker from the expected deployment. */
-async function waitForAliasToServe(t: EveEvalContext, marker: string): Promise<void> {
-  const deadline = Date.now() + 120_000;
-  let lastStatus = "transport error";
-  let lastMarkerMatch = false;
-  while (Date.now() < deadline) {
-    try {
-      const response = await t.target.fetch("/eve/v1/info", { cache: "no-store" });
-      lastStatus = String(response.status);
-      lastMarkerMatch = response.ok && JSON.stringify(await response.json()).includes(marker);
-      if (lastMarkerMatch) return;
-    } catch {
-      // The alias may briefly be unavailable while its deployment propagates.
-    }
-    await t.sleep(1_000);
-  }
-  throw new Error(
-    `Timed out waiting for alias ${new URL(t.target.url).host} to serve marker ${marker}; ` +
-      `last status=${lastStatus}, marker matched=${lastMarkerMatch}.`,
-  );
-}

--- a/e2e/fixtures/agent-inbox-upgrade/agent/agent.ts
+++ b/e2e/fixtures/agent-inbox-upgrade/agent/agent.ts
@@ -1,0 +1,29 @@
+import { e2eAgentConfig } from "@eve-e2e/config";
+import { defineAgent } from "eve";
+import { mockModel, type MockModelRequest, type MockModelResponse } from "eve/evals";
+
+import { UPGRADE_LEGACY_CONFIG } from "./lib/upgrade-marker.ts";
+
+function respond(request: MockModelRequest): MockModelResponse | string {
+  const message = [...request.userMessages].reverse().find((entry) => entry.trim() !== "") ?? "";
+  const upgrade = /^UPGRADE-(read|gate|task)-([a-z0-9]+)$/u.exec(message);
+  if (upgrade === null) return message;
+  const name = `upgrade_${upgrade[1]}`;
+  const key = upgrade[2]!;
+  const id = `${name}-${key}`;
+  const result = request.toolResults.find((entry) => entry.id === id);
+  return result === undefined
+    ? { toolCalls: [{ id, input: { key }, name }] }
+    : `UPGRADE-RESULT ${typeof result.output === "string" ? result.output : JSON.stringify(result.output)}`;
+}
+
+const base = e2eAgentConfig({ mock: respond });
+
+export default defineAgent({
+  ...base,
+  // The published consumer requires an opt-in removed from the current authoring API.
+  ...UPGRADE_LEGACY_CONFIG,
+  limits: { sessionTimeoutMs: false },
+  model: mockModel(respond),
+  modelContextWindowTokens: base.modelContextWindowTokens ?? 1_000_000,
+});

--- a/e2e/fixtures/agent-inbox-upgrade/agent/channels/eve.ts
+++ b/e2e/fixtures/agent-inbox-upgrade/agent/channels/eve.ts
@@ -1,0 +1,16 @@
+import { eveChannel } from "eve/channels/eve";
+
+export default eveChannel({
+  auth: (request) => {
+    const forwarded = request.headers.get("x-eve-forwarded-principal-id");
+    const principalId = forwarded ?? "inbox-upgrade-user";
+    return {
+      attributes: { fixture: "inbox-upgrade" },
+      authenticator: "e2e-fixture",
+      issuer: "e2e",
+      principalId,
+      principalType: "user",
+      subject: principalId,
+    };
+  },
+});

--- a/e2e/fixtures/agent-inbox-upgrade/agent/instructions.md
+++ b/e2e/fixtures/agent-inbox-upgrade/agent/instructions.md
@@ -1,0 +1,1 @@
+Run the tool named by the upgrade directive and return its result.

--- a/e2e/fixtures/agent-inbox-upgrade/agent/lib/upgrade-execution.ts
+++ b/e2e/fixtures/agent-inbox-upgrade/agent/lib/upgrade-execution.ts
@@ -1,0 +1,14 @@
+import { getWorkflowMetadata } from "workflow";
+
+import { UPGRADE_MARKER } from "./upgrade-marker.ts";
+
+/** Captures the actual executable and owner so a resumed old turn cannot pass as a new one. */
+export async function readUpgradeExecution() {
+  "use step";
+
+  return {
+    deploymentId: process.env.VERCEL_DEPLOYMENT_ID ?? "local",
+    marker: UPGRADE_MARKER,
+    runId: getWorkflowMetadata().workflowRunId,
+  };
+}

--- a/e2e/fixtures/agent-inbox-upgrade/agent/lib/upgrade-marker.ts
+++ b/e2e/fixtures/agent-inbox-upgrade/agent/lib/upgrade-marker.ts
@@ -1,0 +1,2 @@
+export const UPGRADE_MARKER = "upgrade-baseline";
+export const UPGRADE_LEGACY_CONFIG = {};

--- a/e2e/fixtures/agent-inbox-upgrade/agent/tools/upgrade_gate.ts
+++ b/e2e/fixtures/agent-inbox-upgrade/agent/tools/upgrade_gate.ts
@@ -1,0 +1,20 @@
+import { defineTool } from "eve/tools";
+import { ask } from "eve/workflow";
+import { z } from "zod";
+
+import { readUpgradeExecution } from "../lib/upgrade-execution.ts";
+
+export default defineTool({
+  description: "Hold a blocking workflow across an eve deployment upgrade.",
+  inputSchema: z.strictObject({ key: z.string() }),
+  async execute({ key }, ctx) {
+    "use workflow";
+
+    const before = await readUpgradeExecution();
+    const answer = await ask(ctx, {
+      prompt: `UPGRADE-GATE ${key} ${JSON.stringify(before)}`,
+      options: [{ id: "continue", label: "Continue" }],
+    });
+    return { key, before, after: await readUpgradeExecution(), answer: answer.optionId };
+  },
+});

--- a/e2e/fixtures/agent-inbox-upgrade/agent/tools/upgrade_read.ts
+++ b/e2e/fixtures/agent-inbox-upgrade/agent/tools/upgrade_read.ts
@@ -1,0 +1,12 @@
+import { defineTool } from "eve/tools";
+import { z } from "zod";
+
+import { readUpgradeExecution } from "../lib/upgrade-execution.ts";
+
+export default defineTool({
+  description: "Read the executable deployment selected for this turn.",
+  inputSchema: z.strictObject({ key: z.string() }),
+  async execute({ key }) {
+    return { key, ...(await readUpgradeExecution()) };
+  },
+});

--- a/e2e/fixtures/agent-inbox-upgrade/agent/tools/upgrade_task.ts
+++ b/e2e/fixtures/agent-inbox-upgrade/agent/tools/upgrade_task.ts
@@ -1,0 +1,22 @@
+import { defineTool } from "eve/tools";
+import { ask } from "eve/workflow";
+import { z } from "zod";
+
+import { readUpgradeExecution } from "../lib/upgrade-execution.ts";
+
+export default defineTool({
+  description:
+    "Hold a background workflow after its initiating turn completes, across an eve upgrade.",
+  execution: "background",
+  inputSchema: z.strictObject({ key: z.string() }),
+  async execute({ key }, ctx) {
+    "use workflow";
+
+    const before = await readUpgradeExecution();
+    const answer = await ask(ctx, {
+      prompt: `UPGRADE-TASK ${key} ${JSON.stringify(before)}`,
+      options: [{ id: "continue", label: "Continue" }],
+    });
+    return { key, before, after: await readUpgradeExecution(), answer: answer.optionId };
+  },
+});

--- a/e2e/fixtures/agent-inbox-upgrade/evals/evals.config.ts
+++ b/e2e/fixtures/agent-inbox-upgrade/evals/evals.config.ts
@@ -1,0 +1,8 @@
+import { defineEvalConfig } from "eve/evals";
+
+export default defineEvalConfig({
+  // Workflow tools dispatch durable runs; serialize so the runs are never
+  // starved past the per-eval timeout.
+  maxConcurrency: 1,
+  timeoutMs: 120_000,
+});

--- a/e2e/fixtures/agent-inbox-upgrade/evals/inbox-upgrade.redeploy.eval.ts
+++ b/e2e/fixtures/agent-inbox-upgrade/evals/inbox-upgrade.redeploy.eval.ts
@@ -88,9 +88,9 @@ export default defineEval({
       await writeMarker(NEW_MARKER);
       await fixture.deploy(fixture.currentPackage, "inbox-upgrade-checkout");
 
-      const next = await idle.send("UPGRADE-read-next");
-      const newExecution = readExecution(next);
-      await requireExecution(t, newExecution, NEW_MARKER);
+      const upgraded = await followCodeDeployment(t, idle, "next", NEW_MARKER, [oldExecution]);
+      const next = upgraded.turn;
+      const newExecution = upgraded.execution;
       await t.require(
         { sessionId: next.sessionId, execution: newExecution },
         satisfies(
@@ -101,10 +101,15 @@ export default defineEval({
           "the published parent starts a child turn on the accepting deployment and retains its session ID",
         ),
       );
-      const replayed = await t.target.watchTurn(sessionId, { startIndex: streamIndex }).result();
-      replayed.expectOk();
-      replayed.messageIncludes(NEW_MARKER);
-      replayed.event("turn.completed", { count: 1 });
+      let replayIndex = streamIndex;
+      for (let attempt = 0; attempt < upgraded.attempts; attempt++) {
+        const replay = t.target.watchTurn(sessionId, { startIndex: replayIndex });
+        const replayed = await replay.result();
+        replayed.expectOk();
+        replayed.event("turn.completed", { count: 1 });
+        if (attempt === upgraded.attempts - 1) replayed.messageIncludes(NEW_MARKER);
+        replayIndex = requireStreamIndex(replay.session);
+      }
 
       const answered = await blocking.respond([
         { requestId: blockingRequest.requestId, optionId: "continue" },
@@ -144,18 +149,14 @@ export default defineEval({
       // Roll back authored code while retaining the runtime that understands both cohorts.
       await writeMarker(OLD_MARKER);
       await fixture.deploy(fixture.currentPackage, "inbox-upgrade-code-rollback");
+      let rollbackDeploymentId: string | undefined;
       for (const session of [idle, fresh]) {
-        const beforeId = session.sessionId;
-        const rollback = await session.send("UPGRADE-read-rollback");
-        const execution = readExecution(rollback);
-        await requireExecution(t, execution, OLD_MARKER);
-        await t.require(
-          rollback.sessionId === beforeId && execution.deploymentId !== newExecution.deploymentId,
-          satisfies(
-            (value: boolean) => value,
-            "code rollback preserves existing session IDs and selects the rollback deployment",
-          ),
-        );
+        const rollback = await followCodeDeployment(t, session, "rollback", OLD_MARKER, [
+          oldExecution,
+          newExecution,
+        ]);
+        rollbackDeploymentId ??= rollback.execution.deploymentId;
+        await requireExecution(t, rollback.execution, OLD_MARKER, rollbackDeploymentId);
       }
     } finally {
       // These isolated fixture sessions have finished the probe; retire their durable resources.
@@ -184,6 +185,41 @@ async function writeMarker(marker: string, legacy = false): Promise<void> {
     `export const UPGRADE_MARKER = ${JSON.stringify(marker)};\n` +
       `export const UPGRADE_LEGACY_CONFIG = ${JSON.stringify(config)};\n`,
   );
+}
+
+async function followCodeDeployment(
+  t: EveEvalContext,
+  session: EveEvalSession,
+  key: string,
+  marker: string,
+  previous: readonly Execution[],
+) {
+  const sessionId = session.sessionId;
+  const signal = AbortSignal.any([t.signal, AbortSignal.timeout(60_000)]);
+  for (let attempt = 0; attempt < 10; attempt++) {
+    // An alias can serve old ingress after an info request reached the new deployment.
+    // Probe with read-only turns; every accepted turn must preserve the session.
+    const turn = await session.send(`UPGRADE-read-${key}${attempt}`, { signal });
+    const execution = readExecution(turn);
+    await t.require(
+      turn.sessionId === sessionId,
+      satisfies(
+        (same: boolean) => same,
+        "code changes preserve the session ID during alias propagation",
+      ),
+    );
+    const prior = previous.find((entry) => entry.deploymentId === execution.deploymentId);
+    if (prior === undefined) {
+      await requireExecution(t, execution, marker);
+      return { turn, execution, attempts: attempt + 1 };
+    }
+    await requireExecution(t, execution, prior.marker, prior.deploymentId);
+    t.log(
+      `${key}: prior deployment still accepted a read-only turn; waiting for alias propagation`,
+    );
+    await t.sleep(1_000);
+  }
+  throw new Error(`Alias did not select ${marker} on a new deployment within ten read-only turns.`);
 }
 
 function requireStreamIndex(session: EveEvalSession): number {

--- a/e2e/fixtures/agent-inbox-upgrade/evals/inbox-upgrade.redeploy.eval.ts
+++ b/e2e/fixtures/agent-inbox-upgrade/evals/inbox-upgrade.redeploy.eval.ts
@@ -144,14 +144,22 @@ export default defineEval({
         receipt.taskId,
         backgroundExecution,
       );
-      const afterTask = await followCodeDeployment(
-        t,
-        completedBackground,
-        "aftertask",
-        NEW_MARKER,
-        [oldExecution],
-      );
-      await requireExecution(t, afterTask.execution, NEW_MARKER, newExecution.deploymentId);
+      let backgroundFollowupError: Error | undefined;
+      try {
+        const afterTask = await followCodeDeployment(
+          t,
+          completedBackground,
+          "aftertask",
+          NEW_MARKER,
+          [oldExecution],
+        );
+        await requireExecution(t, afterTask.execution, NEW_MARKER, newExecution.deploymentId);
+      } catch (error) {
+        if (t.signal.aborted) throw error;
+        // Preserve this failure while collecting evidence from the independent rollback cohorts.
+        backgroundFollowupError = error instanceof Error ? error : new Error(String(error));
+        t.log(`Background follow-up failed: ${backgroundFollowupError.message}`);
+      }
 
       const fresh = await createSessionOnDeployment(t, sessions, newExecution, oldExecution);
 
@@ -167,6 +175,7 @@ export default defineEval({
         rollbackDeploymentId ??= rollback.execution.deploymentId;
         await requireExecution(t, rollback.execution, OLD_MARKER, rollbackDeploymentId);
       }
+      if (backgroundFollowupError !== undefined) throw backgroundFollowupError;
     } finally {
       // These isolated fixture sessions have finished the probe; retire their durable resources.
       for (const session of sessions) {

--- a/e2e/fixtures/agent-inbox-upgrade/evals/inbox-upgrade.redeploy.eval.ts
+++ b/e2e/fixtures/agent-inbox-upgrade/evals/inbox-upgrade.redeploy.eval.ts
@@ -138,7 +138,20 @@ export default defineEval({
       await pendingBackground.respond([
         { requestId: backgroundRequest.requestId, optionId: "continue" },
       ]);
-      await requireTaskCompletion(t, pendingBackground, receipt.taskId, backgroundExecution);
+      const completedBackground = await requireTaskCompletion(
+        t,
+        pendingBackground,
+        receipt.taskId,
+        backgroundExecution,
+      );
+      const afterTask = await followCodeDeployment(
+        t,
+        completedBackground,
+        "aftertask",
+        NEW_MARKER,
+        [oldExecution],
+      );
+      await requireExecution(t, afterTask.execution, NEW_MARKER, newExecution.deploymentId);
 
       const fresh = await createSessionOnDeployment(t, sessions, newExecution, oldExecution);
 
@@ -364,7 +377,7 @@ async function requireTaskCompletion(
       const start = message.indexOf("{");
       if (start === -1) throw new Error("Completed task notification has no result.");
       await requireGateResult(t, JSON.parse(message.slice(start)), "background", expected);
-      return;
+      return session;
     }
     const live = t.target.watchTurn(session.sessionId!, {
       startIndex: requireStreamIndex(session),

--- a/e2e/fixtures/agent-inbox-upgrade/evals/inbox-upgrade.redeploy.eval.ts
+++ b/e2e/fixtures/agent-inbox-upgrade/evals/inbox-upgrade.redeploy.eval.ts
@@ -52,10 +52,13 @@ export default defineEval({
     ];
 
     try {
+      const historicalRuntime = await fixture.stagePublishedEve(historicalPackage);
       await writeMarker(OLD_MARKER, true);
-      await fixture.deploy(historicalPackage, "inbox-upgrade-published");
+      await fixture.deploy(historicalRuntime, "inbox-upgrade-published");
 
-      const first = await idle.send("UPGRADE-read-first");
+      const first = await idle.send("UPGRADE-read-first", {
+        signal: AbortSignal.any([t.signal, AbortSignal.timeout(90_000)]),
+      });
       const oldExecution = readExecution(first);
       await requireExecution(t, oldExecution, OLD_MARKER);
       const sessionId = first.sessionId;

--- a/e2e/fixtures/agent-inbox-upgrade/evals/inbox-upgrade.redeploy.eval.ts
+++ b/e2e/fixtures/agent-inbox-upgrade/evals/inbox-upgrade.redeploy.eval.ts
@@ -151,7 +151,6 @@ export default defineEval({
           ),
         );
       }
-      t.succeeded();
     } finally {
       // These isolated fixture sessions have finished the probe; retire their durable resources.
       for (const session of sessions) {

--- a/e2e/fixtures/agent-inbox-upgrade/evals/inbox-upgrade.redeploy.eval.ts
+++ b/e2e/fixtures/agent-inbox-upgrade/evals/inbox-upgrade.redeploy.eval.ts
@@ -1,0 +1,307 @@
+import { readFile, realpath, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import { createRedeployFixture, readEveVersion } from "@eve-e2e/config/redeploy";
+import { defineEval, type EveEvalContext, type EveEvalSession, type EveEvalTurn } from "eve/evals";
+import { satisfies } from "eve/evals/expect";
+
+const OLD_VERSION = "0.49.0";
+const OLD_MARKER = "upgrade-published";
+const NEW_MARKER = "upgrade-checkout";
+const MARKER_PATH = resolve("agent", "lib", "upgrade-marker.ts");
+
+interface Execution {
+  readonly deploymentId: string;
+  readonly marker: string;
+  readonly runId: string;
+}
+
+interface GateResult {
+  readonly before: Execution;
+  readonly after: Execution;
+  readonly answer: string;
+  readonly key: string;
+}
+
+export default defineEval({
+  description:
+    "Published sessions retain pending work and their stream while later turns execute upgraded and rolled-back agent code.",
+  tags: ["redeploy"],
+  timeoutMs: 30 * 60_000,
+
+  async test(t) {
+    const fixture = await createRedeployFixture(t);
+    const historicalPackage = await realpath(resolve("node_modules", "historical-eve-0-49-0"));
+    if ((await readEveVersion(historicalPackage)) !== OLD_VERSION) {
+      throw new Error(`Expected published eve@${OLD_VERSION}.`);
+    }
+    const originalMarker = await readFile(MARKER_PATH, "utf8");
+    const sessions = [
+      t.newSession(),
+      t.newSession(),
+      t.newSession(),
+      t.newSession(),
+      t.newSession(),
+    ];
+    const [idle, blocking, cancellable, background, fresh] = sessions as [
+      EveEvalSession,
+      EveEvalSession,
+      EveEvalSession,
+      EveEvalSession,
+      EveEvalSession,
+    ];
+
+    try {
+      await writeMarker(OLD_MARKER, true);
+      await fixture.deploy(historicalPackage, "inbox-upgrade-published");
+
+      const first = await idle.send("UPGRADE-read-first");
+      const oldExecution = readExecution(first);
+      await requireExecution(t, oldExecution, OLD_MARKER);
+      const sessionId = first.sessionId;
+      const streamIndex = requireStreamIndex(idle);
+
+      await blocking.send("UPGRADE-gate-blocking");
+      const blockingRequest = blocking.requireInputRequest({ toolName: "upgrade_gate" });
+      const blockingExecution = readRequestedExecution(blockingRequest.prompt);
+      await requireExecution(t, blockingExecution, OLD_MARKER, oldExecution.deploymentId);
+
+      await cancellable.send("UPGRADE-gate-cancel");
+      cancellable.requireInputRequest({ toolName: "upgrade_gate" });
+
+      const admitted = await background.send("UPGRADE-task-background");
+      admitted.expectOk();
+      admitted.event("turn.completed", { count: 1 });
+      const receipt = parseOutput(admitted.requireToolCall("upgrade_task").output) as {
+        taskId?: string;
+      };
+      if (typeof receipt.taskId !== "string")
+        throw new Error("Background task did not return a task ID.");
+      const pendingBackground = await waitForTaskRequest(t, background);
+      const backgroundRequest = pendingBackground.requireInputRequest({ toolName: "upgrade_task" });
+      const backgroundExecution = readRequestedExecution(backgroundRequest.prompt);
+      await requireExecution(t, backgroundExecution, OLD_MARKER, oldExecution.deploymentId);
+
+      await writeMarker(NEW_MARKER);
+      await fixture.deploy(fixture.currentPackage, "inbox-upgrade-checkout");
+
+      const next = await idle.send("UPGRADE-read-next");
+      const newExecution = readExecution(next);
+      await requireExecution(t, newExecution, NEW_MARKER);
+      await t.require(
+        { sessionId: next.sessionId, execution: newExecution },
+        satisfies(
+          (value: { sessionId: string; execution: Execution }) =>
+            value.sessionId === sessionId &&
+            value.execution.deploymentId !== oldExecution.deploymentId &&
+            value.execution.runId !== sessionId,
+          "the published parent starts a child turn on the accepting deployment and retains its session ID",
+        ),
+      );
+      const replayed = await t.target.watchTurn(sessionId, { startIndex: streamIndex }).result();
+      replayed.expectOk();
+      replayed.messageIncludes(NEW_MARKER);
+      replayed.event("turn.completed", { count: 1 });
+
+      const answered = await blocking.respond([
+        { requestId: blockingRequest.requestId, optionId: "continue" },
+      ]);
+      answered.expectOk();
+      await requireGateResult(
+        t,
+        answered.requireToolCall("upgrade_gate").output,
+        "blocking",
+        blockingExecution,
+      );
+      const afterAnswer = await blocking.send("UPGRADE-read-afteranswer");
+      await requireExecution(t, readExecution(afterAnswer), NEW_MARKER, newExecution.deploymentId);
+
+      const cancelledLive = t.target.watchTurn(cancellable.sessionId!, {
+        startIndex: requireStreamIndex(cancellable),
+      });
+      await cancelledLive.cancel();
+      const cancelled = await cancelledLive.result();
+      cancelled.event("turn.cancelled", { count: 1 });
+      cancelled.notEvent("turn.failed");
+      cancelled.notEvent("session.failed");
+      const afterCancel = await cancelledLive.session.send("UPGRADE-read-aftercancel");
+      await requireExecution(t, readExecution(afterCancel), NEW_MARKER, newExecution.deploymentId);
+
+      await pendingBackground.respond([
+        { requestId: backgroundRequest.requestId, optionId: "continue" },
+      ]);
+      await requireTaskCompletion(t, pendingBackground, receipt.taskId, backgroundExecution);
+
+      const newSession = await fresh.send("UPGRADE-read-fresh");
+      await requireExecution(t, readExecution(newSession), NEW_MARKER, newExecution.deploymentId);
+
+      // Roll back authored code while retaining the runtime that understands both cohorts.
+      await writeMarker(OLD_MARKER);
+      await fixture.deploy(fixture.currentPackage, "inbox-upgrade-code-rollback");
+      for (const session of [idle, fresh]) {
+        const beforeId = session.sessionId;
+        const rollback = await session.send("UPGRADE-read-rollback");
+        const execution = readExecution(rollback);
+        await requireExecution(t, execution, OLD_MARKER);
+        await t.require(
+          rollback.sessionId === beforeId && execution.deploymentId !== newExecution.deploymentId,
+          satisfies(
+            (value: boolean) => value,
+            "code rollback preserves existing session IDs and selects the rollback deployment",
+          ),
+        );
+      }
+      t.succeeded();
+    } finally {
+      // These isolated fixture sessions have finished the probe; retire their durable resources.
+      for (const session of sessions) {
+        if (session.sessionId === undefined) continue;
+        try {
+          const response = await t.target.fetch(
+            `/eve/v1/session/${encodeURIComponent(session.sessionId)}/reset`,
+            { method: "POST" },
+          );
+          if (!response.ok) t.log(`Upgrade probe cleanup returned HTTP ${response.status}.`);
+        } catch {
+          t.log("Upgrade probe cleanup could not reach the session reset route.");
+        }
+      }
+      await writeFile(MARKER_PATH, originalMarker);
+      await fixture.restore();
+    }
+  },
+});
+
+async function writeMarker(marker: string, legacy = false): Promise<void> {
+  const config = legacy ? { experimental: { tasks: true } } : {};
+  await writeFile(
+    MARKER_PATH,
+    `export const UPGRADE_MARKER = ${JSON.stringify(marker)};\n` +
+      `export const UPGRADE_LEGACY_CONFIG = ${JSON.stringify(config)};\n`,
+  );
+}
+
+function requireStreamIndex(session: EveEvalSession): number {
+  if (session.state === undefined) throw new Error("Session has no stream cursor.");
+  return session.state.streamIndex;
+}
+
+function readExecution(turn: EveEvalTurn): Execution {
+  turn.expectOk();
+  return parseExecution(turn.requireToolCall("upgrade_read").output);
+}
+
+function readRequestedExecution(prompt: string): Execution {
+  const start = prompt.indexOf("{");
+  if (start === -1) throw new Error("Upgrade request has no execution provenance.");
+  return parseExecution(JSON.parse(prompt.slice(start)));
+}
+
+function parseExecution(value: unknown): Execution {
+  value = parseOutput(value);
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("deploymentId" in value) ||
+    typeof value.deploymentId !== "string" ||
+    !("marker" in value) ||
+    typeof value.marker !== "string" ||
+    !("runId" in value) ||
+    typeof value.runId !== "string"
+  ) {
+    throw new Error("Upgrade probe returned invalid execution provenance.");
+  }
+  return { deploymentId: value.deploymentId, marker: value.marker, runId: value.runId };
+}
+
+function parseOutput(value: unknown): unknown {
+  return typeof value === "string" ? JSON.parse(value) : value;
+}
+
+async function requireExecution(
+  t: EveEvalContext,
+  actual: Execution,
+  marker: string,
+  deploymentId?: string,
+) {
+  await t.require(
+    actual,
+    satisfies(
+      (value: Execution) =>
+        value.marker === marker &&
+        typeof value.runId === "string" &&
+        value.runId.startsWith("wrun_") &&
+        typeof value.deploymentId === "string" &&
+        value.deploymentId.startsWith("dpl_") &&
+        (deploymentId === undefined || value.deploymentId === deploymentId),
+      `execution uses ${marker}${deploymentId === undefined ? "" : ` on ${deploymentId}`}`,
+    ),
+  );
+  t.log(`execution ${JSON.stringify(actual)}`);
+}
+
+async function requireGateResult(
+  t: EveEvalContext,
+  actual: unknown,
+  key: string,
+  expected: Execution,
+) {
+  await t.require(
+    parseOutput(actual),
+    satisfies(
+      (value: GateResult) =>
+        value.key === key &&
+        value.answer === "continue" &&
+        [value.before, value.after].every(
+          (execution) =>
+            execution.marker === expected.marker &&
+            execution.deploymentId === expected.deploymentId &&
+            execution.runId === expected.runId,
+        ),
+      "the pending workflow resumes and completes on its original executable and owner",
+    ),
+  );
+}
+
+async function waitForTaskRequest(
+  t: EveEvalContext,
+  initial: EveEvalSession,
+): Promise<EveEvalSession> {
+  let session = initial;
+  for (let turn = 0; turn < 6; turn++) {
+    if (session.pendingInputRequests.some((request) => request.action.toolName === "upgrade_task"))
+      return session;
+    const live = t.target.watchTurn(session.sessionId!, {
+      startIndex: requireStreamIndex(session),
+    });
+    (await live.result()).noFailedActions();
+    session = live.session;
+  }
+  throw new Error("Background workflow did not publish its input request within six turns.");
+}
+
+async function requireTaskCompletion(
+  t: EveEvalContext,
+  initial: EveEvalSession,
+  taskId: string,
+  expected: Execution,
+) {
+  let session = initial;
+  for (let turn = 0; turn < 6; turn++) {
+    for (const event of session.events) {
+      if (event.type !== "message.received" || typeof event.data.message !== "string") continue;
+      const message = event.data.message;
+      if (!message.includes(`Background task ${taskId} (upgrade_task) is completed.`)) continue;
+      const start = message.indexOf("{");
+      if (start === -1) throw new Error("Completed task notification has no result.");
+      await requireGateResult(t, JSON.parse(message.slice(start)), "background", expected);
+      return;
+    }
+    const live = t.target.watchTurn(session.sessionId!, {
+      startIndex: requireStreamIndex(session),
+    });
+    (await live.result()).expectOk();
+    session = live.session;
+  }
+  throw new Error("Background task did not complete within six turns.");
+}

--- a/e2e/fixtures/agent-inbox-upgrade/evals/inbox-upgrade.redeploy.eval.ts
+++ b/e2e/fixtures/agent-inbox-upgrade/evals/inbox-upgrade.redeploy.eval.ts
@@ -25,7 +25,7 @@ interface GateResult {
 
 export default defineEval({
   description:
-    "Published sessions retain pending work and their stream while later turns execute upgraded and rolled-back agent code.",
+    "Published sessions retain their executable and pending work while new sessions follow code upgrades and rollback.",
   tags: ["redeploy"],
   timeoutMs: 30 * 60_000,
 
@@ -81,17 +81,22 @@ export default defineEval({
       await writeMarker(NEW_MARKER);
       await fixture.deploy(fixture.currentPackage, "inbox-upgrade-checkout");
 
-      const upgraded = await followCodeDeployment(t, idle, "next", NEW_MARKER, [oldExecution]);
+      const { session: fresh, execution: newExecution } = await createSessionOnDeployment(
+        t,
+        sessions,
+        NEW_MARKER,
+        oldExecution,
+      );
+      const upgraded = await followRetainedDeployment(t, idle, "next", oldExecution);
       const next = upgraded.turn;
-      const newExecution = upgraded.execution;
       await t.require(
-        { sessionId: next.sessionId, execution: newExecution },
+        { sessionId: next.sessionId, execution: upgraded.execution },
         satisfies(
           (value: { sessionId: string; execution: Execution }) =>
             value.sessionId === sessionId &&
-            value.execution.deploymentId !== oldExecution.deploymentId &&
+            value.execution.deploymentId === oldExecution.deploymentId &&
             value.execution.runId !== sessionId,
-          "the published parent starts a child turn on the accepting deployment and retains its session ID",
+          "the published parent retains its session ID and executes on its original deployment through a child",
         ),
       );
       let replayIndex = streamIndex;
@@ -100,7 +105,7 @@ export default defineEval({
         const replayed = await replay.result();
         replayed.expectOk();
         replayed.event("turn.completed", { count: 1 });
-        if (attempt === upgraded.attempts - 1) replayed.messageIncludes(NEW_MARKER);
+        if (attempt === upgraded.attempts - 1) replayed.messageIncludes(OLD_MARKER);
         replayIndex = requireStreamIndex(replay.session);
       }
 
@@ -114,10 +119,21 @@ export default defineEval({
         "blocking",
         blockingExecution,
       );
-      const afterAnswer = await followCodeDeployment(t, blocking, "afteranswer", NEW_MARKER, [
-        oldExecution,
+      await followRetainedDeployment(t, blocking, "afteranswer", oldExecution);
+      await blocking.send("UPGRADE-gate-retained");
+      const retainedRequest = blocking.requireInputRequest({ toolName: "upgrade_gate" });
+      const retainedExecution = readRequestedExecution(retainedRequest.prompt);
+      await requireExecution(t, retainedExecution, OLD_MARKER, oldExecution.deploymentId);
+      const retainedAnswer = await blocking.respond([
+        { requestId: retainedRequest.requestId, optionId: "continue" },
       ]);
-      await requireExecution(t, afterAnswer.execution, NEW_MARKER, newExecution.deploymentId);
+      retainedAnswer.expectOk();
+      await requireGateResult(
+        t,
+        retainedAnswer.requireToolCall("upgrade_gate").output,
+        "retained",
+        retainedExecution,
+      );
 
       const cancellation = await cancellable.cancel();
       await t.require(
@@ -128,10 +144,12 @@ export default defineEval({
         ),
       );
       // The parked turn already emitted its boundary; cancellation must not invent another.
-      const afterCancel = await followCodeDeployment(t, cancellable, "aftercancel", NEW_MARKER, [
+      const afterCancel = await followRetainedDeployment(
+        t,
+        cancellable,
+        "aftercancel",
         oldExecution,
-      ]);
-      await requireExecution(t, afterCancel.execution, NEW_MARKER, newExecution.deploymentId);
+      );
       afterCancel.turn.notEvent("turn.cancelled");
       afterCancel.turn.notEvent("input.requested");
 
@@ -144,38 +162,36 @@ export default defineEval({
         receipt.taskId,
         backgroundExecution,
       );
-      let backgroundFollowupError: Error | undefined;
-      try {
-        const afterTask = await followCodeDeployment(
-          t,
-          completedBackground,
-          "aftertask",
-          NEW_MARKER,
-          [oldExecution],
-        );
-        await requireExecution(t, afterTask.execution, NEW_MARKER, newExecution.deploymentId);
-      } catch (error) {
-        if (t.signal.aborted) throw error;
-        // Preserve this failure while collecting evidence from the independent rollback cohorts.
-        backgroundFollowupError = error instanceof Error ? error : new Error(String(error));
-        t.log(`Background follow-up failed: ${backgroundFollowupError.message}`);
-      }
-
-      const fresh = await createSessionOnDeployment(t, sessions, newExecution, oldExecution);
+      await followRetainedDeployment(t, completedBackground, "aftertask", oldExecution);
+      const newTask = await completedBackground.send("UPGRADE-task-afterupgrade");
+      newTask.expectOk();
+      const newReceipt = parseOutput(newTask.requireToolCall("upgrade_task").output) as {
+        taskId: string;
+      };
+      const newPending = await waitForTaskRequest(t, completedBackground);
+      const newRequest = newPending.requireInputRequest({ toolName: "upgrade_task" });
+      const newTaskExecution = readRequestedExecution(newRequest.prompt);
+      await requireExecution(t, newTaskExecution, OLD_MARKER, oldExecution.deploymentId);
+      await newPending.respond([{ requestId: newRequest.requestId, optionId: "continue" }]);
+      const newCompleted = await requireTaskCompletion(
+        t,
+        newPending,
+        newReceipt.taskId,
+        newTaskExecution,
+        "afterupgrade",
+      );
+      await followRetainedDeployment(t, newCompleted, "afternewtask", oldExecution);
 
       // Roll back authored code while retaining the current runtime.
       await writeMarker(OLD_MARKER);
       await fixture.deploy(fixture.currentPackage, "inbox-upgrade-code-rollback");
-      let rollbackDeploymentId: string | undefined;
-      for (const session of [idle, fresh]) {
-        const rollback = await followCodeDeployment(t, session, "rollback", OLD_MARKER, [
-          oldExecution,
-          newExecution,
-        ]);
-        rollbackDeploymentId ??= rollback.execution.deploymentId;
-        await requireExecution(t, rollback.execution, OLD_MARKER, rollbackDeploymentId);
-      }
-      if (backgroundFollowupError !== undefined) throw backgroundFollowupError;
+      const rollback = await followCodeDeployment(t, fresh, "rollback", OLD_MARKER, [
+        oldExecution,
+        newExecution,
+      ]);
+      await requireExecution(t, rollback.execution, OLD_MARKER);
+      await followRetainedDeployment(t, idle, "rollback", oldExecution);
+      await followRetainedDeployment(t, newCompleted, "taskrollback", oldExecution);
     } finally {
       // These isolated fixture sessions have finished the probe; retire their durable resources.
       for (const session of sessions) {
@@ -243,17 +259,17 @@ async function followCodeDeployment(
 async function createSessionOnDeployment(
   t: EveEvalContext,
   sessions: EveEvalSession[],
-  expected: Execution,
+  marker: string,
   previous: Execution,
-): Promise<EveEvalSession> {
+) {
   const signal = AbortSignal.any([t.signal, AbortSignal.timeout(60_000)]);
   for (let attempt = 0; attempt < 10; attempt++) {
     const session = t.newSession();
     sessions.push(session);
     const first = await session.send("UPGRADE-read-fresh", { signal });
     const execution = readExecution(first);
-    if (execution.deploymentId === expected.deploymentId) {
-      await requireExecution(t, execution, expected.marker, expected.deploymentId);
+    if (execution.deploymentId !== previous.deploymentId) {
+      await requireExecution(t, execution, marker);
       await t.require(
         execution.runId === first.sessionId,
         satisfies(
@@ -261,7 +277,7 @@ async function createSessionOnDeployment(
           "the fresh cohort starts its parent on the new deployment",
         ),
       );
-      return session;
+      return { session, execution };
     }
     await requireExecution(t, execution, previous.marker, previous.deploymentId);
     t.log(
@@ -270,6 +286,31 @@ async function createSessionOnDeployment(
     await t.sleep(1_000);
   }
   throw new Error("Alias did not create a session on the new deployment within ten attempts.");
+}
+
+async function followRetainedDeployment(
+  t: EveEvalContext,
+  session: EveEvalSession,
+  key: string,
+  expected: Execution,
+) {
+  const sessionId = session.sessionId;
+  const signal = AbortSignal.any([t.signal, AbortSignal.timeout(60_000)]);
+  for (let attempt = 0; attempt < 10; attempt++) {
+    const turn = await session.send(`UPGRADE-read-${key}${attempt}`, { signal });
+    const execution = readExecution(turn);
+    await requireExecution(t, execution, expected.marker, expected.deploymentId);
+    await t.require(
+      turn.sessionId === sessionId,
+      satisfies((same: boolean) => same, "retained execution preserves the session ID"),
+    );
+    // Old ingress runs this ordinary read inline in the original session.
+    // A child on the old deployment proves the new ingress caused a retained dispatch.
+    if (execution.runId !== sessionId) return { turn, execution, attempts: attempt + 1 };
+    t.log(`${key}: old ingress still executed inline; waiting for a retained child`);
+    await t.sleep(1_000);
+  }
+  throw new Error("Alias did not exercise retained child execution within ten read-only turns.");
 }
 
 function requireStreamIndex(session: EveEvalSession): number {
@@ -376,6 +417,7 @@ async function requireTaskCompletion(
   initial: EveEvalSession,
   taskId: string,
   expected: Execution,
+  key = "background",
 ) {
   let session = initial;
   for (let turn = 0; turn < 6; turn++) {
@@ -385,7 +427,7 @@ async function requireTaskCompletion(
       if (!message.includes(`Background task ${taskId} (upgrade_task) is completed.`)) continue;
       const start = message.indexOf("{");
       if (start === -1) throw new Error("Completed task notification has no result.");
-      await requireGateResult(t, JSON.parse(message.slice(start)), "background", expected);
+      await requireGateResult(t, JSON.parse(message.slice(start)), key, expected);
       return session;
     }
     const live = t.target.watchTurn(session.sessionId!, {

--- a/e2e/fixtures/agent-inbox-upgrade/evals/inbox-upgrade.redeploy.eval.ts
+++ b/e2e/fixtures/agent-inbox-upgrade/evals/inbox-upgrade.redeploy.eval.ts
@@ -36,15 +36,8 @@ export default defineEval({
       throw new Error(`Expected published eve@${OLD_VERSION}.`);
     }
     const originalMarker = await readFile(MARKER_PATH, "utf8");
-    const sessions = [
-      t.newSession(),
-      t.newSession(),
-      t.newSession(),
-      t.newSession(),
-      t.newSession(),
-    ];
-    const [idle, blocking, cancellable, background, fresh] = sessions as [
-      EveEvalSession,
+    const sessions = [t.newSession(), t.newSession(), t.newSession(), t.newSession()];
+    const [idle, blocking, cancellable, background] = sessions as [
       EveEvalSession,
       EveEvalSession,
       EveEvalSession,
@@ -121,8 +114,10 @@ export default defineEval({
         "blocking",
         blockingExecution,
       );
-      const afterAnswer = await blocking.send("UPGRADE-read-afteranswer");
-      await requireExecution(t, readExecution(afterAnswer), NEW_MARKER, newExecution.deploymentId);
+      const afterAnswer = await followCodeDeployment(t, blocking, "afteranswer", NEW_MARKER, [
+        oldExecution,
+      ]);
+      await requireExecution(t, afterAnswer.execution, NEW_MARKER, newExecution.deploymentId);
 
       const cancellation = await cancellable.cancel();
       await t.require(
@@ -133,18 +128,19 @@ export default defineEval({
         ),
       );
       // The parked turn already emitted its boundary; cancellation must not invent another.
-      const afterCancel = await cancellable.send("UPGRADE-read-aftercancel");
-      await requireExecution(t, readExecution(afterCancel), NEW_MARKER, newExecution.deploymentId);
-      afterCancel.notEvent("turn.cancelled");
-      afterCancel.notEvent("input.requested");
+      const afterCancel = await followCodeDeployment(t, cancellable, "aftercancel", NEW_MARKER, [
+        oldExecution,
+      ]);
+      await requireExecution(t, afterCancel.execution, NEW_MARKER, newExecution.deploymentId);
+      afterCancel.turn.notEvent("turn.cancelled");
+      afterCancel.turn.notEvent("input.requested");
 
       await pendingBackground.respond([
         { requestId: backgroundRequest.requestId, optionId: "continue" },
       ]);
       await requireTaskCompletion(t, pendingBackground, receipt.taskId, backgroundExecution);
 
-      const newSession = await fresh.send("UPGRADE-read-fresh");
-      await requireExecution(t, readExecution(newSession), NEW_MARKER, newExecution.deploymentId);
+      const fresh = await createSessionOnDeployment(t, sessions, newExecution, oldExecution);
 
       // Roll back authored code while retaining the runtime that understands both cohorts.
       await writeMarker(OLD_MARKER);
@@ -220,6 +216,38 @@ async function followCodeDeployment(
     await t.sleep(1_000);
   }
   throw new Error(`Alias did not select ${marker} on a new deployment within ten read-only turns.`);
+}
+
+async function createSessionOnDeployment(
+  t: EveEvalContext,
+  sessions: EveEvalSession[],
+  expected: Execution,
+  previous: Execution,
+): Promise<EveEvalSession> {
+  const signal = AbortSignal.any([t.signal, AbortSignal.timeout(60_000)]);
+  for (let attempt = 0; attempt < 10; attempt++) {
+    const session = t.newSession();
+    sessions.push(session);
+    const first = await session.send("UPGRADE-read-fresh", { signal });
+    const execution = readExecution(first);
+    if (execution.deploymentId === expected.deploymentId) {
+      await requireExecution(t, execution, expected.marker, expected.deploymentId);
+      await t.require(
+        execution.runId === first.sessionId,
+        satisfies(
+          (same: boolean) => same,
+          "the fresh cohort starts its parent on the new deployment",
+        ),
+      );
+      return session;
+    }
+    await requireExecution(t, execution, previous.marker, previous.deploymentId);
+    t.log(
+      "A prior ingress created another legacy session during alias propagation; retaining it for cleanup",
+    );
+    await t.sleep(1_000);
+  }
+  throw new Error("Alias did not create a session on the new deployment within ten attempts.");
 }
 
 function requireStreamIndex(session: EveEvalSession): number {

--- a/e2e/fixtures/agent-inbox-upgrade/evals/inbox-upgrade.redeploy.eval.ts
+++ b/e2e/fixtures/agent-inbox-upgrade/evals/inbox-upgrade.redeploy.eval.ts
@@ -119,16 +119,19 @@ export default defineEval({
       const afterAnswer = await blocking.send("UPGRADE-read-afteranswer");
       await requireExecution(t, readExecution(afterAnswer), NEW_MARKER, newExecution.deploymentId);
 
-      const cancelledLive = t.target.watchTurn(cancellable.sessionId!, {
-        startIndex: requireStreamIndex(cancellable),
-      });
-      await cancelledLive.cancel();
-      const cancelled = await cancelledLive.result();
-      cancelled.event("turn.cancelled", { count: 1 });
-      cancelled.notEvent("turn.failed");
-      cancelled.notEvent("session.failed");
-      const afterCancel = await cancelledLive.session.send("UPGRADE-read-aftercancel");
+      const cancellation = await cancellable.cancel();
+      await t.require(
+        cancellation.status,
+        satisfies(
+          (status: string) => status === "accepted",
+          "the old session accepts cancellation",
+        ),
+      );
+      // The parked turn already emitted its boundary; cancellation must not invent another.
+      const afterCancel = await cancellable.send("UPGRADE-read-aftercancel");
       await requireExecution(t, readExecution(afterCancel), NEW_MARKER, newExecution.deploymentId);
+      afterCancel.notEvent("turn.cancelled");
+      afterCancel.notEvent("input.requested");
 
       await pendingBackground.respond([
         { requestId: backgroundRequest.requestId, optionId: "continue" },

--- a/e2e/fixtures/agent-inbox-upgrade/evals/inbox-upgrade.redeploy.eval.ts
+++ b/e2e/fixtures/agent-inbox-upgrade/evals/inbox-upgrade.redeploy.eval.ts
@@ -163,7 +163,7 @@ export default defineEval({
 
       const fresh = await createSessionOnDeployment(t, sessions, newExecution, oldExecution);
 
-      // Roll back authored code while retaining the runtime that understands both cohorts.
+      // Roll back authored code while retaining the current runtime.
       await writeMarker(OLD_MARKER);
       await fixture.deploy(fixture.currentPackage, "inbox-upgrade-code-rollback");
       let rollbackDeploymentId: string | undefined;

--- a/e2e/fixtures/agent-inbox-upgrade/evals/upgrade-tools.eval.ts
+++ b/e2e/fixtures/agent-inbox-upgrade/evals/upgrade-tools.eval.ts
@@ -1,0 +1,29 @@
+import { defineEval } from "eve/evals";
+
+export default defineEval({
+  description: "The upgrade fixture reports execution provenance and resumes a pending answer.",
+  async test(t) {
+    const session = t.newSession();
+    try {
+      const first = await session.send("UPGRADE-read-baseline");
+      first.expectOk();
+      first.messageIncludes("upgrade-baseline");
+
+      await session.send("UPGRADE-gate-baseline");
+      const request = session.requireInputRequest({ toolName: "upgrade_gate" });
+      const answered = await session.respond([
+        { requestId: request.requestId, optionId: "continue" },
+      ]);
+      answered.expectOk();
+      answered.messageIncludes('"answer":"continue"');
+      answered.event("turn.completed", { count: 1 });
+      t.noFailedActions();
+    } finally {
+      if (session.sessionId !== undefined) {
+        await t.target.fetch(`/eve/v1/session/${encodeURIComponent(session.sessionId)}/reset`, {
+          method: "POST",
+        });
+      }
+    }
+  },
+});

--- a/e2e/fixtures/agent-inbox-upgrade/package.json
+++ b/e2e/fixtures/agent-inbox-upgrade/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "agent-inbox-upgrade",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "eve build",
+    "dev": "eve dev",
+    "start": "eve start",
+    "typecheck": "eve build && tsc",
+    "test:e2e": "eve eval --strict"
+  },
+  "dependencies": {
+    "@eve-e2e/config": "workspace:*",
+    "@workflow/world-postgres": "catalog:",
+    "eve": "workspace:*",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "historical-eve-0-49-0": "npm:eve@0.49.0",
+    "typescript": "catalog:"
+  }
+}

--- a/e2e/fixtures/agent-inbox-upgrade/tsconfig.json
+++ b/e2e/fixtures/agent-inbox-upgrade/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": false,
+    "noEmit": true,
+    "types": ["node", "eve/workflow-modules"],
+    "allowImportingTsExtensions": true
+  },
+  "include": ["agent/**/*.ts", "evals/**/*.ts"]
+}

--- a/e2e/fixtures/e2e-config/package.json
+++ b/e2e/fixtures/e2e-config/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./instrumentation": "./src/instrumentation.ts"
+    "./instrumentation": "./src/instrumentation.ts",
+    "./redeploy": "./src/redeploy.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/e2e/fixtures/e2e-config/src/redeploy.ts
+++ b/e2e/fixtures/e2e-config/src/redeploy.ts
@@ -1,6 +1,16 @@
 import { execFile } from "node:child_process";
-import { readFile, readlink, realpath, rm, symlink, writeFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import {
+  cp,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readlink,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { dirname, resolve } from "node:path";
 import { promisify } from "node:util";
 
 import type { EveEvalContext } from "eve/evals";
@@ -27,9 +37,30 @@ export async function createRedeployFixture(t: EveEvalContext) {
   );
   const currentPackage = await realpath(links[0]!.path);
   const execOptions = { ...EXEC_OPTIONS, signal: t.signal };
+  const stagedPackages: string[] = [];
 
   return {
     currentPackage,
+    async stagePublishedEve(packagePath: string): Promise<string> {
+      const cache = resolve("node_modules", ".cache");
+      await mkdir(cache, { recursive: true });
+      const staged = await mkdtemp(resolve(cache, "eve-published-"));
+      stagedPackages.push(staged);
+      await cp(packagePath, staged, {
+        recursive: true,
+        filter: (source) => source !== resolve(packagePath, "node_modules"),
+      });
+      await symlink(dirname(packagePath), resolve(staged, "node_modules"));
+      const manifestPath = resolve(staged, "package.json");
+      const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+      // Historical source-only export conditions point to files absent from npm.
+      // Change package resolution in this copy; preserve every published code byte.
+      await writeFile(
+        manifestPath,
+        `${JSON.stringify(withoutSourceConditions(manifest), null, 2)}\n`,
+      );
+      return staged;
+    },
     async deploy(packagePath: string, marker: string): Promise<string> {
       for (const link of links) await replaceLink(link.path, packagePath);
       await writeFile(instructionsPath, `${instructions}\nDeployment marker: ${marker}.\n`);
@@ -90,8 +121,19 @@ export async function createRedeployFixture(t: EveEvalContext) {
     async restore(): Promise<void> {
       for (const link of links) await replaceLink(link.path, link.target);
       await writeFile(instructionsPath, instructions);
+      for (const staged of stagedPackages) await rm(staged, { force: true, recursive: true });
     },
   };
+}
+
+function withoutSourceConditions(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(withoutSourceConditions);
+  if (value === null || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([key]) => key !== "eve-source")
+      .map(([key, entry]) => [key, withoutSourceConditions(entry)]),
+  );
 }
 
 async function replaceLink(path: string, target: string): Promise<void> {

--- a/e2e/fixtures/e2e-config/src/redeploy.ts
+++ b/e2e/fixtures/e2e-config/src/redeploy.ts
@@ -1,0 +1,108 @@
+import { execFile } from "node:child_process";
+import { readFile, readlink, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { promisify } from "node:util";
+
+import type { EveEvalContext } from "eve/evals";
+
+const execFileAsync = promisify(execFile);
+const EXEC_OPTIONS = { maxBuffer: 64 * 1024 * 1024 } as const;
+
+/** Rebuilds a fixture against exact eve packages while keeping one public alias. */
+export async function createRedeployFixture(t: EveEvalContext) {
+  const alias = process.env.EVE_E2E_REDEPLOY_ALIAS;
+  if (alias === undefined || alias.length === 0) {
+    t.skip("Requires the CI-owned EVE_E2E_REDEPLOY_ALIAS; run via the Vercel redeploy suite.");
+  }
+  if (new URL(t.target.url).host !== alias) {
+    throw new Error("The redeploy alias must match the eval target host.");
+  }
+
+  const instructionsPath = resolve("agent", "instructions.md");
+  const instructions = await readFile(instructionsPath, "utf8");
+  const links = await Promise.all(
+    [resolve("node_modules", "eve"), resolve("..", "e2e-config", "node_modules", "eve")].map(
+      async (path) => ({ path, target: await readlink(path) }),
+    ),
+  );
+  const currentPackage = await realpath(links[0]!.path);
+  const execOptions = { ...EXEC_OPTIONS, signal: t.signal };
+
+  return {
+    currentPackage,
+    async deploy(packagePath: string, marker: string): Promise<string> {
+      for (const link of links) await replaceLink(link.path, packagePath);
+      await writeFile(instructionsPath, `${instructions}\nDeployment marker: ${marker}.\n`);
+      await execFileAsync("pnpm", ["exec", "eve", "build"], {
+        ...execOptions,
+        env: {
+          ...process.env,
+          VERCEL: "1",
+          VERCEL_ENV: "preview",
+          VERCEL_TARGET_ENV: "preview",
+        },
+      });
+      const tokenArgs =
+        process.env.VERCEL_TOKEN === undefined ? [] : ["--token", process.env.VERCEL_TOKEN];
+      const scopeArgs =
+        process.env.VERCEL_ORG_ID === undefined ? [] : ["--scope", process.env.VERCEL_ORG_ID];
+      const modelArgs =
+        process.env.EVE_E2E_MODEL === undefined
+          ? []
+          : ["--env", `EVE_E2E_MODEL=${process.env.EVE_E2E_MODEL}`];
+      const deploy = await execFileAsync(
+        "pnpm",
+        [
+          "exec",
+          "vc",
+          "deploy",
+          "--prebuilt",
+          "--yes",
+          "--target=preview",
+          ...modelArgs,
+          ...tokenArgs,
+        ],
+        execOptions,
+      );
+      const deploymentUrl = deploy.stdout.trim().split("\n").at(-1)?.trim();
+      if (deploymentUrl === undefined || !deploymentUrl.startsWith("https://")) {
+        throw new Error("vc deploy did not return a deployment URL.");
+      }
+      t.log(`deployed ${deploymentUrl} (${marker}); aliasing ${alias}`);
+      await execFileAsync(
+        "pnpm",
+        ["exec", "vc", "alias", "set", deploymentUrl, alias, ...tokenArgs, ...scopeArgs],
+        execOptions,
+      );
+      const deadline = Date.now() + 120_000;
+      while (Date.now() < deadline) {
+        try {
+          const response = await t.target.fetch("/eve/v1/info", { cache: "no-store" });
+          if (response.ok && JSON.stringify(await response.json()).includes(marker))
+            return deploymentUrl;
+        } catch {
+          // The alias can be unavailable briefly while the deployment propagates.
+        }
+        await t.sleep(1_000);
+      }
+      throw new Error(`Timed out waiting for alias to serve ${marker}.`);
+    },
+    async restore(): Promise<void> {
+      for (const link of links) await replaceLink(link.path, link.target);
+      await writeFile(instructionsPath, instructions);
+    },
+  };
+}
+
+async function replaceLink(path: string, target: string): Promise<void> {
+  await rm(path, { force: true });
+  await symlink(target, path);
+}
+
+export async function readEveVersion(packagePath: string): Promise<string> {
+  const manifest = JSON.parse(await readFile(resolve(packagePath, "package.json"), "utf8")) as {
+    version?: string;
+  };
+  if (manifest.version === undefined) throw new Error("eve package is missing its version.");
+  return manifest.version;
+}

--- a/packages/eve/src/execution/durable-session-migrations/turn-workflow.test.ts
+++ b/packages/eve/src/execution/durable-session-migrations/turn-workflow.test.ts
@@ -50,7 +50,7 @@ describe("turn workflow wire migrations", () => {
     ).toEqual({
       capabilities: undefined,
       completionToken: "turn-token",
-      driverCapabilities: { cancelledTurnSettle: true, turnInbox: true },
+      driverCapabilities: { cancelledTurnSettle: true, stateContractVersion: 1, turnInbox: true },
       mode: "conversation",
       stepInput: {
         input: delivery,

--- a/packages/eve/src/execution/durable-session-migrations/turn-workflow.ts
+++ b/packages/eve/src/execution/durable-session-migrations/turn-workflow.ts
@@ -27,6 +27,9 @@ import { turnWorkflowInputV1ToV2 } from "./turn-workflow-v1-to-v2.js";
 
 export const TURN_WORKFLOW_INPUT_VERSION = 2;
 
+/** Includes nested session state and the state returned to the pinned parent. */
+export const TURN_STATE_CONTRACT_VERSION = 1;
+
 /** Trusted runtime-action results collected by the parent turn driver. */
 interface RuntimeActionResultStepInput {
   readonly acceptedAtMsByCallId?: Readonly<Record<string, number>>;
@@ -59,6 +62,7 @@ interface TurnWorkflowInputBase {
   readonly driverCapabilities?: {
     readonly turnInbox?: true;
     readonly cancelledTurnSettle?: true;
+    readonly stateContractVersion?: number;
   };
   readonly mode: RunMode;
   readonly stepInput: TurnStepInput;
@@ -108,7 +112,11 @@ export function createTurnWorkflowInput(input: TurnWorkflowDispatchInput): TurnW
   return {
     capabilities: input.capabilities,
     completionToken: input.completionToken,
-    driverCapabilities: { cancelledTurnSettle: true, turnInbox: true },
+    driverCapabilities: {
+      cancelledTurnSettle: true,
+      stateContractVersion: TURN_STATE_CONTRACT_VERSION,
+      turnInbox: true,
+    },
     initialCancellation: input.initialCancellation,
     initialStep: input.initialStep,
     mode: input.mode,

--- a/packages/eve/src/execution/retained-turn-steps.integration.test.ts
+++ b/packages/eve/src/execution/retained-turn-steps.integration.test.ts
@@ -1,0 +1,64 @@
+import { expect, it, vi } from "vitest";
+
+import { legacySessionDeliveryWorkflow } from "#internal/testing/legacy-session-delivery-workflow.js";
+import { waitForHook } from "#internal/testing/workflow-test-helpers.js";
+import { getRun, getWorld, resumeHook, setWorld } from "#internal/workflow/runtime.js";
+import { createUlid } from "#shared/ulid.js";
+import type { TurnWorkflowInput } from "#execution/durable-session-migrations/turn-workflow.js";
+import { startRetainedTurnStep } from "#execution/retained-turn-steps.js";
+
+vi.mock("#execution/workflow-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("#execution/workflow-runtime.js")>();
+  const { legacySessionDeliveryWorkflow } =
+    await import("#internal/testing/legacy-session-delivery-workflow.js");
+  return { ...actual, turnWorkflowReference: legacySessionDeliveryWorkflow };
+});
+
+it("retains one execution after a lost start acknowledgement and a retry after completion", async () => {
+  const world = await getWorld();
+  const target = { deploymentId: await world.getDeploymentId(), runId: `wrun_${createUlid()}` };
+  const token = `retained-turn:${target.runId}`;
+  let loseAcknowledgement = true;
+  setWorld({
+    ...world,
+    async queue(...args: Parameters<typeof world.queue>) {
+      const result = await world.queue(...args);
+      if (loseAcknowledgement) {
+        loseAcknowledgement = false;
+        throw new Error("lost start acknowledgement");
+      }
+      return result;
+    },
+  });
+  const input = {
+    stepInput: { sessionState: { sessionId: "wrun_parent" }, serializedContext: {} },
+  } as TurnWorkflowInput;
+  const run = getRun<string>(target.runId);
+  try {
+    await expect(startRetainedTurnStep(target, { token }, input)).rejects.toThrow(
+      "lost start acknowledgement",
+    );
+    await startRetainedTurnStep(target, { token }, input);
+    await waitForHook({ runId: target.runId }, { token });
+    await resumeHook(token, {
+      kind: "deliver",
+      payloads: [{ message: "completed once" }],
+      requestId: "once",
+    });
+    await expect(run.returnValue).resolves.toBe("completed once");
+
+    await startRetainedTurnStep(target, { token }, input);
+    await expect(run.returnValue).resolves.toBe("completed once");
+    const workflowName = Reflect.get(legacySessionDeliveryWorkflow, "workflowId");
+    if (typeof workflowName !== "string") throw new Error("Fixture workflow metadata is missing.");
+    const runs = await world.runs.list({
+      workflowName,
+      resolveData: "none",
+    });
+    expect(runs.data.filter((entry) => entry.runId === target.runId)).toHaveLength(1);
+    expect(runs.data).toHaveLength(1);
+  } finally {
+    setWorld(world);
+    if ((await run.status) !== "completed") await run.cancel();
+  }
+});

--- a/packages/eve/src/execution/retained-turn-steps.test.ts
+++ b/packages/eve/src/execution/retained-turn-steps.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { prepareRetainedTurnStep, startRetainedTurnStep } from "./retained-turn-steps.js";
+import type { TurnWorkflowInput } from "./durable-session-migrations/turn-workflow.js";
+import { startWorkflowOnAcceptedDeployment, turnWorkflowReference } from "./workflow-runtime.js";
+
+const { world } = vi.hoisted(() => ({
+  world: { runs: { get: vi.fn() }, createRunId: vi.fn(() => "01ARZ3NDEKTSV4RRFFQ69G5FAV") },
+}));
+vi.mock("#internal/workflow/runtime.js", () => ({ getWorld: async () => world }));
+vi.mock("./workflow-runtime.js", () => ({
+  startWorkflowOnAcceptedDeployment: vi.fn(),
+  turnWorkflowReference: { workflowId: "workflow//eve//turnWorkflow" },
+}));
+
+describe("retained turn dispatch", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("prepares the original deployment and a World-compatible run ID without starting it", async () => {
+    vi.stubEnv("VERCEL_DEPLOYMENT_ID", "dpl_new");
+    world.runs.get.mockResolvedValue({ deploymentId: "dpl_old" });
+
+    await expect(prepareRetainedTurnStep("wrun_parent")).resolves.toEqual({
+      deploymentId: "dpl_old",
+      runId: "wrun_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+    });
+    expect(world.runs.get).toHaveBeenCalledWith("wrun_parent", { resolveData: "none" });
+    expect(world.createRunId).toHaveBeenCalledWith({ deploymentId: "dpl_old" });
+    expect(startWorkflowOnAcceptedDeployment).not.toHaveBeenCalled();
+  });
+
+  it("does not forward a turn already on its parent's deployment", async () => {
+    vi.stubEnv("VERCEL_DEPLOYMENT_ID", "dpl_old");
+    world.runs.get.mockResolvedValue({ deploymentId: "dpl_old" });
+    await expect(prepareRetainedTurnStep("wrun_parent")).resolves.toBeUndefined();
+    expect(world.createRunId).not.toHaveBeenCalled();
+  });
+
+  it("does not claim retained-artifact routing on self-hosted Worlds", async () => {
+    vi.stubEnv("VERCEL_DEPLOYMENT_ID", "");
+    await expect(prepareRetainedTurnStep("wrun_parent")).resolves.toBeUndefined();
+    expect(world.runs.get).not.toHaveBeenCalled();
+  });
+
+  it("reuses its persisted run ID and exact old input on every start attempt", async () => {
+    const target = { deploymentId: "dpl_old", runId: "wrun_01ARZ3NDEKTSV4RRFFQ69G5FAV" };
+    const raw = { old: "input", state: { "eve.tasks": { tasks: [] } } };
+    const input = {
+      stepInput: { sessionState: { sessionId: "wrun_parent" }, serializedContext: {} },
+    } as TurnWorkflowInput;
+    await startRetainedTurnStep(target, raw, input);
+    await startRetainedTurnStep(target, raw, input);
+
+    for (const call of vi.mocked(startWorkflowOnAcceptedDeployment).mock.calls) {
+      expect(call.slice(0, 3)).toEqual([turnWorkflowReference, [raw], "dpl_old"]);
+      expect(call[1][0]).toBe(raw);
+      expect(call[3]?.world?.createRunId?.()).toBe("01ARZ3NDEKTSV4RRFFQ69G5FAV");
+    }
+    expect(startWorkflowOnAcceptedDeployment).toHaveBeenCalledTimes(2);
+    expect(world.createRunId).not.toHaveBeenCalled();
+  });
+});

--- a/packages/eve/src/execution/retained-turn-steps.ts
+++ b/packages/eve/src/execution/retained-turn-steps.ts
@@ -1,0 +1,65 @@
+import { getWorld } from "#internal/workflow/runtime.js";
+import { createLogger } from "#internal/logging.js";
+import { createUlid } from "#shared/ulid.js";
+import { normalizeEveAttributes } from "#runtime/attributes/normalize.js";
+import { buildTurnAttributes, readRootSessionId } from "#execution/eve-workflow-attributes.js";
+import type { TurnWorkflowInput } from "#execution/durable-session-migrations/turn-workflow.js";
+import {
+  startWorkflowOnAcceptedDeployment,
+  turnWorkflowReference,
+} from "#execution/workflow-runtime.js";
+
+interface RetainedTurn {
+  readonly deploymentId: string;
+  readonly runId: string;
+}
+
+/** Persists the target and run identity before starting any retained execution. */
+export async function prepareRetainedTurnStep(
+  sessionId: string,
+): Promise<RetainedTurn | undefined> {
+  "use step";
+
+  const currentDeploymentId = process.env.VERCEL_DEPLOYMENT_ID?.trim();
+  if (!currentDeploymentId) return undefined;
+  const world = await getWorld();
+  const parent = await world.runs.get(sessionId, { resolveData: "none" });
+  if (parent.deploymentId === currentDeploymentId) return undefined;
+
+  const suffix = world.createRunId?.({ deploymentId: parent.deploymentId }) ?? createUlid();
+  return { deploymentId: parent.deploymentId, runId: `wrun_${suffix}` };
+}
+
+/** The retained child speaks directly to the original parent's unchanged control hooks. */
+export async function startRetainedTurnStep(
+  target: RetainedTurn,
+  rawInput: unknown,
+  input: TurnWorkflowInput,
+): Promise<void> {
+  "use step";
+
+  const world = await getWorld();
+  // Workflow start uses the World's ID factory and accepts an existing run ID.
+  // Keep the prepared ID on retries, including after the child disposed its hooks.
+  const startWorld = { ...world, createRunId: () => target.runId.slice("wrun_".length) };
+  const sessionId = input.stepInput.sessionState.sessionId;
+  await startWorkflowOnAcceptedDeployment(turnWorkflowReference, [rawInput], target.deploymentId, {
+    world: startWorld,
+    allowReservedAttributes: true,
+    attributes: normalizeEveAttributes(
+      buildTurnAttributes({
+        parentSessionId: sessionId,
+        rootSessionId: readRootSessionId(input.stepInput.serializedContext) ?? sessionId,
+        serializedContext: input.stepInput.serializedContext,
+      }),
+    ),
+  });
+  createLogger("execution.retained-turn").info(
+    "using retained session code for an incompatible turn state contract",
+    {
+      sessionId,
+      deploymentId: target.deploymentId,
+      runId: target.runId,
+    },
+  );
+}

--- a/packages/eve/src/execution/turn-workflow.test.ts
+++ b/packages/eve/src/execution/turn-workflow.test.ts
@@ -11,6 +11,7 @@ import { releaseAgentInvocationOwnerStep } from "#execution/tools/subagent/invok
 import { cancelAgentInvocationOwnerStep } from "#execution/tools/subagent/task-cancel.js";
 import { runProxySubagentEventStep } from "#subagents/event-proxy-step.js";
 import { turnWorkflow } from "#execution/turn-workflow.js";
+import { prepareRetainedTurnStep, startRetainedTurnStep } from "#execution/retained-turn-steps.js";
 import {
   TURN_WORKFLOW_INPUT_VERSION,
   type TurnWorkflowInput,
@@ -73,6 +74,11 @@ vi.mock("./workflow-steps.js", () => ({
   turnStep: vi.fn(),
 }));
 
+vi.mock("./retained-turn-steps.js", () => ({
+  prepareRetainedTurnStep: vi.fn(),
+  startRetainedTurnStep: vi.fn(),
+}));
+
 vi.mock("#execution/coordination-dispatch-step.js", () => ({
   dispatchCoordinationStep: vi.fn(),
 }));
@@ -111,6 +117,61 @@ describe("turnWorkflow", () => {
     vi.mocked(releaseAgentInvocationOwnerStep).mockReset();
     vi.mocked(cancelAgentInvocationOwnerStep).mockReset();
     definedHookPayloads.clear();
+    vi.mocked(prepareRetainedTurnStep).mockReset();
+    vi.mocked(startRetainedTurnStep).mockReset();
+  });
+
+  it.each([undefined, 2])(
+    "forwards incompatible state contract %s before claiming hooks or running code",
+    async (stateContractVersion) => {
+      const { input } = createInput({ sessionState: createSessionState() });
+      const raw = {
+        ...input,
+        driverCapabilities: { stateContractVersion },
+        legacyField: { retained: true },
+      };
+      const target = { deploymentId: "dpl_old", runId: "wrun_retained" };
+      vi.mocked(prepareRetainedTurnStep).mockResolvedValue(target);
+
+      await turnWorkflow(raw);
+
+      expect(startRetainedTurnStep).toHaveBeenCalledWith(target, raw, raw);
+      expect(turnStep).not.toHaveBeenCalled();
+      expect(createHookMock).not.toHaveBeenCalled();
+      expect(resumeHookMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("executes a matching state contract without looking up a retained deployment", async () => {
+    const sessionState = createSessionState();
+    const { input } = createInput({ sessionState });
+    vi.mocked(turnStep).mockResolvedValueOnce({
+      action: "done",
+      sessionState,
+      output: "ok",
+      serializedContext: {},
+    });
+
+    await turnWorkflow({ ...input, driverCapabilities: { stateContractVersion: 1 } });
+
+    expect(prepareRetainedTurnStep).not.toHaveBeenCalled();
+    expect(startRetainedTurnStep).not.toHaveBeenCalled();
+    expect(turnStep).toHaveBeenCalledOnce();
+  });
+
+  it("reports a retained start failure to the waiting parent without running incompatible code", async () => {
+    const { input } = createInput({ sessionState: createSessionState() });
+    vi.mocked(prepareRetainedTurnStep).mockRejectedValue(
+      new Error("retained deployment unavailable"),
+    );
+
+    await expect(turnWorkflow(input)).rejects.toThrow("retained deployment unavailable");
+
+    expect(resumeHookMock).toHaveBeenCalledWith(
+      "turn-token",
+      expect.objectContaining({ kind: "turn-error" }),
+    );
+    expect(turnStep).not.toHaveBeenCalled();
   });
 
   it("notifies the driver when a turn completes", async () => {

--- a/packages/eve/src/execution/turn-workflow.ts
+++ b/packages/eve/src/execution/turn-workflow.ts
@@ -20,9 +20,11 @@ import { dispatchCoordinationStep } from "#execution/coordination-dispatch-step.
 import { acknowledgeDelegatedTasksStep } from "#execution/tasks/parent/delegate.js";
 import {
   migrateTurnWorkflowInput,
+  TURN_STATE_CONTRACT_VERSION,
   type TurnStepInput,
   type TurnWorkflowInput,
 } from "#execution/durable-session-migrations/turn-workflow.js";
+import { prepareRetainedTurnStep, startRetainedTurnStep } from "#execution/retained-turn-steps.js";
 import { claimHookOwnership, disposeHook, isHookConflictError } from "#execution/hook-ownership.js";
 import type { NextDriverAction } from "#execution/next-driver-action.js";
 import { routeDeliverToChildren } from "#execution/route-child-delivery.js";
@@ -71,6 +73,22 @@ export async function turnWorkflow(rawInput: unknown): Promise<void> {
   "use workflow";
 
   const input = migrateTurnWorkflowInput(rawInput);
+
+  if (input.driverCapabilities?.stateContractVersion !== TURN_STATE_CONTRACT_VERSION) {
+    try {
+      const target = await prepareRetainedTurnStep(input.stepInput.sessionState.sessionId);
+      if (target !== undefined) {
+        await startRetainedTurnStep(target, rawInput, input);
+        return;
+      }
+    } catch (error) {
+      await sendTurnControlStep({
+        controlToken: input.completionToken,
+        payload: { error: normalizeSerializableError(error), kind: "turn-error" },
+      });
+      throw error;
+    }
+  }
 
   if (input.driverCapabilities?.turnInbox !== true) {
     return runLegacyTurnWorkflow(input);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -727,6 +727,31 @@ importers:
         specifier: 'catalog:'
         version: 7.0.2
 
+  e2e/fixtures/agent-inbox-upgrade:
+    dependencies:
+      '@eve-e2e/config':
+        specifier: workspace:*
+        version: link:../e2e-config
+      '@workflow/world-postgres':
+        specifier: 'catalog:'
+        version: 5.0.0-beta.39(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(sql.js@1.14.1)(supports-color@10.2.2)(typescript@7.0.2)
+      eve:
+        specifier: workspace:*
+        version: link:../../../packages/eve
+      zod:
+        specifier: 'catalog:'
+        version: 4.5.4
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      historical-eve-0-49-0:
+        specifier: npm:eve@0.49.0
+        version: eve@0.49.0(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(ai@7.0.84(zod@4.5.4))(braintrust@3.24.0(@aws-sdk/credential-provider-web-identity@3.972.49)(supports-color@10.2.2)(zod@4.5.4))(dotenv@17.4.2)(giget@3.3.0)(jiti@2.7.0)(just-bash@3.1.0(supports-color@10.2.2))(microsandbox@0.5.5)(rollup@4.62.2)(vite@8.1.5(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+
   e2e/fixtures/agent-memory:
     dependencies:
       '@eve-e2e/config':
@@ -10416,6 +10441,26 @@ packages:
       ai: ^7.0.38
       braintrust: ^3.0.0
       just-bash: ^3.0.0
+      microsandbox: ^0.5.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      braintrust:
+        optional: true
+      just-bash:
+        optional: true
+      microsandbox:
+        optional: true
+
+  eve@0.49.0:
+    resolution: {integrity: sha512-ij2RJtGs0RNO+1jKtneHfx/atP9LbjlBmyj8SHVoEsFGPgexOOrl1vlvxzIsI2/LY136VBhJ+Lak+dmPjMtpWA==}
+    engines: {node: '>=24'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+      ai: ^7.0.82
+      braintrust: ^3.0.0
+      just-bash: ^3.1.0
       microsandbox: ^0.5.0
     peerDependenciesMeta:
       '@opentelemetry/api':
@@ -25659,6 +25704,56 @@ snapshots:
       eve: link:packages/eve
 
   eve@0.30.8(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(@vercel/blob@2.8.0)(@vercel/functions@3.9.3(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.3(bufferutil@4.1.0)))(ai@7.0.84(zod@4.5.4))(aws4fetch@1.0.20)(braintrust@3.24.0(@aws-sdk/credential-provider-web-identity@3.972.49)(supports-color@10.2.2)(zod@4.5.4))(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(pg@8.20.0)(sql.js@1.14.1))(giget@3.3.0)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(just-bash@3.1.0(supports-color@10.2.2))(lru-cache@11.5.2)(microsandbox@0.5.5)(rollup@4.62.2)(vite@8.1.5(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)):
+    dependencies:
+      ai: 7.0.84(zod@4.5.4)
+      nitro: 3.0.260610-beta(@upstash/redis@1.38.0)(@vercel/blob@2.8.0)(@vercel/functions@3.9.3(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.3(bufferutil@4.1.0)))(aws4fetch@1.0.20)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(pg@8.20.0)(sql.js@1.14.1))(giget@3.3.0)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(lru-cache@11.5.2)(rollup@4.62.2)(vite@8.1.5(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+      undici: 8.9.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      braintrust: 3.24.0(@aws-sdk/credential-provider-web-identity@3.972.49)(supports-color@10.2.2)(zod@4.5.4)
+      just-bash: 3.1.0(supports-color@10.2.2)
+      microsandbox: 0.5.5
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@netlify/runtime'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vercel/queue'
+      - aws4fetch
+      - better-sqlite3
+      - chokidar
+      - dotenv
+      - drizzle-orm
+      - giget
+      - idb-keyval
+      - ioredis
+      - jiti
+      - lru-cache
+      - miniflare
+      - mongodb
+      - mysql2
+      - rollup
+      - sqlite3
+      - uploadthing
+      - vite
+      - wrangler
+      - xml2js
+      - zephyr-agent
+
+  eve@0.49.0(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(ai@7.0.84(zod@4.5.4))(braintrust@3.24.0(@aws-sdk/credential-provider-web-identity@3.972.49)(supports-color@10.2.2)(zod@4.5.4))(dotenv@17.4.2)(giget@3.3.0)(jiti@2.7.0)(just-bash@3.1.0(supports-color@10.2.2))(microsandbox@0.5.5)(rollup@4.62.2)(vite@8.1.5(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       ai: 7.0.84(zod@4.5.4)
       nitro: 3.0.260610-beta(@upstash/redis@1.38.0)(@vercel/blob@2.8.0)(@vercel/functions@3.9.3(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.3(bufferutil@4.1.0)))(aws4fetch@1.0.20)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(pg@8.20.0)(sql.js@1.14.1))(giget@3.3.0)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(lru-cache@11.5.2)(rollup@4.62.2)(vite@8.1.5(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))

--- a/research/discriminated-workflow-inboxes.md
+++ b/research/discriminated-workflow-inboxes.md
@@ -660,10 +660,50 @@ IDs to distinguish a resumed old body from a child using upgraded agent code.
 It covers idle follow-up and stream resumption, pending blocking and background
 answers, cancellation, new sessions, and agent-code rollback with the current
 runtime retained. Session expiry is disabled. Hosted execution belongs to the
-CI redeploy suite; adding this test does not establish a passing result.
+CI redeploy suite.
 
-This freezes behavior the legacy runner must preserve. It does not implement
-the unified topology or prove arbitrary state projections. Authorization
+The [2026-09-04 hosted run at `617b68328`](https://github.com/vercel/eve/actions/runs/33898147026/job/101106035153)
+found a baseline upgrade blocker before the unified topology is implemented:
+
+| Transition from published `0.49.0`                             | Observed result                                                                                                                                    |
+| -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Idle follow-up and saved stream cursor through current ingress | Same session ID; child executes current agent code on the accepting deployment; stream resumes.                                                    |
+| Answer a parked blocking workflow, then send another message   | Original body finishes on its original run/deployment; the later turn executes current code.                                                       |
+| Cancel a parked workflow, then send another message            | Cancellation is accepted; the next turn executes current code without a duplicate terminal boundary.                                               |
+| Answer a background task after its initiating turn ends        | Original body completes on its original run/deployment and its result reaches the session.                                                         |
+| Send the next user message to that task-owning session         | **Fails:** `turnStep` exhausts three retries and emits `session.failed` because `eve.tasks` has no version; the current reader requires version 2. |
+| Create a fresh session after the upgrade                       | Parent and first turn execute on the new deployment.                                                                                               |
+| Roll back authored code while retaining the current runtime    | Independent old and new task-free sessions preserve their IDs and execute the rolled-back code on a third deployment.                              |
+
+The eval fails overall. It preserves the background-session failure while
+finishing the independent rollback checks; 44 other assertions passed in this run.
+
+The published parent stores an unversioned task index. The
+[current reader](../packages/eve/src/tasks/session-index.ts) rejects it while
+[building turn context](../packages/eve/src/tasks/delivery-context.ts), before
+the requested tool runs. The outer turn-input version does not negotiate or
+migrate this state. Task completion is therefore insufficient evidence of an
+acceptable upgrade: the next ordinary message must also succeed, even when all
+tasks have already settled.
+
+This cannot be fixed by stamping `version: 2` alone. The
+[published reader](https://github.com/vercel/eve/blob/eve%400.49.0/packages/eve/src/tasks/session-index.ts)
+uses a strict unversioned schema and would reject that returned state. The
+compatibility boundary must preserve both parent-readable state and old task
+protocols, or execute this cohort on retained compatible code. Silently deleting
+the task index or requiring a reset is not acceptable. Keep the failing hosted
+probe as the first compatibility implementation gate; do not start replacing
+the owner topology while this baseline remains broken.
+
+The probe also established that alias propagation can route separate requests
+to different deployments after `/info` first reaches the new one. Each code
+transition uses bounded read-only turns and verifies actual execution provenance;
+every accepted turn must preserve the session. The historical build stages the
+published package with unusable source-only export conditions removed, without
+changing runtime code. Retained production artifacts remain necessary.
+
+This records behavior the legacy runner must preserve and a failure it must
+fix. It does not implement the unified topology or prove arbitrary state projections. Authorization
 callbacks, mixed-ingress conversation claims, remaining published cohorts, and
 self-hosted executable retention remain release gates. The existing dev-server
 generation scenarios cover live reload; their crash/restart case is skipped

--- a/research/discriminated-workflow-inboxes.md
+++ b/research/discriminated-workflow-inboxes.md
@@ -710,6 +710,37 @@ generation scenarios cover live reload; their crash/restart case is skipped
 pending abortable local queue delivery, so they do not establish a production
 package-upgrade path.
 
+### First compatibility implementation
+
+The first implementation takes the retained-executable option. New parents stamp
+`driverCapabilities.stateContractVersion: 1`, independently of the outer
+turn-input version. The value covers both nested session state and the state
+returned to the parent; incompatible changes must advance it. A missing or
+nonmatching contract on Vercel resolves the session parent's original deployment
+before the child claims hooks or executes agent code. If the child is already
+on that deployment, it executes there; otherwise it forwards the exact original
+input to the retained `turnWorkflow` entry. That child continues using the same
+parent stream, reply, cancellation, and pending-work contracts. New sessions with
+matching contracts retain ordinary accepting-deployment code upgrades.
+
+This deliberately pins pre-boundary sessions to original agent code, including
+task-free sessions: absence of task state does not prove that the next turn will
+not create incompatible state. There is no state rewrite or automatic conversion.
+The forwarding run does not own or proxy the old child's hooks. Its prepare step
+persists the target and a World-generated run ID before the start step; retries
+of that start reuse the ID, including after child completion and hook disposal.
+The Workflow integration test injects a lost queue acknowledgement and retries
+again after completion. Parent dispatch deduplication across separately created
+forwarding runs remains part of the broader start-idempotency release gate.
+
+The published-consumer probe now requires the formerly failing task-owning
+session to accept its next message on retained code, then admit, answer, and
+finish another background task. It also starts new blocking work after upgrade,
+verifies current code for fresh sessions, and checks both cohorts through
+agent-code rollback. Hosted results for this implementation are pending.
+Self-hosted retained-generation routing and full runtime downgrade remain
+unimplemented release gates.
+
 ### Refactor release gates
 
 Start with these counterexamples before wiring the full runtime. Record the

--- a/research/discriminated-workflow-inboxes.md
+++ b/research/discriminated-workflow-inboxes.md
@@ -737,7 +737,11 @@ The published-consumer probe now requires the formerly failing task-owning
 session to accept its next message on retained code, then admit, answer, and
 finish another background task. It also starts new blocking work after upgrade,
 verifies current code for fresh sessions, and checks both cohorts through
-agent-code rollback. Hosted results for this implementation are pending.
+agent-code rollback. The [hosted run at `e8d44a692`](https://github.com/vercel/eve/actions/runs/33900278614/job/101112516239)
+passed all 56 checks on 2026-09-04. The old task-owning session accepted its next
+message, completed new background work, and remained usable through rollback;
+the fresh session ran current and rolled-back code. The retained `0.30.8`
+consumer test and the Local/Postgres fixture baselines also passed.
 Self-hosted retained-generation routing and full runtime downgrade remain
 unimplemented release gates.
 

--- a/research/discriminated-workflow-inboxes.md
+++ b/research/discriminated-workflow-inboxes.md
@@ -1,7 +1,7 @@
 ---
 issue: https://github.com/vercel/eve/issues/876
 status: proposed
-last_updated: "2026-09-03"
+last_updated: "2026-09-04"
 ---
 
 # One logical inbox per durable owner
@@ -11,7 +11,9 @@ accept the same discriminated event protocol and feed one buffer and reducer.
 Each hook reserves an address through which that owner can receive messages.
 Every session starts with its stable session-ID hook, then adds external
 addresses when they become known. Senders resume the addressed hook directly.
-All eve-owned hooks omit `HookOptions.metadata`.
+New owner-inbox hooks omit `HookOptions.metadata`. Existing sessions keep their
+protocol and addresses through a compatibility path; upgrading eve must not
+require resetting a live session.
 
 This refactor addresses these connected problems:
 
@@ -34,6 +36,29 @@ The background pump merges the hook iterators while foreground work runs.
 The design assumes this is Workflow-safe; a small spike will verify dynamic
 registration, merged ordering, replay, cancellation, and disposal.
 
+## Review and release boundary
+
+The ownership model is worth pursuing. The current
+[inline loop](../packages/eve/src/execution/inline-turn.ts) promotes sleep,
+background-task admission, cancellation, and tool coordination to a child.
+Keeping those operations inline removes an execution boundary and its relays.
+Correlating requests in one owner inbox also removes per-request hook lifetimes.
+The existing session inbox already multiplexes readers, so multiplexing alone
+is not the architectural gain.
+
+The proposal is not implementation-ready. Its release blockers are replay-safe
+pumping, recoverable settlement, and coexistence with persisted old workflows.
+It also adds costs: owner finalization, supervision, buffered input, and retained
+addresses. Long session histories still grow. Measure ordinary inline turns as
+well as tool-heavy turns; reduced hook counts cannot justify a latency regression.
+
+The first release preserves existing session IDs, streams, conversation claims,
+queued input, and pending work. Existing sessions may keep old execution and
+steering semantics and may need to stay on old code. New sessions get the new
+topology. An automatic reset, a silently forked provider thread, or an old parent
+whose next child cannot start is not an acceptable upgrade. This compatibility
+requirement applies to persisted work even where pre-1.0 authoring APIs change.
+
 ## Before and after
 
 A **logical inbox** owns the hook readers, shared buffer, correlations, and
@@ -45,7 +70,8 @@ Cancellation, reports, requests, replies, and individual operations use event
 fields in the existing inbox. There are no lookup-only hooks.
 
 `A` below is one optional authorization callback hook, added when needed.
-Counts exclude application-authored hooks and webhooks.
+Counts describe new owners and exclude application-authored hooks, webhooks,
+and retained legacy owners.
 
 | Owner                                                  | Current hooks                                                                  | Proposed hooks                                                         | Hook count                 |
 | ------------------------------------------------------ | ------------------------------------------------------------------------------ | ---------------------------------------------------------------------- | -------------------------- |
@@ -80,15 +106,15 @@ ownership claims, input forwarding, and settlement exchange.
 
 ### Proposed hook inventory
 
-| Address                | Token                                      | Why this hook exists                                                                                   | Ownership claim              |
-| ---------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------ | ---------------------------- |
-| Stable session         | `eve:session-inbox:v1:<runId>`             | Addresses the session by ID and receives inline-turn traffic                                           | None; unique to the run      |
-| External conversation  | `eve:continuation:v1:<provider-address>`   | Reserves a provider identity so ingress can reach the session without knowing its run ID               | Once per distinct address    |
-| Authorization callback | `eve:auth-callback:v1:<random-capability>` | Gives the session an unguessable callback address; connections and attempts remain event fields        | None; random, session-scoped |
-| Delegated turn         | `eve:turn-inbox:v1:<turnId>`               | Wakes the turn executing on another deployment; a session-inbox event wakes only the session           | Before owner work            |
-| Workflow-tool run      | `eve:workflow-tool-inbox:v1:<operationId>` | Addresses an independent blocking tool execution with its own body, cancellation scope, and settlement | Before owner work            |
-| Background task        | `eve:task-inbox:v1:<taskId>`               | Addresses admitted work whose execution and input requests can outlive the initiating turn             | Before owner work            |
-| Activity collector     | Existing random callback capability        | Addresses the separate activity reducer with its own debounce and expiry                               | Before owner work            |
+| Address                | Token                                       | Why this hook exists                                                                                   | Ownership claim              |
+| ---------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ---------------------------- |
+| Stable session         | `eve:session-inbox:v1:<runId>`              | Addresses the session by ID and receives inline-turn traffic                                           | None; unique to the run      |
+| External conversation  | Existing channel-derived continuation token | Preserves one conversation claim namespace across old and new deployments                              | Once per distinct address    |
+| Authorization callback | `eve:auth-callback:v1:<random-capability>`  | Gives the session an unguessable callback address; connections and attempts remain event fields        | None; random, session-scoped |
+| Delegated turn         | `eve:turn-inbox:v1:<turnId>`                | Wakes the turn executing on another deployment; a session-inbox event wakes only the session           | Before owner work            |
+| Workflow-tool run      | `eve:workflow-tool-inbox:v1:<operationId>`  | Addresses an independent blocking tool execution with its own body, cancellation scope, and settlement | Before owner work            |
+| Background task        | `eve:task-inbox:v1:<taskId>`                | Addresses admitted work whose execution and input requests can outlive the initiating turn             | Before owner work            |
+| Activity collector     | Existing random callback capability         | Addresses the separate activity reducer with its own debounce and expiry                               | Before owner work            |
 
 Every hook above is iterated, server-only (`isWebhook: false`), and created
 without `metadata`. The session creates and owns all of its address hooks,
@@ -98,8 +124,21 @@ Independent owners retain `start()` plus `getConflict()`: each candidate creates
 its inbox and reader before claiming; only the winner executes the body. Losers
 dispose their inboxes and exit without publishing an outcome. A child turn drops
 from two sequential claims to one. Start retries use the same logical token.
-Durable start idempotency remains separate work: a retry after the original
-owner releases its token can still repeat work.
+An ownership claim only excludes simultaneous execution. A retry after the
+winner releases its token can execute the body again. Before shipping, prove
+that starts converge on the same logical operation through their entire retry
+horizon, using a durable start identity or a retained completion record. A live
+hook conflict alone is insufficient. Include any retained hooks in the inventory
+and benchmarks; do not hide that cost in the deduplication claim.
+
+The installed Workflow SDK documents `experimental_minRetention` for retaining
+a claimed token after completion. Evaluate that existing primitive first for
+operation inboxes. Its clock starts at hook creation, not completion; a long run
+can exhaust it before finishing. Explicit disposal defeats retention, and World
+support and limits vary. Prove coverage of the retry horizon instead of choosing
+a fixed duration by intuition. Retained hooks are discoverable but cannot receive
+messages after the run ends, so completed-owner detection must precede forwarding.
+Do not apply operation retention to reusable conversation addresses blindly.
 
 ## Routing and event contract
 
@@ -115,8 +154,9 @@ auth callback -----> resume callback hook -----+   background pump
                                                   session owner
 ```
 
-All session hooks accept the same wire protocol. Tool traffic returns directly
-to the workflow that owns the turn:
+All session hooks feed the same event protocol after decoding, including the
+temporary legacy conversation decoder below. Tool traffic returns directly to
+the workflow that owns the turn:
 
 ```text
 Same deployment: session owns the inline turn
@@ -147,25 +187,35 @@ its return address. A delegated turn supplies its own inbox to blocking tools.
 Background tasks use the stable session address because they can outlive that
 turn. Same-run body results and reports enter the owner's reducer directly.
 
-After existing authorization checks, session-ID ingress derives the stable
-token; provider and callback ingress derive their own namespaced tokens. Each
-calls `resumeHook(token, envelope)` directly. No eve lookup translates an external
-address into the stable address, and no hook metadata selects the protocol.
-Workflow still resolves the token internally. Direct token resume avoids the
-metadata-discovery preflight used by current continuation ingress; ordinary
-stable-session ingress already has a direct fast path. Explicit session lookup
-and child supervision may still read hook ownership when they need the run ID.
+After existing authorization checks, new stable-session and callback ingress
+derive their namespaced tokens and call `resumeHook(token, envelope)` directly.
+Provider ingress keeps the existing continuation token during coexistence. It
+resolves that exact hook, selects its owner's protocol, and resumes the inspected
+hook object. It never translates the address into a different stable hook.
+Identify new owners by their immutable, topology-specific workflow entry ID;
+verify whether the hook's resume context supplies it, otherwise read the owning
+run. Legacy owners retain the current metadata/markerless classification. This
+costs discovery on the provider path but does not add metadata to new hooks.
 
-External addresses include the channel and provider conversation scope. For
-Slack, the identity includes the installation/workspace, channel, and
-`threadTs ?? ts`; a timestamp alone is not a global address.
+Changing a provider key and changing the inbox protocol are separate migrations.
+For example, Slack currently derives a channel-name/channel/thread key; adding
+installation scope at the same time would bypass the existing claim. Keep the
+shipped derivation for existing bindings in this release, retain authorization
+and provider-identity checks, and address broader provider scoping separately.
 
 Internal senders receive an `InboxAddress` containing a token and
 `protocol: { family: "eve-inbox", version: N }` in durable input or
 framework-owned state. That version selects the exact envelope to encode.
-External session, provider, and callback ingress always send version 1 for this
-topology. The token's `:v1:` identifies the topology, independently of later
-envelope versions.
+New external ingress emits version 1 to new owners. Versioned tokens and the
+workflow entry ID identify topology independently of later envelope versions;
+the shared conversation token intentionally does not identify topology.
+
+During coexistence, a new owner's conversation reader also needs a narrow legacy
+decoder: an old ingress or losing old startup can resume that shared token
+without knowing the new protocol. Normalize those historic shapes before the
+common reducer. This is the exception to identical wire acceptance across an
+owner's hooks. Preserve the historical delivery guarantee when old messages lack
+event identities; do not claim new cross-address deduplication for them.
 
 An envelope carries `version`, an event identity `(producer.id, eventId)`, a
 target, and a discriminated event with its existing domain payload:
@@ -203,6 +253,14 @@ The wire contract preserves these invariants:
   server/step-safe encoders and dependency-free workflow decoders, following
   [the wire-schema plan](./session-inbox-wire-schema.md).
 
+Reject an invalid event with a durable diagnostic while keeping the session
+usable. Storage/reader failure is an owner failure, not a malformed-event case.
+Successful resume means durable enqueueing, not application or admission by the
+reducer. An in-memory buffer limit cannot bound the persisted hook backlog;
+ingress admission, byte limits, and bounded drain batches must cover that too.
+Overflow after enqueue needs an observable rejection/recovery outcome. Control
+and settlement traffic must remain serviceable under a message flood.
+
 ## Background pump and turn decisions
 
 One background pump merges the owner's hook iterators while the foreground
@@ -224,6 +282,10 @@ Preserve each hook's persisted order and make the merged order reproducible
 under Workflow replay. Separate hooks do not imply a global arrival order.
 The spike must verify cross-hook ordering relative to foreground step settlement;
 wall-clock promise completion alone is not the contract.
+If replay does not preserve this decision, persist the decision/cut through a
+supported Workflow primitive or narrow the design. Do not add a best-effort
+ordering heuristic and call it durable. Bound each drain so a continuously busy
+inbox cannot prevent a ready foreground step from making progress.
 
 ```text
 hooks -> merged reads -> background pump -> decode / deduplicate
@@ -337,6 +399,13 @@ resumable. A mid-session claim conflict fails that reservation visibly and keeps
 existing addresses intact. It never merges two running sessions. This includes
 a competing start between the first Slack post and its address reservation.
 
+This leaves a real scheduled-post race: replies can establish another owner
+before registration. The losing scheduled session must surface which reservation
+failed and stop treating that thread as its reply route. Neither repeat the
+original post nor silently claim that replies reach it. If seamless scheduled
+anchoring is a release requirement, it needs a separate reservation mechanism;
+the additive-inbox model does not solve it.
+
 The session owns reservations even when a child discovers the address. The child
 requests registration through the parent inbox and awaits the result through
 its own inbox, using the shared request/result protocol. No hook is created in
@@ -382,18 +451,35 @@ by the reducer. Closing the child's admission fixes that set. Late/unapplied
 messages remain the parent's responsibility. Resume retries preserve identity;
 missing-inbox retries cover only bounded startup registration.
 
+Settlement must not overwrite changes the parent made while the child ran.
+The parent owns address reservations, its inbox, and session-level task updates
+and cancellations. The child owns its turn result. Define an explicit merge or
+versioned projection for those fields; blindly adopting the child's full starting
+snapshot plus turn edits can resurrect cancelled tasks or erase a new address.
+Bound settlement acknowledgements by outstanding transferred events, not every
+event the session has ever seen.
+
 Every owner awaiting a child outcome has durable supervision, independent of
 session expiry or new user traffic. A shared Workflow sleep and bounded status
 reads detect terminal children with missing reports, allowing a reconciliation
 interval for delayed settlement. Supervision follows the inbox's owning run,
 which may differ from the candidate returned by `start()`.
 
-A missing report or exhausted supervision reads causes a visible failure while
-retaining the last committed state and unresolved input. Automatic execution
-stops because replaying input could repeat already-applied work. Recovery must
-not invent a second terminal outcome if the child already emitted one. A healthy
-active child remains running. This also applies to tool/task children and remains
-active when `sessionTimeoutMs: false` disables session expiry.
+A missing report first triggers retrieval of the child's committed settlement.
+The finalizer must leave an authoritative, recoverable result with the same
+identity as its report; returning the settlement as the Workflow result is a
+candidate, but the finalize/report/return crash windows must be tested. A status
+of `completed` alone does not contain enough information to adopt state. A late
+report and a recovered result must converge on one adoption and one outcome.
+
+If settlement cannot be recovered, surface an explicit unresolved turn while
+retaining committed state and input. Keep history, diagnostics, and recovery
+controls reachable. Do not replay uncertain tool effects, silently start a
+replacement, or emit a second terminal outcome. Status-read outages are not proof
+of child failure; a healthy active child remains running. This also applies to
+tool/task children and remains active when `sessionTimeoutMs: false` disables
+session expiry. A log followed by an indefinitely parked session is insufficient
+recovery behavior; the retrieval/repair path is a release gate.
 
 ## Workflow-tool and task behavior
 
@@ -426,48 +512,209 @@ Application-authored `createHook` and `createWebhook` remain unchanged.
 
 ## Deployment cut
 
-Ship the new tokens, envelopes, owner inputs, callback routing, and terminal
-emission together as the `owner-inbox-v1` topology. All hooks in an owner's
-inbox share its protocol contract. New routes do not resume old
-hooks: pre-cut session IDs require a reset, and provider activity on an old
-thread starts a new session. Child entry points reject pre-cut inputs before
-creating hooks or executing work.
+`owner-inbox-v1` is a new execution topology for new owners. It is not a reset of
+existing sessions. Ship its tokens, entry IDs, envelopes, callback routing, and
+terminal emission together, alongside the compatibility behavior below.
 
-External ingress stays on the frozen version-one contract. Internal upgrades
-use framework-stamped accepting-deployment capabilities: topology,
-`inboxMaxVersion`, and `turnInputMaxVersion`. The parent selects versions both
-deployments support and passes explicit addresses and inputs. Mixed, missing, or
-unrepresentable capabilities keep execution pinned. Unsupported operations fail
-before resume. New consumers read earlier post-cut versions; incompatible
-external changes require a new routing design or topology cut.
+### Four independent upgrade contracts
 
-This replaces the pre-cut compatibility policy and metadata discovery in the
-[wire-schema plan](./session-inbox-wire-schema.md). The implementation needs a
-minor changeset and coordinated stream/client/adapter updates. Published docs
-and release notes must cover session reset, steering versus interruption,
-`turn.interrupted`, the `ask()` return type, additive continuation addresses,
-and delivery/recovery limits. The session-ID format is unchanged.
+| Contract                        | What changes                                                                   | Upgrade rule                                                                                                                                                                 |
+| ------------------------------- | ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Inbox envelope                  | Messages crossing a live hook                                                  | Encode for the receiver; retain frozen historic decoders. A payload migration does not replace the receiver's workflow.                                                      |
+| Workflow topology/replay        | Entry/step identities, hook cursors, control flow                              | Existing runs keep a compatible executable graph. Introduce distinct entry IDs for new topology; never replay old history through the new loop merely because inputs decode. |
+| Turn input and returned state   | Snapshot, serialized context, pending operations, result, emission state       | Check both directions before delegation. A new child must produce a result and state the pinned parent can adopt without losing meaning.                                     |
+| Authored agent code and clients | Instructions, tools, workflows, connections, lifecycle handlers, stream events | Select code at a safe turn boundary; running work stays on its selected deployment. Wire compatibility alone does not make removed tools or changed authored workflows safe. |
+
+Internal capabilities must describe supported read/write contracts, including
+turn input, settlement/snapshot, and stream semantics. `inboxMaxVersion` and
+`turnInputMaxVersion` alone do not establish compatibility. For example, a v1
+parent may send input a v2 child understands while being unable to read the
+child's v2 snapshot. The child must commit to a v1 return projection before work
+starts, or that turn stays on compatible code. Do not drop fields to make an
+otherwise incompatible result fit.
+
+Framework-stamped accepting-deployment capabilities are immutable delivery data,
+not user input. Negotiate request and return addresses independently and persist
+the selection with the turn input. Missing, mixed, unsupported, or unrepresentable
+capabilities keep a new owner on its pinned deployment, with an inspectable reason.
+Do not silently route an active turn to a newly promoted deployment. Tasks and
+authored workflow bodies already running retain their execution deployment and
+their original reply contracts.
+
+External v1 operations remain encodable for every owner in this topology. New
+external operations require a capability check before persistence or a separately
+versioned route; adding a discriminator and hoping an old reader ignores it is
+not an upgrade strategy. The post-cut decoder retains old envelopes for the
+lifetime of their possible producers and persisted events, not just until the
+next package release.
+
+### Existing agents upgrading to this release
+
+The default upgrade preserves old sessions automatically through a legacy path:
+
+1. **Route to the existing owner.** Session-ID ingress tries the new stable
+   address and uses the existing legacy route on a definitive absence. Preserve
+   session-ID behavior for each historical cohort and continuation-only access
+   where that was its supported surface. Provider ingress uses the shared
+   conversation claim described above. A timeout, uncertain resume, or decode
+   error must never trigger creation of another session.
+2. **Keep old messages readable.** Retain `resumeSessionInbox`, its v0
+   `send`/`deliver` classifier, and every shipped version encoder required by live
+   cohorts. Keep old authorization callback URLs, task replies, subagent replies,
+   streams, cancel, clear, and reset routes usable. New-only operations return a
+   clear unsupported-operation result without terminating the old session.
+   Existing `steer` retains the old owner's semantics; new step-boundary steering
+   is a new-owner behavior.
+3. **Keep old child protocols executable.** Preserve the published stable entry
+   references used by legacy parents and their input, report, request, outcome,
+   cancellation, and state-return contracts. Register new topology under different
+   entry IDs. A new deployment must not reject a supported old parent at the old
+   `turnWorkflow` entry or translate its input into a new child while forgetting
+   the old parent's reply hooks. Initially retain the legacy runner; sharing its
+   internals with the new loop is optional, conditional on parity tests.
+4. **Constrain code upgrades.** For legacy sessions, preserve compatible updated
+   agent-code execution through that runner where verified. Where it cannot be
+   represented, route the next turn to retained compatible code. New ingress
+   must not stamp its own deployment as an execution target for an incompatible
+   legacy parent. Already-persisted dispatches and old producers still require
+   the old entry contract; changing new ingress metadata alone is not a repair.
+5. **Preserve the operator's data and artifacts.** Retain the old deployment,
+   authored modules, secrets/keys needed to read its state, and Workflow data
+   until its runs and callbacks are retired. Upgrading the package does not
+   rewrite hook records, erase history, or create a replacement conversation.
+
+This needs a compatibility implementation, not merely a legacy decoder. Current
+[dispatch](../packages/eve/src/execution/dispatch-turn-step.ts) routes to the
+accepting deployment, and the
+[old input migration](../packages/eve/src/execution/durable-session-migrations/turn-workflow.ts)
+already distinguishes parent capabilities. Freeze actual published inputs and
+outputs, including the unversioned cohort. Before enabling new owners, prove how
+an incompatible dispatch that has already reached the old entry uses retained
+code without another owner or repeated effects. If that cannot be provided for a
+supported cohort, the release is blocked for that cohort; a reset is not the fix.
+
+Keep one external claim key during rollout. Probing a legacy token and then
+claiming an independently versioned token is a check/claim race: an old ingress
+can win the old token while a new ingress wins the new one. The shared claim and
+legacy conversation decoder avoid that split. Unknown owner entry IDs must fail
+visibly rather than be guessed to be legacy or treated as an absent session.
+
+There is no compulsory live-session conversion in the first release. Existing
+sessions may remain on the compatibility path until they end; history transfer
+to a new session with a new ID is a separate, explicit operation. A future
+automatic transfer needs fencing of pending input, work, addresses, and streams.
+Snapshot migration by itself cannot transfer a live run's durable cursors.
+
+### Deployment retention, rollout, and rollback
+
+Vercel deployment pinning is useful only while the old deployment and its
+dependencies remain executable. Local/custom Worlds must also route old runs and
+steps to retained artifacts. Persisting `.eve/.workflow-data` while replacing
+the sole executable bundle does not establish replay compatibility. The rollout
+must include a tested way to retain and route old executable generations on
+supported self-hosted Worlds, or preserve their exact replay entry/step graph.
+Treat this as a release gate; do not advertise in-place replacement as safe based
+on a same-build restart test.
+
+Use two rollout phases, which may be deployments of the same release:
+
+1. Deploy compatibility-capable ingress and legacy execution support with new
+   owner creation disabled. Verify old sessions through that deployment and
+   retain it as the rollback target.
+2. Enable new owners after the upgrade matrix passes. Existing sessions remain
+   on their old topology. Observe routing, unresolved settlements, and retained
+   run counts for both cohorts.
+
+Rollback stops creating new owners and returns to a compatibility-capable
+deployment. Existing new owners keep their pinned executable and routes. Rolling
+the production alias back to a pre-bridge binary is not a supported rollback;
+it cannot be assumed to understand new sessions or stream events. Document this
+before enablement. Also test ordinary authored-code rollback within a supported
+topology, including refusing to delegate new state to an older incompatible child.
+
+Compatibility removal is based on retired runs, descendants, callbacks, queued
+deliveries, and retry/retention horizons. The default 30-day session timeout is
+not a removal deadline: `sessionTimeoutMs: false`, older deployments still
+creating sessions, and delayed work can keep a cohort alive. Provide a bounded,
+resumable inventory of these dependencies before cleanup. Owners that cannot be
+retired keep their compatibility runtime; elapsed time must not brick them.
+
+The implementation needs a minor changeset and coordinated stream/client/adapter
+updates. Release docs must describe retained session behavior, code pinning,
+the two rollout phases and rollback target, operator diagnostics, true steering,
+`turn.interrupted`, the `ask()` return type, and delivery/recovery limits. The
+[wire-schema plan](./session-inbox-wire-schema.md) remains the legacy contract;
+this proposal extends it rather than deleting its compatibility obligations.
 
 ## Verification
 
 These are implementation checks, not results established by this proposal.
 
+### Published-consumer compatibility spike
+
+The [redeploy probe](../e2e/fixtures/agent-inbox-upgrade/evals/inbox-upgrade.redeploy.eval.ts)
+adds a published `eve@0.49.0` consumer alongside the retained `0.30.8` test.
+Unlike the preview-pinned `0.30.8` parent, `0.49.0` dispatches later turns to the
+accepting deployment. The probe records actual deployment IDs and workflow run
+IDs to distinguish a resumed old body from a child using upgraded agent code.
+It covers idle follow-up and stream resumption, pending blocking and background
+answers, cancellation, new sessions, and agent-code rollback with the current
+runtime retained. Session expiry is disabled. Hosted execution belongs to the
+CI redeploy suite; adding this test does not establish a passing result.
+
+This freezes behavior the legacy runner must preserve. It does not implement
+the unified topology or prove arbitrary state projections. Authorization
+callbacks, mixed-ingress conversation claims, remaining published cohorts, and
+self-hosted executable retention remain release gates. The existing dev-server
+generation scenarios cover live reload; their crash/restart case is skipped
+pending abortable local queue delivery, so they do not establish a production
+package-upgrade path.
+
+### Refactor release gates
+
+Start with these counterexamples before wiring the full runtime. Record the
+observed event history and compare live execution with replay; a same-process
+unit mock is insufficient for the Workflow boundaries.
+
+| Pressure test                                                                                                    | Required result                                                                                                           |
+| ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Steer and model settlement arrive through different hooks around finalization; replay after each boundary        | One reproducible decision, no early terminal event, no dropped steer, and foreground progress under sustained input.      |
+| Child finishes, releases its inbox, then the parent's start step retries                                         | The completed logical operation is found; its authored body does not run again.                                           |
+| Child commits terminal state, then crashes before report or return; parent also receives a late duplicate report | Recover one authoritative settlement without repeating effects or terminal emission.                                      |
+| Task cancellation and address registration occur at the parent while a delegated turn finishes                   | Child adoption preserves both parent changes and accounts for every forwarded input.                                      |
+| Old and new ingress concurrently start the same provider conversation                                            | Exactly one claim winner; losing initial input reaches that owner using its understood contract.                          |
+| Older parent starts a child on the new deployment with old input and pending ask/task state                      | Complete the old reply protocol or safely execute on retained compatible code; no rejected entry that strands the parent. |
+| New child can decode old input but cannot represent its result for the old parent                                | Compatibility fails before execution; the owner keeps usable state and compatible execution.                              |
+| Replace/restart a self-hosted deployment with a session waiting on a hook and an authored workflow sleeping      | Old histories and pending steps use their retained executable generation; later input still reaches the same session.     |
+
+Cross-version CI must use actual published consumers, not only current code with
+an old `version` field. Cover the legacy `deliver` cohort, the actual 0.30.8
+`send` consumer, stamped wire cohorts, and the last pre-refactor release. Use a
+synthetic second post-cut contract to test negotiation before a second version
+ships, then retain its published counterpart. For each relevant cohort include an idle follow-up,
+an active tool, a pending answer/auth callback, a background task, and a resumed
+stream. Preserve the existing
+[published-consumer redeploy eval](../e2e/fixtures/agent-channels/evals/custom-channels/cross-version-session-inbox.eval.ts).
+Exercise both ingress directions, code upgrade and rollback, and disabled
+session expiry. Freeze the supported cohort matrix before implementation; do not
+narrow today's support merely to make the new tests pass.
+
 | Area                            | Required evidence                                                                                                                                                                                                                                                                                                   |
 | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Small Workflow spike            | Dynamic reader registration wakes a parked merge; per-hook order and merged step-boundary decisions survive replay/restart; abort and reader failure wake foreground work; disposal releases every reader. Verify supported Worlds, including Local, Vercel, and configured Postgres, plus retry horizons.          |
-| Structural inventory            | One inbox per receiving owner; one hook per address; no per-answer/cancel/report/reply hooks. An inline blocking-tool call starts only the tool run and adds one hook; delegation to another deployment adds one turn run and hook. All hooks omit metadata and accept direct delivery.                             |
+| Structural inventory            | New owners have one inbox, one hook per address, and no per-answer/cancel/report/reply hooks. A blocking tool adds only its own run and hook. New hooks omit metadata; account separately for compatibility discovery, retained legacy owners, and operation retention.                                             |
 | Execution parity                | Inline and delegated turns use the same handlers for tools, asks, runtime calls, sleep, task admission, cancellation, and supervision. Same-deployment work never creates a turn workflow. Background-task replies reach the session after the initiating turn ends.                                                |
 | Turn semantics                  | Steer at natural completion keeps the turn ID without a terminal frame; interrupt/cancel precedence and state preservation hold; finalizer retries retain event identities. Preserve `tasks: true` cancellation during active and parked sessions.                                                                  |
-| Ownership and recovery          | Initial claim losers never run; scheduled anchoring and mid-session claim conflicts behave explicitly; old addresses remain live; handoff never repeats work; settlement accounts for all input. Missing reports remain detectable with session expiry disabled.                                                    |
-| Other traffic and compatibility | Concurrent asks, tasks, subagents, authorization, and collectors share owner inboxes. Cover duplicates across addresses, stale input, all capacity bounds, address cleanup, pre-cut reset, newer ingress to older parents, and internal upgrades/rollback.                                                          |
+| Ownership and recovery          | Initial claim losers never run; scheduled anchoring conflicts are visible; old addresses remain live; late start retries never repeat a completed operation; settlement preserves parent changes and accounts for all input. Recover missing reports with session expiry disabled.                                  |
+| Other traffic and compatibility | Concurrent asks, tasks, subagents, authorization, and collectors share owner inboxes. Cover duplicates across addresses, stale input, durable backlog and capacity bounds, and address cleanup. Run the published-cohort matrix, mixed-ingress claim race, retained-generation restart, and rollback tests.         |
 | Hosted performance              | Same-SDK paired measurements cover inline blocking tools and background tasks as well as delegated turns, including ingress, finalization, supervision, and replay. Verify removal of the extra turn start and relay; report durable operations, state size, and latency against the benchmark's acceptance budget. |
 
 Use unit tests for reducers, Workflow-backed scenarios for scheduling and failure
 boundaries, and deterministic fixture evals in CI for streamed behavior. Relevant
 fixtures include `agent-workflow-tools`, `fixture-tasks`, and `agent-channels`.
 
-Source baseline: eve main `e83e50e4d5801d2d4378ae37aec1b98f55a0d5c6`, with
-`@workflow/core@5.0.0-beta.48`. The current
+Review baseline: `ccbd4b6a4`, with the repository and installed dependency both
+pinning `@workflow/core@5.0.0-beta.47`. The current
 [session inbox](../packages/eve/src/execution/session-command-inbox.ts),
 [child turn](../packages/eve/src/execution/turn-workflow.ts),
 [owner channels](../packages/eve/src/execution/tools/workflow/owner.ts), and
@@ -479,3 +726,7 @@ and [harness emission](../packages/eve/src/harness/emission.ts) establish the
 steering/finalization boundary. Metadata behavior is visible in
 [eve ingress](../packages/eve/src/execution/wire/session-inbox-resume.ts) and
 [Workflow's resume implementation](https://github.com/vercel/workflow/blob/7cc5c88a8bb2fad48353dd006c6ca1f28190ab46/packages/core/src/runtime/resume-hook.ts).
+The upgrade review also uses
+[stable workflow IDs](../packages/eve/src/execution/stable-workflow-names.ts),
+[session runtime routing](../packages/eve/src/execution/workflow-runtime.ts), and
+[Slack token derivation](../packages/eve/src/public/channels/slack/api.ts).

--- a/research/session-inbox-wire-schema.md
+++ b/research/session-inbox-wire-schema.md
@@ -1,7 +1,7 @@
 ---
 issue: https://github.com/vercel/eve/issues/1765
 status: proposed
-last_updated: "2026-08-31"
+last_updated: "2026-09-04"
 ---
 
 # Versioned wire schema for the session inbox
@@ -105,7 +105,7 @@ Normative rules:
   decoder checks version and kind, then normalizes away wire-only fields.
   Legacy v0 is the temporary exception: those writers predate the encoder,
   so its 0→1 migration defensively checks the historic `send`/`deliver`
-  fields until that cohort ages out under the 30-day timeout.
+  fields until that cohort and its possible producers have been retired.
 - **Encode goes through the wire module too.** Every persisted inbox
   payload — sends and controls alike — is built and validated against the
   current schema before it persists, so producer drift dies at the producer
@@ -160,14 +160,22 @@ continuations receive unversioned `deliver`, markerless stable-inbox consumers
 receive unversioned `send` (required by eve 0.30.5–0.31.0), and stamped
 consumers receive their declared version.
 
-| Phase                                               | Emit                                                        | Removable                                                                      |
-| --------------------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| Now                                                 | v0 `deliver`, v0 `send`, or v1 according to the target hook | —                                                                              |
-| Pre-stamp cohorts aged out (30-day session timeout) | current version to stamped hooks                            | markerless classifier and both v0 encoders                                     |
-| Pre-version payloads aged out                       | current version only                                        | legacy unversioned decode paths, `SessionCommand` inbox fallback, mirror field |
+| Phase                                                 | Emit                                                        | Removable                                                                      |
+| ----------------------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Now                                                   | v0 `deliver`, v0 `send`, or v1 according to the target hook | —                                                                              |
+| Pre-stamp owners and producers retired                | current version to stamped hooks                            | markerless classifier and both v0 encoders                                     |
+| Pre-version payloads and all possible writers retired | current version only                                        | legacy unversioned decode paths, `SessionCommand` inbox fallback, mirror field |
 
 Each removable row already has its condition written next to the code it
 deletes; #1765 tracks the cleanups.
+
+The default 30-day timeout is not proof that a cohort has retired. Sessions can
+disable expiry, old deployments can still produce messages, and descendants or
+callbacks can outlive a turn. Removal requires accounting for live owners,
+producers, persisted deliveries, and their retry/retention horizons. The
+[owner-inbox upgrade plan](./discriminated-workflow-inboxes.md#deployment-cut)
+preserves this legacy contract while introducing a new topology for new owners;
+it does not require resetting existing sessions.
 
 ## Enforcement
 


### PR DESCRIPTION
### Summary

A published 0.49.0 session can complete a background task and then fatally fail its next user turn on a newer eve deployment because the task-state contracts differ. This change forwards turns with an unconfirmed state contract to the session’s retained original deployment before executing agent code, preserving the old input, state-return, stream, and control contracts. Pre-boundary sessions keep their original agent code; new sessions declare a state contract and retain ordinary code upgrades. The unified inbox plan records this conservative upgrade path and its remaining release gates.

Stacked on #3005. Related to #876.

### Behavior and boundaries

- A missing or mismatched `driverCapabilities.stateContractVersion` uses retained Vercel execution. The original input reaches the old child unchanged, and it speaks directly to the original parent’s control and cancellation hooks. Task-free legacy sessions are also retained because their next turn could create incompatible state.
- The forwarding start reuses a run ID persisted by its preceding prepare step, including after an ambiguous start result or child completion. Deduplication across separately created forwarding runs remains a broader dispatch release gate.
- Existing sessions require their original deployments, Workflow data, and credentials to remain available. Their authored instructions/tools stay pinned; fresh sessions use current code. Agent-code rollback keeps the current runtime; a package downgrade to a pre-boundary runtime is unsupported.
- This implementation covers Vercel retained deployments. Self-hosted executable replacement, the new inbox topology, the full historical cohort matrix, and mixed-ingress conversation claims remain release gates.
- The published 0.49.0 probe preserves every runtime code byte; its fixture-only package manifest correction removes source-only exports pointing at files absent from npm. The original 0.30.8 consumer test remains in place.

### Validation

- The original hosted failure reproduced at `617b68328`: [Vercel job and execution records](https://github.com/vercel/eve/actions/runs/33898147026/job/101106035153).
- The updated hosted probe requires the old task-owning session to accept its next message, then start and complete another background task. It also covers new blocking work after upgrade, pending answers, cancellation, saved stream cursors, fresh sessions, and code rollback. At `e8d44a692`, all 56 hosted checks passed: [Vercel upgrade and rollback job](https://github.com/vercel/eve/actions/runs/33900278614/job/101112516239). The retained 0.30.8 Vercel test and Local/Postgres fixture baselines also passed. Subsequent changes only record these results in the research plan.
- 113 focused unit tests passed across turn dispatch, state-contract construction, turn control, and retained execution.
- The Workflow integration test passed with an injected lost queue acknowledgement, a retry, completion, and another retry; only one run exists.
- `pnpm --filter eve build` passed, with unresolved-import warnings in the self-modification extension. All 44 workspace typechecks, formatting, `git diff --check`, `pnpm docs:check`, lint, and invariant checks passed; lint reported two unrelated existing warnings.
- E2E runs only in CI. A patch changeset and deployment guidance are included.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
