### PR TITLE
fix(eve): retry model calls cut by an AI Gateway stream timeout

### DIFF
--- a/.changeset/retry-gateway-stream-timeout.md
+++ b/.changeset/retry-gateway-stream-timeout.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Retry model calls that AI Gateway aborts with `gateway_stream_timeout` instead of parking the session after the first cut stream.

--- a/packages/eve/src/harness/model-call-error.test.ts
+++ b/packages/eve/src/harness/model-call-error.test.ts
@@ -185,6 +185,19 @@ describe("classifyModelCallError", () => {
     expect(classifyModelCallError(new Error("stream failed", { cause: overloaded }))).toBe("retry");
   });
 
+  it("returns retry for an AI Gateway stream timeout payload", () => {
+    // The gateway aborts a long stream with a plain payload keyed on
+    // `code`; the harness wraps it through normalizeModelStreamError.
+    const payload = {
+      code: "gateway_stream_timeout",
+      message: "Stream exceeded maximum duration before function timeout",
+      origin: "gateway",
+    };
+
+    expect(classifyModelCallError(normalizeModelStreamError(payload))).toBe("retry");
+    expect(classifyModelCallError(payload)).toBe("retry");
+  });
+
   it("returns retry for HTTP statuses the AI SDK treats as retryable", () => {
     for (const statusCode of [408, 409, 429]) {
       const err = Object.assign(new Error("retryable"), { statusCode });

--- a/packages/eve/src/harness/semantic-errors/rules/gateway.ts
+++ b/packages/eve/src/harness/semantic-errors/rules/gateway.ts
@@ -1,4 +1,12 @@
-import { allOf, anyOf, messageMatches, nameIs, typeIs, type SemanticErrorRule } from "../rule.js";
+import {
+  allOf,
+  anyOf,
+  codeIs,
+  messageMatches,
+  nameIs,
+  typeIs,
+  type SemanticErrorRule,
+} from "../rule.js";
 
 /** The summary `name` shared by the gateway-auth rule variants. */
 const GATEWAY_AUTH_FAILURE_SUMMARY_NAME = "AI Gateway authentication failed";
@@ -104,5 +112,15 @@ export const GATEWAY_RULES: readonly SemanticErrorRule[] = [
     when: anyOf(nameIs("GatewayTimeoutError"), typeIs("timeout_error", "overloaded_error")),
     message: "The model provider is overloaded or timing out upstream of AI Gateway.",
     hint: "This is transient — retry shortly, or switch models with `/model` in `eve dev`.",
+  },
+  {
+    id: "gateway-stream-timeout",
+    name: "AI Gateway stream timed out",
+    tags: ["gateway", "transient"],
+    // The gateway aborts a long stream with a payload that carries `code`,
+    // not the body `type` the rule above reads, so it needs its own match.
+    when: codeIs("gateway_stream_timeout"),
+    message: "AI Gateway ended the model stream before the response finished.",
+    hint: "Retries are automatic. If it persists, split the task into smaller turns or switch models with `/model` in `eve dev`.",
   },
 ];

--- a/packages/eve/src/harness/semantic-errors/semantic-errors.test.ts
+++ b/packages/eve/src/harness/semantic-errors/semantic-errors.test.ts
@@ -90,6 +90,17 @@ describe("summarizeKnownError (catalog table)", () => {
       id: "gateway-upstream-unavailable",
     },
     {
+      title: "gateway stream timeout",
+      error: new Error("Stream exceeded maximum duration before function timeout", {
+        cause: {
+          code: "gateway_stream_timeout",
+          message: "Stream exceeded maximum duration before function timeout",
+          origin: "gateway",
+        },
+      }),
+      id: "gateway-stream-timeout",
+    },
+    {
       title: "provider api key missing",
       error: named("LoadAPIKeyError", "OpenAI API key is missing."),
       id: "model-provider-api-key-missing",


### PR DESCRIPTION
### Summary

Model calls that AI Gateway aborts with `gateway_stream_timeout` now retry through the existing model-call retry loop instead of parking the session after the first cut stream.

- **The classifier fell through to `recoverable`.** The gateway sends the abort as a plain payload keyed on `code`, and the catalog only read the body `type`, so the turn parked with zero retries.
- **One transient catalog rule fixes it.** `gateway-stream-timeout` matches `codeIs("gateway_stream_timeout")`, and the classifier already returns `retry` for any rule tagged `transient`.
- **The rule lives in the catalog, not in `classifyModelCallError`.** The catalog is the documented growth point for new error shapes, and the payload reaches the cause chain through `normalizeModelStreamError`.
- **The summary copy matches its sibling rules.** Users see a one-line cause and a hint to split the task or switch models when retries do not help.

| Area         | Lines added |
| ------------ | ----------- |
| Catalog rule | 19          |
| Changeset    | 5           |
| Tests        | 24          |
| **Total**    | **48**      |

Closes #3084

The reporter also proposed reading `code` inside `classifyModelCallError` itself; that broader change is left for a maintainer decision.

### Validation

Commands run locally on macOS:

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/harness/model-call-error.test.ts src/harness/semantic-errors/semantic-errors.test.ts` passes with 84 tests.
- `pnpm lint`, `pnpm --filter eve run typecheck`, and `pnpm guard:invariants` pass.
- `pnpm test:unit` passes except two tests in `packages/eve/src/cli/telemetry/preference.test.ts`. They fail identically on `origin/main` in this shell because `XDG_CONFIG_HOME` is set, and this branch does not touch telemetry. Three unrelated files timed out under load in the full run and pass on rerun on both this branch and `origin/main`.

The integration, scenario, and e2e suites were not run. The change has no fixture, subprocess, or HTTP surface.

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
