### PR TITLE
Make /eves the primary event page URL

### DIFF
--- a/apps/docs/app/(nights)/eves/page.tsx
+++ b/apps/docs/app/(nights)/eves/page.tsx
@@ -1,7 +1,7 @@
 import { LogoIconVercel } from "@vercel/geistdocs/assets/logos/logo-icon-vercel";
 import type { Metadata, Viewport } from "next";
 import Link from "next/link";
-import { NightsGalaxy } from "./nights-galaxy";
+import { NightsGalaxy } from "../nights/nights-galaxy";
 
 const title = "eve eves";
 const description =
@@ -16,9 +16,13 @@ const ogImage = {
 export const metadata: Metadata = {
   title,
   description,
+  alternates: {
+    canonical: "/eves",
+  },
   openGraph: {
     title,
     description,
+    url: "/eves",
     images: [ogImage],
   },
   twitter: {

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -56,6 +56,11 @@ const config: NextConfig = {
   async redirects() {
     return [
       {
+        source: "/nights",
+        destination: "/eves",
+        permanent: true,
+      },
+      {
         source: "/docs",
         destination: "/docs/getting-started",
         permanent: true,

--- a/apps/docs/proxy.ts
+++ b/apps/docs/proxy.ts
@@ -9,7 +9,7 @@ const geistdocsProxy = createProxy({
   config: geistdocsConfig,
   markdownRoutes,
   trackMarkdownRequest: trackMdRequest,
-  before: ({ request }) => (request.nextUrl.pathname === "/nights" ? NextResponse.next() : null),
+  before: ({ request }) => (request.nextUrl.pathname === "/eves" ? NextResponse.next() : null),
 });
 
 const proxy = async (request: NextRequest, context: NextFetchEvent) =>


### PR DESCRIPTION
### Summary

Makes `/eves` the primary URL for the eve eves event page while keeping existing `/nights` links working through a permanent 308 redirect. The redirect preserves query parameters, and canonical and Open Graph URLs now point to `/eves`. The existing event content and shader presentation are preserved.

### Validation

Verified `/eves` returns 200 and `/nights?utm_source=slack` redirects to `/eves?utm_source=slack`. Confirmed canonical and Open Graph metadata, all three event links, shader readiness, and layouts at 1280×800 and 390×844 with no horizontal overflow or browser errors. Focused formatting, lint, and diff checks passed. Full build and test suites were not run; no changeset is needed for this docs-app-only change.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
