### PR TITLE
fix(eve): opt-in task context caching

### DIFF
--- a/.changeset/task-context-tail.md
+++ b/.changeset/task-context-tail.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add opt-in `experimental.taskContextAtTail` to place changing task context after conversation history for prompt cache reuse. Default message ordering remains unchanged.

--- a/docs/subagents/index.mdx
+++ b/docs/subagents/index.mdx
@@ -5,6 +5,17 @@ description: "Delegate work to root-agent copies or declared specialists with th
 
 eve supports two ways to delegate work: the root-only built-in `agent` tool, which starts or continues a copy of the root agent, and declared subagents, which are specialists with their own directories. Use a subagent to run independent work in parallel, narrow the available tools, or give a task to a specialist.
 
+## Experimental task context placement
+
+Set `experimental: { taskContextAtTail: true }` in the parent agent definition to
+append task status and task-delivery context after conversation history. This
+keeps changing status out of the reusable prompt prefix. The default is off.
+
+This changes context placement and, on the first model step, its role from system
+to user. Authored system instructions, scheduled instructions, and tool-approval
+ordering are unchanged. Evaluate model behavior before enabling it in production;
+provider cache savings have not yet been measured.
+
 ## The built-in `agent` tool
 
 The root session receives `agent` by default. The model calls it to delegate a task to a new copy of the root agent or continue an existing copy:

--- a/packages/eve/extension-contracts/compatibility/dynamicTool/v29.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicTool/v29.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+import { defineDynamic, defineTool } from "#public/tools/index.js";
+
+export default defineDynamic({
+  events: {
+    "session.started": () =>
+      defineTool({
+        description: "Read a report.",
+        inputSchema: z.object({ report: z.string() }),
+        execute: ({ report }) => ({ report }),
+      }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/subagent/v9.ts
+++ b/packages/eve/extension-contracts/compatibility/subagent/v9.ts
@@ -1,0 +1,6 @@
+import { defineAgent } from "#public/index.js";
+
+export default defineAgent({
+  description: "Read report data.",
+  model: "anthropic/claude-sonnet-5",
+});

--- a/packages/eve/extension-contracts/compatibility/tool/v30.ts
+++ b/packages/eve/extension-contracts/compatibility/tool/v30.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+import { defineTool } from "#public/tools/index.js";
+
+export default defineTool({
+  description: "Read a report.",
+  inputSchema: z.object({ report: z.string() }),
+  execute: ({ report }) => ({ report }),
+});

--- a/packages/eve/extension-contracts/reports/dynamicTool/v30.json
+++ b/packages/eve/extension-contracts/reports/dynamicTool/v30.json
@@ -1,0 +1,13 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicTool",
+  "epoch": 30,
+  "sha256": "2434e11da2230221043966f2127643c361afe404986ea272f58c5697bf0589ec",
+  "exports": [
+    "DynamicToolEntry",
+    "DynamicToolEvents",
+    "DynamicToolResult",
+    "DynamicToolSet",
+    "defineDynamic"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/subagent/v10.json
+++ b/packages/eve/extension-contracts/reports/subagent/v10.json
@@ -1,0 +1,20 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "subagent",
+  "epoch": 10,
+  "sha256": "79f63c86332a80e9426c6fa9af7da3808fc1012c738d2a2a46b8fa04a1309e9b",
+  "exports": [
+    "AgentCompactionDefinition",
+    "AgentDefinition",
+    "AgentModelDefinition",
+    "AgentStaticModelDefinition",
+    "DefinedAgent",
+    "DynamicLocalSubagentDefinition",
+    "DynamicSubagentDefinition",
+    "RemoteAgentDefinition",
+    "RemoteAgentDefinitionInput",
+    "defineAgent",
+    "defineDynamic",
+    "defineRemoteAgent"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/tool/v31.json
+++ b/packages/eve/extension-contracts/reports/tool/v31.json
@@ -1,0 +1,20 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "tool",
+  "epoch": 31,
+  "sha256": "6f43abf47f49df510dd69f89e2809ea879dfe405ea2187921cdee4d506970aef",
+  "exports": [
+    "defaultWebSearch",
+    "defineTool",
+    "defineWorkflowTool",
+    "disableTool",
+    "experimental_workflow",
+    "isDisabledToolSentinel",
+    "isExperimentalWorkflowToolDefinition",
+    "isWebSearchToolDefinition",
+    "toolOutput",
+    "toolOutputPart",
+    "toolResultFrom",
+    "webSearch"
+  ]
+}

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -22,8 +22,8 @@ interface ExtensionCapabilityContract {
 const EXTENSION_CAPABILITY_CONTRACTS = {
   extension: { current: 1, supported: [1], dropped: {} },
   tool: {
-    current: 30,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 28, 29, 30],
+    current: 31,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 28, 29, 30, 31],
     dropped: {
       14: "TaskExec.delegated was removed; migrate to workflow-backed background tools",
       15: "TaskExec replaces stageEffect with send",
@@ -42,8 +42,10 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     },
   },
   dynamicTool: {
-    current: 29,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 28, 29],
+    current: 30,
+    supported: [
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 28, 29, 30,
+    ],
     dropped: {
       21: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",
       23: "TaskExec.delegated was removed; migrate to workflow-backed background tools",
@@ -68,8 +70,8 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     },
   },
   subagent: {
-    current: 9,
-    supported: [3, 4, 6, 7, 8, 9],
+    current: 10,
+    supported: [3, 4, 6, 7, 8, 9, 10],
     dropped: {
       1: "Persistent subagent sessions are now the default and the experimental opt-in was removed",
       2: "Persistent subagent sessions are now the default and the experimental opt-in was removed",

--- a/packages/eve/src/compiler/manifest.test.ts
+++ b/packages/eve/src/compiler/manifest.test.ts
@@ -12,6 +12,17 @@ import {
 } from "#compiler/validate-artifact.js";
 
 describe("compiled agent manifest v48", () => {
+  it.each([undefined, false, true])(
+    "round-trips the task context placement opt-in (%s)",
+    async (taskContextAtTail) => {
+      const { manifest } = await compileFromMemory({
+        model: "openai/gpt-5.4",
+        agent: { model: "openai/gpt-5.4", experimental: { taskContextAtTail } },
+      });
+      const parsed = compiledAgentManifestSchema.parse(JSON.parse(JSON.stringify(manifest)));
+      expect(parsed.config.experimental?.taskContextAtTail).toBe(taskContextAtTail);
+    },
+  );
   it("round-trips a real compiled graph through the serialized schema", async () => {
     const { manifest } = await compileFromMemory({
       limits: { maxTokenCostUsdPerSession: 1.5 },

--- a/packages/eve/src/compiler/manifest.ts
+++ b/packages/eve/src/compiler/manifest.ts
@@ -610,6 +610,7 @@ const compiledAgentConfigBaseFields = {
   description: z.string().optional(),
   experimental: z
     .object({
+      taskContextAtTail: z.boolean().optional(),
       instrumentationProviders: z.boolean().optional(),
       workflow: compiledAgentWorkflowDefinitionSchema.optional(),
     })
@@ -1209,6 +1210,7 @@ function cloneCompiledAgentDefinition(config: CompiledAgentDefinition): Compiled
       config.experimental === undefined
         ? undefined
         : {
+            taskContextAtTail: config.experimental.taskContextAtTail,
             instrumentationProviders: config.experimental.instrumentationProviders,
             workflow:
               config.experimental.workflow === undefined

--- a/packages/eve/src/compiler/normalize-agent-config.ts
+++ b/packages/eve/src/compiler/normalize-agent-config.ts
@@ -182,6 +182,10 @@ function normalizeExperimentalDefinition(
 
   const compiledExperimental: Mutable<NonNullable<CompiledAgentDefinition["experimental"]>> = {};
 
+  if (experimental.taskContextAtTail !== undefined) {
+    compiledExperimental.taskContextAtTail = experimental.taskContextAtTail;
+  }
+
   if (experimental.instrumentationProviders !== undefined) {
     compiledExperimental.instrumentationProviders = experimental.instrumentationProviders;
   }

--- a/packages/eve/src/execution/session.test.ts
+++ b/packages/eve/src/execution/session.test.ts
@@ -76,6 +76,23 @@ describe("createCompactionConfig", () => {
 });
 
 describe("createSession", () => {
+  it.each([undefined, false, true])(
+    "carries task context placement through session hydration (%s)",
+    (taskContextAtTail) => {
+      const turnAgent = createTestTurnAgent({ taskContextAtTail });
+      const session = createSession({
+        continuationToken: "root-token",
+        sessionId: "sess-root",
+        turnAgent,
+      });
+      expect(session.agent.taskContextAtTail).toBe(taskContextAtTail);
+      const hydrated = hydrateDurableSession({
+        durable: projectToDurableSession(session),
+        turnAgent,
+      });
+      expect(hydrated.agent.taskContextAtTail).toBe(taskContextAtTail);
+    },
+  );
   it("creates a session with correct agent configuration", () => {
     const outputSchema = { properties: { title: { type: "string" } }, type: "object" } as const;
     const session = createSession({

--- a/packages/eve/src/execution/session.ts
+++ b/packages/eve/src/execution/session.ts
@@ -125,6 +125,7 @@ function createSessionAgent(
   const base = {
     compactionModelReference: turnAgent.compactionModel,
     reasoning: turnAgent.reasoning,
+    taskContextAtTail: turnAgent.taskContextAtTail,
     system,
     tools,
   };

--- a/packages/eve/src/harness/current-messages.test.ts
+++ b/packages/eve/src/harness/current-messages.test.ts
@@ -3,6 +3,39 @@ import { describe, expect, it } from "vitest";
 import { createCurrentMessages } from "#harness/current-messages.js";
 
 describe("createCurrentMessages", () => {
+  it.each([0, 1])(
+    "preserves the history prefix when task status changes in turn %i",
+    (sequence) => {
+      const request = { role: "user" as const, content: "Investigate these sessions" };
+      const history = [request, { role: "assistant" as const, content: "Work started" }];
+      const before = createCurrentMessages(history, { currentTurnMessages: [request] });
+      const after = createCurrentMessages(history, { currentTurnMessages: [request] });
+      before.add(sequence, "Three tasks pending", { placement: "tail" });
+      after.add(sequence, "Two tasks pending", { placement: "tail" });
+      expect(before.systemMessages).toEqual(after.systemMessages);
+      expect(after.systemMessages).toEqual([]);
+      expect(before.nonSystemMessages.slice(0, history.length)).toEqual(history);
+      expect(after.nonSystemMessages.slice(0, history.length)).toEqual(history);
+      expect(after.nonSystemMessages.at(-1)?.content).toBe("Two tasks pending");
+    },
+  );
+
+  it("keeps an approval response at the tail when adding task status", () => {
+    const approval = {
+      role: "tool" as const,
+      content: [
+        {
+          type: "tool-approval-response" as const,
+          approvalId: "approval",
+          approved: true,
+        },
+      ],
+    };
+    const current = createCurrentMessages([approval]);
+    current.add(0, "Task status", { placement: "tail" });
+    expect(current.nonSystemMessages.at(-1)).toBe(approval);
+    expect(current.systemMessages).toEqual([{ role: "system", content: "Task status" }]);
+  });
   it("partitions existing history by role", () => {
     const current = createCurrentMessages([
       { role: "system", content: "system" },

--- a/packages/eve/src/harness/current-messages.ts
+++ b/packages/eve/src/harness/current-messages.ts
@@ -2,6 +2,7 @@ import type { ModelMessage, SystemModelMessage } from "ai";
 
 interface AddCurrentMessageOptions {
   readonly cacheFriendly?: boolean;
+  readonly placement?: "turn" | "tail";
 }
 
 interface CurrentMessagesOptions {
@@ -41,8 +42,11 @@ export function createCurrentMessages(
     currentTurnInsertionIndex !== undefined || !hasTailApprovalResponse(nonSystemMessages);
 
   return {
-    add(turnSequence, message, { cacheFriendly = true } = {}) {
-      if (turnSequence > 0 && cacheFriendly === true && canAppendUserMessages) {
+    add(turnSequence, message, { cacheFriendly = true, placement = "turn" } = {}) {
+      if (placement === "tail" && cacheFriendly && !hasTailApprovalResponse(nonSystemMessages)) {
+        // Changing runtime status must not precede otherwise reusable conversation history.
+        nonSystemMessages.push({ role: "user", content: message });
+      } else if (turnSequence > 0 && cacheFriendly === true && canAppendUserMessages) {
         nonSystemMessages.splice(userInsertionIndex, 0, { role: "user", content: message });
         userInsertionIndex += 1;
       } else {

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -12257,6 +12257,78 @@ describe("createToolLoopHarness", () => {
     });
 
     it.each(["plain", "client context", "compaction", "projected history"])(
+      "keeps framework context before the turn input across durable steps by default (%s)",
+      async (scenario) => {
+        const withClientContext = scenario === "client context";
+        if (scenario === "compaction") {
+          vi.mocked(shouldCompact).mockReturnValueOnce(true);
+          vi.mocked(compactMessages).mockImplementationOnce(async (messages) => messages.slice(2));
+        }
+        const toolCall = {
+          type: "tool-call" as const,
+          toolCallId: "cache-call",
+          toolName: "add",
+          input: { a: 20, b: 22 },
+        };
+        const toolResult = {
+          type: "tool-result" as const,
+          toolCallId: "cache-call",
+          toolName: "add",
+          output: "42",
+        };
+        setupMockAgent({
+          finishReason: "tool-calls",
+          response: {
+            messages: [
+              { role: "assistant", content: [toolCall] },
+              { role: "tool", content: [toolResult] },
+            ],
+          },
+          text: "",
+          toolCalls: [toolCall],
+          toolResults: [{ ...toolResult, input: toolCall.input }],
+        });
+        const ctx = new ContextContainer();
+        ctx.set(TurnTaskStateKey, "Task status: analysis in progress");
+        const runStep = createToolLoopHarness(
+          createTestConfig("conversation", undefined, {
+            historyProjector:
+              scenario === "projected history"
+                ? ({ messages }) =>
+                    messages.filter((message) => message.content !== "Previous answer")
+                : undefined,
+          }),
+        );
+        const initial = setHarnessEmissionState(
+          createTestSession({
+            history: [
+              { role: "user", content: "Previous request" },
+              { role: "assistant", content: "Previous answer" },
+            ],
+          }),
+          { sessionStarted: true, sequence: 1, stepIndex: 0, turnId: "turn_1" },
+        );
+        const input = { context: ["Current channel context"], message: "Add 20 and 22." };
+        const first = await contextStorage.run(ctx, () =>
+          runStep(
+            initial,
+            withClientContext ? attachClientContext(input, ["Client context"]) : input,
+          ),
+        );
+        expect(first.next).toBe(runStep);
+        const firstPrompt = structuredClone(getLastAgentSettings().messages);
+        setupMockAgent(defaultModelResult());
+        const restored = JSON.parse(JSON.stringify(first.session)) as HarnessSession;
+        await contextStorage.run(ctx, () => runStep(restored));
+        const nextPrompt = getLastAgentSettings().messages;
+        expect(nextPrompt.slice(0, firstPrompt.length)).toEqual(firstPrompt);
+        expect(
+          nextPrompt.filter((message) => message.content === "Task status: analysis in progress"),
+        ).toHaveLength(1);
+      },
+    );
+
+    it.each(["plain", "client context", "compaction", "projected history"])(
       "preserves history ahead of changing task context when opted in (%s)",
       async (scenario) => {
         const withClientContext = scenario === "client context";

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -12257,7 +12257,7 @@ describe("createToolLoopHarness", () => {
     });
 
     it.each(["plain", "client context", "compaction", "projected history"])(
-      "keeps framework context before the turn input across durable steps (%s)",
+      "preserves history ahead of changing task context when opted in (%s)",
       async (scenario) => {
         const withClientContext = scenario === "client context";
         if (scenario === "compaction") {
@@ -12305,6 +12305,7 @@ describe("createToolLoopHarness", () => {
               { role: "user", content: "Previous request" },
               { role: "assistant", content: "Previous answer" },
             ],
+            agent: { ...createTestSession().agent, taskContextAtTail: true },
           }),
           { sessionStarted: true, sequence: 1, stepIndex: 0, turnId: "turn_1" },
         );
@@ -12319,12 +12320,17 @@ describe("createToolLoopHarness", () => {
         const firstPrompt = structuredClone(getLastAgentSettings().messages);
         setupMockAgent(defaultModelResult());
         const restored = JSON.parse(JSON.stringify(first.session)) as HarnessSession;
+        ctx.set(TurnTaskStateKey, "Task status: analysis completed");
         await contextStorage.run(ctx, () => runStep(restored));
         const nextPrompt = getLastAgentSettings().messages;
-        expect(nextPrompt.slice(0, firstPrompt.length)).toEqual(firstPrompt);
+        expect(nextPrompt.slice(0, firstPrompt.length - 1)).toEqual(firstPrompt.slice(0, -1));
+        expect(nextPrompt.at(-1)).toEqual({
+          role: "user",
+          content: "Task status: analysis completed",
+        });
         expect(
           nextPrompt.filter((message) => message.content === "Task status: analysis in progress"),
-        ).toHaveLength(1);
+        ).toHaveLength(0);
       },
     );
 

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -1259,11 +1259,16 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       }
       const taskState = ctx.get(TurnTaskStateKey);
       if (taskState !== undefined) {
-        currentMessages.add(emissionState.sequence, taskState);
+        currentMessages.add(emissionState.sequence, taskState, {
+          placement: session.agent.taskContextAtTail === true ? "tail" : "turn",
+        });
       }
     }
     if (deliveryPolicy.instruction !== undefined) {
-      currentMessages.add(emissionState.sequence, deliveryPolicy.instruction);
+      currentMessages.add(emissionState.sequence, deliveryPolicy.instruction, {
+        placement:
+          session.agent.taskContextAtTail === true && !hasScheduleProvenance ? "tail" : "turn",
+      });
     }
     const pendingApprovals = renderPendingApprovalsInstruction(
       getPendingInputBatches(session.state).flatMap((batch) => batch.requests),

--- a/packages/eve/src/harness/types.ts
+++ b/packages/eve/src/harness/types.ts
@@ -46,6 +46,7 @@ export interface CompactionConfig {
  * Serializable agent configuration stored on the session.
  */
 interface SessionAgentBase {
+  readonly taskContextAtTail?: boolean;
   /**
    * Optional model used only for compaction summaries.
    *

--- a/packages/eve/src/internal/authored-definition/core.ts
+++ b/packages/eve/src/internal/authored-definition/core.ts
@@ -285,8 +285,19 @@ function normalizeAgentExperimentalDefinition(
   message: string,
 ): NonNullable<NormalizedAgentDefinition["experimental"]> {
   const record = expectObjectRecord(value, message);
-  expectOnlyKnownKeys(record, ["instrumentationProviders", "workflow"], message);
+  expectOnlyKnownKeys(
+    record,
+    ["instrumentationProviders", "workflow", "taskContextAtTail"],
+    message,
+  );
   const normalizedDefinition: Mutable<NonNullable<NormalizedAgentDefinition["experimental"]>> = {};
+
+  if (record.taskContextAtTail !== undefined) {
+    normalizedDefinition.taskContextAtTail = expectBoolean(
+      record.taskContextAtTail,
+      `${message} "experimental.taskContextAtTail" must be a boolean.`,
+    );
+  }
 
   if (record.instrumentationProviders !== undefined) {
     if (typeof record.instrumentationProviders !== "boolean") {

--- a/packages/eve/src/runtime/agent/bootstrap.ts
+++ b/packages/eve/src/runtime/agent/bootstrap.ts
@@ -32,6 +32,7 @@ export type RuntimeDynamicModelReference = Readonly<
  * Minimal runtime-owned agent shape prepared for one harness turn.
  */
 interface RuntimeTurnAgentBase {
+  readonly taskContextAtTail?: boolean;
   readonly availableSkills?: readonly AvailableSkillDescription[];
   readonly id: string;
   readonly instructions: readonly string[];
@@ -122,6 +123,7 @@ export function createResolvedRuntimeTurnAgent(input: {
     nodeId: input.nodeId,
     outputSchema: config?.outputSchema,
     reasoning: config?.reasoning,
+    taskContextAtTail: config?.experimental?.taskContextAtTail,
     tools: [...input.tools],
     workspaceSpec: agent.workspaceSpec,
   };

--- a/packages/eve/src/runtime/resolve-agent.ts
+++ b/packages/eve/src/runtime/resolve-agent.ts
@@ -241,6 +241,7 @@ function createResolvedAgentConfig(
 
   if (manifest.config.experimental !== undefined) {
     config.experimental = {
+      taskContextAtTail: manifest.config.experimental.taskContextAtTail,
       instrumentationProviders: manifest.config.experimental.instrumentationProviders,
       workflow:
         manifest.config.experimental.workflow === undefined

--- a/packages/eve/src/shared/agent-definition.ts
+++ b/packages/eve/src/shared/agent-definition.ts
@@ -204,6 +204,8 @@ export interface AgentLimitsDefinition {
  * These options are unstable and may change or be removed in any release.
  */
 export interface AgentExperimentalDefinition {
+  /** Append task context as user-role messages after history to improve prompt cache reuse. */
+  readonly taskContextAtTail?: boolean;
   /**
    * Reads instrumentation from an `instrumentation/` directory of providers
    * rather than a single `agent/instrumentation.ts` config object.


### PR DESCRIPTION
### Summary

Changing task status breaks the reusable prompt prefix before conversation history. Add `experimental.taskContextAtTail` to move it after history. Default behavior is unchanged.

```ts
defineAgent({
  // ...
  experimental: { taskContextAtTail: true },
});

// Before (simplified)
[system, "2 tasks pending", ...history]
[system, "1 task pending",  ...history]

// Opted in: only the tail changes
[system, ...history, "2 tasks pending"]
[system, ...history, "1 task pending"]
```

Applies to task status and task-delivery context. On the first model step this also changes that context from system-role to user-role. Authored system instructions, scheduled instructions, and tool-approval ordering are unchanged. Opt-in while we evaluate model behavior and provider cache reuse.

### Validation

- Focused harness, session, compiler, and runtime tests pass, covering default ordering, opted-in placement, and session hydration.
- Synthetic 28 KB request retained ~30 characters of common prefix before the change versus ~28 KB after it. This measures request construction, not billed cache savings.
- No live model savings measured yet.

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
