### PR TITLE
fix(eve): dynamic tools - isolate callback replay bindings

### DIFF
--- a/.changeset/isolate-dynamic-callback-bindings.md
+++ b/.changeset/isolate-dynamic-callback-bindings.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Keep dynamic tool callbacks isolated by session, lifecycle scope, and resolver. Replaying a tool now retains its own implementation when another session or scope registers the same tool name.

--- a/docs/guides/dynamic-capabilities.md
+++ b/docs/guides/dynamic-capabilities.md
@@ -257,11 +257,11 @@ Call expressions such as `execute: makeExecutor()` are not transformed. Put the 
 
 ### Identity and redeploys
 
-A parked call binds to its callback by **tool name and phase** — the same identity a static tool uses — never by source position. This gives dynamic tools static-tool semantics across deploys:
+A parked call binds to its callback within its session, lifecycle scope, and resolver entry. Another session or scope can expose the same tool name without replacing that binding. Callback identity does not depend on source position:
 
-- Editing a callback body (or anything else that does not change tool names) is safe: replaying a parked call runs the latest deployed code with the closure values snapshotted when the call was made.
-- If a persisted callback has no registered implementation (fresh process after a crash, or after a redeploy), eve re-runs `session.started` resolvers once to rebind it, then replays.
-- If the tool no longer exists under that name, replay fails closed with an explicit error instead of invoking something else. Ordinary turn-scoped and step-scoped tools are not rebound; a parked call to a missing one errors. Framework-provided resolvers such as memory provider-tool wrappers opt into the same generic missing-callback rebind while preserving their locked scope.
+- Editing a callback body while keeping its resolver entry and tool names is safe: replaying a parked call runs the latest deployed code with the closure values snapshotted when the call was made.
+- If a persisted session-scoped callback has no registered implementation (a fresh process, a redeploy, or an expired in-process binding), eve re-runs `session.started` resolvers once to rebind it, then replays.
+- If the owning resolver no longer returns that tool, replay fails closed with an explicit error instead of invoking something else. Ordinary turn-scoped and step-scoped tools are not rebound; a parked call to a missing one errors. Framework-provided resolvers such as memory provider-tool wrappers opt into the same generic missing-callback rebind while preserving their locked scope.
 
 ### Naming
 

--- a/e2e/fixtures/agent-tools/agent/agent.ts
+++ b/e2e/fixtures/agent-tools/agent/agent.ts
@@ -2,6 +2,17 @@ import { e2eAgentConfig } from "@eve-e2e/config";
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  ...e2eAgentConfig(),
+  ...e2eAgentConfig({
+    mock(request) {
+      if (request.lastUserMessage?.includes("`callback_identity`")) {
+        const roles = request.messages.map((message) => message.role);
+        if (roles.lastIndexOf("tool") <= roles.lastIndexOf("user")) {
+          return { toolCalls: [{ name: "callback_identity", input: {} }] };
+        }
+        return "Callback identity checked.";
+      }
+      return `Mock reply: ${request.lastUserMessage ?? ""}`;
+    },
+  }),
   reasoning: "high",
 });

--- a/e2e/fixtures/agent-tools/agent/tools/dynamic-callback-identity.ts
+++ b/e2e/fixtures/agent-tools/agent/tools/dynamic-callback-identity.ts
@@ -1,0 +1,33 @@
+import { isChannel } from "eve/channels";
+import { defineDynamic, defineTool } from "eve/tools";
+import metadataProvider from "../channels/metadata-provider";
+
+export default defineDynamic({
+  events: {
+    "session.started": (_event, ctx) => {
+      if (!isChannel(ctx.channel, metadataProvider)) return null;
+      const topic = ctx.channel.metadata.topic;
+      if (topic === "callback-guarded") {
+        return {
+          callback_identity: defineTool({
+            description:
+              "Returns the guarded callback identity. Call when asked for callback_identity.",
+            inputSchema: { type: "object", properties: {} },
+            execute: () => ({ implementation: "guarded", topic }),
+          }),
+        };
+      }
+      if (topic === "callback-open") {
+        return {
+          callback_identity: defineTool({
+            description:
+              "Returns the open callback identity. Call when asked for callback_identity.",
+            inputSchema: { type: "object", properties: {} },
+            execute: () => ({ implementation: "open", topic }),
+          }),
+        };
+      }
+      return null;
+    },
+  },
+});

--- a/e2e/fixtures/agent-tools/evals/dynamic-tools/callback-identity.eval.ts
+++ b/e2e/fixtures/agent-tools/evals/dynamic-tools/callback-identity.eval.ts
@@ -1,0 +1,37 @@
+import { defineEval } from "eve/evals";
+
+import { startChannelSession } from "../channel-metadata/shared";
+
+const message = "Call the `callback_identity` tool and report its implementation and topic.";
+
+export default defineEval({
+  description:
+    "Dynamic callbacks keep their session's implementation when another session registers the same tool name.",
+  async test(t) {
+    const guardedId = await startChannelSession(t.target, "/metadata-provider/start", {
+      message,
+      topic: "callback-guarded",
+    });
+    const guarded = await t.target.attachSession(guardedId);
+    guarded.succeeded();
+    guarded.calledTool("callback_identity", {
+      output: { implementation: "guarded", topic: "callback-guarded" },
+    });
+
+    const openId = await startChannelSession(t.target, "/metadata-provider/start", {
+      message,
+      topic: "callback-open",
+    });
+    const open = await t.target.attachSession(openId);
+    open.succeeded();
+    open.calledTool("callback_identity", {
+      output: { implementation: "open", topic: "callback-open" },
+    });
+
+    const replayed = await guarded.send(message);
+    replayed.expectOk();
+    replayed.calledTool("callback_identity", {
+      output: { implementation: "guarded", topic: "callback-guarded" },
+    });
+  },
+});

--- a/packages/eve/src/context/build-dynamic-tools.ts
+++ b/packages/eve/src/context/build-dynamic-tools.ts
@@ -2,6 +2,7 @@ import type { HarnessToolDefinition } from "#harness/execute-tool.js";
 import type { HarnessToolMap } from "#harness/types.js";
 import type { ContextReader } from "#context/key.js";
 import {
+  SessionIdKey,
   SessionDynamicToolMetadataKey,
   StepDynamicToolMetadataKey,
   TurnDynamicToolMetadataKey,
@@ -23,6 +24,7 @@ import {
   callDurableDynamicCallback,
   lookupDurableDynamicCallback,
   type DurableDynamicCallbackPhase,
+  type DynamicToolCallbackOwner,
 } from "#tools/durable-callbacks.js";
 import { toInputSchema, toOutputSchema } from "#tools/schema.js";
 
@@ -41,11 +43,12 @@ function missingCallbackError(
 
 function buildReplayedApproval(
   metadata: CurrentDynamicToolMetadata,
+  owner: DynamicToolCallbackOwner,
 ): HarnessToolDefinition["approval"] | undefined {
   const requestReference = metadata.callbacks.approvalRequest;
   if (requestReference === undefined) return undefined;
 
-  const request = lookupDurableDynamicCallback(metadata.name, "approvalRequest");
+  const request = lookupDurableDynamicCallback(owner, "approvalRequest");
   const requestPolicy =
     request === undefined
       ? async () => {
@@ -62,7 +65,7 @@ function buildReplayedApproval(
   const responseReference = metadata.callbacks.approvalResponse;
   if (responseReference === undefined) return requestPolicy;
 
-  const response = lookupDurableDynamicCallback(metadata.name, "approvalResponse");
+  const response = lookupDurableDynamicCallback(owner, "approvalResponse");
   return {
     request: requestPolicy,
     response:
@@ -87,20 +90,25 @@ function buildReplayedApproval(
 /** Reconstructs every callback exclusively from its durable descriptor. */
 export function replayDynamicTools(
   metadata: readonly CurrentDynamicToolMetadata[],
+  scope: Pick<DynamicToolCallbackOwner, "sessionId" | "scope">,
 ): HarnessToolDefinition[] {
+  if (metadata.length > 0 && scope.sessionId.length === 0) {
+    throw new Error("Dynamic tool replay requires a session id.");
+  }
   return metadata.map((entry) => {
+    const owner = { ...entry, ...scope };
     const approvalKeyReference = entry.callbacks.approvalKey;
     const approvalKey =
       approvalKeyReference === undefined
         ? undefined
-        : lookupDurableDynamicCallback(entry.name, "approvalKey");
+        : lookupDurableDynamicCallback(owner, "approvalKey");
     const executeReference = entry.callbacks.execute;
-    const execute = lookupDurableDynamicCallback(entry.name, "execute");
+    const execute = lookupDurableDynamicCallback(owner, "execute");
     const toModelOutputReference = entry.callbacks.toModelOutput;
     const toModelOutput =
       toModelOutputReference === undefined
         ? undefined
-        : lookupDurableDynamicCallback(entry.name, "toModelOutput");
+        : lookupDurableDynamicCallback(owner, "toModelOutput");
 
     return {
       description: entry.description,
@@ -139,7 +147,7 @@ export function replayDynamicTools(
       inputSchema: toInputSchema(entry.inputSchema),
       name: entry.name,
       execution: entry.execution,
-      approval: buildReplayedApproval(entry),
+      approval: buildReplayedApproval(entry, owner),
       ...(approvalKeyReference === undefined
         ? {}
         : {
@@ -212,12 +220,15 @@ export function buildResponseAuthorizationTools(input: {
 export function buildDynamicTools(ctx: ContextReader): readonly HarnessToolDefinition[] {
   const step = replayDynamicTools(
     requireCurrentDynamicToolMetadata(ctx.get(StepDynamicToolMetadataKey) ?? []),
+    { sessionId: ctx.get(SessionIdKey) ?? "", scope: "step" },
   );
   const turn = replayDynamicTools(
     requireCurrentDynamicToolMetadata(ctx.get(TurnDynamicToolMetadataKey) ?? []),
+    { sessionId: ctx.get(SessionIdKey) ?? "", scope: "turn" },
   );
   const session = replayDynamicTools(
     requireCurrentDynamicToolMetadata(ctx.get(SessionDynamicToolMetadataKey) ?? []),
+    { sessionId: ctx.get(SessionIdKey) ?? "", scope: "session" },
   );
   return [...step, ...turn, ...session];
 }

--- a/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
@@ -42,6 +42,7 @@ import {
   TurnDynamicToolMetadataKey,
 } from "#context/keys.js";
 import {
+  clearDurableDynamicCallbacks,
   lookupDurableDynamicCallback,
   registerDurableDynamicCallback,
   stampDurableDynamicToolCallbacks,
@@ -125,7 +126,7 @@ describe("durable callback capture validation", () => {
     stampDurableDynamicToolCallbacks(entry, {
       execute: { callback: () => null, closure: closure as JsonObject },
     });
-    return validateDurableDynamicToolCallbacks("captured", entry);
+    return validateDurableDynamicToolCallbacks("captured", entry, callbackOwner("captured"));
   }
 
   it("preserves JSON values and explicitly omits undefined object properties", () => {
@@ -175,26 +176,34 @@ describe("durable callback capture validation", () => {
 // replayDynamicSessionTools — name+phase lookup + closure replay
 // ---------------------------------------------------------------------------
 
-const dynamicCallbackRegistrySym = Symbol.for("eve:dynamic-tool-callbacks");
+function callbackOwner(
+  name: string,
+  overrides: Partial<import("#tools/durable-callbacks.js").DynamicToolCallbackOwner> = {},
+) {
+  return {
+    sessionId: "test-session",
+    scope: "session" as const,
+    resolverSlug: "test",
+    entryKey: name,
+    name,
+    ...overrides,
+  };
+}
 
-function getDynamicCallbackRegistry(): Map<string, Map<string, Function>> {
-  const g = globalThis as Record<symbol, Map<string, Map<string, Function>> | undefined>;
-  const existing = g[dynamicCallbackRegistrySym];
-  if (existing !== undefined) return existing;
-  const fresh = new Map<string, Map<string, Function>>();
-  g[dynamicCallbackRegistrySym] = fresh;
-  return fresh;
+function getDynamicCallbackRegistry() {
+  return { delete: (_name: string) => clearDurableDynamicCallbacks("test-session") };
 }
 
 function registerTestCallback(
   toolName: string,
   phase: string,
   callback: (closure: unknown, ...args: unknown[]) => unknown,
+  overrides: Partial<import("#tools/durable-callbacks.js").DynamicToolCallbackOwner> = {},
 ): void {
   registerDurableDynamicCallback({
     callback: callback as never,
     phase: phase as never,
-    toolName,
+    owner: callbackOwner(toolName, overrides),
   });
 }
 
@@ -224,7 +233,7 @@ describe("replayDynamicSessionTools", () => {
   }
 
   it("fails execution closed when the registered callback is unavailable", async () => {
-    const [tool] = replayDynamicSessionTools([metadata("unregistered")], []);
+    const [tool] = replayDynamicSessionTools([metadata("unregistered")], [], "test-session");
     await expect(tool!.execute!({}, executeOptions)).rejects.toThrow(
       'Dynamic tool "unregistered" cannot replay its execute callback',
     );
@@ -243,7 +252,7 @@ describe("replayDynamicSessionTools", () => {
         tenantName: "Acme",
       });
 
-      const tools = replayDynamicSessionTools([durable], []);
+      const tools = replayDynamicSessionTools([durable], [], "test-session");
       expect(tools).toHaveLength(1);
       expect(tools[0]!.name).toBe("replay-tool");
       expect(tools[0]!.description).toBe("replay-tool description");
@@ -263,12 +272,12 @@ describe("replayDynamicSessionTools", () => {
 
   it("runs the latest registered implementation after a redeploy rebinds the name", async () => {
     registerTestCallback("latest-tool", "execute", () => ({ version: 1 }));
-    const tools = replayDynamicSessionTools([metadata("latest-tool")], []);
+    const tools = replayDynamicSessionTools([metadata("latest-tool")], [], "test-session");
     await expect(tools[0]!.execute!({}, executeOptions)).resolves.toEqual({ version: 1 });
 
     // A redeploy re-resolves and replaces the binding under the same identity.
     registerTestCallback("latest-tool", "execute", () => ({ version: 2 }));
-    const rebound = replayDynamicSessionTools([metadata("latest-tool")], []);
+    const rebound = replayDynamicSessionTools([metadata("latest-tool")], [], "test-session");
     await expect(rebound[0]!.execute!({}, executeOptions)).resolves.toEqual({ version: 2 });
     getDynamicCallbackRegistry().delete("latest-tool");
   });
@@ -282,7 +291,11 @@ describe("replayDynamicSessionTools", () => {
 
     try {
       const closureVars = { counter: 1, label: "v1" };
-      const tools = replayDynamicSessionTools([metadata("snapshot-tool", closureVars)], []);
+      const tools = replayDynamicSessionTools(
+        [metadata("snapshot-tool", closureVars)],
+        [],
+        "test-session",
+      );
 
       const tool = tools[0]!;
       tool.execute!({}, executeOptions);
@@ -310,7 +323,7 @@ describe("replayDynamicSessionTools", () => {
         metadata("tenant__export", { tenant: "acme" }),
       ];
 
-      const tools = replayDynamicSessionTools(durable, []);
+      const tools = replayDynamicSessionTools(durable, [], "test-session");
       expect(tools).toHaveLength(2);
       expect(tools[0]!.name).toBe("tenant__query");
       expect(tools[1]!.name).toBe("tenant__export");
@@ -382,12 +395,8 @@ function makeEvent(type: string): UnstampedMessageStreamEvent {
   return { type, data: {} } as UnstampedMessageStreamEvent;
 }
 
-const dynamicCallbackRegistry = getDynamicCallbackRegistry();
-
 function simulateColdStart(ctx: ContextContainer): void {
-  for (const metadata of ctx.get(SessionDynamicToolMetadataKey) ?? []) {
-    dynamicCallbackRegistry.delete(metadata.name);
-  }
+  clearDurableDynamicCallbacks(ctx.require(SessionIdKey));
   ctx.clearVirtualContext();
 }
 
@@ -570,7 +579,12 @@ describe("dispatchDynamicToolEvent", () => {
     simulateColdStart(ctx);
 
     // Fresh process: bindings are gone although the bundle did not change.
-    expect(lookupDurableDynamicCallback("tool", "execute")).toBeUndefined();
+    expect(
+      lookupDurableDynamicCallback(
+        callbackOwner("tool", { sessionId: ctx.require(SessionIdKey), resolverSlug: "live" }),
+        "execute",
+      ),
+    ).toBeUndefined();
 
     await refreshDynamicSessionToolsForRuntimeRevision({
       ctx,
@@ -742,9 +756,9 @@ describe("dispatchDynamicToolEvent", () => {
     stampDurableDynamicToolCallbacks(entry, {
       execute: { closure: {}, stepId: "eve:dynamic-tool//old/execute/0-100" } as never,
     });
-    expect(() => validateDurableDynamicToolCallbacks("legacy", entry)).toThrow(
-      /pre-release eve version/,
-    );
+    expect(() =>
+      validateDurableDynamicToolCallbacks("legacy", entry, callbackOwner("legacy")),
+    ).toThrow(/pre-release eve version/);
   });
 
   it("clears removed session resolvers on a new runtime revision", async () => {
@@ -1479,7 +1493,7 @@ describe("programmatic dynamic tools (no bundler transform)", () => {
       const [tool] = buildDynamicTools(ctx);
       expect(tool!.approvalKey?.({ scope: "repo" })).toBe("risky:repo");
       expect(tool!.approvalKey?.({ scope: "other" })).toBe("risky:other");
-      getDynamicCallbackRegistry().delete("risky");
+      clearDurableDynamicCallbacks(ctx.require(SessionIdKey));
       const [missing] = buildDynamicTools(ctx);
       expect(() => missing!.approvalKey?.({ scope: "repo" })).toThrow(
         "cannot replay its approvalKey callback",
@@ -1525,8 +1539,18 @@ describe("programmatic dynamic tools (no bundler transform)", () => {
   it("replays phase-specific turn metadata", async () => {
     const ctx = createCtx();
     const approval = vi.fn(() => "user-approval" as const);
-    registerTestCallback("guarded", "execute", () => ({ ok: true }));
-    registerTestCallback("guarded", "approvalRequest", approval);
+    registerTestCallback("guarded", "execute", () => ({ ok: true }), {
+      sessionId: ctx.require(SessionIdKey),
+      scope: "turn",
+      resolverSlug: "legacy",
+      entryKey: "legacy:guarded",
+    });
+    registerTestCallback("guarded", "approvalRequest", approval, {
+      sessionId: ctx.require(SessionIdKey),
+      scope: "turn",
+      resolverSlug: "legacy",
+      entryKey: "legacy:guarded",
+    });
     ctx.set(TurnDynamicToolMetadataKey, [
       {
         callbacks: {
@@ -1712,4 +1736,287 @@ describe("programmatic dynamic tools (no bundler transform)", () => {
     const result2 = await tools[0]!.execute!({}, executeOptions);
     expect(result2).toEqual({ version: 2 });
   });
+});
+
+describe("dynamic callback binding isolation", () => {
+  function variantTool(implementation: string, captured: string) {
+    const entry = defineTool({
+      description: implementation,
+      inputSchema: { type: "object" },
+      execute: async () => null,
+      approvalKey: () => "",
+      approval: {
+        request: () => "user-approval",
+        response: () => ({ status: "allowed" }),
+      },
+      toModelOutput: () => ({ type: "text", value: "" }),
+    });
+    stampDurableDynamicToolCallbacks(entry, {
+      execute: {
+        callback: (closure) => ({ implementation, captured: closure.captured }),
+        closure: { captured },
+      },
+      approvalKey: { callback: () => implementation, closure: {} },
+      approvalRequest: {
+        callback: () => (implementation === "guarded" ? "user-approval" : "not-applicable"),
+        closure: {},
+      },
+      approvalResponse: {
+        callback: () => ({ status: "allowed", reason: implementation }),
+        closure: {},
+      },
+      toModelOutput: { callback: () => ({ type: "text", value: implementation }), closure: {} },
+    });
+    return entry;
+  }
+
+  it.each([false, true])(
+    "isolates conditional implementations across sessions (cold replay: %s)",
+    async (cold) => {
+      const first = createCtx();
+      const second = createCtx();
+      const resolver = createResolver("conditional", ["session.started"], (_event, rawContext) => {
+        const context = rawContext as { session: { id: string } };
+        return {
+          search: variantTool(
+            context.session.id === first.require(SessionIdKey) ? "guarded" : "open",
+            "original",
+          ),
+        };
+      });
+      for (const ctx of [first, second]) {
+        await dispatchDynamicToolEvent({
+          ctx,
+          resolvers: [resolver],
+          event: makeEvent("session.started"),
+          messages: [],
+        });
+        ctx.set(SessionDynamicToolRuntimeRevisionKey, "deployment:stable");
+      }
+      const restored = await deserializeContext(serializeContext(first));
+      if (cold) {
+        clearDurableDynamicCallbacks(first.require(SessionIdKey));
+        const changedCapture = createResolver("conditional", ["session.started"], () => ({
+          search: variantTool("guarded", "recaptured"),
+        }));
+        await refreshDynamicSessionToolsForRuntimeRevision({
+          ctx: restored,
+          resolvers: [changedCapture],
+          event: createSessionStartedEvent(),
+          messages: [],
+          runtimeRevision: "deployment:stable",
+        });
+      }
+      const [tool] = buildDynamicTools(restored);
+      await expect(tool!.execute!({}, executeOptions)).resolves.toEqual({
+        implementation: "guarded",
+        captured: "original",
+      });
+      expect(tool!.approvalKey!({})).toBe("guarded");
+      await expect(
+        resolveApprovalPolicy(tool!.approval!)(createApprovalContext({ toolName: "search" })),
+      ).resolves.toBe("user-approval");
+      expect(await tool!.toModelOutput!({})).toEqual({ type: "text", value: "guarded" });
+      const approval = tool!.approval!;
+      if (typeof approval === "function") throw new Error("Expected approval response callback.");
+      await expect(approval.response!({} as never)).resolves.toMatchObject({ reason: "guarded" });
+      await expect(buildDynamicTools(second)[0]!.execute!({}, executeOptions)).resolves.toEqual({
+        implementation: "open",
+        captured: "original",
+      });
+    },
+  );
+
+  it("isolates different resolver owners across sessions", async () => {
+    const first = createCtx();
+    const second = createCtx();
+    for (const [ctx, slug, implementation] of [
+      [first, "guarded-owner", "guarded"],
+      [second, "open-owner", "open"],
+    ] as const) {
+      await dispatchDynamicToolEvent({
+        ctx,
+        resolvers: [
+          createResolver(slug, ["session.started"], () => ({
+            search: variantTool(implementation, slug),
+          })),
+        ],
+        event: makeEvent("session.started"),
+        messages: [],
+      });
+    }
+    await expect(buildDynamicTools(first)[0]!.execute!({}, executeOptions)).resolves.toMatchObject({
+      implementation: "guarded",
+    });
+  });
+
+  it("keeps narrower lifecycle scopes from replacing session callbacks", async () => {
+    const ctx = createCtx();
+    for (const scope of ["session", "turn", "step"] as const) {
+      const eventName = `${scope}.started`;
+      await dispatchDynamicToolEvent({
+        ctx,
+        resolvers: [
+          createResolver("shared-owner", [eventName], () => ({
+            search: variantTool(scope, scope),
+          })),
+        ],
+        event: makeEvent(eventName),
+        messages: [],
+      });
+    }
+    const tools = buildDynamicTools(await deserializeContext(serializeContext(ctx)));
+    const outputs = await Promise.all(tools.map((tool) => tool.execute!({}, executeOptions)));
+    expect(outputs).toEqual(
+      ["step", "turn", "session"].map((scope) => ({ implementation: scope, captured: scope })),
+    );
+  });
+
+  it("does not use another session's binding when its own resolver no longer returns the tool", async () => {
+    const first = createCtx();
+    const second = createCtx();
+    const resolver = createResolver("conditional", ["session.started"], () => ({
+      search: variantTool("guarded", "original"),
+    }));
+    for (const ctx of [first, second]) {
+      await dispatchDynamicToolEvent({
+        ctx,
+        resolvers: [resolver],
+        event: makeEvent("session.started"),
+        messages: [],
+      });
+      ctx.set(SessionDynamicToolRuntimeRevisionKey, "deployment:stable");
+    }
+    clearDurableDynamicCallbacks(first.require(SessionIdKey));
+    await refreshDynamicSessionToolsForRuntimeRevision({
+      ctx: first,
+      resolvers: [createResolver("conditional", ["session.started"], () => null)],
+      event: createSessionStartedEvent(),
+      messages: [],
+      runtimeRevision: "deployment:stable",
+    });
+    await expect(buildDynamicTools(first)[0]!.execute!({}, executeOptions)).rejects.toThrow(
+      "cannot replay its execute callback",
+    );
+  });
+
+  it("clears completed sessions without clearing another session's bindings", async () => {
+    const first = createCtx();
+    const second = createCtx();
+    const resolver = createResolver("conditional", ["session.started"], () => ({
+      search: variantTool("guarded", "original"),
+    }));
+    for (const ctx of [first, second]) {
+      await dispatchDynamicToolEvent({
+        ctx,
+        resolvers: [resolver],
+        event: makeEvent("session.started"),
+        messages: [],
+      });
+    }
+    await dispatchDynamicToolEvent({
+      ctx: first,
+      resolvers: [],
+      event: { type: "session.completed" },
+      messages: [],
+    });
+    await expect(buildDynamicTools(first)[0]!.execute!({}, executeOptions)).rejects.toThrow(
+      "cannot replay its execute callback",
+    );
+    await expect(buildDynamicTools(second)[0]!.execute!({}, executeOptions)).resolves.toMatchObject(
+      { implementation: "guarded" },
+    );
+  });
+});
+
+describe("dynamic callback cache recovery", () => {
+  it.each(["null", "throw", "invalid"])(
+    "clears withdrawn and partially registered callbacks when a resolver returns %s",
+    async (outcome) => {
+      const ctx = createCtx();
+      const original = createResolver("changing", ["session.started"], () => ({
+        changed: createReplayableTool(),
+      }));
+      const other = createResolver("other", ["session.started"], () => ({
+        other: createReplayableTool(),
+      }));
+      await dispatchDynamicToolEvent({
+        ctx,
+        resolvers: [original, other],
+        event: makeEvent("session.started"),
+        messages: [],
+      });
+      const previous = await deserializeContext(serializeContext(ctx));
+      const replacement = createResolver("changing", ["session.started"], () => {
+        if (outcome === "throw") throw new Error("resolver unavailable");
+        if (outcome === "null") return null;
+        return {
+          changed: createReplayableTool("partially registered", () => ({ wrong: true })),
+          invalid: defineTool({
+            description: "missing descriptor",
+            inputSchema: {},
+            execute: async () => null,
+          }),
+        };
+      });
+      await dispatchDynamicToolEvent({
+        ctx,
+        resolvers: [replacement],
+        event: makeEvent("session.started"),
+        messages: [],
+      });
+      const tools = buildDynamicTools(previous);
+      await expect(
+        tools.find((tool) => tool.name === "changed")!.execute!({}, executeOptions),
+      ).rejects.toThrow("cannot replay its execute callback");
+      await expect(
+        tools.find((tool) => tool.name === "other")!.execute!({}, executeOptions),
+      ).resolves.toEqual({ ok: true });
+    },
+  );
+
+  it.each(["session", "turn", "step"] as const)(
+    "handles eviction of %s bindings without calling another session's implementation",
+    async (scope) => {
+      const ctx = createCtx();
+      const eventName = `${scope}.started`;
+      const resolver = createResolver("evicted", [eventName], () => ({
+        search: createReplayableTool(),
+      }));
+      await dispatchDynamicToolEvent({
+        ctx,
+        resolvers: [resolver],
+        event: makeEvent(eventName),
+        messages: [],
+      });
+      ctx.set(SessionDynamicToolRuntimeRevisionKey, "stable");
+      for (let index = 0; index < 1_024; index++) {
+        registerTestCallback("search", "execute", () => ({ wrong: true }), {
+          sessionId: `cache-pressure-${index}`,
+          scope,
+          resolverSlug: "evicted",
+        });
+      }
+      const restored = await deserializeContext(serializeContext(ctx));
+      if (scope === "session") {
+        await refreshDynamicSessionToolsForRuntimeRevision({
+          ctx: restored,
+          resolvers: [resolver],
+          event: createSessionStartedEvent(),
+          messages: [],
+          runtimeRevision: "stable",
+        });
+        await expect(buildDynamicTools(restored)[0]!.execute!({}, executeOptions)).resolves.toEqual(
+          { ok: true },
+        );
+      } else {
+        await expect(buildDynamicTools(restored)[0]!.execute!({}, executeOptions)).rejects.toThrow(
+          "cannot replay its execute callback",
+        );
+      }
+      clearDurableDynamicCallbacks(ctx.require(SessionIdKey));
+      for (let index = 0; index < 1_024; index++)
+        clearDurableDynamicCallbacks(`cache-pressure-${index}`);
+    },
+  );
 });

--- a/packages/eve/src/context/dynamic-tool-lifecycle.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.ts
@@ -6,6 +6,7 @@ import { replayDynamicTools } from "#context/build-dynamic-tools.js";
 import { contextStorage, type AlsContext } from "#context/container.js";
 import type { ContextKey } from "#context/key.js";
 import {
+  SessionIdKey,
   SessionDynamicToolMetadataKey,
   SessionDynamicToolRuntimeRevisionKey,
   StepDynamicToolMetadataKey,
@@ -29,6 +30,9 @@ import { ALLOWED_DYNAMIC_TOOL_EVENTS } from "#dynamic/definition.js";
 import { isBrandedToolEntry, type DynamicToolEntry } from "#tools/dynamic.js";
 import {
   hasUnregisteredDurableDynamicCallbacks,
+  clearDurableDynamicCallbacks,
+  type DynamicToolCallbackOwner,
+  type DynamicToolCallbackScope,
   type DurableDynamicCallbackPhase,
   type DurableDynamicCallbackReference,
   type DurableDynamicToolCallbacks,
@@ -68,8 +72,9 @@ function qualifyDynamicToolNames(
 export function replayDynamicSessionTools(
   metadata: readonly CurrentDynamicToolMetadata[],
   _resolvers: readonly ResolvedDynamicToolResolver[],
+  sessionId: string,
 ): readonly HarnessToolDefinition[] {
-  return replayDynamicTools(metadata);
+  return replayDynamicTools(metadata, { sessionId, scope: "session" });
 }
 
 function durableKeyForEvent(
@@ -123,6 +128,7 @@ function readDynamicToolResult(
 
 function validateReference(input: {
   readonly name: string;
+  readonly owner: DynamicToolCallbackOwner;
   readonly phase: DurableDynamicCallbackPhase;
   readonly stamped: StampedDurableDynamicCallback | undefined;
   readonly required: boolean;
@@ -167,7 +173,7 @@ function validateReference(input: {
   registerDurableDynamicCallback({
     callback: input.stamped.callback,
     phase: input.phase,
-    toolName: input.name,
+    owner: input.owner,
   });
   return { closure };
 }
@@ -175,6 +181,7 @@ function validateReference(input: {
 export function validateDurableDynamicToolCallbacks(
   name: string,
   entry: DynamicToolEntry,
+  owner: DynamicToolCallbackOwner,
 ): DurableDynamicToolCallbacks {
   const raw = readDurableDynamicToolCallbacks(entry) ?? {};
   const unknownPhases = Object.keys(raw).filter(
@@ -198,30 +205,35 @@ export function validateDurableDynamicToolCallbacks(
     entry.approval.response !== undefined;
   const execute = validateReference({
     name,
+    owner,
     phase: "execute",
     stamped: raw.execute,
     required: true,
   })!;
   const approvalKey = validateReference({
     name,
+    owner,
     phase: "approvalKey",
     stamped: raw.approvalKey,
     required: entry.approvalKey !== undefined,
   });
   const approvalRequest = validateReference({
     name,
+    owner,
     phase: "approvalRequest",
     stamped: raw.approvalRequest,
     required: hasApproval,
   });
   const approvalResponse = validateReference({
     name,
+    owner,
     phase: "approvalResponse",
     stamped: raw.approvalResponse,
     required: hasApprovalResponse,
   });
   const toModelOutput = validateReference({
     name,
+    owner,
     phase: "toModelOutput",
     stamped: raw.toModelOutput,
     required: entry.toModelOutput !== undefined,
@@ -242,13 +254,21 @@ export function validateDurableDynamicToolCallbacks(
 }
 
 function createMetadata(input: {
+  readonly sessionId: string;
+  readonly scope: DynamicToolCallbackScope;
   readonly entry: DynamicToolEntry;
   readonly entryKey: string;
   readonly name: string;
   readonly resolver: ResolvedDynamicToolResolver;
 }): CurrentDynamicToolMetadata {
   return {
-    callbacks: validateDurableDynamicToolCallbacks(input.name, input.entry),
+    callbacks: validateDurableDynamicToolCallbacks(input.name, input.entry, {
+      sessionId: input.sessionId,
+      scope: input.scope,
+      resolverSlug: input.resolver.slug,
+      entryKey: input.entryKey,
+      name: input.name,
+    }),
     description: input.entry.description,
     execution: input.entry.execution === "background" ? "background" : undefined,
     entryKey: input.entryKey,
@@ -269,20 +289,28 @@ async function resolveToolsFromEvent(
   event: UnstampedMessageStreamEvent,
   messages: readonly ModelMessage[],
 ): Promise<ResolvedDynamicToolEvent> {
+  const sessionId = ctx.require(SessionIdKey);
+  const scope = event.type.split(".")[0] as DynamicToolCallbackScope;
   const outcomes = await Promise.allSettled(
     resolvers.map(async (resolver) => {
       const handler = resolver.events[event.type];
       if (handler === undefined) return null;
-      const rawResult = await handler(event, buildResolveContext(ctx, messages));
-      if (rawResult === null || rawResult === undefined) return null;
-      const { entries, isSingle } = readDynamicToolResult(resolver, rawResult);
-      const named = qualifyDynamicToolNames(resolver, isSingle, entries);
-      return {
-        metadata: named.map(({ name, entryKey, entry }) =>
-          createMetadata({ entry, entryKey, name, resolver }),
-        ),
-        resolver,
-      };
+      clearDurableDynamicCallbacks(sessionId, { scope, resolverSlug: resolver.slug });
+      try {
+        const rawResult = await handler(event, buildResolveContext(ctx, messages));
+        if (rawResult === null || rawResult === undefined) return null;
+        const { entries, isSingle } = readDynamicToolResult(resolver, rawResult);
+        const named = qualifyDynamicToolNames(resolver, isSingle, entries);
+        return {
+          metadata: named.map(({ name, entryKey, entry }) =>
+            createMetadata({ entry, entryKey, name, resolver, sessionId, scope }),
+          ),
+          resolver,
+        };
+      } catch (error) {
+        clearDurableDynamicCallbacks(sessionId, { scope, resolverSlug: resolver.slug });
+        throw error;
+      }
     }),
   );
 
@@ -363,7 +391,13 @@ export async function preparePersistedStepDynamicToolMetadata(input: {
 }): Promise<void> {
   const persisted = input.ctx.get(StepDynamicToolMetadataKey) ?? [];
   const current = persisted.filter(isCurrentDynamicToolMetadata);
-  if (current.length === persisted.length && !hasUnregisteredDurableDynamicCallbacks(current)) {
+  if (
+    current.length === persisted.length &&
+    !hasUnregisteredDurableDynamicCallbacks(current, {
+      sessionId: input.ctx.require(SessionIdKey),
+      scope: "step",
+    })
+  ) {
     if (current.length > 0) {
       storeResolvedStepTools({ ctx: input.ctx, event: input.event, metadata: current });
     }
@@ -388,6 +422,11 @@ export async function dispatchDynamicToolEvent(input: {
   readonly event: UnstampedMessageStreamEvent;
   readonly messages: readonly ModelMessage[];
 }): Promise<void> {
+  if (input.event.type === "session.completed") {
+    const sessionId = input.ctx.get(SessionIdKey);
+    if (sessionId !== undefined) clearDurableDynamicCallbacks(sessionId);
+    return;
+  }
   if (!ALLOWED_DYNAMIC_TOOL_EVENTS.has(input.event.type)) return;
   if (input.event.type === "step.started") {
     await resolveStepDynamicTools({ ...input, event: input.event });
@@ -432,7 +471,14 @@ export async function refreshDynamicSessionToolsForRuntimeRevision(input: {
   const hasOldMetadata = current.length !== persisted.length;
   const revisionChanged =
     input.ctx.get(SessionDynamicToolRuntimeRevisionKey) !== input.runtimeRevision;
-  if (!revisionChanged && !hasOldMetadata && !hasUnregisteredDurableDynamicCallbacks(current)) {
+  if (
+    !revisionChanged &&
+    !hasOldMetadata &&
+    !hasUnregisteredDurableDynamicCallbacks(current, {
+      sessionId: input.ctx.require(SessionIdKey),
+      scope: "session",
+    })
+  ) {
     return;
   }
   const matching = input.resolvers.filter((resolver) =>
@@ -460,7 +506,11 @@ export async function rebindMissingCompiledDynamicToolCallbacks(input: {
     input.ctx.get(TurnDynamicToolMetadataKey) ?? [];
   const needsResolution = persisted.filter(
     (entry) =>
-      !isCurrentDynamicToolMetadata(entry) || hasUnregisteredDurableDynamicCallbacks([entry]),
+      !isCurrentDynamicToolMetadata(entry) ||
+      hasUnregisteredDurableDynamicCallbacks([entry], {
+        sessionId: input.ctx.require(SessionIdKey),
+        scope: "turn",
+      }),
   );
   if (needsResolution.length === 0) return;
   const resolverSlugs = new Set(needsResolution.map((entry) => entry.resolverSlug));
@@ -491,7 +541,11 @@ export async function rebindMissingCompiledDynamicToolCallbacks(input: {
       needsResolution.some(
         (candidate) =>
           candidate.resolverSlug === entry.resolverSlug && candidate.name === entry.name,
-      ) && hasUnregisteredDurableDynamicCallbacks([entry]),
+      ) &&
+      hasUnregisteredDurableDynamicCallbacks([entry], {
+        sessionId: input.ctx.require(SessionIdKey),
+        scope: "turn",
+      }),
   );
   if (unresolved.length > 0) {
     throw new Error(

--- a/packages/eve/src/context/dynamic-tool-metadata.ts
+++ b/packages/eve/src/context/dynamic-tool-metadata.ts
@@ -11,7 +11,7 @@ interface DynamicToolMetadataBase {
   readonly entryKey: string;
 }
 
-/** Current schema: callback identity is the surrounding tool name and phase. */
+/** Callback identity is supplied by the surrounding session, scope, and resolver metadata. */
 export interface CurrentDynamicToolMetadata extends DynamicToolMetadataBase {
   readonly callbacks: DurableDynamicToolCallbacks;
 }

--- a/packages/eve/src/context/memory-tools.test.ts
+++ b/packages/eve/src/context/memory-tools.test.ts
@@ -10,6 +10,7 @@ import { AuthKey, SessionIdKey, SessionKey, TurnMemoryLocksKey } from "#context/
 import { createMemoryToolDynamicDefinition } from "#context/memory-tools.js";
 import { resolveApprovalPolicy } from "#approval/definition.js";
 import { defineTool } from "#tools/definition.js";
+import { clearDurableDynamicCallbacks } from "#tools/durable-callbacks.js";
 import { defineMemory } from "#public/memory/index.js";
 import { always } from "#public/tools/approval/index.js";
 import type { ResolvedDynamicToolResolver } from "#runtime/types.js";
@@ -95,11 +96,7 @@ describe("memory provider tools", () => {
       name: "profile__save",
     });
 
-    const registry = Reflect.get(globalThis, Symbol.for("eve:dynamic-tool-callbacks")) as Map<
-      string,
-      Map<string, unknown>
-    >;
-    registry.get("profile__save")?.clear();
+    clearDurableDynamicCallbacks(ctx.require(SessionIdKey));
     deployedVersion = 2;
     ctx.set(TurnMemoryLocksKey, createContext("user_2").require(TurnMemoryLocksKey));
 

--- a/packages/eve/src/harness/tool-loop-generate-approval-resume.integration.test.ts
+++ b/packages/eve/src/harness/tool-loop-generate-approval-resume.integration.test.ts
@@ -12,6 +12,7 @@ import { PendingSkillAnnouncementKey } from "#context/dynamic-skill-lifecycle.js
 import {
   AuthKey,
   SessionKey,
+  SessionIdKey,
   SessionDynamicToolMetadataKey,
   TurnDynamicToolMetadataKey,
   StepDynamicToolMetadataKey,
@@ -211,6 +212,7 @@ function createApprovalContext(): ContextContainer {
   };
   const ctx = new ContextContainer();
   ctx.set(AuthKey, responder);
+  ctx.set(SessionIdKey, "generate-approval-resume-session");
   ctx.set(SessionKey, {
     auth: { current: responder, initiator: null },
     sessionId: "generate-approval-resume-session",
@@ -288,12 +290,19 @@ describe("tool loop generate approval resume (real AI SDK)", () => {
     ].flatMap((scope) => ["structured", "text"].map((response) => ({ ...scope, response }))),
   )(
     "records the scoped key for a $response approval of a $scope dynamic tool",
-    async ({ metadataKey, response }) => {
+    async ({ metadataKey, response, scope }) => {
       const ctx = createApprovalContext();
       const execute = vi.fn(async () => "/workspace");
-      registerDurableDynamicCallback({ toolName: "bash", phase: "execute", callback: execute });
+      const owner = {
+        sessionId: ctx.require(SessionIdKey),
+        scope: scope as "session" | "turn" | "step",
+        resolverSlug: "dynamic-shell",
+        entryKey: "bash",
+        name: "bash",
+      };
+      registerDurableDynamicCallback({ owner, phase: "execute", callback: execute });
       registerDurableDynamicCallback({
-        toolName: "bash",
+        owner,
         phase: "approvalKey",
         callback: (_closure, input: { command: string }) => `bash:${input.command}`,
       });
@@ -389,6 +398,7 @@ describe("tool loop generate approval resume (real AI SDK)", () => {
       principalType: "user" as const,
     };
     ctx.set(AuthKey, responder);
+    ctx.set(SessionIdKey, "generate-approval-resume-session");
     ctx.set(SessionKey, {
       auth: { current: responder, initiator: null },
       sessionId: "generate-approval-resume-session",
@@ -516,6 +526,7 @@ describe("tool loop generate approval resume (real AI SDK)", () => {
     };
     const ctx = new ContextContainer();
     ctx.set(AuthKey, responder);
+    ctx.set(SessionIdKey, "generate-approval-resume-session");
     ctx.set(SessionKey, {
       auth: { current: responder, initiator: null },
       sessionId: "generate-approval-resume-session",

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -2329,15 +2329,23 @@ describe("createToolLoopHarness", () => {
       sessionId: "test-session",
       turn: { id: "turn-test", sequence: 0 },
     });
+    ctx.set(SessionIdKey, "test-session");
+    const owner = {
+      sessionId: "test-session",
+      scope: "step" as const,
+      resolverSlug: "tfl",
+      entryKey: "tfl__getLineStatus",
+      name: "tfl__getLineStatus",
+    };
     registerDurableDynamicCallback({
       callback: () => ({ ok: true }),
       phase: "execute",
-      toolName: "tfl__getLineStatus",
+      owner,
     });
     registerDurableDynamicCallback({
       callback: (_closure: unknown, approvalContext: unknown) => approval(approvalContext as never),
       phase: "approvalRequest",
-      toolName: "tfl__getLineStatus",
+      owner,
     });
     ctx.set(StepDynamicToolMetadataKey, [
       {

--- a/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.test.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.test.ts
@@ -87,7 +87,7 @@ function durableCallbacks(tool: unknown): StampedCallbacks {
 
 // Clear resolve-time registrations between tests so each assertion observes only its module.
 beforeEach(() => {
-  const sym = Symbol.for("eve:dynamic-tool-callbacks");
+  const sym = Symbol.for("eve:scoped-dynamic-tool-callbacks");
   const reg = (globalThis as Record<symbol, Map<string, Function> | undefined>)[sym];
   if (reg) reg.clear();
 });

--- a/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.ts
+++ b/packages/eve/src/internal/workflow-bundle/dynamic-tool-transform.ts
@@ -2,7 +2,7 @@
  * Stamps callbacks passed to authored `defineTool()` calls with durable replay
  * descriptors. Each callback body is hoisted into a module-suffix function and
  * the live callback is stamped with that function plus the lexical values its
- * body references; identity `(toolName, phase)` is assigned at resolve time.
+ * body references; the session, scope, and resolver bind its identity at resolve time.
  */
 
 import { parseWithNitroRolldownAst } from "#internal/bundler/nitro-rolldown.js";

--- a/packages/eve/src/tools/durable-callbacks.test.ts
+++ b/packages/eve/src/tools/durable-callbacks.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  clearDurableDynamicCallbacks,
+  lookupDurableDynamicCallback,
+  registerDurableDynamicCallback,
+  type DynamicToolCallbackOwner,
+} from "#tools/durable-callbacks.js";
+
+const owner: DynamicToolCallbackOwner = {
+  sessionId: "cache-owner",
+  scope: "session",
+  resolverSlug: "search",
+  entryKey: "query",
+  name: "query",
+};
+
+describe("durable callback cache", () => {
+  it("evicts old sessions and allows their own callback to rebind", () => {
+    const callback = () => "original";
+    registerDurableDynamicCallback({ owner, phase: "execute", callback });
+    for (let index = 0; index < 1_024; index++) {
+      registerDurableDynamicCallback({
+        owner: { ...owner, sessionId: `other-${index}` },
+        phase: "execute",
+        callback: () => "other session",
+      });
+    }
+    expect(lookupDurableDynamicCallback(owner, "execute")).toBeUndefined();
+    registerDurableDynamicCallback({ owner, phase: "execute", callback });
+    expect(lookupDurableDynamicCallback(owner, "execute")).toBe(callback);
+    clearDurableDynamicCallbacks(owner.sessionId);
+    for (let index = 0; index < 1_024; index++) clearDurableDynamicCallbacks(`other-${index}`);
+  });
+
+  it("removes only the replaced resolver and scope", () => {
+    const callback = () => null;
+    for (const scope of ["session", "turn"] as const) {
+      for (const resolverSlug of ["search", "other"]) {
+        registerDurableDynamicCallback({
+          owner: { ...owner, scope, resolverSlug },
+          phase: "execute",
+          callback,
+        });
+      }
+    }
+    clearDurableDynamicCallbacks(owner.sessionId, { scope: "session", resolverSlug: "search" });
+    expect(lookupDurableDynamicCallback(owner, "execute")).toBeUndefined();
+    expect(lookupDurableDynamicCallback({ ...owner, scope: "turn" }, "execute")).toBe(callback);
+    expect(lookupDurableDynamicCallback({ ...owner, resolverSlug: "other" }, "execute")).toBe(
+      callback,
+    );
+    clearDurableDynamicCallbacks(owner.sessionId);
+  });
+});

--- a/packages/eve/src/tools/durable-callbacks.ts
+++ b/packages/eve/src/tools/durable-callbacks.ts
@@ -13,7 +13,8 @@ export type DurableDynamicCallbackFn = (closure: JsonObject, ...args: never[]) =
 
 /**
  * Persisted binding for one callback phase. Identity is
- * `(toolName, phase)` — carried by the surrounding metadata — so only the
+ * session, lifecycle scope, resolver, entry, tool name, and phase — carried
+ * by the surrounding context and metadata — so only the
  * snapshotted closure values persist.
  */
 export interface DurableDynamicCallbackReference {
@@ -46,43 +47,79 @@ export type LiveDurableDynamicToolCallbacks = Partial<{
 const STAMPED_CALLBACK = Symbol.for("eve:durable-dynamic-callback");
 export const DURABLE_DYNAMIC_TOOL_CALLBACKS = Symbol.for("eve:durable-dynamic-tool-callbacks");
 
-const REGISTRY = Symbol.for("eve:dynamic-tool-callbacks");
+const REGISTRY = Symbol.for("eve:scoped-dynamic-tool-callbacks");
+const MAX_CACHED_SESSIONS = 1_024;
 
-type Registry = Map<string, Map<DurableDynamicCallbackPhase, DurableDynamicCallbackFn>>;
+export type DynamicToolCallbackScope = "session" | "turn" | "step";
+
+export interface DynamicToolCallbackOwner {
+  readonly sessionId: string;
+  readonly scope: DynamicToolCallbackScope;
+  readonly resolverSlug: string;
+  readonly entryKey: string;
+  readonly name: string;
+}
+
+type Registry = Map<string, Map<string, DurableDynamicCallbackFn>>;
 
 function getRegistry(): Registry {
   const global = globalThis as Record<symbol, Registry | undefined>;
-  const existing = global[REGISTRY];
-  if (existing !== undefined) return existing;
-
-  const registry: Registry = new Map();
-  global[REGISTRY] = registry;
-  return registry;
+  return (global[REGISTRY] ??= new Map());
 }
 
-/**
- * Binds the current implementation of one tool callback phase. Re-resolution
- * replaces the binding, so replay after a redeploy runs the latest code.
- */
+function getSessionBindings(sessionId: string): Map<string, DurableDynamicCallbackFn> | undefined {
+  const registry = getRegistry();
+  const bindings = registry.get(sessionId);
+  if (bindings !== undefined) {
+    registry.delete(sessionId);
+    registry.set(sessionId, bindings);
+  }
+  return bindings;
+}
+
+function callbackKey(owner: DynamicToolCallbackOwner, phase: DurableDynamicCallbackPhase): string {
+  return JSON.stringify([owner.scope, owner.resolverSlug, owner.entryKey, owner.name, phase]);
+}
+
+/** Re-resolution updates only the same session's resolver and lifecycle scope. */
 export function registerDurableDynamicCallback(input: {
   readonly callback: DurableDynamicCallbackFn;
   readonly phase: DurableDynamicCallbackPhase;
-  readonly toolName: string;
+  readonly owner: DynamicToolCallbackOwner;
 }): void {
   const registry = getRegistry();
-  let phases = registry.get(input.toolName);
-  if (phases === undefined) {
-    phases = new Map();
-    registry.set(input.toolName, phases);
+  let bindings = getSessionBindings(input.owner.sessionId);
+  if (bindings === undefined) {
+    bindings = new Map();
+    registry.set(input.owner.sessionId, bindings);
+    // Eviction behaves like a process restart: missing bindings must rebind or fail closed.
+    if (registry.size > MAX_CACHED_SESSIONS) registry.delete(registry.keys().next().value!);
   }
-  phases.set(input.phase, input.callback);
+  bindings.set(callbackKey(input.owner, input.phase), input.callback);
 }
 
 export function lookupDurableDynamicCallback(
-  toolName: string,
+  owner: DynamicToolCallbackOwner,
   phase: DurableDynamicCallbackPhase,
 ): DurableDynamicCallbackFn | undefined {
-  return getRegistry().get(toolName)?.get(phase);
+  return getSessionBindings(owner.sessionId)?.get(callbackKey(owner, phase));
+}
+
+/** Discards completed sessions or a resolver's previous result before replacement. */
+export function clearDurableDynamicCallbacks(
+  sessionId: string,
+  resolver?: { readonly scope: DynamicToolCallbackScope; readonly resolverSlug: string },
+): void {
+  if (resolver === undefined) {
+    getRegistry().delete(sessionId);
+    return;
+  }
+  const bindings = getSessionBindings(sessionId);
+  if (bindings === undefined) return;
+  const prefix = JSON.stringify([resolver.scope, resolver.resolverSlug]).slice(0, -1) + ",";
+  for (const key of bindings.keys()) {
+    if (key.startsWith(prefix)) bindings.delete(key);
+  }
 }
 
 /** Invokes a registered callback with its snapshotted closure and live arguments. */
@@ -96,11 +133,17 @@ export function callDurableDynamicCallback(
 
 /** True when any persisted callback of these tools has no registered binding. */
 export function hasUnregisteredDurableDynamicCallbacks(
-  metadata: readonly { callbacks: DurableDynamicToolCallbacks; name: string }[],
+  metadata: readonly {
+    callbacks: DurableDynamicToolCallbacks;
+    name: string;
+    resolverSlug: string;
+    entryKey: string;
+  }[],
+  scope: Pick<DynamicToolCallbackOwner, "sessionId" | "scope">,
 ): boolean {
   return metadata.some((entry) =>
     (Object.keys(entry.callbacks) as DurableDynamicCallbackPhase[]).some(
-      (phase) => lookupDurableDynamicCallback(entry.name, phase) === undefined,
+      (phase) => lookupDurableDynamicCallback({ ...entry, ...scope }, phase) === undefined,
     ),
   );
 }

--- a/packages/eve/test/scenarios/dynamic-tool-cold-replay.scenario.test.ts
+++ b/packages/eve/test/scenarios/dynamic-tool-cold-replay.scenario.test.ts
@@ -197,8 +197,8 @@ describe("dynamic tool cold replay", () => {
         }
 
         // The fresh process rebinds persisted callbacks by re-running session
-        // resolvers exactly once (identity is the tool name, so the same
-        // definitions re-register); replay itself never depends on it.
+        // resolvers exactly once for this session; the same resolver entries
+        // re-register without replacing another session's bindings.
         const resolverRunsAfterRestart = (
           await readFile(join(app.appRoot, ".dynamic-resolver-runs"), "utf8")
         )


### PR DESCRIPTION
### Summary

Two sessions can resolve different dynamic tools with the same name; replay previously used the most recently registered implementation with the earlier session's captured values. Bind callbacks by session, lifecycle scope, and resolver entry so another session or a narrower scope cannot replace them. The bounded cache preserves existing cold-rebind and fail-closed behavior, and replay remains independent of source positions. Closes #2445.

### Validation

- Reproduced the wrong implementation on unchanged main with a lifecycle serialization/replay test.
- `pnpm fmt`, `pnpm lint`, `pnpm docs:check`, `pnpm guard:invariants`, and `pnpm typecheck` passed.
- `pnpm --filter eve build` passed.
- Focused unit tests for callback identity, lifecycle, memory callbacks, metadata, tool loop, and compiler transformation passed: 376 tests.
- Real AI SDK approval-resume integration passed: 17 tests.
- Real process cold-replay and source-edit scenarios passed: 2 tests.
- Added a fixture-owned eval for two sessions sharing a tool name, with a scripted responder for the mock-model world suites. E2E execution runs in CI.
- The full local unit suite has two existing macOS telemetry config-path assertion failures, also reproduced on unchanged main. A transient self-import startup failure passed on rerun (19 tests).

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
