### PR TITLE
[3/3] feat(eve): create sessions before their first turn

### DIFF
--- a/.changeset/idle-session-creation.md
+++ b/.changeset/idle-session-creation.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add `from(address).create()` for application code that needs to reserve a channel address before sending its first message. An idle session has normal identity and channel configuration, but does not start a model turn until its fixed session handle sends a message.

--- a/docs/channels/custom.mdx
+++ b/docs/channels/custom.mdx
@@ -151,6 +151,25 @@ Attaching does no lookup. The first operation reports whether the ID is active.
 Call `resolveSession(address)` only when you explicitly need to snapshot an
 address's current owner as a fixed handle.
 
+Use `from(address).create({ auth, ... })` when application code needs to reserve
+an address and initialize a session before its first model turn. The returned
+fixed `Session` starts normal execution only when its `send()` method is called;
+idle creation itself does not emit model, tool, or channel events. `create()`
+waits until the session owns the address, so an immediate fixed-handle operation
+is safe. `create()` is get-or-create: concurrent calls converge on the address
+winner, and an existing owner's auth, state, title, and other configuration are
+not replaced by later options. Use an operation-specific address for private work:
+
+```ts
+const research = await from("private-research:op_123").create({ auth });
+await registerResearchExecution(research.id);
+await research.appendHistory({
+  operationId: "op_123:initial",
+  messages: priorHistory,
+});
+await research.send("Research the approved question.", { auth });
+```
+
 ## Operation semantics
 
 - `cancel` cooperatively stops the active turn. Confirm it with `turn.cancelled`

--- a/packages/eve/extension-contracts/compatibility/channel/v20.ts
+++ b/packages/eve/extension-contracts/compatibility/channel/v20.ts
@@ -1,0 +1,10 @@
+import { defineChannel, POST } from "#public/channels/index.js";
+
+export default defineChannel({
+  routes: [
+    POST("/continue/:sessionId", async (_request, { attachSession, params }) => {
+      const result = await attachSession(params.sessionId!).send("Continue.", { auth: null });
+      return Response.json({ accepted: result.status === "accepted" });
+    }),
+  ],
+});

--- a/packages/eve/extension-contracts/reports/channel/v21.json
+++ b/packages/eve/extension-contracts/reports/channel/v21.json
@@ -1,0 +1,21 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "channel",
+  "epoch": 21,
+  "sha256": "355f42c0be1dc4f4f5b3059760d3c824a85f40aac75fcc53b7d3f2c7fd6a0826",
+  "exports": [
+    "DELETE",
+    "GET",
+    "HEAD",
+    "OPTIONS",
+    "PATCH",
+    "POST",
+    "PUT",
+    "WS",
+    "createWebSocketUpgradeServer",
+    "defineChannel",
+    "disableRoute",
+    "isChannel",
+    "isDisabledRouteSentinel"
+  ]
+}

--- a/packages/eve/src/channel/channel-address.test.ts
+++ b/packages/eve/src/channel/channel-address.test.ts
@@ -11,10 +11,11 @@ function createRuntime(): Runtime {
   return {
     createSession: vi.fn(),
     dispatchContinuation: vi.fn().mockResolvedValue({ sessionId: "sess_1", status: "accepted" }),
-    dispatchSession: vi.fn(),
+    dispatchSession: vi.fn().mockResolvedValue({ sessionId: "sess_idle", status: "accepted" }),
     getEventStream: vi.fn(),
     getStreamTailIndex: vi.fn(),
     resolveContinuation: vi.fn(),
+    waitForSessionReady: vi.fn().mockResolvedValue({ sessionId: "sess_idle" }),
   };
 }
 
@@ -28,6 +29,82 @@ describe("createChannelAddress", () => {
         runtime: createRuntime(),
       }),
     ).toThrow("reserved session namespace");
+  });
+
+  it("creates an idle session without a model delivery", async () => {
+    const runtime = createRuntime();
+    vi.mocked(runtime.createSession).mockResolvedValue({
+      events: new ReadableStream(),
+      sessionId: "sess_idle",
+    });
+    const address = createChannelAddress({
+      adapter: { kind: "slack" },
+      channelName: "slack",
+      continuationToken: "C1:T1",
+      runtime,
+    });
+
+    const session = await address.create({ auth: null, title: "Private research" });
+
+    expect(session.id).toBe("sess_idle");
+    expect(runtime.dispatchContinuation).not.toHaveBeenCalled();
+    expect(runtime.waitForSessionReady).toHaveBeenCalledWith("slack:C1:T1");
+    await expect(session.send("Research this", { auth: null })).resolves.toEqual({
+      sessionId: "sess_idle",
+      status: "accepted",
+    });
+    expect(runtime.dispatchSession).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: "sess_idle" }),
+    );
+    expect(runtime.createSession).toHaveBeenCalledWith({
+      adapter: { kind: "slack" },
+      auth: null,
+      capabilities: { requestInput: true },
+      channelName: "slack",
+      continuationToken: "slack:C1:T1",
+      initiatorAuth: undefined,
+      input: { message: "" },
+      mode: "conversation",
+      start: "idle",
+      title: "Private research",
+    });
+  });
+
+  it("returns the authoritative owner when the address is already owned", async () => {
+    const runtime = createRuntime();
+    vi.mocked(runtime.resolveContinuation).mockResolvedValue({ sessionId: "sess_existing" });
+    const address = createChannelAddress({
+      adapter: { kind: "slack" },
+      channelName: "slack",
+      continuationToken: "C1:T1",
+      runtime,
+    });
+
+    await expect(address.create({ auth: null })).resolves.toMatchObject({ id: "sess_existing" });
+    expect(runtime.createSession).not.toHaveBeenCalled();
+  });
+
+  it("converges concurrent idle creation on the authoritative address owner", async () => {
+    const runtime = createRuntime();
+    vi.mocked(runtime.resolveContinuation).mockResolvedValue(undefined);
+    vi.mocked(runtime.createSession)
+      .mockResolvedValueOnce({ events: new ReadableStream(), sessionId: "candidate-1" })
+      .mockResolvedValueOnce({ events: new ReadableStream(), sessionId: "candidate-2" });
+    vi.mocked(runtime.waitForSessionReady!).mockResolvedValue({ sessionId: "winner" });
+    const address = createChannelAddress({
+      adapter: { kind: "slack" },
+      channelName: "slack",
+      continuationToken: "C1:T1",
+      runtime,
+    });
+
+    const [first, second] = await Promise.all([
+      address.create({ auth: null }),
+      address.create({ auth: null }),
+    ]);
+
+    expect(first.id).toBe("winner");
+    expect(second.id).toBe("winner");
   });
 
   it("sends directly through the address and returns a fixed session handle", async () => {

--- a/packages/eve/src/channel/channel-address.ts
+++ b/packages/eve/src/channel/channel-address.ts
@@ -39,12 +39,21 @@ export type ChannelAddressDeliveryOptions<TState = undefined> = [TState] extends
   ? BaseChannelAddressDeliveryOptions
   : BaseChannelAddressDeliveryOptions & { readonly state?: Partial<TState> };
 
+/** Options for creating an idle channel session before its first message. */
+export type ChannelCreateOptions<TState = undefined> = [TState] extends [undefined]
+  ? Pick<BaseChannelAddressDeliveryOptions, "auth" | "initiatorAuth" | "mode" | "title">
+  : Pick<BaseChannelAddressDeliveryOptions, "auth" | "initiatorAuth" | "mode" | "title"> & {
+      readonly state?: Partial<TState>;
+    };
+
 /**
  * Dynamic handle for whichever durable session currently owns one channel-local address.
  * Only {@link send} may create a session when the address is unowned.
  */
 export interface ChannelAddress<TState = undefined> {
   readonly continuationToken: string;
+  /** Creates an idle session at this address. Its first fixed-handle send starts execution. */
+  create(options: ChannelCreateOptions<TState>): Promise<Session>;
   deliver(input: SendPayload, options: ChannelAddressDeliveryOptions<TState>): Promise<Session>;
   send(
     message: string | UserContent,
@@ -83,6 +92,44 @@ export function createChannelAddress<TState = undefined>(input: {
 
   return {
     continuationToken: input.continuationToken,
+    async create(options) {
+      const existing = await input.runtime.resolveContinuation(namespacedToken);
+      if (existing !== undefined) {
+        return createSession(existing.sessionId, input.runtime, {
+          ...metadata,
+          turnPolicy: input.turnPolicy,
+        });
+      }
+      const state = (options as { readonly state?: TState }).state;
+      const adapter =
+        state === undefined
+          ? input.adapter
+          : {
+              ...input.adapter,
+              state: { ...input.adapter.state, ...(state as Record<string, unknown>) },
+            };
+      if (adapter !== input.adapter) copyChannelActivityPresentation(input.adapter, adapter);
+      await input.runtime.createSession({
+        adapter,
+        auth: options.auth,
+        capabilities: options.mode === "task" ? undefined : { requestInput: true },
+        channelName: input.channelName,
+        continuationToken: namespacedToken,
+        initiatorAuth: options.initiatorAuth,
+        input: { message: "" },
+        mode: options.mode ?? "conversation",
+        start: "idle",
+        title: options.title,
+      });
+      if (input.runtime.waitForSessionReady === undefined) {
+        throw new Error("This eve runtime does not support idle session readiness.");
+      }
+      const owner = await input.runtime.waitForSessionReady(namespacedToken);
+      return createSession(owner.sessionId, input.runtime, {
+        ...metadata,
+        turnPolicy: input.turnPolicy,
+      });
+    },
     async deliver(sendInput, options) {
       const delivery =
         metadata.channelKind !== undefined && metadata.channelName !== undefined

--- a/packages/eve/src/channel/channel-operations.ts
+++ b/packages/eve/src/channel/channel-operations.ts
@@ -5,6 +5,7 @@ import type { ChannelDeliverySource } from "#channel/delivery-metadata.js";
 import {
   createChannelAddressFn,
   type ChannelAddressDeliveryOptions,
+  type ChannelCreateOptions,
 } from "#channel/channel-address.js";
 import type { SendPayload } from "#channel/routes.js";
 import type { Session } from "#channel/session.js";
@@ -25,6 +26,8 @@ import {
 } from "#shared/input.js";
 import type { JsonObject } from "#shared/json.js";
 import type { RunMode } from "#shared/run-mode.js";
+
+export type { ChannelCreateOptions } from "#channel/channel-address.js";
 
 interface BaseChannelSendOptions {
   readonly auth: SessionAuthContext | null;
@@ -54,6 +57,8 @@ export type ChannelRespondOptions<TState = undefined> = BaseChannelRespondOption
 
 /** Dynamic handle for whichever session currently owns one channel-local address. */
 export interface ChannelSource<TState = undefined> {
+  /** Creates an idle session. Its first fixed-session send starts a turn. */
+  create(options: ChannelCreateOptions<TState>): Promise<Session>;
   /** Starts or resumes a turn with a user message. May create a session. */
   send(message: string | UserContent, options: ChannelSendOptions<TState>): Promise<Session>;
   /** Answers pending input requests. Never creates a session. */
@@ -107,6 +112,9 @@ export function createChannelOperations<TState = undefined>(input: {
     from(address) {
       const bound = channelAddress(address);
       const source: InternalChannelSource<TState> = {
+        async create(options) {
+          return await bound.create(options);
+        },
         async send(message, options) {
           return await bound.deliver(
             {

--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -476,6 +476,8 @@ export interface SessionCapabilities {
  */
 export interface RunInput {
   readonly adapter: ChannelAdapter<any>;
+  /** Creates a durable session that waits for its first explicit send. */
+  readonly start?: "idle";
   /** Framework task that owns this run, when the run is a task executor. */
   readonly taskId?: string;
   /**
@@ -539,6 +541,7 @@ export interface RunInput {
    */
   readonly initiatorAuth?: SessionAuthContext | null;
   readonly input: {
+    /** Ignored for an initially idle session. */
     readonly message: string | UserContent;
     readonly context?: readonly string[];
     readonly outputSchema?: JsonObject;

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -56,8 +56,8 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     },
   },
   channel: {
-    current: 20,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19, 20],
+    current: 21,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19, 20, 21],
     dropped: {
       12: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",
     },

--- a/packages/eve/src/execution/create-session-step.test.ts
+++ b/packages/eve/src/execution/create-session-step.test.ts
@@ -75,6 +75,25 @@ describe("createSessionStep", () => {
     expect(state.snapshot?.session.agent.system).not.toContain("Background task updates");
   });
 
+  it("does not seed static user messages into an idle session", async () => {
+    vi.mocked(getCompiledRuntimeAgentBundle).mockResolvedValue({
+      resolvedAgent: { config: {} },
+      turnAgent: {
+        ...TestTurnAgent,
+        initialMessages: [{ content: "Static user instruction", role: "user" }],
+      },
+    } as never);
+
+    const { state } = await createSessionStep({
+      compiledArtifactsSource: { kind: "bundled" },
+      continuationToken: "private:research",
+      sessionId: "sess-idle",
+      start: "idle",
+    });
+
+    expect(state.snapshot?.session.history).toEqual([]);
+  });
+
   it("defaults root sessions to the root input token budget", async () => {
     vi.mocked(getCompiledRuntimeAgentBundle).mockResolvedValue({
       resolvedAgent: {

--- a/packages/eve/src/execution/create-session-step.ts
+++ b/packages/eve/src/execution/create-session-step.ts
@@ -40,6 +40,7 @@ export async function createSessionStep(input: {
   readonly nodeId?: string;
   readonly rootSessionId?: string;
   readonly sessionId: string;
+  readonly start?: "idle";
   readonly taskId?: string;
 }): Promise<CreateSessionStepResult> {
   "use step";
@@ -90,6 +91,7 @@ export async function createSessionStep(input: {
     rootSessionId: input.rootSessionId,
     sessionId: input.sessionId,
     systemPromptAdditions: taskUpdatesEnabled ? [TASK_UPDATE_SESSION_INSTRUCTION] : undefined,
+    initialHistory: input.start === "idle" ? "empty" : undefined,
     taskId: input.taskId,
     turnAgent: effectiveAgent.turnAgent,
     workflowMaxSubagents: bundle.resolvedAgent.workflowTool?.maxSubagents,

--- a/packages/eve/src/execution/session.ts
+++ b/packages/eve/src/execution/session.ts
@@ -71,6 +71,7 @@ export interface CreateSessionInput {
   readonly rootSessionId?: string;
   readonly sessionId: string;
   readonly turnAgent: RuntimeTurnAgent;
+  readonly initialHistory?: "empty";
   readonly limits?: AuthoredSessionLimits;
   readonly outputSchema?: HarnessSession["outputSchema"];
   readonly systemPromptAdditions?: readonly string[];
@@ -96,7 +97,7 @@ export function createSession(input: CreateSessionInput): HarnessSession {
       thresholdPercent: input.compactionOverrides?.thresholdPercent,
     }),
     continuationToken: input.continuationToken,
-    history: [...(turnAgent.initialMessages ?? [])],
+    history: input.initialHistory === "empty" ? [] : [...(turnAgent.initialMessages ?? [])],
     sessionId: input.sessionId,
   };
 

--- a/packages/eve/src/execution/workflow-entry.integration.test.ts
+++ b/packages/eve/src/execution/workflow-entry.integration.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getWorld, resumeHook, start } from "#internal/workflow/runtime.js";
+import { getRun, getWorld, resumeHook, start } from "#internal/workflow/runtime.js";
 import { hydrateWorkflowArguments } from "@workflow/core/serialization";
 
 import { createChannelAddress } from "#channel/channel-address.js";
@@ -791,6 +791,79 @@ describe("workflowEntry integration", () => {
       }
     });
   });
+
+  it("creates a ready idle session, appends history, then starts its first turn", async () => {
+    const runtime = await createTestRuntime({ agent: { name: "workflow-entry-idle" } });
+
+    await runtime.run(async () => {
+      const workflowRuntime = createWorkflowRuntime({
+        compiledArtifactsSource: createBundledRuntimeCompiledArtifactsSource(),
+      });
+      const session = await createChannelAddress({
+        adapter: { kind: "http" },
+        channelName: "http",
+        continuationToken: "workflow-entry-idle",
+        runtime: workflowRuntime,
+      }).create({ auth: null });
+
+      expect(await workflowRuntime.getStreamTailIndex(session.id)).toBe(-1);
+      await expect(
+        session.appendHistory({
+          messages: [
+            {
+              content: [
+                {
+                  input: { query: "approved" },
+                  toolCallId: "call-1",
+                  toolName: "lookup",
+                  type: "tool-call",
+                },
+                {
+                  approvalId: "approval-1",
+                  toolCallId: "call-1",
+                  type: "tool-approval-request",
+                },
+              ],
+              role: "assistant",
+            },
+            {
+              content: [
+                {
+                  approvalId: "approval-1",
+                  approved: true,
+                  type: "tool-approval-response",
+                },
+                {
+                  output: { type: "text", value: "approved result" },
+                  toolCallId: "call-1",
+                  toolName: "lookup",
+                  type: "tool-result",
+                },
+              ],
+              role: "tool",
+            },
+          ],
+          operationId: "research:initial",
+        }),
+      ).resolves.toMatchObject({ outcome: "appended", status: "ok" });
+      expect(await workflowRuntime.getStreamTailIndex(session.id)).toBe(-1);
+
+      const run = getRun(session.id);
+      const stream = captureTurnEvents(run);
+      try {
+        await expect(session.send("Start research", { auth: null })).resolves.toMatchObject({
+          sessionId: session.id,
+          status: "accepted",
+        });
+        const firstTurn = await stream.nextTurn();
+        expect(firstTurn.at(-1)?.type).toBe("session.waiting");
+        expect(filterEventsByType(firstTurn, "turn.failed")).toHaveLength(0);
+      } finally {
+        stream.dispose();
+        await run.cancel();
+      }
+    });
+  }, 30_000);
 
   it("publishes the session ID as the waiting address for an ID-only session", async () => {
     const runtime = await createTestRuntime({ agent: { name: "workflow-entry-id-only" } });

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -69,6 +69,7 @@ export interface WorkflowEntryInput {
   readonly limits?: RunInput["limits"];
   readonly sessionTimeoutMs?: number | false;
   readonly serializedContext: Record<string, unknown>;
+  readonly start?: "idle";
   readonly taskId?: string;
 }
 
@@ -204,6 +205,7 @@ export async function workflowEntry(input: WorkflowEntryInput): Promise<Workflow
             outputSchema: input.input.outputSchema,
             rootSessionId: rootSessionIdFromParent,
             sessionId,
+            start: input.start,
             taskId: input.taskId,
           }),
           commandInbox.claimStable(stableCommandToken),
@@ -250,31 +252,34 @@ export async function workflowEntry(input: WorkflowEntryInput): Promise<Workflow
         capabilities,
         commandInbox,
         driverWritable,
-        initialInput: {
-          deliveryMetadata:
-            input.serializedContext["eve.channelDelivery"] === undefined
-              ? undefined
-              : [
-                  {
-                    ...(input.serializedContext["eve.channelDelivery"] as NonNullable<
-                      RunInput["delivery"]
-                    >),
-                    payloadIndex: 0,
-                  },
+        initialInput:
+          input.start === "idle"
+            ? undefined
+            : {
+                deliveryMetadata:
+                  input.serializedContext["eve.channelDelivery"] === undefined
+                    ? undefined
+                    : [
+                        {
+                          ...(input.serializedContext["eve.channelDelivery"] as NonNullable<
+                            RunInput["delivery"]
+                          >),
+                          payloadIndex: 0,
+                        },
+                      ],
+                kind: "deliver",
+                payloads: [
+                  attachClientContext(
+                    {
+                      message: input.input.message,
+                      context: input.input.context,
+                      outputSchema: input.input.outputSchema,
+                    },
+                    readClientContext(input.input),
+                  ),
                 ],
-          kind: "deliver",
-          payloads: [
-            attachClientContext(
-              {
-                message: input.input.message,
-                context: input.input.context,
-                outputSchema: input.input.outputSchema,
+                requestId: readChannelRequestId(input.serializedContext),
               },
-              readClientContext(input.input),
-            ),
-          ],
-          requestId: readChannelRequestId(input.serializedContext),
-        },
         crashCleanupState,
         mode,
         serializedContext: input.serializedContext,
@@ -388,7 +393,7 @@ async function runDriverLoop(input: {
   readonly capabilities?: SessionCapabilities;
   readonly commandInbox: SessionCommandInbox;
   readonly driverWritable: WritableStream<Uint8Array>;
-  readonly initialInput: HookPayload;
+  readonly initialInput: HookPayload | undefined;
   readonly crashCleanupState: CrashCleanupState;
   readonly mode: RunMode;
   readonly serializedContext: Record<string, unknown>;
@@ -538,9 +543,35 @@ async function runDriverLoop(input: {
   try {
     await sessionTimeout?.start();
 
-    let action: TurnDriverAction = await runTurn(input.initialInput);
+    let action: TurnDriverAction | undefined =
+      input.initialInput === undefined ? undefined : await runTurn(input.initialInput);
 
     while (true) {
+      if (action === undefined) {
+        const next = await nextParkedActivity({ expectedAttemptIds: [] });
+        if (next.kind === "turn") {
+          action = await runTurn(next.delivery);
+          continue;
+        }
+        if (next.kind === "clear" || next.kind === "compact") {
+          action = await runTurn({ kind: next.kind });
+          continue;
+        }
+        if (next.kind === "reset" || next.kind === "closed" || next.kind === "expired") {
+          return {
+            kind: "result",
+            result: await finalizeExpiredSession({
+              caller: input.crashCleanupState.caller,
+              driverWritable: input.driverWritable,
+              mode: input.mode,
+              serializedContext: stateCursor.serializedContext,
+              sessionState: stateCursor.sessionState,
+              terminalState: input.crashCleanupState,
+            }),
+          };
+        }
+        continue;
+      }
       if (action.kind === "done") {
         return {
           kind: "result",

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -211,6 +211,7 @@ export function createWorkflowRuntime(config: {
       } = {
         input: input.input,
         limits: input.limits,
+        start: input.start,
         serializedContext,
       };
       const taskId = input.taskId ?? input.callback?.taskId;

--- a/packages/eve/src/internal/testing/mocks/mock-channel-operations.ts
+++ b/packages/eve/src/internal/testing/mocks/mock-channel-operations.ts
@@ -1,6 +1,7 @@
 import type { UserContent } from "ai";
 
 import type {
+  ChannelCreateOptions,
   ChannelReceiveContext,
   ChannelRespondOptions,
   ChannelSendOptions,
@@ -10,6 +11,7 @@ import { INTERNAL_CHANNEL_DELIVER } from "#channel/channel-operations.js";
 import { type InputResponse, inputResponseSchema } from "#shared/input.js";
 
 export type ObservedChannelDelivery<TState> =
+  | ChannelCreateOptions<TState>
   | (ChannelSendOptions<TState> & { readonly message: string | UserContent })
   | (ChannelRespondOptions<TState> & { readonly inputResponses: readonly InputResponse[] });
 
@@ -25,6 +27,9 @@ export function mockChannelContext<TState = undefined>(
   return {
     from(continuationToken) {
       const source: InternalChannelSource<TState> = {
+        async create(options) {
+          return (await observeDelivery(continuationToken, options)) as never;
+        },
         async send(message, options) {
           return (await observeDelivery(continuationToken, { ...options, message })) as never;
         },

--- a/packages/eve/src/public/channels/index.ts
+++ b/packages/eve/src/public/channels/index.ts
@@ -15,6 +15,7 @@ export {
   type CompactSessionResult,
   type ResetSessionResult,
   type Channel,
+  type ChannelCreateOptions,
   type ChannelAudience,
   type ChannelAudienceMetadata,
   type ChannelFrom,

--- a/packages/eve/src/public/definitions/channel.ts
+++ b/packages/eve/src/public/definitions/channel.ts
@@ -8,6 +8,7 @@ import {
 import { normalizeChannelCors, type ChannelCorsOptions } from "#channel/cors.js";
 import { HTTP_ADAPTER_KIND } from "#channel/http.js";
 import type {
+  ChannelCreateOptions,
   ChannelFrom,
   ChannelReceiveContext,
   ChannelResolveSession,
@@ -38,6 +39,7 @@ export type { Session, SessionHandle } from "#channel/session.js";
 export type { ChannelAudience, ChannelAudienceMetadata } from "#shared/channel-audience.js";
 export type { SessionRespondOptions, SessionSendOptions } from "#channel/session.js";
 export type {
+  ChannelCreateOptions,
   ChannelFrom,
   ChannelReceiveContext,
   ChannelResolveSession,


### PR DESCRIPTION
### Summary

Separates session creation from the first model turn so applications can register ownership and import history before execution starts. Adds `from(address).create()`, which returns a ready, idle session; repeated or concurrent calls converge on the address's existing owner. Options passed on a later call do not reconfigure that session.

```ts
const research = await from("research:op_123").create({ auth });
await registerResearchExecution(research.id);
await research.appendHistory({
  operationId: "op_123:initial",
  messages: priorHistory,
});
await research.send("Research this question.", { auth });
```

Depends on #3185. Ownership registration and research policy above are application code, not new framework concepts.

### Validation

Adds a runtime integration test for create → populate with a completed approval transcript → immediate send, with no stream events before execution. Unit coverage checks address reuse and concurrent creation.

🤖
