### PR TITLE
fix(eve): stop serializing BYOK credentials in the /eve/v1/info response

### DIFF
--- a/.changeset/redact-agent-info-credentials.md
+++ b/.changeset/redact-agent-info-credentials.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Redact BYOK credentials and credential-shaped provider options from `/eve/v1/info` responses while preserving non-secret provider settings.

--- a/packages/eve/src/internal/nitro/routes/agent-info/build-agent-info-response.test.ts
+++ b/packages/eve/src/internal/nitro/routes/agent-info/build-agent-info-response.test.ts
@@ -211,4 +211,48 @@ describe("buildAgentInfoResponse", () => {
       }),
     );
   });
+
+  it("never serializes BYOK or credential-shaped providerOptions values", async () => {
+    const { manifest } = await compileFromMemory({
+      model: "openai/gpt-5.4",
+      name: "info-agent",
+    });
+    const model = manifest.config.model;
+    if (model === undefined) throw new Error("Expected a static compiled model.");
+    // The shipped BYOK scaffold places the owner's provider key under
+    // `gateway.byok`; a custom provider may carry other credential fields.
+    model.providerOptions = {
+      gateway: {
+        byok: { openai: [{ apiKey: "sk-canary-byok" }] },
+        serviceTier: "priority",
+      },
+      openai: {
+        apiKey: "sk-canary-direct",
+        headers: { authorization: "Bearer canary-header" },
+        reasoningEffort: "high",
+      },
+    };
+
+    const response = buildAgentInfoResponse(
+      { manifest, schedules: [] },
+      {
+        gatewayCredentials: { apiKey: false, oidc: false },
+        mode: "production",
+      },
+    );
+
+    const serialized = JSON.stringify(response);
+    expect(serialized).not.toContain("sk-canary-byok");
+    expect(serialized).not.toContain("sk-canary-direct");
+    expect(serialized).not.toContain("canary-header");
+    // Non-secret options survive for the dev TUI (`gateway.serviceTier`).
+    expect(response.agent.model.providerOptions).toEqual({
+      gateway: { serviceTier: "priority" },
+      openai: {
+        apiKey: "[redacted]",
+        headers: "[redacted]",
+        reasoningEffort: "high",
+      },
+    });
+  });
 });

--- a/packages/eve/src/internal/nitro/routes/agent-info/build-agent-info-response.ts
+++ b/packages/eve/src/internal/nitro/routes/agent-info/build-agent-info-response.ts
@@ -15,6 +15,7 @@ import {
   resolveModelEndpointStatus,
 } from "#internal/resolve-model-endpoint-status.js";
 import type { ChatGptAuthState } from "#public/models/openai/chatgpt/token-broker.js";
+import type { JsonObject, JsonValue } from "#shared/json.js";
 import { WORKFLOW_TOOL_NAME } from "#shared/workflow-sandbox.js";
 
 export type AgentInfoResponse = AgentInfoResult;
@@ -61,7 +62,9 @@ export function buildAgentInfoResponse(
                 toChatGptEndpoint(input.chatgptAuth),
               ),
               id: manifest.config.model.id,
-              providerOptions: manifest.config.model.providerOptions,
+              providerOptions: sanitizeProviderOptionsForInfo(
+                manifest.config.model.providerOptions,
+              ),
               reasoning: manifest.config.reasoning,
               routing: manifest.config.model.routing,
               source:
@@ -221,6 +224,64 @@ export function buildAgentInfoResponse(
       rootEntries: [...manifest.workspaceResourceRoot.rootEntries],
     },
   };
+}
+
+/**
+ * `providerOptions` can carry deployment-owner credentials: the shipped BYOK
+ * scaffold places the provider `apiKey` under `gateway.byok`, and custom
+ * providers may accept credential-bearing fields such as `headers`. The info
+ * route is served to every caller the application's channel auth admits, so
+ * the inspection payload must never serialize credential material. Drop the
+ * BYOK block (its provider slug is already reported via `routing.byok`) and
+ * redact credential-shaped keys recursively, while keeping non-secret options
+ * such as `gateway.serviceTier` that the dev TUI reads.
+ */
+const CREDENTIAL_OPTION_KEY =
+  /^(api[-_]?key|access[-_]?token|auth|authorization|bearer|client[-_]?secret|credentials?|headers|password|private[-_]?key|secret|token)$/i;
+
+const REDACTED_CREDENTIAL = "[redacted]";
+
+function sanitizeProviderOptionsForInfo(
+  providerOptions: Record<string, JsonObject> | undefined,
+): Record<string, JsonObject> | undefined {
+  if (providerOptions === undefined) return undefined;
+  const sanitized: Record<string, JsonObject> = {};
+  for (const [provider, options] of Object.entries(providerOptions)) {
+    sanitized[provider] = redactCredentialOptions(options);
+  }
+  return sanitized;
+}
+
+function redactCredentialOptions(value: JsonValue): JsonObject {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  const redacted: Record<string, JsonValue> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (key === "byok") {
+      // BYOK entries are `{ apiKey }` credential objects; the provider slug is
+      // already exposed through `routing.byok`.
+      continue;
+    }
+    if (CREDENTIAL_OPTION_KEY.test(key)) {
+      redacted[key] = REDACTED_CREDENTIAL;
+      continue;
+    }
+    if (entry !== null && typeof entry === "object") {
+      if (Array.isArray(entry)) {
+        redacted[key] = entry.map((item) =>
+          item !== null && typeof item === "object" && !Array.isArray(item)
+            ? redactCredentialOptions(item)
+            : item,
+        );
+      } else {
+        redacted[key] = redactCredentialOptions(entry);
+      }
+      continue;
+    }
+    redacted[key] = entry;
+  }
+  return redacted;
 }
 
 function toModuleSource(


### PR DESCRIPTION
The agent info response copied manifest.config.model.providerOptions verbatim. The shipped BYOK scaffold places the deployment owner's provider apiKey under gateway.byok, so any caller the application's channel auth admits to GET /eve/v1/info received the owner's reusable provider credential, usable externally against the provider at the owner's expense.

Sanitize providerOptions before serialization: drop the BYOK credential block (the provider slug is already reported via routing.byok) and redact credential-shaped keys recursively, keeping non-secret options such as gateway.serviceTier that the dev TUI reads. Adds a regression test with canary credential values.

### Summary

<!--
Keep this short. Start with the concrete problem, user need, or decision that
prompted the change, then explain the solution and meaningful behavior or
decisions—not changed files or commits. Link an existing issue or discussion
when one exists (for example, "Closes #123" or "Related to #123"). Do not
create an issue solely to accompany this pull request. Call out breaking
changes, preserved behavior, scope boundaries, or stacked PRs when relevant.
-->

### Validation

<!--
List the exact commands you ran and useful manual coverage. Include relevant
results or limitations. Explain when tests are not applicable.
-->

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
