### PR TITLE
test(eve): cover parent actions after background results

### DIFF
--- a/e2e/fixtures/agent-task-reporting/agent/tools/report.ts
+++ b/e2e/fixtures/agent-task-reporting/agent/tools/report.ts
@@ -6,14 +6,11 @@ const validated = defineState("task-reporting.inventory-validated", () => false)
 
 export default defineTool({
   description: "Validate the two warehouse inventories or publish their validated report.",
-  inputSchema: z.discriminatedUnion("action", [
-    z.strictObject({
-      action: z.literal("validate"),
-      first: z.string(),
-      second: z.string(),
-    }),
-    z.strictObject({ action: z.literal("publish") }),
-  ]),
+  inputSchema: z.strictObject({
+    action: z.enum(["validate", "publish"]),
+    first: z.string().optional(),
+    second: z.string().optional(),
+  }),
   execute(input) {
     if (input.action === "validate") {
       if (input.first !== "oranges" || input.second !== "pears") {

--- a/e2e/fixtures/agent-task-reporting/agent/tools/report.ts
+++ b/e2e/fixtures/agent-task-reporting/agent/tools/report.ts
@@ -1,0 +1,28 @@
+import { defineState } from "eve/context";
+import { defineTool } from "eve/tools";
+import { z } from "zod";
+
+const validated = defineState("task-reporting.inventory-validated", () => false);
+
+export default defineTool({
+  description: "Validate the two warehouse inventories or publish their validated report.",
+  inputSchema: z.discriminatedUnion("action", [
+    z.strictObject({
+      action: z.literal("validate"),
+      first: z.string(),
+      second: z.string(),
+    }),
+    z.strictObject({ action: z.literal("publish") }),
+  ]),
+  execute(input) {
+    if (input.action === "validate") {
+      if (input.first !== "oranges" || input.second !== "pears") {
+        throw new Error("The report must contain the inventory returned by both warehouses.");
+      }
+      validated.update(() => true);
+      return { validated: true };
+    }
+    if (!validated.get()) throw new Error("The inventory report has not been validated.");
+    return { published: true, reportId: "inventory-first-second" };
+  },
+});

--- a/e2e/fixtures/agent-task-reporting/evals/complete-after-results.eval.ts
+++ b/e2e/fixtures/agent-task-reporting/evals/complete-after-results.eval.ts
@@ -1,0 +1,72 @@
+import { defineEval, type EveEvalSession, type EveEvalTurn } from "eve/evals";
+import { satisfies } from "eve/evals/expect";
+
+const COMPLETION = /Background task (task_[a-z0-9]+) \([^)]+\) is completed\./giu;
+
+export default defineEval({
+  description:
+    "The parent validates and publishes a report after background lookups finish, without another user message.",
+  tags: ["real-model"],
+  async test(t) {
+    const started =
+      await t.send(`Alice needs a published inventory report for our first and second sample warehouses. Use two background agents to look up the inventories: ask one to call probe with check=first and the other to call probe with check=second, and have each report its result value. Start both lookups without waiting for either result; delegate the lookups rather than calling probe yourself.
+
+After both agents return, use report to validate their inventories and then publish the report. Give Alice the published report ID when the work is complete.`);
+    started.expectOk();
+    started.calledSubagent("agent", { count: 2 });
+    started.notCalledTool("probe");
+    started.notCalledTool("report");
+
+    const taskIds = new Set(
+      started.events.flatMap((event) =>
+        event.type === "subagent.completed" &&
+        event.data.subagentName === "agent" &&
+        event.data.backgroundTask !== undefined
+          ? [event.data.backgroundTask.taskId]
+          : [],
+      ),
+    );
+    await t.require(
+      taskIds.size,
+      satisfies((count: number) => count === 2, "two background lookups were accepted"),
+    );
+
+    let session: EveEvalSession | typeof t = t;
+    const completed = new Set<string>();
+    let settled: EveEvalTurn | undefined;
+    for (let attempt = 0; attempt < 8 && completed.size < taskIds.size; attempt += 1) {
+      if (session.state === undefined) throw new Error("Task continuation has no stream index.");
+      const live = t.target.watchTurn(started.sessionId, {
+        startIndex: session.state.streamIndex,
+      });
+      const turn = await live.result();
+      turn.expectOk();
+      turn.noFailedActions();
+      for (const event of turn.events) {
+        if (event.type !== "message.received") continue;
+        const message = JSON.stringify(event.data.message);
+        for (const match of message.matchAll(COMPLETION)) {
+          if (taskIds.has(match[1]!)) completed.add(match[1]!);
+        }
+      }
+      t.log(`lookups completed: ${completed.size}/${taskIds.size}; reply: ${turn.message}`);
+      if (completed.size < taskIds.size) turn.notCalledTool("report");
+      else settled = turn;
+      session = live.session;
+    }
+
+    if (settled === undefined) throw new Error("The parent did not receive both lookup results.");
+    settled.calledTool("report", {
+      count: 1,
+      input: { action: "validate", first: "oranges", second: "pears" },
+      output: { validated: true },
+    });
+    settled.calledTool("report", {
+      count: 1,
+      input: { action: "publish" },
+      output: { published: true, reportId: "inventory-first-second" },
+    });
+    settled.messageIncludes("inventory-first-second");
+    t.noFailedActions();
+  },
+});


### PR DESCRIPTION
### Summary

Task-reporting coverage currently checks that a parent summarizes background results, but does not require it to finish subsequent actions. Add a real-model `eve eval` that asks the parent to validate and publish an inventory report after two background lookups return, without another user message. The assertions require successful validation and publication tool results plus the published report ID, so a progress-only final reply fails. This uses the existing fixture and model matrix; it does not change runtime behavior or establish the cause of premature stopping.

### Validation

- `pnpm --filter eve build` passed.
- `pnpm --filter agent-task-reporting typecheck` passed, including the fixture build.
- Focused `oxfmt`, `oxlint --deny-warnings`, and `git diff --check` passed.
- The first Sol CI run passed all 9 cases, including the new continuation eval. This has not reproduced the production failure.
- The first Opus run rejected the new tool's top-level union schema before executing the scenarios. The tool now exposes an object schema, checked locally; the updated CI run is pending.

### Checklist

- [x] This change was requested or approved by a maintainer
- [ ] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

No changeset is required for fixture-only changes.
