### PR TITLE
fix(eve): opt-in task wakeup batching

### DIFF
--- a/.changeset/task-completion-batching.md
+++ b/.changeset/task-completion-batching.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add opt-in `experimental.batchTaskCompletions` to combine adjacent queued successful sibling completions into one parent turn. Every result is retained without waiting for unfinished tasks; default delivery behavior is unchanged.

--- a/docs/subagents/index.mdx
+++ b/docs/subagents/index.mdx
@@ -5,6 +5,17 @@ description: "Delegate work to root-agent copies or declared specialists with th
 
 eve supports two ways to delegate work: the root-only built-in `agent` tool, which starts or continues a copy of the root agent, and declared subagents, which are specialists with their own directories. Use a subagent to run independent work in parallel, narrow the available tools, or give a task to a specialist.
 
+## Experimental completion batching
+
+Set `experimental: { batchTaskCompletions: true }` in the parent agent definition
+to combine adjacent successful completions already queued from tasks launched in
+the same parent turn. The default is off. Every result is retained, but the parent
+responds to the batch rather than between individual completions.
+
+There is no debounce timer or waiting for unfinished tasks. Failures, input
+requests, explicit updates, user messages, and different task cohorts remain
+separate delivery boundaries.
+
 ## The built-in `agent` tool
 
 The root session receives `agent` by default. The model calls it to delegate a task to a new copy of the root agent or continue an existing copy:

--- a/packages/eve/extension-contracts/compatibility/dynamicTool/v29.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicTool/v29.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+import { defineDynamic, defineTool } from "#public/tools/index.js";
+
+export default defineDynamic({
+  events: {
+    "session.started": () =>
+      defineTool({
+        description: "Read a report.",
+        inputSchema: z.object({ report: z.string() }),
+        execute: ({ report }) => ({ report }),
+      }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/subagent/v9.ts
+++ b/packages/eve/extension-contracts/compatibility/subagent/v9.ts
@@ -1,0 +1,6 @@
+import { defineAgent } from "#public/index.js";
+
+export default defineAgent({
+  description: "Read report data.",
+  model: "anthropic/claude-sonnet-5",
+});

--- a/packages/eve/extension-contracts/compatibility/tool/v30.ts
+++ b/packages/eve/extension-contracts/compatibility/tool/v30.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+import { defineTool } from "#public/tools/index.js";
+
+export default defineTool({
+  description: "Read a report.",
+  inputSchema: z.object({ report: z.string() }),
+  execute: ({ report }) => ({ report }),
+});

--- a/packages/eve/extension-contracts/reports/dynamicTool/v30.json
+++ b/packages/eve/extension-contracts/reports/dynamicTool/v30.json
@@ -1,0 +1,13 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicTool",
+  "epoch": 30,
+  "sha256": "ff674c3ddb9c99c0844ab6e5d8c7e3ff5078f564f1dcdaed9f9164ab41e050ac",
+  "exports": [
+    "DynamicToolEntry",
+    "DynamicToolEvents",
+    "DynamicToolResult",
+    "DynamicToolSet",
+    "defineDynamic"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/subagent/v10.json
+++ b/packages/eve/extension-contracts/reports/subagent/v10.json
@@ -1,0 +1,20 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "subagent",
+  "epoch": 10,
+  "sha256": "d5c40c2b54ca994b6318512250b6d3773b65e67aefd949d9420ca5040efd5a7f",
+  "exports": [
+    "AgentCompactionDefinition",
+    "AgentDefinition",
+    "AgentModelDefinition",
+    "AgentStaticModelDefinition",
+    "DefinedAgent",
+    "DynamicLocalSubagentDefinition",
+    "DynamicSubagentDefinition",
+    "RemoteAgentDefinition",
+    "RemoteAgentDefinitionInput",
+    "defineAgent",
+    "defineDynamic",
+    "defineRemoteAgent"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/tool/v31.json
+++ b/packages/eve/extension-contracts/reports/tool/v31.json
@@ -1,0 +1,20 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "tool",
+  "epoch": 31,
+  "sha256": "b483a3567838b134ca136e3def3cc0611f751636a4520e6bdcdec503561a19bd",
+  "exports": [
+    "defaultWebSearch",
+    "defineTool",
+    "defineWorkflowTool",
+    "disableTool",
+    "experimental_workflow",
+    "isDisabledToolSentinel",
+    "isExperimentalWorkflowToolDefinition",
+    "isWebSearchToolDefinition",
+    "toolOutput",
+    "toolOutputPart",
+    "toolResultFrom",
+    "webSearch"
+  ]
+}

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -22,8 +22,8 @@ interface ExtensionCapabilityContract {
 const EXTENSION_CAPABILITY_CONTRACTS = {
   extension: { current: 1, supported: [1], dropped: {} },
   tool: {
-    current: 30,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 28, 29, 30],
+    current: 31,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 28, 29, 30, 31],
     dropped: {
       14: "TaskExec.delegated was removed; migrate to workflow-backed background tools",
       15: "TaskExec replaces stageEffect with send",
@@ -42,8 +42,10 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     },
   },
   dynamicTool: {
-    current: 29,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 28, 29],
+    current: 30,
+    supported: [
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 28, 29, 30,
+    ],
     dropped: {
       21: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",
       23: "TaskExec.delegated was removed; migrate to workflow-backed background tools",
@@ -68,8 +70,8 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     },
   },
   subagent: {
-    current: 9,
-    supported: [3, 4, 6, 7, 8, 9],
+    current: 10,
+    supported: [3, 4, 6, 7, 8, 9, 10],
     dropped: {
       1: "Persistent subagent sessions are now the default and the experimental opt-in was removed",
       2: "Persistent subagent sessions are now the default and the experimental opt-in was removed",

--- a/packages/eve/src/compiler/manifest.test.ts
+++ b/packages/eve/src/compiler/manifest.test.ts
@@ -12,6 +12,17 @@ import {
 } from "#compiler/validate-artifact.js";
 
 describe("compiled agent manifest v48", () => {
+  it.each([undefined, false, true])(
+    "round-trips the completion batching opt-in (%s)",
+    async (batchTaskCompletions) => {
+      const { manifest } = await compileFromMemory({
+        model: "openai/gpt-5.4",
+        agent: { model: "openai/gpt-5.4", experimental: { batchTaskCompletions } },
+      });
+      const parsed = compiledAgentManifestSchema.parse(JSON.parse(JSON.stringify(manifest)));
+      expect(parsed.config.experimental?.batchTaskCompletions).toBe(batchTaskCompletions);
+    },
+  );
   it("round-trips a real compiled graph through the serialized schema", async () => {
     const { manifest } = await compileFromMemory({
       limits: { maxTokenCostUsdPerSession: 1.5 },

--- a/packages/eve/src/compiler/manifest.ts
+++ b/packages/eve/src/compiler/manifest.ts
@@ -610,6 +610,7 @@ const compiledAgentConfigBaseFields = {
   description: z.string().optional(),
   experimental: z
     .object({
+      batchTaskCompletions: z.boolean().optional(),
       instrumentationProviders: z.boolean().optional(),
       workflow: compiledAgentWorkflowDefinitionSchema.optional(),
     })
@@ -1209,6 +1210,7 @@ function cloneCompiledAgentDefinition(config: CompiledAgentDefinition): Compiled
       config.experimental === undefined
         ? undefined
         : {
+            batchTaskCompletions: config.experimental.batchTaskCompletions,
             instrumentationProviders: config.experimental.instrumentationProviders,
             workflow:
               config.experimental.workflow === undefined

--- a/packages/eve/src/compiler/normalize-agent-config.ts
+++ b/packages/eve/src/compiler/normalize-agent-config.ts
@@ -182,6 +182,10 @@ function normalizeExperimentalDefinition(
 
   const compiledExperimental: Mutable<NonNullable<CompiledAgentDefinition["experimental"]>> = {};
 
+  if (experimental.batchTaskCompletions !== undefined) {
+    compiledExperimental.batchTaskCompletions = experimental.batchTaskCompletions;
+  }
+
   if (experimental.instrumentationProviders !== undefined) {
     compiledExperimental.instrumentationProviders = experimental.instrumentationProviders;
   }

--- a/packages/eve/src/execution/durable-session-store.ts
+++ b/packages/eve/src/execution/durable-session-store.ts
@@ -88,6 +88,7 @@ export interface DurableSession {
   readonly taskId?: string;
   readonly workflowMaxSubagents?: number;
   readonly agent: {
+    readonly batchTaskCompletions?: boolean;
     readonly system: string;
   };
   readonly compaction?: {

--- a/packages/eve/src/execution/parked-delivery-wait.test.ts
+++ b/packages/eve/src/execution/parked-delivery-wait.test.ts
@@ -116,6 +116,110 @@ describe("nextTurnDelivery", () => {
     vi.mocked(routeDeliverToChildren).mockReset();
   });
 
+  it.each([
+    "completed",
+    "failed",
+    "input_required",
+    "other-cohort",
+    "user",
+    "caller",
+    "disabled",
+    "unset",
+  ])("batches successful siblings without crossing a %s delivery boundary", async (boundary) => {
+    const completion = (id: string): DeliverHookPayload => ({
+      kind: "deliver",
+      taskDeliveryId: `${id}:ready:completed`,
+      payloads: [
+        {
+          message: id,
+          task: {
+            views: [
+              {
+                taskId: id,
+                status: "completed",
+                metadata: { kind: "subagent", name: "signal" },
+                lastOutput: { type: "result", data: id },
+              },
+            ],
+          },
+        },
+      ],
+    });
+    const first = completion("task_1");
+    const second = completion("task_2");
+    const last: DeliverHookPayload =
+      boundary === "user"
+        ? { kind: "deliver", payloads: [{ message: "user direction" }] }
+        : boundary === "caller"
+          ? {
+              ...completion("task_3"),
+              caller: {
+                callId: "call",
+                subagentName: "worker",
+                replyTo: { kind: "hook", token: "reply" },
+                taskId: "task_3",
+              },
+            }
+          : {
+              ...completion("task_3"),
+              taskDeliveryId: `task_3:ready:${boundary === "other-cohort" ? "completed" : boundary}`,
+            };
+    const bufferedDeliveries = [first, second, last];
+    const input = waitInput(createMockInbox([]));
+    input.stateCursor.adoptState({
+      sessionState: {
+        ...sessionState,
+        snapshot: {
+          version: 1,
+          session: {
+            sessionId: "session",
+            continuationToken: "token",
+            agent: {
+              system: "",
+              batchTaskCompletions: boundary === "unset" ? undefined : boundary !== "disabled",
+            },
+            history: [],
+            state: {
+              "eve.tasks": {
+                version: 2,
+                tasks: ["task_1", "task_2", "task_3"].map((taskId) => ({
+                  taskId,
+                  taskRunId: `run-${taskId}`,
+                  taskInboxToken: `inbox-${taskId}`,
+                  createdByTurnId:
+                    taskId === "task_3" && boundary === "other-cohort" ? "turn-2" : "turn-1",
+                  metadata: { kind: "subagent", name: "signal" },
+                })),
+              },
+            },
+          },
+        },
+      },
+    });
+    vi.mocked(routeDeliverToChildren).mockImplementation(
+      async ({ delivery, sessionState, serializedContext }) => ({
+        kind: "continue",
+        remainder: delivery,
+        sessionState,
+        serializedContext,
+      }),
+    );
+    const next = await nextTurnDelivery({ ...input, bufferedDeliveries });
+    const count =
+      boundary === "disabled" || boundary === "unset" ? 1 : boundary === "completed" ? 3 : 2;
+    expect(next).toMatchObject({
+      kind: "turn",
+      delivery: {
+        taskDeliveryId: first.taskDeliveryId,
+        payloads: [first, ...(count >= 2 ? [second] : []), ...(count === 3 ? [last] : [])].flatMap(
+          (item) => item.payloads,
+        ),
+      },
+    });
+    expect(bufferedDeliveries).toEqual(count === 1 ? [second, last] : count === 3 ? [] : [last]);
+    expect(routeDeliverToChildren).toHaveBeenCalledTimes(1);
+  });
+
   it("surfaces an authorization callback as its own instruction", async () => {
     const inbox = createMockInbox([authorizationRead()]);
 

--- a/packages/eve/src/execution/parked-delivery-wait.ts
+++ b/packages/eve/src/execution/parked-delivery-wait.ts
@@ -10,6 +10,7 @@ import {
   type DecodedSessionInbox,
 } from "#execution/wire/session-inbox-wire.js";
 import { coalesceDeliveries } from "#harness/messages.js";
+import { getSessionTaskIndex, type SessionTaskIndexEntry } from "#tasks/session-index.js";
 
 type NextSessionAction =
   | { readonly kind: "clear" }
@@ -166,7 +167,12 @@ async function waitForNextSessionAction(input: {
     input.bufferedDeliveries.length > 0
   ) {
     return {
-      delivery: takeBufferedTurnDelivery(input.bufferedDeliveries),
+      delivery: takeBufferedTurnDelivery(
+        input.bufferedDeliveries,
+        input.stateCursor.sessionState.snapshot?.session.agent.batchTaskCompletions === true
+          ? getSessionTaskIndex(input.stateCursor.sessionState.snapshot.session.state)
+          : [],
+      ),
       kind: "delivery",
     };
   }
@@ -267,7 +273,10 @@ function isCancelledTaskDeliveryId(
   );
 }
 
-function takeBufferedTurnDelivery(bufferedDeliveries: DeliverHookPayload[]): DeliverHookPayload {
+function takeBufferedTurnDelivery(
+  bufferedDeliveries: DeliverHookPayload[],
+  tasks: readonly SessionTaskIndexEntry[],
+): DeliverHookPayload {
   const first = bufferedDeliveries.shift();
   if (first === undefined) {
     throw new Error("Cannot take a turn delivery from an empty buffer.");
@@ -275,12 +284,13 @@ function takeBufferedTurnDelivery(bufferedDeliveries: DeliverHookPayload[]): Del
 
   const turnDeliveries = [first];
   let caller = first.caller;
+  const cohort = completionCohort(first, tasks);
   while (bufferedDeliveries.length > 0) {
     const next = bufferedDeliveries[0];
     if (
       next === undefined ||
-      first.taskDeliveryId !== undefined ||
-      next.taskDeliveryId !== undefined ||
+      ((first.taskDeliveryId !== undefined || next.taskDeliveryId !== undefined) &&
+        (cohort === undefined || completionCohort(next, tasks) !== cohort)) ||
       (caller !== undefined && next.caller !== undefined)
     ) {
       break;
@@ -295,4 +305,14 @@ function takeBufferedTurnDelivery(bufferedDeliveries: DeliverHookPayload[]): Del
   }
 
   return coalesceDeliveries(turnDeliveries);
+}
+
+/** Only successful sibling notifications can share their existing cohort context. */
+function completionCohort(
+  delivery: DeliverHookPayload,
+  tasks: readonly SessionTaskIndexEntry[],
+): string | undefined {
+  if (delivery.caller !== undefined) return undefined;
+  return tasks.find((task) => delivery.taskDeliveryId === `${task.taskId}:ready:completed`)
+    ?.createdByTurnId;
 }

--- a/packages/eve/src/execution/session.test.ts
+++ b/packages/eve/src/execution/session.test.ts
@@ -76,6 +76,22 @@ describe("createCompactionConfig", () => {
 });
 
 describe("createSession", () => {
+  it.each([undefined, false, true])(
+    "preserves the completion batching option in durable state (%s)",
+    (batchTaskCompletions) => {
+      const turnAgent = createTestTurnAgent({ batchTaskCompletions });
+      const session = createSession({
+        continuationToken: "root-token",
+        sessionId: "sess-root",
+        turnAgent,
+      });
+      const durable = projectToDurableSession(session);
+      expect(durable.agent.batchTaskCompletions).toBe(batchTaskCompletions);
+      expect(hydrateDurableSession({ durable, turnAgent }).agent.batchTaskCompletions).toBe(
+        batchTaskCompletions,
+      );
+    },
+  );
   it("creates a session with correct agent configuration", () => {
     const outputSchema = { properties: { title: { type: "string" } }, type: "object" } as const;
     const session = createSession({

--- a/packages/eve/src/execution/session.ts
+++ b/packages/eve/src/execution/session.ts
@@ -125,6 +125,7 @@ function createSessionAgent(
   const base = {
     compactionModelReference: turnAgent.compactionModel,
     reasoning: turnAgent.reasoning,
+    batchTaskCompletions: turnAgent.batchTaskCompletions,
     system,
     tools,
   };
@@ -200,7 +201,7 @@ export function mintSubagentContinuationToken(suffix?: string): string {
  */
 export function projectToDurableSession(session: HarnessSession): DurableSession {
   const durable: {
-    agent: { system: string };
+    agent: { system: string; batchTaskCompletions?: boolean };
     compaction?: {
       lastKnownInputTokens?: number;
       lastKnownPromptMessageCount?: number;
@@ -216,7 +217,10 @@ export function projectToDurableSession(session: HarnessSession): DurableSession
     taskId?: string;
     workflowMaxSubagents?: number;
   } = {
-    agent: { system: session.agent.system },
+    agent: {
+      system: session.agent.system,
+      batchTaskCompletions: session.agent.batchTaskCompletions,
+    },
     continuationToken: session.continuationToken,
     history: session.history,
     sessionId: session.sessionId,

--- a/packages/eve/src/harness/types.ts
+++ b/packages/eve/src/harness/types.ts
@@ -46,6 +46,7 @@ export interface CompactionConfig {
  * Serializable agent configuration stored on the session.
  */
 interface SessionAgentBase {
+  readonly batchTaskCompletions?: boolean;
   /**
    * Optional model used only for compaction summaries.
    *

--- a/packages/eve/src/internal/authored-definition/core.ts
+++ b/packages/eve/src/internal/authored-definition/core.ts
@@ -285,8 +285,19 @@ function normalizeAgentExperimentalDefinition(
   message: string,
 ): NonNullable<NormalizedAgentDefinition["experimental"]> {
   const record = expectObjectRecord(value, message);
-  expectOnlyKnownKeys(record, ["instrumentationProviders", "workflow"], message);
+  expectOnlyKnownKeys(
+    record,
+    ["instrumentationProviders", "workflow", "batchTaskCompletions"],
+    message,
+  );
   const normalizedDefinition: Mutable<NonNullable<NormalizedAgentDefinition["experimental"]>> = {};
+
+  if (record.batchTaskCompletions !== undefined) {
+    normalizedDefinition.batchTaskCompletions = expectBoolean(
+      record.batchTaskCompletions,
+      `${message} "experimental.batchTaskCompletions" must be a boolean.`,
+    );
+  }
 
   if (record.instrumentationProviders !== undefined) {
     if (typeof record.instrumentationProviders !== "boolean") {

--- a/packages/eve/src/runtime/agent/bootstrap.ts
+++ b/packages/eve/src/runtime/agent/bootstrap.ts
@@ -32,6 +32,7 @@ export type RuntimeDynamicModelReference = Readonly<
  * Minimal runtime-owned agent shape prepared for one harness turn.
  */
 interface RuntimeTurnAgentBase {
+  readonly batchTaskCompletions?: boolean;
   readonly availableSkills?: readonly AvailableSkillDescription[];
   readonly id: string;
   readonly instructions: readonly string[];
@@ -122,6 +123,7 @@ export function createResolvedRuntimeTurnAgent(input: {
     nodeId: input.nodeId,
     outputSchema: config?.outputSchema,
     reasoning: config?.reasoning,
+    batchTaskCompletions: config?.experimental?.batchTaskCompletions,
     tools: [...input.tools],
     workspaceSpec: agent.workspaceSpec,
   };

--- a/packages/eve/src/runtime/resolve-agent.ts
+++ b/packages/eve/src/runtime/resolve-agent.ts
@@ -241,6 +241,7 @@ function createResolvedAgentConfig(
 
   if (manifest.config.experimental !== undefined) {
     config.experimental = {
+      batchTaskCompletions: manifest.config.experimental.batchTaskCompletions,
       instrumentationProviders: manifest.config.experimental.instrumentationProviders,
       workflow:
         manifest.config.experimental.workflow === undefined

--- a/packages/eve/src/shared/agent-definition.ts
+++ b/packages/eve/src/shared/agent-definition.ts
@@ -204,6 +204,8 @@ export interface AgentLimitsDefinition {
  * These options are unstable and may change or be removed in any release.
  */
 export interface AgentExperimentalDefinition {
+  /** Coalesce adjacent queued successful sibling completions into one parent turn. Defaults to false. */
+  readonly batchTaskCompletions?: boolean;
   /**
    * Reads instrumentation from an `instrumentation/` directory of providers
    * rather than a single `agent/instrumentation.ts` config object.

--- a/packages/eve/test/scenarios/mounted-extension-installed.scenario.test.ts
+++ b/packages/eve/test/scenarios/mounted-extension-installed.scenario.test.ts
@@ -249,7 +249,7 @@ describe("mounted extension installed under node_modules", () => {
     );
     expect(
       JSON.parse(extensionFiles[`node_modules/${PACKAGE_NAME}/dist/extension/_manifest.json`]!),
-    ).toMatchObject({ requires: { channel: 18, schedule: 10, subagent: 9 } });
+    ).toMatchObject({ requires: { channel: 18, schedule: 10, subagent: 10 } });
     const app = await scenarioApp({
       name: "mounted-extension-installed",
       installDependencies: true,


### PR DESCRIPTION
## Change

Batch adjacent queued sibling completions into one parent turn. Opt-in; defaults unchanged.

```ts
defineAgent({
  experimental: { batchTaskCompletions: true },
});

// Same parent-turn cohort; both results already queued
queue = [completed(A), completed(B)]

// Before
resumeParent(resultA)
resumeParent(resultB)

// Opted in
resumeParent([resultA, resultB])
```

- Retain every result. No timer or waiting for unfinished tasks.
- Stop batching at failures, input requests, explicit updates, user messages, or different task cohorts.
- Parent does not get a turn between batched completions—hence opt-in.

Independent of #3129. Both change extension contract reports; regenerate those in whichever merges second.

## Verification

- Focused tests cover opt-in/default behavior, batching boundaries, manifest round-trip, and durable configuration.
- Live model behavior and cost savings not measured.

## Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)