### PR TITLE
fix(docs): repair tutorial setup and chart downloads

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -14,6 +14,15 @@ You need:
 
 The default scaffolded model routes through the Vercel AI Gateway. Set `AI_GATEWAY_API_KEY`, or link a Vercel project to use `VERCEL_OIDC_TOKEN`. To use a model provider directly, install its AI SDK provider package and set the provider's API key.
 
+To use your ChatGPT subscription, install the Codex CLI and sign in before selecting **ChatGPT subscription** in the dev TUI's `/model` menu:
+
+```bash
+npm install -g @openai/codex
+codex login
+```
+
+eve uses the Codex login on the machine running the agent. For headless login and runtime requirements, see [ChatGPT subscription models](./reference/typescript-api#chatgpt-subscription-models).
+
 Choose a model, provider, and channel that meet your data-processing and compliance requirements.
 
 ## Create a project

--- a/docs/reference/typescript-api.md
+++ b/docs/reference/typescript-api.md
@@ -187,7 +187,7 @@ Pass another bare OpenAI model slug to override the default. `experimental_chatg
 
 Authentication is delegated entirely to the Codex CLI:
 
-1. Install or upgrade `codex` and run `codex login`.
+1. Install or upgrade the Codex CLI with `npm install -g @openai/codex`, then run `codex login`.
 2. `eve dev` asks `codex app-server` for a usable access token. Codex owns refresh and credential persistence; eve does not read or write Codex login files.
 3. Normal token expiry is refreshed automatically. If the login is revoked, the status line shows `codex login`; completing login inside or outside eve repairs the running dev session without restarting it.
 

--- a/docs/sandbox.mdx
+++ b/docs/sandbox.mdx
@@ -31,12 +31,17 @@ export default defineTool({
     const sandbox = await ctx.getSandbox();
     await sandbox.writeTextFile({ path: "analysis/run.py", content: script });
     const result = await sandbox.run({ command: "python analysis/run.py" });
-    return { stdout: result.stdout };
+    if (result.exitCode !== 0) {
+      throw new Error(`Analysis failed (${result.exitCode}): ${result.stderr}`);
+    }
+    return { stdout: result.stdout, stderr: result.stderr };
   },
 });
 ```
 
 `ctx.getSandbox()` takes no arguments, is async, and only works inside authored runtime execution.
+
+`sandbox.run()` resolves with `{ exitCode, stdout, stderr }` even when the command fails. Check `exitCode` before returning a successful tool result. Python needs a backend that runs real binaries; `just-bash` cannot run it. See [Run analysis](./tutorial/run-analysis#install-the-chart-dependencies) for a complete Python and matplotlib bootstrap.
 
 `/workspace` is one namespace across every backend, so `/workspace/foo` points at the same file whether the backend is local or Vercel. When you need to interpolate a path into a generated command, `sandbox.resolvePath("repo/build.py")` anchors a relative path to its absolute `/workspace/repo/build.py` form.
 
@@ -44,7 +49,7 @@ The handle does more than `run` and `writeTextFile`. In every method, relative p
 
 | Method                                   | Does                                                                                            |
 | ---------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `run({ command })`                       | run one command, block until it exits, return `{ stdout, stderr, ... }`                         |
+| `run({ command })`                       | run one command, block until it exits, return `{ exitCode, stdout, stderr }`                    |
 | `spawn(options)`                         | launch a long-running process (server, watcher) and return a `SandboxProcess` handle            |
 | `readTextFile` / `writeTextFile`         | read/write a UTF-8 (or specified encoding) file; `readTextFile` supports 1-based line ranges    |
 | `readBinaryFile` / `writeBinaryFile`     | read/write raw bytes (images, archives, anything non-text)                                      |

--- a/docs/tutorial/connect-a-warehouse.mdx
+++ b/docs/tutorial/connect-a-warehouse.mdx
@@ -1,11 +1,13 @@
 ---
-title: "Connect a Warehouse"
+title: "Connect a Warehouse (Optional)"
 description: "Part 4 of the Build an Agent tutorial. Let each user connect their own warehouse over an OAuth MCP via Vercel Connect."
 ---
 
-The sample dataset got the analytics assistant running, but it's a stand-in. Now point the agent at a real warehouse and let each user connect their own by signing in through their browser. That's what a connection is for. It's an MCP server the model reaches through tools, with auth that eve drives for you.
+You can complete the tutorial using the Step 3 sample database. Continue to [Run analysis](./run-analysis) with no warehouse or Vercel Connect setup.
 
-This step depends on Vercel Connect, which is in private beta. No Connect access? Keep the Step 3 sample dataset and read this step for the connection model. Steps 5 through 9 work against the sample dataset, so you can complete the tutorial without a warehouse.
+If you already have a warehouse exposed through an OAuth MCP server, this optional step shows how to connect it. A connection exposes the MCP server's tools to the model, with authentication resolved by eve.
+
+This example uses [Vercel Connect](https://vercel.com/connect). You need a Vercel account, a linked project, an OAuth MCP server for your warehouse, and authenticated app users. The placeholder URL below is not a hosted tutorial service. Follow the [Connect setup guide](https://vercel.com/kb/guide/vercel-connect) to register and link your client.
 
 The filename sets the runtime name. Put the file at `agent/connections/warehouse.ts` and it registers as `"warehouse"`, with its tools surfaced as `warehouse__<tool>`.
 
@@ -28,7 +30,7 @@ export default defineMcpClientConnection({
 
 Before testing the warehouse from a web app, make sure the eve channel route auth maps your signed-in app user to `principalType: "user"`. A Connect-backed connection can only start per-user OAuth when the active session already has an authenticated user principal. If route auth still only accepts `localDev()`, a runtime token, or a placeholder guard, the first warehouse tool call fails with `reason: "principal_required"` instead of showing the sign-in challenge.
 
-Once Connect is enabled on your account, wire it up:
+With those prerequisites in place, wire it up:
 
 1. Install the package: `npm install @vercel/connect`.
 2. Create the Connect client: `vercel connect create <type> --name warehouse`.
@@ -45,7 +47,7 @@ Ask a question that needs the warehouse:
 How many enterprise customers signed up last month?
 ```
 
-The first time, the model picks a warehouse tool but there's no token yet, so the turn parks and the channel shows a "Sign in" affordance. You authorize in the browser, and once the OAuth callback completes, the turn resumes from exactly that step (the durable parking from [Step 2](./how-it-runs)) and the query runs. Later calls in the session reuse the cached per-user token, so there's no prompt.
+The first time, the model picks a warehouse tool but there's no token yet, so the turn parks and the channel shows a "Sign in" affordance. You authorize in the browser, and once the OAuth callback completes, the turn resumes from exactly that step (the durable parking from [Step 2](./how-it-runs)) and the query runs. Vercel Connect manages token storage and refresh for subsequent calls.
 
 ## The token never reaches the model
 

--- a/docs/tutorial/first-agent.mdx
+++ b/docs/tutorial/first-agent.mdx
@@ -3,14 +3,17 @@ title: "Your First Agent"
 description: "Part 1 of the Build an Agent tutorial. Scaffold the analytics assistant, give it an analyst persona, run it, and ask a question."
 ---
 
-The Build an Agent tutorial constructs one app end to end, a data analytics assistant. You ask in natural language, and over the next nine steps it learns to query a warehouse, run analysis in a sandbox, remember your team's metric definitions, and refuse to exceed your query budget without asking.
+The Build an Agent tutorial constructs one app end to end, a data analytics assistant. You ask in natural language, and over the next nine steps it learns to query a sample database, run analysis in a sandbox, remember your team's metric definitions, and refuse to exceed your query budget without asking.
 
-Step 1 gets it talking. The scaffold bundles a small sample dataset, so your first question works with zero setup.
+Step 1 gets it talking. In Step 3 you add a small sample database that supports the rest of the tutorial. You do not need a warehouse or Vercel Connect; Step 4 is an optional connection example.
 
 ## Prerequisites
 
 - Node 24 or newer and npm.
 - A model credential. The scaffold's default model goes through the [Vercel AI Gateway](../getting-started), so you need `AI_GATEWAY_API_KEY` (or `VERCEL_OIDC_TOKEN` pulled via `vercel link`). A direct provider model like `anthropic("claude-opus-4-8")` instead needs that provider's AI SDK package and key, here `@ai-sdk/anthropic` and `ANTHROPIC_API_KEY`.
+- For charting in Step 5, a running Docker-compatible runtime or [Vercel Sandbox credentials](https://vercel.com/docs/sandbox/concepts/authentication). The sample database in Step 3 needs neither.
+
+To use a ChatGPT subscription instead, install the Codex CLI with `npm install -g @openai/codex` and run `codex login` before selecting **ChatGPT subscription** in `/model`. eve uses the Codex login on the machine running the agent. See [ChatGPT subscription models](../reference/typescript-api#chatgpt-subscription-models).
 
 If you have not run eve before, complete [Getting Started](../getting-started) first. Without a credential, "Run the agent" below fails when the runtime tries to reach the model; the dev TUI's `/model` flow walks you through pasting a key or linking a project.
 
@@ -23,14 +26,14 @@ cd analytics-assistant
 
 The command writes the starter agent with eve's default model and built-in HTTP API
 channel (`agent/channels/eve.ts`), installs dependencies, initializes Git, and
-starts the development server. Stop the server before continuing with the edits
+offers to start the development server. Stop the server before continuing with the edits
 below. It does not create a Vercel project or deploy. `init` creates the
 `analytics-assistant/` directory, so `cd` into it before running further
 commands.
 
 ## Set the model
 
-`agent/agent.ts` holds the model and config. Use a capable model for analysis work:
+`agent/agent.ts` holds the model and config. Keep the model configured by `/model`, including its imports. If you chose AI Gateway, you can use:
 
 ```ts
 import { defineAgent } from "eve";

--- a/docs/tutorial/query-sample-data.mdx
+++ b/docs/tutorial/query-sample-data.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Query Sample Data"
-description: "Part 3 of the Build an Agent tutorial. Add a run_sql tool over the bundled sample dataset and watch the tool loop."
+description: "Part 3 of the Build an Agent tutorial. Add a run_sql tool over a local sample dataset and watch the tool loop."
 ---
 
 The analytics assistant can hold a conversation, but it can't see a single row of data. Give it a tool. A tool is the action primitive. Typed input goes in, your code runs, structured output comes back. The name the model sees is the filename, so `agent/tools/run_sql.ts` becomes the tool `run_sql`.
@@ -14,7 +14,7 @@ npm install sql.js
 npm install --save-dev @types/sql.js
 ```
 
-`sql.js` loads its WebAssembly binary from the installed package at runtime. Keep the package external so the binary remains next to its JavaScript:
+`sql.js` loads its WebAssembly binary from the installed package at runtime. Keep the package external so the binary remains next to its JavaScript. Add `build.externalDependencies` to your existing config, preserving the model and provider imports you set in Step 1:
 
 ```ts title="agent/agent.ts" {5-7}
 import { defineAgent } from "eve";
@@ -31,10 +31,10 @@ Restart the dev server after changing `externalDependencies`. eve reads this set
 
 ## A tiny sample dataset
 
-Store a small in-memory dataset under `agent/lib/`. Keep it tiny. This is throwaway scaffolding, not the real warehouse (that comes in Step 4).
+Store a small in-memory dataset under `agent/lib/`. This database supports every remaining tutorial step. Step 4 shows an optional connection to a warehouse.
 
 ```ts title="agent/lib/sample-db.ts"
-// A toy SQLite-in-memory stand-in. Swap for your real warehouse in Step 4.
+// Sample data for the tutorial; no external database is required.
 import initSqlJs from "sql.js";
 
 const SEED = `
@@ -100,6 +100,6 @@ Which customer has spent the most, and how much?
 
 Watch the loop play out in the TUI. The model emits a `run_sql` call, eve runs your `execute`, and the rows come back as a tool result. The model reads them and answers with a real number. eve drove the whole loop. All you supplied was the tool.
 
-→ Next: [Connect a warehouse](./connect-a-warehouse)
+→ Next: [Run analysis](./run-analysis), or optionally [connect a warehouse](./connect-a-warehouse).
 
 Learn more: [Tools](../tools)

--- a/docs/tutorial/run-analysis.mdx
+++ b/docs/tutorial/run-analysis.mdx
@@ -1,15 +1,15 @@
 ---
 title: "Run Analysis"
-description: "Part 5 of the Build an Agent tutorial. Seed the warehouse schema into the sandbox workspace, then compute and chart beyond SQL."
+description: "Part 5 of the Build an Agent tutorial. Seed the sample schema into the sandbox workspace, then compute and chart beyond SQL."
 ---
 
-SQL tells the analytics assistant the numbers, but a cohort curve, a forecast, or a chart needs real computation. That's what the sandbox is for. It's an isolated bash environment with a `/workspace` filesystem, and every agent gets exactly one.
+The analytics assistant can chart the Step 3 sample data by running Python in its sandbox, then returning the PNG to your machine. The sandbox is an isolated environment with a `/workspace` filesystem.
 
-This takes two pieces. First seed reference files the model can read, then compute against them.
+This step installs matplotlib, seeds the sample schema, and adds a chart tool. Keep using the sample database; a warehouse connection is optional.
 
 ## Seed the schema into the workspace
 
-Mount the warehouse schema into the sandbox so the model isn't guessing at table shapes. Seeding uses the folder sandbox layout, where anything under `agent/sandbox/workspace/` lands in the live `/workspace` cwd at session bootstrap.
+Mount the sample database schema into the sandbox so the model isn't guessing at table shapes. Seeding uses the folder sandbox layout, where anything under `agent/sandbox/workspace/` lands in the live `/workspace` cwd at session bootstrap.
 
 ```text
 agent/sandbox/
@@ -22,66 +22,154 @@ agent/sandbox/
 -- agent/sandbox/workspace/schema.sql
 -- Reference only: table shapes the analyst can read before writing queries.
 CREATE TABLE orders     (id INT, customer_id INT, amount_cents INT, created_at DATE);
-CREATE TABLE customers  (id INT, name TEXT, plan TEXT, signed_up_at DATE);
+CREATE TABLE customers  (id INT, name TEXT, plan TEXT);
 ```
 
-Top-level workspace entries get advertised to the model automatically, so it knows `schema.sql` is there to read. No `agent/sandbox/sandbox.ts` required. A `workspace/` folder keeps the default sandbox and seeds your files into it.
+Top-level workspace entries get advertised to the model automatically, so it knows `schema.sql` is there to read.
+
+## Install the chart dependencies
+
+This example needs a sandbox that runs real binaries. For local development, install and start a Docker-compatible runtime, then check `docker info` in your terminal. The `just-bash` fallback cannot run Python or install matplotlib.
+
+Create `agent/sandbox/sandbox.ts` alongside `workspace/`:
+
+```ts title="agent/sandbox/sandbox.ts"
+import { defineSandbox, type SandboxBackend } from "eve/sandbox";
+import { docker } from "eve/sandbox/docker";
+import { vercel } from "eve/sandbox/vercel";
+
+export default defineSandbox({
+  backend: (): SandboxBackend => (process.env.VERCEL ? vercel() : docker()),
+  async bootstrap({ use }) {
+    const sandbox = await use();
+    const result = await sandbox.run({
+      command:
+        "sudo apt-get update && " +
+        "sudo apt-get install -y python3 python3-matplotlib && " +
+        "python3 -c 'import matplotlib'",
+    });
+    if (result.exitCode !== 0) {
+      throw new Error(`Chart dependency setup failed (${result.exitCode}): ${result.stderr}`);
+    }
+  },
+});
+```
+
+The eve base image includes Python; this bootstrap also installs matplotlib and verifies the import. Package installation needs network access. `bootstrap` runs when eve builds the reusable sandbox template, so later sessions inherit the installed packages. Restart `npm run dev` after adding the sandbox definition.
+
+The configuration uses Docker locally and Vercel Sandbox when deployed on Vercel. To use Vercel Sandbox locally too, set `backend: vercel()` and complete its [credential setup](https://vercel.com/docs/sandbox/concepts/authentication).
 
 ## Compute and chart in the sandbox
 
 The built-in `bash`, `read_file`, and `write_file` tools already target the sandbox. When you write your own analysis steps, grab a live handle with `ctx.getSandbox()`:
 
 ```ts title="agent/tools/chart_series.ts"
+import { randomUUID } from "node:crypto";
 import { defineTool } from "eve/tools";
 import { z } from "zod";
 
 export default defineTool({
   description:
     "Plot a time series to a PNG in the workspace. Pass {date, value} points; " +
-    "returns the chart path.",
+    "returns the chart path and PNG bytes for the client to save.",
   inputSchema: z.object({
     title: z.string(),
-    points: z.array(z.object({ date: z.string(), value: z.number() })),
+    points: z
+      .array(z.object({ date: z.string(), value: z.number() }))
+      .min(1)
+      .max(500),
   }),
   async execute({ title, points }, ctx) {
     const sandbox = await ctx.getSandbox();
+    const directory = `analysis/${randomUUID()}`;
     await sandbox.writeTextFile({
-      path: "analysis/series.json",
+      path: `${directory}/series.json`,
       content: JSON.stringify({ title, points }),
     });
     await sandbox.writeTextFile({
-      path: "analysis/plot.py",
+      path: `${directory}/plot.py`,
       content: [
         "import json, matplotlib",
         "matplotlib.use('Agg')",
         "import matplotlib.pyplot as plt",
-        "d = json.load(open('series.json'))",
-        "plt.plot([p['date'] for p in d['points']], [p['value'] for p in d['points']])",
-        "plt.title(d['title']); plt.savefig('chart.png')",
+        "from datetime import date",
+        "from pathlib import Path",
+        "root = Path(__file__).parent",
+        "d = json.loads((root / 'series.json').read_text())",
+        "plt.plot([date.fromisoformat(p['date']) for p in d['points']], [p['value'] for p in d['points']])",
+        "plt.gcf().autofmt_xdate()",
+        "plt.title(d['title']); plt.tight_layout()",
+        "plt.savefig(root / 'chart.png'); plt.close()",
       ].join("\n"),
     });
-    const root = sandbox.resolvePath("analysis");
-    await sandbox.run({ command: `cd ${JSON.stringify(root)} && python plot.py` });
-    return { chart: `${root}/chart.png` };
+    const result = await sandbox.run({ command: `python3 ${directory}/plot.py` });
+    if (result.exitCode !== 0) {
+      throw new Error(`Chart rendering failed (${result.exitCode}): ${result.stderr}`);
+    }
+    const chart = sandbox.resolvePath(`${directory}/chart.png`);
+    const png = await sandbox.readBinaryFile({ path: chart });
+    if (png === null || png.byteLength === 0) {
+      throw new Error("Chart rendering completed without a PNG file.");
+    }
+    return { chart, title, pngBase64: Buffer.from(png).toString("base64") };
+  },
+  toModelOutput({ chart, title }) {
+    return { type: "json", value: { chart, title, status: "rendered" } };
   },
 });
 ```
 
-This tool shells out to `python` with matplotlib, which the sandbox base image does not preinstall. Install the runtime in sandbox bootstrap (or bake it into a custom image) so `python plot.py` resolves. See [Sandbox](../sandbox) for where bootstrap runs.
+`sandbox.run()` returns `{ exitCode, stdout, stderr }`; a nonzero exit code does not throw automatically. This tool throws on failure and reads the file before returning success. Each call writes to its own directory, so concurrent calls cannot overwrite each other's charts. `toModelOutput` keeps the base64 image out of the model context while the client receives the full output.
 
 Now ask for something past plain SQL. If you skipped Step 4, this still works against the Step 3 sample dataset:
 
 ```text
-Plot total order revenue per customer.
+Plot daily total order revenue in dollars for May 2026 using the sample database and chart_series.
 ```
 
-The model queries for the numbers (the warehouse from Step 4, or the sample dataset if you skipped it), checks `schema.sql` to get the grain right, then calls `chart_series` to render the PNG in `/workspace`.
+The model queries the sample database and calls `chart_series`. The expected daily totals are $42, $15, $99, and $8, on May 1, 3, 4, and 6 respectively.
+
+## Save the chart on your machine
+
+A `/workspace/...` path belongs to the sandbox; it is not a local file or a download URL. The tool reads the PNG out of the sandbox and includes its bytes in the client event stream. To generate and save a chart, create this script in the project root:
+
+```js title="save-chart.mjs"
+import { writeFile } from "node:fs/promises";
+import { Client } from "eve/client";
+
+const client = new Client({ host: process.argv[2] ?? "http://127.0.0.1:2000" });
+const { response } = await client.sessions.create({
+  message:
+    "Use the sample database and chart_series to plot daily order revenue in dollars for May 2026.",
+});
+let saved = false;
+for await (const event of response) {
+  if (event.type !== "action.result") continue;
+  const result = event.data.result;
+  if (result.kind !== "tool-result" || result.toolName !== "chart_series") continue;
+  if (result.isError) throw new Error(JSON.stringify(result.output));
+  const output = result.output;
+  if (!output || typeof output !== "object" || typeof output.pngBase64 !== "string") continue;
+  await writeFile("chart.png", Buffer.from(output.pngBase64, "base64"));
+  saved = true;
+  console.log("Saved chart.png in the current directory.");
+}
+if (!saved) throw new Error("The agent did not return a chart. Check the tool result in eve dev.");
+```
+
+Leave `npm run dev` running, then run the script in another terminal, passing the URL printed by eve:
+
+```bash
+node save-chart.mjs http://127.0.0.1:2000
+```
+
+Open `chart.png` from your project directory. The TUI displays tool results but does not turn sandbox paths into downloads. Step 9 shows how to render the same chart output in the web dashboard. For larger artifacts, store the bytes in your application's file storage and return an access-controlled URL instead of embedding them in session history.
 
 ## Secrets stay out of the sandbox
 
-The sandbox has no `process.env` and no access to your app's secrets. Your warehouse token lives in the app runtime, and firewall brokering is the only path it takes to the warehouse host. It never enters the sandbox process.
+The authored tool runs in the app runtime and explicitly transfers the input points into the sandbox. The Python process receives those points, not your app's environment or credentials. If you added the optional MCP connection, its requests and OAuth credentials stay in the app runtime; the chart tool only passes query results into the sandbox.
 
-The local backend runs the sandbox on your laptop during `eve dev`; on Vercel it runs on Vercel Sandbox. Lifecycle, backends, and network policy are in [Sandbox](../sandbox).
+See [Sandbox](../sandbox) for backend selection, lifecycle, and network policy.
 
 → Next: [Remember definitions](./remember-definitions)
 

--- a/docs/tutorial/ship-it.mdx
+++ b/docs/tutorial/ship-it.mdx
@@ -33,9 +33,16 @@ The dashboard talks to the built-in eve HTTP channel (`agent/channels/eve.ts`). 
 
 import { useEveAgent } from "eve/react";
 
-export function AgentChat() {
-  const agent = useEveAgent();
-  const isBusy = agent.status === "submitted" || agent.status === "streaming";
+export function AgentChat({
+  sessionId,
+  sessionless = false,
+}: {
+  sessionId?: string;
+  sessionless?: boolean;
+}) {
+  const initialSession = !sessionless && sessionId ? { sessionId, streamIndex: 0 } : undefined;
+  const agent = useEveAgent({ initialSession, resume: initialSession !== undefined });
+  const isBusy = ["resuming", "submitted", "streaming"].includes(agent.status);
 
   return (
     <form
@@ -49,11 +56,32 @@ export function AgentChat() {
       {agent.data.messages.map((message) => (
         <article key={message.id}>
           <header>{message.role}</header>
-          {message.parts.map((part, index) =>
-            part.type === "text" ? <p key={index}>{part.text}</p> : null,
-          )}
+          {message.parts.map((part, index) => {
+            if (part.type === "text") return <p key={index}>{part.text}</p>;
+            if (
+              part.type === "dynamic-tool" &&
+              part.toolName === "chart_series" &&
+              part.state === "output-available" &&
+              part.output !== null &&
+              typeof part.output === "object" &&
+              "pngBase64" in part.output &&
+              typeof part.output.pngBase64 === "string"
+            ) {
+              const src = `data:image/png;base64,${part.output.pngBase64}`;
+              return (
+                <figure key={index}>
+                  <img src={src} alt="Generated revenue chart" />
+                  <a href={src} download="chart.png">
+                    Download chart
+                  </a>
+                </figure>
+              );
+            }
+            return null;
+          })}
         </article>
       ))}
+      {agent.error && <p role="alert">{agent.error.message}</p>}
       <input name="q" disabled={isBusy} placeholder="Ask about the data…" />
       <button type="submit" disabled={isBusy}>
         Ask
@@ -73,7 +101,11 @@ export default function Page() {
 }
 ```
 
+The optional props also support the generated `/s/[sessionId]` and `/s` pages: the first resumes that session, and `sessionless` starts a new conversation.
+
 `agent.data.messages` and `agent.status` cover most chat UIs. The generated Web Chat renders HITL prompts directly in the conversation: approvals get action controls, and `ask_question` gets a visible form with vertical choices, a text field, or both. The spend approval from [Step 8](./guard-the-spend) uses the same response path. For the full API, see [Frontend](../guides/frontend/overview).
+
+The chart renderer uses the PNG bytes returned by the [Step 5 tool](./run-analysis), so it works without a public sandbox file server. The minimal component above renders text and charts only; keep the generated Web Chat's approval and question controls when using the later human-in-the-loop steps.
 
 ## Replace `placeholderAuth`
 
@@ -131,14 +163,14 @@ On Vercel, the web app stays public and the eve runtime sits behind it on the sa
 npx eve dev https://your-analytics-app.vercel.app
 ```
 
-That's the full assistant, deployed and authed. It queries the warehouse, runs analysis in a sandbox, charts the results, remembers your team's definitions, loads the right playbook per team, and asks before it spends.
+The assistant queries the sample database (or your optional warehouse), runs analysis in a sandbox, charts the results, remembers your team's definitions, loads the right playbook per team, and asks before it spends.
 
 ## What you learned
 
 Across the nine steps you built and shipped one agent, and along the way you used:
 
 - **Tools** to give the model typed actions (`run_sql`, `chart_series`, `define_metric`).
-- **Connections** to reach a warehouse over an OAuth MCP, with per-user tokens eve resolves for you.
+- **Optional connections** to reach a warehouse over an OAuth MCP, with per-user tokens eve resolves for you.
 - **The sandbox** to compute and chart beyond SQL in an isolated `/workspace`.
 - **State** (`defineState`) to remember the team's glossary across turns.
 - **Dynamic skills** (`defineDynamic`) to load the right team playbook per caller.

--- a/packages/eve/test/scenarios/tutorial-analysis.scenario.test.ts
+++ b/packages/eve/test/scenarios/tutorial-analysis.scenario.test.ts
@@ -1,0 +1,157 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { createServer } from "node:http";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { useTemporaryDirectories } from "#internal/testing/use-temporary-app-roots.js";
+import { EVE_MESSAGE_STREAM_VERSION, EVE_STREAM_VERSION_HEADER } from "#protocol/message.js";
+import { mockSandbox } from "#internal/testing/mocks/mock-sandbox.js";
+import type { SandboxSession } from "#shared/sandbox-session.js";
+import type { ToolModelOutput } from "#tools/definition.js";
+
+type ChartInput = { title: string; points: { date: string; value: number }[] };
+type ChartOutput = { chart: string; title: string; pngBase64: string };
+
+let chartTool: {
+  execute(input: ChartInput, ctx: { getSandbox(): Promise<SandboxSession> }): Promise<ChartOutput>;
+  toModelOutput(output: ChartOutput): ToolModelOutput;
+};
+
+const createScratch = useTemporaryDirectories();
+const exec = promisify(execFile);
+
+const input: ChartInput = { title: "Revenue", points: [{ date: "2026-05-01", value: 42 }] };
+
+beforeAll(async () => {
+  // Execute the published snippet itself so docs edits cannot bypass this regression.
+  const page = await readFile(
+    new URL("../../../../docs/tutorial/run-analysis.mdx", import.meta.url),
+    "utf8",
+  );
+  const source = page.split('```ts title="agent/tools/chart_series.ts"\n')[1]?.split("\n```")[0];
+  if (source === undefined) throw new Error("Missing chart_series tutorial snippet");
+  const module = source
+    .replace(
+      '"eve/tools"',
+      JSON.stringify(new URL("../../dist/src/public/tools/index.js", import.meta.url).href),
+    )
+    .replace('"zod"', JSON.stringify(import.meta.resolve("zod")));
+  chartTool = (
+    await import(`data:text/javascript;base64,${Buffer.from(module).toString("base64")}`)
+  ).default;
+});
+
+describe("tutorial chart tool", () => {
+  it("reports Python stderr instead of a successful chart path on command failure", async () => {
+    const sandbox = mockSandbox({
+      run: () => ({
+        exitCode: 1,
+        stdout: "",
+        stderr: "ModuleNotFoundError: No module named 'matplotlib'",
+      }),
+    });
+    await expect(
+      chartTool.execute(input, { getSandbox: async () => sandbox.session }),
+    ).rejects.toThrow("ModuleNotFoundError");
+  });
+
+  it("rejects a successful command that did not create a chart", async () => {
+    const sandbox = mockSandbox();
+    await expect(
+      chartTool.execute(input, { getSandbox: async () => sandbox.session }),
+    ).rejects.toThrow("without a PNG file");
+  });
+
+  it("returns file bytes to clients without putting base64 in model context", async () => {
+    const png = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+a3ioAAAAASUVORK5CYII=",
+      "base64",
+    );
+    const sandbox = mockSandbox({
+      run: async ({ command }) => {
+        const script = command.slice("python3 ".length);
+        await sandbox.session.writeBinaryFile({
+          path: script.replace(/plot\.py$/, "chart.png"),
+          content: png,
+        });
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+    });
+    const ctx = { getSandbox: async () => sandbox.session };
+    const [first, second] = await Promise.all([
+      chartTool.execute(input, ctx),
+      chartTool.execute(input, ctx),
+    ]);
+
+    expect(first.chart).not.toBe(second.chart);
+    expect(Buffer.from(first.pngBase64, "base64")).toEqual(png);
+    expect(JSON.parse(JSON.stringify(first))).toEqual(first);
+    expect(chartTool.toModelOutput(first)).toEqual({
+      type: "json",
+      value: { chart: first.chart, title: input.title, status: "rendered" },
+    });
+  });
+
+  it("saves streamed chart bytes with the documented client script", async () => {
+    const root = await createScratch("eve-tutorial-download-");
+    const page = await readFile(
+      new URL("../../../../docs/tutorial/run-analysis.mdx", import.meta.url),
+      "utf8",
+    );
+    const source = page.split('```js title="save-chart.mjs"\n')[1]?.split("\n```")[0];
+    if (source === undefined) throw new Error("Missing save-chart tutorial snippet");
+    const script = source.replace(
+      '"eve/client"',
+      JSON.stringify(new URL("../../dist/src/client/index.js", import.meta.url).href),
+    );
+    await writeFile(join(root, "save-chart.mjs"), script);
+    const png = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+a3ioAAAAASUVORK5CYII=",
+      "base64",
+    );
+    const events = [
+      {
+        type: "action.result",
+        data: {
+          result: {
+            kind: "tool-result",
+            toolName: "chart_series",
+            callId: "chart-1",
+            output: { pngBase64: png.toString("base64") },
+          },
+        },
+      },
+      { type: "session.waiting", data: { wait: "next-user-message" } },
+    ];
+    const server = createServer((request, response) => {
+      request.resume();
+      if (request.method === "POST") {
+        response.writeHead(202, { "content-type": "application/json" });
+        response.end(JSON.stringify({ sessionId: "chart-session" }));
+        return;
+      }
+      response.writeHead(200, { [EVE_STREAM_VERSION_HEADER]: EVE_MESSAGE_STREAM_VERSION });
+      response.end(events.map((event) => JSON.stringify(event)).join("\n") + "\n");
+    });
+    try {
+      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      const address = server.address();
+      if (!address || typeof address === "string") throw new Error("Missing server address");
+      const result = await exec(
+        process.execPath,
+        [join(root, "save-chart.mjs"), `http://127.0.0.1:${address.port}`],
+        { cwd: root },
+      );
+      expect(result.stdout).toContain("Saved chart.png");
+      expect(await readFile(join(root, "chart.png"))).toEqual(png);
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+});


### PR DESCRIPTION
### Summary

The tutorial returned a chart path after `ModuleNotFoundError`, even though no PNG existed. It also omitted usable chart dependency setup and downloads, and presented a warehouse as the next required step. This corrects the onboarding instructions, keeps sample data as the main path, and makes the chart example check failures and return PNG bytes that clients can save. 

| Flow | Before | After |
| --- | --- | --- |
| Chart command fails | Return a successful sandbox path | Report stderr and reject missing output |
| Chart command succeeds | Return a path the client cannot download | Send PNG bytes to the client; keep bytes out of model context |

All documentation fixes are grouped here, including Codex prerequisites, preserving the selected model, Connect prerequisites, calendar dates, and the generated web session routes. This uses existing eve APIs and can merge independently of the setup diagnostic fix in #3113. Docs and test changes only; no changeset is required.

### Validation

- `pnpm docs:check`, `pnpm --filter eve typecheck`, `pnpm lint`, and `pnpm guard:invariants` pass on this branch.
- `pnpm --filter eve exec vitest run --config vitest.scenario.config.ts test/scenarios/tutorial-analysis.scenario.test.ts` passes all four tests against the documentation snippets.
- A fresh app on Node 24.18.0 used a real ChatGPT login and Docker to query the sample data and render charts. CLI and browser downloads matched the streamed PNG bytes exactly. Reopening the web session restored the chart. The generated web app also typechecked with TypeScript 6.0.3.
- The broader local run passed all 739 integration tests. Two telemetry path unit tests fail on macOS and also fail on unchanged [main at 4b5fad41b](https://github.com/vercel/eve/blob/4b5fad41beeecae1286611974ea970d565d13dde/packages/eve/src/cli/telemetry/preference.test.ts#L68); the implementation uses `Library/Preferences`, while the tests expect Linux XDG paths.

Hosted Vercel Sandbox execution, warehouse OAuth, and fresh interactive Codex login were not exercised.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
