### PR TITLE
fix(eve): do not fail turns expecting structured output when background work is active

### DIFF
--- a/.changeset/structured-background-output.md
+++ b/.changeset/structured-background-output.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Keep structured output requests pending while child background work is still active instead of failing the turn early.

--- a/e2e/fixtures/agent-task-reporting/evals/README.md
+++ b/e2e/fixtures/agent-task-reporting/evals/README.md
@@ -10,6 +10,11 @@ starts the same three warehouse lookups, observes an intermediate completion,
 asks an unrelated arithmetic question, and waits for the combined inventory
 report. The comparison trials do not request compaction.
 
+`structured-output.eval.ts` starts one background warehouse lookup from a turn
+with an output schema. It verifies that the initiating segment remains pending
+without a structured result, then that the task wake satisfies the original
+schema with the lookup result.
+
 The fixture model strips the trial marker from both variants before inference.
 The off variant also removes the current pending-cohort instruction. Task state,
 task results, launch guidance, settled guidance, model settings, and the runtime

--- a/e2e/fixtures/agent-task-reporting/evals/structured-output.eval.ts
+++ b/e2e/fixtures/agent-task-reporting/evals/structured-output.eval.ts
@@ -1,0 +1,45 @@
+import { defineEval } from "eve/evals";
+import { equals } from "eve/evals/expect";
+
+import { requireStreamIndex } from "./reporting.js";
+
+/**
+ * A structured parent turn must remain pending while its background child is
+ * still working, then use the child's result to satisfy the original schema.
+ */
+export default defineEval({
+  description: "Structured output waits for an active background task.",
+  tags: ["real-model"],
+  async test(t) {
+    const started = await t.send(
+      `Find the first sample warehouse's inventory item using the built-in agent tool. Start exactly one background agent with this task: "Call probe with check=first and report its result value."
+
+Do not guess the inventory item or produce the requested structured output until the background agent reports its result.`,
+      {
+        outputSchema: {
+          additionalProperties: false,
+          properties: { item: { type: "string" } },
+          required: ["item"],
+          type: "object",
+        },
+      },
+    );
+
+    started.expectOk();
+    started.calledSubagent("agent", { count: 1 });
+    started.notEvent("result.completed");
+    started.event("session.waiting", { count: 1 });
+    t.check(started.status, equals("waiting"));
+    started.noFailedActions();
+
+    const completed = await t.target
+      .watchTurn(started.sessionId, { startIndex: requireStreamIndex(t) })
+      .result();
+
+    completed.expectOk();
+    completed.event("result.completed", { count: 1 });
+    completed.outputEquals({ item: "oranges" });
+    completed.noFailedActions();
+    t.noFailedActions();
+  },
+});

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -69,7 +69,7 @@ import {
   appendPendingInputBatch,
 } from "#harness/input-requests.js";
 import { activeTurnId } from "#harness/active-turn-id.js";
-import { recordSessionTask } from "#tasks/session-index.js";
+import { cacheTerminalTaskView, recordSessionTask } from "#tasks/session-index.js";
 import { getPendingCoordinationBatch } from "#harness/coordination.js";
 import { AGENT_HANDLES_STATE_KEY } from "#subagents/handles/store.js";
 import { BackgroundToolExecutorKey } from "#harness/background-tools.js";
@@ -2748,6 +2748,76 @@ describe("createToolLoopHarness", () => {
       }),
     );
     expect(result.session.outputSchema).toBeUndefined();
+  });
+
+  it("keeps requested structured output pending while background work is active", async () => {
+    setupMockAgent({
+      finishReason: "stop",
+      response: {
+        messages: [{ content: "The background work is still running.", role: "assistant" }],
+      },
+      text: "The background work is still running.",
+      toolCalls: [],
+      toolResults: [],
+    });
+
+    const { emit, events } = createEventCollector();
+    const runStep = createToolLoopHarness(createTestConfig("conversation", emit));
+    const schema = { type: "object" };
+    const session = recordBackgroundTask(createTestSession({ outputSchema: schema }));
+
+    const result = await runStep(session, { message: "Run the background work." });
+
+    expect(result.next).toBeNull();
+    expect(result.settledTurn).toBeUndefined();
+    expect(result.session.outputSchema).toEqual(schema);
+    expect(getCompatibilityEventTypes(events)).not.toContain("turn.failed");
+    expect(events).not.toContainEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({ code: "OUTPUT_SCHEMA_NOT_FULFILLED" }),
+        type: "step.failed",
+      }),
+    );
+  });
+
+  it("fails requested structured output after background work settles", async () => {
+    setupMockAgent({
+      finishReason: "stop",
+      response: {
+        messages: [{ content: "The background work completed.", role: "assistant" }],
+      },
+      text: "The background work completed.",
+      toolCalls: [],
+      toolResults: [],
+    });
+
+    const { emit, events } = createEventCollector();
+    const runStep = createToolLoopHarness(createTestConfig("conversation", emit));
+    const withTask = recordBackgroundTask(createTestSession({ outputSchema: { type: "object" } }));
+    const session = {
+      ...withTask,
+      state: cacheTerminalTaskView(withTask.state, {
+        lastOutput: { data: "done", type: "result" },
+        metadata: { kind: "report-probe", name: "analysis" },
+        status: "completed",
+        taskId: "analysis",
+      }),
+    };
+
+    const result = await runStep(session, { message: "Report the completed work." });
+
+    expect(result.settledTurn).toEqual({
+      isError: true,
+      output: "The agent could not produce a result matching the requested schema.",
+    });
+    expect(result.session.outputSchema).toBeUndefined();
+    expect(getCompatibilityEventTypes(events)).toContain("turn.failed");
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({ code: "OUTPUT_SCHEMA_NOT_FULFILLED" }),
+        type: "step.failed",
+      }),
+    );
   });
 
   it("returns only the final assistant reply when a completed task step includes tool work", async () => {

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -2893,6 +2893,18 @@ async function finishConversationTurn(input: {
 
   const structured = extractFinalOutput(result);
   if (structured === undefined) {
+    const initiatingTasks = resolveInitiatingTaskContext({
+      state: session.state,
+      turnId: emissionState.turnId,
+    });
+    if (initiatingTasks !== undefined) {
+      if (emit) {
+        emissionState = await emitTurnEpilogue(emit, emissionState, "conversation");
+        session = setHarnessEmissionState(session, emissionState);
+      }
+      return { next: null, session };
+    }
+
     // The schema belongs to the settled turn. A later conversation turn that
     // omits outputSchema must not inherit a failed turn's contract.
     session = { ...session, outputSchema: undefined };


### PR DESCRIPTION
### Summary

Prevents a conversation turn which must emit structured output as pending as long as it still has outstanding background work. This presents it from failing while the background work completes. Once background work completes, if the structured output is not fulfilled, the turn will fail as expected.

### Validation

Adds unit coverage that active background work preserves the schema, then settled background work without structured output follows the existing `OUTPUT_SCHEMA_NOT_FULFILLED` error path.
