### PR TITLE
fix(eve): persist task guidance in conversation history

### DIFF
--- a/.changeset/stable-task-guidance.md
+++ b/.changeset/stable-task-guidance.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Keep background-task guidance in durable conversation history instead of temporary system instructions, preserving prompt prefixes when tasks start. Existing task reporting and approval behavior is unchanged.

--- a/docs/subagents/index.mdx
+++ b/docs/subagents/index.mdx
@@ -7,6 +7,8 @@ eve supports two ways to delegate work: the root-only built-in `agent` tool, whi
 
 ## The built-in `agent` tool
 
+Background-task guidance is recorded in conversation history when it changes, rather than added temporarily to the system prompt. Subsequent steps retain its original position; compaction can restore current guidance if it was removed. This preserves task-reporting behavior and does not change dispatch timing or batch notifications. Pending tool approvals retain their separate trusted runtime instructions.
+
 The root session receives `agent` by default. The model calls it to delegate a task to a new copy of the root agent or continue an existing copy:
 
 ```ts

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -12432,12 +12432,85 @@ describe("createToolLoopHarness", () => {
         runStep(createTestSession(), { message: "Start the background work." }),
       );
 
-      const { instructions } = getLastAgentSettings();
-      expect(instructions).toEqual({
-        role: "system",
-        content: `You are a test assistant.\n\n[Task state]\n{"tasks":[]}\n\n${TASK_DELIVERY_INITIATING_INSTRUCTION}`,
+      const { instructions, messages } = getLastAgentSettings();
+      expect(instructions).toBe("You are a test assistant.");
+      expect(messages).toContainEqual({
+        role: "user",
+        content: `[Background task guidance]\n[Task state]\n{"tasks":[]}\n\n${TASK_DELIVERY_INITIATING_INSTRUCTION}`,
       });
     });
+
+    it.each([false, true])(
+      "preserves task prompt prefixes across steps and restores after compaction=%s",
+      async (compact) => {
+        const toolCall = {
+          type: "tool-call" as const,
+          toolCallId: "cache-call",
+          toolName: "add",
+          input: { a: 20, b: 22 },
+        };
+        const toolResult = {
+          type: "tool-result" as const,
+          toolCallId: "cache-call",
+          toolName: "add",
+          output: "42",
+        };
+        const keepGoing = () =>
+          setupMockAgent({
+            finishReason: "tool-calls",
+            response: {
+              messages: [
+                { role: "assistant", content: [toolCall] },
+                { role: "tool", content: [toolResult] },
+              ],
+            },
+            text: "",
+            toolCalls: [toolCall],
+            toolResults: [{ ...toolResult, input: toolCall.input }],
+          });
+        const runStep = createToolLoopHarness(createTestConfig("conversation"));
+        const ctx = new ContextContainer();
+        keepGoing();
+        const first = await contextStorage.run(ctx, () =>
+          runStep(createTestSession(), { message: "Start work" }),
+        );
+        const before = structuredClone(getLastAgentSettings());
+        ctx.set(TurnTaskDeliveryKey, "initiating");
+        ctx.set(
+          TurnTaskStateKey,
+          '[Task state]\n{"tasks":[{"taskId":"task_A","status":"pending"}]}',
+        );
+        keepGoing();
+        const launched = await contextStorage.run(ctx, () => runStep(first.session));
+        const after = structuredClone(getLastAgentSettings());
+        expect(after.instructions).toEqual(before.instructions);
+        expect(after.messages.slice(0, before.messages.length)).toEqual(before.messages);
+        expect(launched.session.history).toContainEqual(
+          after.messages.find(
+            (m) =>
+              typeof m.content === "string" && m.content.startsWith("[Background task guidance]"),
+          ),
+        );
+        if (compact) {
+          vi.mocked(shouldCompact).mockReturnValueOnce(true);
+          vi.mocked(compactMessages).mockResolvedValueOnce([
+            { role: "user", content: "Compacted work so far" },
+          ]);
+        }
+        setupMockAgent(defaultModelResult());
+        const restored = JSON.parse(JSON.stringify(launched.session)) as HarnessSession;
+        await contextStorage.run(ctx, () => runStep(restored));
+        const next = getLastAgentSettings();
+        expect(next.instructions).toEqual(before.instructions);
+        expect(
+          next.messages.filter(
+            (m) =>
+              typeof m.content === "string" && m.content.startsWith("[Background task guidance]"),
+          ),
+        ).toHaveLength(1);
+        if (!compact) expect(next.messages.slice(0, after.messages.length)).toEqual(after.messages);
+      },
+    );
 
     it("routes later-turn initiating task context through user messages", async () => {
       setupMockAgent(defaultModelResult());
@@ -12459,9 +12532,11 @@ describe("createToolLoopHarness", () => {
 
       const { instructions, messages } = getLastAgentSettings();
       expect(instructions).toBe("You are a test assistant.");
-      expect(messages.slice(-3)).toEqual([
-        { role: "user", content: taskState },
-        { role: "user", content: TASK_DELIVERY_INITIATING_INSTRUCTION },
+      expect(messages.slice(-2)).toEqual([
+        {
+          role: "user",
+          content: `[Background task guidance]\n${taskState}\n\n${TASK_DELIVERY_INITIATING_INSTRUCTION}`,
+        },
         { role: "user", content: "Start the background work." },
       ]);
     });
@@ -12476,10 +12551,11 @@ describe("createToolLoopHarness", () => {
         runStep(createTestSession(), { message: "[Task state]" }),
       );
 
-      const { instructions } = getLastAgentSettings();
-      expect(instructions).toEqual({
-        role: "system",
-        content: `You are a test assistant.\n\n${CONDITIONAL_DELIVERY_INSTRUCTION}`,
+      const { instructions, messages } = getLastAgentSettings();
+      expect(instructions).toBe("You are a test assistant.");
+      expect(messages).toContainEqual({
+        role: "user",
+        content: `[Background task guidance]\n${CONDITIONAL_DELIVERY_INSTRUCTION}`,
       });
     });
 
@@ -12523,7 +12599,7 @@ describe("createToolLoopHarness", () => {
         const { instructions, messages } = getLastAgentSettings();
         expect(instructions).toBe("You are a test assistant.");
         expect(messages.slice(-2)).toEqual([
-          { role: "user", content: instruction },
+          { role: "user", content: `[Background task guidance]\n${instruction}` },
           { role: "user", content: "Background task task_1 is completed." },
         ]);
       },

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -99,7 +99,7 @@ import {
   resolveCompactionModel,
   shouldCompact,
 } from "#harness/compaction.js";
-import { createCurrentMessages } from "#harness/current-messages.js";
+import { createCurrentMessages, hasTailApprovalResponse } from "#harness/current-messages.js";
 import {
   accumulateTurnUsage,
   getTurnUsageState,
@@ -1112,6 +1112,36 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       session = setTurnClientContextState(session, turnClientContext);
     }
 
+    const taskDeliveryPhase = store?.get(TurnTaskDeliveryKey);
+    const deliveryPolicy = resolveDeliveryPolicy({
+      hasScheduleProvenance:
+        emissionState.sequence === 0 && store?.get(ScheduleIdKey) !== undefined,
+      hasOutputSchema: session.outputSchema !== undefined,
+      isChild: store?.get(ParentSessionKey) !== undefined,
+      isFirstTurn: emissionState.sequence === 0,
+      taskDeliveryPhase,
+    });
+    const taskContext = store?.get(TurnTaskStateKey);
+    const taskPrompt = [taskContext, deliveryPolicy.instruction].filter(Boolean).join("\n\n");
+    const persistTaskPrompt =
+      taskDeliveryPhase !== undefined &&
+      taskDeliveryPhase !== "none" &&
+      !hasTailApprovalResponse(messages) &&
+      !hasUnansweredToolCall(messages);
+    const appendTaskPrompt = () => {
+      if (!persistTaskPrompt || taskPrompt.length === 0) return;
+      const content = `[Background task guidance]\n${taskPrompt}`;
+      const previous = messages.findLast(
+        (message) =>
+          message.role === "user" &&
+          typeof message.content === "string" &&
+          message.content.startsWith("[Background task guidance]\n"),
+      );
+      // Keep the original placement on subsequent steps and turns. The
+      // approval-response tail must remain available to the AI SDK unchanged.
+      if (previous?.content !== content) messages.push({ role: "user", content });
+    };
+    appendTaskPrompt();
     messages = [...messages, ...preparedTurnInput];
 
     const createModelMessages = (durableMessages: readonly ModelMessage[]): ModelMessage[] => {
@@ -1200,6 +1230,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         };
         session = setTurnClientContextState(session, turnClientContext);
       }
+      appendTaskPrompt();
     }
     projectedMessages = normalizeModelMessages(
       projectHistory(createModelMessages(messages), session.state),
@@ -1223,16 +1254,6 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         buildResponseAuthorizationTools({ authoredTools: config.tools, context: ctx }),
       ),
     );
-
-    const isFirstTurn = emissionState.sequence === 0;
-    const hasScheduleProvenance = isFirstTurn && ctx?.get(ScheduleIdKey) !== undefined;
-    const deliveryPolicy = resolveDeliveryPolicy({
-      hasScheduleProvenance,
-      hasOutputSchema: session.outputSchema !== undefined,
-      isChild: ctx?.get(ParentSessionKey) !== undefined,
-      isFirstTurn,
-      taskDeliveryPhase: ctx?.get(TurnTaskDeliveryKey),
-    });
 
     // --- Execute via ToolLoopAgent ------------------------------------------
 
@@ -1258,11 +1279,11 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
         currentMessages.add(emissionState.sequence, skillAnnouncement);
       }
       const taskState = ctx.get(TurnTaskStateKey);
-      if (taskState !== undefined) {
+      if (taskState !== undefined && !persistTaskPrompt) {
         currentMessages.add(emissionState.sequence, taskState);
       }
     }
-    if (deliveryPolicy.instruction !== undefined) {
+    if (deliveryPolicy.instruction !== undefined && !persistTaskPrompt) {
       currentMessages.add(emissionState.sequence, deliveryPolicy.instruction);
     }
     const pendingApprovals = renderPendingApprovalsInstruction(

--- a/packages/eve/src/tasks/delivery-context.ts
+++ b/packages/eve/src/tasks/delivery-context.ts
@@ -5,7 +5,7 @@ import { getSessionTaskIndex, type SessionTaskIndexEntry } from "#tasks/session-
 export const TASK_DELIVERY_CONTEXT_LABEL = "[Task state]";
 
 export const TASK_DELIVERY_INITIATING_INSTRUCTION = `Background task reporting: launch acknowledgement
-The accompanying ${TASK_DELIVERY_CONTEXT_LABEL} system message is runtime-authored and lists background tasks accepted so far from the current turn. They continue independently after this turn.
+The accompanying ${TASK_DELIVERY_CONTEXT_LABEL} message is runtime-authored and lists background tasks accepted so far from the current turn. They continue independently after this turn.
 
 Continue carrying out the user's request, including starting any remaining background work. When no further tool calls are needed in this turn, send one brief user-facing acknowledgement that the background work has started. Do not wait for results or report results that are not available yet. End the turn after the acknowledgement.`;
 


### PR DESCRIPTION
### Summary

Task snapshots delivered through `context` already append to history. The prefix change happens in the separate initiating-turn path: task state and reporting guidance are added temporarily to system instructions, then removed on a later turn.

```text
Before
  system: base
  system: base + task guidance     // first turn after delegation
  system: base                     // next turn

After
  system: base
  history: ... → task guidance → ...
```

Persist task guidance at its original position and restore it after compaction when needed. Keep the existing reporting policy, dispatch timing, and approval-response tail handling. No new option.

Replaces #3129, whose claim that delivered task inventories rewrote the prefix was incorrect. This fixes a reproduced request-prefix change, not every historical cache miss. Notification batching remains separate in #3128.

### Validation

- Full harness tests assert unchanged system instructions and preserved message prefixes across task launch and restored steps; compaction restores the guidance.
- SDK approval-resume integration coverage passes.
- Live default-delivery smoke: two workers completed and the parent combined both results without follow-up. The three parent calls after the initial cold call reported 5,335, 5,690, and 6,102 cached input tokens across launch and completion notifications.
- Provider cache savings have not been measured in a controlled comparison.

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
