### PR TITLE
Add Sent MCP connection

### DIFF
--- a/apps/docs/lib/integrations/connection-setup.test.ts
+++ b/apps/docs/lib/integrations/connection-setup.test.ts
@@ -56,6 +56,24 @@ describe("Context connection setup", () => {
   });
 });
 
+describe("Sent connection setup", () => {
+  it("generates only user-scoped OAuth setup for Sent's MCP service", () => {
+    const integration = getIntegration("sent")!;
+    const setup = buildConnectionSetup(integration);
+
+    expect(setup.authModes).toEqual(["user"]);
+    expect(setup.variants["mcp:user"]).toContain('url: "https://mcp.sent.dm/mcp"');
+    expect(setup.variants["mcp:user"]).toContain('auth: connect("sent")');
+    expect(setup.configureVariants["mcp:user"]).toContain(
+      "vercel connect create mcp.sent.dm --name sent",
+    );
+    expect(setup.configureVariants["mcp:user"]).toContain(
+      "one Sent organization and Sender Profile",
+    );
+    expect(buildConnectionInstall(integration)).toContain("eve add connection/sent");
+  });
+});
+
 describe("Neon connection setup", () => {
   it("generates the registry install and Vercel Connect configuration", () => {
     const integration = getIntegration("neon")!;

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -1913,6 +1913,26 @@ const connectionPresentations: Record<string, ConnectionPresentation> = {
     authModes: ["user", "app"],
     relatedResources: [softwareFactoryGuide],
   },
+  sent: {
+    logo: "sent",
+    docsHref: "https://docs.sent.dm/start/llm-docs/mcp-server",
+    keywords: [
+      "mcp",
+      "sms",
+      "whatsapp",
+      "rcs",
+      "business messaging",
+      "deliverability",
+      "oauth",
+      "connect",
+    ],
+    authModes: ["user"],
+    connectors: {
+      user: { service: "mcp.sent.dm", name: "sent" },
+    },
+    configureNote:
+      "Authorization requires an authenticated eve user and selects one Sent organization and Sender Profile. Reauthorize to change scope, or revoke the grant from Sent Dashboard → Settings → MCP Connections. The registry connection allow-lists 19 reviewed tools and requires user approval for message sends, contact creation, contact deletion, and template deletion; Sent's skills also direct the agent to preview the organization, Sender Profile, target, and payload first.",
+  },
   notion: {
     logo: "notion",
     docsHref: "/docs/connections",

--- a/apps/docs/lib/integrations/logos.tsx
+++ b/apps/docs/lib/integrations/logos.tsx
@@ -48,6 +48,16 @@ export const eveLogo = (props: LogoProps) => (
   </svg>
 );
 
+export const sentLogo = (props: LogoProps) => (
+  <svg viewBox="0 0 188 188" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <rect fill="#030712" height="188" rx="32" width="188" />
+    <g fill="#fff" transform="translate(0 6)">
+      <path d="M76.9 46.17c-3.09-1.17-4.65-4.62-3.48-7.71L84.97 7.87c1.17-3.09 4.62-4.65 7.7-3.48l89.46 33.83c3.09 1.17 4.65 4.62 3.48 7.71L151.8 135.46c-1.17 3.09-4.62 4.65-7.7 3.48l-30.56-11.56c-3.09-1.17-4.65-4.62-3.48-7.71l18.03-47.75c1.17-3.09-.39-6.55-3.48-7.72L76.9 46.17z" />
+      <path d="M3.87 78.84C.78 77.67-.78 74.22.39 71.13L11.94 40.54c1.17-3.09 4.62-4.65 7.7-3.48l89.46 33.84c3.09 1.17 4.65 4.62 3.48 7.71l-33.81 89.52c-1.17 3.09-4.62 4.65-7.7 3.48L40.5 160.05c-3.09-1.17-4.65-4.62-3.48-7.71l18.03-47.75c1.17-3.09-.39-6.54-3.48-7.71L3.87 78.84z" />
+    </g>
+  </svg>
+);
+
 export const webLogo = (props: LogoProps) => (
   <svg fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" {...props}>
     <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.5" />
@@ -765,6 +775,7 @@ export const logos = {
   agentcard: agentcardLogo,
   vercel: vercelLogo,
   linear: linearLogo,
+  sent: sentLogo,
   context: contextLogo,
   notion: notionLogo,
   datadog: datadogLogo,

--- a/apps/docs/lib/integrations/sent-registry.test.ts
+++ b/apps/docs/lib/integrations/sent-registry.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import sent from "../../registry/connections/sent";
+
+const PUBLIC_TOOLS = [
+  "account.get",
+  "balance.get",
+  "contacts.create_many",
+  "contacts.delete",
+  "contacts.get",
+  "contacts.list",
+  "contacts.message_summary",
+  "dashboard.contacts",
+  "dashboard.deliverability",
+  "dashboard.messages_sent",
+  "messages.activities.list",
+  "messages.get",
+  "messages.send",
+  "numbers.lookup",
+  "onboarding.status",
+  "templates.delete",
+  "templates.get",
+  "templates.get_by_name",
+  "templates.list",
+] as const;
+
+const MUTATING_TOOLS = [
+  "messages.send",
+  "contacts.create_many",
+  "contacts.delete",
+  "templates.delete",
+] as const;
+
+describe("Sent registry connection", () => {
+  it("uses the reviewed endpoint, user-scoped connector, and exact public tool allow-list", () => {
+    expect(sent.url).toBe("https://mcp.sent.dm/mcp");
+    expect(sent.tools).toEqual({ allow: PUBLIC_TOOLS });
+    expect(sent.auth).toMatchObject({
+      principalType: "user",
+      vercelConnect: { connector: "sent" },
+    });
+  });
+
+  it("requires approval for exactly the four reviewed mutations", async () => {
+    const approval = sent.approval;
+    if (typeof approval !== "function") {
+      throw new TypeError("Sent must define a per-tool approval function");
+    }
+
+    for (const toolName of PUBLIC_TOOLS) {
+      await expect(
+        Promise.resolve(approval({ toolName: `sent__${toolName}` } as never)),
+      ).resolves.toBe(
+        MUTATING_TOOLS.includes(toolName as (typeof MUTATING_TOOLS)[number])
+          ? "user-approval"
+          : "not-applicable",
+      );
+    }
+  });
+});

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -606,6 +606,31 @@
       ]
     },
     {
+      "name": "connection/sent",
+      "type": "registry:item",
+      "title": "Sent",
+      "description": "Send and track SMS, WhatsApp, and RCS through Sent's MCP server.",
+      "meta": {
+        "eve": {
+          "setup": {
+            "command": "eve",
+            "package": "eve",
+            "bin": "eve",
+            "args": ["integration", "connect", "sent", "mcp.sent.dm", "sent"]
+          },
+          "requires": ">=0.52.3"
+        }
+      },
+      "dependencies": ["@vercel/connect"],
+      "files": [
+        {
+          "path": "registry/connections/sent.ts",
+          "type": "registry:file",
+          "target": "agent/connections/sent.ts"
+        }
+      ]
+    },
+    {
       "name": "connection/notion",
       "type": "registry:item",
       "title": "Notion",

--- a/apps/docs/registry/connections/sent.ts
+++ b/apps/docs/registry/connections/sent.ts
@@ -1,0 +1,43 @@
+import { connect } from "@vercel/connect/eve";
+import { defineMcpClientConnection } from "eve/connections";
+
+const APPROVAL_REQUIRED = new Set([
+  "messages.send",
+  "contacts.create_many",
+  "contacts.delete",
+  "templates.delete",
+]);
+
+export default defineMcpClientConnection({
+  url: "https://mcp.sent.dm/mcp",
+  description:
+    "Sent business messaging: send and track SMS, WhatsApp, and RCS; manage contacts and templates; inspect analytics, balance, and account readiness.",
+  auth: connect("sent"),
+  tools: {
+    allow: [
+      "account.get",
+      "balance.get",
+      "contacts.create_many",
+      "contacts.delete",
+      "contacts.get",
+      "contacts.list",
+      "contacts.message_summary",
+      "dashboard.contacts",
+      "dashboard.deliverability",
+      "dashboard.messages_sent",
+      "messages.activities.list",
+      "messages.get",
+      "messages.send",
+      "numbers.lookup",
+      "onboarding.status",
+      "templates.delete",
+      "templates.get",
+      "templates.get_by_name",
+      "templates.list",
+    ],
+  },
+  approval: ({ toolName }) =>
+    [...APPROVAL_REQUIRED].some((name) => toolName.endsWith(`__${name}`))
+      ? "user-approval"
+      : "not-applicable",
+});

--- a/apps/docs/scripts/validate-connection-registry.ts
+++ b/apps/docs/scripts/validate-connection-registry.ts
@@ -47,6 +47,7 @@ const CONNECT_SERVICES: Readonly<Record<string, string>> = {
   agentcard: "mcp.agentcard.sh/mcp",
   vercel: "vercel",
   linear: "mcp.linear.app",
+  sent: "mcp.sent.dm",
   notion: "mcp.notion.com",
   datadog: "mcp.datadoghq.com",
   honeycomb: "mcp.honeycomb.io",
@@ -64,6 +65,41 @@ const CONNECT_PRINCIPAL_TYPES: Readonly<Record<string, "app" | "user">> = {
   neon: "app",
   tinybird: "app",
 };
+const SENT_PUBLIC_TOOLS = [
+  "account.get",
+  "balance.get",
+  "contacts.create_many",
+  "contacts.delete",
+  "contacts.get",
+  "contacts.list",
+  "contacts.message_summary",
+  "dashboard.contacts",
+  "dashboard.deliverability",
+  "dashboard.messages_sent",
+  "messages.activities.list",
+  "messages.get",
+  "messages.send",
+  "numbers.lookup",
+  "onboarding.status",
+  "templates.delete",
+  "templates.get",
+  "templates.get_by_name",
+  "templates.list",
+];
+const SENT_APPROVAL_REQUIRED = [
+  "messages.send",
+  "contacts.create_many",
+  "contacts.delete",
+  "templates.delete",
+];
+
+function stringLiteralsIn(source: string, pattern: RegExp, label: string): string[] {
+  const body = source.match(pattern)?.[1];
+  if (body === undefined) {
+    throw new Error(`Sent registry connection is missing its ${label}.`);
+  }
+  return [...body.matchAll(/"([^"]+)"/g)].map((match) => match[1]!);
+}
 
 if (JSON.stringify(actualSlugs) !== JSON.stringify(expectedSlugs)) {
   throw new Error(
@@ -138,7 +174,35 @@ for (const item of items) {
       `Registry item "${item.name}" must write ${expectedPath} to ${expectedTarget}.`,
     );
   }
-  await access(join(docsRoot, expectedPath));
+  const sourcePath = join(docsRoot, expectedPath);
+  await access(sourcePath);
+
+  if (slug === "sent") {
+    const source = await readFile(sourcePath, "utf8");
+    const tools = stringLiteralsIn(source, /allow:\s*\[([\s\S]*?)\]/, "tool allow-list");
+    const approvals = stringLiteralsIn(
+      source,
+      /APPROVAL_REQUIRED\s*=\s*new Set\(\[([\s\S]*?)\]\)/,
+      "approval allow-list",
+    );
+    if (JSON.stringify(tools) !== JSON.stringify(SENT_PUBLIC_TOOLS)) {
+      throw new Error("Sent registry connection must allow exactly the 19 reviewed public tools.");
+    }
+    if (JSON.stringify(approvals) !== JSON.stringify(SENT_APPROVAL_REQUIRED)) {
+      throw new Error("Sent registry connection must gate exactly the four reviewed mutations.");
+    }
+    for (const required of [
+      'url: "https://mcp.sent.dm/mcp"',
+      'auth: connect("sent")',
+      "toolName.endsWith(`__${name}`)",
+      '? "user-approval"',
+      ': "not-applicable"',
+    ]) {
+      if (!source.includes(required)) {
+        throw new Error(`Sent registry connection is missing required contract: ${required}`);
+      }
+    }
+  }
 
   switch (slug) {
     case "browser-use": {

--- a/packages/eve-catalog/src/index.test.ts
+++ b/packages/eve-catalog/src/index.test.ts
@@ -107,6 +107,19 @@ describe("integration catalog", () => {
     expect(getIntegrationEntry("linear")!.connection!.mcp!.url).toBe("https://mcp.linear.app/mcp");
   });
 
+  it("catalogs Sent as a registry-only OAuth-backed MCP connection", () => {
+    expect(getIntegrationEntry("sent")).toMatchObject({
+      name: "Sent",
+      kind: "connection",
+      surfaces: { scaffoldable: false, registry: true, gallery: true },
+      connection: {
+        description:
+          "Sent business messaging: send and track SMS, WhatsApp, and RCS; manage contacts and templates; inspect analytics, balance, and account readiness.",
+        mcp: { url: "https://mcp.sent.dm/mcp" },
+      },
+    });
+  });
+
   it("exposes Kernel as an extension", () => {
     expect(getIntegrationEntry("kernel")?.kind).toBe("extension");
     expect(getIntegrationEntry("kernel")?.connection).toBeUndefined();

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -401,6 +401,18 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     },
   },
   {
+    slug: "sent",
+    name: "Sent",
+    kind: "connection",
+    tagline: "Send and track SMS, WhatsApp, and RCS through Sent's MCP server.",
+    surfaces: { scaffoldable: false, registry: true, gallery: true },
+    connection: {
+      description:
+        "Sent business messaging: send and track SMS, WhatsApp, and RCS; manage contacts and templates; inspect analytics, balance, and account readiness.",
+      mcp: { url: "https://mcp.sent.dm/mcp" },
+    },
+  },
+  {
     slug: "notion",
     name: "Notion",
     kind: "connection",

--- a/packages/eve/src/cli/commands/integration-connect.test.ts
+++ b/packages/eve/src/cli/commands/integration-connect.test.ts
@@ -58,6 +58,36 @@ describe("runIntegrationConnect", () => {
     );
   });
 
+  it("provisions Sent's service and patches its assigned connector UID", async () => {
+    const deps = dependencies({
+      setupConnectionConnector: vi.fn(async () => ({
+        kind: "existing" as const,
+        connectorUid: "sent/assigned",
+      })),
+    });
+
+    await runIntegrationConnect({
+      appRoot: "/project",
+      slug: "sent",
+      service: "mcp.sent.dm",
+      canonicalConnectorName: "sent",
+      dependencies: deps,
+    });
+
+    expect(deps.setupConnectionConnector).toHaveBeenCalledWith(
+      expect.objectContaining({
+        slug: "sent",
+        service: "mcp.sent.dm",
+        canonicalConnectorName: "sent",
+        project: PROJECT,
+      }),
+    );
+    expect(deps.updateConnectionConnectorUid).toHaveBeenCalledWith(
+      "/project/agent/connections/sent.ts",
+      "sent/assigned",
+    );
+  });
+
   it("passes connector creation options to setup", async () => {
     const deps = dependencies();
 


### PR DESCRIPTION
### Summary

Sent already exposes an OAuth 2.1 MCP server, but eve users currently have to wire it up by hand without a reviewed tool boundary. This adds Sent as an official user-scoped Vercel Connect integration so authenticated users can inspect messaging readiness and manage or send business messages through `eve add connection/sent`.

The generated connection targets `https://mcp.sent.dm/mcp`, exposes exactly the 19 reviewed public tools, and requires user approval for message sends, contact creation, contact deletion, and template deletion. It is available in the registry and gallery but remains outside the interactive connection picker. No eve runtime behavior or inbound messaging channel is added.

Closes #3050

### Validation

- `pnpm --filter eve-docs registry:check`
- `pnpm --filter eve-docs test:unit` (24 files, 178 tests passed)
- `pnpm --filter @eve/catalog test:unit` (28 tests passed)
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/cli/commands/integration-connect.test.ts` (9 tests passed)
- `pnpm typecheck` (44 tasks passed)
- `pnpm check:deps`
- `pnpm lint` (passed with two pre-existing `no-control-regex` warnings)
- `pnpm fmt`
- `pnpm guard:invariants`
- `pnpm docs:check`
- `pnpm test:integration` (100 files, 741 tests passed)
- `pnpm test` ran 8,341 passing unit tests; six unrelated host-environment assertions failed locally: three secret-redaction assertions because the checkout path contains `private`, two Linux XDG-path expectations on macOS, and one sandboxed port-bind assertion. The port-bind test passes outside the sandbox.

No credentialed Sent service test was run or added to CI.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
