### PR TITLE
[2/2] feat(eve): preload workflow subagent history

### DIFF
--- a/.changeset/workflow-subagent-history.md
+++ b/.changeset/workflow-subagent-history.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Allow workflow tools to preload a new local subagent with conversation history through `ctx.agent({ history })`.

--- a/docs/tools/workflows.mdx
+++ b/docs/tools/workflows.mdx
@@ -262,6 +262,21 @@ stable across replay, so use a fixed key for each logical call site. Parallel ca
 keys. `target` is the model-visible subagent name; pass `agentId` to continue an existing child and
 `outputSchema` to require structured output.
 
+Pass `history` to preload a new local subagent before its first message. For example, a workflow can
+seed a private research session with the completed conversation prefix it received:
+
+```ts
+const result = await ctx.agent({
+  key: "private-research-session",
+  target: "research",
+  history: ctx.history,
+  message: task,
+});
+```
+
+`history` applies only when creating a local subagent. It cannot be combined with `agentId` or used
+with a remote agent.
+
 ## Report progress: `yield`
 
 A workflow body may be an async generator. Ordinary yields report progress in both execution

--- a/packages/eve/extension-contracts/compatibility/channel/v19.ts
+++ b/packages/eve/extension-contracts/compatibility/channel/v19.ts
@@ -1,0 +1,10 @@
+import { defineChannel, POST } from "#public/channels/index.js";
+
+export default defineChannel({
+  routes: [
+    POST("/continue/:sessionId", async (_request, { attachSession, params }) => {
+      const result = await attachSession(params.sessionId!).send("Continue.", { auth: null });
+      return Response.json({ accepted: result.status === "accepted" });
+    }),
+  ],
+});

--- a/packages/eve/extension-contracts/compatibility/tool/v35.ts
+++ b/packages/eve/extension-contracts/compatibility/tool/v35.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+import { defineTool, defineWorkflowTool } from "#public/tools/index.js";
+
+export const write = defineTool({
+  description: "Write an approved message.",
+  inputSchema: z.object({ message: z.string() }),
+  outputSchema: z.object({ written: z.string() }),
+  approval: ({ toolInput }) => (toolInput?.message ? "user-approval" : "not-applicable"),
+  label: {
+    start: (input) => `Write ${input.message}`,
+    complete: (_input, output) => `Wrote ${output.written}`,
+  },
+  execute: (input) => ({ written: input.message }),
+  toModelOutput: (output) => ({ type: "text", value: output.written }),
+});
+
+export const workflow = defineWorkflowTool({
+  description: "Run a report workflow.",
+  inputSchema: z.object({ report: z.string() }),
+  async execute(input) {
+    "use workflow";
+    return { report: input.report };
+  },
+});

--- a/packages/eve/extension-contracts/reports/channel/v20.json
+++ b/packages/eve/extension-contracts/reports/channel/v20.json
@@ -1,0 +1,21 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "channel",
+  "epoch": 20,
+  "sha256": "31fd0752d40ceb87625457237b210b399e7a1eaa95caa875d08b468e9a560958",
+  "exports": [
+    "DELETE",
+    "GET",
+    "HEAD",
+    "OPTIONS",
+    "PATCH",
+    "POST",
+    "PUT",
+    "WS",
+    "createWebSocketUpgradeServer",
+    "defineChannel",
+    "disableRoute",
+    "isChannel",
+    "isDisabledRouteSentinel"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/tool/v36.json
+++ b/packages/eve/extension-contracts/reports/tool/v36.json
@@ -1,0 +1,20 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "tool",
+  "epoch": 36,
+  "sha256": "cc08e8006492aa7c220808c567190192c84141ab3492f3286a1c4c4762a242e4",
+  "exports": [
+    "defaultWebSearch",
+    "defineTool",
+    "defineWorkflowTool",
+    "disableTool",
+    "experimental_workflow",
+    "isDisabledToolSentinel",
+    "isExperimentalWorkflowToolDefinition",
+    "isWebSearchToolDefinition",
+    "toolOutput",
+    "toolOutputPart",
+    "toolResultFrom",
+    "webSearch"
+  ]
+}

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -22,8 +22,8 @@ interface ExtensionCapabilityContract {
 const EXTENSION_CAPABILITY_CONTRACTS = {
   extension: { current: 1, supported: [1], dropped: {} },
   tool: {
-    current: 35,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 28, 29, 30, 31, 32, 33, 34, 35],
+    current: 36,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 28, 29, 30, 31, 32, 33, 34, 35, 36],
     dropped: {
       14: "TaskExec.delegated was removed; migrate to workflow-backed background tools",
       15: "TaskExec replaces stageEffect with send",
@@ -56,8 +56,8 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     },
   },
   channel: {
-    current: 19,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19],
+    current: 20,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19, 20],
     dropped: {
       12: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",
     },

--- a/packages/eve/src/execution/create-session-step.test.ts
+++ b/packages/eve/src/execution/create-session-step.test.ts
@@ -19,6 +19,28 @@ const TestTurnAgent: RuntimeTurnAgent = {
 };
 
 describe("createSessionStep", () => {
+  it("preloads history after authored initial messages", async () => {
+    vi.mocked(getCompiledRuntimeAgentBundle).mockResolvedValue({
+      resolvedAgent: { config: {} },
+      turnAgent: {
+        ...TestTurnAgent,
+        initialMessages: [{ content: "Authored context", role: "user" }],
+      },
+    } as never);
+
+    const { state } = await createSessionStep({
+      compiledArtifactsSource: { kind: "bundled" },
+      continuationToken: "subagent:test",
+      history: [{ content: "Parent context", role: "assistant" }],
+      sessionId: "sess-child",
+    });
+
+    expect(state.snapshot?.session.history).toEqual([
+      { content: "Authored context", role: "user" },
+      { content: "Parent context", role: "assistant" },
+    ]);
+  });
+
   it("adds task_update guidance to a task-owned session system prompt", async () => {
     vi.mocked(getCompiledRuntimeAgentBundle).mockResolvedValue({
       resolvedAgent: {

--- a/packages/eve/src/execution/create-session-step.ts
+++ b/packages/eve/src/execution/create-session-step.ts
@@ -10,6 +10,8 @@ import {
 import { createSession } from "#execution/session.js";
 import { resolveInheritedTokenLimit } from "#execution/run-session-limits.js";
 import type { RunSessionLimits } from "#channel/types.js";
+import type { WorkflowHistory } from "#shared/history-message.js";
+import { toModelMessages } from "#execution/tools/workflow/history.js";
 import type { JsonObject } from "#shared/json.js";
 import { resolveEffectiveAgentRuntimeFromConfig } from "#execution/effective-agent-config.js";
 import type { DynamicSubagentAgentConfig } from "#runtime/subagents/dynamic-agent-config.js";
@@ -35,6 +37,7 @@ export async function createSessionStep(input: {
   readonly compiledArtifactsSource: DurableCompiledArtifactsSource;
   readonly continuationToken: string;
   readonly dynamicSubagentAgentConfig?: DynamicSubagentAgentConfig;
+  readonly history?: WorkflowHistory;
   readonly inheritedLimits?: RunSessionLimits;
   readonly outputSchema?: JsonObject;
   readonly nodeId?: string;
@@ -69,6 +72,7 @@ export async function createSessionStep(input: {
       thresholdPercent: effectiveAgent.thresholdPercent,
     },
     continuationToken: input.continuationToken,
+    history: input.history === undefined ? undefined : toModelMessages(input.history),
     limits: {
       // Inherited token limits are the parent's remaining quota share at
       // dispatch time; an authored `false` uncaps only when there is nothing

--- a/packages/eve/src/execution/session.ts
+++ b/packages/eve/src/execution/session.ts
@@ -71,6 +71,7 @@ export interface CreateSessionInput {
   readonly rootSessionId?: string;
   readonly sessionId: string;
   readonly turnAgent: RuntimeTurnAgent;
+  readonly history?: HarnessSession["history"];
   readonly limits?: AuthoredSessionLimits;
   readonly outputSchema?: HarnessSession["outputSchema"];
   readonly systemPromptAdditions?: readonly string[];
@@ -96,7 +97,7 @@ export function createSession(input: CreateSessionInput): HarnessSession {
       thresholdPercent: input.compactionOverrides?.thresholdPercent,
     }),
     continuationToken: input.continuationToken,
-    history: [...(turnAgent.initialMessages ?? [])],
+    history: [...(turnAgent.initialMessages ?? []), ...(input.history ?? [])],
     sessionId: input.sessionId,
   };
 

--- a/packages/eve/src/execution/tools/subagent/invoke-agent.test.ts
+++ b/packages/eve/src/execution/tools/subagent/invoke-agent.test.ts
@@ -44,6 +44,19 @@ describe("workflow helper context errors", () => {
 });
 
 describe("background agent invocation routing", () => {
+  it("rejects combining history with an existing agent id", async () => {
+    await expect(
+      agent({ callId: "call-1" } as ToolContext, {
+        agentId: "agent-1",
+        history: [],
+        key: "research",
+        message: "Continue",
+        target: "research",
+      }),
+    ).rejects.toThrow("cannot combine `agentId` with `history`");
+    expect(mocks.createHook).not.toHaveBeenCalled();
+  });
+
   it("stops waiting when the workflow body is cancelled", async () => {
     const controller = new AbortController();
     mocks.createHook.mockReturnValue({
@@ -124,8 +137,9 @@ describe("background agent invocation routing", () => {
       },
     });
 
+    const history = [{ content: "Prior context", role: "user" as const }];
     await expect(
-      agent(ctx, { key: "research", message: "Find it", target: "research" }),
+      agent(ctx, { history, key: "research", message: "Find it", target: "research" }),
     ).resolves.toBe("available");
 
     expect(mocks.resumeHook).toHaveBeenCalledWith("owner-inbox", {
@@ -133,7 +147,7 @@ describe("background agent invocation routing", () => {
       from,
       replyTo: "agent-reply",
       request: {
-        input: { message: "Find it", target: "research" },
+        input: { history, message: "Find it", target: "research" },
         invocationId: "call-1:research",
         kind: "agent-invoke",
       },

--- a/packages/eve/src/execution/tools/subagent/invoke-agent.ts
+++ b/packages/eve/src/execution/tools/subagent/invoke-agent.ts
@@ -14,6 +14,7 @@ import { resumeHookStep } from "#execution/tools/workflow/resume-hook-step.js";
 import type { RuntimeSubagentChildResult, RuntimeSubagentResult } from "#shared/action-types.js";
 import type { JsonValue } from "#shared/json.js";
 import type { JsonObject } from "#shared/json.js";
+import type { WorkflowHistory } from "#shared/history-message.js";
 import { disposeHook } from "#execution/hook-ownership.js";
 import { sessionCommandHookToken } from "#execution/session-command-token.js";
 import type { AgentInput } from "#tools/workflow-definition.js";
@@ -22,6 +23,7 @@ import type { TaskInboundUpdate } from "#tasks/types.js";
 
 export type InternalAgentInput = {
   readonly agentId?: string;
+  readonly history?: WorkflowHistory;
   readonly message: string;
   readonly outputSchema?: JsonObject;
   readonly target: string;
@@ -66,6 +68,7 @@ export async function agent(ctx: ToolContext, input: AgentInput): Promise<JsonVa
     ctx,
     {
       agentId: input.agentId,
+      history: input.history,
       message: input.message,
       outputSchema: input.outputSchema,
       target: input.target,
@@ -206,6 +209,9 @@ export function validateAgentInput(
     (typeof (input as AgentInput).key !== "string" || (input as AgentInput).key.trim() === "")
   ) {
     throw new TypeError("agent() requires a non-empty `key`.");
+  }
+  if (input.agentId !== undefined && input.history !== undefined) {
+    throw new TypeError("agent() cannot combine `agentId` with `history`.");
   }
   if (typeof input.target !== "string" || input.target.trim() === "") {
     throw new TypeError("agent() requires a non-empty `target`.");

--- a/packages/eve/src/execution/tools/subagent/invoke-preparation.test.ts
+++ b/packages/eve/src/execution/tools/subagent/invoke-preparation.test.ts
@@ -58,6 +58,51 @@ describe("planAgentDispatch", () => {
     ).toMatchObject({ kind: "reject", result: { output: { code: "SUBAGENT_UNAVAILABLE" } } });
   });
 
+  it("preloads history only on a fresh local start", () => {
+    const history = [{ content: "Prior context", role: "user" as const }];
+    expect(
+      planAgentDispatch({
+        action: localAction,
+        bundle: {
+          subagentRegistry: {
+            subagentsByNodeId: new Map([
+              [localAction.nodeId, { definition: { description: "Research", kind: "subagent" } }],
+            ]),
+          },
+          turnAgent: {},
+        } as never,
+        ctx: {} as never,
+        history,
+        session: session() as never,
+      }),
+    ).toMatchObject({ kind: "start", target: { history, kind: "local" } });
+  });
+
+  it("rejects history when continuing an existing agent", () => {
+    expect(() =>
+      planAgentDispatch({
+        action: { ...localAction, input: { agentId: "agent-1", message: "Find it" } },
+        bundle: { subagentRegistry: { subagentsByNodeId: new Map() }, turnAgent: {} } as never,
+        ctx: {} as never,
+        history: [{ content: "Prior context", role: "user" }],
+        knownAgentIds: ["agent-1"],
+        session: session() as never,
+      }),
+    ).toThrow("history can preload only a newly created local subagent");
+  });
+
+  it("rejects history for a remote agent", () => {
+    expect(() =>
+      planAgentDispatch({
+        action: { ...localAction, kind: "remote-agent-call", remoteAgentName: "research" },
+        bundle: { subagentRegistry: { subagentsByNodeId: new Map() }, turnAgent: {} } as never,
+        ctx: {} as never,
+        history: [{ content: "Prior context", role: "user" }],
+        session: session() as never,
+      }),
+    ).toThrow("history can preload only a new local subagent");
+  });
+
   it("falls back to a fresh start for an unknown agentId", () => {
     expect(
       planAgentDispatch({

--- a/packages/eve/src/execution/tools/subagent/invoke-preparation.ts
+++ b/packages/eve/src/execution/tools/subagent/invoke-preparation.ts
@@ -80,6 +80,7 @@ export async function prepareOwnerAgentInvocation(input: {
         action,
         bundle,
         ctx: planContext,
+        history: input.invocation.history,
         knownAgentIds: input.knownAgentIds,
         session,
       }),
@@ -93,6 +94,7 @@ export function planAgentDispatch(input: {
   readonly action: RuntimeAgentDispatchRequest;
   readonly bundle: CompiledBundle;
   readonly ctx: ContextReader;
+  readonly history?: AgentInvocationRequest["input"]["history"];
   readonly knownAgentIds?: readonly string[];
   readonly session: RuntimeSession;
 }): OwnerAgentDispatchPlanEntry {
@@ -105,6 +107,9 @@ export function planAgentDispatch(input: {
     typeof rawAgentId === "string" && rawAgentId.trim() !== "" ? rawAgentId : undefined;
   if (agentId !== undefined && isAgentHandleAction(input.action)) {
     if (knownAgentIds.has(agentId)) {
+      if (input.history !== undefined) {
+        throw new TypeError("agent() history can preload only a newly created local subagent.");
+      }
       const dynamicSubagentSelection =
         input.bundle.subagentRegistry.dynamicNodeIds?.has(input.action.nodeId) === true
           ? getDynamicSubagentSelection(input.ctx, input.action.nodeId)
@@ -128,6 +133,7 @@ export function planAgentDispatch(input: {
 }
 
 function classifyFreshStart(input: {
+  readonly history?: AgentInvocationRequest["input"]["history"];
   readonly action: RuntimeAgentDispatchRequest;
   readonly bundle: CompiledBundle;
   readonly ctx: ContextReader;
@@ -163,6 +169,9 @@ function classifyFreshStart(input: {
     return { kind: "reject", result: createRecursiveAgentRootOnlyResult(action) };
   }
   if (action.kind === "remote-agent-call") {
+    if (input.history !== undefined) {
+      throw new TypeError("agent() history can preload only a new local subagent.");
+    }
     return {
       kind: "start",
       target: {
@@ -195,7 +204,13 @@ function classifyFreshStart(input: {
         };
   return {
     kind: "start",
-    target: { action, dynamicSubagentAgentConfig: dynamicAgentConfig, kind: "local", source },
+    target: {
+      action,
+      dynamicSubagentAgentConfig: dynamicAgentConfig,
+      history: input.history,
+      kind: "local",
+      source,
+    },
   };
 }
 

--- a/packages/eve/src/execution/tools/subagent/start.ts
+++ b/packages/eve/src/execution/tools/subagent/start.ts
@@ -3,6 +3,7 @@ import type { LocalDevRequestProvenance } from "#context/keys.js";
 import type { ActivityWorkIdentityV1 } from "#protocol/activity.js";
 import type { DynamicSubagentAgentConfig } from "#runtime/subagents/dynamic-agent-config.js";
 import type { DynamicRemoteAgentConfig } from "#runtime/subagents/dynamic-remote-agent-config.js";
+import type { WorkflowHistory } from "#shared/history-message.js";
 import type { CompiledBundle } from "#runtime/sessions/runtime-context-keys.js";
 import type {
   RuntimeRemoteAgentDispatchRequest,
@@ -24,6 +25,7 @@ export type SubagentStartTarget =
       readonly kind: "local";
       readonly action: RuntimeSubagentDispatchRequest;
       readonly dynamicSubagentAgentConfig?: DynamicSubagentAgentConfig;
+      readonly history?: WorkflowHistory;
       readonly source: SubagentInputSource;
     }
   | {
@@ -90,6 +92,7 @@ export async function startSubagent(input: {
         currentSession: input.currentSession,
         dynamicSubagentAgentConfig: input.target.dynamicSubagentAgentConfig,
         fanoutSize: input.fanoutSize,
+        history: input.target.history,
         initiatorAuth: input.initiatorAuth,
         localDevRequest: input.localDevRequest,
         parentContinuationToken: input.parentContinuationToken,

--- a/packages/eve/src/execution/wire/session-inbox-contract.ts
+++ b/packages/eve/src/execution/wire/session-inbox-contract.ts
@@ -1,5 +1,5 @@
 /** Every explicit session-inbox wire version still supported by producers. */
-export const SESSION_INBOX_WIRE_VERSIONS = [1, 2, 3, 4, 5, 6] as const;
+export const SESSION_INBOX_WIRE_VERSIONS = [1, 2, 3, 4, 5, 6, 7] as const;
 
 export type SessionInboxWireVersion = (typeof SESSION_INBOX_WIRE_VERSIONS)[number];
 

--- a/packages/eve/src/execution/wire/session-inbox-encoder.ts
+++ b/packages/eve/src/execution/wire/session-inbox-encoder.ts
@@ -34,11 +34,15 @@ import {
   encodeSessionCommandV6,
   type SessionInboxWireV6,
 } from "#execution/wire/session-inbox-wire.v6.js";
+import {
+  encodeSessionCommandV7,
+  type SessionInboxWireV7,
+} from "#execution/wire/session-inbox-wire.v7.js";
 
 type SessionInboxCommand = DeliverHookPayload | SessionCommand | SessionTimeoutHookPayload;
 
 /** Current wire type consumed after migration. */
-export type SessionInboxWire = SessionInboxWireV6;
+export type SessionInboxWire = SessionInboxWireV7;
 
 type LegacySessionInboxWireTarget = Extract<SessionInboxWireTarget, { readonly version: 0 }>;
 type VersionedSessionInboxEncoder = (command: SessionInboxCommand) => unknown;
@@ -55,6 +59,7 @@ const versionedEncoders = {
   5: (command: SessionInboxCommand) =>
     encodeSessionCommandV5(withoutOwnedTaskCancellation(command)),
   6: encodeSessionCommandV6,
+  7: encodeSessionCommandV7,
 } satisfies Record<SessionInboxWireVersion, VersionedSessionInboxEncoder>;
 
 /** Encodes a command for the selected session-inbox consumer. */
@@ -64,6 +69,7 @@ function encode(command: SessionInboxCommand, target: { readonly version: 3 }): 
 function encode(command: SessionInboxCommand, target: { readonly version: 4 }): SessionInboxWireV4;
 function encode(command: SessionInboxCommand, target: { readonly version: 5 }): SessionInboxWireV5;
 function encode(command: SessionInboxCommand, target: { readonly version: 6 }): SessionInboxWireV6;
+function encode(command: SessionInboxCommand, target: { readonly version: 7 }): SessionInboxWireV7;
 function encode(
   command: SessionInboxCommand,
   target: { readonly version: SessionInboxWireVersion },
@@ -82,6 +88,7 @@ function encode(
   | SessionInboxWireV4
   | SessionInboxWireV5
   | SessionInboxWireV6
+  | SessionInboxWireV7
   | Record<string, unknown>;
 function encode(
   command: SessionInboxCommand,
@@ -93,7 +100,13 @@ function encode(
   | SessionInboxWireV4
   | SessionInboxWireV5
   | SessionInboxWireV6
+  | SessionInboxWireV7
   | Record<string, unknown> {
+  if (containsPreloadedAgentHistory(command) && target.version < 7) {
+    throw new SessionInboxWireError(
+      `Cannot encode preloaded workflow subagent history for wire version ${target.version}.`,
+    );
+  }
   if (command.kind === "cancel" && command.tasks === true && target.version < 6) {
     throw new SessionInboxWireError(
       `Cannot encode session-owned task cancellation for wire version ${target.version}.`,
@@ -139,10 +152,22 @@ function encode(
       | SessionInboxWireV3
       | SessionInboxWireV4
       | SessionInboxWireV5
-      | SessionInboxWireV6;
+      | SessionInboxWireV6
+      | SessionInboxWireV7;
   }
   throw new SessionInboxWireError(
     `Cannot encode session inbox payload for unknown wire version ${JSON.stringify((target as { version?: unknown }).version)}.`,
+  );
+}
+
+function containsPreloadedAgentHistory(command: SessionInboxCommand): boolean {
+  if (command.kind !== "send" && command.kind !== "deliver") return false;
+  const payloads = command.kind === "send" ? [command.payload] : command.payloads;
+  return payloads.some((payload) =>
+    (payload.task?.agentRequests ?? []).some(
+      (delivery) =>
+        delivery.request.kind === "agent-invoke" && delivery.request.input.history !== undefined,
+    ),
   );
 }
 

--- a/packages/eve/src/execution/wire/session-inbox-wire.ts
+++ b/packages/eve/src/execution/wire/session-inbox-wire.ts
@@ -53,6 +53,15 @@ const sessionInboxWireV5Migration: VersionMigration = {
   to: 6,
 };
 
+const sessionInboxWireV6Migration: VersionMigration = {
+  from: 6,
+  migrate(prior) {
+    if (!isObject(prior)) throw new Error("session inbox wire v6 value is not an object.");
+    return { ...prior, version: 7 };
+  },
+  to: 7,
+};
+
 const sessionInboxMigrations: readonly VersionMigration[] = [
   sessionInboxWireV0Migration,
   sessionInboxWireV1Migration,
@@ -60,6 +69,7 @@ const sessionInboxMigrations: readonly VersionMigration[] = [
   sessionInboxWireV3Migration,
   sessionInboxWireV4Migration,
   sessionInboxWireV5Migration,
+  sessionInboxWireV6Migration,
 ];
 
 /**

--- a/packages/eve/src/execution/wire/session-inbox-wire.v7.test.ts
+++ b/packages/eve/src/execution/wire/session-inbox-wire.v7.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { sessionInboxWire } from "#execution/wire/session-inbox-encoder.js";
+import { SessionInboxWireError } from "#execution/wire/session-inbox-contract.js";
+import { sessionInboxWire as decoder } from "#execution/wire/session-inbox-wire.js";
+
+const command = {
+  kind: "send" as const,
+  payload: {
+    task: {
+      agentRequests: [
+        {
+          replyTo: "agent-reply",
+          request: {
+            input: {
+              history: [{ content: "Prior context", role: "user" as const }],
+              message: "Continue researching.",
+              target: "research",
+            },
+            invocationId: "call-1:research",
+            kind: "agent-invoke" as const,
+          },
+          taskId: "task-1",
+        },
+      ],
+    },
+  },
+  turnPolicy: "queue" as const,
+};
+
+describe("session inbox wire v7", () => {
+  it("round-trips preloaded workflow subagent history", () => {
+    const wire = sessionInboxWire.encode(command, { version: 7 });
+    expect(decoder.decode(wire)).toMatchObject({
+      kind: "deliver",
+      payloads: [command.payload],
+    });
+  });
+
+  it.each([0, 1, 2, 3, 4, 5, 6] as const)("fails closed for old target v%i", (version) => {
+    const target = version === 0 ? ({ variant: "send", version } as const) : ({ version } as const);
+    expect(() => sessionInboxWire.encode(command, target)).toThrowError(SessionInboxWireError);
+  });
+});

--- a/packages/eve/src/execution/wire/session-inbox-wire.v7.ts
+++ b/packages/eve/src/execution/wire/session-inbox-wire.v7.ts
@@ -1,0 +1,162 @@
+import { z } from "#compiled/zod/index.js";
+
+import type {
+  DeliverHookPayload,
+  DeliverPayload,
+  SessionCommand,
+  SessionTimeoutHookPayload,
+} from "#channel/types.js";
+import { SessionInboxWireError } from "#execution/wire/session-inbox-contract.js";
+import {
+  encodeSessionCommandV6,
+  sessionInboxWireV6Schema,
+} from "#execution/wire/session-inbox-wire.v6.js";
+import { formatValidationError } from "#runtime/validation.js";
+
+const VERSION = 7;
+const version = z.literal(VERSION);
+const v6 = sessionInboxWireV6Schema.options;
+const deliverPayloadV6Schema = v6[0].shape.payload;
+const taskPayloadV6Schema = deliverPayloadV6Schema.shape.task.unwrap();
+const taskAgentRequestV6Schema = taskPayloadV6Schema.shape.agentRequests.unwrap().element;
+const agentRequestV6Schemas = taskAgentRequestV6Schema.shape.request.options;
+const agentInvocationV6Schema = agentRequestV6Schemas[0];
+const agentInvocationInputV7Schema = agentInvocationV6Schema.shape.input.extend({
+  history: z.array(z.unknown()).optional(),
+});
+const taskAgentRequestV7Schema = taskAgentRequestV6Schema.extend({
+  request: z.discriminatedUnion("kind", [
+    agentInvocationV6Schema.extend({ input: agentInvocationInputV7Schema }),
+    agentRequestV6Schemas[1],
+  ]),
+});
+const taskPayloadV7Schema = taskPayloadV6Schema.extend({
+  agentRequests: z.array(taskAgentRequestV7Schema).optional(),
+});
+const deliverPayloadV7Schema = deliverPayloadV6Schema.extend({
+  task: taskPayloadV7Schema.optional(),
+});
+
+/** Version 7 allows workflow-owned subagent invocations to preload history. */
+export const sessionInboxWireV7Schema = z.discriminatedUnion("kind", [
+  v6[0].extend({
+    payload: deliverPayloadV7Schema,
+    payloads: z.array(deliverPayloadV7Schema),
+    version,
+  }),
+  v6[1].extend({ version }),
+  v6[2].extend({ version }),
+  v6[3].extend({ version }),
+  v6[4].extend({ version }),
+  v6[5].extend({ version }),
+]);
+
+export type SessionInboxWireV7 = z.infer<typeof sessionInboxWireV7Schema>;
+
+export function encodeSessionCommandV7(
+  command: DeliverHookPayload | SessionCommand | SessionTimeoutHookPayload,
+): SessionInboxWireV7 {
+  const histories = readInvocationHistories(command);
+  const value = restoreInvocationHistories(
+    { ...encodeSessionCommandV6(withoutInvocationHistories(command)), version: VERSION },
+    histories,
+  );
+  const parsed = sessionInboxWireV7Schema.safeParse(value);
+  if (!parsed.success) {
+    throw new SessionInboxWireError(
+      `Produced a session inbox payload that does not match wire version ${VERSION}: ${formatValidationError(parsed.error)}`,
+    );
+  }
+  return parsed.data;
+}
+
+function readInvocationHistories(
+  command: DeliverHookPayload | SessionCommand | SessionTimeoutHookPayload,
+): ReadonlyMap<string, unknown> {
+  const histories = new Map<string, unknown>();
+  if (command.kind !== "send" && command.kind !== "deliver") return histories;
+  const payloads = command.kind === "send" ? [command.payload] : command.payloads;
+  for (const payload of payloads) {
+    for (const delivery of payload.task?.agentRequests ?? []) {
+      if (
+        delivery.request.kind === "agent-invoke" &&
+        delivery.request.input.history !== undefined
+      ) {
+        histories.set(delivery.request.invocationId, delivery.request.input.history);
+      }
+    }
+  }
+  return histories;
+}
+
+function withoutInvocationHistories(
+  command: DeliverHookPayload | SessionCommand | SessionTimeoutHookPayload,
+): DeliverHookPayload | SessionCommand | SessionTimeoutHookPayload {
+  if (command.kind !== "send" && command.kind !== "deliver") return command;
+  const stripPayload = (payload: DeliverPayload): DeliverPayload => ({
+    ...payload,
+    task:
+      payload.task === undefined
+        ? undefined
+        : {
+            ...payload.task,
+            agentRequests: payload.task.agentRequests?.map((delivery) => {
+              if (delivery.request.kind !== "agent-invoke") return delivery;
+              const { history: _history, ...input } = delivery.request.input;
+              return { ...delivery, request: { ...delivery.request, input } };
+            }),
+          },
+  });
+  return command.kind === "send"
+    ? { ...command, payload: stripPayload(command.payload) }
+    : { ...command, payloads: command.payloads.map(stripPayload) };
+}
+
+function restoreInvocationHistories(
+  value: unknown,
+  histories: ReadonlyMap<string, unknown>,
+): unknown {
+  if (histories.size === 0 || value === null || typeof value !== "object") return value;
+  const wire = value as Record<string, unknown>;
+  const restorePayload = (candidate: unknown): unknown => {
+    if (candidate === null || typeof candidate !== "object") return candidate;
+    const payload = candidate as Record<string, unknown>;
+    const task = payload.task;
+    if (task === null || typeof task !== "object") return payload;
+    const agentRequests = (task as Record<string, unknown>).agentRequests;
+    if (!Array.isArray(agentRequests)) return payload;
+    return {
+      ...payload,
+      task: {
+        ...(task as Record<string, unknown>),
+        agentRequests: agentRequests.map((candidate) => {
+          if (candidate === null || typeof candidate !== "object") return candidate;
+          const delivery = candidate as Record<string, unknown>;
+          const request = delivery.request;
+          if (request === null || typeof request !== "object") return delivery;
+          const requestRecord = request as Record<string, unknown>;
+          const history = histories.get(String(requestRecord.invocationId));
+          if (
+            history === undefined ||
+            requestRecord.input === null ||
+            typeof requestRecord.input !== "object"
+          ) {
+            return delivery;
+          }
+          return {
+            ...delivery,
+            request: {
+              ...requestRecord,
+              input: { ...(requestRecord.input as Record<string, unknown>), history },
+            },
+          };
+        }),
+      },
+    };
+  };
+  return {
+    ...wire,
+    payload: restorePayload(wire.payload),
+    payloads: Array.isArray(wire.payloads) ? wire.payloads.map(restorePayload) : wire.payloads,
+  };
+}

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -65,6 +65,7 @@ const SAFE_OUTER_WORKFLOW_FAILURE_MESSAGE =
 export interface WorkflowEntryInput {
   readonly activityCollectorRunId?: string;
   readonly continuationConflictCommand?: Extract<SessionCommand, { readonly kind: "send" }>;
+  readonly history?: Parameters<typeof createSessionStep>[0]["history"];
   readonly input: RunInput["input"];
   readonly limits?: RunInput["limits"];
   readonly sessionTimeoutMs?: number | false;
@@ -199,6 +200,7 @@ export async function workflowEntry(input: WorkflowEntryInput): Promise<Workflow
             compiledArtifactsSource: serializedBundle.source,
             continuationToken,
             dynamicSubagentAgentConfig,
+            history: input.history,
             inheritedLimits: input.limits,
             nodeId: serializedBundle.nodeId,
             outputSchema: input.input.outputSchema,

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -67,6 +67,7 @@ import { isAgentTraceContext } from "#tracing/agent-trace-context.js";
 import { sessionCommandHookToken } from "#execution/session-command-token.js";
 import { resumeSessionInbox } from "#execution/wire/session-inbox-resume.js";
 import type { DynamicSubagentAgentConfig } from "#runtime/subagents/dynamic-agent-config.js";
+import { isSubagentAdapterState } from "#subagents/adapter-state.js";
 import { initializeSessionInstrumentation } from "#instrumentation/runtime.js";
 import {
   ACTIVITY_COLLECTOR_WORKFLOW_NAME,
@@ -206,6 +207,14 @@ export function createWorkflowRuntime(config: {
         limits: input.limits,
         serializedContext,
       };
+      if (
+        isSubagentAdapterState(input.adapter.state) &&
+        input.adapter.state.history !== undefined
+      ) {
+        workflowInput.history = input.adapter.state.history as NonNullable<
+          WorkflowEntryInput["history"]
+        >;
+      }
       const taskId = input.taskId ?? input.callback?.taskId;
       if (taskId !== undefined) workflowInput.taskId = taskId;
       if (collectorRunId !== undefined) {

--- a/packages/eve/src/subagents/adapter-state.ts
+++ b/packages/eve/src/subagents/adapter-state.ts
@@ -27,6 +27,8 @@ export const SUBAGENT_ADAPTER_KIND = "subagent";
  */
 export interface SubagentAdapterState extends Record<string, unknown> {
   readonly callId: string;
+  /** Internal conversation prefix used while creating this child session. */
+  readonly history?: import("#shared/history-message.js").WorkflowHistory;
   readonly parentContinuationToken: string;
   readonly parentSessionId: string;
   readonly subagentName: string;

--- a/packages/eve/src/subagents/start-local.ts
+++ b/packages/eve/src/subagents/start-local.ts
@@ -26,6 +26,7 @@ export async function startLocalSubagent(input: {
   readonly currentSession: RuntimeSession;
   readonly dynamicSubagentAgentConfig?: DynamicSubagentAgentConfig;
   readonly fanoutSize: number;
+  readonly history?: Parameters<typeof buildSubagentRunInput>[0]["history"];
   readonly initiatorAuth: Parameters<typeof buildSubagentRunInput>[0]["initiatorAuth"];
   readonly localDevRequest?: LocalDevRequestProvenance;
   readonly parentContinuationToken: string | undefined;
@@ -51,6 +52,7 @@ export async function startLocalSubagent(input: {
     fanoutSize: input.fanoutSize,
     initiatorAuth: input.initiatorAuth,
     graph: input.bundle.graph,
+    history: input.history,
     parentContinuationToken: input.parentContinuationToken,
     parentTraceContext: input.parentTraceContext,
     activityObserver: input.activityObserver,

--- a/packages/eve/src/subagents/tool.ts
+++ b/packages/eve/src/subagents/tool.ts
@@ -14,6 +14,7 @@ import type { RuntimeSubagentDispatchRequest } from "#shared/action-types.js";
 import { mintSubagentContinuationToken } from "#execution/session.js";
 import { resolveRemainingSessionTokenLimits } from "#subagents/token-budget.js";
 import type { JsonObject } from "#shared/json.js";
+import type { WorkflowHistory } from "#shared/history-message.js";
 
 /**
  * Pending task batch event metadata needed for child run lineage.
@@ -90,6 +91,8 @@ export function buildSubagentRunInput(input: {
    * dispatching parent's sandbox. Absence means no inheritance.
    */
   readonly graph?: SubagentSandboxGraph;
+  /** Conversation prefix used only when creating this child session. */
+  readonly history?: WorkflowHistory;
   /** Durable session identity of the sandbox currently used by the parent. */
   readonly sandboxSessionId?: string;
   readonly selfAgent: boolean;
@@ -135,6 +138,7 @@ export function buildSubagentRunInput(input: {
     parentSessionId: session.sessionId,
     subagentName: action.subagentName,
   };
+  if (input.history !== undefined) adapterState.history = input.history;
   if (input.taskId !== undefined) adapterState.taskId = input.taskId;
   const sharesSandbox =
     input.graph?.nodesByNodeId.get(action.nodeId)?.sandboxRegistry.sandbox?.definition

--- a/packages/eve/src/tools/workflow-definition.ts
+++ b/packages/eve/src/tools/workflow-definition.ts
@@ -18,6 +18,8 @@ import type { WorkflowHistory } from "#shared/history-message.js";
 
 export interface AgentInput {
   readonly agentId?: string;
+  /** Conversation history used to preload a newly created local subagent. */
+  readonly history?: WorkflowHistory;
   readonly key: string;
   readonly message: string;
   readonly outputSchema?: JsonObject;


### PR DESCRIPTION
### Summary

Allows a workflow tool to seed a new local subagent with conversation history before its first message. This keeps the API narrow to workflow-owned delegation rather than exposing general session creation or history mutation.

```ts
const result = await ctx.agent({
  key: "private-research-session",
  target: "research",
  history: ctx.history,
  message: task,
});
```

`history` cannot be combined with `agentId` or used with a remote agent. Depends on #3184.

### Validation

Adds unit coverage for fresh local preloading, existing and remote agent rejection, child session history ordering, and durable inbox wire round-tripping with older-version rejection.

🤖
