### PR TITLE
feat(docs): add eve changelog

### DIFF
--- a/apps/docs/app/[lang]/changelog-pages.mdx/[page]/route.ts
+++ b/apps/docs/app/[lang]/changelog-pages.mdx/[page]/route.ts
@@ -1,0 +1,7 @@
+import { createChangelogMarkdownRoute } from "@vercel/geistdocs/routes/changelog";
+import { changelogOptions } from "@/lib/geistdocs/changelog";
+
+const changelogRoute = createChangelogMarkdownRoute(changelogOptions);
+
+export const GET = changelogRoute.GET;
+export const generateStaticParams = changelogRoute.generatePageParams;

--- a/apps/docs/app/[lang]/changelog.md/route.ts
+++ b/apps/docs/app/[lang]/changelog.md/route.ts
@@ -1,0 +1,7 @@
+import { createChangelogMarkdownRoute } from "@vercel/geistdocs/routes/changelog";
+import { changelogOptions } from "@/lib/geistdocs/changelog";
+
+const changelogRoute = createChangelogMarkdownRoute(changelogOptions);
+
+export const GET = changelogRoute.GET;
+export const generateStaticParams = changelogRoute.generateStaticParams;

--- a/apps/docs/app/[lang]/changelog/data/[page]/route.ts
+++ b/apps/docs/app/[lang]/changelog/data/[page]/route.ts
@@ -1,0 +1,7 @@
+import { createChangelogDataRoute } from "@vercel/geistdocs/routes/changelog";
+import { changelogOptions } from "@/lib/geistdocs/changelog";
+
+const changelogRoute = createChangelogDataRoute(changelogOptions);
+
+export const GET = changelogRoute.GET;
+export const generateStaticParams = changelogRoute.generateStaticParams;

--- a/apps/docs/app/[lang]/changelog/page.tsx
+++ b/apps/docs/app/[lang]/changelog/page.tsx
@@ -1,0 +1,12 @@
+import { createChangelogPage } from "@vercel/geistdocs/pages/changelog";
+import { changelogOptions } from "@/lib/geistdocs/changelog";
+import { getRootLang } from "@/lib/geistdocs/root-params";
+
+const changelogPage = createChangelogPage({
+  ...changelogOptions,
+  getLang: getRootLang,
+});
+
+export const generateMetadata = changelogPage.generateMetadata;
+export const generateStaticParams = changelogPage.generateStaticParams;
+export default changelogPage.Page;

--- a/apps/docs/app/[lang]/changelog/page/[page]/page.tsx
+++ b/apps/docs/app/[lang]/changelog/page/[page]/page.tsx
@@ -1,0 +1,12 @@
+import { createChangelogPage } from "@vercel/geistdocs/pages/changelog";
+import { changelogOptions } from "@/lib/geistdocs/changelog";
+import { getRootLang } from "@/lib/geistdocs/root-params";
+
+const changelogPage = createChangelogPage({
+  ...changelogOptions,
+  getLang: getRootLang,
+});
+
+export const generateMetadata = changelogPage.generatePaginatedMetadata;
+export const generateStaticParams = changelogPage.generatePageParams;
+export default changelogPage.PaginatedPage;

--- a/apps/docs/geistdocs.tsx
+++ b/apps/docs/geistdocs.tsx
@@ -23,6 +23,10 @@ export const nav = [
     label: "Templates",
     href: "/templates",
   },
+  {
+    label: "Changelog",
+    href: "/changelog",
+  },
 ];
 
 export const suggestions = [
@@ -33,6 +37,13 @@ export const suggestions = [
 ];
 
 export const agent = {
+  links: [
+    {
+      label: "Changelog",
+      href: "/changelog.md",
+      description: "eve release notes as Markdown, with links to older releases.",
+    },
+  ],
   product: {
     name: "eve",
     description:

--- a/apps/docs/lib/geistdocs/changelog-source.ts
+++ b/apps/docs/lib/geistdocs/changelog-source.ts
@@ -1,0 +1,11 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { createChangesetsChangelogSource } from "@vercel/geistdocs/changelog";
+
+const readChangelog = async () => {
+  "use cache";
+
+  return readFile(path.join(process.cwd(), "../../packages/eve/CHANGELOG.md"), "utf8");
+};
+
+export const changelogSource = createChangesetsChangelogSource({ read: readChangelog });

--- a/apps/docs/lib/geistdocs/changelog.test.ts
+++ b/apps/docs/lib/geistdocs/changelog.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { changelogSource } from "./changelog-source";
+
+describe("changelog source", () => {
+  it("publishes the eve release history with stable unique entries", async () => {
+    const entries = await changelogSource.getEntries({ lang: "en" });
+    const release = entries.find(({ version }) => version === "0.52.2");
+
+    expect(release).toMatchObject({
+      id: "0.52.2",
+      version: "0.52.2",
+    });
+    expect(release?.body).toContain(
+      "Ignore OpenAPI `default` and `example` annotations whose values conflict with the declared schema type",
+    );
+    expect(release?.body).not.toMatch(/^- [a-f0-9]{7}: /m);
+    expect(new Set(entries.map(({ id }) => id)).size).toBe(entries.length);
+  });
+});

--- a/apps/docs/lib/geistdocs/changelog.ts
+++ b/apps/docs/lib/geistdocs/changelog.ts
@@ -1,0 +1,12 @@
+import { changelogSource } from "./changelog-source";
+import { config } from "./config";
+
+export const changelogOptions = {
+  config,
+  source: changelogSource,
+  path: "/changelog",
+  markdownPath: "/changelog.md",
+  pageSize: 5,
+  title: "Changelog",
+  description: "New features, breaking changes, and fixes in eve, release by release.",
+};

--- a/apps/docs/lib/geistdocs/llms-index.test.ts
+++ b/apps/docs/lib/geistdocs/llms-index.test.ts
@@ -26,6 +26,7 @@ describe("createLlmsIndex", () => {
     expect(output).toContain("https://eve.dev/sitemap.md");
     expect(output).toContain("https://eve.dev/agents.md");
     expect(output).toContain("https://eve.dev/llms-full.txt");
+    expect(output).toContain("https://eve.dev/changelog.md");
   });
 
   it("uses unique absolute links and stays concise", () => {

--- a/apps/docs/lib/geistdocs/llms-index.ts
+++ b/apps/docs/lib/geistdocs/llms-index.ts
@@ -88,6 +88,7 @@ Documentation links below point directly to Markdown. Remove the \`.md\` suffix 
 
 ## Optional
 
+- [Changelog](${EVE_ORIGIN}/changelog.md): Read eve release notes, including breaking changes and fixes. Follow the next-page links for older releases.
 - [Integrations](${EVE_ORIGIN}/integrations): Browse official channels, connections, extensions, and instrumentation providers.
 - [Templates](${EVE_ORIGIN}/templates): Browse complete example projects and their source.
 - [Official eve Skill](https://github.com/vercel/eve/blob/main/skills/eve/SKILL.md): Install or inspect the coding-agent skill; its guidance defers to version-matched bundled docs.

--- a/apps/docs/lib/geistdocs/markdown-routes.ts
+++ b/apps/docs/lib/geistdocs/markdown-routes.ts
@@ -1,6 +1,8 @@
 import type { GeistdocsMarkdownRoute } from "@vercel/geistdocs/proxy";
 
 export const markdownRoutes: GeistdocsMarkdownRoute[] = [
+  { from: "/changelog/page/*path", to: "/[lang]/changelog-pages.mdx/*path" },
+  { from: "/changelog", to: "/[lang]/changelog.md" },
   { from: "/docs/*path", to: "/[lang]/llms.mdx/*path" },
   { from: "/integrations/*path", to: "/[lang]/llms.mdx/integrations/*path" },
 ];

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -1,4 +1,5 @@
 import { createRequire } from "node:module";
+import path from "node:path";
 import { createGeistdocs } from "@vercel/geistdocs/next";
 import type { NextConfig } from "next";
 import {
@@ -17,6 +18,7 @@ const localSiteHost = "localhost:3000";
 const config: NextConfig = {
   cacheComponents: true,
   partialPrefetching: true,
+  outputFileTracingRoot: path.resolve(import.meta.dirname, "../.."),
 
   env: {
     NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL:

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -25,7 +25,7 @@
     "@icons-pack/react-simple-icons": "13.13.0",
     "@streamdown/code": "1.1.1",
     "@vercel/analytics": "2.0.1",
-    "@vercel/geistdocs": "1.27.0",
+    "@vercel/geistdocs": "1.28.0",
     "@vercel/speed-insights": "2.0.0",
     "@vgpu/core": "0.0.7",
     "@vgpu/render": "0.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,8 +163,8 @@ importers:
         specifier: 2.0.1
         version: 2.0.1(@sveltejs/kit@2.63.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vite@7.3.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@7.3.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(next@16.3.4(@babel/core@7.29.0(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nuxt@4.4.6(fa0ad0f89512d34185b697ca49bcac95))(react@19.2.6)(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vue@3.5.35(typescript@6.0.3))
       '@vercel/geistdocs':
-        specifier: 1.27.0
-        version: 1.27.0(0d8d476fa0b165cdc4ca646b9eff7914)
+        specifier: 1.28.0
+        version: 1.28.0(0d8d476fa0b165cdc4ca646b9eff7914)
       '@vercel/speed-insights':
         specifier: 2.0.0
         version: 2.0.0(@sveltejs/kit@2.63.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vite@7.3.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@7.3.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(next@16.3.4(@babel/core@7.29.0(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(nuxt@4.4.6(fa0ad0f89512d34185b697ca49bcac95))(react@19.2.6)(svelte@5.56.1(@typescript-eslint/types@8.59.4))(vue@3.5.35(typescript@6.0.3))
@@ -8005,8 +8005,8 @@ packages:
   '@vercel/gatsby-plugin-vercel-builder@2.2.44':
     resolution: {integrity: sha512-3A98XSD/4dO9AuYL67klVPqbKGOV15r8Tet88vjs+I7m8D/Nb9+rJypY1dGyGYK+Ts+ypZVBk7f6uGiK+u2KjQ==}
 
-  '@vercel/geistdocs@1.27.0':
-    resolution: {integrity: sha512-AQL9q7upPgiT7rz7ImB4+cLua1DK81kT4TyBcm9ROmtn1x4d5fTDvKAtFS7D7TycYRvzUs/4/1VsIanloljxfQ==}
+  '@vercel/geistdocs@1.28.0':
+    resolution: {integrity: sha512-ZcfwAnZ7EKdXwjwFlHXAvdGoMT17s0+Noq7Su/7Gb8M9L3nsFsViD86nRXwnmsMFUyzEHab4dUosz8T/jFB4pA==}
     hasBin: true
     peerDependencies:
       next: ^16.3.3
@@ -13681,6 +13681,12 @@ packages:
 
   react-is@19.2.6:
     resolution: {integrity: sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==}
+
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
 
   react-medium-image-zoom@5.4.5:
     resolution: {integrity: sha512-58QSIRK6X3uw2fSTejJRnH0JuKTZl7ZJYX+sAMaYx4YTEm33gsNdnP5RuQSCnBiAvisQeErqZWAT31bR89WB6g==}
@@ -22410,7 +22416,7 @@ snapshots:
       etag: 1.8.1
       fs-extra: 11.1.0
 
-  '@vercel/geistdocs@1.27.0(0d8d476fa0b165cdc4ca646b9eff7914)':
+  '@vercel/geistdocs@1.28.0(0d8d476fa0b165cdc4ca646b9eff7914)':
     dependencies:
       '@ai-sdk/react': 3.0.193(react@19.2.6)(zod@4.5.4)
       '@clack/prompts': 0.11.0
@@ -22441,6 +22447,7 @@ snapshots:
       radix-ui: 1.6.4(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
+      react-markdown: 10.1.0(@types/react@19.2.15)(react@19.2.6)(supports-color@10.2.2)
       react-player: 3.4.0(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       remark-frontmatter: 5.0.0(supports-color@10.2.2)
       remark-gfm: 4.0.1(supports-color@10.2.2)
@@ -30417,6 +30424,24 @@ snapshots:
   react-is@18.3.1: {}
 
   react-is@19.2.6: {}
+
+  react-markdown@10.1.0(@types/react@19.2.15)(react@19.2.6)(supports-color@10.2.2):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.15
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6(supports-color@10.2.2)
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.6
+      remark-parse: 11.0.0(supports-color@10.2.2)
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   react-medium-image-zoom@5.4.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:


### PR DESCRIPTION
### Summary

eve release notes were only available in the repository changelog. This adds an opt-in Geistdocs changelog backed by the existing release history, with paginated HTML and Markdown routes plus navigation and agent discovery links.

### Validation

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm check:deps`
- `pnpm exec oxfmt --check <changed files>`
- `pnpm exec oxlint <changed files>`
- `pnpm --filter eve-docs test:unit`
- `pnpm --filter eve-docs exec tsc --noEmit`
- `pnpm docs:check`
- `pnpm --filter eve-docs build`
- Verified production HTML, Markdown negotiation, pagination, Copy page, no-JavaScript fallback, and responsive behavior at 1440px and 390px.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
