### PR TITLE
docs: clarify dynamic connection tool discovery

### DIFF
--- a/docs/guides/dynamic-capabilities.md
+++ b/docs/guides/dynamic-capabilities.md
@@ -180,8 +180,10 @@ export default defineDynamic({
 The returned definitions use the same auth, headers, filtering, provided
 arguments, and approval options as static [MCP](../connections/mcp) and
 [OpenAPI](../connections/openapi) connections. Each resolved connection joins
-the per-step connection registry, appears in `connection_search`, and exposes
-discovered tools as `<connection>__<tool>`.
+the per-step connection registry and appears in `connection_search`. Its tools
+are not exposed to the model up front: the model discovers them by calling
+`connection_search`, and matches become callable as `<connection>__<tool>` on
+the next model call.
 
 Set `instanceKey` on every authenticated dynamic connection. Use a stable,
 non-secret account or tenant identifier, and change it whenever the endpoint,


### PR DESCRIPTION
### Summary

Issue #3025 reports dynamic connections never reaching the model. Neither triage nor an independent reproduction on `main` could confirm the failure (see the investigation comment on the issue). The wording in the dynamic-capabilities guide may contribute to the confusion, though: saying a resolved connection "exposes discovered tools as `<connection>__<tool>`" reads as if the operations are present in the model's tool set from the start. In practice they only become callable after the model calls `connection_search`, with matches surfaced on the next model call — so an agent whose model skips `connection_search` looks like its dynamic connections were silently dropped. This clarifies the guide to describe that discovery sequence.

Related to #3025.

### Validation

- `pnpm docs:check`
- Manual end-to-end check on a local `main` build (0.52.2) with a dynamic-only OpenAPI connection against a loopback server: `connection_search` listed the connection, returned `vendor__getStatus`, and the operation executed on the following step (details in the #3025 comment).

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
