### PR TITLE
fix(eve): forward background subagent activity

### DIFF
--- a/.changeset/tidy-subagent-activity.md
+++ b/.changeset/tidy-subagent-activity.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Forward inherited activity observation when background tasks start local or remote subagents, so their tool activity appears beneath the task row.

--- a/packages/eve/src/execution/tools/subagent/invoke-step.integration.test.ts
+++ b/packages/eve/src/execution/tools/subagent/invoke-step.integration.test.ts
@@ -7,6 +7,7 @@ import {
 } from "#execution/tools/subagent/invoke-step.js";
 import { prepareOwnerAgentInvocation } from "#execution/tools/subagent/invoke-preparation.js";
 import { dispatchToClaimedAgentAddress } from "#subagents/handle-dispatch.js";
+import { startSubagent } from "#execution/tools/subagent/start.js";
 import { getAgentHandleStore, setAgentHandleStore } from "#subagents/handles/store.js";
 
 vi.mock("#execution/tools/subagent/invoke-preparation.js", () => ({
@@ -16,6 +17,7 @@ vi.mock("#subagents/handle-dispatch.js", async (importOriginal) => ({
   ...(await importOriginal()),
   dispatchToClaimedAgentAddress: vi.fn(),
 }));
+vi.mock("#execution/tools/subagent/start.js", () => ({ startSubagent: vi.fn() }));
 
 const address = {
   continuationToken: "child-token",
@@ -71,6 +73,90 @@ describe("blocking workflow agent continuation", () => {
       session: input.currentSession,
       toolName: "research",
     }));
+  });
+
+  it("forwards inherited activity when starting a background subagent", async () => {
+    const activityObserver = {
+      sink: { url: "https://parent.example/activity", version: 1 as const },
+      workIdentity: {
+        id: "work:task",
+        kind: "task" as const,
+        name: "slack",
+        parentId: "work:root",
+        rootSessionId: "root-session",
+        rootTurnId: "root-turn",
+      },
+    };
+    vi.mocked(prepareOwnerAgentInvocation).mockResolvedValue({
+      activityObserver,
+      auth: null,
+      batch: { event: { sequence: 1, stepIndex: 0, turnId: "turn-1" } },
+      bundle: {},
+      capabilities: undefined,
+      channelMetadata: undefined,
+      fanoutSize: 1,
+      initiatorAuth: null,
+      localDevRequest: undefined,
+      parentTraceContext: undefined,
+      plan: [
+        {
+          kind: "start",
+          target: {
+            action: {
+              callId: "call-1",
+              description: "Research",
+              input: { message: "Search Slack", target: "slack" },
+              kind: "subagent-call",
+              name: "slack",
+              nodeId: "subagents/slack",
+              subagentName: "slack",
+            },
+            kind: "local",
+            source: { description: "Search Slack", type: "local" },
+          },
+        },
+      ],
+      sandboxSessionId: "parent",
+      serializedContext: {},
+      session: {
+        agent: { dynamicModel: true as const, system: "", tools: [] },
+        compaction: { recentWindowSize: 5, threshold: 10_000 },
+        continuationToken: "parent-token",
+        history: [],
+        sessionId: "parent",
+      },
+    } as never);
+    vi.mocked(startSubagent).mockResolvedValue({
+      address: { continuationToken: "child-token", kind: "agent/local", sessionId: "child" },
+      callId: "call-1",
+      kind: "called",
+      name: "slack",
+      session: {} as never,
+      toolName: "slack",
+    });
+
+    await dispatchAgentInvocation({
+      callbackBaseUrl: "https://parent.example",
+      ownerId: "workflow-run-1",
+      replyTo: "reply-1",
+      request: {
+        input: { message: "Search Slack", target: "slack" },
+        invocationId: "call-1",
+        kind: "agent-invoke",
+      },
+      serializedContext: {},
+      sessionState: createDurableSessionState({
+        session: {
+          agent: { dynamicModel: true as const, system: "", tools: [] },
+          compaction: { recentWindowSize: 5, threshold: 10_000 },
+          continuationToken: "parent-token",
+          history: [],
+          sessionId: "parent",
+        },
+      }),
+    });
+
+    expect(startSubagent).toHaveBeenCalledWith(expect.objectContaining({ activityObserver }));
   });
 
   it("reuses one handle for two calls from the same workflow run", async () => {

--- a/packages/eve/src/execution/tools/subagent/invoke-step.ts
+++ b/packages/eve/src/execution/tools/subagent/invoke-step.ts
@@ -220,6 +220,7 @@ export async function dispatchAgentInvocation(input: {
       initiatorAuth: prepared.initiatorAuth,
       localDevRequest: prepared.localDevRequest,
       parentContinuationToken: input.replyTo,
+      activityObserver: prepared.activityObserver,
       parentTraceContext: prepared.parentTraceContext,
       sandboxSessionId: prepared.sandboxSessionId,
       serializedContext: prepared.serializedContext,

--- a/packages/eve/src/execution/workflow-steps.test.ts
+++ b/packages/eve/src/execution/workflow-steps.test.ts
@@ -35,7 +35,7 @@ import { getProxyInputRequests, upsertProxyInputRequests } from "#harness/proxy-
 import { appendPendingInputBatch } from "#harness/input-requests.js";
 import type { HarnessSession, StepResult } from "#harness/types.js";
 import { createEmptyHookRegistry } from "#runtime/hooks/registry.js";
-import { createInputRequestedEvent } from "#protocol/message.js";
+import { createActionsRequestedEvent, createInputRequestedEvent } from "#protocol/message.js";
 import { getCompiledRuntimeAgentBundle } from "#runtime/sessions/compiled-agent-cache.js";
 import {
   createDurableSessionState,
@@ -1511,7 +1511,7 @@ describe("turnStep", () => {
     expect(observed).toEqual(expected);
   });
 
-  it("routes remote task HITL only to the parent callback", async () => {
+  it("projects inherited task tool activity while routing HITL only to the parent callback", async () => {
     const inputRequested = vi.fn();
     const remoteTaskAdapter: ChannelAdapter = {
       kind: "remote-task-test",
@@ -1543,6 +1543,21 @@ describe("turnStep", () => {
     installSessionStoreMocks([session]);
     vi.mocked(createExecutionNodeStep).mockImplementation((input) => {
       return async (stepSession): Promise<StepResult> => {
+        await input.handleEvent?.(
+          createActionsRequestedEvent({
+            actions: [
+              {
+                callId: "tool-call-1",
+                input: { query: "activity" },
+                kind: "tool-call",
+                toolName: "search_slack",
+              },
+            ],
+            sequence: 1,
+            stepIndex: 2,
+            turnId: "turn-child",
+          }),
+        );
         await input.handleEvent?.(
           createInputRequestedEvent({
             requests: [
@@ -1621,7 +1636,15 @@ describe("turnStep", () => {
       }),
     );
     expect(inputRequested).not.toHaveBeenCalled();
-    expect(workflowWritesByNamespace.get(DEFAULT_WORKFLOW_STREAM_NAMESPACE) ?? []).toEqual([]);
+    expect(workflowWritesByNamespace.get(DEFAULT_WORKFLOW_STREAM_NAMESPACE) ?? []).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://parent.example/eve/v1/activity/abcdefghijklmnopqrstuvwxyz123456",
+      expect.objectContaining({
+        body: expect.stringContaining(
+          '"action":{"id":"action:work:child:tool-call-1","kind":"tool","name":"search_slack","parentWorkId":"work:child","rootTurnId":"turn-root"',
+        ),
+      }),
+    );
     expect(fetchMock).toHaveBeenCalledWith(
       "https://parent.example/eve/v1/activity/abcdefghijklmnopqrstuvwxyz123456",
       expect.objectContaining({ body: expect.stringContaining('"kind":"blocker.started"') }),

--- a/packages/eve/src/public/channels/slack/activity-progress.test.ts
+++ b/packages/eve/src/public/channels/slack/activity-progress.test.ts
@@ -113,6 +113,41 @@ describe("Slack activity activity", () => {
     expect(selectSlackActivityStatus(completed)).toBe("Found Slack docs");
   });
 
+  it("renders inherited child tool activity beneath an existing task row", () => {
+    const task = {
+      id: "work:task",
+      kind: "task" as const,
+      name: "slack",
+      parentId: root.id,
+      rootSessionId: "root",
+      rootTurnId: "turn",
+    };
+    const activity = reduceActivityBatch(createActivitySnapshot(), {
+      events: [
+        { eventId: "root", kind: "work.started", startedAt: "1", work: root },
+        { eventId: "task", kind: "work.started", startedAt: "2", work: task },
+        {
+          action: {
+            id: "action:work:task:search",
+            kind: "tool",
+            name: "search_slack",
+            parentWorkId: task.id,
+            rootTurnId: "turn",
+            stepIndex: 0,
+          },
+          eventId: "search",
+          kind: "action.started",
+          startedAt: "3",
+        },
+      ],
+      version: 1,
+    });
+
+    expect(activityMessages(activity).get("turn")).toBe(
+      "```\n• Working\n└── • slack\n    └── • search_slack\n```",
+    );
+  });
+
   it("renders a background task instead of its duplicate initiating tool action", () => {
     const task = {
       callId: "call-background",

--- a/packages/eve/src/subagents/start-local.test.ts
+++ b/packages/eve/src/subagents/start-local.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { buildSubagentRunInput, createSession, waitForCommandHookOwner } = vi.hoisted(() => ({
+  buildSubagentRunInput: vi.fn(() => ({
+    childContinuationToken: "child-token",
+    runInput: { input: { message: "work" } },
+  })),
+  createSession: vi.fn(async () => ({ sessionId: "child-session" })),
+  waitForCommandHookOwner: vi.fn(async () => ({ runId: "child-session" })),
+}));
+
+vi.mock("#subagents/tool.js", () => ({ buildSubagentRunInput }));
+vi.mock("#execution/workflow-runtime.js", () => ({
+  createWorkflowRuntime: () => ({ createSession }),
+  waitForCommandHookOwner,
+}));
+
+import { startLocalSubagent } from "#subagents/start-local.js";
+
+describe("startLocalSubagent", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("passes an inherited task activity observer through unchanged", async () => {
+    const activityObserver = {
+      sink: { url: "https://parent.example/activity", version: 1 as const },
+      workIdentity: {
+        id: "work:task",
+        kind: "task" as const,
+        name: "slack",
+        parentId: "work:root",
+        rootSessionId: "root-session",
+        rootTurnId: "root-turn",
+      },
+    };
+
+    await startLocalSubagent({
+      action: {
+        callId: "call-1",
+        input: { message: "Search Slack" },
+        kind: "subagent-call",
+        name: "slack",
+        nodeId: "subagents/slack",
+        subagentName: "slack",
+      },
+      activityObserver,
+      auth: null,
+      batchEvent: { sequence: 0, turnId: "parent-turn" },
+      bundle: { compiledArtifactsSource: {}, graph: {} },
+      capabilities: undefined,
+      channelMetadata: undefined,
+      currentSession: { sessionId: "parent-session" },
+      fanoutSize: 1,
+      initiatorAuth: null,
+      parentContinuationToken: "parent-token",
+      parentTraceContext: undefined,
+      sandboxSessionId: "sandbox-session",
+      session: { sessionId: "parent-session" },
+      source: { description: "Search Slack", type: "local" },
+    } as never);
+
+    expect(buildSubagentRunInput).toHaveBeenCalledWith(
+      expect.objectContaining({ activityObserver }),
+    );
+    expect(createSession).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
### Summary

One-liner fix for tool activity disappearing for local subagents started from background tasks. 

### Validation

Adds an integration test for the missing workflow-owner handoff, plus coverage for local observer pass-through, child event projection, and rendering beneath the existing task row.

