### PR TITLE
feat(eve): inherit history in workflow subagents

### DIFF
--- a/.changeset/workflow-agent-inherit-history.md
+++ b/.changeset/workflow-agent-inherit-history.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Allow workflow tools to seed a newly created local subagent with the parent conversation using `ctx.agent({ inheritHistory: true })`.

--- a/docs/tools/workflows.mdx
+++ b/docs/tools/workflows.mdx
@@ -267,6 +267,19 @@ invocation identity, including repeated and parallel calls to the same subagent.
 continue an existing child. An inline `outputSchema` requires structured output and determines the
 return type, so `result` in the example is typed as `{ findings: string[] }`.
 
+Set `inheritHistory: true` to seed a new local subagent with the parent conversation captured before
+the workflow tool call:
+
+```ts
+const result = await ctx.agent("research", {
+  inheritHistory: true,
+  message: task,
+});
+```
+
+`inheritHistory` applies only when creating a local subagent. It cannot be combined with `agentId` or
+used with a remote agent.
+
 ## Report progress: `yield`
 
 A workflow body may be an async generator. Ordinary yields report progress in both execution

--- a/packages/eve/extension-contracts/compatibility/channel/v19.ts
+++ b/packages/eve/extension-contracts/compatibility/channel/v19.ts
@@ -1,0 +1,10 @@
+import { defineChannel, POST } from "#public/channels/index.js";
+
+export default defineChannel({
+  routes: [
+    POST("/continue/:sessionId", async (_request, { attachSession, params }) => {
+      const result = await attachSession(params.sessionId!).send("Continue.", { auth: null });
+      return Response.json({ accepted: result.status === "accepted" });
+    }),
+  ],
+});

--- a/packages/eve/extension-contracts/compatibility/tool/v34.ts
+++ b/packages/eve/extension-contracts/compatibility/tool/v34.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+import { defineWorkflowTool } from "#public/tools/index.js";
+
+export const workflow = defineWorkflowTool({
+  description: "Ask a reviewer to summarize a report.",
+  inputSchema: z.object({ report: z.string() }),
+  async execute(input, ctx) {
+    "use workflow";
+    return await ctx.agent("reviewer", {
+      message: `Review this report: ${input.report}`,
+      outputSchema: {
+        properties: { summary: { type: "string" } },
+        required: ["summary"],
+        type: "object",
+      },
+    });
+  },
+});

--- a/packages/eve/extension-contracts/reports/channel/v20.json
+++ b/packages/eve/extension-contracts/reports/channel/v20.json
@@ -1,0 +1,21 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "channel",
+  "epoch": 20,
+  "sha256": "fa8fe6750f2dd4c7c8f436df5938589865ffc836dab1d8c54908e0bcc9384bf6",
+  "exports": [
+    "DELETE",
+    "GET",
+    "HEAD",
+    "OPTIONS",
+    "PATCH",
+    "POST",
+    "PUT",
+    "WS",
+    "createWebSocketUpgradeServer",
+    "defineChannel",
+    "disableRoute",
+    "isChannel",
+    "isDisabledRouteSentinel"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/tool/v35.json
+++ b/packages/eve/extension-contracts/reports/tool/v35.json
@@ -1,0 +1,20 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "tool",
+  "epoch": 35,
+  "sha256": "f695985f9b1303c6d7db6d9509079981fcec6873478aa0c0acd893acbaa5b2d4",
+  "exports": [
+    "defaultWebSearch",
+    "defineTool",
+    "defineWorkflowTool",
+    "disableTool",
+    "experimental_workflow",
+    "isDisabledToolSentinel",
+    "isExperimentalWorkflowToolDefinition",
+    "isWebSearchToolDefinition",
+    "toolOutput",
+    "toolOutputPart",
+    "toolResultFrom",
+    "webSearch"
+  ]
+}

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -22,8 +22,8 @@ interface ExtensionCapabilityContract {
 const EXTENSION_CAPABILITY_CONTRACTS = {
   extension: { current: 1, supported: [1], dropped: {} },
   tool: {
-    current: 34,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 28, 29, 30, 31, 32, 34],
+    current: 35,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 28, 29, 30, 31, 32, 34, 35],
     dropped: {
       14: "TaskExec.delegated was removed; migrate to workflow-backed background tools",
       15: "TaskExec replaces stageEffect with send",
@@ -57,8 +57,8 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     },
   },
   channel: {
-    current: 19,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19],
+    current: 20,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19, 20],
     dropped: {
       12: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",
     },

--- a/packages/eve/src/execution/create-session-step.test.ts
+++ b/packages/eve/src/execution/create-session-step.test.ts
@@ -19,6 +19,28 @@ const TestTurnAgent: RuntimeTurnAgent = {
 };
 
 describe("createSessionStep", () => {
+  it("keeps child-authored initial messages before inherited history", async () => {
+    vi.mocked(getCompiledRuntimeAgentBundle).mockResolvedValue({
+      resolvedAgent: { config: {} },
+      turnAgent: {
+        ...TestTurnAgent,
+        initialMessages: [{ content: "Authored context", role: "user" }],
+      },
+    } as never);
+
+    const { state } = await createSessionStep({
+      compiledArtifactsSource: { kind: "bundled" },
+      continuationToken: "subagent:test",
+      parentHistory: [{ content: "Parent context", role: "assistant" }],
+      sessionId: "sess-child",
+    });
+
+    expect(state.snapshot?.session.history).toEqual([
+      { content: "Authored context", role: "user" },
+      { content: "Parent context", role: "assistant" },
+    ]);
+  });
+
   it("adds task_update guidance to a task-owned session system prompt", async () => {
     vi.mocked(getCompiledRuntimeAgentBundle).mockResolvedValue({
       resolvedAgent: {

--- a/packages/eve/src/execution/create-session-step.ts
+++ b/packages/eve/src/execution/create-session-step.ts
@@ -10,6 +10,7 @@ import {
 import { createSession } from "#execution/session.js";
 import { resolveInheritedTokenLimit } from "#execution/run-session-limits.js";
 import type { RunSessionLimits } from "#channel/types.js";
+import type { ModelMessage } from "ai";
 import type { JsonObject } from "#shared/json.js";
 import { resolveEffectiveAgentRuntimeFromConfig } from "#execution/effective-agent-config.js";
 import type { DynamicSubagentAgentConfig } from "#runtime/subagents/dynamic-agent-config.js";
@@ -35,6 +36,7 @@ export async function createSessionStep(input: {
   readonly compiledArtifactsSource: DurableCompiledArtifactsSource;
   readonly continuationToken: string;
   readonly dynamicSubagentAgentConfig?: DynamicSubagentAgentConfig;
+  readonly parentHistory?: readonly ModelMessage[];
   readonly inheritedLimits?: RunSessionLimits;
   readonly outputSchema?: JsonObject;
   readonly nodeId?: string;
@@ -69,6 +71,7 @@ export async function createSessionStep(input: {
       thresholdPercent: effectiveAgent.thresholdPercent,
     },
     continuationToken: input.continuationToken,
+    parentHistory: input.parentHistory === undefined ? undefined : [...input.parentHistory],
     limits: {
       // Inherited token limits are the parent's remaining quota share at
       // dispatch time; an authored `false` uncaps only when there is nothing

--- a/packages/eve/src/execution/session-command-inbox.test.ts
+++ b/packages/eve/src/execution/session-command-inbox.test.ts
@@ -4,6 +4,7 @@ import {
   createSessionCommandInbox,
   type SessionInboxPayload,
 } from "#execution/session-command-inbox.js";
+import { SESSION_INBOX_WIRE_VERSION } from "#execution/wire/session-inbox-contract.js";
 
 const createHookMock = vi.fn();
 
@@ -123,7 +124,10 @@ describe("createSessionCommandInbox", () => {
     );
     expect(createHookMock).toHaveBeenCalledOnce();
     expect(createHookMock).toHaveBeenCalledWith({
-      metadata: { sessionInboxWireVersion: 6, workflowTaskAuthorization: true },
+      metadata: {
+        sessionInboxWireVersion: SESSION_INBOX_WIRE_VERSION,
+        workflowTaskAuthorization: true,
+      },
       token: "stable",
     });
     await inbox.dispose();

--- a/packages/eve/src/execution/session.ts
+++ b/packages/eve/src/execution/session.ts
@@ -71,6 +71,7 @@ export interface CreateSessionInput {
   readonly rootSessionId?: string;
   readonly sessionId: string;
   readonly turnAgent: RuntimeTurnAgent;
+  readonly parentHistory?: HarnessSession["history"];
   readonly limits?: AuthoredSessionLimits;
   readonly outputSchema?: HarnessSession["outputSchema"];
   readonly systemPromptAdditions?: readonly string[];
@@ -96,7 +97,7 @@ export function createSession(input: CreateSessionInput): HarnessSession {
       thresholdPercent: input.compactionOverrides?.thresholdPercent,
     }),
     continuationToken: input.continuationToken,
-    history: [...(turnAgent.initialMessages ?? [])],
+    history: [...(turnAgent.initialMessages ?? []), ...(input.parentHistory ?? [])],
     sessionId: input.sessionId,
   };
 

--- a/packages/eve/src/execution/tasks/parent/tool-execution.ts
+++ b/packages/eve/src/execution/tasks/parent/tool-execution.ts
@@ -466,6 +466,7 @@ class BackgroundToolExecutionScope implements BackgroundToolExecutor {
         callId: taskInput.callId,
         executeInput: workflow.executeInput?.(workflowInput),
         input: workflowInput,
+        parentHistory: [...this.initialSession.history],
         resultKind: workflow.resultKind,
         session: buildCallbackContext().session,
         stepIndex: input.emission.stepIndex,

--- a/packages/eve/src/execution/tools/subagent/invoke-agent.test.ts
+++ b/packages/eve/src/execution/tools/subagent/invoke-agent.test.ts
@@ -53,6 +53,17 @@ describe("agent invocation input", () => {
       "agent() requires a non-empty agent name as its first argument.",
     );
   });
+
+  it("rejects inherited history with an existing agent id", () => {
+    expect(() =>
+      validateAgentInput({
+        agentId: "agent-1",
+        inheritHistory: true,
+        message: "Continue",
+        target: "research",
+      }),
+    ).toThrow("cannot combine `agentId` with `inheritHistory`");
+  });
 });
 
 describe("background agent invocation routing", () => {
@@ -128,12 +139,14 @@ describe("background agent invocation routing", () => {
       turnId: "turn-1",
     };
     const ctx = { callId: "call-1" } as ToolContext;
+    const parentHistory = [{ content: "Prior context", role: "user" as const }];
     attachWorkflowToolRunContext(ctx, {
       admission: Promise.resolve({ status: "accepted" }),
       from,
       owner: {
         inbox: "owner-inbox",
       },
+      parentHistory,
     });
 
     const outputSchema = {
@@ -141,16 +154,16 @@ describe("background agent invocation routing", () => {
       required: ["findings"],
       type: "object",
     };
-    await expect(agent(ctx, "research", { message: "Find it", outputSchema })).resolves.toEqual({
-      findings: ["available"],
-    });
+    await expect(
+      agent(ctx, "research", { inheritHistory: true, message: "Find it", outputSchema }),
+    ).resolves.toEqual({ findings: ["available"] });
 
     expect(mocks.resumeHook).toHaveBeenCalledWith("owner-inbox", {
       kind: "request",
       from,
       replyTo: "agent-reply",
       request: {
-        input: { message: "Find it", outputSchema, target: "research" },
+        input: { parentHistory, message: "Find it", outputSchema, target: "research" },
         invocationId: "call-1:agent-reply",
         kind: "agent-invoke",
       },

--- a/packages/eve/src/execution/tools/subagent/invoke-agent.test.ts
+++ b/packages/eve/src/execution/tools/subagent/invoke-agent.test.ts
@@ -93,6 +93,20 @@ describe("background agent invocation routing", () => {
 
     const result = agent(ctx, "research", { message: "Find it" });
     await vi.waitFor(() => expect(mocks.resumeHook).toHaveBeenCalledOnce());
+    expect(mocks.resumeHook).toHaveBeenCalledWith("owner-inbox", {
+      kind: "request",
+      from: expect.objectContaining({ execution: "background", runId: "run-1" }),
+      replyTo: "agent-reply",
+      request: {
+        input: { message: "Find it", target: "research" },
+        invocationId: "call-1:agent-reply",
+        kind: "agent-invoke",
+      },
+    });
+    const invocation = mocks.resumeHook.mock.calls[0]?.[1] as {
+      readonly request: { readonly input: object };
+    };
+    expect(invocation.request.input).not.toHaveProperty("parentHistory");
     controller.abort(new Error("task cancelled"));
 
     await expect(result).rejects.toThrow("task cancelled");

--- a/packages/eve/src/execution/tools/subagent/invoke-agent.ts
+++ b/packages/eve/src/execution/tools/subagent/invoke-agent.ts
@@ -68,7 +68,7 @@ export async function agent(
   validateAgentInput({ ...input, target });
   return await invokeAgent(ctx, {
     agentId: input.agentId,
-    parentHistory: input.inheritHistory === true ? readWorkflowToolParentHistory(ctx) : undefined,
+    ...(input.inheritHistory === true ? { parentHistory: readWorkflowToolParentHistory(ctx) } : {}),
     message: input.message,
     outputSchema: input.outputSchema,
     target,

--- a/packages/eve/src/execution/tools/subagent/invoke-agent.ts
+++ b/packages/eve/src/execution/tools/subagent/invoke-agent.ts
@@ -6,6 +6,7 @@ import type {
   SubagentInputRequestHookPayload,
 } from "#channel/types.js";
 import {
+  readWorkflowToolParentHistory,
   readWorkflowToolRunAdmission,
   readWorkflowToolRunOwner,
   readWorkflowToolRunRef,
@@ -22,6 +23,7 @@ import type { TaskInboundUpdate } from "#tasks/types.js";
 
 export type InternalAgentInput = {
   readonly agentId?: string;
+  readonly parentHistory?: readonly import("ai").ModelMessage[];
   readonly message: string;
   readonly outputSchema?: JsonObject;
   readonly target: string;
@@ -66,6 +68,7 @@ export async function agent(
   validateAgentInput({ ...input, target });
   return await invokeAgent(ctx, {
     agentId: input.agentId,
+    parentHistory: input.inheritHistory === true ? readWorkflowToolParentHistory(ctx) : undefined,
     message: input.message,
     outputSchema: input.outputSchema,
     target,
@@ -195,7 +198,12 @@ async function nextAgentReply(
   }
 }
 
-export function validateAgentInput(input: InternalAgentInput): void {
+export function validateAgentInput(
+  input: InternalAgentInput | (AgentInput & { target: string }),
+): void {
+  if ("inheritHistory" in input && input.agentId !== undefined && input.inheritHistory === true) {
+    throw new TypeError("agent() cannot combine `agentId` with `inheritHistory`.");
+  }
   if (typeof input.target !== "string" || input.target.trim() === "") {
     throw new TypeError("agent() requires a non-empty agent name as its first argument.");
   }

--- a/packages/eve/src/execution/tools/subagent/invoke-preparation.test.ts
+++ b/packages/eve/src/execution/tools/subagent/invoke-preparation.test.ts
@@ -58,6 +58,54 @@ describe("planAgentDispatch", () => {
     ).toMatchObject({ kind: "reject", result: { output: { code: "SUBAGENT_UNAVAILABLE" } } });
   });
 
+  it("preloads history only on a fresh local start", () => {
+    const history = [{ content: "Prior context", role: "user" as const }];
+    expect(
+      planAgentDispatch({
+        action: localAction,
+        bundle: {
+          subagentRegistry: {
+            subagentsByNodeId: new Map([
+              [localAction.nodeId, { definition: { description: "Research", kind: "subagent" } }],
+            ]),
+          },
+          turnAgent: {},
+        } as never,
+        ctx: {} as never,
+        parentHistory: history,
+        session: session() as never,
+      }),
+    ).toMatchObject({ kind: "start", target: { parentHistory: history, kind: "local" } });
+  });
+
+  it.each([["agent-1"], ["unknown"]] as const)(
+    "rejects inherited history with agent id %s",
+    (agentId) => {
+      expect(() =>
+        planAgentDispatch({
+          action: { ...localAction, input: { agentId, message: "Find it" } },
+          bundle: { subagentRegistry: { subagentsByNodeId: new Map() }, turnAgent: {} } as never,
+          ctx: {} as never,
+          parentHistory: [{ content: "Prior context", role: "user" }],
+          knownAgentIds: ["agent-1"],
+          session: session() as never,
+        }),
+      ).toThrow("cannot combine `agentId` with inherited history");
+    },
+  );
+
+  it("rejects inherited history for a remote agent", () => {
+    expect(() =>
+      planAgentDispatch({
+        action: { ...localAction, kind: "remote-agent-call", remoteAgentName: "research" },
+        bundle: { subagentRegistry: { subagentsByNodeId: new Map() }, turnAgent: {} } as never,
+        ctx: {} as never,
+        parentHistory: [{ content: "Prior context", role: "user" }],
+        session: session() as never,
+      }),
+    ).toThrow("can inherit history only when creating a local subagent");
+  });
+
   it("falls back to a fresh start for an unknown agentId", () => {
     expect(
       planAgentDispatch({

--- a/packages/eve/src/execution/tools/subagent/invoke-preparation.ts
+++ b/packages/eve/src/execution/tools/subagent/invoke-preparation.ts
@@ -80,6 +80,7 @@ export async function prepareOwnerAgentInvocation(input: {
         action,
         bundle,
         ctx: planContext,
+        parentHistory: input.invocation.parentHistory,
         knownAgentIds: input.knownAgentIds,
         session,
       }),
@@ -93,6 +94,7 @@ export function planAgentDispatch(input: {
   readonly action: RuntimeAgentDispatchRequest;
   readonly bundle: CompiledBundle;
   readonly ctx: ContextReader;
+  readonly parentHistory?: AgentInvocationRequest["input"]["parentHistory"];
   readonly knownAgentIds?: readonly string[];
   readonly session: RuntimeSession;
 }): OwnerAgentDispatchPlanEntry {
@@ -103,6 +105,9 @@ export function planAgentDispatch(input: {
   const rawAgentId = input.action.input.agentId;
   const agentId =
     typeof rawAgentId === "string" && rawAgentId.trim() !== "" ? rawAgentId : undefined;
+  if (agentId !== undefined && input.parentHistory !== undefined) {
+    throw new TypeError("agent() cannot combine `agentId` with inherited history.");
+  }
   if (agentId !== undefined && isAgentHandleAction(input.action)) {
     if (knownAgentIds.has(agentId)) {
       const dynamicSubagentSelection =
@@ -128,6 +133,7 @@ export function planAgentDispatch(input: {
 }
 
 function classifyFreshStart(input: {
+  readonly parentHistory?: AgentInvocationRequest["input"]["parentHistory"];
   readonly action: RuntimeAgentDispatchRequest;
   readonly bundle: CompiledBundle;
   readonly ctx: ContextReader;
@@ -163,6 +169,9 @@ function classifyFreshStart(input: {
     return { kind: "reject", result: createRecursiveAgentRootOnlyResult(action) };
   }
   if (action.kind === "remote-agent-call") {
+    if (input.parentHistory !== undefined) {
+      throw new TypeError("agent() can inherit history only when creating a local subagent.");
+    }
     return {
       kind: "start",
       target: {
@@ -195,7 +204,13 @@ function classifyFreshStart(input: {
         };
   return {
     kind: "start",
-    target: { action, dynamicSubagentAgentConfig: dynamicAgentConfig, kind: "local", source },
+    target: {
+      action,
+      dynamicSubagentAgentConfig: dynamicAgentConfig,
+      parentHistory: input.parentHistory,
+      kind: "local",
+      source,
+    },
   };
 }
 

--- a/packages/eve/src/execution/tools/subagent/start.ts
+++ b/packages/eve/src/execution/tools/subagent/start.ts
@@ -3,6 +3,7 @@ import type { LocalDevRequestProvenance } from "#context/keys.js";
 import type { ActivityWorkIdentityV1 } from "#protocol/activity.js";
 import type { DynamicSubagentAgentConfig } from "#runtime/subagents/dynamic-agent-config.js";
 import type { DynamicRemoteAgentConfig } from "#runtime/subagents/dynamic-remote-agent-config.js";
+import type { ModelMessage } from "ai";
 import type { CompiledBundle } from "#runtime/sessions/runtime-context-keys.js";
 import type {
   RuntimeRemoteAgentDispatchRequest,
@@ -24,6 +25,7 @@ export type SubagentStartTarget =
       readonly kind: "local";
       readonly action: RuntimeSubagentDispatchRequest;
       readonly dynamicSubagentAgentConfig?: DynamicSubagentAgentConfig;
+      readonly parentHistory?: readonly ModelMessage[];
       readonly source: SubagentInputSource;
     }
   | {
@@ -90,6 +92,7 @@ export async function startSubagent(input: {
         currentSession: input.currentSession,
         dynamicSubagentAgentConfig: input.target.dynamicSubagentAgentConfig,
         fanoutSize: input.fanoutSize,
+        parentHistory: input.target.parentHistory,
         initiatorAuth: input.initiatorAuth,
         localDevRequest: input.localDevRequest,
         parentContinuationToken: input.parentContinuationToken,

--- a/packages/eve/src/execution/tools/workflow/ask.ts
+++ b/packages/eve/src/execution/tools/workflow/ask.ts
@@ -6,6 +6,7 @@ import type {
 } from "#execution/tools/workflow/messages.js";
 import { resumeHookStep } from "#execution/tools/workflow/resume-hook-step.js";
 import type { ToolContext, ToolInputRequest, ToolInputResponse } from "#tools/definition.js";
+import type { ModelMessage } from "ai";
 import { workflowToolContextErrorMessage } from "#shared/workflow-tool-context.js";
 
 // `Symbol.for`, not a module-local WeakMap: workflow helpers and body setup may
@@ -14,6 +15,7 @@ const WORKFLOW_TOOL_RUN_CONTEXT = Symbol.for("eve.workflow-tool-run.context");
 
 export interface WorkflowToolRunContext {
   readonly authorizationSupported?: boolean;
+  readonly parentHistory?: readonly ModelMessage[];
   /** Compatibility for already-started two-run background workflows. */
   readonly admission?: Promise<
     { readonly status: "accepted" } | { readonly status: "rejected"; readonly reason: string }
@@ -65,6 +67,10 @@ export function readWorkflowToolRunAdmission(
   ctx: ToolContext,
 ): WorkflowToolRunContext["admission"] {
   return readWorkflowToolRunContext(ctx, "agent").admission;
+}
+
+export function readWorkflowToolParentHistory(ctx: ToolContext): readonly ModelMessage[] {
+  return readWorkflowToolRunContext(ctx, "agent").parentHistory ?? [];
 }
 
 /** Returns an answer hook which may be awaited or raced with another workflow operation. */

--- a/packages/eve/src/execution/tools/workflow/body.test.ts
+++ b/packages/eve/src/execution/tools/workflow/body.test.ts
@@ -20,7 +20,12 @@ it("binds workflow-only methods to the run context", async () => {
   const input = {
     callId: "call",
     input: {},
-    session: { id: "session", turn: { id: "turn", sequence: 1 } },
+    parentHistory: [{ content: "Earlier request", role: "user" as const }],
+    session: {
+      auth: { current: null, initiator: null },
+      id: "session",
+      turn: { id: "turn", sequence: 1 },
+    },
     stepIndex: 0,
     toolName: "deploy",
     workflowId: "workflow//test//execute",
@@ -35,6 +40,9 @@ it("binds workflow-only methods to the run context", async () => {
   mocks.agent.mockResolvedValue("reviewed");
   mocks.execute.mockImplementation(async (_input, ctx: WorkflowToolContext & ToolContext) => {
     expect(readWorkflowToolRunRef(ctx).runId).toBe("run");
+    expect(findWorkflowToolRunContext(ctx)?.parentHistory).toEqual([
+      { content: "Earlier request", role: "user" },
+    ]);
     expect(ctx.abortSignal).toBe(signal);
     const answer = await ctx.ask(question);
     const result = await ctx.agent(target, invocation);

--- a/packages/eve/src/execution/tools/workflow/body.ts
+++ b/packages/eve/src/execution/tools/workflow/body.ts
@@ -18,6 +18,11 @@ import type { ToolContext } from "#tools/definition.js";
 import { createTaskMessage, type TaskExec } from "#tools/task.js";
 
 export interface WorkflowBodyDefinition {
+  /**
+   * Immutable completed parent prefix captured before this tool call. Older
+   * in-flight workflow runs omit it and intentionally receive an empty view.
+   */
+  readonly parentHistory?: readonly import("ai").ModelMessage[];
   /** Advertised by the parent driver; absent on runs started before this capability. */
   readonly authorizationSupported?: boolean;
   readonly callId: string;
@@ -59,6 +64,7 @@ export async function executeWorkflowBody(
   attachWorkflowToolRunContext(ctx, {
     from,
     owner: input.owner,
+    parentHistory: input.parentHistory ?? [],
     authorizationSupported: input.execution === "blocking" || input.authorizationSupported === true,
   });
   let reportCount = 0;

--- a/packages/eve/src/execution/tools/workflow/start.ts
+++ b/packages/eve/src/execution/tools/workflow/start.ts
@@ -50,6 +50,7 @@ export async function startWorkflowTask(input: {
     const started = await startWorkflowToolRun({
       callId: task.callId,
       executeInput: task.executeInput,
+      parentHistory: [...session.history],
       input: task.input,
       owner: input.owner,
       resultKind: task.resultKind,

--- a/packages/eve/src/execution/tools/workflow/types.ts
+++ b/packages/eve/src/execution/tools/workflow/types.ts
@@ -1,3 +1,5 @@
+import type { ModelMessage } from "ai";
+
 import type { SessionContext } from "#context/session-context.js";
 import type { JsonObject, JsonValue } from "#shared/json.js";
 import type { TaskExecutorBinding } from "#tools/task.js";
@@ -33,6 +35,11 @@ export interface WorkflowToolRunInput {
   readonly execution?: "background" | "blocking";
   readonly executeInput?: JsonValue;
   readonly hookToken: string;
+  /**
+   * Immutable completed parent prefix captured before this tool call. Older
+   * in-flight workflow runs omit it and intentionally receive an empty view.
+   */
+  readonly parentHistory?: readonly ModelMessage[];
   readonly input: JsonObject;
   readonly owner: WorkflowToolRunOwner;
   readonly resultKind?: "subagent" | "tool";

--- a/packages/eve/src/execution/wire/session-inbox-contract.ts
+++ b/packages/eve/src/execution/wire/session-inbox-contract.ts
@@ -1,5 +1,5 @@
 /** Every explicit session-inbox wire version still supported by producers. */
-export const SESSION_INBOX_WIRE_VERSIONS = [1, 2, 3, 4, 5, 6] as const;
+export const SESSION_INBOX_WIRE_VERSIONS = [1, 2, 3, 4, 5, 6, 7] as const;
 
 export type SessionInboxWireVersion = (typeof SESSION_INBOX_WIRE_VERSIONS)[number];
 

--- a/packages/eve/src/execution/wire/session-inbox-encoder.ts
+++ b/packages/eve/src/execution/wire/session-inbox-encoder.ts
@@ -34,11 +34,15 @@ import {
   encodeSessionCommandV6,
   type SessionInboxWireV6,
 } from "#execution/wire/session-inbox-wire.v6.js";
+import {
+  encodeSessionCommandV7,
+  type SessionInboxWireV7,
+} from "#execution/wire/session-inbox-wire.v7.js";
 
 type SessionInboxCommand = DeliverHookPayload | SessionCommand | SessionTimeoutHookPayload;
 
 /** Current wire type consumed after migration. */
-export type SessionInboxWire = SessionInboxWireV6;
+export type SessionInboxWire = SessionInboxWireV7;
 
 type LegacySessionInboxWireTarget = Extract<SessionInboxWireTarget, { readonly version: 0 }>;
 type VersionedSessionInboxEncoder = (command: SessionInboxCommand) => unknown;
@@ -55,6 +59,7 @@ const versionedEncoders = {
   5: (command: SessionInboxCommand) =>
     encodeSessionCommandV5(withoutOwnedTaskCancellation(command)),
   6: encodeSessionCommandV6,
+  7: encodeSessionCommandV7,
 } satisfies Record<SessionInboxWireVersion, VersionedSessionInboxEncoder>;
 
 /** Encodes a command for the selected session-inbox consumer. */
@@ -64,6 +69,7 @@ function encode(command: SessionInboxCommand, target: { readonly version: 3 }): 
 function encode(command: SessionInboxCommand, target: { readonly version: 4 }): SessionInboxWireV4;
 function encode(command: SessionInboxCommand, target: { readonly version: 5 }): SessionInboxWireV5;
 function encode(command: SessionInboxCommand, target: { readonly version: 6 }): SessionInboxWireV6;
+function encode(command: SessionInboxCommand, target: { readonly version: 7 }): SessionInboxWireV7;
 function encode(
   command: SessionInboxCommand,
   target: { readonly version: SessionInboxWireVersion },
@@ -82,6 +88,7 @@ function encode(
   | SessionInboxWireV4
   | SessionInboxWireV5
   | SessionInboxWireV6
+  | SessionInboxWireV7
   | Record<string, unknown>;
 function encode(
   command: SessionInboxCommand,
@@ -93,7 +100,13 @@ function encode(
   | SessionInboxWireV4
   | SessionInboxWireV5
   | SessionInboxWireV6
+  | SessionInboxWireV7
   | Record<string, unknown> {
+  if (containsPreloadedAgentHistory(command) && target.version < 7) {
+    throw new SessionInboxWireError(
+      `Cannot encode preloaded workflow subagent history for wire version ${target.version}.`,
+    );
+  }
   if (command.kind === "cancel" && command.tasks === true && target.version < 6) {
     throw new SessionInboxWireError(
       `Cannot encode session-owned task cancellation for wire version ${target.version}.`,
@@ -139,10 +152,23 @@ function encode(
       | SessionInboxWireV3
       | SessionInboxWireV4
       | SessionInboxWireV5
-      | SessionInboxWireV6;
+      | SessionInboxWireV6
+      | SessionInboxWireV7;
   }
   throw new SessionInboxWireError(
     `Cannot encode session inbox payload for unknown wire version ${JSON.stringify((target as { version?: unknown }).version)}.`,
+  );
+}
+
+function containsPreloadedAgentHistory(command: SessionInboxCommand): boolean {
+  if (command.kind !== "send" && command.kind !== "deliver") return false;
+  const payloads = command.kind === "send" ? [command.payload] : command.payloads;
+  return payloads.some((payload) =>
+    (payload.task?.agentRequests ?? []).some(
+      (delivery) =>
+        delivery.request.kind === "agent-invoke" &&
+        delivery.request.input.parentHistory !== undefined,
+    ),
   );
 }
 

--- a/packages/eve/src/execution/wire/session-inbox-wire.ts
+++ b/packages/eve/src/execution/wire/session-inbox-wire.ts
@@ -53,6 +53,15 @@ const sessionInboxWireV5Migration: VersionMigration = {
   to: 6,
 };
 
+const sessionInboxWireV6Migration: VersionMigration = {
+  from: 6,
+  migrate(prior) {
+    if (!isObject(prior)) throw new Error("session inbox wire v6 value is not an object.");
+    return { ...prior, version: 7 };
+  },
+  to: 7,
+};
+
 const sessionInboxMigrations: readonly VersionMigration[] = [
   sessionInboxWireV0Migration,
   sessionInboxWireV1Migration,
@@ -60,6 +69,7 @@ const sessionInboxMigrations: readonly VersionMigration[] = [
   sessionInboxWireV3Migration,
   sessionInboxWireV4Migration,
   sessionInboxWireV5Migration,
+  sessionInboxWireV6Migration,
 ];
 
 /**

--- a/packages/eve/src/execution/wire/session-inbox-wire.v7.test.ts
+++ b/packages/eve/src/execution/wire/session-inbox-wire.v7.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { sessionInboxWire } from "#execution/wire/session-inbox-encoder.js";
+import { SessionInboxWireError } from "#execution/wire/session-inbox-contract.js";
+import { sessionInboxWire as decoder } from "#execution/wire/session-inbox-wire.js";
+
+const command = {
+  kind: "send" as const,
+  payload: {
+    task: {
+      agentRequests: [
+        {
+          replyTo: "agent-reply",
+          request: {
+            input: {
+              parentHistory: [{ content: "Prior context", role: "user" as const }],
+              message: "Continue researching.",
+              target: "research",
+            },
+            invocationId: "call-1:research",
+            kind: "agent-invoke" as const,
+          },
+          taskId: "task-1",
+        },
+      ],
+    },
+  },
+  turnPolicy: "queue" as const,
+};
+
+describe("session inbox wire v7", () => {
+  it("round-trips preloaded workflow subagent history", () => {
+    const wire = sessionInboxWire.encode(command, { version: 7 });
+    expect(decoder.decode(wire)).toMatchObject({
+      kind: "deliver",
+      payloads: [command.payload],
+    });
+  });
+
+  it.each([0, 1, 2, 3, 4, 5, 6] as const)("fails closed for old target v%i", (version) => {
+    const target = version === 0 ? ({ variant: "send", version } as const) : ({ version } as const);
+    expect(() => sessionInboxWire.encode(command, target)).toThrowError(SessionInboxWireError);
+  });
+});

--- a/packages/eve/src/execution/wire/session-inbox-wire.v7.ts
+++ b/packages/eve/src/execution/wire/session-inbox-wire.v7.ts
@@ -1,0 +1,88 @@
+import { z } from "#compiled/zod/index.js";
+
+import type {
+  DeliverHookPayload,
+  SessionCommand,
+  SessionTimeoutHookPayload,
+} from "#channel/types.js";
+import { coalesceDeliverPayloads } from "#execution/deliver-payloads.js";
+import { SessionInboxWireError } from "#execution/wire/session-inbox-contract.js";
+import {
+  encodeSessionCommandV6,
+  sessionInboxWireV6Schema,
+} from "#execution/wire/session-inbox-wire.v6.js";
+import { formatValidationError } from "#runtime/validation.js";
+
+const VERSION = 7;
+const version = z.literal(VERSION);
+const v6 = sessionInboxWireV6Schema.options;
+const deliverPayloadV6Schema = v6[0].shape.payload;
+const taskPayloadV6Schema = deliverPayloadV6Schema.shape.task.unwrap();
+const taskAgentRequestV6Schema = taskPayloadV6Schema.shape.agentRequests.unwrap().element;
+const agentRequestV6Schemas = taskAgentRequestV6Schema.shape.request.options;
+const agentInvocationV6Schema = agentRequestV6Schemas[0];
+const agentInvocationInputV7Schema = agentInvocationV6Schema.shape.input.extend({
+  parentHistory: z.array(z.unknown()).optional(),
+});
+const taskAgentRequestV7Schema = taskAgentRequestV6Schema.extend({
+  request: z.discriminatedUnion("kind", [
+    agentInvocationV6Schema.extend({ input: agentInvocationInputV7Schema }),
+    agentRequestV6Schemas[1],
+  ]),
+});
+const taskPayloadV7Schema = taskPayloadV6Schema.extend({
+  agentRequests: z.array(taskAgentRequestV7Schema).optional(),
+});
+const deliverPayloadV7Schema = deliverPayloadV6Schema.extend({
+  task: taskPayloadV7Schema.optional(),
+});
+
+/** Version 7 allows workflow-owned subagent invocations to carry private parent history. */
+export const sessionInboxWireV7Schema = z.discriminatedUnion("kind", [
+  v6[0].extend({
+    payload: deliverPayloadV7Schema,
+    payloads: z.array(deliverPayloadV7Schema),
+    version,
+  }),
+  v6[1].extend({ version }),
+  v6[2].extend({ version }),
+  v6[3].extend({ version }),
+  v6[4].extend({ version }),
+  v6[5].extend({ version }),
+]);
+
+export type SessionInboxWireV7 = z.infer<typeof sessionInboxWireV7Schema>;
+
+export function encodeSessionCommandV7(
+  command: DeliverHookPayload | SessionCommand | SessionTimeoutHookPayload,
+): SessionInboxWireV7 {
+  const value =
+    command.kind === "send"
+      ? {
+          auth: command.auth,
+          caller: command.caller,
+          deliveryMetadata:
+            command.delivery === undefined ? undefined : [{ ...command.delivery, payloadIndex: 0 }],
+          kind: "deliver" as const,
+          payload: command.payload,
+          payloads: [command.payload],
+          requestId: command.requestId,
+          taskDeliveryId: command.taskDeliveryId,
+          turnPolicy: command.turnPolicy,
+          version: VERSION,
+        }
+      : command.kind === "deliver"
+        ? {
+            ...command,
+            payload: coalesceDeliverPayloads(command.payloads),
+            version: VERSION,
+          }
+        : { ...encodeSessionCommandV6(command), version: VERSION };
+  const parsed = sessionInboxWireV7Schema.safeParse(value);
+  if (!parsed.success) {
+    throw new SessionInboxWireError(
+      `Produced a session inbox payload that does not match wire version ${VERSION}: ${formatValidationError(parsed.error)}`,
+    );
+  }
+  return parsed.data;
+}

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -65,6 +65,7 @@ const SAFE_OUTER_WORKFLOW_FAILURE_MESSAGE =
 export interface WorkflowEntryInput {
   readonly activityCollectorRunId?: string;
   readonly continuationConflictCommand?: Extract<SessionCommand, { readonly kind: "send" }>;
+  readonly parentHistory?: Parameters<typeof createSessionStep>[0]["parentHistory"];
   readonly input: RunInput["input"];
   readonly limits?: RunInput["limits"];
   readonly sessionTimeoutMs?: number | false;
@@ -199,6 +200,7 @@ export async function workflowEntry(input: WorkflowEntryInput): Promise<Workflow
             compiledArtifactsSource: serializedBundle.source,
             continuationToken,
             dynamicSubagentAgentConfig,
+            parentHistory: input.parentHistory,
             inheritedLimits: input.limits,
             nodeId: serializedBundle.nodeId,
             outputSchema: input.input.outputSchema,

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -67,6 +67,7 @@ import { isAgentTraceContext } from "#tracing/agent-trace-context.js";
 import { sessionCommandHookToken } from "#execution/session-command-token.js";
 import { resumeSessionInbox } from "#execution/wire/session-inbox-resume.js";
 import type { DynamicSubagentAgentConfig } from "#runtime/subagents/dynamic-agent-config.js";
+import { isSubagentAdapterState } from "#subagents/adapter-state.js";
 import { initializeSessionInstrumentation } from "#instrumentation/runtime.js";
 import {
   ACTIVITY_COLLECTOR_WORKFLOW_NAME,
@@ -206,6 +207,12 @@ export function createWorkflowRuntime(config: {
         limits: input.limits,
         serializedContext,
       };
+      if (
+        isSubagentAdapterState(input.adapter.state) &&
+        input.adapter.state.parentHistory !== undefined
+      ) {
+        workflowInput.parentHistory = input.adapter.state.parentHistory;
+      }
       const taskId = input.taskId ?? input.callback?.taskId;
       if (taskId !== undefined) workflowInput.taskId = taskId;
       if (collectorRunId !== undefined) {

--- a/packages/eve/src/subagents/adapter-state.ts
+++ b/packages/eve/src/subagents/adapter-state.ts
@@ -27,6 +27,8 @@ export const SUBAGENT_ADAPTER_KIND = "subagent";
  */
 export interface SubagentAdapterState extends Record<string, unknown> {
   readonly callId: string;
+  /** Internal conversation prefix used while creating this child session. */
+  readonly parentHistory?: readonly import("ai").ModelMessage[];
   readonly parentContinuationToken: string;
   readonly parentSessionId: string;
   readonly subagentName: string;

--- a/packages/eve/src/subagents/start-local.ts
+++ b/packages/eve/src/subagents/start-local.ts
@@ -26,6 +26,7 @@ export async function startLocalSubagent(input: {
   readonly currentSession: RuntimeSession;
   readonly dynamicSubagentAgentConfig?: DynamicSubagentAgentConfig;
   readonly fanoutSize: number;
+  readonly parentHistory?: Parameters<typeof buildSubagentRunInput>[0]["parentHistory"];
   readonly initiatorAuth: Parameters<typeof buildSubagentRunInput>[0]["initiatorAuth"];
   readonly localDevRequest?: LocalDevRequestProvenance;
   readonly parentContinuationToken: string | undefined;
@@ -51,6 +52,7 @@ export async function startLocalSubagent(input: {
     fanoutSize: input.fanoutSize,
     initiatorAuth: input.initiatorAuth,
     graph: input.bundle.graph,
+    parentHistory: input.parentHistory,
     parentContinuationToken: input.parentContinuationToken,
     parentTraceContext: input.parentTraceContext,
     activityObserver: input.activityObserver,

--- a/packages/eve/src/subagents/tool.ts
+++ b/packages/eve/src/subagents/tool.ts
@@ -14,6 +14,7 @@ import type { RuntimeSubagentDispatchRequest } from "#shared/action-types.js";
 import { mintSubagentContinuationToken } from "#execution/session.js";
 import { resolveRemainingSessionTokenLimits } from "#subagents/token-budget.js";
 import type { JsonObject } from "#shared/json.js";
+import type { ModelMessage } from "ai";
 
 /**
  * Pending task batch event metadata needed for child run lineage.
@@ -90,6 +91,8 @@ export function buildSubagentRunInput(input: {
    * dispatching parent's sandbox. Absence means no inheritance.
    */
   readonly graph?: SubagentSandboxGraph;
+  /** Conversation prefix used only when creating this child session. */
+  readonly parentHistory?: readonly ModelMessage[];
   /** Durable session identity of the sandbox currently used by the parent. */
   readonly sandboxSessionId?: string;
   readonly selfAgent: boolean;
@@ -135,6 +138,7 @@ export function buildSubagentRunInput(input: {
     parentSessionId: session.sessionId,
     subagentName: action.subagentName,
   };
+  if (input.parentHistory !== undefined) adapterState.parentHistory = input.parentHistory;
   if (input.taskId !== undefined) adapterState.taskId = input.taskId;
   const sharesSandbox =
     input.graph?.nodesByNodeId.get(action.nodeId)?.sandboxRegistry.sandbox?.definition

--- a/packages/eve/src/tools/workflow-definition.ts
+++ b/packages/eve/src/tools/workflow-definition.ts
@@ -17,6 +17,8 @@ import type { ToolModelOutput } from "#tools/model-output.js";
 
 export interface AgentInput {
   readonly agentId?: string;
+  /** Seed a newly created local subagent with the parent history captured by this workflow. */
+  readonly inheritHistory?: boolean;
   readonly message: string;
   readonly outputSchema?: JsonObject;
 }

--- a/packages/eve/test/scenarios/mounted-extension-installed.scenario.test.ts
+++ b/packages/eve/test/scenarios/mounted-extension-installed.scenario.test.ts
@@ -249,7 +249,7 @@ describe("mounted extension installed under node_modules", () => {
     );
     expect(
       JSON.parse(extensionFiles[`node_modules/${PACKAGE_NAME}/dist/extension/_manifest.json`]!),
-    ).toMatchObject({ requires: { channel: 19, schedule: 11, subagent: 11 } });
+    ).toMatchObject({ requires: { channel: 20, schedule: 11, subagent: 11 } });
     const app = await scenarioApp({
       name: "mounted-extension-installed",
       installDependencies: true,


### PR DESCRIPTION
### Summary

Allows a workflow to selectively seed a new local subagent with the parent conversation captured before the workflow tool call. 

```ts
const result = await ctx.agent({
  key: "private-research-session",
  target: "research",
  inheritHistory: true,
  message: task,
});
```

The option applies only to new local subagents and cannot be combined with `agentId` or used with remote agents.

### Validation

Adds unit coverage for opt-in and default invocation routing, local-only enforcement, child session history ordering, workflow snapshot capture, and durable inbox compatibility. Also exercises background workflow startup through the parent task executor integration test.

