### PR TITLE
feat(eve): allow disabling default tools

### DIFF
--- a/.changeset/quiet-tools-opt-out.md
+++ b/.changeset/quiet-tools-opt-out.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Allow agents to set `defaultTools: false` to skip eve's default tool set while preserving tools explicitly authored under `agent/tools/`.
+Allow agents to set `defaultTools: false` to skip eve's optional default tools while preserving connection discovery and tools explicitly authored under `agent/tools/`. Every optional default can be re-added from its public `eve/tools/*` subpath.

--- a/.changeset/quiet-tools-opt-out.md
+++ b/.changeset/quiet-tools-opt-out.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Allow agents to set `defaultTools: false` to skip eve's default tool set while preserving tools explicitly authored under `agent/tools/`.

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -285,6 +285,162 @@
       ]
     },
     {
+      "name": "tool/agent",
+      "type": "registry:item",
+      "title": "Agent",
+      "description": "Add root-agent background delegation.",
+      "files": [
+        {
+          "path": "registry/tools/agent.ts",
+          "type": "registry:file",
+          "target": "agent/tools/agent.ts"
+        }
+      ]
+    },
+    {
+      "name": "tool/ask_question",
+      "type": "registry:item",
+      "title": "Ask Question",
+      "description": "Let the agent ask the user a question during a turn.",
+      "files": [
+        {
+          "path": "registry/tools/ask_question.ts",
+          "type": "registry:file",
+          "target": "agent/tools/ask_question.ts"
+        }
+      ]
+    },
+    {
+      "name": "tool/bash",
+      "type": "registry:item",
+      "title": "Bash",
+      "description": "Run shell commands in the agent sandbox.",
+      "files": [
+        {
+          "path": "registry/tools/bash.ts",
+          "type": "registry:file",
+          "target": "agent/tools/bash.ts"
+        }
+      ]
+    },
+    {
+      "name": "tool/connection_search",
+      "type": "registry:item",
+      "title": "Connection Search",
+      "description": "Discover and load tools from the agent connections.",
+      "files": [
+        {
+          "path": "registry/tools/connection_search.ts",
+          "type": "registry:file",
+          "target": "agent/tools/connection_search.ts"
+        }
+      ]
+    },
+    {
+      "name": "tool/load_skill",
+      "type": "registry:item",
+      "title": "Load Skill",
+      "description": "Load instructions from an agent skill.",
+      "files": [
+        {
+          "path": "registry/tools/load_skill.ts",
+          "type": "registry:file",
+          "target": "agent/tools/load_skill.ts"
+        }
+      ]
+    },
+    {
+      "name": "tool/read_file",
+      "type": "registry:item",
+      "title": "Read File",
+      "description": "Read text files from the agent sandbox.",
+      "files": [
+        {
+          "path": "registry/tools/read_file.ts",
+          "type": "registry:file",
+          "target": "agent/tools/read_file.ts"
+        }
+      ]
+    },
+    {
+      "name": "tool/task_cancel",
+      "type": "registry:item",
+      "title": "Task Cancel",
+      "description": "Cancel background tasks from the root session.",
+      "files": [
+        {
+          "path": "registry/tools/task_cancel.ts",
+          "type": "registry:file",
+          "target": "agent/tools/task_cancel.ts"
+        }
+      ]
+    },
+    {
+      "name": "tool/task_update",
+      "type": "registry:item",
+      "title": "Task Update",
+      "description": "Report background-task progress to the parent agent.",
+      "files": [
+        {
+          "path": "registry/tools/task_update.ts",
+          "type": "registry:file",
+          "target": "agent/tools/task_update.ts"
+        }
+      ]
+    },
+    {
+      "name": "tool/todo",
+      "type": "registry:item",
+      "title": "Todo",
+      "description": "Maintain a durable per-session todo list.",
+      "files": [
+        {
+          "path": "registry/tools/todo.ts",
+          "type": "registry:file",
+          "target": "agent/tools/todo.ts"
+        }
+      ]
+    },
+    {
+      "name": "tool/web_fetch",
+      "type": "registry:item",
+      "title": "Web Fetch",
+      "description": "Fetch a URL from the app runtime.",
+      "files": [
+        {
+          "path": "registry/tools/web_fetch.ts",
+          "type": "registry:file",
+          "target": "agent/tools/web_fetch.ts"
+        }
+      ]
+    },
+    {
+      "name": "tool/web_search",
+      "type": "registry:item",
+      "title": "Web Search",
+      "description": "Search the web through the model provider.",
+      "files": [
+        {
+          "path": "registry/tools/web_search.ts",
+          "type": "registry:file",
+          "target": "agent/tools/web_search.ts"
+        }
+      ]
+    },
+    {
+      "name": "tool/write_file",
+      "type": "registry:item",
+      "title": "Write File",
+      "description": "Write complete files in the agent sandbox.",
+      "files": [
+        {
+          "path": "registry/tools/write_file.ts",
+          "type": "registry:file",
+          "target": "agent/tools/write_file.ts"
+        }
+      ]
+    },
+    {
       "name": "connection/browser-use",
       "type": "registry:item",
       "title": "Browser Use",

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -324,19 +324,6 @@
       ]
     },
     {
-      "name": "tool/connection_search",
-      "type": "registry:item",
-      "title": "Connection Search",
-      "description": "Discover and load tools from the agent connections.",
-      "files": [
-        {
-          "path": "registry/tools/connection_search.ts",
-          "type": "registry:file",
-          "target": "agent/tools/connection_search.ts"
-        }
-      ]
-    },
-    {
       "name": "tool/load_skill",
       "type": "registry:item",
       "title": "Load Skill",

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -428,6 +428,45 @@
       ]
     },
     {
+      "name": "tool/glob",
+      "type": "registry:item",
+      "title": "Glob",
+      "description": "Find sandbox files by glob pattern.",
+      "files": [
+        {
+          "path": "registry/tools/glob.ts",
+          "type": "registry:file",
+          "target": "agent/tools/glob.ts"
+        }
+      ]
+    },
+    {
+      "name": "tool/grep",
+      "type": "registry:item",
+      "title": "Grep",
+      "description": "Search sandbox file contents with a regular expression.",
+      "files": [
+        {
+          "path": "registry/tools/grep.ts",
+          "type": "registry:file",
+          "target": "agent/tools/grep.ts"
+        }
+      ]
+    },
+    {
+      "name": "tool/sleep",
+      "type": "registry:item",
+      "title": "Sleep",
+      "description": "Pause and durably resume the current turn.",
+      "files": [
+        {
+          "path": "registry/tools/sleep.ts",
+          "type": "registry:file",
+          "target": "agent/tools/sleep.ts"
+        }
+      ]
+    },
+    {
       "name": "connection/browser-use",
       "type": "registry:item",
       "title": "Browser Use",

--- a/apps/docs/registry/tools/agent.ts
+++ b/apps/docs/registry/tools/agent.ts
@@ -1,0 +1,1 @@
+export { default } from "eve/tools/agent";

--- a/apps/docs/registry/tools/ask_question.ts
+++ b/apps/docs/registry/tools/ask_question.ts
@@ -1,0 +1,1 @@
+export { default } from "eve/tools/ask_question";

--- a/apps/docs/registry/tools/bash.ts
+++ b/apps/docs/registry/tools/bash.ts
@@ -1,0 +1,1 @@
+export { default } from "eve/tools/bash";

--- a/apps/docs/registry/tools/connection_search.ts
+++ b/apps/docs/registry/tools/connection_search.ts
@@ -1,0 +1,1 @@
+export { default } from "eve/tools/connection_search";

--- a/apps/docs/registry/tools/connection_search.ts
+++ b/apps/docs/registry/tools/connection_search.ts
@@ -1,1 +1,0 @@
-export { default } from "eve/tools/connection_search";

--- a/apps/docs/registry/tools/glob.ts
+++ b/apps/docs/registry/tools/glob.ts
@@ -1,0 +1,1 @@
+export { default } from "eve/tools/glob";

--- a/apps/docs/registry/tools/grep.ts
+++ b/apps/docs/registry/tools/grep.ts
@@ -1,0 +1,1 @@
+export { default } from "eve/tools/grep";

--- a/apps/docs/registry/tools/load_skill.ts
+++ b/apps/docs/registry/tools/load_skill.ts
@@ -1,0 +1,1 @@
+export { default } from "eve/tools/load_skill";

--- a/apps/docs/registry/tools/read_file.ts
+++ b/apps/docs/registry/tools/read_file.ts
@@ -1,0 +1,1 @@
+export { default } from "eve/tools/read_file";

--- a/apps/docs/registry/tools/sleep.ts
+++ b/apps/docs/registry/tools/sleep.ts
@@ -1,0 +1,3 @@
+import { sleep } from "eve/tools/sleep";
+
+export default sleep();

--- a/apps/docs/registry/tools/task_cancel.ts
+++ b/apps/docs/registry/tools/task_cancel.ts
@@ -1,0 +1,1 @@
+export { default } from "eve/tools/task_cancel";

--- a/apps/docs/registry/tools/task_update.ts
+++ b/apps/docs/registry/tools/task_update.ts
@@ -1,0 +1,1 @@
+export { default } from "eve/tools/task_update";

--- a/apps/docs/registry/tools/todo.ts
+++ b/apps/docs/registry/tools/todo.ts
@@ -1,0 +1,1 @@
+export { default } from "eve/tools/todo";

--- a/apps/docs/registry/tools/web_fetch.ts
+++ b/apps/docs/registry/tools/web_fetch.ts
@@ -1,0 +1,1 @@
+export { default } from "eve/tools/web_fetch";

--- a/apps/docs/registry/tools/web_search.ts
+++ b/apps/docs/registry/tools/web_search.ts
@@ -1,0 +1,1 @@
+export { default } from "eve/tools/web_search";

--- a/apps/docs/registry/tools/write_file.ts
+++ b/apps/docs/registry/tools/write_file.ts
@@ -1,0 +1,1 @@
+export { default } from "eve/tools/write_file";

--- a/docs/concepts/built-in-tools.md
+++ b/docs/concepts/built-in-tools.md
@@ -400,7 +400,7 @@ export default disableTool();
 
 `connection_search` discovers tools across declared [connections](../connections) and makes matches directly callable by qualified name, such as `linear__list_issues`. eve adds it automatically when connections exist, even when `defaultTools` is `false`, so there is no add command.
 
-An authored `agent/tools/connection_search.ts` replaces the framework behavior. Import the framework definition from `eve/tools/connection_search` when you need to reference it directly.
+An authored `agent/tools/connection_search.ts` replaces the framework behavior. Import the framework definition from `eve/tools/connection_search` when you need to reference it directly. Exporting `disableTool()` from this slot is an error because agents with connections require connection discovery.
 
 Review these tools before production use. Disable, wrap, restrict, or require approval for any tool that can access the filesystem, network, shell, or sensitive data.
 

--- a/docs/concepts/built-in-tools.md
+++ b/docs/concepts/built-in-tools.md
@@ -406,41 +406,89 @@ Review these tools before production use. Disable, wrap, restrict, or require ap
 
 You can also add the opt-in framework tools described below.
 
-## Add framework-provided tools
+## Opt-in framework tools
 
-Some framework-provided tools stay out of the default set. Add the corresponding file when your agent needs one:
+These framework-provided tools are not added by default. Add only the ones the agent needs.
 
-| Tool    | Definition to export             | Purpose                                    |
-| ------- | -------------------------------- | ------------------------------------------ |
-| `glob`  | `glob` from `eve/tools/glob`     | Find sandbox files by glob pattern.        |
-| `grep`  | `grep` from `eve/tools/grep`     | Search sandbox file contents by regex.     |
-| `sleep` | `sleep()` from `eve/tools/sleep` | Pause and durably resume the current turn. |
+### `glob`
 
-For example, add file discovery and content search with two files:
+`glob` finds sandbox files by glob pattern. Add it:
+
+```sh
+eve add tool/glob
+```
 
 ```ts title="agent/tools/glob.ts"
-export { glob as default } from "eve/tools/glob";
+export { default } from "eve/tools/glob";
+```
+
+Customize it by wrapping the framework definition:
+
+```ts title="agent/tools/glob.ts"
+import { defineTool } from "eve/tools";
+import { glob } from "eve/tools/glob";
+
+export default defineTool({
+  ...glob,
+  description: "Find project files by glob pattern.",
+});
+```
+
+Remove the file to remove the tool. `disableTool()` is unnecessary because `glob` is not added by default.
+
+### `grep`
+
+`grep` searches sandbox file contents with a regular expression. Add it:
+
+```sh
+eve add tool/grep
 ```
 
 ```ts title="agent/tools/grep.ts"
-export { grep as default } from "eve/tools/grep";
+export { default } from "eve/tools/grep";
 ```
 
-The filename supplies the model-facing tool name. The tools run against the agent's sandbox and use the same schemas, results, and error behavior as eve's framework implementations. Wrap either definition with `defineTool({ ...glob, description: "..." })` or `defineTool({ ...grep, description: "..." })` when you need to change its description or approval policy.
+Customize it by wrapping the framework definition:
 
-The section below covers `sleep` in more detail.
+```ts title="agent/tools/grep.ts"
+import { defineTool } from "eve/tools";
+import { grep } from "eve/tools/grep";
 
-## The opt-in `sleep` tool
+export default defineTool({
+  ...grep,
+  description: "Search project files with a regular expression.",
+});
+```
 
-The framework also ships a durable `sleep` tool, but does not add it to agents by default. Enable it with `agent/tools/sleep.ts`:
+Remove the file to remove the tool. `disableTool()` is unnecessary because `grep` is not added by default.
 
-```ts
+### `sleep`
+
+`sleep` pauses and durably resumes the current turn. The model calls it with `{ seconds }`; the wait does not hold an application runtime open. Concurrent calls run in parallel, and the turn resumes after the longest wait. Add it:
+
+```sh
+eve add tool/sleep
+```
+
+```ts title="agent/tools/sleep.ts"
 import { sleep } from "eve/tools/sleep";
 
 export default sleep();
 ```
 
-The model calls it with `{ seconds }` when it is useful to wait before checking progress or status again. Each call runs as a durable tool workflow, so it does not hold an application runtime open, and the same turn continues automatically when the duration elapses. Concurrent `sleep` calls run in parallel, so the turn continues after the longest requested duration.
+Customize it by wrapping the framework definition:
+
+```ts title="agent/tools/sleep.ts"
+import { defineWorkflowTool } from "eve/tools";
+import { sleep } from "eve/tools/sleep";
+
+export default defineWorkflowTool({
+  ...sleep(),
+  description: "Pause before checking an external operation again.",
+});
+```
+
+Remove the file to remove the tool. `disableTool()` is unnecessary because `sleep` is not added by default.
 
 ## What to read next
 

--- a/docs/concepts/built-in-tools.md
+++ b/docs/concepts/built-in-tools.md
@@ -21,6 +21,8 @@ The default shell and file tools (`bash`, `read_file`, and `write_file`) run in 
 | `todo`              | Maintain a durable per-session todo list.                                                                                                                                                                           | App runtime   |
 | `ask_question`      | Ask the user a clarifying question or a choice mid-turn and park until they answer. No `execute`; the model calls it with `{ prompt, options?, allowFreeform? }`. See [Human-in-the-loop](/docs/human-in-the-loop). | App runtime   |
 | `agent`             | From the root session, delegate a subtask to a fresh copy of the root agent.                                                                                                                                        | App runtime   |
+| `task_cancel`       | Cancel background tasks from the root session.                                                                                                                                                                      | App runtime   |
+| `task_update`       | Report progress from a background task to its parent.                                                                                                                                                               | App runtime   |
 | `load_skill`        | Pull an on-demand [skill](../skills)'s instructions into the current turn. Present only when the agent declares skills.                                                                                             | App runtime   |
 | `connection_search` | Discover tools across declared [connections](../connections); matched tools become directly callable. Present only when the agent declares connections.                                                             | App runtime   |
 
@@ -36,9 +38,9 @@ Notes:
 
 Review these default tools before production use. Disable, wrap, restrict, or require approval for any tool that can access the filesystem, network, shell, or sensitive data.
 
-### Disable all default tools
+### Disable optional default tools
 
-Default tools are enabled unless you set `defaultTools: false` in `agent/agent.ts`:
+Optional default tools are enabled unless you set `defaultTools: false` in `agent/agent.ts`:
 
 ```ts title="agent/agent.ts"
 import { defineAgent } from "eve";
@@ -49,7 +51,25 @@ export default defineAgent({
 });
 ```
 
-This setting removes only the tools eve adds automatically. Files under `agent/tools/` still add their tools, including same-name replacements such as `agent/tools/bash.ts`. You can also add the opt-in framework tools described below.
+This turns off the optional defaults. eve still adds `connection_search` when the agent has connections because it provides access to their tools. Files under `agent/tools/` also remain available, including same-name replacements such as `agent/tools/bash.ts`.
+
+Re-add any removed tool with a one-line file:
+
+| Tool           | File                          | Contents                                            |
+| -------------- | ----------------------------- | --------------------------------------------------- |
+| `agent`        | `agent/tools/agent.ts`        | `export { default } from "eve/tools/agent";`        |
+| `ask_question` | `agent/tools/ask_question.ts` | `export { default } from "eve/tools/ask_question";` |
+| `bash`         | `agent/tools/bash.ts`         | `export { default } from "eve/tools/bash";`         |
+| `load_skill`   | `agent/tools/load_skill.ts`   | `export { default } from "eve/tools/load_skill";`   |
+| `read_file`    | `agent/tools/read_file.ts`    | `export { default } from "eve/tools/read_file";`    |
+| `task_cancel`  | `agent/tools/task_cancel.ts`  | `export { default } from "eve/tools/task_cancel";`  |
+| `task_update`  | `agent/tools/task_update.ts`  | `export { default } from "eve/tools/task_update";`  |
+| `todo`         | `agent/tools/todo.ts`         | `export { default } from "eve/tools/todo";`         |
+| `web_fetch`    | `agent/tools/web_fetch.ts`    | `export { default } from "eve/tools/web_fetch";`    |
+| `web_search`   | `agent/tools/web_search.ts`   | `export { default } from "eve/tools/web_search";`   |
+| `write_file`   | `agent/tools/write_file.ts`   | `export { default } from "eve/tools/write_file";`   |
+
+You can also add the opt-in framework tools described below.
 
 ## Add framework-provided tools
 
@@ -94,16 +114,21 @@ export default defineTool({
 
 Import each reusable definition from its own subpath:
 
-| Definition  | Import                 | Registered by default |
-| ----------- | ---------------------- | --------------------- |
-| `bash`      | `eve/tools/bash`       | Yes                   |
-| `readFile`  | `eve/tools/read_file`  | Yes                   |
-| `writeFile` | `eve/tools/write_file` | Yes                   |
-| `todo`      | `eve/tools/todo`       | Yes                   |
-| `webFetch`  | `eve/tools/web_fetch`  | Yes                   |
-| `loadSkill` | `eve/tools/load_skill` | Yes                   |
-| `glob`      | `eve/tools/glob`       | No                    |
-| `grep`      | `eve/tools/grep`       | No                    |
+| Definition         | Import                        | Registered by default |
+| ------------------ | ----------------------------- | --------------------- |
+| `bash`             | `eve/tools/bash`              | Yes                   |
+| `readFile`         | `eve/tools/read_file`         | Yes                   |
+| `writeFile`        | `eve/tools/write_file`        | Yes                   |
+| `todo`             | `eve/tools/todo`              | Yes                   |
+| `webFetch`         | `eve/tools/web_fetch`         | Yes                   |
+| `loadSkill`        | `eve/tools/load_skill`        | Yes                   |
+| `connectionSearch` | `eve/tools/connection_search` | With connections      |
+| `agent`            | `eve/tools/agent`             | Yes                   |
+| `askQuestion`      | `eve/tools/ask_question`      | Yes                   |
+| `taskCancel`       | `eve/tools/task_cancel`       | Yes                   |
+| `taskUpdate`       | `eve/tools/task_update`       | Yes                   |
+| `glob`             | `eve/tools/glob`              | No                    |
+| `grep`             | `eve/tools/grep`              | No                    |
 
 Importing a definition does not add it to an agent; export it from the corresponding `agent/tools/*.ts` file. Skip the spread and your replacement owns its own context. A fresh `defineTool` for `todo` does not inherit the default's durable state key.
 
@@ -119,7 +144,7 @@ Set `provider` to `"exa"` or `"parallel"`. Without this file, AI Gateway models 
 
 ## Disable default tools
 
-Set `defaultTools: false` in `agent/agent.ts` to remove every default at once, as described in [Disable all default tools](#disable-all-default-tools). Tools under `agent/tools/` remain available.
+Set `defaultTools: false` in `agent/agent.ts` to remove the optional defaults at once, as described in [Disable optional default tools](#disable-optional-default-tools). `connection_search` remains available when the agent has connections, and tools under `agent/tools/` remain available.
 
 To remove one default, export a `disableTool()` sentinel from a file named after the tool's slug. The filename picks the default to remove:
 

--- a/docs/concepts/built-in-tools.md
+++ b/docs/concepts/built-in-tools.md
@@ -36,6 +36,19 @@ Notes:
 
 Review these default tools before production use. Disable, wrap, restrict, or require approval for any tool that can access the filesystem, network, shell, or sensitive data.
 
+To start with no default tools, set `defaultTools: false` in `agent/agent.ts`:
+
+```ts title="agent/agent.ts"
+import { defineAgent } from "eve";
+
+export default defineAgent({
+  defaultTools: false,
+  model: "openai/gpt-5.4",
+});
+```
+
+Files under `agent/tools/` still add tools when defaults are off. A same-slug file such as `agent/tools/bash.ts` adds your authored `bash` definition without restoring eve's implementation. Framework-provided opt-in tools also remain available when you explicitly add their files.
+
 ## Add framework-provided tools
 
 Some framework-provided tools stay out of the default set. Add the corresponding file when your agent needs one:

--- a/docs/concepts/built-in-tools.md
+++ b/docs/concepts/built-in-tools.md
@@ -117,9 +117,11 @@ export default webSearch({ provider: "parallel" });
 
 Set `provider` to `"exa"` or `"parallel"`. Without this file, AI Gateway models use Exa.
 
-## Disable a default
+## Disable default tools
 
-Export a `disableTool()` sentinel from a file named after the tool's slug. The filename is what picks the default to remove:
+Set `defaultTools: false` in `agent/agent.ts` to remove every default at once, as described in [Disable all default tools](#disable-all-default-tools). Tools under `agent/tools/` remain available.
+
+To remove one default, export a `disableTool()` sentinel from a file named after the tool's slug. The filename picks the default to remove:
 
 ```ts title="agent/tools/bash.ts"
 import { disableTool } from "eve/tools";

--- a/docs/concepts/built-in-tools.md
+++ b/docs/concepts/built-in-tools.md
@@ -36,7 +36,9 @@ Notes:
 
 Review these default tools before production use. Disable, wrap, restrict, or require approval for any tool that can access the filesystem, network, shell, or sensitive data.
 
-To start with no default tools, set `defaultTools: false` in `agent/agent.ts`:
+### Disable all default tools
+
+Default tools are enabled unless you set `defaultTools: false` in `agent/agent.ts`:
 
 ```ts title="agent/agent.ts"
 import { defineAgent } from "eve";
@@ -47,7 +49,7 @@ export default defineAgent({
 });
 ```
 
-Files under `agent/tools/` still add tools when defaults are off. A same-slug file such as `agent/tools/bash.ts` adds your authored `bash` definition without restoring eve's implementation. Framework-provided opt-in tools also remain available when you explicitly add their files.
+This setting removes only the tools eve adds automatically. Files under `agent/tools/` still add their tools, including same-name replacements such as `agent/tools/bash.ts`. You can also add the opt-in framework tools described below.
 
 ## Add framework-provided tools
 

--- a/docs/concepts/built-in-tools.md
+++ b/docs/concepts/built-in-tools.md
@@ -53,23 +53,27 @@ export default defineAgent({
 
 This turns off the optional defaults. eve still adds `connection_search` when the agent has connections because it provides access to their tools. Files under `agent/tools/` also remain available, including same-name replacements such as `agent/tools/bash.ts`.
 
-Add or restore any framework tool with a one-line file:
+Add back only the tools the agent needs. For example, this restores `bash` by creating `agent/tools/bash.ts`:
 
-| Tool           | Add command                 | File contents                                       |
-| -------------- | --------------------------- | --------------------------------------------------- |
-| `agent`        | `eve add tool/agent`        | `export { default } from "eve/tools/agent";`        |
-| `ask_question` | `eve add tool/ask_question` | `export { default } from "eve/tools/ask_question";` |
-| `bash`         | `eve add tool/bash`         | `export { default } from "eve/tools/bash";`         |
-| `load_skill`   | `eve add tool/load_skill`   | `export { default } from "eve/tools/load_skill";`   |
-| `read_file`    | `eve add tool/read_file`    | `export { default } from "eve/tools/read_file";`    |
-| `task_cancel`  | `eve add tool/task_cancel`  | `export { default } from "eve/tools/task_cancel";`  |
-| `task_update`  | `eve add tool/task_update`  | `export { default } from "eve/tools/task_update";`  |
-| `todo`         | `eve add tool/todo`         | `export { default } from "eve/tools/todo";`         |
-| `web_fetch`    | `eve add tool/web_fetch`    | `export { default } from "eve/tools/web_fetch";`    |
-| `web_search`   | `eve add tool/web_search`   | `export { default } from "eve/tools/web_search";`   |
-| `write_file`   | `eve add tool/write_file`   | `export { default } from "eve/tools/write_file";`   |
+```sh
+eve add tool/bash
+```
 
-Each command writes the corresponding one-line file under `agent/tools/`. Re-added definitions keep their normal availability rules; for example, `agent` remains root-only and `task_update` remains limited to background tasks. `connection_search` is not a registry item because eve provides it automatically when connections exist. Import it from `eve/tools/connection_search` only when authoring an override.
+| Tool           | Add command                 |
+| -------------- | --------------------------- |
+| `agent`        | `eve add tool/agent`        |
+| `ask_question` | `eve add tool/ask_question` |
+| `bash`         | `eve add tool/bash`         |
+| `load_skill`   | `eve add tool/load_skill`   |
+| `read_file`    | `eve add tool/read_file`    |
+| `task_cancel`  | `eve add tool/task_cancel`  |
+| `task_update`  | `eve add tool/task_update`  |
+| `todo`         | `eve add tool/todo`         |
+| `web_fetch`    | `eve add tool/web_fetch`    |
+| `web_search`   | `eve add tool/web_search`   |
+| `write_file`   | `eve add tool/write_file`   |
+
+Added tools keep their normal availability rules; for example, `agent` remains root-only and `task_update` remains limited to background tasks. `connection_search` is not listed because eve provides it automatically when connections exist.
 
 You can also add the opt-in framework tools described below.
 

--- a/docs/concepts/built-in-tools.md
+++ b/docs/concepts/built-in-tools.md
@@ -55,22 +55,21 @@ This turns off the optional defaults. eve still adds `connection_search` when th
 
 Add or restore any framework tool with a one-line file:
 
-| Tool                | Add command                      | File contents                                            |
-| ------------------- | -------------------------------- | -------------------------------------------------------- |
-| `agent`             | `eve add tool/agent`             | `export { default } from "eve/tools/agent";`             |
-| `ask_question`      | `eve add tool/ask_question`      | `export { default } from "eve/tools/ask_question";`      |
-| `bash`              | `eve add tool/bash`              | `export { default } from "eve/tools/bash";`              |
-| `connection_search` | `eve add tool/connection_search` | `export { default } from "eve/tools/connection_search";` |
-| `load_skill`        | `eve add tool/load_skill`        | `export { default } from "eve/tools/load_skill";`        |
-| `read_file`         | `eve add tool/read_file`         | `export { default } from "eve/tools/read_file";`         |
-| `task_cancel`       | `eve add tool/task_cancel`       | `export { default } from "eve/tools/task_cancel";`       |
-| `task_update`       | `eve add tool/task_update`       | `export { default } from "eve/tools/task_update";`       |
-| `todo`              | `eve add tool/todo`              | `export { default } from "eve/tools/todo";`              |
-| `web_fetch`         | `eve add tool/web_fetch`         | `export { default } from "eve/tools/web_fetch";`         |
-| `web_search`        | `eve add tool/web_search`        | `export { default } from "eve/tools/web_search";`        |
-| `write_file`        | `eve add tool/write_file`        | `export { default } from "eve/tools/write_file";`        |
+| Tool           | Add command                 | File contents                                       |
+| -------------- | --------------------------- | --------------------------------------------------- |
+| `agent`        | `eve add tool/agent`        | `export { default } from "eve/tools/agent";`        |
+| `ask_question` | `eve add tool/ask_question` | `export { default } from "eve/tools/ask_question";` |
+| `bash`         | `eve add tool/bash`         | `export { default } from "eve/tools/bash";`         |
+| `load_skill`   | `eve add tool/load_skill`   | `export { default } from "eve/tools/load_skill";`   |
+| `read_file`    | `eve add tool/read_file`    | `export { default } from "eve/tools/read_file";`    |
+| `task_cancel`  | `eve add tool/task_cancel`  | `export { default } from "eve/tools/task_cancel";`  |
+| `task_update`  | `eve add tool/task_update`  | `export { default } from "eve/tools/task_update";`  |
+| `todo`         | `eve add tool/todo`         | `export { default } from "eve/tools/todo";`         |
+| `web_fetch`    | `eve add tool/web_fetch`    | `export { default } from "eve/tools/web_fetch";`    |
+| `web_search`   | `eve add tool/web_search`   | `export { default } from "eve/tools/web_search";`   |
+| `write_file`   | `eve add tool/write_file`   | `export { default } from "eve/tools/write_file";`   |
 
-Each command writes the corresponding one-line file under `agent/tools/`. Re-added definitions keep their normal availability rules; for example, `agent` remains root-only and `task_update` remains limited to background tasks. You do not usually need to add `connection_search` because eve provides it automatically when connections exist.
+Each command writes the corresponding one-line file under `agent/tools/`. Re-added definitions keep their normal availability rules; for example, `agent` remains root-only and `task_update` remains limited to background tasks. `connection_search` is not a registry item because eve provides it automatically when connections exist. Import it from `eve/tools/connection_search` only when authoring an override.
 
 You can also add the opt-in framework tools described below.
 

--- a/docs/concepts/built-in-tools.md
+++ b/docs/concepts/built-in-tools.md
@@ -7,36 +7,7 @@ eve provides a default tool set for every agent and additional tools you can add
 
 ## Default tools
 
-Default tools require no imports. The exact set depends on the agent and session. `agent` is available only in the root session; `load_skill` and `connection_search` appear only when the agent declares the corresponding resources; `ask_question` requires a session that can request user input; and `web_search` requires a supported model provider. The harness advertises only the tools available to the current session.
-
-The default shell and file tools (`bash`, `read_file`, and `write_file`) run in the app and proxy their work into the agent's [sandbox](../sandbox). The table shows where each tool's effect lands.
-
-| Tool                | Does                                                                                                                                                                                                                | Where it runs |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `bash`              | Run a shell command.                                                                                                                                                                                                | Sandbox       |
-| `read_file`         | Read a text file with line-numbered output (enables read-before-write).                                                                                                                                             | Sandbox FS    |
-| `write_file`        | Write a complete file; enforces read-before-write and stale-read detection.                                                                                                                                         | Sandbox FS    |
-| `web_fetch`         | Fetch a URL.                                                                                                                                                                                                        | App runtime   |
-| `web_search`        | Search the web (provider-managed; resolved from the model provider).                                                                                                                                                | Provider      |
-| `todo`              | Maintain a durable per-session todo list.                                                                                                                                                                           | App runtime   |
-| `ask_question`      | Ask the user a clarifying question or a choice mid-turn and park until they answer. No `execute`; the model calls it with `{ prompt, options?, allowFreeform? }`. See [Human-in-the-loop](/docs/human-in-the-loop). | App runtime   |
-| `agent`             | From the root session, delegate a subtask to a fresh copy of the root agent.                                                                                                                                        | App runtime   |
-| `task_cancel`       | Cancel background tasks from the root session.                                                                                                                                                                      | App runtime   |
-| `task_update`       | Report progress from a background task to its parent.                                                                                                                                                               | App runtime   |
-| `load_skill`        | Pull an on-demand [skill](../skills)'s instructions into the current turn. Present only when the agent declares skills.                                                                                             | App runtime   |
-| `connection_search` | Discover tools across declared [connections](../connections); matched tools become directly callable. Present only when the agent declares connections.                                                             | App runtime   |
-
-The model-facing file tools accept absolute paths and paths beginning with `$HOME/`. eve resolves `$HOME` against the sandbox before invoking non-shell file operations, so packaged skill references such as `$HOME/.agents/skills/<skill>/references/...` work consistently across `read_file`, `write_file`, and the opt-in `glob` and `grep` tools.
-
-Notes:
-
-- **`agent`** is available only in the root session and always runs in the background. Its call returns a task receipt immediately, and task notifications deliver updates or the final result. The child uses the root's instructions, tools, connections, and sandbox, but starts with fresh conversation history and fresh [state](./state). The child receives neither `agent` nor `Workflow`; declared subagents do not receive the built-in `agent` either. See [Subagents](../subagents).
-- **`load_skill`** only pulls instructions into context. It adds no new execution surface, because behavior still comes from the tools the agent already has.
-- **`connection_search`** surfaces a connection's tools by their qualified name (e.g. `linear__list_issues`), which the model can then call directly. The model sees it only when the agent has connections.
-- **`web_search`** has no local executor; the provider runs it. AI Gateway models use Exa by default. To use Parallel instead, export `webSearch({ provider: "parallel" })` from `agent/tools/web_search.ts`. Direct provider models continue to use their native search implementation. To supply your own implementation, override it with `defineTool()`.
-- **`web_fetch`** follows up to ten redirects, rechecking every destination for SSRF safety. Non-success HTTP responses return a plain-text failure result with the response body when available instead of failing the tool call.
-
-Review these default tools before production use. Disable, wrap, restrict, or require approval for any tool that can access the filesystem, network, shell, or sensitive data.
+Default tools require no imports. The exact set depends on the agent and session, and the harness advertises only the tools available to the current session.
 
 ### Disable optional default tools
 
@@ -51,29 +22,105 @@ export default defineAgent({
 });
 ```
 
-This turns off the optional defaults. eve still adds `connection_search` when the agent has connections because it provides access to their tools. Files under `agent/tools/` also remain available, including same-name replacements such as `agent/tools/bash.ts`.
+This turns off the optional defaults described below. Add back only the tools the agent needs with the command in each tool's section. Existing files under `agent/tools/` remain available, including same-name replacements such as `agent/tools/bash.ts`.
 
-Add back only the tools the agent needs. For example, this restores `bash` by creating `agent/tools/bash.ts`:
+`connection_search` stays available when the agent has connections because it provides access to their tools.
+
+### `bash`
+
+`bash` runs shell commands in the agent's [sandbox](../sandbox).
 
 ```sh
 eve add tool/bash
 ```
 
-| Tool           | Add command                 |
-| -------------- | --------------------------- |
-| `agent`        | `eve add tool/agent`        |
-| `ask_question` | `eve add tool/ask_question` |
-| `bash`         | `eve add tool/bash`         |
-| `load_skill`   | `eve add tool/load_skill`   |
-| `read_file`    | `eve add tool/read_file`    |
-| `task_cancel`  | `eve add tool/task_cancel`  |
-| `task_update`  | `eve add tool/task_update`  |
-| `todo`         | `eve add tool/todo`         |
-| `web_fetch`    | `eve add tool/web_fetch`    |
-| `web_search`   | `eve add tool/web_search`   |
-| `write_file`   | `eve add tool/write_file`   |
+### `read_file`
 
-Added tools keep their normal availability rules; for example, `agent` remains root-only and `task_update` remains limited to background tasks. `connection_search` is not listed because eve provides it automatically when connections exist.
+`read_file` reads text files from the sandbox with line-numbered output. It accepts absolute paths and paths beginning with `$HOME/`.
+
+```sh
+eve add tool/read_file
+```
+
+### `write_file`
+
+`write_file` writes complete files in the sandbox. It enforces read-before-write and stale-read detection, and accepts absolute paths and paths beginning with `$HOME/`.
+
+```sh
+eve add tool/write_file
+```
+
+### `web_fetch`
+
+`web_fetch` fetches URLs from the app runtime. It follows up to ten redirects and checks every destination for SSRF safety. Non-success responses return plain text with the response body when available.
+
+```sh
+eve add tool/web_fetch
+```
+
+### `web_search`
+
+`web_search` uses provider-managed web search and appears only for supported model providers. AI Gateway models use Exa by default; direct provider models use their native search implementation.
+
+```sh
+eve add tool/web_search
+```
+
+To use Parallel with AI Gateway, export `webSearch({ provider: "parallel" })` from `agent/tools/web_search.ts`. To provide your own implementation, override the tool with `defineTool()`.
+
+### `todo`
+
+`todo` maintains a durable todo list for the session.
+
+```sh
+eve add tool/todo
+```
+
+### `ask_question`
+
+`ask_question` asks the user for clarification or a choice, then parks the turn until they answer. It appears only when the session can request user input. See [Human-in-the-loop](/docs/human-in-the-loop).
+
+```sh
+eve add tool/ask_question
+```
+
+### `agent`
+
+`agent` delegates a subtask to a fresh copy of the root agent. It is root-only, always runs in the background, and returns a task receipt immediately. The child receives the root's instructions, tools, connections, and sandbox, but starts with fresh conversation history and [state](./state). See [Subagents](../subagents).
+
+```sh
+eve add tool/agent
+```
+
+### `task_cancel`
+
+`task_cancel` lets the root session cancel background tasks.
+
+```sh
+eve add tool/task_cancel
+```
+
+### `task_update`
+
+`task_update` lets a background task report progress to its parent. It appears only in delegated task sessions.
+
+```sh
+eve add tool/task_update
+```
+
+### `load_skill`
+
+`load_skill` pulls an on-demand [skill](../skills)'s instructions into the current turn. It appears only when the agent declares skills and adds no execution surface by itself.
+
+```sh
+eve add tool/load_skill
+```
+
+### `connection_search`
+
+`connection_search` discovers tools across declared [connections](../connections) and makes matches directly callable by qualified name, such as `linear__list_issues`. eve adds it automatically when connections exist, even when `defaultTools` is `false`, so there is no add command.
+
+Review these tools before production use. Disable, wrap, restrict, or require approval for any tool that can access the filesystem, network, shell, or sensitive data.
 
 You can also add the opt-in framework tools described below.
 

--- a/docs/concepts/built-in-tools.md
+++ b/docs/concepts/built-in-tools.md
@@ -53,21 +53,24 @@ export default defineAgent({
 
 This turns off the optional defaults. eve still adds `connection_search` when the agent has connections because it provides access to their tools. Files under `agent/tools/` also remain available, including same-name replacements such as `agent/tools/bash.ts`.
 
-Re-add any removed tool with a one-line file:
+Add or restore any framework tool with a one-line file:
 
-| Tool           | File                          | Contents                                            |
-| -------------- | ----------------------------- | --------------------------------------------------- |
-| `agent`        | `agent/tools/agent.ts`        | `export { default } from "eve/tools/agent";`        |
-| `ask_question` | `agent/tools/ask_question.ts` | `export { default } from "eve/tools/ask_question";` |
-| `bash`         | `agent/tools/bash.ts`         | `export { default } from "eve/tools/bash";`         |
-| `load_skill`   | `agent/tools/load_skill.ts`   | `export { default } from "eve/tools/load_skill";`   |
-| `read_file`    | `agent/tools/read_file.ts`    | `export { default } from "eve/tools/read_file";`    |
-| `task_cancel`  | `agent/tools/task_cancel.ts`  | `export { default } from "eve/tools/task_cancel";`  |
-| `task_update`  | `agent/tools/task_update.ts`  | `export { default } from "eve/tools/task_update";`  |
-| `todo`         | `agent/tools/todo.ts`         | `export { default } from "eve/tools/todo";`         |
-| `web_fetch`    | `agent/tools/web_fetch.ts`    | `export { default } from "eve/tools/web_fetch";`    |
-| `web_search`   | `agent/tools/web_search.ts`   | `export { default } from "eve/tools/web_search";`   |
-| `write_file`   | `agent/tools/write_file.ts`   | `export { default } from "eve/tools/write_file";`   |
+| Tool                | Add command                      | File contents                                            |
+| ------------------- | -------------------------------- | -------------------------------------------------------- |
+| `agent`             | `eve add tool/agent`             | `export { default } from "eve/tools/agent";`             |
+| `ask_question`      | `eve add tool/ask_question`      | `export { default } from "eve/tools/ask_question";`      |
+| `bash`              | `eve add tool/bash`              | `export { default } from "eve/tools/bash";`              |
+| `connection_search` | `eve add tool/connection_search` | `export { default } from "eve/tools/connection_search";` |
+| `load_skill`        | `eve add tool/load_skill`        | `export { default } from "eve/tools/load_skill";`        |
+| `read_file`         | `eve add tool/read_file`         | `export { default } from "eve/tools/read_file";`         |
+| `task_cancel`       | `eve add tool/task_cancel`       | `export { default } from "eve/tools/task_cancel";`       |
+| `task_update`       | `eve add tool/task_update`       | `export { default } from "eve/tools/task_update";`       |
+| `todo`              | `eve add tool/todo`              | `export { default } from "eve/tools/todo";`              |
+| `web_fetch`         | `eve add tool/web_fetch`         | `export { default } from "eve/tools/web_fetch";`         |
+| `web_search`        | `eve add tool/web_search`        | `export { default } from "eve/tools/web_search";`        |
+| `write_file`        | `eve add tool/write_file`        | `export { default } from "eve/tools/write_file";`        |
+
+Each command writes the corresponding one-line file under `agent/tools/`. Re-added definitions keep their normal availability rules; for example, `agent` remains root-only and `task_update` remains limited to background tasks. You do not usually need to add `connection_search` because eve provides it automatically when connections exist.
 
 You can also add the opt-in framework tools described below.
 
@@ -97,7 +100,7 @@ The section below covers `sleep` in more detail.
 
 ## Override a default
 
-Author a tool at the same slug and it takes over the built-in of that name. The file `agent/tools/write_file.ts` replaces the built-in `write_file` by existing:
+Author a tool at the same slug and it takes over the built-in of that name. When present, `agent/tools/write_file.ts` replaces the built-in `write_file`:
 
 ```ts title="agent/tools/write_file.ts"
 import { defineTool } from "eve/tools";

--- a/docs/concepts/built-in-tools.md
+++ b/docs/concepts/built-in-tools.md
@@ -47,6 +47,10 @@ import { bash } from "eve/tools/bash";
 export default defineTool({
   ...bash,
   description: "Run approved project maintenance commands.",
+  async execute(input, ctx) {
+    console.info("Running sandbox command", input.command);
+    return bash.execute(input, ctx);
+  },
 });
 ```
 
@@ -111,6 +115,12 @@ import { writeFile } from "eve/tools/write_file";
 export default defineTool({
   ...writeFile,
   description: "Write approved project files in the sandbox.",
+  async execute(input, ctx) {
+    if (!input.filePath.startsWith("/workspace/")) {
+      throw new Error("write_file is limited to /workspace");
+    }
+    return writeFile.execute(input, ctx);
+  },
 });
 ```
 
@@ -143,6 +153,13 @@ import { webFetch } from "eve/tools/web_fetch";
 export default defineTool({
   ...webFetch,
   description: "Fetch approved public documentation URLs.",
+  async execute(input, ctx) {
+    const hostname = new URL(input.url).hostname;
+    if (hostname !== "docs.example.com") {
+      throw new Error("web_fetch is limited to docs.example.com");
+    }
+    return webFetch.execute(input, ctx);
+  },
 });
 ```
 
@@ -274,21 +291,7 @@ eve add tool/agent
 export { default } from "eve/tools/agent";
 ```
 
-Replace its delegation behavior with an ordinary authored tool:
-
-```ts title="agent/tools/agent.ts"
-import { defineTool } from "eve/tools";
-
-export default defineTool({
-  description: "Submit work to a custom task service.",
-  inputSchema: { type: "object" },
-  async execute(input) {
-    return { submitted: input };
-  },
-});
-```
-
-Disable it:
+The framework behavior cannot be overridden. Re-export the definition above to restore it, or disable it:
 
 ```ts title="agent/tools/agent.ts"
 import { disableTool } from "eve/tools";
@@ -308,21 +311,7 @@ eve add tool/task_cancel
 export { default } from "eve/tools/task_cancel";
 ```
 
-Replace its cancellation behavior with an ordinary authored tool:
-
-```ts title="agent/tools/task_cancel.ts"
-import { defineTool } from "eve/tools";
-
-export default defineTool({
-  description: "Cancel a task in a custom task service.",
-  inputSchema: { type: "object" },
-  async execute(input) {
-    return { cancelled: input };
-  },
-});
-```
-
-Disable it:
+The framework behavior cannot be overridden. Re-export the definition above to restore it, or disable it:
 
 ```ts title="agent/tools/task_cancel.ts"
 import { disableTool } from "eve/tools";
@@ -342,21 +331,7 @@ eve add tool/task_update
 export { default } from "eve/tools/task_update";
 ```
 
-Replace its progress-reporting behavior with an ordinary authored tool:
-
-```ts title="agent/tools/task_update.ts"
-import { defineTool } from "eve/tools";
-
-export default defineTool({
-  description: "Report progress to a custom task service.",
-  inputSchema: { type: "object" },
-  async execute(input) {
-    return { updated: input };
-  },
-});
-```
-
-Disable it:
+The framework behavior cannot be overridden. Re-export the definition above to restore it, or disable it:
 
 ```ts title="agent/tools/task_update.ts"
 import { disableTool } from "eve/tools";

--- a/docs/concepts/built-in-tools.md
+++ b/docs/concepts/built-in-tools.md
@@ -34,12 +34,60 @@ This turns off the optional defaults described below. Add back only the tools th
 eve add tool/bash
 ```
 
+```ts title="agent/tools/bash.ts"
+export { default } from "eve/tools/bash";
+```
+
+Override its description, approval policy, or executor by wrapping the exported definition:
+
+```ts title="agent/tools/bash.ts"
+import { defineTool } from "eve/tools";
+import { bash } from "eve/tools/bash";
+
+export default defineTool({
+  ...bash,
+  description: "Run approved project maintenance commands.",
+});
+```
+
+Disable only `bash`:
+
+```ts title="agent/tools/bash.ts"
+import { disableTool } from "eve/tools";
+
+export default disableTool();
+```
+
 ### `read_file`
 
 `read_file` reads text files from the sandbox with line-numbered output. It accepts absolute paths and paths beginning with `$HOME/`.
 
 ```sh
 eve add tool/read_file
+```
+
+```ts title="agent/tools/read_file.ts"
+export { default } from "eve/tools/read_file";
+```
+
+Override it:
+
+```ts title="agent/tools/read_file.ts"
+import { defineTool } from "eve/tools";
+import { readFile } from "eve/tools/read_file";
+
+export default defineTool({
+  ...readFile,
+  description: "Read project files from the sandbox.",
+});
+```
+
+Disable it:
+
+```ts title="agent/tools/read_file.ts"
+import { disableTool } from "eve/tools";
+
+export default disableTool();
 ```
 
 ### `write_file`
@@ -50,12 +98,60 @@ eve add tool/read_file
 eve add tool/write_file
 ```
 
+```ts title="agent/tools/write_file.ts"
+export { default } from "eve/tools/write_file";
+```
+
+Override it:
+
+```ts title="agent/tools/write_file.ts"
+import { defineTool } from "eve/tools";
+import { writeFile } from "eve/tools/write_file";
+
+export default defineTool({
+  ...writeFile,
+  description: "Write approved project files in the sandbox.",
+});
+```
+
+Disable it:
+
+```ts title="agent/tools/write_file.ts"
+import { disableTool } from "eve/tools";
+
+export default disableTool();
+```
+
 ### `web_fetch`
 
 `web_fetch` fetches URLs from the app runtime. It follows up to ten redirects and checks every destination for SSRF safety. Non-success responses return plain text with the response body when available.
 
 ```sh
 eve add tool/web_fetch
+```
+
+```ts title="agent/tools/web_fetch.ts"
+export { default } from "eve/tools/web_fetch";
+```
+
+Override it:
+
+```ts title="agent/tools/web_fetch.ts"
+import { defineTool } from "eve/tools";
+import { webFetch } from "eve/tools/web_fetch";
+
+export default defineTool({
+  ...webFetch,
+  description: "Fetch approved public documentation URLs.",
+});
+```
+
+Disable it:
+
+```ts title="agent/tools/web_fetch.ts"
+import { disableTool } from "eve/tools";
+
+export default disableTool();
 ```
 
 ### `web_search`
@@ -66,7 +162,39 @@ eve add tool/web_fetch
 eve add tool/web_search
 ```
 
-To use Parallel with AI Gateway, export `webSearch({ provider: "parallel" })` from `agent/tools/web_search.ts`. To provide your own implementation, override the tool with `defineTool()`.
+```ts title="agent/tools/web_search.ts"
+export { default } from "eve/tools/web_search";
+```
+
+Override the provider-managed configuration for AI Gateway:
+
+```ts title="agent/tools/web_search.ts"
+import { webSearch } from "eve/tools/web_search";
+
+export default webSearch({ provider: "parallel" });
+```
+
+Replace provider-managed search with an authored implementation:
+
+```ts title="agent/tools/web_search.ts"
+import { defineTool } from "eve/tools";
+
+export default defineTool({
+  description: "Search the internal documentation index.",
+  inputSchema: { type: "object" },
+  async execute(input) {
+    return { results: [], query: input };
+  },
+});
+```
+
+Disable it:
+
+```ts title="agent/tools/web_search.ts"
+import { disableTool } from "eve/tools";
+
+export default disableTool();
+```
 
 ### `todo`
 
@@ -74,6 +202,30 @@ To use Parallel with AI Gateway, export `webSearch({ provider: "parallel" })` fr
 
 ```sh
 eve add tool/todo
+```
+
+```ts title="agent/tools/todo.ts"
+export { default } from "eve/tools/todo";
+```
+
+Override it. Spreading the definition preserves its durable state key:
+
+```ts title="agent/tools/todo.ts"
+import { defineTool } from "eve/tools";
+import { todo } from "eve/tools/todo";
+
+export default defineTool({
+  ...todo,
+  description: "Track the current implementation plan.",
+});
+```
+
+Disable it:
+
+```ts title="agent/tools/todo.ts"
+import { disableTool } from "eve/tools";
+
+export default disableTool();
 ```
 
 ### `ask_question`
@@ -84,12 +236,64 @@ eve add tool/todo
 eve add tool/ask_question
 ```
 
+```ts title="agent/tools/ask_question.ts"
+export { default } from "eve/tools/ask_question";
+```
+
+Replace its request-input behavior with an ordinary authored tool:
+
+```ts title="agent/tools/ask_question.ts"
+import { defineTool } from "eve/tools";
+
+export default defineTool({
+  description: "Record a clarification request.",
+  inputSchema: { type: "object" },
+  async execute(input) {
+    return { recorded: input };
+  },
+});
+```
+
+Disable it:
+
+```ts title="agent/tools/ask_question.ts"
+import { disableTool } from "eve/tools";
+
+export default disableTool();
+```
+
 ### `agent`
 
 `agent` delegates a subtask to a fresh copy of the root agent. It is root-only, always runs in the background, and returns a task receipt immediately. The child receives the root's instructions, tools, connections, and sandbox, but starts with fresh conversation history and [state](./state). See [Subagents](../subagents).
 
 ```sh
 eve add tool/agent
+```
+
+```ts title="agent/tools/agent.ts"
+export { default } from "eve/tools/agent";
+```
+
+Replace its delegation behavior with an ordinary authored tool:
+
+```ts title="agent/tools/agent.ts"
+import { defineTool } from "eve/tools";
+
+export default defineTool({
+  description: "Submit work to a custom task service.",
+  inputSchema: { type: "object" },
+  async execute(input) {
+    return { submitted: input };
+  },
+});
+```
+
+Disable it:
+
+```ts title="agent/tools/agent.ts"
+import { disableTool } from "eve/tools";
+
+export default disableTool();
 ```
 
 ### `task_cancel`
@@ -100,12 +304,64 @@ eve add tool/agent
 eve add tool/task_cancel
 ```
 
+```ts title="agent/tools/task_cancel.ts"
+export { default } from "eve/tools/task_cancel";
+```
+
+Replace its cancellation behavior with an ordinary authored tool:
+
+```ts title="agent/tools/task_cancel.ts"
+import { defineTool } from "eve/tools";
+
+export default defineTool({
+  description: "Cancel a task in a custom task service.",
+  inputSchema: { type: "object" },
+  async execute(input) {
+    return { cancelled: input };
+  },
+});
+```
+
+Disable it:
+
+```ts title="agent/tools/task_cancel.ts"
+import { disableTool } from "eve/tools";
+
+export default disableTool();
+```
+
 ### `task_update`
 
 `task_update` lets a background task report progress to its parent. It appears only in delegated task sessions.
 
 ```sh
 eve add tool/task_update
+```
+
+```ts title="agent/tools/task_update.ts"
+export { default } from "eve/tools/task_update";
+```
+
+Replace its progress-reporting behavior with an ordinary authored tool:
+
+```ts title="agent/tools/task_update.ts"
+import { defineTool } from "eve/tools";
+
+export default defineTool({
+  description: "Report progress to a custom task service.",
+  inputSchema: { type: "object" },
+  async execute(input) {
+    return { updated: input };
+  },
+});
+```
+
+Disable it:
+
+```ts title="agent/tools/task_update.ts"
+import { disableTool } from "eve/tools";
+
+export default disableTool();
 ```
 
 ### `load_skill`
@@ -116,9 +372,35 @@ eve add tool/task_update
 eve add tool/load_skill
 ```
 
+```ts title="agent/tools/load_skill.ts"
+export { default } from "eve/tools/load_skill";
+```
+
+Override it:
+
+```ts title="agent/tools/load_skill.ts"
+import { defineTool } from "eve/tools";
+import { loadSkill } from "eve/tools/load_skill";
+
+export default defineTool({
+  ...loadSkill,
+  description: "Load instructions for an available skill.",
+});
+```
+
+Disable it:
+
+```ts title="agent/tools/load_skill.ts"
+import { disableTool } from "eve/tools";
+
+export default disableTool();
+```
+
 ### `connection_search`
 
 `connection_search` discovers tools across declared [connections](../connections) and makes matches directly callable by qualified name, such as `linear__list_issues`. eve adds it automatically when connections exist, even when `defaultTools` is `false`, so there is no add command.
+
+An authored `agent/tools/connection_search.ts` replaces the framework behavior. Import the framework definition from `eve/tools/connection_search` when you need to reference it directly.
 
 Review these tools before production use. Disable, wrap, restrict, or require approval for any tool that can access the filesystem, network, shell, or sensitive data.
 
@@ -147,77 +429,6 @@ export { grep as default } from "eve/tools/grep";
 The filename supplies the model-facing tool name. The tools run against the agent's sandbox and use the same schemas, results, and error behavior as eve's framework implementations. Wrap either definition with `defineTool({ ...glob, description: "..." })` or `defineTool({ ...grep, description: "..." })` when you need to change its description or approval policy.
 
 The section below covers `sleep` in more detail.
-
-## Override a default
-
-Author a tool at the same slug and it takes over the built-in of that name. When present, `agent/tools/write_file.ts` replaces the built-in `write_file`:
-
-```ts title="agent/tools/write_file.ts"
-import { defineTool } from "eve/tools";
-import { writeFile } from "eve/tools/write_file";
-
-export default defineTool({
-  ...writeFile, // keep the default description, schema, and executor
-  async execute(input, ctx) {
-    console.log("[write_file]", input.path);
-    return writeFile.execute(input, ctx);
-  },
-});
-```
-
-Import each reusable definition from its own subpath:
-
-| Definition         | Import                        | Registered by default |
-| ------------------ | ----------------------------- | --------------------- |
-| `bash`             | `eve/tools/bash`              | Yes                   |
-| `readFile`         | `eve/tools/read_file`         | Yes                   |
-| `writeFile`        | `eve/tools/write_file`        | Yes                   |
-| `todo`             | `eve/tools/todo`              | Yes                   |
-| `webFetch`         | `eve/tools/web_fetch`         | Yes                   |
-| `loadSkill`        | `eve/tools/load_skill`        | Yes                   |
-| `connectionSearch` | `eve/tools/connection_search` | With connections      |
-| `agent`            | `eve/tools/agent`             | Yes                   |
-| `askQuestion`      | `eve/tools/ask_question`      | Yes                   |
-| `taskCancel`       | `eve/tools/task_cancel`       | Yes                   |
-| `taskUpdate`       | `eve/tools/task_update`       | Yes                   |
-| `glob`             | `eve/tools/glob`              | No                    |
-| `grep`             | `eve/tools/grep`              | No                    |
-
-Importing a definition does not add it to an agent; export it from the corresponding `agent/tools/*.ts` file. Skip the spread and your replacement owns its own context. A fresh `defineTool` for `todo` does not inherit the default's durable state key.
-
-Provider-managed web search has a dedicated configuration helper instead of an executable default:
-
-```ts title="agent/tools/web_search.ts"
-import { webSearch } from "eve/tools/web_search";
-
-export default webSearch({ provider: "parallel" });
-```
-
-Set `provider` to `"exa"` or `"parallel"`. Without this file, AI Gateway models use Exa.
-
-## Disable default tools
-
-Set `defaultTools: false` in `agent/agent.ts` to remove the optional defaults at once, as described in [Disable optional default tools](#disable-optional-default-tools). `connection_search` remains available when the agent has connections, and tools under `agent/tools/` remain available.
-
-To remove one default, export a `disableTool()` sentinel from a file named after the tool's slug. The filename picks the default to remove:
-
-```ts title="agent/tools/bash.ts"
-import { disableTool } from "eve/tools";
-
-export default disableTool();
-```
-
-Use `agent/tools/agent.ts` to remove the root-only `agent` delegation tool. The root session then receives no tool for delegating to a fresh copy of itself, and the model never sees that tool.
-
-If the filename matches no known framework tool, resolution fails instead of silently doing nothing, so a typo surfaces at build time rather than removing the wrong tool.
-
-## When to override, disable, or author a new tool
-
-Three moves shape the harness. The right one depends on whether the model should keep the built-in capability.
-
-- **Override** when you want the same capability with different behavior. Import its definition from the matching `eve/tools/<name>` subpath and wrap it (logging, an extra guard, or a different backend), and the model still sees a tool by that name. Spreading keeps the default's description, schema, and any framework state, such as the `todo` tool's durable state key. Drop the spread and your replacement owns its own context, losing that wiring.
-- **Disable** when the model should not have the capability at all. A `disableTool()` sentinel removes the built-in, and the model never sees it. Reach for this to lock down `bash` or `web_fetch` in an agent that should not run shell commands or fetch arbitrary URLs.
-- **Author a new tool** when you want a capability the harness does not ship. Give it a fresh slug under `agent/tools/` and it joins the built-ins instead of replacing one. See [Tools](../tools) for the authoring model.
 
 ## The opt-in `sleep` tool
 

--- a/packages/eve/extension-contracts/compatibility/subagent/v8.ts
+++ b/packages/eve/extension-contracts/compatibility/subagent/v8.ts
@@ -1,0 +1,6 @@
+import { defineAgent } from "#public/index.js";
+
+export default defineAgent({
+  description: "Delegate research tasks.",
+  model: "anthropic/claude-sonnet-5",
+});

--- a/packages/eve/extension-contracts/reports/subagent/v9.json
+++ b/packages/eve/extension-contracts/reports/subagent/v9.json
@@ -1,0 +1,20 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "subagent",
+  "epoch": 9,
+  "sha256": "92ea4eff409aec88e08c9e5fbd73dfd6159d7891717eb662d2f7ed028dca8df1",
+  "exports": [
+    "AgentCompactionDefinition",
+    "AgentDefinition",
+    "AgentModelDefinition",
+    "AgentStaticModelDefinition",
+    "DefinedAgent",
+    "DynamicLocalSubagentDefinition",
+    "DynamicSubagentDefinition",
+    "RemoteAgentDefinition",
+    "RemoteAgentDefinitionInput",
+    "defineAgent",
+    "defineDynamic",
+    "defineRemoteAgent"
+  ]
+}

--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -131,6 +131,16 @@
       "import": "./dist/src/public/tools/index.js",
       "default": "./dist/src/public/tools/index.js"
     },
+    "./tools/agent": {
+      "types": "./dist/src/public/tools/agent.d.ts",
+      "import": "./dist/src/public/tools/agent.js",
+      "default": "./dist/src/public/tools/agent.js"
+    },
+    "./tools/ask_question": {
+      "types": "./dist/src/public/tools/ask-question.d.ts",
+      "import": "./dist/src/public/tools/ask-question.js",
+      "default": "./dist/src/public/tools/ask-question.js"
+    },
     "./tools/bash": {
       "types": "./dist/src/public/tools/bash.d.ts",
       "import": "./dist/src/public/tools/bash.js",
@@ -165,6 +175,21 @@
       "types": "./dist/src/public/tools/load-skill.d.ts",
       "import": "./dist/src/public/tools/load-skill.js",
       "default": "./dist/src/public/tools/load-skill.js"
+    },
+    "./tools/connection_search": {
+      "types": "./dist/src/public/tools/connection-search.d.ts",
+      "import": "./dist/src/public/tools/connection-search.js",
+      "default": "./dist/src/public/tools/connection-search.js"
+    },
+    "./tools/task_cancel": {
+      "types": "./dist/src/public/tools/task-cancel.d.ts",
+      "import": "./dist/src/public/tools/task-cancel.js",
+      "default": "./dist/src/public/tools/task-cancel.js"
+    },
+    "./tools/task_update": {
+      "types": "./dist/src/public/tools/task-update.d.ts",
+      "import": "./dist/src/public/tools/task-update.js",
+      "default": "./dist/src/public/tools/task-update.js"
     },
     "./tools/glob": {
       "types": "./dist/src/public/tools/glob.d.ts",

--- a/packages/eve/src/compiler/default-tool-policy.ts
+++ b/packages/eve/src/compiler/default-tool-policy.ts
@@ -1,8 +1,42 @@
 import type { CompiledAgentDefinition } from "#compiler/manifest.js";
 import type { PhaseOneNodeSourceState } from "#compiler/node-source-state.js";
-import { canonicalSourceSlot, composeAgentModuleCandidates } from "#compiler/source-graph.js";
+import type { CompiledToolEntry } from "#compiler/normalize-tool.js";
+import {
+  canonicalSourceSlot,
+  composeAgentModuleCandidates,
+  type AgentSourceCandidate,
+} from "#compiler/source-graph.js";
 
 const REQUIRED_FRAMEWORK_TOOL_SLOTS = new Set(["tools/connection_search"]);
+
+export function assertFrameworkToolPolicy(
+  candidate: AgentSourceCandidate,
+  result: CompiledToolEntry,
+): void {
+  const slot = canonicalSourceSlot(candidate.logicalPath);
+  if (slot === "tools/connection_search" && result.kind === "disabled") {
+    throw new Error(
+      'The required "connection_search" tool cannot be disabled. Remove "agent/tools/connection_search.ts" or export a replacement tool from it.',
+    );
+  }
+  const closedDispatchSlots = {
+    "tools/agent": "self-agent",
+    "tools/task_cancel": "task-cancel",
+    "tools/task_update": "task-update",
+  } as const;
+  const expectedAction = closedDispatchSlots[slot as keyof typeof closedDispatchSlots];
+  if (
+    expectedAction !== undefined &&
+    result.kind === "tool" &&
+    (result.definition.behavior?.handling?.kind !== "dispatch" ||
+      result.definition.behavior.handling.action !== expectedAction)
+  ) {
+    const toolName = slot.slice("tools/".length);
+    throw new Error(
+      `The framework "${toolName}" tool cannot be overridden. Re-export it from "eve/tools/${toolName}" or disable it with disableTool().`,
+    );
+  }
+}
 
 export function applyDefaultToolPolicy(
   phaseOne: PhaseOneNodeSourceState,

--- a/packages/eve/src/compiler/default-tool-policy.ts
+++ b/packages/eve/src/compiler/default-tool-policy.ts
@@ -1,0 +1,26 @@
+import type { CompiledAgentDefinition } from "#compiler/manifest.js";
+import type { PhaseOneNodeSourceState } from "#compiler/node-source-state.js";
+import { canonicalSourceSlot, composeAgentModuleCandidates } from "#compiler/source-graph.js";
+
+export function applyDefaultToolPolicy(
+  phaseOne: PhaseOneNodeSourceState,
+  config: CompiledAgentDefinition,
+): void {
+  if (config.defaultTools !== false) return;
+
+  const overriddenSlots = new Set(
+    phaseOne.graph.orderedCandidates
+      .filter((candidate) => candidate.layer !== "framework-default")
+      .map((candidate) => canonicalSourceSlot(candidate.logicalPath)),
+  );
+  phaseOne.graph.composed = composeAgentModuleCandidates(
+    phaseOne.graph.orderedCandidates.filter((candidate) => {
+      const slot = canonicalSourceSlot(candidate.logicalPath);
+      return (
+        candidate.layer !== "framework-default" ||
+        !slot.startsWith("tools/") ||
+        overriddenSlots.has(slot)
+      );
+    }),
+  );
+}

--- a/packages/eve/src/compiler/default-tool-policy.ts
+++ b/packages/eve/src/compiler/default-tool-policy.ts
@@ -2,6 +2,8 @@ import type { CompiledAgentDefinition } from "#compiler/manifest.js";
 import type { PhaseOneNodeSourceState } from "#compiler/node-source-state.js";
 import { canonicalSourceSlot, composeAgentModuleCandidates } from "#compiler/source-graph.js";
 
+const REQUIRED_FRAMEWORK_TOOL_SLOTS = new Set(["tools/connection_search"]);
+
 export function applyDefaultToolPolicy(
   phaseOne: PhaseOneNodeSourceState,
   config: CompiledAgentDefinition,
@@ -19,6 +21,7 @@ export function applyDefaultToolPolicy(
       return (
         candidate.layer !== "framework-default" ||
         !slot.startsWith("tools/") ||
+        REQUIRED_FRAMEWORK_TOOL_SLOTS.has(slot) ||
         overriddenSlots.has(slot)
       );
     }),

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -68,8 +68,8 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     },
   },
   subagent: {
-    current: 8,
-    supported: [3, 4, 6, 7, 8],
+    current: 9,
+    supported: [3, 4, 6, 7, 8, 9],
     dropped: {
       1: "Persistent subagent sessions are now the default and the experimental opt-in was removed",
       2: "Persistent subagent sessions are now the default and the experimental opt-in was removed",

--- a/packages/eve/src/compiler/manifest.ts
+++ b/packages/eve/src/compiler/manifest.ts
@@ -606,6 +606,7 @@ const compiledWorkflowToolDefinitionSchema: z.ZodType<CompiledWorkflowToolDefini
 const compiledAgentConfigBaseFields = {
   build: compiledAgentBuildDefinitionSchema.optional(),
   compaction: compiledAgentCompactionDefinitionSchema.optional(),
+  defaultTools: z.boolean().optional(),
   description: z.string().optional(),
   experimental: z
     .object({
@@ -1202,6 +1203,7 @@ function cloneCompiledAgentDefinition(config: CompiledAgentDefinition): Compiled
           : cloneCompiledRuntimeModelReference(config.compaction.model),
       thresholdPercent: config.compaction?.thresholdPercent,
     },
+    defaultTools: config.defaultTools,
     description: config.description,
     experimental:
       config.experimental === undefined

--- a/packages/eve/src/compiler/normalize-agent-config.ts
+++ b/packages/eve/src/compiler/normalize-agent-config.ts
@@ -82,6 +82,7 @@ export async function compileAgentConfig(
       model?: CompiledRuntimeModelReference;
       thresholdPercent?: number;
     };
+    defaultTools?: boolean;
     description?: string;
     experimental?: CompiledAgentDefinition["experimental"];
     name: string;
@@ -94,6 +95,10 @@ export async function compileAgentConfig(
     name: manifest.agentId,
     source: { ...configModule },
   };
+
+  if (definition.defaultTools !== undefined) {
+    compiledConfig.defaultTools = definition.defaultTools;
+  }
 
   if (definition.description !== undefined) {
     compiledConfig.description = definition.description;

--- a/packages/eve/src/compiler/normalize-manifest.test.ts
+++ b/packages/eve/src/compiler/normalize-manifest.test.ts
@@ -115,6 +115,59 @@ describe("compileAgentManifest source graph", () => {
     expect(() => validateCompiledModuleMap(compiled, moduleMap)).not.toThrow();
   });
 
+  it("omits default tools while preserving authored tools and same-slug overrides", async () => {
+    const sourceRegistry = registry([
+      {
+        logicalPath: "agent.ts",
+        loadNamespace: async () => ({
+          default: defineAgent({
+            defaultTools: false,
+            model: "openai/gpt-5.4",
+          }),
+        }),
+      },
+      {
+        logicalPath: "tools/bash.ts",
+        loadNamespace: async () => ({
+          default: defineTool({
+            description: "Application-owned shell replacement.",
+            execute: () => ({ ok: true }),
+            inputSchema: { type: "object" },
+          }),
+        }),
+      },
+      {
+        logicalPath: "tools/weather.ts",
+        loadNamespace: async () => ({
+          default: defineTool({
+            description: "Gets weather.",
+            execute: () => ({ ok: true }),
+            inputSchema: { type: "object" },
+          }),
+        }),
+      },
+    ]);
+
+    const compiled = await compileAgentManifest(manifest(), {
+      sourceRegistries: [sourceRegistry],
+    });
+
+    expect(compiled.config.defaultTools).toBe(false);
+    expect(compiled.tools.map((tool) => tool.name).sort()).toEqual(["bash", "weather"]);
+    expect(compiled.tools.find((tool) => tool.name === "bash")?.description).toBe(
+      "Application-owned shell replacement.",
+    );
+    expect(
+      compiled.sourceComposition.entries
+        .filter(
+          (entry) =>
+            entry.source.layer === "framework-default" &&
+            entry.source.logicalPath.startsWith("tools/"),
+        )
+        .map((entry) => entry.source.logicalPath),
+    ).toEqual(["tools/bash.ts"]);
+  });
+
   it("compiles a workflow tool with programmatic executor metadata", async () => {
     const execute = async () => ({ ok: true });
     Reflect.set(execute, "workflowId", "workflow//example/tool//execute");

--- a/packages/eve/src/compiler/normalize-manifest.test.ts
+++ b/packages/eve/src/compiler/normalize-manifest.test.ts
@@ -184,6 +184,30 @@ describe("compileAgentManifest source graph", () => {
     );
   });
 
+  it.each(["agent", "task_cancel", "task_update"])(
+    "rejects overriding closed framework tool %s",
+    async (toolName) => {
+      const sourceRegistry = registry([
+        {
+          logicalPath: `tools/${toolName}.ts`,
+          loadNamespace: async () => ({
+            default: defineTool({
+              description: "Replacement tool.",
+              execute: async () => null,
+              inputSchema: {},
+            }),
+          }),
+        },
+      ]);
+
+      await expect(
+        compileAgentManifest(manifest(), { sourceRegistries: [sourceRegistry] }),
+      ).rejects.toThrow(
+        `The framework "${toolName}" tool cannot be overridden. Re-export it from "eve/tools/${toolName}" or disable it with disableTool().`,
+      );
+    },
+  );
+
   it("compiles a workflow tool with programmatic executor metadata", async () => {
     const execute = async () => ({ ok: true });
     Reflect.set(execute, "workflowId", "workflow//example/tool//execute");
@@ -261,40 +285,6 @@ describe("compileAgentManifest source graph", () => {
         handling: { kind: "provider-tool", provider: "parallel" },
       },
     });
-  });
-
-  it("keeps an authored framework-slot replacement as an ordinary executable tool", async () => {
-    const execute = vi.fn(() => ({ ordinary: true }));
-    const sourceRegistry = registry([
-      {
-        logicalPath: "tools/agent.ts",
-        loadNamespace: async () => ({
-          default: defineTool({ description: "Application agent tool.", execute, inputSchema: {} }),
-        }),
-      },
-    ]);
-    const compiled = await compileAgentManifest(manifest(), {
-      sourceRegistries: [sourceRegistry],
-    });
-    const selected = compiled.tools.find((tool) => tool.name === "agent");
-    expect(selected).toMatchObject({ hasExecute: true, logicalPath: "tools/agent.ts" });
-    expect(selected?.behavior).toEqual({
-      availability: [],
-      shape: { lifetime: "step", suspend: "none" },
-    });
-
-    const moduleMap = await createProgrammaticCompiledModuleMap(compiled, [
-      frameworkAgentSourceRegistry,
-      sourceRegistry,
-    ]);
-    const graph = await resolveRuntimeAgentGraph({ manifest: compiled, moduleMap });
-    const resolved = graph.root.toolRegistry.toolsByName.get("agent")?.definition;
-    expect(resolved?.behavior).toEqual({
-      availability: [],
-      shape: { lifetime: "step", suspend: "none" },
-    });
-    expect(await resolved?.execute?.({}, {} as never)).toEqual({ ordinary: true });
-    expect(execute).toHaveBeenCalledOnce();
   });
 
   it("loads the selected config before any non-config definition", async () => {

--- a/packages/eve/src/compiler/normalize-manifest.test.ts
+++ b/packages/eve/src/compiler/normalize-manifest.test.ts
@@ -169,6 +169,21 @@ describe("compileAgentManifest source graph", () => {
     ).toEqual(["tools/bash.ts"]);
   });
 
+  it("rejects disabling required connection search", async () => {
+    const sourceRegistry = registry([
+      {
+        logicalPath: "tools/connection_search.ts",
+        loadNamespace: async () => ({ default: disableTool() }),
+      },
+    ]);
+
+    await expect(
+      compileAgentManifest(manifest(), { sourceRegistries: [sourceRegistry] }),
+    ).rejects.toThrow(
+      'The required "connection_search" tool cannot be disabled. Remove "agent/tools/connection_search.ts" or export a replacement tool from it.',
+    );
+  });
+
   it("compiles a workflow tool with programmatic executor metadata", async () => {
     const execute = async () => ({ ok: true });
     Reflect.set(execute, "workflowId", "workflow//example/tool//execute");

--- a/packages/eve/src/compiler/normalize-manifest.test.ts
+++ b/packages/eve/src/compiler/normalize-manifest.test.ts
@@ -154,6 +154,7 @@ describe("compileAgentManifest source graph", () => {
 
     expect(compiled.config.defaultTools).toBe(false);
     expect(compiled.tools.map((tool) => tool.name).sort()).toEqual(["bash", "weather"]);
+    expect(compiled.dynamicTools.map((tool) => tool.slug)).toEqual(["connection_search"]);
     expect(compiled.tools.find((tool) => tool.name === "bash")?.description).toBe(
       "Application-owned shell replacement.",
     );

--- a/packages/eve/src/compiler/normalize-manifest.ts
+++ b/packages/eve/src/compiler/normalize-manifest.ts
@@ -606,6 +606,11 @@ class AgentGraphCompiler {
             loadNamespace,
           });
           if (result.kind === "disabled") {
+            if (canonicalSourceSlot(candidate.logicalPath) === "tools/connection_search") {
+              throw new Error(
+                'The required "connection_search" tool cannot be disabled. Remove "agent/tools/connection_search.ts" or export a replacement tool from it.',
+              );
+            }
             state.composed = disableComposedCandidate({ candidate, composed: state.composed });
             delete state.bindings[candidate.sourceId];
             selectedSourceIds.delete(candidate.sourceId);

--- a/packages/eve/src/compiler/normalize-manifest.ts
+++ b/packages/eve/src/compiler/normalize-manifest.ts
@@ -157,6 +157,29 @@ export async function compileAgentManifest(
   });
 }
 
+function applyDefaultToolPolicy(
+  phaseOne: PhaseOneNodeSourceState,
+  config: CompiledAgentDefinition,
+): void {
+  if (config.defaultTools !== false) return;
+
+  const overriddenSlots = new Set(
+    phaseOne.graph.orderedCandidates
+      .filter((candidate) => candidate.layer !== "framework-default")
+      .map((candidate) => canonicalSourceSlot(candidate.logicalPath)),
+  );
+  phaseOne.graph.composed = composeAgentModuleCandidates(
+    phaseOne.graph.orderedCandidates.filter((candidate) => {
+      const slot = canonicalSourceSlot(candidate.logicalPath);
+      return (
+        candidate.layer !== "framework-default" ||
+        !slot.startsWith("tools/") ||
+        overriddenSlots.has(slot)
+      );
+    }),
+  );
+}
+
 class AgentGraphCompiler {
   private readonly context: ManifestCompileContext;
   private readonly registries: readonly AgentSourceRegistry[];
@@ -183,6 +206,7 @@ class AgentGraphCompiler {
       source: phaseOne.selectedConfig.source,
     });
     assertRootOnlyConfig(config, input.isRoot, input.manifest.agentId);
+    applyDefaultToolPolicy(phaseOne, config);
 
     const externalDependencies = mergeExternalDependencies(
       input.inheritedExternalDependencies,
@@ -280,6 +304,7 @@ class AgentGraphCompiler {
           source: phaseOne.selectedConfig.source,
         });
         assertRootOnlyConfig(config, false, source.manifest.agentId);
+        applyDefaultToolPolicy(phaseOne, config);
       } else {
         dynamicBuildDependencies = normalized.build?.externalDependencies;
       }

--- a/packages/eve/src/compiler/normalize-manifest.ts
+++ b/packages/eve/src/compiler/normalize-manifest.ts
@@ -36,7 +36,10 @@ import { assertInstrumentationLayoutConfig } from "#compiler/instrumentation-lay
 import { compileAgentConfig } from "#compiler/normalize-agent-config.js";
 import { compileChannelDefinition } from "#compiler/normalize-channel.js";
 import { compileConnectionDefinition } from "#compiler/normalize-connection.js";
-import { applyDefaultToolPolicy } from "#compiler/default-tool-policy.js";
+import {
+  applyDefaultToolPolicy,
+  assertFrameworkToolPolicy,
+} from "#compiler/default-tool-policy.js";
 import {
   loadModuleBackedDefinition,
   type ManifestCompileContext,
@@ -605,12 +608,8 @@ class AgentGraphCompiler {
             binding: binding!,
             loadNamespace,
           });
+          assertFrameworkToolPolicy(candidate, result);
           if (result.kind === "disabled") {
-            if (canonicalSourceSlot(candidate.logicalPath) === "tools/connection_search") {
-              throw new Error(
-                'The required "connection_search" tool cannot be disabled. Remove "agent/tools/connection_search.ts" or export a replacement tool from it.',
-              );
-            }
             state.composed = disableComposedCandidate({ candidate, composed: state.composed });
             delete state.bindings[candidate.sourceId];
             selectedSourceIds.delete(candidate.sourceId);

--- a/packages/eve/src/compiler/normalize-manifest.ts
+++ b/packages/eve/src/compiler/normalize-manifest.ts
@@ -36,6 +36,7 @@ import { assertInstrumentationLayoutConfig } from "#compiler/instrumentation-lay
 import { compileAgentConfig } from "#compiler/normalize-agent-config.js";
 import { compileChannelDefinition } from "#compiler/normalize-channel.js";
 import { compileConnectionDefinition } from "#compiler/normalize-connection.js";
+import { applyDefaultToolPolicy } from "#compiler/default-tool-policy.js";
 import {
   loadModuleBackedDefinition,
   type ManifestCompileContext,
@@ -155,29 +156,6 @@ export async function compileAgentManifest(
     diagnosticsSummary,
     subagents,
   });
-}
-
-function applyDefaultToolPolicy(
-  phaseOne: PhaseOneNodeSourceState,
-  config: CompiledAgentDefinition,
-): void {
-  if (config.defaultTools !== false) return;
-
-  const overriddenSlots = new Set(
-    phaseOne.graph.orderedCandidates
-      .filter((candidate) => candidate.layer !== "framework-default")
-      .map((candidate) => canonicalSourceSlot(candidate.logicalPath)),
-  );
-  phaseOne.graph.composed = composeAgentModuleCandidates(
-    phaseOne.graph.orderedCandidates.filter((candidate) => {
-      const slot = canonicalSourceSlot(candidate.logicalPath);
-      return (
-        candidate.layer !== "framework-default" ||
-        !slot.startsWith("tools/") ||
-        overriddenSlots.has(slot)
-      );
-    }),
-  );
 }
 
 class AgentGraphCompiler {

--- a/packages/eve/src/framework/sources/registry.ts
+++ b/packages/eve/src/framework/sources/registry.ts
@@ -9,7 +9,7 @@ import {
   type ProgrammaticModuleNamespace,
 } from "#compiler/source-graph.js";
 
-const revision = `eve@${resolveInstalledPackageInfo().version}:compiled-manifest-v46`;
+const revision = `eve@${resolveInstalledPackageInfo().version}:compiled-manifest-v47`;
 
 const localDefaults = defineProgrammaticAgentSource({
   id: "eve:defaults",

--- a/packages/eve/src/internal/authored-definition/core.ts
+++ b/packages/eve/src/internal/authored-definition/core.ts
@@ -6,6 +6,7 @@ import type {
 import type { ScheduleDefinition, ScheduleRunHandler } from "#public/definitions/schedule.js";
 import type { SkillDefinition, SkillFileContent } from "#public/definitions/skill.js";
 import {
+  expectBoolean,
   expectFunction,
   expectObjectRecord,
   expectOnlyKnownKeys,
@@ -48,6 +49,7 @@ export function normalizeAgentDefinition(
     [
       "build",
       "compaction",
+      "defaultTools",
       "description",
       "experimental",
       "limits",
@@ -78,6 +80,10 @@ export function normalizeAgentDefinition(
 
   if (record.description !== undefined) {
     definition.description = expectString(record.description, message);
+  }
+
+  if (record.defaultTools !== undefined) {
+    definition.defaultTools = expectBoolean(record.defaultTools, message);
   }
 
   if (record.compaction !== undefined) {

--- a/packages/eve/src/public/tools/agent.ts
+++ b/packages/eve/src/public/tools/agent.ts
@@ -1,0 +1,1 @@
+export { agent, agent as default } from "#tools/framework/agent.js";

--- a/packages/eve/src/public/tools/ask-question.ts
+++ b/packages/eve/src/public/tools/ask-question.ts
@@ -1,0 +1,1 @@
+export { askQuestion, askQuestion as default } from "#tools/framework/ask-question.js";

--- a/packages/eve/src/public/tools/connection-search.ts
+++ b/packages/eve/src/public/tools/connection-search.ts
@@ -1,0 +1,4 @@
+export {
+  connectionSearch,
+  connectionSearch as default,
+} from "#tools/framework/connection-search.js";

--- a/packages/eve/src/public/tools/task-cancel.ts
+++ b/packages/eve/src/public/tools/task-cancel.ts
@@ -1,0 +1,1 @@
+export { taskCancel, taskCancel as default } from "#tools/framework/task-cancel.js";

--- a/packages/eve/src/public/tools/task-update.ts
+++ b/packages/eve/src/public/tools/task-update.ts
@@ -1,0 +1,1 @@
+export { taskUpdate, taskUpdate as default } from "#tools/framework/task-update.js";

--- a/packages/eve/src/runtime/resolve-agent.ts
+++ b/packages/eve/src/runtime/resolve-agent.ts
@@ -188,6 +188,7 @@ function createResolvedAgentConfig(
 ): NonNullable<ResolvedAgent["config"]> {
   const config: {
     compaction?: NonNullable<ResolvedAgent["config"]>["compaction"];
+    defaultTools?: boolean;
     experimental?: NonNullable<ResolvedAgent["config"]>["experimental"];
     name: string;
     outputSchema?: NonNullable<ResolvedAgent["config"]>["outputSchema"];
@@ -197,6 +198,10 @@ function createResolvedAgentConfig(
   } = {
     name: manifest.config.name,
   };
+
+  if (manifest.config.defaultTools !== undefined) {
+    config.defaultTools = manifest.config.defaultTools;
+  }
 
   if (manifest.config.compaction !== undefined) {
     const compaction: {

--- a/packages/eve/src/runtime/subagents/dynamic-agent-config.ts
+++ b/packages/eve/src/runtime/subagents/dynamic-agent-config.ts
@@ -40,6 +40,9 @@ export async function normalizeDynamicSubagentAgentConfig(input: {
   if (definition.build !== undefined) {
     throw new Error(`${message} The "build" field cannot be selected at runtime.`);
   }
+  if (definition.defaultTools !== undefined) {
+    throw new Error(`${message} The "defaultTools" field cannot be selected at runtime.`);
+  }
   if (definition.experimental !== undefined) {
     throw new Error(`${message} The "experimental" field cannot be selected at runtime.`);
   }

--- a/packages/eve/src/shared/agent-definition.ts
+++ b/packages/eve/src/shared/agent-definition.ts
@@ -275,6 +275,7 @@ export type InternalAgentDefinition = {
   description?: string;
   build?: AgentBuildDefinition;
   compaction?: InternalAgentCompactionDefinition;
+  defaultTools?: boolean;
   experimental?: AgentExperimentalDefinition;
   model: InternalAgentModelDefinition;
   outputSchema?: JsonObject;
@@ -299,6 +300,11 @@ type PublicAgentDefinitionBase = {
   readonly description?: string;
   readonly build?: AgentBuildDefinition;
   readonly compaction?: PublicAgentCompactionDefinition;
+  /**
+   * Whether eve automatically adds its default tools. Defaults to `true`.
+   * Tools authored under `agent/tools/` remain available when this is `false`.
+   */
+  readonly defaultTools?: boolean;
   /**
    * Experimental, opt-in capabilities. Unstable, see
    * {@link AgentExperimentalDefinition}.

--- a/packages/eve/src/shared/agent-definition.ts
+++ b/packages/eve/src/shared/agent-definition.ts
@@ -301,8 +301,9 @@ type PublicAgentDefinitionBase = {
   readonly build?: AgentBuildDefinition;
   readonly compaction?: PublicAgentCompactionDefinition;
   /**
-   * Whether eve automatically adds its default tools. Defaults to `true`.
-   * Tools authored under `agent/tools/` remain available when this is `false`.
+   * Whether eve automatically adds its optional default tools. Defaults to `true`.
+   * Required connection tooling and tools authored under `agent/tools/` remain
+   * available when this is `false`.
    */
   readonly defaultTools?: boolean;
   /**

--- a/packages/eve/test/scenarios/mounted-extension-installed.scenario.test.ts
+++ b/packages/eve/test/scenarios/mounted-extension-installed.scenario.test.ts
@@ -249,7 +249,7 @@ describe("mounted extension installed under node_modules", () => {
     );
     expect(
       JSON.parse(extensionFiles[`node_modules/${PACKAGE_NAME}/dist/extension/_manifest.json`]!),
-    ).toMatchObject({ requires: { channel: 17, schedule: 9, subagent: 8 } });
+    ).toMatchObject({ requires: { channel: 17, schedule: 9, subagent: 9 } });
     const app = await scenarioApp({
       name: "mounted-extension-installed",
       installDependencies: true,


### PR DESCRIPTION
### Summary

Related to #1309. Agents currently need one `disableTool()` file per unwanted built-in; `defineAgent` now accepts `defaultTools: false` to skip optional default tools. Required `connection_search` remains available when connections exist, and tools explicitly authored under `agent/tools/` still win. Every framework tool has a public `eve/tools/*` re-export, and every optional default has a matching `eve add tool/*` registry item; `connection_search` stays automatic.

### Validation

Focused compiler and structural coverage passes all 27 tests, including regression coverage for removing optional defaults, preserving connection discovery, rejecting attempts to disable it, and closing framework-owned dispatch slots. The installed-extension scenario and eve package typecheck pass. Registry build and validation, extension compatibility checks, invariant guards, docs validation, formatting, and linting also pass.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 3 files · `+422 / -68`

Reworks the built-in tools reference into one self-contained section per tool, colocating behavior, availability, add/restore code, override guidance, and disable code. It also records release and generated contract metadata.

**Implementation** — 31 files · `+332 / -3`

Carries the option through agent normalization and source composition, exposes framework definitions through public subpaths, and adds one registry item per framework tool. Most lines are declarative registry metadata; each generated tool file is a one-line re-export.

**Tests** — 3 files · `+100 / -35`

Covers the effective tool set, retains a representative fixture for the previous subagent authoring contract, and updates the installed-extension scenario for the new epoch.
