### PR TITLE
[1/2] feat(eve): expose workflow history context

### DIFF
--- a/.changeset/workflow-history-context.md
+++ b/.changeset/workflow-history-context.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Expose an immutable completed conversation prefix to workflow tools as `ctx.history`. The captured history excludes the calling tool exchange, letting workflows carry prior context into controlled follow-up work without a session history endpoint.

--- a/docs/tools/workflows.mdx
+++ b/docs/tools/workflows.mdx
@@ -78,8 +78,8 @@ or days later, the run resumes, deploys, and returns. The model sees one tool re
 - Import `createHook`, `createWebhook`, `sleep`, and `FatalError` from `workflow` in the body.
   `start`, `getRun`, and `resumeHook` from `workflow/api` belong in steps. Your app does not install
   the SDK; for types, new projects list `eve/workflow-modules` in the tsconfig `types`.
-- In the body, `ctx` has `session`, `callId`, `toolName`, `abortSignal`, `agent`, and `ask`.
-  `getToken` and `requireAuth` work inside a `"use step"` helper that receives `ctx` as a direct argument;
+- In the body, `ctx` has `session`, `history`, `callId`, `toolName`, `abortSignal`, `agent`, and `ask`.
+  `history` is an immutable copy of the completed conversation prefix captured before this tool call, so it excludes the calling tool exchange and does not provide live session access. `getToken` and `requireAuth` work inside a `"use step"` helper that receives `ctx` as a direct argument;
   they throw in the workflow body. `getSandbox` and `getSkill` remain unavailable.
 - The tool's input must be a JSON object. Workflow bodies are for static tools under `agent/tools/`,
   not tools returned from `defineDynamic` resolvers.

--- a/packages/eve/extension-contracts/compatibility/tool/v33.ts
+++ b/packages/eve/extension-contracts/compatibility/tool/v33.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+import { defineTool, defineWorkflowTool } from "#public/tools/index.js";
+
+export const write = defineTool({
+  description: "Write an approved message.",
+  inputSchema: z.object({ message: z.string() }),
+  outputSchema: z.object({ written: z.string() }),
+  approval: ({ toolInput }) => (toolInput?.message ? "user-approval" : "not-applicable"),
+  label: {
+    start: (input) => `Write ${input.message}`,
+    complete: (_input, output) => `Wrote ${output.written}`,
+  },
+  execute: (input) => ({ written: input.message }),
+  toModelOutput: (output) => ({ type: "text", value: output.written }),
+});
+
+export const workflow = defineWorkflowTool({
+  description: "Run a report workflow.",
+  inputSchema: z.object({ report: z.string() }),
+  async execute(input) {
+    "use workflow";
+    return { report: input.report };
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/tool/v34.ts
+++ b/packages/eve/extension-contracts/compatibility/tool/v34.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+import { defineTool, defineWorkflowTool } from "#public/tools/index.js";
+
+export const write = defineTool({
+  description: "Write an approved message.",
+  inputSchema: z.object({ message: z.string() }),
+  outputSchema: z.object({ written: z.string() }),
+  approval: ({ toolInput }) => (toolInput?.message ? "user-approval" : "not-applicable"),
+  label: {
+    start: (input) => `Write ${input.message}`,
+    complete: (_input, output) => `Wrote ${output.written}`,
+  },
+  execute: (input) => ({ written: input.message }),
+  toModelOutput: (output) => ({ type: "text", value: output.written }),
+});
+
+export const workflow = defineWorkflowTool({
+  description: "Run a report workflow.",
+  inputSchema: z.object({ report: z.string() }),
+  async execute(input) {
+    "use workflow";
+    return { report: input.report };
+  },
+});

--- a/packages/eve/extension-contracts/reports/tool/v34.json
+++ b/packages/eve/extension-contracts/reports/tool/v34.json
@@ -1,0 +1,20 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "tool",
+  "epoch": 34,
+  "sha256": "24ac82caa24b01a28471025de71f88dc5fd09e05dfb7a1b3c1894eb7ef556e8b",
+  "exports": [
+    "defaultWebSearch",
+    "defineTool",
+    "defineWorkflowTool",
+    "disableTool",
+    "experimental_workflow",
+    "isDisabledToolSentinel",
+    "isExperimentalWorkflowToolDefinition",
+    "isWebSearchToolDefinition",
+    "toolOutput",
+    "toolOutputPart",
+    "toolResultFrom",
+    "webSearch"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/tool/v35.json
+++ b/packages/eve/extension-contracts/reports/tool/v35.json
@@ -1,0 +1,20 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "tool",
+  "epoch": 35,
+  "sha256": "6cbe0762655665a8f1d8e29af1bbf02a0416a71d5d91af61635af33a14839c23",
+  "exports": [
+    "defaultWebSearch",
+    "defineTool",
+    "defineWorkflowTool",
+    "disableTool",
+    "experimental_workflow",
+    "isDisabledToolSentinel",
+    "isExperimentalWorkflowToolDefinition",
+    "isWebSearchToolDefinition",
+    "toolOutput",
+    "toolOutputPart",
+    "toolResultFrom",
+    "webSearch"
+  ]
+}

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -22,8 +22,8 @@ interface ExtensionCapabilityContract {
 const EXTENSION_CAPABILITY_CONTRACTS = {
   extension: { current: 1, supported: [1], dropped: {} },
   tool: {
-    current: 33,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 28, 29, 30, 31, 32, 33],
+    current: 35,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 28, 29, 30, 31, 32, 33, 34, 35],
     dropped: {
       14: "TaskExec.delegated was removed; migrate to workflow-backed background tools",
       15: "TaskExec replaces stageEffect with send",

--- a/packages/eve/src/execution/tools/workflow/body.test.ts
+++ b/packages/eve/src/execution/tools/workflow/body.test.ts
@@ -19,8 +19,13 @@ it("binds workflow-only methods to the run context", async () => {
   const signal = new AbortController().signal;
   const input = {
     callId: "call",
+    history: [{ content: "Earlier request", role: "user" }],
     input: {},
-    session: { id: "session", turn: { id: "turn", sequence: 1 } },
+    session: {
+      auth: { current: null, initiator: null },
+      id: "session",
+      turn: { id: "turn", sequence: 1 },
+    },
     stepIndex: 0,
     toolName: "deploy",
     workflowId: "workflow//test//execute",
@@ -35,6 +40,8 @@ it("binds workflow-only methods to the run context", async () => {
   mocks.execute.mockImplementation(async (_input, ctx: WorkflowToolContext & ToolContext) => {
     expect(readWorkflowToolRunRef(ctx).runId).toBe("run");
     expect(ctx.abortSignal).toBe(signal);
+    expect(ctx.history).toEqual([{ content: "Earlier request", role: "user" }]);
+    expect(Object.isFrozen(ctx.history)).toBe(true);
     const answer = await ctx.ask(question);
     const result = await ctx.agent(invocation);
     expect(mocks.ask).toHaveBeenCalledWith(ctx, question);
@@ -64,6 +71,7 @@ it.each([
         {
           authorizationSupported,
           callId: "call",
+          history: [],
           input: {},
           session: {
             id: "session",

--- a/packages/eve/src/execution/tools/workflow/body.ts
+++ b/packages/eve/src/execution/tools/workflow/body.ts
@@ -2,6 +2,7 @@ import { getWorkflowMetadata } from "#compiled/@workflow/core/index.js";
 
 import type { SessionContext } from "#context/session-context.js";
 import { agent } from "#execution/tools/subagent/invoke-agent.js";
+import { copyWorkflowHistory } from "#execution/tools/workflow/history.js";
 import type { WorkflowToolContext } from "#tools/workflow-definition.js";
 import { ask, attachWorkflowToolRunContext } from "#execution/tools/workflow/ask.js";
 import {
@@ -18,6 +19,11 @@ import type { ToolContext } from "#tools/definition.js";
 import { createTaskMessage, type TaskExec } from "#tools/task.js";
 
 export interface WorkflowBodyDefinition {
+  /**
+   * Immutable completed parent prefix captured before this tool call. Older
+   * in-flight workflow runs omit it and intentionally receive an empty view.
+   */
+  readonly history?: import("#execution/tools/workflow/history.js").WorkflowHistory;
   /** Advertised by the parent driver; absent on runs started before this capability. */
   readonly authorizationSupported?: boolean;
   readonly callId: string;
@@ -149,6 +155,7 @@ function createWorkflowBodyContext(
     getSkill: () => unavailable("getSkill()", "skills are read through the session sandbox"),
     getToken: () =>
       unavailable("getToken()", 'pass ctx directly to a "use step" helper to resolve credentials'),
+    history: copyWorkflowHistory(input.history ?? []),
     requireAuth: () =>
       unavailable(
         "requireAuth()",

--- a/packages/eve/src/execution/tools/workflow/history.test.ts
+++ b/packages/eve/src/execution/tools/workflow/history.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import type { ModelMessage } from "ai";
+
+import { copyWorkflowHistory } from "#execution/tools/workflow/history.js";
+
+describe("copyWorkflowHistory", () => {
+  it("copies and deeply freezes plain workflow history", () => {
+    const source = [
+      {
+        content: [
+          {
+            text: "Earlier request",
+            type: "text" as const,
+          },
+        ],
+        role: "user" as const,
+      },
+    ];
+
+    const history = copyWorkflowHistory(source);
+
+    expect(history).toEqual(source);
+    expect(history).not.toBe(source);
+    expect(history[0]).not.toBe(source[0]);
+    expect(Object.isFrozen(history)).toBe(true);
+    expect(Object.isFrozen(history[0])).toBe(true);
+    expect(Object.isFrozen(history[0]?.content)).toBe(true);
+    expect(Object.isFrozen((history[0]?.content as readonly unknown[])[0])).toBe(true);
+  });
+
+  it("copies URL and binary attachment values without freezing their views", () => {
+    const url = new URL("https://example.com/chart.png");
+    const bytes = Buffer.from([1, 2, 3]);
+    const source = [
+      {
+        role: "user",
+        content: [
+          { type: "image", image: url },
+          { type: "image", image: bytes },
+        ],
+      },
+    ] as ModelMessage[];
+
+    const history = copyWorkflowHistory(source);
+    const content = history[0]?.content;
+    if (!Array.isArray(content)) throw new Error("Expected structured history content.");
+    const urlPart = content[0];
+    const bytesPart = content[1];
+    if (urlPart?.type !== "image" || bytesPart?.type !== "image") {
+      throw new Error("Expected image history parts.");
+    }
+
+    expect(urlPart.image).toBeInstanceOf(URL);
+    expect(urlPart.image).not.toBe(url);
+    expect(bytesPart.image).toBeInstanceOf(Uint8Array);
+    if (!(bytesPart.image instanceof Uint8Array)) throw new Error("Expected copied bytes.");
+    expect(bytesPart.image).not.toBe(bytes);
+    expect(Array.from(bytesPart.image)).toEqual([1, 2, 3]);
+    bytes[0] = 9;
+    expect(Array.from(bytesPart.image)).toEqual([1, 2, 3]);
+  });
+});

--- a/packages/eve/src/execution/tools/workflow/history.ts
+++ b/packages/eve/src/execution/tools/workflow/history.ts
@@ -1,0 +1,51 @@
+import type { ModelMessage } from "ai";
+
+import type { WorkflowHistory } from "#shared/history-message.js";
+
+export type {
+  HistoryBinaryData,
+  HistoryContentPart,
+  HistoryCustomPart,
+  HistoryFileData,
+  HistoryFilePart,
+  HistoryImagePart,
+  HistoryMessage,
+  HistoryProviderReference,
+  HistoryReasoningPart,
+  HistoryTextPart,
+  HistoryToolApprovalRequestPart,
+  HistoryToolApprovalResponsePart,
+  HistoryToolCallPart,
+  HistoryToolResultPart,
+  WorkflowHistory,
+} from "#shared/history-message.js";
+
+/** Copies supported rich values without retaining mutable session references. */
+export function copyWorkflowHistory(
+  history: readonly ModelMessage[] | WorkflowHistory,
+): WorkflowHistory {
+  return copyValue(history) as WorkflowHistory;
+}
+
+export function toModelMessages(history: WorkflowHistory): ModelMessage[] {
+  return copyValue(history) as ModelMessage[];
+}
+
+function copyValue(value: unknown): unknown {
+  if (value instanceof URL) return new URL(value.href);
+  if (value instanceof Uint8Array) return new Uint8Array(value);
+  if (value instanceof ArrayBuffer) return value.slice(0);
+  if (Array.isArray(value)) return Object.freeze(value.map(copyValue));
+  if (isPlainRecord(value)) {
+    return Object.freeze(
+      Object.fromEntries(Object.entries(value).map(([key, child]) => [key, copyValue(child)])),
+    );
+  }
+  return value;
+}
+
+function isPlainRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  if (typeof value !== "object" || value === null) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}

--- a/packages/eve/src/execution/tools/workflow/start.test.ts
+++ b/packages/eve/src/execution/tools/workflow/start.test.ts
@@ -14,6 +14,7 @@ vi.mock("#execution/workflow-runtime.js", () => ({
 
 const input: Omit<WorkflowToolRunInput, "hookToken"> = {
   callId: "call-1",
+  history: [{ content: "Earlier request", role: "user" }],
   input: { service: "api" },
   owner: { inbox: "owner-inbox" },
   session: {

--- a/packages/eve/src/execution/tools/workflow/start.ts
+++ b/packages/eve/src/execution/tools/workflow/start.ts
@@ -1,6 +1,7 @@
 import type { SessionAuth, SessionParent } from "#context/session-context.js";
 import { createRuntimeToolResultFromValue } from "#harness/action-result-helpers.js";
 import { recordWorkflowToolRun } from "#harness/workflow-tool-runs.js";
+import { copyWorkflowHistory } from "#execution/tools/workflow/history.js";
 import { createLogger, logError } from "#internal/logging.js";
 import type { RuntimeSession } from "#subagents/handle-dispatch.js";
 import type {
@@ -50,6 +51,7 @@ export async function startWorkflowTask(input: {
     const started = await startWorkflowToolRun({
       callId: task.callId,
       executeInput: task.executeInput,
+      history: copyWorkflowHistory(session.history),
       input: task.input,
       owner: input.owner,
       resultKind: task.resultKind,

--- a/packages/eve/src/execution/tools/workflow/types.ts
+++ b/packages/eve/src/execution/tools/workflow/types.ts
@@ -1,4 +1,5 @@
 import type { SessionContext } from "#context/session-context.js";
+import type { WorkflowHistory } from "#execution/tools/workflow/history.js";
 import type { JsonObject, JsonValue } from "#shared/json.js";
 import type { TaskExecutorBinding } from "#tools/task.js";
 import type { WorkflowToolRunOwner } from "#execution/tools/workflow/messages.js";
@@ -33,6 +34,11 @@ export interface WorkflowToolRunInput {
   readonly execution?: "background" | "blocking";
   readonly executeInput?: JsonValue;
   readonly hookToken: string;
+  /**
+   * Immutable completed parent prefix captured before this tool call. Older
+   * in-flight workflow runs omit it and intentionally receive an empty view.
+   */
+  readonly history?: WorkflowHistory;
   readonly input: JsonObject;
   readonly owner: WorkflowToolRunOwner;
   readonly resultKind?: "subagent" | "tool";

--- a/packages/eve/src/execution/tools/workflow/workflow-tool-run.integration.test.ts
+++ b/packages/eve/src/execution/tools/workflow/workflow-tool-run.integration.test.ts
@@ -16,6 +16,7 @@ import {
   deployServiceWorkflow,
   failingDeployWorkflow,
   holdUntilAbortedWorkflow,
+  readHistoryWorkflow,
   reportingDeployWorkflow,
   stepThenRaceWorkflow,
   stepReferenceWorkflow,
@@ -143,6 +144,37 @@ function eventsText(events: readonly { readonly data?: unknown }[]): string {
 }
 
 describe("workflow step authorization", () => {
+  it("receives the completed parent prefix before the workflow tool exchange", async () => {
+    const runtime = await createWorkflowToolRuntime({
+      agentName: "workflow-history-read",
+      execute: readHistoryWorkflow,
+      toolName: "research",
+    });
+
+    await runtime.run(async () => {
+      const run = await start(workflowEntry, [
+        {
+          input: { message: 'Run research with service "api"' },
+          serializedContext: buildSerializedContext({
+            continuationToken: "http:workflow-history-read",
+            mode: "conversation",
+          }),
+        },
+      ]);
+      const stream = captureTurnEvents(run);
+      try {
+        const settled = await stream.nextTurn();
+        const result = filterEventsByType(settled, "action.result").at(-1);
+        expect(result?.data.result.output).toMatchObject({
+          lastContent: 'Run research with service "api"',
+          length: 1,
+        });
+      } finally {
+        stream.dispose();
+        await run.cancel();
+      }
+    });
+  }, 30_000);
   it.each(["blocking", "background"] as const)(
     "runs %s auth with no advertised driver support",
     async (execution) => {

--- a/packages/eve/src/internal/testing/workflow-tool-fixtures.ts
+++ b/packages/eve/src/internal/testing/workflow-tool-fixtures.ts
@@ -25,6 +25,18 @@ export interface DeployInput {
   readonly service: string;
 }
 
+export async function readHistoryWorkflow(
+  _input: DeployInput,
+  ctx: WorkflowToolContext,
+): Promise<{ readonly lastContent: unknown; readonly length: number }> {
+  "use workflow";
+
+  return {
+    lastContent: ctx.history.at(-1)?.content,
+    length: ctx.history.length,
+  };
+}
+
 export async function deployServiceWorkflow(
   input: DeployInput,
   ctx: WorkflowToolContext,

--- a/packages/eve/src/public/tools/index.ts
+++ b/packages/eve/src/public/tools/index.ts
@@ -43,3 +43,20 @@ export {
   type AgentInput,
 } from "#tools/workflow-definition.js";
 export type { ToolInputRequest, ToolInputResponse } from "#tools/definition.js";
+export type {
+  HistoryBinaryData,
+  HistoryContentPart,
+  HistoryCustomPart,
+  HistoryFileData,
+  HistoryFilePart,
+  HistoryImagePart,
+  HistoryMessage,
+  HistoryProviderReference,
+  HistoryReasoningPart,
+  HistoryTextPart,
+  HistoryToolApprovalRequestPart,
+  HistoryToolApprovalResponsePart,
+  HistoryToolCallPart,
+  HistoryToolResultPart,
+  WorkflowHistory,
+} from "#shared/history-message.js";

--- a/packages/eve/src/shared/history-message.ts
+++ b/packages/eve/src/shared/history-message.ts
@@ -1,0 +1,94 @@
+import type { JsonObject, JsonValue } from "#shared/json.js";
+
+interface HistoryPartBase {
+  readonly providerOptions?: Readonly<Record<string, JsonObject>>;
+}
+
+export interface HistoryTextPart extends HistoryPartBase {
+  readonly text: string;
+  readonly type: "text";
+}
+
+export interface HistoryReasoningPart extends HistoryPartBase {
+  readonly text: string;
+  readonly type: "reasoning";
+}
+
+export type HistoryProviderReference = Readonly<Record<string, string>>;
+export type HistoryBinaryData = string | Uint8Array | ArrayBuffer;
+export type HistoryFileData =
+  | HistoryBinaryData
+  | URL
+  | HistoryProviderReference
+  | { readonly data: HistoryBinaryData; readonly type: "data" }
+  | { readonly reference: HistoryProviderReference; readonly type: "reference" }
+  | { readonly text: string; readonly type: "text" }
+  | { readonly type: "url"; readonly url: string | URL };
+
+export interface HistoryImagePart extends HistoryPartBase {
+  readonly image: HistoryBinaryData | URL | HistoryProviderReference;
+  readonly mediaType?: string;
+  readonly type: "image";
+}
+
+export interface HistoryFilePart extends HistoryPartBase {
+  readonly data: HistoryFileData;
+  readonly filename?: string;
+  readonly mediaType: string;
+  readonly type: "file" | "reasoning-file";
+}
+
+export interface HistoryToolCallPart extends HistoryPartBase {
+  readonly input: JsonValue;
+  readonly providerExecuted?: boolean;
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly type: "tool-call";
+}
+
+export interface HistoryToolResultPart extends HistoryPartBase {
+  readonly output: JsonValue;
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly type: "tool-result";
+}
+
+export interface HistoryToolApprovalRequestPart {
+  readonly approvalId: string;
+  readonly isAutomatic?: boolean;
+  readonly toolCallId: string;
+  readonly type: "tool-approval-request";
+}
+
+export interface HistoryToolApprovalResponsePart {
+  readonly approvalId: string;
+  readonly approved: boolean;
+  readonly reason?: string;
+  readonly type: "tool-approval-response";
+}
+
+export interface HistoryCustomPart extends HistoryPartBase {
+  readonly kind: `${string}.${string}`;
+  readonly type: "custom";
+}
+
+export type HistoryContentPart =
+  | HistoryCustomPart
+  | HistoryFilePart
+  | HistoryImagePart
+  | HistoryReasoningPart
+  | HistoryTextPart
+  | HistoryToolApprovalRequestPart
+  | HistoryToolApprovalResponsePart
+  | HistoryToolCallPart
+  | HistoryToolResultPart;
+
+/** eve-owned model-history value accepted by privileged session operations. */
+export interface HistoryMessage {
+  readonly role: "assistant" | "tool" | "user";
+  readonly content: string | readonly HistoryContentPart[];
+  readonly providerOptions?: Readonly<Record<string, JsonObject>>;
+}
+
+/** Immutable-by-value conversation prefix supplied to a workflow tool. */
+export type WorkflowHistory = readonly HistoryMessage[];

--- a/packages/eve/src/tools/workflow-definition.ts
+++ b/packages/eve/src/tools/workflow-definition.ts
@@ -14,6 +14,7 @@ import {
 } from "#tools/definition.js";
 import type { TaskExec } from "#tools/task.js";
 import type { ToolModelOutput } from "#tools/model-output.js";
+import type { WorkflowHistory } from "#shared/history-message.js";
 
 export interface AgentInput {
   readonly agentId?: string;
@@ -31,6 +32,12 @@ export type WorkflowToolContext = Pick<
   ToolContext,
   "abortSignal" | "callId" | "session" | "toolName" | "getToken" | "requireAuth"
 > & {
+  /**
+   * Immutable completed conversation prefix captured before this workflow tool
+   * call. It excludes the calling tool exchange and never exposes live session
+   * state.
+   */
+  readonly history: WorkflowHistory;
   /** Invoke a visible subagent. The key must be unique within this workflow run. */
   agent(input: AgentInput): Promise<JsonValue>;
   /** Ask the human on the session's channel; awaiting the answer suspends the run. */


### PR DESCRIPTION
### Summary

Adds `ctx.history` so authored workflows can use the conversation that led to a tool call, rather than relying on the model to summarize it into tool arguments. This supports application-controlled handoffs and research with the actual prior context. The value is a detached, read-only copy of the completed prefix; it excludes the calling tool exchange and grants no live session access.

```ts
// Inside defineWorkflowTool({ ... }):
async execute(input, ctx) {
  "use workflow";
  return await prepareHandoff(input, ctx.history); // application-owned step
}
```

History mutation and session initialization follow in #3185 and #3186.

### Validation

Adds a real workflow integration test for the captured pre-tool-call prefix, plus copy-isolation tests for attachment values.

🤖
