### PR TITLE
fix(eve): run workspace services in vercel dev

### DIFF
--- a/.changeset/compose-workspace-services.md
+++ b/.changeset/compose-workspace-services.md
@@ -1,5 +1,5 @@
 ---
-"eve": minor
+"eve": patch
 ---
 
 Add `withEve` from `eve/vercel` for composing native workspace agents with authored services in `vercel.ts`. Vercel resolves the generated agent services and transport routes before independently building each service.

--- a/.changeset/compose-workspace-services.md
+++ b/.changeset/compose-workspace-services.md
@@ -1,0 +1,5 @@
+---
+"eve": minor
+---
+
+Add `withEve` from `eve/vercel` for composing native workspace agents with authored services in `vercel.ts`. Vercel resolves the generated agent services and transport routes before independently building each service.

--- a/.changeset/quiet-cats-develop.md
+++ b/.changeset/quiet-cats-develop.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Run generated workspace agent services with the correct agent identity and public route prefix during `vercel dev`.

--- a/docs/guides/deployment/vercel.mdx
+++ b/docs/guides/deployment/vercel.mdx
@@ -94,7 +94,7 @@ export default await withEve({
 
 Vercel evaluates `vercel.ts` before resolving the service graph. `withEve` discovers direct workspace members, adds their services and transport routes, and returns a plain Vercel configuration. Vercel can then build `web` and every eve agent independently. The frontend does not need `withEve` in its framework configuration or a build script that builds the agents.
 
-Generated transport routes are inserted before a filesystem handler or an authored catch-all route. eve reserves each generated `eve-<agent>` service name and exact `/<agent>/eve/v1/*` transport route; other service names, routes, bindings, and Cron Jobs remain authored in `vercel.ts`.
+Generated transport routes are inserted before a filesystem handler or, when no filesystem handler exists, before authored routes. `withEve` throws instead of overwriting an authored service key or exact transport route that belongs to a generated agent. Remove the authored route, and remove or rename the authored service; `withEve` adds both automatically. Names in the array form of `services` must also be unique. Other service names, routes, bindings, and Cron Jobs remain authored in `vercel.ts`.
 
 Custom agent channel endpoints are not published automatically. Expose one explicitly by routing it to the generated service:
 

--- a/docs/guides/deployment/vercel.mdx
+++ b/docs/guides/deployment/vercel.mdx
@@ -67,7 +67,58 @@ In an eve workspace, eve discovers direct `agents/<name>/` children that contain
 
 Create this layout with `eve init my-project --agents support,research`, or add one agent to an existing workspace with `eve init billing`.
 
-With no authored `vercel.json#services`, `eve build` derives the complete Vercel Services graph on every build. If `vercel.json` declares `services`, that authored graph is authoritative instead; use `vercel build` to build and validate the complete project. This supports heterogeneous projects with frontends, private APIs, bindings, and other non-eve services without generated configuration files.
+For an agent-only workspace, run `eve build`. eve owns the Vercel Build Output and generates one independently built service and a `/<name>/eve/v1/*` transport route for each workspace member.
+
+### Compose agents with other Vercel services
+
+Use Vercel's programmatic configuration when a workspace also deploys a frontend, private API, or another non-eve service. Replace `vercel.json` with a root `vercel.ts` and compose the authored graph with `withEve`:
+
+```typescript title="vercel.ts"
+import { withEve } from "eve/vercel";
+
+export default await withEve({
+  services: {
+    web: {
+      framework: "nextjs",
+      root: "apps/web",
+    },
+  },
+  routes: [
+    {
+      src: "^(.*)$",
+      destination: { type: "service", service: "web" },
+    },
+  ],
+});
+```
+
+Vercel evaluates `vercel.ts` before resolving the service graph. `withEve` discovers direct workspace members, adds their services and transport routes, and returns a plain Vercel configuration. Vercel can then build `web` and every eve agent independently. The frontend does not need `withEve` in its framework configuration or a build script that builds the agents.
+
+Generated transport routes are inserted before a filesystem handler or an authored catch-all route. eve reserves each generated `eve-<agent>` service name and exact `/<agent>/eve/v1/*` transport route; other service names, routes, bindings, and Cron Jobs remain authored in `vercel.ts`.
+
+Custom agent channel endpoints are not published automatically. Expose one explicitly by routing it to the generated service:
+
+```typescript title="vercel.ts"
+import { withEve } from "eve/vercel";
+
+export default await withEve({
+  services: {
+    web: { framework: "nextjs", root: "apps/web" },
+  },
+  routes: [
+    {
+      src: "^/webhooks/github$",
+      destination: { type: "service", service: "eve-triage" },
+    },
+    {
+      src: "^(.*)$",
+      destination: { type: "service", service: "web" },
+    },
+  ],
+});
+```
+
+A Vercel project can use only one configuration source, so remove `vercel.json` when adopting `vercel.ts`. Keep `eve` in the root package dependencies so Vercel can import `eve/vercel` while evaluating the configuration. Pass `{ root: "/absolute/workspace/path" }` as the second argument only when `vercel.ts` is evaluated from somewhere other than the workspace root.
 
 An authored eve service routed at `/eve/v1` already uses the protocol path; callbacks remain at `/eve/v1/callback/*`. A named mount such as `/support` adds that mount before the protocol path, giving `/support/eve/v1/callback/*`.
 

--- a/docs/guides/deployment/vercel.mdx
+++ b/docs/guides/deployment/vercel.mdx
@@ -94,6 +94,14 @@ export default await withEve({
 
 Vercel evaluates `vercel.ts` before resolving the service graph. `withEve` discovers direct workspace members, adds their services and transport routes, and returns a plain Vercel configuration. Vercel can then build `web` and every eve agent independently. The frontend does not need `withEve` in its framework configuration or a build script that builds the agents.
 
+Run the complete graph locally with Vercel's service orchestrator:
+
+```bash
+vercel dev
+```
+
+Vercel starts each authored service and one headless `eve dev` process per agent, routes them through a single local origin using the same transport prefixes as production, and combines their logs. Run `eve dev --agent <name>` instead when you want the interactive TUI for one agent without starting the other services.
+
 Generated transport routes are inserted before a filesystem handler or, when no filesystem handler exists, before authored routes. `withEve` throws instead of overwriting an authored service key or exact transport route that belongs to a generated agent. Remove the authored route, and remove or rename the authored service; `withEve` adds both automatically. Names in the array form of `services` must also be unique. Other service names, routes, bindings, and Cron Jobs remain authored in `vercel.ts`.
 
 Custom agent channel endpoints are not published automatically. Expose one explicitly by routing it to the generated service:

--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -86,6 +86,12 @@
       "import": "./dist/src/public/next/index.js",
       "default": "./dist/src/public/next/index.js"
     },
+    "./vercel": {
+      "eve-source": "./src/public/vercel/index.ts",
+      "types": "./dist/src/public/vercel/index.d.ts",
+      "import": "./dist/src/public/vercel/index.js",
+      "default": "./dist/src/public/vercel/index.js"
+    },
     "./nuxt": {
       "types": "./dist/src/public/nuxt/index.d.ts",
       "import": "./dist/src/public/nuxt/index.js",

--- a/packages/eve/src/execution/workflow-callback-url.test.ts
+++ b/packages/eve/src/execution/workflow-callback-url.test.ts
@@ -69,6 +69,17 @@ describe("resolveWorkflowCallbackBaseUrl", () => {
     expect(resolveWorkflowCallbackBaseUrl("http://localhost:3000")).toBe("http://127.0.0.1:2000");
   });
 
+  it("prefers the public Vercel dev router over a private service origin", () => {
+    vi.stubEnv("VERCEL_ENV", "development");
+    vi.stubEnv("VERCEL_URL", "localhost:3000");
+    vi.stubEnv("WORKFLOW_LOCAL_BASE_URL", "http://127.0.0.1:2000");
+    vi.stubEnv("EVE_PUBLIC_ROUTE_PREFIX", "/support");
+
+    expect(resolveWorkflowCallbackBaseUrl("http://127.0.0.1:3001")).toBe(
+      "http://localhost:3000/support",
+    );
+  });
+
   it("prefers the stable Vercel production URL over a local world override", () => {
     vi.stubEnv("VERCEL_ENV", "production");
     vi.stubEnv("VERCEL_PROJECT_PRODUCTION_URL", "agent.example.com");

--- a/packages/eve/src/execution/workflow-callback-url.ts
+++ b/packages/eve/src/execution/workflow-callback-url.ts
@@ -47,7 +47,12 @@ export function resolveVercelProductionCallbackBaseUrl(): string | null {
 export function resolveWorkflowCallbackBaseUrl(metadataUrl: string): string {
   const configuredLocalBaseUrl = process.env[WORKFLOW_LOCAL_BASE_URL_ENV]?.trim();
   const localBaseUrl = configuredLocalBaseUrl ? configuredLocalBaseUrl : undefined;
-  const resolved = resolveVercelProductionCallbackBaseUrl() ?? localBaseUrl ?? metadataUrl;
+  const vercelDevBaseUrl =
+    process.env.VERCEL_ENV === "development" && process.env.VERCEL_URL
+      ? `http://${process.env.VERCEL_URL}`
+      : undefined;
+  const resolved =
+    resolveVercelProductionCallbackBaseUrl() ?? vercelDevBaseUrl ?? localBaseUrl ?? metadataUrl;
   const baseUrl = resolved.replace(/\/$/, "");
   const publicRoutePrefix = normalizePublicRoutePrefix(process.env[EVE_PUBLIC_ROUTE_PREFIX_ENV]);
   return publicRoutePrefix === undefined ? baseUrl : `${baseUrl}${publicRoutePrefix}`;

--- a/packages/eve/src/internal/vercel/build-agent-workspace.integration.test.ts
+++ b/packages/eve/src/internal/vercel/build-agent-workspace.integration.test.ts
@@ -93,6 +93,6 @@ describe("buildAgentWorkspace", () => {
     const root = await createWorkspace();
     await writeFile(join(root, "vercel.json"), JSON.stringify({ services: {} }));
     const workspace = await resolveWorkspace(root);
-    await expect(buildAgentWorkspace(workspace)).rejects.toThrow(/Run `vercel build`/);
+    await expect(buildAgentWorkspace(workspace)).rejects.toThrow(/vercel\.ts.*eve\/vercel/);
   });
 });

--- a/packages/eve/src/internal/vercel/build-agent-workspace.ts
+++ b/packages/eve/src/internal/vercel/build-agent-workspace.ts
@@ -18,7 +18,7 @@ export async function buildAgentWorkspace(workspace: AgentWorkspace): Promise<st
     config.experimentalServicesV2 !== undefined
   ) {
     throw new Error(
-      "This project defines its Vercel service graph in vercel.json. Run `vercel build` to build the complete project, or run `eve build` from an individual agent directory.",
+      "This project defines its Vercel service graph in vercel.json. Compose generated workspace agents from a programmatic vercel.ts with `withEve` from `eve/vercel`, manually define every service and run `vercel build`, or run `eve build` from an individual agent directory.",
     );
   }
 

--- a/packages/eve/src/internal/vercel/eve-service-contribution.ts
+++ b/packages/eve/src/internal/vercel/eve-service-contribution.ts
@@ -121,18 +121,14 @@ export function compileEveVercelService(input: {
     serviceName,
   });
 
-  return {
-    rootDirectory: build.rootDirectory,
-    routeSrc,
-    service: {
-      buildCommand: build.buildCommand,
-      framework: "eve",
-      root: build.root,
-      routes: [createEveRequestPathRoute(routeSrc)],
-      ...(input.agent.publicRoutePrefix.length > 0
-        ? { routePrefix: input.agent.publicRoutePrefix }
-        : {}),
-    },
-    serviceName,
+  const service: GeneratedVercelServiceConfig = {
+    buildCommand: build.buildCommand,
+    framework: "eve",
+    root: build.root,
+    routePrefix:
+      input.agent.publicRoutePrefix.length > 0 ? input.agent.publicRoutePrefix : undefined,
+    routes: [createEveRequestPathRoute(routeSrc)],
   };
+
+  return { rootDirectory: build.rootDirectory, routeSrc, service, serviceName };
 }

--- a/packages/eve/src/internal/vercel/eve-service-contribution.ts
+++ b/packages/eve/src/internal/vercel/eve-service-contribution.ts
@@ -27,6 +27,7 @@ const EVE_VERCEL_SERVICES_DIRECTORY = ".eve/vercel-services";
 export interface EveVercelAgentTarget {
   readonly appRoot: string;
   readonly buildCommand: string;
+  readonly devCommand?: string;
   readonly name?: string;
   readonly publicRoutePrefix: string;
   readonly workspaceMember?: boolean;
@@ -82,12 +83,17 @@ export function createEvePublicRoute(serviceName: string, routeSrc: string): Ver
   return { destination: { service: serviceName, type: "service" }, src: routeSrc };
 }
 
-function createIsolatedBuild(input: {
+function createIsolatedService(input: {
   readonly agent: EveVercelAgentTarget;
   readonly hostOutputDirectory: string;
   readonly projectRoot: string;
   readonly serviceName: string;
-}): { readonly buildCommand: string; readonly root: string; readonly rootDirectory: string } {
+}): {
+  readonly buildCommand: string;
+  readonly devCommand?: string;
+  readonly root: string;
+  readonly rootDirectory: string;
+} {
   const rootDirectory = join(input.projectRoot, EVE_VERCEL_SERVICES_DIRECTORY, input.serviceName);
   const outputDirectory = join(rootDirectory, ".vercel", "output");
   const prefix = normalizePublicRoutePrefix(input.agent.publicRoutePrefix);
@@ -100,8 +106,16 @@ function createIsolatedBuild(input: {
       ? ` && export ${EVE_INTERNAL_AGENT_WORKSPACE_MEMBER_ENV}=1`
       : "";
 
+  const appRoot = quoteVercelShellArgument(
+    toVercelRelativePath(rootDirectory, input.agent.appRoot),
+  );
   return {
-    buildCommand: `cd ${quoteVercelShellArgument(toVercelRelativePath(rootDirectory, input.agent.appRoot))} && export ${EVE_INTERNAL_BUILD_OUTPUT_DIRECTORY_ENV}=${quoteVercelShellArgument(toVercelRelativePath(input.agent.appRoot, outputDirectory))} && export ${EVE_INTERNAL_HOST_BUILD_OUTPUT_DIRECTORY_ENV}=${quoteVercelShellArgument(toVercelRelativePath(input.agent.appRoot, input.hostOutputDirectory))}${prefixExport}${workspaceMemberExport} && ${input.agent.buildCommand}`,
+    buildCommand: `cd ${appRoot} && export ${EVE_INTERNAL_BUILD_OUTPUT_DIRECTORY_ENV}=${quoteVercelShellArgument(toVercelRelativePath(input.agent.appRoot, outputDirectory))} && export ${EVE_INTERNAL_HOST_BUILD_OUTPUT_DIRECTORY_ENV}=${quoteVercelShellArgument(toVercelRelativePath(input.agent.appRoot, input.hostOutputDirectory))}${prefixExport}${workspaceMemberExport} && ${input.agent.buildCommand}`,
+    ...(input.agent.devCommand === undefined
+      ? {}
+      : {
+          devCommand: `cd ${appRoot}${prefixExport}${workspaceMemberExport} && ${input.agent.devCommand}`,
+        }),
     root: toVercelRelativePath(input.projectRoot, rootDirectory),
     rootDirectory,
   };
@@ -114,7 +128,7 @@ export function compileEveVercelService(input: {
 }): EveVercelServiceContribution {
   const serviceName = createEveServiceName(input.agent.name);
   const routeSrc = createEveServiceRouteSrc(input.agent.publicRoutePrefix);
-  const build = createIsolatedBuild({
+  const isolated = createIsolatedService({
     agent: input.agent,
     hostOutputDirectory: input.target.hostOutputDirectory,
     projectRoot: input.target.projectRoot,
@@ -122,13 +136,14 @@ export function compileEveVercelService(input: {
   });
 
   const service: GeneratedVercelServiceConfig = {
-    buildCommand: build.buildCommand,
+    buildCommand: isolated.buildCommand,
+    devCommand: isolated.devCommand,
     framework: "eve",
-    root: build.root,
+    root: isolated.root,
     routePrefix:
       input.agent.publicRoutePrefix.length > 0 ? input.agent.publicRoutePrefix : undefined,
     routes: [createEveRequestPathRoute(routeSrc)],
   };
 
-  return { rootDirectory: build.rootDirectory, routeSrc, service, serviceName };
+  return { rootDirectory: isolated.rootDirectory, routeSrc, service, serviceName };
 }

--- a/packages/eve/src/internal/vercel/vercel-services-config.ts
+++ b/packages/eve/src/internal/vercel/vercel-services-config.ts
@@ -29,6 +29,7 @@ export interface VercelRouteConfig {
 
 export interface VercelServiceConfig {
   readonly buildCommand?: string;
+  readonly devCommand?: string;
   readonly entrypoint?: string;
   readonly framework?: string;
   readonly mount?: string | VercelServiceMount;
@@ -40,6 +41,7 @@ export interface VercelServiceConfig {
 
 export interface GeneratedVercelServiceConfig extends VercelServiceConfig {
   readonly buildCommand: string;
+  readonly devCommand?: string;
   readonly framework: "eve";
   readonly root: string;
   readonly routes: readonly VercelRouteConfig[];
@@ -132,6 +134,7 @@ function parseServiceConfig(value: JsonValue, path: string): VercelServiceConfig
   return {
     ...service,
     buildCommand: optionalString(service.buildCommand, `${path}.buildCommand`),
+    devCommand: optionalString(service.devCommand, `${path}.devCommand`),
     entrypoint: optionalString(service.entrypoint, `${path}.entrypoint`),
     framework: optionalString(service.framework, `${path}.framework`),
     mount: parseMount(service.mount, `${path}.mount`),

--- a/packages/eve/src/public/vercel/index.integration.test.ts
+++ b/packages/eve/src/public/vercel/index.integration.test.ts
@@ -55,6 +55,8 @@ describe("withEve", () => {
     expect(config.services["eve-support"]).toEqual({
       buildCommand:
         "cd '../../../agents/support' && export EVE_INTERNAL_BUILD_OUTPUT_DIRECTORY='../../.eve/vercel-services/eve-support/.vercel/output' && export EVE_INTERNAL_HOST_BUILD_OUTPUT_DIRECTORY='../../.vercel/output' && export EVE_PUBLIC_ROUTE_PREFIX='/support' && export EVE_INTERNAL_AGENT_WORKSPACE_MEMBER=1 && node 'node_modules/eve/bin/eve.js' build",
+      devCommand:
+        "cd '../../../agents/support' && export EVE_PUBLIC_ROUTE_PREFIX='/support' && export EVE_INTERNAL_AGENT_WORKSPACE_MEMBER=1 && node 'node_modules/eve/bin/eve.js' dev --no-ui",
       framework: "eve",
       root: ".eve/vercel-services/eve-support",
       routes: [

--- a/packages/eve/src/public/vercel/index.integration.test.ts
+++ b/packages/eve/src/public/vercel/index.integration.test.ts
@@ -1,0 +1,101 @@
+import { access, mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("#shared/resolve-eve-binary.js", () => ({
+  resolveEveBinaryPath: (root: string) => join(root, "node_modules", "eve", "bin", "eve.js"),
+}));
+
+import { withEve } from "./index.js";
+
+async function createWorkspace(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "eve-vercel-config-"));
+  await writeFile(
+    join(root, "package.json"),
+    JSON.stringify({ dependencies: { eve: "*" }, packageManager: "pnpm@10.0.0", private: true }),
+  );
+  await Promise.all([
+    mkdir(join(root, "agents", "support", "agent"), { recursive: true }),
+    mkdir(join(root, "agents", "research", "agent"), { recursive: true }),
+  ]);
+  return root;
+}
+
+describe("withEve", () => {
+  it("composes workspace agents with authored Vercel services and routes", async () => {
+    const root = await createWorkspace();
+    const config = await withEve(
+      {
+        crons: [{ path: "/api/dispatch", schedule: "* * * * *" }],
+        routes: [
+          { destination: { service: "web", type: "service" }, src: "^/api/(.*)$" },
+          { handle: "filesystem" },
+        ],
+        services: { web: { framework: "nextjs", root: "apps/web" } },
+      },
+      { root },
+    );
+
+    expect(config.crons).toEqual([{ path: "/api/dispatch", schedule: "* * * * *" }]);
+    expect(config.routes).toEqual([
+      { destination: { service: "web", type: "service" }, src: "^/api/(.*)$" },
+      {
+        destination: { service: "eve-research", type: "service" },
+        src: "^/research/eve/v1/(.*)$",
+      },
+      {
+        destination: { service: "eve-support", type: "service" },
+        src: "^/support/eve/v1/(.*)$",
+      },
+      { handle: "filesystem" },
+    ]);
+    expect(config.services.web).toEqual({ framework: "nextjs", root: "apps/web" });
+    expect(config.services["eve-support"]).toEqual({
+      buildCommand:
+        "cd '../../../agents/support' && export EVE_INTERNAL_BUILD_OUTPUT_DIRECTORY='../../.eve/vercel-services/eve-support/.vercel/output' && export EVE_INTERNAL_HOST_BUILD_OUTPUT_DIRECTORY='../../.vercel/output' && export EVE_PUBLIC_ROUTE_PREFIX='/support' && export EVE_INTERNAL_AGENT_WORKSPACE_MEMBER=1 && node 'node_modules/eve/bin/eve.js' build",
+      framework: "eve",
+      root: ".eve/vercel-services/eve-support",
+      routes: [
+        {
+          src: "^/support/eve/v1/(.*)$",
+          transforms: [{ args: "/eve/v1/$1", op: "set", type: "request.path" }],
+        },
+      ],
+    });
+    await expect(
+      access(join(root, ".eve", "vercel-services", "eve-support")),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not modify the root Build Output", async () => {
+    const root = await createWorkspace();
+    const marker = join(root, ".vercel", "output", "services", "web", "config.json");
+    await mkdir(join(marker, ".."), { recursive: true });
+    await writeFile(marker, "web output");
+
+    await withEve({}, { root });
+
+    await expect(access(marker)).resolves.toBeUndefined();
+  });
+
+  it("reserves generated service names and transport routes", async () => {
+    const root = await createWorkspace();
+
+    await expect(
+      withEve({ services: { "eve-support": { framework: "nextjs" } } }, { root }),
+    ).rejects.toThrow(/eve-support.*reserved/);
+    await expect(
+      withEve({ routes: [{ src: "^/support/eve/v1/(.*)$" }] }, { root }),
+    ).rejects.toThrow(/route.*support.*reserved/);
+  });
+
+  it("requires an eve workspace root", async () => {
+    const root = await mkdtemp(join(tmpdir(), "eve-vercel-config-standalone-"));
+    await writeFile(join(root, "package.json"), JSON.stringify({ dependencies: { eve: "*" } }));
+    await mkdir(join(root, "agent"), { recursive: true });
+
+    await expect(withEve({}, { root })).rejects.toThrow(/workspace root/);
+  });
+});

--- a/packages/eve/src/public/vercel/index.integration.test.ts
+++ b/packages/eve/src/public/vercel/index.integration.test.ts
@@ -80,15 +80,60 @@ describe("withEve", () => {
     await expect(access(marker)).resolves.toBeUndefined();
   });
 
-  it("reserves generated service names and transport routes", async () => {
+  it("rejects authored service keys owned by generated agents", async () => {
     const root = await createWorkspace();
 
     await expect(
       withEve({ services: { "eve-support": { framework: "nextjs" } } }, { root }),
-    ).rejects.toThrow(/eve-support.*reserved/);
+    ).rejects.toThrow(
+      'Vercel service key "eve-support" conflicts with the service generated for eve workspace agent "support". Remove or rename the authored service; withEve owns this key.',
+    );
+  });
+
+  it("rejects authored routes owned by generated agents", async () => {
+    const root = await createWorkspace();
+
     await expect(
       withEve({ routes: [{ src: "^/support/eve/v1/(.*)$" }] }, { root }),
-    ).rejects.toThrow(/route.*support.*reserved/);
+    ).rejects.toThrow(
+      'Vercel route "^/support/eve/v1/(.*)$" conflicts with the transport route generated for eve workspace agent "support". Remove the authored route; withEve adds it automatically.',
+    );
+  });
+
+  it("rejects duplicate names in a service array", async () => {
+    const root = await createWorkspace();
+
+    await expect(
+      withEve(
+        {
+          services: [
+            { framework: "nextjs", name: "web", root: "apps/first" },
+            { framework: "nuxtjs", name: "web", root: "apps/second" },
+          ],
+        },
+        { root },
+      ),
+    ).rejects.toThrow(
+      'withEve received duplicate Vercel service name "web". Give every entry in the services array a unique name.',
+    );
+  });
+
+  it("rejects obsolete service fields", async () => {
+    const root = await createWorkspace();
+
+    await expect(withEve({ experimentalServicesV2: {} }, { root })).rejects.toThrow(
+      "withEve cannot compose experimentalServices or experimentalServicesV2. Remove the obsolete field and define authored services under services.",
+    );
+  });
+
+  it("requires at least one workspace agent", async () => {
+    const root = await mkdtemp(join(tmpdir(), "eve-vercel-config-empty-workspace-"));
+    await writeFile(join(root, "package.json"), JSON.stringify({ dependencies: { eve: "*" } }));
+    await mkdir(join(root, "agents"));
+
+    await expect(withEve({}, { root })).rejects.toThrow(
+      `withEve found no workspace agents under ${join(root, "agents")}. Add an agent or remove withEve from vercel.ts.`,
+    );
   });
 
   it("requires an eve workspace root", async () => {

--- a/packages/eve/src/public/vercel/index.ts
+++ b/packages/eve/src/public/vercel/index.ts
@@ -26,6 +26,7 @@ export interface EveVercelRouteConfig {
 /** A service accepted by eve's Vercel configuration composer. */
 export interface EveVercelServiceConfig {
   readonly buildCommand?: string;
+  readonly devCommand?: string;
   readonly entrypoint?: string;
   readonly framework?: string;
   readonly mount?: string | { readonly path?: string; readonly subdomain?: string };
@@ -132,21 +133,25 @@ export async function withEve<TConfig extends EveVercelConfig>(
   const outputDirectory = join(root, ".vercel", "output");
   const internalConfig = toInternalConfig(config);
   const assembled = assembleEveVercelServices({
-    agents: workspace.members.map((member) => ({
-      agent: {
-        appRoot: member.appRoot,
-        buildCommand: `node ${quoteVercelShellArgument(
-          toVercelRelativePath(member.appRoot, resolveEveBinaryPath(member.appRoot)),
-        )} build`,
-        name: member.name,
-        publicRoutePrefix: `/${member.name}`,
-        workspaceMember: true,
-      },
-      target: {
-        hostOutputDirectory: outputDirectory,
-        projectRoot: root,
-      },
-    })),
+    agents: workspace.members.map((member) => {
+      const binary = quoteVercelShellArgument(
+        toVercelRelativePath(member.appRoot, resolveEveBinaryPath(member.appRoot)),
+      );
+      return {
+        agent: {
+          appRoot: member.appRoot,
+          buildCommand: `node ${binary} build`,
+          devCommand: `node ${binary} dev --no-ui`,
+          name: member.name,
+          publicRoutePrefix: `/${member.name}`,
+          workspaceMember: true,
+        },
+        target: {
+          hostOutputDirectory: outputDirectory,
+          projectRoot: root,
+        },
+      };
+    }),
     routes: internalConfig.routes,
     services: createServiceConfigRecord(internalConfig.services),
   });

--- a/packages/eve/src/public/vercel/index.ts
+++ b/packages/eve/src/public/vercel/index.ts
@@ -1,0 +1,152 @@
+import { mkdir } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+import { resolveEveProjectContext } from "#internal/project-context.js";
+import { assembleEveVercelServices } from "#internal/vercel/assemble-eve-services.js";
+import { quoteVercelShellArgument, toVercelRelativePath } from "#internal/vercel/build-command.js";
+import {
+  createEveServiceName,
+  createEveServiceRouteSrc,
+} from "#internal/vercel/eve-service-contribution.js";
+import {
+  createServiceConfigRecord,
+  type VercelServicesConfig,
+} from "#internal/vercel/vercel-services-config.js";
+import { resolveEveBinaryPath } from "#shared/resolve-eve-binary.js";
+
+/** A route accepted by eve's Vercel configuration composer. */
+export interface EveVercelRouteConfig {
+  readonly destination?: string | { readonly service?: string; readonly type?: string };
+  readonly handle?: string;
+  readonly src?: string;
+  readonly transforms?: readonly Record<string, unknown>[];
+  readonly [key: string]: unknown;
+}
+
+/** A service accepted by eve's Vercel configuration composer. */
+export interface EveVercelServiceConfig {
+  readonly buildCommand?: string;
+  readonly entrypoint?: string;
+  readonly framework?: string;
+  readonly mount?: string | { readonly path?: string; readonly subdomain?: string };
+  readonly routes?: readonly EveVercelRouteConfig[];
+  readonly root?: string;
+  readonly type?: string;
+  readonly [key: string]: unknown;
+}
+
+/** The portion of a programmatic Vercel configuration composed by eve. */
+export interface EveVercelConfig {
+  readonly experimentalServices?: unknown;
+  readonly experimentalServicesV2?: unknown;
+  readonly routes?: readonly EveVercelRouteConfig[];
+  readonly services?:
+    | Readonly<Record<string, EveVercelServiceConfig>>
+    | readonly (EveVercelServiceConfig & { readonly name: string })[];
+  readonly [key: string]: unknown;
+}
+
+/** Options for composing an eve workspace into a programmatic Vercel configuration. */
+export interface WithEveOptions {
+  /** Eve workspace root. Defaults to the directory evaluating `vercel.ts`. */
+  readonly root?: string;
+}
+
+function toInternalConfig(config: EveVercelConfig): VercelServicesConfig {
+  return config as unknown as VercelServicesConfig;
+}
+
+function assertComposableConfig(config: EveVercelConfig, agentNames: readonly string[]): void {
+  if (config.experimentalServices !== undefined || config.experimentalServicesV2 !== undefined) {
+    throw new Error(
+      "withEve does not support experimentalServices. Use services or remove the obsolete configuration.",
+    );
+  }
+
+  const internalConfig = toInternalConfig(config);
+  const services = createServiceConfigRecord(internalConfig.services);
+  for (const name of agentNames) {
+    const serviceName = createEveServiceName(name);
+    if (services[serviceName] !== undefined) {
+      throw new Error(
+        `Vercel service ${JSON.stringify(serviceName)} is reserved for eve workspace agent ${JSON.stringify(name)}.`,
+      );
+    }
+
+    const routeSrc = createEveServiceRouteSrc(`/${name}`);
+    if (config.routes?.some((route) => route.src === routeSrc)) {
+      throw new Error(
+        `Vercel route ${JSON.stringify(routeSrc)} is reserved for eve workspace agent ${JSON.stringify(name)}.`,
+      );
+    }
+  }
+}
+
+/**
+ * Add a hostless eve workspace's generated agent services and transport routes to `vercel.ts`.
+ *
+ * The returned object is a plain Vercel configuration. Vercel resolves it before independently
+ * building the authored services and each generated eve agent service.
+ */
+export async function withEve<TConfig extends EveVercelConfig>(
+  config: TConfig,
+  options: WithEveOptions = {},
+): Promise<
+  Omit<TConfig, "routes" | "services"> & {
+    readonly routes: readonly EveVercelRouteConfig[];
+    readonly services: Readonly<Record<string, EveVercelServiceConfig>>;
+  }
+> {
+  const root = resolve(options.root ?? process.cwd());
+  const context = await resolveEveProjectContext(root);
+  if (context.kind !== "workspace" || context.workspace.root !== root) {
+    throw new Error(`withEve must run at an eve workspace root; received ${root}.`);
+  }
+
+  const { workspace } = context;
+  const agentNames = workspace.members.map((member) => member.name);
+  const generatedServiceNames = new Set(agentNames.map(createEveServiceName));
+  assertComposableConfig(config, agentNames);
+
+  const outputDirectory = join(root, ".vercel", "output");
+  const internalConfig = toInternalConfig(config);
+  const assembled = assembleEveVercelServices({
+    agents: workspace.members.map((member) => ({
+      agent: {
+        appRoot: member.appRoot,
+        buildCommand: `node ${quoteVercelShellArgument(
+          toVercelRelativePath(member.appRoot, resolveEveBinaryPath(member.appRoot)),
+        )} build`,
+        name: member.name,
+        publicRoutePrefix: `/${member.name}`,
+        workspaceMember: true,
+      },
+      target: {
+        hostOutputDirectory: outputDirectory,
+        projectRoot: root,
+      },
+    })),
+    routes: internalConfig.routes,
+    services: createServiceConfigRecord(internalConfig.services),
+  });
+
+  await Promise.all(
+    assembled.rootDirectories.map((directory) => mkdir(directory, { recursive: true })),
+  );
+
+  const services = Object.fromEntries(
+    Object.entries(assembled.services).map(([name, service]) => {
+      if (!generatedServiceNames.has(name)) {
+        return [name, service];
+      }
+      const { routePrefix: _routePrefix, ...vercelSourceService } = service;
+      return [name, vercelSourceService];
+    }),
+  );
+
+  return {
+    ...config,
+    routes: assembled.routes as readonly EveVercelRouteConfig[],
+    services: services as Readonly<Record<string, EveVercelServiceConfig>>,
+  };
+}

--- a/packages/eve/src/public/vercel/index.ts
+++ b/packages/eve/src/public/vercel/index.ts
@@ -53,30 +53,45 @@ export interface WithEveOptions {
 }
 
 function toInternalConfig(config: EveVercelConfig): VercelServicesConfig {
-  return config as unknown as VercelServicesConfig;
+  return config as VercelServicesConfig;
+}
+
+function assertUniqueNamedServices(services: EveVercelConfig["services"]): void {
+  if (!Array.isArray(services)) return;
+
+  const seen = new Set<string>();
+  for (const service of services) {
+    if (seen.has(service.name)) {
+      throw new Error(
+        `withEve received duplicate Vercel service name ${JSON.stringify(service.name)}. Give every entry in the services array a unique name.`,
+      );
+    }
+    seen.add(service.name);
+  }
 }
 
 function assertComposableConfig(config: EveVercelConfig, agentNames: readonly string[]): void {
   if (config.experimentalServices !== undefined || config.experimentalServicesV2 !== undefined) {
     throw new Error(
-      "withEve does not support experimentalServices. Use services or remove the obsolete configuration.",
+      "withEve cannot compose experimentalServices or experimentalServicesV2. Remove the obsolete field and define authored services under services.",
     );
   }
 
+  assertUniqueNamedServices(config.services);
   const internalConfig = toInternalConfig(config);
   const services = createServiceConfigRecord(internalConfig.services);
   for (const name of agentNames) {
     const serviceName = createEveServiceName(name);
-    if (services[serviceName] !== undefined) {
+    if (Object.hasOwn(services, serviceName)) {
       throw new Error(
-        `Vercel service ${JSON.stringify(serviceName)} is reserved for eve workspace agent ${JSON.stringify(name)}.`,
+        `Vercel service key ${JSON.stringify(serviceName)} conflicts with the service generated for eve workspace agent ${JSON.stringify(name)}. Remove or rename the authored service; withEve owns this key.`,
       );
     }
 
     const routeSrc = createEveServiceRouteSrc(`/${name}`);
     if (config.routes?.some((route) => route.src === routeSrc)) {
       throw new Error(
-        `Vercel route ${JSON.stringify(routeSrc)} is reserved for eve workspace agent ${JSON.stringify(name)}.`,
+        `Vercel route ${JSON.stringify(routeSrc)} conflicts with the transport route generated for eve workspace agent ${JSON.stringify(name)}. Remove the authored route; withEve adds it automatically.`,
       );
     }
   }
@@ -104,6 +119,12 @@ export async function withEve<TConfig extends EveVercelConfig>(
   }
 
   const { workspace } = context;
+  if (workspace.members.length === 0) {
+    throw new Error(
+      `withEve found no workspace agents under ${join(root, "agents")}. Add an agent or remove withEve from vercel.ts.`,
+    );
+  }
+
   const agentNames = workspace.members.map((member) => member.name);
   const generatedServiceNames = new Set(agentNames.map(createEveServiceName));
   assertComposableConfig(config, agentNames);

--- a/packages/eve/test/scenarios/public-api-portability.scenario.test.ts
+++ b/packages/eve/test/scenarios/public-api-portability.scenario.test.ts
@@ -42,6 +42,29 @@ const PORTABILITY_CASES: readonly PortabilityCase[] = [
   {
     descriptor: {
       files: {
+        "agent/vercel.ts": `import { withEve, type EveVercelConfig } from "eve/vercel";
+
+const config = {
+  routes: [{ destination: { service: "web", type: "service" }, src: "^(.*)$" }],
+  services: { web: { framework: "nextjs", root: "apps/web" } },
+} satisfies EveVercelConfig;
+
+export default withEve(config);
+`,
+      },
+      name: "vercel-composer-public-api-portability",
+    },
+    include: ["src/public/vercel/index.ts"],
+    name: "lets tsc typecheck withEve from the public Vercel subpath",
+    packageExports: {
+      "./vercel": {
+        types: "./dist/src/public/vercel/index.d.ts",
+      },
+    },
+  },
+  {
+    descriptor: {
+      files: {
         "agent/sandbox.ts": `import { defaultBackend, defineSandbox } from "eve/sandbox";
 import { docker } from "eve/sandbox/docker";
 import { justbash } from "eve/sandbox/just-bash";


### PR DESCRIPTION
### Summary

Mixed-service workspaces composed by `withEve()` should run locally through the same Vercel service graph they deploy. This stacked change gives each generated agent service an explicit headless development command carrying its production route prefix and workspace-member identity, so `vercel dev` starts every agent with correct callback routing and per-agent namespaces. It depends on #3038 and on the Vercel CLI programmatic-services fix in vercel/vercel-internal#815.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/public/vercel/index.integration.test.ts`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/internal/vercel/vercel-services-config.test.ts`
- `pnpm --filter eve typecheck`
- `pnpm docs:check`
- `pnpm lint`
- `pnpm --filter eve build`
- Built the local Vercel CLI from vercel/vercel-internal#815 and ran `vercel dev` against a disposable named Next.js + eve workspace; both `/` and `/hello/eve/v1/health` returned HTTP 200, and the generated eve process received `EVE_PUBLIC_ROUTE_PREFIX=/hello` plus `EVE_INTERNAL_AGENT_WORKSPACE_MEMBER=1`

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
