### PR TITLE
test(eve): hold busy-worker until steering begins

### DIFF
--- a/e2e/fixtures/fixture-tasks/agent/agent.ts
+++ b/e2e/fixtures/fixture-tasks/agent/agent.ts
@@ -509,12 +509,12 @@ function raceBusyWorker(request: MockModelRequest): MockModelResponse | string {
       toolCalls: [
         {
           id: "child-task-exclusivity-send-a",
-          input: { agentId, message: "Return BUSY-WORKER-A." },
+          input: { agentId, message: "EXCLUSIVITY-GATE: Return BUSY-WORKER-A." },
           name: "busy-worker",
         },
         {
           id: "child-task-exclusivity-send-b",
-          input: { agentId, message: "Return BUSY-WORKER-B." },
+          input: { agentId, message: "EXCLUSIVITY-GATE: Return BUSY-WORKER-B." },
           name: "busy-worker",
         },
       ],

--- a/e2e/fixtures/fixture-tasks/agent/subagents/busy-worker/agent.ts
+++ b/e2e/fixtures/fixture-tasks/agent/subagents/busy-worker/agent.ts
@@ -11,7 +11,13 @@ export default defineAgent({
     if (message.includes("BUSY-WORKER-A") || message.includes("BUSY-WORKER-B")) {
       if (!request.toolResults.some((result) => result.id === "exclusivity-hold")) {
         return {
-          toolCalls: [{ id: "exclusivity-hold", input: { marker: "HOLD" }, name: "hold" }],
+          toolCalls: [
+            {
+              id: "exclusivity-hold",
+              input: { marker: message.includes("EXCLUSIVITY-GATE") ? "EXCLUSIVITY" : "HOLD" },
+              name: "hold",
+            },
+          ],
         };
       }
     }

--- a/e2e/fixtures/fixture-tasks/agent/subagents/busy-worker/tools/hold.ts
+++ b/e2e/fixtures/fixture-tasks/agent/subagents/busy-worker/tools/hold.ts
@@ -2,10 +2,12 @@ import { defineTool } from "eve/tools";
 import { z } from "zod";
 
 export default defineTool({
-  description: "Keep an admitted continuation nonterminal long enough for a later-turn check.",
-  inputSchema: z.object({ marker: z.literal("HOLD") }),
+  description: "Hold a continuation until approval, or briefly delay other fixture work.",
+  inputSchema: z.object({ marker: z.enum(["HOLD", "EXCLUSIVITY"]) }),
+  approval: ({ toolInput }) =>
+    toolInput?.marker === "EXCLUSIVITY" ? "user-approval" : "not-applicable",
   execute: async ({ marker }) => {
-    await new Promise((resolve) => setTimeout(resolve, 5_000));
+    if (marker === "HOLD") await new Promise((resolve) => setTimeout(resolve, 5_000));
     return { marker, released: true };
   },
 });

--- a/e2e/fixtures/fixture-tasks/evals/task.agent.steer.accepted-busy.eval.ts
+++ b/e2e/fixtures/fixture-tasks/evals/task.agent.steer.accepted-busy.eval.ts
@@ -7,6 +7,7 @@ import {
   parseToolErrorOutput,
   sendAndFollowQueuedTurn,
   waitForCompletedTask,
+  waitForTaskInput,
   waitForTaskNotification,
 } from "./shared.js";
 
@@ -62,10 +63,11 @@ export default defineTaskEval({
       status: "failed",
     });
 
+    const held = await waitForTaskInput(t, race.session, "hold");
     const later = await sendAndFollowQueuedTurn(
       t,
       `CHILD-TASK-EXCLUSIVITY-LATER ${agentId}`,
-      race.session,
+      held.session,
     );
     later.turn.expectOk();
     later.turn.calledSubagent("busy-worker", { count: 1, status: "completed" });


### PR DESCRIPTION
### Summary

The busy-worker eval can miss the state it intends to test: in the [failed run](https://github.com/vercel/eve/actions/runs/34049174153/artifacts/9994174857), the child completed before the later continuation arrived. Hold the child at an approval gate and wait until that gate is visible before steering it. The eval then checks that steering cancels the held task and completes a replacement on the same agent, without relying on the five-second delay.

Extracted from #3073; this fixture fix is independent of workflow authorization.

### Validation

- `pnpm typecheck`: 44 tasks passed, including building and typechecking `fixture-tasks`.
- `pnpm --filter fixture-tasks validate:transitions`: 19 declarations passed.
- `pnpm fmt` and `pnpm lint` passed.
- E2E execution is CI-only; the extracted branch needs its own CI run.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
