### PR TITLE
fix(eve): resolve ten session, tool, and integration failures

### DIFF
--- a/.changeset/clean-tools-schema.md
+++ b/.changeset/clean-tools-schema.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Ignore OpenAPI `default` and `example` annotations whose values conflict with the declared schema type, so models are not prompted to submit invalid tool input.

--- a/.changeset/fast-settled-session-resume.md
+++ b/.changeset/fast-settled-session-resume.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Resume settled sessions without waiting for the live stream idle timeout while preserving catch-up for turns accepted during replay.

--- a/.changeset/fix-node-esm-comma-bindings.md
+++ b/.changeset/fix-node-esm-comma-bindings.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Prevent `eve dev` bundles that inline comma-separated CommonJS path globals from failing to load with duplicate declarations.

--- a/.changeset/fix-piped-eval-json.md
+++ b/.changeset/fix-piped-eval-json.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Ensure `eve eval --json` writes the complete report when stdout is piped to another process.

--- a/.changeset/fix-slack-auth-button-label.md
+++ b/.changeset/fix-slack-auth-button-label.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Keep Slack connection authorization buttons valid when a connection has a long display name.

--- a/.changeset/fix-workflow-webhook-registration.md
+++ b/.changeset/fix-workflow-webhook-registration.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Workflow tools now create publicly resumable webhooks, fixing callbacks that returned 404. Webhook response options are preserved, and authored webhook tokens are rejected consistently with Workflow.

--- a/.changeset/quiet-ravens-steer.md
+++ b/.changeset/quiet-ravens-steer.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Preserve steering replacements when cancelled turn work throws a generic `AbortError`, so the session returns to waiting instead of failing.

--- a/.changeset/safe-compaction-unicode.md
+++ b/.changeset/safe-compaction-unicode.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Preserve complete Unicode characters when truncating compaction transcripts and tool results, preventing emoji at the cutoff from causing provider request failures.

--- a/.changeset/strong-snails-approve.md
+++ b/.changeset/strong-snails-approve.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Preserve input-scoped approval keys on dynamic tools, including durable replay, so approvals record the intended key instead of the bare tool name.

--- a/.changeset/tender-streams-reconnect.md
+++ b/.changeset/tender-streams-reconnect.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Reconnect session streams when browser response-body reads fail with vendor-specific `TypeError` messages, while keeping initial fetch retries limited to known transport errors.

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -451,6 +451,8 @@ events: {
 },
 ```
 
+The private authorization button uses the label **Sign in**, so long connection display names do not make the button invalid. The public status identifies the connection.
+
 ### Proactive sessions
 
 Start a session without an inbound message through `ctx.to(slack, target).send(message, { auth })` from another channel, or `to(slack, target).send(message, { auth })` from a schedule `run` handler. The proactive target shape is `{ channelId, installationTeamId?, threadTs?, initialMessage? }`. Set `installationTeamId` to the app installation workspace when a function-form bot token must select an installation. This sends turn input to the agent; it is not a direct Slack post.

--- a/docs/connections/openapi.mdx
+++ b/docs/connections/openapi.mdx
@@ -150,6 +150,10 @@ export default defineOpenAPIConnection({
 
 The parameter `name` must exactly match the placeholder inside the path. If the spec omits an `in: "path"` parameter, the generated tool has no input for that segment and eve cannot fill it in from query parameters.
 
+## Schema annotations
+
+eve removes `default` and `example` annotations when their values conflict with the declared schema type. For example, a boolean property with `default: "false"` loses that annotation, while `default: false` is retained. This prevents invalid examples from guiding model input; eve does not coerce annotation values.
+
 ## Approval gates
 
 Generated operations can mutate state like authored tools. Use the shared connection `approval` option for human approval, and combine it with `operations.allow` for the smallest practical surface. See [Per-connection approval](../connections#per-connection-approval) for the helpers and [Human-in-the-loop](../human-in-the-loop#approvals) for policy behavior.

--- a/docs/evals/running.mdx
+++ b/docs/evals/running.mdx
@@ -35,6 +35,8 @@ Tag filters compose: `--tag` keeps evals carrying at least one listed tag, then 
 
 An eval that calls `t.skip(reason)` is reported as skipped, does not count as passed or failed, and never changes the exit code.
 
+`eve eval --json` flushes the complete report before exiting, including when stdout is piped to another process or redirected to a file.
+
 ## Artifacts
 
 Each run drops artifacts under `.eve/evals/<timestamp>/`: a run `summary.json`, a `results.jsonl` index, and per-eval assertion results, verdicts, captured event streams, and `t.log` lines under `evals/`. The console output stays tight on purpose; when an eval fails, the artifact has the full story.

--- a/docs/guides/client/streaming.mdx
+++ b/docs/guides/client/streaming.mdx
@@ -153,6 +153,8 @@ The stream can emit an interim `session.waiting` while the authorization callbac
 
 HTTP connections can end before a run does. The client reconnects from the number of events already consumed, so long turns continue without replaying events. By default, a turn response keeps reconnecting until it reaches a turn boundary or is aborted, including while the turn is paused for authorization. A manually opened `session.stream()` eventually stops after repeated empty streams when it can no longer make progress.
 
+Browser failures while reading a response body, including `TypeError: Load failed` and `TypeError: network error`, use the same reconnect policy. Invalid stream events still fail the read.
+
 If your consumer persists events, key on `event.meta.id`. It is stable across reconnects and rewinds, so an overlapping replay is safe to ingest twice. See [the event envelope](../../concepts/sessions-runs-and-streaming#the-event-envelope).
 
 Set `streamReconnectPolicy: { reconnect: false }` when a relay or proxy owns the cursor and reconnection policy. This makes a single stream GET attempt and returns when that connection ends; it does not stop the server-side turn:

--- a/docs/guides/dynamic-capabilities.md
+++ b/docs/guides/dynamic-capabilities.md
@@ -219,7 +219,7 @@ the handler.
 
 ## Dynamic tools
 
-Pass `defineDynamic` an `events` object whose handlers return either a single `defineTool(...)`, a `Record<string, defineTool(...)>`, or `null` for no tools. Wrap every entry in `defineTool()`. eve records durable descriptors for `execute`, approval request and response policies, and `toModelOutput`, so a parked call can reconstruct the same callbacks in a fresh process.
+Pass `defineDynamic` an `events` object whose handlers return either a single `defineTool(...)`, a `Record<string, defineTool(...)>`, or `null` for no tools. Wrap every entry in `defineTool()`. eve records durable descriptors for `execute`, approval request and response policies, input-scoped `approvalKey` callbacks, and `toModelOutput`, so a parked call can reconstruct the same callbacks in a fresh process.
 
 Dynamic tool executors receive the same `ToolContext` as static authored tools, including inline provider auth through `ctx.getToken(provider)` and `ctx.requireAuth(provider)`.
 

--- a/docs/guides/frontend/overview.mdx
+++ b/docs/guides/frontend/overview.mdx
@@ -306,7 +306,7 @@ then save a final snapshot in `onFinish`.
 
 For multiple chat threads, keep one saved event log and session cursor per thread. `agent`, `host`, `reducer`, `session`, `initialEvents`, `initialSession`, `auth`, `headers`, `optimistic`, and `resume` are read when the hook creates its store, so remount the chat component when switching threads, for example with `key={chat.id}`.
 
-Pass `resume: true` with `initialSession` to rebuild the projection from the durable stream after mount. While `status` is `"resuming"`, render hydrated `data` but disable message and HITL submission; do not present cancellation or active-turn progress controls. If catch-up finds an in-flight turn, `status` changes to `"streaming"` before the binding follows it to a boundary. A settled tail changes directly to `"ready"`, and a terminal session failure changes to `"error"`.
+Pass `resume: true` with `initialSession` to rebuild the projection from the durable stream after mount. While `status` is `"resuming"`, render hydrated `data` but disable message and HITL submission; do not present cancellation or active-turn progress controls. If catch-up finds an in-flight turn, `status` changes to `"streaming"` before the binding follows it to a boundary. A settled tail changes directly to `"ready"` after a bounded catch-up check, without waiting for the live stream idle timeout. If that check finds a newly started turn or pending authorization, eve keeps following it. A terminal session failure changes to `"error"`.
 
 ```tsx
 const agent = useEveAgent({

--- a/docs/memory/custom-provider.md
+++ b/docs/memory/custom-provider.md
@@ -173,7 +173,10 @@ turn recalls the same data again.
 ## Failure behavior
 
 - A throwing or invalid `recall["turn.started"]` fails the turn before the
-  model call. No slot's recall results are committed.
+  model call. No slot's recall results are committed. If the turn's
+  `abortSignal` is already aborted, eve treats the error as cancellation and
+  continues with any queued steering replacement. An `AbortError` with an active
+  signal still fails the turn.
 - A throwing `capture["compaction.requested"]` leaves history unchanged.
 - A throwing `recall["compaction.completed"]` fails an automatic turn. For
   standalone compaction, eve logs the error and returns the session to waiting,

--- a/docs/tools/workflows.mdx
+++ b/docs/tools/workflows.mdx
@@ -317,7 +317,9 @@ export default defineWorkflowTool({
 ```
 
 `createWebhook` mints a URL under `/.well-known/workflow/v1/webhook/` that eve serves. The external
-system posts to it when it is done. Nothing runs in between.
+system posts to it when it is done. Nothing runs in between. Webhook tokens are generated for
+you; use `createHook` with `resumeHook` if you need a deterministic token. To customize the HTTP
+response, pass `respondWith: new Response(...)` to `createWebhook`.
 
 ### Ask now, act when answered
 

--- a/e2e/fixtures/agent-tools-hitl/agent/agent.ts
+++ b/e2e/fixtures/agent-tools-hitl/agent/agent.ts
@@ -3,6 +3,8 @@ import { defineAgent } from "eve";
 import type { MockModelRequest, MockModelResponse } from "eve/evals";
 
 const AUTH_PROBE_DIRECTIVE = /call the auth-probe tool exactly once with marker "([^"]+)"/iu;
+const SCOPED_APPROVAL_DIRECTIVE =
+  /call the dynamic_scoped_approval tool exactly once with scope "([^"]+)"/iu;
 const REPLY_DIRECTIVE = /reply with exactly ([A-Z0-9-]+)/iu;
 
 /**
@@ -17,6 +19,17 @@ function respond(request: MockModelRequest): MockModelResponse | string {
   const reply = REPLY_DIRECTIVE.exec(message);
   if (reply?.[1] !== undefined) {
     return reply[1];
+  }
+
+  const scopedApproval = SCOPED_APPROVAL_DIRECTIVE.exec(message);
+  if (scopedApproval?.[1] !== undefined) {
+    const roles = request.messages.map((entry) => entry.role);
+    if (roles.lastIndexOf("tool") < roles.lastIndexOf("user")) {
+      return {
+        toolCalls: [{ input: { scope: scopedApproval[1] }, name: "dynamic_scoped_approval" }],
+      };
+    }
+    return `Approved scope: ${scopedApproval[1]}`;
   }
 
   const authProbe = AUTH_PROBE_DIRECTIVE.exec(message);

--- a/e2e/fixtures/agent-tools-hitl/agent/tools/dynamic-scoped-approval.js
+++ b/e2e/fixtures/agent-tools-hitl/agent/tools/dynamic-scoped-approval.js
@@ -1,0 +1,24 @@
+import { defineDynamic, defineTool } from "eve/tools";
+
+export default defineDynamic({
+  events: {
+    "session.started": () => ({
+      dynamic_scoped_approval: defineTool({
+        description:
+          "Echoes a scope after approving that scope. Only call when explicitly asked for dynamic_scoped_approval.",
+        inputSchema: {
+          type: "object",
+          properties: { scope: { type: "string" } },
+          required: ["scope"],
+          additionalProperties: false,
+        },
+        approvalKey: (input) => `dynamic_scoped_approval:${input.scope}`,
+        approval: ({ approvedTools, toolInput }) =>
+          approvedTools.has(`dynamic_scoped_approval:${toolInput?.scope}`)
+            ? "not-applicable"
+            : "user-approval",
+        execute: (input) => ({ scope: input.scope }),
+      }),
+    }),
+  },
+});

--- a/e2e/fixtures/agent-tools-hitl/agent/tools/dynamic-scoped-approval.ts
+++ b/e2e/fixtures/agent-tools-hitl/agent/tools/dynamic-scoped-approval.ts
@@ -1,4 +1,5 @@
 import { defineDynamic, defineTool } from "eve/tools";
+import { z } from "zod";
 
 export default defineDynamic({
   events: {
@@ -6,12 +7,7 @@ export default defineDynamic({
       dynamic_scoped_approval: defineTool({
         description:
           "Echoes a scope after approving that scope. Only call when explicitly asked for dynamic_scoped_approval.",
-        inputSchema: {
-          type: "object",
-          properties: { scope: { type: "string" } },
-          required: ["scope"],
-          additionalProperties: false,
-        },
+        inputSchema: z.object({ scope: z.string() }),
         approvalKey: (input) => `dynamic_scoped_approval:${input.scope}`,
         approval: ({ approvedTools, toolInput }) =>
           approvedTools.has(`dynamic_scoped_approval:${toolInput?.scope}`)

--- a/e2e/fixtures/agent-tools-hitl/evals/hitl/dynamic-scoped-approval.eval.ts
+++ b/e2e/fixtures/agent-tools-hitl/evals/hitl/dynamic-scoped-approval.eval.ts
@@ -1,0 +1,28 @@
+import { defineEval } from "eve/evals";
+
+const TOOL_NAME = "dynamic_scoped_approval";
+
+export default defineEval({
+  description:
+    "Dynamic input-scoped approval grants survive replay without authorizing other scopes.",
+  async test(t) {
+    const first = await t.send(`Call the ${TOOL_NAME} tool exactly once with scope "repo-a".`);
+    first.calledTool(TOOL_NAME, { status: "pending", count: 1 });
+    t.requireInputRequest({ toolName: TOOL_NAME });
+    const approved = await t.respondAll("approve");
+    approved.expectOk();
+    approved.calledTool(TOOL_NAME, { status: "completed", count: 1 });
+
+    const repeated = await t.send(`Call the ${TOOL_NAME} tool exactly once with scope "repo-a".`);
+    repeated.succeeded();
+    repeated.calledTool(TOOL_NAME, { status: "completed", count: 1 });
+
+    const other = await t.send(`Call the ${TOOL_NAME} tool exactly once with scope "repo-b".`);
+    other.calledTool(TOOL_NAME, { status: "pending", count: 1 });
+    t.requireInputRequest({ toolName: TOOL_NAME });
+    const approvedOther = await t.respondAll("approve");
+    approvedOther.expectOk();
+    t.succeeded();
+    t.calledTool(TOOL_NAME, { status: "completed", count: 3 });
+  },
+});

--- a/e2e/fixtures/agent-workflow-tools/agent/agent.ts
+++ b/e2e/fixtures/agent-workflow-tools/agent/agent.ts
@@ -40,6 +40,7 @@ function respond(request: MockModelRequest): MockModelResponse | string {
     ["WORKFLOW-ESCALATE-START", "escalate_deploy"],
     ["WORKFLOW-HOLD-START", "hold_deploy"],
     ["WORKFLOW-FANOUT-START", "fanout_deploy"],
+    ["WORKFLOW-WEBHOOK-START", "webhook_deploy"],
     ["WORKFLOW-AGENT-FANOUT-START", "fanout_agents"],
   ] as const) {
     if (!message.includes(directive)) continue;

--- a/e2e/fixtures/agent-workflow-tools/agent/lib/webhook.ts
+++ b/e2e/fixtures/agent-workflow-tools/agent/lib/webhook.ts
@@ -1,0 +1,16 @@
+export async function postWorkflowCallback(url: string, service: string): Promise<void> {
+  "use step";
+
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  const bypass = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+  if (bypass) headers["x-vercel-protection-bypass"] = bypass;
+  const response = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ service }),
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (response.status !== 202 || (await response.text()) !== "callback accepted") {
+    throw new Error(`Workflow callback returned an unexpected response (${response.status}).`);
+  }
+}

--- a/e2e/fixtures/agent-workflow-tools/agent/tools/webhook_deploy.ts
+++ b/e2e/fixtures/agent-workflow-tools/agent/tools/webhook_deploy.ts
@@ -1,0 +1,21 @@
+import { defineWorkflowTool } from "eve/tools";
+import { createWebhook } from "workflow";
+import { z } from "zod";
+
+import { postWorkflowCallback } from "../lib/webhook.ts";
+
+export default defineWorkflowTool({
+  description: "Verify a deploy callback through the public workflow webhook route.",
+  inputSchema: z.strictObject({ service: z.string() }),
+  async execute({ service }) {
+    "use workflow";
+
+    using callback = createWebhook({
+      respondWith: new Response("callback accepted", { status: 202 }),
+    });
+    await callback.getConflict();
+    await postWorkflowCallback(callback.url, service);
+    const request = await callback;
+    return { callback: await request.json() };
+  },
+});

--- a/e2e/fixtures/agent-workflow-tools/evals/webhook-deploy.eval.ts
+++ b/e2e/fixtures/agent-workflow-tools/evals/webhook-deploy.eval.ts
@@ -1,0 +1,12 @@
+import { defineEval } from "eve/evals";
+
+export default defineEval({
+  description: "A bundled workflow webhook accepts a public callback and preserves its response.",
+  async test(t) {
+    const turn = await t.send("WORKFLOW-WEBHOOK-START");
+    turn.expectOk();
+    turn.calledTool("webhook_deploy", { output: /"callback":\{"service":"api"\}/u });
+    turn.messageIncludes("WORKFLOW-WEBHOOK-RESULT");
+    t.noFailedActions();
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/tool/v29.ts
+++ b/packages/eve/extension-contracts/compatibility/tool/v29.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+import { defineTool, defineWorkflowTool } from "#public/tools/index.js";
+
+export const write = defineTool({
+  description: "Write an approved message.",
+  inputSchema: z.object({ message: z.string() }),
+  outputSchema: z.object({ written: z.string() }),
+  approval: ({ toolInput }) => (toolInput?.message ? "user-approval" : "not-applicable"),
+  execute: (input) => ({ written: input.message }),
+  toModelOutput: (output) => ({ type: "text", value: output.written }),
+});
+
+export const workflow = defineWorkflowTool({
+  description: "Run a report workflow.",
+  inputSchema: z.object({ report: z.string() }),
+  async execute(input) {
+    "use workflow";
+    return { report: input.report };
+  },
+});

--- a/packages/eve/extension-contracts/reports/dynamicTool/v29.json
+++ b/packages/eve/extension-contracts/reports/dynamicTool/v29.json
@@ -1,0 +1,13 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicTool",
+  "epoch": 29,
+  "sha256": "119a44f66829ba64537d008f89f18681d6636fa1343270f8f512966ae43ad1c1",
+  "exports": [
+    "DynamicToolEntry",
+    "DynamicToolEvents",
+    "DynamicToolResult",
+    "DynamicToolSet",
+    "defineDynamic"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/tool/v30.json
+++ b/packages/eve/extension-contracts/reports/tool/v30.json
@@ -1,0 +1,20 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "tool",
+  "epoch": 30,
+  "sha256": "9aa353a05fd889df5ea41d25f095b162e829f45c69dd6470dfb1cd54aa054545",
+  "exports": [
+    "defaultWebSearch",
+    "defineTool",
+    "defineWorkflowTool",
+    "disableTool",
+    "experimental_workflow",
+    "isDisabledToolSentinel",
+    "isExperimentalWorkflowToolDefinition",
+    "isWebSearchToolDefinition",
+    "toolOutput",
+    "toolOutputPart",
+    "toolResultFrom",
+    "webSearch"
+  ]
+}

--- a/packages/eve/src/client/eve-agent-store.test.ts
+++ b/packages/eve/src/client/eve-agent-store.test.ts
@@ -4,6 +4,8 @@ import { detachEveAgentStore, EveAgentStore } from "#client/eve-agent-store.js";
 import { defaultMessageReducer } from "#client/message-reducer.js";
 import { stampTestEvents } from "#internal/testing/events.js";
 import {
+  createAuthorizationCompletedEvent,
+  createAuthorizationRequiredEvent,
   createMessageAppendedEvent,
   createMessageCompletedEvent,
   createMessageReceivedEvent,
@@ -377,6 +379,24 @@ describe("EveAgentStore stream overlap", () => {
 });
 
 describe("EveAgentStore session resume", () => {
+  it("finishes a settled replay without waiting for the probe stream to idle", async () => {
+    const events = turnEvents();
+    const probe = controlledStreamResponse();
+    probe.response.headers.set("x-eve-stream-tail-index", String(events.length - 1));
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(boundedStreamResponse(events))
+      .mockResolvedValueOnce(probe.response);
+    const store = new EveAgentStore({
+      initialSession: { sessionId: "session_1", streamIndex: 0 },
+      reducer: defaultMessageReducer(),
+    });
+
+    await store.resume();
+
+    expect(store.snapshot.events).toEqual(events);
+    expect(store.snapshot.status).toBe("ready");
+  });
+
   it("continues a split message from a complete hydrated prefix", async () => {
     const events = streamingTurnEvents();
     const prefix = events.slice(0, 3);
@@ -448,7 +468,7 @@ describe("EveAgentStore session resume", () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(boundedStreamResponse([], events.length - 1))
-      .mockResolvedValueOnce(streamResponse([]));
+      .mockResolvedValueOnce(boundedStreamResponse([], events.length - 1));
     const store = new EveAgentStore({
       initialEvents: events,
       initialSession: { sessionId: "session_1", streamIndex: events.length },
@@ -476,7 +496,7 @@ describe("EveAgentStore session resume", () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(boundedStreamResponse(events))
-      .mockResolvedValueOnce(streamResponse([]));
+      .mockResolvedValueOnce(boundedStreamResponse([], events.length - 1));
     const store = new EveAgentStore({
       initialEvents: events.slice(0, 1),
       initialSession: { sessionId: "session_1", streamIndex: 2 },
@@ -564,12 +584,12 @@ describe("EveAgentStore session resume", () => {
     expect(store.snapshot.error?.message).toBe("Session failed.");
   });
 
-  it("probes beyond a settled replay without reconnecting an idle stream", async () => {
+  it("probes once beyond a settled replay without following an idle stream", async () => {
     const events = turnEvents();
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(boundedStreamResponse(events))
-      .mockResolvedValueOnce(streamResponse([]));
+      .mockResolvedValueOnce(boundedStreamResponse([], events.length - 1));
     const store = new EveAgentStore({
       initialSession: { sessionId: "session_1", streamIndex: 0 },
       reducer: defaultMessageReducer(),
@@ -585,6 +605,11 @@ describe("EveAgentStore session resume", () => {
         "startIndex",
       ),
     ).toBe(String(events.length));
+    expect(
+      new URL(fetchMock.mock.calls[1]![0].toString(), "http://localhost").searchParams.get(
+        "includeTailIndex",
+      ),
+    ).toBe("1");
     expect(publishedEventCounts).not.toContain(1);
     expect(publishedEventCounts).not.toContain(2);
     expect(store.snapshot.status).toBe("ready");
@@ -616,25 +641,29 @@ describe("EveAgentStore session resume", () => {
     ] as UnstampedMessageStreamEvent[]);
     const settled = events.slice(0, 3);
     const [received, started, completed, waiting] = events.slice(3);
-    const live = controlledStreamResponse();
-    vi.spyOn(globalThis, "fetch")
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(boundedStreamResponse(settled))
-      .mockResolvedValueOnce(live.response);
+      .mockResolvedValueOnce(boundedStreamResponse([received!, started!], settled.length + 1))
+      .mockResolvedValueOnce(streamResponse([completed!, waiting!]));
     const store = new EveAgentStore({
       initialSession: { sessionId: "session_1", streamIndex: 0 },
       reducer: defaultMessageReducer(),
     });
 
-    const resuming = store.resume();
-    await vi.waitFor(() => expect(store.snapshot.events).toEqual(settled));
+    await store.resume();
 
-    live.emit(received!);
-    live.emit(started!);
-    live.emit(completed!);
-    live.emit(waiting!);
-    live.close();
-    await resuming;
-
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(
+      new URL(fetchMock.mock.calls[1]![0].toString(), "http://localhost").searchParams.get(
+        "includeTailIndex",
+      ),
+    ).toBe("1");
+    expect(
+      new URL(fetchMock.mock.calls[2]![0].toString(), "http://localhost").searchParams.get(
+        "includeTailIndex",
+      ),
+    ).toBeNull();
     expect(store.snapshot.status).toBe("ready");
     expect(store.snapshot.events.slice(settled.length).map((event) => event.type)).toEqual([
       "message.received",
@@ -648,6 +677,88 @@ describe("EveAgentStore session resume", () => {
       text: "A second reply.",
       type: "text",
     });
+  });
+
+  it("reads past intermediate boundaries before following the latest turn", async () => {
+    const events = stampTestEvents([
+      ...turnEvents(),
+      ...turnEvents(),
+      createMessageReceivedEvent({ message: "Again", sequence: 0, turnId: "turn_3" }),
+      createTurnStartedEvent({ sequence: 1, turnId: "turn_3" }),
+      createMessageCompletedEvent({
+        finishReason: "stop",
+        message: "Latest reply.",
+        sequence: 2,
+        stepIndex: 0,
+        turnId: "turn_3",
+      }),
+      createSessionWaitingEvent(),
+    ]);
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(boundedStreamResponse(events.slice(0, 3)))
+      .mockResolvedValueOnce(boundedStreamResponse(events.slice(3, 8), 7))
+      .mockResolvedValueOnce(streamResponse(events.slice(8)));
+    const store = new EveAgentStore({
+      initialSession: { sessionId: "session_1", streamIndex: 0 },
+      reducer: defaultMessageReducer(),
+    });
+
+    await store.resume();
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(store.snapshot.status).toBe("ready");
+    expect(store.snapshot.events).toEqual(events);
+    expect(store.snapshot.session?.streamIndex).toBe(events.length);
+  });
+
+  it("keeps following when a bounded probe ends with pending authorization", async () => {
+    const events = stampTestEvents([
+      createMessageReceivedEvent({ message: "Hello", sequence: 0, turnId: "turn_1" }),
+      createMessageCompletedEvent({
+        finishReason: "stop",
+        message: "Hi there.",
+        sequence: 1,
+        stepIndex: 0,
+        turnId: "turn_1",
+      }),
+      createSessionWaitingEvent(),
+      createAuthorizationRequiredEvent({
+        authorization: { url: "https://idp.example.com/authorize" },
+        description: "Linear",
+        name: "linear",
+        sequence: 0,
+        stepIndex: 0,
+        turnId: "turn_2",
+        webhookUrl: "https://agent.example.com/eve/v1/connections/linear/callback/hook",
+      }),
+      createSessionWaitingEvent(),
+      createAuthorizationCompletedEvent({
+        name: "linear",
+        outcome: "authorized",
+        sequence: 1,
+        stepIndex: 0,
+        turnId: "turn_2",
+      }),
+      createSessionWaitingEvent(),
+    ] as UnstampedMessageStreamEvent[]);
+    const settled = events.slice(0, 3);
+    const [required, waiting, completed, finalWaiting] = events.slice(3);
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(boundedStreamResponse(settled))
+      .mockResolvedValueOnce(boundedStreamResponse([required!, waiting!], settled.length + 1))
+      .mockResolvedValueOnce(streamResponse([completed!, finalWaiting!]));
+    const store = new EveAgentStore({
+      initialSession: { sessionId: "session_1", streamIndex: 0 },
+      reducer: defaultMessageReducer(),
+    });
+
+    await store.resume();
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(store.snapshot.status).toBe("ready");
+    expect(store.snapshot.events).toHaveLength(settled.length + 4);
   });
 
   it("replays history and follows an interrupted turn through its boundary", async () => {

--- a/packages/eve/src/client/eve-agent-store.ts
+++ b/packages/eve/src/client/eve-agent-store.ts
@@ -354,19 +354,26 @@ export class EveAgentStore<TData> {
         const pendingAuthorizations = collectPendingAuthorizations(replayed);
         if (!replaySettled) this.#status = "streaming";
         this.#publish();
-        for await (const event of session.stream({
-          signal: turn.abortController.signal,
-          streamReconnectPolicy: replaySettled ? { reconnect: false } : undefined,
-        })) {
-          if (!this.#isActiveTurn(turn)) return;
-          this.#acceptServerEvent(event);
-          updatePendingAuthorizations(pendingAuthorizations, event);
-          if (
-            isCurrentTurnBoundaryEvent(event) &&
-            (event.type !== "session.waiting" || pendingAuthorizations.size === 0)
-          ) {
-            break;
+        let followLive = !replaySettled;
+        for (;;) {
+          for await (const event of session.stream({
+            follow: followLive ? undefined : false,
+            signal: turn.abortController.signal,
+          })) {
+            if (!this.#isActiveTurn(turn)) return;
+            replayed.push(event);
+            this.#acceptServerEvent(event);
+            updatePendingAuthorizations(pendingAuthorizations, event);
+            if (
+              followLive &&
+              isCurrentTurnBoundaryEvent(event) &&
+              (event.type !== "session.waiting" || pendingAuthorizations.size === 0)
+            )
+              break;
           }
+          if (!this.#isActiveTurn(turn)) return;
+          if (followLive || isSettledSessionTail(replayed)) break;
+          followLive = true;
         }
       } else {
         this.#status = this.#error === undefined ? "ready" : "error";

--- a/packages/eve/src/client/ndjson.ts
+++ b/packages/eve/src/client/ndjson.ts
@@ -106,10 +106,9 @@ async function readWithIdleTimeout(
   reader: ReadableStreamDefaultReader<Uint8Array>,
   idleTimeoutMs: number | undefined,
 ): ReturnType<ReadableStreamDefaultReader<Uint8Array>["read"]> {
-  if (idleTimeoutMs === undefined) return await reader.read();
-
   let timeout: ReturnType<typeof setTimeout> | undefined;
   try {
+    if (idleTimeoutMs === undefined) return await reader.read();
     return await Promise.race([
       reader.read(),
       new Promise<never>((_resolve, reject) => {
@@ -119,6 +118,12 @@ async function readWithIdleTimeout(
         );
       }),
     ]);
+  } catch (error) {
+    // Browsers use vendor-specific TypeError messages for response-body transport failures.
+    if (error instanceof TypeError) {
+      throw new Error("Session stream disconnected.", { cause: error });
+    }
+    throw error;
   } finally {
     if (timeout !== undefined) clearTimeout(timeout);
   }

--- a/packages/eve/src/client/session.test.ts
+++ b/packages/eve/src/client/session.test.ts
@@ -884,6 +884,105 @@ describe("ClientSession", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("does not reconnect after an invalid stream event raises a TypeError", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        createStreamResponse([{ type: "message.appended", data: { messageDelta: 42 } }]),
+      );
+    const session = createSession({ sessionId: "session_1", streamIndex: 0 });
+
+    await expect(async () => {
+      for await (const _event of session.stream()) {
+        // Invalid events fail before delivery.
+      }
+    }).rejects.toThrow("Invalid message append delta for stream version 25.");
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it.each(["Load failed", "network error"])(
+    "does not retry an unrecognized TypeError while opening a stream: %s",
+    async (message) => {
+      const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError(message));
+      const session = createSession({ sessionId: "session_1", streamIndex: 0 });
+
+      await expect(async () => {
+        for await (const _event of session.stream({
+          streamReconnectPolicy: {
+            streamOpenReconnectPolicy: { baseDelayMs: 1, maxAttempts: 2 },
+          },
+        })) {
+          // The stream fails before producing an event.
+        }
+      }).rejects.toThrow(message);
+      expect(fetchMock).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each(["Load failed", "network error"])(
+    "reconnects after a mid-stream TypeError regardless of its message: %s",
+    async (message) => {
+      const encoder = new TextEncoder();
+      const streamUrls: string[] = [];
+      let streamRequest = 0;
+      const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (request, init) => {
+        if ((init?.method ?? "GET") === "POST") {
+          return createAcceptedResponse();
+        }
+
+        const url =
+          typeof request === "string"
+            ? request
+            : request instanceof URL
+              ? request.href
+              : request.url;
+        streamUrls.push(url);
+        streamRequest += 1;
+
+        if (streamRequest === 1) {
+          let emitted = false;
+          return new Response(
+            new ReadableStream<Uint8Array>({
+              pull(controller) {
+                if (!emitted) {
+                  emitted = true;
+                  controller.enqueue(
+                    encoder.encode(`${JSON.stringify({ type: "turn.started", data: {} })}\n`),
+                  );
+                  return;
+                }
+                controller.error(new TypeError(message));
+              },
+            }),
+            { headers: { [EVE_STREAM_VERSION_HEADER]: EVE_MESSAGE_STREAM_VERSION } },
+          );
+        }
+
+        return createStreamResponse([
+          {
+            type: "session.waiting",
+            data: { continuationToken: "session-id", wait: "next-user-message" },
+          },
+        ]);
+      });
+      const session = createSession();
+
+      vi.useFakeTimers();
+      try {
+        const eventTypes = await collectEventTypes(await session.send("first"));
+        expect(eventTypes).toEqual(["turn.started", "session.waiting"]);
+      } finally {
+        vi.useRealTimers();
+      }
+
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(streamUrls.map((url) => new URL(url).searchParams.get("startIndex"))).toEqual([
+        null,
+        "1",
+      ]);
+    },
+  );
+
   it("retries a transient fetch failure while reopening an active turn stream", async () => {
     const encoder = new TextEncoder();
     const streamUrls: string[] = [];

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -42,8 +42,8 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     },
   },
   dynamicTool: {
-    current: 28,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 28],
+    current: 29,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 28, 29],
     dropped: {
       21: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",
       23: "TaskExec.delegated was removed; migrate to workflow-backed background tools",

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -22,8 +22,8 @@ interface ExtensionCapabilityContract {
 const EXTENSION_CAPABILITY_CONTRACTS = {
   extension: { current: 1, supported: [1], dropped: {} },
   tool: {
-    current: 29,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 28, 29],
+    current: 30,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 28, 29, 30],
     dropped: {
       14: "TaskExec.delegated was removed; migrate to workflow-backed background tools",
       15: "TaskExec replaces stageEffect with send",

--- a/packages/eve/src/context/build-dynamic-tools.ts
+++ b/packages/eve/src/context/build-dynamic-tools.ts
@@ -89,6 +89,11 @@ export function replayDynamicTools(
   metadata: readonly CurrentDynamicToolMetadata[],
 ): HarnessToolDefinition[] {
   return metadata.map((entry) => {
+    const approvalKeyReference = entry.callbacks.approvalKey;
+    const approvalKey =
+      approvalKeyReference === undefined
+        ? undefined
+        : lookupDurableDynamicCallback(entry.name, "approvalKey");
     const executeReference = entry.callbacks.execute;
     const execute = lookupDurableDynamicCallback(entry.name, "execute");
     const toModelOutputReference = entry.callbacks.toModelOutput;
@@ -135,6 +140,26 @@ export function replayDynamicTools(
       name: entry.name,
       execution: entry.execution,
       approval: buildReplayedApproval(entry),
+      ...(approvalKeyReference === undefined
+        ? {}
+        : {
+            approvalKey: (input: Readonly<Record<string, unknown>>) => {
+              if (approvalKey === undefined) {
+                throw missingCallbackError(entry, "approvalKey");
+              }
+              const key = callDurableDynamicCallback(
+                approvalKey,
+                approvalKeyReference.closure,
+                input,
+              );
+              if (typeof key !== "string") {
+                throw new Error(
+                  `Dynamic tool "${entry.name}" approvalKey callback must return a string.`,
+                );
+              }
+              return key;
+            },
+          }),
       outputSchema: toOutputSchema(entry.outputSchema),
       ...(toModelOutputReference === undefined
         ? {}

--- a/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
@@ -428,6 +428,9 @@ function stampTestTool(entry: DynamicToolEntry): DynamicToolEntry {
         ),
       closure: {},
     },
+    ...(entry.approvalKey === undefined
+      ? {}
+      : { approvalKey: { callback: (_closure, input) => entry.approvalKey!(input), closure: {} } }),
     ...(request === undefined
       ? {}
       : {
@@ -1440,6 +1443,49 @@ describe("programmatic dynamic tools (no bundler transform)", () => {
       "user-approval",
     );
   });
+
+  it.each(["step.started", "turn.started", "session.started"])(
+    "preserves scoped approval keys through %s metadata replay",
+    async (eventName) => {
+      const ctx = createCtx();
+      const approvalKey = vi.fn(
+        (input: Readonly<Record<string, unknown>>) => `risky:${String(input.scope)}`,
+      );
+      const entry = stampTestTool(
+        Object.assign(
+          defineTool({
+            description: "scoped destructive op",
+            inputSchema: { type: "object" },
+            approval: () => "user-approval" as const,
+            execute: async () => ({ ok: true }),
+          }),
+          { approvalKey },
+        ),
+      );
+      const resolver = createResolver("connection", [eventName], () => ({ risky: entry }));
+      await dispatchDynamicToolEvent({
+        ctx,
+        resolvers: [resolver],
+        messages: [],
+        event: makeEvent(eventName),
+      });
+      const metadataKey =
+        eventName === "step.started"
+          ? StepDynamicToolMetadataKey
+          : eventName === "turn.started"
+            ? TurnDynamicToolMetadataKey
+            : SessionDynamicToolMetadataKey;
+      ctx.set(metadataKey, JSON.parse(JSON.stringify(ctx.get(metadataKey))));
+      const [tool] = buildDynamicTools(ctx);
+      expect(tool!.approvalKey?.({ scope: "repo" })).toBe("risky:repo");
+      expect(tool!.approvalKey?.({ scope: "other" })).toBe("risky:other");
+      getDynamicCallbackRegistry().delete("risky");
+      const [missing] = buildDynamicTools(ctx);
+      expect(() => missing!.approvalKey?.({ scope: "repo" })).toThrow(
+        "cannot replay its approvalKey callback",
+      );
+    },
+  );
 
   it("replays approval from session-scoped dynamic tools", async () => {
     const ctx = createCtx();

--- a/packages/eve/src/context/dynamic-tool-lifecycle.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.ts
@@ -180,6 +180,7 @@ export function validateDurableDynamicToolCallbacks(
   const unknownPhases = Object.keys(raw).filter(
     (key) =>
       key !== "execute" &&
+      key !== "approvalKey" &&
       key !== "approvalRequest" &&
       key !== "approvalResponse" &&
       key !== "toModelOutput",
@@ -201,6 +202,12 @@ export function validateDurableDynamicToolCallbacks(
     stamped: raw.execute,
     required: true,
   })!;
+  const approvalKey = validateReference({
+    name,
+    phase: "approvalKey",
+    stamped: raw.approvalKey,
+    required: entry.approvalKey !== undefined,
+  });
   const approvalRequest = validateReference({
     name,
     phase: "approvalRequest",
@@ -222,10 +229,12 @@ export function validateDurableDynamicToolCallbacks(
 
   const callbacks: {
     execute: DurableDynamicCallbackReference;
+    approvalKey?: DurableDynamicCallbackReference;
     approvalRequest?: DurableDynamicCallbackReference;
     approvalResponse?: DurableDynamicCallbackReference;
     toModelOutput?: DurableDynamicCallbackReference;
   } = { execute };
+  if (approvalKey !== undefined) callbacks.approvalKey = approvalKey;
   if (approvalRequest !== undefined) callbacks.approvalRequest = approvalRequest;
   if (approvalResponse !== undefined) callbacks.approvalResponse = approvalResponse;
   if (toModelOutput !== undefined) callbacks.toModelOutput = toModelOutput;

--- a/packages/eve/src/evals/cli/eval-json-report.scenario.test.ts
+++ b/packages/eve/src/evals/cli/eval-json-report.scenario.test.ts
@@ -1,0 +1,155 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { mkdir, writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { join } from "node:path";
+
+import { expect, it } from "vitest";
+
+import { createTestAgentInfoResult } from "#internal/testing/agent-info-fixture.js";
+import { useTemporaryDirectories } from "#internal/testing/use-temporary-app-roots.js";
+
+const PAYLOAD_SIZE = 2_000_000;
+const createScratchDirectory = useTemporaryDirectories();
+
+it("writes the complete JSON report to piped stdout", async () => {
+  const appRoot = await createScratchDirectory("eve-eval-json-report-");
+  await createEvalApp(appRoot);
+
+  const server = createEvalTargetServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+
+  try {
+    const address = server.address() as AddressInfo;
+    const result = await runEvalCli(appRoot, `http://127.0.0.1:${address.port}`);
+
+    expect(result.exitCode, result.stderr).toBe(0);
+    expect(result.stderr).toBe("");
+
+    const report = JSON.parse(result.stdout) as {
+      results: [{ result: { logs: [string] } }];
+    };
+    expect(report.results[0].result.logs[0]).toHaveLength(PAYLOAD_SIZE);
+  } finally {
+    await closeServer(server);
+  }
+});
+
+it.each([
+  { name: "the pipe consumer closes early", mode: "close-early" as const },
+  { name: "its descriptor is closed", mode: "closed" as const },
+])("still exits when stdout $name", async ({ mode }) => {
+  const appRoot = await createScratchDirectory("eve-eval-json-closed-pipe-");
+  await createEvalApp(appRoot);
+
+  const server = createEvalTargetServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+
+  try {
+    const address = server.address() as AddressInfo;
+    const result = await runEvalCli(appRoot, `http://127.0.0.1:${address.port}`, mode);
+
+    expect(result.exitCode, result.stderr).toBe(0);
+  } finally {
+    await closeServer(server);
+  }
+});
+
+async function createEvalApp(appRoot: string): Promise<void> {
+  await mkdir(join(appRoot, "agent"), { recursive: true });
+  await mkdir(join(appRoot, "evals"), { recursive: true });
+  await writeFile(
+    join(appRoot, "package.json"),
+    `${JSON.stringify({ name: "eval-json-report-test", private: true, type: "module" })}\n`,
+  );
+  await writeFile(
+    join(appRoot, "agent", "agent.js"),
+    'export default { model: "openai/gpt-5.4" };\n',
+  );
+  await writeFile(
+    join(appRoot, "evals", "large-report.eval.ts"),
+    [
+      "export default {",
+      '  _tag: "EveEval",',
+      "  async test(t) {",
+      `    t.log("A".repeat(${PAYLOAD_SIZE}));`,
+      "  },",
+      "};",
+      "",
+    ].join("\n"),
+  );
+  await writeFile(
+    join(appRoot, "evals", "evals.config.ts"),
+    'export default { _tag: "EveEvalConfig" };\n',
+  );
+}
+
+function createEvalTargetServer(): Server {
+  const info = createTestAgentInfoResult({ name: "eval-json-report-test" });
+  return createServer((request, response) => {
+    response.setHeader("content-type", "application/json");
+    if (request.url === "/eve/v1/health") {
+      response.end(JSON.stringify({ ok: true, status: "ready", workflowId: "test-workflow" }));
+      return;
+    }
+    if (request.url === "/eve/v1/info") {
+      response.end(JSON.stringify(info));
+      return;
+    }
+    response.statusCode = 404;
+    response.end(JSON.stringify({ error: "not found" }));
+  });
+}
+
+async function runEvalCli(
+  appRoot: string,
+  targetUrl: string,
+  stdoutMode: "collect" | "close-early" | "closed" = "collect",
+): Promise<{ exitCode: number | null; stderr: string; stdout: string }> {
+  const cliEntrypointUrl = new URL("../../../dist/src/cli/run.js", import.meta.url).href;
+  const closeStdout =
+    stdoutMode === "closed" ? 'const { closeSync } = await import("node:fs"); closeSync(1);' : "";
+  const script = `${closeStdout} const { runCli } = await import(${JSON.stringify(cliEntrypointUrl)}); await runCli(["eval", "--json", "--url", ${JSON.stringify(targetUrl)}]);`;
+  const child = spawn(process.execPath, ["--input-type=module", "--eval", script], {
+    cwd: appRoot,
+    env: { ...process.env, EVE_EVAL_AUTH_TOKEN: "test-token" },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  const stdout: Buffer[] = [];
+  const stderr: Buffer[] = [];
+  if (stdoutMode === "close-early") {
+    child.stdout.destroy();
+  } else {
+    child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+  }
+  child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+
+  const exitCode = await new Promise<number | null>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error("eve eval did not exit after stdout closed"));
+    }, 10_000);
+    child.once("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.once("close", (code) => {
+      clearTimeout(timeout);
+      resolve(code);
+    });
+  });
+  return {
+    exitCode,
+    stderr: Buffer.concat(stderr).toString("utf8"),
+    stdout: Buffer.concat(stdout).toString("utf8"),
+  };
+}
+
+async function closeServer(server: Server): Promise<void> {
+  server.close();
+  await once(server, "close");
+}

--- a/packages/eve/src/evals/cli/eval.ts
+++ b/packages/eve/src/evals/cli/eval.ts
@@ -202,7 +202,33 @@ export async function runEvalCommand(
   }
 
   const exitCode = typeof process.exitCode === "number" ? process.exitCode : 0;
+  await flushStandardStreams();
   process.exit(exitCode);
+}
+
+async function flushStandardStreams(): Promise<void> {
+  await Promise.all([flushStream(process.stdout), flushStream(process.stderr)]);
+}
+
+async function flushStream(stream: NodeJS.WriteStream): Promise<void> {
+  await new Promise<void>((resolve) => {
+    let settled = false;
+    const settle = () => {
+      if (settled) return;
+      settled = true;
+      setImmediate(() => {
+        stream.off("error", settle);
+        resolve();
+      });
+    };
+
+    stream.once("error", settle);
+    try {
+      stream.write("", settle);
+    } catch {
+      settle();
+    }
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/eve/src/execution/turn-cancellation.integration.test.ts
+++ b/packages/eve/src/execution/turn-cancellation.integration.test.ts
@@ -22,6 +22,7 @@ import type { RouteHandlerArgs } from "#channel/routes.js";
 import { createSession } from "#channel/session.js";
 import { none } from "#public/channels/auth.js";
 import { eveChannel } from "#public/channels/eve.js";
+import { defineMemory } from "#public/memory/index.js";
 import type { ToolContext } from "#tools/definition.js";
 import type { ResolvedToolDefinition } from "#runtime/types.js";
 import { toInputSchema } from "#tools/schema.js";
@@ -125,6 +126,74 @@ async function createWaitToolRuntime(agentName: string): Promise<WaitToolFixture
     default: { execute: waitTool.execute },
   };
   return { runtime, toolStarted, toolAborts: () => aborts, toolStarts: () => starts };
+}
+
+interface AbortRecallFixture {
+  readonly recallStarted: Promise<void>;
+  readonly runtime: TestRuntime;
+  recalls(): readonly {
+    readonly input: string;
+    readonly messages: string;
+    readonly sequence: number;
+  }[];
+}
+
+function abortError(): Error {
+  return Object.assign(new Error("This operation was aborted"), { name: "AbortError" });
+}
+
+async function createAbortRecallRuntime(
+  agentName: string,
+  options: { readonly waitForAbort: boolean },
+): Promise<AbortRecallFixture> {
+  let resolveRecallStarted: (() => void) | undefined;
+  const recallStarted = new Promise<void>((resolve) => {
+    resolveRecallStarted = resolve;
+  });
+  const recalls: Array<{ input: string; messages: string; sequence: number }> = [];
+  const runtime = await createTestRuntime({
+    agent: { name: agentName },
+    modules: [
+      {
+        loadNamespace: async () => ({
+          default: defineMemory({
+            provider: {
+              recall: {
+                "turn.started": async (context) => {
+                  recalls.push({
+                    input: JSON.stringify(context.turn.input),
+                    messages: JSON.stringify(context.messages),
+                    sequence: context.turn.sequence,
+                  });
+                  if (context.turn.sequence > 0) return null;
+
+                  resolveRecallStarted?.();
+                  if (!options.waitForAbort) {
+                    throw abortError();
+                  }
+
+                  return await new Promise((_resolve, reject) => {
+                    const abort = (): void => {
+                      reject(abortError());
+                    };
+                    if (context.abortSignal.aborted) {
+                      abort();
+                      return;
+                    }
+                    context.abortSignal.addEventListener("abort", abort, { once: true });
+                  });
+                },
+              },
+            },
+            scope: "test",
+          }),
+        }),
+        logicalPath: "memory/abort-recall.ts",
+      },
+    ],
+  });
+
+  return { recallStarted, recalls: () => recalls, runtime };
 }
 
 /** Polls the world until the given run reaches `completed`. */
@@ -276,6 +345,110 @@ async function expectCancelResponse(
 }
 
 describe("turn cancellation integration", () => {
+  it("settles an abort-shaped memory recall error as cancellation after steering", async () => {
+    const fixture = await createAbortRecallRuntime("turn-steer-memory-recall", {
+      waitForAbort: true,
+    });
+    const rawToken = "turn-steer-memory-recall";
+    const continuationToken = `http:${rawToken}`;
+    const workflowRuntime = createWorkflowRuntime({
+      compiledArtifactsSource: createBundledRuntimeCompiledArtifactsSource(),
+    });
+    const address = createChannelAddress({
+      adapter: { kind: "http" },
+      channelName: "http",
+      continuationToken: rawToken,
+      runtime: workflowRuntime,
+    });
+
+    await fixture.runtime.run(async () => {
+      const run = await start(workflowEntry, [
+        {
+          input: { message: "remember this interrupted request" },
+          serializedContext: buildSerializedContext({
+            channelKind: "http",
+            continuationToken,
+            mode: "conversation",
+          }),
+        },
+      ]);
+      const stream = captureTurnEvents(run);
+
+      try {
+        await waitForHookByToken(continuationToken);
+        const cancelHook = await waitForHookByToken(
+          turnCancellationHookToken(`${run.runId}:turn-control:0`),
+        );
+        await fixture.recallStarted;
+
+        await expect(
+          address.send("replacement after recall abort", { auth: null }),
+        ).resolves.toMatchObject({ id: run.runId });
+
+        const cancelledTurn = await stream.nextTurn();
+        expect(
+          containsEventSequence(cancelledTurn, [
+            "turn.started",
+            "turn.cancelled",
+            "session.waiting",
+          ]),
+        ).toBe(true);
+        expectNoFailureEvents(cancelledTurn);
+        await expectNoStepRetries(cancelHook.runId);
+
+        const replacementTurn = await stream.nextTurn();
+        expect(filterEventsByType(replacementTurn, "turn.started")).toHaveLength(1);
+        expect(filterEventsByType(replacementTurn, "turn.cancelled")).toHaveLength(0);
+        expectNoFailureEvents(replacementTurn);
+        expect(
+          replacementTurn.some(
+            (event) =>
+              event.type === "message.received" &&
+              typeof event.data.message === "string" &&
+              event.data.message.includes("replacement after recall abort"),
+          ),
+        ).toBe(true);
+
+        const replacementRecall = fixture.recalls().find((recall) => recall.sequence === 1);
+        expect(replacementRecall?.messages).toContain("remember this interrupted request");
+        expect(replacementRecall?.input).toContain("replacement after recall abort");
+      } finally {
+        stream.dispose();
+        await run.cancel();
+      }
+    });
+  }, 60_000);
+
+  it("keeps an abort-shaped memory recall error terminal while the turn signal is active", async () => {
+    const fixture = await createAbortRecallRuntime("turn-active-memory-abort", {
+      waitForAbort: false,
+    });
+
+    await fixture.runtime.run(async () => {
+      const run = await start(workflowEntry, [
+        {
+          input: { message: "fail memory recall" },
+          serializedContext: buildSerializedContext({
+            channelKind: "http",
+            continuationToken: "http:turn-active-memory-abort",
+            mode: "conversation",
+          }),
+        },
+      ]);
+      const stream = captureTurnEvents(run);
+
+      try {
+        await fixture.recallStarted;
+        const failedTurn = await stream.nextTurn();
+        expect(failedTurn.at(-1)?.type).toBe("session.failed");
+        expect(filterEventsByType(failedTurn, "turn.cancelled")).toHaveLength(0);
+      } finally {
+        stream.dispose();
+        await run.cancel();
+      }
+    });
+  });
+
   it("buffers a default steering message before replacing the active turn", async () => {
     const fixture = await createWaitToolRuntime("turn-steer-message");
     const rawToken = "turn-steer-message";

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -542,7 +542,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
       return runHarnessStep(schemaSession, resolved);
     });
   } catch (error) {
-    if (!isTurnCancellation(error)) {
+    if (!isTurnCancellation(error) && input.abortSignal?.aborted !== true) {
       await failChannelDeliveries(error);
       throw error;
     }

--- a/packages/eve/src/execution/workflow-webhook-route.test.ts
+++ b/packages/eve/src/execution/workflow-webhook-route.test.ts
@@ -30,7 +30,36 @@ describe("workflow webhook route", () => {
     const response = await handleWorkflowWebhookRequest(request, route({ token: "tok" }));
 
     expect(response).toBe(accepted);
-    expect(runtime.resumeWebhook).toHaveBeenCalledWith("tok", request);
+    const [token, callback] = runtime.resumeWebhook.mock.calls.at(-1)!;
+    expect(token).toBe("tok");
+    expect(callback.url).toBe(request.url);
+    expect(callback.method).toBe("POST");
+    await expect(callback.text()).resolves.toBe("{}");
+  });
+
+  it("materializes lazy server headers before Workflow serializes the request", async () => {
+    const headers = Object.create(Headers.prototype, {
+      [Symbol.iterator]: {
+        value: function* () {
+          yield ["x-callback", "accepted"];
+        },
+      },
+    });
+    const request = new Request("https://agent.example/callback", {
+      method: "POST",
+      body: "payload",
+    });
+    Object.defineProperty(request, "headers", { value: headers });
+    expect(() => Headers.prototype.entries.call(headers).next()).toThrow(TypeError);
+    runtime.resumeWebhook.mockResolvedValueOnce(new Response(null, { status: 202 }));
+
+    await handleWorkflowWebhookRequest(request, route({ token: "tok" }));
+
+    const [, callback] = runtime.resumeWebhook.mock.calls.at(-1)!;
+    expect([...Headers.prototype.entries.call(callback.headers)]).toEqual([
+      ["x-callback", "accepted"],
+    ]);
+    await expect(callback.text()).resolves.toBe("payload");
   });
 
   it("rejects a missing token and reports an unknown hook as not pending", async () => {

--- a/packages/eve/src/execution/workflow-webhook-route.ts
+++ b/packages/eve/src/execution/workflow-webhook-route.ts
@@ -17,7 +17,15 @@ export async function handleWorkflowWebhookRequest(
   }
 
   try {
-    return await resumeWebhook(token, request);
+    // Nitro can supply lazy Headers objects that Workflow's native serializer cannot read.
+    const callback = new Request(request.url, {
+      method: request.method,
+      headers: new Headers(request.headers),
+      body: request.body,
+      signal: request.signal,
+      duplex: "half",
+    } as RequestInit & { duplex: "half" });
+    return await resumeWebhook(token, callback);
   } catch (error) {
     for (const candidate of walkCauseChain(error)) {
       if (HookNotFoundError.is(candidate)) {

--- a/packages/eve/src/harness/approval-delivery-coordinator.test.ts
+++ b/packages/eve/src/harness/approval-delivery-coordinator.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import type { SessionAuthContext } from "#channel/types.js";
 import { settleDirectApprovalResponse } from "#harness/approval-candidates.js";
-import { coordinateApprovalDelivery } from "#harness/approval-delivery-coordinator.js";
+import {
+  coordinateApprovalDelivery,
+  shouldPrepareApprovalReplayTools,
+} from "#harness/approval-delivery-coordinator.js";
 import { appendPendingInputBatch, getPendingInputBatches } from "#harness/pending-input-batches.js";
 import type { HarnessSession } from "#harness/types.js";
 import type { InputRequest } from "#shared/input.js";
@@ -104,5 +107,73 @@ describe("coordinateApprovalDelivery", () => {
         batch.requests.map((pending) => pending.requestId),
       ),
     ).toEqual([request.requestId]);
+  });
+});
+
+describe("text approval replay preparation", () => {
+  function sessionWithRequests(
+    requests: InputRequest[] = [request],
+    responseAuthRequiredRequestIds?: string[],
+  ) {
+    const base = parkedSession();
+    return appendPendingInputBatch({
+      requests,
+      responseAuthRequiredRequestIds,
+      responseMessages: [],
+      session: { ...base, state: undefined },
+    });
+  }
+
+  it.each(["approve", "APPROVE", "1"])("prepares a matching text approval: %s", (message) => {
+    expect(
+      shouldPrepareApprovalReplayTools({ session: sessionWithRequests(), stepInput: { message } }),
+    ).toBe(true);
+  });
+
+  it.each(["cancel", "unrelated follow-up"])("does not prepare tools for %s", (message) => {
+    expect(
+      shouldPrepareApprovalReplayTools({ session: sessionWithRequests(), stepInput: { message } }),
+    ).toBe(false);
+  });
+
+  it("does not treat a question option named approve as tool approval", () => {
+    expect(
+      shouldPrepareApprovalReplayTools({
+        session: sessionWithRequests([{ ...request, kind: "question" }]),
+        stepInput: { message: "approve" },
+      }),
+    ).toBe(false);
+  });
+
+  it("does not bypass responder authorization with text", () => {
+    expect(
+      shouldPrepareApprovalReplayTools({
+        session: sessionWithRequests([request], [request.requestId]),
+        stepInput: { message: "approve" },
+      }),
+    ).toBe(false);
+  });
+
+  it("does not interpret text when multiple batches are pending", () => {
+    const session = appendPendingInputBatch({
+      requests: [{ ...request, requestId: "approval-2" }],
+      responseMessages: [],
+      session: sessionWithRequests(),
+    });
+    expect(shouldPrepareApprovalReplayTools({ session, stepInput: { message: "approve" } })).toBe(
+      false,
+    );
+  });
+
+  it("preserves an explicit cancellation over approval text", () => {
+    expect(
+      shouldPrepareApprovalReplayTools({
+        session: sessionWithRequests(),
+        stepInput: {
+          message: "approve",
+          inputResponses: [{ optionId: "cancel", requestId: request.requestId }],
+        },
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/eve/src/harness/approval-delivery-coordinator.ts
+++ b/packages/eve/src/harness/approval-delivery-coordinator.ts
@@ -1,3 +1,4 @@
+import { resolveTextToResponses } from "#channel/resolve-text.js";
 import type { SessionAuthContext } from "#channel/types.js";
 import { buildCallbackContext } from "#context/build-callback-context.js";
 import { contextStorage } from "#context/container.js";
@@ -103,15 +104,35 @@ export function shouldPrepareApprovalReplayTools(input: {
 }): boolean {
   if (shouldPrepareApprovalPolicyTools(input)) return true;
 
+  const batches = getPendingInputBatches(input.session.state);
+  const responses = [
+    ...(input.stepInput?.attributedInputResponses ?? []).map(({ response }) => response),
+    ...(input.stepInput?.inputResponses ?? []),
+  ];
+  const batch = batches.length === 1 ? batches[0] : undefined;
+  if (
+    batch !== undefined &&
+    typeof input.stepInput?.message === "string" &&
+    !responses.some((response) =>
+      batch.requests.some((request) => request.requestId === response.requestId),
+    )
+  ) {
+    // Match the text-only approvals resolvePendingInput will consume after preparation.
+    responses.push(
+      ...resolveTextToResponses(
+        input.stepInput.message,
+        batch.requests.filter(
+          (request) => !batch.responseAuthRequiredRequestIds?.includes(request.requestId),
+        ),
+      ),
+    );
+  }
   const approvedRequestIds = new Set(
-    [
-      ...(input.stepInput?.attributedInputResponses ?? []).map(({ response }) => response),
-      ...(input.stepInput?.inputResponses ?? []),
-    ]
+    responses
       .filter((response) => response.optionId === "approve")
       .map((response) => response.requestId),
   );
-  return getPendingInputBatches(input.session.state).some((batch) =>
+  return batches.some((batch) =>
     batch.requests.some(
       (request) => isApprovalRequest(request) && approvedRequestIds.has(request.requestId),
     ),

--- a/packages/eve/src/harness/compaction-prompt.test.ts
+++ b/packages/eve/src/harness/compaction-prompt.test.ts
@@ -1,7 +1,12 @@
 import type { ModelMessage } from "ai";
 import { describe, expect, it } from "vitest";
 
-import { COMPACTION_PROMPT_ENVELOPE, createCompactionPrompt } from "#harness/compaction-prompt.js";
+import {
+  COMPACTION_PROMPT_ENVELOPE,
+  createCompactionPrompt,
+  sliceUtf16Safe,
+  TRANSCRIPT_PAYLOAD_LIMIT,
+} from "#harness/compaction-prompt.js";
 
 describe("createCompactionPrompt", () => {
   it("preserves the previous checkpoint without applying transcript truncation", () => {
@@ -180,5 +185,39 @@ describe("createCompactionPrompt", () => {
 
     expect(result.prompt).not.toContain("OLDEST_TAIL_MARKER");
     expect(result.prompt).toContain("NEWEST_TAIL_MARKER");
+  });
+
+  it("does not split a UTF-16 surrogate pair when capping degraded conversational text", () => {
+    // 📥 is U+1F4E5 — two UTF-16 units. Place its high surrogate exactly at
+    // the degraded-text limit boundary (index 1999 of the 2000-unit cap).
+    const content = "x".repeat(1999) + "📥" + " tail ".repeat(400);
+    const { prompt } = createCompactionPrompt({
+      messages: [{ role: "user", content }],
+      previousCheckpoint: undefined,
+      transcriptBudgetTokens: 100,
+    });
+
+    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(prompt)).toBe(false);
+    expect(prompt).toBe(prompt.toWellFormed());
+    expect(prompt).toContain(`${"x".repeat(1999)}…`);
+  });
+});
+
+describe("sliceUtf16Safe", () => {
+  it("steps back when the cut falls on a high surrogate", () => {
+    const value = "x".repeat(1999) + "📥" + "y";
+    expect(value.charCodeAt(1999)).toBe(0xd83d);
+    expect(value.charCodeAt(2000)).toBe(0xdce5);
+
+    const sliced = sliceUtf16Safe(value, TRANSCRIPT_PAYLOAD_LIMIT);
+    expect(sliced).toBe("x".repeat(1999));
+    expect(sliced).toBe(sliced.toWellFormed());
+  });
+
+  it("keeps a complete astral character that fits inside the limit", () => {
+    const value = "x".repeat(1998) + "📥" + "yyyy";
+    const sliced = sliceUtf16Safe(value, TRANSCRIPT_PAYLOAD_LIMIT);
+    expect(sliced).toBe("x".repeat(1998) + "📥");
+    expect(sliced).toBe(sliced.toWellFormed());
   });
 });

--- a/packages/eve/src/harness/compaction-prompt.ts
+++ b/packages/eve/src/harness/compaction-prompt.ts
@@ -313,11 +313,27 @@ function renderConversationText(value: string, limit?: number): string {
   return limit === undefined ? value.trim() : capText(value, limit);
 }
 
+// Providers reject lone surrogates created by cutting an astral character in half.
+export function sliceUtf16Safe(value: string, limit: number): string {
+  if (limit <= 0) {
+    return "";
+  }
+  if (value.length <= limit) {
+    return value;
+  }
+  let end = limit;
+  const last = value.charCodeAt(end - 1);
+  if (last >= 0xd800 && last <= 0xdbff) {
+    end -= 1;
+  }
+  return value.slice(0, end);
+}
+
 function capText(value: string, limit: number): string {
   const normalized = value.replace(/\s+/g, " ").trim();
   if (normalized.length <= limit) {
     return normalized;
   }
 
-  return `${normalized.slice(0, limit).trimEnd()}…`;
+  return `${sliceUtf16Safe(normalized, limit).trimEnd()}…`;
 }

--- a/packages/eve/src/harness/compaction.test.ts
+++ b/packages/eve/src/harness/compaction.test.ts
@@ -397,6 +397,43 @@ describe("compactMessages: tool-result cap heuristic", () => {
     expect(shouldCompact(result, { recentWindowSize: 1, threshold: ROOMY })).toBe(false);
   });
 
+  it("does not split a UTF-16 surrogate pair when capping tool results", async () => {
+    // JSON.stringify of this output places 📥's high surrogate at index 1999
+    // of the 2000-unit TRANSCRIPT_PAYLOAD_LIMIT cut.
+    const content = `${"x".repeat(1964)}📥${"y".repeat(500)}`;
+    const call: ModelMessage = {
+      content: [{ input: {}, toolCallId: "call-0", toolName: "grep", type: "tool-call" }],
+      role: "assistant",
+    };
+    const resultMsg: ModelMessage = {
+      content: [
+        {
+          output: { type: "json", value: { content } },
+          toolCallId: "call-0",
+          toolName: "grep",
+          type: "tool-result",
+        },
+      ],
+      role: "tool",
+    };
+    const messages = [user("investigate"), call, resultMsg, user("what did you find?")];
+
+    const { result, summarizer } = await compact(messages, { recentWindowSize: 1 });
+
+    expect(summarizer).not.toHaveBeenCalled();
+    const cappedPart = Array.isArray(result[2]?.content) ? result[2].content[0] : undefined;
+    const output = cappedPart?.type === "tool-result" ? cappedPart.output : undefined;
+    const value =
+      typeof output === "object" && output !== null && "value" in output
+        ? String(output.value)
+        : "";
+    expect(value).toContain("Truncated by eve");
+    expect(value).toBe(value.toWellFormed());
+    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(value)).toBe(false);
+    expect(value).not.toContain("📥");
+    expect(value).toContain("x".repeat(1964));
+  });
+
   it("stubs content-output file parts instead of truncating into their payloads", async () => {
     const base64 = "iVBORw0KGgo".repeat(500);
     const messages: ModelMessage[] = [

--- a/packages/eve/src/harness/compaction.ts
+++ b/packages/eve/src/harness/compaction.ts
@@ -5,6 +5,7 @@ import {
   COMPACTION_PROMPT_ENVELOPE,
   COMPACTION_RESUMPTION_MESSAGE,
   createCompactionPrompt,
+  sliceUtf16Safe,
   stubContentOutputFileParts,
   TODO_COMPACTION_PRESERVATION_LABEL,
   TRANSCRIPT_PAYLOAD_LIMIT,
@@ -295,7 +296,7 @@ function capToolResults(messages: readonly ModelMessage[]): ModelMessage[] {
         ...part,
         output: {
           type: "text" as const,
-          value: `${CAPPED_RESULT_ANNOTATION}\n\n${serialized.slice(0, TRANSCRIPT_PAYLOAD_LIMIT)}`,
+          value: `${CAPPED_RESULT_ANNOTATION}\n\n${sliceUtf16Safe(serialized, TRANSCRIPT_PAYLOAD_LIMIT)}`,
         },
       };
     });

--- a/packages/eve/src/harness/tool-loop-generate-approval-resume.integration.test.ts
+++ b/packages/eve/src/harness/tool-loop-generate-approval-resume.integration.test.ts
@@ -280,42 +280,57 @@ function findPart(
 }
 
 describe("tool loop generate approval resume (real AI SDK)", () => {
-  it.each([
-    { scope: "step", metadataKey: StepDynamicToolMetadataKey },
-    { scope: "turn", metadataKey: TurnDynamicToolMetadataKey },
-    { scope: "session", metadataKey: SessionDynamicToolMetadataKey },
-  ])("records the scoped key when approving a $scope dynamic tool", async ({ metadataKey }) => {
-    const ctx = createApprovalContext();
-    const execute = vi.fn(async () => "/workspace");
-    registerDurableDynamicCallback({ toolName: "bash", phase: "execute", callback: execute });
-    registerDurableDynamicCallback({
-      toolName: "bash",
-      phase: "approvalKey",
-      callback: (_closure, input: { command: string }) => `bash:${input.command}`,
-    });
-    ctx.set(metadataKey, [
-      {
-        name: "bash",
-        description: "Run a shell command.",
-        inputSchema: { type: "object" },
-        resolverSlug: "dynamic-shell",
-        entryKey: "bash",
-        callbacks: { execute: { closure: {} }, approvalKey: { closure: {} } },
-      },
-    ]);
-    const staticExecute = vi.fn(async () => "static");
-    const runStep = createToolLoopHarness(createConfig(createModel(), staticExecute));
+  it.each(
+    [
+      { scope: "step", metadataKey: StepDynamicToolMetadataKey },
+      { scope: "turn", metadataKey: TurnDynamicToolMetadataKey },
+      { scope: "session", metadataKey: SessionDynamicToolMetadataKey },
+    ].flatMap((scope) => ["structured", "text"].map((response) => ({ ...scope, response }))),
+  )(
+    "records the scoped key for a $response approval of a $scope dynamic tool",
+    async ({ metadataKey, response }) => {
+      const ctx = createApprovalContext();
+      const execute = vi.fn(async () => "/workspace");
+      registerDurableDynamicCallback({ toolName: "bash", phase: "execute", callback: execute });
+      registerDurableDynamicCallback({
+        toolName: "bash",
+        phase: "approvalKey",
+        callback: (_closure, input: { command: string }) => `bash:${input.command}`,
+      });
+      ctx.set(metadataKey, [
+        {
+          name: "bash",
+          description: "Run a shell command.",
+          inputSchema: { type: "object" },
+          resolverSlug: "dynamic-shell",
+          entryKey: "bash",
+          callbacks: { execute: { closure: {} }, approvalKey: { closure: {} } },
+        },
+      ]);
+      const staticExecute = vi.fn(async () => "static");
+      const resolveStepDynamicTools = vi.fn(async () => {});
+      const runStep = createToolLoopHarness({
+        ...createConfig(createModel(), staticExecute),
+        resolveStepDynamicTools,
+      });
 
-    const result = await contextStorage.run(ctx, () =>
-      runStep(createPendingApprovalSession(), {
-        inputResponses: [{ optionId: "approve", requestId: approvalRequest.approvalId }],
-      }),
-    );
+      const result = await contextStorage.run(ctx, () =>
+        runStep(
+          createPendingApprovalSession(),
+          response === "text"
+            ? { message: "approve" }
+            : {
+                inputResponses: [{ optionId: "approve", requestId: approvalRequest.approvalId }],
+              },
+        ),
+      );
+      expect(resolveStepDynamicTools).toHaveBeenCalledOnce();
 
-    expect(getApprovedTools(result.session)).toEqual(new Set(["bash:pwd"]));
-    expect(execute).toHaveBeenCalledOnce();
-    expect(staticExecute).not.toHaveBeenCalled();
-  });
+      expect(getApprovedTools(result.session)).toEqual(new Set(["bash:pwd"]));
+      expect(execute).toHaveBeenCalledOnce();
+      expect(staticExecute).not.toHaveBeenCalled();
+    },
+  );
 
   it.each([
     { label: "direct", responseAuthorization: false },

--- a/packages/eve/src/harness/tool-loop-generate-approval-resume.integration.test.ts
+++ b/packages/eve/src/harness/tool-loop-generate-approval-resume.integration.test.ts
@@ -12,20 +12,25 @@ import { PendingSkillAnnouncementKey } from "#context/dynamic-skill-lifecycle.js
 import {
   AuthKey,
   SessionKey,
+  SessionDynamicToolMetadataKey,
+  TurnDynamicToolMetadataKey,
   StepDynamicToolMetadataKey,
   TurnTaskStateKey,
 } from "#context/keys.js";
 import { setHarnessEmissionState } from "#harness/emission.js";
 import type { HarnessToolDefinition } from "#harness/execute-tool.js";
 import type { InputRequest } from "#shared/input.js";
-import { appendPendingInputBatch } from "#harness/input-requests.js";
+import { appendPendingInputBatch, getApprovedTools } from "#harness/input-requests.js";
 import { getPendingInputBatches } from "#harness/pending-input-batches.js";
 import { createToolLoopHarness } from "#harness/tool-loop.js";
 import { setTurnUsageState } from "#harness/turn-tag-state.js";
 import type { HarnessSession, ToolLoopHarnessConfig } from "#harness/types.js";
 import { once } from "#tools/approval/policies.js";
 import { defineTool } from "#tools/definition.js";
-import { stampDurableDynamicCallback } from "#tools/durable-callbacks.js";
+import {
+  registerDurableDynamicCallback,
+  stampDurableDynamicCallback,
+} from "#tools/durable-callbacks.js";
 
 const usage = {
   inputTokens: {
@@ -275,6 +280,43 @@ function findPart(
 }
 
 describe("tool loop generate approval resume (real AI SDK)", () => {
+  it.each([
+    { scope: "step", metadataKey: StepDynamicToolMetadataKey },
+    { scope: "turn", metadataKey: TurnDynamicToolMetadataKey },
+    { scope: "session", metadataKey: SessionDynamicToolMetadataKey },
+  ])("records the scoped key when approving a $scope dynamic tool", async ({ metadataKey }) => {
+    const ctx = createApprovalContext();
+    const execute = vi.fn(async () => "/workspace");
+    registerDurableDynamicCallback({ toolName: "bash", phase: "execute", callback: execute });
+    registerDurableDynamicCallback({
+      toolName: "bash",
+      phase: "approvalKey",
+      callback: (_closure, input: { command: string }) => `bash:${input.command}`,
+    });
+    ctx.set(metadataKey, [
+      {
+        name: "bash",
+        description: "Run a shell command.",
+        inputSchema: { type: "object" },
+        resolverSlug: "dynamic-shell",
+        entryKey: "bash",
+        callbacks: { execute: { closure: {} }, approvalKey: { closure: {} } },
+      },
+    ]);
+    const staticExecute = vi.fn(async () => "static");
+    const runStep = createToolLoopHarness(createConfig(createModel(), staticExecute));
+
+    const result = await contextStorage.run(ctx, () =>
+      runStep(createPendingApprovalSession(), {
+        inputResponses: [{ optionId: "approve", requestId: approvalRequest.approvalId }],
+      }),
+    );
+
+    expect(getApprovedTools(result.session)).toEqual(new Set(["bash:pwd"]));
+    expect(execute).toHaveBeenCalledOnce();
+    expect(staticExecute).not.toHaveBeenCalled();
+  });
+
   it.each([
     { label: "direct", responseAuthorization: false },
     { label: "response-authorized", responseAuthorization: true },

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -144,7 +144,6 @@ import {
 } from "#harness/approval-candidates.js";
 import {
   coordinateApprovalDelivery,
-  shouldPrepareApprovalPolicyTools,
   shouldPrepareApprovalReplayTools,
 } from "#harness/approval-delivery-coordinator.js";
 import type { InstrumentationAttempt, InstrumentationStepScope } from "#instrumentation/runtime.js";
@@ -457,7 +456,6 @@ function buildHarnessToolsWithDynamicSubagents(
 
 export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
   const baseEmit = config.handleEvent;
-  const resolveApprovalKey = resolveApprovalKeyFromTools(config.tools);
 
   async function runStep(
     initialSession: Readonly<Parameters<StepFn>[0]>,
@@ -674,7 +672,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         messages: projectHistory(resolvedCoordination.messages, session.state),
       });
     }
-    const responseAuthorizationTools = shouldPrepareApprovalPolicyTools({
+    const responseAuthorizationTools = shouldPrepareApprovalReplayTools({
       session,
       stepInput: effectiveStepInput,
     })
@@ -813,7 +811,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     const pending = resolvePendingInput({
       deferMessagesWhileApprovalsPending: config.mode !== "conversation",
       history: resolvedCoordination.messages,
-      resolveApprovalKey,
+      resolveApprovalKey: resolveApprovalKeyFromTools(responseAuthorizationTools),
       session,
       stepInput: coordinated.stepInput,
     });
@@ -1181,7 +1179,12 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         projectedMessages,
       );
     }
-    const approvedTools = getApprovedTools(session, resolveApprovalKey);
+    const approvedTools = getApprovedTools(
+      session,
+      resolveApprovalKeyFromTools(
+        buildResponseAuthorizationTools({ authoredTools: config.tools, context: ctx }),
+      ),
+    );
 
     const isFirstTurn = emissionState.sequence === 0;
     const hasScheduleProvenance = isFirstTurn && ctx?.get(ScheduleIdKey) !== undefined;

--- a/packages/eve/src/internal/authored-definition/schema-backed.ts
+++ b/packages/eve/src/internal/authored-definition/schema-backed.ts
@@ -124,6 +124,7 @@ export function normalizeToolDefinition(value: unknown, message: string): Normal
       "execution",
       "inputSchema",
       "approval",
+      "approvalKey",
       "outputSchema",
       "toModelOutput",
     ],
@@ -178,6 +179,10 @@ export function normalizeToolDefinition(value: unknown, message: string): Normal
    */
   if (record.approval !== undefined) {
     normalizeApproval(record.approval, message);
+  }
+
+  if (record.approvalKey !== undefined) {
+    expectFunction(record.approvalKey, message);
   }
 
   if (record.toModelOutput !== undefined) {

--- a/packages/eve/src/internal/node-esm-compat-banner.scenario.test.ts
+++ b/packages/eve/src/internal/node-esm-compat-banner.scenario.test.ts
@@ -1,0 +1,32 @@
+import { Buffer } from "node:buffer";
+
+import { describe, expect, it } from "vitest";
+
+import { buildSingleRolldownChunk } from "#internal/bundler/nitro-rolldown.js";
+import { createNodeEsmCompatBannerPlugin } from "#internal/node-esm-compat-banner.js";
+
+describe("Node ESM compatibility banner bundling", () => {
+  it("loads a chunk with comma-separated compatibility bindings", async () => {
+    const source = `const logs = [], require = () => "required", __filename = "/agent/index.mjs", __dirname = "/agent";
+export const value = [logs, require(), __filename, __dirname];`;
+    const chunk = await buildSingleRolldownChunk("compatibility bindings", {
+      input: "virtual:compatibility",
+      platform: "node",
+      plugins: [
+        {
+          name: "compatibility-fixture",
+          resolveId: (id: string) => (id === "virtual:compatibility" ? id : undefined),
+          load: () => source,
+          renderChunk: () => source,
+        },
+        createNodeEsmCompatBannerPlugin({ includeRequire: true }),
+      ],
+      output: { format: "esm" },
+    });
+
+    const namespace = await import(
+      `data:text/javascript;base64,${Buffer.from(chunk.code).toString("base64")}`
+    );
+    expect(namespace.value).toEqual([[], "required", "/agent/index.mjs", "/agent"]);
+  });
+});

--- a/packages/eve/src/internal/node-esm-compat-banner.test.ts
+++ b/packages/eve/src/internal/node-esm-compat-banner.test.ts
@@ -5,9 +5,34 @@ import {
   createNodeEsmCompatBannerPlugin,
 } from "#internal/node-esm-compat-banner.js";
 
+type TestProgram = Parameters<typeof buildNodeEsmCompatBanner>[0];
+type TestPlugin = ReturnType<typeof createNodeEsmCompatBannerPlugin>;
+
+const EMPTY_PROGRAM: TestProgram = { body: [] };
+
+function programWithTopLevelBindings(...names: string[]): TestProgram {
+  return {
+    body: [
+      {
+        type: "VariableDeclaration",
+        declarations: names.map((name) => ({ id: { type: "Identifier", name } })),
+      },
+    ],
+  };
+}
+
+function renderChunk(
+  plugin: TestPlugin,
+  code: string,
+  program: TestProgram = EMPTY_PROGRAM,
+  chunk?: { readonly fileName?: string },
+) {
+  return plugin.renderChunk.call({ parse: () => program }, code, chunk);
+}
+
 describe("buildNodeEsmCompatBanner", () => {
   it("emits both path globals when the chunk declares neither", () => {
-    const banner = buildNodeEsmCompatBanner('console.log("noop");');
+    const banner = buildNodeEsmCompatBanner(EMPTY_PROGRAM);
 
     expect(banner).toContain("const __filename = __eveFileURLToPath(import.meta.url);");
     expect(banner).toContain("const __dirname = __eveDirname(__filename);");
@@ -15,7 +40,7 @@ describe("buildNodeEsmCompatBanner", () => {
   });
 
   it("includes the require shim when requested", () => {
-    const banner = buildNodeEsmCompatBanner('console.log("noop");', { includeRequire: true });
+    const banner = buildNodeEsmCompatBanner(EMPTY_PROGRAM, { includeRequire: true });
 
     expect(banner).toContain("const require = __eveCreateRequire(import.meta.url);");
   });
@@ -25,16 +50,7 @@ describe("buildNodeEsmCompatBanner", () => {
     // `const __dirname = ...`, producing `SyntaxError: Identifier
     // '__dirname' has already been declared` when bundled output
     // re-declared the path global itself.
-    const chunk = [
-      'import { fileURLToPath } from "node:url";',
-      'import { dirname } from "node:path";',
-      "const __filename = fileURLToPath(import.meta.url);",
-      "const __dirname = dirname(__filename);",
-      "",
-      'export const value = "noop";',
-    ].join("\n");
-
-    const banner = buildNodeEsmCompatBanner(chunk);
+    const banner = buildNodeEsmCompatBanner(programWithTopLevelBindings("__filename", "__dirname"));
 
     expect(banner).not.toContain("__dirname");
     expect(banner).not.toContain("__filename");
@@ -43,9 +59,7 @@ describe("buildNodeEsmCompatBanner", () => {
   });
 
   it("emits only the missing path global", () => {
-    const chunk = ["var __dirname = somethingElse;", 'export const value = "noop";'].join("\n");
-
-    const banner = buildNodeEsmCompatBanner(chunk);
+    const banner = buildNodeEsmCompatBanner(programWithTopLevelBindings("__dirname"));
 
     expect(banner).toContain("const __filename = __eveFileURLToPath(import.meta.url);");
     expect(banner).not.toContain("const __dirname = __eveDirname(__filename);");
@@ -53,9 +67,7 @@ describe("buildNodeEsmCompatBanner", () => {
   });
 
   it("does not read a chunk-provided __filename before it initializes", () => {
-    const chunk = ["const __filename = '/x/file.js';", 'export const value = "noop";'].join("\n");
-
-    const banner = buildNodeEsmCompatBanner(chunk);
+    const banner = buildNodeEsmCompatBanner(programWithTopLevelBindings("__filename"));
 
     expect(banner).not.toContain("const __filename");
     expect(banner).toContain(
@@ -64,27 +76,19 @@ describe("buildNodeEsmCompatBanner", () => {
   });
 
   it("omits the require shim when the chunk binds require", () => {
-    const chunk = [
-      'import { createRequire } from "node:module";',
-      "const require = createRequire(import.meta.url);",
-      'export const value = "noop";',
-    ].join("\n");
-
-    const banner = buildNodeEsmCompatBanner(chunk, { includeRequire: true });
+    const banner = buildNodeEsmCompatBanner(programWithTopLevelBindings("require"), {
+      includeRequire: true,
+    });
 
     expect(banner).not.toContain("__eveCreateRequire");
     expect(banner).not.toContain("const require");
   });
 
   it("does not treat bundler-suffixed bindings as compatibility globals", () => {
-    const chunk = [
-      "const __filename$1 = '/x/file.js';",
-      "const __dirname$1 = '/x';",
-      "const require$1 = () => {};",
-      'export const value = "noop";',
-    ].join("\n");
-
-    const banner = buildNodeEsmCompatBanner(chunk, { includeRequire: true });
+    const banner = buildNodeEsmCompatBanner(
+      programWithTopLevelBindings("__filename$1", "__dirname$1", "require$1"),
+      { includeRequire: true },
+    );
 
     expect(banner).toContain("const __filename = __eveFileURLToPath(import.meta.url);");
     expect(banner).toContain("const __dirname = __eveDirname(__filename);");
@@ -92,15 +96,22 @@ describe("buildNodeEsmCompatBanner", () => {
   });
 
   it("ignores nested declarations inside functions", () => {
-    const chunk = [
-      "function inner() {",
-      "  const __dirname = 'shadowed';",
-      "  return __dirname;",
-      "}",
-      "export { inner };",
-    ].join("\n");
-
-    const banner = buildNodeEsmCompatBanner(chunk);
+    const banner = buildNodeEsmCompatBanner({
+      body: [
+        {
+          type: "FunctionDeclaration",
+          body: {
+            type: "BlockStatement",
+            body: [
+              {
+                type: "VariableDeclaration",
+                declarations: [{ id: { type: "Identifier", name: "__dirname" } }],
+              },
+            ],
+          },
+        },
+      ],
+    });
 
     // The chunk has not bound `__dirname` at the top level, so the
     // banner must still provide it.
@@ -110,10 +121,24 @@ describe("buildNodeEsmCompatBanner", () => {
 });
 
 describe("createNodeEsmCompatBannerPlugin", () => {
+  it("omits bindings declared later in a top-level variable list", () => {
+    const plugin = createNodeEsmCompatBannerPlugin({ includeRequire: true });
+    const chunk =
+      "const logs = getLogs(), require = createRequire(import.meta.url), __filename = fileURLToPath(import.meta.url), __dirname = dirname(__filename);";
+
+    expect(
+      renderChunk(
+        plugin,
+        chunk,
+        programWithTopLevelBindings("logs", "require", "__filename", "__dirname"),
+      ),
+    ).toBeNull();
+  });
+
   it("prepends the banner to chunks that need it", () => {
     const plugin = createNodeEsmCompatBannerPlugin();
     const code = 'export const value = "noop";';
-    const result = plugin.renderChunk(code, { fileName: "agent.mjs" });
+    const result = renderChunk(plugin, code, EMPTY_PROGRAM, { fileName: "agent.mjs" });
 
     expect(result).not.toBeNull();
     expect(result?.code).toMatch(/^import \{ fileURLToPath as __eveFileURLToPath \}/);
@@ -130,7 +155,7 @@ describe("createNodeEsmCompatBannerPlugin", () => {
   it("maps original chunk lines after the prepended banner", () => {
     const plugin = createNodeEsmCompatBannerPlugin();
     const code = ['const value = "noop";', "export { value };"].join("\n");
-    const result = plugin.renderChunk(code);
+    const result = renderChunk(plugin, code);
 
     expect(result?.map.mappings).toBe(";;;;AAAA;AACA");
   });
@@ -143,6 +168,8 @@ describe("createNodeEsmCompatBannerPlugin", () => {
       'export const value = "noop";',
     ].join("\n");
 
-    expect(plugin.renderChunk(chunk)).toBeNull();
+    expect(
+      renderChunk(plugin, chunk, programWithTopLevelBindings("__filename", "__dirname")),
+    ).toBeNull();
   });
 });

--- a/packages/eve/src/internal/node-esm-compat-banner.ts
+++ b/packages/eve/src/internal/node-esm-compat-banner.ts
@@ -16,23 +16,30 @@ interface NodeEsmCompatBannerOptions {
 interface BannerLine {
   readonly importLine: string;
   readonly declarationLine: string;
-  readonly bindingPattern: RegExp;
+  readonly bindingName: string;
 }
 
-// Match `const|let|var <name>` at the literal start of a line. Bundler
-// output places module-scope declarations at column zero; indented
-// declarations live inside functions, classes, or blocks and therefore do
-// not collide with the banner.
+interface ParsedNode {
+  readonly body?: ParsedNode | readonly ParsedNode[];
+  readonly type: string;
+  readonly name?: string;
+  readonly declarations?: readonly { readonly id: ParsedNode }[];
+}
+
+interface ParsedProgram {
+  readonly body: readonly ParsedNode[];
+}
+
 const BANNER_LINES: readonly BannerLine[] = [
   {
     importLine: 'import { fileURLToPath as __eveFileURLToPath } from "node:url";',
     declarationLine: "const __filename = __eveFileURLToPath(import.meta.url);",
-    bindingPattern: /^(?:const|let|var)\s+__filename(?![\w$])/m,
+    bindingName: "__filename",
   },
   {
     importLine: 'import { dirname as __eveDirname } from "node:path";',
     declarationLine: "const __dirname = __eveDirname(__filename);",
-    bindingPattern: /^(?:const|let|var)\s+__dirname(?![\w$])/m,
+    bindingName: "__dirname",
   },
 ];
 
@@ -42,19 +49,18 @@ const DIRNAME_BANNER_LINE = BANNER_LINES[1]!;
 const REQUIRE_LINE: BannerLine = {
   importLine: 'import { createRequire as __eveCreateRequire } from "node:module";',
   declarationLine: "const require = __eveCreateRequire(import.meta.url);",
-  bindingPattern: /^(?:const|let|var)\s+require(?![\w$])/m,
+  bindingName: "require",
 };
 
 /**
- * Builds the ESM CommonJS-compatibility banner appropriate for a single
- * bundle chunk's code. Identifiers the chunk already binds at the top
- * level (e.g. `const __dirname = ...` emitted by an inlined module) are
- * skipped so the prepended banner never re-declares them.
+ * Builds the ESM CommonJS-compatibility banner appropriate for a parsed
+ * bundle chunk. Identifiers the chunk already binds in a top-level variable
+ * declaration are skipped so the prepended banner never re-declares them.
  *
  * Returns an empty string when the chunk already provides every binding.
  */
 export function buildNodeEsmCompatBanner(
-  code: string,
+  program: ParsedProgram,
   options: NodeEsmCompatBannerOptions = {},
 ): string {
   const lines: BannerLine[] = [...BANNER_LINES];
@@ -65,11 +71,12 @@ export function buildNodeEsmCompatBanner(
 
   const imports: string[] = [];
   const declarations: string[] = [];
-  const chunkProvidesFilename = FILENAME_BANNER_LINE.bindingPattern.test(code);
-  const chunkProvidesDirname = DIRNAME_BANNER_LINE.bindingPattern.test(code);
+  const topLevelBindings = collectTopLevelVariableBindings(program);
+  const chunkProvidesFilename = topLevelBindings.has(FILENAME_BANNER_LINE.bindingName);
+  const chunkProvidesDirname = topLevelBindings.has(DIRNAME_BANNER_LINE.bindingName);
 
   for (const line of lines) {
-    if (line.bindingPattern.test(code)) {
+    if (topLevelBindings.has(line.bindingName)) {
       continue;
     }
 
@@ -93,9 +100,32 @@ export function buildNodeEsmCompatBanner(
   return [...imports, ...declarations].join("\n");
 }
 
+function collectTopLevelVariableBindings(program: ParsedProgram): ReadonlySet<string> {
+  const bindings = new Set<string>();
+
+  for (const statement of program.body) {
+    if (statement.type !== "VariableDeclaration") {
+      continue;
+    }
+
+    for (const declaration of statement.declarations ?? []) {
+      if (declaration.id.type === "Identifier" && declaration.id.name !== undefined) {
+        bindings.add(declaration.id.name);
+      }
+    }
+  }
+
+  return bindings;
+}
+
+interface BannerPluginContext {
+  parse(code: string): ParsedProgram;
+}
+
 interface BannerPlugin {
   readonly name: string;
   renderChunk(
+    this: BannerPluginContext,
     code: string,
     chunk?: { readonly fileName?: string },
   ): { code: string; map: SourceMap } | null;
@@ -120,7 +150,7 @@ export function createNodeEsmCompatBannerPlugin(
   return {
     name: "eve-node-esm-compat-banner",
     renderChunk(code, chunk) {
-      const banner = buildNodeEsmCompatBanner(code, options);
+      const banner = buildNodeEsmCompatBanner(this.parse(code), options);
 
       if (banner === "") {
         return null;

--- a/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.test.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.test.ts
@@ -53,6 +53,7 @@ async function transformAndEval(
       entry,
       collectDurableDynamicToolCallbacks({
         approval: entry.approval as never,
+        approvalKey: entry.approvalKey as never,
         execute: entry.execute as never,
         toModelOutput: entry.toModelOutput as never,
       }),
@@ -2424,5 +2425,34 @@ export default defineDynamic({
 
     expect(code).toContain("const { tag } = __vars");
     expect(code).toMatch(/\(\.\.\.__args\) => __eve_dynamic_exec_\d+\(\{ tag \}, \.\.\.__args\)/);
+  });
+});
+
+describe("approvalKey callbacks", () => {
+  it("captures input-scoped approval keys for durable replay", async () => {
+    const { callHandler } = await transformAndEval(
+      "tools/scoped.ts",
+      `
+      import { defineDynamic, defineTool } from "eve";
+      export default defineDynamic({ events: { "step.started": () => {
+        const prefix = "repo";
+        return { write: defineTool({
+          description: "write",
+          inputSchema: { type: "object" },
+          execute: () => ({ ok: true }),
+          approvalKey: (input) => prefix + ":" + input.branch,
+        }) };
+      } } });
+    `,
+    );
+    const result = await callHandler();
+    const entry = result.write as { approvalKey: (input: unknown) => string };
+    const descriptor = readDurableDynamicCallback(entry.approvalKey)!;
+    expect(descriptor.closure).toEqual({ prefix: "repo" });
+    expect(
+      (descriptor.callback as Function)(JSON.parse(JSON.stringify(descriptor.closure)), {
+        branch: "main",
+      }),
+    ).toBe("repo:main");
   });
 });

--- a/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.ts
@@ -13,8 +13,19 @@ import {
   walkNode,
 } from "#internal/workflow-bundle/dynamic-tool-ast-references.js";
 
-type CallbackPhase = "approvalRequest" | "approvalResponse" | "execute" | "toModelOutput";
-type CallbackPropertyName = "approval" | "execute" | "request" | "response" | "toModelOutput";
+type CallbackPhase =
+  | "approvalKey"
+  | "approvalRequest"
+  | "approvalResponse"
+  | "execute"
+  | "toModelOutput";
+type CallbackPropertyName =
+  | "approvalKey"
+  | "approval"
+  | "execute"
+  | "request"
+  | "response"
+  | "toModelOutput";
 
 interface CallbackInfo {
   readonly body: string;
@@ -176,6 +187,15 @@ function collectToolCallbacks(
     findProperty(tool, "toModelOutput"),
     "toModelOutput",
     "toModelOutput",
+    results,
+    nestedScopes,
+  );
+
+  collectCallbackProperty(
+    source,
+    findProperty(tool, "approvalKey"),
+    "approvalKey",
+    "approvalKey",
     results,
     nestedScopes,
   );

--- a/packages/eve/src/internal/workflow-bundle/workflow-core-shim.test.ts
+++ b/packages/eve/src/internal/workflow-bundle/workflow-core-shim.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { sleep } from "#internal/workflow-bundle/workflow-core-shim.js";
+import { createWebhook, sleep } from "#internal/workflow-bundle/workflow-core-shim.js";
 
 const WORKFLOW_SLEEP = Symbol.for("WORKFLOW_SLEEP");
 const workflowGlobal = globalThis as typeof globalThis & Record<symbol, unknown>;
@@ -27,5 +27,45 @@ describe("workflow core shim sleep", () => {
     delete workflowGlobal[WORKFLOW_SLEEP];
 
     expect(() => sleep(2_500)).toThrow("`sleep()` can only be called inside a workflow function");
+  });
+});
+
+describe("workflow core shim webhooks", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  function installHook() {
+    const hook = { token: "generated/token", getConflict: vi.fn() };
+    const create = vi.fn(() => hook);
+    vi.stubGlobal(Symbol.for("WORKFLOW_CREATE_HOOK"), create);
+    vi.stubGlobal(Symbol.for("WORKFLOW_CONTEXT"), { url: "https://agent.example" });
+    return { create, hook };
+  }
+
+  it("creates a publicly resumable webhook with an encoded generated token", () => {
+    const { create, hook } = installHook();
+    const webhook = createWebhook();
+    expect(webhook).toBe(hook);
+    expect(webhook.url).toBe(
+      "https://agent.example/.well-known/workflow/v1/webhook/generated%2Ftoken",
+    );
+    expect(create).toHaveBeenCalledExactlyOnceWith({ isWebhook: true, metadata: undefined });
+  });
+
+  it.each(["manual", new Response("accepted", { status: 202 })])(
+    "preserves the webhook response mode as hook metadata",
+    (respondWith) => {
+      const { create } = installHook();
+      createWebhook({ respondWith });
+      expect(create).toHaveBeenCalledExactlyOnceWith({
+        isWebhook: true,
+        metadata: { respondWith },
+      });
+    },
+  );
+
+  it("rejects authored tokens before creating a public hook", () => {
+    const { create } = installHook();
+    expect(() => createWebhook({ token: "predictable" })).toThrow("does not accept a `token`");
+    expect(create).not.toHaveBeenCalled();
   });
 });

--- a/packages/eve/src/internal/workflow-bundle/workflow-core-shim.ts
+++ b/packages/eve/src/internal/workflow-bundle/workflow-core-shim.ts
@@ -84,7 +84,17 @@ export function getWritable<T = unknown>(options: { namespace?: string } = {}): 
  * Creates a Workflow webhook from inside a durable workflow body.
  */
 export function createWebhook<T = unknown>(options?: unknown): WorkflowHook<T> & { url?: string } {
-  const hook = createHook<T>(options) as WorkflowHook<T> & { url?: string };
+  const { respondWith, token, ...rest } = (options ?? {}) as Record<string, unknown>;
+  if (token !== undefined) {
+    throw new Error(
+      "`createWebhook()` does not accept a `token` option. Use `createHook()` with `resumeHook()` for deterministic tokens.",
+    );
+  }
+  const hook = createHook<T>({
+    ...rest,
+    metadata: respondWith === undefined ? undefined : { respondWith },
+    isWebhook: true,
+  }) as WorkflowHook<T> & { url?: string };
   const metadata = getWorkflowMetadata();
   const baseUrl = typeof metadata.url === "string" ? metadata.url : "";
 

--- a/packages/eve/src/public/channels/slack/connections.test.ts
+++ b/packages/eve/src/public/channels/slack/connections.test.ts
@@ -76,9 +76,20 @@ describe("buildAuthEphemeralBlocks", () => {
       style: string;
     };
     expect(button.type).toBe("button");
-    expect(button.text.text).toBe("Sign in with Linear");
+    expect(button.text.text).toBe("Sign in");
     expect(button.url).toBe("https://connect.example.com/authorize/sca_abc");
     expect(button.style).toBe("primary");
+  });
+
+  it("keeps the button label within Slack's limit for long display names", () => {
+    const blocks = buildAuthEphemeralBlocks({
+      displayName: "x".repeat(63),
+      url: "https://connect.example.com/authorize/sca_abc",
+    });
+    const actions = blocks[0] as { elements: Array<{ text: { text: string } }> };
+    const button = actions.elements[0] as { text: { text: string } };
+    expect(button.text.text).toBe("Sign in");
+    expect(button.text.text.length).toBeLessThanOrEqual(75);
   });
 
   it("prepends a section with the device user code when one is provided", () => {

--- a/packages/eve/src/public/channels/slack/connections.ts
+++ b/packages/eve/src/public/channels/slack/connections.ts
@@ -6,7 +6,7 @@
  * challenge is a credential: anyone in a shared thread could complete a
  * posted sign-in link and bind their own identity to the session. The
  * default handler therefore posts a link-free public status while
- * delivering the actual challenge as an ephemeral "Sign in with X"
+ * delivering the actual challenge as an ephemeral "Sign in"
  * message visible only to the triggering user.
  *
  * When no user can be targeted (no triggering user id, no challenge
@@ -66,7 +66,7 @@ export function buildAuthCompletedText(input: {
 }
 
 /**
- * Block Kit blocks for the ephemeral "Sign in with X" link button.
+ * Block Kit blocks for the ephemeral "Sign in" link button.
  * Device-code flows carry a `userCode` the user must enter after
  * following the link, so it is rendered alongside the button. Slack
  * ephemerals accept the same block list shape as regular messages so the
@@ -89,7 +89,7 @@ export function buildAuthEphemeralBlocks(input: {
     elements: [
       {
         type: "button",
-        text: { type: "plain_text", text: `Sign in with ${input.displayName}` },
+        text: { type: "plain_text", text: "Sign in" },
         url: input.url,
         style: "primary",
       },

--- a/packages/eve/src/react/use-eve-agent.test.ts
+++ b/packages/eve/src/react/use-eve-agent.test.ts
@@ -689,7 +689,7 @@ describe("useEveAgent", () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(createBoundedStreamResponse([], events.length - 1))
-      .mockResolvedValueOnce(createEagerStreamResponse([]));
+      .mockResolvedValueOnce(createBoundedStreamResponse([], events.length - 1));
     let helpers: UseEveAgentHelpers<EveMessageData> | undefined;
     const statuses: string[] = [];
 

--- a/packages/eve/src/runtime/connections/openapi-client.test.ts
+++ b/packages/eve/src/runtime/connections/openapi-client.test.ts
@@ -734,6 +734,70 @@ describe("OpenApiConnectionClient", () => {
     expect(props.mix?.type).toEqual(["string", "null"]);
   });
 
+  it("drops default and example values that contradict their schema type", async () => {
+    const spec: Record<string, unknown> = {
+      openapi: "3.0.3",
+      info: { title: "T", version: "1" },
+      paths: {
+        "/things": {
+          post: {
+            operationId: "createThing",
+            requestBody: {
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      default: { type: "boolean", default: "false" },
+                      example: { type: "boolean", example: "false" },
+                      hasAttachments: {
+                        type: "boolean",
+                        default: "false",
+                        example: "false",
+                      },
+                      sendCopy: { type: "boolean", default: true, example: false },
+                      note: { type: "string", nullable: true, default: null, example: null },
+                      metadata: {
+                        type: "object",
+                        default: { type: "invoice", nullable: true },
+                        example: { type: "credit-note", nullable: false },
+                      },
+                      untyped: { default: "false", example: "false" },
+                    },
+                  },
+                },
+              },
+            },
+            responses: { "200": { description: "ok" } },
+          },
+        },
+      },
+    };
+    const client = new OpenApiConnectionClient(makeConnection({ spec }));
+    const createThing = (await client.getToolMetadata()).find((m) => m.name === "createThing");
+    const properties = (
+      createThing!.inputSchema as {
+        properties: { body: { properties: Record<string, Record<string, unknown>> } };
+      }
+    ).properties.body.properties;
+
+    expect(properties.default).toEqual({ type: "boolean" });
+    expect(properties.example).toEqual({ type: "boolean" });
+    expect(properties.hasAttachments).toEqual({ type: "boolean" });
+    expect(properties.sendCopy).toEqual({ type: "boolean", default: true, example: false });
+    expect(properties.note).toEqual({
+      type: ["string", "null"],
+      default: null,
+      example: null,
+    });
+    expect(properties.metadata).toEqual({
+      type: "object",
+      default: { type: "invoice", nullable: true },
+      example: { type: "credit-note", nullable: false },
+    });
+    expect(properties.untyped).toEqual({ default: "false", example: "false" });
+  });
+
   it("keeps operations whose input schemas cannot be locally validated", async () => {
     const spec: Record<string, unknown> = {
       openapi: "3.0.3",

--- a/packages/eve/src/runtime/connections/openapi-schema.ts
+++ b/packages/eve/src/runtime/connections/openapi-schema.ts
@@ -104,10 +104,29 @@ export function derefSchema(
   }
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(node)) {
-    result[key] = derefSchema(document, value, depth + 1, seen);
+    if (key === "default" || key === "example") {
+      result[key] = value;
+    } else if (
+      (key === "properties" ||
+        key === "patternProperties" ||
+        key === "$defs" ||
+        key === "definitions") &&
+      isObject(value)
+    ) {
+      // Property and definition names can themselves be annotation keywords.
+      result[key] = Object.fromEntries(
+        Object.entries(value).map(([name, schema]) => [
+          name,
+          derefSchema(document, schema, depth + 2, seen),
+        ]),
+      );
+    } else {
+      result[key] = derefSchema(document, value, depth + 1, seen);
+    }
   }
   normalizeSchemaType(result);
   normalizeNullable(result);
+  normalizeSchemaAnnotations(result);
   return result;
 }
 
@@ -175,6 +194,44 @@ function normalizeNullable(schema: Record<string, unknown>): void {
   } else if (isArray(schema.enum) && !schema.enum.includes(null)) {
     schema.enum = [...schema.enum, null];
   }
+}
+
+/** Drops model-facing annotations that contradict the node's effective type. */
+function normalizeSchemaAnnotations(schema: Record<string, unknown>): void {
+  const type = schema.type;
+  if (typeof type !== "string" && !isArray(type)) {
+    return;
+  }
+
+  for (const keyword of ["default", "example"] as const) {
+    if (keyword in schema && !matchesSchemaType(schema[keyword], type)) {
+      delete schema[keyword];
+    }
+  }
+}
+
+function matchesSchemaType(value: unknown, type: string | readonly unknown[]): boolean {
+  const types = typeof type === "string" ? [type] : type;
+  return types.some((entry) => {
+    switch (entry) {
+      case "string":
+        return typeof value === "string";
+      case "number":
+        return typeof value === "number" && Number.isFinite(value);
+      case "integer":
+        return typeof value === "number" && Number.isInteger(value);
+      case "boolean":
+        return typeof value === "boolean";
+      case "object":
+        return isObject(value);
+      case "array":
+        return isArray(value);
+      case "null":
+        return value === null;
+      default:
+        return false;
+    }
+  });
 }
 
 /** Resolves a local JSON pointer ref (`#/components/...`) against the document. */

--- a/packages/eve/src/runtime/resolve-tool.test.ts
+++ b/packages/eve/src/runtime/resolve-tool.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { defineTool } from "#tools/definition.js";
+import { normalizeToolDefinition } from "#internal/authored-definition/schema-backed.js";
+import { resolveToolDefinition } from "#runtime/resolve-tool.js";
+
+describe("authored tool approval keys", () => {
+  it("validates and reattaches the scoped key callback", async () => {
+    const authored = defineTool({
+      description: "Scoped write",
+      inputSchema: { type: "object" },
+      approvalKey: (input) => `write:${input.scope}`,
+      execute: () => null,
+    });
+    expect(normalizeToolDefinition(authored, "Invalid tool").kind).toBe("tool");
+    const resolved = await resolveToolDefinition(
+      {
+        description: authored.description,
+        name: "write",
+        inputSchema: { type: "object" },
+        logicalPath: "tools/write.ts",
+        sourceId: "tools/write.ts",
+        sourceKind: "module",
+        hasExecute: true,
+        requiresApproval: false,
+        hasModelOutputProjection: false,
+      },
+      { nodes: { __root__: { modules: { "tools/write.ts": { default: authored } } } } },
+      undefined,
+      { kind: "application" },
+    );
+    expect(resolved.approvalKey?.({ scope: "repo" })).toBe("write:repo");
+    expect(() =>
+      normalizeToolDefinition({ ...authored, approvalKey: "invalid" }, "Invalid tool"),
+    ).toThrow();
+  });
+});

--- a/packages/eve/src/runtime/resolve-tool.ts
+++ b/packages/eve/src/runtime/resolve-tool.ts
@@ -111,7 +111,7 @@ export async function resolveToolDefinition(
  * result without clobbering required fields with `undefined`.
  */
 type OptionalResolvedFields = {
-  -readonly [K in "approval" | "toModelOutput"]?: ResolvedToolDefinition[K];
+  -readonly [K in "approval" | "approvalKey" | "toModelOutput"]?: ResolvedToolDefinition[K];
 };
 
 /**
@@ -130,6 +130,13 @@ function extractOptionalHooks(
       record.approval,
       describe(definition, "to provide a valid approval definition"),
     );
+  }
+
+  if (record.approvalKey !== undefined) {
+    optional.approvalKey = expectFunction(
+      record.approvalKey,
+      describe(definition, "to provide an approvalKey function"),
+    ) as ResolvedToolDefinition["approvalKey"];
   }
 
   if (record.toModelOutput !== undefined) {

--- a/packages/eve/src/svelte/use-eve-agent.test.ts
+++ b/packages/eve/src/svelte/use-eve-agent.test.ts
@@ -41,9 +41,12 @@ function createEagerStreamResponse(events: readonly UnstampedMessageStreamEvent[
   );
 }
 
-function createBoundedStreamResponse(events: readonly UnstampedMessageStreamEvent[]): Response {
+function createBoundedStreamResponse(
+  events: readonly UnstampedMessageStreamEvent[],
+  tailIndex = events.length - 1,
+): Response {
   const response = createEagerStreamResponse(events);
-  response.headers.set("x-eve-stream-tail-index", String(events.length - 1));
+  response.headers.set("x-eve-stream-tail-index", String(tailIndex));
   return response;
 }
 
@@ -103,7 +106,7 @@ describe("useEveAgent (Svelte rune binding)", () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(createBoundedStreamResponse(events))
-      .mockResolvedValueOnce(createEagerStreamResponse([]));
+      .mockResolvedValueOnce(createBoundedStreamResponse([], events.length - 1));
     const seenEvents: UnstampedMessageStreamEvent[] = [];
 
     useEveAgent({

--- a/packages/eve/src/tools/definition-auth.test.ts
+++ b/packages/eve/src/tools/definition-auth.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
+
+import { z } from "zod";
 
 import { defineTool } from "#tools/definition.js";
 
@@ -16,5 +18,34 @@ describe("defineTool auth field", () => {
     };
 
     expect(() => defineTool(definition as never)).toThrow(/"auth" field is no longer supported/);
+  });
+});
+
+describe("defineTool approvalKey", () => {
+  it("infers readonly input from the schema", () => {
+    const definition = defineTool({
+      description: "Scoped write",
+      inputSchema: z.object({ scope: z.string() }),
+      approvalKey(input) {
+        expectTypeOf(input).toEqualTypeOf<Readonly<{ scope: string }>>();
+        return `write:${input.scope}`;
+      },
+      execute: (input) => input.scope,
+    });
+    expect(definition.approvalKey?.({ scope: "repo" })).toBe("write:repo");
+  });
+
+  it("infers readonly input for background tools with input schemas", () => {
+    const definition = defineTool({
+      description: "Scoped background write",
+      execution: "background",
+      inputSchema: z.object({ scope: z.string() }),
+      approvalKey(input) {
+        expectTypeOf(input).toEqualTypeOf<Readonly<{ scope: string }>>();
+        return `write:${input.scope}`;
+      },
+      execute: async (input) => input.scope,
+    });
+    expect(definition.approvalKey?.({ scope: "repo" })).toBe("write:repo");
   });
 });

--- a/packages/eve/src/tools/definition.ts
+++ b/packages/eve/src/tools/definition.ts
@@ -348,6 +348,7 @@ export function stampToolDefinition<
     readonly description: string;
     readonly execute: (...args: never[]) => unknown;
     readonly approval?: Approval<never>;
+    readonly approvalKey?: (...args: never[]) => unknown;
     readonly toModelOutput?: (...args: never[]) => unknown;
   },
 >(definition: T, definer: "defineTool" | "defineWorkflowTool"): T {
@@ -362,6 +363,7 @@ export function stampToolDefinition<
     definition,
     collectDurableDynamicToolCallbacks({
       approval: definition.approval,
+      approvalKey: definition.approvalKey,
       execute: definition.execute,
       toModelOutput: definition.toModelOutput,
     }),

--- a/packages/eve/src/tools/definition.ts
+++ b/packages/eve/src/tools/definition.ts
@@ -76,6 +76,8 @@ export interface PublicToolDefinition<
    * The AI SDK can use this for tool result typing.
    */
   outputSchema?: PublicToolOutputSchema<TOutput>;
+  /** Derives the input-scoped key recorded when this tool is approved. */
+  approvalKey?: (input: Readonly<ApprovalContextInput<TInput>>) => string;
 }
 
 export interface InternalToolDefinitionWithExecuteFn<
@@ -255,6 +257,10 @@ export function defineTool<
   outputSchema?: PublicToolDefinition<unknown, TaskReceipt>["outputSchema"];
   execute(input: StandardSchemaV1.InferOutput<TSchema>, ctx: ToolContext, task: TaskExec): TReturn;
   approval?: BackgroundToolDefinition<StandardSchemaV1.InferOutput<TSchema>, unknown>["approval"];
+  approvalKey?: BackgroundToolDefinition<
+    StandardSchemaV1.InferOutput<TSchema>,
+    unknown
+  >["approvalKey"];
   toModelOutput?: BackgroundToolDefinition<
     unknown,
     BackgroundToolOutputFromExecuteReturn<TReturn>
@@ -277,6 +283,7 @@ export function defineTool<
   outputSchema: TOutputSchema;
   execute(input: StandardSchemaV1.InferOutput<TInputSchema>, ctx: ToolContext): TReturn;
   approval?: ToolDefinition<StandardSchemaV1.InferOutput<TInputSchema>, unknown>["approval"];
+  approvalKey?: ToolDefinition<StandardSchemaV1.InferOutput<TInputSchema>, unknown>["approvalKey"];
   toModelOutput?: ToolDefinition<
     unknown,
     StandardJSONSchemaV1.InferOutput<TOutputSchema>
@@ -295,6 +302,7 @@ export function defineTool<
   outputSchema?: JsonObject;
   execute(input: StandardSchemaV1.InferOutput<TSchema>, ctx: ToolContext): TReturn;
   approval?: ToolDefinition<StandardSchemaV1.InferOutput<TSchema>, unknown>["approval"];
+  approvalKey?: ToolDefinition<StandardSchemaV1.InferOutput<TSchema>, unknown>["approvalKey"];
   toModelOutput?: ToolDefinition<unknown, ToolOutputFromExecuteReturn<TReturn>>["toModelOutput"];
 }): ToolDefinitionWithExecuteReturn<
   StandardSchemaV1.InferOutput<TSchema>,
@@ -313,6 +321,7 @@ export function defineTool<
   outputSchema: TOutputSchema;
   execute(input: Record<string, unknown>, ctx: ToolContext): TReturn;
   approval?: ToolDefinition<Record<string, unknown>, unknown>["approval"];
+  approvalKey?: ToolDefinition<Record<string, unknown>, unknown>["approvalKey"];
   toModelOutput?: ToolDefinition<
     unknown,
     StandardJSONSchemaV1.InferOutput<TOutputSchema>
@@ -328,6 +337,7 @@ export function defineTool<TReturn>(definition: {
   outputSchema?: JsonObject;
   execute(input: Record<string, unknown>, ctx: ToolContext): TReturn;
   approval?: ToolDefinition<Record<string, unknown>, unknown>["approval"];
+  approvalKey?: ToolDefinition<Record<string, unknown>, unknown>["approvalKey"];
   toModelOutput?: ToolDefinition<unknown, ToolOutputFromExecuteReturn<TReturn>>["toModelOutput"];
 }): ToolDefinitionWithExecuteReturn<
   Record<string, unknown>,

--- a/packages/eve/src/tools/durable-callbacks.ts
+++ b/packages/eve/src/tools/durable-callbacks.ts
@@ -3,6 +3,7 @@ import { resolveApprovalPolicy } from "#approval/definition.js";
 import type { JsonObject } from "#shared/json.js";
 
 export type DurableDynamicCallbackPhase =
+  | "approvalKey"
   | "approvalRequest"
   | "approvalResponse"
   | "execute"
@@ -22,6 +23,7 @@ export interface DurableDynamicCallbackReference {
 
 export interface DurableDynamicToolCallbacks {
   readonly execute: DurableDynamicCallbackReference;
+  readonly approvalKey?: DurableDynamicCallbackReference;
   readonly approvalRequest?: DurableDynamicCallbackReference;
   readonly approvalResponse?: DurableDynamicCallbackReference;
   readonly toModelOutput?: DurableDynamicCallbackReference;
@@ -35,6 +37,7 @@ export interface StampedDurableDynamicCallback {
 
 export type LiveDurableDynamicToolCallbacks = Partial<{
   execute: StampedDurableDynamicCallback;
+  approvalKey: StampedDurableDynamicCallback;
   approvalRequest: StampedDurableDynamicCallback;
   approvalResponse: StampedDurableDynamicCallback;
   toModelOutput: StampedDurableDynamicCallback;
@@ -134,6 +137,7 @@ export function stampDurableDynamicToolCallbacks(
 
 export function collectDurableDynamicToolCallbacks(input: {
   readonly approval?: Approval<never>;
+  readonly approvalKey?: (...args: never[]) => unknown;
   readonly execute: (...args: never[]) => unknown;
   readonly toModelOutput?: (...args: never[]) => unknown;
 }): LiveDurableDynamicToolCallbacks {
@@ -146,10 +150,12 @@ export function collectDurableDynamicToolCallbacks(input: {
       ? undefined
       : readDurableDynamicCallback(input.approval.response);
 
+  const approvalKey = readDurableDynamicCallback(input.approvalKey);
   const execute = readDurableDynamicCallback(input.execute);
   const toModelOutput = readDurableDynamicCallback(input.toModelOutput);
   const callbacks: LiveDurableDynamicToolCallbacks = {};
   if (execute !== undefined) callbacks.execute = execute;
+  if (approvalKey !== undefined) callbacks.approvalKey = approvalKey;
   if (approvalRequest !== undefined) callbacks.approvalRequest = approvalRequest;
   if (approvalResponse !== undefined) callbacks.approvalResponse = approvalResponse;
   if (toModelOutput !== undefined) callbacks.toModelOutput = toModelOutput;

--- a/packages/eve/src/tools/dynamic.ts
+++ b/packages/eve/src/tools/dynamic.ts
@@ -35,6 +35,8 @@ export interface DynamicToolEntry<TInput = Record<string, unknown>, TOutput = an
    * use the same durable descriptor boundary as `execute` and `toModelOutput`.
    */
   readonly approval?: Approval;
+  /** Derives the input-scoped key recorded when this tool is approved. */
+  readonly approvalKey?: (toolInput: Readonly<Record<string, unknown>>) => string;
 }
 
 /**

--- a/packages/eve/src/tools/workflow-definition.test.ts
+++ b/packages/eve/src/tools/workflow-definition.test.ts
@@ -23,6 +23,10 @@ describe("defineWorkflowTool", () => {
         void ctx.getSandbox;
         return { deployed: input.service };
       },
+      approvalKey(input) {
+        expectTypeOf(input).toEqualTypeOf<Readonly<{ service: string }>>();
+        return `deploy:${input.service}`;
+      },
       toModelOutput(output) {
         expectTypeOf(output).toEqualTypeOf<{ deployed: string }>();
         return { type: "text", value: output.deployed };

--- a/packages/eve/src/vue/use-eve-agent.test.ts
+++ b/packages/eve/src/vue/use-eve-agent.test.ts
@@ -47,9 +47,12 @@ function createEagerStreamResponse(events: readonly UnstampedMessageStreamEvent[
   );
 }
 
-function createBoundedStreamResponse(events: readonly UnstampedMessageStreamEvent[]): Response {
+function createBoundedStreamResponse(
+  events: readonly UnstampedMessageStreamEvent[],
+  tailIndex = events.length - 1,
+): Response {
   const response = createEagerStreamResponse(events);
-  response.headers.set("x-eve-stream-tail-index", String(events.length - 1));
+  response.headers.set("x-eve-stream-tail-index", String(tailIndex));
   return response;
 }
 
@@ -361,7 +364,7 @@ describe("useEveAgent (Vue composable wiring)", () => {
     ];
     vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(createBoundedStreamResponse(events))
-      .mockResolvedValueOnce(createEagerStreamResponse([]));
+      .mockResolvedValueOnce(createBoundedStreamResponse([], events.length - 1));
     const scope = effectScope();
     const agent = scope.run(() =>
       useEveAgent({


### PR DESCRIPTION
### Summary

Routine operations can currently terminate healthy sessions, lose approval scope, reject valid integrations, or leave clients and automation unable to recover. This fixes ten reported failures across compaction, steering cancellation, workflow callbacks, dynamic approvals, streaming, eval output, bundle loading, OpenAPI schemas, and Slack sign-in. Regression coverage includes real bundle/subprocess tests and deterministic fixture evals for public webhook callbacks and durable approval scoping.

Closes #3062, closes #2952, closes #3081, closes #2319, closes #2532, closes #2781, closes #2195, closes #2716, closes #2369, closes #2779.

Adapted from the existing proposals in #3075, #2954, #2321, #2533, #2783, #2196, #2719, #2370, and #2782. The dynamic approval and stream fixes are updated for current durable callback reconstruction and event validation rather than applying the older patches unchanged.

### Validation

- `pnpm typecheck`: all 43 workspace tasks passed.
- Focused unit suites for compaction, compatibility banners, webhook shims/routes, dynamic tools, OpenAPI, Slack, and client stores passed.
- `pnpm test:integration`: 722 tests passed before the final approval-settlement regression; the expanded approval-resume suite passed all 17 tests afterward, including structured and text responses across step-, turn-, and session-scoped tools.
- Focused scenario suites for actual Rolldown output and piped eval reports: 4 tests passed.
- `pnpm build`, `pnpm lint`, `pnpm fmt`, `pnpm check:deps`, `pnpm docs:check`, `pnpm guard:fixtures`, and `pnpm guard:invariants` passed.
- Local `pnpm test:unit`: 8,117 passed, 1 skipped, and five macOS/path-sensitive failures in unchanged tests under `/private/tmp`. CI runs the full unit suite on Linux.
- GitHub API-created commits have verified signatures and DCO sign-offs.
- Independent subagent reviews covered runtime behavior, request serialization, approval scopes, stream races, and public TypeScript authoring. CI exposed two additional defects in the new fixture paths, both addressed in follow-up changes.

CI is green on `34d1ef44d764bb5cb2d9e65c25a05ad8d2661885`: 116 successful checks, one intentionally skipped check, no failures or pending checks. All required checks pass. The real-model cancellation eval passed on a targeted retry after one instruction-following refusal.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
