### PR TITLE
fix(eve): derive the Vercel function runtime from vercel.json bunVersion

### DIFF
--- a/.changeset/vercel-bun-runtime-from-bun-version.md
+++ b/.changeset/vercel-bun-runtime-from-bun-version.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Derive the Vercel function runtime from `bunVersion` in the app's `vercel.json` during production builds, so an app that selects `"1.4.x"` runs its functions on Bun 1.4 instead of Nitro's default `bun1.x` mapping.

--- a/packages/eve/src/internal/nitro/host/create-application-nitro.ts
+++ b/packages/eve/src/internal/nitro/host/create-application-nitro.ts
@@ -39,7 +39,10 @@ import type {
   PreparedApplicationHost,
   PreparedDevelopmentApplicationHost,
 } from "#internal/nitro/host/types.js";
-import { createEveVercelOptions } from "#internal/nitro/host/vercel-build-output-config.js";
+import {
+  createEveVercelOptions,
+  readVercelBunVersion,
+} from "#internal/nitro/host/vercel-build-output-config.js";
 import { applyWorkflowTransform } from "#internal/workflow-bundle/workflow-builders.js";
 import type { CompiledAgentManifest } from "#compiler/manifest.js";
 
@@ -839,6 +842,8 @@ export async function createProductionApplicationNitro(
       enabled: preset === "vercel",
       publicRoutePrefix: options.publicRoutePrefix,
       workspaceMember: options.workspaceMember,
+      bunVersion:
+        preset === "vercel" ? await readVercelBunVersion(preparedHost.appRoot) : undefined,
     }),
   });
   await writeEveVersionedCacheMetadata(options.buildDir);

--- a/packages/eve/src/internal/nitro/host/vercel-build-output-config.test.ts
+++ b/packages/eve/src/internal/nitro/host/vercel-build-output-config.test.ts
@@ -5,10 +5,30 @@ import { EVE_PACKAGE_NAME } from "#internal/package-name.js";
 import {
   createEveVercelOptions,
   EVE_WORKFLOW_FLOW_ROUTE_PATH,
+  parseVercelBunVersion,
 } from "#internal/nitro/host/vercel-build-output-config.js";
 import { deriveEveWorkflowQueueTopic } from "#internal/workflow/queue-namespace.js";
 
 describe("createEveVercelOptions", () => {
+  it("derives the function runtime from the vercel.json bunVersion", () => {
+    expect(
+      createEveVercelOptions({ agentName: "test-agent", enabled: true, bunVersion: "1.4.x" })
+        ?.functions,
+    ).toEqual({ runtime: "bun1.4.x" });
+    expect(
+      createEveVercelOptions({ agentName: "test-agent", enabled: true, bunVersion: "1.x" })
+        ?.functions,
+    ).toEqual({ runtime: "bun1.x" });
+  });
+
+  it("leaves the runtime to Nitro when no Bun version is selected", () => {
+    for (const bunVersion of [undefined, "", "latest", "1.4.1"]) {
+      expect(
+        createEveVercelOptions({ agentName: "test-agent", enabled: true, bunVersion }),
+      ).not.toHaveProperty("functions");
+    }
+  });
+
   it("returns undefined when the Vercel build output is disabled", () => {
     expect(createEveVercelOptions({ agentName: "test-agent", enabled: false })).toBeUndefined();
   });
@@ -90,5 +110,27 @@ describe("createEveVercelOptions", () => {
     expect(workspaceMember?.functionRules[EVE_WORKFLOW_FLOW_ROUTE_PATH].environment).toMatchObject({
       EVE_INTERNAL_AGENT_WORKSPACE_MEMBER: "1",
     });
+  });
+});
+
+describe("parseVercelBunVersion", () => {
+  it("accepts the values Vercel documents", () => {
+    expect(parseVercelBunVersion({ bunVersion: "1.4.x" })).toBe("1.4.x");
+    expect(parseVercelBunVersion({ bunVersion: "1.x" })).toBe("1.x");
+  });
+
+  it("ignores missing and malformed values", () => {
+    for (const config of [
+      undefined,
+      null,
+      "1.4.x",
+      {},
+      { framework: "eve" },
+      { bunVersion: 1.4 },
+      { bunVersion: "1.4.1" },
+      { bunVersion: "latest" },
+    ]) {
+      expect(parseVercelBunVersion(config)).toBeUndefined();
+    }
   });
 });

--- a/packages/eve/src/internal/nitro/host/vercel-build-output-config.ts
+++ b/packages/eve/src/internal/nitro/host/vercel-build-output-config.ts
@@ -1,3 +1,6 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
 import { EVE_INTERNAL_AGENT_WORKSPACE_MEMBER_ENV } from "#internal/application/build-output-environment.js";
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
 import { EVE_PACKAGE_NAME } from "#internal/package-name.js";
@@ -10,20 +13,53 @@ import {
 
 export { EVE_WORKFLOW_FLOW_ROUTE_PATH };
 
+/** `vercel.json` `bunVersion` values Vercel accepts, e.g. `1.x` or `1.4.x`. */
+const VERCEL_BUN_VERSION_PATTERN = /^\d+(?:\.\d+)?\.x$/;
+
+/** The `bunVersion` an app's `vercel.json` selects, or undefined when absent or not a value Vercel accepts. */
+export function parseVercelBunVersion(config: unknown): string | undefined {
+  const bunVersion =
+    typeof config === "object" && config !== null && "bunVersion" in config
+      ? (config as { bunVersion?: unknown }).bunVersion
+      : undefined;
+  return typeof bunVersion === "string" && VERCEL_BUN_VERSION_PATTERN.test(bunVersion)
+    ? bunVersion
+    : undefined;
+}
+
+/**
+ * Reads `bunVersion` from the app's `vercel.json`, the same file Nitro's Vercel
+ * preset reads to decide the function runtime. A missing or unparsable file
+ * selects nothing.
+ */
+export async function readVercelBunVersion(appRoot: string): Promise<string | undefined> {
+  try {
+    return parseVercelBunVersion(JSON.parse(await readFile(join(appRoot, "vercel.json"), "utf8")));
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Builds eve's Vercel preset options.
  *
  * The flow route's `functionRules` entry makes Nitro emit a dedicated
  * `flow.func` from the same build output, carrying the agent's queue trigger,
  * an extended execution window, and the environment the deployed workflow
- * runtime needs. Every other function setting (runtime, memory, streaming) is
- * inherited from the base server function config.
+ * runtime needs. Every other function setting (memory, streaming) is inherited
+ * from the base server function config.
+ *
+ * When `vercel.json` selects a Bun version, the function runtime is derived from
+ * it (`1.4.x` → `bun1.4.x`). Nitro's own detection maps every `bunVersion` to
+ * `bun1.x`, which would silently pin the deployed function to an older Bun than
+ * the one that installed and built it.
  */
 export function createEveVercelOptions(input: {
   agentName: string;
   enabled: boolean;
   publicRoutePrefix?: string;
   workspaceMember?: boolean;
+  bunVersion?: string;
 }) {
   if (!input.enabled) {
     return undefined;
@@ -46,6 +82,11 @@ export function createEveVercelOptions(input: {
     environment[EVE_INTERNAL_AGENT_WORKSPACE_MEMBER_ENV] = "1";
   }
 
+  const functions =
+    input.bunVersion !== undefined && VERCEL_BUN_VERSION_PATTERN.test(input.bunVersion)
+      ? { runtime: `bun${input.bunVersion}` }
+      : undefined;
+
   return {
     config: {
       version: 3 as const,
@@ -54,6 +95,7 @@ export function createEveVercelOptions(input: {
         version: resolveInstalledPackageInfo().version,
       },
     },
+    ...(functions === undefined ? {} : { functions }),
     functionRules: {
       [EVE_WORKFLOW_FLOW_ROUTE_PATH]: {
         maxDuration: "max" as const,


### PR DESCRIPTION
### Summary

Vercel's Bun runtime accepts two `bunVersion` values, `"1.x"` (Bun 1.3.14 today) and `"1.4.x"`. Nitro's Vercel preset reads `bunVersion` from `vercel.json` but maps every value to the `bun1.x` function runtime (`resolveVercelRuntime` in `src/presets/vercel/utils.ts`), unless the app passes `vercel.functions.runtime` explicitly. eve owns the Nitro config and never passes it, so an eve app that sets `bunVersion: "1.4.x"` installs and builds with Bun 1.4 and then runs its functions on Bun 1.3, with no way to correct it from the app.

This reads `bunVersion` from the app's `vercel.json` during production builds and passes the matching runtime (`1.4.x` → `bun1.4.x`, `1.x` → `bun1.x`) through `createEveVercelOptions`. Apps without a `bunVersion`, or with a value outside Vercel's `<major>.<minor>.x` shape, are unchanged and keep Nitro's detection. Development builds are untouched.

The mapping arguably belongs in Nitro itself; this is the eve-side fix so apps on today's Nitro get the runtime they asked for. Happy to drop it if a Nitro fix is preferred and eve bumps to it.

### Validation

- `pnpm run build:compiled && pnpm exec vitest run --config vitest.unit.config.ts src/internal/nitro/host/vercel-build-output-config.test.ts` — 10 tests pass (4 new: runtime derivation for both accepted values, no `functions` key for missing/malformed values, `parseVercelBunVersion` accept/reject cases).
- `pnpm exec tsc -p tsconfig.json --noEmit` in `packages/eve` passes.
- `oxfmt` and `oxlint` via the pre-commit hook.
- Observed on Vercel before this change: an app with `bunVersion: "1.4.x"` builds with `bun install v1.4.1` and emits `"runtime": "bun1.x"` in `.vc-config.json`; overriding `vercel.functions.runtime` to `bun1.4.x` is what a TanStack Start + Nitro app in our monorepo has to do by hand today.

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
