### PR TITLE
fix(eve): file memory - provision Blob with OIDC

### DIFF
--- a/.changeset/fix-file-memory-blob-oidc.md
+++ b/.changeset/fix-file-memory-blob-oidc.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix file-memory setup to connect private Vercel Blob storage with `EVE_MEMORY_BLOB_*` variables and OIDC authentication without provisioning a read-write token. Prefer OIDC for attached stores and let the Blob SDK resolve and refresh tokens instead of caching them in the memory backend.

--- a/docs/memory/file.md
+++ b/docs/memory/file.md
@@ -18,9 +18,10 @@ eve add memory/file
 
 After you choose **Install and set up**, eve creates or reuses one private
 Vercel Blob store for the linked project, connects it to production, preview,
-and development with `EVE_MEMORY_`-prefixed variables, and pulls the updated
-environment. It uses the project's first configured function region, falling
-back to `iad1`. Blob usage may incur charges.
+and development using OIDC, and pulls the updated environment. The connection
+sets `EVE_MEMORY_BLOB_STORE_ID` and `EVE_MEMORY_BLOB_WEBHOOK_PUBLIC_KEY`
+without adding a read-write token. It uses the project's first configured
+function region, falling back to `iad1`. Blob usage may incur charges.
 
 The registry writes:
 
@@ -96,13 +97,21 @@ provider: fileMemory({ backend: inMemory() });
 ### Vercel Blob
 
 Provisioned bindings use the `EVE_MEMORY_BLOB_*` namespace so file memory does
-not take over an application's own Blob store. `fileMemory()` checks Vercel
-credentials in this order:
+not take over an application's own Blob store. Vercel supplies the OIDC token;
+the Blob SDK resolves the current token for each operation and handles refresh.
+File-memory reads and writes need the store ID. The webhook public key is for upload callbacks
+and is not used by file memory.
 
-1. `EVE_MEMORY_BLOB_READ_WRITE_TOKEN`
-2. `EVE_MEMORY_BLOB_STORE_ID` with Vercel OIDC from the environment or request context
-3. `BLOB_READ_WRITE_TOKEN`
-4. `BLOB_STORE_ID` with Vercel OIDC from the environment or request context
+`fileMemory()` checks Vercel configuration in this order:
+
+1. `EVE_MEMORY_BLOB_STORE_ID` with Vercel OIDC from the environment or request context
+2. `EVE_MEMORY_BLOB_READ_WRITE_TOKEN`
+3. `BLOB_STORE_ID` with Vercel OIDC from the environment or request context
+4. `BLOB_READ_WRITE_TOKEN`
+
+Prefer OIDC on Vercel. You do not need to set a read-write token or copy
+`VERCEL_OIDC_TOKEN` into your configuration. Redeploy after connecting the
+store: changes to project environment variables apply to new deployments.
 
 Generic `BLOB_*` variables remain supported for a store you attach manually.
 Run setup again without reinstalling the memory definition when a previous
@@ -113,8 +122,11 @@ eve integration setup file-memory
 ```
 
 Setup repairs the deterministic unconnected private store left by a partial
-run and reuses a complete `EVE_MEMORY_` connection. It does not adopt an
-arbitrary application store, change a `BLOB_*` connection, or replace a public
+run and reuses a complete `EVE_MEMORY_BLOB` connection. If an earlier setup
+created an `EVE_MEMORY_` connection, reconnect that same store with the
+`EVE_MEMORY_BLOB` prefix and OIDC in Vercel, then redeploy. Keep the existing
+store to preserve its memory documents. Setup does not adopt an arbitrary
+application store, change a `BLOB_*` connection, or replace a public
 or incompatible store. If the linked project later moves to another primary
 region, setup preserves the existing memory store and warns about the drift
 instead of risking data loss.
@@ -134,7 +146,8 @@ provider: fileMemory({
 `vercelBlob()` accepts `token`, `oidcToken`, `storeId`, and `prefix`. The
 default prefix is `eve/memory/file`; documents are stored privately under
 `<prefix>/<scope key>/MEMORY.md`. Passing these options continues to override
-the generic environment defaults directly.
+the generic environment defaults directly. Leave `oidcToken` unset on Vercel
+so the Blob SDK can manage token refresh.
 
 ### Custom backend
 

--- a/packages/eve/src/public/memory/file/backends/default.test.ts
+++ b/packages/eve/src/public/memory/file/backends/default.test.ts
@@ -57,7 +57,7 @@ describe("default file-memory backend", () => {
       "eve/memory/file/mem_a/MEMORY.md",
       expect.objectContaining({
         access: "private",
-        oidcToken: "oidc_test",
+        oidcToken: undefined,
         storeId: "store_test",
         useCache: false,
       }),
@@ -125,7 +125,7 @@ describe("default file-memory backend", () => {
     await expect(backend.read({ key: "mem_a", signal })).resolves.toBeNull();
     expect(get).toHaveBeenCalledWith(
       "eve/memory/file/mem_a/MEMORY.md",
-      expect.objectContaining({ oidcToken: "oidc_test", storeId: "store_eve_memory" }),
+      expect.objectContaining({ oidcToken: undefined, storeId: "store_eve_memory" }),
     );
   });
 
@@ -145,6 +145,42 @@ describe("default file-memory backend", () => {
       expect.objectContaining({ storeId: "store_eve_memory" }),
     );
   });
+
+  it.each(["EVE_MEMORY_BLOB", "BLOB"])(
+    "prefers %s store identity over static tokens without capturing OIDC credentials",
+    async (prefix) => {
+      vi.stubEnv("VERCEL", "1");
+      vi.stubEnv("EVE_DEV", undefined);
+      vi.stubEnv(`${prefix}_STORE_ID`, "store_memory");
+      vi.stubEnv(`${prefix}_READ_WRITE_TOKEN`, "static-token");
+      vi.stubEnv("BLOB_READ_WRITE_TOKEN", "application-token");
+      vi.stubEnv("VERCEL_OIDC_TOKEN", "first-oidc-token");
+      vi.mocked(get).mockResolvedValue(null);
+      vi.mocked(put).mockResolvedValue({
+        contentDisposition: 'attachment; filename="MEMORY.md"',
+        contentType: "text/markdown; charset=utf-8",
+        downloadUrl: "https://example.private.blob.vercel-storage.com/MEMORY.md?download=1",
+        etag: "etag-next",
+        pathname: "eve/memory/file/mem_a/MEMORY.md",
+        url: "https://example.private.blob.vercel-storage.com/MEMORY.md",
+      });
+
+      const backend = defaultFileMemoryBackend();
+      await expect(backend.read({ key: "mem_a", signal })).resolves.toBeNull();
+      vi.stubEnv("VERCEL_OIDC_TOKEN", "rotated-oidc-token");
+      await expect(
+        backend.write({ content: "memory", expectedVersion: null, key: "mem_a", signal }),
+      ).resolves.toEqual({ content: "memory", version: "etag-next" });
+
+      const credentials = expect.objectContaining({
+        oidcToken: undefined,
+        storeId: "store_memory",
+        token: undefined,
+      });
+      expect(get).toHaveBeenCalledWith("eve/memory/file/mem_a/MEMORY.md", credentials);
+      expect(put).toHaveBeenCalledWith("eve/memory/file/mem_a/MEMORY.md", "memory", credentials);
+    },
+  );
 
   it("uses Vercel Blob with an attached store and request-scoped OIDC", async () => {
     vi.stubEnv("VERCEL", "1");
@@ -185,7 +221,7 @@ describe("default file-memory backend", () => {
     const backend = defaultFileMemoryBackend();
 
     await expect(async () => await backend.read({ key: "mem_a", signal })).rejects.toThrow(
-      "eve integration setup file-memory",
+      /EVE_MEMORY_BLOB_STORE_ID.*eve integration setup file-memory.*redeploy/u,
     );
     expect(get).not.toHaveBeenCalled();
     expect(put).not.toHaveBeenCalled();

--- a/packages/eve/src/public/memory/file/backends/default.ts
+++ b/packages/eve/src/public/memory/file/backends/default.ts
@@ -5,7 +5,6 @@ import { lazyBackend } from "#public/memory/file/backends/lazy.js";
 import { vercelBlob } from "#public/memory/file/backends/vercel-blob.js";
 
 interface VercelBlobCredentials {
-  readonly oidcToken?: string;
   readonly storeId?: string;
   readonly token?: string;
 }
@@ -41,7 +40,7 @@ function selectDefaultFileMemoryBackend(
     const credentials = probes.vercelBlobCredentials();
     if (credentials !== undefined) return vercelBlob(credentials);
     throw new Error(
-      "fileMemory() requires Vercel Blob storage. Run `/add memory/file` in eve dev or `eve integration setup file-memory`, or pass fileMemory({ backend }).",
+      "fileMemory() requires Vercel Blob storage. Set up EVE_MEMORY_BLOB_STORE_ID with `/add memory/file` in eve dev or `eve integration setup file-memory`, then redeploy. Alternatively, pass fileMemory({ backend }).",
     );
   }
   if (probes.isEveDevelopment()) return DEVELOPMENT_BACKEND;
@@ -57,14 +56,12 @@ function hasEnvironmentValue(name: string): boolean {
 function credentialsFromEnvironment(
   prefix: "BLOB" | "EVE_MEMORY_BLOB",
 ): VercelBlobCredentials | undefined {
-  const token = environmentValue(`${prefix}_READ_WRITE_TOKEN`);
-  if (token !== undefined) return { token };
-
   const storeId = environmentValue(`${prefix}_STORE_ID`);
-  if (storeId === undefined) return undefined;
+  // Let the Blob SDK resolve and refresh the current environment or request-scoped OIDC token.
+  if (storeId !== undefined) return { storeId };
 
-  // The OIDC token may be request-scoped on Vercel; the store ID is the stable attachment signal.
-  return { oidcToken: environmentValue("VERCEL_OIDC_TOKEN"), storeId };
+  const token = environmentValue(`${prefix}_READ_WRITE_TOKEN`);
+  return token === undefined ? undefined : { token };
 }
 
 function environmentValue(name: string): string | undefined {

--- a/packages/eve/src/setup/integrations/file-memory/vercel-client.test.ts
+++ b/packages/eve/src/setup/integrations/file-memory/vercel-client.test.ts
@@ -24,7 +24,7 @@ beforeEach(() => {
 });
 
 describe("file-memory Vercel CLI client", () => {
-  it("uses authenticated API reads and a Vercel 57-compatible resource connection command", async () => {
+  it("connects the private store with namespaced OIDC configuration and no read-write token", async () => {
     captureVercel
       .mockResolvedValueOnce({
         ok: true,
@@ -57,7 +57,7 @@ describe("file-memory Vercel CLI client", () => {
         }),
       })
       .mockResolvedValueOnce({ ok: true, stdout: JSON.stringify({ store }) })
-      .mockResolvedValueOnce({ ok: true, stdout: "{}" })
+      .mockResolvedValueOnce({ ok: true, stdout: "" })
       .mockResolvedValueOnce({ ok: true, stdout: "" });
 
     const client = createFileMemoryVercelClient({ appRoot: "/project", project });
@@ -72,7 +72,7 @@ describe("file-memory Vercel CLI client", () => {
       environments: FILE_MEMORY_BLOB_ENVIRONMENTS,
       prefix: FILE_MEMORY_BLOB_PREFIX,
       projectId: project.projectId,
-      storeName: store.name,
+      storeId: store.id,
     });
     await client.pullEnvironment();
 
@@ -101,23 +101,26 @@ describe("file-memory Vercel CLI client", () => {
     expect(captureVercel).toHaveBeenNthCalledWith(
       6,
       [
-        "integration-resource",
-        "connect",
-        store.name,
-        project.projectId,
-        "--prefix",
-        FILE_MEMORY_BLOB_PREFIX,
-        "--environment",
-        "production",
-        "--environment",
-        "preview",
-        "--environment",
-        "development",
-        "--yes",
+        "api",
+        "/v1/storage/stores/store_memory/connections",
+        "-X",
+        "POST",
+        "--header",
+        "x-vercel-use-oidc: 1",
+        "--input",
+        "-",
         "--scope",
         "team_acme",
       ],
-      expect.objectContaining({ nonInteractive: true }),
+      expect.objectContaining({
+        nonInteractive: true,
+        stdin: JSON.stringify({
+          envVarEnvironments: ["production", "preview", "development"],
+          envVarPrefix: "EVE_MEMORY_BLOB",
+          projectId: project.projectId,
+          skipReadWriteToken: true,
+        }),
+      }),
     );
     expect(captureVercel).toHaveBeenNthCalledWith(
       7,

--- a/packages/eve/src/setup/integrations/file-memory/vercel.test.ts
+++ b/packages/eve/src/setup/integrations/file-memory/vercel.test.ts
@@ -28,7 +28,7 @@ const privateStore: BlobStore = {
 };
 const exactConnection: BlobStoreConnection = {
   envVarEnvironments: [...FILE_MEMORY_BLOB_ENVIRONMENTS],
-  envVarPrefix: FILE_MEMORY_BLOB_PREFIX,
+  envVarPrefix: "EVE_MEMORY_BLOB",
   projectId: project.projectId,
 };
 
@@ -156,15 +156,18 @@ describe("file-memory Blob reconciliation", () => {
     await expect(prepareWith(storageClient)).resolves.toMatchObject({ action: "create" });
   });
 
-  it("rejects an incompatible eve-prefixed binding", async () => {
-    const storageClient = client({
-      getConnections: vi.fn(async () => [
-        { ...exactConnection, envVarPrefix: "EVE_MEMORY_LEGACY_" },
-      ]),
-      listStores: vi.fn(async () => [reference(privateStore)]),
-    });
-    await expect(prepareWith(storageClient)).rejects.toThrow("incompatible eve file-memory prefix");
-  });
+  it.each(["EVE_MEMORY_", "EVE_MEMORY_BLOB_", "EVE_MEMORY_LEGACY_"])(
+    "rejects an incompatible eve-prefixed binding: %s",
+    async (envVarPrefix) => {
+      const storageClient = client({
+        getConnections: vi.fn(async () => [{ ...exactConnection, envVarPrefix }]),
+        listStores: vi.fn(async () => [reference(privateStore)]),
+      });
+      await expect(prepareWith(storageClient)).rejects.toThrow(
+        "incompatible eve file-memory prefix",
+      );
+    },
+  );
 
   it("rejects a public store connected as eve memory", async () => {
     const storageClient = client({
@@ -228,7 +231,7 @@ describe("file-memory Blob apply", () => {
       environments: FILE_MEMORY_BLOB_ENVIRONMENTS,
       prefix: FILE_MEMORY_BLOB_PREFIX,
       projectId: project.projectId,
-      storeName,
+      storeId: privateStore.id,
     });
     expect(storageClient.pullEnvironment).toHaveBeenCalledOnce();
   });

--- a/packages/eve/src/setup/integrations/file-memory/vercel.ts
+++ b/packages/eve/src/setup/integrations/file-memory/vercel.ts
@@ -10,7 +10,7 @@ import {
   type VercelCaptureResult,
 } from "#setup/primitives/run-vercel.js";
 
-export const FILE_MEMORY_BLOB_PREFIX = "EVE_MEMORY_";
+export const FILE_MEMORY_BLOB_PREFIX = "EVE_MEMORY_BLOB";
 export const FILE_MEMORY_BLOB_ENVIRONMENTS = ["production", "preview", "development"] as const;
 const DEFAULT_BLOB_REGION = "iad1";
 
@@ -68,7 +68,7 @@ export interface FileMemoryVercelClient {
     environments: readonly string[];
     prefix: string;
     projectId: string;
-    storeName: string;
+    storeId: string;
   }): Promise<void>;
   getConnections(storeId: string): Promise<readonly BlobStoreConnection[]>;
   getProject(): Promise<VercelProjectConfiguration>;
@@ -139,8 +139,8 @@ export function createFileMemoryVercelClient(
     return parseJson(result.stdout, schema, label.toLowerCase());
   }
 
-  async function captureMutation(args: string[], label: string): Promise<void> {
-    const result = await captureVercel(args, baseOptions);
+  async function captureMutation(args: string[], label: string, stdin?: string): Promise<void> {
+    const result = await captureVercel(args, { ...baseOptions, stdin });
     input.signal?.throwIfAborted();
     if (!result.ok) throw commandFailure(label, result);
   }
@@ -155,19 +155,27 @@ export function createFileMemoryVercelClient(
       );
       return response.store;
     },
-    async connectStore({ environments, prefix, projectId, storeName }) {
-      const args = [
-        "integration-resource",
-        "connect",
-        storeName,
-        projectId,
-        "--prefix",
-        prefix,
-        ...environments.flatMap((environment) => ["--environment", environment]),
-        "--yes",
-        ...scope,
-      ];
-      await captureMutation(args, "Vercel Blob project connection");
+    async connectStore({ environments, prefix, projectId, storeId }) {
+      await captureMutation(
+        [
+          "api",
+          `/v1/storage/stores/${encodeURIComponent(storeId)}/connections`,
+          "-X",
+          "POST",
+          "--header",
+          "x-vercel-use-oidc: 1",
+          "--input",
+          "-",
+          ...scope,
+        ],
+        "Vercel Blob project connection",
+        JSON.stringify({
+          envVarEnvironments: environments,
+          envVarPrefix: prefix,
+          projectId,
+          skipReadWriteToken: true,
+        }),
+      );
     },
     async getConnections(storeId) {
       const response = await captureJson(
@@ -269,7 +277,7 @@ function exactConnection(connection: BlobStoreConnection, projectId: string): bo
 function isEveMemoryConnection(connection: BlobStoreConnection, projectId: string): boolean {
   return (
     connection.projectId === projectId &&
-    connection.envVarPrefix?.startsWith(FILE_MEMORY_BLOB_PREFIX) === true
+    connection.envVarPrefix?.startsWith("EVE_MEMORY_") === true
   );
 }
 
@@ -501,7 +509,7 @@ export async function applyFileMemoryBlob(input: {
           environments: FILE_MEMORY_BLOB_ENVIRONMENTS,
           prefix: FILE_MEMORY_BLOB_PREFIX,
           projectId: input.plan.project.projectId,
-          storeName: input.plan.storeName,
+          storeId,
         }),
     );
   }


### PR DESCRIPTION
### Summary

File-memory setup could provision `EVE_MEMORY_READ_WRITE_TOKEN`, which the runtime ignored, leaving newly configured agents unable to start. Connect private Blob stores with the `EVE_MEMORY_BLOB` prefix and OIDC, adding only the store ID and webhook public key to the project. Prefer attached-store OIDC over static tokens and let the Blob SDK resolve and refresh credentials instead of pinning an expiring token in the cached backend. Existing stores are preserved; the docs explain reconnecting bindings created with the old prefix.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/setup/integrations/file-memory src/public/memory/file/backends` — 44 tests passed.
- `pnpm test:integration` — 720 tests passed across 99 files.
- `pnpm lint`, `pnpm typecheck`, `pnpm docs:check`, and `pnpm guard:invariants` — passed. Ran `pnpm fmt` on the changed files.
- `pnpm test` — eve's unit suite reported 8,091 passed, 1 skipped, and 2 failures in the unchanged `src/cli/telemetry/preference.test.ts`. Those tests expect Linux XDG paths on macOS. Both failures also reproduce with `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/cli/telemetry/preference.test.ts`; their implementation and tests match `main`.
- Verified the connection request against Vercel's API implementation. Live store provisioning and fixture-owned e2e were not run locally; existing agent-memory evals cover deployed persistence in CI.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
