### PR TITLE
fix(eve): avoid duplicating the service callback protocol path

### DIFF
--- a/.changeset/fix-canonical-service-callbacks.md
+++ b/.changeset/fix-canonical-service-callbacks.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix remote-agent progress and completion callbacks for Vercel services mounted at `/eve/v1`. The build no longer adds the protocol path twice, which caused callback 404s and left parent agents waiting without an answer or failure notification.

--- a/docs/guides/deployment/vercel.mdx
+++ b/docs/guides/deployment/vercel.mdx
@@ -69,6 +69,8 @@ Create this layout with `eve init my-project --agents support,research`, or add 
 
 With no authored `vercel.json#services`, `eve build` derives the complete Vercel Services graph on every build. If `vercel.json` declares `services`, that authored graph is authoritative instead; use `vercel build` to build and validate the complete project. This supports heterogeneous projects with frontends, private APIs, bindings, and other non-eve services without generated configuration files.
 
+An authored eve service routed at `/eve/v1` already uses the protocol path; callbacks remain at `/eve/v1/callback/*`. A named mount such as `/support` adds that mount before the protocol path, giving `/support/eve/v1/callback/*`.
+
 Deploy the linked project to production:
 
 ```bash

--- a/e2e/fixtures/fixture-tasks/agent/agent.ts
+++ b/e2e/fixtures/fixture-tasks/agent/agent.ts
@@ -21,6 +21,42 @@ function respond(request: MockModelRequest): MockModelResponse | string {
 
   // Framework agent-list notes are model context, not scenario turns.
   const message = [...request.userMessages].reverse().find(isScenarioMessage) ?? "";
+  if (message.includes("TASK-REMOTE-UPDATE-CHILD")) {
+    const result = resultById(request, "remote-update-progress");
+    if (result === undefined) {
+      return {
+        toolCalls: [
+          {
+            id: "remote-update-progress",
+            name: "task_update",
+            input: { message: "TASK-UPDATE-PROGRESS" },
+          },
+        ],
+      };
+    }
+    if (
+      result.output === null ||
+      typeof result.output !== "object" ||
+      Reflect.get(result.output, "status") !== "sent"
+    ) {
+      throw new Error("Remote task_update did not confirm delivery.");
+    }
+    return "TASK-REMOTE-UPDATE-DONE";
+  }
+  if (message === "TASK-REMOTE-UPDATE-SETUP") {
+    if (resultById(request, "remote-update-worker") === undefined) {
+      return {
+        toolCalls: [
+          {
+            id: "remote-update-worker",
+            name: "remote-loopback",
+            input: { message: "TASK-REMOTE-UPDATE-CHILD" },
+          },
+        ],
+      };
+    }
+    return "TASK-UPDATE-STARTED";
+  }
   if (request.userMessages.some((entry) => entry.includes("TASK-UPDATE-PROGRESS"))) {
     return "TASK-UPDATE-RECEIVED";
   }

--- a/e2e/fixtures/fixture-tasks/evals/task.update.emitted-working.remote.eval.ts
+++ b/e2e/fixtures/fixture-tasks/evals/task.update.emitted-working.remote.eval.ts
@@ -1,0 +1,77 @@
+import { satisfies } from "eve/evals/expect";
+
+import { defineTaskEval } from "./task-transition.js";
+import {
+  requireBackgroundTaskId,
+  requireSessionStreamIndex,
+  waitForTaskNotification,
+} from "./shared.js";
+
+const UPDATE = "TASK-UPDATE-PROGRESS";
+
+export default defineTaskEval({
+  description:
+    "A remote child delivers progress and completion through the canonical service callback mount.",
+  transition: {
+    primary: "task.update.emitted-working",
+    setup: ["task.dispatch.start.accepted-acknowledged"],
+    dimensions: { transport: "remote", parentPhase: "parked" },
+  },
+  async test(t) {
+    const started = await t.send("TASK-REMOTE-UPDATE-SETUP");
+    started.expectOk();
+    started.messageIncludes("TASK-UPDATE-STARTED");
+    const taskId = requireBackgroundTaskId(started);
+
+    const sessionId = t.sessionId;
+    if (sessionId === undefined) throw new Error("Task update eval has no parent session id.");
+    const live = t.target.watchTurn(sessionId, {
+      startIndex: requireSessionStreamIndex(t, "Task update wait"),
+    });
+    const updateTurn = await live.result();
+    updateTurn.expectOk();
+    updateTurn.messageIncludes("TASK-UPDATE-RECEIVED");
+    await t.require(
+      updateTurn.events,
+      satisfies(
+        (events: typeof updateTurn.events) =>
+          events.some(
+            (event) =>
+              event.type === "message.received" &&
+              messageText(event.data.message).includes(
+                `Background task ${taskId} (remote-loopback) update: ${UPDATE}`,
+              ),
+          ),
+        "parent receives the child update with its owning task identity",
+      ),
+    );
+    updateTurn.notEvent("subagent.completed");
+    const completed = await waitForTaskNotification(t, live.session, taskId, "completed", [
+      updateTurn,
+    ]);
+    completed.turn.expectOk();
+    completed.turn.eventsSatisfy("parent receives the remote final answer", (events) =>
+      events.some(
+        (event) =>
+          event.type === "message.received" &&
+          messageText(event.data.message).includes("TASK-REMOTE-UPDATE-DONE"),
+      ),
+    );
+    t.noFailedActions();
+  },
+});
+
+function messageText(message: unknown): string {
+  if (typeof message === "string") return message;
+  if (!Array.isArray(message)) return "";
+  return message
+    .flatMap((part) =>
+      part !== null &&
+      typeof part === "object" &&
+      Reflect.get(part, "type") === "text" &&
+      typeof Reflect.get(part, "text") === "string"
+        ? [Reflect.get(part, "text") as string]
+        : [],
+    )
+    .join("\n");
+}

--- a/e2e/fixtures/fixture-tasks/vercel.json
+++ b/e2e/fixtures/fixture-tasks/vercel.json
@@ -1,0 +1,9 @@
+{
+  "experimentalServices": {
+    "eve": {
+      "entrypoint": ".",
+      "framework": "eve",
+      "routePrefix": "/eve/v1"
+    }
+  }
+}

--- a/packages/eve/src/internal/nitro/host/build-application.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/host/build-application.scenario.test.ts
@@ -715,51 +715,63 @@ describe("buildApplication", () => {
     });
   });
 
-  it("normalizes eve function output from legacy root service config", async () => {
-    vi.stubEnv("VERCEL", "1");
-    const appRoot = await createScratchDirectory("eve-build-application-vercel-root-config-");
+  it.each([
+    { routePrefix: "/_eve_internal/eve", publicRoutePrefix: "/_eve_internal/eve" },
+    { routePrefix: "/eve/v1", publicRoutePrefix: undefined },
+    { routePrefix: "/eve/v1/", publicRoutePrefix: undefined },
+  ])(
+    "normalizes legacy service $routePrefix without duplicating protocol routes",
+    async ({ routePrefix, publicRoutePrefix }) => {
+      vi.stubEnv("VERCEL", "1");
+      const appRoot = await createScratchDirectory("eve-build-application-vercel-root-config-");
 
-    prepareProductionApplicationHostMock.mockImplementationOnce(prepareHostBuildWorkspace);
-    createProductionApplicationNitroMock.mockImplementation(
-      async (_preparedHost: PreparedApplicationHost, options: { outputDir: string }) =>
-        createNitroStub(options.outputDir),
-    );
-    await writeFile(
-      join(appRoot, "vercel.json"),
-      `${JSON.stringify(
-        {
-          experimentalServices: {
-            eve: {
-              entrypoint: ".",
-              framework: "eve",
-              routePrefix: "/_eve_internal/eve",
-            },
-            web: {
-              entrypoint: ".",
-              framework: "nextjs",
-              routePrefix: "/",
+      prepareProductionApplicationHostMock.mockImplementationOnce(prepareHostBuildWorkspace);
+      createProductionApplicationNitroMock.mockImplementation(
+        async (_preparedHost: PreparedApplicationHost, options: { outputDir: string }) =>
+          createNitroStub(options.outputDir),
+      );
+      await writeFile(
+        join(appRoot, "vercel.json"),
+        `${JSON.stringify(
+          {
+            experimentalServices: {
+              eve: {
+                entrypoint: ".",
+                framework: "eve",
+                routePrefix,
+              },
+              web: {
+                entrypoint: ".",
+                framework: "nextjs",
+                routePrefix: "/",
+              },
             },
           },
-        },
-        null,
-        2,
-      )}\n`,
-    );
+          null,
+          2,
+        )}\n`,
+      );
 
-    const { buildApplication } = await import("#internal/nitro/host/build-application.js");
-    const outputDir = await buildApplication(appRoot, DEPLOYABLE_BUILD_OPTIONS);
+      const { buildApplication } = await import("#internal/nitro/host/build-application.js");
+      const outputDir = await buildApplication(appRoot, DEPLOYABLE_BUILD_OPTIONS);
 
-    expect(outputDir).toBe(join(appRoot, ".vercel", "output"));
-    const vercelConfig = JSON.parse(
-      await readFile(join(appRoot, ".vercel", "output", "config.json"), "utf8"),
-    ) as {
-      routes: unknown[];
-    };
-    expect(vercelConfig.routes).toContainEqual({
-      dest: "/eve/__server",
-      src: "/eve/v1/health",
-    });
-  });
+      expect(createProductionApplicationNitroMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ publicRoutePrefix }),
+      );
+
+      expect(outputDir).toBe(join(appRoot, ".vercel", "output"));
+      const vercelConfig = JSON.parse(
+        await readFile(join(appRoot, ".vercel", "output", "config.json"), "utf8"),
+      ) as {
+        routes: unknown[];
+      };
+      expect(vercelConfig.routes).toContainEqual({
+        dest: "/eve/__server",
+        src: "/eve/v1/health",
+      });
+    },
+  );
 
   it("leaves standalone Vercel Nitro output routable at the root", async () => {
     vi.stubEnv("VERCEL", "1");

--- a/packages/eve/src/internal/nitro/host/build-application.ts
+++ b/packages/eve/src/internal/nitro/host/build-application.ts
@@ -44,6 +44,8 @@ import { resolveEveServicePrefixByRoot } from "#internal/vercel/vercel-service-c
 import { parseVercelServicesConfig } from "#internal/vercel/vercel-services-config.js";
 import { createDiskRuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
 import { isObject } from "#shared/guards.js";
+import { EVE_ROUTE_PREFIX } from "#protocol/routes.js";
+import { normalizePublicRoutePrefix } from "#shared/public-route-prefix.js";
 
 function trimTrailingSlash(path: string): string {
   return path.replace(/[\\/]+$/, "");
@@ -294,16 +296,21 @@ async function buildApplicationInWorkspace(
         ),
       )
     : undefined;
+  // A service routed at the protocol path has no additional public mount.
+  // Keep servicePrefix intact for function-output routing below.
+  const normalizedServicePrefix = normalizePublicRoutePrefix(servicePrefix);
+  const inferredPublicRoutePrefix =
+    normalizedServicePrefix === EVE_ROUTE_PREFIX ? undefined : normalizedServicePrefix;
   if (
     options.publicRoutePrefix !== undefined &&
-    servicePrefix !== undefined &&
-    options.publicRoutePrefix !== servicePrefix
+    inferredPublicRoutePrefix !== undefined &&
+    options.publicRoutePrefix !== inferredPublicRoutePrefix
   ) {
     throw new Error(
       `EVE_PUBLIC_ROUTE_PREFIX ${JSON.stringify(options.publicRoutePrefix)} conflicts with the configured Vercel service prefix ${JSON.stringify(servicePrefix)}.`,
     );
   }
-  const publicRoutePrefix = options.publicRoutePrefix ?? servicePrefix;
+  const publicRoutePrefix = options.publicRoutePrefix ?? inferredPublicRoutePrefix;
   const nitro = await measureBuildPhase(profiler, "nitro.create", () =>
     createProductionApplicationNitro(preparedHost, {
       buildDir: workspace.nitro.buildDir,


### PR DESCRIPTION
### Summary

Production `v` callbacks reached `/eve/v1/eve/v1/callback/…` and returned 404: the remote agent's `task_update` failed, then its failure notification failed too, leaving Slack with only an acknowledgment. [PR #1926](https://github.com/vercel/eve/pull/1926) introduced this by passing the detected service prefix into the runtime public prefix; previously the detected value only controlled function-output routing.

Treat an inferred `/eve/v1` service route as the protocol path, with no additional public mount. Callback paths become `/eve/v1/callback/…`; named mounts keep their existing prefix. The remote-task fixture now uses the production service configuration and adds an E2E assertion that both progress and the final result reach the parent. [Incident failure logs](https://clickstate.vercel.sh/vercel_main/sql/s/hE1VAdu5Jx).

### Validation

- Build scenario regression: two failing cases before the fix (`/eve/v1` and `/eve/v1/`); all 14 build-application scenarios pass after the fix.
- `pnpm build`, `pnpm typecheck`, `pnpm lint`, `pnpm fmt`, `pnpm guard:invariants`, `pnpm docs:check`, and fixture transition validation passed.
- All 716 integration tests passed. The full local unit run passed 8,034 tests; two unchanged telemetry assertions fail on macOS paths, and one schedule test timed out but passed when rerun alone. CI Linux unit tests passed.
- The new remote callback E2E passed all 7 gates on Vercel, local, and Postgres. All 20 evals in each full task fixture suite passed. [Deployed Vercel E2E](https://github.com/vercel/eve/actions/runs/33902520523/job/101119718698).
- All CI checks passed; the unrelated real-model cancellation eval passed on retry.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
