### PR TITLE
chore: remove selfmod changeset

### DIFF
--- a/.changeset/selfmod-trace-mount.md
+++ b/.changeset/selfmod-trace-mount.md
@@ -1,5 +1,0 @@
----
-"@eve/self-modification": patch
----
-
-Mount local `eve dev` traces read-only at `/traces` in the self-modification sandbox, and use the `session.started` trace coordinates to point the subagent at its invoking trace when local segments are available.


### PR DESCRIPTION
### Summary

The trace mount PR still carries release metadata for the standalone `@eve/self-modification` package, which is now vendored. Remove that obsolete changeset; this stacked cleanup changes no runtime behavior.

### Validation

- `git diff --check`

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [ ] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
