### PR TITLE
feat(eve): add custom principal authorization for deployed self-modification

### DIFF
--- a/packages/eve/src/self-modification/agent.test.ts
+++ b/packages/eve/src/self-modification/agent.test.ts
@@ -1,4 +1,6 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { DynamicResolveContext } from "#dynamic/definition.js";
 
 import { DEFAULT_SELF_MODIFICATION_MODEL, defineSelfModificationAgent } from "./agent.js";
 
@@ -8,6 +10,7 @@ const deployed = {
   deployed: {
     source: { git: { directory: ".", repository: "github.com/acme/agent" } },
     target: { branch: "main" },
+    authorize: () => true,
     credentials: { pat: true },
   },
 } as const;
@@ -52,12 +55,80 @@ describe("defineSelfModificationAgent", () => {
   it("requires configured deployment and credential preflight", async () => {
     delete process.env.EVE_DEV;
     const agent = defineSelfModificationAgent({ config: deployed });
-    expect(agent.events["session.started"]?.({}, {} as never)).toBeNull();
+    const ctx = { channel: {}, session: { auth: { current: null, initiator: null } } } as never;
+    await expect(agent.events["session.started"]?.({}, ctx)).resolves.toBeNull();
 
     process.env.EVE_SELF_MODIFICATION_GITHUB_TOKEN = "secret";
-    const definition = await agent.events["session.started"]?.({}, {} as never);
+    const definition = await agent.events["session.started"]?.({}, ctx);
     expect(definition?.description).toContain("draft pull request");
     expect(definition?.description).toContain("non-secret answers");
+  });
+
+  it("authorizes the current principal from its channel family", async () => {
+    delete process.env.EVE_DEV;
+    process.env.EVE_SELF_MODIFICATION_GITHUB_TOKEN = "secret";
+    const authorize = vi.fn(
+      ({
+        channel,
+        principal,
+      }: {
+        channel: { kind?: string };
+        principal: { principalId: string } | null;
+      }) => channel.kind === "slack" && principal?.principalId === "slack:T1:U1",
+    );
+    const agent = defineSelfModificationAgent({
+      config: { deployed: { ...deployed.deployed, authorize } },
+    });
+    const ctx = {
+      channel: { kind: "slack" },
+      session: {
+        id: "session-1",
+        auth: {
+          current: {
+            attributes: {},
+            authenticator: "slack-webhook",
+            principalId: "slack:T1:U1",
+            principalType: "user",
+          },
+          initiator: null,
+        },
+      },
+    } as DynamicResolveContext;
+
+    expect(await agent.events["session.started"]?.({}, ctx)).toMatchObject({
+      model: DEFAULT_SELF_MODIFICATION_MODEL,
+    });
+    expect(authorize).toHaveBeenCalledWith({
+      channel: ctx.channel,
+      principal: ctx.session.auth.current,
+    });
+    expect(
+      await agent.events["turn.started"]?.(
+        {},
+        {
+          ...ctx,
+          session: { ...ctx.session, auth: { ...ctx.session.auth, current: null } },
+        },
+      ),
+    ).toBeNull();
+  });
+
+  it("fails closed when authorization rejects or throws", async () => {
+    delete process.env.EVE_DEV;
+    process.env.EVE_SELF_MODIFICATION_GITHUB_TOKEN = "secret";
+    const ctx = { channel: {}, session: { auth: { current: null, initiator: null } } } as never;
+
+    for (const authorize of [
+      () => false,
+      () => {
+        throw new Error("no");
+      },
+    ]) {
+      const agent = defineSelfModificationAgent({
+        config: { deployed: { ...deployed.deployed, authorize } },
+      });
+      expect(await agent.events["session.started"]?.({}, ctx)).toBeNull();
+    }
   });
 
   it("keeps configured deployment local under eve dev", async () => {

--- a/packages/eve/src/self-modification/agent.ts
+++ b/packages/eve/src/self-modification/agent.ts
@@ -1,3 +1,4 @@
+import type { DynamicResolveContext } from "#dynamic/definition.js";
 import { defineAgent, defineDynamic, type AgentStaticModelDefinition } from "#public/index.js";
 
 import { resolveSelfModificationConfig, type SelfModificationConfig } from "./config.js";
@@ -47,11 +48,23 @@ export function defineSelfModificationAgent(options: SelfModificationAgentOption
   const model = options.model ?? DEFAULT_SELF_MODIFICATION_MODEL;
   const config = resolveSelfModificationConfig(options.config);
 
-  const resolve = () => {
+  const resolve = async (_event: unknown, ctx: DynamicResolveContext) => {
     const mode = resolveSelfModificationMode(config);
     if (mode === "local") return defineAgent({ description: localDescription, model });
     if (mode !== "deployed" || config.deployed === undefined) return null;
     if (config.deployed.credentials.kind === "pat" && !hasGitHubCredential()) return null;
+    try {
+      if (
+        !(await config.deployed.authorize({
+          channel: ctx.channel,
+          principal: ctx.session.auth.current,
+        }))
+      ) {
+        return null;
+      }
+    } catch {
+      return null;
+    }
     return defineAgent({ description: deployedDescription, model });
   };
 

--- a/packages/eve/src/self-modification/config.test.ts
+++ b/packages/eve/src/self-modification/config.test.ts
@@ -14,6 +14,7 @@ const deployed = {
   deployed: {
     source: { git: { directory: "apps/weather", repository: "github.com/vercel/eve" } },
     target: { branch: "main" },
+    authorize: () => true,
     credentials: { pat: true },
   },
 } as const;
@@ -77,7 +78,19 @@ describe("self-modification deployed configuration", () => {
   it("requires complete deployed configuration", () => {
     expect(() =>
       resolveSelfModificationConfig({ deployed: { source: deployed.deployed.source } } as never),
-    ).toThrow("both source and target");
+    ).toThrow("source, target, and authorization");
+  });
+
+  it("requires a deployed authorization policy", () => {
+    expect(() => {
+      const { authorize: _authorize, ...withoutAuthorize } = deployed.deployed;
+      resolveSelfModificationConfig({ deployed: withoutAuthorize } as never);
+    }).toThrow("source, target, and authorization");
+    expect(() =>
+      resolveSelfModificationConfig({
+        deployed: { ...deployed.deployed, authorize: true as never },
+      }),
+    ).toThrow("authorize must be a function");
   });
 
   it("rejects ambiguous or malformed credential configuration", () => {
@@ -100,15 +113,33 @@ describe("self-modification deployed configuration", () => {
     [null, "configuration must be an object"],
     [{ local: null }, "local must be an object"],
     [
-      { deployed: { source: null, target: deployed.deployed.target } },
+      {
+        deployed: {
+          authorize: deployed.deployed.authorize,
+          source: null,
+          target: deployed.deployed.target,
+        },
+      },
       "deployed.source must be an object",
     ],
     [
-      { deployed: { source: {}, target: deployed.deployed.target } },
+      {
+        deployed: {
+          authorize: deployed.deployed.authorize,
+          source: {},
+          target: deployed.deployed.target,
+        },
+      },
       "deployed.source.git must be an object",
     ],
     [
-      { deployed: { source: deployed.deployed.source, target: null } },
+      {
+        deployed: {
+          authorize: deployed.deployed.authorize,
+          source: deployed.deployed.source,
+          target: null,
+        },
+      },
       "deployed.target must be an object",
     ],
   ])("rejects malformed nested configuration", (config, message) => {

--- a/packages/eve/src/self-modification/config.ts
+++ b/packages/eve/src/self-modification/config.ts
@@ -1,4 +1,21 @@
+import type { SessionAuthContext } from "#channel/types.js";
+
 import { assertGitRef, assertRepositoryPart } from "./identifiers.js";
+
+/** Principal and channel that requested a deployed source modification. */
+export interface SelfModificationAuthorizationContext {
+  readonly channel: {
+    /** Channel adapter family, such as `"slack"` or `"http"`. */
+    readonly kind?: string;
+    readonly metadata?: Readonly<Record<string, unknown>>;
+  };
+  readonly principal: SessionAuthContext | null;
+}
+
+/** Decides whether a principal may use deployed self-modification. */
+export type SelfModificationAuthorization = (
+  context: SelfModificationAuthorizationContext,
+) => boolean | Promise<boolean>;
 
 export interface SelfModificationConfig {
   readonly local?: { readonly enabled?: boolean };
@@ -12,6 +29,8 @@ export interface SelfModificationConfig {
       };
     };
     readonly target: { readonly branch: string };
+    /** Fail-closed policy for principals that may create draft proposals. */
+    readonly authorize: SelfModificationAuthorization;
     readonly credentials?: {
       /** Ephemeral, repository-scoped GitHub App credentials from Vercel Connect. */
       readonly vercelConnect?: { readonly connector: string };
@@ -30,6 +49,7 @@ export interface ResolvedSelfModificationConfig {
 }
 
 export interface ResolvedDeployedSelfModificationConfig {
+  readonly authorize: SelfModificationAuthorization;
   readonly credentials: ResolvedGitHubCredentials;
   readonly directory: string;
   readonly repository: GitHubRepository;
@@ -70,15 +90,20 @@ export function resolveSelfModificationConfig(
   const deployed = config.deployed;
   if (deployed === undefined) return { localEnabled };
   if (!isRecord(deployed)) throw new Error("Self-modification deployed must be an object.");
-  const { source, target, credentials } = deployed;
-  if (source === undefined || target === undefined) {
-    throw new Error("Self-modification deployed requires both source and target configuration.");
+  const { source, target, authorize, credentials } = deployed;
+  if (source === undefined || target === undefined || authorize === undefined) {
+    throw new Error(
+      "Self-modification deployed requires source, target, and authorization configuration.",
+    );
   }
   if (!isRecord(source)) throw new Error("Self-modification deployed.source must be an object.");
   if (!isRecord(source.git)) {
     throw new Error("Self-modification deployed.source.git must be an object.");
   }
   if (!isRecord(target)) throw new Error("Self-modification deployed.target must be an object.");
+  if (typeof authorize !== "function") {
+    throw new Error("Self-modification deployed.authorize must be a function.");
+  }
 
   const { git } = source;
   if (typeof git.repository !== "string" || typeof git.directory !== "string") {
@@ -91,6 +116,7 @@ export function resolveSelfModificationConfig(
   }
   return {
     deployed: {
+      authorize: authorize as SelfModificationAuthorization,
       credentials: parseCredentials(credentials),
       directory: parseDirectory(git.directory),
       repository: parseGitHubRepository(git.repository),

--- a/packages/eve/src/self-modification/extension/extension.ts
+++ b/packages/eve/src/self-modification/extension/extension.ts
@@ -1,6 +1,8 @@
 import { defineExtension } from "eve/extension";
 import { z } from "zod";
 
+import type { SelfModificationAuthorization } from "../config.js";
+
 export const selfModificationConfigSchema = z.object({
   local: z.object({ enabled: z.boolean().optional() }).optional(),
   deployed: z
@@ -15,6 +17,7 @@ export const selfModificationConfigSchema = z.object({
         git: z.object({ directory: z.string(), repository: z.string() }),
       }),
       target: z.object({ branch: z.string() }),
+      authorize: z.custom<SelfModificationAuthorization>((value) => typeof value === "function"),
     })
     .optional(),
 });

--- a/packages/eve/src/self-modification/package-consumption.scenario.test.ts
+++ b/packages/eve/src/self-modification/package-consumption.scenario.test.ts
@@ -121,7 +121,7 @@ describe("packed package consumption", () => {
     await writeAppFile(
       appRoot,
       "agent/subagents/self-modification/config.ts",
-      'import { defineSelfModificationConfig } from "eve/self-modification/config";\n\nexport default defineSelfModificationConfig({ deployed: { source: { git: { directory: ".", repository: "github.com/acme/agent" } }, target: { branch: "main" }, credentials: { vercelConnect: { connector: "github/selfmod-acme-agent" } } } });\n',
+      'import { defineSelfModificationConfig } from "eve/self-modification/config";\n\nexport default defineSelfModificationConfig({ deployed: { source: { git: { directory: ".", repository: "github.com/acme/agent" } }, target: { branch: "main" }, authorize: () => false, credentials: { vercelConnect: { connector: "github/selfmod-acme-agent" } } } });\n',
     );
     await writeAppFile(
       appRoot,

--- a/packages/eve/src/self-modification/registry-add.test.ts
+++ b/packages/eve/src/self-modification/registry-add.test.ts
@@ -150,6 +150,7 @@ describe("resolveRegistryAddTool", () => {
     const tool = resolveRegistryAddTool({
       localEnabled: true,
       deployed: {
+        authorize: () => true,
         credentials: { kind: "pat" },
         directory: ".",
         repository: { owner: "acme", repo: "agent" },

--- a/packages/eve/src/self-modification/sandbox.test.ts
+++ b/packages/eve/src/self-modification/sandbox.test.ts
@@ -12,6 +12,7 @@ const connectConfig: SelfModificationConfig = {
     credentials: { vercelConnect: { connector: "github/selfmod-acme-agent" } },
     source: { git: { directory: ".", repository: "github.com/acme/agent" } },
     target: { branch: "main" },
+    authorize: () => true,
   },
 };
 

--- a/packages/eve/src/self-modification/setup.test.ts
+++ b/packages/eve/src/self-modification/setup.test.ts
@@ -22,6 +22,7 @@ describe("self-modification setup", () => {
     expect(source).toContain('directory: "apps/support"');
     expect(source).toContain('target: { branch: "release/production" }');
     expect(source).toContain('connector: "github/selfmod-acme-agents"');
+    expect(source).toContain("authorize: () => false");
     expect(source).not.toContain("EVE_SELF_MODIFICATION_GITHUB_TOKEN");
     expect(classifySelfModificationConfig(source)).toBe("generated");
   });

--- a/packages/eve/src/self-modification/setup.test.ts
+++ b/packages/eve/src/self-modification/setup.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import { win32 } from "node:path";
+import { runInNewContext } from "node:vm";
+
+import { defineSelfModificationConfig } from "./config.js";
 
 import {
   classifySelfModificationConfig,
@@ -14,23 +17,105 @@ describe("self-modification setup", () => {
   it("renders a generated Connect-backed deployed configuration", () => {
     const source = renderSelfModificationConfig({
       branch: "release/production",
+      channelNames: ["slack", "eve"],
       connector: "github/selfmod-acme-agents",
       directory: "apps/support",
       repository: "github.com/acme/agents",
+      vercelBackend: true,
     });
     expect(source).toContain('repository: "github.com/acme/agents"');
     expect(source).toContain('directory: "apps/support"');
     expect(source).toContain('target: { branch: "release/production" }');
     expect(source).toContain('connector: "github/selfmod-acme-agents"');
-    expect(source).toContain("authorize: () => false");
+    expect(source).toContain('case "http"');
+    expect(source).toContain("const projectId = process.env.VERCEL_PROJECT_ID");
+    expect(source).toContain('principal?.authenticator === "oidc"');
+    expect(source).toContain("principal.attributes.project_id === projectId");
+    expect(source).toContain('case "channel:slack"');
+    expect(source).toContain(
+      "// Authorize trusted principals for this channel before returning true.\n        return false;",
+    );
+    expect(source).toContain(
+      "// Add another branch when you add a trusted channel.\n          return false;",
+    );
+    expect(source).not.toContain("authorize: () => false");
     expect(source).not.toContain("EVE_SELF_MODIFICATION_GITHUB_TOKEN");
     expect(classifySelfModificationConfig(source)).toBe("generated");
+  });
+
+  it.each([
+    ["https://oidc.vercel.com", true],
+    ["https://oidc.vercel.com/acme", true],
+    ["https://identity.example.com", false],
+    ["https://oidc.vercel.com.attacker.example", false],
+    ["https://oidc.vercel.com@attacker.example", false],
+    [undefined, false],
+  ])("checks the generated policy's issuer %s", (issuer, allowed) => {
+    const source = renderSelfModificationConfig({
+      branch: "main",
+      channelNames: ["slack"],
+      connector: "github/selfmod-acme-agents",
+      directory: ".",
+      repository: "github.com/acme/agents",
+      vercelBackend: true,
+    });
+    const config = runInNewContext(
+      source
+        .replace('import { defineSelfModificationConfig } from "eve/self-modification/config";', "")
+        .replace("export default ", ""),
+      {
+        defineSelfModificationConfig,
+        process: { env: { VERCEL_PROJECT_ID: "prj_123" } },
+      },
+    ) as ReturnType<typeof defineSelfModificationConfig>;
+    const authorize = config.deployed!.authorize;
+    const principal = {
+      attributes: { project_id: "prj_123" },
+      authenticator: "oidc",
+      issuer,
+      principalId: "caller",
+      principalType: "service",
+    };
+
+    expect(authorize({ channel: { kind: "http" }, principal })).toBe(allowed);
+    expect(
+      authorize({
+        channel: { kind: "http" },
+        principal: { ...principal, attributes: { project_id: "prj_other" } },
+      }),
+    ).toBe(false);
+    expect(
+      authorize({
+        channel: { kind: "http" },
+        principal: { ...principal, authenticator: "jwt-hmac" },
+      }),
+    ).toBe(false);
+    expect(authorize({ channel: { kind: "channel:slack" }, principal })).toBe(false);
+    expect(authorize({ channel: { kind: "http" }, principal: null })).toBe(false);
+  });
+
+  it("renders no HTTP authorization branch without a Vercel backend", () => {
+    const source = renderSelfModificationConfig({
+      branch: "main",
+      channelNames: [],
+      connector: "github/selfmod-acme-agents",
+      directory: ".",
+      repository: "github.com/acme/agents",
+      vercelBackend: false,
+    });
+
+    expect(source).not.toContain('case "http"');
+    expect(source).not.toContain('case "channel:');
+    expect(source).not.toContain("VERCEL_PROJECT_ID");
+    expect(source).toContain(
+      "switch (channel.kind) {\n        default:\n          // Add another branch when you add a trusted channel.",
+    );
   });
 
   it("refuses altered generated configuration as authored", () => {
     expect(
       classifySelfModificationConfig(
-        `${renderSelfModificationConfig({ branch: "main", connector: "github/selfmod-acme-agents", directory: ".", repository: "github.com/acme/agents" })}\n// edited`,
+        `${renderSelfModificationConfig({ branch: "main", channelNames: [], connector: "github/selfmod-acme-agents", directory: ".", repository: "github.com/acme/agents", vercelBackend: false })}\n// edited`,
       ),
     ).toBe("authored");
   });

--- a/packages/eve/src/self-modification/setup.ts
+++ b/packages/eve/src/self-modification/setup.ts
@@ -4,6 +4,9 @@ import { readFile, writeFile } from "node:fs/promises";
 import { join, relative } from "node:path";
 import { promisify } from "node:util";
 
+import { discoverAgent } from "#discover/discover-agent.js";
+import { stripLogicalPathExtension } from "#discover/filesystem.js";
+
 import { SELF_MODIFICATION_CONFIG_PATH } from "./git-workspace.js";
 
 const runFile = promisify(execFile);
@@ -11,9 +14,11 @@ const GENERATED_MARKER = "// eve-self-modification: generated-v1";
 
 export interface SelfModificationSetupValues {
   readonly branch: string;
+  readonly channelNames: readonly string[];
   readonly connector: string;
   readonly directory: string;
   readonly repository: string;
+  readonly vercelBackend: boolean;
 }
 export interface DetectedGitRepository {
   readonly branch?: string;
@@ -24,6 +29,7 @@ export interface DetectedGitRepository {
 }
 export interface SelfModificationSetupOperations {
   attachConnector(connector: string): Promise<void>;
+  detectChannelNames(): Promise<readonly string[]>;
   detectGitRepository(): Promise<DetectedGitRepository>;
   findOrCreateConnector(name: string): Promise<string>;
   readConfig(): Promise<string | undefined>;
@@ -38,6 +44,29 @@ export function renderSelfModificationConfig(values?: SelfModificationSetupValue
   if (values === undefined) {
     return `import { defineSelfModificationConfig } from "eve/self-modification/config";\n\nexport default defineSelfModificationConfig({});\n`;
   }
+  const channelNames = [...new Set(values.channelNames)].filter((name) => name !== "eve").sort();
+  const channelCases = (values.vercelBackend ? channelNames : [])
+    .map(
+      (name) => `      case ${JSON.stringify(`channel:${name}`)}:
+        // Authorize trusted principals for this channel before returning true.
+        return false;`,
+    )
+    .join("\n");
+  const httpCase = values.vercelBackend
+    ? `        case "http": {
+          const projectId = process.env.VERCEL_PROJECT_ID;
+          return (
+            projectId !== undefined &&
+            projectId.length > 0 &&
+            principal?.authenticator === "oidc" &&
+            (principal.issuer === "https://oidc.vercel.com" ||
+              principal.issuer?.startsWith("https://oidc.vercel.com/") === true) &&
+            principal.attributes.project_id === projectId
+          );
+        }
+`
+    : "";
+  const switchCases = `${httpCase}${channelCases}`;
   const body = `import { defineSelfModificationConfig } from "eve/self-modification/config";
 
 export default defineSelfModificationConfig({
@@ -52,8 +81,13 @@ export default defineSelfModificationConfig({
     credentials: {
       vercelConnect: { connector: ${JSON.stringify(values.connector)} },
     },
-    // Allow only principals from channels you trust to propose source changes.
-    authorize: () => false,
+    authorize: ({ channel, principal }) => {
+      switch (channel.kind) {
+${switchCases}        default:
+          // Add another branch when you add a trusted channel.
+          return false;
+      }
+    },
   },
 });
 `;
@@ -91,6 +125,12 @@ export function defaultSelfModificationSetupOperations(
 ): SelfModificationSetupOperations {
   const configPath = join(appRoot, SELF_MODIFICATION_CONFIG_PATH);
   return {
+    async detectChannelNames() {
+      const discovered = await discoverAgent({ appRoot, agentRoot: join(appRoot, "agent") });
+      return discovered.manifest.channels.map((source) =>
+        stripLogicalPathExtension(source.logicalPath).replace(/^channels\//, ""),
+      );
+    },
     async detectGitRepository() {
       const remote = await gitOutput(appRoot, ["config", "--get", "remote.origin.url"]);
       const repository = remote === undefined ? undefined : parseGitHubRemote(remote);

--- a/packages/eve/src/self-modification/setup.ts
+++ b/packages/eve/src/self-modification/setup.ts
@@ -52,6 +52,8 @@ export default defineSelfModificationConfig({
     credentials: {
       vercelConnect: { connector: ${JSON.stringify(values.connector)} },
     },
+    // Allow only principals from channels you trust to propose source changes.
+    authorize: () => false,
   },
 });
 `;

--- a/packages/eve/src/setup/integrations/self-modification/setup.test.ts
+++ b/packages/eve/src/setup/integrations/self-modification/setup.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createFakePrompter } from "#internal/testing/fake-prompter.js";
 import type { SelfModificationSetupOperations } from "#self-modification/setup.js";
 import { headlessAsker, withAnswers } from "#setup/ask.js";
+import type { ProjectResolution } from "#setup/project-resolution.js";
 
 import { integrationSetupEnvironment } from "../shared/environment.js";
 import { createSetupContexts } from "../shared/ui.js";
@@ -21,6 +22,7 @@ function operations(config?: string): SelfModificationSetupOperations & {
 } {
   return {
     attachConnector: vi.fn(async () => {}),
+    detectChannelNames: vi.fn(async () => ["eve", "slack"]),
     detectGitRepository: vi.fn(async () => ({
       branch: "main",
       directory: "apps/support",
@@ -34,14 +36,21 @@ function operations(config?: string): SelfModificationSetupOperations & {
   };
 }
 
-function contexts(answers: Record<string, unknown>) {
-  return createSetupContexts({
-    appRoot: "/project",
-    asker: withAnswers(answers)(headlessAsker()),
-    environment: integrationSetupEnvironment("authenticated", { kind: "unresolved" }),
-    prompter: createFakePrompter().prompter,
-    resolveVercelProject: async () => ({ orgId: "team", projectId: "project" }),
-  });
+function contexts(
+  answers: Record<string, unknown>,
+  project: ProjectResolution = { kind: "unresolved" },
+) {
+  const fake = createFakePrompter();
+  return {
+    ...createSetupContexts({
+      appRoot: "/project",
+      asker: withAnswers(answers)(headlessAsker()),
+      environment: integrationSetupEnvironment("authenticated", project),
+      prompter: fake.prompter,
+      resolveVercelProject: async () => ({ orgId: "team", projectId: "project" }),
+    }),
+    note: fake.prompter.note,
+  };
 }
 
 describe("self-modification integration setup", () => {
@@ -59,13 +68,16 @@ describe("self-modification integration setup", () => {
 
   it("prepares deployed configuration before applying connector effects", async () => {
     const effects = operations();
-    const ctx = contexts({
-      "self-modification-repository-owner": "acme",
-      "self-modification-repository-name": "agents",
-      "self-modification-repository-directory": "apps/support",
-      "self-modification-target-branch": "main",
-      "self-modification-confirm": true,
-    });
+    const ctx = contexts(
+      {
+        "self-modification-repository-owner": "acme",
+        "self-modification-repository-name": "agents",
+        "self-modification-repository-directory": "apps/support",
+        "self-modification-target-branch": "main",
+        "self-modification-confirm": true,
+      },
+      { kind: "linked", projectId: "project" },
+    );
 
     const plan = await prepareSelfModificationSetup(ctx.prepare, effects);
     expect(effects.findOrCreateConnector).not.toHaveBeenCalled();
@@ -75,6 +87,43 @@ describe("self-modification integration setup", () => {
     expect(effects.attachConnector).toHaveBeenCalledWith("github/selfmod-acme-agents");
     expect(effects.writeConfig).toHaveBeenCalledWith(
       expect.stringContaining('repository: "github.com/acme/agents"'),
+    );
+    expect(effects.writeConfig).toHaveBeenCalledWith(
+      expect.stringContaining('case "channel:slack"'),
+    );
+    expect(effects.writeConfig).toHaveBeenCalledWith(expect.stringContaining('case "http"'));
+    expect(ctx.note).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "After deployment, try self-modification by running `eve dev <deployment-url>`",
+      ),
+      "Next steps",
+      { tone: "success" },
+    );
+  });
+
+  it("omits Vercel authorization when no Vercel backend is configured", async () => {
+    const effects = operations();
+    const ctx = contexts({
+      "self-modification-repository-owner": "acme",
+      "self-modification-repository-name": "agents",
+      "self-modification-repository-directory": "apps/support",
+      "self-modification-target-branch": "main",
+      "self-modification-confirm": true,
+    });
+
+    const plan = await prepareSelfModificationSetup(ctx.prepare, effects);
+    await applySelfModificationSetup(plan, ctx.apply, effects);
+
+    expect(effects.writeConfig).toHaveBeenCalledWith(expect.not.stringContaining('case "http"'));
+    expect(effects.writeConfig).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "switch (channel.kind) {\n        default:\n          // Add another branch when you add a trusted channel.",
+      ),
+    );
+    expect(ctx.note).toHaveBeenCalledWith(
+      expect.stringContaining("configure `deployed.authorize`"),
+      "Next steps",
+      { tone: "success" },
     );
   });
 

--- a/packages/eve/src/setup/integrations/self-modification/setup.ts
+++ b/packages/eve/src/setup/integrations/self-modification/setup.ts
@@ -48,7 +48,10 @@ export async function prepareSelfModificationSetup(
     return { kind: "authored" };
   }
 
-  const detected = await operations.detectGitRepository();
+  const [detected, channelNames] = await Promise.all([
+    operations.detectGitRepository(),
+    operations.detectChannelNames(),
+  ]);
   const owner = await context.asker.ask(
     text({
       key: "self-modification-repository-owner",
@@ -88,9 +91,13 @@ export async function prepareSelfModificationSetup(
   const name = connectorName(owner, repo);
   const values = {
     branch,
+    channelNames,
     connector: `github/${name}`,
     directory,
     repository: `github.com/${owner}/${repo}`,
+    vercelBackend:
+      context.environment.vercel.kind === "available" &&
+      context.environment.vercel.project.kind !== "unresolved",
   };
   context.presenter.note(
     renderSelfModificationConfig(values),
@@ -132,7 +139,10 @@ export async function applySelfModificationSetup(
   await operations.writeConfig(renderSelfModificationConfig({ ...plan.values, connector }));
   context.presenter.log.success(`Updated ${SELF_MODIFICATION_CONFIG_PATH}.`);
   context.presenter.nextSteps([
-    "Install the managed GitHub App for the configured repository, then redeploy.",
+    "Install the managed GitHub App for the configured repository, then deploy or redeploy.",
+    plan.values.vercelBackend
+      ? "After deployment, try self-modification by running `eve dev <deployment-url>` from this linked project. The generated policy admits its Vercel OIDC identity over HTTP; configured channels remain denied until you update `agent/subagents/self-modification/config.ts`."
+      : "Before deployment, configure `deployed.authorize` in `agent/subagents/self-modification/config.ts` to admit a trusted principal for your deployment's channel. After deployment, use that channel to try self-modification.",
   ]);
   return {
     deploymentRequired: true as const,


### PR DESCRIPTION
### Summary

Current deployed self-modification has a permissive authorization policy, the deployed draft-PR flow is completely accessible to everyone.  This PR adds the authorization hook, which fails closed.  

For Vercel-backend deployments, this PR also scaffolds some defaults into the selfmod configuration that admits Vercel OIDC principals for the linked project over HTTP.  The initial setup directs the developer to the post-deployment path or to configure `deployed.authorize` when Vercel is unavailable.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/setup/integrations/self-modification/setup.test.ts src/self-modification/setup.test.ts`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/setup/integrations/self-modification/setup.test.ts`

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
