### PR TITLE
refactor(eve): share authorization across tools and connections

### DIFF
--- a/.changeset/shared-authorization-runtime.md
+++ b/.changeset/shared-authorization-runtime.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Share authorization handling across connection search, authored tools, and approval responses so token resolution, callback completion, and rejected-token handling use the same implementation.

--- a/packages/eve/src/execution/tool-auth.ts
+++ b/packages/eve/src/execution/tool-auth.ts
@@ -1,59 +1,11 @@
-/**
- * Tool-hosted authorization wiring for authored tools that resolve auth
- * providers inline with {@link ToolContext.getToken} and
- * {@link ToolContext.requireAuth}.
- *
- * Mirrors the connection authorization flow used by connection search but scopes the
- * per-step token cache and framework-owned callback URL by the tool's
- * path-derived name and provider key instead of a connection name. All the shared
- * machinery — principal resolution, cache reads/writes, the park/resume
- * webhook dance, and the loop guard — lives in
- * `runtime/connections/scoped-authorization.ts`; this module is the thin
- * execution-layer adapter that wraps one tool's `execute`.
- */
-
 import { buildBaseToolContext } from "#context/build-base-tool-context.js";
 import type { SessionAuthContext } from "#channel/types.js";
-import {
-  ConnectionAuthorizationFailedError,
-  ConnectionAuthorizationRequiredError,
-  isConnectionAuthorizationRequiredError,
-} from "#connections/errors.js";
 import type { ApprovalResponseAuth } from "#approval/definition.js";
-import type { ToolAuthOptions, ToolAuthProvider, ToolContext } from "#tools/definition.js";
-import { type AuthorizationChallenge, requestAuthorization } from "#harness/authorization.js";
-import {
-  type AuthorizationDefinition,
-  supportsInteractiveAuthorization,
-  type TokenResult,
-} from "#shared/connection-types.js";
-import { normalizeAuthorizationSpec } from "#shared/validate-authorization.js";
-import {
-  completeScopedAuthorization,
-  evictScopedToken,
-  resolveScopedToken,
-  startScopedAuthorization,
-  type ScopedAuthorization,
-} from "#runtime/connections/scoped-authorization.js";
-import type { ToolExecuteOptions } from "#tools/definition.js";
+import type { ToolAuthOptions, ToolContext, ToolExecuteOptions } from "#tools/definition.js";
 import type { TaskExec } from "#tools/task.js";
-import { isAsyncIterable } from "#shared/async-iterable.js";
+import { createAuthorizationContext } from "#runtime/authorization-context.js";
+import { handleAuthorizationError } from "#runtime/connections/scoped-authorization.js";
 
-/**
- * Wraps one authored tool's `execute` with a context that supports inline
- * provider auth (`ctx.getToken(connect("..."))`).
- *
- * On a thrown provider-scoped authorization request — implicit from
- * `ctx.getToken(provider)` or explicit via `ctx.requireAuth(provider)` — the
- * wrapper either fails terminally (token rejected immediately after sign-in)
- * or evicts the rejected token from the per-step cache and starts the
- * interactive flow, returning an `AuthorizationSignal` to park the turn.
- * Interactive strategies never rethrow the raw `Required` into the model: if
- * no callback URL can be minted, they fail with a classified
- * {@link ConnectionAuthorizationFailedError} instead. Non-interactive
- * strategies rethrow the original error because they have no consent flow to
- * park on.
- */
 type ToolExecuteWithAuthInput<TInput> = {
   readonly scope: string;
 } & (
@@ -67,101 +19,37 @@ type ToolExecuteWithAuthInput<TInput> = {
     }
 );
 
-export function createToolExecuteWithAuth<TInput>(
-  input: ToolExecuteWithAuthInput<TInput>,
-): (
-  toolInput: TInput,
-  options: ToolExecuteOptions,
-  task?: TaskExec,
-) => Promise<unknown> | AsyncIterable<unknown> {
-  const { scope } = input;
-
-  // An async wrapper would turn an async generator into Promise<AsyncIterable>,
-  // which the AI SDK treats as one non-serializable terminal output.
-  return (
-    toolInput: TInput,
-    options: ToolExecuteOptions,
-    task?: TaskExec,
-  ): Promise<unknown> | AsyncIterable<unknown> => {
-    const justAuthorizedScopes = new Set<string>();
-    const ctx = buildToolContext({
-      inlineAuthState: {},
-      justAuthorizedScopes,
-      options,
-      scope,
-    });
-
-    try {
-      let output: unknown;
+/** Supplies the shared auth capability to one authored tool execution. */
+export function createToolExecuteWithAuth<TInput>(input: ToolExecuteWithAuthInput<TInput>) {
+  return (toolInput: TInput, options: ToolExecuteOptions, task?: TaskExec) => {
+    const auth = createAuthorizationContext({ scope: input.scope });
+    const ctx: ToolContext = {
+      ...buildBaseToolContext({ options, toolName: input.scope }),
+      getToken: auth.getToken,
+      requireAuth: auth.requireAuth,
+    };
+    return auth.run(() => {
       if (input.execution === "background") {
-        if (task === undefined) {
+        if (task === undefined)
           throw new Error("Background tool execution requires a task runtime.");
-        }
-        output = input.execute(toolInput, ctx, task);
-      } else {
-        output = input.execute(toolInput, ctx, task);
+        return input.execute(toolInput, ctx, task);
       }
-      if (isAsyncIterable(output)) {
-        return handleToolIterableErrors(output);
-      }
-      return Promise.resolve(output).catch(handleToolError);
-    } catch (err) {
-      return handleToolError(err);
-    }
-
-    async function handleToolError(error: unknown): Promise<unknown> {
-      if (isToolAuthorizationRequiredError(error)) {
-        return await handleAuthorizationRequests(error.requests);
-      }
-      throw error;
-    }
-
-    async function* handleToolIterableErrors(
-      output: AsyncIterable<unknown>,
-    ): AsyncIterable<unknown> {
-      try {
-        for await (const value of output) {
-          yield value;
-        }
-      } catch (error) {
-        yield await handleToolError(error);
-      }
-    }
+      return input.execute(toolInput, ctx, task);
+    });
   };
 }
 
-/** Builds the narrow token capability used by approval response authorizers. */
+/** Binds the same capability to the person responding to an approval. */
 export function buildApprovalResponseAuth(input: {
   readonly responder: SessionAuthContext;
   readonly scope: string;
 }): ApprovalResponseAuth {
-  const inlineAuthState: InlineAuthState = {};
-  const justAuthorizedScopes = new Set<string>();
+  const auth = createAuthorizationContext({ scope: input.scope, boundResponder: input.responder });
   return {
-    async getToken(provider?: ToolAuthProvider, options?: ToolAuthOptions): Promise<TokenResult> {
-      if (provider === undefined) throw missingProviderError("ctx.getToken");
-      return await resolveInlineToken({
-        boundResponder: input.responder,
-        inlineAuthState,
-        justAuthorizedScopes,
-        options: namespaceApprovalAuthOptions(input.scope, options),
-        provider,
-        toolScope: input.scope,
-      });
-    },
-    requireAuth(provider?: ToolAuthProvider, options?: ToolAuthOptions): never {
-      if (provider === undefined) throw missingProviderError("ctx.requireAuth");
-      const scoped = buildInlineScopedAuthorization({
-        boundResponder: input.responder,
-        inlineAuthState,
-        options: namespaceApprovalAuthOptions(input.scope, options),
-        provider,
-        toolScope: input.scope,
-      });
-      throw new ToolAuthorizationRequiredError([
-        { justAuthorized: justAuthorizedScopes.has(scoped.scope), scoped },
-      ]);
-    },
+    getToken: (provider, options) =>
+      auth.getToken(provider, namespaceApprovalAuthOptions(input.scope, options)),
+    requireAuth: (provider, options) =>
+      auth.requireAuth(provider, namespaceApprovalAuthOptions(input.scope, options)),
   };
 }
 
@@ -176,243 +64,5 @@ function namespaceApprovalAuthOptions(
 
 /** Starts authorization requested by an approval response authorizer. */
 export async function handleApprovalResponsePolicyError(error: unknown): Promise<unknown> {
-  if (!isToolAuthorizationRequiredError(error)) throw error;
-  return await handleAuthorizationRequests(error.requests);
-}
-
-function buildToolContext(input: {
-  readonly options: ToolExecuteOptions;
-  readonly scope: string;
-  readonly justAuthorizedScopes: Set<string>;
-  readonly inlineAuthState: InlineAuthState;
-}): ToolContext {
-  const { scope, justAuthorizedScopes, inlineAuthState } = input;
-  const base = buildBaseToolContext({ options: input.options, toolName: scope });
-  return {
-    ...base,
-    async getToken(provider?: ToolAuthProvider, options?: ToolAuthOptions): Promise<TokenResult> {
-      if (provider === undefined) throw missingProviderError("ctx.getToken");
-      return await resolveInlineToken({
-        inlineAuthState,
-        justAuthorizedScopes,
-        options,
-        provider,
-        toolScope: scope,
-      });
-    },
-    requireAuth(provider?: ToolAuthProvider, options?: ToolAuthOptions): never {
-      if (provider === undefined) throw missingProviderError("ctx.requireAuth");
-      const scoped = buildInlineScopedAuthorization({
-        inlineAuthState,
-        options,
-        provider,
-        toolScope: scope,
-      });
-      throw new ToolAuthorizationRequiredError([
-        {
-          justAuthorized: justAuthorizedScopes.has(scoped.scope),
-          scoped,
-        },
-      ]);
-    },
-  };
-}
-
-async function resolveInlineToken(input: {
-  readonly boundResponder?: SessionAuthContext;
-  readonly toolScope: string;
-  readonly provider: ToolAuthProvider;
-  readonly options?: ToolAuthOptions;
-  readonly justAuthorizedScopes: Set<string>;
-  readonly inlineAuthState: InlineAuthState;
-}): Promise<TokenResult> {
-  const { justAuthorizedScopes } = input;
-  const scoped = buildInlineScopedAuthorization(input);
-  if (!justAuthorizedScopes.has(scoped.scope) && (await completeScopedAuthorization(scoped))) {
-    justAuthorizedScopes.add(scoped.scope);
-  }
-
-  try {
-    return await resolveScopedToken(scoped);
-  } catch (err) {
-    if (!isConnectionAuthorizationRequiredError(err)) throw err;
-    throw new ToolAuthorizationRequiredError([
-      {
-        cause: err,
-        justAuthorized: justAuthorizedScopes.has(scoped.scope),
-        scoped,
-      },
-    ]);
-  }
-}
-
-async function handleAuthorizationRequests(
-  requests: readonly ToolAuthorizationRequiredRequest[],
-): Promise<unknown> {
-  const challenges: AuthorizationChallenge[] = [];
-  let nonInteractiveError: Error | undefined;
-
-  for (const request of requests) {
-    const { scoped } = request;
-
-    // Loop guard: a token minted this turn that is still rejected
-    // means the grant itself is broken — fail terminally instead of
-    // re-prompting into an infinite sign-in loop.
-    if (request.justAuthorized) {
-      throw new ConnectionAuthorizationFailedError(scoped.scope, {
-        message: `Tool "${scoped.scope}" rejected the token immediately after authorization.`,
-        reason: "token_rejected_after_authorization",
-        retryable: false,
-      });
-    }
-
-    // The resolved bearer was rejected (a downstream 401 mapped to
-    // requireAuth, or getToken re-reporting Required). Drop it from
-    // every cache layer — eve's per-step cache and the strategy's own
-    // (e.g. the @vercel/connect token cache) — so the
-    // re-authorization re-resolves a genuinely fresh token instead of
-    // re-reading the rejected one. Mirrors the MCP client.
-    await evictScopedToken(scoped);
-
-    const signal = await startScopedAuthorization(scoped);
-    if (signal !== undefined) {
-      challenges.push(...signal.challenges);
-      continue;
-    }
-
-    // No park signal. For an interactive strategy this means the
-    // framework could not mint a callback URL (no session id / base
-    // URL in context). Never let the raw `Required` reach the model —
-    // it improvises by surfacing the auth URL as text and loops
-    // (see research/per-tool-auth-known-issues.md, issue 2). Fail with
-    // a classified, terminal authorization error instead. Non-interactive
-    // strategies have no consent flow, so their original error is the
-    // right thing for the model to see.
-    if (supportsInteractiveAuthorization(scoped.authorization)) {
-      throw new ConnectionAuthorizationFailedError(scoped.scope, {
-        message:
-          `Tool "${scoped.scope}" requires sign-in, but no authorization callback URL ` +
-          `could be minted for this run (missing session context).`,
-        reason: "authorization_callback_unavailable",
-        retryable: false,
-      });
-    }
-
-    nonInteractiveError ??=
-      request.cause instanceof Error
-        ? request.cause
-        : new ConnectionAuthorizationRequiredError(scoped.scope);
-  }
-
-  if (challenges.length > 0) {
-    return requestAuthorization(challenges);
-  }
-
-  throw nonInteractiveError ?? new Error("Tool authorization is required.");
-}
-
-function buildInlineScopedAuthorization(input: {
-  readonly boundResponder?: SessionAuthContext;
-  readonly toolScope: string;
-  readonly provider: ToolAuthProvider;
-  readonly options?: ToolAuthOptions;
-  readonly inlineAuthState: InlineAuthState;
-}): ScopedAuthorization {
-  const authorization = normalizeInlineProvider(input.provider, input.options);
-  return {
-    authorization,
-    boundResponder: input.boundResponder,
-    connection: input.options?.connection ?? { url: "" },
-    scope:
-      input.options?.authKey === undefined
-        ? deriveInlineScope({
-            authorization,
-            inlineAuthState: input.inlineAuthState,
-            provider: input.provider,
-            toolScope: input.toolScope,
-          })
-        : validateInlineAuthKey(input.options.authKey),
-  };
-}
-
-function normalizeInlineProvider(
-  provider: ToolAuthProvider,
-  options: ToolAuthOptions | undefined,
-): AuthorizationDefinition {
-  const authorization = normalizeAuthorizationSpec(provider, "ctx.getToken:", "provider");
-  if (options?.displayName === undefined) {
-    return authorization;
-  }
-  if (options.displayName.length === 0) {
-    throw new Error(`ctx.getToken: The "options.displayName" field must be a non-empty string.`);
-  }
-  return { ...authorization, displayName: options.displayName };
-}
-
-function deriveInlineScope(input: {
-  readonly toolScope: string;
-  readonly authorization: AuthorizationDefinition;
-  readonly provider: ToolAuthProvider;
-  readonly inlineAuthState: InlineAuthState;
-}): string {
-  const connector = input.authorization.vercelConnect?.connector;
-  if (connector !== undefined) {
-    return `${input.toolScope}__${sanitizeScopeSegment(connector)}`;
-  }
-
-  if (input.inlineAuthState.anonymousProvider === undefined) {
-    input.inlineAuthState.anonymousProvider = input.provider;
-  } else if (input.inlineAuthState.anonymousProvider !== input.provider) {
-    throw new Error(
-      `ctx.getToken: Multiple inline auth providers without provider metadata need explicit auth keys. ` +
-        `Pass options.authKey for each provider, for example ` +
-        `ctx.getToken(auth, { authKey: "github" }).`,
-    );
-  }
-
-  return `${input.toolScope}__inline_auth`;
-}
-
-function validateInlineAuthKey(authKey: string): string {
-  if (!/^[A-Za-z0-9_.:-]+$/u.test(authKey)) {
-    throw new Error(
-      `ctx.getToken: The "options.authKey" field must contain only letters, digits, "_", "-", ".", or ":".`,
-    );
-  }
-  return authKey;
-}
-
-function sanitizeScopeSegment(value: string): string {
-  const sanitized = value.replace(/[^A-Za-z0-9_.:-]+/gu, "_").replace(/^_+|_+$/gu, "");
-  return sanitized.length > 0 ? sanitized : "provider";
-}
-
-interface ToolAuthorizationRequiredRequest {
-  readonly scoped: ScopedAuthorization;
-  readonly justAuthorized: boolean;
-  readonly cause?: unknown;
-}
-
-interface InlineAuthState {
-  anonymousProvider?: ToolAuthProvider;
-}
-
-class ToolAuthorizationRequiredError extends Error {
-  readonly requests: readonly ToolAuthorizationRequiredRequest[];
-
-  constructor(requests: readonly ToolAuthorizationRequiredRequest[]) {
-    super("Tool authorization required.");
-    this.name = "ToolAuthorizationRequiredError";
-    this.requests = requests;
-  }
-}
-
-function isToolAuthorizationRequiredError(err: unknown): err is ToolAuthorizationRequiredError {
-  return err instanceof Error && err.name === "ToolAuthorizationRequiredError";
-}
-
-function missingProviderError(method: "ctx.getToken" | "ctx.requireAuth"): Error {
-  return new Error(
-    `${method}: Pass an auth provider, for example ${method}(connect("github/myagent")).`,
-  );
+  return await handleAuthorizationError(error);
 }

--- a/packages/eve/src/execution/tools/connection-search.test.ts
+++ b/packages/eve/src/execution/tools/connection-search.test.ts
@@ -20,6 +20,7 @@ import type { ResolvedConnectionDefinition } from "#runtime/types.js";
 import { isBrandedToolEntry, type DynamicToolSet } from "#tools/dynamic.js";
 import type { DynamicResolveContext } from "#dynamic/definition.js";
 import { readDurableDynamicToolCallbacks } from "#tools/durable-callbacks.js";
+import { resolveHeaders } from "#runtime/connections/mcp-client.js";
 
 function connection(name: string): ResolvedConnectionDefinition {
   return {
@@ -478,6 +479,83 @@ describe("connection_search", () => {
       },
     ]);
   });
+
+  it.each([false, true])(
+    "completes connection auth through the shared token cache (fresh token refused: %s)",
+    async (refused) => {
+      const getToken = vi.fn(async () => {
+        throw new ConnectionAuthorizationRequiredError("salesforce");
+      });
+      const startAuthorization = vi.fn(async () => ({
+        challenge: { url: "https://idp.example.com/authorize" },
+      }));
+      const completeAuthorization = vi.fn(async () => ({ token: "fresh-token" }));
+      const salesforce: ResolvedConnectionDefinition = {
+        ...connection("salesforce"),
+        instanceId: "salesforce-instance",
+        authorization: {
+          principalType: "user",
+          getToken,
+          startAuthorization,
+          completeAuthorization,
+        },
+      };
+      const connectionRegistry = registry({
+        connections: [salesforce],
+        loadTools: {
+          salesforce: async () => {
+            const headers = await resolveHeaders(salesforce);
+            expect(headers.Authorization).toBe("Bearer fresh-token");
+            if (refused) throw new ConnectionAuthorizationRequiredError("salesforce");
+            return [{ name: "list_accounts", description: "List accounts", inputSchema: {} }];
+          },
+        },
+      });
+      const setup = (ctx: ContextContainer) => {
+        ctx.set(SessionIdKey, "session-auth");
+        ctx.set(CallbackBaseUrlKey, "https://agent.example.com");
+        ctx.set(AuthKey, {
+          attributes: {},
+          authenticator: "test-idp",
+          issuer: "test-idp",
+          principalId: "user-1",
+          principalType: "user",
+        });
+      };
+      const input = { connection: "salesforce", keywords: "accounts" };
+      const pending = await executeConnectionSearch(connectionRegistry, input, setup);
+      if (!isAuthorizationSignal(pending)) throw new Error("expected authorization signal");
+      const challenge = pending.challenges[0]!;
+      expect(challenge).toMatchObject({
+        instanceId: "salesforce-instance",
+        principal: { type: "user", id: "user-1", issuer: "test-idp" },
+      });
+      const resumed = executeConnectionSearch(connectionRegistry, input, (ctx) => {
+        setup(ctx);
+        ctx.set(PendingAuthorizationResultKey, [
+          {
+            ...challenge,
+            callback: { method: "GET", params: { code: "approved" } },
+          },
+        ]);
+      });
+      if (refused) {
+        await expect(resumed).rejects.toThrow("rejected the token immediately after authorization");
+      } else {
+        await expect(resumed).resolves.toMatchObject([
+          { qualifiedName: "salesforce__list_accounts" },
+        ]);
+      }
+      expect(getToken).toHaveBeenCalledOnce();
+      expect(startAuthorization).toHaveBeenCalledOnce();
+      expect(completeAuthorization).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          principal: challenge.principal,
+          callback: { method: "GET", params: { code: "approved" } },
+        }),
+      );
+    },
+  );
 
   it("replays authorization from the step-scoped durable execute descriptor", async () => {
     const salesforce: ResolvedConnectionDefinition = {

--- a/packages/eve/src/execution/tools/connection-search.ts
+++ b/packages/eve/src/execution/tools/connection-search.ts
@@ -5,13 +5,10 @@ import { ContextKey } from "#context/key.js";
 import {
   type AuthorizationChallenge,
   type AuthorizationSignal,
-  consumeAuthorizationResult,
-  createAuthorizationAttempt,
   getAuthorizationResults,
   requestAuthorization,
 } from "#harness/authorization.js";
 import {
-  ConnectionAuthorizationFailedError,
   isConnectionAuthorizationFailedError,
   isConnectionAuthorizationRequiredError,
 } from "#connections/errors.js";
@@ -22,20 +19,15 @@ import {
   type ApprovalContext,
   type ApprovalResponseContext,
 } from "#approval/definition.js";
-import type { JsonValue } from "#shared/json.js";
 import type { JsonObject } from "#shared/json.js";
 import { stampDurableDynamicToolCallbacks } from "#tools/durable-callbacks.js";
-import { writeCachedToken } from "#runtime/connections/authorization-tokens.js";
-import { connectionAuthorizationScope } from "#runtime/connections/instance-identity.js";
-import { principalKey, resolveConnectionPrincipal } from "#runtime/connections/principal.js";
 import { resolveConnectionAuthorization } from "#runtime/connections/resolve-authorization.js";
 import {
-  resolveAuthorizationCallbackUrl,
-  stampChallengeDisplayName,
+  createAuthorizationExecution,
+  type ScopedAuthorization,
 } from "#runtime/connections/scoped-authorization.js";
 import {
   type ConnectionToolMetadata,
-  type InteractiveAuthorizationDefinition,
   supportsInteractiveAuthorization,
 } from "#shared/connection-types.js";
 import type { ConnectionRegistry } from "#runtime/connections/registry-types.js";
@@ -138,49 +130,32 @@ function scoreMatch(queryTokens: string[], tool: ConnectionToolMetadata): number
 async function resolveInteractiveAuth(
   registry: ConnectionRegistry,
   connectionName: string,
-): Promise<InteractiveAuthorizationDefinition | undefined> {
+): Promise<ScopedAuthorization | undefined> {
   const conn = registry.getConnections().find((c) => c.connectionName === connectionName);
   if (conn === undefined) return undefined;
   const authorization = await resolveConnectionAuthorization(conn);
-  if (!supportsInteractiveAuthorization(authorization)) return undefined;
-  return authorization as InteractiveAuthorizationDefinition;
+  if (authorization === undefined || !supportsInteractiveAuthorization(authorization))
+    return undefined;
+  return {
+    scope: conn.connectionName,
+    instanceId: conn.instanceId,
+    connection: { url: conn.url ?? "" },
+    authorization,
+  };
 }
 
-/**
- * Completes any authorizations whose callback arrived this turn,
- * returning the set of connection names that were just (re-)authorized.
- *
- * Callers use the returned set as a loop guard: if a connection that was
- * just authorized still fails with `Required` on the immediately
- * following load, the freshly minted token is itself being rejected, so
- * the connection must fail terminally rather than re-challenge forever.
- */
+/** Complete only callbacks for the connections targeted by this search. */
 async function completePendingAuthorizations(
   registry: ConnectionRegistry,
   connections: readonly ResolvedConnectionDefinition[],
-): Promise<Set<string>> {
+  auth: ReturnType<typeof createAuthorizationExecution>,
+): Promise<void> {
   assertPendingConnectionAuthorizationInstances(registry);
-  const ctx = loadContext();
-  const completed = new Set<string>();
   for (const conn of connections) {
-    const result = consumeAuthorizationResult(conn.connectionName, conn.instanceId);
-    if (!result) continue;
-    const auth = await resolveInteractiveAuth(registry, conn.connectionName);
-    if (!auth) continue;
-    const principal = result.principal ?? resolveConnectionPrincipal(conn.connectionName, auth);
-    const token = await (
-      auth as InteractiveAuthorizationDefinition<JsonValue>
-    ).completeAuthorization({
-      callbackUrl: result.hookUrl,
-      connection: { url: conn.url ?? "" },
-      principal,
-      resume: result.resume,
-      callback: result.callback,
-    });
-    writeCachedToken(ctx, connectionAuthorizationScope(conn), principalKey(principal), token);
-    completed.add(conn.connectionName);
+    if (!getAuthorizationResults().some((result) => result.name === conn.connectionName)) continue;
+    const scoped = await resolveInteractiveAuth(registry, conn.connectionName);
+    if (scoped !== undefined) await auth.complete(scoped);
   }
-  return completed;
 }
 
 async function executeConnectionSearch(
@@ -208,7 +183,8 @@ async function executeConnectionSearch(
     );
   }
 
-  const justAuthorized = await completePendingAuthorizations(registry, targetConnections);
+  const auth = createAuthorizationExecution();
+  await completePendingAuthorizations(registry, targetConnections, auth);
 
   const authChallenges: AuthorizationChallenge[] = [];
 
@@ -219,59 +195,25 @@ async function executeConnectionSearch(
       tools = await client.getToolMetadata();
     } catch (err) {
       if (isConnectionAuthorizationRequiredError(err)) {
-        // Loop guard: a connection authorized earlier this turn that is
-        // still rejected means the new token itself is bad. Fail it
-        // terminally instead of re-challenging into an infinite sign-in
-        // loop.
-        if (justAuthorized.has(conn.connectionName)) {
-          logger.warn("connection still unauthorized after authorization", {
-            connection: conn.connectionName,
-          });
-          failedConnections.push({
-            connection: conn.connectionName,
-            description: conn.description,
-            error: `Authorization for "${conn.connectionName}" did not take effect; the token was rejected after sign-in.`,
-          });
-          continue;
-        }
-
-        const auth = await resolveInteractiveAuth(registry, conn.connectionName);
-        if (auth) {
-          const attempt = createAuthorizationAttempt(conn.connectionName);
-          if (attempt) {
-            const principal = resolveConnectionPrincipal(conn.connectionName, auth);
-            const callbackUrl = resolveAuthorizationCallbackUrl({
-              authorization: auth,
-              callbackUrl: attempt.hookUrl,
+        const scoped = await resolveInteractiveAuth(registry, conn.connectionName);
+        if (scoped !== undefined) {
+          try {
+            const signal = await auth.handleError(err, scoped);
+            authChallenges.push(...signal.challenges);
+          } catch (startErr) {
+            const error = toError(startErr);
+            logger.warn("connection authorization failed", {
+              connection: conn.connectionName,
+              error,
             });
-            try {
-              const { challenge, resume } = await auth.startAuthorization({
-                callbackUrl,
-                connection: { url: conn.url ?? "" },
-                principal,
-              });
-              authChallenges.push({
-                attemptId: attempt.attemptId,
-                name: conn.connectionName,
-                challenge: stampChallengeDisplayName(challenge, auth),
-                hookUrl: callbackUrl,
-                instanceId: conn.instanceId,
-                principal,
-                resume,
-              });
-            } catch (startErr) {
-              const error = toError(startErr);
-              logger.warn("startAuthorization failed", {
-                connection: conn.connectionName,
-                error,
-              });
-              failedConnections.push({
-                connection: conn.connectionName,
-                description: conn.description,
-                error: `Failed to start authorization for "${conn.connectionName}": ${error.message}`,
-              });
-              continue;
-            }
+            failedConnections.push({
+              connection: conn.connectionName,
+              description: conn.description,
+              error: isConnectionAuthorizationFailedError(error)
+                ? error.message
+                : `Failed to start authorization for "${conn.connectionName}": ${error.message}`,
+            });
+            continue;
           }
         }
         failedConnections.push({
@@ -388,38 +330,10 @@ async function executeDiscoveredConnectionTool(
   if (registry === undefined) {
     throw new Error("Connection registry is unavailable while replaying a discovered tool.");
   }
-  const conn = registry
-    .getConnections()
-    .find((candidate) => candidate.connectionName === connectionName);
   assertPendingConnectionAuthorizationInstances(registry);
-  const interactiveAuth = (await resolveInteractiveAuth(registry, connectionName)) as
-    | InteractiveAuthorizationDefinition<JsonValue>
-    | undefined;
-
-  let justCompletedAuth = false;
-  if (interactiveAuth) {
-    const authResult = consumeAuthorizationResult(connectionName, conn?.instanceId);
-    if (authResult) {
-      justCompletedAuth = true;
-      const ctx = loadContext();
-      const principal =
-        authResult.principal ?? resolveConnectionPrincipal(connectionName, interactiveAuth);
-      const token = await interactiveAuth.completeAuthorization({
-        callbackUrl: authResult.hookUrl,
-        connection: { url: conn?.url ?? "" },
-        principal,
-        resume: authResult.resume,
-        callback: authResult.callback,
-      });
-      writeCachedToken(
-        ctx,
-        conn === undefined ? connectionName : connectionAuthorizationScope(conn),
-        principalKey(principal),
-        token,
-      );
-    }
-  }
-
+  const scoped = await resolveInteractiveAuth(registry, connectionName);
+  const auth = createAuthorizationExecution();
+  if (scoped !== undefined) await auth.complete(scoped);
   try {
     const client = registry.getClient(connectionName);
     return await client.executeTool(toolName, input, {
@@ -427,38 +341,7 @@ async function executeDiscoveredConnectionTool(
       callId: executeCtx.callId,
     });
   } catch (error) {
-    if (!isConnectionAuthorizationRequiredError(error) || !interactiveAuth) throw error;
-    if (justCompletedAuth) {
-      throw new ConnectionAuthorizationFailedError(connectionName, {
-        retryable: false,
-        reason: "token_rejected_after_authorization",
-        message: `Connection "${connectionName}" rejected the token immediately after authorization.`,
-      });
-    }
-
-    const attempt = createAuthorizationAttempt(connectionName);
-    if (!attempt) throw error;
-    const principal = resolveConnectionPrincipal(connectionName, interactiveAuth);
-    const callbackUrl = resolveAuthorizationCallbackUrl({
-      authorization: interactiveAuth,
-      callbackUrl: attempt.hookUrl,
-    });
-    const { challenge, resume } = await interactiveAuth.startAuthorization({
-      callbackUrl,
-      connection: { url: conn?.url ?? "" },
-      principal,
-    });
-    return requestAuthorization([
-      {
-        attemptId: attempt.attemptId,
-        name: connectionName,
-        challenge: stampChallengeDisplayName(challenge, interactiveAuth),
-        hookUrl: callbackUrl,
-        instanceId: conn?.instanceId,
-        principal,
-        resume,
-      },
-    ]);
+    return await auth.handleError(error, scoped);
   }
 }
 

--- a/packages/eve/src/runtime/authorization-context.ts
+++ b/packages/eve/src/runtime/authorization-context.ts
@@ -1,0 +1,117 @@
+import type { SessionAuthContext } from "#channel/types.js";
+import type { ToolAuthOptions, ToolAuthProvider } from "#tools/definition.js";
+import type { AuthorizationDefinition, TokenResult } from "#shared/connection-types.js";
+import { normalizeAuthorizationSpec } from "#shared/validate-authorization.js";
+import {
+  createAuthorizationExecution,
+  type ScopedAuthorization,
+} from "#runtime/connections/scoped-authorization.js";
+
+/** Shared getToken/requireAuth capability, independent of the executing tool or workflow. */
+export function createAuthorizationContext(input: {
+  readonly scope: string;
+  readonly boundResponder?: SessionAuthContext;
+  readonly completeAuthorization?: (scoped: ScopedAuthorization) => Promise<boolean>;
+}) {
+  const execution = createAuthorizationExecution(input);
+  const inlineAuthState: InlineAuthState = {};
+  const resolve = (provider: ToolAuthProvider, options?: ToolAuthOptions) =>
+    buildInlineScopedAuthorization({ ...input, inlineAuthState, provider, options });
+  return {
+    async getToken(provider?: ToolAuthProvider, options?: ToolAuthOptions): Promise<TokenResult> {
+      if (provider === undefined) throw missingProviderError("ctx.getToken");
+      return await execution.getToken(resolve(provider, options));
+    },
+    requireAuth(provider?: ToolAuthProvider, options?: ToolAuthOptions): never {
+      if (provider === undefined) throw missingProviderError("ctx.requireAuth");
+      return execution.requireAuth(resolve(provider, options));
+    },
+    run: execution.run,
+  };
+}
+
+function buildInlineScopedAuthorization(input: {
+  readonly boundResponder?: SessionAuthContext;
+  readonly scope: string;
+  readonly provider: ToolAuthProvider;
+  readonly options?: ToolAuthOptions;
+  readonly inlineAuthState: InlineAuthState;
+}): ScopedAuthorization {
+  const authorization = normalizeInlineProvider(input.provider, input.options);
+  return {
+    authorization,
+    boundResponder: input.boundResponder,
+    connection: input.options?.connection ?? { url: "" },
+    scope:
+      input.options?.authKey === undefined
+        ? deriveInlineScope({
+            authorization,
+            inlineAuthState: input.inlineAuthState,
+            provider: input.provider,
+            scope: input.scope,
+          })
+        : validateInlineAuthKey(input.options.authKey),
+  };
+}
+
+function normalizeInlineProvider(
+  provider: ToolAuthProvider,
+  options: ToolAuthOptions | undefined,
+): AuthorizationDefinition {
+  const authorization = normalizeAuthorizationSpec(provider, "ctx.getToken:", "provider");
+  if (options?.displayName === undefined) {
+    return authorization;
+  }
+  if (options.displayName.length === 0) {
+    throw new Error(`ctx.getToken: The "options.displayName" field must be a non-empty string.`);
+  }
+  return { ...authorization, displayName: options.displayName };
+}
+
+function deriveInlineScope(input: {
+  readonly scope: string;
+  readonly authorization: AuthorizationDefinition;
+  readonly provider: ToolAuthProvider;
+  readonly inlineAuthState: InlineAuthState;
+}): string {
+  const connector = input.authorization.vercelConnect?.connector;
+  if (connector !== undefined) {
+    return `${input.scope}__${sanitizeScopeSegment(connector)}`;
+  }
+
+  if (input.inlineAuthState.anonymousProvider === undefined) {
+    input.inlineAuthState.anonymousProvider = input.provider;
+  } else if (input.inlineAuthState.anonymousProvider !== input.provider) {
+    throw new Error(
+      `ctx.getToken: Multiple inline auth providers without provider metadata need explicit auth keys. ` +
+        `Pass options.authKey for each provider, for example ` +
+        `ctx.getToken(auth, { authKey: "github" }).`,
+    );
+  }
+
+  return `${input.scope}__inline_auth`;
+}
+
+function validateInlineAuthKey(authKey: string): string {
+  if (!/^[A-Za-z0-9_.:-]+$/u.test(authKey)) {
+    throw new Error(
+      `ctx.getToken: The "options.authKey" field must contain only letters, digits, "_", "-", ".", or ":".`,
+    );
+  }
+  return authKey;
+}
+
+function sanitizeScopeSegment(value: string): string {
+  const sanitized = value.replace(/[^A-Za-z0-9_.:-]+/gu, "_").replace(/^_+|_+$/gu, "");
+  return sanitized.length > 0 ? sanitized : "provider";
+}
+
+interface InlineAuthState {
+  anonymousProvider?: ToolAuthProvider;
+}
+
+function missingProviderError(method: "ctx.getToken" | "ctx.requireAuth"): Error {
+  return new Error(
+    `${method}: Pass an auth provider, for example ${method}(connect("github/myagent")).`,
+  );
+}

--- a/packages/eve/src/runtime/connections/scoped-authorization.ts
+++ b/packages/eve/src/runtime/connections/scoped-authorization.ts
@@ -1,6 +1,6 @@
 /**
  * Scope-parameterized authorization flow shared by MCP connections and
- * authored tools that declare `auth`.
+ * authored tools and workflow steps using inline providers.
  *
  * A *scope* names the framework-owned callback URL — a connection name for
  * an MCP connection, a tool name for tool-hosted auth. Connection-hosted
@@ -12,7 +12,13 @@
  */
 
 import { type AlsContext, contextStorage, loadContext } from "#context/container.js";
-import type { ConnectionAuthorizationChallenge } from "#connections/errors.js";
+import {
+  type ConnectionAuthorizationChallenge,
+  ConnectionAuthorizationFailedError,
+  ConnectionAuthorizationRequiredError,
+  isConnectionAuthorizationRequiredError,
+} from "#connections/errors.js";
+import { isAsyncIterable } from "#shared/async-iterable.js";
 import {
   type AuthorizationSignal,
   consumeAuthorizationResult,
@@ -54,6 +60,131 @@ export interface ScopedAuthorization {
   readonly scope: string;
   readonly authorization: Readonly<AuthorizationDefinition>;
   readonly connection: ConnectionAuthorizationContext;
+}
+
+/** One execution's token capability and authorization interruption boundary. */
+export function createAuthorizationExecution(
+  options: {
+    readonly completeAuthorization?: typeof completeScopedAuthorization;
+  } = {},
+) {
+  const justAuthorized = new Set<string>();
+
+  async function complete(scoped: ScopedAuthorization): Promise<void> {
+    const key = scoped.instanceId ?? scoped.scope;
+    if (
+      !justAuthorized.has(key) &&
+      (await (options.completeAuthorization ?? completeScopedAuthorization)(scoped))
+    ) {
+      justAuthorized.add(key);
+    }
+  }
+
+  function requireAuth(scoped: ScopedAuthorization, cause?: unknown): never {
+    throw new ScopedAuthorizationRequiredError(
+      scoped,
+      justAuthorized.has(scoped.instanceId ?? scoped.scope),
+      cause,
+    );
+  }
+
+  return {
+    complete,
+    async getToken(scoped: ScopedAuthorization): Promise<TokenResult> {
+      await complete(scoped);
+      try {
+        return await resolveScopedToken(scoped);
+      } catch (error) {
+        if (!isConnectionAuthorizationRequiredError(error)) throw error;
+        return requireAuth(scoped, error);
+      }
+    },
+    requireAuth,
+    async handleError(error: unknown, scoped?: ScopedAuthorization): Promise<AuthorizationSignal> {
+      if (scoped !== undefined && isConnectionAuthorizationRequiredError(error)) {
+        return await handleAuthorizationError(
+          new ScopedAuthorizationRequiredError(
+            scoped,
+            justAuthorized.has(scoped.instanceId ?? scoped.scope),
+            error,
+          ),
+          // Connection transports evict refused bearers when classifying their errors.
+          { evictToken: false },
+        );
+      }
+      return await handleAuthorizationError(error);
+    },
+    run: executeWithAuthorization,
+  };
+}
+
+class ScopedAuthorizationRequiredError extends Error {
+  readonly scoped: ScopedAuthorization;
+  readonly justAuthorized: boolean;
+
+  constructor(scoped: ScopedAuthorization, justAuthorized: boolean, cause?: unknown) {
+    super("Authorization required.", { cause });
+    this.name = "ScopedAuthorizationRequiredError";
+    this.scoped = scoped;
+    this.justAuthorized = justAuthorized;
+  }
+}
+
+function isScopedAuthorizationRequiredError(
+  error: unknown,
+): error is ScopedAuthorizationRequiredError {
+  return error instanceof Error && error.name === "ScopedAuthorizationRequiredError";
+}
+
+/** Produces the shared challenge; the caller owns parking and resumption. */
+export async function handleAuthorizationError(
+  error: unknown,
+  options: { readonly evictToken: boolean } = { evictToken: true },
+): Promise<AuthorizationSignal> {
+  if (!isScopedAuthorizationRequiredError(error)) throw error;
+  const { scoped } = error;
+  if (error.justAuthorized) {
+    throw new ConnectionAuthorizationFailedError(scoped.scope, {
+      message: `Authorization for "${scoped.scope}" failed: the service rejected the token immediately after authorization.`,
+      reason: "token_rejected_after_authorization",
+      retryable: false,
+    });
+  }
+
+  if (options.evictToken) await evictScopedToken(scoped);
+  const signal = await startScopedAuthorization(scoped);
+  if (signal !== undefined) return signal;
+
+  if (supportsInteractiveAuthorization(scoped.authorization)) {
+    throw new ConnectionAuthorizationFailedError(scoped.scope, {
+      message: `Authorization for "${scoped.scope}" requires sign-in, but no authorization callback URL could be minted for this run (missing session context).`,
+      reason: "authorization_callback_unavailable",
+      retryable: false,
+    });
+  }
+  throw error.cause ?? new ConnectionAuthorizationRequiredError(scoped.scope);
+}
+
+function executeWithAuthorization(
+  execute: () => unknown,
+): Promise<unknown> | AsyncIterable<unknown> {
+  // Keep generator results as iterables, including errors raised during iteration.
+  try {
+    const output = execute();
+    return isAsyncIterable(output)
+      ? handleIterable(output)
+      : Promise.resolve(output).catch(handleAuthorizationError);
+  } catch (error) {
+    return handleAuthorizationError(error);
+  }
+}
+
+async function* handleIterable(output: AsyncIterable<unknown>): AsyncIterable<unknown> {
+  try {
+    for await (const value of output) yield value;
+  } catch (error) {
+    yield await handleAuthorizationError(error);
+  }
 }
 
 /**


### PR DESCRIPTION
### Summary

Connection search and authored tools currently duplicate callback completion and authorization error handling. Route both through the same implementation, including approval-response auth, so workflow steps can reuse the existing `getToken` and `requireAuth` behavior. Provider calls, token caching, and the guard against repeatedly requesting sign-in now have one owner; callers still control how execution resumes.

This is the prerequisite for #3073. It contains no workflow-step adapter or session-capability changes.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/runtime/connections/scoped-authorization.test.ts src/execution/tools/connection-search.test.ts src/harness/inline-tool-authorization.test.ts`: 24 passed, including callback completion through the real token cache and rejection immediately after sign-in.
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/execution/tool-auth.integration.test.ts`: 23 passed, covering authored tools and approval responses.
- `pnpm build`, `pnpm typecheck` (44 tasks), `pnpm fmt`, and `pnpm lint` passed. E2Es run in CI.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
