### PR TITLE
feat(eve): log eval workflow run IDs

### DIFF
--- a/.changeset/verbose-eval-workflow-runs.md
+++ b/.changeset/verbose-eval-workflow-runs.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Print each eval session's workflow run ID when `eve eval --verbose` runs, including primary and secondary sessions.

--- a/docs/evals/running.mdx
+++ b/docs/evals/running.mdx
@@ -16,7 +16,7 @@ eve eval --timeout 60000       # per-eval timeout in milliseconds
 eve eval --max-concurrency 4   # cap concurrent eval executions (default 8)
 eve eval --junit .eve/junit.xml  # write JUnit XML
 eve eval --list                # print discovered evals without running
-eve eval --verbose             # stream per-eval t.log lines to stdout
+eve eval --verbose             # stream per-eval logs and workflow run IDs
 eve eval --json                # machine-readable output
 eve eval --skip-report         # skip config and eval-defined reporters (e.g. Braintrust)
 ```
@@ -36,6 +36,8 @@ Tag filters compose: `--tag` keeps evals carrying at least one listed tag, then 
 An eval that calls `t.skip(reason)` is reported as skipped, does not count as passed or failed, and never changes the exit code.
 
 `eve eval --json` flushes the complete report before exiting, including when stdout is piped to another process or redirected to a file.
+
+With `--verbose`, eve prefixes each line with its eval ID. It streams authored `t.log()` lines as they occur, then prints the workflow run ID for every captured primary and secondary session. Use those `wrun_...` IDs to find the corresponding runs in your workflow provider.
 
 ## Artifacts
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -372,7 +372,7 @@ Runs all discovered evals when no eval ids are given; ids match exactly or by di
 | `--json`                 | flag   | off     | Output results as JSON                                        |
 | `--junit <path>`         | string | none    | Write JUnit XML results to a file                             |
 | `--skip-report`          | flag   | off     | Skip eval-defined reporters (e.g. Braintrust)                 |
-| `--verbose`              | flag   | off     | Stream per-eval `t.log` lines to stdout                       |
+| `--verbose`              | flag   | off     | Stream per-eval logs and workflow run IDs to stdout           |
 
 See [Evals](../evals/overview) for authoring evals.
 

--- a/e2e/fixtures/agent-workflow-stress/evals/concurrent-workflow-turns.eval.ts
+++ b/e2e/fixtures/agent-workflow-stress/evals/concurrent-workflow-turns.eval.ts
@@ -26,9 +26,6 @@ export default defineEval({
       }),
     );
     const firstBatchDurationMs = performance.now() - firstBatchStartedAt;
-    firstTurns.forEach((turn, index) => {
-      t.log(`workflow run id (${index + 1}/${SESSION_COUNT}): ${turn.result.sessionId}`);
-    });
     const secondBatchStartedAt = performance.now();
     const secondTurns = await Promise.all(
       sessions.map(async (session, index) => {

--- a/e2e/fixtures/agent-workflow-stress/evals/sequential-workflow-turns.eval.ts
+++ b/e2e/fixtures/agent-workflow-stress/evals/sequential-workflow-turns.eval.ts
@@ -25,10 +25,7 @@ export default defineEval({
         `turn ${String(turnNumber).padStart(3, "0")}/${TURN_COUNT} completed in ${elapsedSeconds.toFixed(3)}s`,
       );
 
-      if (sessionId === undefined) {
-        sessionId = result.sessionId;
-        t.log(`workflow run id: ${sessionId}`);
-      }
+      sessionId ??= result.sessionId;
 
       const turn = result.expectOk();
 

--- a/packages/eve/src/cli/run.ts
+++ b/packages/eve/src/cli/run.ts
@@ -621,7 +621,7 @@ export function createCliProgram(
     .option("--json", "Output results as JSON")
     .option("--junit <path>", "Write JUnit XML results to a file")
     .option("--skip-report", "Skip eval-defined reporters (e.g. Braintrust)")
-    .option("--verbose", "Stream per-eval t.log lines to stdout")
+    .option("--verbose", "Stream per-eval logs and workflow run IDs to stdout")
     .action(async (evalIds: string[], options: EvalCliOptions) => {
       const runEvalCommand = runtime.runEvalCommand ?? (await loadRunEvalCommand());
       await runEvalCommand(evalIds, options, logger, applicationContext.root);

--- a/packages/eve/src/evals/runner/run-evals.test.ts
+++ b/packages/eve/src/evals/runner/run-evals.test.ts
@@ -339,6 +339,49 @@ describe("runEvals", () => {
     ]);
   });
 
+  it("streams every captured workflow run id through verbose output", async () => {
+    mockArtifacts();
+    mockedRunnerDependencies.executeTask.mockResolvedValue({
+      ...createTaskResult("done"),
+      result: {
+        ...createTaskResult("done").result,
+        sessions: [
+          {
+            derived: createEmptyDerivedFacts(),
+            events: [],
+            primary: true,
+            sessionId: "wrun_primary",
+            state: undefined,
+            traceContexts: [],
+          },
+          {
+            derived: createEmptyDerivedFacts(),
+            events: [],
+            primary: false,
+            sessionId: "wrun_secondary",
+            state: undefined,
+            traceContexts: [],
+          },
+        ],
+      },
+    });
+    const onEvalLog = vi.fn();
+
+    await run({
+      evaluations: [createEval("delegation")],
+      target: localTarget,
+      client: unusedClient,
+      appRoot: "/tmp/app",
+      reporters: [],
+      onEvalLog,
+    });
+
+    expect(onEvalLog.mock.calls).toEqual([
+      ["delegation", "workflow run id (primary session): wrun_primary"],
+      ["delegation", "workflow run id (secondary session): wrun_secondary"],
+    ]);
+  });
+
   it("scopes eval-defined reporters to the evals referencing them", async () => {
     mockArtifacts();
     mockedRunnerDependencies.executeTask.mockResolvedValue(createTaskResult("done"));

--- a/packages/eve/src/evals/runner/run-evals.ts
+++ b/packages/eve/src/evals/runner/run-evals.ts
@@ -33,7 +33,7 @@ export interface RunEvalsOptions {
   readonly maxConcurrency?: number;
   /** Overrides every eval's `timeoutMs` when set (CLI `--timeout`). */
   readonly timeoutMs?: number;
-  /** Receives `t.log` lines as evals run (used by `--verbose`). */
+  /** Receives verbose activity lines as evals run. */
   readonly onEvalLog?: (evalId: string, message: string) => void;
 }
 
@@ -139,6 +139,12 @@ export async function runEvals(options: RunEvalsOptions): Promise<EveEvalRunSumm
           timeoutMs: options.timeoutMs,
         });
         results.push(result);
+
+        for (const session of result.result.sessions ?? []) {
+          if (session.sessionId === undefined) continue;
+          const role = session.primary ? "primary session" : "secondary session";
+          options.onEvalLog?.(evaluation.id, `workflow run id (${role}): ${session.sessionId}`);
+        }
 
         enqueueReporterCallback(evaluation, async (reporter) => {
           await reporter.onEvalComplete(result, {


### PR DESCRIPTION
### Summary

`eve eval --verbose` now prints the workflow run ID for every captured primary and secondary session after its eval completes. This makes remote eval output directly searchable in Vercel Agent Runs without requiring each eval to add its own `t.log()` call; the workflow stress fixture's duplicate ID logging is removed.

### Validation

Focused runner coverage passes for primary and secondary session output. Workspace type checking, docs checks, invariant guards, formatting, and linting pass; the full unit suite reached 8,395 passing tests but had five unrelated environment-sensitive failures involving `/private/tmp` redaction assertions and mocked macOS config paths.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 3 files · `+9 / -2`

Updates the CLI and eval guidance and records the user-visible change for release notes.

**Implementation** — 2 files · `+8 / -2`

Keeps session reporting in the existing verbose-output path and updates the CLI help text.

**Tests** — 3 files · `+44 / -7`

Covers primary and secondary workflow IDs and removes now-redundant fixture-specific logging while preserving stress assertions and metrics.
