### PR TITLE
fix(eve): group queued deliveries by auth context

### DIFF
--- a/.changeset/separate-queued-deliveries.md
+++ b/.changeset/separate-queued-deliveries.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Process queued message deliveries separately in session-inbox order, preserving each request's auth, attachments, and context instead of merging requests under the latest sender's auth. This also keeps multiple queued requests from the same user separate.

--- a/.changeset/separate-queued-deliveries.md
+++ b/.changeset/separate-queued-deliveries.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Process queued message deliveries separately in session-inbox order, preserving each request's auth, attachments, and context instead of merging requests under the latest sender's auth. This also keeps multiple queued requests from the same user separate.
+Only batch adjacent queued deliveries when their full auth contexts match, preventing one sender's input from running under another sender's auth. Anonymous deliveries stay separate; matching authenticated follow-ups still batch with their attachments and context in order.

--- a/docs/channels/overview.mdx
+++ b/docs/channels/overview.mdx
@@ -28,7 +28,7 @@ export default defineChannel({
 });
 ```
 
-Queued message deliveries are processed separately in the order they reach the session inbox, even when they come from the same user. Each delivery keeps its original auth, attachments, and context; a later sender's auth does not replace an earlier queued request's auth. Turns still share the session's conversation history.
+Adjacent queued messages can combine into one turn only when their full auth contexts match, including identity, issuer, authenticator, and authorization attributes. Their attachments and context stay in payload order. A different auth context ends the batch; eve does not regroup messages across intervening senders. Anonymous deliveries stay separate. Turns still share the session's conversation history.
 
 `from(address).send(...)`, fixed `Session.send(...)`, cross-channel sends, and Chat SDK bridge sends also accept a per-send `turnPolicy` override. Pure `inputResponses` deliveries answer their pending request without steering. Explicit `cancel()` remains the stop-without-replacement operation.
 

--- a/docs/channels/overview.mdx
+++ b/docs/channels/overview.mdx
@@ -28,6 +28,8 @@ export default defineChannel({
 });
 ```
 
+Queued message deliveries are processed separately in the order they reach the session inbox, even when they come from the same user. Each delivery keeps its original auth, attachments, and context; a later sender's auth does not replace an earlier queued request's auth. Turns still share the session's conversation history.
+
 `from(address).send(...)`, fixed `Session.send(...)`, cross-channel sends, and Chat SDK bridge sends also accept a per-send `turnPolicy` override. Pure `inputResponses` deliveries answer their pending request without steering. Explicit `cancel()` remains the stop-without-replacement operation.
 
 Channel admission still runs first. Ignored mentions, rejected signatures, duplicates, and any other dropped platform events never affect the active turn.

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -294,7 +294,7 @@ export default slackChannel({
 });
 ```
 
-With `"queue"`, each message delivery is processed separately in session-inbox order with its original auth, attachments, and context. Messages from different users are not merged into a turn under the last sender's auth. Turns still share the thread's session history.
+With `"queue"`, adjacent messages with matching full auth contexts can combine into one turn, keeping their attachments and context in order. Messages from different users, or from the same user with different authorization attributes, stay separate. Anonymous deliveries also stay separate. Batching follows session-inbox order, and turns still share the thread's session history.
 
 Message hooks (`onMessage`, `onAppMention`, and `onDirectMessage`) also receive thread-bound session operations directly on `ctx`. `ctx.cancel({ turnId? })` remains useful for a Stop button: it cancels without sending replacement input. `"accepted"` means the live thread session durably queued that request; a parked session consumes it as a no-op, and `"no_active_turn"` means the thread has no active session owner.
 

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -294,6 +294,8 @@ export default slackChannel({
 });
 ```
 
+With `"queue"`, each message delivery is processed separately in session-inbox order with its original auth, attachments, and context. Messages from different users are not merged into a turn under the last sender's auth. Turns still share the thread's session history.
+
 Message hooks (`onMessage`, `onAppMention`, and `onDirectMessage`) also receive thread-bound session operations directly on `ctx`. `ctx.cancel({ turnId? })` remains useful for a Stop button: it cancels without sending replacement input. `"accepted"` means the live thread session durably queued that request; a parked session consumes it as a no-op, and `"no_active_turn"` means the thread has no active session owner.
 
 Message and interaction hooks expose every current-owner operation directly on `ctx`:

--- a/docs/guides/instrumentation.md
+++ b/docs/guides/instrumentation.md
@@ -69,8 +69,9 @@ Instrumentation providers receive `channel.delivery.started` followed by
 `channel.delivery.failed` for every inbound channel operation. The lifecycle
 covers durable processing through the terminal state of the resulting turn, not
 messages an adapter sends back to Slack, Telegram, Twilio, or another platform.
-Queued message deliveries are processed separately, each with its own lifecycle
-pair. An adapter can also consume a delivery without starting a turn.
+Adjacent queued messages with matching authenticated identities and authorization
+attributes can share a turn while retaining separate lifecycle pairs. An adapter
+can also consume a delivery without starting a turn.
 
 Each operation has a framework-owned `deliveryId` distinct from its optional
 platform request ID. Metadata-only providers receive identity, channel, session,

--- a/docs/guides/instrumentation.md
+++ b/docs/guides/instrumentation.md
@@ -69,8 +69,8 @@ Instrumentation providers receive `channel.delivery.started` followed by
 `channel.delivery.failed` for every inbound channel operation. The lifecycle
 covers durable processing through the terminal state of the resulting turn, not
 messages an adapter sends back to Slack, Telegram, Twilio, or another platform.
-Several deliveries can coalesce into one turn while retaining separate lifecycle
-pairs, and an adapter can consume a delivery without starting a turn.
+Queued message deliveries are processed separately, each with its own lifecycle
+pair. An adapter can also consume a delivery without starting a turn.
 
 Each operation has a framework-owned `deliveryId` distinct from its optional
 platform request ID. Metadata-only providers receive identity, channel, session,

--- a/e2e/fixtures/agent-cancellation/agent/agent.ts
+++ b/e2e/fixtures/agent-cancellation/agent/agent.ts
@@ -11,13 +11,26 @@ function respond(request: MockModelRequest): MockModelResponse | string {
       toolCalls: [{ id: "wait-for-cancellation", input: {}, name: "wait-for-cancellation" }],
     };
   }
-  const marker = /record-request with marker "([^"]+)"/u.exec(message)?.[1];
-  if (marker !== undefined) {
-    const id = `record-${marker}`;
-    const result = request.toolResults.find((entry) => entry.id === id);
-    return result === undefined
-      ? { toolCalls: [{ id, input: { marker }, name: "record-request" }] }
-      : String(result.output);
+  const markers = [...message.matchAll(/record-request with marker "([^"]+)"/gu)].map(
+    (match) => match[1]!,
+  );
+  if (markers.length > 0) {
+    const pending = markers.filter(
+      (marker) => !request.toolResults.some((entry) => entry.id === `record-${marker}`),
+    );
+    return pending.length > 0
+      ? {
+          toolCalls: pending.map((marker) => ({
+            id: `record-${marker}`,
+            input: { marker },
+            name: "record-request",
+          })),
+        }
+      : markers
+          .map((marker) =>
+            String(request.toolResults.find((entry) => entry.id === `record-${marker}`)?.output),
+          )
+          .join("\n");
   }
   if (message.includes("call the sleeper subagent")) {
     return {

--- a/e2e/fixtures/agent-cancellation/agent/agent.ts
+++ b/e2e/fixtures/agent-cancellation/agent/agent.ts
@@ -11,6 +11,14 @@ function respond(request: MockModelRequest): MockModelResponse | string {
       toolCalls: [{ id: "wait-for-cancellation", input: {}, name: "wait-for-cancellation" }],
     };
   }
+  const marker = /record-request with marker "([^"]+)"/u.exec(message)?.[1];
+  if (marker !== undefined) {
+    const id = `record-${marker}`;
+    const result = request.toolResults.find((entry) => entry.id === id);
+    return result === undefined
+      ? { toolCalls: [{ id, input: { marker }, name: "record-request" }] }
+      : String(result.output);
+  }
   if (message.includes("call the sleeper subagent")) {
     return {
       toolCalls: [

--- a/e2e/fixtures/agent-cancellation/agent/channels/threads.ts
+++ b/e2e/fixtures/agent-cancellation/agent/channels/threads.ts
@@ -20,10 +20,11 @@ export default defineChannel({
     POST("/threads/:threadId/messages", async (request, { from, params }) => {
       const body = (await request.json().catch(() => ({}))) as {
         message?: string;
+        actor?: "alice" | "bob" | "carol" | null;
         turnPolicy?: TurnPolicy;
       };
       const session = await from(params.threadId ?? "").send(body.message ?? "", {
-        auth: AUTH,
+        auth: body.actor === null ? null : { ...AUTH, principalId: body.actor ?? AUTH.principalId },
         turnPolicy: body.turnPolicy,
       });
       return Response.json({ ok: true, sessionId: session.id });

--- a/e2e/fixtures/agent-cancellation/agent/tools/record-request.ts
+++ b/e2e/fixtures/agent-cancellation/agent/tools/record-request.ts
@@ -1,0 +1,13 @@
+import { defineTool } from "eve/tools";
+import { never } from "eve/tools/approval";
+import { z } from "zod";
+
+export default defineTool({
+  description:
+    "Records a request marker with the current authenticated actor. Call only when asked to record a request.",
+  inputSchema: z.object({ marker: z.string() }),
+  approval: never(),
+  execute({ marker }, ctx) {
+    return `request=${marker};actor=${ctx.session.auth.current?.principalId ?? "anonymous"}`;
+  },
+});

--- a/e2e/fixtures/agent-cancellation/evals/cancellation/queued-request-identity.eval.ts
+++ b/e2e/fixtures/agent-cancellation/evals/cancellation/queued-request-identity.eval.ts
@@ -2,7 +2,8 @@ import { defineEval } from "eve/evals";
 import { equals } from "eve/evals/expect";
 
 export default defineEval({
-  description: "Queued channel requests run separately in arrival order with their original auth.",
+  description:
+    "Queued channel requests batch only adjacent matching identities and retain their auth.",
   timeoutMs: 240_000,
   async test(t) {
     const threadId = crypto.randomUUID();
@@ -27,18 +28,20 @@ export default defineEval({
       },
     });
 
-    const requests = [
-      { actor: "bob", marker: "bob-first" },
-      { actor: "carol", marker: "carol-first" },
-      { actor: "carol", marker: "carol-second" },
-      { actor: null, marker: "guest-first" },
+    const groups = [
+      { actor: "bob", markers: ["bob-first"] },
+      { actor: "carol", markers: ["carol-first", "carol-second"] },
+      { actor: "bob", markers: ["bob-second"] },
+      { actor: null, markers: ["guest-first"] },
+      { actor: null, markers: ["guest-second"] },
     ] as const;
-    const messages: string[] = [];
-    for (const { actor, marker } of requests) {
-      const message = `The team is recording separate work requests. Please call record-request with marker "${marker}" exactly once for this request, then report its result.`;
-      messages.push(message);
-      const accepted = await post(message, actor);
-      t.check(accepted.sessionId, equals(sessionId));
+    const messageFor = (marker: string) =>
+      `The team is recording work requests. Please call record-request with marker "${marker}" exactly once for this request, then report its result.`;
+    for (const { actor, markers } of groups) {
+      for (const marker of markers) {
+        const accepted = await post(messageFor(marker), actor);
+        t.check(accepted.sessionId, equals(sessionId));
+      }
     }
 
     // Cancellation releases the held turn only after every follow-up is accepted.
@@ -52,37 +55,40 @@ export default defineEval({
     if (cursor === undefined) throw new Error("Missing stream cursor after cancellation.");
     const turnIds = new Set<string>();
     const deliveryIds = new Set<string>();
-    for (const [index, { actor, marker }] of requests.entries()) {
+    for (const { actor, markers } of groups) {
       const live = t.target.watchTurn(sessionId, { startIndex: cursor });
       const turn = await live.result();
       turn.expectOk();
-      turn.calledTool("record-request", { count: 1, status: "completed" });
-      turn.event("message.received", { count: 1, data: { message: messages[index] } });
-      turn.event("action.result", {
-        count: 1,
-        data: {
-          status: "completed",
-          result: {
-            kind: "tool-result",
-            toolName: "record-request",
-            output: `request=${marker};actor=${actor ?? "anonymous"}`,
+      turn.calledTool("record-request", { count: markers.length, status: "completed" });
+      const message = markers.map(messageFor).join("\n\n");
+      turn.event("message.received", { count: 1, data: { message } });
+      for (const marker of markers) {
+        turn.event("action.result", {
+          count: 1,
+          data: {
+            status: "completed",
+            result: {
+              kind: "tool-result",
+              toolName: "record-request",
+              output: `request=${marker};actor=${actor ?? "anonymous"}`,
+            },
           },
-        },
-      });
+        });
+      }
       turn.notEvent("turn.cancelled");
       turn.notEvent("turn.failed");
       const received = turn.events.find((event) => event.type === "message.received");
       if (received === undefined) throw new Error("Missing queued message event.");
-      await t.require(received.data.message, equals(messages[index]));
+      await t.require(received.data.message, equals(message));
       turnIds.add(received.data.turnId);
       const ids = received.meta.deliveryIds ?? [];
-      t.check(ids.length, equals(1)).label("the turn belongs to one delivery");
+      t.check(ids.length, equals(markers.length)).label("the turn retains every batched delivery");
       for (const id of ids) deliveryIds.add(id);
       cursor = live.session.state?.streamIndex;
       if (cursor === undefined) throw new Error("Missing stream cursor after queued turn.");
     }
-    t.check(turnIds.size, equals(requests.length)).label("each request owns a distinct turn");
-    t.check(deliveryIds.size, equals(requests.length)).label(
+    t.check(turnIds.size, equals(groups.length)).label("each identity group owns a distinct turn");
+    t.check(deliveryIds.size, equals(groups.flatMap((group) => group.markers).length)).label(
       "each request retains its delivery ID",
     );
     t.succeeded();

--- a/e2e/fixtures/agent-cancellation/evals/cancellation/queued-request-identity.eval.ts
+++ b/e2e/fixtures/agent-cancellation/evals/cancellation/queued-request-identity.eval.ts
@@ -1,0 +1,90 @@
+import { defineEval } from "eve/evals";
+import { equals } from "eve/evals/expect";
+
+export default defineEval({
+  description: "Queued channel requests run separately in arrival order with their original auth.",
+  timeoutMs: 240_000,
+  async test(t) {
+    const threadId = crypto.randomUUID();
+    const post = async (message: string, actor: "alice" | "bob" | "carol" | null) => {
+      const response = await t.target.fetch(`/threads/${threadId}/messages`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ actor, message, turnPolicy: "queue" }),
+      });
+      if (!response.ok) throw new Error(`Message delivery failed (${response.status}).`);
+      return (await response.json()) as { sessionId: string };
+    };
+
+    const { sessionId } = await post("Please wait for cancellation.", "alice");
+    const active = t.target.watchTurn(sessionId);
+    await active.waitForEvent("actions.requested", {
+      data: {
+        actions: (actions) =>
+          actions.some(
+            (action) => action.kind === "tool-call" && action.toolName === "wait-for-cancellation",
+          ),
+      },
+    });
+
+    const requests = [
+      { actor: "bob", marker: "bob-first" },
+      { actor: "carol", marker: "carol-first" },
+      { actor: "carol", marker: "carol-second" },
+      { actor: null, marker: "guest-first" },
+    ] as const;
+    const messages: string[] = [];
+    for (const { actor, marker } of requests) {
+      const message = `The team is recording separate work requests. Please call record-request with marker "${marker}" exactly once for this request, then report its result.`;
+      messages.push(message);
+      const accepted = await post(message, actor);
+      t.check(accepted.sessionId, equals(sessionId));
+    }
+
+    // Cancellation releases the held turn only after every follow-up is accepted.
+    const stop = await t.target.fetch(`/threads/${threadId}/stop`, { method: "POST" });
+    if (!stop.ok) throw new Error(`Stop failed (${stop.status}).`);
+    const cancelled = await active.result();
+    cancelled.event("turn.cancelled", { count: 1 });
+    cancelled.notEvent("turn.failed");
+
+    let cursor = active.session.state?.streamIndex;
+    if (cursor === undefined) throw new Error("Missing stream cursor after cancellation.");
+    const turnIds = new Set<string>();
+    const deliveryIds = new Set<string>();
+    for (const [index, { actor, marker }] of requests.entries()) {
+      const live = t.target.watchTurn(sessionId, { startIndex: cursor });
+      const turn = await live.result();
+      turn.expectOk();
+      turn.calledTool("record-request", { count: 1, status: "completed" });
+      turn.event("message.received", { count: 1, data: { message: messages[index] } });
+      turn.event("action.result", {
+        count: 1,
+        data: {
+          status: "completed",
+          result: {
+            kind: "tool-result",
+            toolName: "record-request",
+            output: `request=${marker};actor=${actor ?? "anonymous"}`,
+          },
+        },
+      });
+      turn.notEvent("turn.cancelled");
+      turn.notEvent("turn.failed");
+      const received = turn.events.find((event) => event.type === "message.received");
+      if (received === undefined) throw new Error("Missing queued message event.");
+      await t.require(received.data.message, equals(messages[index]));
+      turnIds.add(received.data.turnId);
+      const ids = received.meta.deliveryIds ?? [];
+      t.check(ids.length, equals(1)).label("the turn belongs to one delivery");
+      for (const id of ids) deliveryIds.add(id);
+      cursor = live.session.state?.streamIndex;
+      if (cursor === undefined) throw new Error("Missing stream cursor after queued turn.");
+    }
+    t.check(turnIds.size, equals(requests.length)).label("each request owns a distinct turn");
+    t.check(deliveryIds.size, equals(requests.length)).label(
+      "each request retains its delivery ID",
+    );
+    t.succeeded();
+  },
+});

--- a/e2e/fixtures/agent-session-limits/evals/limits/session-token-limit-approve.eval.ts
+++ b/e2e/fixtures/agent-session-limits/evals/limits/session-token-limit-approve.eval.ts
@@ -45,27 +45,31 @@ export default defineEval({
     if (activeState === undefined) {
       throw new Error("The active eval session did not expose client state.");
     }
-    // Both messages were queued behind the active turn, so eve delivers them
-    // coalesced into one follow-up turn while the limit prompt stays pending.
-    const queuedSession = t.target.watchTurn(active.sessionId, {
+    const firstQueuedSession = t.target.watchTurn(active.sessionId, {
       startIndex: activeState.streamIndex,
     });
+    const firstQueued = await firstQueuedSession.result();
+    firstQueued.event("message.received", {
+      count: 1,
+      data: { message: 'Queued message A: preserve the original reply "approved".' },
+    });
+    firstQueued.notEvent("input.requested");
+
+    const firstQueuedState = firstQueuedSession.session.state;
+    if (firstQueuedState === undefined) throw new Error("Missing first queued turn cursor.");
+    const queuedSession = t.target.watchTurn(active.sessionId, {
+      startIndex: firstQueuedState.streamIndex,
+    });
     const queued = await queuedSession.result();
-    queued.event("message.received", { count: 1 });
+    queued.event("message.received", {
+      count: 1,
+      data: { message: 'Queued message B: preserve the original reply "approved".' },
+    });
     queued.notEvent("input.requested");
-    queued.eventsSatisfy(
-      "coalesces messages A and B in order while preserving the pending prompt",
-      (events) => {
-        const received = events.find((event) => event.type === "message.received");
-        if (received === undefined) return false;
-        const messageAIndex = received.data.message.indexOf("Queued message A");
-        const messageBIndex = received.data.message.indexOf("Queued message B");
-        return messageAIndex !== -1 && messageBIndex > messageAIndex;
-      },
-    );
     t.check(
-      [...prompted.events, ...queued.events].filter((event) => event.type === "input.requested")
-        .length,
+      [...prompted.events, ...firstQueued.events, ...queued.events].filter(
+        (event) => event.type === "input.requested",
+      ).length,
       equals(1),
     );
 

--- a/e2e/fixtures/agent-session-limits/evals/limits/session-token-limit-approve.eval.ts
+++ b/e2e/fixtures/agent-session-limits/evals/limits/session-token-limit-approve.eval.ts
@@ -45,31 +45,27 @@ export default defineEval({
     if (activeState === undefined) {
       throw new Error("The active eval session did not expose client state.");
     }
-    const firstQueuedSession = t.target.watchTurn(active.sessionId, {
+    // These requests have the same local-dev auth, so they can batch while
+    // the session-limit prompt remains pending.
+    const queuedSession = t.target.watchTurn(active.sessionId, {
       startIndex: activeState.streamIndex,
     });
-    const firstQueued = await firstQueuedSession.result();
-    firstQueued.event("message.received", {
-      count: 1,
-      data: { message: 'Queued message A: preserve the original reply "approved".' },
-    });
-    firstQueued.notEvent("input.requested");
-
-    const firstQueuedState = firstQueuedSession.session.state;
-    if (firstQueuedState === undefined) throw new Error("Missing first queued turn cursor.");
-    const queuedSession = t.target.watchTurn(active.sessionId, {
-      startIndex: firstQueuedState.streamIndex,
-    });
     const queued = await queuedSession.result();
-    queued.event("message.received", {
-      count: 1,
-      data: { message: 'Queued message B: preserve the original reply "approved".' },
-    });
+    queued.event("message.received", { count: 1 });
     queued.notEvent("input.requested");
+    queued.eventsSatisfy(
+      "coalesces messages A and B in order while preserving the pending prompt",
+      (events) => {
+        const received = events.find((event) => event.type === "message.received");
+        if (received === undefined) return false;
+        const messageAIndex = received.data.message.indexOf("Queued message A");
+        const messageBIndex = received.data.message.indexOf("Queued message B");
+        return messageAIndex !== -1 && messageBIndex > messageAIndex;
+      },
+    );
     t.check(
-      [...prompted.events, ...firstQueued.events, ...queued.events].filter(
-        (event) => event.type === "input.requested",
-      ).length,
+      [...prompted.events, ...queued.events].filter((event) => event.type === "input.requested")
+        .length,
       equals(1),
     );
 

--- a/e2e/fixtures/agent-tools/evals/channel-events/batched-delivery.eval.ts
+++ b/e2e/fixtures/agent-tools/evals/channel-events/batched-delivery.eval.ts
@@ -6,7 +6,7 @@ import { coalesceDeliverPayloads } from "../../../../../packages/eve/src/executi
 
 export default defineEval({
   tags: ["real-model"],
-  description: "Delivery batching smoke: queued messages and context coalesce in arrival order.",
+  description: "Payloads within one delivery combine their messages and context in order.",
   async test(t) {
     const firstMessage = "Remember synthetic marker BATCH-FIRST.";
     const secondMessage = "Remember synthetic marker BATCH-SECOND.";

--- a/packages/eve/src/execution/parked-delivery-wait.test.ts
+++ b/packages/eve/src/execution/parked-delivery-wait.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { DeliverHookPayload } from "#channel/types.js";
+import type { DeliverHookPayload, SessionAuthContext } from "#channel/types.js";
 import { nextTurnDelivery } from "#execution/parked-delivery-wait.js";
 import { routeDeliverToChildren } from "#execution/route-child-delivery.js";
 import type {
@@ -117,6 +117,89 @@ function waitInput(inbox: SessionCommandInbox): Parameters<typeof nextTurnDelive
 }
 
 describe("nextTurnDelivery", () => {
+  it("batches adjacent queued deliveries with equivalent auth", async () => {
+    const auth: SessionAuthContext = {
+      attributes: { scopes: ["read", "write"], team: "support" },
+      authenticator: "slack",
+      issuer: "workspace",
+      principalId: "bob",
+      principalType: "user",
+      subject: "bob-subject",
+    };
+    const first = authenticatedDelivery("first", auth);
+    const second = authenticatedDelivery("second", {
+      ...auth,
+      attributes: { team: "support", scopes: ["read", "write"] },
+    });
+    const input = batchingInputFor([first, second]);
+
+    const next = await nextTurnDelivery(input);
+
+    expect(next).toMatchObject({
+      kind: "turn",
+      delivery: {
+        auth,
+        payloads: [...first.payloads, ...second.payloads],
+        deliveryMetadata: [
+          first.deliveryMetadata![0],
+          { ...second.deliveryMetadata![0], payloadIndex: 1 },
+        ],
+      },
+    });
+    expect(input.bufferedDeliveries).toEqual([]);
+  });
+
+  it("keeps different principals in FIFO turns without regrouping later messages", async () => {
+    const alice = slackAuth("alice");
+    const bob = slackAuth("bob");
+    const deliveries = [
+      authenticatedDelivery("alice-1", alice),
+      authenticatedDelivery("alice-2", alice),
+      authenticatedDelivery("bob", bob),
+      authenticatedDelivery("alice-3", alice),
+    ];
+    const input = batchingInputFor(deliveries);
+
+    await expect(nextTurnDelivery(input)).resolves.toMatchObject({
+      delivery: { payloads: [{ message: "alice-1" }, { message: "alice-2" }] },
+      kind: "turn",
+    });
+    await expect(nextTurnDelivery(input)).resolves.toMatchObject({
+      delivery: { payloads: [{ message: "bob" }] },
+      kind: "turn",
+    });
+    await expect(nextTurnDelivery(input)).resolves.toMatchObject({
+      delivery: { payloads: [{ message: "alice-3" }] },
+      kind: "turn",
+    });
+    expect(input.bufferedDeliveries).toEqual([]);
+  });
+
+  it.each([
+    { authenticator: "other" },
+    { issuer: "other" },
+    { principalType: "service" },
+    { subject: "other" },
+    { attributes: { scopes: ["write"] } },
+  ])("does not batch when auth context changes: %j", async (change) => {
+    const auth = slackAuth("alice");
+    const first = authenticatedDelivery("first", auth);
+    const second = authenticatedDelivery("second", { ...auth, ...change });
+    const input = batchingInputFor([first, second]);
+
+    await expect(nextTurnDelivery(input)).resolves.toEqual({ delivery: first, kind: "turn" });
+    expect(input.bufferedDeliveries).toEqual([second]);
+  });
+
+  it.each([null, undefined])("does not batch deliveries with auth %j", async (auth) => {
+    const first: DeliverHookPayload = { auth, kind: "deliver", payloads: [{ message: "first" }] };
+    const second: DeliverHookPayload = { auth, kind: "deliver", payloads: [{ message: "second" }] };
+    const input = batchingInputFor([first, second]);
+
+    await expect(nextTurnDelivery(input)).resolves.toEqual({ delivery: first, kind: "turn" });
+    expect(input.bufferedDeliveries).toEqual([second]);
+  });
+
   it("surfaces an authorization callback as its own instruction", async () => {
     const inbox = createMockInbox([authorizationRead()]);
 
@@ -233,6 +316,47 @@ describe("nextTurnDelivery", () => {
     });
   });
 });
+
+function slackAuth(principalId: string): SessionAuthContext {
+  return {
+    attributes: { scopes: ["read"], team: "support" },
+    authenticator: "slack",
+    issuer: "workspace",
+    principalId,
+    principalType: "user",
+    subject: principalId,
+  };
+}
+
+function authenticatedDelivery(message: string, auth: SessionAuthContext): DeliverHookPayload {
+  return {
+    auth,
+    deliveryMetadata: [
+      {
+        channelKind: "slack",
+        channelName: "slack",
+        deliveryId: message,
+        payloadIndex: 0,
+      },
+    ],
+    kind: "deliver",
+    payloads: [{ message }],
+    turnPolicy: "queue",
+  };
+}
+
+function batchingInputFor(bufferedDeliveries: DeliverHookPayload[]) {
+  const input = waitInput(createMockInbox([]));
+  vi.mocked(routeDeliverToChildren).mockImplementation(
+    async ({ delivery, serializedContext, sessionState }) => ({
+      kind: "continue",
+      remainder: delivery,
+      serializedContext,
+      sessionState,
+    }),
+  );
+  return { ...input, bufferedDeliveries };
+}
 
 describe("nextTurnDelivery routing", () => {
   it("keeps waiting instead of starting a parent turn for a fully routed task response", async () => {

--- a/packages/eve/src/execution/parked-delivery-wait.ts
+++ b/packages/eve/src/execution/parked-delivery-wait.ts
@@ -1,4 +1,5 @@
 import type { DeliverHookPayload, DeliverPayload } from "#channel/types.js";
+import { jsonValuesEqual } from "#shared/json.js";
 import { cancelAllIndexedSessionTasksStep } from "#execution/cancel-indexed-session-tasks-step.js";
 import { routeDeliverToChildren } from "#execution/route-child-delivery.js";
 import type { SessionCommandInbox } from "#execution/session-command-inbox.js";
@@ -280,15 +281,18 @@ function takeBufferedTurnDelivery(
     throw new Error("Cannot take a turn delivery from an empty buffer.");
   }
 
+  const cohort = completionCohort(first, cohorts);
+  const authenticated = first.auth != null && first.auth.principalType !== "anonymous";
   const turnDeliveries = [first];
   let caller = first.caller;
-  const cohort = completionCohort(first, cohorts);
   while (bufferedDeliveries.length > 0) {
     const next = bufferedDeliveries[0];
     if (
       next === undefined ||
       ((first.taskDeliveryId !== undefined || next.taskDeliveryId !== undefined) &&
         (cohort === undefined || completionCohort(next, cohorts) !== cohort)) ||
+      (first.taskDeliveryId === undefined &&
+        (!authenticated || !jsonValuesEqual(first.auth, next.auth))) ||
       (caller !== undefined && next.caller !== undefined)
     ) {
       break;


### PR DESCRIPTION
### Summary

Fixes queued messages from different users merging into one turn under the last sender's auth.

Adjacent deliveries still batch when their full auth contexts match. Different auth contexts and anonymous deliveries stay separate and are handled in separate turns, e.g.:

Queued messages: Alice, Alice, Bob, Alice
Turns: [Alice, Alice], [Bob], [Alice]



### Validation

Adds unit coverage for matching auth, changed permissions, anonymous input, and ordering. The e2e eval queues several users behind a held turn and checks same-auth batching, separate turns across identities, and tool-visible auth. 