### PR TITLE
feat(eve-a2a): prototype A2A tools and channel as an extension

### DIFF
--- a/apps/fixtures/a2a-public-api/.gitignore
+++ b/apps/fixtures/a2a-public-api/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.eve/
+.output/
+.nitro/
+dist/
+*.log

--- a/apps/fixtures/a2a-public-api/README.md
+++ b/apps/fixtures/a2a-public-api/README.md
@@ -1,0 +1,27 @@
+# A2A extension consumer
+
+This deterministic fixture mounts the private [`@eve/a2a` prototype](../../../packages/eve-a2a/README.md) through `agent/extensions/a2a.ts`. The extension provides `a2a__send`, `a2a__get`, `a2a__cancel`, and the A2A channel. The durable `a2a_delegate` watcher remains an application tool because the current extension compiler rejects workflow directives.
+
+From the repository root:
+
+```sh
+pnpm --filter @eve/a2a... build
+pnpm --filter fixture-a2a-public-api verify
+```
+
+For manual exploration, run `pnpm --filter fixture-a2a-public-api dev`. The server listens on `127.0.0.1:4317` with local demonstration credentials `alice:prototype-only` and `bob:other-prototype-only`. Its fixed signing key and credentials belong only to this fixture.
+
+```sh
+curl -u alice:prototype-only http://localhost:4317/a2a \
+  -H 'content-type: application/json' \
+  -H 'a2a-version: 1.0' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"SendMessage","params":{"message":{"messageId":"demo-1","role":"ROLE_USER","parts":[{"text":"REMOTE ask"}]}}}'
+```
+
+This waits for `TASK_STATE_INPUT_REQUIRED`. Send another message with the returned task ID in `message.taskId` and the answer as a text part. Other deterministic inputs are `REMOTE hello` and `REMOTE wait 5`.
+
+POST `{"message":"DELEGATE wait 5"}` to `/demo` with the same credentials to exercise `a2a_delegate` through the model. Read the resulting session events at `/demo/<returned-id>/events`.
+
+`A2A_ORIGIN` controls the advertised origin and `A2A_REMOTE_ORIGIN` selects the remote agent; both default to `http://localhost:4317`. The fixture mount supplies local defaults for `A2A_DEMO_PASSWORD`, `A2A_OTHER_PASSWORD`, and `A2A_SIGNING_SECRET`. The extension itself requires explicit configuration.
+
+`verify` copies the built extension distribution into a temporary consumer with fresh local state. It covers discovery, authentication, owner isolation, blocking and immediate sends, input replies, cancellation, SSE, namespaced tool dispatch, parent notifications, and recovery of a remote task and its watcher after server restart. It uses a deterministic model; it does not establish real-model tool selection or external A2A interoperability.

--- a/apps/fixtures/a2a-public-api/agent/agent.ts
+++ b/apps/fixtures/a2a-public-api/agent/agent.ts
@@ -1,0 +1,36 @@
+import { defineAgent } from "eve";
+import { mockModel } from "eve/evals";
+
+export default defineAgent({
+  modelContextWindowTokens: 100_000,
+  model: mockModel((request) => {
+    const message =
+      request.userMessages.find((value) => /^(DELEGATE |REMOTE |CALL )/.test(value)) ??
+      request.lastUserMessage ??
+      "";
+    const result = request.toolResults.at(-1);
+    if (message.startsWith("DELEGATE ")) {
+      if (!result)
+        return {
+          toolCalls: [{ name: "a2a_delegate", input: { message: `REMOTE ${message.slice(9)}` } }],
+        };
+      return `PARENT ${request.lastUserMessage ?? ""} ${JSON.stringify(result.output)}`;
+    }
+    if (message.startsWith("CALL ")) {
+      if (result) return JSON.stringify(result.output);
+      const command = JSON.parse(message.slice(5));
+      return { toolCalls: [{ name: command.tool, input: command.input }] };
+    }
+    if (message === "REMOTE ask") {
+      return result
+        ? `City: ${JSON.stringify(result.output)}`
+        : { toolCalls: [{ name: "demo_job", input: { kind: "ask" } }] };
+    }
+    const wait = /^REMOTE wait (\d+)$/.exec(message);
+    if (wait)
+      return result
+        ? `Finished: ${JSON.stringify(result.output)}`
+        : { toolCalls: [{ name: "demo_job", input: { kind: "wait", seconds: Number(wait[1]) } }] };
+    return `Echo: ${message.replace(/^REMOTE /, "")}`;
+  }),
+});

--- a/apps/fixtures/a2a-public-api/agent/channels/demo.ts
+++ b/apps/fixtures/a2a-public-api/agent/channels/demo.ts
@@ -1,0 +1,46 @@
+import { randomUUID } from "node:crypto";
+import { defineChannel, GET, POST } from "eve/channels";
+import { routeAuth } from "eve/channels/auth";
+import { z } from "zod";
+import { demoAuth } from "../lib/demo-auth";
+import { demoIdentity } from "../lib/demo-identity";
+
+const identity = demoIdentity(
+  process.env.A2A_SIGNING_SECRET ?? "local-prototype-signing-key-do-not-deploy",
+);
+export default defineChannel({
+  routes: [
+    POST("/demo", async (request, { from }) => {
+      const auth = await routeAuth(request, demoAuth);
+      if (auth instanceof Response) return auth;
+      const { message } = z.object({ message: z.string() }).parse(await request.json());
+      const session = await from(randomUUID()).send(message, { auth });
+      return Response.json({
+        id: identity.issue(session.id, JSON.stringify([auth.authenticator, auth.principalId])),
+      });
+    }),
+    GET("/demo/:id/events", async (request, { attachSession, params }) => {
+      const auth = await routeAuth(request, demoAuth);
+      if (auth instanceof Response) return auth;
+      const session = attachSession(
+        identity.read(params.id, JSON.stringify([auth.authenticator, auth.principalId])),
+      );
+      const tail = await session.getStreamTailIndex();
+      const events = [];
+      if (tail >= 0) {
+        const reader = (await session.getEventStream()).getReader();
+        try {
+          for (let index = 0; index <= tail; index++) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            events.push(value);
+          }
+        } finally {
+          await reader.cancel();
+          reader.releaseLock();
+        }
+      }
+      return Response.json(events);
+    }),
+  ],
+});

--- a/apps/fixtures/a2a-public-api/agent/channels/eve.ts
+++ b/apps/fixtures/a2a-public-api/agent/channels/eve.ts
@@ -1,0 +1,4 @@
+import { eveChannel } from "eve/channels/eve";
+import { demoAuth } from "../lib/demo-auth";
+
+export default eveChannel({ auth: demoAuth });

--- a/apps/fixtures/a2a-public-api/agent/extensions/a2a.ts
+++ b/apps/fixtures/a2a-public-api/agent/extensions/a2a.ts
@@ -1,0 +1,22 @@
+import a2a from "@eve/a2a";
+
+// Fixed credentials belong only to this loopback demonstration fixture.
+process.env.A2A_DEMO_PASSWORD ??= "prototype-only";
+process.env.A2A_OTHER_PASSWORD ??= "other-prototype-only";
+process.env.A2A_SIGNING_SECRET ??= "local-prototype-signing-key-do-not-deploy";
+
+export default a2a({
+  server: {
+    origin: process.env.A2A_ORIGIN ?? "http://localhost:4317",
+    signingSecretEnv: "A2A_SIGNING_SECRET",
+    users: [
+      { username: "alice", passwordEnv: "A2A_DEMO_PASSWORD" },
+      { username: "bob", passwordEnv: "A2A_OTHER_PASSWORD" },
+    ],
+  },
+  remote: {
+    origin: process.env.A2A_REMOTE_ORIGIN ?? "http://localhost:4317",
+    username: "alice",
+    passwordEnv: "A2A_DEMO_PASSWORD",
+  },
+});

--- a/apps/fixtures/a2a-public-api/agent/instructions.md
+++ b/apps/fixtures/a2a-public-api/agent/instructions.md
@@ -1,0 +1,5 @@
+You demonstrate an A2A integration assembled from authored eve tools and channels.
+Use a2a__send to start or answer a remote task; a2a__get to inspect it; a2a__cancel to
+cancel it; a2a_delegate to monitor it durably in the background. Remote A2A task
+IDs and local eve watcher task IDs are different. Canceling a watcher only stops
+monitoring. The configured model is deterministic so this prototype needs no API key.

--- a/apps/fixtures/a2a-public-api/agent/lib/demo-auth.ts
+++ b/apps/fixtures/a2a-public-api/agent/lib/demo-auth.ts
@@ -1,0 +1,9 @@
+import { httpBasic } from "eve/channels/auth";
+
+export const demoAuth = [
+  httpBasic({ username: "alice", password: process.env.A2A_DEMO_PASSWORD ?? "prototype-only" }),
+  httpBasic({
+    username: "bob",
+    password: process.env.A2A_OTHER_PASSWORD ?? "other-prototype-only",
+  }),
+];

--- a/apps/fixtures/a2a-public-api/agent/lib/demo-identity.ts
+++ b/apps/fixtures/a2a-public-api/agent/lib/demo-identity.ts
@@ -1,0 +1,27 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+// Keep the test session handle scoped to its authenticated owner across server restarts.
+export function demoIdentity(secret: string) {
+  const sign = (value: string) => createHmac("sha256", secret).update(value).digest();
+  return {
+    issue(sessionId: string, owner: string): string {
+      const payload = Buffer.from(JSON.stringify({ sessionId, owner })).toString("base64url");
+      return `${payload}.${sign(payload).toString("base64url")}`;
+    },
+    read(id: string, owner: string): string {
+      try {
+        const [payload, signature, extra] = id.split(".");
+        if (!payload || !signature || extra) throw new Error();
+        const supplied = Buffer.from(signature, "base64url");
+        const expected = sign(payload);
+        if (supplied.length !== expected.length || !timingSafeEqual(supplied, expected))
+          throw new Error();
+        const claims = JSON.parse(Buffer.from(payload, "base64url").toString());
+        if (claims.owner !== owner || typeof claims.sessionId !== "string") throw new Error();
+        return claims.sessionId;
+      } catch {
+        throw new Error("Demo session not found");
+      }
+    },
+  };
+}

--- a/apps/fixtures/a2a-public-api/agent/lib/remote-steps.ts
+++ b/apps/fixtures/a2a-public-api/agent/lib/remote-steps.ts
@@ -1,0 +1,11 @@
+import * as remote from "@eve/a2a/client";
+
+export async function sendRemote(message: string) {
+  "use step";
+  return remote.sendRemote(message);
+}
+
+export async function readRemote(taskId: string) {
+  "use step";
+  return remote.readRemote(taskId);
+}

--- a/apps/fixtures/a2a-public-api/agent/tools/a2a_delegate.ts
+++ b/apps/fixtures/a2a-public-api/agent/tools/a2a_delegate.ts
@@ -1,0 +1,53 @@
+import { defineWorkflowTool } from "eve/tools";
+import { sleep } from "workflow";
+import { z } from "zod";
+import { readRemote, sendRemote } from "../lib/remote-steps";
+
+export default defineWorkflowTool({
+  description:
+    "Delegate to an A2A agent and monitor durably in the background. Supply taskId instead of message to watch an existing remote task. Canceling this local watcher does not cancel remote work; use a2a__cancel.",
+  inputSchema: z
+    .object({ message: z.string().optional(), taskId: z.string().optional() })
+    .refine(
+      (input) => Boolean(input.message) !== Boolean(input.taskId),
+      "Supply message or taskId, not both",
+    ),
+  execution: "background",
+  async *execute(input, ctx, task) {
+    "use workflow";
+    let remote = input.taskId ? await readRemote(input.taskId) : await sendRemote(input.message!);
+    yield task.postMessage(`A2A remote task ${remote.id} started. Local watcher ${task.taskId}.`);
+    let lastQuestion = "";
+    while (
+      ![
+        "TASK_STATE_COMPLETED",
+        "TASK_STATE_FAILED",
+        "TASK_STATE_CANCELED",
+        "TASK_STATE_REJECTED",
+      ].includes(remote.status.state)
+    ) {
+      if (ctx.abortSignal.aborted) return { remoteTaskId: remote.id, monitoringStopped: true };
+      if (
+        remote.status.state === "TASK_STATE_INPUT_REQUIRED" ||
+        remote.status.state === "TASK_STATE_AUTH_REQUIRED"
+      ) {
+        const question = JSON.stringify(remote.status);
+        if (question !== lastQuestion) {
+          yield task.postMessage(
+            `A2A task ${remote.id} needs input: ${JSON.stringify(remote.status.message)}. Use a2a__send with this remote taskId to reply.`,
+          );
+          lastQuestion = question;
+        }
+      }
+      yield { remoteTaskId: remote.id, state: remote.status.state };
+      await sleep("1s");
+      remote = await readRemote(remote.id);
+    }
+    if (
+      remote.status.state === "TASK_STATE_FAILED" ||
+      remote.status.state === "TASK_STATE_REJECTED"
+    )
+      throw new Error(`A2A task failed: ${JSON.stringify(remote.status.message)}`);
+    return remote;
+  },
+});

--- a/apps/fixtures/a2a-public-api/agent/tools/demo_job.ts
+++ b/apps/fixtures/a2a-public-api/agent/tools/demo_job.ts
@@ -1,0 +1,20 @@
+import { defineWorkflowTool } from "eve/tools";
+import { sleep } from "workflow";
+import { z } from "zod";
+
+export default defineWorkflowTool({
+  description: "Deterministic local demo: wait or ask one question.",
+  inputSchema: z.object({
+    kind: z.enum(["wait", "ask"]),
+    seconds: z.number().min(0).max(120).default(2),
+  }),
+  async execute({ kind, seconds }, ctx) {
+    "use workflow";
+    if (kind === "ask") {
+      const answer = await ctx.ask({ prompt: "Which city?", display: "text", allowFreeform: true });
+      return { city: answer.text };
+    }
+    await sleep(`${seconds}s`);
+    return { waited: seconds };
+  },
+});

--- a/apps/fixtures/a2a-public-api/package.json
+++ b/apps/fixtures/a2a-public-api/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "fixture-a2a-public-api",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "eve dev --no-ui --host 127.0.0.1 --port 4317",
+    "build": "eve build",
+    "start": "eve start --host 127.0.0.1 --port 4317",
+    "typecheck": "tsc --noEmit",
+    "smoke": "node scripts/smoke.mjs",
+    "verify": "node scripts/verify.mjs",
+    "test:scenario": "node scripts/verify.mjs"
+  },
+  "dependencies": {
+    "@eve/a2a": "workspace:*",
+    "ai": "catalog:",
+    "eve": "workspace:*",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/apps/fixtures/a2a-public-api/scripts/smoke.mjs
+++ b/apps/fixtures/a2a-public-api/scripts/smoke.mjs
@@ -1,0 +1,201 @@
+import assert from "node:assert/strict";
+import { setTimeout as delay } from "node:timers/promises";
+
+const origin = process.env.A2A_ORIGIN ?? "http://localhost:4317";
+const authorization = `Basic ${Buffer.from(`alice:${process.env.A2A_DEMO_PASSWORD ?? "prototype-only"}`).toString("base64")}`;
+const headers = { authorization, "content-type": "application/json", "a2a-version": "1.0" };
+const message = (text, taskId) => ({
+  message: {
+    messageId: crypto.randomUUID(),
+    role: "ROLE_USER",
+    parts: [{ text }],
+    ...(taskId ? { taskId } : {}),
+  },
+});
+const terminal = (task) =>
+  [
+    "TASK_STATE_COMPLETED",
+    "TASK_STATE_FAILED",
+    "TASK_STATE_CANCELED",
+    "TASK_STATE_REJECTED",
+  ].includes(task.status.state);
+
+async function rpc(method, params, extraHeaders = {}) {
+  const response = await fetch(`${origin}/a2a`, {
+    method: "POST",
+    headers: { ...headers, ...extraHeaders },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+    signal: AbortSignal.timeout(45_000),
+  });
+  assert.equal(response.status, 200);
+  return response.json();
+}
+async function eventually(read, accept, label) {
+  const deadline = Date.now() + 45_000;
+  let value;
+  while (Date.now() < deadline) {
+    value = await read();
+    if (accept(value)) return value;
+    await delay(250);
+  }
+  throw new Error(`${label}: ${JSON.stringify(value).slice(-6000)}`);
+}
+const getTask = async (id) => {
+  const response = await rpc("GetTask", { id });
+  assert.equal(response.error, undefined, JSON.stringify(response));
+  return response.result;
+};
+async function start(text) {
+  const response = await rpc("SendMessage", {
+    ...message(text),
+    configuration: { returnImmediately: true },
+  });
+  assert.equal(response.error, undefined, JSON.stringify(response));
+  return response.result.task;
+}
+async function demo(text) {
+  const response = await fetch(`${origin}/demo`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ message: text }),
+  });
+  assert.equal(response.status, 200);
+  return (await response.json()).id;
+}
+async function events(id) {
+  const response = await fetch(`${origin}/demo/${encodeURIComponent(id)}/events`, { headers });
+  assert.equal(response.status, 200);
+  return response.json();
+}
+async function callTool(tool, input) {
+  const id = await demo(`CALL ${JSON.stringify({ tool, input })}`);
+  const list = await eventually(
+    () => events(id),
+    (list) => list.some((event) => event.type === "action.result"),
+    `tool ${tool}`,
+  );
+  const result = list.find((event) => event.type === "action.result");
+  assert.equal(result.data.status, "completed", JSON.stringify(result));
+  return result.data.result.output;
+}
+
+const card = await (await fetch(`${origin}/.well-known/agent-card.json`)).json();
+assert.equal(card.supportedInterfaces[0].protocolVersion, "1.0");
+assert.deepEqual(card.securityRequirements, [{ schemes: { basic: { list: [] } } }]);
+assert.equal((await fetch(`${origin}/a2a`, { method: "POST", body: "{}" })).status, 401);
+assert.equal((await rpc("GetTask", { id: "missing" })).error.code, -32001);
+assert.equal(
+  (await rpc("GetTask", { id: "missing" }, { "a2a-version": "0.3" })).error.code,
+  -32009,
+);
+console.log("PASS discovery, authentication, unknown task, version negotiation");
+
+const started = await start("REMOTE hello");
+assert.equal(started.status.state, "TASK_STATE_SUBMITTED");
+const complete = await eventually(() => getTask(started.id), terminal, "echo completion");
+assert.equal(complete.status.state, "TASK_STATE_COMPLETED");
+assert.match(JSON.stringify(complete.artifacts), /Echo: hello/);
+const bob = `Basic ${Buffer.from(`bob:${process.env.A2A_OTHER_PASSWORD ?? "other-prototype-only"}`).toString("base64")}`;
+assert.equal((await rpc("GetTask", { id: started.id }, { authorization: bob })).error.code, -32001);
+assert.equal((await rpc("CancelTask", { id: started.id })).error.code, -32002);
+assert.equal((await rpc("SendMessage", message("again", started.id))).error.code, -32004);
+console.log("PASS asynchronous completion, owner isolation, terminal task immutability");
+
+const question = await rpc("SendMessage", message("REMOTE ask"));
+assert.equal(question.error, undefined, JSON.stringify(question));
+assert.equal(question.result.task.status.state, "TASK_STATE_INPUT_REQUIRED");
+const replied = await rpc("SendMessage", message("Lisbon", question.result.task.id));
+assert.equal(replied.error, undefined, JSON.stringify(replied));
+assert.equal(replied.result.task.id, question.result.task.id);
+assert.equal(replied.result.task.status.state, "TASK_STATE_COMPLETED");
+assert.match(JSON.stringify(replied.result.task.artifacts), /Lisbon/);
+console.log("PASS blocking send, interrupted task, reply on the same task");
+
+const waiting = await start("REMOTE wait 30");
+const cancelled = await rpc("CancelTask", { id: waiting.id });
+assert.equal(cancelled.error, undefined, JSON.stringify(cancelled));
+assert.equal(cancelled.result.status.state, "TASK_STATE_CANCELED");
+console.log("PASS explicit remote cancellation during a durable wait");
+
+const sse = await fetch(`${origin}/a2a`, {
+  method: "POST",
+  headers,
+  body: JSON.stringify({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "SendStreamingMessage",
+    params: message("REMOTE wait 2"),
+  }),
+  signal: AbortSignal.timeout(45_000),
+});
+assert.match(sse.headers.get("content-type"), /text\/event-stream/);
+const frames = (await sse.text())
+  .split("\n\n")
+  .filter(Boolean)
+  .map((frame) => JSON.parse(frame.slice(6)).result);
+assert.ok(frames[0].task);
+assert.ok(frames.some((frame) => frame.artifactUpdate));
+assert.equal(frames.at(-1).statusUpdate.status.state, "TASK_STATE_COMPLETED");
+console.log("PASS SSE initial task, artifact, and terminal status");
+
+const subscribed = await start("REMOTE wait 2");
+const subscription = await fetch(`${origin}/a2a`, {
+  method: "POST",
+  headers,
+  body: JSON.stringify({
+    jsonrpc: "2.0",
+    id: 3,
+    method: "SubscribeToTask",
+    params: { id: subscribed.id },
+  }),
+  signal: AbortSignal.timeout(45_000),
+});
+const subscriptionText = await subscription.text();
+assert.match(subscriptionText, /TASK_STATE_COMPLETED/);
+assert.match(subscriptionText, /artifactUpdate/);
+console.log("PASS subscription resumes from the task snapshot");
+
+const parent = await demo("DELEGATE wait 3");
+const parentEvents = await eventually(
+  () => events(parent),
+  (list) => JSON.stringify(list).includes("TASK_STATE_COMPLETED"),
+  "background delegation",
+);
+const resultEvents = parentEvents.filter((event) => event.type === "action.result");
+assert.ok(
+  JSON.stringify(resultEvents).includes("working"),
+  "parent must receive a background receipt",
+);
+assert.match(JSON.stringify(parentEvents), /Finished:/);
+console.log(
+  "PASS model calls authored A2A workflow tool, receives receipt, and receives remote completion",
+);
+
+const asking = await callTool("a2a__send", { message: "REMOTE ask" });
+await eventually(
+  () => getTask(asking.id),
+  (task) => task.status.state === "TASK_STATE_INPUT_REQUIRED",
+  "remote question",
+);
+const watcher = await demo(
+  `CALL ${JSON.stringify({ tool: "a2a_delegate", input: { taskId: asking.id } })}`,
+);
+await eventually(
+  () => events(watcher),
+  (list) => JSON.stringify(list).includes("needs input"),
+  "watcher reports question",
+);
+const reply = await callTool("a2a__send", { taskId: asking.id, message: "Porto" });
+assert.equal(reply.id, asking.id);
+await eventually(
+  () => events(watcher),
+  (list) => JSON.stringify(list).includes("TASK_STATE_COMPLETED"),
+  "watcher completes after independent reply",
+);
+const inspected = await callTool("a2a__get", { taskId: asking.id });
+assert.match(JSON.stringify(inspected.artifacts), /Porto/);
+const longTask = await callTool("a2a__send", { message: "REMOTE wait 30" });
+const stopped = await callTool("a2a__cancel", { taskId: longTask.id });
+assert.equal(stopped.status.state, "TASK_STATE_CANCELED");
+console.log("PASS authored send/get/cancel tools and reply to a task with an active watcher");
+console.log(JSON.stringify({ completedTaskId: started.id, parentId: parent }));

--- a/apps/fixtures/a2a-public-api/scripts/verify.mjs
+++ b/apps/fixtures/a2a-public-api/scripts/verify.mjs
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createServer } from "node:net";
+import { once } from "node:events";
+import {
+  appendFileSync,
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { setTimeout as delay } from "node:timers/promises";
+
+const fixtureRoot = process.cwd();
+const appRoot = mkdtempSync(join(tmpdir(), "eve-a2a-consumer-"));
+const logPath = join(fixtureRoot, "verify.log");
+for (const path of ["agent", "package.json", "tsconfig.json"])
+  cpSync(join(fixtureRoot, path), join(appRoot, path), { recursive: true });
+mkdirSync(join(appRoot, "node_modules", "@eve", "a2a"), { recursive: true });
+for (const entry of readdirSync(join(fixtureRoot, "node_modules"))) {
+  if (entry.startsWith(".") || entry === "@eve") continue;
+  symlinkSync(
+    join(fixtureRoot, "node_modules", entry),
+    join(appRoot, "node_modules", entry),
+    "junction",
+  );
+}
+// Only the distribution is available to this consumer; no extension source can mask a missing export.
+for (const path of ["dist", "package.json"])
+  cpSync(
+    resolve(fixtureRoot, "../../../packages/eve-a2a", path),
+    join(appRoot, "node_modules", "@eve", "a2a", path),
+    { recursive: true },
+  );
+
+const reservation = createServer();
+reservation.listen(0, "127.0.0.1");
+await once(reservation, "listening");
+const port = reservation.address().port;
+reservation.close();
+await once(reservation, "close");
+const origin = `http://127.0.0.1:${port}`;
+const env = { ...process.env, A2A_ORIGIN: origin, A2A_REMOTE_ORIGIN: origin };
+const cli = "node_modules/eve/bin/eve.js";
+writeFileSync(logPath, "");
+
+function run(args) {
+  const child = spawn(process.execPath, args, {
+    cwd: appRoot,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  for (const stream of [child.stdout, child.stderr])
+    stream.on("data", (data) => appendFileSync(logPath, data));
+  return child;
+}
+async function finish(args) {
+  const child = run(args);
+  const [code] = await once(child, "exit");
+  assert.equal(code, 0, `${args.join(" ")} failed; see verify.log`);
+}
+async function eventually(read, accept, label) {
+  const deadline = Date.now() + 45_000;
+  let value;
+  while (Date.now() < deadline) {
+    value = await read();
+    if (accept(value)) return value;
+    await delay(250);
+  }
+  throw new Error(`${label}: ${JSON.stringify(value).slice(-3000)}`);
+}
+let server;
+async function startServer() {
+  server = run([cli, "start", "--host", "127.0.0.1", "--port", String(port)]);
+  await eventually(
+    async () => {
+      if (server.exitCode !== null) throw new Error("Server exited; see verify.log");
+      try {
+        return (await fetch(`${origin}/.well-known/agent-card.json`)).ok;
+      } catch {
+        return false;
+      }
+    },
+    Boolean,
+    "server readiness",
+  );
+}
+async function stopServer() {
+  if (!server || server.exitCode !== null) return;
+  const exited = once(server, "exit");
+  server.kill("SIGTERM");
+  const timeout = setTimeout(() => server.kill("SIGKILL"), 5000);
+  await exited;
+  clearTimeout(timeout);
+}
+const headers = {
+  authorization: `Basic ${Buffer.from(`alice:${env.A2A_DEMO_PASSWORD ?? "prototype-only"}`).toString("base64")}`,
+  "content-type": "application/json",
+  "a2a-version": "1.0",
+};
+async function rpc(method, params) {
+  const response = await fetch(`${origin}/a2a`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+  });
+  const body = await response.json();
+  assert.equal(body.error, undefined, JSON.stringify(body));
+  return body.result;
+}
+async function events(id) {
+  return (await fetch(`${origin}/demo/${id}/events`, { headers })).json();
+}
+
+try {
+  await finish([cli, "build"]);
+  console.log("PASS extension distribution builds in an isolated consumer");
+  await startServer();
+  await finish([join(fixtureRoot, "scripts/smoke.mjs")]);
+  console.log("PASS HTTP and authored-tool scenarios (details in verify.log)");
+  const { task } = await rpc("SendMessage", {
+    message: {
+      messageId: crypto.randomUUID(),
+      role: "ROLE_USER",
+      parts: [{ text: "REMOTE wait 12" }],
+    },
+    configuration: { returnImmediately: true },
+  });
+  const parent = await (
+    await fetch(`${origin}/demo`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        message: `CALL ${JSON.stringify({ tool: "a2a_delegate", input: { taskId: task.id } })}`,
+      }),
+    })
+  ).json();
+  await eventually(
+    () => events(parent.id),
+    (list) => JSON.stringify(list).includes("A2A remote task"),
+    "watcher starts",
+  );
+  const before = await rpc("GetTask", { id: task.id });
+  assert.equal(before.status.state, "TASK_STATE_WORKING");
+  await stopServer();
+  await startServer();
+  const completed = await eventually(
+    () => rpc("GetTask", { id: task.id }),
+    (task) => task.status.state === "TASK_STATE_COMPLETED",
+    "remote task resumes",
+  );
+  assert.equal(completed.id, task.id);
+  assert.match(JSON.stringify(completed.artifacts), /12/);
+  const received = await eventually(
+    () => events(parent.id),
+    (list) => JSON.stringify(list).includes("TASK_STATE_COMPLETED"),
+    "watcher resumes",
+  );
+  const starts = received.filter(
+    (event) =>
+      event.type === "actions.requested" &&
+      event.data.actions.some((action) => action.toolName === "a2a_delegate"),
+  );
+  assert.equal(starts.length, 1);
+  console.log("PASS server restart: same remote task and existing workflow watcher resume");
+} finally {
+  await stopServer();
+  rmSync(appRoot, { recursive: true, force: true });
+}

--- a/apps/fixtures/a2a-public-api/tsconfig.json
+++ b/apps/fixtures/a2a-public-api/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "types": ["node", "eve/workflow-modules"]
+  },
+  "include": ["agent/**/*.ts"]
+}

--- a/apps/fixtures/a2a-public-api/turbo.json
+++ b/apps/fixtures/a2a-public-api/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "test:scenario": {
+      "dependsOn": ["^build"]
+    }
+  }
+}

--- a/packages/eve-a2a/.gitignore
+++ b/packages/eve-a2a/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.eve
+*.tgz

--- a/packages/eve-a2a/README.md
+++ b/packages/eve-a2a/README.md
@@ -1,0 +1,99 @@
+# @eve/a2a prototype
+
+This prototype serves and consumes an A2A 1.0 subset entirely through authored tools, a channel, and application-owned helpers, using the existing eve extension contract. The package is private and is not released to npm.
+
+## Mount the extension
+
+Build from the repository root:
+
+```sh
+pnpm install --frozen-lockfile
+pnpm --filter @eve/a2a... build
+```
+
+Declare `"@eve/a2a": "workspace:*"` in the consuming agent's dependencies and create `agent/extensions/a2a.ts`:
+
+```ts
+import a2a from "@eve/a2a";
+
+export default a2a({
+  server: {
+    origin: "https://your-agent.example",
+    signingSecretEnv: "A2A_SIGNING_SECRET",
+    users: [{ username: "caller", passwordEnv: "A2A_SERVER_PASSWORD" }],
+  },
+  remote: {
+    origin: "https://remote-agent.example",
+    username: "caller",
+    passwordEnv: "A2A_REMOTE_PASSWORD",
+  },
+});
+```
+
+Set the named environment variables in the consuming application. The extension reads secrets at runtime; it has no default credentials or signing key. Keep the signing key stable across restarts. Both sides currently use HTTP Basic authentication. Use HTTPS outside local development. Discovery accepts only a same-origin JSON-RPC endpoint from the configured remote's Agent Card.
+
+The mount contributes `a2a__send`, `a2a__get`, and `a2a__cancel`. A different mount filename changes that prefix. The channel serves `/a2a` and `/.well-known/agent-card.json`; these paths are fixed, so mount one copy per agent. This prototype configures both serving and consuming together.
+
+## Durable watcher boundary
+
+The extension packages the channel and three ordinary tools. The consumer owns the [durable watcher](../../apps/fixtures/a2a-public-api/agent/tools/a2a_delegate.ts) and its two [step wrappers](../../apps/fixtures/a2a-public-api/agent/lib/remote-steps.ts). These wrappers call the extension's `@eve/a2a/client` export. The workflow body never imports the extension's compiled JavaScript directly; that output includes Node.js module setup, which belongs inside a step.
+
+`eve extension build` currently rejects `"use workflow"` and `"use step"` in extension source. The [application-module check](../eve/src/internal/workflow-bundle/workflow-builders.ts) also excludes dependencies outside the consuming application. Packaging the whole watcher as an extension contribution requires framework support beyond the existing APIs. This draft preserves the working application workflow and makes that limitation explicit; it adds no framework APIs or compiler exceptions.
+
+## Run the demonstration
+
+The [consumer fixture](../../apps/fixtures/a2a-public-api/README.md) mounts the built extension. Its deterministic `mockModel` needs no model credentials, while requests execute the real compiler, session runtime, tools, workflows, and HTTP transport.
+
+```sh
+pnpm --filter @eve/a2a test:unit
+pnpm --filter fixture-a2a-public-api verify
+```
+
+The verification script copies only the extension distribution into an isolated consumer, builds it, runs HTTP and namespaced tool scenarios, restarts the server during a durable wait, and checks that the existing task and watcher resume. It uses an available loopback port and stops its server afterward. Detailed output goes to the fixture's `verify.log`.
+
+## Implementation boundary
+
+| File                                                                              | Responsibility                                                   | Existing API                                                        |
+| --------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------- |
+| [a2a-channel.ts](extension/lib/a2a-channel.ts)                                    | Agent Card, JSON-RPC, input replies, cancellation, SSE           | `defineChannel`, `GET`, `POST`, `routeAuth`, public session handles |
+| [projection.ts](extension/lib/projection.ts)                                      | Reconstruct A2A task state from persisted session events         | `Session.getEventStream`, `getStreamTailIndex`                      |
+| [identity.ts](extension/lib/identity.ts)                                          | Bind the task ID to its session and authenticated owner          | Node HMAC; application code                                         |
+| [send.ts](extension/tools/send.ts)                                                | Start a remote task or answer its pending question               | `defineTool`                                                        |
+| [get.ts](extension/tools/get.ts), [cancel.ts](extension/tools/cancel.ts)          | Inspect or cancel remote work                                    | `defineTool`                                                        |
+| [a2a_delegate.ts](../../apps/fixtures/a2a-public-api/agent/tools/a2a_delegate.ts) | Submit or attach to remote work, poll durably, notify the parent | `defineWorkflowTool`, `sleep`, `yield task.postMessage`             |
+| [client.ts](extension/lib/client.ts)                                              | Discovery and authenticated A2A requests                         | `fetch`; the consumer adds `"use step"` wrappers                    |
+
+The remote **A2A task ID** and the local **eve watcher task ID** identify different work. The workflow keeps the remote ID in a local variable across durable waits. An independent `send` tool call answers that remote task directly; the existing watcher observes the result on its next poll. No parent-to-workflow inbox is needed.
+
+On the server, one A2A task owns one eve conversation session. Conversation mode makes input requests available through the existing public channel API. `contextId` equals the signed task ID in this prototype. Completed tasks stay immutable in the projection, even if another surface subsequently adds events to the underlying session. The signature binds the session ID and owner; it does not encrypt them. State reads fold the persisted stream, so there is no process-local task registry to lose on restart.
+
+## Demonstrated behavior
+
+- Agent Card discovery at `/.well-known/agent-card.json`.
+- A2A 1.0 JSON-RPC `SendMessage`, `GetTask`, `CancelTask`, `SendStreamingMessage`, and `SubscribeToTask`.
+- Blocking and immediate sends; one free-text question and a reply on the same task.
+- Authenticated owner isolation, terminal-state rejection, final text artifacts, and SSE status/artifact updates.
+- Real model-to-tool dispatch through a deterministic model, background receipts, parent notifications, and independent reply tools.
+- An explicit remote cancellation operation. Canceling a local watcher stops monitoring; it does not cancel the remote task.
+
+## Limits exposed by the prototype
+
+- This is a text-only protocol subset, not a general A2A SDK or a conformance claim. It excludes context continuation across tasks, task listing, push notifications, extended cards, file parts, arbitrary structured input batches, and remote authorization flows. The Agent Card still has fixed prototype metadata. The server emits tasks; the client currently expects a task response rather than A2A's direct-message alternative.
+- The server's task status describes completion of the served invocation. Agents that launch detached background work and acknowledge immediately need an application policy for deciding when their A2A task is complete.
+- Reads fold the full session event stream. This favors a small implementation over an indexed task store; cost grows with session history. Sessions remain in eve's storage under its retention policy.
+- A network failure after accepting `SendMessage` can leave an ambiguous result. This prototype does not deduplicate submissions by `messageId`; workflow step retry is not a guarantee of exactly-once remote submission.
+- Blocking HTTP requests and SSE connections remain subject to host/request lifetimes. A disconnect does not cancel the task; reconnect or poll for its state.
+- The application watcher is a static workflow tool. There is no dynamic `defineA2AAgent` factory or new subagent kind in this implementation.
+
+Two behaviors observed during the original `eve@0.52.2` spike are handled by the extension:
+
+1. A literal `.json` route gives eve's virtual JavaScript handler a `.json` suffix, triggering the bundler's JSON parser. The channel declares `/.well-known/:document` and accepts only `agent-card.json`, preserving the discovery URL.
+2. A parked workflow can emit `turn.completed` while its tool is pending, and answering it can settle the tool without `input.resolved`. The projection tracks pending tool calls and clears their questions on `action.result`. A turn boundary alone is insufficient evidence of task completion.
+
+The local scenarios and projection tests cover these boundaries. They do not establish interoperability with another A2A implementation, real-model tool selection, or hosted deployment behavior.
+
+## References
+
+- [A2A 1.0 specification](https://a2a-protocol.org/v1.0.0/specification/): wire messages, task states, JSON-RPC envelopes, and SSE events.
+- [A2A 1.0 protocol definitions](https://github.com/a2aproject/A2A/blob/v1.0.0/specification/a2a.proto): message fields and Agent Card security requirements.
+- [eve extensions](../../docs/extensions.md), [workflow tools](../../docs/tools/workflows.mdx), and [custom channels](../../docs/channels/custom.mdx): existing authoring APIs.

--- a/packages/eve-a2a/extension/channels/a2a.ts
+++ b/packages/eve-a2a/extension/channels/a2a.ts
@@ -1,0 +1,15 @@
+import { a2aChannel } from "../lib/a2a-channel";
+import { httpBasic } from "eve/channels/auth";
+import extension from "../extension";
+import { requiredEnv } from "../lib/env";
+
+export default a2aChannel(() => {
+  const { server } = extension.config;
+  return {
+    origin: server.origin,
+    secret: requiredEnv(server.signingSecretEnv),
+    auth: server.users.map(({ username, passwordEnv }) =>
+      httpBasic({ username, password: requiredEnv(passwordEnv) }),
+    ),
+  };
+});

--- a/packages/eve-a2a/extension/extension.ts
+++ b/packages/eve-a2a/extension/extension.ts
@@ -1,0 +1,15 @@
+import { defineExtension } from "eve/extension";
+import { z } from "zod";
+
+const credentials = z.object({ username: z.string().min(1), passwordEnv: z.string().min(1) });
+
+export default defineExtension({
+  config: z.object({
+    server: z.object({
+      origin: z.string().url(),
+      signingSecretEnv: z.string().min(1),
+      users: z.array(credentials).min(1),
+    }),
+    remote: credentials.extend({ origin: z.string().url() }),
+  }),
+});

--- a/packages/eve-a2a/extension/instructions.md
+++ b/packages/eve-a2a/extension/instructions.md
@@ -1,0 +1,3 @@
+Use this extension's send tool to start a remote A2A task or answer its pending
+question, get to inspect it, and cancel to cancel remote work. A remote task ID
+identifies work on the A2A server; it is not a local eve background-task ID.

--- a/packages/eve-a2a/extension/lib/a2a-channel.ts
+++ b/packages/eve-a2a/extension/lib/a2a-channel.ts
@@ -1,0 +1,154 @@
+import { randomUUID } from "node:crypto";
+import { defineChannel, GET, POST } from "eve/channels";
+import { routeAuth, type AuthFn } from "eve/channels/auth";
+import { parseInputResponses } from "eve/client";
+import { taskIdentity } from "./identity";
+import { initial, snapshot, streamTask, waitForState } from "./projection";
+import {
+  RpcError,
+  failure,
+  interrupted,
+  rpcRequest,
+  sendRequest,
+  success,
+  taskRequest,
+  terminal,
+} from "./protocol";
+
+export function a2aChannel(
+  readOptions: () => {
+    origin: string;
+    secret: string;
+    auth: AuthFn<Request> | readonly AuthFn<Request>[];
+  },
+) {
+  return defineChannel({
+    routes: [
+      // A literal .json route makes eve 0.52.2's virtual JS handler enter the JSON loader.
+      GET("/.well-known/:document", async (_request, { params }) => {
+        const options = readOptions();
+        return params.document !== "agent-card.json"
+          ? new Response(null, { status: 404 })
+          : Response.json({
+              name: "eve public API prototype",
+              description: "Echo, durable delay, and human input using an authored eve channel.",
+              version: "0.1.0",
+              supportedInterfaces: [
+                {
+                  url: new URL("/a2a", options.origin).href,
+                  protocolBinding: "JSONRPC",
+                  protocolVersion: "1.0",
+                },
+              ],
+              capabilities: { streaming: true, pushNotifications: false, extendedAgentCard: false },
+              defaultInputModes: ["text/plain"],
+              defaultOutputModes: ["text/plain"],
+              securitySchemes: { basic: { httpAuthSecurityScheme: { scheme: "basic" } } },
+              securityRequirements: [{ schemes: { basic: { list: [] } } }],
+              skills: [
+                {
+                  id: "demo",
+                  name: "Demo",
+                  description: "Echo a message, wait, or ask a question.",
+                  tags: ["prototype"],
+                },
+              ],
+            });
+      }),
+      POST("/a2a", async (request, args) => {
+        const options = readOptions();
+        const identity = taskIdentity(options.secret);
+        const auth = await routeAuth(request, options.auth);
+        if (auth instanceof Response) return auth;
+        let id: string | number | null = null;
+        try {
+          let raw: unknown;
+          try {
+            raw = await request.json();
+          } catch {
+            throw new RpcError(-32700, "Invalid JSON payload");
+          }
+          const parsed = rpcRequest.safeParse(raw);
+          if (!parsed.success) throw new RpcError(-32600, "Invalid JSON-RPC request");
+          const rpc = parsed.data;
+          id = rpc.id;
+          if (request.headers.get("a2a-version") !== "1.0")
+            throw new RpcError(-32009, "A2A-Version must be 1.0");
+          const owner = JSON.stringify([auth.authenticator, auth.principalId]);
+          const attach = (taskId: string) => args.attachSession(identity.read(taskId, owner));
+
+          if (rpc.method === "SendMessage" || rpc.method === "SendStreamingMessage") {
+            const input = sendRequest.parse(rpc.params);
+            const { message } = input;
+            const text = message.parts.map((part) => part.text).join("\n");
+            let session;
+            let view;
+            if (message.taskId) {
+              if (message.contextId && message.contextId !== message.taskId)
+                throw new RpcError(-32602, "Mismatched contextId and taskId");
+              session = attach(message.taskId);
+              view = await snapshot(session, message.taskId);
+              if (terminal(view.task))
+                throw new RpcError(-32004, "Terminal tasks cannot be resumed");
+              if (view.pending.length !== 1 || view.pending[0].kind !== "question")
+                throw new RpcError(-32004, "Prototype supports replies to one pending question");
+              await session.respond(
+                parseInputResponses([{ requestId: view.pending[0].requestId, text }]),
+                { auth },
+              );
+              // Read beyond the old INPUT_REQUIRED snapshot before deciding a blocking reply is done.
+              view.pending = [];
+              view.task.status = { state: "TASK_STATE_WORKING" };
+            } else {
+              if (message.contextId)
+                throw new RpcError(-32004, "Prototype does not support context continuation");
+              session = await args.from(randomUUID()).send(text, { auth, mode: "conversation" });
+              view = initial(identity.issue(session.id, owner));
+            }
+            if (rpc.method === "SendStreamingMessage") return streamTask(session, view, id);
+            if (!input.configuration?.returnImmediately) {
+              view = await waitForState(
+                session,
+                view,
+                (task) => terminal(task) || interrupted(task),
+                request.signal,
+              );
+            }
+            return success(id, { task: view.task });
+          }
+          if (["GetTask", "CancelTask", "SubscribeToTask"].includes(rpc.method)) {
+            const input = taskRequest.parse(rpc.params);
+            const session = attach(input.id);
+            let view = await snapshot(session, input.id);
+            if (rpc.method === "SubscribeToTask") {
+              if (terminal(view.task))
+                throw new RpcError(-32004, "Cannot subscribe to a terminal task");
+              return streamTask(session, view, id);
+            }
+            if (rpc.method === "CancelTask") {
+              if (terminal(view.task)) throw new RpcError(-32002, "Task is not cancelable");
+              if (!view.turnId)
+                view = await waitForState(
+                  session,
+                  view,
+                  (task) => task.status.state !== "TASK_STATE_SUBMITTED",
+                  request.signal,
+                );
+              if (terminal(view.task)) throw new RpcError(-32002, "Task is not cancelable");
+              await session.cancel({ turnId: view.turnId, tasks: true });
+              view = await waitForState(session, view, terminal, request.signal);
+            }
+            return success(id, view.task);
+          }
+          if (rpc.method.includes("PushNotification"))
+            throw new RpcError(-32003, "Push notifications are not supported");
+          if (rpc.method === "ListTasks" || rpc.method === "GetExtendedAgentCard")
+            throw new RpcError(-32004, "Operation not supported by this prototype");
+          throw new RpcError(-32601, "Method not found");
+        } catch (error) {
+          return failure(id, error);
+        }
+      }),
+    ],
+  });
+}

--- a/packages/eve-a2a/extension/lib/client.ts
+++ b/packages/eve-a2a/extension/lib/client.ts
@@ -1,0 +1,74 @@
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+import { taskSchema, RpcError, type Task } from "./protocol";
+import extension from "../extension";
+import { requiredEnv } from "./env";
+
+// Read credentials only at execution time; never return them to the caller.
+async function requestRemote(method: string, params: unknown): Promise<unknown> {
+  const { origin, username, passwordEnv } = extension.config.remote;
+  const headers = {
+    authorization: `Basic ${Buffer.from(`${username}:${requiredEnv(passwordEnv)}`).toString("base64")}`,
+    "content-type": "application/json",
+    "a2a-version": "1.0",
+  };
+  const cardResponse = await fetch(new URL("/.well-known/agent-card.json", origin), {
+    headers,
+    signal: AbortSignal.timeout(10_000),
+    redirect: "error",
+  });
+  if (!cardResponse.ok) throw new Error(`Agent Card HTTP ${cardResponse.status}`);
+  const card = z
+    .object({
+      supportedInterfaces: z.array(
+        z.object({
+          url: z.string().url(),
+          protocolBinding: z.string(),
+          protocolVersion: z.string(),
+        }),
+      ),
+    })
+    .parse(await cardResponse.json());
+  const endpoint = card.supportedInterfaces.find(
+    (entry) => entry.protocolBinding === "JSONRPC" && entry.protocolVersion === "1.0",
+  );
+  if (!endpoint || new URL(endpoint.url).origin !== new URL(origin).origin)
+    throw new Error("Expected a same-origin A2A 1.0 JSON-RPC interface");
+  const response = await fetch(endpoint.url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ jsonrpc: "2.0", id: randomUUID(), method, params }),
+    signal: AbortSignal.timeout(30_000),
+    redirect: "error",
+  });
+  if (!response.ok) throw new Error(`A2A HTTP ${response.status}`);
+  const rpc = z
+    .object({
+      result: z.unknown().optional(),
+      error: z.object({ code: z.number(), message: z.string() }).optional(),
+    })
+    .parse(await response.json());
+  if (rpc.error) throw new RpcError(rpc.error.code, rpc.error.message);
+  return rpc.result;
+}
+
+export async function sendRemote(message: string, taskId?: string): Promise<Task> {
+  const result = await requestRemote("SendMessage", {
+    message: {
+      messageId: randomUUID(),
+      role: "ROLE_USER",
+      parts: [{ text: message }],
+      taskId,
+    },
+    configuration: { returnImmediately: true },
+  });
+  return z.object({ task: taskSchema }).parse(result).task;
+}
+
+export async function readRemote(taskId: string): Promise<Task> {
+  return taskSchema.parse(await requestRemote("GetTask", { id: taskId }));
+}
+
+export async function cancelRemote(taskId: string): Promise<Task> {
+  return taskSchema.parse(await requestRemote("CancelTask", { id: taskId }));
+}

--- a/packages/eve-a2a/extension/lib/env.ts
+++ b/packages/eve-a2a/extension/lib/env.ts
@@ -1,0 +1,5 @@
+export function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`A2A requires environment variable ${name}`);
+  return value;
+}

--- a/packages/eve-a2a/extension/lib/identity.ts
+++ b/packages/eve-a2a/extension/lib/identity.ts
@@ -1,0 +1,28 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { RpcError } from "./protocol";
+
+// The signed task ID carries its session binding, so restart needs no process-local registry.
+export function taskIdentity(secret: string) {
+  const sign = (value: string) => createHmac("sha256", secret).update(value).digest();
+  return {
+    issue(sessionId: string, owner: string): string {
+      const payload = Buffer.from(JSON.stringify({ sessionId, owner })).toString("base64url");
+      return `${payload}.${sign(payload).toString("base64url")}`;
+    },
+    read(id: string, owner: string): string {
+      try {
+        const [payload, signature, extra] = id.split(".");
+        if (!payload || !signature || extra) throw new Error();
+        const supplied = Buffer.from(signature, "base64url");
+        const expected = sign(payload);
+        if (supplied.length !== expected.length || !timingSafeEqual(supplied, expected))
+          throw new Error();
+        const claims = JSON.parse(Buffer.from(payload, "base64url").toString());
+        if (claims.owner !== owner || typeof claims.sessionId !== "string") throw new Error();
+        return claims.sessionId;
+      } catch {
+        throw new RpcError(-32001, "Task not found");
+      }
+    },
+  };
+}

--- a/packages/eve-a2a/extension/lib/projection.ts
+++ b/packages/eve-a2a/extension/lib/projection.ts
@@ -1,0 +1,207 @@
+import type { MessageStreamEvent, InputRequest } from "eve/client";
+import type { Session } from "eve/channels";
+import { terminal, type Task, type TaskState } from "./protocol";
+
+export interface Projection {
+  task: Task;
+  pending: readonly InputRequest[];
+  cursor: number;
+  activeCalls: Set<string>;
+  turnId?: string;
+}
+
+export function initial(id: string): Projection {
+  return {
+    task: { id, contextId: id, status: { state: "TASK_STATE_SUBMITTED" } },
+    pending: [],
+    cursor: 0,
+    activeCalls: new Set(),
+  };
+}
+
+export function applyEvent(view: Projection, event: MessageStreamEvent): void {
+  view.cursor += 1;
+  if (terminal(view.task)) return;
+  const setState = (state: TaskState, message?: unknown) => {
+    view.task.status = {
+      state,
+      timestamp: event.meta.at,
+      message,
+    };
+  };
+  switch (event.type) {
+    case "actions.requested":
+      for (const action of event.data.actions) view.activeCalls.add(action.callId);
+      break;
+    case "action.result":
+      view.activeCalls.delete(event.data.result.callId);
+      // Workflow answers in 0.52.2 can settle the owning tool without input.resolved.
+      view.pending = view.pending.filter(
+        (request) => request.action?.callId !== event.data.result.callId,
+      );
+      if (view.pending.length === 0 && view.task.status.state === "TASK_STATE_INPUT_REQUIRED")
+        setState("TASK_STATE_WORKING");
+      break;
+    case "turn.started":
+      view.turnId = event.data.turnId;
+      setState("TASK_STATE_WORKING");
+      break;
+    case "input.requested":
+      view.pending = event.data.requests;
+      setState("TASK_STATE_INPUT_REQUIRED", {
+        messageId: event.meta.id,
+        role: "ROLE_AGENT",
+        taskId: view.task.id,
+        contextId: view.task.contextId,
+        parts: [{ text: event.data.requests.map((request) => request.prompt).join("\n") }],
+      });
+      break;
+    case "input.resolved":
+      view.pending = view.pending.filter(
+        (request) => !event.data.resolutions.some((r) => r.requestId === request.requestId),
+      );
+      if (view.pending.length === 0) setState("TASK_STATE_WORKING");
+      break;
+    case "authorization.required":
+      setState("TASK_STATE_AUTH_REQUIRED");
+      break;
+    case "authorization.completed":
+      setState("TASK_STATE_WORKING");
+      break;
+    case "message.completed":
+      if (event.data.finishReason !== "tool-calls" && event.data.message !== null) {
+        view.task.artifacts = [{ artifactId: "result", parts: [{ text: event.data.message }] }];
+      }
+      break;
+    case "result.completed":
+      view.task.artifacts = [{ artifactId: "result", parts: [{ data: event.data.result }] }];
+      break;
+    case "turn.completed":
+      // In eve 0.52.2 a parked workflow can emit turn.completed with its tool still pending.
+      if (view.activeCalls.size === 0 && view.pending.length === 0)
+        setState("TASK_STATE_COMPLETED");
+      break;
+    case "turn.cancelled":
+      setState("TASK_STATE_CANCELED");
+      break;
+    case "turn.failed":
+    case "session.failed":
+      setState("TASK_STATE_FAILED", {
+        messageId: event.meta.id,
+        role: "ROLE_AGENT",
+        taskId: view.task.id,
+        contextId: view.task.contextId,
+        parts: [{ text: "Agent execution failed" }],
+      });
+      break;
+  }
+}
+
+export async function snapshot(session: Session, id: string): Promise<Projection> {
+  const view = initial(id);
+  const tail = await session.getStreamTailIndex();
+  if (tail < 0) return view;
+  const reader = (await session.getEventStream({ startIndex: 0 })).getReader();
+  try {
+    while (view.cursor <= tail) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      applyEvent(view, value);
+    }
+    return view;
+  } finally {
+    await reader.cancel();
+    reader.releaseLock();
+  }
+}
+
+export async function waitForState(
+  session: Session,
+  view: Projection,
+  ready: (task: Task) => boolean,
+  signal: AbortSignal,
+): Promise<Projection> {
+  if (ready(view.task)) return view;
+  const reader = (await session.getEventStream({ startIndex: view.cursor })).getReader();
+  const cancel = () => {
+    void reader.cancel();
+  };
+  signal.addEventListener("abort", cancel, { once: true });
+  try {
+    signal.throwIfAborted();
+    while (!ready(view.task)) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      applyEvent(view, value);
+    }
+    signal.throwIfAborted();
+    if (!ready(view.task)) throw new Error("Session stream ended before the expected task state");
+    return view;
+  } finally {
+    signal.removeEventListener("abort", cancel);
+    await reader.cancel();
+    reader.releaseLock();
+  }
+}
+
+export function streamTask(session: Session, view: Projection, id: string | number): Response {
+  let reader: ReadableStreamDefaultReader<MessageStreamEvent> | undefined;
+  let cancelled = false;
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const send = (result: unknown) =>
+        controller.enqueue(
+          encoder.encode(`data: ${JSON.stringify({ jsonrpc: "2.0", id, result })}\n\n`),
+        );
+      try {
+        send({ task: view.task });
+        reader = (await session.getEventStream({ startIndex: view.cursor })).getReader();
+        if (cancelled) {
+          await reader.cancel();
+          return;
+        }
+        while (!terminal(view.task)) {
+          const { done, value } = await reader.read();
+          if (done || cancelled) break;
+          const previousStatus = JSON.stringify(view.task.status);
+          const previousArtifacts = JSON.stringify(view.task.artifacts);
+          applyEvent(view, value);
+          if (previousArtifacts !== JSON.stringify(view.task.artifacts)) {
+            for (const artifact of view.task.artifacts ?? [])
+              send({
+                artifactUpdate: {
+                  taskId: view.task.id,
+                  contextId: view.task.contextId,
+                  artifact,
+                  append: false,
+                  lastChunk: true,
+                },
+              });
+          }
+          if (previousStatus !== JSON.stringify(view.task.status))
+            send({
+              statusUpdate: {
+                taskId: view.task.id,
+                contextId: view.task.contextId,
+                status: view.task.status,
+              },
+            });
+        }
+        if (!cancelled) controller.close();
+      } catch (error) {
+        if (!cancelled) controller.error(error);
+      } finally {
+        await reader?.cancel();
+        reader?.releaseLock();
+      }
+    },
+    async cancel() {
+      cancelled = true;
+      await reader?.cancel();
+    },
+  });
+  return new Response(body, {
+    headers: { "content-type": "text/event-stream", "cache-control": "no-cache" },
+  });
+}

--- a/packages/eve-a2a/extension/lib/protocol.ts
+++ b/packages/eve-a2a/extension/lib/protocol.ts
@@ -1,0 +1,93 @@
+import { z } from "zod";
+
+export const taskStates = [
+  "TASK_STATE_SUBMITTED",
+  "TASK_STATE_WORKING",
+  "TASK_STATE_INPUT_REQUIRED",
+  "TASK_STATE_AUTH_REQUIRED",
+  "TASK_STATE_COMPLETED",
+  "TASK_STATE_FAILED",
+  "TASK_STATE_CANCELED",
+  "TASK_STATE_REJECTED",
+] as const;
+export const taskSchema = z.object({
+  id: z.string(),
+  contextId: z.string(),
+  status: z.object({
+    state: z.enum(taskStates),
+    timestamp: z.string().optional(),
+    message: z.unknown().optional(),
+  }),
+  artifacts: z.array(z.object({ artifactId: z.string(), parts: z.array(z.unknown()) })).optional(),
+});
+export type Task = z.infer<typeof taskSchema>;
+export type TaskState = Task["status"]["state"];
+
+export function terminal(task: Task): boolean {
+  return [
+    "TASK_STATE_COMPLETED",
+    "TASK_STATE_FAILED",
+    "TASK_STATE_CANCELED",
+    "TASK_STATE_REJECTED",
+  ].includes(task.status.state);
+}
+
+export function interrupted(task: Task): boolean {
+  return (
+    task.status.state === "TASK_STATE_INPUT_REQUIRED" ||
+    task.status.state === "TASK_STATE_AUTH_REQUIRED"
+  );
+}
+
+export class RpcError extends Error {
+  constructor(
+    readonly code: number,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+export const rpcRequest = z.object({
+  jsonrpc: z.literal("2.0"),
+  id: z.union([z.string(), z.number()]),
+  method: z.string(),
+  params: z.unknown().optional(),
+});
+
+export const sendRequest = z.object({
+  message: z.object({
+    messageId: z.string().min(1),
+    role: z.literal("ROLE_USER"),
+    parts: z.array(z.object({ text: z.string() }).strict()).min(1),
+    taskId: z.string().optional(),
+    contextId: z.string().optional(),
+  }),
+  configuration: z.object({ returnImmediately: z.boolean().optional() }).optional(),
+});
+
+export const taskRequest = z.object({
+  id: z.string().min(1),
+  historyLength: z.number().int().nonnegative().optional(),
+});
+
+export function success(id: string | number, result: unknown): Response {
+  return Response.json({ jsonrpc: "2.0", id, result });
+}
+
+export function failure(id: string | number | null, error: unknown): Response {
+  const known = error instanceof RpcError;
+  if (!known && !(error instanceof z.ZodError)) console.error(error);
+  return Response.json({
+    jsonrpc: "2.0",
+    id,
+    error: {
+      code: known ? error.code : error instanceof z.ZodError ? -32602 : -32603,
+      message: known
+        ? error.message
+        : error instanceof z.ZodError
+          ? "Invalid parameters"
+          : "Internal error",
+    },
+  });
+}

--- a/packages/eve-a2a/extension/tools/cancel.ts
+++ b/packages/eve-a2a/extension/tools/cancel.ts
@@ -1,0 +1,9 @@
+import { defineTool } from "eve/tools";
+import { z } from "zod";
+import { cancelRemote } from "../lib/client";
+
+export default defineTool({
+  description: "Explicitly cancel the remote A2A task, independently of any local watcher.",
+  inputSchema: z.object({ taskId: z.string() }),
+  execute: ({ taskId }) => cancelRemote(taskId),
+});

--- a/packages/eve-a2a/extension/tools/get.ts
+++ b/packages/eve-a2a/extension/tools/get.ts
@@ -1,0 +1,9 @@
+import { defineTool } from "eve/tools";
+import { z } from "zod";
+import { readRemote } from "../lib/client";
+
+export default defineTool({
+  description: "Read the remote A2A task by its remote taskId.",
+  inputSchema: z.object({ taskId: z.string() }),
+  execute: ({ taskId }) => readRemote(taskId),
+});

--- a/packages/eve-a2a/extension/tools/send.ts
+++ b/packages/eve-a2a/extension/tools/send.ts
@@ -1,0 +1,10 @@
+import { defineTool } from "eve/tools";
+import { z } from "zod";
+import { sendRemote } from "../lib/client";
+
+export default defineTool({
+  description:
+    "Send a message to the configured A2A agent. Pass its remote taskId to answer an interrupted task.",
+  inputSchema: z.object({ message: z.string(), taskId: z.string().optional() }),
+  execute: ({ message, taskId }) => sendRemote(message, taskId),
+});

--- a/packages/eve-a2a/package.json
+++ b/packages/eve-a2a/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@eve/a2a",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Prototype A2A tools and channel built with public eve APIs.",
+  "license": "Apache-2.0",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.mjs"
+    },
+    "./tools": {
+      "types": "./dist/tools/index.d.ts",
+      "default": "./dist/tools/index.mjs"
+    },
+    "./client": {
+      "types": "./dist/extension/lib/client.d.ts",
+      "default": "./dist/extension/lib/client.mjs"
+    }
+  },
+  "scripts": {
+    "build": "eve extension build",
+    "prepack": "pnpm run build",
+    "typecheck": "tsc --noEmit",
+    "test:unit": "vitest run --config vitest.unit.config.ts"
+  },
+  "dependencies": {
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "eve": "workspace:*",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "eve": "workspace:*"
+  },
+  "engines": {
+    "node": ">=24"
+  },
+  "eve": {
+    "extension": {
+      "source": "./extension",
+      "dist": "./dist/extension"
+    }
+  }
+}

--- a/packages/eve-a2a/test/projection.test.ts
+++ b/packages/eve-a2a/test/projection.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import type { MessageStreamEvent } from "eve/client";
+import { applyEvent, initial } from "../extension/lib/projection.ts";
+import { taskIdentity } from "../extension/lib/identity.ts";
+
+function event(type: string, data: unknown): MessageStreamEvent {
+  return { type, data, meta: { id: "event-1", at: "2026-09-09T00:00:00Z" } } as MessageStreamEvent;
+}
+
+test("a task's result stays immutable even if its eve session receives another turn", () => {
+  const view = initial("task-1");
+  applyEvent(view, event("turn.started", { turnId: "turn-1" }));
+  applyEvent(
+    view,
+    event("message.completed", { finishReason: "tool-calls", message: "Private planning" }),
+  );
+  assert.equal(JSON.stringify(view.task.artifacts), undefined);
+  applyEvent(view, event("message.completed", { finishReason: "stop", message: "First result" }));
+  applyEvent(view, event("turn.completed", { turnId: "turn-1" }));
+  applyEvent(view, event("turn.started", { turnId: "turn-2" }));
+  applyEvent(view, event("message.completed", { finishReason: "stop", message: "Later result" }));
+  assert.equal(view.task.status.state, "TASK_STATE_COMPLETED");
+  assert.deepEqual(view.task.artifacts?.[0].parts, [{ text: "First result" }]);
+});
+
+test("input interrupts the same task until its addressed request is resolved", () => {
+  const view = initial("task-1");
+  applyEvent(
+    view,
+    event("input.requested", {
+      requests: [{ requestId: "city", kind: "question", prompt: "Which city?" }],
+    }),
+  );
+  assert.equal(view.task.status.state, "TASK_STATE_INPUT_REQUIRED");
+  applyEvent(view, event("turn.completed", { turnId: "turn-1" }));
+  assert.equal(view.task.status.state, "TASK_STATE_INPUT_REQUIRED");
+  applyEvent(view, event("input.resolved", { resolutions: [{ requestId: "unrelated" }] }));
+  assert.equal(view.task.status.state, "TASK_STATE_INPUT_REQUIRED");
+  applyEvent(view, event("input.resolved", { resolutions: [{ requestId: "city" }] }));
+  assert.equal(view.task.status.state, "TASK_STATE_WORKING");
+  assert.equal(view.task.id, "task-1");
+});
+
+test("task identifiers recover their binding after restart and reject other owners or tampering", () => {
+  const issued = taskIdentity("key").issue("session-1", "alice");
+  assert.equal(taskIdentity("key").read(issued, "alice"), "session-1");
+  assert.throws(() => taskIdentity("key").read(issued, "bob"), /Task not found/);
+  assert.throws(() => taskIdentity("different key").read(issued, "alice"), /Task not found/);
+  assert.throws(() => taskIdentity("key").read(`x${issued}`, "alice"), /Task not found/);
+});
+
+test("execution failures close the task without exposing internal error details", () => {
+  const view = initial("task-1");
+  applyEvent(view, event("session.failed", { error: "Private infrastructure detail" }));
+  applyEvent(view, event("turn.completed", {}));
+  assert.equal(view.task.status.state, "TASK_STATE_FAILED");
+  assert.deepEqual(view.task.status.message, {
+    messageId: "event-1",
+    role: "ROLE_AGENT",
+    taskId: "task-1",
+    contextId: "task-1",
+    parts: [{ text: "Agent execution failed" }],
+  });
+});
+
+test("replaying a workflow answer clears the question when its owning tool settles", () => {
+  const view = initial("task-1");
+  applyEvent(view, event("actions.requested", { actions: [{ callId: "call-1" }] }));
+  applyEvent(
+    view,
+    event("input.requested", {
+      requests: [
+        {
+          requestId: "city",
+          kind: "question",
+          prompt: "Which city?",
+          action: { callId: "call-1" },
+        },
+      ],
+    }),
+  );
+  applyEvent(view, event("turn.completed", {}));
+  assert.equal(view.task.status.state, "TASK_STATE_INPUT_REQUIRED");
+  applyEvent(view, event("action.result", { result: { callId: "call-1" } }));
+  applyEvent(view, event("message.completed", { finishReason: "stop", message: "Porto" }));
+  applyEvent(view, event("turn.completed", {}));
+  assert.equal(view.task.status.state, "TASK_STATE_COMPLETED");
+  assert.equal(view.pending.length, 0);
+});

--- a/packages/eve-a2a/tsconfig.json
+++ b/packages/eve-a2a/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "types": ["node", "eve/workflow-modules"]
+  },
+  "include": ["extension/**/*.ts", "test/**/*.ts", "vitest.unit.config.ts"]
+}

--- a/packages/eve-a2a/vitest.unit.config.ts
+++ b/packages/eve-a2a/vitest.unit.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: { include: ["test/**/*.test.ts"] },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,6 +389,28 @@ importers:
         specifier: 'catalog:'
         version: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  apps/fixtures/a2a-public-api:
+    dependencies:
+      '@eve/a2a':
+        specifier: workspace:*
+        version: link:../../../packages/eve-a2a
+      ai:
+        specifier: 'catalog:'
+        version: 7.0.84(zod@4.5.4)
+      eve:
+        specifier: workspace:*
+        version: link:../../../packages/eve
+      zod:
+        specifier: 'catalog:'
+        version: 4.5.4
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.3
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+
   apps/fixtures/agent-tui-client:
     dependencies:
       eve:
@@ -1548,6 +1570,25 @@ importers:
       zod-validation-error:
         specifier: 5.0.0
         version: 5.0.0(zod@4.5.4)
+
+  packages/eve-a2a:
+    dependencies:
+      zod:
+        specifier: 'catalog:'
+        version: 4.5.4
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.3
+      eve:
+        specifier: workspace:*
+        version: link:../eve
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/eve-buzz-acp-adapter:
     dependencies:
@@ -33134,6 +33175,35 @@ snapshots:
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 7.3.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@edge-runtime/vm': 3.2.0
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 24.13.3
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@edge-runtime/vm': 3.2.0


### PR DESCRIPTION
### Summary

Prototype A2A as a private `@eve/a2a` extension in `packages/eve-a2a`, using existing eve APIs. Related to #2887 as a reference; this does not implement its proposed framework APIs.

Mounting the extension gives an agent `send`, `get`, and `cancel` tools plus a channel: incoming A2A messages start eve sessions, and persisted session events become task status and SSE updates. A reply tool answers a remote question while the existing local watcher continues monitoring that task.

The packaging boundary matters: the [current extension builder rejects workflow directives](https://github.com/vercel/eve/blob/51c47192a1cac0629aee4720bc4d4e451c8be1d9/packages/eve/src/internal/authored-module-loader.ts#L558). The durable watcher therefore stays in the consumer fixture, with two application step wrappers around the extension's client export. The compiler, harness, and public eve APIs are unchanged. This is a text-only prototype with fixed card metadata, not an A2A conformance or release claim.

### Validation

Built the extension and copied only its distribution into an isolated consumer. HTTP scenarios passed for authentication, owner isolation, sends, input replies, cancellation, SSE, and model dispatch to namespaced extension tools. Restarting the server preserved the remote task and resumed its existing workflow watcher. Five unit tests cover projection and identity boundaries. External A2A interoperability and hosted behavior remain unverified.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

No changeset is needed for the private prototype package and its fixture.

### Diff size

**Docs** — 4 files · `+134 / -0`

Mount configuration, operating limits, the workflow packaging boundary, and agent instructions.

**Implementation** — 15 files · `+759 / -0`

Protocol translation, event projection, authentication, and extension packaging. The lockfile adds the two workspace packages and their test dependency resolution.

**Tests** — 17 files · `+749 / -0`

A deterministic consumer exercises the built extension over HTTP and through real tool dispatch, including a server restart. Most test code is the consumer and server lifecycle harness; unit tests cover the pure state and identity rules.
