### PR TITLE
fix(eve): reject workspace Web Chat installs

### DIFF
--- a/.changeset/reject-workspace-web-chat.md
+++ b/.changeset/reject-workspace-web-chat.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Reject `eve add channel/web` before it writes files when the selected agent belongs to a top-level `agents/` workspace. The error directs users to configure a root Next.js app with `withEve({ agents })` instead.

--- a/docs/install-integrations.mdx
+++ b/docs/install-integrations.mdx
@@ -19,6 +19,8 @@ eve add memory/file
 
 If an item is not found, `eve add` searches the available catalogs and prints close matches without installing anything.
 
+Web Chat installs a project-level Next.js application and cannot currently be added to a top-level `agents/` workspace. For that topology, create a root Next.js application and configure [`withEve({ agents })`](./guides/frontend/nextjs) instead. eve rejects `eve add channel/web` before writing files when the selected agent belongs to such a workspace.
+
 If you do not know an item name yet, run `eve add` without an argument. Its help output shows how to search the registry with `eve registry search <query>`.
 
 Extensions may create a mount under `agent/extensions/`. Connections write their initial definition under `agent/connections/` and install `@vercel/connect` when required. Instrumentation providers write `agent/instrumentation.ts`; because an agent has one instrumentation file, compose multiple exporters there by hand. Configure generated files and required environment variables before running your agent.

--- a/packages/eve/src/cli/commands/registry-project.ts
+++ b/packages/eve/src/cli/commands/registry-project.ts
@@ -8,6 +8,7 @@ import {
   parse as parseJsonc,
 } from "#compiled/jsonc-parser/index.js";
 import type { RegistryConfig, RegistrySource } from "#compiled/shadcn-registry/index.js";
+import { resolveEveProjectContext } from "#internal/project-context.js";
 import { WEB_APP_TEMPLATE_FILES } from "#setup/scaffold/create/web-template.js";
 
 interface RegistryPackage {
@@ -81,6 +82,13 @@ function parseRegistryMapping(argument: string): { namespace: string; url: strin
     );
   }
   return { namespace, url };
+}
+
+export async function assertCanInstallWebChat(appRoot: string): Promise<void> {
+  if ((await resolveEveProjectContext(appRoot)).kind === "standalone") return;
+  throw new Error(
+    "Web Chat installs a project-level Next.js application and cannot currently be added to a top-level agents/ workspace. Configure a root Next.js app with withEve({ agents }) instead.",
+  );
 }
 
 /** Reads registry namespace mappings from package.json. */

--- a/packages/eve/src/cli/commands/registry.test.ts
+++ b/packages/eve/src/cli/commands/registry.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { EveProjectContext } from "#internal/project-context.js";
 import { createFakePrompter } from "#internal/testing/fake-prompter.js";
 import { WizardCancelledError } from "#setup/step.js";
 import {
@@ -25,6 +26,7 @@ const {
   isEveProject,
   prepareDeclaredPnpmBuildPolicy,
   readFile,
+  resolveEveProjectContext,
   resolveInstalledPackageInfo,
   unlink,
   searchRegistries,
@@ -36,6 +38,11 @@ const {
   isEveProject: vi.fn(),
   prepareDeclaredPnpmBuildPolicy: vi.fn(async () => true),
   readFile: vi.fn(),
+  resolveEveProjectContext: vi.fn(async (appRoot: string): Promise<EveProjectContext> => ({
+    appRoot,
+    environmentRoot: appRoot,
+    kind: "standalone",
+  })),
   resolveInstalledPackageInfo: vi.fn(() => ({ name: "eve", version: "0.27.8" })),
   unlink: vi.fn(),
   searchRegistries: vi.fn(),
@@ -49,6 +56,7 @@ vi.mock("#compiled/shadcn-registry/index.js", () => ({
 }));
 
 vi.mock("#setup/scaffold/index.js", () => ({ isEveProject }));
+vi.mock("#internal/project-context.js", () => ({ resolveEveProjectContext }));
 vi.mock("./registry-pnpm-build-policy-flow.js", () => ({ prepareDeclaredPnpmBuildPolicy }));
 vi.mock("#setup/scaffold/workspace-root.js", () => ({ applyPackageManagerWorkspaceConfiguration }));
 vi.mock("#internal/application/package.js", () => ({ resolveInstalledPackageInfo }));
@@ -412,6 +420,29 @@ describe("registry commands", () => {
       },
     });
     expect(process.exitCode).toBe(2);
+  });
+
+  it("rejects Web Chat before it can write into an agent workspace member", async () => {
+    const logger = createLogger();
+    const appRoot = "/project/agents/support";
+    resolveEveProjectContext.mockResolvedValueOnce({
+      environmentRoot: "/project",
+      kind: "workspace-member",
+      member: { appRoot, name: "support" },
+      workspace: {
+        root: "/project",
+        members: [{ appRoot, name: "support" }],
+      },
+    });
+
+    await runAddCommand(logger, appRoot, "channel/web", {});
+
+    expect(logger.errors).toEqual([
+      "Web Chat installs a project-level Next.js application and cannot currently be added to a top-level agents/ workspace. Configure a root Next.js app with withEve({ agents }) instead.",
+    ]);
+    expect(getRegistryItems).not.toHaveBeenCalled();
+    expect(addRegistryItems).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
   });
 
   it("surfaces required deployment in non-interactive completion", async () => {

--- a/packages/eve/src/cli/commands/registry.ts
+++ b/packages/eve/src/cli/commands/registry.ts
@@ -40,6 +40,7 @@ import type { runRegistrySetupCommand } from "./registry-setup-command.js";
 import { serializeHeadlessSetupEvent } from "./setup-headless.js";
 import {
   addRegistryMappings,
+  assertCanInstallWebChat,
   prepareWebRegistryProject,
   readRegistryConfig,
 } from "./registry-project.js";
@@ -149,12 +150,10 @@ const CATALOG_PAGE_SIZE = 100;
 const DEFAULT_SEARCH_LIMIT = 10;
 const ADD_SUGGESTION_LIMIT = 5;
 
-function isRegistryAddress(value: string): boolean {
-  return value.startsWith("@") || /^https?:\/\//.test(value);
-}
-
 function itemAddress(item: string): string {
-  return isRegistryAddress(item) ? item : `${OFFICIAL_REGISTRY}/${item}.json`;
+  return item.startsWith("@") || /^https?:\/\//.test(item)
+    ? item
+    : `${OFFICIAL_REGISTRY}/${item}.json`;
 }
 
 /** Installs an official registry item without running its declared setup command. */
@@ -203,7 +202,7 @@ function configuredRegistrySources(config: RegistryConfig): string[] {
 }
 
 function validateRegistrySource(source: string | undefined): void {
-  if (source !== undefined && !isRegistryAddress(source)) {
+  if (source !== undefined && !source.startsWith("@") && !/^https?:\/\//.test(source)) {
     throw new Error(`Registry sources must be a namespace or URL: ${source}`);
   }
 }
@@ -462,8 +461,9 @@ export async function runAddCommand(
   dependencies: AddCommandDependencies = defaultAddCommandDependencies,
 ): Promise<RegistrySetupCompletion | false | undefined> {
   return runRegistryAction(logger, appRoot, async () => {
-    const config = await readEveRegistryConfig(appRoot);
     const address = itemAddress(item);
+    if (address === itemAddress("channel/web")) await assertCanInstallWebChat(appRoot);
+    const config = await readEveRegistryConfig(appRoot);
     if (options.skipInstall === true) {
       if (options.overwrite === true) {
         throw new Error("--overwrite cannot be used with --skip-install.");


### PR DESCRIPTION
### Summary

Web Chat scaffolds an entire Next.js host application, so running `eve add channel/web` for a member of a hostless `agents/` workspace can write project files into the member and turn it into a separate package. This detects that topology before registry lookup or installation, rejects the command without writing files, and directs the user to configure a root Next.js app with `withEve({ agents })`. Full multi-agent Web Chat scaffolding remains outside this change.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/cli/commands/registry.test.ts` (59 tests passed)
- `pnpm --filter eve typecheck`
- `pnpm docs:check`
- `pnpm lint`
- `pnpm guard:invariants`
- `git diff --check`

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
