### PR TITLE
fix(eve): scope toolResultFrom identity warning to fallback lookups

### DIFF
--- a/.changeset/tool-result-from-warning-wording.md
+++ b/.changeset/tool-result-from-warning-wording.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Clarified the `toolResultFrom` shared-identity warning: only lookups that fall back to the shared identity will not match, while definitions loaded by eve keep resolving through their source identity.

--- a/packages/eve/src/internal/authored-definition/source-identity.ts
+++ b/packages/eve/src/internal/authored-definition/source-identity.ts
@@ -28,8 +28,8 @@ export function registerDefinitionSource(key: string, entry: DefinitionSourceEnt
         [
           `eve could not assign a unique toolResultFrom identity for ${JSON.stringify(key)}.`,
           `Conflicting definitions: ${formatDefinitionSourceForWarning(existing)} and ${formatDefinitionSourceForWarning(entry)}.`,
-          "Multiple authored definitions share that fallback identity, so toolResultFrom will not match through it.",
-          "Use the original definition object loaded by eve so source-derived identity can be used instead.",
+          "Multiple authored definitions share that fallback identity, so only lookups that fall back to it will not match.",
+          "Definitions loaded by eve resolve through their source identity, so use the original definition object loaded by eve.",
         ].join(" "),
       );
     }

--- a/packages/eve/src/public/tools/result.test.ts
+++ b/packages/eve/src/public/tools/result.test.ts
@@ -277,6 +277,11 @@ describe("toolResultFrom", () => {
         'Conflicting definitions: connection "first" from "connections/first.ts" and connection "second" from "connections/second.ts".',
       ),
     );
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Multiple authored definitions share that fallback identity, so only lookups that fall back to it will not match.",
+      ),
+    );
     expect(toolResultFrom(toolResult("first__search", []), first)).toEqual({
       callId: "call_1",
       connectionToolName: "search",


### PR DESCRIPTION
### Summary

When two authored connections legitimately share one endpoint, every cold start emits a `toolResultFrom` identity warning stating that "toolResultFrom will not match through it." As #3085 demonstrates, that overstates the consequence: definitions loaded by eve are stamped with a unique source key, so they keep resolving correctly, and only lookups that fall back to the shared URL key are actually ambiguous. The warning is still correct in principle — an unstamped object falling back to the shared key cannot match — so this keeps it firing and keeps the fallback marked ambiguous, but scopes the wording to that fallback path so a legitimate shared-endpoint setup no longer reads as broken.

Fixes #3085.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/tools/result.test.ts` — 12 passed; added an assertion for the scoped wording in the shared-URL connection case
- `pnpm --filter eve run typecheck`
- `pnpm fmt`

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
