### PR TITLE
CI validation for #3076

### DIFF
--- a/.changeset/eve-source-dist-exports.md
+++ b/.changeset/eve-source-dist-exports.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Point published `eve-source` export conditions at `dist` so Workflow bundle resolution works without the unpublished `src` tree.

--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -182,7 +182,7 @@
       "default": "./dist/src/public/tools/workflow.js"
     },
     "./workflow-modules": {
-      "eve-source": "./src/public/workflow-modules.d.ts",
+      "eve-source": "./dist/src/public/workflow-modules.d.ts",
       "types": "./dist/src/public/workflow-modules.d.ts"
     },
     "./models/openai": {
@@ -276,19 +276,19 @@
       "default": "./dist/src/public/local-dev.js"
     },
     "./self-modification": {
-      "eve-source": "./src/self-modification/extension/extension.ts",
+      "eve-source": "./dist/src/self-modification/extension/extension.js",
       "types": "./dist/src/self-modification/extension/extension.d.ts",
       "import": "./dist/src/self-modification/extension/extension.js",
       "default": "./dist/src/self-modification/extension/extension.js"
     },
     "./self-modification/agent": {
-      "eve-source": "./src/self-modification/agent.ts",
+      "eve-source": "./dist/src/self-modification/agent.js",
       "types": "./dist/src/self-modification/agent.d.ts",
       "import": "./dist/src/self-modification/agent.js",
       "default": "./dist/src/self-modification/agent.js"
     },
     "./self-modification/sandbox": {
-      "eve-source": "./src/self-modification/sandbox.ts",
+      "eve-source": "./dist/src/self-modification/sandbox.js",
       "types": "./dist/src/self-modification/sandbox.d.ts",
       "import": "./dist/src/self-modification/sandbox.js",
       "default": "./dist/src/self-modification/sandbox.js"
@@ -385,13 +385,13 @@
     },
     "./package.json": "./package.json",
     "./setup/scaffold": {
-      "eve-source": "./src/setup/scaffold/index.ts",
+      "eve-source": "./dist/src/setup/scaffold/index.js",
       "types": "./dist/src/setup/scaffold/index.d.ts",
       "import": "./dist/src/setup/scaffold/index.js",
       "default": "./dist/src/setup/scaffold/index.js"
     },
     "./setup": {
-      "eve-source": "./src/setup/index.ts",
+      "eve-source": "./dist/src/setup/index.js",
       "types": "./dist/src/setup/index.d.ts",
       "import": "./dist/src/setup/index.js",
       "default": "./dist/src/setup/index.js"


### PR DESCRIPTION
## Summary

Temporary credentialed CI validation for #3076. This branch points to the exact same GitHub-signed commit and verified file tree as that contributor PR. Fork-triggered TUI and E2E jobs cannot access model-provider or Vercel credentials, so this draft runs those checks in the upstream repository. Merge #3076 after validation; close this draft without merging it.

## Test plan

- [x] Reproduced the published export failure before the patch and successful workflow driver evaluation and execution after it.
- [x] Verified all five JavaScript exports through eve's workflow resolver.
- [x] Package build and 13 relevant scenario tests pass.
- [ ] Required credentialed CI checks pass.
