### PR TITLE
feat(docs): add fullscreen Ask AI preview

### DIFF
--- a/patches/@vercel__geistdocs@1.25.0.patch
+++ b/patches/@vercel__geistdocs@1.25.0.patch
@@ -1,0 +1,70 @@
+diff --git a/dist/internal/chat/shell.js b/dist/internal/chat/shell.js
+index 2efcb9eafbc0e2cad246e915944969c2b909ca05..39d12d45832f16181b843654ce2549ab55d80be7 100644
+--- a/dist/internal/chat/shell.js
++++ b/dist/internal/chat/shell.js
+@@ -3,7 +3,7 @@ import { jsx as _jsx, jsxs as _jsxs, Fragment as _Fragment } from "react/jsx-run
+ import { useChat } from "@ai-sdk/react";
+ import { DefaultChatTransport } from "ai";
+ import { useLiveQuery } from "dexie-react-hooks";
+-import { ChevronRightIcon, Trash } from "lucide-react";
++import { ChevronRightIcon, Maximize2Icon, Minimize2Icon, Trash } from "lucide-react";
+ import { catchError } from "next/error";
+ import { usePathname } from "next/navigation";
+ import { Portal } from "radix-ui";
+@@ -90,7 +90,7 @@ const useChatPersistence = (title) => {
+         clearMessages,
+     };
+ };
+-const GeistdocsChatInner = ({ isOpen }) => {
++const GeistdocsChatInner = ({ isExpanded = false, isOpen, onExpandedChange }) => {
+     const id = useId();
+     const pathname = usePathname();
+     const textareaRef = useRef(null);
+@@ -167,9 +167,9 @@ const GeistdocsChatInner = ({ isOpen }) => {
+     if (isLoading) {
+         return (_jsx("div", { className: "flex size-full w-full flex-col items-center justify-center overflow-hidden whitespace-nowrap rounded-xl xl:max-w-md xl:border xl:bg-background-100", children: _jsx(Spinner, {}) }));
+     }
+-    return (_jsxs("div", { className: "flex size-full w-full flex-col overflow-hidden whitespace-nowrap bg-background-100", children: [_jsxs("div", { className: "flex items-center justify-between px-4 py-2.5", children: [_jsx("h2", { className: "font-semibold text-sm", children: "Chat" }), _jsx("div", { className: "flex items-center gap-3", children: _jsxs(ButtonGroup, { children: [_jsx(CopyChat, { messages: messages }), _jsxs(Tooltip, { children: [_jsx(TooltipTrigger, { asChild: true, children: _jsx(Button, { "aria-label": "Clear chat", disabled: messages.length === 0, onClick: handleClearChat, size: "icon-sm", variant: "ghost", children: _jsx(Trash, { className: "size-3.5" }) }) }), _jsx(TooltipContent, { children: "Clear chat" })] }), _jsxs(Tooltip, { children: [_jsx(TooltipTrigger, { asChild: true, children: _jsx(Button, { "aria-label": "Close chat", onClick: () => setIsOpen(false), size: "icon-sm", variant: "ghost", children: _jsx(ChevronRightIcon, { className: "size-3.5" }) }) }), _jsx(TooltipContent, { children: "Close chat" })] })] }) })] }), _jsxs(Conversation, { children: [_jsxs(ConversationContent, { children: [messages.map((message) => (_jsxs(Message, { className: "max-w-[90%]", from: message.role, children: [_jsx(MessageMetadata, { inProgress: status === "submitted" || status === "streaming", parts: message.parts }), message.parts
++    return (_jsxs("div", { className: "flex size-full w-full flex-col overflow-hidden whitespace-nowrap bg-background-100", children: [_jsxs("div", { className: cn("flex items-center justify-between px-4 py-2.5", isExpanded && "mx-auto w-full max-w-5xl px-6"), children: [_jsx("h2", { className: "font-semibold text-sm", children: "Chat" }), _jsx("div", { className: "flex items-center gap-3", children: _jsxs(ButtonGroup, { children: [_jsx(CopyChat, { messages: messages }), onExpandedChange ? (_jsxs(Tooltip, { children: [_jsx(TooltipTrigger, { asChild: true, children: _jsx(Button, { "aria-label": isExpanded ? "Collapse chat" : "Expand chat", "aria-pressed": isExpanded, onClick: () => onExpandedChange(!isExpanded), size: "icon-sm", variant: "ghost", children: isExpanded ? _jsx(Minimize2Icon, { className: "size-3.5" }) : _jsx(Maximize2Icon, { className: "size-3.5" }) }) }), _jsx(TooltipContent, { children: isExpanded ? "Collapse chat" : "Expand chat" })] })) : null, _jsxs(Tooltip, { children: [_jsx(TooltipTrigger, { asChild: true, children: _jsx(Button, { "aria-label": "Clear chat", disabled: messages.length === 0, onClick: handleClearChat, size: "icon-sm", variant: "ghost", children: _jsx(Trash, { className: "size-3.5" }) }) }), _jsx(TooltipContent, { children: "Clear chat" })] }), _jsxs(Tooltip, { children: [_jsx(TooltipTrigger, { asChild: true, children: _jsx(Button, { "aria-label": "Close chat", onClick: () => setIsOpen(false), size: "icon-sm", variant: "ghost", children: _jsx(ChevronRightIcon, { className: "size-3.5" }) }) }), _jsx(TooltipContent, { children: "Close chat" })] })] }) })] }), _jsxs(Conversation, { children: [_jsxs(ConversationContent, { className: cn(isExpanded && "mx-auto w-full max-w-5xl px-6"), children: [messages.map((message) => (_jsxs(Message, { className: cn(isExpanded ? "max-w-full" : "max-w-[90%]"), from: message.role, children: [_jsx(MessageMetadata, { inProgress: status === "submitted" || status === "streaming", parts: message.parts }), message.parts
+                                         .filter((part) => part.type === "text")
+-                                        .map((part) => (_jsx(MessageContent, { children: _jsx(MessageResponse, { className: "text-wrap", children: part.text }) }, `${message.id}-${part.type}-${part.text}`)))] }, message.id))), status === "submitted" ? (_jsx("div", { className: "size-12 text-gray-800 text-sm", children: _jsx(Spinner, {}) })) : null] }), _jsx(ConversationScrollButton, {})] }), _jsxs("div", { className: "relative grid w-auto shrink-0 gap-4 p-4", children: [messages.length ? null : (_jsxs(_Fragment, { children: [_jsx(Suggestions, { className: "flex-col items-start gap-px", children: suggestions.map((text) => (_jsx(Suggestion, { className: "rounded-none p-0 text-copy-14", onClick: handleSuggestionClick, suggestion: text, variant: "link" }, text))) }), _jsxs("p", { className: "text-gray-800 text-sm", children: ["Tip: You can open and close chat with", " ", _jsxs(KbdGroup, { children: [_jsx(Kbd, { className: "border bg-transparent", children: "\u2318" }), _jsx(Kbd, { className: "border bg-transparent", children: "I" })] })] })] })), _jsx(ChatPromptInput, { onChange: setPrompt, onStop: stop, onSubmit: (event) => {
++                                        .map((part) => (_jsx(MessageContent, { children: _jsx(MessageResponse, { className: "text-wrap", children: part.text }) }, `${message.id}-${part.type}-${part.text}`)))] }, message.id))), status === "submitted" ? (_jsx("div", { className: "size-12 text-gray-800 text-sm", children: _jsx(Spinner, {}) })) : null] }), _jsx(ConversationScrollButton, {})] }), _jsxs("div", { className: cn("relative grid w-auto shrink-0 gap-4 p-4", isExpanded && "mx-auto w-full max-w-5xl px-6"), children: [messages.length ? null : (_jsxs(_Fragment, { children: [_jsx(Suggestions, { className: "flex-col items-start gap-px", children: suggestions.map((text) => (_jsx(Suggestion, { className: "rounded-none p-0 text-copy-14", onClick: handleSuggestionClick, suggestion: text, variant: "link" }, text))) }), _jsxs("p", { className: "text-gray-800 text-sm", children: ["Tip: You can open and close chat with", " ", _jsxs(KbdGroup, { children: [_jsx(Kbd, { className: "border bg-transparent", children: "\u2318" }), _jsx(Kbd, { className: "border bg-transparent", children: "I" })] })] })] })), _jsx(ChatPromptInput, { onChange: setPrompt, onStop: stop, onSubmit: (event) => {
+                             event.preventDefault();
+                             handleSubmit().catch((error) => {
+                                 console.error("Failed to submit chat message:", error);
+@@ -181,8 +181,19 @@ const GeistdocsChatErrorBoundary = catchError(GeistdocsChatErrorFallback);
+ export const GeistdocsChatShell = () => {
+     const { enabled, isOpen, setIsOpen } = useGeistdocsChat();
+     const isMobile = useIsMobile();
++    const [isExpanded, setIsExpanded] = useState(false);
++    useEffect(() => {
++        if (!isOpen) {
++            setIsExpanded(false);
++        }
++    }, [isOpen]);
+     useEffect(() => {
+         const handleKeyDown = (event) => {
++            if (event.key === "Escape" && isExpanded) {
++                event.preventDefault();
++                setIsExpanded(false);
++                return;
++            }
+             if ((event.metaKey || event.ctrlKey) &&
+                 !event.altKey &&
+                 !event.shiftKey &&
+@@ -193,7 +204,7 @@ export const GeistdocsChatShell = () => {
+         };
+         window.addEventListener("keydown", handleKeyDown);
+         return () => window.removeEventListener("keydown", handleKeyDown);
+-    }, [setIsOpen]);
++    }, [isExpanded, setIsOpen]);
+     if (!enabled) {
+         return null;
+     }
+@@ -202,5 +213,5 @@ export const GeistdocsChatShell = () => {
+                     // modal surfaces like the search command menu, dialogs, and
+                     // dropdowns (z-50), so opening the command menu paints over an
+                     // open chat panel.
+-                    "fixed inset-y-0 right-0 z-45 flex h-full w-3/4 max-w-sm flex-col gap-4 border-l bg-background-100 transition-all", "translate-x-full data-[state=open]:translate-x-0"), "data-state": isOpen ? "open" : "closed", children: _jsx(GeistdocsChatErrorBoundary, { onClose: () => setIsOpen(false), children: _jsx(GeistdocsChatInner, { isOpen: isOpen }) }) }) }), _jsx("div", { className: "md:hidden", children: _jsx(Drawer, { onOpenChange: isMobile ? setIsOpen : undefined, open: isMobile ? isOpen : false, children: _jsxs(DrawerContent, { className: "h-[80dvh]", children: [_jsx(DrawerTitle, { className: "sr-only", children: "Ask AI" }), _jsx(DrawerDescription, { className: "sr-only", children: "Chat with the documentation." }), _jsx(GeistdocsChatErrorBoundary, { onClose: () => setIsOpen(false), children: _jsx(GeistdocsChatInner, { isOpen: isOpen }) })] }) }) })] }));
++                    "fixed inset-y-0 right-0 z-45 flex h-full flex-col gap-4 border-l bg-background-100 transition-all", isExpanded ? "w-screen max-w-none border-l-0" : "w-3/4 max-w-sm", "translate-x-full data-[state=open]:translate-x-0"), "data-state": isOpen ? "open" : "closed", children: _jsx(GeistdocsChatErrorBoundary, { onClose: () => setIsOpen(false), children: _jsx(GeistdocsChatInner, { isExpanded: isExpanded, isOpen: isOpen, onExpandedChange: setIsExpanded }) }) }) }), _jsx("div", { className: "md:hidden", children: _jsx(Drawer, { onOpenChange: isMobile ? setIsOpen : undefined, open: isMobile ? isOpen : false, children: _jsxs(DrawerContent, { className: "h-[80dvh]", children: [_jsx(DrawerTitle, { className: "sr-only", children: "Ask AI" }), _jsx(DrawerDescription, { className: "sr-only", children: "Chat with the documentation." }), _jsx(GeistdocsChatErrorBoundary, { onClose: () => setIsOpen(false), children: _jsx(GeistdocsChatInner, { isOpen: isOpen }) })] }) }) })] }));
+ };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,9 @@ catalogs:
       specifier: 4.5.4
       version: 4.5.4
 
+patchedDependencies:
+  '@vercel/geistdocs@1.25.0': c461093e0bed7dc3a9def47fa2d87458a459a0134a3360b0477b48936648e8ca
+
 importers:
 
   .:
@@ -164,7 +167,7 @@ importers:
         version: 2.0.1(@sveltejs/kit@2.63.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vite@7.3.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@7.3.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(next@16.3.4(@babel/core@7.29.0(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nuxt@4.4.6(fa0ad0f89512d34185b697ca49bcac95))(react@19.2.6)(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vue@3.5.35(typescript@6.0.3))
       '@vercel/geistdocs':
         specifier: 1.25.0
-        version: 1.25.0(6a40d060eba145b214d02f61b72a465a)
+        version: 1.25.0(patch_hash=c461093e0bed7dc3a9def47fa2d87458a459a0134a3360b0477b48936648e8ca)(6a40d060eba145b214d02f61b72a465a)
       '@vercel/speed-insights':
         specifier: 2.0.0
         version: 2.0.0(@sveltejs/kit@2.63.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vite@7.3.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@7.3.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(next@16.3.4(@babel/core@7.29.0(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nuxt@4.4.6(fa0ad0f89512d34185b697ca49bcac95))(react@19.2.6)(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vue@3.5.35(typescript@6.0.3))
@@ -22403,7 +22406,7 @@ snapshots:
       etag: 1.8.1
       fs-extra: 11.1.0
 
-  '@vercel/geistdocs@1.25.0(6a40d060eba145b214d02f61b72a465a)':
+  '@vercel/geistdocs@1.25.0(patch_hash=c461093e0bed7dc3a9def47fa2d87458a459a0134a3360b0477b48936648e8ca)(6a40d060eba145b214d02f61b72a465a)':
     dependencies:
       '@ai-sdk/react': 3.0.193(react@19.2.6)(zod@4.5.4)
       '@clack/prompts': 0.11.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -73,3 +73,6 @@ minimumReleaseAgeExclude:
   - unstorage@2.0.0-alpha.10
   - run
   - workflow
+
+patchedDependencies:
+  "@vercel/geistdocs@1.25.0": patches/@vercel__geistdocs@1.25.0.patch


### PR DESCRIPTION
### Summary

Ask AI responses are constrained to a narrow desktop sidebar, which makes code blocks difficult to read. This vendors the Geistdocs fullscreen chat change from vercel/geistdocs#312 as a pnpm patch so the eve docs preview can be tested before an upstream release: users can expand the existing chat to the viewport, retain the active conversation, and press `Escape` to collapse it. The expanded header, transcript, and composer share a centered content container rather than touching the viewport edges. Mobile keeps the existing drawer behavior.

### Validation

Built the production docs site with `pnpm --filter eve-docs exec next build`, then used Playwright against that production build to confirm the chat transitions from 384px to the full 1440px viewport and back to 384px with `Escape`; the expanded header content stays centered between x=232 and x=1208. Workspace formatting, linting, type checking, and invariant checks also passed.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [ ] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

Tests and a package changeset are not included because this is a temporary docs-only vendor patch for preview testing; the source coverage and release metadata belong in Geistdocs.

### Diff size

**Docs** — 0 files · `+0 / -0`

Not applicable.

**Implementation** — 3 files · `+78 / -2`

The compiled Geistdocs patch contains the fullscreen interaction; pnpm workspace and lockfile entries apply it reproducibly to the docs app.

**Tests** — 0 files · `+0 / -0`

The behavior was manually covered against the production build; reusable component coverage remains with the upstream Geistdocs source change.

