### PR TITLE
fix(eve): preserve Codex setup diagnostics

### DIFF
--- a/.changeset/friendly-tutorial-login.md
+++ b/.changeset/friendly-tutorial-login.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Show the Codex CLI installation command when ChatGPT subscription setup cannot find Codex. Preserve authentication diagnostics instead of replacing them with a failed login attempt.

--- a/packages/eve/src/public/models/openai/chatgpt/codex-app-server.test.ts
+++ b/packages/eve/src/public/models/openai/chatgpt/codex-app-server.test.ts
@@ -36,7 +36,7 @@ describe("Codex app-server client", () => {
     });
 
     await expect(client.getAuthStatus({ refreshToken: false })).rejects.toThrow(
-      "requires the Codex CLI",
+      "npm install -g @openai/codex",
     );
   });
 });

--- a/packages/eve/src/public/models/openai/chatgpt/codex-app-server.ts
+++ b/packages/eve/src/public/models/openai/chatgpt/codex-app-server.ts
@@ -245,7 +245,7 @@ function unrefStream(stream: NodeJS.ReadableStream | NodeJS.WritableStream): voi
 function codexUnavailableError(error: unknown): Error {
   if (error instanceof Error && "code" in error && error.code === "ENOENT") {
     return new Error(
-      "ChatGPT subscription authentication requires the Codex CLI. Install or upgrade `codex`, then run `codex login`.",
+      "ChatGPT subscription authentication requires the Codex CLI. Install or upgrade it with `npm install -g @openai/codex`, then run `codex login` and retry.",
     );
   }
   const message = error instanceof Error ? error.message : String(error);

--- a/packages/eve/src/setup/flows/chatgpt-auth.test.ts
+++ b/packages/eve/src/setup/flows/chatgpt-auth.test.ts
@@ -1,0 +1,75 @@
+import { EventEmitter } from "node:events";
+import { spawn } from "node:child_process";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getDefaultCodexTokenBroker } from "#public/models/openai/chatgpt/token-broker.js";
+import type { ChatGptAuthState } from "#public/models/openai/chatgpt/token-broker.js";
+
+import { ensureChatGptAuth } from "./chatgpt-auth.js";
+
+vi.mock("node:child_process", () => ({ spawn: vi.fn() }));
+vi.mock("#public/models/openai/chatgpt/token-broker.js", () => ({
+  getDefaultCodexTokenBroker: vi.fn(),
+}));
+
+const refreshState = vi.fn<() => Promise<ChatGptAuthState>>();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  refreshState.mockReset();
+  vi.mocked(getDefaultCodexTokenBroker).mockReturnValue({
+    refreshState,
+    state: () => ({ kind: "checking" }),
+    getToken: vi.fn(),
+  });
+});
+
+describe("ChatGPT setup authentication", () => {
+  it("preserves the missing CLI diagnostic instead of attempting login", async () => {
+    const reason = "ChatGPT subscription authentication requires the Codex CLI.";
+    refreshState.mockResolvedValue({ kind: "unavailable", reason });
+    const child = new EventEmitter();
+    vi.mocked(spawn).mockImplementation(() => {
+      queueMicrotask(() => child.emit("error", new Error("spawn codex ENOENT")));
+      return child as ReturnType<typeof spawn>;
+    });
+
+    await expect(ensureChatGptAuth()).rejects.toThrow(reason);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("keeps an existing usable login", async () => {
+    refreshState.mockResolvedValue({ kind: "ready" });
+    await ensureChatGptAuth();
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("logs in a signed-out user and verifies the new session", async () => {
+    refreshState
+      .mockResolvedValueOnce({ kind: "signed-out" })
+      .mockResolvedValueOnce({ kind: "ready" });
+    const child = new EventEmitter();
+    vi.mocked(spawn).mockImplementation(() => {
+      queueMicrotask(() => child.emit("exit", 0, null));
+      return child as ReturnType<typeof spawn>;
+    });
+
+    await ensureChatGptAuth();
+    expect(spawn).toHaveBeenCalledWith("codex", ["login"], { stdio: "inherit" });
+    expect(refreshState).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves a diagnostic when the post-login probe is unavailable", async () => {
+    refreshState
+      .mockResolvedValueOnce({ kind: "signed-out" })
+      .mockResolvedValueOnce({ kind: "unavailable", reason: "Codex app-server exited" });
+    const child = new EventEmitter();
+    vi.mocked(spawn).mockImplementation(() => {
+      queueMicrotask(() => child.emit("exit", 0, null));
+      return child as ReturnType<typeof spawn>;
+    });
+
+    await expect(ensureChatGptAuth()).rejects.toThrow("Codex app-server exited");
+  });
+});

--- a/packages/eve/src/setup/flows/chatgpt-auth.ts
+++ b/packages/eve/src/setup/flows/chatgpt-auth.ts
@@ -6,6 +6,7 @@ import { getDefaultCodexTokenBroker } from "#public/models/openai/chatgpt/token-
 export async function ensureChatGptAuth(): Promise<void> {
   const state = await getDefaultCodexTokenBroker().refreshState();
   if (state.kind === "ready") return;
+  if (state.kind === "unavailable") throw new Error(state.reason);
 
   const child = spawn("codex", ["login"], { stdio: "inherit" });
   await new Promise<void>((resolve, reject) => {
@@ -17,6 +18,7 @@ export async function ensureChatGptAuth(): Promise<void> {
   });
 
   const refreshed = await getDefaultCodexTokenBroker().refreshState();
+  if (refreshed.kind === "unavailable") throw new Error(refreshed.reason);
   if (refreshed.kind !== "ready") {
     throw new Error("Codex login completed without a usable ChatGPT session.");
   }

--- a/packages/eve/src/setup/flows/provider.ts
+++ b/packages/eve/src/setup/flows/provider.ts
@@ -127,7 +127,7 @@ function providerOptions(
       hint:
         selectionExplicit && selectedProvider === "chatgpt"
           ? "Current"
-          : "Authenticate through the Codex CLI",
+          : "Requires the Codex CLI: npm install -g @openai/codex",
       checked: (selectionExplicit && selectedProvider === "chatgpt") || undefined,
     },
     {


### PR DESCRIPTION
### Summary

ChatGPT setup discarded the broker's missing-CLI diagnostic and attempted `codex login`, which returned the raw `spawn codex ENOENT` error. Preserve the unavailable reason before and after login, include `npm install -g @openai/codex` in the diagnostic, and show that prerequisite in the provider picker. An existing usable login still returns immediately, and signed-out users still enter the login flow.

Tutorial instructions are grouped in #3112. This PR changes setup diagnostics and includes the package changeset; neither PR depends on the other.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/setup/flows/chatgpt-auth.test.ts src/setup/flows/model.test.ts src/setup/flows/provider.test.ts src/public/models/openai/chatgpt/codex-app-server.test.ts` passes all 53 tests.
- `pnpm --filter eve build`, `pnpm --filter eve typecheck`, `pnpm lint`, and `pnpm guard:invariants` pass on this branch.
- The installed patched package returned the install/login instructions with Codex absent from `PATH`, without mocks. An existing real Codex login was also verified usable. Fresh interactive login was not exercised.
- The broader local run passed all 739 integration tests. The eve unit suite had 8,143 passing tests, one skip, and two telemetry path failures on macOS. Both failures reproduce on unchanged [main at 4b5fad41b](https://github.com/vercel/eve/blob/4b5fad41beeecae1286611974ea970d565d13dde/packages/eve/src/cli/telemetry/preference.test.ts#L68), which selects `Library/Preferences` while those tests expect Linux XDG paths.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
