### PR TITLE
fix(eve): serialize Vercel Workflow replays per run

### DIFF
--- a/.changeset/bright-tools-sing.md
+++ b/.changeset/bright-tools-sing.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Serialize concurrent Workflow replays for each agent run on Vercel while continuing to run steps in parallel. This avoids replay contention when a task has multiple pending hooks or wakes.

--- a/packages/eve/src/internal/nitro/host/vercel-build-output-config.test.ts
+++ b/packages/eve/src/internal/nitro/host/vercel-build-output-config.test.ts
@@ -36,10 +36,12 @@ describe("createEveVercelOptions", () => {
             consumer: "default",
             retryAfterSeconds: 5,
             initialDelaySeconds: 0,
+            maxConcurrency: 1,
           },
         ],
         environment: {
           WORKFLOW_PRECONDITION_GUARD: "1",
+          WORKFLOW_SEQUENTIAL_REPLAYS: "1",
         },
       },
     });
@@ -67,6 +69,7 @@ describe("createEveVercelOptions", () => {
 
     expect(options?.functionRules[EVE_WORKFLOW_FLOW_ROUTE_PATH].environment).toEqual({
       WORKFLOW_PRECONDITION_GUARD: "1",
+      WORKFLOW_SEQUENTIAL_REPLAYS: "1",
       EVE_PUBLIC_ROUTE_PREFIX: "/eve/agents/support",
     });
   });

--- a/packages/eve/src/internal/nitro/host/vercel-build-output-config.ts
+++ b/packages/eve/src/internal/nitro/host/vercel-build-output-config.ts
@@ -1,7 +1,10 @@
 import { EVE_INTERNAL_AGENT_WORKSPACE_MEMBER_ENV } from "#internal/application/build-output-environment.js";
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
 import { EVE_PACKAGE_NAME } from "#internal/package-name.js";
-import { createEveWorkflowQueueTrigger } from "#internal/workflow/queue-namespace.js";
+import {
+  createEveWorkflowQueueTrigger,
+  WORKFLOW_SEQUENTIAL_REPLAYS_ENV,
+} from "#internal/workflow/queue-namespace.js";
 import { EVE_WORKFLOW_FLOW_ROUTE_PATH } from "#internal/workflow-bundle/eve-service-route-output.js";
 import {
   EVE_PUBLIC_ROUTE_PREFIX_ENV,
@@ -33,6 +36,7 @@ export function createEveVercelOptions(input: {
     // Reject replay decisions made from an event log that missed a
     // concurrent wake.
     WORKFLOW_PRECONDITION_GUARD: "1",
+    [WORKFLOW_SEQUENTIAL_REPLAYS_ENV]: "1",
   };
 
   // Bake the agent's public mount into the flow function so callback-URL

--- a/packages/eve/src/internal/workflow/queue-namespace.test.ts
+++ b/packages/eve/src/internal/workflow/queue-namespace.test.ts
@@ -6,6 +6,7 @@ import {
   deriveEveWorkflowQueueTopic,
   installEveWorkflowQueueNamespace,
   WORKFLOW_QUEUE_NAMESPACE_ENV,
+  WORKFLOW_SEQUENTIAL_REPLAYS_ENV,
 } from "#internal/workflow/queue-namespace.js";
 
 describe("workflow queue namespace", () => {
@@ -34,6 +35,7 @@ describe("workflow queue namespace", () => {
         "eve776561746865722d6167656e74",
       );
       expect(process.env[WORKFLOW_QUEUE_NAMESPACE_ENV]).toBe("eve776561746865722d6167656e74");
+      expect(process.env[WORKFLOW_SEQUENTIAL_REPLAYS_ENV]).toBe("1");
     } finally {
       vi.unstubAllEnvs();
     }

--- a/packages/eve/src/internal/workflow/queue-namespace.ts
+++ b/packages/eve/src/internal/workflow/queue-namespace.ts
@@ -1,4 +1,5 @@
 export const WORKFLOW_QUEUE_NAMESPACE_ENV = "WORKFLOW_QUEUE_NAMESPACE";
+export const WORKFLOW_SEQUENTIAL_REPLAYS_ENV = "WORKFLOW_SEQUENTIAL_REPLAYS";
 
 /** Derives a stable Workflow queue namespace from an eve agent's unique name. */
 export function deriveEveWorkflowQueueNamespace(agentName: string): string {
@@ -27,6 +28,7 @@ export function createEveWorkflowQueueTrigger(agentName: string) {
     consumer: "default",
     retryAfterSeconds: 5,
     initialDelaySeconds: 0,
+    maxConcurrency: 1,
   };
 }
 
@@ -34,5 +36,6 @@ export function createEveWorkflowQueueTrigger(agentName: string) {
 export function installEveWorkflowQueueNamespace(agentName: string): string {
   const namespace = deriveEveWorkflowQueueNamespace(agentName);
   process.env[WORKFLOW_QUEUE_NAMESPACE_ENV] = namespace;
+  process.env[WORKFLOW_SEQUENTIAL_REPLAYS_ENV] = "1";
   return namespace;
 }


### PR DESCRIPTION
### Summary

Long-lived task workflows on Vercel intermittently spent about 1.3–1.6 seconds between completed steps and the next step starting when concurrent wakes replayed the same run. Workflow's supported per-run replay serialization requires both runtime topic selection and a `maxConcurrency: 1` flow trigger; eve generated the trigger itself but did not configure either half. Enable both for eve Vercel deployments, preserving parallel steps while allowing only one orchestrator replay for a run at a time.

A focused `fixture-tasks` Vercel experiment reduced the representative eval from 67s to 51.2s. The two task lifecycles retained the same 22 steps and 95 events, while their slow non-hook step continuations fell from 4/5 to 0/0. This is an internal Vercel deployment configuration change; eve's task protocol and public API are unchanged.

### Validation

- `pnpm exec vitest run --config vitest.unit.config.ts src/internal/workflow/queue-namespace.test.ts src/internal/nitro/host/vercel-build-output-config.test.ts` — 9 passed
- `pnpm exec oxfmt --check packages/eve/src/internal/workflow/queue-namespace.ts packages/eve/src/internal/workflow/queue-namespace.test.ts packages/eve/src/internal/nitro/host/vercel-build-output-config.ts packages/eve/src/internal/nitro/host/vercel-build-output-config.test.ts`
- `cd packages/eve && pnpm exec tsc -p tsconfig.json --noEmit`
- `EVE_E2E_MODEL=mock pnpm exec eve eval --strict --json` in `e2e/fixtures/fixture-tasks` — 19 passed
- Focused Vercel eval: [run 33906026119](https://github.com/vercel/eve/actions/runs/33906026119) — passed in 51.2s

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
