### PR TITLE
docs: recommend templates before tutorial

### DIFF
--- a/docs/tutorial/first-agent.mdx
+++ b/docs/tutorial/first-agent.mdx
@@ -3,7 +3,13 @@ title: "Your First Agent"
 description: "Part 1 of the Build an Agent tutorial. Scaffold the analytics assistant, give it an analyst persona, run it, and ask a question."
 ---
 
-The Build an Agent tutorial constructs one app end to end, a data analytics assistant. You ask in natural language, and over the next nine steps it learns to query a warehouse, run analysis in a sandbox, remember your team's metric definitions, and refuse to exceed your query budget without asking.
+Start with the [eve template gallery](https://eve.dev/templates) or ask your coding agent to build your use case. For example:
+
+- “Build an eve Slack agent that answers questions from our team’s documentation.”
+- “Build an eve incident-response agent that investigates alerts using our observability tools.”
+- “Build an eve GitHub maintainer that triages issues and summarizes pull requests.”
+
+If you prefer a step-by-step walkthrough, continue with this tutorial. It constructs one app end to end: a data analytics assistant. You ask in natural language, and over the next nine steps it learns to query a warehouse, run analysis in a sandbox, remember your team's metric definitions, and refuse to exceed your query budget without asking.
 
 Step 1 gets it talking. The scaffold bundles a small sample dataset, so your first question works with zero setup.
 

--- a/docs/tutorial/first-agent.mdx
+++ b/docs/tutorial/first-agent.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Your First Agent"
-description: "Part 1 of the Build an Agent tutorial. Scaffold the analytics assistant, give it an analyst persona, run it, and ask a question."
+description: "Scaffold the analytics assistant, give it an analyst persona, run it, and ask a question."
 ---
 
 Start with the [eve template gallery](https://eve.dev/templates) or ask your coding agent to build your use case. For example:

--- a/docs/tutorial/first-agent.mdx
+++ b/docs/tutorial/first-agent.mdx
@@ -3,7 +3,7 @@ title: "Your First Agent"
 description: "Scaffold the analytics assistant, give it an analyst persona, run it, and ask a question."
 ---
 
-Start with the [eve template gallery](https://eve.dev/templates) or ask your coding agent to build your use case. For example:
+For a bespoke learning experience, start with the [eve template gallery](https://eve.dev/templates) or ask your coding agent to build your use case. For example:
 
 - “Build an eve Slack agent that answers questions from our team’s documentation.”
 - “Build an eve incident-response agent that investigates alerts using our observability tools.”

--- a/docs/tutorial/first-agent.mdx
+++ b/docs/tutorial/first-agent.mdx
@@ -11,8 +11,6 @@ Start with the [eve template gallery](https://eve.dev/templates) or ask your cod
 
 If you prefer a step-by-step walkthrough, continue with this tutorial. It constructs one app end to end: a data analytics assistant. You ask in natural language, and over the next nine steps it learns to query a warehouse, run analysis in a sandbox, remember your team's metric definitions, and refuse to exceed your query budget without asking.
 
-Step 1 gets it talking. The scaffold bundles a small sample dataset, so your first question works with zero setup.
-
 ## Prerequisites
 
 - Node 24 or newer and npm.


### PR DESCRIPTION
### Summary

The tutorial currently sends every reader through the full walkthrough before pointing them toward a practical starting point. This recommends the eve template gallery or a coding-agent prompt first, with copyable examples for common use cases, while keeping the data analytics tutorial as the step-by-step path.

### Validation

- `pnpm docs:check`
- `git diff --check`

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
