### PR TITLE
fix(eve): authored bundles - preserve Node resolution conditions

### DIFF
--- a/.changeset/fix-react-server-module-map.md
+++ b/.changeset/fix-react-server-module-map.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Preserve Node.js custom resolution conditions when bundling authored modules. Production builds with a channel importing `server-only` under `react-server` now produce a valid module map.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -161,6 +161,10 @@ eve build [--profile <path>] [--skip-sandbox-prewarm]
 
 Compiles and bundles in an invocation-owned directory under `.eve/builds/`, then publishes the completed host output and prints its path. Scratch workspaces are removed after success or failure.
 
+Authored bundles preserve custom Node.js resolution conditions supplied through `--conditions`,
+`-C`, or `NODE_OPTIONS`. For example, `NODE_OPTIONS="--conditions=react-server" eve build`
+keeps a channel's `server-only` imports on the same export used during compilation.
+
 | Flag                     | Type   | Default | Description                                                                                   |
 | ------------------------ | ------ | ------- | --------------------------------------------------------------------------------------------- |
 | `--profile <path>`       | string | off     | Best-effort versioned JSON report with build-phase timings and final output-size measurements |

--- a/packages/eve/src/internal/authored-module-conditions.test.ts
+++ b/packages/eve/src/internal/authored-module-conditions.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { authoredModuleConditions } from "./authored-module-conditions.js";
+
+describe("authoredModuleConditions", () => {
+  it("leaves ordinary builds on eve's source condition", () => {
+    expect(authoredModuleConditions(["--enable-source-maps"], "")).toEqual(["eve-source"]);
+  });
+
+  it.each([
+    ["--conditions=react-server"],
+    ["--conditions", "react-server"],
+    ["-C", "react-server"],
+  ])("preserves command-line conditions %j", (...args) => {
+    expect(authoredModuleConditions(args, "")).toEqual(["eve-source", "react-server"]);
+  });
+
+  it("reads quoted NODE_OPTIONS and combines repeated conditions", () => {
+    expect(
+      authoredModuleConditions(
+        ["--conditions=react-server", "-C", "custom"],
+        '--conditions="react-server" --require "./path with spaces/preload.js" -C "custom condition"',
+      ),
+    ).toEqual(["eve-source", "react-server", "custom condition", "custom"]);
+  });
+
+  it("preserves escaped quotes in NODE_OPTIONS", () => {
+    expect(authoredModuleConditions([], '--conditions="custom\\"condition"')).toEqual([
+      "eve-source",
+      'custom"condition',
+    ]);
+  });
+
+  it("leaves standard condition selection to each bundler import edge", () => {
+    expect(
+      authoredModuleConditions(
+        [
+          "--conditions=import",
+          "--conditions=require",
+          "--conditions=node",
+          "--conditions=default",
+          "--conditions=browser",
+        ],
+        "",
+      ),
+    ).toEqual(["eve-source"]);
+  });
+});

--- a/packages/eve/src/internal/authored-module-conditions.ts
+++ b/packages/eve/src/internal/authored-module-conditions.ts
@@ -1,0 +1,41 @@
+import { parseArgs } from "node:util";
+
+import { ROLLDOWN_STANDARD_CONDITION_NAMES } from "#internal/bundler/nitro-rolldown.js";
+
+/** Keep authored evaluation and its immutable bundle on the same conditional exports. */
+export function authoredModuleConditions(
+  args: readonly string[] = process.execArgv,
+  nodeOptions: string = process.env.NODE_OPTIONS ?? "",
+): string[] {
+  const { values } = parseArgs({
+    args: [...splitNodeOptions(nodeOptions), ...args],
+    allowPositionals: true,
+    strict: false,
+    options: { conditions: { type: "string", multiple: true, short: "C" } },
+  });
+  return [...new Set(["eve-source", ...(values.conditions ?? [])])].filter(
+    (condition): condition is string =>
+      typeof condition === "string" && !ROLLDOWN_STANDARD_CONDITION_NAMES.has(condition),
+  );
+}
+
+function splitNodeOptions(source: string): string[] {
+  const args: string[] = [];
+  let argument = "";
+  let quoted = false;
+  for (let index = 0; index < source.length; index++) {
+    const character = source[index]!;
+    if (character === "\\" && quoted && index + 1 < source.length) {
+      argument += source[++index];
+    } else if (character === '"') {
+      quoted = !quoted;
+    } else if (/\s/.test(character) && !quoted) {
+      if (argument.length > 0) args.push(argument);
+      argument = "";
+    } else {
+      argument += character;
+    }
+  }
+  if (argument.length > 0) args.push(argument);
+  return args;
+}

--- a/packages/eve/src/internal/authored-module-loader.ts
+++ b/packages/eve/src/internal/authored-module-loader.ts
@@ -5,6 +5,7 @@ import { dirname, join, relative, resolve, sep } from "node:path";
 import type { CompiledAgentManifest } from "#compiler/manifest.js";
 import { createCompiledModuleMapSource } from "#compiler/module-map.js";
 import { createAuthoredAssetImportPlugin } from "#internal/authored-asset-import-plugin.js";
+import { authoredModuleConditions } from "#internal/authored-module-conditions.js";
 import { createAuthoredModuleBundleError } from "#internal/authored-module-bundle.js";
 import { createAuthoredModuleEvaluationError } from "#internal/authored-module-evaluation-error.js";
 import { createAuthoredPackageTsConfigPathsPlugin } from "#internal/authored-package-tsconfig-paths.js";
@@ -329,7 +330,7 @@ export async function bundleAuthoredModuleMapForGeneration(input: {
       platform: "node",
       plugins,
       resolve: {
-        conditionNames: ["eve-source"],
+        conditionNames: authoredModuleConditions(),
         extensions: [...RESOLVE_EXTENSIONS],
       },
       tsconfig: resolveAuthoredTsConfigPath(packageRoot),
@@ -528,7 +529,7 @@ async function buildAuthoredModuleBundle(
       platform: "node",
       plugins,
       resolve: {
-        conditionNames: ["eve-source"],
+        conditionNames: authoredModuleConditions(),
         extensions: [...RESOLVE_EXTENSIONS],
       },
       tsconfig: tsconfigPath,

--- a/packages/eve/src/internal/bundler/nitro-rolldown.ts
+++ b/packages/eve/src/internal/bundler/nitro-rolldown.ts
@@ -103,7 +103,7 @@ export async function buildWithNitroRolldown(
   return await build(options);
 }
 
-const ROLLDOWN_STANDARD_CONDITION_NAMES = new Set([
+export const ROLLDOWN_STANDARD_CONDITION_NAMES: ReadonlySet<string> = new Set([
   "browser",
   "default",
   "import",

--- a/packages/eve/src/internal/nitro/host/react-server-module-map.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/host/react-server-module-map.scenario.test.ts
@@ -1,0 +1,71 @@
+import { execFile } from "node:child_process";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+import { describe, expect, it } from "vitest";
+
+import { useScenarioApp } from "#internal/testing/scenario-app.js";
+
+const execFileAsync = promisify(execFile);
+
+describe("react-server module maps", () => {
+  const scenarioApp = useScenarioApp();
+
+  it.each(["argument", "NODE_OPTIONS"])(
+    "builds and loads server-only channels with conditions from %s",
+    async (conditionSource) => {
+      const app = await scenarioApp({
+        name: "react-server-module-map",
+        installDependencies: true,
+        dependencies: { "server-only": "0.0.1" },
+        files: {
+          "agent/agent.ts": 'export default { model: "openai/gpt-5.4" };',
+          "agent/instructions.md": "Reply concisely.",
+          "agent/channels/probe.ts":
+            'import "server-only"; import { defineChannel, GET } from "eve/channels"; export default defineChannel({ routes: [GET("/probe", () => new Response("server-only-ready"))] });',
+          "check.mjs": [
+            'import { createServer } from "node:net";',
+            'import { spawn } from "node:child_process";',
+            'import { once } from "node:events";',
+            'const portProbe = createServer().listen(0, "127.0.0.1");',
+            'await once(portProbe, "listening");',
+            "const port = portProbe.address().port;",
+            "await new Promise((resolve) => portProbe.close(resolve));",
+            'const child = spawn(process.execPath, [".output/server/index.mjs"], { env: { ...process.env, HOST: "127.0.0.1", PORT: String(port) }, stdio: "ignore" });',
+            'const exited = once(child, "exit");',
+            "try {",
+            "  for (let attempt = 0; attempt < 100; attempt++) {",
+            "    try { const response = await fetch(`http://127.0.0.1:${port}/probe`); if (response.ok) { console.log(await response.text()); break; } } catch {}",
+            "    await new Promise((resolve) => setTimeout(resolve, 100));",
+            "  }",
+            '} finally { if (child.exitCode === null) child.kill("SIGTERM"); await exited; }',
+          ].join("\n"),
+        },
+      });
+      await execFileAsync(
+        process.execPath,
+        [
+          ...(conditionSource === "argument" ? ["--conditions=react-server"] : []),
+          join(app.appRoot, "node_modules/eve/bin/eve.js"),
+          "build",
+        ],
+        {
+          cwd: app.appRoot,
+          timeout: 90_000,
+          maxBuffer: 10 * 1024 * 1024,
+          env: {
+            ...process.env,
+            ...(conditionSource === "NODE_OPTIONS"
+              ? { NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --conditions="react-server"` }
+              : {}),
+          },
+        },
+      );
+      const { stdout } = await execFileAsync(process.execPath, ["check.mjs"], {
+        cwd: app.appRoot,
+        timeout: 20_000,
+      });
+      expect(stdout).toContain("server-only-ready");
+    },
+  );
+});


### PR DESCRIPTION
### Summary

A channel importing `server-only` compiled successfully under Node's `react-server` condition, but the authored bundle ignored that condition and selected the package's throwing default export. Rolldown then emitted an undefined `moduleMap` export and the production build failed. Preserve explicit Node conditions in authored bundles, including quoted `NODE_OPTIONS`, while leaving standard `import`/`require` resolution to each bundler edge.

Closes #2735.

### Validation

- Added a packed-install regression that reproduced the undefined `moduleMap` export before the fix. Both direct `--conditions=react-server` and quoted `NODE_OPTIONS` now build and serve the custom channel from the production output.
- `pnpm fmt`, `pnpm lint`, `pnpm typecheck` (43 workspace tasks), `pnpm --filter eve build`, `pnpm docs:check`, and `pnpm guard:invariants` passed.
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts authored-module-conditions.test.ts` — 7 passed.
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts nitro-rolldown.integration.test.ts --maxWorkers=2` — 4 passed.
- Scenario coverage: `react-server-module-map.scenario.test.ts` and `authored-runtime-artifacts.scenario.test.ts` passed using `vitest.scenario.config.ts`, covering conditioned builds and ordinary authored bundles.
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts --maxWorkers=4` — only two existing macOS telemetry path assertions failed; both were independently reproduced on unchanged main. CI runs the unit suite on Linux.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
