### PR TITLE
fix(eve): resolve workspace registry package

### DIFF
--- a/.changeset/fix-workspace-registry-package-root.md
+++ b/.changeset/fix-workspace-registry-package-root.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Read registry configuration from the shared project package when `eve add` targets an agent in a top-level `agents/` workspace. Registry files still install into the selected agent.

--- a/packages/eve/src/cli/commands/registry-project.integration.test.ts
+++ b/packages/eve/src/cli/commands/registry-project.integration.test.ts
@@ -1,0 +1,26 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { readRegistryConfig } from "./registry-project.js";
+
+describe("readRegistryConfig", () => {
+  it("reads registry mappings from an agent workspace package", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "eve-registry-workspace-"));
+    const agentRoot = join(workspaceRoot, "agents", "support");
+    await mkdir(join(agentRoot, "agent"), { recursive: true });
+    await writeFile(
+      join(workspaceRoot, "package.json"),
+      JSON.stringify({
+        dependencies: { eve: "*" },
+        registries: { "@acme": "https://example.com/r/{name}.json" },
+      }),
+    );
+
+    await expect(readRegistryConfig(agentRoot)).resolves.toEqual({
+      registries: { "@acme": "https://example.com/r/{name}.json" },
+    });
+  });
+});

--- a/packages/eve/src/cli/commands/registry-project.ts
+++ b/packages/eve/src/cli/commands/registry-project.ts
@@ -8,6 +8,7 @@ import {
   parse as parseJsonc,
 } from "#compiled/jsonc-parser/index.js";
 import type { RegistryConfig, RegistrySource } from "#compiled/shadcn-registry/index.js";
+import { resolveEveProjectContext } from "#internal/project-context.js";
 import { WEB_APP_TEMPLATE_FILES } from "#setup/scaffold/create/web-template.js";
 
 interface RegistryPackage {
@@ -49,7 +50,8 @@ function parseRegistries(path: string, value: unknown): Record<string, RegistryS
 }
 
 async function readRegistryPackage(appRoot: string): Promise<RegistryPackage> {
-  const path = join(appRoot, "package.json");
+  const context = await resolveEveProjectContext(appRoot);
+  const path = join(context.environmentRoot, "package.json");
   let parsed: unknown;
   try {
     parsed = JSON.parse(await readFile(path, "utf8"));

--- a/packages/eve/src/cli/commands/registry.test.ts
+++ b/packages/eve/src/cli/commands/registry.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { EveProjectContext } from "#internal/project-context.js";
 import { createFakePrompter } from "#internal/testing/fake-prompter.js";
 import { WizardCancelledError } from "#setup/step.js";
 import {
@@ -25,6 +26,7 @@ const {
   isEveProject,
   prepareDeclaredPnpmBuildPolicy,
   readFile,
+  resolveEveProjectContext,
   resolveInstalledPackageInfo,
   unlink,
   searchRegistries,
@@ -36,6 +38,11 @@ const {
   isEveProject: vi.fn(),
   prepareDeclaredPnpmBuildPolicy: vi.fn(async () => true),
   readFile: vi.fn(),
+  resolveEveProjectContext: vi.fn(async (appRoot: string): Promise<EveProjectContext> => ({
+    appRoot,
+    environmentRoot: appRoot,
+    kind: "standalone",
+  })),
   resolveInstalledPackageInfo: vi.fn(() => ({ name: "eve", version: "0.27.8" })),
   unlink: vi.fn(),
   searchRegistries: vi.fn(),
@@ -49,6 +56,7 @@ vi.mock("#compiled/shadcn-registry/index.js", () => ({
 }));
 
 vi.mock("#setup/scaffold/index.js", () => ({ isEveProject }));
+vi.mock("#internal/project-context.js", () => ({ resolveEveProjectContext }));
 vi.mock("./registry-pnpm-build-policy-flow.js", () => ({ prepareDeclaredPnpmBuildPolicy }));
 vi.mock("#setup/scaffold/workspace-root.js", () => ({ applyPackageManagerWorkspaceConfiguration }));
 vi.mock("#internal/application/package.js", () => ({ resolveInstalledPackageInfo }));
@@ -131,6 +139,31 @@ describe("registry commands", () => {
       silent: undefined,
     });
     expect(logger.errors).toEqual([]);
+  });
+
+  it("reads registry configuration from a workspace package while targeting its agent", async () => {
+    const logger = createLogger();
+    const appRoot = "/project/agents/support";
+    resolveEveProjectContext.mockResolvedValueOnce({
+      environmentRoot: "/project",
+      kind: "workspace-member",
+      member: { appRoot, name: "support" },
+      workspace: {
+        root: "/project",
+        members: [{ appRoot, name: "support" }],
+      },
+    });
+    getRegistryItems.mockResolvedValue([{ name: "channel/teams", type: "registry:item" }]);
+
+    await runAddCommand(logger, appRoot, "channel/teams", {});
+
+    expect(readFile).toHaveBeenCalledWith("/project/package.json", "utf8");
+    expect(addRegistryItems).toHaveBeenCalledWith(["https://eve.dev/r/channel/teams.json"], {
+      config: expect.any(Object),
+      cwd: appRoot,
+      overwrite: undefined,
+      silent: undefined,
+    });
   });
 
   it("prepares declared pnpm build policy before installing", async () => {


### PR DESCRIPTION
### Summary

`eve add --agent <name>` targets a hostless workspace member, but registry configuration was read from that member's nonexistent `package.json` instead of the shared project package. Resolve the owning eve project context before reading registry mappings, while keeping registry file installation targeted at the selected agent. This intentionally addresses the shared-package lookup only; setup flows with additional project-root assumptions remain outside this change.

### Validation

- `pnpm --filter eve typecheck`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/cli/commands/registry.test.ts src/cli/commands/registry-project.test.ts` (62 tests passed)
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/cli/commands/registry-project.integration.test.ts` (1 test passed)
- `pnpm lint`
- `pnpm guard:invariants`
- `pnpm docs:check`
- `git diff --check`

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
