### PR TITLE
fix(eve): evals - explain conversation counter workflow

### DIFF
--- a/e2e/fixtures/agent-tools/evals/dynamic-tools/messages.eval.ts
+++ b/e2e/fixtures/agent-tools/evals/dynamic-tools/messages.eval.ts
@@ -8,13 +8,17 @@ export default defineEval({
   description: "Dynamic tools smoke: step.started resolver sees accumulated message history.",
   async test(t) {
     const first = await t.send(
-      "Use the `check_messages` tool with label 'turn1' and tell me the messageCount.",
+      "Alice is checking the conversation history tracking in her support assistant. " +
+        "Use the check_messages tool with label 'turn1' to record the initial count " +
+        "from the application's conversation log, then summarize the returned counts.",
     );
     first.expectOk();
     const firstOutput = first.requireToolCall("check_messages").output;
 
     const second = await t.send(
-      "Use the `check_messages` tool again with label 'turn2' and tell me the messageCount.",
+      "Bob has added this follow-up to the support conversation. Use the check_messages " +
+        "tool with label 'turn2' to record the updated count from the application's " +
+        "conversation log, then summarize the returned counts so Alice can compare them.",
     );
     const secondOutput = second.requireToolCall("check_messages").output;
     t.check(


### PR DESCRIPTION
### Summary

The dynamic conversation-history eval intermittently fails with Anthropic content filtering after both `check_messages` calls succeed: the history-growth and tool-result gates pass, but the provider returns an empty filtered summary. Give both requests a concrete Alice/Bob support-assistant workflow so the model understands it is reporting application conversation counters. Every assertion, label, tool implementation, and live-model requirement is unchanged. This follows the existing guidance to use ordinary workflow narratives for model-facing evals.

Observed in the [auth PR's CI job](https://github.com/vercel/eve/actions/runs/34137837713/job/101792881407); its saved model traces record `content-filter` with zero output tokens on the second-turn summary and its empty-response retry. The same fixture failed in the preceding run and passed when rerun. This PR is independent of the authentication implementation in #3120.

### Validation

- Formatted the changed eval with `pnpm exec oxfmt`.
- `pnpm lint`
- `git diff --check`
- Reviewed the diff to confirm all existing assertions and tool semantics are unchanged.
- Fixture-owned live-model evals run in CI, as required by the repository. No model-provider requests were run locally.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
