### PR TITLE
fix(eve): allow exiting a pending TUI cancellation

### DIFF
--- a/.changeset/force-dev-turn-cancel.md
+++ b/.changeset/force-dev-turn-cancel.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Allow `Ctrl+C` to interrupt a pending dev TUI turn cancellation and arm the next press to exit.

--- a/docs/guides/dev-tui.md
+++ b/docs/guides/dev-tui.md
@@ -59,17 +59,17 @@ The UI installs planner selections in order and offers deployment once after the
 
 Type a message and press `Enter` to send it. When the agent asks a question or requests tool approval, respond in the prompt shown by the UI. Connection authorization can open a browser; keep local `eve dev` running until the browser returns to it.
 
-While a turn is running, `Enter` queues a follow-up message. Press `Esc` or `Ctrl+C` to cancel the turn; when messages are queued, this uses the oldest queued message as the next turn instead. At an idle prompt, press `Ctrl+C` twice to exit.
+While a turn is running, `Enter` queues a follow-up message. Press `Esc` or `Ctrl+C` to cancel the turn; when messages are queued, this uses the oldest queued message as the next turn instead. If a direct cancellation requested with `/cancel` or `Ctrl+C` does not settle, press `Ctrl+C` to stop waiting. The UI then returns to the prompt and asks you to press `Ctrl+C` again to exit. At an idle prompt, press `Ctrl+C` twice to exit.
 
-| Key           | Action                                                                              |
-| ------------- | ----------------------------------------------------------------------------------- |
-| `Enter`       | Send the current message or answer.                                                 |
-| `Shift+Enter` | Insert a newline. Requires a terminal that reports modified keys.                   |
-| `Esc`         | Cancel a running turn, or steer with the oldest queued message.                     |
-| `Ctrl+C`      | Cancel or steer during a turn; clear input, then exit on a second press, when idle. |
-| `↑` / `↓`     | Move through input lines or sent-message history.                                   |
-| `Ctrl+L`      | Cycle log display modes.                                                            |
-| `Ctrl+R`      | Redraw the screen.                                                                  |
+| Key           | Action                                                                                                                  |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `Enter`       | Send the current message or answer.                                                                                     |
+| `Shift+Enter` | Insert a newline. Requires a terminal that reports modified keys.                                                       |
+| `Esc`         | Cancel a running turn, or steer with the oldest queued message.                                                         |
+| `Ctrl+C`      | Cancel or steer during a turn; stop a pending cancellation, then exit on the next press; press twice to exit when idle. |
+| `↑` / `↓`     | Move through input lines or sent-message history.                                                                       |
+| `Ctrl+L`      | Cycle log display modes.                                                                                                |
+| `Ctrl+R`      | Redraw the screen.                                                                                                      |
 
 ## Logs and traces
 

--- a/packages/eve/src/cli/dev/tui/message-queue.test.ts
+++ b/packages/eve/src/cli/dev/tui/message-queue.test.ts
@@ -147,5 +147,6 @@ describe("renderMessageQueueRows", () => {
     const queue = new MessageQueue();
     queue.handleEscape();
     expect(render(queue)).toEqual([expect.stringContaining("Cancelling turn…")]);
+    expect(render(queue)[0]).toContain("Ctrl+C to stop waiting, then again to exit");
   });
 });

--- a/packages/eve/src/cli/dev/tui/message-queue.ts
+++ b/packages/eve/src/cli/dev/tui/message-queue.ts
@@ -180,7 +180,12 @@ export function renderMessageQueueRows(input: MessageQueuePanelRowsInput): strin
   if (view.messages.length === 0 && !view.steering) {
     if (!working) return [];
     if (view.cancelling) {
-      return [clipVisible(`${lead}${c.yellow(g.dotActive)} ${c.dim("Cancelling turn…")}`, width)];
+      return [
+        clipVisible(
+          `${lead}${c.yellow(g.dotActive)} ${c.dim("Cancelling turn… · Ctrl+C to stop waiting, then again to exit")}`,
+          width,
+        ),
+      ];
     }
     return [];
   }

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.test.ts
@@ -1993,6 +1993,44 @@ describe("TerminalRenderer (inline scrollback)", () => {
     renderer.shutdown();
   });
 
+  it("interrupts a pending /cancel on Ctrl+C and arms the next press to exit", async () => {
+    const { screen, input, renderer } = makeRenderer();
+    const abort = vi.fn();
+    const cancel = vi.fn();
+    const rendering = renderer.renderStream(
+      {
+        abort,
+        cancel,
+        events: new ReadableStream<AgentTUIStreamEvent>(),
+      },
+      { submittedPrompt: "long task", continueSession: true },
+    );
+
+    await vi.waitFor(() => {
+      expect(screen.snapshot()).toContain("›");
+    });
+    input.type("/cancel");
+    input.enter();
+    await vi.waitFor(() => {
+      expect(cancel).toHaveBeenCalledOnce();
+      expect(screen.snapshot()).toContain("Cancelling turn…");
+    });
+
+    input.ctrlC();
+    await expect(rendering).resolves.toBeUndefined();
+
+    expect(abort).toHaveBeenCalledOnce();
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(screen.snapshot()).toContain("Interrupted");
+
+    const prompt = renderer.readPrompt();
+    expect(screen.snapshot()).toContain("Press Ctrl+C again to exit");
+    input.ctrlC();
+    await expect(prompt).rejects.toThrow();
+    expect(renderer.exitRequested()).toBe(true);
+    renderer.shutdown();
+  });
+
   it("pops the oldest queued message on Esc, cancels the turn, and stages the steer prompt", async () => {
     const { screen, input, renderer } = makeRenderer();
     const escape = async () => {

--- a/packages/eve/src/cli/dev/tui/terminal-renderer.ts
+++ b/packages/eve/src/cli/dev/tui/terminal-renderer.ts
@@ -487,6 +487,8 @@ export class TerminalRenderer implements AgentTUIRenderer {
   #exitRequested = false;
   /** True after the first consecutive Ctrl+C at the idle chat prompt. */
   #exitArmed = false;
+  /** Carries a pending-cancel interrupt into the next prompt as the first exit press. */
+  #armExitOnNextPrompt = false;
   readonly #onExitRequest?: () => void;
   #caretVisible = true;
   #spinnerIndex = 0;
@@ -715,7 +717,8 @@ export class TerminalRenderer implements AgentTUIRenderer {
     this.#promptPlaceholderActive = true;
     this.#turnIndicator = { kind: "idle" };
     this.#status = "";
-    this.#exitArmed = false;
+    this.#exitArmed = this.#armExitOnNextPrompt;
+    this.#armExitOnNextPrompt = false;
     // A draft typed during the turn carries into the prompt; an explicit
     // initial draft (`eve dev --input`) wins over it. Queued messages the
     // runner never drained (an interrupted or failed turn) fold back in
@@ -3212,6 +3215,18 @@ export class TerminalRenderer implements AgentTUIRenderer {
       }
       case "ctrl-c":
       case "escape": {
+        // Once a direct cancellation is pending, Ctrl+C is the hard escape
+        // hatch. Esc remains cooperative and repeated Ctrl+C presses can still
+        // pop queued messages into a steer payload.
+        if (key.type === "ctrl-c" && this.#messageQueue.view().cancelling) {
+          this.#interrupted = true;
+          this.#armExitOnNextPrompt = true;
+          this.#turnIndicator = { kind: "idle" };
+          this.#status = "Interrupted";
+          this.#resolveStreamInterrupt?.();
+          this.#paint();
+          break;
+        }
         // Esc and Ctrl+C drive steering and cancellation: pop the oldest
         // queued message and cancel the running turn so the runner submits it
         // as the replacement turn; with nothing queued, cancel immediately.


### PR DESCRIPTION
### Summary

When `/cancel` remained pending in the dev TUI, subsequent `Ctrl+C` presses repeated the cooperative cancellation request and left no path to the normal exit gesture. `Ctrl+C` now stops waiting for a pending direct cancellation, returns to an exit-armed prompt, and a second press exits the TUI. The first `Ctrl+C` during an otherwise active turn still requests cooperative cancellation, and queued-message steering remains unchanged.

### Validation

Focused message-queue and terminal-renderer unit suites passed with 209 tests, including regression coverage for `/cancel` → `Ctrl+C` → prompted `Ctrl+C` exit. The eve package typecheck, docs checks, lint, formatting, and invariant guard also passed.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+16 / -11`

Updates the dev TUI cancellation instructions and includes the required patch changeset.

**Implementation** — 2 files · `+22 / -2`

Keeps the behavior local to the terminal renderer's cancellation and exit state, with a visible stop-waiting hint in the cancellation panel.

**Tests** — 2 files · `+39 / -0`

Covers the pending-cancellation exit sequence and its user-facing hint.
