### PR TITLE
fix(eve): finalize expired sessions without resuming agents

### DIFF
--- a/.changeset/quiet-session-expiration.md
+++ b/.changeset/quiet-session-expiration.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Session expiry now cancels the active turn and completes the session without delivering a synthetic result to a parent agent or invoking a session callback. Expired sessions no longer resume agent work when their children reach their own deadlines.

--- a/docs/agent-config.md
+++ b/docs/agent-config.md
@@ -165,10 +165,13 @@ export default defineAgent({
 
 `sessionTimeoutMs` sets an absolute lifetime for every session, including
 delegated sessions. It defaults to 30 days, starts at creation, and survives
-restarts and redeployments. At the deadline, eve lets an active turn settle,
-then emits `session.completed` and releases the continuation; the next
-qualifying channel message starts fresh. Set it to `false` to disable the
-timeout. Expiration does not delete stored session data.
+restarts and redeployments. At the deadline, eve cancels the active turn,
+terminates owned child sessions, emits `session.completed`, and releases the
+continuation. Expiration does not start another turn, deliver a result to a
+parent agent, or invoke a session callback. The next qualifying channel message
+starts fresh. Cancellation is cooperative: work already running must observe
+its abort signal to stop early. Set the limit to `false` to disable the timeout.
+Expiration does not delete stored session data.
 
 Input tokens, output tokens, and model token cost are checked independently.
 The model call that crosses a limit is allowed to finish because exact usage

--- a/docs/concepts/sessions-runs-and-streaming.md
+++ b/docs/concepts/sessions-runs-and-streaming.md
@@ -18,8 +18,9 @@ by the eve HTTP session API. See [Custom channels](../channels/custom#channel-op
 
 Sessions last 30 days by default; configure `limits.sessionTimeoutMs` in
 `agent.ts`, or set it to `false` to disable the deadline. At expiration, eve
-lets an active turn settle, emits `session.completed`, and releases the
-continuation so the next qualifying channel message starts fresh. Stored
+cooperatively cancels the active turn, emits `session.completed`, and releases
+the continuation so the next qualifying channel message starts fresh. Expiry
+does not resume agent execution or send a completion result to a parent. Stored
 session data is not deleted. See [Agent config](../agent-config#runtime-limits).
 
 React, Vue, and Svelte apps reach for [`useEveAgent()`](../guides/frontend/overview) instead of calling these routes by hand. Next.js and Nuxt apps can proxy them to the eve runtime from the same origin.

--- a/e2e/fixtures/agent-session-timeout/agent/agent.ts
+++ b/e2e/fixtures/agent-session-timeout/agent/agent.ts
@@ -2,7 +2,7 @@ import { e2eAgentConfig } from "@eve-e2e/config";
 import { defineAgent } from "eve";
 import { mockModel } from "eve/evals";
 
-const ACTIVE_TURN_DELAY_MS = 1_500;
+const ACTIVE_TURN_DELAY_MS = 15_000;
 
 export default defineAgent({
   // Harness config wires the workflow world; the model is always this

--- a/e2e/fixtures/agent-session-timeout/evals/session-timeout-channel-rollover.eval.ts
+++ b/e2e/fixtures/agent-session-timeout/evals/session-timeout-channel-rollover.eval.ts
@@ -24,7 +24,7 @@ async function postJson<T>(target: EveEvalTargetHandle, path: string, body: unkn
 
 export default defineEval({
   description:
-    "Session TTL lets an active turn settle, then the same channel thread starts a new session.",
+    "Session expiry cancels active work, then the same channel thread starts a new session.",
 
   async test(t) {
     const threadId = crypto.randomUUID();
@@ -40,18 +40,13 @@ export default defineEval({
     );
     const expiredSessionId = initial.sessionId!;
 
-    const activeTurn = await t.target.watchTurn(expiredSessionId).result();
-    activeTurn.expectOk();
-    activeTurn.notEvent("turn.failed");
-    await t.require(activeTurn.message, equals("timeout-ack:SLOW-TURN"));
-
-    const terminal = await t.target
-      .watchTurn(expiredSessionId, { startIndex: activeTurn.events.length })
-      .result();
+    const terminal = await t.target.watchTurn(expiredSessionId).result();
     await t.require(terminal.status, equals("completed"));
     terminal.event("session.completed");
     terminal.notEvent("turn.failed");
     terminal.notEvent("session.failed");
+    terminal.notEvent("turn.completed");
+    await t.require(terminal.message, equals(""));
 
     let owner: OwnerResponse = { sessionId: expiredSessionId };
     for (let attempt = 0; attempt < 50 && owner.sessionId !== null; attempt += 1) {

--- a/packages/eve/src/execution/turn-cancellation.integration.test.ts
+++ b/packages/eve/src/execution/turn-cancellation.integration.test.ts
@@ -449,6 +449,53 @@ describe("turn cancellation integration", () => {
     });
   });
 
+  it.each([false, true])(
+    "expires active work without another turn (delegated: %s)",
+    async (delegated) => {
+      const fixture = await createWaitToolRuntime(`session-expiry-${String(delegated)}`);
+      const continuationToken = `http:session-expiry-${String(delegated)}`;
+
+      await fixture.runtime.run(async () => {
+        const run = await start(workflowEntry, [
+          {
+            input: {
+              message: `${delegated ? "Delegate through Workflow to a subagent: " : ""}Use the ${WAIT_TOOL_NAME} tool.`,
+            },
+            serializedContext: buildSerializedContext({
+              channelKind: "http",
+              continuationToken,
+              mode: "conversation",
+            }),
+          },
+        ]);
+        const stream = captureTurnEvents(run);
+        try {
+          await fixture.toolStarted;
+          const turnToken = `${run.runId}:turn-control:0`;
+          const turn = await waitForHookByToken(turnCancellationHookToken(turnToken));
+          await resumeHook(sessionCommandHookToken(run.runId), { kind: "session-timeout" });
+
+          const events = await stream.nextTurn();
+          expect(events.at(-1)?.type).toBe("session.completed");
+          expect(filterEventsByType(events, "turn.started")).toHaveLength(1);
+          expect(filterEventsByType(events, "turn.completed")).toHaveLength(0);
+          expect(filterEventsByType(events, "subagent.called")).toHaveLength(delegated ? 1 : 0);
+          expectNoFailureEvents(events);
+          await expect(run.returnValue).resolves.toEqual({ output: "" });
+          await waitForRunCompletion(turn.runId);
+          await expectNoStepRetries(turn.runId);
+          await waitForHookSweep(continuationToken);
+          expect(fixture.toolStarts()).toBe(1);
+          expect(fixture.toolAborts()).toBe(1);
+        } finally {
+          stream.dispose();
+          if ((await run.status) === "running") await run.cancel();
+        }
+      });
+    },
+    60_000,
+  );
+
   it("buffers a default steering message before replacing the active turn", async () => {
     const fixture = await createWaitToolRuntime("turn-steer-message");
     const rawToken = "turn-steer-message";

--- a/packages/eve/src/execution/turn-control-receiver.test.ts
+++ b/packages/eve/src/execution/turn-control-receiver.test.ts
@@ -155,6 +155,70 @@ describe("TurnControlReceiver", () => {
       { kind: "deliver", payloads: [{ message: "legacy follow up" }] },
     ]);
     expect(bufferedSessionControls).toEqual(["clear", "compact", "expired"]);
+    expect(forwardTurnCancellationStep).toHaveBeenCalledWith({
+      payload: {},
+      token: "turn-control:cancel",
+    });
+  });
+
+  it("does not forward buffered input after the session expires", async () => {
+    installControlHook([deliveryRequest("req-1"), parkResult()], true);
+    const bufferedDeliveries: DeliverHookPayload[] = [
+      {
+        kind: "deliver",
+        payloads: [{ inputResponses: [{ requestId: "input-1", text: "late answer" }] }],
+      },
+    ];
+    await runReceiver(bufferedDeliveries, {
+      commandInbox: createCommandInbox([
+        { kind: "session-timeout" },
+        { kind: "send", payload: { message: "late message" }, turnPolicy: "steer" },
+        { kind: "session-timeout" },
+      ]),
+    });
+    expect(forwardTurnCancellationStep).toHaveBeenCalledOnce();
+    expect(forwardTurnDeliveryStep).not.toHaveBeenCalled();
+    expect(bufferedDeliveries).toHaveLength(1);
+  });
+
+  it("stops an input-response relay when expiry arrives during its wait", async () => {
+    const timeout = Promise.withResolvers<IteratorResult<SessionInboxPayload>>();
+    const reads: Promise<IteratorResult<SessionInboxPayload>>[] = [
+      timeout.promise,
+      Promise.resolve({
+        done: false,
+        value: {
+          kind: "send",
+          payload: { inputResponses: [{ requestId: "input-1", text: "late answer" }] },
+        },
+      }),
+    ];
+    const commands = createCommandInbox([], {
+      next: () => reads[0] ?? new Promise(() => {}),
+      consumeNext: () => {
+        reads.shift();
+      },
+      rekeyContinuation: async () => {
+        timeout.resolve({ done: false, value: { kind: "session-timeout" } });
+      },
+    });
+    let read = 0;
+    createHookMock.mockReturnValue({
+      token: "turn-control",
+      dispose: vi.fn(),
+      [Symbol.asyncIterator]() {
+        return {
+          next: async () => {
+            if (read++ === 0) return { done: false, value: deliveryRequest("req-1") };
+            await new Promise<void>((resolve) => setTimeout(resolve, 0));
+            return { done: false, value: parkResult() };
+          },
+        };
+      },
+    });
+    await runReceiver([], { commandInbox: commands });
+    expect(forwardTurnCancellationStep).toHaveBeenCalledOnce();
+    expect(forwardTurnDeliveryStep).not.toHaveBeenCalled();
   });
 
   it("consumes a replayed task delivery only once", async () => {

--- a/packages/eve/src/execution/turn-control-receiver.ts
+++ b/packages/eve/src/execution/turn-control-receiver.ts
@@ -91,6 +91,7 @@ export class TurnControlReceiver {
   private async handleSessionCommand(
     command: DecodedSessionInbox,
   ): Promise<TurnDriverAction | undefined> {
+    if (this.bufferedSessionControls.includes("expired")) return undefined;
     if (command.kind === "deliver") {
       if (!this.acceptTaskDelivery(command)) return undefined;
       await this.bufferDelivery(command);
@@ -102,6 +103,10 @@ export class TurnControlReceiver {
     }
     if (command.kind === "session-timeout") {
       this.bufferedSessionControls.push("expired");
+      await forwardTurnCancellationStep({
+        payload: {},
+        token: turnCancellationHookToken(this.control.token),
+      });
       return undefined;
     }
     if (command.kind === "cancel") {
@@ -219,10 +224,12 @@ export class TurnControlReceiver {
   private async serviceDeliveryRequest(
     request: DeliveryRequest,
   ): Promise<TurnDriverAction | undefined> {
+    if (this.bufferedSessionControls.includes("expired")) return undefined;
     await this.commandInbox.rekeyContinuation(request.continuationToken);
 
     let delivery = this.takeInputResponseDelivery();
     while (delivery === undefined) {
+      if (this.bufferedSessionControls.includes("expired")) return undefined;
       const winner = await Promise.race([
         this.getControlPromise().then((value) => ({ kind: "control" as const, value })),
         this.commandInbox.next().then((value) => ({ kind: "command" as const, value })),

--- a/packages/eve/src/execution/turn-workflow.test.ts
+++ b/packages/eve/src/execution/turn-workflow.test.ts
@@ -665,6 +665,33 @@ describe("turnWorkflow", () => {
     expect(inbox.createIterator).toHaveBeenCalledOnce();
   });
 
+  it("does not dispatch a pending action batch after cancellation", async () => {
+    const pendingState = createSessionState();
+    installInbox([], { cancelPayloads: [{}], stayOpen: true });
+    vi.mocked(turnStep).mockImplementationOnce(async ({ abortSignal }) => {
+      await vi.waitFor(() => expect(abortSignal?.aborted).toBe(true));
+      return {
+        action: "park",
+        hasPendingAuthorization: false,
+        hasPendingInputBatch: false,
+        pendingCoordinationCallIds: ["call-1"],
+        serializedContext: { state: "pending" },
+        sessionState: pendingState,
+      };
+    });
+    const { input } = createInput({
+      driverCapabilities: { cancelledTurnSettle: true, turnInbox: true },
+    });
+    await turnWorkflow(input);
+
+    expect(turnStep).toHaveBeenCalledOnce();
+    expect(dispatchCoordinationStep).not.toHaveBeenCalled();
+    expect(cancelDescendantTurnsStep).toHaveBeenCalledWith({
+      serializedContext: { state: "pending" },
+      sessionState: pendingState,
+    });
+  });
+
   it("waits for dispatch adoption before cascading a cancellation", async () => {
     const initialState = createSessionState({ continuationToken: "http:parent" });
     const pendingState = createSessionState({ continuationToken: "http:parent:turn" });
@@ -683,7 +710,17 @@ describe("turnWorkflow", () => {
     }>((resolve) => {
       finishDispatch = resolve;
     });
-    installInbox([], { cancelPayloads: [{}], stayOpen: true });
+    const inbox = installInbox([], { stayOpen: true });
+    const cancelRead = Promise.withResolvers<IteratorResult<unknown>>();
+    const cancelHook = createCancelHookMock("turn-token:cancel") as object;
+    createHookMock.mockImplementation(({ token }: { token: string }) =>
+      token.endsWith(":cancel")
+        ? {
+            ...cancelHook,
+            [Symbol.asyncIterator]: () => ({ next: () => cancelRead.promise }),
+          }
+        : inbox.hook,
+    );
     vi.mocked(dispatchCoordinationStep).mockReturnValue(dispatchResult);
     vi.mocked(turnStep)
       .mockResolvedValueOnce({
@@ -707,6 +744,10 @@ describe("turnWorkflow", () => {
     });
     const workflow = turnWorkflow(input);
     await vi.waitFor(() => expect(dispatchCoordinationStep).toHaveBeenCalledOnce());
+    cancelRead.resolve({ done: false, value: {} });
+    await vi.waitFor(() =>
+      expect(vi.mocked(turnStep).mock.calls[0]?.[0].abortSignal?.aborted).toBe(true),
+    );
     expect(cancelDescendantTurnsStep).not.toHaveBeenCalled();
 
     finishDispatch?.({ results: [], sessionState: adoptedState, pendingTasks: [] });

--- a/packages/eve/src/execution/turn-workflow.ts
+++ b/packages/eve/src/execution/turn-workflow.ts
@@ -213,6 +213,10 @@ export async function runTurnOwnedWorkflow(
         (result.action === "park" || result.action === "dispatch-workflow-tasks")
       ) {
         await cursor.adopt(result);
+        if (cancellation?.signal.aborted === true) {
+          await finishCancelledTurn({ bufferedDeliveries, cancellation, cursor });
+          return;
+        }
         const dispatchResult = await dispatchCoordinationStep({
           action: result.action,
           callbackBaseUrl: resolveWorkflowCallbackBaseUrl(getWorkflowMetadata().url),

--- a/packages/eve/src/execution/workflow-entry-finalization.ts
+++ b/packages/eve/src/execution/workflow-entry-finalization.ts
@@ -13,6 +13,7 @@ import type { RunMode } from "#shared/run-mode.js";
 import type { TokenUsage } from "#shared/token-usage.js";
 
 export async function finalizeExpiredSession(input: {
+  readonly reason: "expired" | "reset" | "closed";
   readonly caller: TurnCaller | undefined;
   readonly driverWritable: WritableStream<Uint8Array>;
   readonly mode: RunMode;
@@ -29,6 +30,8 @@ export async function finalizeExpiredSession(input: {
     serializedContext: input.serializedContext,
   });
   if (input.terminalState !== undefined) input.terminalState.terminalEmitted = true;
+
+  if (input.reason === "expired") return { output: "" };
 
   if (input.mode === "task") {
     await fireSessionCallbackStep({

--- a/packages/eve/src/execution/workflow-entry.test.ts
+++ b/packages/eve/src/execution/workflow-entry.test.ts
@@ -30,6 +30,11 @@ import type { SessionInboxPayload } from "#execution/session-command-inbox.js";
 import { sessionCommandHookToken } from "#execution/session-command-token.js";
 import { SESSION_INBOX_WIRE_VERSION } from "#execution/wire/session-inbox-contract.js";
 import { settleContinuationConflictStep } from "#execution/continuation-conflict-step.js";
+import { forwardTurnCancellationStep } from "#execution/forward-turn-cancellation-step.js";
+
+vi.mock("./forward-turn-cancellation-step.js", () => ({
+  forwardTurnCancellationStep: vi.fn().mockResolvedValue(true),
+}));
 
 vi.mock("#compiled/@workflow/core/index.js", () => ({
   createHook: vi.fn(),
@@ -588,6 +593,7 @@ describe("workflowEntry", () => {
     );
     expect(fireSessionCallbackStep).not.toHaveBeenCalled();
     expect(notifyTurnCallerStep).not.toHaveBeenCalled();
+    expect(notifyDelegatedParentStep).not.toHaveBeenCalled();
   });
 
   it("dispatches a compact control without converting it into a delivery", async () => {
@@ -646,68 +652,125 @@ describe("workflowEntry", () => {
     expect(routeDeliverToChildren).not.toHaveBeenCalled();
   });
 
-  it("completes at the deadline after the active turn settles", async () => {
-    const sessionState = createBaseSessionState();
-    const dispose = vi.fn();
-    let settleTurn: ((result: IteratorResult<TurnControlPayload>) => void) | undefined;
-    const activeTurn = new Promise<IteratorResult<TurnControlPayload>>((resolve) => {
-      settleTurn = resolve;
-    });
+  it.each(["park", "done"] as const)(
+    "expires an active turn even when cancellation returns %s",
+    async (action) => {
+      const sessionState = createBaseSessionState();
+      const dispose = vi.fn();
+      let settleTurn: ((result: IteratorResult<TurnControlPayload>) => void) | undefined;
+      const activeTurn = new Promise<IteratorResult<TurnControlPayload>>((resolve) => {
+        settleTurn = resolve;
+      });
 
-    vi.mocked(createSessionStep).mockResolvedValue(createSessionStepResultForMock(sessionState));
-    let deliveredTimeout = false;
-    vi.mocked(createHook).mockImplementation((options?: { readonly token?: string }) => {
-      const token = options?.token ?? "";
-      if (isTurnCompletionToken(token)) {
-        return createMockHook({
-          next: () => activeTurn,
-          token,
-          values: [],
-        }) as never;
-      }
-      if (token.endsWith(":auth")) {
-        return createMockHook({ token, values: [] }) as never;
-      }
-      return token === sessionCommandHookToken("wrun_test_123")
-        ? (createMockHook({
-            dispose,
-            next: () => {
-              if (deliveredTimeout) {
-                return new Promise<IteratorResult<SessionInboxPayload>>(() => {});
-              }
-              deliveredTimeout = true;
-              return Promise.resolve({ done: false, value: { kind: "session-timeout" } });
-            },
+      vi.mocked(createSessionStep).mockResolvedValue(createSessionStepResultForMock(sessionState));
+      const commands: SessionInboxPayload[] = [
+        { kind: "send", payload: { message: "queued follow-up" } },
+        { kind: "compact" },
+        { kind: "session-timeout" },
+      ];
+      vi.mocked(createHook).mockImplementation((options?: { readonly token?: string }) => {
+        const token = options?.token ?? "";
+        if (isTurnCompletionToken(token)) {
+          return createMockHook({
+            next: () => activeTurn,
             token,
             values: [],
-          }) as never)
-        : (createMockHook({
-            dispose,
-            next: () => new Promise<IteratorResult<SessionInboxPayload>>(() => {}),
-            token,
-            values: [],
-          }) as never);
-    });
+          }) as never;
+        }
+        if (token.endsWith(":auth")) {
+          return createMockHook({ token, values: [] }) as never;
+        }
+        return token === sessionCommandHookToken("wrun_test_123")
+          ? (createMockHook({
+              dispose,
+              next: () => {
+                const value = commands.shift();
+                if (value === undefined) {
+                  return new Promise<IteratorResult<SessionInboxPayload>>(() => {});
+                }
+                return Promise.resolve({ done: false, value });
+              },
+              token,
+              values: [],
+            }) as never)
+          : (createMockHook({
+              dispose,
+              next: () => new Promise<IteratorResult<SessionInboxPayload>>(() => {}),
+              token,
+              values: [],
+            }) as never);
+      });
 
-    const result = workflowEntry({
-      input: { message: "hello there" },
-      serializedContext: createSerializedContext(),
-      sessionTimeoutMs: 1,
-    });
+      const result = workflowEntry({
+        input: { message: "hello there" },
+        serializedContext: createSerializedContext(),
+        sessionTimeoutMs: 1,
+      });
 
-    await vi.waitFor(() => {
+      await vi.waitFor(() => {
+        expect(forwardTurnCancellationStep).toHaveBeenCalledWith({
+          payload: {},
+          token: "wrun_test_123:turn-control:0:cancel",
+        });
+      });
+      expect(emitTerminalSessionCompletionStep).not.toHaveBeenCalled();
+
+      settleTurn?.({
+        done: false,
+        value: turnResult({ action, output: "late answer", sessionState }),
+      });
+
+      await expect(result).resolves.toEqual({ output: "" });
+      expect(emitTerminalSessionCompletionStep).toHaveBeenCalledOnce();
       expect(dispatchTurnStep).toHaveBeenCalledOnce();
-    });
-    expect(emitTerminalSessionCompletionStep).not.toHaveBeenCalled();
+      expect(notifyTurnCallerStep).not.toHaveBeenCalled();
+      expect(notifyDelegatedParentStep).not.toHaveBeenCalled();
+      expect(fireSessionCallbackStep).not.toHaveBeenCalled();
+    },
+  );
 
-    settleTurn?.({
-      done: false,
-      value: turnResult({ action: "park", sessionState }),
-    });
+  it.each(["conversation", "task"])(
+    "expires a parked %s without resuming its caller",
+    async (mode) => {
+      const sessionState = createBaseSessionState();
+      const caller = {
+        callId: "call-1",
+        replyTo: { kind: "hook" as const, token: "parent-token" },
+        subagentName: "researcher",
+      };
+      vi.mocked(createSessionStep).mockResolvedValue(createSessionStepResultForMock(sessionState));
+      vi.mocked(resolveInitialTurnCallerStep).mockResolvedValueOnce(caller);
+      installHookMocks({
+        stableHook: { values: [{ kind: "session-timeout" }] },
+        turnControls: [turnResult({ action: "park", sessionState })],
+      });
 
-    await expect(result).resolves.toEqual({ output: "" });
-    expect(emitTerminalSessionCompletionStep).toHaveBeenCalledOnce();
-  });
+      await expect(
+        workflowEntry({
+          input: { message: "delegate" },
+          serializedContext: createSerializedContext({
+            "eve.mode": mode,
+            "eve.channel": {
+              kind: "subagent",
+              state: {
+                callId: "call-1",
+                parentContinuationToken: "parent-token",
+                subagentName: "researcher",
+              },
+            },
+          }),
+        }),
+      ).resolves.toEqual({ output: "" });
+
+      expect(terminateChildSessionsStep).toHaveBeenCalledOnce();
+      expect(emitTerminalSessionCompletionStep).toHaveBeenCalledOnce();
+      expect(notifyTurnCallerStep).not.toHaveBeenCalled();
+      expect(notifyDelegatedParentStep).not.toHaveBeenCalled();
+      expect(fireSessionCallbackStep).not.toHaveBeenCalled();
+      expect(emitTerminalSessionFailureStep).not.toHaveBeenCalled();
+      expect(dispatchTurnStep).toHaveBeenCalledOnce();
+    },
+  );
 
   it("allows the session timeout to be disabled", async () => {
     const sessionState = createBaseSessionState();

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -295,6 +295,7 @@ export async function workflowEntry(input: WorkflowEntryInput): Promise<Workflow
       return outcome.result;
     }
     return await finalizeExpiredSession({
+      reason: "expired",
       caller: crashCleanupState.caller,
       driverWritable,
       mode,
@@ -541,6 +542,13 @@ async function runDriverLoop(input: {
     let action: TurnDriverAction = await runTurn(input.initialInput);
 
     while (true) {
+      if (bufferedSessionControls.includes("expired")) {
+        return {
+          kind: "expired",
+          serializedContext: stateCursor.serializedContext,
+          sessionState: stateCursor.sessionState,
+        };
+      }
       if (action.kind === "done") {
         return {
           kind: "result",
@@ -630,10 +638,11 @@ async function runDriverLoop(input: {
         };
       }
 
-      if (next.kind === "reset") {
+      if (next.kind === "reset" || next.kind === "closed") {
         return {
           kind: "result",
           result: await finalizeExpiredSession({
+            reason: next.kind,
             caller: input.crashCleanupState.caller,
             driverWritable: input.driverWritable,
             mode: input.mode,
@@ -647,20 +656,6 @@ async function runDriverLoop(input: {
       if (next.kind === "clear" || next.kind === "compact") {
         action = await runTurn({ kind: next.kind });
         continue;
-      }
-
-      if (next.kind === "closed") {
-        return {
-          kind: "result",
-          result: await finalizeExpiredSession({
-            caller: input.crashCleanupState.caller,
-            driverWritable: input.driverWritable,
-            mode: input.mode,
-            serializedContext: stateCursor.serializedContext,
-            sessionState: stateCursor.sessionState,
-            terminalState: input.crashCleanupState,
-          }),
-        };
       }
 
       if (next.kind === "cancel-turn") {

--- a/packages/eve/src/shared/agent-definition.ts
+++ b/packages/eve/src/shared/agent-definition.ts
@@ -148,8 +148,8 @@ export interface AgentLimitsDefinition {
    * Maximum lifetime of one durable session, in milliseconds.
    *
    * The deadline starts when the session is created and survives process
-   * restarts and redeployments. If it elapses during an active turn, eve lets
-   * that turn settle before completing the session normally.
+   * restarts and redeployments. At expiry, eve cancels the active turn and
+   * completes the session without starting another turn or notifying callers.
    *
    * `false` disables the timeout.
    *


### PR DESCRIPTION
### Summary

Session expiry could deliver an empty successful result to a parent and resume its agent execution. Expiry now cancels the active turn, stops further input and child dispatch, and completes the session without notifying callers or invoking session callbacks. It still terminates owned children, emits `session.completed`, and releases the continuation. Cancellation is cooperative; reset and channel closure keep their existing behavior.

### Validation

- 86 focused unit tests and 30 integration tests passed.
- Typecheck, lint, invariant guard, and docs checks passed.
- Two telemetry unit failures on macOS also reproduce on unchanged `main`.
- E2E coverage updated; awaiting CI.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
