### PR TITLE
test(e2e): demo agent snapshot prewarming

### DIFF
--- a/e2e/fixtures/agent-prewarm-control/.gitignore
+++ b/e2e/fixtures/agent-prewarm-control/.gitignore
@@ -1,0 +1,10 @@
+node_modules
+.env*
+.eve
+.vercel
+.next
+.output
+.nitro
+dist
+.DS_Store
+*.tsbuildinfo

--- a/e2e/fixtures/agent-prewarm-control/.vercelignore
+++ b/e2e/fixtures/agent-prewarm-control/.vercelignore
@@ -1,0 +1,7 @@
+.env*.local
+node_modules
+.eve
+.next
+.output
+.nitro
+dist

--- a/e2e/fixtures/agent-prewarm-control/agent/agent.ts
+++ b/e2e/fixtures/agent-prewarm-control/agent/agent.ts
@@ -1,0 +1,13 @@
+import { e2eAgentConfig } from "@eve-e2e/config";
+import { defineAgent } from "eve";
+import { mockModel } from "eve/evals";
+
+export default defineAgent({
+  ...e2eAgentConfig(),
+  model: mockModel(({ toolResults }) => {
+    const result = toolResults.at(-1);
+    if (result !== undefined) return "done";
+    return { toolCalls: [{ input: { command: "true" }, name: "bash" }] };
+  }),
+  modelContextWindowTokens: 1_000_000,
+});

--- a/e2e/fixtures/agent-prewarm-control/agent/instructions.md
+++ b/e2e/fixtures/agent-prewarm-control/agent/instructions.md
@@ -1,0 +1,1 @@
+Run the requested sandbox command.

--- a/e2e/fixtures/agent-prewarm-control/agent/sandbox.ts
+++ b/e2e/fixtures/agent-prewarm-control/agent/sandbox.ts
@@ -1,0 +1,7 @@
+import { defaultBackend, defineSandbox } from "eve/sandbox";
+
+export default defineSandbox({
+  backend: defaultBackend(),
+  revalidationKey: () => "control-v1",
+  async bootstrap() {},
+});

--- a/e2e/fixtures/agent-prewarm-control/agent/tools/bash.ts
+++ b/e2e/fixtures/agent-prewarm-control/agent/tools/bash.ts
@@ -1,0 +1,5 @@
+import { defineTool } from "eve/tools";
+import { never } from "eve/tools/approval";
+import { bash } from "eve/tools/bash";
+
+export default defineTool({ ...bash, approval: never() });

--- a/e2e/fixtures/agent-prewarm-control/evals/evals.config.ts
+++ b/e2e/fixtures/agent-prewarm-control/evals/evals.config.ts
@@ -1,0 +1,4 @@
+import { e2eJudgeModel } from "@eve-e2e/config";
+import { defineEvalConfig } from "eve/evals";
+
+export default defineEvalConfig({ judge: { model: e2eJudgeModel() } });

--- a/e2e/fixtures/agent-prewarm-control/evals/prewarm-control.eval.ts
+++ b/e2e/fixtures/agent-prewarm-control/evals/prewarm-control.eval.ts
@@ -1,0 +1,89 @@
+import { defineEval, type EveEvalContext, type EveEvalSession } from "eve/evals";
+import { equals } from "eve/evals/expect";
+
+const MEASURED_SESSION_COUNT = 12;
+const METRIC_PREFIX = "EVE_AGENT_SNAPSHOT_PREWARM=";
+
+interface Sample {
+  readonly durationMs: number;
+  readonly endedAtMs: number;
+  readonly sessionId: string | undefined;
+  readonly sessionNumber: number;
+  readonly startedAtMs: number;
+}
+
+export default defineEval({
+  description: "Agent snapshot prewarm control: measure fresh sessions without warm-up restores.",
+  tags: ["sandbox", "performance"],
+  timeoutMs: 5 * 60_000,
+  async test(t) {
+    requireVercelMockWorld(t);
+
+    const experimentStartedAtMs = Date.now();
+    const measuredStartedAt = performance.now();
+    const measuredStartedAtMs = Date.now();
+    const measured = await runConcurrentSessions(t, MEASURED_SESSION_COUNT, "measured");
+    const measuredEndedAtMs = Date.now();
+
+    t.log(
+      `${METRIC_PREFIX}${JSON.stringify({
+        experimentDurationMs: measuredEndedAtMs - experimentStartedAtMs,
+        fixture: "agent-prewarm-control",
+        measured: {
+          batchDurationMs: performance.now() - measuredStartedAt,
+          endedAtMs: measuredEndedAtMs,
+          samples: measured,
+          sessionCount: MEASURED_SESSION_COUNT,
+          startedAtMs: measuredStartedAtMs,
+        },
+        prewarm: null,
+        schemaVersion: 1,
+        variant: "no-agent-snapshot-prewarm",
+      })}`,
+    );
+    t.succeeded();
+  },
+});
+
+async function runConcurrentSessions(
+  t: EveEvalContext,
+  count: number,
+  phase: string,
+): Promise<Sample[]> {
+  return await Promise.all(
+    Array.from({ length: count }, async (_, index) => {
+      const session = t.newSession();
+      return await runSession(t, session, phase, index);
+    }),
+  );
+}
+
+async function runSession(
+  t: EveEvalContext,
+  session: EveEvalSession,
+  phase: string,
+  index: number,
+): Promise<Sample> {
+  const startedAt = performance.now();
+  const startedAtMs = Date.now();
+  const result = await session.send(`${phase}-${index}`);
+  result.expectOk();
+  await t.require(result.message, equals("done"));
+  return {
+    durationMs: performance.now() - startedAt,
+    endedAtMs: Date.now(),
+    sessionId: result.sessionId,
+    sessionNumber: index + 1,
+    startedAtMs,
+  };
+}
+
+function requireVercelMockWorld(t: EveEvalContext): void {
+  if (
+    t.target.kind !== "remote" ||
+    process.env.EVE_E2E_MODEL !== "mock" ||
+    process.env.EVE_E2E_WORKFLOW_WORLD !== undefined
+  ) {
+    t.skip("Temporary performance experiment runs only in the Vercel mock-world suite.");
+  }
+}

--- a/e2e/fixtures/agent-prewarm-control/package.json
+++ b/e2e/fixtures/agent-prewarm-control/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "agent-prewarm-control",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "eve build",
+    "dev": "eve dev",
+    "start": "eve start",
+    "typecheck": "eve build && tsc",
+    "test:e2e": "eve eval --strict"
+  },
+  "dependencies": {
+    "@eve-e2e/config": "workspace:*",
+    "@workflow/world-postgres": "catalog:",
+    "eve": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/e2e/fixtures/agent-prewarm-control/tsconfig.json
+++ b/e2e/fixtures/agent-prewarm-control/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["agent/**/*.ts", "evals/**/*.ts"]
+}

--- a/e2e/fixtures/agent-prewarm-prefetch/.gitignore
+++ b/e2e/fixtures/agent-prewarm-prefetch/.gitignore
@@ -1,0 +1,10 @@
+node_modules
+.env*
+.eve
+.vercel
+.next
+.output
+.nitro
+dist
+.DS_Store
+*.tsbuildinfo

--- a/e2e/fixtures/agent-prewarm-prefetch/.vercelignore
+++ b/e2e/fixtures/agent-prewarm-prefetch/.vercelignore
@@ -1,0 +1,7 @@
+.env*.local
+node_modules
+.eve
+.next
+.output
+.nitro
+dist

--- a/e2e/fixtures/agent-prewarm-prefetch/agent/agent.ts
+++ b/e2e/fixtures/agent-prewarm-prefetch/agent/agent.ts
@@ -1,0 +1,13 @@
+import { e2eAgentConfig } from "@eve-e2e/config";
+import { defineAgent } from "eve";
+import { mockModel } from "eve/evals";
+
+export default defineAgent({
+  ...e2eAgentConfig(),
+  model: mockModel(({ toolResults }) => {
+    const result = toolResults.at(-1);
+    if (result !== undefined) return "done";
+    return { toolCalls: [{ input: { command: "true" }, name: "bash" }] };
+  }),
+  modelContextWindowTokens: 1_000_000,
+});

--- a/e2e/fixtures/agent-prewarm-prefetch/agent/instructions.md
+++ b/e2e/fixtures/agent-prewarm-prefetch/agent/instructions.md
@@ -1,0 +1,1 @@
+Run the requested sandbox command.

--- a/e2e/fixtures/agent-prewarm-prefetch/agent/sandbox.ts
+++ b/e2e/fixtures/agent-prewarm-prefetch/agent/sandbox.ts
@@ -1,0 +1,7 @@
+import { defaultBackend, defineSandbox } from "eve/sandbox";
+
+export default defineSandbox({
+  backend: defaultBackend(),
+  revalidationKey: () => "prefetch-v1",
+  async bootstrap() {},
+});

--- a/e2e/fixtures/agent-prewarm-prefetch/agent/tools/bash.ts
+++ b/e2e/fixtures/agent-prewarm-prefetch/agent/tools/bash.ts
@@ -1,0 +1,5 @@
+import { defineTool } from "eve/tools";
+import { never } from "eve/tools/approval";
+import { bash } from "eve/tools/bash";
+
+export default defineTool({ ...bash, approval: never() });

--- a/e2e/fixtures/agent-prewarm-prefetch/evals/evals.config.ts
+++ b/e2e/fixtures/agent-prewarm-prefetch/evals/evals.config.ts
@@ -1,0 +1,4 @@
+import { e2eJudgeModel } from "@eve-e2e/config";
+import { defineEvalConfig } from "eve/evals";
+
+export default defineEvalConfig({ judge: { model: e2eJudgeModel() } });

--- a/e2e/fixtures/agent-prewarm-prefetch/evals/prewarm-prefetch.eval.ts
+++ b/e2e/fixtures/agent-prewarm-prefetch/evals/prewarm-prefetch.eval.ts
@@ -1,0 +1,104 @@
+import { defineEval, type EveEvalContext, type EveEvalSession } from "eve/evals";
+import { equals } from "eve/evals/expect";
+
+const PREWARM_SESSION_COUNT = 5;
+const MEASURED_SESSION_COUNT = 12;
+const METRIC_PREFIX = "EVE_AGENT_SNAPSHOT_PREWARM=";
+
+interface Sample {
+  readonly durationMs: number;
+  readonly endedAtMs: number;
+  readonly sessionId: string | undefined;
+  readonly sessionNumber: number;
+  readonly startedAtMs: number;
+}
+
+export default defineEval({
+  description:
+    "Agent snapshot prewarm demo: materialize a template through throwaway sessions before measured fan-out.",
+  tags: ["sandbox", "performance"],
+  timeoutMs: 5 * 60_000,
+  async test(t) {
+    requireVercelMockWorld(t);
+
+    const experimentStartedAtMs = Date.now();
+    const prewarmStartedAt = performance.now();
+    const prewarmStartedAtMs = Date.now();
+    const prewarm = await runConcurrentSessions(t, PREWARM_SESSION_COUNT, "prewarm");
+    const prewarmDurationMs = performance.now() - prewarmStartedAt;
+    const prewarmEndedAtMs = Date.now();
+
+    const measuredStartedAt = performance.now();
+    const measuredStartedAtMs = Date.now();
+    const measured = await runConcurrentSessions(t, MEASURED_SESSION_COUNT, "measured");
+    const measuredEndedAtMs = Date.now();
+
+    t.log(
+      `${METRIC_PREFIX}${JSON.stringify({
+        experimentDurationMs: measuredEndedAtMs - experimentStartedAtMs,
+        fixture: "agent-prewarm-prefetch",
+        measured: {
+          batchDurationMs: performance.now() - measuredStartedAt,
+          endedAtMs: measuredEndedAtMs,
+          samples: measured,
+          sessionCount: MEASURED_SESSION_COUNT,
+          startedAtMs: measuredStartedAtMs,
+        },
+        prewarm: {
+          batchDurationMs: prewarmEndedAtMs - prewarmStartedAtMs,
+          endedAtMs: prewarmEndedAtMs,
+          samples: prewarm,
+          sessionCount: PREWARM_SESSION_COUNT,
+          startedAtMs: prewarmStartedAtMs,
+          timerDurationMs: prewarmDurationMs,
+        },
+        schemaVersion: 1,
+        variant: "five-throwaway-agent-snapshot-prewarms",
+      })}`,
+    );
+    t.succeeded();
+  },
+});
+
+async function runConcurrentSessions(
+  t: EveEvalContext,
+  count: number,
+  phase: string,
+): Promise<Sample[]> {
+  return await Promise.all(
+    Array.from({ length: count }, async (_, index) => {
+      const session = t.newSession();
+      return await runSession(t, session, phase, index);
+    }),
+  );
+}
+
+async function runSession(
+  t: EveEvalContext,
+  session: EveEvalSession,
+  phase: string,
+  index: number,
+): Promise<Sample> {
+  const startedAt = performance.now();
+  const startedAtMs = Date.now();
+  const result = await session.send(`${phase}-${index}`);
+  result.expectOk();
+  await t.require(result.message, equals("done"));
+  return {
+    durationMs: performance.now() - startedAt,
+    endedAtMs: Date.now(),
+    sessionId: result.sessionId,
+    sessionNumber: index + 1,
+    startedAtMs,
+  };
+}
+
+function requireVercelMockWorld(t: EveEvalContext): void {
+  if (
+    t.target.kind !== "remote" ||
+    process.env.EVE_E2E_MODEL !== "mock" ||
+    process.env.EVE_E2E_WORKFLOW_WORLD !== undefined
+  ) {
+    t.skip("Temporary performance experiment runs only in the Vercel mock-world suite.");
+  }
+}

--- a/e2e/fixtures/agent-prewarm-prefetch/package.json
+++ b/e2e/fixtures/agent-prewarm-prefetch/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "agent-prewarm-prefetch",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "eve build",
+    "dev": "eve dev",
+    "start": "eve start",
+    "typecheck": "eve build && tsc",
+    "test:e2e": "eve eval --strict"
+  },
+  "dependencies": {
+    "@eve-e2e/config": "workspace:*",
+    "@workflow/world-postgres": "catalog:",
+    "eve": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/e2e/fixtures/agent-prewarm-prefetch/tsconfig.json
+++ b/e2e/fixtures/agent-prewarm-prefetch/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["agent/**/*.ts", "evals/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -842,6 +842,44 @@ importers:
         specifier: 'catalog:'
         version: 7.0.2
 
+  e2e/fixtures/agent-prewarm-control:
+    dependencies:
+      '@eve-e2e/config':
+        specifier: workspace:*
+        version: link:../e2e-config
+      '@workflow/world-postgres':
+        specifier: 'catalog:'
+        version: 5.0.0-beta.40(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@upstash/redis@1.38.4)(sql.js@1.14.1)(supports-color@10.2.2)(typescript@7.0.2)
+      eve:
+        specifier: workspace:*
+        version: link:../../../packages/eve
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.3
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+
+  e2e/fixtures/agent-prewarm-prefetch:
+    dependencies:
+      '@eve-e2e/config':
+        specifier: workspace:*
+        version: link:../e2e-config
+      '@workflow/world-postgres':
+        specifier: 'catalog:'
+        version: 5.0.0-beta.40(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@upstash/redis@1.38.4)(sql.js@1.14.1)(supports-color@10.2.2)(typescript@7.0.2)
+      eve:
+        specifier: workspace:*
+        version: link:../../../packages/eve
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.3
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+
   e2e/fixtures/agent-prompt-cache:
     dependencies:
       '@eve-e2e/config':
@@ -17816,7 +17854,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.9.1
+      '@types/node': 22.20.1
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -21462,13 +21500,13 @@ snapshots:
 
   '@slack/logger@4.0.1':
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 22.20.1
 
   '@slack/socket-mode@2.0.7(bufferutil@4.1.0)(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
       '@slack/logger': 4.0.1
       '@slack/web-api': 7.19.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
-      '@types/node': 25.9.1
+      '@types/node': 22.20.1
       '@types/ws': 8.18.1
       eventemitter3: 5.0.4
       ws: 8.21.3(bufferutil@4.1.0)
@@ -21484,7 +21522,7 @@ snapshots:
     dependencies:
       '@slack/logger': 4.0.1
       '@slack/types': 2.21.1
-      '@types/node': 25.9.1
+      '@types/node': 22.20.1
       '@types/retry': 0.12.0
       axios: 1.16.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
       eventemitter3: 5.0.4
@@ -22152,7 +22190,7 @@ snapshots:
 
   '@types/pg@8.20.0':
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 22.20.1
       pg-protocol: 1.15.0
       pg-types: 2.2.0
 
@@ -22201,7 +22239,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 22.20.1
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -24361,7 +24399,7 @@ snapshots:
 
   chrome-launcher@0.15.2(supports-color@10.2.2):
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 22.20.1
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2(supports-color@10.2.2)
@@ -24380,7 +24418,7 @@ snapshots:
 
   chromium-edge-launcher@0.3.0(supports-color@10.2.2):
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 22.20.1
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2(supports-color@10.2.2)
@@ -27450,7 +27488,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.9.1
+      '@types/node': 22.20.1
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -27467,7 +27505,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 22.20.1
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1


### PR DESCRIPTION
### Summary

Agent templates are reused across many fresh Sandbox sessions, but generic warm pools do not materialize an agent's snapshot before the first command. This temporary E2E A/B measures whether five throwaway sessions using an exact agent template improve a subsequent 12-session fan-out through incidental box-local cache reuse. It reports both measured latency and total latency including prewarming; the draft is diagnostic and should not merge.

### Validation

- `pnpm install --frozen-lockfile`
- `pnpm fmt`
- `pnpm lint`
- `pnpm guard:invariants`
- `pnpm --filter agent-prewarm-control typecheck`
- `pnpm --filter agent-prewarm-prefetch typecheck`

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
