### PR TITLE
docs: clarify development TUI

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -50,7 +50,7 @@ Choose **Start eve dev** after scaffolding, or run this from the project root:
 npm run dev
 ```
 
-This starts an interactive session where you can send messages to your agent.
+This starts the development TUI, where you can send messages to your agent.
 
 ## Project layout
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -85,7 +85,9 @@ pnpm test:e2e
 
 Vercel e2e uses the same fixture evals against immutable preview deployment
 URLs. All fixture deployments link to the same Vercel project id; isolation
-comes from the deployment URL returned by `vc deploy --prebuilt`.
+comes from the deployment URL returned by `vc deploy --prebuilt`. The deploy
+output also includes an **Inspect** URL for the exact Vercel deployment exercised
+by that matrix job.
 
 One-time project setup:
 


### PR DESCRIPTION
### Summary

Clarifies that `npm run dev` opens the development TUI and that Vercel e2e output includes an **Inspect** URL for the deployment exercised by each matrix job.

### Validation

`pnpm docs:check` and focused formatting checks passed.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+4 / -2`

Two focused clarifications in the getting started and e2e guides.

**Implementation** — 0 files · `+0 / -0`

Not applicable.

**Tests** — 0 files · `+0 / -0`

Not applicable for these copy-only changes.
