### PR TITLE
fix(eve): truncate compaction payloads on UTF-16 code-point boundaries

### DIFF
--- a/packages/eve/src/harness/compaction-prompt.test.ts
+++ b/packages/eve/src/harness/compaction-prompt.test.ts
@@ -1,7 +1,12 @@
 import type { ModelMessage } from "ai";
 import { describe, expect, it } from "vitest";
 
-import { COMPACTION_PROMPT_ENVELOPE, createCompactionPrompt } from "#harness/compaction-prompt.js";
+import {
+  COMPACTION_PROMPT_ENVELOPE,
+  createCompactionPrompt,
+  sliceUtf16Safe,
+  TRANSCRIPT_PAYLOAD_LIMIT,
+} from "#harness/compaction-prompt.js";
 
 describe("createCompactionPrompt", () => {
   it("preserves the previous checkpoint without applying transcript truncation", () => {
@@ -180,5 +185,39 @@ describe("createCompactionPrompt", () => {
 
     expect(result.prompt).not.toContain("OLDEST_TAIL_MARKER");
     expect(result.prompt).toContain("NEWEST_TAIL_MARKER");
+  });
+
+  it("does not split a UTF-16 surrogate pair when capping degraded conversational text", () => {
+    // 📥 is U+1F4E5 — two UTF-16 units. Place its high surrogate exactly at
+    // the degraded-text limit boundary (index 1999 of the 2000-unit cap).
+    const content = "x".repeat(1999) + "📥" + " tail ".repeat(400);
+    const { prompt } = createCompactionPrompt({
+      messages: [{ role: "user", content }],
+      previousCheckpoint: undefined,
+      transcriptBudgetTokens: 100,
+    });
+
+    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(prompt)).toBe(false);
+    expect(prompt).toBe(prompt.toWellFormed());
+    expect(() => JSON.stringify({ prompt })).not.toThrow();
+  });
+});
+
+describe("sliceUtf16Safe", () => {
+  it("steps back when the cut falls on a high surrogate", () => {
+    const value = "x".repeat(1999) + "📥" + "y";
+    expect(value.charCodeAt(1999)).toBe(0xd83d);
+    expect(value.charCodeAt(2000)).toBe(0xdce5);
+
+    const sliced = sliceUtf16Safe(value, TRANSCRIPT_PAYLOAD_LIMIT);
+    expect(sliced).toBe("x".repeat(1999));
+    expect(sliced).toBe(sliced.toWellFormed());
+  });
+
+  it("keeps a complete astral character that fits inside the limit", () => {
+    const value = "x".repeat(1998) + "📥" + "yyyy";
+    const sliced = sliceUtf16Safe(value, TRANSCRIPT_PAYLOAD_LIMIT);
+    expect(sliced).toBe("x".repeat(1998) + "📥");
+    expect(sliced).toBe(sliced.toWellFormed());
   });
 });

--- a/packages/eve/src/harness/compaction-prompt.ts
+++ b/packages/eve/src/harness/compaction-prompt.ts
@@ -313,11 +313,32 @@ function renderConversationText(value: string, limit?: number): string {
   return limit === undefined ? value.trim() : capText(value, limit);
 }
 
+/**
+ * Prefix of `value` with at most `limit` UTF-16 code units that never ends on
+ * a high surrogate. Raw `.slice(0, limit)` can split an astral character
+ * (emoji, etc.); JSON then serializes a lone `\ud800`-range escape and
+ * providers reject the body.
+ */
+export function sliceUtf16Safe(value: string, limit: number): string {
+  if (limit <= 0) {
+    return "";
+  }
+  if (value.length <= limit) {
+    return value;
+  }
+  let end = limit;
+  const last = value.charCodeAt(end - 1);
+  if (last >= 0xd800 && last <= 0xdbff) {
+    end -= 1;
+  }
+  return value.slice(0, end);
+}
+
 function capText(value: string, limit: number): string {
   const normalized = value.replace(/\s+/g, " ").trim();
   if (normalized.length <= limit) {
     return normalized;
   }
 
-  return `${normalized.slice(0, limit).trimEnd()}…`;
+  return `${sliceUtf16Safe(normalized, limit).trimEnd()}…`;
 }

--- a/packages/eve/src/harness/compaction.test.ts
+++ b/packages/eve/src/harness/compaction.test.ts
@@ -397,6 +397,42 @@ describe("compactMessages: tool-result cap heuristic", () => {
     expect(shouldCompact(result, { recentWindowSize: 1, threshold: ROOMY })).toBe(false);
   });
 
+  it("does not split a UTF-16 surrogate pair when capping tool results", async () => {
+    // JSON.stringify of this output places 📥's high surrogate at index 1999
+    // of the 2000-unit TRANSCRIPT_PAYLOAD_LIMIT cut.
+    const content = `${"x".repeat(1964)}📥${"y".repeat(500)}`;
+    const call: ModelMessage = {
+      content: [{ input: {}, toolCallId: "call-0", toolName: "grep", type: "tool-call" }],
+      role: "assistant",
+    };
+    const resultMsg: ModelMessage = {
+      content: [
+        {
+          output: { type: "json", value: { content } },
+          toolCallId: "call-0",
+          toolName: "grep",
+          type: "tool-result",
+        },
+      ],
+      role: "tool",
+    };
+    const messages = [user("investigate"), call, resultMsg, user("what did you find?")];
+
+    const { result, summarizer } = await compact(messages, { recentWindowSize: 1 });
+
+    expect(summarizer).not.toHaveBeenCalled();
+    const cappedPart = Array.isArray(result[2]?.content) ? result[2].content[0] : undefined;
+    const output = cappedPart?.type === "tool-result" ? cappedPart.output : undefined;
+    const value =
+      typeof output === "object" && output !== null && "value" in output
+        ? String(output.value)
+        : "";
+    expect(value).toContain("Truncated by eve");
+    expect(value).toBe(value.toWellFormed());
+    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(value)).toBe(false);
+    expect(() => JSON.stringify({ value })).not.toThrow();
+  });
+
   it("stubs content-output file parts instead of truncating into their payloads", async () => {
     const base64 = "iVBORw0KGgo".repeat(500);
     const messages: ModelMessage[] = [

--- a/packages/eve/src/harness/compaction.ts
+++ b/packages/eve/src/harness/compaction.ts
@@ -5,6 +5,7 @@ import {
   COMPACTION_PROMPT_ENVELOPE,
   COMPACTION_RESUMPTION_MESSAGE,
   createCompactionPrompt,
+  sliceUtf16Safe,
   stubContentOutputFileParts,
   TODO_COMPACTION_PRESERVATION_LABEL,
   TRANSCRIPT_PAYLOAD_LIMIT,
@@ -289,7 +290,7 @@ function capToolResults(messages: readonly ModelMessage[]): ModelMessage[] {
         ...part,
         output: {
           type: "text" as const,
-          value: `${CAPPED_RESULT_ANNOTATION}\n\n${serialized.slice(0, TRANSCRIPT_PAYLOAD_LIMIT)}`,
+          value: `${CAPPED_RESULT_ANNOTATION}\n\n${sliceUtf16Safe(serialized, TRANSCRIPT_PAYLOAD_LIMIT)}`,
         },
       };
     });


### PR DESCRIPTION
## Summary
- Compaction truncated tool/transcript payloads with `String.slice(0, 2000)`, which can split a UTF-16 surrogate pair when an astral character (emoji) lands on the cut.
- That left a lone high surrogate; `JSON.stringify` then emitted an invalid `\ud800`-range escape, providers returned 400, and the turn died after retries.
- Introduce `sliceUtf16Safe` and use it in `capText` / `capToolResults` so the cap never ends on a high surrogate.

## Test plan
- [x] Unit: `sliceUtf16Safe` steps back on a high-surrogate boundary and keeps a complete emoji that fits
- [x] Unit: degraded conversational text under budget pressure stays well-formed when 📥 straddles the 2000-unit cap
- [x] Unit: `capToolResults` oversized tool JSON with emoji on the 2000 boundary stays `toWellFormed()` and has no lone surrogates
- [x] `vitest` compaction-prompt + compaction unit suites (39 tests) pass

Closes #3062