### PR TITLE
docs(eve): tutorial - enforce read-only sample queries

### DIFF
--- a/docs/tutorial/guard-the-spend.mdx
+++ b/docs/tutorial/guard-the-spend.mdx
@@ -30,7 +30,7 @@ const THRESHOLD_GB = 50;
 
 export default defineTool({
   description: "Run a read-only SQL query against the analytics tables.",
-  inputSchema: z.object({ sql: z.string() }),
+  inputSchema: z.object({ sql: z.string().max(10_000) }),
   // Cost-based gate: only the expensive queries need a human yes.
   approval: ({ toolInput }) =>
     estimateScanGb(toolInput?.sql ?? "") > THRESHOLD_GB ? "user-approval" : "not-applicable",

--- a/docs/tutorial/query-sample-data.mdx
+++ b/docs/tutorial/query-sample-data.mdx
@@ -60,11 +60,26 @@ async function db() {
 
 export async function runReadOnlySql(sql: string) {
   const database = await db();
-  const [result] = database.exec(sql);
-  if (!result) return { columns: [], rows: [] as unknown[][] };
-  return { columns: result.columns, rows: result.values };
+  const query = `SELECT * FROM (${sql.trim().replace(/;$/, "")}) LIMIT 501`;
+  const statement = database.prepare(query);
+  try {
+    // prepare() accepts the first statement; reject any unparsed trailing SQL.
+    if (statement.getSQL() !== query) {
+      throw new Error("Provide a single SELECT query.");
+    }
+    const columns = statement.getColumnNames();
+    const rows: unknown[][] = [];
+    while (rows.length < 501 && statement.step()) rows.push(statement.get());
+    return { columns, rows };
+  } finally {
+    statement.free();
+  }
 }
 ```
+
+The outer `SELECT` lets SQLite accept queries, including `WITH` queries, while rejecting writes and configuration statements. The helper prepares one statement, rejects trailing SQL, and reads at most 501 rows. The extra row lets the tool report that its 500-row output was truncated. It frees the statement even when a query fails.
+
+This is an in-memory tutorial database. A row limit does not bound the work needed to compute a query; use database-enforced read-only permissions and query timeouts when adapting the tool to a production database.
 
 ## Define the run_sql tool
 
@@ -78,7 +93,7 @@ export default defineTool({
     "Run a read-only SQL query against the analytics tables (orders, customers) " +
     "and return the columns and rows.",
   inputSchema: z.object({
-    sql: z.string().describe("A single read-only SELECT statement."),
+    sql: z.string().max(10_000).describe("A single read-only SELECT statement."),
   }),
   async execute({ sql }) {
     const { columns, rows } = await runReadOnlySql(sql);

--- a/docs/tutorial/query-sample-data.mdx
+++ b/docs/tutorial/query-sample-data.mdx
@@ -60,7 +60,7 @@ async function db() {
 
 export async function runReadOnlySql(sql: string) {
   const database = await db();
-  const query = `SELECT * FROM (${sql.trim().replace(/;$/, "")}) LIMIT 501`;
+  const query = `SELECT * FROM (\n${sql.trim().replace(/;$/, "")}\n) LIMIT 501`;
   const statement = database.prepare(query);
   try {
     // prepare() accepts the first statement; reject any unparsed trailing SQL.


### PR DESCRIPTION
### Summary

The tutorial's `runReadOnlySql` helper executes arbitrary statements, so a tool call can mutate or delete the sample data despite its read-only description. Execute a single prepared outer `SELECT`, reject unparsed trailing SQL, and free the statement after success or failure. Read at most 501 rows to support the existing 500-row truncation result and bound SQL input in both tutorial versions of the tool. This keeps the sample stable for later exercises; production database permissions and query timeouts remain necessary.

### Validation

- `pnpm exec oxfmt docs/tutorial/query-sample-data.mdx docs/tutorial/guard-the-spend.mdx`
- `pnpm docs:check` — all 88 pages compile; frontmatter/navigation and snippet imports pass.
- `git diff --check`
- Executed the exact edited helper extracted from Markdown with sql.js 1.14.1: SELECT, CTE, leading/trailing line comments, optional trailing semicolon, and empty results pass; DELETE, UPDATE, DROP, PRAGMA, multiple statements, and closing-parenthesis escapes reject without changing the seed data.
- A 10,000-row recursive query returns only 501 rows; queries remain usable after failures, and the expected $164 total remains intact.
- Verified prepared-statement semantics against the installed sql.js implementation and its [public API reference](https://sql.js.org/documentation/Statement.html). No eve runtime API changed.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
