### PR TITLE
feat(eve): add interactive channel sender auth

### DIFF
--- a/.changeset/tidy-cats-sign-in.md
+++ b/.changeset/tidy-cats-sign-in.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add durable Slack and eve channel sender authentication with ordered auth strategies and interactive sign-in that parks messages before model or tool execution.

--- a/apps/frameworks/README.md
+++ b/apps/frameworks/README.md
@@ -3,6 +3,7 @@
 These apps verify eve's frontend framework integrations and act as runnable examples for maintainers.
 
 - `framework-next` covers `eve/next` and `withEve()`.
+- `framework-next-interactive-auth` combines `withEve()`, eve and Slack sender auth, and a Next.js callback form.
 - `framework-next-multi-agent` covers `withEve({ agents })` and named `useEveAgent({ agent })` calls.
 - `framework-nuxt` covers the `eve/nuxt` module.
 - `framework-sveltekit` covers the `eve/sveltekit` Vite plugin.

--- a/apps/frameworks/next-interactive-auth/.gitignore
+++ b/apps/frameworks/next-interactive-auth/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+.eve
+.output
+.vercel
+*.tsbuildinfo
+.env*

--- a/apps/frameworks/next-interactive-auth/README.md
+++ b/apps/frameworks/next-interactive-auth/README.md
@@ -1,0 +1,34 @@
+# Next.js interactive channel auth example
+
+This app exercises durable sender authentication from both the eve HTTP channel and Slack with one Next.js sign-in page. When either channel receives a message from an unknown sender, eve parks the accepted message before model or tool execution. The channel sends the user to `/sign-in`; submitting a name and email completes the callback, installs the email as `principalId`, and resumes the original message.
+
+The chat UI on `/` uses `useEveAgent()` and renders the default `authorization` message part as a sign-in link. It keeps streaming after the callback. Slack delivers the same challenge privately with its default authorization handler.
+
+## Configure the app
+
+The browser test only needs the public origin that serves the Next.js app:
+
+```sh
+AUTH_FORM_ORIGIN=http://localhost:3003
+```
+
+To test Slack too, also set its credentials:
+
+```sh
+SLACK_BOT_TOKEN=xoxb-your-token
+SLACK_SIGNING_SECRET=your-signing-secret
+```
+
+Configure the Slack app's event and interaction request URLs as `https://your-public-app.example/eve/v1/slack`. Subscribe to `app_mention`; add `message.im` and the `im:history` scope to test DMs. See the [Slack channel setup](../../../docs/channels/slack.mdx#manage-slack-credentials-yourself) for the complete app and scope configuration.
+
+`AUTH_FORM_ORIGIN` must be the origin that serves the Next.js app. `http://localhost:3003` works for the browser test. For Slack, expose the app through a tunnel and use that public HTTPS origin instead.
+
+## Run the example
+
+```sh
+AUTH_FORM_ORIGIN=http://localhost:3003 pnpm --filter framework-next-interactive-auth dev
+```
+
+Open the app and send a message, or mention or DM the bot in Slack. Open the sign-in link, submit the form, and return to the original channel. The `whoami` tool reads `ctx.session.auth.current`, allowing the agent to confirm that the completed form became the session auth context.
+
+This app is for local and preview testing. The form does not verify email ownership, its eve stream route is intentionally readable for browser testing, and its bounded in-memory sender mapping is lost on restart or a serverless cold start. Replace these test shortcuts with application route auth, a verified sign-in flow, and a durable account store before using this pattern in production.

--- a/apps/frameworks/next-interactive-auth/agent/agent.ts
+++ b/apps/frameworks/next-interactive-auth/agent/agent.ts
@@ -1,0 +1,5 @@
+import { defineAgent } from "eve";
+
+export default defineAgent({
+  model: "openai/gpt-5.6-luna-fast",
+});

--- a/apps/frameworks/next-interactive-auth/agent/auth/required-sign-in.ts
+++ b/apps/frameworks/next-interactive-auth/agent/auth/required-sign-in.ts
@@ -1,0 +1,78 @@
+import type { AuthInteractionRequired } from "eve/channels/auth";
+import type { SessionAuthContext } from "eve/context";
+
+const MAX_LOCAL_SESSIONS = 1_000;
+const signedInUsers = new Map<string, SessionAuthContext>();
+
+type SignInResume = {
+  senderKey: string;
+};
+
+function authFormOrigin(): string {
+  const value = process.env.AUTH_FORM_ORIGIN;
+  if (value === undefined || value.length === 0) {
+    throw new Error("AUTH_FORM_ORIGIN must be set to the public origin of the Next.js app.");
+  }
+  const url = new URL(value);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("AUTH_FORM_ORIGIN must use http or https.");
+  }
+  return url.origin;
+}
+
+export function requiredSignIn(
+  senderKey: string,
+): SessionAuthContext | AuthInteractionRequired<SignInResume> {
+  const signedIn = signedInUsers.get(senderKey);
+  if (signedIn !== undefined) return signedIn;
+
+  return {
+    interaction: "required",
+    async startAuthorization({ callbackUrl }) {
+      const url = new URL("/sign-in", authFormOrigin());
+      url.searchParams.set("callbackUrl", callbackUrl);
+      return {
+        challenge: {
+          displayName: "Example profile",
+          instructions: "Enter your name and email to continue this message.",
+          url: url.toString(),
+        },
+        resume: { senderKey },
+      };
+    },
+    async completeAuthorization({ callback, resume }) {
+      if (resume === undefined || typeof resume.senderKey !== "string") {
+        throw new Error("The interactive sign-in state is missing.");
+      }
+
+      const email = callback.params.email?.trim().toLowerCase();
+      const name = callback.params.name?.trim();
+      if (
+        email === undefined ||
+        email.length > 320 ||
+        !email.includes("@") ||
+        name === undefined ||
+        name.length === 0 ||
+        name.length > 100
+      ) {
+        throw new Error("A valid email and a name of at most 100 characters are required.");
+      }
+
+      const auth: SessionAuthContext = {
+        attributes: { email, name },
+        authenticator: "example-profile-form",
+        issuer: authFormOrigin(),
+        principalId: email,
+        principalType: "user",
+        subject: email,
+      };
+
+      if (!signedInUsers.has(resume.senderKey) && signedInUsers.size >= MAX_LOCAL_SESSIONS) {
+        const oldest = signedInUsers.keys().next().value;
+        if (oldest !== undefined) signedInUsers.delete(oldest);
+      }
+      signedInUsers.set(resume.senderKey, auth);
+      return auth;
+    },
+  };
+}

--- a/apps/frameworks/next-interactive-auth/agent/channels/eve.ts
+++ b/apps/frameworks/next-interactive-auth/agent/channels/eve.ts
@@ -1,0 +1,25 @@
+import type { AuthFn } from "eve/channels/auth";
+import { eveChannel } from "eve/channels/eve";
+import type { SessionAuthContext } from "eve/context";
+import { requiredSignIn } from "../auth/required-sign-in";
+
+const publicReadAuth: SessionAuthContext = {
+  attributes: {},
+  authenticator: "interactive-auth-example",
+  principalId: "public-read",
+  principalType: "anonymous",
+};
+
+const interactiveProfileAuth: AuthFn<Request> = (request) => {
+  if (request.method === "GET") return publicReadAuth;
+
+  const pathname = new URL(request.url).pathname;
+  if (pathname === "/eve/v1/session" || /^\/eve\/v1\/session\/[^/]+$/.test(pathname)) {
+    return requiredSignIn("eve:test-browser");
+  }
+  return null;
+};
+
+export default eveChannel({
+  auth: interactiveProfileAuth,
+});

--- a/apps/frameworks/next-interactive-auth/agent/channels/slack.ts
+++ b/apps/frameworks/next-interactive-auth/agent/channels/slack.ts
@@ -1,0 +1,26 @@
+import type { AuthFn } from "eve/channels/auth";
+import { slackChannel, type SlackEvent } from "eve/channels/slack";
+import { requiredSignIn } from "../auth/required-sign-in";
+import { connectSlackCredentials } from "@vercel/connect/eve";
+
+function eventString(event: SlackEvent, key: string): string | undefined {
+  const value = event[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function senderKey(event: SlackEvent): string | null {
+  const userId = eventString(event, "user");
+  if (userId === undefined) return null;
+  return `${eventString(event, "team") ?? "unknown-workspace"}:${userId}`;
+}
+
+const interactiveProfileAuth: AuthFn<SlackEvent> = (event) => {
+  const key = senderKey(event);
+  if (key === null) return null;
+  return requiredSignIn(`slack:${key}`);
+};
+
+export default slackChannel({
+  credentials: connectSlackCredentials("slack/aap-v"),
+  auth: interactiveProfileAuth,
+});

--- a/apps/frameworks/next-interactive-auth/agent/instructions.md
+++ b/apps/frameworks/next-interactive-auth/agent/instructions.md
@@ -1,0 +1,3 @@
+You are an assistant used to test interactive channel sender authentication.
+
+Call the `whoami` tool before your first reply in each conversation. Greet the user by name and confirm the email address that eve installed in the session auth context.

--- a/apps/frameworks/next-interactive-auth/agent/tools/whoami.ts
+++ b/apps/frameworks/next-interactive-auth/agent/tools/whoami.ts
@@ -1,0 +1,10 @@
+import { defineTool } from "eve/tools";
+import { z } from "zod";
+
+export default defineTool({
+  description: "Return the identity installed by interactive sender authentication.",
+  inputSchema: z.object({}),
+  execute(_input, ctx) {
+    return ctx.session.auth.current;
+  },
+});

--- a/apps/frameworks/next-interactive-auth/app/Chat.tsx
+++ b/apps/frameworks/next-interactive-auth/app/Chat.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useEveAgent, type EveMessagePart } from "eve/react";
+import { useEffect, useRef, useState, type FormEvent } from "react";
+
+function AuthorizationPrompt({ part }: { readonly part: EveMessagePart }) {
+  if (part.type !== "authorization") return null;
+
+  if (part.state === "completed") {
+    return (
+      <p className="authorization-status">
+        {part.outcome === "authorized"
+          ? "Sign-in completed. Continuing your message…"
+          : `Sign-in ${part.outcome}.`}
+      </p>
+    );
+  }
+
+  return (
+    <section className="authorization-card">
+      <strong>{part.displayName}</strong>
+      <p>{part.description}</p>
+      {part.authorization?.userCode ? <code>{part.authorization.userCode}</code> : null}
+      {part.authorization?.url ? (
+        <a href={part.authorization.url} rel="noreferrer" target="_blank">
+          Sign in to continue
+        </a>
+      ) : null}
+    </section>
+  );
+}
+
+export function Chat() {
+  const agent = useEveAgent();
+  const [message, setMessage] = useState("");
+  const feedRef = useRef<HTMLDivElement | null>(null);
+  const isBusy = agent.status === "submitted" || agent.status === "streaming";
+  const isResuming = agent.status === "resuming";
+
+  useEffect(() => {
+    const feed = feedRef.current;
+    if (feed === null) return;
+    feed.scrollTo({ behavior: "smooth", top: feed.scrollHeight });
+  }, [agent.data.messages, agent.status]);
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const trimmed = message.trim();
+    if (trimmed.length === 0 || isBusy || isResuming) return;
+    setMessage("");
+    await agent.send(trimmed);
+  }
+
+  return (
+    <main className="chat-page">
+      <header className="chat-header">
+        <span>eve</span>
+        <button onClick={() => agent.reset()} type="button">
+          New chat
+        </button>
+      </header>
+
+      <div className="message-feed" ref={feedRef}>
+        {agent.data.messages.length === 0 ? (
+          <section className="empty-state">
+            <h1>How can I help?</h1>
+            <p>Send a message to start a conversation.</p>
+          </section>
+        ) : (
+          <div className="message-list">
+            {agent.data.messages.map((item) => (
+              <article className={`message message-${item.role}`} key={item.id}>
+                <div className="message-content">
+                  {item.parts.map((part, index) => {
+                    if (part.type === "text") {
+                      return <p key={index}>{part.text}</p>;
+                    }
+                    if (part.type === "authorization") {
+                      return <AuthorizationPrompt key={index} part={part} />;
+                    }
+                    return null;
+                  })}
+                </div>
+              </article>
+            ))}
+            {agent.status === "submitted" ? (
+              <article className="message message-assistant">
+                <div className="message-content pending">Thinking…</div>
+              </article>
+            ) : null}
+          </div>
+        )}
+      </div>
+
+      <form className="composer" onSubmit={submit}>
+        <label className="visually-hidden" htmlFor="message">
+          Message
+        </label>
+        <textarea
+          disabled={isBusy || isResuming}
+          id="message"
+          onChange={(event) => setMessage(event.currentTarget.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && !event.shiftKey) {
+              event.preventDefault();
+              event.currentTarget.form?.requestSubmit();
+            }
+          }}
+          placeholder="Message eve…"
+          rows={1}
+          value={message}
+        />
+        <button
+          aria-label="Send message"
+          disabled={isBusy || isResuming || message.trim().length === 0}
+          type="submit"
+        >
+          ↑
+        </button>
+        {agent.error !== undefined ? <p className="composer-error">{agent.error.message}</p> : null}
+      </form>
+    </main>
+  );
+}

--- a/apps/frameworks/next-interactive-auth/app/layout.tsx
+++ b/apps/frameworks/next-interactive-auth/app/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import "./styles.css";
+
+export const metadata: Metadata = {
+  description: "Chat with an eve agent using interactive sender authentication.",
+  title: "eve chat",
+};
+
+export default function RootLayout({ children }: Readonly<{ children: ReactNode }>) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/frameworks/next-interactive-auth/app/page.tsx
+++ b/apps/frameworks/next-interactive-auth/app/page.tsx
@@ -1,0 +1,5 @@
+import { Chat } from "./Chat";
+
+export default function Home() {
+  return <Chat />;
+}

--- a/apps/frameworks/next-interactive-auth/app/sign-in/page.tsx
+++ b/apps/frameworks/next-interactive-auth/app/sign-in/page.tsx
@@ -1,0 +1,62 @@
+type SignInPageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+function callbackUrl(value: string | string[] | undefined): string | null {
+  const configuredOrigin = process.env.AUTH_FORM_ORIGIN;
+  if (typeof value !== "string" || configuredOrigin === undefined) return null;
+  try {
+    const url = new URL(value);
+    const allowedOrigin = new URL(configuredOrigin).origin;
+    if (
+      (url.protocol !== "http:" && url.protocol !== "https:") ||
+      url.origin !== allowedOrigin ||
+      !url.pathname.startsWith("/eve/v1/connections/session-auth/callback/")
+    ) {
+      return null;
+    }
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+export default async function SignInPage({ searchParams }: SignInPageProps) {
+  const params = await searchParams;
+  const action = callbackUrl(params.callbackUrl);
+
+  return (
+    <main className="sign-in-shell">
+      <section className="sign-in-card">
+        <p className="eyebrow">Example profile</p>
+        <h1>Sign in to continue</h1>
+        {action === null ? (
+          <p className="error">
+            This sign-in link is invalid or incomplete. Request a new link from the agent.
+          </p>
+        ) : (
+          <form action={action} method="get">
+            <label htmlFor="name">Name</label>
+            <input autoComplete="name" id="name" name="name" maxLength={100} required />
+
+            <label htmlFor="email">Email</label>
+            <input
+              autoComplete="email"
+              id="email"
+              name="email"
+              type="email"
+              maxLength={320}
+              required
+            />
+
+            <button type="submit">Sign in and continue</button>
+          </form>
+        )}
+        <p className="note">
+          This test form does not verify ownership of the email address. Do not use it as production
+          authentication.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/apps/frameworks/next-interactive-auth/app/styles.css
+++ b/apps/frameworks/next-interactive-auth/app/styles.css
@@ -1,0 +1,301 @@
+:root {
+  color: #171717;
+  background: #f7f7f7;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+  margin: 0;
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+}
+
+button,
+a {
+  -webkit-tap-highlight-color: transparent;
+}
+
+.chat-page {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  height: 100vh;
+}
+
+.chat-header {
+  align-items: center;
+  border-bottom: 1px solid #e5e5e5;
+  display: flex;
+  justify-content: space-between;
+  padding: 14px 20px;
+}
+
+.chat-header span {
+  font-size: 18px;
+  font-weight: 650;
+  letter-spacing: -0.04em;
+}
+
+.chat-header button {
+  background: transparent;
+  border: 1px solid #d4d4d4;
+  border-radius: 8px;
+  color: inherit;
+  cursor: pointer;
+  padding: 7px 11px;
+}
+
+.message-feed {
+  min-height: 0;
+  overflow-y: auto;
+  padding: 28px 24px;
+}
+
+.empty-state {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: center;
+  text-align: center;
+}
+
+.empty-state h1 {
+  font-size: clamp(32px, 5vw, 48px);
+  font-weight: 550;
+  letter-spacing: -0.05em;
+  margin: 0;
+}
+
+.empty-state p {
+  color: #737373;
+  margin: 12px 0 0;
+}
+
+.message-list {
+  display: grid;
+  gap: 20px;
+  margin: 0 auto;
+  max-width: 760px;
+}
+
+.message {
+  display: flex;
+}
+
+.message-user {
+  justify-content: flex-end;
+}
+
+.message-content {
+  line-height: 1.6;
+  max-width: min(85%, 680px);
+}
+
+.message-content > p {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.message-content > p + p {
+  margin-top: 12px;
+}
+
+.message-user .message-content {
+  background: #171717;
+  border-radius: 16px;
+  color: #fff;
+  padding: 10px 15px;
+}
+
+.pending {
+  color: #737373;
+}
+
+.authorization-card {
+  background: #fff;
+  border: 1px solid #dedede;
+  border-radius: 14px;
+  padding: 18px;
+}
+
+.authorization-card p {
+  color: #525252;
+  margin: 6px 0 14px;
+}
+
+.authorization-card code {
+  display: block;
+  margin-bottom: 14px;
+}
+
+.authorization-card a {
+  background: #171717;
+  border-radius: 8px;
+  color: #fff;
+  display: inline-block;
+  font-weight: 600;
+  padding: 9px 13px;
+  text-decoration: none;
+}
+
+.authorization-status {
+  color: #287a3d;
+}
+
+.composer {
+  align-items: end;
+  background: #fff;
+  border: 1px solid #dedede;
+  border-radius: 18px;
+  box-shadow: 0 8px 30px rgb(0 0 0 / 7%);
+  display: grid;
+  gap: 10px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  margin: 0 auto 24px;
+  padding: 12px;
+  width: min(calc(100% - 32px), 720px);
+}
+
+.composer textarea {
+  background: transparent;
+  border: 0;
+  color: inherit;
+  line-height: 1.5;
+  max-height: 160px;
+  min-height: 28px;
+  outline: 0;
+  padding: 5px 4px;
+  resize: vertical;
+}
+
+.composer button {
+  background: #171717;
+  border: 0;
+  border-radius: 50%;
+  color: #fff;
+  cursor: pointer;
+  height: 34px;
+  width: 34px;
+}
+
+.composer button:disabled,
+.composer textarea:disabled {
+  cursor: default;
+  opacity: 0.4;
+}
+
+.composer-error {
+  color: #b42318;
+  font-size: 13px;
+  grid-column: 1 / -1;
+  margin: 0;
+}
+
+.visually-hidden {
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  clip: rect(0 0 0 0);
+}
+
+.sign-in-shell {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 24px;
+}
+
+.sign-in-card {
+  background: #fff;
+  border: 1px solid #dedede;
+  border-radius: 18px;
+  box-shadow: 0 20px 60px rgb(0 0 0 / 8%);
+  padding: 40px;
+  width: min(100%, 520px);
+}
+
+.eyebrow {
+  color: #666;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin: 0 0 10px;
+  text-transform: uppercase;
+}
+
+.sign-in-card h1 {
+  font-size: 38px;
+  letter-spacing: -0.04em;
+  margin: 0 0 16px;
+}
+
+.sign-in-card form {
+  display: grid;
+  gap: 8px;
+  margin-top: 28px;
+}
+
+.sign-in-card label {
+  font-weight: 650;
+  margin-top: 10px;
+}
+
+.sign-in-card input {
+  background: #fff;
+  border: 1px solid #b8b8b8;
+  border-radius: 8px;
+  color: inherit;
+  padding: 11px 13px;
+  width: 100%;
+}
+
+.sign-in-card button {
+  background: #171717;
+  border: 0;
+  border-radius: 8px;
+  color: #fff;
+  cursor: pointer;
+  font-weight: 650;
+  margin-top: 18px;
+  padding: 11px 16px;
+}
+
+.note,
+.error {
+  font-size: 14px;
+  margin: 24px 0 0;
+}
+
+.note {
+  color: #666;
+}
+
+.error {
+  color: #b42318;
+}
+
+@media (max-width: 560px) {
+  .message-feed {
+    padding: 20px 16px;
+  }
+
+  .sign-in-card {
+    padding: 28px 22px;
+  }
+}

--- a/apps/frameworks/next-interactive-auth/next-env.d.ts
+++ b/apps/frameworks/next-interactive-auth/next-env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/frameworks/next-interactive-auth/next.config.ts
+++ b/apps/frameworks/next-interactive-auth/next.config.ts
@@ -1,0 +1,6 @@
+import type { NextConfig } from "next";
+import { withEve } from "eve/next";
+
+const nextConfig: NextConfig = {};
+
+export default withEve(nextConfig);

--- a/apps/frameworks/next-interactive-auth/package.json
+++ b/apps/frameworks/next-interactive-auth/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "framework-next-interactive-auth",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "next build",
+    "dev": "next dev --port 3003",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@vercel/connect": "^2",
+    "eve": "workspace:*",
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/apps/frameworks/next-interactive-auth/tsconfig.json
+++ b/apps/frameworks/next-interactive-auth/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "incremental": true,
+    "jsx": "preserve",
+    "lib": ["dom", "dom.iterable", "es2024"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "resolveJsonModule": true,
+    "target": "es2024"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -140,10 +140,10 @@ Check the delivery path in order so you can identify where a Slack event stops:
 
 ### Message hooks
 
-Message hooks return `{ auth }` to dispatch, `null` to drop, or `{ auth, context }` to inject background into history. Public conversations use the returned `title`, or the triggering message text when `title` is omitted. DMs and private channels always use `Private message` so the run title does not expose message details.
+Message hooks return an object to dispatch, `null` to drop, or `{ context }` to inject background into history. Include `auth` only when the handler should supply the final sender identity itself. Public conversations use the returned `title`, or the triggering message text when `title` is omitted. DMs and private channels always use `Private message` so the run title does not expose message details.
 
 - `onMessage(ctx, message)` handles Slack `message` events. eve drops messages authored by the installed app before this hook runs, preventing self-reply loops. Messages from other bots remain visible; check `message.author?.isBot` when those should also be ignored. `ctx.isBotMentioned()` and `ctx.isSubscribed()` support mention and active-thread policies.
-- `onAppMention(ctx, message)` handles only `app_mention` and takes precedence over `onMessage`. Its default derives workspace-scoped auth and posts `Thinking…`.
+- `onAppMention(ctx, message)` handles only `app_mention` and takes precedence over `onMessage`. Its default posts `Thinking…`; the channel then resolves sender auth.
 - `onDirectMessage(ctx, message)` handles only DMs and takes precedence over `onMessage`. Bot-authored messages and edits are filtered first; Slack requires `message.im` and `im:history`.
 
 | Incoming event         | Handler order                                                       |
@@ -222,6 +222,48 @@ export default slackChannel({
 Override every enabled inbound handler; leaving `onDirectMessage` out would retain eve's default DM behavior. Apply the same policy in `onInputResponse` so someone who cannot start a turn cannot resume one through an eve-owned HITL control. Slack Connect can deliver events from external users, so authorize the explicit user and current conversation IDs your policy expects. If access depends on organization membership, resolve it from Slack's shared-channel and user data instead of inferring it from the request signature.
 
 Keep authorization checks inside sensitive tools too. The inbound allowlist controls who can start a turn; tool-level checks control what that authenticated Slack principal may read or change.
+
+#### Authenticate Slack senders
+
+Set `auth` on the Slack channel when an accepted message must resolve to an application identity before it reaches the model. The option accepts one `AuthFn<SlackEvent>` or an ordered array:
+
+- Return a `SessionAuthContext` to accept the sender and stop the walk.
+- Return `null` or `undefined` to continue to the next strategy.
+- Return `{ interaction: "required", ... }` to claim the message and start sign-in.
+
+```ts title="agent/channels/slack.ts"
+import { type AuthFn } from "eve/channels/auth";
+import { slackChannel, type SlackEvent } from "eve/channels/slack";
+
+const appAccount: AuthFn<SlackEvent> = async (event) => {
+  const session = await findAppSession(event);
+  if (session) return session.auth;
+
+  return {
+    interaction: "required",
+    startAuthorization: ({ callbackUrl }) => startAppSignIn({ callbackUrl, event }),
+    completeAuthorization: ({ callback, callbackUrl, resume }) =>
+      completeAppSignIn({ callback, callbackUrl, resume }),
+  };
+};
+
+export default slackChannel({
+  auth: [appAccount],
+});
+```
+
+`startAuthorization` returns `{ challenge, resume? }`. The challenge uses the same shape rendered for connection authorization, and `resume` must be JSON-serializable. eve journals the accepted message and `resume`, emits `authorization.required`, and parks the session before model or tool execution. When the callback arrives, eve runs the same strategy again and calls `completeAuthorization`; that callback must return the final `SessionAuthContext`. The default Slack authorization handlers deliver the sign-in challenge privately and resume the original message after success.
+
+This auth walk runs only after a message hook accepts a message. It does not replace Slack request-signature verification or the hook's allowlist checks. If the channel has no `auth` option, eve retains its built-in workspace-scoped Slack identity.
+
+A message hook can bypass the configured walk by returning an explicit `auth` property. This is a final override; `{ auth: null }` intentionally starts the turn without an authenticated sender. Omitting the property, as in `return {}`, uses the configured walk:
+
+```ts
+onAppMention(_ctx, message) {
+  if (isTrustedAutomation(message)) return { auth: automationAuth };
+  return {}; // resolve through slackChannel({ auth })
+},
+```
 
 `onInputResponse` runs after eve decodes a built-in HITL answer but before the parked session resumes. Return `{ auth }` to accept the answer. Returning `null` or throwing rejects it, leaves the request pending, and keeps the Slack controls active. `ctx.defaultAuth` identifies the Slack user who submitted the signed interaction; it does not authorize that user by itself.
 
@@ -416,7 +458,7 @@ Outbound text preserves bare `@` tokens as literal text. To mention a user, embe
 
 When a session starts without a `threadTs` (say, from a schedule's `to(slack, target).send(...)`), eve gives it a unique temporary continuation token. The first agent post anchors the session to the Slack message timestamp, and later posts and mentions resume that same session. Pass `initialMessage` with a `Card` to land a structured anchor first instead. `threadTs` and `initialMessage` are mutually exclusive.
 
-The example below overrides `onAppMention` to gate on an authored message and posts the completed reply to the thread. Event handlers receive `(eventData, channel, ctx)`, with Slack platform handles on `channel.thread` and `channel.slack`:
+The example below overrides `onAppMention` to gate on an authored message and posts the completed reply to the thread. Its explicit `auth` bypasses the channel-level auth resolver. Event handlers receive `(eventData, channel, ctx)`, with Slack platform handles on `channel.thread` and `channel.slack`:
 
 ```ts
 import { defaultSlackAuth, slackChannel } from "eve/channels/slack";
@@ -439,7 +481,7 @@ export default slackChannel({
 
 HITL renders as Slack buttons and selects. Fixed-choice actions and freeform modal submissions pass through `onInputResponse` before the parked session resumes. The initial **Type your answer** action only opens eve's modal; the hook runs when the user submits an answer.
 
-Authorization prompts split public status from private credentials. A sign-in challenge (OAuth URL, device code) is a credential. Anyone who completes it binds their identity to the session's connection. The default `authorization.required` handler posts a public, link-free status in the thread, delivers the actual challenge ephemerally to the triggering user, device code included, and then updates that public status when `authorization.completed` fires. The handler receives a private-delivery context with `postEphemeral`, `postDirectMessage` (needs the `im:write` scope), and `state`. There is, intentionally, no public `post` and no raw API access.
+Authorization prompts split public status from private credentials. A sign-in challenge (OAuth URL, device code) is a credential. Anyone who completes a connection challenge binds their identity to that session connection; a sender-auth challenge sets the session's current identity. The default `authorization.required` handler posts a public, link-free status in the thread, delivers the actual challenge ephemerally to the triggering user, device code included, and then updates that public status when `authorization.completed` fires. The handler receives a private-delivery context with `postEphemeral`, `postDirectMessage` (needs the `im:write` scope), and `state`. There is, intentionally, no public `post` and no raw API access. Check `eventData.purpose === "session"` when an override needs different copy for sender sign-in; an absent purpose is connection authorization.
 
 ```ts
 events: {

--- a/docs/guides/auth-and-route-protection.md
+++ b/docs/guides/auth-and-route-protection.md
@@ -1,11 +1,12 @@
 ---
 title: "Authentication"
-description: "Secure your agent's HTTP routes with an ordered auth walk, verifier helpers, and connection OAuth via Vercel Connect."
+description: "Secure HTTP routes, resolve channel senders, and authorize outbound tools and connections."
 ---
 
-eve has two independent auth systems:
+eve has three auth boundaries:
 
 - **Route auth** (inbound) decides who can reach your agent's HTTP routes. It runs at the channel layer, gating the request before any model work runs.
+- **Channel sender auth** (inbound) resolves the person represented by an accepted platform message. A durable channel can pause that message for sign-in before any model or tool work runs.
 - **Tool and connection auth** (outbound) is how your agent signs in to an external service it calls, like an OAuth MCP server. It happens later, when a tool or connection actually reaches out.
 
 Start with route auth.
@@ -36,10 +37,11 @@ export default eveChannel({
 
 ## The ordered auth walk
 
-`auth` takes a single `AuthFn` or an array that eve walks in order. Each entry has three possible outcomes:
+`auth` takes a single `AuthFn` or an array that eve walks in order. Each entry has four possible outcomes:
 
 - returns a `SessionAuthContext`: accept the request and stop the walk
 - returns `null` / `undefined`: skip to the next entry
+- returns `{ interaction: "required", ... }`: on an eve create or message request, accept and park the input for sign-in
 - **throws**: reject with a specific status
 
 If every entry skips, the request gets a `401` whose `WWW-Authenticate` header advertises the challenge scheme(s) the configured entries declare — `Basic` for `httpBasic()`, `Bearer` for the token-based helpers (`jwtHmac`, `jwtEcdsa`, `oidc`, `vercelOidc`), both when you mix them, and `Bearer` as a fallback for entries that don't declare a scheme (custom `AuthFn`s, or an empty array). See [`withAuthChallenges`](#custom-verifiers) to declare a scheme on a custom `AuthFn`.
@@ -82,6 +84,36 @@ throw new ForbiddenError({ message: "Not allowed on this workspace." }); // 403
 ```
 
 Any other thrown error follows the normal channel failure path. When building a custom channel on `defineChannel`, call `routeAuth(request, auth)` from `eve/channels/auth` to reuse the same walk semantics.
+
+### Interactive eve channel auth
+
+An eve create or follow-up message can pause for sign-in before model or tool execution. Return an `AuthInteractionRequired` result from the `AuthFn<Request>` that handles those two POST routes:
+
+```ts title="agent/channels/eve.ts"
+import { type AuthFn } from "eve/channels/auth";
+import { eveChannel } from "eve/channels/eve";
+import { readAppSession, requiredSignIn, transportSession } from "@/lib/auth";
+
+const appAuth: AuthFn<Request> = async (request) => {
+  const url = new URL(request.url);
+  const isMessage =
+    request.method === "POST" &&
+    (url.pathname === "/eve/v1/session" || /^\/eve\/v1\/session\/[^/]+$/.test(url.pathname));
+
+  if (!isMessage) return transportSession(request);
+
+  const session = await readAppSession(request);
+  return session?.auth ?? requiredSignIn();
+};
+
+export default eveChannel({ auth: appAuth });
+```
+
+eve creates or attaches the durable session, stores the message, emits `authorization.required`, and parks before dynamic capabilities, the model, or tools run. After the callback, `completeAuthorization` supplies `SessionAuthContext` and eve resumes the stored message. `onMessage` may return an explicit `auth` property as a final override; `{ auth: null }` bypasses the configured walk, while `{}` preserves it.
+
+The same `auth` function still protects the info, stream, and control routes. Those routes cannot park, so they need an immediate `SessionAuthContext` or a fallthrough to another accepting strategy. A browser commonly uses an application session for route access while requiring a stronger account mapping for message POSTs.
+
+Only the selected strategy index and a scrubbed request descriptor cross into the durable workflow. eve removes headers, cookies, credentials, query parameters, and the body. The strategy must recreate the same interactive result from stable application configuration; carry callback-specific JSON state through `startAuthorization`'s `resume` result. Interactive eve auth is not accepted for `operationId`, forwarded-principal, delegated callback, or `inputResponses` requests because those operations require an identity at the HTTP boundary.
 
 ## Verifier helpers
 
@@ -262,6 +294,16 @@ Use the principal on `auth.current` (or `auth.initiator`) to scope tools, resolv
 
 Route auth does not enforce session ownership. If multiple users or tenants can reach the same route, you must implement the per-user, per-tenant, or per-session authorization your application requires.
 
+## Channel sender auth
+
+Route auth proves that a request may reach a channel; sender auth decides which person an accepted message represents. Slack mentions and DMs resolve a workspace-scoped Slack user by default. The eve channel can turn an interactive result from its message-route auth walk into sender auth. Set `auth` on either channel when the sender must map to an application account or complete sign-in first.
+
+Slack walks one `AuthFn<SlackEvent>` or an array in order. A strategy can return a `SessionAuthContext`, return `null` or `undefined` to try the next strategy, or return `{ interaction: "required", ... }` to claim the message and begin interactive sign-in. eve stores the accepted input, emits `authorization.required`, and parks the session before creating a model execution. After the callback, `completeAuthorization` returns the final `SessionAuthContext`; eve installs it and resumes the stored input.
+
+Message hooks still own admission. Returning `null` from `onAppMention`, `onDirectMessage`, or `onMessage` drops the message. Returning an object with an explicit `auth` property is a final override—even `{ auth: null }`—and bypasses the configured sender-auth walk. See [Authenticate Slack senders](../channels/slack#authenticate-slack-senders) for the API and an example.
+
+`routeAuth(...)` still rejects `AuthInteractionRequired` because a generic HTTP route has no durable input to park. `eveChannel(...)` handles the result specially on its create and follow-up message routes and hands the accepted input to the shared durable sender-auth gate.
+
 ## Tool and connection auth
 
 Tool and connection auth is how your agent reaches an external service that wants an interactive sign-in, like an OAuth MCP server. Connections declare `auth` on the connection definition. Tools should resolve providers inline with `ctx.getToken(provider)` and call `ctx.requireAuth(provider)` only when a downstream service rejects a token; eve drives the sign-in, caches the token per step, and re-runs the call once the caller authorizes.
@@ -311,7 +353,7 @@ export default eveChannel({
 
 Keep `principalId` stable for the same person, and include an `issuer` when the same app may accept users from multiple identity providers. The connection token cache keys user credentials by issuer and principal id so two providers cannot accidentally share a grant.
 
-Built-in platform channels that identify a human sender, such as Slack, Discord, Teams, Telegram, Twilio, Linear, and GitHub, attach a user principal for that sender by default. A Slack mention, DM, or button click can therefore authorize a user-scoped connection for the Slack user who sent it without adding a separate browser-session auth function.
+Built-in platform channels that identify a human sender attach a user principal for that sender by default. A Slack mention or DM can therefore authorize a user-scoped connection for the Slack user who sent it without adding a separate application sign-in. Configure Slack sender auth when that platform identity must resolve to a different principal.
 
 ### On a connection
 

--- a/packages/eve/extension-contracts/compatibility/channel/v18.ts
+++ b/packages/eve/extension-contracts/compatibility/channel/v18.ts
@@ -1,0 +1,10 @@
+import { defineChannel, POST } from "#public/channels/index.js";
+
+export default defineChannel({
+  routes: [
+    POST("/continue/:sessionId", async (_request, { attachSession, params }) => {
+      const result = await attachSession(params.sessionId!).send("Continue.", { auth: null });
+      return Response.json({ accepted: result.status === "accepted" });
+    }),
+  ],
+});

--- a/packages/eve/extension-contracts/compatibility/connection/v14.ts
+++ b/packages/eve/extension-contracts/compatibility/connection/v14.ts
@@ -1,0 +1,6 @@
+import { defineMcpClientConnection } from "#public/connections/index.js";
+
+export default defineMcpClientConnection({
+  description: "Call-aware MCP service",
+  url: "https://example.com/mcp",
+});

--- a/packages/eve/extension-contracts/compatibility/dynamicInstructions/v17.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicInstructions/v17.ts
@@ -1,0 +1,8 @@
+import { defineDynamic, defineInstructions } from "#public/instructions/index.js";
+
+export default defineDynamic({
+  events: {
+    "session.started": (_event, ctx) =>
+      defineInstructions({ markdown: `Use session ${ctx.session.id} for correlation.` }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/dynamicSkill/v16.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicSkill/v16.ts
@@ -1,0 +1,11 @@
+import { defineDynamic, defineSkill } from "#public/skills/index.js";
+
+export default defineDynamic({
+  events: {
+    "turn.started": (_event, ctx) =>
+      defineSkill({
+        description: `Review session ${ctx.session.id}.`,
+        markdown: "# Review\n\nCheck each claim.",
+      }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/dynamicTool/v29.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicTool/v29.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+import { defineDynamic, defineTool } from "#public/tools/index.js";
+
+export default defineDynamic({
+  events: {
+    "session.started": () =>
+      defineTool({
+        description: "Delegate a background report.",
+        execution: "background",
+        inputSchema: z.object({ reportId: z.string() }),
+        async *execute({ reportId }) {
+          yield { reportId };
+          return { reportId };
+        },
+      }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/hook/v21.ts
+++ b/packages/eve/extension-contracts/compatibility/hook/v21.ts
@@ -1,0 +1,9 @@
+import { defineHook } from "#public/hooks/index.js";
+
+export default defineHook({
+  events: {
+    "turn.started"(event, ctx) {
+      console.info(event.meta.id, event.data.turnId, ctx.session.id);
+    },
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/schedule/v10.ts
+++ b/packages/eve/extension-contracts/compatibility/schedule/v10.ts
@@ -1,0 +1,8 @@
+import { defineSchedule } from "#public/schedules/index.js";
+
+export default defineSchedule({
+  cron: "0 9 * * *",
+  run({ waitUntil, appAuth }) {
+    waitUntil(Promise.resolve(appAuth.principalId));
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/subagent/v9.ts
+++ b/packages/eve/extension-contracts/compatibility/subagent/v9.ts
@@ -1,0 +1,6 @@
+import { defineAgent } from "#public/index.js";
+
+export default defineAgent({
+  description: "Delegate research tasks.",
+  model: "anthropic/claude-sonnet-5",
+});

--- a/packages/eve/extension-contracts/reports/channel/v19.json
+++ b/packages/eve/extension-contracts/reports/channel/v19.json
@@ -1,0 +1,21 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "channel",
+  "epoch": 19,
+  "sha256": "80a40f9a2e37fe2261b4f328158abd1acb441012c8846076191ace3cb59f1ff4",
+  "exports": [
+    "DELETE",
+    "GET",
+    "HEAD",
+    "OPTIONS",
+    "PATCH",
+    "POST",
+    "PUT",
+    "WS",
+    "createWebSocketUpgradeServer",
+    "defineChannel",
+    "disableRoute",
+    "isChannel",
+    "isDisabledRouteSentinel"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/connection/v15.json
+++ b/packages/eve/extension-contracts/reports/connection/v15.json
@@ -1,0 +1,16 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "connection",
+  "epoch": 15,
+  "sha256": "b110b2998af1c948af7936ec974ae4c85ae9081d53c46bf97a2396b337afedb7",
+  "exports": [
+    "ConnectionAuthorizationFailedError",
+    "ConnectionAuthorizationRequiredError",
+    "defineDynamic",
+    "defineInteractiveAuthorization",
+    "defineMcpClientConnection",
+    "defineOpenAPIConnection",
+    "isConnectionAuthorizationFailedError",
+    "isConnectionAuthorizationRequiredError"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/dynamicInstructions/v18.json
+++ b/packages/eve/extension-contracts/reports/dynamicInstructions/v18.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicInstructions",
+  "epoch": 18,
+  "sha256": "cfa9b350866d57f2079dc31c20e51ca2f6dd11bb102ec8816aed6c801e9cd2d7",
+  "exports": ["defineDynamic"]
+}

--- a/packages/eve/extension-contracts/reports/dynamicSkill/v17.json
+++ b/packages/eve/extension-contracts/reports/dynamicSkill/v17.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicSkill",
+  "epoch": 17,
+  "sha256": "db39c3ff00ca8478c877841ddbd6a8ec74121d8a85ae9ec0c8cc20964ef10a17",
+  "exports": ["defineDynamic"]
+}

--- a/packages/eve/extension-contracts/reports/dynamicTool/v30.json
+++ b/packages/eve/extension-contracts/reports/dynamicTool/v30.json
@@ -1,0 +1,13 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicTool",
+  "epoch": 30,
+  "sha256": "ba9d92b6f834d82532bf83743cab52a18f7661b414f91b80bf8bf7f0f002c37d",
+  "exports": [
+    "DynamicToolEntry",
+    "DynamicToolEvents",
+    "DynamicToolResult",
+    "DynamicToolSet",
+    "defineDynamic"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/hook/v22.json
+++ b/packages/eve/extension-contracts/reports/hook/v22.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "hook",
+  "epoch": 22,
+  "sha256": "5d82cef983eefdec0127859fe040b3ecac536a4f438e1d8dea3c96255d82627f",
+  "exports": ["defineHook"]
+}

--- a/packages/eve/extension-contracts/reports/schedule/v11.json
+++ b/packages/eve/extension-contracts/reports/schedule/v11.json
@@ -1,0 +1,14 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "schedule",
+  "epoch": 11,
+  "sha256": "653f819f8dbd882d54295018ce4c1a27b49e6277baf5d7dc12d7d5c995a20798",
+  "exports": [
+    "ScheduleDefinition",
+    "ScheduleHandlerArgs",
+    "ScheduleRunHandler",
+    "ScheduleToFn",
+    "TypedReceiveTarget",
+    "defineSchedule"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/subagent/v10.json
+++ b/packages/eve/extension-contracts/reports/subagent/v10.json
@@ -1,0 +1,20 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "subagent",
+  "epoch": 10,
+  "sha256": "73c6d45205f3c65eecf02c0207c697f3531a0100b7758ebeae0e13208dcf8e0a",
+  "exports": [
+    "AgentCompactionDefinition",
+    "AgentDefinition",
+    "AgentModelDefinition",
+    "AgentStaticModelDefinition",
+    "DefinedAgent",
+    "DynamicLocalSubagentDefinition",
+    "DynamicSubagentDefinition",
+    "RemoteAgentDefinition",
+    "RemoteAgentDefinitionInput",
+    "defineAgent",
+    "defineDynamic",
+    "defineRemoteAgent"
+  ]
+}

--- a/packages/eve/src/channel/adapter.ts
+++ b/packages/eve/src/channel/adapter.ts
@@ -11,6 +11,11 @@ import type {
   FetchFileFunction,
 } from "#shared/channel-definition.js";
 import type { ChannelAudienceMetadata } from "#shared/channel-audience.js";
+import type {
+  ChannelAuthenticationCallbackInput,
+  ChannelAuthenticationResolution,
+} from "#channel/authentication.js";
+import type { SessionAuthContext } from "#channel/types.js";
 
 const log = createLogger("channel.adapter");
 
@@ -146,6 +151,17 @@ export type ChannelAdapter<TCtx extends ChannelAdapterContext<any> = ChannelAdap
    * return void to use the default payload projection.
    */
   deliver?(payload: DeliverPayload, ctx: TCtx): StepInput | void | Promise<StepInput | void>;
+
+  authenticateSender?(
+    event: unknown,
+    callbackUrl: string,
+    ctx: TCtx,
+  ): Promise<ChannelAuthenticationResolution>;
+
+  completeSenderAuthentication?(
+    input: ChannelAuthenticationCallbackInput,
+    ctx: TCtx,
+  ): Promise<SessionAuthContext>;
 
   /**
    * Optional factory that builds the adapter context for this adapter.

--- a/packages/eve/src/channel/authentication.ts
+++ b/packages/eve/src/channel/authentication.ts
@@ -1,0 +1,36 @@
+import type { SessionAuthContext } from "#channel/types.js";
+import type { ConnectionAuthorizationChallenge } from "#connections/errors.js";
+import type { AuthorizationCallback } from "#shared/connection-types.js";
+import type { JsonValue } from "#shared/json.js";
+
+export const CHANNEL_AUTHENTICATION_PAYLOAD_KEY = "eve.channelAuthentication";
+
+export interface ChannelAuthenticationPayload {
+  readonly event: unknown;
+}
+
+export type ChannelAuthenticationResolution =
+  | { readonly kind: "authenticated"; readonly auth: SessionAuthContext }
+  | { readonly kind: "not-authenticated" }
+  | {
+      readonly kind: "interaction-required";
+      readonly challenge: ConnectionAuthorizationChallenge;
+      readonly resume?: JsonValue;
+      readonly strategyIndex: number;
+    };
+
+export interface ChannelAuthenticationCallbackInput {
+  readonly callback: AuthorizationCallback;
+  readonly callbackUrl: string;
+  readonly event: unknown;
+  readonly resume?: JsonValue;
+  readonly strategyIndex: number;
+}
+
+export function readChannelAuthenticationPayload(
+  payload: Readonly<Record<string, unknown>>,
+): ChannelAuthenticationPayload | undefined {
+  const value = payload[CHANNEL_AUTHENTICATION_PAYLOAD_KEY];
+  if (typeof value !== "object" || value === null || !("event" in value)) return undefined;
+  return value as ChannelAuthenticationPayload;
+}

--- a/packages/eve/src/channel/channel-address.ts
+++ b/packages/eve/src/channel/channel-address.ts
@@ -2,6 +2,7 @@ import type { UserContent } from "ai";
 
 import type { ChannelAdapter } from "#channel/adapter.js";
 import { copyChannelActivityPresentation } from "#channel/activity-renderer.js";
+import { readChannelAuthenticationPayload } from "#channel/authentication.js";
 import {
   createChannelDeliveryMetadata,
   type ChannelDeliverySource,
@@ -152,6 +153,7 @@ export function createChannelAddress<TState = undefined>(input: {
           context: payload.context,
           message: serializeUrlFilePartsInMessage(payload.message) ?? "",
           outputSchema: payload.outputSchema,
+          senderAuthentication: readChannelAuthenticationPayload(payload),
         },
         mode: options.mode ?? "conversation",
         requestId: metadata.requestId,

--- a/packages/eve/src/channel/session.ts
+++ b/packages/eve/src/channel/session.ts
@@ -30,6 +30,7 @@ import {
 import type { JsonObject } from "#shared/json.js";
 import { toChannelLocalContinuationToken } from "#shared/continuation-token.js";
 import { attachClientContext, readClientContext } from "#internal/client-context.js";
+import { CHANNEL_AUTHENTICATION_PAYLOAD_KEY } from "#channel/authentication.js";
 
 /** Immutable-ID handle for one exact durable session. */
 export interface Session {
@@ -67,6 +68,8 @@ interface SessionDeliveryOptions {
   readonly callback?: SessionCallback;
   readonly context?: readonly string[];
   readonly outputSchema?: JsonObject;
+  /** @internal Durable sender-auth input supplied by a channel route. */
+  readonly senderAuthentication?: { readonly event: unknown };
 }
 
 /** Options for sending a message through a fixed session handle. */
@@ -108,6 +111,11 @@ export function createSession(
       }>({ message: serializeUrlFilePartsInMessage(message) }, readClientContext(options));
       if (options.context !== undefined) payload.context = options.context;
       if (options.outputSchema !== undefined) payload.outputSchema = options.outputSchema;
+      if (options.senderAuthentication !== undefined) {
+        Object.assign(payload, {
+          [CHANNEL_AUTHENTICATION_PAYLOAD_KEY]: options.senderAuthentication,
+        });
+      }
       const commandWithoutCaller = {
         auth: options.auth,
         delivery,

--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -517,9 +517,11 @@ export interface RunInput {
    */
   readonly initiatorAuth?: SessionAuthContext | null;
   readonly input: {
-    readonly message: string | UserContent;
     readonly context?: readonly string[];
+    readonly message: string | UserContent;
     readonly outputSchema?: JsonObject;
+    /** @internal Durable channel sender-auth input carried into the first delivery. */
+    readonly senderAuthentication?: { readonly event: unknown };
   };
   readonly mode: RunMode;
   readonly parent?: SessionParent;

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -42,8 +42,10 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     },
   },
   dynamicTool: {
-    current: 29,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 28, 29],
+    current: 30,
+    supported: [
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 28, 29, 30,
+    ],
     dropped: {
       21: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",
       23: "TaskExec.delegated was removed; migrate to workflow-backed background tools",
@@ -54,22 +56,22 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     },
   },
   channel: {
-    current: 18,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18],
+    current: 19,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19],
     dropped: {
       12: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",
     },
   },
   schedule: {
-    current: 10,
-    supported: [1, 2, 3, 4, 6, 7, 8, 9, 10],
+    current: 11,
+    supported: [1, 2, 3, 4, 6, 7, 8, 9, 10, 11],
     dropped: {
       5: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",
     },
   },
   subagent: {
-    current: 9,
-    supported: [3, 4, 6, 7, 8, 9],
+    current: 10,
+    supported: [3, 4, 6, 7, 8, 9, 10],
     dropped: {
       1: "Persistent subagent sessions are now the default and the experimental opt-in was removed",
       2: "Persistent subagent sessions are now the default and the experimental opt-in was removed",
@@ -77,16 +79,16 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     },
   },
   connection: {
-    current: 14,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 13, 14],
+    current: 15,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 13, 14, 15],
     dropped: {
       9: "Dynamic connection resolvers no longer receive conversation or channel continuation data",
       10: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",
     },
   },
   hook: {
-    current: 21,
-    supported: [10, 11, 12, 13, 14, 15, 17, 18, 19, 20, 21],
+    current: 22,
+    supported: [10, 11, 12, 13, 14, 15, 17, 18, 19, 20, 21, 22],
     dropped: {
       1: "Model identity moved from session.started runtime metadata to step.started call attribution.",
       2: "Model identity moved from session.started runtime metadata to step.started call attribution.",
@@ -102,16 +104,16 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
   },
   skill: { current: 1, supported: [1], dropped: {} },
   dynamicSkill: {
-    current: 16,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 15, 16],
+    current: 17,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 15, 16, 17],
     dropped: {
       13: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",
     },
   },
   instructions: { current: 2, supported: [1, 2], dropped: {} },
   dynamicInstructions: {
-    current: 17,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 16, 17],
+    current: 18,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 16, 17, 18],
     dropped: {
       14: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",
     },

--- a/packages/eve/src/context/providers/session.ts
+++ b/packages/eve/src/context/providers/session.ts
@@ -8,24 +8,30 @@ import {
 } from "#context/keys.js";
 import type { FrameworkContextProvider } from "#context/provider.js";
 import { getHarnessEmissionState } from "#harness/emission.js";
+import type { ContextContainer } from "#context/container.js";
+import type { HarnessSession } from "#harness/types.js";
+
+export function createSessionContext(ctx: ContextContainer, session: HarnessSession): Session {
+  const currentAuth = ctx.require(AuthKey);
+  const emission = getHarnessEmissionState(session.state);
+  const turnId = emission.turnId.length > 0 ? emission.turnId : `turn_${emission.sequence}`;
+
+  return Object.freeze({
+    auth: {
+      current: currentAuth,
+      initiator: ctx.get(InitiatorAuthKey) ?? currentAuth,
+    },
+    parent: ctx.get(ParentSessionKey),
+    sessionId: ctx.require(SessionIdKey),
+    turn: { id: turnId, sequence: emission.sequence },
+  });
+}
 
 export const sessionProvider: FrameworkContextProvider<Session> = {
   key: SessionKey,
   create(ctx, session) {
-    const currentAuth = ctx.require(AuthKey);
-    const emission = getHarnessEmissionState(session.state);
-    const turnId = emission.turnId.length > 0 ? emission.turnId : `turn_${emission.sequence}`;
-
     return {
-      value: Object.freeze({
-        auth: {
-          current: currentAuth,
-          initiator: ctx.get(InitiatorAuthKey) ?? currentAuth,
-        },
-        parent: ctx.get(ParentSessionKey),
-        sessionId: ctx.require(SessionIdKey),
-        turn: { id: turnId, sequence: emission.sequence },
-      }),
+      value: createSessionContext(ctx, session),
     };
   },
 };

--- a/packages/eve/src/eve-channel/authentication.ts
+++ b/packages/eve/src/eve-channel/authentication.ts
@@ -1,0 +1,111 @@
+import type {
+  ChannelAuthenticationCallbackInput,
+  ChannelAuthenticationResolution,
+} from "#channel/authentication.js";
+import type { SessionAuthContext } from "#channel/types.js";
+import {
+  isAuthInteractionRequired,
+  type AuthFn,
+  type AuthInteractionMatch,
+} from "#public/channels/auth.js";
+
+interface EveSenderAuthenticationEvent {
+  readonly request: {
+    readonly method: string;
+    readonly url: string;
+  };
+  readonly strategyIndex: number;
+}
+
+function authStrategies(
+  auth: AuthFn<Request> | readonly AuthFn<Request>[],
+): readonly AuthFn<Request>[] {
+  return Array.isArray(auth) ? auth : [auth as AuthFn<Request>];
+}
+
+function readSenderAuthenticationEvent(value: unknown): EveSenderAuthenticationEvent {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("request" in value) ||
+    typeof value.request !== "object" ||
+    value.request === null ||
+    !("method" in value.request) ||
+    typeof value.request.method !== "string" ||
+    !("url" in value.request) ||
+    typeof value.request.url !== "string" ||
+    !("strategyIndex" in value) ||
+    typeof value.strategyIndex !== "number" ||
+    !Number.isSafeInteger(value.strategyIndex) ||
+    value.strategyIndex < 0
+  ) {
+    throw new Error("Invalid eve sender-auth event.");
+  }
+  return value as EveSenderAuthenticationEvent;
+}
+
+function rebuildSenderAuthenticationRequest(event: EveSenderAuthenticationEvent): Request {
+  return new Request(event.request.url, { method: event.request.method });
+}
+
+export function createEveSenderAuthenticationEvent(
+  request: Request,
+  interaction: AuthInteractionMatch,
+): EveSenderAuthenticationEvent {
+  const url = new URL(request.url);
+  url.username = "";
+  url.password = "";
+  url.search = "";
+  url.hash = "";
+  return {
+    request: { method: request.method, url: url.toString() },
+    strategyIndex: interaction.strategyIndex,
+  };
+}
+
+export async function authenticateEveSender(
+  auth: AuthFn<Request> | readonly AuthFn<Request>[],
+  event: unknown,
+  callbackUrl: string,
+): Promise<ChannelAuthenticationResolution> {
+  const parsed = readSenderAuthenticationEvent(event);
+  const strategy = authStrategies(auth)[parsed.strategyIndex];
+  if (strategy === undefined) {
+    throw new Error("eve sender authentication strategy changed while sign-in was pending.");
+  }
+  const result = await strategy(rebuildSenderAuthenticationRequest(parsed));
+  if (result === null || result === undefined) return { kind: "not-authenticated" };
+  if (!isAuthInteractionRequired(result)) {
+    return { auth: result, kind: "authenticated" };
+  }
+  const started = await result.startAuthorization({ callbackUrl });
+  return {
+    challenge: started.challenge,
+    kind: "interaction-required",
+    resume: started.resume,
+    strategyIndex: parsed.strategyIndex,
+  };
+}
+
+export async function completeEveSenderAuthentication(
+  auth: AuthFn<Request> | readonly AuthFn<Request>[],
+  callback: ChannelAuthenticationCallbackInput,
+): Promise<SessionAuthContext> {
+  const parsed = readSenderAuthenticationEvent(callback.event);
+  if (parsed.strategyIndex !== callback.strategyIndex) {
+    throw new Error("eve sender authentication strategy changed while sign-in was pending.");
+  }
+  const strategy = authStrategies(auth)[callback.strategyIndex];
+  if (strategy === undefined) {
+    throw new Error("eve sender authentication strategy changed while sign-in was pending.");
+  }
+  const result = await strategy(rebuildSenderAuthenticationRequest(parsed));
+  if (!isAuthInteractionRequired(result)) {
+    throw new Error("eve sender authentication strategy changed while sign-in was pending.");
+  }
+  return await result.completeAuthorization({
+    callback: callback.callback,
+    callbackUrl: callback.callbackUrl,
+    resume: callback.resume,
+  });
+}

--- a/packages/eve/src/eve-channel/index.ts
+++ b/packages/eve/src/eve-channel/index.ts
@@ -54,7 +54,7 @@ import {
   FAIL_CLOSED_FORWARDED_TRACE_ASSERTION,
   formatTraceContentCeiling,
 } from "#shared/forwarded-trace-policy.js";
-import { routeAuth } from "#public/channels/auth.js";
+import { resolveAuth, routeAuth, type AuthInteractionMatch } from "#public/channels/auth.js";
 import { mergeUploadPolicy } from "#public/channels/upload-policy.js";
 import { defineChannel, DELETE, GET, HEAD, PATCH, POST, PUT } from "#public/definitions/channel.js";
 import {
@@ -80,17 +80,35 @@ import {
   resolveOnMessage,
 } from "#eve-channel/support.js";
 import type { EveChannel, EveChannelInput, EveEventContext } from "#eve-channel/types.js";
+import {
+  authenticateEveSender,
+  completeEveSenderAuthentication,
+  createEveSenderAuthenticationEvent,
+} from "#eve-channel/authentication.js";
 
 export * from "#eve-channel/types.js";
 
 const log = createLogger("eve.channel");
+
+function interactionRejectedResponse(): Response {
+  return Response.json(
+    {
+      error:
+        "Interactive sign-in is only supported for top-level eve message requests without operationId.",
+      ok: false,
+    },
+    { headers: { "www-authenticate": "Bearer" }, status: 401 },
+  );
+}
 
 /**
  * Builds the default eve HTTP channel: a {@link defineChannel} instance serving the
  * built-in `/eve/v1` routes (GET inspects the agent, POST creates a session,
  * ID-addressed POST routes deliver follow-ups and controls, and GET streams a
  * session's NDJSON event feed). Every route
- * runs {@link EveChannelInput.auth} via {@link routeAuth} before dispatching.
+ * runs {@link EveChannelInput.auth} before dispatching. Message routes can
+ * hand an interactive result to the durable sender-auth gate; all other routes
+ * require an immediate route-auth result.
  * Default-export the result as your `agent/channels/eve.ts` channel; reach for
  * {@link defineChannel} directly only for a custom transport.
  */
@@ -100,6 +118,12 @@ export function eveChannel(input: EveChannelInput): EveChannel {
   return defineChannel<undefined, EveEventContext>({
     cors: normalizeEveCors(input.cors),
     turnPolicy: input.turnPolicy,
+    async authenticateSender(event, callbackUrl) {
+      return await authenticateEveSender(input.auth, event, callbackUrl);
+    },
+    async completeSenderAuthentication(callback) {
+      return await completeEveSenderAuthentication(input.auth, callback);
+    },
     routes: [
       GET(EVE_HEALTH_ROUTE_PATH, async () => healthResponse()),
       HEAD(EVE_HEALTH_ROUTE_PATH, async () => healthResponse()),
@@ -133,23 +157,37 @@ export function eveChannel(input: EveChannelInput): EveChannel {
       DELETE(WORKFLOW_WEBHOOK_ROUTE_PATTERN, handleWorkflowWebhookRequest),
 
       POST(EVE_SESSION_ROUTE_PATH, async (req, args) => {
-        const authResult = await routeAuth(req, input.auth);
+        const authResult = await resolveAuth(req, input.auth);
         if (authResult instanceof Response) return authResult;
+        let interaction: AuthInteractionMatch | undefined;
+        let authenticatedAuth: SessionAuthContext | undefined;
+        if ("interaction" in authResult) interaction = authResult;
+        else authenticatedAuth = authResult;
 
         const payload = await parseJsonRequest(req);
         if (payload instanceof Response) return payload;
         const tokenRejection = rejectSessionContinuationToken(payload);
         if (tokenRejection !== null) return tokenRejection;
 
-        const forwarded = await resolveForwardedPrincipal({
-          trustedForwarders: input.trustedForwarders,
-          forwarder: authResult,
-          payload,
-        });
-        if (forwarded instanceof Response) return forwarded;
-
         const body = parseCreateBody(payload);
         if (body instanceof Response) return body;
+        if (
+          interaction !== undefined &&
+          (payload.forwardedPrincipal !== undefined ||
+            body.callback !== undefined ||
+            body.operationId !== undefined)
+        ) {
+          return interactionRejectedResponse();
+        }
+        const forwarded =
+          interaction === undefined
+            ? await resolveForwardedPrincipal({
+                trustedForwarders: input.trustedForwarders,
+                forwarder: authenticatedAuth!,
+                payload,
+              })
+            : { accepted: false as const, auth: null };
+        if (forwarded instanceof Response) return forwarded;
         // Top-level sessions own their trace. Callback sessions are delegated
         // remote agents and intentionally continue the dispatching agent trace.
         const parsedParentTraceContext =
@@ -160,7 +198,7 @@ export function eveChannel(input: EveChannelInput): EveChannel {
         const policyRejection = checkUploadPolicy(body, uploadPolicy);
         if (policyRejection !== null) return policyRejection;
 
-        if (body.operationId !== undefined && forwarded.auth.principalType === "anonymous") {
+        if (body.operationId !== undefined && forwarded.auth?.principalType === "anonymous") {
           return Response.json(
             { error: "operationId requires an authenticated principal.", ok: false },
             { status: 400 },
@@ -170,7 +208,7 @@ export function eveChannel(input: EveChannelInput): EveChannel {
           body.operationId === undefined
             ? undefined
             : await deriveOperationContinuationToken({
-                auth: forwarded.auth,
+                auth: forwarded.auth!,
                 operationId: body.operationId,
               });
         if (operationToken !== undefined) {
@@ -213,18 +251,18 @@ export function eveChannel(input: EveChannelInput): EveChannel {
         }
         if (forwardedTraceAssertion === "malformed") {
           log.warn("using metadata-only policy for malformed forwarded audience baggage", {
-            forwarder: authResult.principalId,
+            forwarder: "principalId" in authResult ? authResult.principalId : "interactive",
           });
         } else if (typeof forwardedTraceAssertion === "object") {
           if (acceptedForwardedTracePolicy !== undefined) {
             log.info("accepted forwarded trace policy", {
               audience: forwardedTraceAssertion.originAudience,
               ceiling: formatTraceContentCeiling(forwardedTraceAssertion.ceiling),
-              forwarder: authResult.principalId,
+              forwarder: "principalId" in authResult ? authResult.principalId : "interactive",
             });
           } else {
             log.warn("ignoring forwarded trace policy without an accepted sampled principal", {
-              forwarder: authResult.principalId,
+              forwarder: "principalId" in authResult ? authResult.principalId : "interactive",
             });
           }
         }
@@ -236,6 +274,13 @@ export function eveChannel(input: EveChannelInput): EveChannel {
           request: req,
         });
         if (messageResult instanceof Response) return messageResult;
+        const senderAuthentication =
+          interaction === undefined || messageResult.hasAuthOverride
+            ? undefined
+            : { event: createEveSenderAuthenticationEvent(req, interaction) };
+        const dispatchAuth = messageResult.hasAuthOverride
+          ? (messageResult.auth ?? null)
+          : forwarded.auth;
         const createSession = readRouteSessionCreator(args);
         if (createSession === undefined) {
           return Response.json(
@@ -248,7 +293,7 @@ export function eveChannel(input: EveChannelInput): EveChannel {
         try {
           handle = await createSession({
             activityObserver: body.activityObserver,
-            auth: messageResult.auth,
+            auth: dispatchAuth,
             capabilities:
               body.capabilities ?? (body.mode === "task" ? undefined : { requestInput: true }),
             callback: body.callback,
@@ -259,6 +304,7 @@ export function eveChannel(input: EveChannelInput): EveChannel {
                 message: body.message,
                 context: messageResult.context,
                 outputSchema: body.outputSchema,
+                senderAuthentication,
               },
               body.context,
             ),
@@ -287,27 +333,43 @@ export function eveChannel(input: EveChannelInput): EveChannel {
       }),
 
       POST(EVE_SESSION_ROUTE_PATTERN, async (req, { attachSession, params }) => {
-        const authResult = await routeAuth(req, input.auth);
+        const authResult = await resolveAuth(req, input.auth);
         if (authResult instanceof Response) return authResult;
+        let interaction: AuthInteractionMatch | undefined;
+        let authenticatedAuth: SessionAuthContext | undefined;
+        if ("interaction" in authResult) interaction = authResult;
+        else authenticatedAuth = authResult;
 
         const sessionId = requireSessionId(params);
         if (sessionId instanceof Response) return sessionId;
         const payload = await parseJsonRequest(req);
         if (payload instanceof Response) return payload;
-        const forwarded = await resolveForwardedPrincipal({
-          trustedForwarders: input.trustedForwarders,
-          forwarder: authResult,
-          payload,
-        });
-        if (forwarded instanceof Response) return forwarded;
         const body = parseSessionMessageBody(payload);
         if (body instanceof Response) return body;
+        if (
+          interaction !== undefined &&
+          (payload.forwardedPrincipal !== undefined ||
+            body.callback !== undefined ||
+            body.inputResponses !== undefined)
+        ) {
+          return interactionRejectedResponse();
+        }
+        const forwarded =
+          interaction === undefined
+            ? await resolveForwardedPrincipal({
+                trustedForwarders: input.trustedForwarders,
+                forwarder: authenticatedAuth!,
+                payload,
+              })
+            : { accepted: false as const, auth: null };
+        if (forwarded instanceof Response) return forwarded;
 
         const policyRejection = checkUploadPolicy(body, uploadPolicy);
         if (policyRejection !== null) return policyRejection;
 
         let context: readonly string[] | undefined;
         let dispatchAuth: SessionAuthContext | null = forwarded.auth;
+        let senderAuthentication: { readonly event: unknown } | undefined;
         if (body.message !== undefined) {
           const messageResult = await resolveOnMessage({
             auth: forwarded.auth,
@@ -318,7 +380,11 @@ export function eveChannel(input: EveChannelInput): EveChannel {
           });
           if (messageResult instanceof Response) return messageResult;
           context = messageResult.context;
-          dispatchAuth = messageResult.auth;
+          if (messageResult.hasAuthOverride) {
+            dispatchAuth = messageResult.auth ?? null;
+          } else if (interaction !== undefined) {
+            senderAuthentication = { event: createEveSenderAuthenticationEvent(req, interaction) };
+          }
         }
 
         let result: Awaited<ReturnType<Session["send"]>>;
@@ -331,6 +397,7 @@ export function eveChannel(input: EveChannelInput): EveChannel {
               callback: body.callback,
               context,
               outputSchema: body.outputSchema,
+              senderAuthentication,
               turnPolicy: body.turnPolicy,
             },
             body.context,

--- a/packages/eve/src/eve-channel/support.ts
+++ b/packages/eve/src/eve-channel/support.ts
@@ -6,7 +6,6 @@ import { createLogger, logError } from "#internal/logging.js";
 import type { MessageStreamEvent, SubagentCalledStreamEvent } from "#protocol/message.js";
 import type { ChannelCors } from "#public/definitions/channel.js";
 import {
-  defaultEveAuth,
   type EveChannelCors,
   type EveChannelCorsOptions,
   type EveChannelInput,
@@ -121,7 +120,8 @@ export function normalizeEveCorsOrigin(
 }
 
 interface OnMessageOutcome {
-  readonly auth: SessionAuthContext | null;
+  readonly auth?: SessionAuthContext | null;
+  readonly hasAuthOverride: boolean;
   readonly context?: readonly string[];
   readonly title?: string;
 }
@@ -144,7 +144,7 @@ export async function resolveOnMessage(input: {
     const ctx: EveMessageContext = { eve };
     result = await handler(ctx, input.message);
     if (result === null || result === undefined) {
-      throw new TypeError("eveChannel onMessage must return an auth result.");
+      throw new TypeError("eveChannel onMessage must return a result object.");
     }
   } catch (error) {
     const errorId = logError(log, "onMessage handler failed", error, {
@@ -156,9 +156,14 @@ export async function resolveOnMessage(input: {
     );
   }
 
-  return { auth: result.auth, context: result.context, title: result.title };
+  return {
+    auth: result.auth,
+    context: result.context,
+    hasAuthOverride: Object.prototype.hasOwnProperty.call(result, "auth"),
+    title: result.title,
+  };
 }
 
-export function defaultOnMessage(ctx: EveMessageContext): EveMessageResult {
-  return { auth: defaultEveAuth(ctx) };
+export function defaultOnMessage(_ctx: EveMessageContext): EveMessageResult {
+  return {};
 }

--- a/packages/eve/src/eve-channel/types.ts
+++ b/packages/eve/src/eve-channel/types.ts
@@ -66,7 +66,8 @@ export interface EveMessageContext {
  * optionally prepending `context` strings as user messages.
  */
 export type EveMessageResult = {
-  readonly auth: SessionAuthContext | null;
+  /** Final sender identity. When present, bypasses the channel-level `auth` walk. */
+  readonly auth?: SessionAuthContext | null;
   readonly context?: readonly string[];
   /** Overrides the workflow run title without changing the message sent to the model. */
   readonly title?: string;
@@ -89,9 +90,11 @@ export function defaultEveAuth(ctx: EveMessageContext): SessionAuthContext | nul
  */
 export interface EveChannelInput {
   /**
-   * Route auth policy: a single {@link AuthFn} or an ordered array walked by {@link routeAuth}.
+   * Request and sender auth policy: a single {@link AuthFn} or an ordered array.
    * The first entry returning a {@link SessionAuthContext} wins; `null` / `undefined` skips to
-   * the next; exhaustion (including the empty array) rejects with 401. Include `none()` last for anonymous traffic.
+   * the next; exhaustion (including the empty array) rejects with 401. On a message route,
+   * `{ interaction: "required" }` accepts and parks the input for durable sign-in before model
+   * or tool execution. Other HTTP routes cannot park and reject an interactive result.
    */
   readonly auth: AuthFn<Request> | readonly AuthFn<Request>[];
   /**

--- a/packages/eve/src/execution/authorization-callback-match.ts
+++ b/packages/eve/src/execution/authorization-callback-match.ts
@@ -44,7 +44,9 @@ export function matchAuthorizationCallbacks(
     if (
       challenge === undefined ||
       attemptKey === undefined ||
-      (challenge.principal === undefined && callback.legacy !== true) ||
+      (challenge.principal === undefined &&
+        challenge.senderAuthentication === undefined &&
+        callback.legacy !== true) ||
       matchedAttemptKeys.has(attemptKey)
     ) {
       continue;
@@ -61,6 +63,7 @@ export function matchAuthorizationCallbacks(
         name: challenge.name,
         principal: challenge.principal,
         resume: challenge.resume,
+        senderAuthentication: challenge.senderAuthentication,
       },
     });
   }

--- a/packages/eve/src/execution/channel-sender-authentication.ts
+++ b/packages/eve/src/execution/channel-sender-authentication.ts
@@ -1,0 +1,294 @@
+import type { ChannelAdapter, ChannelAdapterContext } from "#channel/adapter.js";
+import { callAdapterEventHandler, defaultDeliverResult } from "#channel/adapter.js";
+import {
+  readChannelAuthenticationPayload,
+  type ChannelAuthenticationPayload,
+} from "#channel/authentication.js";
+import { contextStorage } from "#context/container.js";
+import type { ContextContainer } from "#context/container.js";
+import { AuthKey, InitiatorAuthKey, SessionKey, TurnDeliveryIdsKey } from "#context/keys.js";
+import { createSessionContext } from "#context/providers/session.js";
+import { serializeContext } from "#context/serialize.js";
+import { activeTurnId } from "#harness/active-turn-id.js";
+import { createAuthorizationAttempt, setPendingAuthorization } from "#harness/authorization.js";
+import type { HarnessEmissionState } from "#harness/emission.js";
+import {
+  consumeDeferredStepInput,
+  queueDeferredStepInput,
+} from "#harness/pending-input-batches.js";
+import type { HarnessSession, StepInput } from "#harness/types.js";
+import { coalesceTurnInputs } from "#harness/messages.js";
+import { RuntimeActionSettlementTimesKey } from "#harness/runtime-action-settlement-state.js";
+import {
+  createAuthorizationCompletedEvent,
+  createAuthorizationRequiredEvent,
+  encodeMessageStreamEvent,
+  stampMessageStreamEvent,
+  type MessageStreamEvent,
+  type UnstampedMessageStreamEvent,
+} from "#protocol/message.js";
+import type { MatchedAuthorizationCallback } from "#execution/authorization-callback-match.js";
+import { setChannelContext } from "#execution/channel-context.js";
+import { createDurableSessionState } from "#execution/durable-session-store.js";
+import type { DurableStepResult } from "#execution/next-driver-action.js";
+import { derivePendingState } from "#execution/pending-turn-state.js";
+import type { TurnStepPayload } from "#execution/durable-session-migrations/turn-workflow.js";
+
+export type ChannelAuthenticationEventEmitter = (
+  event: UnstampedMessageStreamEvent,
+) => Promise<MessageStreamEvent>;
+
+export function createChannelAuthenticationEventEmitter(input: {
+  readonly adapter: ChannelAdapter;
+  readonly adapterCtx: ChannelAdapterContext;
+  readonly ctx: ContextContainer;
+  readonly parentWritable: WritableStream<Uint8Array>;
+  readonly session: HarnessSession;
+}): ChannelAuthenticationEventEmitter {
+  return async (event) => {
+    input.ctx.setVirtualContext(SessionKey, createSessionContext(input.ctx, input.session));
+    const toEmit = await contextStorage.run(input.ctx, () =>
+      callAdapterEventHandler(input.adapter, event, input.adapterCtx),
+    );
+    setChannelContext(input.ctx, {
+      ...input.adapter,
+      state: { ...input.adapterCtx.state },
+    });
+    const stamped = stampMessageStreamEvent(toEmit, input.ctx.get(TurnDeliveryIdsKey));
+    const writer = input.parentWritable.getWriter();
+    try {
+      await writer.write(encodeMessageStreamEvent(stamped));
+    } finally {
+      writer.releaseLock();
+    }
+    return stamped;
+  };
+}
+
+export async function completeChannelSenderAuthentication(input: {
+  readonly adapter: ChannelAdapter;
+  readonly adapterCtx: ChannelAdapterContext;
+  readonly completedAuths: readonly MatchedAuthorizationCallback[] | undefined;
+  readonly ctx: ContextContainer;
+  readonly emit: ChannelAuthenticationEventEmitter;
+  readonly emissionState: HarnessEmissionState;
+  readonly session: HarnessSession;
+}): Promise<{
+  readonly completedAuths: readonly MatchedAuthorizationCallback[] | undefined;
+  readonly resumedInput: StepInput | undefined;
+  readonly session: HarnessSession;
+}> {
+  const senderAuths =
+    input.completedAuths?.filter((match) => match.result.senderAuthentication !== undefined) ?? [];
+
+  for (const match of senderAuths) {
+    const sender = match.result.senderAuthentication!;
+    if (input.adapter.completeSenderAuthentication === undefined) {
+      throw new Error("The channel no longer supports the pending sender sign-in.");
+    }
+    const auth = await input.adapter.completeSenderAuthentication(
+      {
+        callback: match.result.callback,
+        callbackUrl: match.result.hookUrl,
+        event: sender.event,
+        resume: match.result.resume,
+        strategyIndex: sender.strategyIndex,
+      },
+      input.adapterCtx,
+    );
+    input.ctx.set(AuthKey, auth);
+    if (!input.emissionState.sessionStarted && input.ctx.get(InitiatorAuthKey) == null) {
+      input.ctx.set(InitiatorAuthKey, auth);
+    }
+    await input.emit(
+      createAuthorizationCompletedEvent({
+        attemptId: match.result.attemptId,
+        authorization: match.authorization,
+        name: match.result.name,
+        outcome: "authorized",
+        purpose: "session",
+        sequence: input.emissionState.sequence,
+        stepIndex: input.emissionState.stepIndex,
+        turnId: activeTurnId(input.emissionState),
+      }),
+    );
+  }
+
+  const deferred =
+    senderAuths.length === 0
+      ? { input: undefined, session: input.session }
+      : consumeDeferredStepInput({ session: input.session });
+  const remaining = input.completedAuths?.filter(
+    (match) => match.result.senderAuthentication === undefined,
+  );
+  return {
+    completedAuths: remaining?.length === 0 ? undefined : remaining,
+    resumedInput: deferred.input,
+    session: deferred.session,
+  };
+}
+
+export async function runChannelSenderAuthentication(input: {
+  readonly adapter: ChannelAdapter;
+  readonly adapterCtx: ChannelAdapterContext;
+  readonly authentication: ChannelAuthenticationPayload | undefined;
+  readonly ctx: ContextContainer;
+  readonly emit: ChannelAuthenticationEventEmitter;
+  readonly emissionState: HarnessEmissionState;
+  readonly resolved: StepInput | undefined;
+  readonly session: HarnessSession;
+}): Promise<DurableStepResult | undefined> {
+  if (input.authentication === undefined) return undefined;
+  if (input.adapter.authenticateSender === undefined) {
+    throw new Error("The channel does not support durable sender authentication.");
+  }
+
+  const attempt = contextStorage.run(input.ctx, () => createAuthorizationAttempt("session-auth"));
+  const authentication = await input.adapter.authenticateSender(
+    input.authentication.event,
+    attempt?.hookUrl ?? "",
+    input.adapterCtx,
+  );
+  if (authentication.kind === "not-authenticated") {
+    throw new Error("The channel sender could not be authenticated.");
+  }
+  if (authentication.kind === "authenticated") {
+    input.ctx.set(AuthKey, authentication.auth);
+    if (!input.emissionState.sessionStarted && input.ctx.get(InitiatorAuthKey) == null) {
+      input.ctx.set(InitiatorAuthKey, authentication.auth);
+    }
+    return undefined;
+  }
+  if (attempt === undefined) {
+    throw new Error("Interactive sender sign-in requires a callback URL.");
+  }
+  if (input.resolved === undefined) {
+    throw new Error("Interactive sender sign-in requires an accepted channel input.");
+  }
+
+  await input.emit(
+    createAuthorizationRequiredEvent({
+      attemptId: attempt.attemptId,
+      authorization: authentication.challenge,
+      description:
+        authentication.challenge.instructions ?? "Sign in to continue this conversation.",
+      name: "session-auth",
+      purpose: "session",
+      sequence: input.emissionState.sequence,
+      stepIndex: input.emissionState.stepIndex,
+      turnId: activeTurnId(input.emissionState),
+      webhookUrl: attempt.hookUrl,
+    }),
+  );
+  const parkedSession = queueDeferredStepInput(input.session, input.resolved);
+  const session = {
+    ...parkedSession,
+    state: setPendingAuthorization(parkedSession.state, {
+      challenges: [
+        {
+          attemptId: attempt.attemptId,
+          challenge: authentication.challenge,
+          hookUrl: attempt.hookUrl,
+          name: "session-auth",
+          resume: authentication.resume,
+          senderAuthentication: {
+            event: input.authentication.event,
+            strategyIndex: authentication.strategyIndex,
+          },
+        },
+      ],
+    }),
+  };
+  return {
+    action: "park",
+    ...derivePendingState(session),
+    serializedContext: serializeContext(input.ctx),
+    sessionState: createDurableSessionState({ session }),
+  };
+}
+
+export async function resolveAuthenticatedChannelInput(input: {
+  readonly adapter: ChannelAdapter;
+  readonly adapterCtx: ChannelAdapterContext;
+  readonly completedAuths: readonly MatchedAuthorizationCallback[] | undefined;
+  readonly ctx: ContextContainer;
+  readonly emissionState: HarnessEmissionState;
+  readonly failDelivery: (error: unknown) => Promise<void>;
+  readonly parentWritable: WritableStream<Uint8Array>;
+  readonly session: HarnessSession;
+  readonly turnInput: TurnStepPayload | undefined;
+}): Promise<{
+  readonly completedAuths: readonly MatchedAuthorizationCallback[] | undefined;
+  readonly parked: DurableStepResult | undefined;
+  readonly resolved: StepInput | undefined;
+  readonly session: HarnessSession;
+}> {
+  const emit = createChannelAuthenticationEventEmitter({
+    adapter: input.adapter,
+    adapterCtx: input.adapterCtx,
+    ctx: input.ctx,
+    parentWritable: input.parentWritable,
+    session: input.session,
+  });
+  const completed = await completeChannelSenderAuthentication({
+    adapter: input.adapter,
+    adapterCtx: input.adapterCtx,
+    completedAuths: input.completedAuths,
+    ctx: input.ctx,
+    emit,
+    emissionState: input.emissionState,
+    session: input.session,
+  });
+
+  let resolved: StepInput | undefined;
+  if (input.turnInput?.kind === "deliver") {
+    const results: StepInput[] = [];
+    try {
+      for (const payload of input.turnInput.payloads) {
+        const result = input.adapter.deliver
+          ? await input.adapter.deliver(payload, input.adapterCtx)
+          : defaultDeliverResult(payload);
+        if (result !== undefined && result !== null) results.push(result);
+      }
+    } catch (error) {
+      await input.failDelivery(error);
+      throw error;
+    }
+    resolved = results.length === 0 ? undefined : results.reduce(coalesceTurnInputs);
+  } else if (input.turnInput?.kind === "runtime-action-result") {
+    if (input.turnInput.acceptedAtMsByCallId !== undefined) {
+      input.ctx.set(RuntimeActionSettlementTimesKey, input.turnInput.acceptedAtMsByCallId);
+    }
+    resolved = { runtimeActionResults: input.turnInput.results };
+  }
+  if (completed.resumedInput !== undefined) {
+    resolved =
+      resolved === undefined
+        ? completed.resumedInput
+        : coalesceTurnInputs(completed.resumedInput, resolved);
+  }
+
+  const authentication =
+    input.turnInput?.kind === "deliver"
+      ? input.turnInput.payloads
+          .map((payload) => readChannelAuthenticationPayload(payload))
+          .filter((value) => value !== undefined)
+          .at(-1)
+      : undefined;
+  const parked = await runChannelSenderAuthentication({
+    adapter: input.adapter,
+    adapterCtx: input.adapterCtx,
+    authentication,
+    ctx: input.ctx,
+    emit,
+    emissionState: input.emissionState,
+    resolved,
+    session: completed.session,
+  });
+  return {
+    completedAuths: completed.completedAuths,
+    parked,
+    resolved,
+    session: completed.session,
+  };
+}

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -1,5 +1,6 @@
 import { getWorkflowMetadata, getWritable } from "#compiled/@workflow/core/index.js";
 
+import { CHANNEL_AUTHENTICATION_PAYLOAD_KEY } from "#channel/authentication.js";
 import type {
   DeliverHookPayload,
   DeliverPayload,
@@ -266,6 +267,9 @@ export async function workflowEntry(input: WorkflowEntryInput): Promise<Workflow
           payloads: [
             attachClientContext(
               {
+                ...(input.input.senderAuthentication && {
+                  [CHANNEL_AUTHENTICATION_PAYLOAD_KEY]: input.input.senderAuthentication,
+                }),
                 message: input.input.message,
                 context: input.input.context,
                 outputSchema: input.input.outputSchema,

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -1,16 +1,19 @@
 import type { ModelMessage } from "ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ChannelAdapter, ChannelAdapterContext } from "#channel/adapter.js";
+import { CHANNEL_AUTHENTICATION_PAYLOAD_KEY } from "#channel/authentication.js";
 import type {
   DeliverPayload,
   SessionAuthContext,
   SubagentInputRequestHookPayload,
 } from "#channel/types.js";
 import { ContextContainer, contextStorage, loadContext } from "#context/container.js";
+import { buildCallbackContext } from "#context/build-callback-context.js";
 import { ContextKey } from "#context/key.js";
 import {
   ActivityObserverKey,
   AuthKey,
+  InitiatorAuthKey,
   ChannelInstrumentationKey,
   ContinuationTokenKey,
   DynamicSubagentAgentConfigKey,
@@ -31,6 +34,7 @@ import { serializeContext } from "#context/serialize.js";
 import { getPendingCoordinationBatch, setPendingCoordinationBatch } from "#harness/coordination.js";
 import { TurnCancelledError } from "#harness/turn-cancellation.js";
 import { getPendingAuthorization, setPendingAuthorization } from "#harness/authorization.js";
+import { CallbackBaseUrlKey } from "#harness/authorization.js";
 import { getProxyInputRequests, upsertProxyInputRequests } from "#harness/proxy-input-requests.js";
 import { appendPendingInputBatch } from "#harness/input-requests.js";
 import type { HarnessSession, StepResult } from "#harness/types.js";
@@ -225,12 +229,15 @@ function createStubSession(overrides: Partial<HarnessSession> = {}): HarnessSess
 
 function createSerializedContext(
   mode: "conversation" | "task" = "conversation",
+  adapter: ChannelAdapter = threadContextAdapter,
+  callbackBaseUrl?: string,
 ): Record<string, unknown> {
   const ctx = new ContextContainer();
   ctx.set(AuthKey, null);
+  ctx.set(InitiatorAuthKey, null);
   ctx.set(BundleKey, {
     adapterRegistry: {
-      adaptersByKind: new Map([[threadContextAdapter.kind, threadContextAdapter]]),
+      adaptersByKind: new Map([[adapter.kind, adapter]]),
     },
     compiledArtifactsSource: {} as never,
     graph: {
@@ -246,10 +253,11 @@ function createSerializedContext(
     toolRegistry: {},
     turnAgent: TestTurnAgent,
   } as never);
-  ctx.set(ChannelKey, threadContextAdapter);
+  ctx.set(ChannelKey, adapter);
   ctx.set(ContinuationTokenKey, "http:thread-context");
   ctx.set(ModeKey, mode);
   ctx.set(SessionIdKey, "session-1");
+  if (callbackBaseUrl !== undefined) ctx.set(CallbackBaseUrlKey, callbackBaseUrl);
   return serializeContext(ctx);
 }
 
@@ -1161,6 +1169,158 @@ describe("dispatchCoordinationStep", () => {
 });
 
 describe("turnStep", () => {
+  it("parks sender sign-in before model execution and resumes the deferred input with final auth", async () => {
+    const authenticated: SessionAuthContext = {
+      attributes: { email: "alice@example.com" },
+      authenticator: "example-oidc",
+      issuer: "https://idp.example",
+      principalId: "alice",
+      principalType: "user",
+    };
+    const authenticateSender = vi.fn(async (_event: unknown, callbackUrl: string) => ({
+      challenge: { displayName: "Example", url: `${callbackUrl}?start=1` },
+      kind: "interaction-required" as const,
+      resume: { verifier: "pkce" },
+      strategyIndex: 1,
+    }));
+    const completeSenderAuthentication = vi.fn(async () => authenticated);
+    const authorizationSessions: unknown[] = [];
+    const adapter: ChannelAdapter = {
+      ...threadContextAdapter,
+      "authorization.completed": () => {
+        authorizationSessions.push(buildCallbackContext().session);
+      },
+      "authorization.required": () => {
+        authorizationSessions.push(buildCallbackContext().session);
+      },
+      kind: "sender-auth-test",
+      authenticateSender,
+      completeSenderAuthentication,
+    };
+    vi.mocked(getCompiledRuntimeAgentBundle).mockResolvedValue({
+      adapterRegistry: { adaptersByKind: new Map([[adapter.kind, adapter]]) },
+      compiledArtifactsSource: {},
+      graph: {
+        nodesByNodeId: new Map(),
+        root: { sandboxRegistry: { sandbox: null }, turnAgent: TestTurnAgent },
+      },
+      moduleMap: { nodes: {} },
+      hookRegistry: createEmptyHookRegistry(),
+      resolvedAgent: { config: {} },
+      subagentRegistry: {},
+      toolRegistry: {},
+      turnAgent: TestTurnAgent,
+    } as never);
+    const session = createStubSession();
+    installSessionStoreMocks([session]);
+    const serializedContext = createSerializedContext(
+      "conversation",
+      adapter,
+      "https://agent.example",
+    );
+
+    const first = await turnStep({
+      input: {
+        kind: "deliver",
+        payloads: [
+          {
+            [CHANNEL_AUTHENTICATION_PAYLOAD_KEY]: {
+              event: { actor: "U01", type: "app_mention" },
+            },
+            message: "hello",
+          },
+        ],
+      },
+      parentWritable: createTestWritable("sender-auth-required"),
+      serializedContext,
+      sessionState: createStubSessionState(),
+    });
+
+    expect(first).toMatchObject({
+      action: "park",
+      authorizationNames: ["session-auth"],
+      hasPendingAuthorization: true,
+    });
+    expect(createExecutionNodeStep).not.toHaveBeenCalled();
+    expect(first.serializedContext[AuthKey.name]).toBeNull();
+    expect(authorizationSessions).toEqual([
+      expect.objectContaining({
+        auth: { current: null, initiator: null },
+        id: "session-1",
+      }),
+    ]);
+    const parkedSession = vi.mocked(createDurableSessionState).mock.calls.at(-1)?.[0].session;
+    const pending = getPendingAuthorization(parkedSession?.state);
+    expect(pending?.challenges[0]).toMatchObject({
+      name: "session-auth",
+      resume: { verifier: "pkce" },
+      senderAuthentication: {
+        event: { actor: "U01", type: "app_mention" },
+        strategyIndex: 1,
+      },
+    });
+    const requiredEvents = (workflowWritesByNamespace.get("sender-auth-required") ?? []).map(
+      (chunk) => JSON.parse(new TextDecoder().decode(chunk as Uint8Array)),
+    );
+    expect(requiredEvents).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({ name: "session-auth", purpose: "session" }),
+        type: "authorization.required",
+      }),
+    ]);
+
+    if (parkedSession === undefined || pending?.challenges[0]?.attemptId === undefined) {
+      throw new Error("Expected a parked sender-auth attempt.");
+    }
+    installSessionStoreMocks([parkedSession]);
+    let resumedInput: unknown;
+    vi.mocked(createExecutionNodeStep).mockImplementation(() => async (stepSession, stepInput) => {
+      resumedInput = stepInput;
+      return { next: null, session: stepSession };
+    });
+    const attempt = pending.challenges[0];
+    const resumed = await turnStep({
+      input: {
+        kind: "deliver",
+        payloads: [
+          {
+            authorizationCallback: {
+              attemptId: attempt.attemptId,
+              callback: {
+                method: "GET",
+                params: { code: "oauth-code" },
+              },
+              connectionName: "session-auth",
+            },
+          },
+        ],
+      },
+      parentWritable: createTestWritable("sender-auth-completed"),
+      serializedContext: first.serializedContext,
+      sessionState: first.sessionState,
+    });
+
+    expect(completeSenderAuthentication).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callback: expect.objectContaining({ params: { code: "oauth-code" } }),
+        event: { actor: "U01", type: "app_mention" },
+        resume: { verifier: "pkce" },
+        strategyIndex: 1,
+      }),
+      expect.anything(),
+    );
+    expect(resumed.serializedContext[AuthKey.name]).toEqual(authenticated);
+    expect(resumed.serializedContext[InitiatorAuthKey.name]).toEqual(authenticated);
+    expect(authorizationSessions).toEqual([
+      expect.objectContaining({ auth: { current: null, initiator: null } }),
+      expect.objectContaining({
+        auth: { current: authenticated, initiator: authenticated },
+        id: "session-1",
+      }),
+    ]);
+    expect(resumedInput).toEqual({ message: "thread=unset; user=hello" });
+  });
+
   it("retains coalesced delivery ownership across steps and replaces it for the next message", async () => {
     const session = createStubSession({
       state: {

--- a/packages/eve/src/execution/workflow-steps.ts
+++ b/packages/eve/src/execution/workflow-steps.ts
@@ -1,5 +1,5 @@
 import { buildAdapterContext } from "#channel/adapter-context.js";
-import { callAdapterEventHandler, defaultDeliverResult } from "#channel/adapter.js";
+import { callAdapterEventHandler } from "#channel/adapter.js";
 import type { DeliverHookPayload } from "#channel/types.js";
 import { contextStorage } from "#context/container.js";
 import { dispatchStreamEventHooks } from "#context/hook-lifecycle.js";
@@ -43,7 +43,6 @@ import {
 } from "#harness/emission.js";
 import { bindSessionInstrumentation } from "#instrumentation/runtime.js";
 import { preserveSerializedInstrumentationState } from "#instrumentation/state.js";
-import { RuntimeActionSettlementTimesKey } from "#harness/runtime-action-settlement-state.js";
 import { preserveSerializedAgentTraceState } from "#tracing/agent-trace-context-store.js";
 import { matchAuthorizationCallbacks } from "#execution/authorization-callback-match.js";
 import { isTurnCancellation, throwIfTurnAborted } from "#harness/turn-cancellation.js";
@@ -51,7 +50,6 @@ import { setChannelContext } from "#execution/channel-context.js";
 import { observeSessionActivity } from "#execution/session-activity-projection.js";
 import { hasPendingInputBatch } from "#harness/input-requests.js";
 import { activeTurnId } from "#harness/active-turn-id.js";
-import { coalesceTurnInputs } from "#harness/messages.js";
 import { getWorkflowTaskCallIds, isWorkflowTaskInterrupt } from "#harness/workflow-task-state.js";
 import { getPendingWorkflowInterrupt } from "#harness/workflow-interrupt-state.js";
 import type { HarnessSession, StepInput, StepResult } from "#harness/types.js";
@@ -63,9 +61,9 @@ import {
   createSessionStartedEvent,
   createTurnStartedEvent,
   encodeMessageStreamEvent,
-  type UnstampedMessageStreamEvent,
-  stampMessageStreamEvent,
   type MessageStreamEvent,
+  stampMessageStreamEvent,
+  type UnstampedMessageStreamEvent,
 } from "#protocol/message.js";
 import {
   CallbackBaseUrlKey,
@@ -98,6 +96,7 @@ import { createWorkflowRuntime } from "#execution/workflow-runtime.js";
 import { bindDynamicConnections } from "#execution/dynamic-connections.js";
 import { preserveCancelledTurnMessage } from "#execution/cancelled-turn-message.js";
 import { deferMismatchedInlineTurnStep } from "#execution/accepted-delivery-deployment.js";
+import { resolveAuthenticatedChannelInput } from "#execution/channel-sender-authentication.js";
 
 const TASK_DONE_WITH_PENDING_INPUT_ERROR_MESSAGE =
   "Task mode cannot complete while input requests remain pending.";
@@ -162,7 +161,12 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
     input = { ...input, input: { ...input.input, payloads: remainingPayloads } };
     if (matches.length > 0) {
       const authResults = matches.map((match) => match.result);
-      ctx.set(PendingAuthorizationResultKey, authResults);
+      const connectionAuthResults = authResults.filter(
+        (result) => result.senderAuthentication === undefined,
+      );
+      if (connectionAuthResults.length > 0) {
+        ctx.set(PendingAuthorizationResultKey, connectionAuthResults);
+      }
       durableSession = {
         ...durableSession,
         state: clearPendingAuthorization(
@@ -183,7 +187,7 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
     ctx.set(AuthKey, input.input.auth ?? null);
   }
 
-  const initialSession = hydrateDurableSession({
+  let initialSession = hydrateDurableSession({
     compactionOverrides: {
       thresholdPercent: effectiveAgent.thresholdPercent,
     },
@@ -238,33 +242,21 @@ export async function turnStep(rawInput: TurnStepInput): Promise<DurableStepResu
     await instrumentation?.flush();
   };
   const adapterCtx = buildAdapterContext(adapter, ctx);
-
-  // Run the adapter's deliver hook for each queued payload and
-  // coalesce the resulting StepInput values.
-  let resolved: StepInput | undefined;
-  if (input.input?.kind === "deliver") {
-    const results: StepInput[] = [];
-    try {
-      for (const payload of input.input.payloads) {
-        const result = adapter.deliver
-          ? await adapter.deliver(payload, adapterCtx)
-          : defaultDeliverResult(payload);
-
-        if (result !== undefined && result !== null) {
-          results.push(result);
-        }
-      }
-    } catch (error) {
-      await failChannelDeliveries(error);
-      throw error;
-    }
-    resolved = results.length === 0 ? undefined : results.reduce(coalesceTurnInputs);
-  } else if (input.input?.kind === "runtime-action-result") {
-    if (input.input.acceptedAtMsByCallId !== undefined) {
-      ctx.set(RuntimeActionSettlementTimesKey, input.input.acceptedAtMsByCallId);
-    }
-    resolved = { runtimeActionResults: input.input.results };
-  }
+  const authenticatedInput = await resolveAuthenticatedChannelInput({
+    adapter,
+    adapterCtx,
+    completedAuths,
+    ctx,
+    emissionState: initialEmissionState,
+    failDelivery: failChannelDeliveries,
+    parentWritable: input.parentWritable,
+    session: initialSession,
+    turnInput: input.input,
+  });
+  completedAuths = authenticatedInput.completedAuths;
+  initialSession = authenticatedInput.session;
+  let resolved = authenticatedInput.resolved;
+  if (authenticatedInput.parked !== undefined) return authenticatedInput.parked;
 
   if (
     resolved !== undefined &&

--- a/packages/eve/src/harness/authorization.ts
+++ b/packages/eve/src/harness/authorization.ts
@@ -64,6 +64,11 @@ export interface AuthorizationChallenge {
    * journaled across the park. Absent for provider-owned flows.
    */
   readonly resume?: JsonValue;
+  /** Durable sender-auth state for a channel-level sign-in challenge. */
+  readonly senderAuthentication?: {
+    readonly event: unknown;
+    readonly strategyIndex: number;
+  };
 }
 
 export interface AuthorizationSignal {
@@ -87,6 +92,7 @@ export interface AuthorizationResult {
   readonly callback: AuthorizationCallback;
   readonly hookUrl: string;
   readonly principal?: ConnectionPrincipal;
+  readonly senderAuthentication?: AuthorizationChallenge["senderAuthentication"];
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/eve/src/protocol/message.test.ts
+++ b/packages/eve/src/protocol/message.test.ts
@@ -444,6 +444,7 @@ describe("message stream protocol", () => {
       authorization: { url: "https://idp.example.com/authorize" },
       name: "linear",
       description: "Linear",
+      purpose: "session",
       sequence: 3,
       stepIndex: 1,
       turnId: "turn_0",
@@ -453,6 +454,7 @@ describe("message stream protocol", () => {
       url: "https://idp.example.com/authorize",
     });
     expect(full.data.webhookUrl).toBe(webhookUrl);
+    expect(full.data.purpose).toBe("session");
   });
 
   it("builds authorization.completed with optional reason", () => {
@@ -491,6 +493,7 @@ describe("message stream protocol", () => {
       authorization: { displayName: "Linear", url: "https://idp.example.com/authorize" },
       name: "linear",
       outcome: "authorized",
+      purpose: "session",
       sequence: 7,
       stepIndex: 1,
       turnId: "turn_0",
@@ -499,6 +502,7 @@ describe("message stream protocol", () => {
       displayName: "Linear",
       url: "https://idp.example.com/authorize",
     });
+    expect(withChallenge.data.purpose).toBe("session");
   });
 
   it("normalizes failed action results onto the event payload", () => {

--- a/packages/eve/src/protocol/message.ts
+++ b/packages/eve/src/protocol/message.ts
@@ -645,6 +645,8 @@ export interface AuthorizationRequiredStreamEvent {
     candidateId?: string;
     description: string;
     name: string;
+    /** Whether the challenge establishes the session caller or authorizes a tool/connection. */
+    purpose?: "connection" | "session";
     sequence: number;
     stepIndex: number;
     turnId: string;
@@ -685,6 +687,8 @@ export interface AuthorizationCompletedStreamEvent {
     authorization?: ConnectionAuthorizationChallenge;
     name: string;
     outcome: AuthorizationOutcome;
+    /** Whether the challenge established the session caller or authorized a tool/connection. */
+    purpose?: "connection" | "session";
     reason?: string;
     sequence: number;
     stepIndex: number;
@@ -1136,6 +1140,7 @@ export function createAuthorizationRequiredEvent(input: {
   readonly candidateId?: string;
   readonly description: string;
   readonly name: string;
+  readonly purpose?: "connection" | "session";
   readonly sequence: number;
   readonly stepIndex: number;
   readonly turnId: string;
@@ -1160,6 +1165,9 @@ export function createAuthorizationRequiredEvent(input: {
   if (input.webhookUrl !== undefined) {
     data.webhookUrl = input.webhookUrl;
   }
+  if (input.purpose !== undefined) {
+    data.purpose = input.purpose;
+  }
   return {
     data,
     type: "authorization.required",
@@ -1177,6 +1185,7 @@ export function createAuthorizationCompletedEvent(input: {
   readonly candidateId?: string;
   readonly name: string;
   readonly outcome: AuthorizationOutcome;
+  readonly purpose?: "connection" | "session";
   readonly reason?: string;
   readonly sequence: number;
   readonly stepIndex: number;
@@ -1200,6 +1209,9 @@ export function createAuthorizationCompletedEvent(input: {
   }
   if (input.reason !== undefined) {
     data.reason = input.reason;
+  }
+  if (input.purpose !== undefined) {
+    data.purpose = input.purpose;
   }
   return {
     data,

--- a/packages/eve/src/public/channels/auth.test.ts
+++ b/packages/eve/src/public/channels/auth.test.ts
@@ -16,6 +16,7 @@ import {
   localDev,
   none,
   placeholderAuth,
+  resolveAuth,
   routeAuth,
   type UnauthorizedChallenge,
   UnauthenticatedError,
@@ -509,6 +510,30 @@ describe("routeAuth", () => {
     const result = await routeAuth(makeRequest(), [asyncAccept]);
 
     expect(result).toEqual(SAMPLE_CONTEXT);
+  });
+
+  it("rejects an interactive result because route auth cannot park the request", async () => {
+    await expect(
+      routeAuth(makeRequest(), () => ({
+        interaction: "required",
+        startAuthorization: async () => ({ challenge: {} }),
+        completeAuthorization: async () => SAMPLE_CONTEXT,
+      })),
+    ).rejects.toThrow(
+      "Interactive sign-in requires a durable channel sender-auth gate and cannot run during HTTP route authentication.",
+    );
+  });
+
+  it("returns an interactive result and its strategy index to durable channel factories", async () => {
+    const interaction = {
+      interaction: "required" as const,
+      startAuthorization: async () => ({ challenge: {} }),
+      completeAuthorization: async () => SAMPLE_CONTEXT,
+    };
+
+    const result = await resolveAuth(makeRequest(), [() => null, () => interaction]);
+
+    expect(result).toEqual({ interaction, strategyIndex: 1 });
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/eve/src/public/channels/auth.ts
+++ b/packages/eve/src/public/channels/auth.ts
@@ -8,6 +8,7 @@
 import { decodeJwt } from "#compiled/jose/index.js";
 
 import type { SessionAuthContext } from "#channel/types.js";
+import type { ConnectionAuthorizationChallenge } from "#connections/errors.js";
 import { isEveDevEnvironment } from "#internal/application/dev-environment.js";
 import { createLogger } from "#internal/logging.js";
 import { authenticateHttpBasicStrategy } from "#channel/auth/http-basic.js";
@@ -31,6 +32,8 @@ import {
   type RuntimeIpAllowList,
 } from "#channel/ip-allow-list.js";
 import { isLoopbackHostname } from "#shared/network-address.js";
+import type { AuthorizationCallback } from "#shared/connection-types.js";
+import type { JsonValue } from "#shared/json.js";
 
 // ---------------------------------------------------------------------------
 // Result types
@@ -509,19 +512,57 @@ export class ForbiddenError extends Error {
 }
 
 /**
- * Route auth callback. Returned value semantics inside {@link routeAuth}:
+ * Interactive sign-in request returned by a channel auth strategy.
  *
- * - A {@link SessionAuthContext} accepts the request and halts the walk.
- * - `null` or `undefined` skips to the next entry.
+ * The channel runtime mints {@link startAuthorization.callbackUrl}, journals
+ * `resume`, parks the accepted input, and calls `completeAuthorization` when
+ * the callback arrives. Returning this value claims the auth walk; later
+ * strategies are not evaluated.
+ */
+export interface AuthInteractionRequired<Resume extends JsonValue = JsonValue> {
+  readonly interaction: "required";
+  startAuthorization(opts: { readonly callbackUrl: string }): Promise<{
+    readonly challenge: ConnectionAuthorizationChallenge;
+    readonly resume?: Resume;
+  }>;
+  completeAuthorization(opts: {
+    readonly callback: AuthorizationCallback;
+    readonly callbackUrl: string;
+    readonly resume?: Resume;
+  }): Promise<SessionAuthContext>;
+}
+
+/** Result accepted from one {@link AuthFn}. */
+export type AuthResult = SessionAuthContext | AuthInteractionRequired;
+
+export function isAuthInteractionRequired(value: unknown): value is AuthInteractionRequired {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { readonly interaction?: unknown }).interaction === "required" &&
+    typeof (value as { readonly startAuthorization?: unknown }).startAuthorization === "function" &&
+    typeof (value as { readonly completeAuthorization?: unknown }).completeAuthorization ===
+      "function"
+  );
+}
+
+/**
+ * Authentication strategy shared by route and sender-auth walks.
  *
- * If every entry skips (including the empty `[]` case), the walker returns a
- * 401. To reject with a specific response, throw an
- * {@link UnauthenticatedError} or {@link ForbiddenError}. To accept anonymous
- * traffic, include {@link none} as the final entry.
+ * A {@link SessionAuthContext} accepts and `null` or `undefined` falls through
+ * to the next strategy. Durable channel sender-auth gates additionally accept
+ * {@link AuthInteractionRequired}; route auth rejects that result because an
+ * HTTP request cannot be parked for a callback.
  */
 export type AuthFn<TEvent = Request> = (
   event: TEvent,
-) => SessionAuthContext | null | undefined | Promise<SessionAuthContext | null | undefined>;
+) => AuthResult | null | undefined | Promise<AuthResult | null | undefined>;
+
+/** An interactive auth result together with the strategy that claimed the walk. */
+export interface AuthInteractionMatch {
+  readonly interaction: AuthInteractionRequired;
+  readonly strategyIndex: number;
+}
 
 /**
  * OAuth protected-resource metadata attached to an inbound auth policy.
@@ -590,6 +631,11 @@ export function oauthResource(
   const composed: AuthFn<Request> = async (request) => {
     for (const fn of list) {
       const result = await fn(request);
+      if (isAuthInteractionRequired(result)) {
+        throw new Error(
+          "Interactive sign-in requires a durable channel sender-auth gate and cannot run during HTTP route authentication.",
+        );
+      }
       if (result) return result;
     }
     return null;
@@ -703,13 +749,35 @@ export async function routeAuth(
   request: Request,
   auth: AuthFn<Request> | readonly AuthFn<Request>[],
 ): Promise<SessionAuthContext | Response> {
+  const result = await resolveAuth(request, auth);
+  if ("interaction" in result) {
+    throw new Error(
+      "Interactive sign-in requires a durable channel sender-auth gate and cannot run during HTTP route authentication.",
+    );
+  }
+  return result;
+}
+
+/**
+ * Resolves an auth walk while preserving an interactive result for a channel
+ * factory that can hand it to a durable sender-auth gate. Most HTTP routes
+ * should call {@link routeAuth}; accepting an interaction requires the route
+ * to durably retain the input before returning.
+ */
+export async function resolveAuth(
+  request: Request,
+  auth: AuthFn<Request> | readonly AuthFn<Request>[],
+): Promise<SessionAuthContext | AuthInteractionMatch | Response> {
   const list: readonly AuthFn<Request>[] = Array.isArray(auth)
     ? (auth as readonly AuthFn<Request>[])
     : [auth as AuthFn<Request>];
 
   try {
-    for (const fn of list) {
+    for (const [strategyIndex, fn] of list.entries()) {
       const result = await fn(request);
+      if (isAuthInteractionRequired(result)) {
+        return { interaction: result, strategyIndex };
+      }
       if (result) return result;
     }
   } catch (error) {

--- a/packages/eve/src/public/channels/eve.test.ts
+++ b/packages/eve/src/public/channels/eve.test.ts
@@ -1759,6 +1759,160 @@ describe("eveChannel — auth array shape", () => {
     expect(response.status).toBe(202);
     expect(handler.send.mock.calls[0]?.[1]).toMatchObject({ auth: ACCEPTED });
   });
+
+  it("hands an interactive create request to the durable sender-auth gate", async () => {
+    const interaction = {
+      interaction: "required" as const,
+      startAuthorization: async () => ({ challenge: { url: "https://app.example/sign-in" } }),
+      completeAuthorization: async () => ACCEPTED,
+    };
+    const handler = createEveCreateHandler({ auth: [() => null, () => interaction] });
+
+    const response = await handler.fetch(createJsonMessageRequest({ message: "hi" }));
+
+    expect(response.status).toBe(202);
+    const runInput = handler.createSession.mock.calls[0]?.[0];
+    expect(runInput?.auth).toBeNull();
+    expect(runInput?.input.senderAuthentication).toEqual({
+      event: {
+        request: { method: "POST", url: "https://example.com/eve/v1/session" },
+        strategyIndex: 1,
+      },
+    });
+  });
+
+  it("hands an interactive follow-up message to the durable sender-auth gate", async () => {
+    const handler = createEveContinueHandler({
+      auth: () => ({
+        interaction: "required",
+        startAuthorization: async () => ({ challenge: {} }),
+        completeAuthorization: async () => ACCEPTED,
+      }),
+    });
+
+    const response = await handler.fetch(
+      new Request("https://example.com/eve/v1/session/test-session-id?credential=secret", {
+        body: JSON.stringify({ message: "follow-up" }),
+        headers: {
+          authorization: "Bearer secret",
+          "content-type": "application/json",
+        },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    expect(handler.send.mock.calls[0]?.[1]).toMatchObject({
+      auth: null,
+      senderAuthentication: {
+        event: {
+          request: {
+            method: "POST",
+            url: "https://example.com/eve/v1/session/test-session-id",
+          },
+          strategyIndex: 0,
+        },
+      },
+    });
+  });
+
+  it("rejects operation-id creation when final identity requires interaction", async () => {
+    const handler = createEveCreateHandler({
+      auth: () => ({
+        interaction: "required",
+        startAuthorization: async () => ({ challenge: {} }),
+        completeAuthorization: async () => ACCEPTED,
+      }),
+    });
+
+    const response = await handler.fetch(
+      createJsonMessageRequest({ message: "hi", operationId: "operation-1" }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(handler.createSession).not.toHaveBeenCalled();
+  });
+
+  it("lets an explicit onMessage auth override bypass an interactive result", async () => {
+    const handler = createEveCreateHandler({
+      auth: () => ({
+        interaction: "required",
+        startAuthorization: async () => ({ challenge: {} }),
+        completeAuthorization: async () => ACCEPTED,
+      }),
+      onMessage: () => ({ auth: OVERRIDE_AUTH }),
+    });
+
+    const response = await handler.fetch(createJsonMessageRequest({ message: "hi" }));
+
+    expect(response.status).toBe(202);
+    const runInput = handler.createSession.mock.calls[0]?.[0];
+    expect(runInput?.auth).toEqual(OVERRIDE_AUTH);
+    expect(runInput?.input.senderAuthentication).toBeUndefined();
+  });
+
+  it("treats an explicit null onMessage auth as a final override", async () => {
+    const handler = createEveCreateHandler({
+      auth: () => ({
+        interaction: "required",
+        startAuthorization: async () => ({ challenge: {} }),
+        completeAuthorization: async () => ACCEPTED,
+      }),
+      onMessage: () => ({ auth: null }),
+    });
+
+    const response = await handler.fetch(createJsonMessageRequest({ message: "hi" }));
+
+    expect(response.status).toBe(202);
+    const runInput = handler.createSession.mock.calls[0]?.[0];
+    expect(runInput?.auth).toBeNull();
+    expect(runInput?.input.senderAuthentication).toBeUndefined();
+  });
+
+  it("starts and completes the selected interactive strategy in the durable adapter", async () => {
+    const startAuthorization = vi.fn(async ({ callbackUrl }: { callbackUrl: string }) => ({
+      challenge: { url: `https://app.example/sign-in?callback=${encodeURIComponent(callbackUrl)}` },
+      resume: { nonce: "test" },
+    }));
+    const completeAuthorization = vi.fn(async () => ACCEPTED);
+    const adapter = getEveAdapter({
+      auth: [
+        () => null,
+        () => ({ interaction: "required", startAuthorization, completeAuthorization }),
+      ],
+    });
+    const ctx = new ContextContainer();
+    const adapterCtx = buildAdapterContext(adapter, contextAccessorFor(ctx));
+    const event = {
+      request: { method: "POST", url: "https://example.com/eve/v1/session" },
+      strategyIndex: 1,
+    };
+
+    await expect(
+      adapter.authenticateSender?.(event, "https://example.com/callback", adapterCtx),
+    ).resolves.toEqual({
+      challenge: {
+        url: "https://app.example/sign-in?callback=https%3A%2F%2Fexample.com%2Fcallback",
+      },
+      kind: "interaction-required",
+      resume: { nonce: "test" },
+      strategyIndex: 1,
+    });
+    await expect(
+      adapter.completeSenderAuthentication?.(
+        {
+          callback: { method: "GET", params: { email: "alice@example.com" } },
+          callbackUrl: "https://example.com/callback",
+          event,
+          resume: { nonce: "test" },
+          strategyIndex: 1,
+        },
+        adapterCtx,
+      ),
+    ).resolves.toEqual(ACCEPTED);
+    expect(startAuthorization).toHaveBeenCalledOnce();
+    expect(completeAuthorization).toHaveBeenCalledOnce();
+  });
 });
 
 describe("eveChannel — cancel turn", () => {

--- a/packages/eve/src/public/channels/slack/connections.ts
+++ b/packages/eve/src/public/channels/slack/connections.ts
@@ -41,10 +41,14 @@ export function formatConnectionDisplayName(connectionName: string): string {
 export function buildAuthRequiredPublicText(input: {
   readonly displayName: string;
   readonly hasUser: boolean;
+  readonly purpose?: "connection" | "session";
 }): string {
   if (!input.hasUser) {
-    return `Authorization required for ${input.displayName} (no triggering user)`;
+    return input.purpose === "session"
+      ? "Sign-in required (no triggering user)"
+      : `Authorization required for ${input.displayName} (no triggering user)`;
   }
+  if (input.purpose === "session") return "Sign in to continue";
   return `Connect with ${input.displayName} to continue`;
 }
 
@@ -56,13 +60,18 @@ export function buildAuthRequiredPublicText(input: {
 export function buildAuthCompletedText(input: {
   readonly displayName: string;
   readonly outcome: ConnectionAuthorizationOutcome;
+  readonly purpose?: "connection" | "session";
   readonly reason?: string;
 }): string {
   if (input.outcome === "authorized") {
-    return `:white_check_mark: ${input.displayName} connected`;
+    return input.purpose === "session"
+      ? ":white_check_mark: Signed in"
+      : `:white_check_mark: ${input.displayName} connected`;
   }
   const tail = input.reason !== undefined ? ` (${input.reason})` : "";
-  return `:x: ${input.displayName} authorization ${input.outcome}${tail}`;
+  return input.purpose === "session"
+    ? `:x: Sign-in ${input.outcome}${tail}`
+    : `:x: ${input.displayName} authorization ${input.outcome}${tail}`;
 }
 
 /**

--- a/packages/eve/src/public/channels/slack/defaults.ts
+++ b/packages/eve/src/public/channels/slack/defaults.ts
@@ -134,11 +134,9 @@ function blockContainsRequestAction(block: unknown, requestId: string): boolean 
 }
 
 /**
- * Workspace-scoped projection of the Slack actor that produced
- * `message`, derived into a {@link SessionAuthContext}. Used by both
- * {@link defaultOnAppMention} and {@link defaultOnDirectMessage} when
- * the customer hasn't supplied their own `onAppMention` /
- * `onDirectMessage`. Returns `null` when the message has no author.
+ * Workspace-scoped projection of the Slack actor that produced `message`,
+ * derived into a {@link SessionAuthContext}. Used as the Slack channel's
+ * default sender-auth result. Returns `null` when the message has no author.
  */
 export function defaultSlackAuth(
   message: SlackMessage,
@@ -159,29 +157,29 @@ export function defaultSlackAuth(
 }
 
 /**
- * Default `onAppMention` — derives auth from the Slack actor and posts
- * a `"Thinking…"` typing indicator before the workflow runtime starts.
+ * Default `onAppMention` — posts a `"Thinking…"` typing indicator before
+ * the workflow runtime starts. Sender identity is resolved by the channel's
+ * durable auth gate.
  */
 export async function defaultOnAppMention(
   ctx: SlackContext,
-  message: SlackMessage,
+  _message: SlackMessage,
 ): Promise<SlackMentionResult> {
   await ctx.thread.startTyping("Thinking...");
-  return { auth: defaultSlackAuth(message, ctx) };
+  return {};
 }
 
 /**
- * Default `onDirectMessage` — derives auth from the Slack actor and
- * posts a `"Thinking…"` typing indicator before the workflow runtime
- * starts. Matches the default mention behavior; replace the option to
- * customize gating, auth derivation, or pre-dispatch side effects.
+ * Default `onDirectMessage` — posts a `"Thinking…"` typing indicator before
+ * the workflow runtime starts. Matches the default mention behavior; replace
+ * the option to customize routing or pre-dispatch side effects.
  */
 export async function defaultOnDirectMessage(
   ctx: SlackContext,
-  message: SlackMessage,
+  _message: SlackMessage,
 ): Promise<SlackMentionResult> {
   await ctx.thread.startTyping("Thinking...");
-  return { auth: defaultSlackAuth(message, ctx) };
+  return {};
 }
 
 /**
@@ -455,7 +453,9 @@ export const defaultEvents: SlackChannelInternalEvents = {
   },
 
   async "authorization.required"(event, channel, ctx) {
-    const displayName = event.authorization?.displayName ?? formatConnectionDisplayName(event.name);
+    const displayName =
+      event.authorization?.displayName ??
+      (event.purpose === "session" ? "your account" : formatConnectionDisplayName(event.name));
     const triggeringUserId =
       event.candidateId === undefined
         ? (slackUserIdFromAuthContext(ctx.session.auth.current) ??
@@ -472,6 +472,7 @@ export const defaultEvents: SlackChannelInternalEvents = {
       const publicText = buildAuthRequiredPublicText({
         displayName,
         hasUser: triggeringUserId !== null,
+        purpose: event.purpose,
       });
       try {
         const sent = await channel.thread.post(publicText);
@@ -517,9 +518,15 @@ export const defaultEvents: SlackChannelInternalEvents = {
   },
 
   async "authorization.completed"(event, channel, _ctx) {
-    const displayName = event.authorization?.displayName ?? formatConnectionDisplayName(event.name);
+    const displayName =
+      event.authorization?.displayName ??
+      (event.purpose === "session" ? "your account" : formatConnectionDisplayName(event.name));
     if (event.outcome === "authorized" && event.candidateId === undefined) {
-      await channel.thread.startTyping(`Connected to ${displayName}. Resuming...`);
+      await channel.thread.startTyping(
+        event.purpose === "session"
+          ? "Signed in. Resuming..."
+          : `Connected to ${displayName}. Resuming...`,
+      );
     }
 
     const pending = channel.state.pendingAuthMessageTs ?? {};
@@ -529,6 +536,7 @@ export const defaultEvents: SlackChannelInternalEvents = {
     const text = buildAuthCompletedText({
       displayName,
       outcome: event.outcome as ConnectionAuthorizationOutcome,
+      purpose: event.purpose,
       reason: event.reason,
     });
 

--- a/packages/eve/src/public/channels/slack/session-operations.ts
+++ b/packages/eve/src/public/channels/slack/session-operations.ts
@@ -9,8 +9,23 @@ import type { SessionAuthContext } from "#channel/types.js";
 import type { InputResponse, StrictInputResponses } from "#shared/input.js";
 import type { UserContent } from "ai";
 import type { SlackChannelState } from "#public/channels/slack/slackChannel.js";
+import {
+  INTERNAL_CHANNEL_DELIVER,
+  type InternalChannelSource,
+} from "#channel/channel-operations.js";
+import { CHANNEL_AUTHENTICATION_PAYLOAD_KEY } from "#channel/authentication.js";
 
 type SlackSource = ChannelSource<SlackChannelState>;
+
+export const INTERNAL_SLACK_AUTHENTICATED_SEND = Symbol("eve.slack.authenticated-send");
+
+interface SlackSessionOperationsInternal extends SlackSessionOperations {
+  [INTERNAL_SLACK_AUTHENTICATED_SEND](
+    message: string | UserContent,
+    event: unknown,
+    options?: SlackSendOptions,
+  ): ReturnType<SlackSource["send"]>;
+}
 
 /** Options for a message send already bound to one Slack thread. */
 export type SlackSendOptions = Omit<ChannelSendOptions<SlackChannelState>, "auth" | "state"> & {
@@ -43,12 +58,27 @@ export function bindSlackSessionOperations(input: {
   readonly from: ChannelFrom<SlackChannelState>;
   readonly resolveSession: ChannelResolveSession;
   readonly state: SlackChannelState;
-}): SlackSessionOperations {
-  const source = input.from(input.address);
+}): SlackSessionOperationsInternal {
+  const source = input.from(input.address) as InternalChannelSource<SlackChannelState>;
   const auth = (value: SessionAuthContext | null | undefined) =>
     value === undefined ? input.defaultAuth : value;
 
   return {
+    async [INTERNAL_SLACK_AUTHENTICATED_SEND](message, event, options = {}) {
+      return await source[INTERNAL_CHANNEL_DELIVER](
+        {
+          [CHANNEL_AUTHENTICATION_PAYLOAD_KEY]: { event },
+          context: options.context,
+          message,
+          outputSchema: options.outputSchema,
+        },
+        {
+          ...options,
+          auth: null,
+          state: input.state,
+        },
+      );
+    },
     async send(message, options = {}) {
       return await source.send(message, {
         ...options,

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -3,8 +3,10 @@ import { createHmac } from "node:crypto";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { buildAdapterContext } from "#channel/adapter-context.js";
+import { CHANNEL_AUTHENTICATION_PAYLOAD_KEY } from "#channel/authentication.js";
 import { callAdapterEventHandler, type ChannelAdapter } from "#channel/adapter.js";
 import { isCompiledChannel, type CompiledChannel } from "#channel/compiled-channel.js";
+import type { SessionAuthContext } from "#channel/types.js";
 import type { ChannelFrom, ChannelSource } from "#channel/channel-operations.js";
 import { isHttpRouteDefinition } from "#channel/routes.js";
 import { ContextContainer, contextStorage } from "#context/container.js";
@@ -1490,7 +1492,9 @@ describe("slackChannel() inbound mention pipeline", () => {
   });
 
   it("dispatches when onAppMention returns an auth result", async () => {
+    const channelAuth = vi.fn(() => null);
     const channel = slackChannel({
+      auth: channelAuth,
       credentials: { botToken: "xoxb-test" },
       onAppMention: () => ({
         auth: {
@@ -1512,6 +1516,105 @@ describe("slackChannel() inbound mention pipeline", () => {
       authenticator: "test",
       principalId: "U999",
       principalType: "user",
+    });
+    expect(options).not.toHaveProperty(CHANNEL_AUTHENTICATION_PAYLOAD_KEY);
+    expect(channelAuth).not.toHaveBeenCalled();
+  });
+
+  it("carries the Slack event to the durable auth gate when the handler omits auth", async () => {
+    const channel = slackChannel({
+      auth: () => null,
+      credentials: { botToken: "xoxb-test" },
+      onAppMention: () => ({}),
+    });
+    const { body } = buildMentionBody({ user: "U_AUTH" });
+    const { send } = await firePost(channel, buildSignedRequest({ body }));
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const [, delivery] = send.mock.calls[0]!;
+    expect(delivery).toMatchObject({
+      [CHANNEL_AUTHENTICATION_PAYLOAD_KEY]: {
+        event: {
+          defaultAuth: expect.objectContaining({ principalId: "slack:T01:U_AUTH" }),
+          event: expect.objectContaining({ type: "app_mention", user: "U_AUTH" }),
+        },
+      },
+      auth: null,
+    });
+  });
+
+  it("walks Slack auth strategies and preserves null as fallthrough", async () => {
+    const principal: SessionAuthContext = {
+      attributes: { role: "member" },
+      authenticator: "test",
+      principalId: "user-1",
+      principalType: "user",
+    };
+    const skip = vi.fn(() => null);
+    const accept = vi.fn(() => principal);
+    const adapter = getAdapter(slackChannel({ auth: [skip, accept] }));
+    const event = { type: "app_mention", user: "U01" } as never;
+
+    await expect(
+      adapter.authenticateSender!(
+        { defaultAuth: null, event },
+        "https://agent.example/callback",
+        buildAdapterContext(adapter, stubAccessor()),
+      ),
+    ).resolves.toEqual({ auth: principal, kind: "authenticated" });
+    expect(skip).toHaveBeenCalledWith(event);
+    expect(accept).toHaveBeenCalledWith(event);
+  });
+
+  it("starts and completes an interactive Slack auth strategy", async () => {
+    const principal: SessionAuthContext = {
+      attributes: {},
+      authenticator: "test-oidc",
+      principalId: "user-1",
+      principalType: "user",
+    };
+    const startAuthorization = vi.fn(async () => ({
+      challenge: { url: "https://idp.example/authorize" },
+      resume: { verifier: "pkce" },
+    }));
+    const completeAuthorization = vi.fn(async () => principal);
+    const required = {
+      interaction: "required" as const,
+      startAuthorization,
+      completeAuthorization,
+    };
+    const auth = vi.fn(() => required);
+    const adapter = getAdapter(slackChannel({ auth }));
+    const wrappedEvent = {
+      defaultAuth: null,
+      event: { type: "app_mention", user: "U01" },
+    };
+    const adapterCtx = buildAdapterContext(adapter, stubAccessor());
+
+    await expect(
+      adapter.authenticateSender!(wrappedEvent, "https://agent.example/callback", adapterCtx),
+    ).resolves.toEqual({
+      challenge: { url: "https://idp.example/authorize" },
+      kind: "interaction-required",
+      resume: { verifier: "pkce" },
+      strategyIndex: 0,
+    });
+    await expect(
+      adapter.completeSenderAuthentication!(
+        {
+          callback: { method: "GET", params: { code: "code" } },
+          callbackUrl: "https://agent.example/callback",
+          event: wrappedEvent,
+          resume: { verifier: "pkce" },
+          strategyIndex: 0,
+        },
+        adapterCtx,
+      ),
+    ).resolves.toEqual(principal);
+    expect(completeAuthorization).toHaveBeenCalledWith({
+      callback: { method: "GET", params: { code: "code" } },
+      callbackUrl: "https://agent.example/callback",
+      resume: { verifier: "pkce" },
     });
   });
 

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -10,6 +10,7 @@ import { defaultDeliverResult } from "#channel/adapter.js";
 import type { Session, SessionHandle } from "#channel/session.js";
 import { setChannelActivityRenderers } from "#channel/compiled-channel.js";
 import type { SessionAuthContext, TurnPolicy } from "#channel/types.js";
+import { type ChannelAuthenticationResolution } from "#channel/authentication.js";
 import type { CardElement } from "#compiled/chat/index.js";
 import type { SessionContext } from "#public/definitions/callback-context.js";
 import type { ChannelContinuationOps } from "#public/definitions/channel.js";
@@ -36,6 +37,7 @@ import {
   defaultInputRequestedHandler,
   defaultOnAppMention,
   defaultOnDirectMessage,
+  defaultSlackAuth,
 } from "#public/channels/slack/defaults.js";
 import {
   parseMessageEvent,
@@ -63,9 +65,11 @@ import { SLACK_CHANNEL_DEFAULT_ROUTE } from "#public/channels/slack/constants.js
 import { handleInteractionPost } from "#public/channels/slack/interactions.js";
 import {
   bindSlackSessionOperations,
+  INTERNAL_SLACK_AUTHENTICATED_SEND,
   type SlackSendOptions,
   type SlackSessionOperations,
 } from "#public/channels/slack/session-operations.js";
+import { isAuthInteractionRequired, type AuthFn } from "#public/channels/auth.js";
 import {
   mergeUploadPolicy,
   type UploadPolicy,
@@ -89,6 +93,11 @@ export type {
 
 const log = createLogger("slack.channel");
 const PRIVATE_SLACK_RUN_TITLE = "Private message";
+
+interface SlackSenderAuthenticationEvent {
+  readonly defaultAuth: SessionAuthContext | null;
+  readonly event: SlackEvent;
+}
 
 type EventData<T extends UnstampedMessageStreamEvent["type"]> =
   Extract<UnstampedMessageStreamEvent, { type: T }> extends { data: infer D } ? D : undefined;
@@ -536,7 +545,8 @@ export type SlackInputResponseResult = { readonly auth: SessionAuthContext | nul
  * workflow run title without changing the message sent to the model.
  */
 export type SlackMentionResult = {
-  readonly auth: SessionAuthContext | null;
+  /** Final sender identity. When present, bypasses the channel-level `auth` walk. */
+  readonly auth?: SessionAuthContext | null;
   readonly context?: readonly string[];
   readonly title?: string;
 } | null;
@@ -607,6 +617,15 @@ export interface SlackChannelConfig {
   readonly credentials?: SlackChannelCredentials;
   readonly botName?: string;
 
+  /**
+   * Resolves the sender identity for dispatched Slack events. Strategies run
+   * in order inside the durable session: `null` skips, a
+   * `SessionAuthContext` accepts, and `{ interaction: "required" }` parks the
+   * input for sign-in. A handler result with its own `auth` property bypasses
+   * this walk.
+   */
+  readonly auth?: AuthFn<SlackEvent> | readonly AuthFn<SlackEvent>[];
+
   /** Optional presentation-only activity rendered without starting parent turns. */
   readonly activity?: {
     readonly renderers: readonly SlackActivityRenderer[];
@@ -643,17 +662,19 @@ export interface SlackChannelConfig {
 
   /**
    * Invoked when a Slack `app_mention` event arrives (only `app_mention`;
-   * other event types are ignored). Decides whether to dispatch and with
-   * what auth, and may run pre-dispatch side effects (e.g.
+   * other event types are ignored). Decides whether to dispatch and may run
+   * pre-dispatch side effects (e.g.
    * `ctx.thread.startTyping("Thinking...")`) on the inbound webhook side
    * before the runtime cold-starts.
    *
-   * Return `{ auth }` to dispatch with that session auth context, or `null`
-   * to drop the mention. May be sync or async; the result is awaited before
+   * Return an object to dispatch, or `null` to drop the mention. Including an
+   * `auth` property supplies the final session auth and bypasses the configured
+   * sender-auth walk. May be sync or async; the result is awaited before
    * dispatching. Thrown errors are caught and logged and the mention is
    * dropped; wrap best-effort side effects in `try/catch` to keep them
-   * non-fatal. Defaults to a workspace-scoped auth derivation that posts a
-   * `"Thinking..."` typing indicator; replacing this replaces both.
+   * non-fatal. The default posts a `"Thinking..."` typing indicator; sender
+   * identity is then resolved by the configured auth walk or Slack's built-in
+   * workspace-scoped identity.
    */
   onAppMention?(
     ctx: SlackInboundMessageContext,
@@ -665,15 +686,17 @@ export interface SlackChannelConfig {
    * `channel_type: "im"`. Subtype messages (edits, deletes, joins, etc.)
    * and bot messages (`bot_id` set, including the bot's own replies) are
    * filtered out first, so handlers only see plain user-authored DMs.
-   * Decides whether to dispatch and with what auth, and may run
-   * pre-dispatch side effects on the inbound webhook side before cold-start.
+   * Decides whether to dispatch and may run pre-dispatch side effects on the
+   * inbound webhook side before cold-start.
    *
-   * Return `{ auth }` to dispatch with that session auth context, or `null`
-   * to drop the message. May be sync or async; the result is awaited before
+   * Return an object to dispatch, or `null` to drop the message. Including an
+   * `auth` property supplies the final session auth and bypasses the configured
+   * sender-auth walk. May be sync or async; the result is awaited before
    * dispatching. Thrown errors are caught and logged and the message is
    * dropped; wrap best-effort side effects in `try/catch` to keep them
-   * non-fatal. Defaults to a workspace-scoped auth derivation that posts a
-   * `"Thinking..."` typing indicator; replacing this replaces both.
+   * non-fatal. The default posts a `"Thinking..."` typing indicator; sender
+   * identity is then resolved by the configured auth walk or Slack's built-in
+   * workspace-scoped identity.
    * Requires the bot's Slack app to subscribe to `message.im` with the
    * `im:history` scope.
    */
@@ -939,6 +962,59 @@ export function slackChannel(config: SlackChannelConfig = {}): SlackChannel {
         };
       }
       return defaultDeliverResult(payload);
+    },
+
+    async authenticateSender(event, callbackUrl): Promise<ChannelAuthenticationResolution> {
+      const input = event as SlackSenderAuthenticationEvent;
+      const configured = config.auth;
+      if (configured === undefined) {
+        return input.defaultAuth === null
+          ? { kind: "not-authenticated" }
+          : { auth: input.defaultAuth, kind: "authenticated" };
+      }
+
+      const strategies: readonly AuthFn<SlackEvent>[] = Array.isArray(configured)
+        ? configured
+        : [configured as AuthFn<SlackEvent>];
+      for (const [strategyIndex, strategy] of strategies.entries()) {
+        const result = await strategy(input.event);
+        if (result === null || result === undefined) continue;
+        if (isAuthInteractionRequired(result)) {
+          const started = await result.startAuthorization({ callbackUrl });
+          return {
+            challenge: started.challenge,
+            kind: "interaction-required",
+            resume: started.resume,
+            strategyIndex,
+          };
+        }
+        return { auth: result, kind: "authenticated" };
+      }
+      return { kind: "not-authenticated" };
+    },
+
+    async completeSenderAuthentication(input) {
+      const event = input.event as SlackSenderAuthenticationEvent;
+      const configured = config.auth;
+      if (configured === undefined) {
+        throw new Error("Slack sender authentication callback has no configured auth strategy.");
+      }
+      const strategies: readonly AuthFn<SlackEvent>[] = Array.isArray(configured)
+        ? configured
+        : [configured as AuthFn<SlackEvent>];
+      const strategy = strategies[input.strategyIndex];
+      if (strategy === undefined) {
+        throw new Error("Slack sender authentication strategy changed while sign-in was pending.");
+      }
+      const result = await strategy(event.event);
+      if (!isAuthInteractionRequired(result)) {
+        throw new Error("Slack sender authentication strategy changed while sign-in was pending.");
+      }
+      return await result.completeAuthorization({
+        callback: input.callback,
+        callbackUrl: input.callbackUrl,
+        resume: input.resume,
+      });
     },
 
     routes: [
@@ -1375,6 +1451,7 @@ async function dispatchSlackMessage(input: {
     isPrivateConversation,
     isMentioned: isBotMentioned,
     message: input.message,
+    defaultAuth: defaultSlackAuth(input.message, { slack, thread }),
     result,
     sessionOperations,
     thread,
@@ -1471,8 +1548,9 @@ async function verifyInbound(
 
 async function deliverSlackMessage(input: {
   readonly botUserId: string | undefined;
-  readonly sessionOperations: SlackSessionOperations;
+  readonly sessionOperations: ReturnType<typeof bindSlackSessionOperations>;
   readonly credentials: SlackChannelCredentials | undefined;
+  readonly defaultAuth: SessionAuthContext | null;
   readonly isPrivateConversation: boolean;
   readonly isMentioned: boolean;
   readonly kind: string;
@@ -1517,11 +1595,20 @@ async function deliverSlackMessage(input: {
       ? PRIVATE_SLACK_RUN_TITLE
       : (input.result.title ?? message.markdown);
     const sendOptions: SlackSendOptions =
-      channelContext.length === 0
-        ? { auth: input.result.auth, title }
-        : { auth: input.result.auth, context: channelContext, title };
+      channelContext.length === 0 ? { title } : { context: channelContext, title };
 
-    await input.sessionOperations.send(turnMessage, sendOptions);
+    if (Object.hasOwn(input.result, "auth")) {
+      await input.sessionOperations.send(turnMessage, { ...sendOptions, auth: input.result.auth });
+    } else {
+      await input.sessionOperations[INTERNAL_SLACK_AUTHENTICATED_SEND](
+        turnMessage,
+        {
+          defaultAuth: input.defaultAuth,
+          event: message.raw,
+        },
+        sendOptions,
+      );
+    }
   } catch (error) {
     logError(log, `${input.kind} delivery failed`, error, { channelId: message.channelId });
   }

--- a/packages/eve/src/public/definitions/channel.ts
+++ b/packages/eve/src/public/definitions/channel.ts
@@ -327,7 +327,10 @@ function buildAdapter<TState, TCtx, TReceiveTarget, TMetadata extends Record<str
   const hasFetchFile = definition.fetchFile !== undefined;
   const metadata = definition.metadata;
   const hasMetadata = metadata !== undefined;
-  const hasBehavior = hasState || hasContext || hasMetadata;
+  const hasSenderAuthentication =
+    definition.authenticateSender !== undefined ||
+    definition.completeSenderAuthentication !== undefined;
+  const hasBehavior = hasState || hasContext || hasMetadata || hasSenderAuthentication;
 
   const eventHandlers: Record<string, unknown> = {};
   let hasEventHandlers = false;
@@ -399,6 +402,18 @@ function buildAdapter<TState, TCtx, TReceiveTarget, TMetadata extends Record<str
       if (definition.deliver === undefined) return defaultDeliverResult(payload);
       return definition.deliver(payload, adapterCtx as TCtx);
     },
+
+    authenticateSender:
+      definition.authenticateSender === undefined
+        ? undefined
+        : (event, callbackUrl, adapterCtx) =>
+            definition.authenticateSender!(event, callbackUrl, adapterCtx as TCtx),
+
+    completeSenderAuthentication:
+      definition.completeSenderAuthentication === undefined
+        ? undefined
+        : (input, adapterCtx) =>
+            definition.completeSenderAuthentication!(input, adapterCtx as TCtx),
 
     ...eventHandlers,
   } as ChannelAdapter<any>;

--- a/packages/eve/src/runtime/channels/registry.ts
+++ b/packages/eve/src/runtime/channels/registry.ts
@@ -45,6 +45,8 @@ const ADAPTER_NON_EVENT_FIELDS: ReadonlySet<string> = new Set([
   "createAdapterContext",
   "fetchFile",
   "instrumentation",
+  "authenticateSender",
+  "completeSenderAuthentication",
 ]);
 
 /**
@@ -171,6 +173,13 @@ function carriesAdapterBehavior(adapter: ChannelAdapter): boolean {
   }
 
   if (adapter.createAdapterContext !== undefined) {
+    return true;
+  }
+
+  if (
+    adapter.authenticateSender !== undefined ||
+    adapter.completeSenderAuthentication !== undefined
+  ) {
     return true;
   }
 

--- a/packages/eve/src/shared/channel-definition.ts
+++ b/packages/eve/src/shared/channel-definition.ts
@@ -6,6 +6,10 @@ import type { Session, SessionHandle } from "#channel/session.js";
 import type { DeliverPayload, SessionAuthContext, TurnPolicy } from "#channel/types.js";
 import type { StepInput } from "#harness/types.js";
 import type { ChannelAudienceMetadata } from "#shared/channel-audience.js";
+import type {
+  ChannelAuthenticationCallbackInput,
+  ChannelAuthenticationResolution,
+} from "#channel/authentication.js";
 
 /**
  * Enriched return shape from a channel's {@link ChannelAdapter.fetchFile}
@@ -63,6 +67,17 @@ export interface GenericChannelDefinition<
   /** Policy used by message sends that do not provide an explicit override. */
   readonly turnPolicy?: TurnPolicy;
   deliver?(payload: DeliverPayload, ctx: TCtx): StepInput | void | Promise<StepInput | void>;
+  /** @internal Channel factories use this to install a durable sender-auth gate. */
+  authenticateSender?(
+    event: unknown,
+    callbackUrl: string,
+    ctx: TCtx,
+  ): Promise<ChannelAuthenticationResolution>;
+  /** @internal Completes a sender-auth interaction started by `authenticateSender`. */
+  completeSenderAuthentication?(
+    input: ChannelAuthenticationCallbackInput,
+    ctx: TCtx,
+  ): Promise<SessionAuthContext>;
   readonly state?: TState;
   /**
    * CORS policy for this channel's HTTP routes. `true` enables H3/Nitro's

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -466,6 +466,40 @@ importers:
         specifier: 6.0.3
         version: 6.0.3
 
+  apps/frameworks/next-interactive-auth:
+    dependencies:
+      '@vercel/connect':
+        specifier: ^2
+        version: 2.0.2(@ai-sdk/mcp@2.0.29(zod@4.5.4))(@auth/core@0.41.2)(@chat-adapter/slack@4.34.0(ai@7.0.84(zod@4.5.4))(bufferutil@4.1.0)(supports-color@10.2.2)(zod@4.5.4))(ai@7.0.84(zod@4.5.4))(eve@packages+eve)
+      eve:
+        specifier: workspace:*
+        version: link:../../../packages/eve
+      next:
+        specifier: 'catalog:'
+        version: 16.3.4(@babel/core@7.29.0(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
+      zod:
+        specifier: 'catalog:'
+        version: 4.5.4
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.3
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.15)
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+
   apps/frameworks/next-multi-agent:
     dependencies:
       ai:
@@ -7919,6 +7953,29 @@ packages:
 
   '@vercel/connect@1.0.0':
     resolution: {integrity: sha512-otk4ElH9v+uimUwTz7ecjFn6vPsHJcFUzTNlL7VHrTcwKPw8PV17bgtquQExMoFPihlN44oF+fD2oIMnlM75nw==}
+    peerDependencies:
+      '@ai-sdk/mcp': ^1 || ^2
+      '@auth/core': '>=0.37.0'
+      '@chat-adapter/slack': ^4.0.0
+      ai: ^6 || ^7.0.0-beta.0
+      better-auth: '>=1.5.0'
+      eve: '>=0.13.7'
+    peerDependenciesMeta:
+      '@ai-sdk/mcp':
+        optional: true
+      '@auth/core':
+        optional: true
+      '@chat-adapter/slack':
+        optional: true
+      ai:
+        optional: true
+      better-auth:
+        optional: true
+      eve:
+        optional: true
+
+  '@vercel/connect@2.0.2':
+    resolution: {integrity: sha512-cW+J44Ac0x9tng3vg+R7Uzn1rjz66MeWArJkiBIyJSQm84L9EskKx8ibBfc8Gn2kh8xT4o/iHOFtlkrsicKr7A==}
     peerDependencies:
       '@ai-sdk/mcp': ^1 || ^2
       '@auth/core': '>=0.37.0'
@@ -22299,6 +22356,16 @@ snapshots:
       eve: link:packages/eve
 
   '@vercel/connect@1.0.0(@ai-sdk/mcp@2.0.29(zod@4.5.4))(@auth/core@0.41.2)(@chat-adapter/slack@4.34.0(ai@7.0.84(zod@4.5.4))(bufferutil@4.1.0)(supports-color@10.2.2)(zod@4.5.4))(ai@7.0.84(zod@4.5.4))(eve@packages+eve)':
+    dependencies:
+      '@vercel/oidc': 3.8.5
+    optionalDependencies:
+      '@ai-sdk/mcp': 2.0.29(zod@4.5.4)
+      '@auth/core': 0.41.2
+      '@chat-adapter/slack': 4.34.0(ai@7.0.84(zod@4.5.4))(bufferutil@4.1.0)(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(zod@4.5.4)
+      ai: 7.0.84(zod@4.5.4)
+      eve: link:packages/eve
+
+  '@vercel/connect@2.0.2(@ai-sdk/mcp@2.0.29(zod@4.5.4))(@auth/core@0.41.2)(@chat-adapter/slack@4.34.0(ai@7.0.84(zod@4.5.4))(bufferutil@4.1.0)(supports-color@10.2.2)(zod@4.5.4))(ai@7.0.84(zod@4.5.4))(eve@packages+eve)':
     dependencies:
       '@vercel/oidc': 3.8.5
     optionalDependencies:

--- a/research/interactive-channel-sender-auth.md
+++ b/research/interactive-channel-sender-auth.md
@@ -1,0 +1,50 @@
+---
+issue: TBD
+status: implemented
+last_updated: "2026-09-07"
+---
+
+# Interactive channel sender auth
+
+## Goal
+
+Let a durable channel resolve an accepted message's sender into `SessionAuthContext` before model or tool execution, including a sign-in flow that can park and later resume the original input.
+
+## Authoring API
+
+Slack accepts `AuthFn<SlackEvent>` and the eve HTTP channel accepts `AuthFn<Request>`, each as one strategy or an array. The ordered walk has three non-error outcomes:
+
+- `SessionAuthContext` accepts the sender.
+- `null` or `undefined` falls through.
+- `AuthInteractionRequired` (`{ interaction: "required", startAuthorization, completeAuthorization }`) claims the input and starts sign-in.
+
+A message handler that returns its own `auth` property supplies a final override and bypasses the configured walk. Property presence is intentional: `{ auth: null }` bypasses, while `{}` uses the resolver.
+
+## Lifecycle and boundaries
+
+```text
+accepted channel input
+  -> route verification / message hook admission
+  -> durable sender-auth walk
+       -> authenticated: set current auth and continue
+       -> interaction required: emit authorization.required, journal input, park
+  -> callback: complete auth, set current auth, replay input
+  -> dynamic capabilities, model, and tools
+```
+
+The framework core owns the durable gate, callback correlation, pending authorization state, and deferred input. Channel adapters own event typing and the configured auth walk. Sender sign-in reuses the existing authorization challenge, callback, protocol event, and private Slack rendering machinery; protocol events mark sender auth with `purpose: "session"`, while an absent purpose retains the existing connection-auth meaning.
+
+Generic route auth remains separate and cannot park arbitrary HTTP work. `eveChannel` recognizes an interactive result only on create and follow-up message requests, retains the parsed message, and hands a scrubbed request descriptor to the shared durable gate. Its info, stream, control, forwarded-principal, delegated callback, operation-id, and input-response paths still require immediate route identity. Slack request-signature verification and handler admission also remain separate from sender identity resolution.
+
+## Invariants
+
+- An interactive result parks before dynamic capability or model setup.
+- The original accepted input and JSON-serializable resume data survive the callback.
+- Only `completeAuthorization` supplies the final session identity.
+- The session initiator is set on first successful sender authentication and is not replaced on later turns.
+- Sign-in challenges use the existing private-delivery channel surface and are never included in model-visible authorization signals.
+- Exhausting the configured walk fails closed.
+
+## Coverage
+
+Unit coverage exercises ordered fallthrough, Slack and eve message admission, explicit handler overrides, credential scrubbing, interactive start/completion, durable parking before model creation, and callback replay with final current and initiator auth.


### PR DESCRIPTION
### Summary

Durable channel messages could not require application sign-in before reaching the model or tools, forcing authors to resolve identity in admission hooks or downstream tools. This adds a shared sender-auth gate for Slack and the eve HTTP channel: ordered `AuthFn` strategies may authenticate, fall through, or request an interaction that durably parks the accepted message until its callback resolves `SessionAuthContext`. Existing Slack identity remains the default when `auth` is omitted, and an explicit handler-returned `auth` remains a final override.

### Approach

- Channel adapters expose sender-auth start and completion hooks, while the shared workflow gate owns callback correlation, `authorization.required`/`authorization.completed`, pending authorization state, and deferred input replay.
- The gate runs after transport verification and message admission, but before dynamic capabilities, model creation, or tools. Slack therefore keeps signature verification and mention/DM routing independent from application identity resolution.
- Interactive state uses the existing JSON-serializable authorization resume protocol. Slack delivers challenges privately through its existing authorization renderer.
- The eve HTTP channel supports interaction on create and follow-up message routes. It retains only the selected strategy and a scrubbed request descriptor; headers, cookies, credentials, query parameters, and bodies do not enter durable workflow state. Routes that require identity at the HTTP boundary continue to require immediate authentication.

### Slack example

```ts
import { type AuthFn } from "eve/channels/auth";
import { slackChannel, type SlackEvent } from "eve/channels/slack";

const appAccount: AuthFn<SlackEvent> = async (event) => {
  const account = await findAccountForSlackUser(event);
  if (account) return account.auth;

  return {
    interaction: "required",
    startAuthorization: ({ callbackUrl }) =>
      startAppSignIn({ callbackUrl, slackEvent: event }),
    completeAuthorization: ({ callback, callbackUrl, resume }) =>
      completeAppSignIn({ callback, callbackUrl, resume }),
  };
};

export default slackChannel({ auth: [appAccount] });
```

Returning `null` tries the next strategy. Returning `{ interaction: "required" }` claims and parks the message. A message hook can bypass the configured walk with an explicit final override such as `{ auth: automationAuth }` or `{ auth: null }`.

### Validation

- `vitest run --config vitest.unit.config.ts src/public/channels/auth.test.ts src/public/channels/eve.test.ts src/public/channels/slack/slackChannel.test.ts src/public/definitions/channel.test.ts src/execution/workflow-steps.test.ts` — 413 tests passed.
- `tsc -p packages/eve/tsconfig.json --noEmit`
- `tsc --noEmit -p apps/frameworks/next-interactive-auth/tsconfig.json`
- eve package production build, including type declarations and rolldown bundles.
- `AUTH_FORM_ORIGIN=http://localhost:3000 next build` for the Next.js example.
- `node scripts/check-docs.mjs && node scripts/check-doc-snippets.mjs && node scripts/check-doc-mdx.mjs`
- `node scripts/extension-capability-contracts.mjs`
- `node scripts/guard-invariants.mjs`
- Focused `oxfmt --check` and `oxlint` checks for changed implementation and example files.
- A full unit run passed 8,216 tests and exposed three environment-sensitive failures: two telemetry preference tests used the host macOS config path instead of their stub, and the production-server test could not bind a sandboxed port (`EPERM`). The change-related file-length failure found by that run was fixed and retested.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
