### PR TITLE
Fix authored module loading for workspace-linked eve installs

### DIFF
--- a/.changeset/fix-authored-eve-self-imports.md
+++ b/.changeset/fix-authored-eve-self-imports.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Fix loading eve-owned authored modules, including the self-modification extension, from workspace-linked installations. Package builds now also preserve eve self-imports without unresolved-import warnings.

--- a/packages/eve/scripts/build-rolldown.mjs
+++ b/packages/eve/scripts/build-rolldown.mjs
@@ -177,6 +177,13 @@ const EXTERNAL_PACKAGES = new Set([
 ]);
 
 function isExternalPackageSpecifier(source) {
+  // Public self-imports must remain bare in the published package. Resolving
+  // them during a clean build would target output that does not exist yet;
+  // resolving them during an incremental build could consume stale output.
+  if (source === "eve" || source.startsWith("eve/")) {
+    return true;
+  }
+
   // All `#*` subpath imports stay external so the published dist keeps
   // the bare-specifier shape the runtime resolves at load time. Source
   // files routinely depend on a 1:1 mapping (workflow

--- a/packages/eve/src/internal/authored-package-boundary.test.ts
+++ b/packages/eve/src/internal/authored-package-boundary.test.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
+import { resolvePackageDependencyPath } from "#internal/application/package.js";
 import {
   createGenerationPackageBoundaryPlugin,
   createRuntimeLoaderPackageBoundaryPlugin,
@@ -12,6 +13,30 @@ import {
 const PACKAGE_ROOT = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
 
 describe("createGenerationPackageBoundaryPlugin", () => {
+  it("keeps eve imports portable", async () => {
+    const plugin = createGenerationPackageBoundaryPlugin({
+      externalDependencies: [],
+      packageRoot: PACKAGE_ROOT,
+    });
+    const resolveId = plugin.resolveId as (
+      this: RolldownResolveContext,
+      source: string,
+      importer: string | undefined,
+      options: { kind: string },
+    ) => Promise<unknown>;
+    const context: RolldownResolveContext = {
+      async resolve() {
+        throw new Error("framework imports should resolve before delegating");
+      },
+    };
+
+    await expect(
+      resolveId.call(context, "eve/tools", join(PACKAGE_ROOT, "agent/tools/probe.ts"), {
+        kind: "import-statement",
+      }),
+    ).resolves.toEqual({ external: true, id: "eve/tools" });
+  });
+
   it("resolves package-private imports from the importing dependency", async () => {
     const plugin = createGenerationPackageBoundaryPlugin({
       externalDependencies: [],
@@ -43,6 +68,36 @@ describe("createGenerationPackageBoundaryPlugin", () => {
 });
 
 describe("createRuntimeLoaderPackageBoundaryPlugin", () => {
+  it("binds eve imports to the executing framework installation", async () => {
+    const plugin = createRuntimeLoaderPackageBoundaryPlugin({
+      externalDependencies: [],
+      packageRoot: PACKAGE_ROOT,
+    });
+    const resolveId = plugin.resolveId as (
+      this: RolldownResolveContext,
+      source: string,
+      importer: string | undefined,
+      options: { kind: string },
+    ) => Promise<unknown>;
+    const context: RolldownResolveContext = {
+      async resolve() {
+        throw new Error("framework imports should resolve before delegating");
+      },
+    };
+
+    await expect(
+      resolveId.call(
+        context,
+        "eve/tools",
+        join(PACKAGE_ROOT, "dist/src/self-modification/extension/tools/edit_file.js"),
+        { kind: "import-statement" },
+      ),
+    ).resolves.toEqual({
+      external: true,
+      id: resolvePackageDependencyPath("eve/tools"),
+    });
+  });
+
   it("resolves eve package imports through the published dist mapping", async () => {
     const plugin = createRuntimeLoaderPackageBoundaryPlugin({
       externalDependencies: [],

--- a/packages/eve/src/internal/authored-package-boundary.ts
+++ b/packages/eve/src/internal/authored-package-boundary.ts
@@ -3,7 +3,10 @@ import { createRequire, isBuiltin } from "node:module";
 import { dirname, join, resolve, sep } from "node:path";
 
 import { normalizeEsmImportSpecifier } from "#internal/application/import-specifier.js";
-import { resolveWorkflowModulePath } from "#internal/application/package.js";
+import {
+  resolvePackageDependencyPath,
+  resolveWorkflowModulePath,
+} from "#internal/application/package.js";
 
 export const CACHED_CHANNEL_PREFIX = "eve-cached-channel:";
 
@@ -100,7 +103,10 @@ export function createRuntimeLoaderPackageBoundaryPlugin(input: {
       }
 
       if (isFrameworkRuntimeImport(source, importer)) {
-        return { external: true, id: resolveFrameworkRuntimeImport(source) };
+        return {
+          external: true,
+          id: resolveRuntimeLoaderFrameworkImport(source),
+        };
       }
 
       // The published package maps #imports to dist, while the eve-source
@@ -418,6 +424,19 @@ function resolveFrameworkRuntimeImport(source: string): string {
     return source;
   }
   return normalizeEsmImportSpecifier(resolveWorkflowModulePath(source));
+}
+
+/**
+ * Immediate loader bundles live in a cache below the authored package root.
+ * Resolve eve self-references before moving eve-owned authored modules below a
+ * nested node_modules boundary, where Node can no longer see the owning package
+ * scope. Generation bundles remain portable and keep these imports bare.
+ */
+function resolveRuntimeLoaderFrameworkImport(source: string): string {
+  if (source === "eve" || source.startsWith("eve/")) {
+    return normalizeEsmImportSpecifier(resolvePackageDependencyPath(source));
+  }
+  return resolveFrameworkRuntimeImport(source);
 }
 
 export function isNodeModulesPath(path: string): boolean {


### PR DESCRIPTION
### Summary

eve-owned authored modules could fail during development when eve was workspace-linked because cached bundles retained bare `eve/*` imports outside the package scope where Node could resolve them. 

Practically, this would only affect the selfmod vendored package, since it's importing using eve's public imports in order to signal the use of public APIs.

This PR resolves those imports to the active eve installation for immediate loading while preserving portable bare imports in generated artifacts. Package builds also explicitly externalize eve self-imports, removing unresolved-import warnings and avoiding stale build output.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/internal/authored-package-boundary.test.ts`
- `pnpm --filter eve typecheck`
- `pnpm exec oxlint packages/eve/src/internal/authored-package-boundary.ts packages/eve/src/internal/authored-package-boundary.test.ts`
- `pnpm --filter eve build:js`
- Loaded the workspace-linked self-modification `edit_file.js` through `loadAuthoredModuleNamespace` after rebuilding
- Confirmed the build no longer reports unresolved `eve/*` imports

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
