### PR TITLE
fix(eve): normalize mixed provider tool history

### DIFF
--- a/.changeset/fix-mixed-provider-tool-history.md
+++ b/.changeset/fix-mixed-provider-tool-history.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Normalize mixed provider-executed and local tool calls into replay-safe history so Gemini conversations can continue after the tool results are persisted.

--- a/packages/eve/src/harness/provider-tool-history.test.ts
+++ b/packages/eve/src/harness/provider-tool-history.test.ts
@@ -141,4 +141,97 @@ describe("normalizeProviderToolHistory", () => {
     expect(normalized.messages).toEqual(messages);
     expect(normalized.outcomeEndsResponse).toBe(true);
   });
+
+  it("normalizes provider-owned results when the turn also calls a local tool", () => {
+    const messages: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "search-1",
+            toolName: "web_search",
+            input: { query: "Current result" },
+            providerExecuted: true,
+          },
+          {
+            type: "tool-result",
+            toolCallId: "search-1",
+            toolName: "web_search",
+            output: { type: "json", value: { results: [] } },
+          },
+          {
+            type: "tool-call",
+            toolCallId: "todo-1",
+            toolName: "todo",
+            input: { todos: [] },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "todo-1",
+            toolName: "todo",
+            output: { type: "json", value: { todos: [] } },
+          },
+        ],
+      },
+    ];
+
+    const normalized = normalizeProviderToolHistory({
+      messages,
+      providerExecutedOutcomeIds: new Set(["search-1"]),
+    });
+
+    expect(normalized.messages).toEqual([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "search-1",
+            toolName: "web_search",
+            input: { query: "Current result" },
+            providerExecuted: false,
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "search-1",
+            toolName: "web_search",
+            output: { type: "json", value: { results: [] } },
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "todo-1",
+            toolName: "todo",
+            input: { todos: [] },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "todo-1",
+            toolName: "todo",
+            output: { type: "json", value: { todos: [] } },
+          },
+        ],
+      },
+    ]);
+  });
 });

--- a/packages/eve/src/harness/provider-tool-history.ts
+++ b/packages/eve/src/harness/provider-tool-history.ts
@@ -4,17 +4,17 @@ import type { ModelMessage, ToolModelMessage } from "ai";
  * Converts provider-executed tool outcomes into replay-safe model messages.
  *
  * Provider SDKs can return a tool call and its result inside one assistant
- * message. When the result is provider-executed but the call lacks the matching
- * marker, each matching call is rewritten as a normal call and consecutive
- * results are moved into a tool message at their original position. Native
- * provider-owned call/result pairs remain untouched. Text before a result
- * remains before it; text after a result remains after it.
+ * message. Each matching call is rewritten as a normal call and consecutive
+ * results are moved into a tool message at their original position when the
+ * call lacks the matching marker or shares an assistant message with a local
+ * tool call. Native provider-only call/result pairs remain untouched. Text
+ * before a result remains before it; text after a result remains after it.
  */
 export function normalizeProviderToolHistory(input: {
   readonly messages: readonly ModelMessage[];
   readonly providerExecutedOutcomeIds: ReadonlySet<string>;
 }): { readonly messages: ModelMessage[]; readonly outcomeEndsResponse: boolean } {
-  const toolCallIdsToNormalize = findUnmarkedProviderToolCalls(input);
+  const toolCallIdsToNormalize = findProviderToolCallsToNormalize(input);
   if (input.providerExecutedOutcomeIds.size === 0) {
     return { messages: [...input.messages], outcomeEndsResponse: false };
   }
@@ -83,7 +83,7 @@ export function normalizeProviderToolHistory(input: {
   };
 }
 
-function findUnmarkedProviderToolCalls(input: {
+function findProviderToolCallsToNormalize(input: {
   readonly messages: readonly ModelMessage[];
   readonly providerExecutedOutcomeIds: ReadonlySet<string>;
 }): ReadonlySet<string> {
@@ -92,11 +92,18 @@ function findUnmarkedProviderToolCalls(input: {
   for (const message of input.messages) {
     if (message.role !== "assistant" || !Array.isArray(message.content)) continue;
 
+    const hasLocalToolCall = message.content.some(
+      (part) =>
+        part.type === "tool-call" &&
+        part.providerExecuted !== true &&
+        !input.providerExecutedOutcomeIds.has(part.toolCallId),
+    );
+
     for (const part of message.content) {
       if (
         part.type === "tool-call" &&
-        part.providerExecuted !== true &&
-        input.providerExecutedOutcomeIds.has(part.toolCallId)
+        input.providerExecutedOutcomeIds.has(part.toolCallId) &&
+        (part.providerExecuted !== true || hasLocalToolCall)
       ) {
         result.add(part.toolCallId);
       }


### PR DESCRIPTION
### Description

Fixes Gemini replay failures when a model step mixes a provider-executed tool with a local tool call. The returned provider call was marked with `providerExecuted: true`, though some of the tools were not actually executed in the provder. Gemini would fail trying to replay the entire step because of the local tool call.

This change has eve separate the provider call and the local call into separate messages, which can then safely replay  on Gemini.

Builds on the regression in #3199.

### Validation

Adds a unit regression for a provider-executed `web_search` followed by a local `todo` call in the same assistant message.
