### PR TITLE
fix(compiler): ignore non-string nested metadata in skill frontmatter

### DIFF
--- a/.changeset/ignore-nested-skill-metadata.md
+++ b/.changeset/ignore-nested-skill-metadata.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Ignore non-string nested metadata in skill frontmatter without failing build.

--- a/packages/eve/src/discover/skills.integration.test.ts
+++ b/packages/eve/src/discover/skills.integration.test.ts
@@ -238,4 +238,47 @@ describe("discoverSkills (memory)", () => {
       DISCOVER_SKILL_COLLISION,
     ]);
   });
+
+  it("discovers skills with nested metadata by ignoring non-string entries", async () => {
+    const project = buildMemoryAgentProject({
+      agentFiles: {
+        "skills/lark-skill/SKILL.md": [
+          "---",
+          "name: demo",
+          "description: Demo skill.",
+          "metadata:",
+          "  requires:",
+          "    bins:",
+          "      - some-cli",
+          "  cliHelp: some-cli --help",
+          "---",
+          "Body.",
+        ].join("\n"),
+      },
+    });
+
+    const result = await discoverSkills({
+      agentRoot: project.agentRoot,
+      source: project.source,
+    });
+    const larkSkillRoot = join(resolve(project.agentRoot), "skills", "lark-skill");
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.skills).toEqual([
+      {
+        description: "Demo skill.",
+        sourceKind: "skill-package",
+        logicalPath: "skills/lark-skill/SKILL.md",
+        markdown: "Body.",
+        metadata: {
+          cliHelp: "some-cli --help",
+        },
+        name: "lark-skill",
+        rootPath: larkSkillRoot,
+        skillFilePath: join(larkSkillRoot, "SKILL.md"),
+        skillId: "lark-skill",
+        sourceId: "skills/lark-skill/SKILL.md",
+      },
+    ]);
+  });
 });

--- a/packages/eve/src/internal/helpers/markdown.test.ts
+++ b/packages/eve/src/internal/helpers/markdown.test.ts
@@ -236,4 +236,103 @@ body`;
     );
     expect(Reflect.get(globalThis, "__eveScheduleRce")).toBeUndefined();
   });
+
+  it("preserves flat string metadata in skill markdown frontmatter", () => {
+    const markdown = `---
+description: Use the weather tool before answering forecast questions.
+metadata:
+  version: "1.0"
+  author: eve
+---
+When the user asks about weather, call the weather tool before answering.`;
+
+    expect(lowerSkillMarkdown(markdown)).toEqual(
+      defineSkill({
+        description: "Use the weather tool before answering forecast questions.",
+        metadata: {
+          version: "1.0",
+          author: "eve",
+        },
+        markdown: "When the user asks about weather, call the weather tool before answering.",
+      }),
+    );
+  });
+
+  it("ignores nested metadata fields in skill markdown frontmatter", () => {
+    const markdown = `---
+name: demo
+description: Demo skill.
+metadata:
+  requires:
+    bins:
+      - some-cli
+  cliHelp: some-cli --help
+---
+Body.`;
+
+    expect(lowerSkillMarkdown(markdown)).toEqual(
+      defineSkill({
+        description: "Demo skill.",
+        metadata: {
+          cliHelp: "some-cli --help",
+        },
+        markdown: "Body.",
+      }),
+    );
+  });
+
+  it("omits metadata entirely when all entries are non-string or nested", () => {
+    const markdown = `---
+name: demo
+description: Demo skill.
+metadata:
+  requires:
+    bins:
+      - some-cli
+---
+Body.`;
+
+    expect(lowerSkillMarkdown(markdown)).toEqual(
+      defineSkill({
+        description: "Demo skill.",
+        markdown: "Body.",
+      }),
+    );
+  });
+
+  it("ignores non-object metadata frontmatter without failing", () => {
+    const markdown = `---
+description: Demo skill.
+metadata: not-an-object
+---
+Body.`;
+
+    expect(lowerSkillMarkdown(markdown)).toEqual(
+      defineSkill({
+        description: "Demo skill.",
+        markdown: "Body.",
+      }),
+    );
+  });
+
+  it("requires skill markdown description to be a string", () => {
+    expect(() =>
+      lowerSkillMarkdown(`---
+description:
+  text: invalid
+---
+Body.`),
+    ).toThrow('Expected "description" frontmatter to be a string.');
+  });
+
+  it("requires skill markdown license to be a string", () => {
+    expect(() =>
+      lowerSkillMarkdown(`---
+description: Demo skill.
+license:
+  name: MIT
+---
+Body.`),
+    ).toThrow('Expected "license" frontmatter to be a string.');
+  });
 });

--- a/packages/eve/src/internal/helpers/markdown.ts
+++ b/packages/eve/src/internal/helpers/markdown.ts
@@ -194,7 +194,7 @@ function applyOptionalSkillFrontmatter(
     rawDefinition.license = license;
   }
 
-  const metadata = toOptionalStringRecord(frontmatter.metadata, "metadata");
+  const metadata = toOptionalStringRecord(frontmatter.metadata);
   if (metadata !== undefined) {
     rawDefinition.metadata = metadata;
   }
@@ -222,25 +222,18 @@ function requireStringFrontmatter(value: unknown, fieldName: string): string {
   return normalizedValue;
 }
 
-function toOptionalStringRecord(
-  value: unknown,
-  fieldName: string,
-): Record<string, string> | undefined {
-  if (value === undefined || value === null) {
+function toOptionalStringRecord(value: unknown): Record<string, string> | undefined {
+  if (value === undefined || value === null || !isObject(value)) {
     return undefined;
   }
 
-  if (!isObject(value)) {
-    throw new Error(`Expected "${fieldName}" frontmatter to be an object.`);
+  const stringEntries = Object.entries(value).filter(
+    (entry): entry is [string, string] => typeof entry[1] === "string",
+  );
+
+  if (stringEntries.length === 0) {
+    return undefined;
   }
-
-  const stringEntries = Object.entries(value).map(([key, entryValue]) => {
-    if (typeof entryValue !== "string") {
-      throw new Error(`Expected "${fieldName}.${key}" frontmatter to be a string.`);
-    }
-
-    return [key, entryValue] as const;
-  });
 
   return Object.fromEntries(stringEntries);
 }


### PR DESCRIPTION
### Summary

Fixes #3105.

Agent skills authored for other platforms (such as Lark/Feishu) often carry nested metadata structures (e.g., `metadata.requires: { bins: [...] }`). In `lowerSkillMarkdown`, encountering non-string values inside `metadata` previously threw a hard `DISCOVER_SKILL_FRONTMATTER_INVALID` discovery error, failing the build and blocking portable agent skills from compiling.

This change updates `toOptionalStringRecord` in `packages/eve/src/internal/helpers/markdown.ts` to filter out non-string and nested entries from `metadata` instead of throwing an unhandled diagnostic. If no valid string entries remain or `metadata` is not an object, the field is cleanly omitted as `undefined`. Strict string validation is strictly preserved on required load-bearing frontmatter keys (`description` and `license`).

### Validation

- Ran `pnpm --filter eve test:unit src/internal/helpers/markdown.test.ts` (all 24 tests passed, including new cases for flat metadata retention, nested metadata omission, and invalid description/license enforcement).
- Ran `oxlint --fix` (0 warnings, 0 errors across 3,677 files).
- Verified `Turborepo` workspace typechecking (`turbo run typecheck`) across core packages.

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)