### PR TITLE
docs: document multi-agent project structure

### DIFF
--- a/apps/docs/lib/geistdocs/llms-index.ts
+++ b/apps/docs/lib/geistdocs/llms-index.ts
@@ -25,6 +25,7 @@ Documentation links below point directly to Markdown. Remove the \`.md\` suffix 
 
 ## Build
 
+- [Project Structure](${EVE_ORIGIN}/docs/project-structure.md): Organize one or more independently addressed root agents, select them with the CLI, and deploy them together.
 - [Agents](${EVE_ORIGIN}/docs/agent-config.md): Configure the model, reasoning effort, compaction, and runtime behavior.
 - [Instructions](${EVE_ORIGIN}/docs/instructions.md): Write the agent's always-on system prompt.
 - [Tools](${EVE_ORIGIN}/docs/tools.md): Define typed actions and gate sensitive calls on human approval.

--- a/apps/docs/lib/geistdocs/redirects.test.ts
+++ b/apps/docs/lib/geistdocs/redirects.test.ts
@@ -107,8 +107,8 @@ describe("docsRedirects", () => {
     ["/docs/introduction.md", "/docs/getting-started.md"],
     ["/docs/installation", "/docs/getting-started"],
     ["/docs/installation.md", "/docs/getting-started.md"],
-    ["/docs/project-structure", "/docs/getting-started"],
-    ["/docs/project-structure.md", "/docs/getting-started.md"],
+    ["/docs/getting-started/project-structure", "/docs/project-structure"],
+    ["/docs/getting-started/project-structure.md", "/docs/project-structure.md"],
     ["/docs/reference/http-api", "/docs/channels/eve"],
     ["/docs/project-layout", "/docs/getting-started"],
     ["/docs/reference/project-layout", "/docs/getting-started"],
@@ -135,7 +135,7 @@ describe("rootMarkdownRedirects", () => {
   it.each([
     ["/getting-started.mdx", "/docs/getting-started.mdx"],
     ["/installation.md", "/docs/getting-started.md"],
-    ["/project-structure.mdx", "/docs/getting-started.mdx"],
+    ["/project-structure.mdx", "/docs/project-structure.mdx"],
     ["/tools/overview.md", "/docs/tools.md"],
     ["/channels/eve.mdx", "/docs/channels/eve.mdx"],
   ])("redirects observed root Markdown alias %s to %s", (source, destination) => {

--- a/apps/docs/lib/geistdocs/redirects.ts
+++ b/apps/docs/lib/geistdocs/redirects.ts
@@ -47,7 +47,6 @@ export const createIntegrationRedirects = (source: string, destination: string):
 export const docsRedirects: DocsRedirect[] = [
   ...createDocsRedirects("/introduction", "/getting-started"),
   ...createDocsRedirects("/installation", "/getting-started"),
-  ...createDocsRedirects("/project-structure", "/getting-started"),
   ...createDocsRedirects("/channels", "/channels/overview"),
   ...createDocsRedirects("/channels/http", "/channels/eve"),
   ...createDocsRedirects("/reference/http-api", "/channels/eve"),
@@ -71,7 +70,7 @@ export const docsRedirects: DocsRedirect[] = [
   ...createDocsRedirects("/evals", "/evals/overview"),
   ...createDocsRedirects("/advanced/evals", "/evals/overview"),
   ...createDocsRedirects("/getting-started/installation", "/getting-started"),
-  ...createDocsRedirects("/getting-started/project-structure", "/getting-started"),
+  ...createDocsRedirects("/getting-started/project-structure", "/project-structure"),
   ...createDocsRedirects("/getting-started/first-agent", "/tutorial/first-agent"),
 ];
 
@@ -79,7 +78,7 @@ export const rootMarkdownRedirects: DocsRedirect[] = [
   ["/getting-started", "/getting-started"],
   ["/install-integrations", "/install-integrations"],
   ["/installation", "/getting-started"],
-  ["/project-structure", "/getting-started"],
+  ["/project-structure", "/project-structure"],
   ["/instructions", "/instructions"],
   ["/tools/overview", "/tools"],
   ["/skills", "/skills"],

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,8 @@ Important naming note:
 
 | To do this                                               | Read this                                                                              |
 | -------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| Create a project, or understand the file layout          | [Getting Started](./getting-started.mdx)                                               |
+| Create your first project                                | [Getting Started](./getting-started.mdx)                                               |
+| Organize one or more peer agents in a project            | [Project Structure](./project-structure.md)                                            |
 | Set the model, reasoning, or other agent-wide config     | [Agents](./agent-config.md)                                                            |
 | Change what the agent does and how it behaves            | [Instructions](./instructions.mdx)                                                     |
 | Give the agent a typed capability it can call            | [Tools](./tools/overview.mdx)                                                          |
@@ -54,24 +55,25 @@ Unless you configure stricter controls, eve agents may operate with permissive s
 For a full picture rather than a single task, read in this order:
 
 1. [Getting Started](./getting-started.mdx)
-2. [Tutorial](./tutorial/first-agent.mdx)
-3. [Agents](./agent-config.md)
-4. [TypeScript API Reference](./reference/typescript-api.md)
-5. [Context Control](./concepts/context-control.md)
-6. [Skills](./skills.mdx)
-7. [Tools](./tools/overview.mdx)
-8. [Connections](./connections/overview.mdx)
-9. [Sandboxes](./sandbox.mdx)
-10. [Channels](./channels/overview.mdx)
-11. [Session Context](./guides/session-context.md)
-12. [Sessions and Streaming](./concepts/sessions-runs-and-streaming.md)
-13. [Client SDK](./guides/client/overview.mdx)
-14. [Subagents](./subagents/index.mdx)
-15. [Schedules](./schedules.mdx)
-16. [Evals](./evals/overview.mdx)
-17. [Authentication](./guides/auth-and-route-protection.md)
-18. [Deployment](./guides/deployment/overview.md)
-19. [CLI](./reference/cli.md)
+2. [Project Structure](./project-structure.md)
+3. [Tutorial](./tutorial/first-agent.mdx)
+4. [Agents](./agent-config.md)
+5. [TypeScript API Reference](./reference/typescript-api.md)
+6. [Context Control](./concepts/context-control.md)
+7. [Skills](./skills.mdx)
+8. [Tools](./tools/overview.mdx)
+9. [Connections](./connections/overview.mdx)
+10. [Sandboxes](./sandbox.mdx)
+11. [Channels](./channels/overview.mdx)
+12. [Session Context](./guides/session-context.md)
+13. [Sessions and Streaming](./concepts/sessions-runs-and-streaming.md)
+14. [Client SDK](./guides/client/overview.mdx)
+15. [Subagents](./subagents/index.mdx)
+16. [Schedules](./schedules.mdx)
+17. [Evals](./evals/overview.mdx)
+18. [Authentication](./guides/auth-and-route-protection.md)
+19. [Deployment](./guides/deployment/overview.md)
+20. [CLI](./reference/cli.md)
 
 ## The public mental model
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -197,7 +197,9 @@ The same mount shape works with an npm package, a workspace dependency, or a lin
 
 ### Use an extension in a workspace
 
-A workspace extension is a regular extension package kept in the same monorepo as its consumers. It is useful when several agents need the same capabilities, or when a private capability should evolve alongside the agents that use it.
+A workspace extension is a regular extension package kept in the same package-manager workspace as its consumers. It is useful when several agents need the same capabilities, or when a private capability should evolve alongside the agents that use it.
+
+A package-manager workspace is not necessarily an eve multi-agent project. The example below contains two independently deployable agent packages. For several peer agents deployed together from one eve project, see [Project Structure](./project-structure#multi-agent-project); the extension is still mounted separately by each agent.
 
 For example, a pnpm workspace can keep one extension next to two independently deployable agents:
 

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -42,6 +42,14 @@ To initialize the agent with a different AI Gateway model or reasoning effort, p
 npx eve@latest init my-agent --model openai/gpt-5.6-terra --reasoning high
 ```
 
+To create several independently addressed root agents in one project, pass their names with `--agents`:
+
+```bash
+npx eve@latest init my-project --agents support,billing
+```
+
+This creates `agents/support/agent/` and `agents/billing/agent/` under one project root. See [Project Structure](./project-structure) for agent selection, ownership, routes, and deployment.
+
 ## Run the agent
 
 Choose **Start eve dev** after scaffolding, or run this from the project root:
@@ -54,7 +62,7 @@ This starts an interactive session where you can send messages to your agent.
 
 ## Project layout
 
-eve builds an agent by walking the filesystem under `agent/`. Each directory is an authored slot, and the slot a file lands in determines how eve loads it.
+eve builds an agent by walking the filesystem under `agent/`. Each directory is an authored slot, and the slot a file lands in determines how eve loads it. In a multi-agent project, each peer has the same authored shape under `agents/<name>/agent/`; see [Project Structure](./project-structure) for the project-level layout.
 
 ### Naming from paths
 

--- a/docs/guides/deployment/vercel.mdx
+++ b/docs/guides/deployment/vercel.mdx
@@ -51,7 +51,7 @@ See [Sandbox](../../sandbox) for resource limits, network policy, and lifecycle 
 
 ## Deploy the agent
 
-A project containing only several independently addressed root agents can use eve's hostless workspace layout:
+A project containing several independently addressed root agents can use eve's hostless multi-agent layout. Read [Project Structure](../../project-structure) first for the project model, CLI selection, ownership, and route topology:
 
 ```text
 my-project/
@@ -92,11 +92,18 @@ Vercel uses the generated output to configure these services:
 
 ## Verify the deployment
 
-Check the health route and connect the development TUI:
+For a standalone agent, check the health route and connect the development TUI at the deployment origin:
 
 ```bash
-curl https://your_agent.vercel.app/support/eve/v1/health
-eve dev https://your_agent.vercel.app/support
+curl https://your-agent.vercel.app/eve/v1/health
+eve dev https://your-agent.vercel.app
+```
+
+For a hostless multi-agent project, include the member name:
+
+```bash
+curl https://your-project.vercel.app/support/eve/v1/health
+eve dev https://your-project.vercel.app/support
 ```
 
 Set `VERCEL_AUTOMATION_BYPASS_SECRET` locally before connecting if the deployment uses Deployment Protection.

--- a/docs/guides/frontend/nextjs.mdx
+++ b/docs/guides/frontend/nextjs.mdx
@@ -45,7 +45,9 @@ export default withEve(nextConfig, {
 });
 ```
 
-Named agents mount under `/eve/agents/<name>/eve/v1/*`. Call the matching agent from React with `agent`:
+Named agents mount under `/eve/agents/<name>/eve/v1/*`. This is a frontend-owned topology, distinct from the hostless multi-agent project whose peers use `/<name>/eve/v1/*`. See [Project Structure](../../project-structure#choose-a-project-shape) for the comparison.
+
+Call the matching agent from React with `agent`:
 
 ```tsx
 const support = useEveAgent({ agent: "support" });

--- a/docs/meta.json
+++ b/docs/meta.json
@@ -4,6 +4,7 @@
     "getting-started",
     "concepts",
     "---Build---",
+    "project-structure",
     "agent-config",
     "instructions",
     "memory",

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -1,0 +1,209 @@
+---
+title: "Project Structure"
+description: "Organize one or more independently addressed eve agents in a project, select them with the CLI, and deploy them together."
+---
+
+An eve project can contain one root agent or several peer root agents. Use a multi-agent project when the agents should share one project environment and deployment but keep separate instructions, capabilities, sessions, and public routes.
+
+A peer agent is not a [subagent](./subagents). Peer agents are independently addressed root agents. A subagent is a child capability that one root agent can call.
+
+## Choose a project shape
+
+| Shape                        | Use it when                                                                | Agent location                          | Default public route                      |
+| ---------------------------- | -------------------------------------------------------------------------- | --------------------------------------- | ----------------------------------------- |
+| Standalone agent             | One root agent has its own project and deployment                          | `agent/`                                | `/eve/v1/*`                               |
+| Hostless multi-agent project | Several peer agents deploy together without a frontend                     | `agents/<name>/agent/`                  | `/<name>/eve/v1/*`                        |
+| Frontend with named agents   | A framework application owns the public site and mounts one or more agents | Configured by the framework integration | `/eve/agents/<name>/eve/v1/*` for Next.js |
+
+Keep agents in separate projects when they need separate Vercel projects, environment ownership, or deployment lifecycles. A package-manager monorepo can contain several standalone eve projects without making them one eve multi-agent project.
+
+## Standalone project
+
+A standalone project has one authored agent root:
+
+```text
+support-agent/
+├── package.json
+├── agent/
+│   ├── agent.ts
+│   ├── instructions.md
+│   ├── channels/
+│   ├── connections/
+│   ├── skills/
+│   └── tools/
+└── evals/
+```
+
+Run agent and project commands from the same project root. The HTTP API is mounted at `/eve/v1/*` unless a host integration gives it another prefix.
+
+See [Getting Started](./getting-started#project-layout) for every supported path under `agent/`.
+
+## Multi-agent project
+
+A hostless multi-agent project puts each peer under `agents/<name>/`. Each peer has a complete `agent/` tree and can have its own `evals/`:
+
+```text
+customer-operations/
+├── package.json
+├── tsconfig.json
+├── agents/
+│   ├── support/
+│   │   ├── agent/
+│   │   │   ├── instructions.md
+│   │   │   ├── channels/
+│   │   │   └── tools/
+│   │   └── evals/
+│   └── billing/
+│       ├── agent/
+│       │   ├── instructions.md
+│       │   ├── connections/
+│       │   └── skills/
+│       └── evals/
+└── packages/
+    └── shared-capabilities/
+```
+
+The project root owns the eve dependency, environment files, Vercel link, and deployment. Every direct, discoverable child of `agents/` is a workspace member. Its directory name selects the member in the CLI and becomes its public URL segment. Use lowercase letters, numbers, underscores, or hyphens, starting and ending with a letter or number. A multi-agent project has no implicit primary agent.
+
+Do not put an independent eve project directly under the multi-agent project's `agents/` directory. A child with its own `package.json` and `eve` dependency is a separate project boundary rather than a member of the enclosing project.
+
+### Create the project
+
+Pass comma-separated names to `eve init`:
+
+```bash
+npx eve@latest init customer-operations --agents support,billing
+cd customer-operations
+```
+
+To add another peer later, run `eve init` from the multi-agent project root with the new name:
+
+```bash
+eve init research
+```
+
+This adds `agents/research/agent/` without replacing the project package, dependencies, or TypeScript configuration. Add `agents/research/evals/` when the new agent needs evals.
+
+### Work with one agent
+
+Pass `--agent <name>` to an agent-specific command at the project root:
+
+```bash
+eve dev --agent support
+eve info --agent billing
+eve eval --agent research
+```
+
+You can instead run the command from that member's directory:
+
+```bash
+cd agents/support
+eve dev
+```
+
+When an interactive command runs at the project root and more than one agent exists, eve opens a picker. A non-interactive command cannot use the picker, so pass `--agent <name>`. If the project has only one member, eve selects it automatically.
+
+### Work with the whole project
+
+Project-level Vercel commands run from the project root:
+
+| Task                                               | Run from                                                    | Result                                                    |
+| -------------------------------------------------- | ----------------------------------------------------------- | --------------------------------------------------------- |
+| Develop, inspect, configure, or evaluate one agent | Project root with `--agent <name>`, or the member directory | Selects one peer agent                                    |
+| Link to Vercel                                     | Project root                                                | Links the shared Vercel project and pulls its environment |
+| Build for Vercel                                   | Project root                                                | Builds every peer into one Vercel service graph           |
+| Deploy to Vercel                                   | Project root                                                | Deploys every peer together                               |
+
+`eve link` and `eve deploy` reject a member directory because the Vercel project belongs to the multi-agent project root. Run those commands from the root instead.
+
+## Understand ownership and isolation
+
+Peer agents share the project boundary but not their authored agent surfaces:
+
+| Resource                                                                 | Ownership                                      |
+| ------------------------------------------------------------------------ | ---------------------------------------------- |
+| Vercel project, deployment, and environment                              | Shared by the project                          |
+| Root package, dependencies, and build scripts                            | Shared by the project                          |
+| Instructions, tools, connections, channels, skills, hooks, and schedules | Owned by each agent                            |
+| Sessions and subagents                                                   | Owned by each agent                            |
+| Sandbox definition and session sandboxes                                 | Owned by each agent                            |
+| Evals                                                                    | Owned by each agent under its member directory |
+| Default memory namespace                                                 | Separate for each workspace agent              |
+
+A peer does not automatically see or call its siblings. To let one deployed agent call another, declare the target as a [remote agent](./guides/remote-agents) and configure the required authentication.
+
+## Share capabilities deliberately
+
+Use an [extension](./extensions) when several agents need the same tools, connections, skills, hooks, instructions, schedules, or declared subagents. Keep the extension in a package under the same package-manager workspace, install it from the project root, and mount it separately in each consuming agent:
+
+```text
+customer-operations/
+├── agents/
+│   ├── support/agent/extensions/shared.ts
+│   └── billing/agent/extensions/shared.ts
+└── packages/
+    └── shared-capabilities/
+        ├── package.json
+        └── extension/
+```
+
+```ts title="agents/support/agent/extensions/shared.ts"
+export { default } from "@acme/shared-capabilities";
+```
+
+Each mount has its own namespace and belongs only to that agent. See [Use an extension in a workspace](./extensions#use-an-extension-in-a-workspace) for package and build configuration.
+
+## Address deployed agents
+
+A hostless multi-agent deployment prefixes each agent's eve API with its member name:
+
+```text
+https://customer-operations.vercel.app/support/eve/v1/*
+https://customer-operations.vercel.app/billing/eve/v1/*
+```
+
+Check or open one agent by including that prefix:
+
+```bash
+curl https://customer-operations.vercel.app/support/eve/v1/health
+eve dev https://customer-operations.vercel.app/support
+eve eval --url https://customer-operations.vercel.app/billing
+```
+
+A frontend integration can use a different named route shape. For example, [`withEve({ agents })`](./guides/frontend/nextjs) mounts Next.js agents under `/eve/agents/<name>/eve/v1/*`, and the frontend hook selects one by name:
+
+```tsx
+import { useEveAgent } from "eve/react";
+
+const support = useEveAgent({ agent: "support" });
+```
+
+Use the route shape defined by the deployment topology. The `agent` hook option selects a framework-mounted named agent; it does not select a hostless `/<name>` route.
+
+## Choose peers or subagents
+
+| Requirement                                                                             | Use                                                              |
+| --------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| An independently addressed root agent with its own channels, sessions, and public route | Peer agent under `agents/<name>/`                                |
+| A specialist available only to one parent agent                                         | [Declared subagent](./subagents#declared-subagents)              |
+| An independently deployed agent called through another agent's tool surface             | [Remote agent](./guides/remote-agents)                           |
+| A parallel copy of the root agent working with the same capabilities and sandbox        | The built-in [`agent` tool](./subagents#the-built-in-agent-tool) |
+
+A root agent can combine these patterns. For example, the `support` peer can own a local `triage` subagent and call an independently deployed fulfillment agent remotely.
+
+## Troubleshooting
+
+| Symptom                                                        | Check                                                        | Next action                                                                                                        |
+| -------------------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| A non-interactive command says it requires a specific agent    | The project has multiple peers and no selection was supplied | Add `--agent <name>` or run from `agents/<name>/`                                                                  |
+| `eve link` or `eve deploy` rejects the member directory        | The member belongs to a multi-agent project                  | Run the command from the project root                                                                              |
+| A capability is available to one peer but missing from another | Peer agents do not inherit authored capabilities             | Author it in both agents or mount a shared extension in both                                                       |
+| A deployed health URL returns `404`                            | The URL may use the wrong topology's prefix                  | Use `/<name>/eve/v1/health` for a hostless project or `/eve/agents/<name>/eve/v1/health` for a named Next.js mount |
+| A sibling cannot be called as a tool                           | Peer agents are not automatically connected                  | Declare it as a remote agent and configure authentication                                                          |
+
+## What to read next
+
+- [Deploy to Vercel](./guides/deployment/vercel): link, build, and deploy the complete project.
+- [Extensions](./extensions): share packaged capabilities across agents.
+- [Subagents](./subagents): delegate work inside one root agent.
+- [Next.js](./guides/frontend/nextjs): mount multiple agents behind a frontend application.

--- a/docs/subagents/index.mdx
+++ b/docs/subagents/index.mdx
@@ -5,6 +5,8 @@ description: "Delegate work to root-agent copies or declared specialists with th
 
 eve supports two ways to delegate work: the root-only built-in `agent` tool, which starts or continues a copy of the root agent, and declared subagents, which are specialists with their own directories. Use a subagent to run independent work in parallel, narrow the available tools, or give a task to a specialist.
 
+A subagent is not a peer root agent in a multi-agent project. Peer agents are independently addressed and own separate channels, sessions, and public routes; see [Project Structure](/docs/project-structure#choose-peers-or-subagents).
+
 ## The built-in `agent` tool
 
 The root session receives `agent` by default. The model calls it to delegate a task to a new copy of the root agent or continue an existing copy:


### PR DESCRIPTION
### Summary

Multi-agent projects are currently documented across deployment, CLI, frontend, extensions, and subagent pages, which makes the core project model difficult to discover. This adds a first-class Project Structure guide covering standalone and multi-agent layouts, command ownership, isolation, shared capabilities, routing, and the distinction between peer agents and subagents. It also updates adjacent guides and preserves prior project-structure aliases for the new canonical page.

### Validation

- `pnpm docs:check`
- `pnpm --filter eve-docs exec vitest run --config vitest.config.ts lib/geistdocs/redirects.test.ts lib/geistdocs/llms-index.test.ts` (42 tests passed)
- `git diff --check`

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
