### PR TITLE
perf(eve): support eager sandbox startup

### DIFF
--- a/.changeset/eager-sandbox-startup.md
+++ b/.changeset/eager-sandbox-startup.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Allow sandbox definitions to opt into eager startup so opening the live sandbox can overlap model work before the first sandbox-backed tool runs. Lazy first-use startup remains the default.

--- a/docs/sandbox.mdx
+++ b/docs/sandbox.mdx
@@ -128,6 +128,22 @@ export default defineSandbox({
 
 `defineSandbox` and `defaultBackend` live on `eve/sandbox`. Omit `backend` and the runtime falls back to `defaultBackend()` (see [Backends](#backends)).
 
+### Start the sandbox before first use
+
+By default, eve opens a live sandbox only when authored code or a built-in tool first accesses it. Set `startup: "eager"` when the agent is expected to use its sandbox on most turns:
+
+```ts title="agent/sandbox.ts"
+import { defineSandbox } from "eve/sandbox";
+
+export default defineSandbox({
+  startup: "eager",
+});
+```
+
+Eager startup begins when eve creates the turn context. It does not block model execution, so sandbox startup can overlap the model call before the first sandbox-backed tool runs. `bootstrap` remains build-time and `onSession` still runs once before the live session is first used.
+
+Use eager startup only when most turns need the sandbox. It can start billable compute on a turn that never invokes a sandbox-backed tool. Omit `startup`, or set it to `"lazy"`, to preserve the default first-use behavior.
+
 ### Sharing a parent's sandbox
 
 Sandbox definitions use two distinct forms. Pass an object to give an agent or subagent an independent sandbox. Passing a callback to `defineSandbox` opts a declared subagent into sharing: return `parent.sandbox` to select the dispatching agent's exact live sandbox. A raw function export remains a zero-argument definition factory.

--- a/e2e/fixtures/agent-tools-sandbox/agent/sandbox/sandbox.ts
+++ b/e2e/fixtures/agent-tools-sandbox/agent/sandbox/sandbox.ts
@@ -141,6 +141,7 @@ const backend =
 
 export default defineSandbox({
   backend,
+  startup: "eager",
   // Bump when the bootstrap output changes so the reusable template snapshot
   // is rebuilt rather than served stale.
   revalidationKey: () => "agent-tools-sandbox-bootstrap-v3",

--- a/packages/eve/src/compiler/manifest.ts
+++ b/packages/eve/src/compiler/manifest.ts
@@ -753,6 +753,7 @@ const compiledSandboxDefinitionSchema = z
     sourceHash: z.string(),
     sourceId: z.string(),
     sourceKind: z.literal("module"),
+    startup: z.enum(["eager", "lazy"]).optional(),
   })
   .strict();
 

--- a/packages/eve/src/compiler/normalize-sandbox.scenario.test.ts
+++ b/packages/eve/src/compiler/normalize-sandbox.scenario.test.ts
@@ -12,7 +12,8 @@ describe("sandbox compilation", () => {
   it("preserves zero-argument sandbox definition factories", async () => {
     const app = await scenarioApp({
       files: {
-        "agent/sandbox.ts": "export default () => ({ description: 'factory sandbox' });\n",
+        "agent/sandbox.ts":
+          "export default () => ({ description: 'factory sandbox', startup: 'eager' });\n",
       },
       name: "sandbox-definition-factory",
     });
@@ -26,6 +27,7 @@ describe("sandbox compilation", () => {
     expect(manifest.sandbox).toMatchObject({
       description: "factory sandbox",
       inheritsParent: undefined,
+      startup: "eager",
     });
   });
 

--- a/packages/eve/src/compiler/normalize-sandbox.ts
+++ b/packages/eve/src/compiler/normalize-sandbox.ts
@@ -47,6 +47,7 @@ export async function compileSandboxDefinition(
     sourceHash: await resolveSandboxSourceHash(options.binding),
     sourceId: source.sourceId,
     sourceKind: "module",
+    startup: normalized.startup,
   };
 }
 

--- a/packages/eve/src/context/providers/sandbox.test.ts
+++ b/packages/eve/src/context/providers/sandbox.test.ts
@@ -87,6 +87,31 @@ describe("sandboxProvider", () => {
     );
   });
 
+  it("opens an eager sandbox without blocking context creation", async () => {
+    const ctx = new ContextContainer();
+    const stub = createStubSandboxRegistry();
+    const registry: RuntimeSandboxRegistry = {
+      sandbox: {
+        ...stub.sandbox!,
+        definition: { ...stub.sandbox!.definition, startup: "eager" },
+      },
+    };
+    const get = vi.fn(() => new Promise<null>(() => {}));
+    vi.mocked(ensureSandboxAccess).mockResolvedValueOnce({
+      captureState: vi.fn().mockResolvedValue({ initialized: false, session: null }),
+      get,
+      stop: vi.fn().mockResolvedValue(undefined),
+    });
+
+    ctx.set(BundleKey, createBundle({ agentName: "weather-agent", registry }));
+    ctx.set(ChannelKey, { kind: "slack" });
+    ctx.set(SessionIdKey, "session_1");
+
+    await sandboxProvider.create(ctx, createHarnessSession());
+
+    expect(get).toHaveBeenCalledOnce();
+  });
+
   it("tags sandbox backend resources with agent, channel, and session id", async () => {
     const ctx = new ContextContainer();
     const registry: RuntimeSandboxRegistry = createStubSandboxRegistry();

--- a/packages/eve/src/context/providers/sandbox.ts
+++ b/packages/eve/src/context/providers/sandbox.ts
@@ -30,22 +30,29 @@ export const sandboxProvider: FrameworkContextProvider<SandboxAccess> = {
     const sharesSandbox = inheritsParent || sharedSandboxSessionId !== undefined;
     const sandboxSessionId = sharesSandbox ? (sharedSandboxSessionId ?? sessionId) : sessionId;
 
-    return {
-      value: await ensureSandboxAccess({
-        compiledArtifactsSource: bundle.compiledArtifactsSource,
-        nodeId: node.nodeId,
-        ownsSandbox: !sharesSandbox,
-        registry,
-        runOnSession: async (callback) => await contextStorage.run(ctx, callback),
-        sessionId: sandboxSessionId,
-        state: session.sandboxState ?? (sharesSandbox ? parentSandboxState : undefined) ?? null,
-        tags: {
-          agent: resolveTagAgentName({ bundle, node }),
-          channel: resolveTagChannelKind(channel),
-          sessionId,
-        },
-      }),
-    };
+    const access = await ensureSandboxAccess({
+      compiledArtifactsSource: bundle.compiledArtifactsSource,
+      nodeId: node.nodeId,
+      ownsSandbox: !sharesSandbox,
+      registry,
+      runOnSession: async (callback) => await contextStorage.run(ctx, callback),
+      sessionId: sandboxSessionId,
+      state: session.sandboxState ?? (sharesSandbox ? parentSandboxState : undefined) ?? null,
+      tags: {
+        agent: resolveTagAgentName({ bundle, node }),
+        channel: resolveTagChannelKind(channel),
+        sessionId,
+      },
+    });
+
+    if (
+      (registry.sandbox?.inheritance?.definition ?? registry.sandbox?.definition)?.startup ===
+      "eager"
+    ) {
+      void access.get().catch(() => {});
+    }
+
+    return { value: access };
   },
 
   async commit(access, session) {

--- a/packages/eve/src/internal/authored-definition/sandbox.test.ts
+++ b/packages/eve/src/internal/authored-definition/sandbox.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeSandboxDefinition } from "#internal/authored-definition/sandbox.js";
+
+describe("normalizeSandboxDefinition", () => {
+  it.each(["eager", "lazy"] as const)("accepts %s startup", (startup) => {
+    expect(normalizeSandboxDefinition({ startup }, "invalid sandbox")).toMatchObject({
+      startup,
+    });
+  });
+
+  it("rejects an unsupported startup mode", () => {
+    expect(() => normalizeSandboxDefinition({ startup: "automatic" }, "invalid sandbox")).toThrow(
+      'invalid sandbox The "startup" field must be "eager" or "lazy" when set.',
+    );
+  });
+});

--- a/packages/eve/src/internal/authored-definition/sandbox.ts
+++ b/packages/eve/src/internal/authored-definition/sandbox.ts
@@ -28,7 +28,7 @@ export function normalizeSandboxDefinition(
   const record = expectObjectRecord(value, message);
   expectOnlyKnownKeys(
     record,
-    ["backend", "bootstrap", "description", "onSession", "revalidationKey"],
+    ["backend", "bootstrap", "description", "onSession", "revalidationKey", "startup"],
     message,
   );
   const definition: {
@@ -37,6 +37,7 @@ export function normalizeSandboxDefinition(
     bootstrap?: NormalizedSandboxDefinition["bootstrap"];
     onSession?: NormalizedSandboxDefinition["onSession"];
     revalidationKey?: NormalizedSandboxDefinition["revalidationKey"];
+    startup?: NormalizedSandboxDefinition["startup"];
   } = {};
 
   if (record.backend !== undefined) {
@@ -48,6 +49,13 @@ export function normalizeSandboxDefinition(
       throw new Error(`${message} The "description" field must be a string when set.`);
     }
     definition.description = record.description;
+  }
+
+  if (record.startup !== undefined) {
+    if (record.startup !== "eager" && record.startup !== "lazy") {
+      throw new Error(`${message} The "startup" field must be "eager" or "lazy" when set.`);
+    }
+    definition.startup = record.startup;
   }
 
   if (record.bootstrap !== undefined) {

--- a/packages/eve/src/runtime/resolve-sandbox.ts
+++ b/packages/eve/src/runtime/resolve-sandbox.ts
@@ -56,6 +56,7 @@ export async function resolveSandboxDefinition(
       sourceHash: definition.sourceHash,
       sourceId: definition.sourceId,
       sourceKind: "module",
+      startup: definition.startup,
     };
   } catch (error) {
     if (error instanceof ResolveAgentError) {

--- a/packages/eve/src/runtime/types.ts
+++ b/packages/eve/src/runtime/types.ts
@@ -141,6 +141,7 @@ export type ResolvedSandboxDefinition = ResolvedModuleSourceRef & {
   readonly bootstrap?: (input: SandboxBootstrapContext) => Promise<void> | void;
   readonly revalidationKey?: string;
   readonly sourceHash?: string;
+  readonly startup?: "eager" | "lazy";
   /**
    * Resolved backend value. The authored `SandboxDefinition.backend`
    * accepts either a `SandboxBackend` or a `() => SandboxBackend`; by

--- a/packages/eve/src/shared/sandbox-definition.ts
+++ b/packages/eve/src/shared/sandbox-definition.ts
@@ -95,6 +95,15 @@ interface SandboxDefinitionBase<BO = Record<string, never>, SO = Record<string, 
   /** Human-readable description of this sandbox, surfaced in tooling. */
   readonly description?: string;
   /**
+   * Controls when eve opens the live sandbox. The default, `"lazy"`, waits
+   * until authored code first accesses it. `"eager"` starts opening it when
+   * the turn context is created so startup can overlap model work.
+   *
+   * Eager startup may create billable compute on turns that never access the
+   * sandbox.
+   */
+  readonly startup?: "eager" | "lazy";
+  /**
    * Runs once per live session before authored steps use the sandbox.
    * Call `input.use(options?)` to open the session and apply per-session
    * backend options (typed by `SO`).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17816,7 +17816,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.9.1
+      '@types/node': 22.20.1
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -21462,13 +21462,13 @@ snapshots:
 
   '@slack/logger@4.0.1':
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 22.20.1
 
   '@slack/socket-mode@2.0.7(bufferutil@4.1.0)(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
       '@slack/logger': 4.0.1
       '@slack/web-api': 7.19.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
-      '@types/node': 25.9.1
+      '@types/node': 22.20.1
       '@types/ws': 8.18.1
       eventemitter3: 5.0.4
       ws: 8.21.3(bufferutil@4.1.0)
@@ -21484,7 +21484,7 @@ snapshots:
     dependencies:
       '@slack/logger': 4.0.1
       '@slack/types': 2.21.1
-      '@types/node': 25.9.1
+      '@types/node': 22.20.1
       '@types/retry': 0.12.0
       axios: 1.16.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
       eventemitter3: 5.0.4
@@ -22152,7 +22152,7 @@ snapshots:
 
   '@types/pg@8.20.0':
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 22.20.1
       pg-protocol: 1.15.0
       pg-types: 2.2.0
 
@@ -22201,7 +22201,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 22.20.1
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -24361,7 +24361,7 @@ snapshots:
 
   chrome-launcher@0.15.2(supports-color@10.2.2):
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 22.20.1
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2(supports-color@10.2.2)
@@ -24380,7 +24380,7 @@ snapshots:
 
   chromium-edge-launcher@0.3.0(supports-color@10.2.2):
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 22.20.1
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2(supports-color@10.2.2)
@@ -27450,7 +27450,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.9.1
+      '@types/node': 22.20.1
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -27467,7 +27467,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 22.20.1
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1


### PR DESCRIPTION
### Summary

Template-backed Sandboxes defer readiness until the first tool command, adding up to 15 seconds to tool latency in recent measurements. Sandbox definitions can now opt into `startup: "eager"`, which starts opening the live session during turn context creation so startup overlaps model work; lazy first-use startup remains the default because eager startup may create billable compute on turns that never use the sandbox. A controlled Vercel A/B reduced mean turn latency by 1.07 seconds despite the eager group receiving slightly slower Sandbox infrastructure.

### Validation

- `pnpm install --frozen-lockfile`
- `pnpm fmt`
- `pnpm lint`
- `pnpm guard:invariants`
- `pnpm docs:check`
- `pnpm typecheck`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/context/providers/sandbox.test.ts src/execution/sandbox/ensure.test.ts src/execution/workflow-steps.test.ts src/internal/authored-definition/sandbox.test.ts` — 79 tests passed
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/subagents/auth-proxy.integration.test.ts` — 2 tests passed
- `pnpm --filter eve build`
- `pnpm --filter eve exec vitest run --config vitest.scenario.config.ts src/compiler/normalize-sandbox.scenario.test.ts` — 2 tests passed
- Controlled Vercel A/B: eager mean 8.15s vs lazy 9.22s across 12 fresh sessions per variant; eager first-command P50 was 814ms vs 713ms, confirming the gain came from overlap rather than faster placement
- Public API Vercel A/B: both fixture jobs passed; eager completed all 12 sessions within 9.1s while lazy had two 15–16s tail sessions

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
