### PR TITLE
test(e2e): measure sandbox template cache locality

### DIFF
--- a/e2e/fixtures/sandbox-template-cache-locality/.gitignore
+++ b/e2e/fixtures/sandbox-template-cache-locality/.gitignore
@@ -1,0 +1,10 @@
+node_modules
+.env*
+.eve
+.vercel
+.next
+.output
+.nitro
+dist
+.DS_Store
+*.tsbuildinfo

--- a/e2e/fixtures/sandbox-template-cache-locality/.vercelignore
+++ b/e2e/fixtures/sandbox-template-cache-locality/.vercelignore
@@ -1,0 +1,7 @@
+.env*.local
+node_modules
+.eve
+.next
+.output
+.nitro
+dist

--- a/e2e/fixtures/sandbox-template-cache-locality/agent/agent.ts
+++ b/e2e/fixtures/sandbox-template-cache-locality/agent/agent.ts
@@ -1,0 +1,13 @@
+import { e2eAgentConfig } from "@eve-e2e/config";
+import { defineAgent } from "eve";
+import { mockModel } from "eve/evals";
+
+export default defineAgent({
+  ...e2eAgentConfig(),
+  model: mockModel(({ toolResults }) => {
+    const result = toolResults.at(-1);
+    if (result !== undefined) return "done";
+    return { toolCalls: [{ input: { command: "true" }, name: "bash" }] };
+  }),
+  modelContextWindowTokens: 1_000_000,
+});

--- a/e2e/fixtures/sandbox-template-cache-locality/agent/instructions.md
+++ b/e2e/fixtures/sandbox-template-cache-locality/agent/instructions.md
@@ -1,0 +1,1 @@
+Run the requested sandbox command.

--- a/e2e/fixtures/sandbox-template-cache-locality/agent/sandbox.ts
+++ b/e2e/fixtures/sandbox-template-cache-locality/agent/sandbox.ts
@@ -1,0 +1,6 @@
+import { defaultBackend, defineSandbox } from "eve/sandbox";
+
+export default defineSandbox({
+  backend: defaultBackend(),
+  async bootstrap() {},
+});

--- a/e2e/fixtures/sandbox-template-cache-locality/agent/tools/bash.ts
+++ b/e2e/fixtures/sandbox-template-cache-locality/agent/tools/bash.ts
@@ -1,0 +1,5 @@
+import { defineTool } from "eve/tools";
+import { never } from "eve/tools/approval";
+import { bash } from "eve/tools/bash";
+
+export default defineTool({ ...bash, approval: never() });

--- a/e2e/fixtures/sandbox-template-cache-locality/evals/cache-locality.eval.ts
+++ b/e2e/fixtures/sandbox-template-cache-locality/evals/cache-locality.eval.ts
@@ -1,0 +1,91 @@
+import { defineEval, type EveEvalContext, type EveEvalSession } from "eve/evals";
+import { equals } from "eve/evals/expect";
+
+const CONCURRENT_SESSION_COUNT = 20;
+const SEQUENTIAL_SESSION_COUNT = 12;
+const METRIC_PREFIX = "EVE_SANDBOX_CACHE_LOCALITY=";
+
+interface Sample {
+  readonly durationMs: number;
+  readonly endedAtMs: number;
+  readonly sessionId: string | undefined;
+  readonly sessionNumber: number;
+  readonly startedAtMs: number;
+}
+
+export default defineEval({
+  description:
+    "Sandbox snapshot cache locality: compare concurrent cold fan-out with later sequential sessions.",
+  tags: ["sandbox", "performance"],
+  timeoutMs: 5 * 60_000,
+  async test(t) {
+    if (
+      t.target.kind !== "remote" ||
+      process.env.EVE_E2E_MODEL !== "mock" ||
+      process.env.EVE_E2E_WORKFLOW_WORLD !== undefined
+    ) {
+      t.skip("Temporary performance experiment runs only in the Vercel mock-world suite.");
+    }
+
+    const concurrentSessions = Array.from({ length: CONCURRENT_SESSION_COUNT }, () =>
+      t.newSession(),
+    );
+    const concurrentStartedAt = performance.now();
+    const concurrentStartedAtMs = Date.now();
+    const concurrent = await Promise.all(
+      concurrentSessions.map(async (session, index) => runSession(t, session, "concurrent", index)),
+    );
+    const concurrentDurationMs = performance.now() - concurrentStartedAt;
+    const concurrentEndedAtMs = Date.now();
+
+    const sequentialStartedAt = performance.now();
+    const sequentialStartedAtMs = Date.now();
+    const sequential: Sample[] = [];
+    for (let index = 0; index < SEQUENTIAL_SESSION_COUNT; index += 1) {
+      sequential.push(await runSession(t, t.newSession(), "sequential", index));
+    }
+
+    t.log(
+      `${METRIC_PREFIX}${JSON.stringify({
+        concurrent: {
+          batchDurationMs: concurrentDurationMs,
+          endedAtMs: concurrentEndedAtMs,
+          samples: concurrent,
+          sessionCount: CONCURRENT_SESSION_COUNT,
+          startedAtMs: concurrentStartedAtMs,
+        },
+        fixture: "sandbox-template-cache-locality",
+        schemaVersion: 1,
+        sequential: {
+          batchDurationMs: performance.now() - sequentialStartedAt,
+          endedAtMs: Date.now(),
+          samples: sequential,
+          sessionCount: SEQUENTIAL_SESSION_COUNT,
+          startedAtMs: sequentialStartedAtMs,
+        },
+        variant: "shared-template-snapshot",
+      })}`,
+    );
+    t.succeeded();
+  },
+});
+
+async function runSession(
+  t: EveEvalContext,
+  session: EveEvalSession,
+  phase: "concurrent" | "sequential",
+  index: number,
+): Promise<Sample> {
+  const startedAt = performance.now();
+  const startedAtMs = Date.now();
+  const result = await session.send(`${phase}-${index}`);
+  result.expectOk();
+  await t.require(result.message, equals("done"));
+  return {
+    durationMs: performance.now() - startedAt,
+    endedAtMs: Date.now(),
+    sessionId: result.sessionId,
+    sessionNumber: index + 1,
+    startedAtMs,
+  };
+}

--- a/e2e/fixtures/sandbox-template-cache-locality/evals/evals.config.ts
+++ b/e2e/fixtures/sandbox-template-cache-locality/evals/evals.config.ts
@@ -1,0 +1,4 @@
+import { e2eJudgeModel } from "@eve-e2e/config";
+import { defineEvalConfig } from "eve/evals";
+
+export default defineEvalConfig({ judge: { model: e2eJudgeModel() } });

--- a/e2e/fixtures/sandbox-template-cache-locality/package.json
+++ b/e2e/fixtures/sandbox-template-cache-locality/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "sandbox-template-cache-locality",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "eve build",
+    "dev": "eve dev",
+    "start": "eve start",
+    "typecheck": "eve build && tsc",
+    "test:e2e": "eve eval --strict"
+  },
+  "dependencies": {
+    "@eve-e2e/config": "workspace:*",
+    "@workflow/world-postgres": "catalog:",
+    "eve": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/e2e/fixtures/sandbox-template-cache-locality/tsconfig.json
+++ b/e2e/fixtures/sandbox-template-cache-locality/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["agent/**/*.ts", "evals/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1298,6 +1298,44 @@ importers:
         specifier: 'catalog:'
         version: 7.0.2
 
+  e2e/fixtures/sandbox-template-cache-locality:
+    dependencies:
+      '@eve-e2e/config':
+        specifier: workspace:*
+        version: link:../e2e-config
+      '@workflow/world-postgres':
+        specifier: 'catalog:'
+        version: 5.0.0-beta.40(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@upstash/redis@1.38.4)(sql.js@1.14.1)(supports-color@10.2.2)(typescript@7.0.2)
+      eve:
+        specifier: workspace:*
+        version: link:../../../packages/eve
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.3
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+
+  e2e/fixtures/sandbox-template-direct:
+    dependencies:
+      '@eve-e2e/config':
+        specifier: workspace:*
+        version: link:../e2e-config
+      '@workflow/world-postgres':
+        specifier: 'catalog:'
+        version: 5.0.0-beta.40(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@upstash/redis@1.38.4)(sql.js@1.14.1)(supports-color@10.2.2)(typescript@7.0.2)
+      eve:
+        specifier: workspace:*
+        version: link:../../../packages/eve
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.3
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+
   e2e/fixtures/toolkit-extension:
     dependencies:
       zod:


### PR DESCRIPTION
### Summary

The template A/B experiment showed a modest typical benefit from avoiding snapshots but exposed a larger unanswered question: fresh sessions sharing the exact same eve template snapshot still appear to restore it repeatedly. This temporary diagnostic runs 20 concurrent fresh sessions followed by 12 sequential fresh sessions from one template. It records session IDs, timestamps, and phase durations so box placement, cache hits, duplicate in-flight restores, and post-warm behavior can be correlated in Hive and Sandbox traces. It runs only in the Vercel mock-world suite and should not be merged.

### Validation

- `pnpm --filter sandbox-template-cache-locality typecheck`
- `pnpm fmt`
- `pnpm lint`
- `pnpm guard:invariants`
- `pnpm install --frozen-lockfile`

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
