### PR TITLE
fix(eve): preserve execution caller across approval responses

### DIFF
--- a/.changeset/quiet-operators-retain-callers.md
+++ b/.changeset/quiet-operators-retain-callers.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Preserve the active execution caller when answering pending tool approvals or session-limit continuations, while authorizing and auditing tool approvals as their actual responder. Keep buffered deliveries from different authenticated callers in separate turns.

--- a/docs/guides/auth-and-route-protection.md
+++ b/docs/guides/auth-and-route-protection.md
@@ -256,6 +256,7 @@ Inside runtime code, `ctx.session.auth` carries the result of the channel's rout
 - `auth.current`: the caller on the active inbound turn.
 - `auth.initiator`: the caller that started the durable session.
 - A follow-up message updates `auth.current` but leaves `auth.initiator` alone. When a different caller follows up on the same session, `auth.current` tracks the new caller for that turn while `auth.initiator` stays pinned to whoever started it.
+- An authenticated response answering a pending tool approval or session-limit continuation without a new message preserves the execution caller. Tool approval policies and `approval.settled` still identify the actual responder. Stale responses that become new messages use the responder as their caller.
 - Both are `null` only on internal runtime paths (subagents, for instance) that never went through an authored route. HTTP traffic always populates `auth.current`, since the walk either accepts with a `SessionAuthContext` or returns `401`.
 
 Use the principal on `auth.current` (or `auth.initiator`) to scope tools, resolve [dynamic capabilities](./dynamic-capabilities) per principal, or enforce tenant boundaries. There's no second per-session ownership ACL stacked on top of route auth. Access is decided at the HTTP boundary, and the durable session carries the caller snapshot forward into your runtime code.

--- a/e2e/fixtures/agent-tools-hitl/agent/channels/eve.ts
+++ b/e2e/fixtures/agent-tools-hitl/agent/channels/eve.ts
@@ -9,7 +9,7 @@ export default eveChannel({
       authenticator: "e2e-fixture",
       issuer: "e2e",
       principalId,
-      principalType: "user",
+      principalType: principalId === "e2e-approval-operator" ? "service" : "user",
       subject: principalId,
     };
   },

--- a/e2e/fixtures/agent-tools-hitl/agent/tools/authorized-gate.ts
+++ b/e2e/fixtures/agent-tools-hitl/agent/tools/authorized-gate.ts
@@ -8,11 +8,12 @@ export default defineTool({
   approval: {
     request: always(),
     response: ({ response, responder }) =>
-      response.decision === "approve" && responder.principalId === "e2e-approval-responder"
+      response.decision === "approve" &&
+      ["e2e-approval-responder", "e2e-approval-operator"].includes(responder.principalId)
         ? ({ status: "allowed" } as const)
         : ({ status: "rejected", reason: "Unexpected eval responder." } as const),
   },
-  async execute({ marker }) {
-    return { executed: true, marker };
+  async execute({ marker }, ctx) {
+    return { executed: true, marker, caller: ctx.session.auth.current?.principalId };
   },
 });

--- a/e2e/fixtures/agent-tools-hitl/evals/hitl/operator-response-identity.eval.ts
+++ b/e2e/fixtures/agent-tools-hitl/evals/hitl/operator-response-identity.eval.ts
@@ -1,0 +1,49 @@
+import { defineEval } from "eve/evals";
+
+export default defineEval({
+  tags: ["real-model"],
+  description: "Operator approval is audited separately from the suspended user's tool execution.",
+  async test(t) {
+    const parked = await t.send('Call `authorized-gate` with marker "operator-identity".');
+    const request = t.requireInputRequest({ display: "confirmation", toolName: "authorized-gate" });
+    const state = t.state;
+    if (!state) throw new Error("Expected active client state");
+    const resumed = t.target.watchTurn(parked.sessionId, { startIndex: state.streamIndex });
+    const response = await t.target.fetch(
+      `/eve/v1/session/${encodeURIComponent(parked.sessionId)}`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-eve-fixture-user": "e2e-approval-operator",
+        },
+        body: JSON.stringify({
+          inputResponses: [{ requestId: request.requestId, optionId: "approve" }],
+        }),
+      },
+    );
+    if (!response.ok) throw new Error(`Approval failed: ${response.status}`);
+    const result = await resumed.result();
+    result.expectOk();
+    result.event("approval.settled", {
+      data: {
+        requestId: request.requestId,
+        outcome: "approved",
+        responderPrincipalId: "e2e-approval-operator",
+      },
+      count: 1,
+    });
+    result.event("action.result", {
+      data: {
+        status: "completed",
+        result: {
+          kind: "tool-result",
+          toolName: "authorized-gate",
+          output: /"caller"\s*:\s*"e2e-approval-responder"/,
+        },
+      },
+      count: 1,
+    });
+    t.succeeded();
+  },
+});

--- a/packages/eve/src/execution/approval-caller.integration.test.ts
+++ b/packages/eve/src/execution/approval-caller.integration.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import type { SessionAuthContext } from "#channel/types.js";
+import { workflowEntry } from "#execution/workflow-entry.js";
+import { createTestRuntime } from "#internal/testing/app-harness.js";
+import { captureTurnEvents, filterEventsByType } from "#internal/testing/events.js";
+import { resumeHook, start } from "#internal/workflow/runtime.js";
+import { defineHook } from "#public/definitions/hook.js";
+import { createBundledRuntimeCompiledArtifactsSource } from "#runtime/compiled-artifacts-source.js";
+
+const user: SessionAuthContext = {
+  authenticator: "test",
+  principalType: "user",
+  principalId: "user-a",
+  attributes: {},
+};
+const operator: SessionAuthContext = {
+  authenticator: "oidc",
+  principalType: "service",
+  principalId: "operator",
+  attributes: {},
+};
+
+describe("approval delivery execution identity", () => {
+  it.each([
+    { queued: false, caller: user },
+    { queued: true, caller: user },
+    { queued: true, caller: { ...user, principalId: "user-b" } },
+  ])(
+    "keeps $caller.principalId execution after operator continuation (queued=$queued)",
+    async ({ queued, caller }) => {
+      const completedCallers: Array<SessionAuthContext | null> = [];
+      const runtime = await createTestRuntime({
+        agent: { name: "approval-caller", limits: { maxInputTokensPerSession: 1 } },
+        modules: [
+          {
+            logicalPath: "hooks/capture-caller.ts",
+            loadNamespace: async () => ({
+              default: defineHook({
+                events: {
+                  "message.completed"(_event, ctx) {
+                    completedCallers.push(ctx.session.auth.current);
+                  },
+                },
+              }),
+            }),
+          },
+        ],
+      });
+      const token = `http:approval-caller-${queued}-${caller.principalId}`;
+      await runtime.run(async () => {
+        const run = await start(workflowEntry, [
+          {
+            input: { message: "Hello" },
+            serializedContext: {
+              "eve.auth": user,
+              "eve.bundle": { source: createBundledRuntimeCompiledArtifactsSource() },
+              "eve.channel": { kind: "http", state: {} },
+              "eve.continuationToken": token,
+              "eve.mode": "conversation",
+            },
+          },
+        ]);
+        const stream = captureTurnEvents(run);
+        try {
+          await stream.nextTurn();
+          await resumeHook(token, { kind: "send", auth: caller, payload: { message: "Continue" } });
+          const parked = await stream.nextTurn();
+          const request = filterEventsByType(parked, "input.requested")[0]?.data.requests[0];
+          expect(request?.kind).toBe("session-limit");
+          if (!request) throw new Error("Expected a session-limit request");
+          if (queued)
+            await resumeHook(token, {
+              kind: "send",
+              auth: caller,
+              payload: { message: "Please report the problem" },
+            });
+          await resumeHook(token, {
+            kind: "send",
+            auth: operator,
+            payload: { inputResponses: [{ requestId: request.requestId, optionId: "continue" }] },
+          });
+          for (let i = 0; i < 4 && completedCallers.length < 2; i++) await stream.nextTurn();
+          expect(completedCallers.length).toBeGreaterThanOrEqual(2);
+          expect(
+            completedCallers
+              .slice(1)
+              .every((observed) => observed?.principalId === caller.principalId),
+          ).toBe(true);
+        } finally {
+          stream.dispose();
+          await run.cancel();
+        }
+      });
+    },
+  );
+});

--- a/packages/eve/src/execution/input-response-auth.test.ts
+++ b/packages/eve/src/execution/input-response-auth.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import type { SessionAuthContext } from "#channel/types.js";
+import { attributeInputResponses } from "#execution/input-response-auth.js";
+import { appendPendingInputBatch } from "#harness/input-requests.js";
+import type { HarnessSession } from "#harness/types.js";
+import type { InputRequest } from "#shared/input.js";
+
+const caller: SessionAuthContext = {
+  authenticator: "test",
+  principalType: "user",
+  principalId: "user-b",
+  attributes: {},
+};
+const responder: SessionAuthContext = {
+  authenticator: "oidc",
+  principalType: "service",
+  principalId: "operator",
+  attributes: {},
+};
+const session: HarnessSession = {
+  agent: { modelReference: { id: "test" }, system: "", tools: [] },
+  compaction: { recentWindowSize: 10, threshold: 100_000 },
+  history: [],
+  sessionId: "test",
+  continuationToken: "test",
+};
+function state(kind: InputRequest["kind"]) {
+  return appendPendingInputBatch({
+    session,
+    responseMessages: [],
+    requests: [
+      {
+        kind,
+        requestId: "r",
+        prompt: "Continue?",
+        action: { kind: "tool-call", callId: "c", toolName: "test", input: {} },
+      },
+    ],
+  }).state;
+}
+const response = { requestId: "r", optionId: "approve" };
+
+describe("input response caller attribution", () => {
+  for (const kind of ["tool-approval", "session-limit"] as const) {
+    it(`retains the suspended caller for ${kind} and keeps responder attribution`, () => {
+      const result = attributeInputResponses({
+        caller,
+        responder,
+        state: state(kind),
+        stepInput: { inputResponses: [response] },
+      });
+      expect(result.caller).toEqual(caller);
+      if (kind === "tool-approval")
+        expect(result.stepInput).toEqual({
+          attributedInputResponses: [{ auth: responder, response }],
+        });
+      else expect(result.stepInput).toEqual({ inputResponses: [response] });
+    });
+  }
+  it("does not upgrade stale responses, question answers, or messages to the prior user", () => {
+    for (const stepInput of [
+      { inputResponses: [{ ...response, requestId: "stale" }] },
+      { message: "new task" },
+      { message: "new task", inputResponses: [response] },
+    ]) {
+      expect(
+        attributeInputResponses({ caller, responder, state: state("tool-approval"), stepInput })
+          .caller,
+      ).toEqual(responder);
+    }
+    expect(
+      attributeInputResponses({
+        caller,
+        responder,
+        state: state("question"),
+        stepInput: { inputResponses: [response] },
+      }).caller,
+    ).toEqual(responder);
+  });
+  it("never gives an unauthenticated response the previous user's identity", () => {
+    expect(
+      attributeInputResponses({
+        caller,
+        responder: null,
+        state: state("session-limit"),
+        stepInput: { inputResponses: [response] },
+      }).caller,
+    ).toBeNull();
+  });
+});

--- a/packages/eve/src/execution/input-response-auth.ts
+++ b/packages/eve/src/execution/input-response-auth.ts
@@ -1,0 +1,49 @@
+import type { SessionAuthContext } from "#channel/types.js";
+import { getPendingInputBatches } from "#harness/pending-input-batches.js";
+import type { SessionStateMap, StepInput } from "#harness/types.js";
+
+/** Separate approval authority from the caller whose suspended work resumes. */
+export function attributeInputResponses(input: {
+  readonly caller: SessionAuthContext | null;
+  readonly responder: SessionAuthContext | null;
+  readonly state?: SessionStateMap;
+  readonly stepInput?: StepInput;
+}): { caller: SessionAuthContext | null; stepInput?: StepInput } {
+  const result = { caller: input.responder, stepInput: input.stepInput };
+  if (!input.stepInput?.inputResponses?.length) return result;
+  const requests = new Map(
+    getPendingInputBatches(input.state)
+      .flatMap((batch) => batch.requests)
+      .map((request) => [request.requestId, request]),
+  );
+  const { inputResponses, ...rest } = input.stepInput;
+  const approvalResponses = inputResponses.filter(
+    (response) => requests.get(response.requestId)?.kind === "tool-approval",
+  );
+  if (approvalResponses.length > 0) {
+    const remaining = inputResponses.filter(
+      (response) => requests.get(response.requestId)?.kind !== "tool-approval",
+    );
+    const stepInput: { -readonly [K in keyof StepInput]: StepInput[K] } = {
+      ...rest,
+      attributedInputResponses: approvalResponses.map((response) => ({
+        auth: input.responder,
+        response,
+      })),
+    };
+    if (remaining.length > 0) stepInput.inputResponses = remaining;
+    result.stepInput = stepInput;
+  }
+  // Stale answers can become user messages; only live approvals retain the
+  // suspended caller. Questions and new messages carry their responder's auth.
+  if (
+    input.responder !== null &&
+    input.stepInput.message === undefined &&
+    inputResponses.every((response) => {
+      const kind = requests.get(response.requestId)?.kind;
+      return kind === "tool-approval" || kind === "session-limit";
+    })
+  )
+    result.caller = input.caller;
+  return result;
+}

--- a/packages/eve/src/execution/parked-delivery-wait.test.ts
+++ b/packages/eve/src/execution/parked-delivery-wait.test.ts
@@ -116,6 +116,49 @@ describe("nextTurnDelivery", () => {
     vi.mocked(routeDeliverToChildren).mockReset();
   });
 
+  it("keeps buffered caller identities in separate deliveries", async () => {
+    const auth = {
+      authenticator: "test",
+      principalType: "user",
+      principalId: "user-a",
+      attributes: {},
+    };
+    const buffered: DeliverHookPayload[] = [
+      { kind: "deliver", auth, payloads: [{ message: "a1" }] },
+      { kind: "deliver", auth: { ...auth }, payloads: [{ message: "a2" }] },
+      { kind: "deliver", auth: { ...auth, principalId: "user-b" }, payloads: [{ message: "b" }] },
+      {
+        kind: "deliver",
+        auth: { ...auth, principalId: "operator", principalType: "service" },
+        payloads: [{ inputResponses: [{ requestId: "r", optionId: "approve" }] }],
+      },
+    ];
+    vi.mocked(routeDeliverToChildren).mockImplementation(async ({ delivery }) => ({
+      kind: "continue",
+      remainder: delivery,
+      serializedContext: {},
+      sessionState,
+    }));
+    const input = {
+      ...waitInput(createMockInbox([])),
+      awaitAuthorizationCallbacks: false,
+      bufferedDeliveries: buffered,
+    };
+    expect(await nextTurnDelivery(input)).toMatchObject({
+      kind: "turn",
+      delivery: { auth, payloads: [{ message: "a1" }, { message: "a2" }] },
+    });
+    expect(await nextTurnDelivery(input)).toMatchObject({
+      kind: "turn",
+      delivery: { auth: { principalId: "user-b" }, payloads: [{ message: "b" }] },
+    });
+    expect(await nextTurnDelivery(input)).toMatchObject({
+      kind: "turn",
+      delivery: { auth: { principalType: "service" } },
+    });
+    expect(buffered).toEqual([]);
+  });
+
   it("surfaces an authorization callback as its own instruction", async () => {
     const inbox = createMockInbox([authorizationRead()]);
 

--- a/packages/eve/src/execution/parked-delivery-wait.ts
+++ b/packages/eve/src/execution/parked-delivery-wait.ts
@@ -1,3 +1,4 @@
+import { jsonValuesEqual } from "#shared/json.js";
 import type { DeliverHookPayload, DeliverPayload } from "#channel/types.js";
 import { cancelAllIndexedSessionTasksStep } from "#execution/cancel-indexed-session-tasks-step.js";
 import { routeDeliverToChildren } from "#execution/route-child-delivery.js";
@@ -279,6 +280,7 @@ function takeBufferedTurnDelivery(bufferedDeliveries: DeliverHookPayload[]): Del
     const next = bufferedDeliveries[0];
     if (
       next === undefined ||
+      !jsonValuesEqual(first.auth, next.auth) ||
       first.taskDeliveryId !== undefined ||
       next.taskDeliveryId !== undefined ||
       (caller !== undefined && next.caller !== undefined)

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -1353,7 +1353,7 @@ describe("turnStep", () => {
     expect(workflowWritesByNamespace.get(DEFAULT_WORKFLOW_STREAM_NAMESPACE) ?? []).toEqual([]);
   });
 
-  it.each([
+  it.each<{ expected: SessionAuthContext | null; title: string; approvalOnly: boolean }>([
     {
       expected: {
         attributes: { user_id: "U456" },
@@ -1364,12 +1364,24 @@ describe("turnStep", () => {
         subject: "U456",
       } satisfies SessionAuthContext,
       title: "replaces the previous caller",
+      approvalOnly: false,
     },
-    { expected: null, title: "clears the previous caller" },
-  ])("$title from deliver-time auth", async ({ expected }) => {
+    { expected: null, title: "clears the previous caller", approvalOnly: false },
+    {
+      expected: {
+        attributes: {},
+        authenticator: "oidc",
+        principalId: "operator",
+        principalType: "service",
+      } satisfies SessionAuthContext,
+      title: "preserves the execution caller for approval-only delivery",
+      approvalOnly: true,
+    },
+  ])("$title from deliver-time auth", async ({ expected, approvalOnly }) => {
+    const authAdapter: ChannelAdapter = { kind: "auth-test" };
     const bundle = {
       adapterRegistry: {
-        adaptersByKind: new Map([[threadContextAdapter.kind, threadContextAdapter]]),
+        adaptersByKind: new Map([[authAdapter.kind, authAdapter]]),
       },
       compiledArtifactsSource: {} as never,
       graph: {
@@ -1387,7 +1399,23 @@ describe("turnStep", () => {
       turnAgent: TestTurnAgent,
     } as never;
     vi.mocked(getCompiledRuntimeAgentBundle).mockResolvedValue(bundle);
-    installSessionStoreMocks([createStubSession()]);
+    installSessionStoreMocks([
+      approvalOnly
+        ? appendPendingInputBatch({
+            session: createStubSession(),
+            responseMessages: [],
+            requests: [
+              {
+                kind: "tool-approval",
+                requestId: "approval-1",
+                prompt: "Approve?",
+                action: { callId: "call-1", kind: "tool-call", toolName: "test", input: {} },
+                options: [{ id: "approve", label: "Approve" }],
+              },
+            ],
+          })
+        : createStubSession(),
+    ]);
 
     const previous: SessionAuthContext = {
       attributes: { user_id: "U123" },
@@ -1400,27 +1428,45 @@ describe("turnStep", () => {
     const ctx = new ContextContainer();
     ctx.set(AuthKey, previous);
     ctx.set(BundleKey, bundle);
-    ctx.set(ChannelKey, threadContextAdapter);
+    ctx.set(ChannelKey, authAdapter);
     ctx.set(ContinuationTokenKey, "http:auth-replacement");
     ctx.set(ModeKey, "conversation");
     ctx.set(SessionIdKey, "session-1");
 
     let observed: SessionAuthContext | null | undefined;
+    let observedInput: unknown;
     vi.mocked(createExecutionNodeStep).mockImplementation(() => {
-      return async (session): Promise<StepResult> => {
+      return async (session, stepInput): Promise<StepResult> => {
+        observedInput = stepInput;
         observed = loadContext().get(AuthKey);
         return { next: null, session };
       };
     });
 
     await turnStep({
-      input: { auth: expected, kind: "deliver", payloads: [{ message: "follow up" }] },
+      input: {
+        auth: expected,
+        kind: "deliver",
+        payloads: [
+          approvalOnly
+            ? { inputResponses: [{ requestId: "approval-1", optionId: "approve" }] }
+            : { message: "follow up" },
+        ],
+      },
       parentWritable: createTestWritable(),
       serializedContext: serializeContext(ctx),
       sessionState: createStubSessionState(),
     });
 
-    expect(observed).toEqual(expected);
+    expect(observed).toEqual(approvalOnly ? previous : expected);
+    if (approvalOnly) {
+      expect(observedInput).toMatchObject({
+        attributedInputResponses: [
+          { auth: expected, response: { requestId: "approval-1", optionId: "approve" } },
+        ],
+      });
+      expect(observedInput).not.toHaveProperty("inputResponses");
+    }
   });
 
   it("routes remote task HITL only to the parent callback", async () => {

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -1,6 +1,7 @@
 import { buildAdapterContext } from "#channel/adapter-context.js";
 import { callAdapterEventHandler, defaultDeliverResult } from "#channel/adapter.js";
 import type { DeliverHookPayload } from "#channel/types.js";
+import { attributeInputResponses } from "#execution/input-response-auth.js";
 import { contextStorage } from "#context/container.js";
 import { dispatchStreamEventHooks } from "#context/hook-lifecycle.js";
 import {
@@ -121,6 +122,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
 
   let durableSession = await readDurableSession(input.sessionState);
   const ctx = await deserializeContext(input.serializedContext);
+  const executionAuth = ctx.get(AuthKey) ?? null;
   if (rawInput.input?.kind === "deliver") {
     ctx.set(TurnTaskDeliveryKey, "none");
     ctx.delete(TurnTaskStateKey);
@@ -245,6 +247,14 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
       throw error;
     }
     resolved = results.length === 0 ? undefined : results.reduce(coalesceTurnInputs);
+    const attributed = attributeInputResponses({
+      caller: executionAuth,
+      responder: ctx.get(AuthKey) ?? null,
+      state: durableSession.state,
+      stepInput: resolved,
+    });
+    resolved = attributed.stepInput;
+    ctx.set(AuthKey, attributed.caller);
   } else if (input.input?.kind === "runtime-action-result") {
     if (input.input.acceptedAtMsByCallId !== undefined) {
       ctx.set(RuntimeActionSettlementTimesKey, input.input.acceptedAtMsByCallId);

--- a/packages/eve/src/harness/tool-loop-generate-approval-resume.integration.test.ts
+++ b/packages/eve/src/harness/tool-loop-generate-approval-resume.integration.test.ts
@@ -15,6 +15,8 @@ import {
   StepDynamicToolMetadataKey,
   TurnTaskStateKey,
 } from "#context/keys.js";
+import { attributeInputResponses } from "#execution/input-response-auth.js";
+import { getApprovalAuditState } from "#harness/approval-candidates.js";
 import { setHarnessEmissionState } from "#harness/emission.js";
 import type { HarnessToolDefinition } from "#harness/execute-tool.js";
 import type { InputRequest } from "#shared/input.js";
@@ -275,6 +277,53 @@ function findPart(
 }
 
 describe("tool loop generate approval resume (real AI SDK)", () => {
+  it("authorizes and audits the operator while executing as the suspended caller", async () => {
+    const ctx = createApprovalContext();
+    const operator = {
+      authenticator: "oidc",
+      principalType: "service" as const,
+      principalId: "operator",
+      attributes: {},
+    };
+    const authorize = vi.fn(({ responder }: { responder: { principalId: string } }) => {
+      expect(responder.principalId).toBe("operator");
+      return { status: "allowed" as const };
+    });
+    const execute = vi.fn(async () => {
+      expect(contextStorage.getStore()?.get(AuthKey)?.principalId).toBe("user-1");
+      return "/workspace";
+    });
+    const session = createPendingApprovalSession(undefined, true);
+    const attributed = attributeInputResponses({
+      caller: ctx.get(AuthKey) ?? null,
+      responder: operator,
+      state: session.state,
+      stepInput: {
+        inputResponses: [{ requestId: approvalRequest.approvalId, optionId: "approve" }],
+      },
+    });
+    ctx.set(AuthKey, attributed.caller);
+    const runStep = createToolLoopHarness(
+      createConfig(createModel(), execute, {
+        request: () => "user-approval",
+        response: authorize,
+      }),
+    );
+    let result = await contextStorage.run(ctx, () => runStep(session, attributed.stepInput));
+    while (typeof result.next === "function") {
+      const { next, session: resumedSession } = result;
+      result = await contextStorage.run(ctx, () => next(resumedSession));
+    }
+    expect(authorize).toHaveBeenCalledOnce();
+    expect(execute).toHaveBeenCalledOnce();
+    expect(getApprovalAuditState(result.session.state).settlements).toEqual([
+      expect.objectContaining({
+        actor: expect.objectContaining({ principalId: "operator" }),
+        outcome: "allowed",
+      }),
+    ]);
+  });
+
   it.each([
     { label: "direct", responseAuthorization: false },
     { label: "response-authorized", responseAuthorization: true },


### PR DESCRIPTION
### Summary

When an operator answers a parked approval or session-limit prompt, eve replaces the suspended caller with the responder, so resumed user-scoped work can run as the operator service. Preserve the active caller for authenticated responses to live control requests, pass tool responses through the existing attributed-response path for authorization and audit, and keep buffered deliveries with different auth contexts separate. New messages, question answers, stale responses, and unauthenticated responses retain their existing caller behavior; this does not fall back to the session initiator.

### Validation

- Reproduced the bug on unmodified `1807ff9c`: all three new workflow regression cases fail. With this change, the direct continuation, queued user work, and a caller different from the initiator pass.
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/execution/input-response-auth.test.ts src/execution/workflow-steps.test.ts src/execution/parked-delivery-wait.test.ts src/internal/structural-tests/file-length.test.ts` — 71 passed.
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/execution/approval-caller.integration.test.ts src/execution/session-limit-cancellation.integration.test.ts src/harness/tool-loop-generate-approval-resume.integration.test.ts` — 16 passed; after adding the operator policy/audit/tool execution assertion, reran the tool-loop file: 12 passed (17 distinct integration cases total).
- `pnpm --filter eve exec tsc -p tsconfig.json --noEmit`, `pnpm --filter agent-tools-hitl exec tsc --noEmit`, targeted `oxlint`/format checks, `pnpm guard:invariants`, and `pnpm docs:check` passed. Built compiled dependencies and package JS before integration tests.
- Full unit suite: **8,100 passed, 1 skipped, 5 failed**. The same five failures reproduce with unmodified production sources on this macOS checkout: three callback-log redaction assertions match `/private/tmp` in stack traces; two telemetry preference assertions expect Linux config paths. No new failures remain.
- Added a real-model HTTP approval eval to `agent-tools-hitl`; not run locally, per the repository's CI-only E2E rule. All local regression tests use synthetic identities and a mock model; no production sessions were resumed or cancelled.

- Upstream CI/E2E workflows currently require maintainer approval for this fork (`action_required`); Vercel preview deployments also require authorization. DCO and commit signature verification pass.

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
