### PR TITLE
feat(eve): preserve prompt cache prefixes with task event delivery

### DIFF
--- a/.changeset/task-event-delivery.md
+++ b/.changeset/task-event-delivery.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Add opt-in `experimental.taskEventDelivery` for agents that orchestrate background work. Task notifications remain chronological instead of reinjecting mutable cohort state; the agent decides when to continue or report, with task identities restored after compaction.
+Add opt-in `experimental.taskEventDelivery` for agents that orchestrate background work. Task notifications remain chronological, compaction restores task identities, and queued child requests are serviced between parent steps without requiring the parent to end its turn.

--- a/.changeset/task-event-delivery.md
+++ b/.changeset/task-event-delivery.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add opt-in `experimental.taskEventDelivery` for agents that orchestrate background work. Task notifications remain chronological instead of reinjecting mutable cohort state; the agent decides when to continue or report, with task identities restored after compaction.

--- a/docs/subagents/index.mdx
+++ b/docs/subagents/index.mdx
@@ -5,6 +5,16 @@ description: "Delegate work to root-agent copies or declared specialists with th
 
 eve supports two ways to delegate work: the root-only built-in `agent` tool, which starts or continues a copy of the root agent, and declared subagents, which are specialists with their own directories. Use a subagent to run independent work in parallel, narrow the available tools, or give a task to a specialist.
 
+## Agent-directed task delivery
+
+Set `experimental: { taskEventDelivery: true }` in the parent agent definition to let its instructions govern how it handles background results. This disables the default launch acknowledgement and cohort reporting instructions, and stops injecting the changing task inventory into model requests. Existing task receipts and notifications remain in conversation history; task ownership, cancellation, approvals, and notification delivery are unchanged.
+
+Tell the parent to continue useful work after delegation, consume results as they arrive, and distinguish finishing its current turn from completing the user's request. Background notification turns may intentionally deliver nothing when there is nothing new to report. Child sessions and structured-output sessions still require an output.
+
+After compaction, eve adds a point-in-time index of task IDs, names, and terminal or unsettled statuses. It does not duplicate result bodies or private executor credentials. The compaction summary retains relevant results and artifact paths. Keep large findings in shared artifacts and return their locations in task results. Later notifications supersede the recovery snapshot.
+
+The option defaults to off. It reduces changing prompt context but does not guarantee provider cache hits.
+
 ## The built-in `agent` tool
 
 The root session receives `agent` by default. The model calls it to delegate a task to a new copy of the root agent or continue an existing copy:

--- a/docs/subagents/index.mdx
+++ b/docs/subagents/index.mdx
@@ -9,6 +9,8 @@ eve supports two ways to delegate work: the root-only built-in `agent` tool, whi
 
 Set `experimental: { taskEventDelivery: true }` in the parent agent definition to let its instructions govern how it handles background results. This disables the default launch acknowledgement and cohort reporting instructions, and stops injecting the changing task inventory into model requests. Existing task receipts and notifications remain in conversation history; task ownership, cancellation, approvals, and notification delivery are unchanged.
 
+With this option, the runtime services queued child requests between parent model steps. The parent does not need to end its turn to start a child, but requests arriving during an in-flight model or tool step wait for a safe step boundary. User messages and task-result notifications still follow their normal turn-delivery policy.
+
 Tell the parent to continue useful work after delegation, consume results as they arrive, and distinguish finishing its current turn from completing the user's request. Background notification turns may intentionally deliver nothing when there is nothing new to report. Child sessions and structured-output sessions still require an output.
 
 After compaction, eve adds a point-in-time index of task IDs, names, and terminal or unsettled statuses. It does not duplicate result bodies or private executor credentials. The compaction summary retains relevant results and artifact paths. Keep large findings in shared artifacts and return their locations in task results. Later notifications supersede the recovery snapshot.

--- a/packages/eve/extension-contracts/compatibility/dynamicTool/v29.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicTool/v29.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+import { defineDynamic, defineTool } from "#public/tools/index.js";
+
+export default defineDynamic({
+  events: {
+    "session.started": () =>
+      defineTool({
+        description: "Read a report.",
+        inputSchema: z.object({ report: z.string() }),
+        execute: ({ report }) => ({ report }),
+      }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/subagent/v9.ts
+++ b/packages/eve/extension-contracts/compatibility/subagent/v9.ts
@@ -1,0 +1,6 @@
+import { defineAgent } from "#public/definitions/agent.js";
+
+export default defineAgent({
+  model: "openai/gpt-5.5",
+  description: "Inspect a report.",
+});

--- a/packages/eve/extension-contracts/compatibility/tool/v30.ts
+++ b/packages/eve/extension-contracts/compatibility/tool/v30.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+import { defineTool } from "#public/tools/index.js";
+
+export default defineTool({
+  description: "Read a report.",
+  inputSchema: z.object({ report: z.string() }),
+  execute: ({ report }) => ({ report }),
+});

--- a/packages/eve/extension-contracts/reports/dynamicTool/v30.json
+++ b/packages/eve/extension-contracts/reports/dynamicTool/v30.json
@@ -1,0 +1,13 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicTool",
+  "epoch": 30,
+  "sha256": "fc1240ef5a9d41023d6847bf856505a4e8ec9ac135e343b17677e4b413629c61",
+  "exports": [
+    "DynamicToolEntry",
+    "DynamicToolEvents",
+    "DynamicToolResult",
+    "DynamicToolSet",
+    "defineDynamic"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/subagent/v10.json
+++ b/packages/eve/extension-contracts/reports/subagent/v10.json
@@ -1,0 +1,20 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "subagent",
+  "epoch": 10,
+  "sha256": "947460b56cab11573a22ee71731121356bde6073c46bc33c15a245e3ca476ec2",
+  "exports": [
+    "AgentCompactionDefinition",
+    "AgentDefinition",
+    "AgentModelDefinition",
+    "AgentStaticModelDefinition",
+    "DefinedAgent",
+    "DynamicLocalSubagentDefinition",
+    "DynamicSubagentDefinition",
+    "RemoteAgentDefinition",
+    "RemoteAgentDefinitionInput",
+    "defineAgent",
+    "defineDynamic",
+    "defineRemoteAgent"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/tool/v31.json
+++ b/packages/eve/extension-contracts/reports/tool/v31.json
@@ -1,0 +1,20 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "tool",
+  "epoch": 31,
+  "sha256": "6e33c63a9a14307ea6456f75dc7c25eca93b99d45e980484a162ce583cdb5e60",
+  "exports": [
+    "defaultWebSearch",
+    "defineTool",
+    "defineWorkflowTool",
+    "disableTool",
+    "experimental_workflow",
+    "isDisabledToolSentinel",
+    "isExperimentalWorkflowToolDefinition",
+    "isWebSearchToolDefinition",
+    "toolOutput",
+    "toolOutputPart",
+    "toolResultFrom",
+    "webSearch"
+  ]
+}

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -22,8 +22,8 @@ interface ExtensionCapabilityContract {
 const EXTENSION_CAPABILITY_CONTRACTS = {
   extension: { current: 1, supported: [1], dropped: {} },
   tool: {
-    current: 30,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 28, 29, 30],
+    current: 31,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 28, 29, 30, 31],
     dropped: {
       14: "TaskExec.delegated was removed; migrate to workflow-backed background tools",
       15: "TaskExec replaces stageEffect with send",
@@ -42,8 +42,10 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     },
   },
   dynamicTool: {
-    current: 29,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 28, 29],
+    current: 30,
+    supported: [
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 28, 29, 30,
+    ],
     dropped: {
       21: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",
       23: "TaskExec.delegated was removed; migrate to workflow-backed background tools",
@@ -68,8 +70,8 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     },
   },
   subagent: {
-    current: 9,
-    supported: [3, 4, 6, 7, 8, 9],
+    current: 10,
+    supported: [3, 4, 6, 7, 8, 9, 10],
     dropped: {
       1: "Persistent subagent sessions are now the default and the experimental opt-in was removed",
       2: "Persistent subagent sessions are now the default and the experimental opt-in was removed",

--- a/packages/eve/src/compiler/manifest.test.ts
+++ b/packages/eve/src/compiler/manifest.test.ts
@@ -12,6 +12,17 @@ import {
 } from "#compiler/validate-artifact.js";
 
 describe("compiled agent manifest v48", () => {
+  it.each([undefined, false, true])(
+    "round-trips the task event delivery opt-in (%s)",
+    async (taskEventDelivery) => {
+      const { manifest } = await compileFromMemory({
+        model: "openai/gpt-5.4",
+        agent: { model: "openai/gpt-5.4", experimental: { taskEventDelivery } },
+      });
+      const parsed = compiledAgentManifestSchema.parse(JSON.parse(JSON.stringify(manifest)));
+      expect(parsed.config.experimental?.taskEventDelivery).toBe(taskEventDelivery);
+    },
+  );
   it("round-trips a real compiled graph through the serialized schema", async () => {
     const { manifest } = await compileFromMemory({
       limits: { maxTokenCostUsdPerSession: 1.5 },

--- a/packages/eve/src/compiler/manifest.ts
+++ b/packages/eve/src/compiler/manifest.ts
@@ -610,6 +610,7 @@ const compiledAgentConfigBaseFields = {
   description: z.string().optional(),
   experimental: z
     .object({
+      taskEventDelivery: z.boolean().optional(),
       instrumentationProviders: z.boolean().optional(),
       workflow: compiledAgentWorkflowDefinitionSchema.optional(),
     })
@@ -1209,6 +1210,7 @@ function cloneCompiledAgentDefinition(config: CompiledAgentDefinition): Compiled
       config.experimental === undefined
         ? undefined
         : {
+            taskEventDelivery: config.experimental.taskEventDelivery,
             instrumentationProviders: config.experimental.instrumentationProviders,
             workflow:
               config.experimental.workflow === undefined

--- a/packages/eve/src/compiler/normalize-agent-config.ts
+++ b/packages/eve/src/compiler/normalize-agent-config.ts
@@ -182,6 +182,10 @@ function normalizeExperimentalDefinition(
 
   const compiledExperimental: Mutable<NonNullable<CompiledAgentDefinition["experimental"]>> = {};
 
+  if (experimental.taskEventDelivery !== undefined) {
+    compiledExperimental.taskEventDelivery = experimental.taskEventDelivery;
+  }
+
   if (experimental.instrumentationProviders !== undefined) {
     compiledExperimental.instrumentationProviders = experimental.instrumentationProviders;
   }

--- a/packages/eve/src/execution/durable-session-migrations/turn-workflow.test.ts
+++ b/packages/eve/src/execution/durable-session-migrations/turn-workflow.test.ts
@@ -50,7 +50,7 @@ describe("turn workflow wire migrations", () => {
     ).toEqual({
       capabilities: undefined,
       completionToken: "turn-token",
-      driverCapabilities: { cancelledTurnSettle: true, turnInbox: true },
+      driverCapabilities: { bufferedDeliveries: true, cancelledTurnSettle: true, turnInbox: true },
       mode: "conversation",
       stepInput: {
         input: delivery,

--- a/packages/eve/src/execution/durable-session-migrations/turn-workflow.ts
+++ b/packages/eve/src/execution/durable-session-migrations/turn-workflow.ts
@@ -58,6 +58,7 @@ interface TurnWorkflowInputBase {
    */
   readonly driverCapabilities?: {
     readonly turnInbox?: true;
+    readonly bufferedDeliveries?: true;
     readonly cancelledTurnSettle?: true;
   };
   readonly mode: RunMode;
@@ -108,7 +109,7 @@ export function createTurnWorkflowInput(input: TurnWorkflowDispatchInput): TurnW
   return {
     capabilities: input.capabilities,
     completionToken: input.completionToken,
-    driverCapabilities: { cancelledTurnSettle: true, turnInbox: true },
+    driverCapabilities: { bufferedDeliveries: true, cancelledTurnSettle: true, turnInbox: true },
     initialCancellation: input.initialCancellation,
     initialStep: input.initialStep,
     mode: input.mode,

--- a/packages/eve/src/execution/durable-session-store.ts
+++ b/packages/eve/src/execution/durable-session-store.ts
@@ -89,6 +89,7 @@ export interface DurableSession {
   readonly workflowMaxSubagents?: number;
   readonly agent: {
     readonly system: string;
+    readonly taskEventDelivery?: boolean;
   };
   readonly compaction?: {
     readonly lastKnownInputTokens?: number;

--- a/packages/eve/src/execution/session.test.ts
+++ b/packages/eve/src/execution/session.test.ts
@@ -86,6 +86,7 @@ describe("createSession", () => {
         turnAgent,
       });
       expect(session.agent.taskEventDelivery).toBe(taskEventDelivery);
+      expect(projectToDurableSession(session).agent.taskEventDelivery).toBe(taskEventDelivery);
       const hydrated = hydrateDurableSession({
         durable: projectToDurableSession(session),
         turnAgent,

--- a/packages/eve/src/execution/session.test.ts
+++ b/packages/eve/src/execution/session.test.ts
@@ -76,6 +76,23 @@ describe("createCompactionConfig", () => {
 });
 
 describe("createSession", () => {
+  it.each([undefined, false, true])(
+    "carries task event delivery through session hydration (%s)",
+    (taskEventDelivery) => {
+      const turnAgent = createTestTurnAgent({ taskEventDelivery });
+      const session = createSession({
+        continuationToken: "root-token",
+        sessionId: "sess-root",
+        turnAgent,
+      });
+      expect(session.agent.taskEventDelivery).toBe(taskEventDelivery);
+      const hydrated = hydrateDurableSession({
+        durable: projectToDurableSession(session),
+        turnAgent,
+      });
+      expect(hydrated.agent.taskEventDelivery).toBe(taskEventDelivery);
+    },
+  );
   it("creates a session with correct agent configuration", () => {
     const outputSchema = { properties: { title: { type: "string" } }, type: "object" } as const;
     const session = createSession({

--- a/packages/eve/src/execution/session.ts
+++ b/packages/eve/src/execution/session.ts
@@ -125,6 +125,7 @@ function createSessionAgent(
   const base = {
     compactionModelReference: turnAgent.compactionModel,
     reasoning: turnAgent.reasoning,
+    taskEventDelivery: turnAgent.taskEventDelivery,
     system,
     tools,
   };

--- a/packages/eve/src/execution/session.ts
+++ b/packages/eve/src/execution/session.ts
@@ -201,7 +201,7 @@ export function mintSubagentContinuationToken(suffix?: string): string {
  */
 export function projectToDurableSession(session: HarnessSession): DurableSession {
   const durable: {
-    agent: { system: string };
+    agent: DurableSession["agent"];
     compaction?: {
       lastKnownInputTokens?: number;
       lastKnownPromptMessageCount?: number;
@@ -217,7 +217,12 @@ export function projectToDurableSession(session: HarnessSession): DurableSession
     taskId?: string;
     workflowMaxSubagents?: number;
   } = {
-    agent: { system: session.agent.system },
+    agent: {
+      system: session.agent.system,
+      ...(session.agent.taskEventDelivery !== undefined
+        ? { taskEventDelivery: session.agent.taskEventDelivery }
+        : {}),
+    },
     continuationToken: session.continuationToken,
     history: session.history,
     sessionId: session.sessionId,

--- a/packages/eve/src/execution/turn-control-protocol.ts
+++ b/packages/eve/src/execution/turn-control-protocol.ts
@@ -26,6 +26,7 @@ export type TurnControlPayload =
       readonly inboxToken: string;
       readonly kind: "turn-delivery-request";
       readonly requestId: string;
+      readonly bufferedOnly?: boolean;
     }
   | { readonly kind: "turn-delivery-accepted"; readonly requestId: string }
   | { readonly kind: "turn-delivery-cancelled"; readonly requestId: string };

--- a/packages/eve/src/execution/turn-control-receiver.test.ts
+++ b/packages/eve/src/execution/turn-control-receiver.test.ts
@@ -39,6 +39,26 @@ describe("TurnControlReceiver", () => {
     createHookMock.mockReset();
   });
 
+  it("answers an empty between-step poll without consuming queued user messages", async () => {
+    installControlHook([
+      { ...deliveryRequest("poll-1"), bufferedOnly: true },
+      { kind: "turn-delivery-accepted", requestId: "poll-1" },
+      parkResult(),
+    ]);
+    const message: DeliverHookPayload = { kind: "deliver", payloads: [{ message: "follow-up" }] };
+    const buffered = [message];
+    await runReceiver(buffered);
+    expect(forwardTurnDeliveryStep).toHaveBeenCalledWith({
+      inboxToken: "turn-inbox",
+      payload: {
+        kind: "driver-delivery",
+        requestId: "poll-1",
+        delivery: { kind: "deliver", payloads: [] },
+      },
+    });
+    expect(buffered).toEqual([message]);
+  });
+
   it("forwards a buffered delivery and consumes it once the turn accepts", async () => {
     const delivery: DeliverHookPayload = {
       kind: "deliver",
@@ -318,7 +338,9 @@ function runReceiver(
   return receiver.waitForAction().finally(() => receiver.dispose());
 }
 
-function deliveryRequest(requestId: string): TurnControlPayload {
+function deliveryRequest(
+  requestId: string,
+): Extract<TurnControlPayload, { kind: "turn-delivery-request" }> {
   return {
     continuationToken: "http:test",
     inboxToken: "turn-inbox",

--- a/packages/eve/src/execution/turn-control-receiver.ts
+++ b/packages/eve/src/execution/turn-control-receiver.ts
@@ -222,6 +222,10 @@ export class TurnControlReceiver {
     await this.commandInbox.rekeyContinuation(request.continuationToken);
 
     let delivery = this.takeInputResponseDelivery();
+    // A between-step poll must not park the model waiting for future input.
+    if (delivery === undefined && request.bufferedOnly === true) {
+      delivery = { kind: "deliver", payloads: [] };
+    }
     while (delivery === undefined) {
       const winner = await Promise.race([
         this.getControlPromise().then((value) => ({ kind: "control" as const, value })),

--- a/packages/eve/src/execution/turn-workflow.test.ts
+++ b/packages/eve/src/execution/turn-workflow.test.ts
@@ -283,6 +283,93 @@ describe("turnWorkflow", () => {
     );
   });
 
+  it.each([
+    { enabled: false, supported: true },
+    { enabled: true, supported: false },
+    { enabled: true, supported: true },
+  ])(
+    "services task launches before the next model step (event delivery=$enabled, driver=$supported)",
+    async ({ enabled, supported }) => {
+      const shouldPoll = enabled && supported;
+      const state = withRunningChildren(createSessionState(), []);
+      const sessionState: DurableSessionState = {
+        ...state,
+        snapshot: {
+          version: 1,
+          session: {
+            ...state.snapshot!.session,
+            agent: { system: "", taskEventDelivery: enabled },
+          },
+        },
+      };
+      const launchedState = withRunningChildren(sessionState, [
+        { callId: "worker-1", sessionId: "child-1" },
+      ]);
+      const delivery = {
+        kind: "deliver" as const,
+        payloads: [
+          {
+            task: {
+              agentRequests: [
+                {
+                  taskId: "task-1",
+                  replyTo: "agent-reply",
+                  request: {
+                    kind: "agent-invoke" as const,
+                    invocationId: "worker-1",
+                    input: { message: "Review", target: "worker" },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      };
+      installInbox([
+        { kind: "driver-delivery", requestId: "turn-token:inbox:delivery:0", delivery },
+        {
+          kind: "driver-delivery",
+          requestId: "turn-token:inbox:delivery:1",
+          delivery,
+        },
+        {
+          kind: "driver-delivery",
+          requestId: "turn-token:inbox:delivery:2",
+          delivery: { kind: "deliver", payloads: [] },
+        },
+      ]);
+      vi.mocked(routeDeliverToChildren).mockResolvedValue({
+        kind: "continue",
+        remainder: undefined,
+        serializedContext: { dispatched: true },
+        sessionState: launchedState,
+      });
+      vi.mocked(turnStep)
+        .mockResolvedValueOnce({ action: "continue", serializedContext: {}, sessionState })
+        .mockImplementationOnce(async (input) => {
+          expect(input.sessionState).toBe(shouldPoll ? launchedState : sessionState);
+          expect(routeDeliverToChildren).toHaveBeenCalledTimes(shouldPoll ? 3 : 0);
+          return {
+            action: "done",
+            output: "done",
+            serializedContext: {},
+            sessionState: input.sessionState,
+          };
+        });
+      const { input } = createInput({
+        driverCapabilities: { bufferedDeliveries: supported ? true : undefined, turnInbox: true },
+        sessionState,
+      });
+      await turnWorkflow(input);
+      if (shouldPoll) {
+        expect(resumeHookMock).toHaveBeenCalledWith(
+          "turn-token",
+          expect.objectContaining({ kind: "turn-delivery-request", bufferedOnly: true }),
+        );
+      }
+    },
+  );
+
   it("parks when an authorization is pending", async () => {
     const sessionState = createSessionState();
     vi.mocked(turnStep).mockResolvedValueOnce({

--- a/packages/eve/src/execution/turn-workflow.ts
+++ b/packages/eve/src/execution/turn-workflow.ts
@@ -47,6 +47,7 @@ import type { RuntimeActionResult } from "#shared/action-types.js";
 import { handleWorkflowToolRunMessage } from "#execution/turn-workflow-tool-run.js";
 
 const TASK_MODE_WAIT_ERROR_MESSAGE = "Task mode cannot wait for follow-up input (`next: null`).";
+const MAX_DELIVERIES_PER_STEP = 64;
 
 export type { TurnWorkflowInput };
 
@@ -273,6 +274,29 @@ export async function runTurnOwnedWorkflow(
       }
 
       await cursor.adopt(result);
+      if (
+        input.driverCapabilities?.bufferedDeliveries === true &&
+        cursor.sessionState.snapshot?.session.agent.taskEventDelivery === true
+      ) {
+        // Only the turn owns this snapshot. Route task launches between model
+        // steps so an in-flight step cannot overwrite newly dispatched handles.
+        const serviced = await waitForRuntimeActionResults({
+          bufferedDeliveries,
+          cancellation,
+          cursor,
+          inboxToken: inbox.token,
+          initialAcceptedAtMs: undefined,
+          initialResults: [],
+          nextDeliveryRequestId,
+          readers,
+          pendingCallIds: [],
+          pollDeliveries: true,
+        });
+        if (serviced === "cancel-turn") {
+          await finishCancelledTurn({ bufferedDeliveries, cancellation, cursor });
+          return;
+        }
+      }
       nextStepInput = undefined;
     }
   } catch (error) {
@@ -337,8 +361,11 @@ async function waitForRuntimeActionResults(input: {
   readonly nextDeliveryRequestId: () => string;
   readonly pendingCallIds: readonly string[];
   readonly readers: TurnReaders;
+  readonly pollDeliveries?: boolean;
 }): Promise<AcceptedRuntimeActionBatch | "cancelled" | "cancel-turn"> {
   let pendingDeliveryRequest: string | undefined;
+  let polledDeliveries = input.pollDeliveries !== true;
+  let deliveredCount = 0;
   const results: RuntimeActionResult[] = [...input.initialResults];
   const acceptedAtMsByCallId = new Map<string, number>();
   if (input.initialAcceptedAtMs !== undefined) {
@@ -352,7 +379,7 @@ async function waitForRuntimeActionResults(input: {
       pendingCallIds: input.pendingCallIds,
       results,
     });
-    if (ready !== undefined) {
+    if (ready !== undefined && polledDeliveries) {
       if (pendingDeliveryRequest !== undefined) {
         // The entry may already be racing public input against this wait.
         // Cancellation keeps that input available for the next parent turn.
@@ -369,13 +396,17 @@ async function waitForRuntimeActionResults(input: {
       };
     }
 
-    if (input.cursor.sessionState.hasProxyInputRequests && pendingDeliveryRequest === undefined) {
+    if (
+      (!polledDeliveries || input.cursor.sessionState.hasProxyInputRequests) &&
+      pendingDeliveryRequest === undefined
+    ) {
       pendingDeliveryRequest = input.nextDeliveryRequestId();
       await input.cursor.send({
         continuationToken: input.cursor.sessionState.continuationToken,
         inboxToken: input.inboxToken,
         kind: "turn-delivery-request",
         requestId: pendingDeliveryRequest,
+        bufferedOnly: !polledDeliveries ? true : undefined,
       });
     }
 
@@ -462,6 +493,13 @@ async function waitForRuntimeActionResults(input: {
     if (value.kind === "driver-delivery" && value.requestId === pendingDeliveryRequest) {
       await input.cursor.send({ kind: "turn-delivery-accepted", requestId: value.requestId });
       pendingDeliveryRequest = undefined;
+      // Drain the buffered launch batch without paying for a model call per
+      // child. Bound the drain so a busy child cannot starve the parent.
+      deliveredCount += 1;
+      polledDeliveries =
+        input.pollDeliveries !== true ||
+        value.delivery.payloads.length === 0 ||
+        deliveredCount >= MAX_DELIVERIES_PER_STEP;
 
       const routed = await routeDeliverToChildren({
         delivery: value.delivery,

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -27,7 +27,7 @@ import {
   TurnTaskStateKey,
 } from "#context/keys.js";
 import { BundleKey, ChannelKey } from "#runtime/sessions/runtime-context-keys.js";
-import { serializeContext } from "#context/serialize.js";
+import { deserializeContext, serializeContext } from "#context/serialize.js";
 import { getPendingCoordinationBatch, setPendingCoordinationBatch } from "#harness/coordination.js";
 import { TurnCancelledError } from "#harness/turn-cancellation.js";
 import { getPendingAuthorization, setPendingAuthorization } from "#harness/authorization.js";
@@ -2184,74 +2184,89 @@ describe("turnStep", () => {
     });
   });
 
-  it("sets task-delivery provenance only when the runtime supplies owned task state", async () => {
-    const observedTaskDeliveries: unknown[] = [];
-    const observedTaskStates: unknown[] = [];
-    const metadata = { kind: "report-probe", name: "report_probe" } as const;
-    const session = createStubSession({
-      state: {
-        "eve.tasks": {
-          tasks: [
-            {
-              taskInboxToken: "task-token",
-              createdByTurnId: "turn-parent",
-              metadata,
-              taskId: "task_1",
-              taskRunId: "run_1",
-              terminalView: {
-                lastOutput: { data: { result: "done" }, type: "result" },
+  it.each([false, true])(
+    "sets owned task-delivery provenance (taskEventDelivery=%s)",
+    async (taskEventDelivery) => {
+      const observedInputs: unknown[] = [];
+      const observedTaskDeliveries: unknown[] = [];
+      const observedTaskStates: unknown[] = [];
+      const metadata = { kind: "report-probe", name: "report_probe" } as const;
+      const session = createStubSession({
+        state: {
+          "eve.tasks": {
+            tasks: [
+              {
+                taskInboxToken: "task-token",
+                createdByTurnId: "turn-parent",
                 metadata,
-                status: "completed",
                 taskId: "task_1",
+                taskRunId: "run_1",
+                terminalView: {
+                  lastOutput: { data: { result: "done" }, type: "result" },
+                  metadata,
+                  status: "completed",
+                  taskId: "task_1",
+                },
               },
-            },
-          ],
-          version: 2,
+            ],
+            version: 2,
+          },
         },
-      },
-    });
-    installSessionStoreMocks([session, session, session]);
-    vi.mocked(createExecutionNodeStep).mockImplementation(() => {
-      return async (stepSession): Promise<StepResult> => {
-        observedTaskDeliveries.push(contextStorage.getStore()?.get(TurnTaskDeliveryKey));
-        observedTaskStates.push(contextStorage.getStore()?.get(TurnTaskStateKey));
-        return { next: { done: true, output: "ok" }, session: stepSession };
-      };
-    });
+      });
+      installSessionStoreMocks([session, session, session]);
+      vi.mocked(createExecutionNodeStep).mockImplementation(() => {
+        return async (stepSession, input): Promise<StepResult> => {
+          observedInputs.push(input);
+          observedTaskDeliveries.push(contextStorage.getStore()?.get(TurnTaskDeliveryKey));
+          observedTaskStates.push(contextStorage.getStore()?.get(TurnTaskStateKey));
+          return { next: { done: true, output: "ok" }, session: stepSession };
+        };
+      });
 
-    const initialSerializedContext = createSerializedContext();
-    initialSerializedContext[TurnTaskStateKey.name] = "stale task state";
+      const initialSerializedContext = createSerializedContext();
+      const runtimeContext = await deserializeContext(initialSerializedContext);
+      const bundle = runtimeContext.require(BundleKey);
+      vi.mocked(getCompiledRuntimeAgentBundle).mockResolvedValue({
+        ...bundle,
+        turnAgent: { ...bundle.turnAgent, taskEventDelivery },
+      });
+      initialSerializedContext[TurnTaskStateKey.name] = "stale task state";
 
-    const first = await turnStep({
-      input: {
-        kind: "deliver",
-        payloads: [{ message: "Background task task_1 is completed." }],
-        taskDeliveryId: "task_1:ready:completed",
-      },
-      parentWritable: createTestWritable(),
-      serializedContext: initialSerializedContext,
-      sessionState: createStubSessionState(),
-    });
-    const second = await turnStep({
-      input: {
-        kind: "deliver",
-        payloads: [{ message: "Background task task_unknown is completed." }],
-        taskDeliveryId: "task_unknown:ready:completed",
-      },
-      parentWritable: createTestWritable(),
-      serializedContext: first.serializedContext,
-      sessionState: first.sessionState,
-    });
-    await turnStep({
-      input: { kind: "deliver", payloads: [{ message: "What happened?" }] },
-      parentWritable: createTestWritable(),
-      serializedContext: second.serializedContext,
-      sessionState: second.sessionState,
-    });
+      const first = await turnStep({
+        input: {
+          kind: "deliver",
+          payloads: [{ message: "Background task task_1 is completed." }],
+          taskDeliveryId: "task_1:ready:completed",
+        },
+        parentWritable: createTestWritable(),
+        serializedContext: initialSerializedContext,
+        sessionState: createStubSessionState(),
+      });
+      const second = await turnStep({
+        input: {
+          kind: "deliver",
+          payloads: [{ message: "Background task task_unknown is completed." }],
+          taskDeliveryId: "task_unknown:ready:completed",
+        },
+        parentWritable: createTestWritable(),
+        serializedContext: first.serializedContext,
+        sessionState: first.sessionState,
+      });
+      await turnStep({
+        input: { kind: "deliver", payloads: [{ message: "What happened?" }] },
+        parentWritable: createTestWritable(),
+        serializedContext: second.serializedContext,
+        sessionState: second.sessionState,
+      });
 
-    expect(observedTaskDeliveries).toEqual(["settled", "none", "none"]);
-    expect(observedTaskStates).toEqual([undefined, undefined, undefined]);
-  });
+      expect(observedTaskDeliveries).toEqual(["settled", "none", "none"]);
+      expect(observedTaskStates).toEqual([undefined, undefined, undefined]);
+      expect(observedInputs[0]).toMatchObject({
+        message: expect.stringContaining("Background task task_1 is completed."),
+      });
+      expect(JSON.stringify(observedInputs[0]).includes("[Task state]")).toBe(!taskEventDelivery);
+    },
+  );
 
   it("supplies initiating task state after the active turn accepts delegated work", async () => {
     const tasksBundle = {

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -277,10 +277,12 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
     });
     if (taskContext !== undefined) {
       ctx.set(TurnTaskDeliveryKey, taskContext.phase);
-      resolved = {
-        ...resolved,
-        context: [...(resolved.context ?? []), taskContext.context],
-      };
+      if (!effectiveAgent.turnAgent.taskEventDelivery) {
+        resolved = {
+          ...resolved,
+          context: [...(resolved.context ?? []), taskContext.context],
+        };
+      }
     }
   }
 

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -9964,7 +9964,8 @@ describe("createToolLoopHarness", () => {
     async (compactOnly) => {
       vi.mocked(shouldCompact).mockReturnValue(true);
       vi.mocked(compactMessages).mockResolvedValue([
-        { role: "user", content: "Compacted request" },
+        { role: "user", content: "Summary of our conversation so far:" },
+        { role: "assistant", content: "Retained results and artifact paths" },
       ]);
       setupMockAgent({
         finishReason: "stop",
@@ -10005,6 +10006,13 @@ describe("createToolLoopHarness", () => {
       });
       expect(JSON.stringify(result.session.history)).not.toContain("private-token");
       expect(JSON.stringify(result.session.history)).not.toContain("private-run");
+      await runStep(result.session, { message: "Continue again" });
+      const nextCompactionInput = vi.mocked(compactMessages).mock.calls.at(-1)![0];
+      expect(nextCompactionInput.slice(0, 2)).toEqual([
+        { role: "user", content: "Summary of our conversation so far:" },
+        { role: "assistant", content: "Retained results and artifact paths" },
+      ]);
+      expect(JSON.stringify(nextCompactionInput)).not.toContain("[Task recovery after compaction]");
     },
   );
 

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -70,6 +70,7 @@ import {
 } from "#harness/input-requests.js";
 import { getPendingCoordinationBatch } from "#harness/coordination.js";
 import { AGENT_HANDLES_STATE_KEY } from "#subagents/handles/store.js";
+import { SESSION_TASKS_STATE_KEY } from "#tasks/session-index.js";
 import { BackgroundToolExecutorKey } from "#harness/background-tools.js";
 import { stashToolInterrupt } from "#harness/tool-interrupts.js";
 import { appendMissingToolResultMessages, createToolLoopHarness } from "#harness/tool-loop.js";
@@ -9958,6 +9959,55 @@ describe("createToolLoopHarness", () => {
     });
   });
 
+  it.each([false, true])(
+    "restores task identities during compaction (manual=%s)",
+    async (compactOnly) => {
+      vi.mocked(shouldCompact).mockReturnValue(true);
+      vi.mocked(compactMessages).mockResolvedValue([
+        { role: "user", content: "Compacted request" },
+      ]);
+      setupMockAgent({
+        finishReason: "stop",
+        response: { messages: [{ role: "assistant", content: "Resuming." }] },
+        text: "Resuming.",
+        toolCalls: [],
+        toolResults: [],
+      });
+      const initial = createTestSession({ history: [{ role: "user", content: "Old request" }] });
+      const runStep = createToolLoopHarness(
+        createTestConfig("conversation", undefined, { compactOnly }),
+      );
+      const result = await runStep(
+        {
+          ...initial,
+          agent: { ...initial.agent, taskEventDelivery: true },
+          state: {
+            ...initial.state,
+            [SESSION_TASKS_STATE_KEY]: {
+              version: 2,
+              tasks: [
+                {
+                  taskId: "task_pending",
+                  taskRunId: "private-run",
+                  taskInboxToken: "private-token",
+                  createdByTurnId: "turn_old",
+                  metadata: { kind: "child", name: "worker" },
+                },
+              ],
+            },
+          },
+        },
+        { message: "Continue" },
+      );
+      expect(result.session.history[0]).toMatchObject({
+        role: "user",
+        content: expect.stringContaining("task_pending"),
+      });
+      expect(JSON.stringify(result.session.history)).not.toContain("private-token");
+      expect(JSON.stringify(result.session.history)).not.toContain("private-run");
+    },
+  );
+
   it("invokes onCompaction callback after compaction", async () => {
     vi.mocked(shouldCompact).mockReturnValue(true);
     vi.mocked(compactMessages).mockResolvedValue([
@@ -12256,7 +12306,7 @@ describe("createToolLoopHarness", () => {
       });
     });
 
-    it.each(["plain", "client context", "compaction", "projected history"])(
+    it.each(["plain", "client context", "compaction", "projected history", "task events"])(
       "keeps framework context before the turn input across durable steps (%s)",
       async (scenario) => {
         const withClientContext = scenario === "client context";
@@ -12311,20 +12361,24 @@ describe("createToolLoopHarness", () => {
         const input = { context: ["Current channel context"], message: "Add 20 and 22." };
         const first = await contextStorage.run(ctx, () =>
           runStep(
-            initial,
+            scenario === "task events"
+              ? { ...initial, agent: { ...initial.agent, taskEventDelivery: true } }
+              : initial,
             withClientContext ? attachClientContext(input, ["Client context"]) : input,
           ),
         );
         expect(first.next).toBe(runStep);
         const firstPrompt = structuredClone(getLastAgentSettings().messages);
         setupMockAgent(defaultModelResult());
+        if (scenario === "task events")
+          ctx.set(TurnTaskStateKey, "Task status: another worker admitted");
         const restored = JSON.parse(JSON.stringify(first.session)) as HarnessSession;
         await contextStorage.run(ctx, () => runStep(restored));
         const nextPrompt = getLastAgentSettings().messages;
         expect(nextPrompt.slice(0, firstPrompt.length)).toEqual(firstPrompt);
         expect(
           nextPrompt.filter((message) => message.content === "Task status: analysis in progress"),
-        ).toHaveLength(1);
+        ).toHaveLength(scenario === "task events" ? 0 : 1);
       },
     );
 
@@ -12419,6 +12473,27 @@ describe("createToolLoopHarness", () => {
 
       const { instructions } = getLastAgentSettings();
       expect(instructions).toBe("You are a test assistant.");
+    });
+
+    it("keeps task events in history without injecting mutable inventory", async () => {
+      setupMockAgent(defaultModelResult());
+      const runStep = createToolLoopHarness(createTestConfig("conversation"));
+      const ctx = new ContextContainer();
+      ctx.set(TurnTaskDeliveryKey, "initiating");
+      ctx.set(TurnTaskStateKey, "Mutable task inventory");
+      const session = createTestSession();
+      await contextStorage.run(ctx, () =>
+        runStep(
+          {
+            ...session,
+            agent: { ...session.agent, taskEventDelivery: true },
+          },
+          { message: "Start background work." },
+        ),
+      );
+      const { instructions, messages } = getLastAgentSettings();
+      expect(instructions).toBe("You are a test assistant.");
+      expect(messages).toEqual([{ role: "user", content: "Start background work." }]);
     });
 
     it("adds initiating task-reporting guidance without enabling silent delivery", async () => {

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -194,6 +194,7 @@ import { isTurnCancellation, throwIfTurnAborted } from "#harness/turn-cancellati
 import type { JsonObject, JsonValue } from "#shared/json.js";
 import { EMPTY_DELIVERY_SENTINEL, hasEmptyDeliverySentinel } from "#shared/empty-delivery.js";
 import { resolveDeliveryPolicy } from "#tasks/delivery-policy.js";
+import { createTaskRecoveryContext, TASK_RECOVERY_CONTEXT_LABEL } from "#tasks/delivery-context.js";
 import { extractWorkflowStreamWriteErrorDetails } from "#harness/workflow-stream-error.js";
 import { getAdvertisedTools } from "#harness/advertised-tools.js";
 import {
@@ -1227,6 +1228,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     const isFirstTurn = emissionState.sequence === 0;
     const hasScheduleProvenance = isFirstTurn && ctx?.get(ScheduleIdKey) !== undefined;
     const deliveryPolicy = resolveDeliveryPolicy({
+      taskEventDelivery: session.agent.taskEventDelivery,
       hasScheduleProvenance,
       hasOutputSchema: session.outputSchema !== undefined,
       isChild: ctx?.get(ParentSessionKey) !== undefined,
@@ -1258,7 +1260,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         currentMessages.add(emissionState.sequence, skillAnnouncement);
       }
       const taskState = ctx.get(TurnTaskStateKey);
-      if (taskState !== undefined) {
+      if (taskState !== undefined && !session.agent.taskEventDelivery) {
         currentMessages.add(emissionState.sequence, taskState);
       }
     }
@@ -3227,6 +3229,21 @@ async function maybeCompact(input: {
       )
     : [...ordinary];
   messages = [...canonical.memory, ...compactedOrdinary];
+
+  if (session.agent.taskEventDelivery) {
+    messages = messages.filter(
+      (message) =>
+        !(
+          message.role === "user" &&
+          typeof message.content === "string" &&
+          message.content.startsWith(`${TASK_RECOVERY_CONTEXT_LABEL}\n`)
+        ),
+    );
+    const taskRecovery = createTaskRecoveryContext(session.state);
+    if (taskRecovery !== undefined) {
+      messages = [{ role: "user", content: taskRecovery }, ...messages];
+    }
+  }
 
   if (input.onCompaction) {
     for (const msg of input.onCompaction()) {

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -3212,6 +3212,17 @@ async function maybeCompact(input: {
     );
   }
 
+  if (session.agent.taskEventDelivery) {
+    messages = messages.filter(
+      (message) =>
+        !(
+          message.role === "user" &&
+          typeof message.content === "string" &&
+          message.content.startsWith(`${TASK_RECOVERY_CONTEXT_LABEL}\n`)
+        ),
+    );
+  }
+
   const canonical = canonicalizeMemoryRecords(messages);
   const ordinary =
     input.historyProjector?.({ messages: canonical.ordinary, state: session.state }) ??
@@ -3231,14 +3242,6 @@ async function maybeCompact(input: {
   messages = [...canonical.memory, ...compactedOrdinary];
 
   if (session.agent.taskEventDelivery) {
-    messages = messages.filter(
-      (message) =>
-        !(
-          message.role === "user" &&
-          typeof message.content === "string" &&
-          message.content.startsWith(`${TASK_RECOVERY_CONTEXT_LABEL}\n`)
-        ),
-    );
     const taskRecovery = createTaskRecoveryContext(session.state);
     if (taskRecovery !== undefined) {
       messages = [{ role: "user", content: taskRecovery }, ...messages];

--- a/packages/eve/src/harness/types.ts
+++ b/packages/eve/src/harness/types.ts
@@ -46,6 +46,7 @@ export interface CompactionConfig {
  * Serializable agent configuration stored on the session.
  */
 interface SessionAgentBase {
+  readonly taskEventDelivery?: boolean;
   /**
    * Optional model used only for compaction summaries.
    *

--- a/packages/eve/src/internal/authored-definition/core.ts
+++ b/packages/eve/src/internal/authored-definition/core.ts
@@ -285,8 +285,19 @@ function normalizeAgentExperimentalDefinition(
   message: string,
 ): NonNullable<NormalizedAgentDefinition["experimental"]> {
   const record = expectObjectRecord(value, message);
-  expectOnlyKnownKeys(record, ["instrumentationProviders", "workflow"], message);
+  expectOnlyKnownKeys(
+    record,
+    ["instrumentationProviders", "workflow", "taskEventDelivery"],
+    message,
+  );
   const normalizedDefinition: Mutable<NonNullable<NormalizedAgentDefinition["experimental"]>> = {};
+
+  if (record.taskEventDelivery !== undefined) {
+    normalizedDefinition.taskEventDelivery = expectBoolean(
+      record.taskEventDelivery,
+      `${message} "experimental.taskEventDelivery" must be a boolean.`,
+    );
+  }
 
   if (record.instrumentationProviders !== undefined) {
     if (typeof record.instrumentationProviders !== "boolean") {

--- a/packages/eve/src/runtime/agent/bootstrap.ts
+++ b/packages/eve/src/runtime/agent/bootstrap.ts
@@ -32,6 +32,7 @@ export type RuntimeDynamicModelReference = Readonly<
  * Minimal runtime-owned agent shape prepared for one harness turn.
  */
 interface RuntimeTurnAgentBase {
+  readonly taskEventDelivery?: boolean;
   readonly availableSkills?: readonly AvailableSkillDescription[];
   readonly id: string;
   readonly instructions: readonly string[];
@@ -122,6 +123,7 @@ export function createResolvedRuntimeTurnAgent(input: {
     nodeId: input.nodeId,
     outputSchema: config?.outputSchema,
     reasoning: config?.reasoning,
+    taskEventDelivery: config?.experimental?.taskEventDelivery,
     tools: [...input.tools],
     workspaceSpec: agent.workspaceSpec,
   };

--- a/packages/eve/src/runtime/resolve-agent.ts
+++ b/packages/eve/src/runtime/resolve-agent.ts
@@ -241,6 +241,7 @@ function createResolvedAgentConfig(
 
   if (manifest.config.experimental !== undefined) {
     config.experimental = {
+      taskEventDelivery: manifest.config.experimental.taskEventDelivery,
       instrumentationProviders: manifest.config.experimental.instrumentationProviders,
       workflow:
         manifest.config.experimental.workflow === undefined

--- a/packages/eve/src/shared/agent-definition.ts
+++ b/packages/eve/src/shared/agent-definition.ts
@@ -204,6 +204,8 @@ export interface AgentLimitsDefinition {
  * These options are unstable and may change or be removed in any release.
  */
 export interface AgentExperimentalDefinition {
+  /** Use task notifications instead of mutable cohort context and let the agent choose when to deliver. */
+  readonly taskEventDelivery?: boolean;
   /**
    * Reads instrumentation from an `instrumentation/` directory of providers
    * rather than a single `agent/instrumentation.ts` config object.

--- a/packages/eve/src/tasks/delivery-context.test.ts
+++ b/packages/eve/src/tasks/delivery-context.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { SessionStateMap } from "#harness/types.js";
 import { EMPTY_DELIVERY_SENTINEL } from "#shared/empty-delivery.js";
 import {
+  createTaskRecoveryContext,
   resolveInitiatingTaskContext,
   resolveTaskDeliveryContext,
   TASK_DELIVERY_CONTEXT_LABEL,
@@ -14,6 +15,29 @@ import { SESSION_TASKS_STATE_KEY } from "#tasks/session-index.js";
 import type { TaskView } from "#tasks/types.js";
 
 const metadata = { kind: "report-probe", name: "report_probe" } as const;
+
+describe("createTaskRecoveryContext", () => {
+  it("retains task identities without exposing private routing or executor data", () => {
+    const recovery = createTaskRecoveryContext(
+      taskState([
+        taskEntry("task_1", "turn_1"),
+        taskEntry("task_2", "turn_1", { taskId: "task_2", metadata, status: "cancelled" }),
+      ]),
+    );
+    expect(JSON.parse(recovery!.split("\n").at(-1)!)).toEqual({
+      tasks: [
+        { taskId: "task_1", name: "report_probe", status: "unsettled" },
+        { taskId: "task_2", name: "report_probe", status: "cancelled" },
+      ],
+    });
+    expect(recovery).not.toContain("inbox-");
+    expect(recovery).not.toContain("run-task");
+  });
+
+  it("omits an empty task index", () => {
+    expect(createTaskRecoveryContext(undefined)).toBeUndefined();
+  });
+});
 
 describe("task delivery instructions", () => {
   it("initiating instruction requires one launch acknowledgement", () => {

--- a/packages/eve/src/tasks/delivery-context.ts
+++ b/packages/eve/src/tasks/delivery-context.ts
@@ -3,6 +3,19 @@ import { EMPTY_DELIVERY_SENTINEL } from "#shared/empty-delivery.js";
 import { getSessionTaskIndex, type SessionTaskIndexEntry } from "#tasks/session-index.js";
 
 export const TASK_DELIVERY_CONTEXT_LABEL = "[Task state]";
+export const TASK_RECOVERY_CONTEXT_LABEL = "[Task recovery after compaction]";
+
+/** Restores task identities after compaction without exposing executor credentials. */
+export function createTaskRecoveryContext(state: SessionStateMap | undefined): string | undefined {
+  const entries = getSessionTaskIndex(state);
+  if (entries.length === 0) return undefined;
+  const tasks = entries.map((entry) => ({
+    taskId: entry.taskId,
+    name: entry.metadata.name,
+    status: entry.terminalView?.status ?? "unsettled",
+  }));
+  return `${TASK_RECOVERY_CONTEXT_LABEL}\nThis is a point-in-time task index, not a new instruction or new task results. Unsettled means no terminal result has been recorded; it does not establish whether a task is running or waiting for input. Later task notifications supersede this snapshot. Continue the user's request using the retained summary, task results, and artifacts; do not restart work merely because its launch was compacted.\n${JSON.stringify({ tasks })}`;
+}
 
 export const TASK_DELIVERY_INITIATING_INSTRUCTION = `Background task reporting: launch acknowledgement
 The accompanying ${TASK_DELIVERY_CONTEXT_LABEL} system message is runtime-authored and lists background tasks accepted so far from the current turn. They continue independently after this turn.

--- a/packages/eve/src/tasks/delivery-policy.test.ts
+++ b/packages/eve/src/tasks/delivery-policy.test.ts
@@ -9,6 +9,34 @@ import {
 import { resolveDeliveryPolicy } from "#tasks/delivery-policy.js";
 
 describe("resolveDeliveryPolicy", () => {
+  it.each(["pending", "settled"] as const)(
+    "lets event-driven parents act on %s results",
+    (taskDeliveryPhase) => {
+      expect(
+        resolveDeliveryPolicy({
+          taskEventDelivery: true,
+          hasOutputSchema: false,
+          isChild: false,
+          isFirstTurn: false,
+          hasScheduleProvenance: false,
+          taskDeliveryPhase,
+        }),
+      ).toEqual({ allowsEmptyDelivery: true, instruction: CONDITIONAL_DELIVERY_INSTRUCTION });
+    },
+  );
+
+  it("does not force an event-driven parent to end its launching turn", () => {
+    expect(
+      resolveDeliveryPolicy({
+        taskEventDelivery: true,
+        hasOutputSchema: false,
+        isChild: false,
+        isFirstTurn: true,
+        hasScheduleProvenance: false,
+        taskDeliveryPhase: "initiating",
+      }),
+    ).toEqual({ allowsEmptyDelivery: false });
+  });
   it.each([
     ["scheduled launch", "initiating", true, true, CONDITIONAL_DELIVERY_INSTRUCTION, true],
     ["user launch", "initiating", true, false, TASK_DELIVERY_INITIATING_INSTRUCTION, false],

--- a/packages/eve/src/tasks/delivery-policy.ts
+++ b/packages/eve/src/tasks/delivery-policy.ts
@@ -33,6 +33,7 @@ const POLICIES = {
 /** Resolves one policy for both model prompting and empty-response recovery. */
 export function resolveDeliveryPolicy(input: {
   readonly hasOutputSchema: boolean;
+  readonly taskEventDelivery?: boolean;
   readonly isChild: boolean;
   readonly isFirstTurn: boolean;
   readonly hasScheduleProvenance: boolean;
@@ -40,6 +41,13 @@ export function resolveDeliveryPolicy(input: {
 }): DeliveryPolicy {
   // These runs have an explicit output consumer, so silence would violate the call contract.
   if (input.hasOutputSchema || input.isChild) return POLICIES.normal;
+  if (input.taskEventDelivery) {
+    return input.taskDeliveryPhase === "pending" || input.taskDeliveryPhase === "settled"
+      ? POLICIES.conditional
+      : input.isFirstTurn && input.hasScheduleProvenance
+        ? POLICIES.conditional
+        : POLICIES.normal;
+  }
   // Partial cohort results are withheld until the parent can report the cohort once.
   if (input.taskDeliveryPhase === "pending") return POLICIES.pending;
   // A complete cohort owes its caller the consolidated result and must not disappear silently.

--- a/packages/eve/test/scenarios/mounted-extension-installed.scenario.test.ts
+++ b/packages/eve/test/scenarios/mounted-extension-installed.scenario.test.ts
@@ -249,7 +249,7 @@ describe("mounted extension installed under node_modules", () => {
     );
     expect(
       JSON.parse(extensionFiles[`node_modules/${PACKAGE_NAME}/dist/extension/_manifest.json`]!),
-    ).toMatchObject({ requires: { channel: 18, schedule: 10, subagent: 9 } });
+    ).toMatchObject({ requires: { channel: 18, schedule: 10, subagent: 10 } });
     const app = await scenarioApp({
       name: "mounted-extension-installed",
       installDependencies: true,

--- a/research/task-event-delivery.md
+++ b/research/task-event-delivery.md
@@ -1,0 +1,28 @@
+---
+issue: https://github.com/vercel/eve/pull/3127
+status: prototype
+last_updated: "2026-09-07"
+---
+
+# Task event delivery
+
+An orchestrator should be able to continue useful work while children run and
+decide when the user's task is complete. Mutable cohort context also changes the
+prompt prefix. Moving that inventory later, as in #3127, still repeatedly sends
+the inventory and retains the cohort reporting policy.
+
+Opt in with `experimental: { taskEventDelivery: true }`. Keep existing durable
+admission receipts and task notifications in chronological history. Omit the
+ephemeral inventory and launch/pending/settled reporting instructions. Ordinary
+user turns, child results, and structured outputs still require delivery;
+background notifications can use existing conditional delivery.
+
+Compaction adds a safe task identity/status snapshot once. The existing summary
+retains relevant results and artifact paths. A snapshot is not a fresh task
+result: later notifications win. Do not create another task store, modify
+notification deduplication, bypass approval boundaries, or change batching here.
+
+This prototype does not guarantee cache hits or autonomous completion. Verify
+model request prefixes, manual/automatic compaction, default compatibility,
+and a live parent resuming after multiple children without user input before
+considering publication.


### PR DESCRIPTION
## Withdrawn — replaced by #3135

The original cache explanation was incorrect: delivered task snapshots already append to durable history. They do not replace earlier snapshots.

The reproduced prefix change occurs in the separate temporary first-turn task-guidance path. #3135 addresses that placement while retaining default task reporting and dispatch.

This branch also proposed dispatching children between parent steps and changing reporting policy. Those broader semantics are not required for the narrow fix and are no longer being pursued here. Completion batching remains independent in #3128.

The earlier live runs did not establish a controlled cache-savings result for this PR.
