### PR TITLE
feat(subagents): expose per-call model, reasoning and budget selection

### DIFF
--- a/.changeset/quiet-delegate-options.md
+++ b/.changeset/quiet-delegate-options.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Allow local subagents to opt into per-call model, reasoning and cost selection with `delegationModels`. Fresh calls can supply `execution`; existing children retain their configuration and requested cost ceilings cannot raise inherited quotas.

--- a/.changeset/quiet-delegate-options.md
+++ b/.changeset/quiet-delegate-options.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Allow local subagents to opt into per-call model, reasoning and cost selection with `delegationModels`. Fresh calls can supply `execution`; existing children retain their configuration and requested cost ceilings cannot raise inherited quotas.
+Let parent agents choose a model, reasoning effort and cost ceiling for each task delegated to an opted-in local subagent. Authors configure allowed models with `delegationModels`; calls without overrides keep their defaults, and requested budgets cannot raise inherited or authored limits.

--- a/docs/subagents/index.mdx
+++ b/docs/subagents/index.mdx
@@ -5,6 +5,38 @@ description: "Delegate work to root-agent copies or declared specialists with th
 
 eve supports two ways to delegate work: the root-only built-in `agent` tool, which starts or continues a copy of the root agent, and declared subagents, which are specialists with their own directories. Use a subagent to run independent work in parallel, narrow the available tools, or give a task to a specialist.
 
+## Per-call execution for declared subagents
+
+A declared local subagent can opt into model selection by listing `delegationModels`
+in its `defineAgent` configuration. Its default model must be static. For example:
+
+```ts
+export default defineAgent({
+  description: "Complete a bounded assignment using the shared workspace.",
+  model: "openai/gpt-5.5",
+  delegationModels: ["openai/gpt-5.5", "google/gemini-2.5-flash"],
+  limits: { maxTokenCostUsdPerSession: 2 },
+});
+```
+
+The parent can then call that subagent with:
+
+```ts
+worker({
+  message: "Read the assigned transcripts and save your findings.",
+  execution: {
+    model: "google/gemini-2.5-flash",
+    maxCostUsd: 0.25,
+  },
+});
+```
+
+`execution.reasoning` optionally selects an existing eve reasoning level; model
+support still applies. Omit `execution` to keep authored settings. It is only
+accepted for fresh children, not `agentId` follow-ups, remote agents or root copies.
+An explicit cost ceiling cannot raise the inherited parent quota or authored child
+limit. This does not reserve cost across overlapping dispatch batches.
+
 ## The built-in `agent` tool
 
 The root session receives `agent` by default. The model calls it to delegate a task to a new copy of the root agent or continue an existing copy:

--- a/docs/subagents/index.mdx
+++ b/docs/subagents/index.mdx
@@ -5,10 +5,14 @@ description: "Delegate work to root-agent copies or declared specialists with th
 
 eve supports two ways to delegate work: the root-only built-in `agent` tool, which starts or continues a copy of the root agent, and declared subagents, which are specialists with their own directories. Use a subagent to run independent work in parallel, narrow the available tools, or give a task to a specialist.
 
-## Per-call execution for declared subagents
+## Select models and budgets per task
 
-A declared local subagent can opt into model selection by listing `delegationModels`
-in its `defineAgent` configuration. Its default model must be static. For example:
+Let the parent choose how much intelligence to spend on a delegation: repeated
+extraction may use a cheaper model, while a difficult review may use a stronger
+model with more reasoning. Both can use the same worker and tools.
+
+A declared local subagent opts in by listing allowed AI Gateway model IDs in
+`delegationModels`. Its default model must be static. For example:
 
 ```ts
 export default defineAgent({
@@ -23,13 +27,20 @@ The parent can then call that subagent with:
 
 ```ts
 worker({
-  message: "Read the assigned transcripts and save your findings.",
+  message:
+    "Extract the dates from /workspace/documents/report.txt and save them to /workspace/results/dates.json.",
   execution: {
     model: "google/gemini-2.5-flash",
     maxCostUsd: 0.25,
   },
 });
 ```
+
+Use parent instructions or skills to explain model strengths, task requirements
+and budget tradeoffs. The parent selects from the allowlist; eve does not infer
+the best model, supply live pricing guidance, or automatically route the request.
+Adopting a new model means updating the catalog and guidance, not adding another
+worker implementation. Different fresh delegations can choose different models.
 
 `execution.reasoning` optionally selects an existing eve reasoning level; model
 support still applies. Omit `execution` to keep authored settings. It is only

--- a/e2e/fixtures/agent-subagents/agent/subagents/selectable-worker/agent.ts
+++ b/e2e/fixtures/agent-subagents/agent/subagents/selectable-worker/agent.ts
@@ -1,0 +1,8 @@
+import { defineAgent } from "eve";
+
+export default defineAgent({
+  description: "Keep a short note for Alice and answer follow-up questions about that note.",
+  model: "openai/gpt-5.5",
+  delegationModels: ["openai/gpt-5.5"],
+  limits: { maxTokenCostUsdPerSession: 1 },
+});

--- a/e2e/fixtures/agent-subagents/agent/subagents/selectable-worker/instructions.md
+++ b/e2e/fixtures/agent-subagents/agent/subagents/selectable-worker/instructions.md
@@ -1,0 +1,2 @@
+Remember the note supplied in your assignment. Reply with the note when asked.
+Follow-up questions refer to this conversation, not other workers' conversations.

--- a/e2e/fixtures/agent-subagents/evals/delegation-execution.eval.ts
+++ b/e2e/fixtures/agent-subagents/evals/delegation-execution.eval.ts
@@ -1,0 +1,29 @@
+import { defineEval } from "eve/evals";
+
+export default defineEval({
+  tags: ["real-model"],
+  description:
+    "An opted-in delegate accepts execution options and retains its conversation on follow-up.",
+  async test(t) {
+    const started = await t.send(
+      [
+        "Alice wants to keep a note in a separate worker conversation.",
+        "Call selectable-worker with the message 'Remember Alice's note: cobalt lantern'.",
+        "For that new child, set execution.model to openai/gpt-5.5, execution.reasoning to low, and execution.maxCostUsd to 0.5.",
+        "After it replies, send the same worker a follow-up using its agentId, without execution options, asking for Alice's note.",
+        "Then report the note to Alice. Do not start a second worker.",
+      ].join(" "),
+    );
+    started.expectOk();
+    const streamIndex = t.state?.streamIndex;
+    if (streamIndex === undefined) throw new Error("Parent session has no stream index.");
+    const completed = await t.target
+      .watchTurn(started.sessionId, { startIndex: streamIndex })
+      .result();
+    completed.expectOk();
+    completed.messageIncludes("cobalt lantern");
+    t.succeeded();
+    t.calledSubagent("selectable-worker", { count: 2 });
+    t.noFailedActions();
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/channel/v19.ts
+++ b/packages/eve/extension-contracts/compatibility/channel/v19.ts
@@ -1,0 +1,12 @@
+import { defineChannel, POST } from "#public/channels/index.js";
+
+export default defineChannel({
+  routes: [
+    POST("/continue/:sessionId", async (_request, { attachSession, params }) => {
+      const result = await attachSession(params.sessionId!).send("Continue the delegated task.", {
+        auth: null,
+      });
+      return Response.json({ accepted: result.status === "accepted" });
+    }),
+  ],
+});

--- a/packages/eve/extension-contracts/compatibility/subagent/v10.ts
+++ b/packages/eve/extension-contracts/compatibility/subagent/v10.ts
@@ -1,0 +1,8 @@
+import { defineAgent } from "#public/index.js";
+
+export default defineAgent({
+  description: "Complete a bounded research assignment.",
+  model: "openai/gpt-5.5",
+  reasoning: "low",
+  limits: { maxTokenCostUsdPerSession: 1 },
+});

--- a/packages/eve/extension-contracts/reports/channel/v20.json
+++ b/packages/eve/extension-contracts/reports/channel/v20.json
@@ -1,0 +1,21 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "channel",
+  "epoch": 20,
+  "sha256": "9578599fca73a9d518b865f6b20adb1396877ab0bcbb933baa07a78df900fb40",
+  "exports": [
+    "DELETE",
+    "GET",
+    "HEAD",
+    "OPTIONS",
+    "PATCH",
+    "POST",
+    "PUT",
+    "WS",
+    "createWebSocketUpgradeServer",
+    "defineChannel",
+    "disableRoute",
+    "isChannel",
+    "isDisabledRouteSentinel"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/subagent/v11.json
+++ b/packages/eve/extension-contracts/reports/subagent/v11.json
@@ -1,0 +1,20 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "subagent",
+  "epoch": 11,
+  "sha256": "ab342a27db36ddb5b45a33d66062c5b1403b7d62837e0ca5d63a3702087d4564",
+  "exports": [
+    "AgentCompactionDefinition",
+    "AgentDefinition",
+    "AgentModelDefinition",
+    "AgentStaticModelDefinition",
+    "DefinedAgent",
+    "DynamicLocalSubagentDefinition",
+    "DynamicSubagentDefinition",
+    "RemoteAgentDefinition",
+    "RemoteAgentDefinitionInput",
+    "defineAgent",
+    "defineDynamic",
+    "defineRemoteAgent"
+  ]
+}

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -56,8 +56,8 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     },
   },
   channel: {
-    current: 19,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19],
+    current: 20,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19, 20],
     dropped: {
       12: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",
     },
@@ -70,8 +70,8 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     },
   },
   subagent: {
-    current: 10,
-    supported: [3, 4, 6, 7, 8, 9, 10],
+    current: 11,
+    supported: [3, 4, 6, 7, 8, 9, 10, 11],
     dropped: {
       1: "Persistent subagent sessions are now the default and the experimental opt-in was removed",
       2: "Persistent subagent sessions are now the default and the experimental opt-in was removed",

--- a/packages/eve/src/compiler/manifest.test.ts
+++ b/packages/eve/src/compiler/manifest.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { compileFromMemory } from "#compiler/compile-from-memory.js";
+import { defineAgent } from "#public/definitions/agent.js";
 import {
   COMPILED_AGENT_MANIFEST_VERSION,
   compiledAgentManifestSchema,
@@ -12,6 +13,17 @@ import {
 } from "#compiler/validate-artifact.js";
 
 describe("compiled agent manifest v48", () => {
+  it("preserves delegation model choices through compilation and serialization", async () => {
+    const models = ["openai/gpt-5.4", "google/gemini-2.5-flash"];
+    const { manifest } = await compileFromMemory({
+      model: "openai/gpt-5.4",
+      agent: defineAgent({ model: "openai/gpt-5.4", delegationModels: models }),
+    });
+    const parsed = compiledAgentManifestSchema.parse(JSON.parse(JSON.stringify(manifest)));
+    expect(parsed.config.delegationModels).toEqual(models);
+    expect(() => validateCompiledAgentManifest(parsed)).not.toThrow();
+  });
+
   it("round-trips a real compiled graph through the serialized schema", async () => {
     const { manifest } = await compileFromMemory({
       limits: { maxTokenCostUsdPerSession: 1.5 },

--- a/packages/eve/src/compiler/manifest.ts
+++ b/packages/eve/src/compiler/manifest.ts
@@ -607,6 +607,7 @@ const compiledAgentConfigBaseFields = {
   build: compiledAgentBuildDefinitionSchema.optional(),
   compaction: compiledAgentCompactionDefinitionSchema.optional(),
   defaultTools: z.boolean().optional(),
+  delegationModels: z.array(z.string()).nonempty().optional(),
   description: z.string().optional(),
   experimental: z
     .object({
@@ -1220,6 +1221,8 @@ function cloneCompiledAgentDefinition(config: CompiledAgentDefinition): Compiled
     name: config.name,
     outputSchema: config.outputSchema,
     reasoning: config.reasoning,
+    delegationModels:
+      config.delegationModels === undefined ? undefined : [...config.delegationModels],
     limits:
       config.limits === undefined
         ? undefined

--- a/packages/eve/src/compiler/normalize-agent-config.ts
+++ b/packages/eve/src/compiler/normalize-agent-config.ts
@@ -83,6 +83,7 @@ export async function compileAgentConfig(
       thresholdPercent?: number;
     };
     defaultTools?: boolean;
+    delegationModels?: readonly string[];
     description?: string;
     experimental?: CompiledAgentDefinition["experimental"];
     name: string;
@@ -98,6 +99,9 @@ export async function compileAgentConfig(
 
   if (definition.defaultTools !== undefined) {
     compiledConfig.defaultTools = definition.defaultTools;
+  }
+  if (definition.delegationModels !== undefined) {
+    compiledConfig.delegationModels = [...definition.delegationModels];
   }
 
   if (definition.description !== undefined) {

--- a/packages/eve/src/execution/tools/subagent/invoke-agent.ts
+++ b/packages/eve/src/execution/tools/subagent/invoke-agent.ts
@@ -21,6 +21,7 @@ import type { ToolContext } from "#tools/definition.js";
 import type { TaskInboundUpdate } from "#tasks/types.js";
 
 export type InternalAgentInput = {
+  readonly execution?: JsonObject;
   readonly agentId?: string;
   readonly message: string;
   readonly outputSchema?: JsonObject;

--- a/packages/eve/src/execution/tools/subagent/invoke-preparation.test.ts
+++ b/packages/eve/src/execution/tools/subagent/invoke-preparation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { planAgentDispatch } from "#execution/tools/subagent/invoke-preparation.js";
+import type { JsonObject, JsonValue } from "#shared/json.js";
 
 const localAction = {
   callId: "call-1",
@@ -24,6 +25,77 @@ function session(rootSessionId?: string) {
 }
 
 describe("planAgentDispatch", () => {
+  it.each<{ models: string[] | undefined; execution: JsonObject; agentId: string | undefined }>([
+    { models: undefined, execution: { model: "openai/gpt-5.5" }, agentId: undefined },
+    { models: ["openai/gpt-5.5"], execution: { model: "other/model" }, agentId: undefined },
+    {
+      models: ["openai/gpt-5.5"],
+      execution: { model: "openai/gpt-5.5", maxCostUsd: -1 },
+      agentId: undefined,
+    },
+    { models: ["openai/gpt-5.5"], execution: { model: "openai/gpt-5.5" }, agentId: "existing" },
+  ])(
+    "rejects unauthorized or invalid execution settings before dispatch: %j",
+    ({ models, execution, agentId }) => {
+      const input: Record<string, JsonValue> = { message: "Review", execution };
+      if (agentId !== undefined) input.agentId = agentId;
+      expect(
+        planAgentDispatch({
+          action: {
+            ...localAction,
+            input,
+          },
+          bundle: {
+            subagentRegistry: {
+              subagentsByNodeId: new Map([
+                [
+                  localAction.nodeId,
+                  {
+                    definition: {
+                      kind: "subagent",
+                      description: "Review",
+                      delegationModels: models,
+                    },
+                  },
+                ],
+              ]),
+            },
+            turnAgent: {},
+          } as never,
+          ctx: {} as never,
+          session: session() as never,
+        }),
+      ).toMatchObject({ kind: "reject", result: { output: { code: "invalid_execution" } } });
+    },
+  );
+
+  it("plans a fresh child with authorized execution settings", () => {
+    const execution = { model: "openai/gpt-5.5", reasoning: "low", maxCostUsd: 0.2 };
+    expect(
+      planAgentDispatch({
+        action: { ...localAction, input: { message: "Review", execution } },
+        bundle: {
+          subagentRegistry: {
+            subagentsByNodeId: new Map([
+              [
+                localAction.nodeId,
+                {
+                  definition: {
+                    kind: "subagent",
+                    description: "Review",
+                    delegationModels: [execution.model],
+                  },
+                },
+              ],
+            ]),
+          },
+          turnAgent: {},
+        } as never,
+        ctx: {} as never,
+        session: session() as never,
+      }),
+    ).toMatchObject({ kind: "start", target: { action: { input: { execution } } } });
+  });
   it("rejects recursive self-agent starts outside the root session", () => {
     expect(
       planAgentDispatch({

--- a/packages/eve/src/execution/tools/subagent/invoke-preparation.ts
+++ b/packages/eve/src/execution/tools/subagent/invoke-preparation.ts
@@ -16,7 +16,11 @@ import type { JsonObject } from "#shared/json.js";
 import type { AgentInvocationRequest } from "#execution/tools/subagent/invoke-agent.js";
 import { BundleKey, type CompiledBundle } from "#runtime/sessions/runtime-context-keys.js";
 import { ROOT_RUNTIME_AGENT_NODE_ID } from "#runtime/graph.js";
-import { AGENT_TOOL_DESCRIPTION, AGENT_TOOL_NAME } from "#tools/framework/agent-contract.js";
+import {
+  AGENT_TOOL_DESCRIPTION,
+  AGENT_TOOL_NAME,
+  SUBAGENT_EXECUTION_SCHEMA,
+} from "#tools/framework/agent-contract.js";
 import {
   SessionDynamicSubagentSelectionsKey,
   TurnDynamicSubagentSelectionsKey,
@@ -25,6 +29,7 @@ import {
 import type { DynamicRemoteAgentConfig } from "#runtime/subagents/dynamic-remote-agent-config.js";
 import {
   isAgentHandleAction,
+  createAgentErrorResult,
   type RuntimeAgentHandleAction,
   type RuntimeSession,
 } from "#subagents/handle-dispatch.js";
@@ -103,6 +108,34 @@ export function planAgentDispatch(input: {
   const rawAgentId = input.action.input.agentId;
   const agentId =
     typeof rawAgentId === "string" && rawAgentId.trim() !== "" ? rawAgentId : undefined;
+  if (input.action.input.execution !== undefined) {
+    const registered = input.bundle.subagentRegistry.subagentsByNodeId.get(input.action.nodeId);
+    const models =
+      registered?.definition.kind === "subagent"
+        ? registered.definition.delegationModels
+        : undefined;
+    const parsed = SUBAGENT_EXECUTION_SCHEMA.safeParse(input.action.input.execution);
+    const error =
+      agentId !== undefined
+        ? "Execution settings cannot change when resuming a child. Start a new child to change models."
+        : models === undefined
+          ? "This subagent does not allow execution overrides."
+          : !parsed.success
+            ? "Invalid execution settings: provide model, optional supported reasoning, and a positive finite maxCostUsd."
+            : !models.includes(parsed.data.model)
+              ? `Select an authorized delegation model: ${models.join(", ")}.`
+              : undefined;
+    if (error !== undefined) {
+      return {
+        kind: "reject",
+        result: createAgentErrorResult({
+          action: input.action,
+          code: "invalid_execution",
+          message: error,
+        }),
+      };
+    }
+  }
   if (agentId !== undefined && isAgentHandleAction(input.action)) {
     if (knownAgentIds.has(agentId)) {
       const dynamicSubagentSelection =
@@ -260,12 +293,14 @@ function resolveAgentInvocationAction(input: {
     throw new Error(`Agent target "${input.input.target}" is not available to this agent.`);
   }
   const actionInput: {
+    execution?: JsonObject;
     agentId?: string;
     message: string;
     outputSchema?: JsonObject;
   } = { message: input.input.message };
   if (input.input.agentId !== undefined) actionInput.agentId = input.input.agentId;
   if (input.input.outputSchema !== undefined) actionInput.outputSchema = input.input.outputSchema;
+  if (input.input.execution !== undefined) actionInput.execution = input.input.execution;
   const common = {
     callId: input.invocationId,
     description: definition.description ?? "",

--- a/packages/eve/src/internal/authored-definition/core.test.ts
+++ b/packages/eve/src/internal/authored-definition/core.test.ts
@@ -10,6 +10,40 @@ import { defineDynamic } from "#dynamic/definition.js";
 const FAILURE_MESSAGE = "Expected the agent config to match the public eve shape.";
 
 describe("normalizeAgentDefinition", () => {
+  it("retains an explicit delegation model allowlist", () => {
+    expect(
+      normalizeAgentDefinition(
+        {
+          model: "openai/gpt-5.5",
+          delegationModels: ["openai/gpt-5.5", "google/gemini-2.5-flash"],
+        },
+        FAILURE_MESSAGE,
+      ).delegationModels,
+    ).toEqual(["openai/gpt-5.5", "google/gemini-2.5-flash"]);
+  });
+
+  it.each(
+    [[], ["model"], ["provider/"], ["/model"], [" provider/model"], [null]].map(
+      (delegationModels) => ({ delegationModels }),
+    ),
+  )("rejects invalid delegation model allowlists: %j", ({ delegationModels }) => {
+    expect(() =>
+      normalizeAgentDefinition({ model: "openai/gpt-5.5", delegationModels }, FAILURE_MESSAGE),
+    ).toThrow();
+  });
+
+  it("rejects competing dynamic and per-delegation model selection", () => {
+    expect(() =>
+      normalizeAgentDefinition(
+        {
+          model: defineDynamic({ events: { "session.started": () => "openai/gpt-5.5" } }),
+          delegationModels: ["openai/gpt-5.5"],
+        },
+        FAILURE_MESSAGE,
+      ),
+    ).toThrow("requires a static default model");
+  });
+
   it("accepts provider-agnostic reasoning effort", () => {
     const definition = normalizeAgentDefinition(
       {

--- a/packages/eve/src/internal/authored-definition/core.ts
+++ b/packages/eve/src/internal/authored-definition/core.ts
@@ -50,6 +50,7 @@ export function normalizeAgentDefinition(
       "build",
       "compaction",
       "defaultTools",
+      "delegationModels",
       "description",
       "experimental",
       "limits",
@@ -80,6 +81,22 @@ export function normalizeAgentDefinition(
 
   if (record.description !== undefined) {
     definition.description = expectString(record.description, message);
+  }
+
+  if (record.delegationModels !== undefined) {
+    if (!Array.isArray(record.delegationModels) || record.delegationModels.length === 0) {
+      throw new Error(`${message} delegationModels must be a non-empty list of model IDs.`);
+    }
+    definition.delegationModels = record.delegationModels.map((model) => {
+      const id = expectString(model, message);
+      if (id.trim() !== id || id.indexOf("/") <= 0 || id.endsWith("/")) {
+        throw new Error(`${message} delegationModels must contain provider/model IDs.`);
+      }
+      return id;
+    });
+    if (isDynamicSentinel(definition.model)) {
+      throw new Error(`${message} delegationModels requires a static default model.`);
+    }
   }
 
   if (record.defaultTools !== undefined) {

--- a/packages/eve/src/runtime/resolve-agent-graph.ts
+++ b/packages/eve/src/runtime/resolve-agent-graph.ts
@@ -254,6 +254,8 @@ async function resolveRuntimeSubagent(input: {
   const resolvedSubagent: ResolvedRuntimeSubagentNode = {
     ...variant,
     kind: "subagent",
+    delegationModels:
+      "config" in input.sourceRef.agent ? input.sourceRef.agent.config.delegationModels : undefined,
     logicalPath: input.sourceRef.logicalPath,
     name: input.sourceRef.name,
     nodeId: toRuntimeNodeId(input.sourceRef.nodeId),

--- a/packages/eve/src/runtime/resolve-agent.ts
+++ b/packages/eve/src/runtime/resolve-agent.ts
@@ -189,6 +189,7 @@ function createResolvedAgentConfig(
   const config: {
     compaction?: NonNullable<ResolvedAgent["config"]>["compaction"];
     defaultTools?: boolean;
+    delegationModels?: readonly string[];
     experimental?: NonNullable<ResolvedAgent["config"]>["experimental"];
     name: string;
     outputSchema?: NonNullable<ResolvedAgent["config"]>["outputSchema"];
@@ -197,6 +198,7 @@ function createResolvedAgentConfig(
     limits?: NonNullable<ResolvedAgent["config"]>["limits"];
   } = {
     name: manifest.config.name,
+    delegationModels: manifest.config.delegationModels,
   };
 
   if (manifest.config.defaultTools !== undefined) {

--- a/packages/eve/src/runtime/subagents/dynamic-agent-config.ts
+++ b/packages/eve/src/runtime/subagents/dynamic-agent-config.ts
@@ -43,6 +43,11 @@ export async function normalizeDynamicSubagentAgentConfig(input: {
   if (definition.defaultTools !== undefined) {
     throw new Error(`${message} The "defaultTools" field cannot be selected at runtime.`);
   }
+  if (definition.delegationModels !== undefined) {
+    throw new Error(
+      `${message} The "delegationModels" field requires a statically declared local subagent.`,
+    );
+  }
   if (definition.experimental !== undefined) {
     throw new Error(`${message} The "experimental" field cannot be selected at runtime.`);
   }

--- a/packages/eve/src/runtime/subagents/registry.ts
+++ b/packages/eve/src/runtime/subagents/registry.ts
@@ -6,7 +6,10 @@ import type {
 } from "#runtime/types.js";
 import type { JsonObject } from "#shared/json.js";
 import { serializeInputSchema, serializeOutputSchema } from "#tools/schema.js";
-import { SUBAGENT_TOOL_INPUT_SCHEMA } from "#tools/framework/agent-contract.js";
+import {
+  SUBAGENT_TOOL_INPUT_SCHEMA,
+  createSubagentInputSchema,
+} from "#tools/framework/agent-contract.js";
 import { SUBAGENT_TASK_RECEIPT_OUTPUT_SCHEMA } from "#tools/framework/task-contract.js";
 import { subagentToolExecuteWorkflowReference } from "#runtime/subagents/workflow-reference.js";
 
@@ -145,7 +148,10 @@ export function createPreparedRuntimeSubagentTool(
     },
     description: `${definition.description}\n\nThis call starts a background task and returns a task receipt immediately.`,
     execution: "background",
-    inputSchema,
+    inputSchema:
+      definition.kind === "subagent" && definition.delegationModels !== undefined
+        ? serializeInputSchema(createSubagentInputSchema(definition.delegationModels))
+        : inputSchema,
     kind: definition.kind,
     logicalPath: definition.logicalPath,
     name: definition.name,

--- a/packages/eve/src/runtime/subagents/workflow.ts
+++ b/packages/eve/src/runtime/subagents/workflow.ts
@@ -9,6 +9,7 @@ interface JsonObject {
 }
 
 export interface SubagentWorkflowInput {
+  readonly execution?: JsonObject;
   readonly agentId?: string | null;
   readonly message: string;
   readonly outputSchema?: Record<string, unknown>;
@@ -25,6 +26,7 @@ export async function subagentToolExecuteWorkflow(
       ? { agentId: input.agentId }
       : {}),
     message: input.message,
+    execution: input.execution,
     outputSchema: input.outputSchema as JsonObject | undefined,
     target: ctx.toolName,
   };

--- a/packages/eve/src/runtime/types.ts
+++ b/packages/eve/src/runtime/types.ts
@@ -283,6 +283,7 @@ export type ResolvedRuntimeSubagentNode = Readonly<
   ModuleSourceRef &
     Node & {
       kind: "subagent";
+      delegationModels?: readonly string[];
       name: string;
     } & (
       | {

--- a/packages/eve/src/shared/agent-definition.ts
+++ b/packages/eve/src/shared/agent-definition.ts
@@ -271,6 +271,7 @@ export interface AgentWorkflowDefinition {
  * stamps the path-derived `agentId` onto every compiled agent node.
  */
 export type InternalAgentDefinition = {
+  delegationModels?: readonly string[];
   name: string;
   description?: string;
   build?: AgentBuildDefinition;
@@ -292,6 +293,8 @@ export type InternalAgentDefinition = {
  * a `name` field.
  */
 type PublicAgentDefinitionBase = {
+  /** Allow fresh local delegations to select one of these gateway model IDs. Omit to keep execution settings fixed. */
+  readonly delegationModels?: readonly string[];
   /**
    * Human-readable description of the agent's purpose. Required for
    * subagents (authored under `subagents/<id>/agent.ts`): surfaced to

--- a/packages/eve/src/subagents/start-local.integration.test.ts
+++ b/packages/eve/src/subagents/start-local.integration.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from "vitest";
+import { startLocalSubagent } from "#subagents/start-local.js";
+import { createWorkflowRuntime, waitForCommandHookOwner } from "#execution/workflow-runtime.js";
+import { resolveRuntimeModelSelection } from "#runtime/agent/resolve-model.js";
+import type { RunInput } from "#channel/types.js";
+
+vi.mock("#execution/workflow-runtime.js", () => ({
+  createWorkflowRuntime: vi.fn(),
+  waitForCommandHookOwner: vi.fn(),
+}));
+vi.mock("#runtime/agent/resolve-model.js", () => ({
+  resolveRuntimeModelSelection: vi.fn(),
+}));
+
+describe("local delegation execution", () => {
+  it("returns a recoverable dispatch error when model resolution fails", async () => {
+    vi.mocked(resolveRuntimeModelSelection).mockRejectedValue(
+      new Error("Model catalog unavailable"),
+    );
+    const session = { sessionId: "parent" };
+    const result = await startLocalSubagent({
+      action: {
+        callId: "call",
+        name: "worker",
+        subagentName: "worker",
+        nodeId: "worker",
+        kind: "subagent-call",
+        description: "Work",
+        input: { message: "Review", execution: { model: "openai/gpt-5.5" } },
+      },
+      bundle: {
+        graph: {
+          nodesByNodeId: new Map([
+            [
+              "worker",
+              {
+                agent: { config: { delegationModels: ["openai/gpt-5.5"] } },
+              },
+            ],
+          ]),
+        },
+      },
+      currentSession: session,
+      source: { type: "local" },
+    } as never);
+    expect(result).toMatchObject({
+      kind: "error",
+      session,
+      result: { isError: true, output: { message: "Model catalog unavailable" } },
+    });
+  });
+  it("starts separate children with selected models while retaining authored limits and shared sandbox", async () => {
+    const createSession = vi
+      .fn<(input: RunInput) => Promise<{ runId: string }>>()
+      .mockResolvedValue({ runId: "child" });
+    vi.mocked(createWorkflowRuntime).mockReturnValue({ createSession } as never);
+    vi.mocked(waitForCommandHookOwner).mockResolvedValue({ runId: "child" } as never);
+    vi.mocked(resolveRuntimeModelSelection).mockImplementation(async ({ selection }) => ({
+      reference: {
+        id:
+          typeof selection === "string"
+            ? selection
+            : "model" in selection
+              ? String(selection.model)
+              : selection.modelId,
+      },
+    }));
+    const session = {
+      agent: { modelReference: { id: "parent" }, system: "", tools: [] },
+      compaction: { recentWindowSize: 5, threshold: 10000 },
+      continuationToken: "parent-token",
+      history: [],
+      limits: { maxTokenCostUsdPerSession: 4 },
+      sessionId: "parent",
+      sandboxState: { sandboxId: "shared" },
+    };
+    for (const [index, model] of ["openai/gpt-5.5", "google/gemini-2.5-flash"].entries()) {
+      await startLocalSubagent({
+        action: {
+          callId: `call-${index}`,
+          name: "worker",
+          subagentName: "worker",
+          nodeId: "worker",
+          kind: "subagent-call",
+          description: "Work",
+          input: {
+            message: "Read the assignment",
+            execution: { model, reasoning: "low", maxCostUsd: 0.25 },
+          },
+        },
+        auth: null,
+        initiatorAuth: null,
+        batchEvent: { sequence: 0, turnId: "turn" },
+        bundle: {
+          compiledArtifactsSource: {},
+          graph: {
+            nodesByNodeId: new Map([
+              [
+                "worker",
+                {
+                  agent: {
+                    config: {
+                      model: { id: "default" },
+                      description: "Work",
+                      delegationModels: ["openai/gpt-5.5", "google/gemini-2.5-flash"],
+                      limits: { maxTokenCostUsdPerSession: 2, maxOutputTokensPerSession: 1000 },
+                    },
+                  },
+                  sandboxRegistry: { sandbox: { definition: { inheritsParent: true } } },
+                },
+              ],
+            ]),
+          },
+        },
+        currentSession: session,
+        session,
+        fanoutSize: 2,
+        sandboxSessionId: "parent",
+        source: { type: "local", description: "Work" },
+      } as never);
+      expect(vi.mocked(createWorkflowRuntime).mock.calls[index]?.[0]).toMatchObject({
+        nodeId: "worker",
+        dynamicSubagentAgentConfig: {
+          model: { id: model },
+          reasoning: "low",
+          limits: { maxTokenCostUsdPerSession: 2, maxOutputTokensPerSession: 1000 },
+        },
+      });
+      expect(createSession.mock.calls[index]?.[0]).toMatchObject({
+        limits: { maxTokenCostUsdPerSession: 0.25 },
+        adapter: {
+          state: { sandboxSessionId: "parent", parentSandboxState: { sandboxId: "shared" } },
+        },
+      });
+    }
+  });
+});

--- a/packages/eve/src/subagents/start-local.ts
+++ b/packages/eve/src/subagents/start-local.ts
@@ -8,6 +8,8 @@ import { createLogger, logError } from "#internal/logging.js";
 import type { RuntimeSubagentDispatchRequest } from "#shared/action-types.js";
 import type { CompiledBundle } from "#runtime/sessions/runtime-context-keys.js";
 import { toErrorMessage } from "#shared/errors.js";
+import { SUBAGENT_EXECUTION_SCHEMA } from "#tools/framework/agent-contract.js";
+import { resolveRuntimeModelSelection } from "#runtime/agent/resolve-model.js";
 
 const log = createLogger("execution.subagent-start-local");
 
@@ -37,37 +39,69 @@ export async function startLocalSubagent(input: {
   readonly taskId?: string;
 }): Promise<DispatchOutcome> {
   const { action, source } = input;
-  const childRuntime = createWorkflowRuntime({
-    compiledArtifactsSource: input.bundle.compiledArtifactsSource,
-    dynamicSubagentAgentConfig: input.dynamicSubagentAgentConfig,
-    nodeId: action.nodeId,
-  });
-  const { childContinuationToken, runInput } = buildSubagentRunInput({
-    action,
-    auth: input.auth,
-    batchEvent: input.batchEvent,
-    capabilities: input.capabilities,
-    channelMetadata: input.channelMetadata,
-    fanoutSize: input.fanoutSize,
-    initiatorAuth: input.initiatorAuth,
-    graph: input.bundle.graph,
-    parentContinuationToken: input.parentContinuationToken,
-    parentTraceContext: input.parentTraceContext,
-    activityObserver: input.activityObserver,
-    sandboxSessionId: input.sandboxSessionId,
-    session: input.session,
-    selfAgent: source.type === "runtime",
-    source,
-    taskId: input.taskId,
-  });
-
   const targetKind = source.type === "runtime" ? ("agent/self" as const) : ("agent/local" as const);
-  let childSessionId: string;
   try {
+    let agentConfig = input.dynamicSubagentAgentConfig;
+    if (action.input.execution !== undefined) {
+      const execution = SUBAGENT_EXECUTION_SCHEMA.parse(action.input.execution);
+      const base = input.bundle.graph.nodesByNodeId.get(action.nodeId)?.agent.config;
+      if (base === undefined || !base.delegationModels?.includes(execution.model)) {
+        throw new Error("Delegation execution settings are not authorized for this child.");
+      }
+      const selected = await resolveRuntimeModelSelection({
+        durability: "durable",
+        selection: { model: execution.model },
+        state: new ContextContainer(),
+      });
+      agentConfig = {
+        description: base.description ?? action.description,
+        model: selected.reference,
+        reasoning: execution.reasoning ?? base.reasoning,
+        limits: base.limits,
+        outputSchema: base.outputSchema,
+        compaction: base.compaction,
+      };
+    }
+    const childRuntime = createWorkflowRuntime({
+      compiledArtifactsSource: input.bundle.compiledArtifactsSource,
+      dynamicSubagentAgentConfig: agentConfig,
+      nodeId: action.nodeId,
+    });
+    const { childContinuationToken, runInput } = buildSubagentRunInput({
+      action,
+      auth: input.auth,
+      batchEvent: input.batchEvent,
+      capabilities: input.capabilities,
+      channelMetadata: input.channelMetadata,
+      fanoutSize: input.fanoutSize,
+      initiatorAuth: input.initiatorAuth,
+      graph: input.bundle.graph,
+      parentContinuationToken: input.parentContinuationToken,
+      parentTraceContext: input.parentTraceContext,
+      activityObserver: input.activityObserver,
+      sandboxSessionId: input.sandboxSessionId,
+      session: input.session,
+      selfAgent: source.type === "runtime",
+      source,
+      taskId: input.taskId,
+    });
+
     await contextStorage.run(new ContextContainer({ localDevRequest: input.localDevRequest }), () =>
       childRuntime.createSession(runInput),
     );
-    childSessionId = (await waitForCommandHookOwner(childContinuationToken)).runId;
+    const childSessionId = (await waitForCommandHookOwner(childContinuationToken)).runId;
+    return {
+      address: {
+        continuationToken: childContinuationToken,
+        kind: targetKind,
+        sessionId: childSessionId,
+      },
+      callId: action.callId,
+      kind: "called",
+      name: action.name,
+      session: input.currentSession,
+      toolName: action.subagentName,
+    };
   } catch (error) {
     logError(log, "local subagent start failed", error, {
       callId: action.callId,
@@ -90,18 +124,4 @@ export async function startLocalSubagent(input: {
       session: input.currentSession,
     };
   }
-
-  const address = {
-    continuationToken: childContinuationToken,
-    kind: targetKind,
-    sessionId: childSessionId,
-  } as const;
-  return {
-    address,
-    callId: action.callId,
-    kind: "called",
-    name: action.name,
-    session: input.currentSession,
-    toolName: action.subagentName,
-  };
 }

--- a/packages/eve/src/subagents/tool.test.ts
+++ b/packages/eve/src/subagents/tool.test.ts
@@ -52,6 +52,25 @@ function makeInheritingGraph(nodeId: string) {
 }
 
 describe("buildSubagentRunInput", () => {
+  it.each([
+    { requested: 0.25, expected: 0.25 },
+    { requested: 20, expected: 2 },
+  ])("caps requested cost $requested at the inherited batch share", ({ requested, expected }) => {
+    const session = { ...makeSession(), limits: { maxTokenCostUsdPerSession: 4 } };
+    const action = makeAction();
+    const { runInput } = buildRuntimeSubagentRunInput({
+      action: {
+        ...action,
+        input: { ...action.input, execution: { model: "openai/gpt-5.5", maxCostUsd: requested } },
+      },
+      auth: null,
+      initiatorAuth: null,
+      batchEvent: { sequence: 0, turnId: "turn-0" },
+      fanoutSize: 2,
+      session,
+    });
+    expect(runInput.limits?.maxTokenCostUsdPerSession).toBe(expected);
+  });
   it("forwards parent capabilities to the child run input", () => {
     const { runInput } = buildRuntimeSubagentRunInput({
       action: makeAction(),

--- a/packages/eve/src/subagents/tool.ts
+++ b/packages/eve/src/subagents/tool.ts
@@ -14,6 +14,7 @@ import type { RuntimeSubagentDispatchRequest } from "#shared/action-types.js";
 import { mintSubagentContinuationToken } from "#execution/session.js";
 import { resolveRemainingSessionTokenLimits } from "#subagents/token-budget.js";
 import type { JsonObject } from "#shared/json.js";
+import { SUBAGENT_EXECUTION_SCHEMA } from "#tools/framework/agent-contract.js";
 
 /**
  * Pending task batch event metadata needed for child run lineage.
@@ -128,6 +129,14 @@ export function buildSubagentRunInput(input: {
   const inheritedLimits: {
     -readonly [K in keyof RunSessionLimits]: RunSessionLimits[K];
   } = resolveRemainingSessionTokenLimits(session, input.fanoutSize);
+  if (action.input.execution !== undefined) {
+    const { maxCostUsd } = SUBAGENT_EXECUTION_SCHEMA.parse(action.input.execution);
+    if (maxCostUsd !== undefined) {
+      const inherited = inheritedLimits.maxTokenCostUsdPerSession;
+      inheritedLimits.maxTokenCostUsdPerSession =
+        typeof inherited === "number" ? Math.min(inherited, maxCostUsd) : maxCostUsd;
+    }
+  }
   const requestedOutputSchema = normalizeRequestedOutputSchema(action.input.outputSchema);
   const adapterState: Record<string, unknown> = {
     callId: action.callId,

--- a/packages/eve/src/tools/framework/agent-contract.ts
+++ b/packages/eve/src/tools/framework/agent-contract.ts
@@ -29,3 +29,21 @@ export const SUBAGENT_TOOL_INPUT_SCHEMA = z.strictObject({
     )
     .optional(),
 });
+
+export const SUBAGENT_EXECUTION_SCHEMA = z.strictObject({
+  model: z.string().min(1),
+  reasoning: z
+    .enum(["provider-default", "none", "minimal", "low", "medium", "high", "xhigh"])
+    .optional(),
+  maxCostUsd: z.number().finite().positive().optional(),
+});
+
+export function createSubagentInputSchema(models: readonly string[]) {
+  return SUBAGENT_TOOL_INPUT_SCHEMA.extend({
+    execution: SUBAGENT_EXECUTION_SCHEMA.extend({ model: z.enum(models) })
+      .describe(
+        "Optional execution settings for a new child only. Omit when resuming with agentId. Cost can only lower inherited limits. Reasoning support depends on the model.",
+      )
+      .optional(),
+  });
+}

--- a/packages/eve/src/tools/framework/agent-contract.ts
+++ b/packages/eve/src/tools/framework/agent-contract.ts
@@ -34,15 +34,31 @@ export const SUBAGENT_EXECUTION_SCHEMA = z.strictObject({
   model: z.string().min(1),
   reasoning: z
     .enum(["provider-default", "none", "minimal", "low", "medium", "high", "xhigh"])
+    .describe(
+      "Choose reasoning effort for this task using the selected model's supported levels. Omit to retain the worker's authored reasoning setting.",
+    )
     .optional(),
-  maxCostUsd: z.number().finite().positive().optional(),
+  maxCostUsd: z
+    .number()
+    .finite()
+    .positive()
+    .describe(
+      "Optional child-session model cost ceiling in USD. Choose a budget appropriate to the assignment; it cannot raise inherited or authored limits and is not a reservation from a shared budget.",
+    )
+    .optional(),
 });
 
 export function createSubagentInputSchema(models: readonly string[]) {
   return SUBAGENT_TOOL_INPUT_SCHEMA.extend({
-    execution: SUBAGENT_EXECUTION_SCHEMA.extend({ model: z.enum(models) })
+    execution: SUBAGENT_EXECUTION_SCHEMA.extend({
+      model: z
+        .enum(models)
+        .describe(
+          "Choose an allowed model appropriate to the task's complexity, quality requirements, latency and cost, using available instructions or skills. No automatic routing is performed.",
+        ),
+    })
       .describe(
-        "Optional execution settings for a new child only. Omit when resuming with agentId. Cost can only lower inherited limits. Reasoning support depends on the model.",
+        "Select model, reasoning effort and budget for a new delegation. Omit to use the worker's defaults. Do not supply when resuming with agentId; an existing child retains its configuration.",
       )
       .optional(),
   });

--- a/research/delegation-execution.md
+++ b/research/delegation-execution.md
@@ -1,0 +1,42 @@
+---
+issue: "No issue filed; local implementation proposal"
+status: in-progress
+last_updated: "2026-09-08"
+---
+
+# Per-call delegation execution
+
+One general worker should support inexpensive extraction and deeper investigation
+without separate domain agents or a replacement task scheduler.
+
+```ts
+// subagents/worker/agent.ts
+export default defineAgent({
+  description: "Complete a bounded assignment in the shared workspace.",
+  model: "openai/gpt-5.5",
+  delegationModels: ["openai/gpt-5.5", "google/gemini-2.5-flash"],
+  limits: { maxTokenCostUsdPerSession: 2 },
+});
+
+worker({
+  message: "Read the assigned source files and save the findings.",
+  execution: { model: "google/gemini-2.5-flash", maxCostUsd: 0.25 },
+});
+```
+
+The field is opt-in and local-delegate-only. Calls without overrides retain their
+configuration. Resume calls cannot supply overrides. Model IDs are allowlisted;
+reasoning uses the existing provider-agnostic vocabulary. Provider support still
+requires validation. Explicit cost is a lower ceiling alongside inherited and
+authored limits, not an allocation increase or an atomic tree-wide reservation.
+
+The native workflow invocation carries execution settings to dispatch planning.
+The selected durable model reference becomes the child runtime configuration,
+preserving sandbox, tools, approvals, history and native completion reporting.
+No model options are inferred from prompt text. Dynamic default models are not
+supported in the initial opt-in surface.
+
+Verification must cover compiler round-trip, fresh selection, invalid options,
+budget clamping, continuation, native workflow transport and actual child model
+calls before integration. The application using it is intentionally separate from
+the earlier Signals agent and must import no implementation from that agent.

--- a/research/delegation-execution.md
+++ b/research/delegation-execution.md
@@ -1,13 +1,21 @@
 ---
-issue: "No issue filed; local implementation proposal"
+issue: "https://github.com/vercel/eve/pull/3162"
 status: in-progress
 last_updated: "2026-09-08"
 ---
 
-# Per-call delegation execution
+# Model-directed delegation
 
-One general worker should support inexpensive extraction and deeper investigation
-without separate domain agents or a replacement task scheduler.
+A parent agent should choose how much intelligence to spend on each delegated task.
+Repeated extraction and ambiguous reasoning can use the same worker with different
+models, reasoning effort and cost ceilings, rather than separate model-specific
+subagent definitions.
+
+Authors supply an allowed catalog of AI Gateway model IDs. Instructions or skills
+can describe their strengths and selection criteria; the parent chooses per call.
+New models can be adopted by updating the authored catalog and guidance without
+restructuring the worker or task lifecycle. This proposal does not discover models,
+benchmark them, or automatically route requests by price or complexity.
 
 ```ts
 // subagents/worker/agent.ts
@@ -38,5 +46,4 @@ supported in the initial opt-in surface.
 
 Verification must cover compiler round-trip, fresh selection, invalid options,
 budget clamping, continuation, native workflow transport and actual child model
-calls before integration. The application using it is intentionally separate from
-the earlier Signals agent and must import no implementation from that agent.
+calls before integration.


### PR DESCRIPTION
### Summary

eve already supports application-selected models and subagent configurations through `defineDynamic`. This proposes exposing model, reasoning effort and cost selection to the **parent model on each delegation call**. The parent can use task context and instructions or skills to choose different settings for independent calls to the same worker, including within one fanout. Authors supply allowed AI Gateway model IDs; eve validates the choice and starts the child through its existing task lifecycle, without hardcoding a routing policy.

```ts
// subagents/worker/agent.ts
export default defineAgent({
  description: "Complete a bounded assignment in the shared workspace.",
  model: "openai/gpt-5.5",
  delegationModels: ["openai/gpt-5.5", "google/gemini-2.5-flash"],
});

// Example model-facing calls: settings chosen separately for each assignment
worker({
  message: "Extract dates from /workspace/report.txt into /workspace/dates.json.",
  execution: { model: "google/gemini-2.5-flash", reasoning: "low", maxCostUsd: 0.25 },
});

worker({
  message: "Review /workspace/proposal.md for correctness and explain any gaps.",
  execution: { model: "openai/gpt-5.5", reasoning: "high", maxCostUsd: 2 },
});
```

- **Selection stays with the parent.** Model guidance can evolve as new models become available, without restructuring the worker. This does not discover or benchmark models, supply live pricing, or automatically select the cheapest model.
- **Opt-in.** Without `delegationModels`, the tool schema stays unchanged. Without `execution`, the worker uses its authored settings.
- **Fresh children only.** Settings are retained for the child session; `agentId` follow-ups cannot replace them. Reasoning support depends on the selected model. Cost limits can lower inherited/authored ceilings, not raise them or reserve a tree-wide budget.
- **Native lifecycle.** Tools, sandbox inheritance, approvals and task delivery remain owned by eve. This initial API covers statically declared local subagents, not remote/dynamic declarations or the built-in recursive agent.

### Existing capabilities and related work

- Merged #581 and #1485 already support code-selected dynamic models and subagent configurations. This proposal is specifically about **model-facing per-invocation arguments**, not introducing dynamic model selection itself.
- Open #769 adds reasoning to dynamic model resolver selections; #3015 proposes a revised code-side subagent invocation API. These are adjacent surfaces to coordinate with, not prerequisites claimed by this PR.
- Related #629 was closed as not planned while #769 remains open. The history does not establish approval of this API. Keeping this draft for agreement on the per-call contract before further integration.

### Validation

- 150 focused unit tests passed, covering compilation/serialization, dispatch validation and budget inheritance. The 33 dispatch/budget tests were rerun after updating model-facing guidance.
- Two integration tests passed: distinct model configurations with shared sandbox state, and recoverable model-resolution failure.
- Integration tests mock model resolution and workflow startup; they do **not** verify live provider selection or durable replay.
- Added a fixture eval for delegation and follow-up. Still pending that end-to-end run, live reasoning support, reconnect and compaction verification.

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
