### PR TITLE
fix(eve): task caching and wakeup batching

### DIFF
--- a/.changeset/cached-task-completions.md
+++ b/.changeset/cached-task-completions.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Keep changing task status behind conversation history to preserve reusable model prompt prefixes. Combine successful sibling completions already queued for the parent into one turn, retaining every result without waiting for unfinished tasks.

--- a/docs/subagents/index.mdx
+++ b/docs/subagents/index.mdx
@@ -50,6 +50,8 @@ export default defineAgent({
 
 A child running as a background task receives the framework `task_update` tool. It uses `task_update` to report progress to its parent. `task_cancel` is available to sessions that own background tasks, including a child that starts nested background work.
 
+Successful completions already queued from tasks launched in the same parent turn can be delivered together in one model turn. Every result is retained; eve does not wait for unfinished tasks. Failures, input requests, explicit updates, and user messages remain separate delivery boundaries.
+
 A mounted extension can also contribute declared subagents from `extension/subagents/`. The mount namespace prefixes the subagent visible to the consuming agent node: mounting an extension as `crm` exposes its `reviewer` subagent as `crm__reviewer`. The contributed subagent keeps its own isolated tools, connections, skills, hooks, instructions, sandbox, and nested subagents, and its modules can read configuration from the extension handle. See [Extensions](./extensions#add-a-subagent) for the authoring and override behavior.
 
 ### Conditional availability

--- a/packages/eve/src/execution/parked-delivery-wait.test.ts
+++ b/packages/eve/src/execution/parked-delivery-wait.test.ts
@@ -116,6 +116,100 @@ describe("nextTurnDelivery", () => {
     vi.mocked(routeDeliverToChildren).mockReset();
   });
 
+  it.each(["completed", "failed", "input_required", "other-cohort", "user", "caller"])(
+    "batches successful siblings without crossing a %s delivery boundary",
+    async (boundary) => {
+      const completion = (id: string): DeliverHookPayload => ({
+        kind: "deliver",
+        taskDeliveryId: `${id}:ready:completed`,
+        payloads: [
+          {
+            message: id,
+            task: {
+              views: [
+                {
+                  taskId: id,
+                  status: "completed",
+                  metadata: { kind: "subagent", name: "signal" },
+                  lastOutput: { type: "result", data: id },
+                },
+              ],
+            },
+          },
+        ],
+      });
+      const first = completion("task_1");
+      const second = completion("task_2");
+      const last: DeliverHookPayload =
+        boundary === "user"
+          ? { kind: "deliver", payloads: [{ message: "user direction" }] }
+          : boundary === "caller"
+            ? {
+                ...completion("task_3"),
+                caller: {
+                  callId: "call",
+                  subagentName: "worker",
+                  replyTo: { kind: "hook", token: "reply" },
+                  taskId: "task_3",
+                },
+              }
+            : {
+                ...completion("task_3"),
+                taskDeliveryId: `task_3:ready:${boundary === "other-cohort" ? "completed" : boundary}`,
+              };
+      const bufferedDeliveries = [first, second, last];
+      const input = waitInput(createMockInbox([]));
+      input.stateCursor.adoptState({
+        sessionState: {
+          ...sessionState,
+          snapshot: {
+            version: 1,
+            session: {
+              sessionId: "session",
+              continuationToken: "token",
+              agent: { system: "" },
+              history: [],
+              state: {
+                "eve.tasks": {
+                  version: 2,
+                  tasks: ["task_1", "task_2", "task_3"].map((taskId) => ({
+                    taskId,
+                    taskRunId: `run-${taskId}`,
+                    taskInboxToken: `inbox-${taskId}`,
+                    createdByTurnId:
+                      taskId === "task_3" && boundary === "other-cohort" ? "turn-2" : "turn-1",
+                    metadata: { kind: "subagent", name: "signal" },
+                  })),
+                },
+              },
+            },
+          },
+        },
+      });
+      vi.mocked(routeDeliverToChildren).mockImplementation(
+        async ({ delivery, sessionState, serializedContext }) => ({
+          kind: "continue",
+          remainder: delivery,
+          sessionState,
+          serializedContext,
+        }),
+      );
+      const next = await nextTurnDelivery({ ...input, bufferedDeliveries });
+      const count = boundary === "completed" ? 3 : 2;
+      expect(next).toMatchObject({
+        kind: "turn",
+        delivery: {
+          taskDeliveryId: first.taskDeliveryId,
+          payloads: [first, second, ...(count === 3 ? [last] : [])].flatMap(
+            (item) => item.payloads,
+          ),
+        },
+      });
+      expect(bufferedDeliveries).toEqual(count === 3 ? [] : [last]);
+      expect(routeDeliverToChildren).toHaveBeenCalledTimes(1);
+    },
+  );
+
   it("surfaces an authorization callback as its own instruction", async () => {
     const inbox = createMockInbox([authorizationRead()]);
 

--- a/packages/eve/src/execution/parked-delivery-wait.ts
+++ b/packages/eve/src/execution/parked-delivery-wait.ts
@@ -10,6 +10,7 @@ import {
   type DecodedSessionInbox,
 } from "#execution/wire/session-inbox-wire.js";
 import { coalesceDeliveries } from "#harness/messages.js";
+import { getSessionTaskIndex, type SessionTaskIndexEntry } from "#tasks/session-index.js";
 
 type NextSessionAction =
   | { readonly kind: "clear" }
@@ -166,7 +167,10 @@ async function waitForNextSessionAction(input: {
     input.bufferedDeliveries.length > 0
   ) {
     return {
-      delivery: takeBufferedTurnDelivery(input.bufferedDeliveries),
+      delivery: takeBufferedTurnDelivery(
+        input.bufferedDeliveries,
+        getSessionTaskIndex(input.stateCursor.sessionState.snapshot?.session.state),
+      ),
       kind: "delivery",
     };
   }
@@ -267,7 +271,10 @@ function isCancelledTaskDeliveryId(
   );
 }
 
-function takeBufferedTurnDelivery(bufferedDeliveries: DeliverHookPayload[]): DeliverHookPayload {
+function takeBufferedTurnDelivery(
+  bufferedDeliveries: DeliverHookPayload[],
+  tasks: readonly SessionTaskIndexEntry[],
+): DeliverHookPayload {
   const first = bufferedDeliveries.shift();
   if (first === undefined) {
     throw new Error("Cannot take a turn delivery from an empty buffer.");
@@ -275,12 +282,13 @@ function takeBufferedTurnDelivery(bufferedDeliveries: DeliverHookPayload[]): Del
 
   const turnDeliveries = [first];
   let caller = first.caller;
+  const cohort = completionCohort(first, tasks);
   while (bufferedDeliveries.length > 0) {
     const next = bufferedDeliveries[0];
     if (
       next === undefined ||
-      first.taskDeliveryId !== undefined ||
-      next.taskDeliveryId !== undefined ||
+      ((first.taskDeliveryId !== undefined || next.taskDeliveryId !== undefined) &&
+        (cohort === undefined || completionCohort(next, tasks) !== cohort)) ||
       (caller !== undefined && next.caller !== undefined)
     ) {
       break;
@@ -295,4 +303,14 @@ function takeBufferedTurnDelivery(bufferedDeliveries: DeliverHookPayload[]): Del
   }
 
   return coalesceDeliveries(turnDeliveries);
+}
+
+/** Only successful sibling notifications can share their existing cohort context. */
+function completionCohort(
+  delivery: DeliverHookPayload,
+  tasks: readonly SessionTaskIndexEntry[],
+): string | undefined {
+  if (delivery.caller !== undefined) return undefined;
+  return tasks.find((task) => delivery.taskDeliveryId === `${task.taskId}:ready:completed`)
+    ?.createdByTurnId;
 }

--- a/packages/eve/src/harness/current-messages.test.ts
+++ b/packages/eve/src/harness/current-messages.test.ts
@@ -3,6 +3,39 @@ import { describe, expect, it } from "vitest";
 import { createCurrentMessages } from "#harness/current-messages.js";
 
 describe("createCurrentMessages", () => {
+  it.each([0, 1])(
+    "preserves the history prefix when task status changes in turn %i",
+    (sequence) => {
+      const request = { role: "user" as const, content: "Investigate these sessions" };
+      const history = [request, { role: "assistant" as const, content: "Work started" }];
+      const before = createCurrentMessages(history, { currentTurnMessages: [request] });
+      const after = createCurrentMessages(history, { currentTurnMessages: [request] });
+      before.add(sequence, "Three tasks pending", { placement: "tail" });
+      after.add(sequence, "Two tasks pending", { placement: "tail" });
+      expect(before.systemMessages).toEqual(after.systemMessages);
+      expect(after.systemMessages).toEqual([]);
+      expect(before.nonSystemMessages.slice(0, history.length)).toEqual(history);
+      expect(after.nonSystemMessages.slice(0, history.length)).toEqual(history);
+      expect(after.nonSystemMessages.at(-1)?.content).toBe("Two tasks pending");
+    },
+  );
+
+  it("keeps an approval response at the tail when adding task status", () => {
+    const approval = {
+      role: "tool" as const,
+      content: [
+        {
+          type: "tool-approval-response" as const,
+          approvalId: "approval",
+          approved: true,
+        },
+      ],
+    };
+    const current = createCurrentMessages([approval]);
+    current.add(0, "Task status", { placement: "tail" });
+    expect(current.nonSystemMessages.at(-1)).toBe(approval);
+    expect(current.systemMessages).toEqual([{ role: "system", content: "Task status" }]);
+  });
   it("partitions existing history by role", () => {
     const current = createCurrentMessages([
       { role: "system", content: "system" },

--- a/packages/eve/src/harness/current-messages.ts
+++ b/packages/eve/src/harness/current-messages.ts
@@ -2,6 +2,7 @@ import type { ModelMessage, SystemModelMessage } from "ai";
 
 interface AddCurrentMessageOptions {
   readonly cacheFriendly?: boolean;
+  readonly placement?: "turn" | "tail";
 }
 
 interface CurrentMessagesOptions {
@@ -41,8 +42,11 @@ export function createCurrentMessages(
     currentTurnInsertionIndex !== undefined || !hasTailApprovalResponse(nonSystemMessages);
 
   return {
-    add(turnSequence, message, { cacheFriendly = true } = {}) {
-      if (turnSequence > 0 && cacheFriendly === true && canAppendUserMessages) {
+    add(turnSequence, message, { cacheFriendly = true, placement = "turn" } = {}) {
+      if (placement === "tail" && cacheFriendly && !hasTailApprovalResponse(nonSystemMessages)) {
+        // Changing runtime status must not precede otherwise reusable conversation history.
+        nonSystemMessages.push({ role: "user", content: message });
+      } else if (turnSequence > 0 && cacheFriendly === true && canAppendUserMessages) {
         nonSystemMessages.splice(userInsertionIndex, 0, { role: "user", content: message });
         userInsertionIndex += 1;
       } else {

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -12257,7 +12257,7 @@ describe("createToolLoopHarness", () => {
     });
 
     it.each(["plain", "client context", "compaction", "projected history"])(
-      "keeps framework context before the turn input across durable steps (%s)",
+      "preserves conversation history ahead of changing task context across durable steps (%s)",
       async (scenario) => {
         const withClientContext = scenario === "client context";
         if (scenario === "compaction") {
@@ -12317,14 +12317,21 @@ describe("createToolLoopHarness", () => {
         );
         expect(first.next).toBe(runStep);
         const firstPrompt = structuredClone(getLastAgentSettings().messages);
+        const firstInstructions = structuredClone(getLastAgentSettings().instructions);
         setupMockAgent(defaultModelResult());
         const restored = JSON.parse(JSON.stringify(first.session)) as HarnessSession;
+        ctx.set(TurnTaskStateKey, "Task status: analysis completed");
         await contextStorage.run(ctx, () => runStep(restored));
         const nextPrompt = getLastAgentSettings().messages;
-        expect(nextPrompt.slice(0, firstPrompt.length)).toEqual(firstPrompt);
+        expect(getLastAgentSettings().instructions).toEqual(firstInstructions);
+        expect(nextPrompt.slice(0, firstPrompt.length - 1)).toEqual(firstPrompt.slice(0, -1));
+        expect(nextPrompt.at(-1)).toEqual({
+          role: "user",
+          content: "Task status: analysis completed",
+        });
         expect(
           nextPrompt.filter((message) => message.content === "Task status: analysis in progress"),
-        ).toHaveLength(1);
+        ).toHaveLength(0);
       },
     );
 
@@ -12432,11 +12439,12 @@ describe("createToolLoopHarness", () => {
         runStep(createTestSession(), { message: "Start the background work." }),
       );
 
-      const { instructions } = getLastAgentSettings();
-      expect(instructions).toEqual({
-        role: "system",
-        content: `You are a test assistant.\n\n[Task state]\n{"tasks":[]}\n\n${TASK_DELIVERY_INITIATING_INSTRUCTION}`,
-      });
+      const { instructions, messages } = getLastAgentSettings();
+      expect(instructions).toBe("You are a test assistant.");
+      expect(messages.slice(-2)).toEqual([
+        { role: "user", content: '[Task state]\n{"tasks":[]}' },
+        { role: "user", content: TASK_DELIVERY_INITIATING_INSTRUCTION },
+      ]);
     });
 
     it("routes later-turn initiating task context through user messages", async () => {
@@ -12460,9 +12468,9 @@ describe("createToolLoopHarness", () => {
       const { instructions, messages } = getLastAgentSettings();
       expect(instructions).toBe("You are a test assistant.");
       expect(messages.slice(-3)).toEqual([
+        { role: "user", content: "Start the background work." },
         { role: "user", content: taskState },
         { role: "user", content: TASK_DELIVERY_INITIATING_INSTRUCTION },
-        { role: "user", content: "Start the background work." },
       ]);
     });
 
@@ -12523,8 +12531,8 @@ describe("createToolLoopHarness", () => {
         const { instructions, messages } = getLastAgentSettings();
         expect(instructions).toBe("You are a test assistant.");
         expect(messages.slice(-2)).toEqual([
-          { role: "user", content: instruction },
           { role: "user", content: "Background task task_1 is completed." },
+          { role: "user", content: instruction },
         ]);
       },
     );

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -1259,11 +1259,13 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       }
       const taskState = ctx.get(TurnTaskStateKey);
       if (taskState !== undefined) {
-        currentMessages.add(emissionState.sequence, taskState);
+        currentMessages.add(emissionState.sequence, taskState, { placement: "tail" });
       }
     }
     if (deliveryPolicy.instruction !== undefined) {
-      currentMessages.add(emissionState.sequence, deliveryPolicy.instruction);
+      currentMessages.add(emissionState.sequence, deliveryPolicy.instruction, {
+        placement: hasScheduleProvenance ? "turn" : "tail",
+      });
     }
     const pendingApprovals = renderPendingApprovalsInstruction(
       getPendingInputBatches(session.state).flatMap((batch) => batch.requests),


### PR DESCRIPTION
### Summary

Task status changes invalidate the prompt prefix ahead of reusable history. Queued sibling completions also trigger separate parent turns. Move changing task context to the tail and coalesce adjacent successful completions already in the queue.

**Prompt ordering** (simplified):

```ts
// Before: changing task state breaks the prefix before history
[instructions, taskState, history]

// After: history stays in the reusable prefix
[instructions, history, taskState]
```

Applies to task status and task-delivery context. Scheduled instructions and tool-approval ordering retain their existing behavior.

**Parent wakeups** (A/B/C launched in the same parent turn):

```ts
queue = [completed(A), completed(B), completed(C)]

// Before
parentTurn(A)
parentTurn(B)
parentTurn(C)

// After
parentTurn(A, B, C)
```

No debounce or waiting for unfinished tasks. Every result is retained. Failures, input requests, explicit updates, user messages, and different task cohorts stop coalescing.

### Validation

- Reproduced the prefix break with changing task status: a synthetic 28 KB request retained only ~30 characters before the change, versus ~28 KB afterward. This checks request construction, not provider cache billing.
- 285 focused tests pass, including history-prefix preservation and completion batching across failure, input, caller, and cohort boundaries.
- Live cache-hit and cost savings have not been measured yet; the consuming app still runs the released runtime.

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
