### PR TITLE
fix(eve): release workflow - restore GitHub release detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,11 +170,10 @@ jobs:
 
       - name: Create release pull request or publish
         id: changesets
-        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
+        uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
         with:
-          version: pnpm version-packages
-          publish: pnpm release
-          commitMode: github-api
+          version-script: pnpm version-packages
+          publish-script: pnpm release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -182,7 +181,7 @@ jobs:
         if: steps.changesets.outputs.published == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.published-packages }}
         run: |
           version="$(jq -r '.[] | select(.name == "eve") | .version' <<< "$PUBLISHED_PACKAGES")"
           if [[ -n "$version" ]]; then


### PR DESCRIPTION
### Summary

The release run published `eve@0.52.2` to npm, but `changesets/action@v1.9.0` did not recognize the structured output from `@changesets/cli@3.0.1`. Its `published` output remained false, so GitHub release creation and the follow-up step that marks `eve` as the latest release were skipped. Upgrade to `changesets/action@v2.1.1` and use its renamed inputs and output while preserving the existing GitHub API commit and tag behavior through v2's defaults.

### Validation

- `pnpm guard:invariants`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml: valid YAML"'`
- `git diff HEAD^ --check`

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
