### PR TITLE
fix: detect eve dev-server readiness url

### DIFF
--- a/.changeset/sveltekit-dev-server-ready-line.md
+++ b/.changeset/sveltekit-dev-server-ready-line.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+The SvelteKit plugin now proxies `/eve/v1/**` to the URL on eve's `server listening at ...` line. Before, it took the first URL in the dev server's output, so a documentation link in a dependency warning could become the proxy target and serve 404s.

--- a/packages/eve/src/public/sveltekit/dev-server.test.ts
+++ b/packages/eve/src/public/sveltekit/dev-server.test.ts
@@ -1,6 +1,46 @@
 import { describe, expect, it } from "vitest";
 
-import { normalizeDevServerRegistry } from "./dev-server.js";
+import { extractEveDevServerOrigin, normalizeDevServerRegistry } from "./dev-server.js";
+
+describe("extractEveDevServerOrigin", () => {
+  it("returns undefined when the chunk has no readiness line", () => {
+    expect(
+      extractEveDevServerOrigin("resolving rolldown... https://rolldown.rs/guide"),
+    ).toBeUndefined();
+  });
+
+  it("returns the origin from the readiness line", () => {
+    expect(extractEveDevServerOrigin("[DEV] server listening at http://127.0.0.1:50036/\n")).toBe(
+      "http://127.0.0.1:50036",
+    );
+  });
+
+  it("does not depend on the CLI tag", () => {
+    expect(extractEveDevServerOrigin("server listening at http://127.0.0.1:50036/\n")).toBe(
+      "http://127.0.0.1:50036",
+    );
+  });
+
+  it("ignores unrelated URLs that appear before the readiness line", () => {
+    expect(
+      extractEveDevServerOrigin(
+        "warn: https://rolldown.rs/guide\n[DEV] server listening at http://127.0.0.1:50036/\n",
+      ),
+    ).toBe("http://127.0.0.1:50036");
+  });
+
+  it("accepts a chunk that ends at the URL without a trailing newline", () => {
+    expect(extractEveDevServerOrigin("[DEV] server listening at http://127.0.0.1:50036")).toBe(
+      "http://127.0.0.1:50036",
+    );
+  });
+
+  it("accepts an IPv6 loopback origin", () => {
+    expect(extractEveDevServerOrigin("[DEV] server listening at http://[::1]:50036/")).toBe(
+      "http://[::1]:50036",
+    );
+  });
+});
 
 describe("normalizeDevServerRegistry", () => {
   it("normalizes a well-formed record and canonicalizes the origin", () => {

--- a/packages/eve/src/public/sveltekit/dev-server.ts
+++ b/packages/eve/src/public/sveltekit/dev-server.ts
@@ -17,7 +17,7 @@ const DEV_SERVER_STALE_LOCK_MS = 30_000;
 const EVE_CACHE_DIRECTORY_NAME = ".eve";
 const EVE_SVELTEKIT_DEV_SERVER_FILE_NAME = "sveltekit-dev-server.json";
 const EVE_SVELTEKIT_DEV_SERVER_LOCK_FILE_NAME = "sveltekit-dev-server.lock";
-const LOCAL_SERVER_URL_PATTERN = /https?:\/\/(?:\[[^\]\s]+\]|[^\s/:[\]]+)(?::\d+)?/;
+const EVE_DEV_SERVER_READY_PATTERN = /server listening at (https?:\/\/[^\s]+)/;
 
 export interface EveProcessHandle {
   readonly origin: string;
@@ -162,6 +162,12 @@ function createEveBinaryPath(): string {
   return join(resolvePackageRoot(), "bin", "eve.js");
 }
 
+export function extractEveDevServerOrigin(chunk: string): string | undefined {
+  const url = EVE_DEV_SERVER_READY_PATTERN.exec(chunk)?.[1];
+  if (url === undefined) return undefined;
+  return normalizeOrigin(url);
+}
+
 function startServerProcess(input: {
   readonly args: readonly string[];
   readonly command: string;
@@ -203,11 +209,11 @@ function startServerProcess(input: {
     let resolved = false;
     const handleOutput = (chunk: Buffer) => {
       if (resolved) return;
-      const match = LOCAL_SERVER_URL_PATTERN.exec(chunk.toString("utf8"));
-      if (match === null) return;
+      const origin = extractEveDevServerOrigin(chunk.toString("utf8"));
+      if (origin === undefined) return;
       resolved = true;
       cleanup();
-      resolvePromise({ origin: normalizeOrigin(match[0]), process: child });
+      resolvePromise({ origin, process: child });
     };
 
     child.once("error", handleError);


### PR DESCRIPTION
### Summary

was having issues with other urls appearing in dev server startup being caught
via the regex check and then proxying requests there that should be going to the eve agent.

### Example

```bash
$ vite dev
✓ Compiled workflows in 429ms (32 steps, 3 workflows)
☰eve  v0.49.0
node_modules/@vercel/otel/dist/node/index.js (23:28893) [EVAL] Use of direct `eval` function is strongly discouraged as it poses security risks and may cause issues with minification.
 - Use of direct `eval` here. in node_modules/@vercel/otel/dist/node/index.js at 254579..254583
  │
  │ Help: Consider using indirect eval. For more information, check the documentation: https://rolldown.rs/guide/troubleshooting#avoiding-direct-eval


  VITE v8.2.2  ready in 2621 ms

  ➜  Local:   http://localhost:5173/
  ➜  Network: use --host to expose
  ➜  press h + enter to show help
```

this would fail and write the following to `sveltekit-dev-server.json` file:

```json
{
  "appRoot": "example/dir",
  "origin": "https://rolldown.rs",
  "pid": 12345,
  "updatedAt": "2026-09-04T00:00:00.000Z"
}
```

another signal is the fact that the application dev server which is proxying to the agent starts up after this, signaling that it "found" the URL in the startup and doesn't need to wait any more. The actual eve dev startup happens some time a little later with the URL we actually need to await.

```bash
[DEV] server listening at http://127.0.0.1:50036/
```

### Validation

- confirmed that this was the case by writing RED tests for general `https://` urls against the dev server startup
- wrote a more robust regex check which is rooted against the `/server listening at/` substring from the eve cli
- confirmed this worked through GREEN tests

### Checklist

- [ ] This change was requested or approved by a maintainer
- [X] I ran the relevant checks from `CONTRIBUTING.md`
- [X] I added tests and documentation where relevant
- [X] I added a changeset if this touches the published `eve` package
- [ ] DCO sign-off passes for every commit (`git commit --signoff`)
