### PR TITLE
test(e2e): compare sandbox template startup

### DIFF
--- a/e2e/fixtures/sandbox-template-control/.gitignore
+++ b/e2e/fixtures/sandbox-template-control/.gitignore
@@ -1,0 +1,10 @@
+node_modules
+.env*
+.eve
+.vercel
+.next
+.output
+.nitro
+dist
+.DS_Store
+*.tsbuildinfo

--- a/e2e/fixtures/sandbox-template-control/.vercelignore
+++ b/e2e/fixtures/sandbox-template-control/.vercelignore
@@ -1,0 +1,7 @@
+.env*.local
+node_modules
+.eve
+.next
+.output
+.nitro
+dist

--- a/e2e/fixtures/sandbox-template-control/agent/agent.ts
+++ b/e2e/fixtures/sandbox-template-control/agent/agent.ts
@@ -1,0 +1,13 @@
+import { e2eAgentConfig } from "@eve-e2e/config";
+import { defineAgent } from "eve";
+import { mockModel } from "eve/evals";
+
+export default defineAgent({
+  ...e2eAgentConfig(),
+  model: mockModel(({ toolResults }) => {
+    const result = toolResults.at(-1);
+    if (result !== undefined) return "done";
+    return { toolCalls: [{ input: { command: "true" }, name: "bash" }] };
+  }),
+  modelContextWindowTokens: 1_000_000,
+});

--- a/e2e/fixtures/sandbox-template-control/agent/instructions.md
+++ b/e2e/fixtures/sandbox-template-control/agent/instructions.md
@@ -1,0 +1,1 @@
+Run the requested sandbox command.

--- a/e2e/fixtures/sandbox-template-control/agent/sandbox.ts
+++ b/e2e/fixtures/sandbox-template-control/agent/sandbox.ts
@@ -1,0 +1,6 @@
+import { defaultBackend, defineSandbox } from "eve/sandbox";
+
+export default defineSandbox({
+  backend: defaultBackend(),
+  async bootstrap() {},
+});

--- a/e2e/fixtures/sandbox-template-control/agent/tools/bash.ts
+++ b/e2e/fixtures/sandbox-template-control/agent/tools/bash.ts
@@ -1,0 +1,5 @@
+import { defineTool } from "eve/tools";
+import { never } from "eve/tools/approval";
+import { bash } from "eve/tools/bash";
+
+export default defineTool({ ...bash, approval: never() });

--- a/e2e/fixtures/sandbox-template-control/evals/evals.config.ts
+++ b/e2e/fixtures/sandbox-template-control/evals/evals.config.ts
@@ -1,0 +1,4 @@
+import { e2eJudgeModel } from "@eve-e2e/config";
+import { defineEvalConfig } from "eve/evals";
+
+export default defineEvalConfig({ judge: { model: e2eJudgeModel() } });

--- a/e2e/fixtures/sandbox-template-control/evals/template-control.eval.ts
+++ b/e2e/fixtures/sandbox-template-control/evals/template-control.eval.ts
@@ -1,0 +1,53 @@
+import { defineEval } from "eve/evals";
+import { equals } from "eve/evals/expect";
+
+const SESSION_COUNT = 20;
+const METRIC_PREFIX = "EVE_SANDBOX_TEMPLATE_AB=";
+
+export default defineEval({
+  description: "Sandbox startup control: an empty bootstrap forces an eve template snapshot.",
+  tags: ["sandbox", "performance"],
+  async test(t) {
+    if (
+      t.target.kind !== "remote" ||
+      process.env.EVE_E2E_MODEL !== "mock" ||
+      process.env.EVE_E2E_WORKFLOW_WORLD !== undefined
+    ) {
+      t.skip("Temporary performance experiment runs only in the Vercel mock-world suite.");
+    }
+
+    const sessions = Array.from({ length: SESSION_COUNT }, () => t.newSession());
+    const batchStartedAt = performance.now();
+    const batchStartedAtMs = Date.now();
+    const samples = await Promise.all(
+      sessions.map(async (session, index) => {
+        const startedAt = performance.now();
+        const startedAtMs = Date.now();
+        const result = await session.send(`template-control-${index}`);
+        result.expectOk();
+        await t.require(result.message, equals("done"));
+        return {
+          durationMs: performance.now() - startedAt,
+          endedAtMs: Date.now(),
+          sessionId: result.sessionId,
+          sessionNumber: index + 1,
+          startedAtMs,
+        };
+      }),
+    );
+
+    t.log(
+      `${METRIC_PREFIX}${JSON.stringify({
+        batchDurationMs: performance.now() - batchStartedAt,
+        batchEndedAtMs: Date.now(),
+        batchStartedAtMs,
+        fixture: "sandbox-template-control",
+        samples,
+        schemaVersion: 1,
+        sessionCount: SESSION_COUNT,
+        variant: "template-empty-bootstrap",
+      })}`,
+    );
+    t.succeeded();
+  },
+});

--- a/e2e/fixtures/sandbox-template-control/package.json
+++ b/e2e/fixtures/sandbox-template-control/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "sandbox-template-control",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "eve build",
+    "dev": "eve dev",
+    "start": "eve start",
+    "typecheck": "eve build && tsc",
+    "test:e2e": "eve eval --strict"
+  },
+  "dependencies": {
+    "@eve-e2e/config": "workspace:*",
+    "@workflow/world-postgres": "catalog:",
+    "eve": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/e2e/fixtures/sandbox-template-control/tsconfig.json
+++ b/e2e/fixtures/sandbox-template-control/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["agent/**/*.ts", "evals/**/*.ts"]
+}

--- a/e2e/fixtures/sandbox-template-direct/.gitignore
+++ b/e2e/fixtures/sandbox-template-direct/.gitignore
@@ -1,0 +1,10 @@
+node_modules
+.env*
+.eve
+.vercel
+.next
+.output
+.nitro
+dist
+.DS_Store
+*.tsbuildinfo

--- a/e2e/fixtures/sandbox-template-direct/.vercelignore
+++ b/e2e/fixtures/sandbox-template-direct/.vercelignore
@@ -1,0 +1,7 @@
+.env*.local
+node_modules
+.eve
+.next
+.output
+.nitro
+dist

--- a/e2e/fixtures/sandbox-template-direct/agent/agent.ts
+++ b/e2e/fixtures/sandbox-template-direct/agent/agent.ts
@@ -1,0 +1,13 @@
+import { e2eAgentConfig } from "@eve-e2e/config";
+import { defineAgent } from "eve";
+import { mockModel } from "eve/evals";
+
+export default defineAgent({
+  ...e2eAgentConfig(),
+  model: mockModel(({ toolResults }) => {
+    const result = toolResults.at(-1);
+    if (result !== undefined) return "done";
+    return { toolCalls: [{ input: { command: "true" }, name: "bash" }] };
+  }),
+  modelContextWindowTokens: 1_000_000,
+});

--- a/e2e/fixtures/sandbox-template-direct/agent/instructions.md
+++ b/e2e/fixtures/sandbox-template-direct/agent/instructions.md
@@ -1,0 +1,1 @@
+Run the requested sandbox command.

--- a/e2e/fixtures/sandbox-template-direct/agent/sandbox.ts
+++ b/e2e/fixtures/sandbox-template-direct/agent/sandbox.ts
@@ -1,0 +1,3 @@
+import { defaultBackend, defineSandbox } from "eve/sandbox";
+
+export default defineSandbox({ backend: defaultBackend() });

--- a/e2e/fixtures/sandbox-template-direct/agent/tools/bash.ts
+++ b/e2e/fixtures/sandbox-template-direct/agent/tools/bash.ts
@@ -1,0 +1,5 @@
+import { defineTool } from "eve/tools";
+import { never } from "eve/tools/approval";
+import { bash } from "eve/tools/bash";
+
+export default defineTool({ ...bash, approval: never() });

--- a/e2e/fixtures/sandbox-template-direct/evals/evals.config.ts
+++ b/e2e/fixtures/sandbox-template-direct/evals/evals.config.ts
@@ -1,0 +1,4 @@
+import { e2eJudgeModel } from "@eve-e2e/config";
+import { defineEvalConfig } from "eve/evals";
+
+export default defineEvalConfig({ judge: { model: e2eJudgeModel() } });

--- a/e2e/fixtures/sandbox-template-direct/evals/template-direct.eval.ts
+++ b/e2e/fixtures/sandbox-template-direct/evals/template-direct.eval.ts
@@ -1,0 +1,54 @@
+import { defineEval } from "eve/evals";
+import { equals } from "eve/evals/expect";
+
+const SESSION_COUNT = 20;
+const METRIC_PREFIX = "EVE_SANDBOX_TEMPLATE_AB=";
+
+export default defineEval({
+  description:
+    "Sandbox startup experiment: no bootstrap or managed files skips the eve template snapshot.",
+  tags: ["sandbox", "performance"],
+  async test(t) {
+    if (
+      t.target.kind !== "remote" ||
+      process.env.EVE_E2E_MODEL !== "mock" ||
+      process.env.EVE_E2E_WORKFLOW_WORLD !== undefined
+    ) {
+      t.skip("Temporary performance experiment runs only in the Vercel mock-world suite.");
+    }
+
+    const sessions = Array.from({ length: SESSION_COUNT }, () => t.newSession());
+    const batchStartedAt = performance.now();
+    const batchStartedAtMs = Date.now();
+    const samples = await Promise.all(
+      sessions.map(async (session, index) => {
+        const startedAt = performance.now();
+        const startedAtMs = Date.now();
+        const result = await session.send(`template-direct-${index}`);
+        result.expectOk();
+        await t.require(result.message, equals("done"));
+        return {
+          durationMs: performance.now() - startedAt,
+          endedAtMs: Date.now(),
+          sessionId: result.sessionId,
+          sessionNumber: index + 1,
+          startedAtMs,
+        };
+      }),
+    );
+
+    t.log(
+      `${METRIC_PREFIX}${JSON.stringify({
+        batchDurationMs: performance.now() - batchStartedAt,
+        batchEndedAtMs: Date.now(),
+        batchStartedAtMs,
+        fixture: "sandbox-template-direct",
+        samples,
+        schemaVersion: 1,
+        sessionCount: SESSION_COUNT,
+        variant: "template-less",
+      })}`,
+    );
+    t.succeeded();
+  },
+});

--- a/e2e/fixtures/sandbox-template-direct/package.json
+++ b/e2e/fixtures/sandbox-template-direct/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "sandbox-template-direct",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "eve build",
+    "dev": "eve dev",
+    "start": "eve start",
+    "typecheck": "eve build && tsc",
+    "test:e2e": "eve eval --strict"
+  },
+  "dependencies": {
+    "@eve-e2e/config": "workspace:*",
+    "@workflow/world-postgres": "catalog:",
+    "eve": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/e2e/fixtures/sandbox-template-direct/tsconfig.json
+++ b/e2e/fixtures/sandbox-template-direct/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["agent/**/*.ts", "evals/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1298,6 +1298,44 @@ importers:
         specifier: 'catalog:'
         version: 7.0.2
 
+  e2e/fixtures/sandbox-template-control:
+    dependencies:
+      '@eve-e2e/config':
+        specifier: workspace:*
+        version: link:../e2e-config
+      '@workflow/world-postgres':
+        specifier: 'catalog:'
+        version: 5.0.0-beta.40(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@upstash/redis@1.38.4)(sql.js@1.14.1)(supports-color@10.2.2)(typescript@7.0.2)
+      eve:
+        specifier: workspace:*
+        version: link:../../../packages/eve
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.3
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+
+  e2e/fixtures/sandbox-template-direct:
+    dependencies:
+      '@eve-e2e/config':
+        specifier: workspace:*
+        version: link:../e2e-config
+      '@workflow/world-postgres':
+        specifier: 'catalog:'
+        version: 5.0.0-beta.40(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@upstash/redis@1.38.4)(sql.js@1.14.1)(supports-color@10.2.2)(typescript@7.0.2)
+      eve:
+        specifier: workspace:*
+        version: link:../../../packages/eve
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.3
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+
   e2e/fixtures/toolkit-extension:
     dependencies:
       zod:


### PR DESCRIPTION
### Summary

Fresh eve sessions can start from either an eve-managed template snapshot or the managed base image directly, but observational traffic does not isolate the performance difference. This temporary diagnostic adds matched fixtures for both paths and runs 20 concurrent fresh sessions through the same `bash true` operation. It records per-session IDs, timestamps, durations, and batch duration so CI output can be correlated with Sandbox and Hive traces. The experiment runs only in the Vercel mock-world suite and should not be merged.

### Validation

- `pnpm --filter sandbox-template-control typecheck`
- `pnpm --filter sandbox-template-direct typecheck`
- `pnpm fmt`
- `pnpm lint`
- `pnpm guard:invariants`
- Confirmed the control has an empty `bootstrap()` while the direct variant has no bootstrap or managed files.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
