### PR TITLE
Add publisher organization schema

### DIFF
--- a/apps/docs/app/[lang]/(home)/components/file-tree.tsx
+++ b/apps/docs/app/[lang]/(home)/components/file-tree.tsx
@@ -111,8 +111,7 @@ export default defineTool({
     NavIcon: IconSandbox,
     description:
       "Every agent includes an isolated sandbox. Add sandbox/sandbox.ts to swap in any backend or customize its setup.",
-    code: `import { defineSandbox } from
-  "eve/sandbox";
+    code: `import { defineSandbox } from "eve/sandbox";
 
 export default defineSandbox({
   async bootstrap({ sandbox }) {

--- a/apps/docs/app/[lang]/layout.tsx
+++ b/apps/docs/app/[lang]/layout.tsx
@@ -8,6 +8,7 @@ import { mono, sans } from "@/lib/geistdocs/fonts";
 import { staticOgImage } from "@/lib/geistdocs/og";
 import { supportedLanguages } from "@/lib/geistdocs/languages";
 import { rootTitleMetadata } from "@/lib/geistdocs/metadata-title";
+import { organizationSchemaJson } from "@/lib/geistdocs/organization-schema";
 import { getRootLang } from "@/lib/geistdocs/root-params";
 import { getSiteOrigin } from "@/lib/geistdocs/url";
 import { cn } from "@/lib/utils";
@@ -40,6 +41,11 @@ const Layout = async ({ children }: LayoutProps<"/[lang]">) => {
       suppressHydrationWarning
     >
       <body>
+        <script
+          dangerouslySetInnerHTML={{ __html: organizationSchemaJson }}
+          id="organization-structured-data"
+          type="application/ld+json"
+        />
         <GeistdocsProvider basePath={config.basePath} lang={lang}>
           <Navbar config={config} />
           {children}

--- a/apps/docs/lib/geistdocs/organization-schema.test.ts
+++ b/apps/docs/lib/geistdocs/organization-schema.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { organizationSchema, organizationSchemaJson } from "./organization-schema";
+
+describe("organization schema", () => {
+  it("publishes Vercel's minimal publisher identity as JSON-LD", () => {
+    expect(organizationSchema).toEqual({
+      "@context": "https://schema.org",
+      "@id": "https://eve.dev/#publisher",
+      "@type": "Organization",
+      name: "Vercel",
+      sameAs: [
+        "https://en.wikipedia.org/wiki/Vercel",
+        "https://www.wikidata.org/wiki/Q56069184",
+        "https://github.com/vercel",
+        "https://x.com/vercel",
+      ],
+      url: "https://vercel.com",
+    });
+    expect(JSON.parse(organizationSchemaJson)).toEqual(organizationSchema);
+  });
+
+  it("escapes HTML-significant characters in the inline JSON-LD payload", () => {
+    expect(organizationSchemaJson).not.toContain("<");
+  });
+});

--- a/apps/docs/lib/geistdocs/organization-schema.ts
+++ b/apps/docs/lib/geistdocs/organization-schema.ts
@@ -1,0 +1,15 @@
+export const organizationSchema = {
+  "@context": "https://schema.org",
+  "@id": "https://eve.dev/#publisher",
+  "@type": "Organization",
+  name: "Vercel",
+  sameAs: [
+    "https://en.wikipedia.org/wiki/Vercel",
+    "https://www.wikidata.org/wiki/Q56069184",
+    "https://github.com/vercel",
+    "https://x.com/vercel",
+  ],
+  url: "https://vercel.com",
+} as const;
+
+export const organizationSchemaJson = JSON.stringify(organizationSchema).replace(/</g, "\\u003c");


### PR DESCRIPTION
### Summary

The eve home page had no Organization JSON-LD, leaving the publisher identity unavailable to crawlers and agents. Add a minimal Vercel publisher entity modeled on Next.js and Nuxt’s framework-site schemas, with a stable identity URL and corporate public profiles. The existing SoftwareApplication schema and all visible site behavior remain unchanged. This PR also keeps the homepage Sandbox example’s `defineSandbox` import on one line for readability.

### Validation

- `pnpm --filter eve-docs test:unit` — 24 files and 177 tests passed
- `pnpm --filter eve-docs build` — passed
- `pnpm docs:check` — passed
- `pnpm lint` — passed with two pre-existing warnings in `packages/eve`
- Production build manual checks: homepage JSON-LD parsed and contained the Organization entity; `/robots.txt`, `/sitemap.xml`, `/sitemap.md`, `/llms.txt`, `/llms-full.txt`, `/agents.md`, and `/rss.xml` returned HTTP 200
- `git diff --check`

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
