### PR TITLE
feat(selfmod): mount dev logs in sandbox

### DIFF
--- a/.changeset/selfmod-dev-logs.md
+++ b/.changeset/selfmod-dev-logs.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Mount local `eve dev` diagnostic logs read-only at `/logs` in the self-modification sandbox so the subagent can use them while debugging.

--- a/.changeset/selfmod-dev-logs.md
+++ b/.changeset/selfmod-dev-logs.md
@@ -1,5 +1,0 @@
----
-"eve": patch
----
-
-Mount local `eve dev` diagnostic logs read-only at `/logs` in the self-modification sandbox so the subagent can use them while debugging.

--- a/packages/eve/src/self-modification/extension/instructions.ts
+++ b/packages/eve/src/self-modification/extension/instructions.ts
@@ -20,6 +20,8 @@ Registry installation is outside the source sandbox.
 
 The eve framework documentation is mounted read-only at /eve-docs. Read the eve guide directly relevant to an unfamiliar public API. Prefer an existing local implementation pattern over broad documentation research.
 
+Local eve dev logs are available read-only at /logs.
+
 You cannot access application files outside the authored agent directory or run host binaries such as git, node, pnpm, or tsc.
 
 Treat a successful file-edit tool result as confirmation; do not reread a file solely to verify that the edit succeeded. Do not approximate unavailable build or test commands with broad source searches.

--- a/packages/eve/src/self-modification/filesystem.ts
+++ b/packages/eve/src/self-modification/filesystem.ts
@@ -10,9 +10,11 @@ export async function createSelfModificationFilesystem(input: {
 }): Promise<IFileSystem> {
   const { MountableFs, OverlayFs, ReadWriteFs } = input.justBash;
   const traceRoot = resolve(input.appRoot, ".eve/traces/v1");
+  const logsRoot = resolve(input.appRoot, ".eve/logs");
   await Promise.all([
     input.defaultFilesystem.mkdir("/source", { recursive: true }),
     mkdir(traceRoot, { recursive: true }),
+    mkdir(logsRoot, { recursive: true }),
   ]);
   return new MountableFs({
     base: input.defaultFilesystem,
@@ -32,6 +34,14 @@ export async function createSelfModificationFilesystem(input: {
           root: traceRoot,
         }),
         mountPoint: "/traces",
+      },
+      {
+        filesystem: new OverlayFs({
+          mountPoint: "/",
+          readOnly: true,
+          root: logsRoot,
+        }),
+        mountPoint: "/logs",
       },
       {
         filesystem: new OverlayFs({

--- a/packages/eve/src/self-modification/sandbox.integration.test.ts
+++ b/packages/eve/src/self-modification/sandbox.integration.test.ts
@@ -17,7 +17,7 @@ afterEach(async () => {
   );
 });
 
-async function createAppRoot(options: { traces?: boolean } = {}): Promise<string> {
+async function createAppRoot(options: { traces?: boolean; logs?: boolean } = {}): Promise<string> {
   const appRoot = await mkdtemp(join(tmpdir(), "eve-self-modification-sandbox-"));
   temporaryDirectories.push(appRoot);
   await mkdir(join(appRoot, "agent"), { recursive: true });
@@ -26,12 +26,16 @@ async function createAppRoot(options: { traces?: boolean } = {}): Promise<string
     await mkdir(join(appRoot, ".eve/traces/v1/trace-1/segments"), { recursive: true });
     await writeFile(join(appRoot, ".eve/traces/v1/trace-1/segments/span.otlp.json"), "trace\n");
   }
+  if (options.logs !== false) {
+    await mkdir(join(appRoot, ".eve/logs"), { recursive: true });
+    await writeFile(join(appRoot, ".eve/logs/dev-test.log"), "diagnostic log\n");
+  }
   await writeFile(join(appRoot, "node_modules/eve/docs/README.md"), "installed eve docs\n");
   return appRoot;
 }
 
 describe("self-modification filesystem", () => {
-  it("mounts authored source read-write and traces and eve docs read-only", async () => {
+  it("mounts authored source read-write and traces, logs, and eve docs read-only", async () => {
     const appRoot = await createAppRoot();
     const filesystem = await createSelfModificationFilesystem({
       appRoot,
@@ -44,6 +48,11 @@ describe("self-modification filesystem", () => {
       filesystem.writeFile("/traces/trace-1/segments/span.otlp.json", "changed\n"),
     ).rejects.toThrow(/read-only file system/u);
 
+    expect(await filesystem.readFile("/logs/dev-test.log")).toBe("diagnostic log\n");
+    await expect(filesystem.writeFile("/logs/dev-test.log", "changed\n")).rejects.toThrow(
+      /read-only file system/u,
+    );
+
     expect(await filesystem.readFile("/eve-docs/README.md")).toBe("installed eve docs\n");
     await expect(filesystem.writeFile("/eve-docs/README.md", "changed\n")).rejects.toThrow(
       /read-only file system/u,
@@ -53,8 +62,8 @@ describe("self-modification filesystem", () => {
     expect(await readFile(join(appRoot, "agent/instructions.md"), "utf8")).toBe("authored\n");
   });
 
-  it("mounts an empty trace directory when no local traces have been captured", async () => {
-    const appRoot = await createAppRoot({ traces: false });
+  it("mounts empty trace and log directories when nothing has been captured", async () => {
+    const appRoot = await createAppRoot({ traces: false, logs: false });
     const filesystem = await createSelfModificationFilesystem({
       appRoot,
       defaultFilesystem: new justBash.InMemoryFs(),
@@ -62,5 +71,6 @@ describe("self-modification filesystem", () => {
     });
 
     expect(await filesystem.readdir("/traces")).toEqual([]);
+    expect(await filesystem.readdir("/logs")).toEqual([]);
   });
 });


### PR DESCRIPTION
### Summary

The development self-modification subagent cannot currently inspect the diagnostic logs that capture framework and runtime failures. This mounts local `eve dev` logs read-only at `/logs`, including an empty mount before any logs exist, and adds a terse instruction that points the subagent there. No changeset is included because selfmod is vendored.

### Validation

- `pnpm --filter eve typecheck`
- `pnpm --filter eve build:js`
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/self-modification/sandbox.integration.test.ts`
- `pnpm exec oxlint packages/eve/src/self-modification/filesystem.ts packages/eve/src/self-modification/sandbox.integration.test.ts packages/eve/src/self-modification/extension/instructions.ts`
- `pnpm exec oxfmt --check packages/eve/src/self-modification/filesystem.ts packages/eve/src/self-modification/sandbox.integration.test.ts packages/eve/src/self-modification/extension/instructions.ts`

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
