### PR TITLE
feat(eve): expose enabled session activity

### DIFF
--- a/.changeset/session-activity-api.md
+++ b/.changeset/session-activity-api.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Expose enabled root-session activity snapshots through the authenticated eve API and `session.activity` TypeScript client methods, with independent durable streaming and cursor state.

--- a/docs/channels/eve.mdx
+++ b/docs/channels/eve.mdx
@@ -31,6 +31,7 @@ The default eve channel inspects the agent, creates sessions, accepts callbacks 
 - `POST /eve/v1/session/:sessionId/compact` (compact the session's context)
 - `POST /eve/v1/session/:sessionId/reset` (retire the session)
 - `GET /eve/v1/session/:sessionId/stream` (stream events as NDJSON)
+- `GET /eve/v1/session/:sessionId/activity/stream` (stream enabled activity snapshots as NDJSON)
 
 The session routes use only durable session IDs. Create a session explicitly, then put its returned ID in every follow-up, control, and stream path.
 
@@ -88,6 +89,18 @@ creates or follows a replacement session.
 ### Stream events
 
 Stream a session as newline-delimited JSON from `GET /eve/v1/session/:sessionId/stream`. The [session protocol](../concepts/sessions-runs-and-streaming#stream-a-session) defines the event set, envelopes, cursors, and reconnection behavior.
+
+### Stream activity
+
+`GET /eve/v1/session/:sessionId/activity/stream` exposes complete
+`ActivitySnapshotV1` revisions when the root session's channel enabled an
+activity renderer. The route uses the same authentication, durable cursor, and
+bounded-read query parameters as the session event stream. It returns `404` for
+unknown sessions, child sessions, and root sessions without activity enabled.
+
+Activity snapshots summarize work, actions, and blockers. They do not contain
+assistant text, reasoning, tool inputs, or tool results. Use the ordinary
+session stream for transcript content.
 
 ### Cancel a turn
 

--- a/docs/guides/client/streaming.mdx
+++ b/docs/guides/client/streaming.mdx
@@ -241,6 +241,33 @@ Unlike `stream()`, `snapshot()` does not advance the originating
 `ClientSession`. Its returned cursor contains the fixed session ID and the exact
 stream index after the captured prefix.
 
+## Stream activity snapshots
+
+A root session whose channel enabled activity rendering exposes the same
+channel-neutral progress snapshots to clients:
+
+```ts
+const current = await session.activity.snapshot();
+console.log(current.snapshot?.revision);
+
+for await (const activity of session.activity.stream()) {
+  console.log(activity.work, activity.actions, activity.blockers);
+}
+```
+
+`session.activity` has its own `streamIndex`; reading it does not change
+`session.state.streamIndex`. Its `stream()` method accepts the same
+`startIndex`, `follow`, `signal`, and reconnection options as
+`session.stream()`. `snapshot()` returns the latest snapshot and the matching
+activity cursor without advancing the handle. It returns `snapshot: undefined`
+when collection is enabled but no revision has been published yet.
+
+Activity is available only when the session is a root session and its channel
+already enabled an activity renderer. Disabled, child, unknown, and unmapped
+sessions return `404` as `ClientError`. Activity snapshots describe work,
+actions, and blockers; continue reading the session event stream for assistant
+text, reasoning, and tool details.
+
 ## Abort a request
 
 Pass an `AbortSignal` to cancel the POST or stream. Aborting is local transport cancellation: turns are resumable across disconnects, so detaching never stops server-side work. Use `session.cancel()` to stop the active turn, or `session.cancel({ tasks: true })` to also stop background tasks owned by the session. Cancellation is asynchronous; watch the stream for `turn.cancelled` followed by `session.waiting`, and inspect task state in a later turn to confirm task cancellation.

--- a/packages/eve/src/client/index.ts
+++ b/packages/eve/src/client/index.ts
@@ -13,6 +13,7 @@ export { defaultMessageReducer } from "#client/message-reducer.js";
 export { createDataUrlFilePart, createTextWithFileContent } from "#client/file-parts.js";
 export { MessageResponse } from "#client/message-response.js";
 export { ClientSession } from "#client/session.js";
+export { ClientSessionActivity } from "#client/session-activity.js";
 export { ClientSessions, type CreatedClientSession } from "#client/sessions.js";
 
 // ---------------------------------------------------------------------------
@@ -28,6 +29,7 @@ export type {
 } from "#client/eve-agent-store.js";
 
 export type {
+  ActivitySessionSnapshot,
   AgentInfoEntry,
   AgentInfoChannelEntry,
   AgentInfoChannels,
@@ -66,6 +68,23 @@ export type {
   StreamReconnectRetryPolicy,
   TokenValue,
 } from "#client/types.js";
+
+export type {
+  ActivityActionIdentityV1,
+  ActivityActionKind,
+  ActivityActionPhase,
+  ActivityActionStateV1,
+  ActivityBlockerIdentityV1,
+  ActivityBlockerKind,
+  ActivityBlockerPhase,
+  ActivityBlockerStateV1,
+  ActivitySnapshotV1,
+  ActivityWorkIdentityV1,
+  PendingActivitySettlementV1,
+  ActivityWorkKind,
+  ActivityWorkPhase,
+  ActivityWorkStateV1,
+} from "#protocol/activity.js";
 
 export type {
   EveAgentReducer,

--- a/packages/eve/src/client/ndjson.ts
+++ b/packages/eve/src/client/ndjson.ts
@@ -45,6 +45,16 @@ export async function* readNdjsonStream(
     readonly streamVersion: MessageStreamVersion;
   },
 ): AsyncGenerator<MessageStreamEvent> {
+  yield* readJsonNdjsonStream(body, {
+    idleTimeoutMs: options.idleTimeoutMs,
+    parse: (line) => parseMessageStreamEvent(line, options.streamVersion),
+  });
+}
+
+export async function* readJsonNdjsonStream<T>(
+  body: ReadableStream<Uint8Array>,
+  options: { readonly idleTimeoutMs?: number; readonly parse: (line: string) => T },
+): AsyncGenerator<T> {
   const reader = body.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
@@ -72,7 +82,7 @@ export async function* readNdjsonStream(
         buffer = buffer.slice(newlineIndex + 1);
 
         if (line.length > 0) {
-          yield parseMessageStreamEvent(line, options.streamVersion);
+          yield options.parse(line);
         }
 
         newlineIndex = buffer.indexOf("\n");
@@ -82,7 +92,7 @@ export async function* readNdjsonStream(
     // Yield any trailing content without a final newline.
     const trailing = buffer.trim();
     if (trailing.length > 0) {
-      yield parseMessageStreamEvent(trailing, options.streamVersion);
+      yield options.parse(trailing);
     }
   } finally {
     if (!reachedEof) {

--- a/packages/eve/src/client/open-stream.ts
+++ b/packages/eve/src/client/open-stream.ts
@@ -1,6 +1,5 @@
 import type { MessageStreamEvent } from "#protocol/message.js";
 import { EVE_STREAM_TAIL_INDEX_HEADER } from "#protocol/message.js";
-import type { MessageStreamVersion } from "#protocol/message-version.js";
 import { createEveSessionStreamRoutePath } from "#protocol/routes.js";
 import { ClientError } from "#client/client-error.js";
 import { isStreamDisconnectError, readNdjsonStream } from "#client/ndjson.js";
@@ -92,6 +91,7 @@ interface FollowStreamInput {
   readonly startIndex: number;
   /** Follow the live stream after the durable tail (default). `false` bounds the read at the tail. */
   readonly follow?: boolean;
+  readonly path?: string;
 }
 
 /** One connection open; `requestTailIndex` asks the server to report the durable tail index. */
@@ -115,6 +115,18 @@ interface OpenStreamInput extends FollowStreamInput {
 export async function* followStreamIterable(
   input: FollowStreamInput,
 ): AsyncGenerator<MessageStreamEvent> {
+  yield* followDurableStreamIterable(input, (connection, idleTimeoutMs) =>
+    readNdjsonStream(connection.body, {
+      idleTimeoutMs,
+      streamVersion: readMessageStreamVersion(connection.headers),
+    }),
+  );
+}
+
+export async function* followDurableStreamIterable<T>(
+  input: FollowStreamInput,
+  read: (connection: OpenedStream, idleTimeoutMs: number) => AsyncIterable<T>,
+): AsyncGenerator<T> {
   if (input.follow === false && input.startIndex < 0) {
     throw new Error(
       "stream({ follow: false }) requires a nonnegative startIndex; a tail-relative cursor cannot be bounded.",
@@ -163,10 +175,10 @@ export async function* followStreamIterable(
 
     let deliveredEvent = false;
     try {
-      for await (const event of readNdjsonStream(connection.body, {
-        idleTimeoutMs: input.streamReadIdleTimeoutMs ?? DEFAULT_STREAM_READ_IDLE_TIMEOUT_MS,
-        streamVersion: connection.streamVersion,
-      })) {
+      for await (const event of read(
+        connection,
+        input.streamReadIdleTimeoutMs ?? DEFAULT_STREAM_READ_IDLE_TIMEOUT_MS,
+      )) {
         startIndex += 1;
         deliveredEvent = true;
         reconnectDelayMs = idleRetryPolicy.baseDelayMs;
@@ -206,10 +218,10 @@ export async function* followStreamIterable(
 }
 
 /** An opened connection: the response body plus the tail index from the response header, if any. */
-interface OpenedStream {
+export interface OpenedStream {
   readonly body: ReadableStream<Uint8Array>;
   close(): void;
-  readonly streamVersion: MessageStreamVersion;
+  readonly headers: Headers;
   readonly tailIndex: number | undefined;
 }
 
@@ -240,7 +252,7 @@ export async function openStreamBody(
   for (let attempt = 0; attempt < openRetryPolicy.maxAttempts; attempt += 1) {
     const url = createClientUrl(
       input.host,
-      createEveSessionStreamRoutePath(input.sessionId),
+      input.path ?? createEveSessionStreamRoutePath(input.sessionId),
       Object.keys(searchParams).length > 0 ? searchParams : undefined,
     );
 
@@ -287,7 +299,7 @@ export async function openStreamBody(
           response.body?.cancel().catch(() => {});
           connectionController.abort();
         },
-        streamVersion: readMessageStreamVersion(response.headers),
+        headers: response.headers,
         tailIndex: parseTailIndexHeader(response.headers),
       };
     }

--- a/packages/eve/src/client/session-activity.test.ts
+++ b/packages/eve/src/client/session-activity.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ClientSession } from "#client/session.js";
+import {
+  EVE_ACTIVITY_STREAM_FORMAT,
+  EVE_ACTIVITY_STREAM_VERSION,
+  type ActivitySnapshotV1,
+} from "#protocol/activity.js";
+import {
+  EVE_STREAM_FORMAT_HEADER,
+  EVE_STREAM_TAIL_INDEX_HEADER,
+  EVE_STREAM_VERSION_HEADER,
+} from "#protocol/message.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+const snapshot: ActivitySnapshotV1 = {
+  actions: {},
+  blockers: {},
+  pendingSettlements: {},
+  revision: 1,
+  seenEventIds: [],
+  version: 1,
+  work: {},
+};
+
+function response(snapshots: readonly unknown[], tailIndex = snapshots.length - 1) {
+  return new Response(snapshots.map((value) => `${JSON.stringify(value)}\n`).join(""), {
+    headers: activityHeaders(tailIndex),
+  });
+}
+
+function activityHeaders(tailIndex?: number) {
+  const headers = new Headers({
+    [EVE_STREAM_FORMAT_HEADER]: EVE_ACTIVITY_STREAM_FORMAT,
+    [EVE_STREAM_VERSION_HEADER]: EVE_ACTIVITY_STREAM_VERSION,
+  });
+  if (tailIndex !== undefined) {
+    headers.set(EVE_STREAM_TAIL_INDEX_HEADER, String(tailIndex));
+  }
+  return headers;
+}
+
+function session() {
+  return new ClientSession(
+    {
+      host: "https://eve.test",
+      resolveHeaders: async () => new Headers({ authorization: "Bearer token" }),
+    },
+    { sessionId: "session_1", streamIndex: 4 },
+  );
+}
+
+describe("ClientSession.activity", () => {
+  it("reads the latest snapshot without changing either cursor", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(response([snapshot]));
+    const attached = session();
+
+    await expect(attached.activity.snapshot()).resolves.toEqual({
+      snapshot,
+      session: { sessionId: "session_1", streamIndex: 1 },
+    });
+
+    expect(attached.state.streamIndex).toBe(4);
+    expect(attached.activity.streamIndex).toBe(0);
+    const request = new URL(fetchMock.mock.calls[0]![0] as string);
+    expect(request.pathname).toBe("/eve/v1/session/session_1/activity/stream");
+    expect(request.searchParams.get("includeTailIndex")).toBe("1");
+  });
+
+  it("rejects malformed nested snapshot state", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      response([{ ...snapshot, actions: { action: { id: "action", phase: "running" } } }]),
+    );
+    const attached = session();
+
+    await expect(attached.activity.snapshot()).rejects.toThrow(
+      "Activity stream returned an invalid snapshot.",
+    );
+  });
+
+  it("reconnects an activity stream after the shared idle timeout", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(new ReadableStream<Uint8Array>(), { headers: activityHeaders() }),
+      )
+      .mockResolvedValueOnce(response([snapshot]));
+    const attached = session();
+    const iterator = attached.activity
+      .stream({
+        streamReconnectPolicy: {
+          streamIdleReconnectPolicy: { baseDelayMs: 250, maxAttempts: 1, maxDelayMs: 250 },
+        },
+      })
+      [Symbol.asyncIterator]();
+
+    const next = iterator.next();
+    await vi.advanceTimersByTimeAsync(15_250);
+
+    await expect(next).resolves.toEqual({ done: false, value: snapshot });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await iterator.return?.();
+  });
+
+  it("advances an activity-only cursor when streaming", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response([snapshot]));
+    const attached = session();
+
+    const revisions: number[] = [];
+    for await (const update of attached.activity.stream({
+      follow: false,
+      streamReconnectPolicy: { reconnect: false },
+    })) {
+      revisions.push(update.revision);
+    }
+
+    expect(revisions).toEqual([1]);
+    expect(attached.activity.streamIndex).toBe(1);
+    expect(attached.state.streamIndex).toBe(4);
+  });
+});

--- a/packages/eve/src/client/session-activity.ts
+++ b/packages/eve/src/client/session-activity.ts
@@ -1,0 +1,131 @@
+import {
+  EVE_ACTIVITY_STREAM_FORMAT,
+  EVE_ACTIVITY_STREAM_VERSION,
+  parseActivitySnapshotV1,
+  type ActivitySnapshotV1,
+} from "#protocol/activity.js";
+import { EVE_STREAM_FORMAT_HEADER, EVE_STREAM_VERSION_HEADER } from "#protocol/message.js";
+import { createEveSessionActivityStreamRoutePath } from "#protocol/routes.js";
+import { readJsonNdjsonStream } from "#client/ndjson.js";
+import { followDurableStreamIterable } from "#client/open-stream.js";
+import type { ClientSessionContext } from "#client/session.js";
+import type {
+  ActivitySessionSnapshot,
+  StreamOptions,
+  StreamReconnectPolicy,
+} from "#client/types.js";
+
+/** Activity snapshots associated with one fixed root session. */
+export class ClientSessionActivity {
+  readonly #context: ClientSessionContext;
+  readonly #sessionId: string;
+  #streamIndex = 0;
+
+  /** @internal */
+  constructor(context: ClientSessionContext, sessionId: string) {
+    this.#context = context;
+    this.#sessionId = sessionId;
+  }
+
+  /** Current activity-stream cursor. */
+  get streamIndex(): number {
+    return this.#streamIndex;
+  }
+
+  /** Reads the latest persisted snapshot without advancing this handle. */
+  async snapshot(options?: { readonly signal?: AbortSignal }): Promise<ActivitySessionSnapshot> {
+    options?.signal?.throwIfAborted();
+    let snapshot: ActivitySnapshotV1 | undefined;
+    let streamIndex = 0;
+    for await (const update of this.#read({
+      follow: false,
+      signal: options?.signal,
+      startIndex: 0,
+    })) {
+      snapshot = update;
+      streamIndex += 1;
+    }
+    options?.signal?.throwIfAborted();
+    return { snapshot, session: { sessionId: this.#sessionId, streamIndex } };
+  }
+
+  /** Opens the durable activity snapshot stream and advances its independent cursor. */
+  stream(options?: StreamOptions): AsyncIterable<ActivitySnapshotV1> {
+    const startIndex = options?.startIndex ?? this.#streamIndex;
+    if (options?.follow === false && startIndex < 0) {
+      throw new Error(
+        "activity.stream({ follow: false }) requires a nonnegative startIndex; a tail-relative cursor cannot be bounded.",
+      );
+    }
+    return this.#streamAndAdvance(startIndex, options);
+  }
+
+  async *#streamAndAdvance(
+    startIndex: number,
+    options?: StreamOptions,
+  ): AsyncGenerator<ActivitySnapshotV1> {
+    let count = 0;
+    try {
+      for await (const snapshot of this.#read({
+        follow: options?.follow,
+        signal: options?.signal,
+        startIndex,
+        streamReconnectPolicy: options?.streamReconnectPolicy,
+      })) {
+        count += 1;
+        yield snapshot;
+      }
+    } finally {
+      if (startIndex >= 0) this.#streamIndex = Math.max(this.#streamIndex, startIndex + count);
+    }
+  }
+
+  #read(input: {
+    readonly follow?: boolean;
+    readonly signal?: AbortSignal;
+    readonly startIndex: number;
+    readonly streamReconnectPolicy?: StreamOptions["streamReconnectPolicy"];
+  }): AsyncIterable<ActivitySnapshotV1> {
+    return followDurableStreamIterable(
+      {
+        follow: input.follow,
+        host: this.#context.host,
+        path: createEveSessionActivityStreamRoutePath(this.#sessionId),
+        redirect: this.#context.redirect,
+        resolveHeaders: () => this.#context.resolveHeaders(),
+        sessionId: this.#sessionId,
+        signal: input.signal,
+        startIndex: input.startIndex,
+        streamReconnectPolicy: activityReconnectPolicy(input.streamReconnectPolicy),
+      },
+      (connection, idleTimeoutMs) => {
+        if (
+          connection.headers.get(EVE_STREAM_FORMAT_HEADER) !== EVE_ACTIVITY_STREAM_FORMAT ||
+          connection.headers.get(EVE_STREAM_VERSION_HEADER) !== EVE_ACTIVITY_STREAM_VERSION
+        ) {
+          throw new Error("Activity stream returned an unsupported format or version.");
+        }
+        return readJsonNdjsonStream(connection.body, {
+          idleTimeoutMs,
+          parse: parseActivitySnapshot,
+        });
+      },
+    );
+  }
+}
+
+function activityReconnectPolicy(policy: StreamReconnectPolicy | undefined): StreamReconnectPolicy {
+  if (policy && "reconnect" in policy) return policy;
+  return {
+    ...policy,
+    retryableErrorStatuses: (
+      policy?.retryableErrorStatuses ?? [409, 425, 500, 502, 503, 504]
+    ).filter((status) => status !== 404),
+  };
+}
+
+function parseActivitySnapshot(line: string): ActivitySnapshotV1 {
+  const snapshot = parseActivitySnapshotV1(JSON.parse(line));
+  if (snapshot === undefined) throw new Error("Activity stream returned an invalid snapshot.");
+  return snapshot;
+}

--- a/packages/eve/src/client/session.ts
+++ b/packages/eve/src/client/session.ts
@@ -3,6 +3,7 @@ import { EVE_SESSION_ID_HEADER, isCurrentTurnBoundaryEvent } from "#protocol/mes
 import { EVE_SESSION_ROUTE_PATH, createEveSessionRoutePath } from "#protocol/routes.js";
 import { ClientError } from "#client/client-error.js";
 import { MessageResponse } from "#client/message-response.js";
+import { ClientSessionActivity } from "#client/session-activity.js";
 import { followStreamIterable, sleep } from "#client/open-stream.js";
 import {
   cancelClientSession,
@@ -46,10 +47,14 @@ export class ClientSession {
   readonly #context: ClientSessionContext;
   #state: ClientSessionState;
 
+  /** Activity snapshots for this fixed root session, when its channel enabled activity. */
+  readonly activity: ClientSessionActivity;
+
   /** @internal */
   constructor(context: ClientSessionContext, state: ClientSessionState) {
     this.#context = context;
     this.#state = state;
+    this.activity = new ClientSessionActivity(context, state.sessionId);
   }
 
   /** @internal */

--- a/packages/eve/src/client/types.ts
+++ b/packages/eve/src/client/types.ts
@@ -2,6 +2,7 @@ import type { UserContent } from "ai";
 import type { StandardJSONSchemaV1 } from "#compiled/@standard-schema/spec/index.js";
 
 import type { MessageStreamEvent } from "#protocol/message.js";
+import type { ActivitySnapshotV1 } from "#protocol/activity.js";
 import type { CancelTurnResult } from "#protocol/cancel-turn.js";
 import type { ClearStatus } from "#protocol/clear-session.js";
 import type { CompactStatus } from "#protocol/compact-session.js";
@@ -316,6 +317,15 @@ export interface MessageResult<TOutput = unknown> {
 export interface ClientSessionState {
   readonly sessionId: string;
   readonly streamIndex: number;
+}
+
+/** Latest persisted activity state and its independent stream cursor. */
+export interface ActivitySessionSnapshot {
+  readonly snapshot: ActivitySnapshotV1 | undefined;
+  readonly session: {
+    readonly sessionId: string;
+    readonly streamIndex: number;
+  };
 }
 
 /**

--- a/packages/eve/src/eve-channel/index.ts
+++ b/packages/eve/src/eve-channel/index.ts
@@ -17,6 +17,7 @@ import {
   readAgentInfoRouteResponse,
   readRemoteAgentStreamHeadersResolver,
   readRouteSessionCreator,
+  readSessionActivityReader,
 } from "#internal/nitro/routes/channel-route-context.js";
 import {
   EVE_SESSION_ID_HEADER,
@@ -33,6 +34,7 @@ import {
   EVE_INFO_ROUTE_PATH,
   EVE_LEGACY_CONNECTION_CALLBACK_ROUTE_PATTERN,
   EVE_SESSION_ROUTE_PATH,
+  EVE_SESSION_ACTIVITY_STREAM_ROUTE_PATTERN,
   EVE_SESSION_CANCEL_ROUTE_PATTERN,
   EVE_SESSION_CLEAR_ROUTE_PATTERN,
   EVE_SESSION_COMPACT_ROUTE_PATTERN,
@@ -59,6 +61,7 @@ import { mergeUploadPolicy } from "#public/channels/upload-policy.js";
 import { defineChannel, DELETE, GET, HEAD, PATCH, POST, PUT } from "#public/definitions/channel.js";
 import {
   checkUploadPolicy,
+  createSessionActivityStreamResponse,
   createSessionStreamResponse,
   deriveOperationContinuationToken,
   parseCancelTurnBody,
@@ -501,6 +504,21 @@ export function eveChannel(input: EveChannelInput): EveChannel {
             : ({ ok: true, status: "no_active_session" } satisfies ResetResponse),
           { headers: { "cache-control": "no-store" } },
         );
+      }),
+
+      GET(EVE_SESSION_ACTIVITY_STREAM_ROUTE_PATTERN, async (req, args) => {
+        const authResult = await routeAuth(req, input.auth);
+        if (authResult instanceof Response) return authResult;
+        const sessionId = requireSessionId(args.params);
+        if (sessionId instanceof Response) return sessionId;
+        const activity = readSessionActivityReader(args);
+        if (activity === undefined) {
+          return Response.json(
+            { error: "Session activity requires internal channel dispatch context.", ok: false },
+            { status: 500 },
+          );
+        }
+        return await createSessionActivityStreamResponse(req, sessionId, activity);
       }),
 
       GET(EVE_SESSION_STREAM_ROUTE_PATTERN, async (req, { attachSession, params }) => {

--- a/packages/eve/src/eve-channel/request.ts
+++ b/packages/eve/src/eve-channel/request.ts
@@ -31,6 +31,12 @@ import {
 import { isInputResponse, type ValidatedInputResponse } from "#shared/input.js";
 import { parseJsonObject, type JsonObject } from "#shared/json.js";
 import type { RunMode } from "#shared/run-mode.js";
+import type { SessionActivityReader } from "#internal/nitro/routes/channel-route-context.js";
+import {
+  EVE_ACTIVITY_STREAM_CONTENT_TYPE,
+  EVE_ACTIVITY_STREAM_FORMAT,
+  EVE_ACTIVITY_STREAM_VERSION,
+} from "#protocol/activity.js";
 
 interface ParsedCreateBody {
   activityObserver?: ActivityObserverConfig;
@@ -297,6 +303,36 @@ export function rejectSessionContinuationToken(payload: Record<string, unknown>)
 export function requireSessionId(params: Readonly<Record<string, string>>): string | Response {
   const sessionId = params.sessionId;
   return sessionId || Response.json({ error: "Missing session id.", ok: false }, { status: 400 });
+}
+
+export async function createSessionActivityStreamResponse(
+  request: Request,
+  sessionId: string,
+  activity: SessionActivityReader,
+): Promise<Response> {
+  const startIndex = parseStartIndex(request);
+  if (startIndex instanceof Response) return startIndex;
+  const includeTailIndex = parseIncludeTailIndex(request);
+
+  try {
+    const tailIndex = includeTailIndex ? await activity.getTailIndex(sessionId) : undefined;
+    const snapshots = await activity.getStream(sessionId, { startIndex });
+    const headers = new Headers({
+      "cache-control": "no-store, no-transform",
+      "content-type": EVE_ACTIVITY_STREAM_CONTENT_TYPE,
+      "x-accel-buffering": "no",
+      [EVE_SESSION_ID_HEADER]: sessionId,
+      [EVE_STREAM_FORMAT_HEADER]: EVE_ACTIVITY_STREAM_FORMAT,
+      [EVE_STREAM_VERSION_HEADER]: EVE_ACTIVITY_STREAM_VERSION,
+    });
+    if (tailIndex !== undefined) headers.set(EVE_STREAM_TAIL_INDEX_HEADER, String(tailIndex));
+    return new Response(
+      serializeAsNdjson(snapshots, request.signal, streamEventLimit(startIndex, tailIndex)),
+      { headers },
+    );
+  } catch {
+    return Response.json({ error: "Session activity not found.", ok: false }, { status: 404 });
+  }
 }
 
 export async function createSessionStreamResponse(

--- a/packages/eve/src/execution/activity-collector.integration.test.ts
+++ b/packages/eve/src/execution/activity-collector.integration.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ACTIVITY_SNAPSHOT_STREAM_NAMESPACE,
+  activityCollectorWorkflow,
+} from "#execution/activity-collector.js";
+import { getRun, resumeHook, start } from "#internal/workflow/runtime.js";
+import { createTestRuntime } from "#internal/testing/app-harness.js";
+import { waitForHook } from "#internal/testing/workflow-test-helpers.js";
+import type { ActivityBatchV1, ActivitySnapshotV1 } from "#protocol/activity.js";
+
+describe("activityCollectorWorkflow", () => {
+  it("publishes revision-changing snapshots to its named durable stream", async () => {
+    const runtime = await createTestRuntime();
+    await runtime.run(async () => {
+      const token = "activity-collector-integration";
+      const run = await start(activityCollectorWorkflow, [
+        { expiresAt: "2099-01-01T00:00:00.000Z", serializedContext: {}, token },
+      ]);
+      await waitForHook({ runId: run.runId }, { token });
+      const work = {
+        id: "root:work",
+        kind: "root-turn" as const,
+        rootSessionId: "session",
+        rootTurnId: "turn",
+      };
+      const batch: ActivityBatchV1 = {
+        events: [{ eventId: "start", kind: "work.started", startedAt: "1", work }],
+        version: 1,
+      };
+
+      try {
+        await resumeHook(token, batch);
+        const stream = getRun(run.runId).getReadable({
+          namespace: ACTIVITY_SNAPSHOT_STREAM_NAMESPACE,
+        });
+        const reader = stream.getReader();
+        const result = await reader.read();
+        const snapshot = result.value as ActivitySnapshotV1;
+
+        expect(snapshot.revision).toBe(1);
+        expect(snapshot.work[work.id]).toMatchObject({ phase: "running", ...work });
+        await reader.cancel();
+      } finally {
+        await run.cancel();
+      }
+    });
+  });
+});

--- a/packages/eve/src/execution/activity-collector.test.ts
+++ b/packages/eve/src/execution/activity-collector.test.ts
@@ -10,6 +10,9 @@ import type { ActivityBatchV1 } from "#protocol/activity.js";
 const mocks = vi.hoisted(() => ({
   createHook: vi.fn(),
   disposeSessionActivityStep: vi.fn(),
+  getWritable: vi.fn(),
+  releaseLock: vi.fn(),
+  write: vi.fn(),
   renderSessionActivityStep: vi.fn(),
   sleep: vi.fn(),
 }));
@@ -17,6 +20,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("#compiled/@workflow/core/index.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("#compiled/@workflow/core/index.js")>()),
   createHook: mocks.createHook,
+  getWritable: mocks.getWritable,
   sleep: mocks.sleep,
 }));
 vi.mock("#execution/session-activity-renderer-step.js", () => ({
@@ -27,6 +31,10 @@ vi.mock("#execution/session-activity-renderer-step.js", () => ({
 beforeEach(() => {
   vi.resetAllMocks();
   mocks.disposeSessionActivityStep.mockResolvedValue(undefined);
+  mocks.getWritable.mockReturnValue({
+    getWriter: () => ({ releaseLock: mocks.releaseLock, write: mocks.write }),
+  });
+  mocks.write.mockResolvedValue(undefined);
 });
 
 const work = {
@@ -73,6 +81,7 @@ describe("activityCollectorWorkflow", () => {
         rendererStates: {},
         serializedContext: {},
       });
+      expect(mocks.write).toHaveBeenCalledTimes(debouncing ? 1 : 0);
     },
     1_000,
   );

--- a/packages/eve/src/execution/activity-collector.ts
+++ b/packages/eve/src/execution/activity-collector.ts
@@ -1,4 +1,4 @@
-import { createHook, sleep } from "#compiled/@workflow/core/index.js";
+import { createHook, getWritable, sleep } from "#compiled/@workflow/core/index.js";
 
 import { claimHookOwnership, isHookConflictError } from "#execution/hook-ownership.js";
 import { createActivitySnapshot, reduceActivityBatch } from "#execution/session-activity.js";
@@ -9,6 +9,9 @@ import {
 } from "#execution/session-activity-renderer-step.js";
 
 const RENDER_DEBOUNCE_MS = 350;
+
+export const ACTIVITY_SNAPSHOT_STREAM_NAMESPACE = "eve.activity.snapshots";
+export const ACTIVITY_COLLECTOR_RUN_ATTRIBUTE = "$eve.activity_collector";
 
 export interface ActivityCollectorInput {
   readonly expiresAt: string;
@@ -26,6 +29,9 @@ export async function activityCollectorWorkflow(input: ActivityCollectorInput): 
   const expiry = sleep(new Date(input.expiresAt)).then(() => ({ kind: "expired" as const }));
   let snapshot = createActivitySnapshot();
   let rendererStates: Readonly<Record<string, unknown>> = {};
+  const snapshotStream = getWritable<ActivitySnapshotV1>({
+    namespace: ACTIVITY_SNAPSHOT_STREAM_NAMESPACE,
+  });
 
   try {
     await claimHookOwnership(batches);
@@ -46,6 +52,7 @@ export async function activityCollectorWorkflow(input: ActivityCollectorInput): 
       const reduced = reduceCollectorActivity(snapshot, next.value.value);
       snapshot = reduced.snapshot;
       if (!reduced.presentationChanged) continue;
+      await publishActivitySnapshotStep(snapshotStream, snapshot);
 
       const debounce = sleep(RENDER_DEBOUNCE_MS).then(() => ({ kind: "render" as const }));
       while (true) {
@@ -59,7 +66,11 @@ export async function activityCollectorWorkflow(input: ActivityCollectorInput): 
         if (buffered.kind === "render") break;
         if (buffered.value.done === true) return;
         pendingRead = undefined;
-        snapshot = reduceActivityBatch(snapshot, buffered.value.value);
+        const bufferedReduction = reduceCollectorActivity(snapshot, buffered.value.value);
+        snapshot = bufferedReduction.snapshot;
+        if (bufferedReduction.presentationChanged) {
+          await publishActivitySnapshotStep(snapshotStream, snapshot);
+        }
       }
 
       const rendered = await renderSessionActivityStep({
@@ -74,6 +85,20 @@ export async function activityCollectorWorkflow(input: ActivityCollectorInput): 
       rendererStates,
       serializedContext: input.serializedContext,
     }).catch(() => {});
+  }
+}
+
+async function publishActivitySnapshotStep(
+  writable: WritableStream<ActivitySnapshotV1>,
+  snapshot: ActivitySnapshotV1,
+): Promise<void> {
+  "use step";
+
+  const writer = writable.getWriter();
+  try {
+    await writer.write(snapshot);
+  } finally {
+    writer.releaseLock();
   }
 }
 

--- a/packages/eve/src/execution/eve-workflow-attributes.ts
+++ b/packages/eve/src/execution/eve-workflow-attributes.ts
@@ -26,6 +26,7 @@
  * - `$eve.schedule`     — authored schedule that created the session
  * - `$eve.invocation_token` — channel-local continuation token for an external invocation
  * - `$eve.invocation_owner` — SHA-256 fingerprint of the invocation's initiating principal
+ * - `$eve.activity_collector` — collector run ID for root sessions with channel activity enabled
  * - `$eve.is_trace_content_visible` — whether observability may read content-bearing workflow data
  * - `$eve.is_otel_trace_enabled` — whether hosted Agent Runs OTEL is enabled for the run
  * - `$eve.trace_id` — trace id of the `agent.session` span, read from the pre-allocated

--- a/packages/eve/src/execution/session-activity.test.ts
+++ b/packages/eve/src/execution/session-activity.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 
 import { createActivitySnapshot, reduceActivityBatch } from "#execution/session-activity.js";
-import { parseActivityBatchV1, type ActivityEventV1 } from "#protocol/activity.js";
+import {
+  MAX_ACTIVITY_ENTITIES,
+  parseActivityBatchV1,
+  parseActivitySnapshotV1,
+  type ActivityEventV1,
+  type ActivitySnapshotV1,
+} from "#protocol/activity.js";
 
 const work = {
   id: "root:session:turn",
@@ -13,6 +19,103 @@ const work = {
 function reduce(events: readonly ActivityEventV1[]) {
   return reduceActivityBatch(createActivitySnapshot(), { events, version: 1 });
 }
+
+describe("activity snapshot protocol", () => {
+  const populatedSnapshot: ActivitySnapshotV1 = {
+    actions: {
+      action: {
+        id: "action",
+        kind: "tool",
+        label: "Search issues",
+        name: "search",
+        parentWorkId: work.id,
+        phase: "completed",
+        rootTurnId: "turn",
+        settledAt: "3",
+        startedAt: "2",
+        stepIndex: 0,
+      },
+    },
+    blockers: {
+      input: {
+        id: "input",
+        kind: "input",
+        parentActionId: "action",
+        parentWorkId: work.id,
+        phase: "blocked",
+        rootTurnId: "turn",
+        startedAt: "3",
+      },
+    },
+    pendingSettlements: {
+      "work:future": {
+        entityKind: "work",
+        eventId: "future:settled",
+        outcome: "failed",
+        settledAt: "4",
+      },
+    },
+    revision: 3,
+    seenEventIds: ["root", "action"],
+    version: 1,
+    work: {
+      [work.id]: { ...work, phase: "running", startedAt: "1" },
+    },
+  };
+
+  it("fully parses a populated snapshot", () => {
+    expect(parseActivitySnapshotV1(populatedSnapshot)).toMatchObject(populatedSnapshot);
+  });
+
+  it.each([
+    ["unknown top-level field", { ...populatedSnapshot, extra: true }],
+    [
+      "mismatched action key",
+      { ...populatedSnapshot, actions: { wrong: populatedSnapshot.actions.action } },
+    ],
+    [
+      "invalid nested phase",
+      {
+        ...populatedSnapshot,
+        blockers: { input: { ...populatedSnapshot.blockers.input, phase: "running" } },
+      },
+    ],
+    [
+      "active work with a settlement timestamp",
+      {
+        ...populatedSnapshot,
+        work: { [work.id]: { ...populatedSnapshot.work[work.id]!, settledAt: "4" } },
+      },
+    ],
+    [
+      "outcome inconsistent with pending entity kind",
+      {
+        ...populatedSnapshot,
+        pendingSettlements: {
+          "work:future": {
+            ...populatedSnapshot.pendingSettlements["work:future"],
+            outcome: "rejected",
+          },
+        },
+      },
+    ],
+    ["malformed seen event id", { ...populatedSnapshot, seenEventIds: [""] }],
+    [
+      "oversized entity collection",
+      {
+        ...populatedSnapshot,
+        actions: Object.fromEntries(
+          Array.from({ length: MAX_ACTIVITY_ENTITIES + 1 }, (_, index) => {
+            const id = `action-${index}`;
+            return [id, { ...populatedSnapshot.actions.action, id }];
+          }),
+        ),
+      },
+    ],
+  ])("rejects %s", (_name, candidate) => {
+    expect(parseActivitySnapshotV1(candidate)).toBeUndefined();
+  });
+});
 
 describe("activity protocol and reducer", () => {
   it("retains known siblings while ignoring additive unknown events", () => {

--- a/packages/eve/src/execution/session-activity.ts
+++ b/packages/eve/src/execution/session-activity.ts
@@ -1,5 +1,8 @@
 import { normalizePresentationText } from "#shared/presentation-text.js";
 import {
+  MAX_ACTIVITY_ENTITIES,
+  MAX_ACTIVITY_EVENT_IDS,
+  MAX_ACTIVITY_PENDING_SETTLEMENTS,
   type PendingActivitySettlementV1,
   type ActivityActionPhase,
   type ActivityBatchV1,
@@ -9,10 +12,6 @@ import {
   type ActivityWorkPhase,
   type ActivityWorkStateV1,
 } from "#protocol/activity.js";
-
-export const MAX_ACTIVITY_EVENT_IDS = 1_000;
-export const MAX_ACTIVITY_PENDING_SETTLEMENTS = 500;
-export const MAX_ACTIVITY_ENTITIES = 500;
 
 export function createActivitySnapshot(): ActivitySnapshotV1 {
   return {

--- a/packages/eve/src/execution/workflow-runtime.test.ts
+++ b/packages/eve/src/execution/workflow-runtime.test.ts
@@ -13,6 +13,7 @@ import { ChannelRequestIdKey, ActivityObserverKey } from "#context/keys.js";
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
 import {
   createWorkflowRuntime,
+  getWorkflowActivityStream,
   waitForCommandHookOwner,
   activityCollectorWorkflowReference,
   sessionTimeoutWorkflowReference,
@@ -30,7 +31,11 @@ import { markAgentTraceContext } from "#tracing/agent-trace-context.js";
 
 const getHookByTokenMock = vi.fn();
 const getRawHookByTokenMock = vi.fn();
-const world = { hooks: { getByToken: getRawHookByTokenMock } };
+const getWorldRunMock = vi.fn();
+const world = {
+  hooks: { getByToken: getRawHookByTokenMock },
+  runs: { get: getWorldRunMock },
+};
 const getRunMock = vi.fn();
 const getWorldMock = vi.fn();
 const resumeHookMock = vi.fn();
@@ -60,6 +65,7 @@ beforeEach(() => {
 afterEach(() => {
   getHookByTokenMock.mockReset();
   getRawHookByTokenMock.mockReset();
+  getWorldRunMock.mockReset();
   getRunMock.mockReset();
   getWorldMock.mockReset();
   resumeHookMock.mockReset();
@@ -130,6 +136,33 @@ describe("startWorkflowOnCurrentDeployment", () => {
       contextManager.disable();
     }
     expect(observedParents).toEqual([caller, undefined]);
+  });
+});
+
+describe("createWorkflowRuntime activity streams", () => {
+  it("resolves the collector through the root session attribute", async () => {
+    const readable = new ReadableStream();
+    const getReadable = vi.fn().mockReturnValue(readable);
+    getWorldRunMock.mockResolvedValue({
+      attributes: { "$eve.activity_collector": "collector-run" },
+    });
+    getRunMock.mockReturnValue({ getReadable });
+    await expect(getWorkflowActivityStream("session-run", { startIndex: 3 })).resolves.toBe(
+      readable,
+    );
+    expect(getReadable).toHaveBeenCalledWith({
+      namespace: "eve.activity.snapshots",
+      startIndex: 3,
+    });
+    expect(getRunMock).toHaveBeenCalledWith("collector-run");
+  });
+
+  it("rejects sessions without a collector association", async () => {
+    getWorldRunMock.mockResolvedValue({ attributes: {} });
+    await expect(getWorkflowActivityStream("session-run")).rejects.toThrow(
+      "Session activity not found.",
+    );
+    expect(getRunMock).not.toHaveBeenCalled();
   });
 });
 
@@ -609,7 +642,9 @@ describe("createWorkflowRuntime#createSession", () => {
     });
     expect(collectorInput.token).toHaveLength(43);
     const workflowInput = startMock.mock.calls[1]?.[1][0];
+    const workflowOptions = startMock.mock.calls[1]?.[2];
     expect(workflowInput.activityCollectorRunId).toBe("collector-run");
+    expect(workflowOptions.attributes["$eve.activity_collector"]).toBe("collector-run");
     expect(workflowInput.serializedContext[ActivityObserverKey.name]).toEqual({
       sink: {
         url: `https://agent.example.com/eve/v1/activity/${collectorInput.token}`,

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -42,6 +42,7 @@ import {
   type WorkflowMetadata,
 } from "#internal/workflow/runtime.js";
 import type { MessageStreamEvent } from "#protocol/message.js";
+import type { ActivitySnapshotV1 } from "#protocol/activity.js";
 import {
   normalizePersistedMessageStreamEvent,
   type MessageStreamEventForVersion,
@@ -55,7 +56,11 @@ import { buildRunContext } from "#execution/runtime-context.js";
 import { resolveEffectiveAgentRuntime } from "#execution/effective-agent-config.js";
 import { parseNdjsonStream } from "#execution/ndjson-stream.js";
 import type { WorkflowEntryInput } from "#execution/workflow-entry.js";
-import type { ActivityCollectorInput } from "#execution/activity-collector.js";
+import {
+  ACTIVITY_COLLECTOR_RUN_ATTRIBUTE,
+  ACTIVITY_SNAPSHOT_STREAM_NAMESPACE,
+  type ActivityCollectorInput,
+} from "#execution/activity-collector.js";
 import { createEveActivityRoutePath } from "#protocol/routes.js";
 import {
   createWorkflowCallbackUrl,
@@ -233,6 +238,9 @@ export function createWorkflowRuntime(config: {
             });
       const attributes = {
         ...sessionAttributes,
+        ...(collectorRunId === undefined
+          ? {}
+          : { [ACTIVITY_COLLECTOR_RUN_ATTRIBUTE]: collectorRunId }),
         ...(input.externalInvocation === undefined
           ? {}
           : buildInvocationAttributes(input.externalInvocation)),
@@ -318,6 +326,36 @@ export function createWorkflowRuntime(config: {
       }
     },
   };
+}
+
+export async function getWorkflowActivityStream(
+  sessionId: string,
+  options?: GetEventStreamOptions,
+): Promise<ReadableStream<ActivitySnapshotV1>> {
+  const collectorRunId = await resolveActivityCollectorRunId(sessionId);
+  return getRun(collectorRunId).getReadable({
+    namespace: ACTIVITY_SNAPSHOT_STREAM_NAMESPACE,
+    startIndex: options?.startIndex,
+  });
+}
+
+export async function getWorkflowActivityStreamTailIndex(sessionId: string): Promise<number> {
+  const collectorRunId = await resolveActivityCollectorRunId(sessionId);
+  const readable = getRun(collectorRunId).getReadable({
+    namespace: ACTIVITY_SNAPSHOT_STREAM_NAMESPACE,
+  });
+  try {
+    return await readable.getTailIndex();
+  } finally {
+    await readable.cancel().catch(() => {});
+  }
+}
+
+async function resolveActivityCollectorRunId(sessionId: string): Promise<string> {
+  const run = await (await getWorld()).runs.get(sessionId);
+  const collectorRunId = run.attributes[ACTIVITY_COLLECTOR_RUN_ATTRIBUTE];
+  if (collectorRunId === undefined) throw new Error("Session activity not found.");
+  return collectorRunId;
 }
 
 function normalizePersistedEvent(value: unknown): MessageStreamEvent {

--- a/packages/eve/src/internal/nitro/routes/channel-dispatch.ts
+++ b/packages/eve/src/internal/nitro/routes/channel-dispatch.ts
@@ -16,7 +16,12 @@ import {
   attachRouteChannelName,
   attachRemoteAgentStreamHeadersResolver,
   attachRouteSessionCreator,
+  attachSessionActivityReader,
 } from "#internal/nitro/routes/channel-route-context.js";
+import {
+  getWorkflowActivityStream,
+  getWorkflowActivityStreamTailIndex,
+} from "#execution/workflow-runtime.js";
 import type { NitroArtifactsConfig } from "#internal/nitro/routes/runtime-artifacts.js";
 import { traceChannelRequest } from "#internal/nitro/routes/channel-request-instrumentation.js";
 import { resolveNitroChannelRuntimeBundle } from "#internal/nitro/routes/runtime-stack.js";
@@ -257,39 +262,45 @@ function buildRouteArgs(
   });
   const to = createCrossChannelToFn(bundle.runtime, toCrossChannelTargets(bundle.channels));
 
-  const args = attachRouteSessionCreator(
-    attachHomeRouteMetadata(
-      attachRouteChannelName(
-        attachAgentInfoRouteResponse(
-          {
-            attachSession,
-            ...channelOperations,
-            params,
-            requestIp,
-            to,
-            waitUntil,
-          },
-          async () => {
-            const { handleAgentInfoRequest } = await import("#internal/nitro/routes/info.js");
-            return await handleAgentInfoRequest(config);
-          },
+  const args = attachSessionActivityReader(
+    attachRouteSessionCreator(
+      attachHomeRouteMetadata(
+        attachRouteChannelName(
+          attachAgentInfoRouteResponse(
+            {
+              attachSession,
+              ...channelOperations,
+              params,
+              requestIp,
+              to,
+              waitUntil,
+            },
+            async () => {
+              const { handleAgentInfoRequest } = await import("#internal/nitro/routes/info.js");
+              return await handleAgentInfoRequest(config);
+            },
+          ),
+          channelName,
         ),
-        channelName,
+        { agentName: bundle.agentName },
       ),
-      { agentName: bundle.agentName },
+      async (input) =>
+        await bundle.runtime.createSession({
+          ...input,
+          adapter,
+          channelName,
+          continuationToken:
+            input.continuationToken === undefined
+              ? undefined
+              : `${channelName}:${input.continuationToken}`,
+          delivery: createChannelDeliveryMetadata(deliverySource),
+          requestId,
+        }),
     ),
-    async (input) =>
-      await bundle.runtime.createSession({
-        ...input,
-        adapter,
-        channelName,
-        continuationToken:
-          input.continuationToken === undefined
-            ? undefined
-            : `${channelName}:${input.continuationToken}`,
-        delivery: createChannelDeliveryMetadata(deliverySource),
-        requestId,
-      }),
+    {
+      getStream: getWorkflowActivityStream,
+      getTailIndex: getWorkflowActivityStreamTailIndex,
+    },
   );
   if (bundle.resolveRemoteAgentStreamHeaders !== undefined) {
     attachRemoteAgentStreamHeadersResolver(args, bundle.resolveRemoteAgentStreamHeaders);

--- a/packages/eve/src/internal/nitro/routes/channel-route-context.ts
+++ b/packages/eve/src/internal/nitro/routes/channel-route-context.ts
@@ -1,5 +1,6 @@
 import type { RouteHandlerArgs } from "#channel/routes.js";
 import type { RunHandle, RunInput } from "#channel/types.js";
+import type { ActivitySnapshotV1 } from "#protocol/activity.js";
 
 type AgentInfoRouteResponse = () => Promise<Response>;
 export interface HomeRouteMetadata {
@@ -25,6 +26,7 @@ const homeRouteMetadataKey = "__eveHomeRouteMetadata";
 const routeChannelNameKey = "__eveRouteChannelName";
 const remoteAgentStreamHeadersResolverKey = "__eveRemoteAgentStreamHeadersResolver";
 const routeSessionCreatorKey = "__eveRouteSessionCreator";
+const sessionActivityReaderKey = "__eveSessionActivityReader";
 
 type InternalRouteArgs = RouteHandlerArgs & {
   [agentInfoRouteResponseKey]?: AgentInfoRouteResponse;
@@ -32,7 +34,16 @@ type InternalRouteArgs = RouteHandlerArgs & {
   [routeChannelNameKey]?: string;
   [remoteAgentStreamHeadersResolverKey]?: RemoteAgentStreamHeadersResolver;
   [routeSessionCreatorKey]?: RouteSessionCreator;
+  [sessionActivityReaderKey]?: SessionActivityReader;
 };
+
+export interface SessionActivityReader {
+  getStream(
+    sessionId: string,
+    options?: { readonly startIndex?: number },
+  ): Promise<ReadableStream<ActivitySnapshotV1>>;
+  getTailIndex(sessionId: string): Promise<number>;
+}
 
 export function attachRouteChannelName<TArgs extends RouteHandlerArgs>(
   args: TArgs,
@@ -90,6 +101,22 @@ export function attachRouteSessionCreator<TArgs extends RouteHandlerArgs>(
 export function readRouteSessionCreator(args: RouteHandlerArgs): RouteSessionCreator | undefined {
   const routeArgs: InternalRouteArgs = args;
   return routeArgs[routeSessionCreatorKey];
+}
+
+export function attachSessionActivityReader<TArgs extends RouteHandlerArgs>(
+  args: TArgs,
+  reader: SessionActivityReader,
+): TArgs {
+  const routeArgs: InternalRouteArgs = args;
+  routeArgs[sessionActivityReaderKey] = reader;
+  return args;
+}
+
+export function readSessionActivityReader(
+  args: RouteHandlerArgs,
+): SessionActivityReader | undefined {
+  const routeArgs: InternalRouteArgs = args;
+  return routeArgs[sessionActivityReaderKey];
 }
 
 export function attachRemoteAgentStreamHeadersResolver<TArgs extends RouteHandlerArgs>(

--- a/packages/eve/src/protocol/activity.ts
+++ b/packages/eve/src/protocol/activity.ts
@@ -1,4 +1,11 @@
 export const MAX_ACTIVITY_EVENTS_PER_BATCH = 100;
+export const MAX_ACTIVITY_EVENT_IDS = 1_000;
+export const MAX_ACTIVITY_PENDING_SETTLEMENTS = 500;
+export const MAX_ACTIVITY_ENTITIES = 500;
+
+export const EVE_ACTIVITY_STREAM_CONTENT_TYPE = "application/x-ndjson";
+export const EVE_ACTIVITY_STREAM_FORMAT = "eve-activity-snapshot-ndjson";
+export const EVE_ACTIVITY_STREAM_VERSION = "1";
 
 export type ActivityWorkKind = "root-turn" | "subagent" | "remote-agent" | "task";
 export type ActivityWorkPhase = "running" | "completed" | "failed" | "cancelled";
@@ -123,6 +130,68 @@ export interface ActivitySnapshotV1 {
   readonly seenEventIds: readonly string[];
   readonly version: 1;
   readonly work: Readonly<Record<string, ActivityWorkStateV1>>;
+}
+
+/** Parses a complete persisted activity snapshot at the version 1 protocol boundary. */
+export function parseActivitySnapshotV1(value: unknown): ActivitySnapshotV1 | undefined {
+  if (
+    !isRecord(value) ||
+    !hasOnlyKeys(value, [
+      "actions",
+      "blockers",
+      "pendingSettlements",
+      "revision",
+      "seenEventIds",
+      "version",
+      "work",
+    ]) ||
+    value.version !== 1 ||
+    !Number.isSafeInteger(value.revision) ||
+    (value.revision as number) < 0 ||
+    !isBoundedStringArray(value.seenEventIds, MAX_ACTIVITY_EVENT_IDS)
+  )
+    return undefined;
+
+  const actions = parseStateRecord(value.actions, MAX_ACTIVITY_ENTITIES, (candidate, key) => {
+    const state = parseActionState(candidate);
+    return state?.id === key ? state : undefined;
+  });
+  const blockers = parseStateRecord(value.blockers, MAX_ACTIVITY_ENTITIES, (candidate, key) => {
+    const state = parseBlockerState(candidate);
+    return state?.id === key ? state : undefined;
+  });
+  const pendingSettlements = parseStateRecord(
+    value.pendingSettlements,
+    MAX_ACTIVITY_PENDING_SETTLEMENTS,
+    (candidate, key) => {
+      const state = parsePendingSettlement(candidate);
+      return state !== undefined && isPendingSettlementKey(key, state.entityKind)
+        ? state
+        : undefined;
+    },
+    isPotentialPendingSettlementKey,
+  );
+  const work = parseStateRecord(value.work, MAX_ACTIVITY_ENTITIES, (candidate, key) => {
+    const state = parseWorkState(candidate);
+    return state?.id === key ? state : undefined;
+  });
+  if (
+    actions === undefined ||
+    blockers === undefined ||
+    pendingSettlements === undefined ||
+    work === undefined
+  )
+    return undefined;
+
+  return {
+    actions,
+    blockers,
+    pendingSettlements,
+    revision: value.revision as number,
+    seenEventIds: value.seenEventIds,
+    version: 1,
+    work,
+  };
 }
 
 export function parseActivityWorkIdentityV1(value: unknown): ActivityWorkIdentityV1 | undefined {
@@ -291,6 +360,139 @@ function parseKnownEvent(value: Record<string, unknown>): ActivityEventV1 | null
   }
 }
 
+function parseWorkState(value: unknown): ActivityWorkStateV1 | undefined {
+  if (
+    !isRecord(value) ||
+    !hasOnlyKeys(value, [
+      "callId",
+      "id",
+      "kind",
+      "name",
+      "parentId",
+      "phase",
+      "rootSessionId",
+      "rootTurnId",
+      "sessionId",
+      "settledAt",
+      "startedAt",
+      "turnId",
+    ])
+  )
+    return undefined;
+  const identity = parseActivityWorkIdentityV1(
+    omitStateKeys(value, ["phase", "settledAt", "startedAt"]),
+  );
+  if (
+    identity === undefined ||
+    !isOneOf(value.phase, ["running", "completed", "failed", "cancelled"] as const) ||
+    !isOptionalBoundedString(value.settledAt) ||
+    !isBoundedString(value.startedAt) ||
+    !hasConsistentSettlement(value.phase, value.settledAt, "running")
+  )
+    return undefined;
+  return {
+    ...identity,
+    phase: value.phase,
+    settledAt: value.settledAt,
+    startedAt: value.startedAt,
+  };
+}
+
+function parseActionState(value: unknown): ActivityActionStateV1 | undefined {
+  if (
+    !isRecord(value) ||
+    !hasOnlyKeys(value, [
+      "id",
+      "kind",
+      "label",
+      "name",
+      "parentWorkId",
+      "phase",
+      "rootTurnId",
+      "settledAt",
+      "startedAt",
+      "stepIndex",
+    ])
+  )
+    return undefined;
+  const identity = parseActionIdentity(
+    omitStateKeys(value, ["label", "phase", "settledAt", "startedAt"]),
+  );
+  if (
+    identity === undefined ||
+    !isOptionalBoundedString(value.label) ||
+    !isOneOf(value.phase, ["running", "completed", "failed", "rejected", "cancelled"] as const) ||
+    !isOptionalBoundedString(value.settledAt) ||
+    !isBoundedString(value.startedAt) ||
+    !hasConsistentSettlement(value.phase, value.settledAt, "running")
+  )
+    return undefined;
+  return {
+    ...identity,
+    label: value.label,
+    phase: value.phase,
+    settledAt: value.settledAt,
+    startedAt: value.startedAt,
+  };
+}
+
+function parseBlockerState(value: unknown): ActivityBlockerStateV1 | undefined {
+  if (
+    !isRecord(value) ||
+    !hasOnlyKeys(value, [
+      "id",
+      "kind",
+      "label",
+      "parentActionId",
+      "parentWorkId",
+      "phase",
+      "rootTurnId",
+      "settledAt",
+      "startedAt",
+    ])
+  )
+    return undefined;
+  const identity = parseBlockerIdentity(omitStateKeys(value, ["phase", "settledAt", "startedAt"]));
+  if (
+    identity === undefined ||
+    !isOneOf(value.phase, ["blocked", "completed", "cancelled", "failed"] as const) ||
+    !isOptionalBoundedString(value.settledAt) ||
+    !isBoundedString(value.startedAt) ||
+    !hasConsistentSettlement(value.phase, value.settledAt, "blocked")
+  )
+    return undefined;
+  return {
+    ...identity,
+    phase: value.phase,
+    settledAt: value.settledAt,
+    startedAt: value.startedAt,
+  };
+}
+
+function parsePendingSettlement(value: unknown): PendingActivitySettlementV1 | undefined {
+  if (
+    !isRecord(value) ||
+    !hasOnlyKeys(value, ["entityKind", "eventId", "outcome", "settledAt"]) ||
+    !isOneOf(value.entityKind, ["action", "blocker", "work"] as const) ||
+    !isIdentity(value.eventId) ||
+    !isBoundedString(value.settledAt)
+  )
+    return undefined;
+  const validOutcome =
+    value.entityKind === "action"
+      ? isOneOf(value.outcome, ["completed", "failed", "rejected", "cancelled"] as const)
+      : value.entityKind === "blocker"
+        ? isOneOf(value.outcome, ["completed", "cancelled", "failed"] as const)
+        : isOneOf(value.outcome, ["completed", "failed", "cancelled"] as const);
+  if (!validOutcome) return undefined;
+  return {
+    entityKind: value.entityKind,
+    eventId: value.eventId,
+    outcome: value.outcome as PendingActivitySettlementV1["outcome"],
+    settledAt: value.settledAt,
+  };
+}
+
 function parseActionIdentity(value: unknown): ActivityActionIdentityV1 | undefined {
   if (
     !isRecord(value) ||
@@ -303,7 +505,7 @@ function parseActionIdentity(value: unknown): ActivityActionIdentityV1 | undefin
     !isBoundedString(value.name) ||
     !isIdentity(value.parentWorkId) ||
     !isIdentity(value.rootTurnId) ||
-    !Number.isInteger(value.stepIndex) ||
+    !Number.isSafeInteger(value.stepIndex) ||
     (value.stepIndex as number) < 0
   )
     return undefined;
@@ -340,6 +542,57 @@ function parseBlockerIdentity(value: unknown): ActivityBlockerIdentityV1 | undef
     parentWorkId: value.parentWorkId,
     rootTurnId: value.rootTurnId,
   };
+}
+
+function parseStateRecord<T>(
+  value: unknown,
+  maxSize: number,
+  parse: (value: unknown, key: string) => T | undefined,
+  isValidKey: (key: string) => boolean = isIdentity,
+): Readonly<Record<string, T>> | undefined {
+  if (!isRecord(value)) return undefined;
+  const entries = Object.entries(value);
+  if (entries.length > maxSize) return undefined;
+  const parsed: Array<readonly [string, T]> = [];
+  for (const [key, candidate] of entries) {
+    if (!isValidKey(key)) return undefined;
+    const state = parse(candidate, key);
+    if (state === undefined) return undefined;
+    parsed.push([key, state]);
+  }
+  return Object.fromEntries(parsed);
+}
+
+function omitStateKeys(
+  value: Record<string, unknown>,
+  keys: readonly string[],
+): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(value).filter(([key]) => !keys.includes(key)));
+}
+
+function hasConsistentSettlement(phase: unknown, settledAt: unknown, activePhase: string): boolean {
+  return phase === activePhase ? settledAt === undefined : isBoundedString(settledAt);
+}
+
+function isPendingSettlementKey(
+  key: string,
+  entityKind: PendingActivitySettlementV1["entityKind"],
+): boolean {
+  const prefix = `${entityKind}:`;
+  return key.startsWith(prefix) && isIdentity(key.slice(prefix.length));
+}
+
+function isPotentialPendingSettlementKey(key: string): boolean {
+  return (["action", "blocker", "work"] as const).some((kind) => isPendingSettlementKey(key, kind));
+}
+
+function isBoundedStringArray(value: unknown, maxSize: number): value is readonly string[] {
+  return (
+    Array.isArray(value) &&
+    value.length <= maxSize &&
+    new Set(value).size === value.length &&
+    value.every((candidate) => isIdentity(candidate))
+  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/eve/src/protocol/routes.ts
+++ b/packages/eve/src/protocol/routes.ts
@@ -40,6 +40,9 @@ export const EVE_SESSION_RESET_ROUTE_PATTERN = `${EVE_SESSION_ROUTE_PATH}/:sessi
 /** Stable event-stream route pattern for one exact session ID. */
 export const EVE_SESSION_STREAM_ROUTE_PATTERN = `${EVE_SESSION_ROUTE_PATH}/:sessionId/stream`;
 
+/** Stable activity-snapshot stream route pattern for one exact root session ID. */
+export const EVE_SESSION_ACTIVITY_STREAM_ROUTE_PATTERN = `${EVE_SESSION_ROUTE_PATH}/:sessionId/activity/stream`;
+
 /**
  * Parent-origin proxy route for one remotely executed child session stream.
  */
@@ -161,6 +164,11 @@ export function createEveSessionResetRoutePath(sessionId: string): string {
 /** Builds the ID-addressed event-stream route for one session. */
 export function createEveSessionStreamRoutePath(sessionId: string): string {
   return `${EVE_SESSION_ROUTE_PATH}/${encodeURIComponent(sessionId)}/stream`;
+}
+
+/** Builds the activity-snapshot stream route for one root session. */
+export function createEveSessionActivityStreamRoutePath(sessionId: string): string {
+  return `${EVE_SESSION_ROUTE_PATH}/${encodeURIComponent(sessionId)}/activity/stream`;
 }
 
 /**

--- a/packages/eve/src/public/channels/eve.test.ts
+++ b/packages/eve/src/public/channels/eve.test.ts
@@ -5,7 +5,10 @@ import { buildAdapterContext } from "#channel/adapter-context.js";
 import { callAdapterEventHandler, type ChannelAdapter } from "#channel/adapter.js";
 import { isCompiledChannel } from "#channel/compiled-channel.js";
 import { readClientContext } from "#internal/client-context.js";
-import { attachRouteSessionCreator } from "#internal/nitro/routes/channel-route-context.js";
+import {
+  attachRouteSessionCreator,
+  attachSessionActivityReader,
+} from "#internal/nitro/routes/channel-route-context.js";
 import { mockChannelContext } from "#internal/testing/mocks/mock-channel-operations.js";
 import { type AuthFn, none } from "#public/channels/auth.js";
 import { eveChannel, defaultEveAuth, type EveChannelInput } from "#public/channels/eve.js";
@@ -365,6 +368,31 @@ function createEveStreamHandler(input: EveChannelInput) {
   };
 }
 
+function createEveActivityStreamHandler(input: EveChannelInput) {
+  const channel = eveChannel(input);
+  const route = channel.routes.find(
+    (candidate) =>
+      candidate.method === "GET" && candidate.path === "/eve/v1/session/:sessionId/activity/stream",
+  );
+  if (!route) throw new Error("No session activity stream GET route found");
+
+  const getActivityStream = vi.fn().mockResolvedValue(new ReadableStream());
+  const getActivityStreamTailIndex = vi.fn().mockResolvedValue(-1);
+  return {
+    getActivityStream,
+    getActivityStreamTailIndex,
+    async fetch(url: string) {
+      return (route as any).handler(
+        new Request(url),
+        attachSessionActivityReader(
+          { ...createRouteArgs(), params: { sessionId: "test-session-id" } },
+          { getStream: getActivityStream, getTailIndex: getActivityStreamTailIndex },
+        ),
+      );
+    },
+  };
+}
+
 function filePartBody(
   overrides: Partial<FilePart> & { data: FilePart["data"] } & { mediaType: FilePart["mediaType"] },
 ): {
@@ -523,6 +551,64 @@ describe("eveChannel — events", () => {
     });
 
     expect(observed).toEqual(["done", "continuation", "sess-eve-event"]);
+  });
+});
+
+describe("eveChannel — activity stream", () => {
+  it("serves persisted snapshots with an independent durable cursor", async () => {
+    const handler = createEveActivityStreamHandler({ auth: none() });
+    handler.getActivityStreamTailIndex.mockResolvedValueOnce(0);
+    handler.getActivityStream.mockResolvedValueOnce(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue({
+            actions: {},
+            blockers: {},
+            pendingSettlements: {},
+            revision: 1,
+            seenEventIds: [],
+            version: 1,
+            work: {},
+          });
+          controller.close();
+        },
+      }),
+    );
+
+    const response = await handler.fetch(
+      "https://eve.test/eve/v1/session/test-session-id/activity/stream?includeTailIndex=1",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-eve-stream-format")).toBe("eve-activity-snapshot-ndjson");
+    expect(response.headers.get("x-eve-stream-version")).toBe("1");
+    expect(response.headers.get("x-eve-stream-tail-index")).toBe("0");
+    expect(handler.getActivityStream).toHaveBeenCalledWith("test-session-id", {
+      startIndex: undefined,
+    });
+    await expect(response.text()).resolves.toContain('"revision":1');
+  });
+
+  it("authenticates before resolving session activity", async () => {
+    const handler = createEveActivityStreamHandler({ auth: () => null });
+
+    const response = await handler.fetch(
+      "https://eve.test/eve/v1/session/test-session-id/activity/stream",
+    );
+
+    expect(response.status).toBe(401);
+    expect(handler.getActivityStream).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when activity is not enabled or mapped", async () => {
+    const handler = createEveActivityStreamHandler({ auth: none() });
+    handler.getActivityStream.mockRejectedValueOnce(new Error("missing"));
+
+    const response = await handler.fetch(
+      "https://eve.test/eve/v1/session/test-session-id/activity/stream",
+    );
+
+    expect(response.status).toBe(404);
   });
 });
 

--- a/research/session-activity-api.md
+++ b/research/session-activity-api.md
@@ -1,0 +1,29 @@
+---
+issue: TBD
+status: implemented
+last_updated: "2026-09-09"
+---
+
+# Session activity API
+
+> **AI status:** Written entirely by AI; human review pending.
+
+## Goal
+
+Expose the existing activity collector's channel-neutral snapshots to authenticated local and remote clients without enabling collection for any additional agent or channel.
+
+## Public contract
+
+`GET /eve/v1/session/:sessionId/activity/stream` serves an NDJSON stream of complete `ActivitySnapshotV1` revisions. It accepts the session stream's `startIndex` and `includeTailIndex` query parameters and uses the same route authentication. Unknown sessions, child sessions, sessions whose channel did not start a collector, and missing collectors return `404`.
+
+The TypeScript client exposes the same data through `session.activity.snapshot()` and `session.activity.stream()`. Activity uses an independent stream cursor so reading progress cannot advance or rewind session history.
+
+## Persistence and ownership
+
+When an existing channel activity renderer causes a root collector to start, eve records the collector run ID in a private `$eve.activity_collector` attribute on the new root session run. The collector writes each revision-changing snapshot immediately to its named `eve.activity.snapshots` durable stream. Its existing renderer debounce remains independent, so API publication does not delay snapshot readers and snapshot readers do not increase provider updates.
+
+The reporting capability route remains write-only. Clients resolve activity through the authenticated root-session route and never receive its collector token.
+
+## Scope
+
+This change does not start collectors for sessions that did not already opt into channel activity rendering, expose raw activity batches, reconstruct historical activity from session events, or provide activity for child session IDs.


### PR DESCRIPTION
### Summary

Exposes activity snapshots over the eve API so local and remote clients can observe the same progress state already used by channel renderers. This only publishes activity for new root sessions whose channel already enabled an activity renderer; requesting the API does not opt other agents into collection.

```ts
const current = await session.activity.snapshot();

for await (const activity of session.activity.stream({
  startIndex: current.session.streamIndex,
})) {
  console.log(activity.work);
}
```

The HTTP surface is `GET /eve/v1/session/:sessionId/activity/stream`, with the same cursor and bounded-read behavior as session history.

### Validation

Adds integration coverage for publishing collector snapshots to the durable activity stream, plus focused route, client cursor/reconnect, protocol validation, and collector tests. The full unit run had two failures in `subagent-pump.test.ts`; those tests pass with this branch stashed and do not touch this change.

🤖
