### PR TITLE
Add Context7 MCP connection

### DIFF
--- a/apps/docs/lib/integrations/connection-setup.test.ts
+++ b/apps/docs/lib/integrations/connection-setup.test.ts
@@ -30,6 +30,18 @@ describe("Browser Use connection setup", () => {
   });
 });
 
+describe("Context7 connection setup", () => {
+  it("supports anonymous access with an optional bearer token", () => {
+    const integration = getIntegration("context7")!;
+
+    expect(buildConnectionInstall(integration)).toContain("eve add connection/context7");
+    expect(integration.quickStart).toContain("const apiKey = process.env.CONTEXT7_API_KEY");
+    expect(integration.quickStart).toContain('allow: ["resolve-library-id", "query-docs"]');
+    expect(integration.configure).toContain("Authorization: Bearer");
+    expect(integration.configure).toContain("two read-only documentation tools");
+  });
+});
+
 describe("Agentcard connection setup", () => {
   it("uses the standard connector name for the native Vercel Connect service", () => {
     const integration = getIntegration("agentcard")!;

--- a/apps/docs/lib/integrations/data.ts
+++ b/apps/docs/lib/integrations/data.ts
@@ -1876,6 +1876,49 @@ const connectionPresentations: Record<string, ConnectionPresentation> = {
     configureNote:
       "Browser Use runs tasks in managed cloud browsers. Add approval gates or tool filters before allowing unattended browser actions.",
   },
+  context7: {
+    logo: "context7",
+    docsHref: "https://context7.com/docs/integrations/eve",
+    keywords: [
+      "mcp",
+      "documentation",
+      "libraries",
+      "frameworks",
+      "code examples",
+      "developer tools",
+    ],
+    authModes: [],
+    quickStart: `Create \`agent/connections/context7.ts\`. The API key is optional, so the connection can use Context7's anonymous limits when \`CONTEXT7_API_KEY\` is not set:
+
+\`\`\`ts
+import { defineMcpClientConnection } from "eve/connections";
+
+const apiKey = process.env.CONTEXT7_API_KEY;
+
+export default defineMcpClientConnection({
+  url: "https://mcp.context7.com/mcp",
+  description:
+    "Context7: up-to-date, version-specific library documentation and code examples.",
+  ...(apiKey
+    ? {
+        auth: {
+          getToken: async () => ({ token: apiKey }),
+        },
+      }
+    : {}),
+  tools: {
+    allow: ["resolve-library-id", "query-docs"],
+  },
+});
+\`\`\``,
+    configure: `For higher rate limits, create an API key in the [Context7 dashboard](https://context7.com/dashboard) and set it as a server-side environment variable:
+
+\`\`\`bash
+CONTEXT7_API_KEY=your_api_key
+\`\`\`
+
+When the key is present, eve sends it to Context7 as an \`Authorization: Bearer\` token. The explicit tool allowlist limits the connection to Context7's two read-only documentation tools.`,
+  },
   agentcard: {
     logo: "agentcard",
     docsHref: "/docs/connections/mcp",

--- a/apps/docs/lib/integrations/logos.tsx
+++ b/apps/docs/lib/integrations/logos.tsx
@@ -86,6 +86,16 @@ export const browserUseLogo = (props: LogoProps) => (
   </svg>
 );
 
+export const context7Logo = (props: LogoProps) => (
+  <svg fill="none" viewBox="0 0 28 28" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <rect fill="#000" height="28" rx="4" width="28" />
+    <path
+      d="M10.572 15.257c0 2.246-.91 4.121-2.394 5.848h3.454v1.674H6.335v-1.59c1.62-1.832 2.246-3.326 2.246-5.932h1.991ZM17.428 15.257c0 2.246.91 4.121 2.394 5.848h-3.454v1.674h5.297v-1.59c-1.62-1.832-2.246-3.326-2.246-5.932h-1.991ZM10.572 12.744c0-2.246-.91-4.122-2.394-5.849h3.454V5.221H6.335v1.59c1.62 1.832 2.246 3.326 2.246 5.933h1.991ZM17.428 12.744c0-2.246.91-4.122 2.394-5.849h-3.454V5.221h5.297v1.59c-1.62 1.832-2.246 3.326-2.246 5.933h-1.991Z"
+      fill="#fff"
+    />
+  </svg>
+);
+
 export const githubLogo = (props: LogoProps) => (
   <svg fill="none" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" {...props}>
     <path
@@ -756,6 +766,7 @@ export const logos = {
   web: webLogo,
   buzz: BuzzLogo,
   "browser-use": browserUseLogo,
+  context7: context7Logo,
   github: githubLogo,
   slack: slackLogo,
   discord: discordLogo,

--- a/apps/docs/registry.json
+++ b/apps/docs/registry.json
@@ -548,6 +548,19 @@
       ]
     },
     {
+      "name": "connection/context7",
+      "type": "registry:item",
+      "title": "Context7",
+      "description": "Retrieve up-to-date, version-specific library documentation and code examples.",
+      "files": [
+        {
+          "path": "registry/connections/context7.ts",
+          "type": "registry:file",
+          "target": "agent/connections/context7.ts"
+        }
+      ]
+    },
+    {
       "name": "connection/vercel",
       "type": "registry:item",
       "title": "Vercel",

--- a/apps/docs/registry/connections/context7.ts
+++ b/apps/docs/registry/connections/context7.ts
@@ -1,0 +1,18 @@
+import { defineMcpClientConnection } from "eve/connections";
+
+const apiKey = process.env.CONTEXT7_API_KEY;
+
+export default defineMcpClientConnection({
+  url: "https://mcp.context7.com/mcp",
+  description: "Context7: up-to-date, version-specific library documentation and code examples.",
+  ...(apiKey
+    ? {
+        auth: {
+          getToken: async () => ({ token: apiKey }),
+        },
+      }
+    : {}),
+  tools: {
+    allow: ["resolve-library-id", "query-docs"],
+  },
+});

--- a/apps/docs/scripts/validate-connection-registry.ts
+++ b/apps/docs/scripts/validate-connection-registry.ts
@@ -94,7 +94,7 @@ for (const item of items) {
   }
 
   const slug = item.name.slice("connection/".length);
-  if (slug !== "browser-use") {
+  if (slug !== "browser-use" && slug !== "context7") {
     const creationType = CONNECT_CREATION_TYPES[slug];
     const connectionMethod = CONNECT_METHODS[slug];
     const principalType = CONNECT_PRINCIPAL_TYPES[slug];
@@ -145,6 +145,14 @@ for (const item of items) {
       if (item.dependencies !== undefined || !("BROWSER_USE_API_KEY" in (item.envVars ?? {}))) {
         throw new Error(
           'Registry item "connection/browser-use" must declare its API key without Vercel Connect.',
+        );
+      }
+      break;
+    }
+    case "context7": {
+      if (item.dependencies !== undefined || item.envVars !== undefined) {
+        throw new Error(
+          'Registry item "connection/context7" must keep its API key optional and avoid Vercel Connect.',
         );
       }
       break;

--- a/packages/eve-catalog/src/index.test.ts
+++ b/packages/eve-catalog/src/index.test.ts
@@ -173,6 +173,12 @@ describe("integration catalog", () => {
     );
   });
 
+  it("uses Context7's streamable HTTP MCP endpoint", () => {
+    expect(getIntegrationEntry("context7")!.connection!.mcp!.url).toBe(
+      "https://mcp.context7.com/mcp",
+    );
+  });
+
   it("uses Natural's streamable HTTP MCP endpoint", () => {
     expect(getIntegrationEntry("natural")!.connection!.mcp!.url).toBe(
       "https://mcp.natural.com/mcp",

--- a/packages/eve-catalog/src/index.ts
+++ b/packages/eve-catalog/src/index.ts
@@ -378,6 +378,18 @@ export const INTEGRATIONS: readonly IntegrationEntry[] = [
     },
   },
   {
+    slug: "context7",
+    name: "Context7",
+    kind: "connection",
+    tagline: "Up-to-date library documentation and code examples for coding agents.",
+    surfaces: { scaffoldable: false, registry: true, gallery: true },
+    connection: {
+      description:
+        "Context7: up-to-date, version-specific library documentation and code examples.",
+      mcp: { url: "https://mcp.context7.com/mcp" },
+    },
+  },
+  {
     slug: "vercel",
     name: "Vercel",
     kind: "connection",


### PR DESCRIPTION
### Summary

Eve agents currently need to hand-author a connection to use Context7 for current, version-specific library documentation. This adds `connection/context7` to the official registry and integrations gallery.

The generated connection:

- works anonymously with Context7's standard limits
- optionally uses `CONTEXT7_API_KEY` as a bearer token for higher limits
- exposes only the read-only `resolve-library-id` and `query-docs` tools
- does not require Vercel Connect

The API-key environment variable is intentionally not declared as required registry setup because anonymous access remains functional.

Related to #3219.

### Validation

- `pnpm build`
- `pnpm --filter eve-docs registry:check`
- `pnpm --filter eve-docs test:unit -- connection-setup.test.ts` — 23 files, 176 tests passed
- `pnpm --filter @eve/catalog test:unit` — 1 file, 28 tests passed
- `pnpm exec oxfmt --check <changed files>`

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] A changeset is not needed because this does not touch the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
