### PR TITLE
fix(cli): preflight init package manager

### DIFF
--- a/.changeset/preflight-init-package-manager.md
+++ b/.changeset/preflight-init-package-manager.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Verify the package manager selected by `eve init` before changing project files. When it is unavailable, eve now reports the problem before scaffolding or modifying an existing project.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -56,7 +56,7 @@ Creates a new agent app or adds an agent to an existing app. Always installs dep
 
 Coding-agent launches and non-interactive terminals cannot answer the location prompt and fail before writing. Pass a new directory name, such as `eve init my-agent`, in those environments.
 
-After scaffolding, a human terminal usually continues into `eve dev`. If a coding-agent REPL is on `PATH`, the handoff menu can open it instead or exit without starting either process. Coding-agent launches print the next steps instead of opening the TUI, so the session does not get stuck. Fresh projects use the parent workspace's package manager when there is one; otherwise they use the manager that launched `eve init`.
+After scaffolding, a human terminal usually continues into `eve dev`. If a coding-agent REPL is on `PATH`, the handoff menu can open it instead or exit without starting either process. Coding-agent launches print the next steps instead of opening the TUI, so the session does not get stuck. Fresh projects use the parent workspace's package manager when there is one; otherwise they use the manager that launched `eve init`, or pnpm when neither is available. Before writing project files, eve verifies that the selected package manager can start.
 
 | Flag                   | Type   | Default                    | Description                                                                                                              |
 | ---------------------- | ------ | -------------------------- | ------------------------------------------------------------------------------------------------------------------------ |

--- a/packages/eve/src/cli/commands/init-agent-workspace.ts
+++ b/packages/eve/src/cli/commands/init-agent-workspace.ts
@@ -27,6 +27,21 @@ export interface InitCliLogger {
   log(message: string): void;
 }
 
+export function uniqueWorkspaceRootMutations(
+  mutations: readonly WorkspaceRootMutation[],
+): WorkspaceRootMutation[] {
+  const byKey = new Map<string, WorkspaceRootMutation>();
+  for (const mutation of mutations) {
+    const key = `${mutation.kind}:${mutation.path}`;
+    const existing = byKey.get(key);
+    byKey.set(key, {
+      ...mutation,
+      nodeEngineOverride: mutation.nodeEngineOverride ?? existing?.nodeEngineOverride,
+    });
+  }
+  return [...byKey.values()];
+}
+
 export function formatWorkspaceRootMutationWarning(mutation: WorkspaceRootMutation): string {
   const target = mutation.kind === "package-json" ? "package.json" : "configuration";
   const suffix =

--- a/packages/eve/src/cli/commands/init-package-manager.ts
+++ b/packages/eve/src/cli/commands/init-package-manager.ts
@@ -1,0 +1,34 @@
+import type { PackageManagerKind } from "#setup/package-manager.js";
+import { resultSucceeded, type PackageManagerProcessResult } from "#setup/primitives/index.js";
+
+export async function resolveScaffoldPackageManager(input: {
+  detectInvokingPackageManager(): PackageManagerKind | undefined;
+  detectPackageManager(projectPath: string): Promise<{ kind: PackageManagerKind; source: string }>;
+  projectPath: string;
+}): Promise<PackageManagerKind> {
+  const detected = await input.detectPackageManager(input.projectPath);
+  return detected.source === "default"
+    ? (input.detectInvokingPackageManager() ?? "pnpm")
+    : detected.kind;
+}
+
+export function packageManagerPreflightFailureMessage(result: PackageManagerProcessResult): string {
+  if (result.termination.kind === "spawn-error") {
+    return result.termination.code === "ENOENT"
+      ? `${result.command.executable} was not found. Install it before running eve init.`
+      : `Could not start ${result.command.executable}: ${result.termination.message}`;
+  }
+  return `Could not verify ${result.command.executable}. Run ${result.command.executable} --version, then retry eve init.`;
+}
+
+export async function assertPackageManagerAvailable(
+  checkPackageManagerAvailability: (
+    kind: PackageManagerKind,
+    cwd: string,
+  ) => Promise<PackageManagerProcessResult>,
+  kind: PackageManagerKind,
+  cwd: string,
+): Promise<void> {
+  const result = await checkPackageManagerAvailability(kind, cwd);
+  if (!resultSucceeded(result)) throw new Error(packageManagerPreflightFailureMessage(result));
+}

--- a/packages/eve/src/cli/commands/init.integration.test.ts
+++ b/packages/eve/src/cli/commands/init.integration.test.ts
@@ -63,6 +63,9 @@ function logger(): InitCliLogger & { messages: string[]; errors: string[] } {
 function dependencies(
   gitResult: GitInitResult = { kind: "initialized" },
 ): InitCommandDependencies & {
+  checkPackageManagerAvailability: ReturnType<
+    typeof vi.fn<InitCommandDependencies["checkPackageManagerAvailability"]>
+  >;
   detectInvokingPackageManager: ReturnType<
     typeof vi.fn<InitCommandDependencies["detectInvokingPackageManager"]>
   >;
@@ -85,6 +88,11 @@ function dependencies(
       }
       return addAgentToProject(merged);
     },
+    checkPackageManagerAvailability: vi.fn(async (kind, cwd) => ({
+      command: { executable: kind, args: ["--version"], cwd },
+      termination: { kind: "exit", code: 0 },
+      stdout: "",
+    })),
     // Stubbed to "no visible manager" so assertions do not depend on which
     // manager launched the test runner itself.
     detectInvokingPackageManager: vi.fn(() => undefined),
@@ -1254,6 +1262,24 @@ describe("runInitCommand", () => {
       join(parentDirectory, "my-agent"),
       ["exec", "eve", "dev", "--onboard"],
     );
+  });
+
+  it("stops before scaffolding when the selected package manager is unavailable", async () => {
+    const parentDirectory = await mkdtemp(join(tmpdir(), "eve-init-preflight-fail-"));
+    const output = logger();
+    const deps = dependencies();
+    deps.checkPackageManagerAvailability.mockResolvedValue({
+      command: { executable: "pnpm", args: ["--version"], cwd: parentDirectory },
+      termination: { kind: "spawn-error", code: "ENOENT", message: "spawn pnpm ENOENT" },
+      stdout: "",
+    });
+
+    await expect(runInitCommand(output, parentDirectory, "my-agent", {}, deps)).rejects.toThrow(
+      "pnpm was not found. Install it before running eve init.",
+    );
+
+    await expect(pathExists(join(parentDirectory, "my-agent"))).resolves.toBe(false);
+    expect(deps.runPackageManagerInstall).not.toHaveBeenCalled();
   });
 
   it("categorizes a missing package manager without collecting process output", async () => {

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -23,6 +23,7 @@ import {
 } from "#setup/package-manager.js";
 import { pathExists } from "#setup/path-exists.js";
 import {
+  checkPackageManagerAvailability,
   eveDevArguments,
   packageManagerInstallFailureMessage,
   packageManagerInstallSucceeded,
@@ -43,7 +44,11 @@ import {
   type EvePackageContract,
 } from "#setup/scaffold/create/project.js";
 
-import { initAgentDevHandoff, initAgentReplPrompt } from "./agent-instructions.js";
+import {
+  initAgentDevHandoff,
+  initAgentReadySummary,
+  initAgentReplPrompt,
+} from "./agent-instructions.js";
 import {
   installProgressDetail,
   INSTALL_OUTPUT_FALLBACK_LINES,
@@ -55,9 +60,13 @@ import {
   convertScaffoldToAgentWorkspace,
   formatWorkspaceRootMutationWarning,
   type InitCliLogger,
+  uniqueWorkspaceRootMutations,
   type InitCommandOptions,
 } from "./init-agent-workspace.js";
-import { initAgentReadySummary } from "./agent-instructions.js";
+import {
+  assertPackageManagerAvailable,
+  resolveScaffoldPackageManager,
+} from "./init-package-manager.js";
 import {
   cleanupFreshInitTarget,
   workspaceFailureNote,
@@ -71,6 +80,7 @@ export type { InitCliLogger, InitCommandOptions } from "./init-agent-workspace.j
 
 export interface InitCommandDependencies {
   addAgentToProject: typeof addAgentToProject;
+  checkPackageManagerAvailability: typeof checkPackageManagerAvailability;
   detectInvokingPackageManager: typeof detectInvokingPackageManager;
   detectPackageManager: typeof detectPackageManager;
   ensureChannel: typeof ensureChannel;
@@ -87,6 +97,7 @@ export interface InitCommandDependencies {
 
 const defaultDependencies: InitCommandDependencies = {
   addAgentToProject,
+  checkPackageManagerAvailability,
   detectInvokingPackageManager,
   detectPackageManager,
   ensureChannel,
@@ -112,26 +123,12 @@ async function moveDirectoryContents(sourceRoot: string, targetRoot: string): Pr
   }
 }
 
-function uniqueWorkspaceRootMutations(
-  mutations: readonly WorkspaceRootMutation[],
-): WorkspaceRootMutation[] {
-  const byKey = new Map<string, WorkspaceRootMutation>();
-  for (const mutation of mutations) {
-    const key = `${mutation.kind}:${mutation.path}`;
-    const existing = byKey.get(key);
-    byKey.set(key, {
-      ...mutation,
-      nodeEngineOverride: mutation.nodeEngineOverride ?? existing?.nodeEngineOverride,
-    });
-  }
-  return [...byKey.values()];
-}
-
 async function addToExistingProject(
   targetPath: string,
   options: InitCommandOptions,
   dependencies: InitCommandDependencies,
   evePackage: EvePackageContract | undefined,
+  packageManager: PackageManagerKind,
 ): Promise<{
   configurationFilesChanged: string[];
   dependenciesAdded: string[];
@@ -151,32 +148,20 @@ async function addToExistingProject(
     if (rejection !== null) throw new Error(rejection);
   }
 
-  const manager = await dependencies.detectPackageManager(targetPath);
   const result = await dependencies.addAgentToProject({
     projectRoot: targetPath,
     model: options.model ?? DEFAULT_AGENT_MODEL_ID,
     reasoning: options.reasoning,
-    packageManager: manager.kind,
+    packageManager,
     evePackage,
   });
   return {
     configurationFilesChanged: result.configurationFilesChanged,
     dependenciesAdded: result.dependenciesAdded,
     filesWritten: result.filesWritten,
-    packageManager: manager.kind,
+    packageManager,
     nodeEngineOverride: result.nodeEngineOverride,
   };
-}
-
-async function resolveScaffoldPackageManager(
-  projectPath: string,
-  dependencies: InitCommandDependencies,
-): Promise<PackageManagerKind> {
-  const detected = await dependencies.detectPackageManager(projectPath);
-  if (detected.source !== "default") {
-    return detected.kind;
-  }
-  return dependencies.detectInvokingPackageManager() ?? "pnpm";
 }
 
 async function scaffoldProject(
@@ -344,6 +329,18 @@ async function runInitSteps(input: {
   const agentLaunched = await dependencies.isCodingAgentLaunch();
   const initTarget = await resolveInitTarget({ parentDirectory, target });
   const evePackage = resolveInitEvePackageOverride();
+  const packageManager =
+    initTarget.kind === "fresh"
+      ? await resolveScaffoldPackageManager({
+          ...dependencies,
+          projectPath: initTarget.projectPath,
+        })
+      : (await dependencies.detectPackageManager(initTarget.projectPath)).kind;
+  await assertPackageManagerAvailable(
+    dependencies.checkPackageManagerAvailability,
+    packageManager,
+    parentDirectory,
+  );
 
   let progress = startCliLiveRow(logger);
   let activeInitStep: EveCliSetupStep = "scaffold";
@@ -357,10 +354,6 @@ async function runInitSteps(input: {
     const agentStartedAt = dependencies.now();
     let project: PreparedInitProject;
     if (initTarget.kind === "fresh") {
-      const packageManager = await resolveScaffoldPackageManager(
-        initTarget.projectPath,
-        dependencies,
-      );
       const workspaceMember = isPackageManagerWorkspaceMember(
         packageManager,
         initTarget.projectPath,
@@ -412,6 +405,7 @@ async function runInitSteps(input: {
         options,
         dependencies,
         evePackage,
+        packageManager,
       );
       project =
         addition.nodeEngineOverride === undefined

--- a/packages/eve/src/setup/primitives/index.ts
+++ b/packages/eve/src/setup/primitives/index.ts
@@ -1,4 +1,5 @@
 export {
+  checkPackageManagerAvailability,
   eveDevArguments,
   packageManagerInstallFailureMessage,
   packageManagerInstallSucceeded,

--- a/packages/eve/src/setup/primitives/pm/run.ts
+++ b/packages/eve/src/setup/primitives/pm/run.ts
@@ -4,6 +4,7 @@ import type { PackageManagerKind } from "../../package-manager.js";
 import { armProcessAbort } from "../process-abort.js";
 import { createProcessOutputBuffer, type ProcessOutputHandler } from "../process-output.js";
 import { getPackageManagerStrategy } from "./index.js";
+import type { PackageManagerInvocation } from "./types.js";
 import {
   createPackageProcessStdoutCollector,
   type PackageManagerProcessResult,
@@ -39,20 +40,15 @@ function abortedTermination(signal: AbortSignal | undefined): PackageManagerProc
     : { kind: "aborted", reason: reason instanceof Error ? reason.message : String(reason) };
 }
 
-/** Runs one package-manager command and returns its complete process evidence. */
-export function spawnPackageManager(
-  kind: PackageManagerKind,
-  projectRoot: string,
-  args: readonly string[],
+function spawnPackageManagerInvocation(
+  invocation: PackageManagerInvocation,
+  cwd: string,
   options: RunPackageManagerOptions = {},
 ): Promise<PackageManagerProcessResult> {
-  const strategy = getPackageManagerStrategy(kind);
-  const managerArgs = strategy.prepareArguments(projectRoot, args);
-  const invocation = strategy.resolveInvocation(managerArgs);
   const command = {
     executable: invocation.command,
     args: [...invocation.args],
-    cwd: projectRoot,
+    cwd,
   };
   if (options.signal?.aborted === true) {
     return Promise.resolve({
@@ -70,7 +66,7 @@ export function spawnPackageManager(
     let child;
     try {
       child = spawn(invocation.command, [...invocation.args], {
-        cwd: projectRoot,
+        cwd,
         stdio: captureOutput
           ? [options.nonInteractive ? "ignore" : "inherit", "pipe", "pipe"]
           : "inherit",
@@ -117,6 +113,32 @@ export function spawnPackageManager(
       else settle({ kind: "exit", code: code ?? 1 });
     });
   });
+}
+
+/** Runs one package-manager command and returns its complete process evidence. */
+export function spawnPackageManager(
+  kind: PackageManagerKind,
+  projectRoot: string,
+  args: readonly string[],
+  options: RunPackageManagerOptions = {},
+): Promise<PackageManagerProcessResult> {
+  const strategy = getPackageManagerStrategy(kind);
+  return spawnPackageManagerInvocation(
+    strategy.resolveInvocation(strategy.prepareArguments(projectRoot, args)),
+    projectRoot,
+    options,
+  );
+}
+
+/** Verifies that the selected package-manager executable can start without touching a project. */
+export function checkPackageManagerAvailability(
+  kind: PackageManagerKind,
+  cwd: string,
+): Promise<PackageManagerProcessResult> {
+  return spawnPackageManagerInvocation(
+    getPackageManagerStrategy(kind).resolveInvocation(["--version"]),
+    cwd,
+  );
 }
 
 export interface RunInstallOptions extends RunPackageManagerOptions, PackageManagerInstallOptions {}

--- a/packages/eve/src/setup/primitives/run-pnpm.test.ts
+++ b/packages/eve/src/setup/primitives/run-pnpm.test.ts
@@ -4,6 +4,7 @@ import { PassThrough } from "node:stream";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import {
+  checkPackageManagerAvailability,
   eveDevArguments,
   runPackageManagerInstall,
   runPnpmInstall,
@@ -142,6 +143,18 @@ describe("runPnpmInstall", () => {
     expect(onOutput.mock.calls.map(([line]) => line)).toEqual([
       { stream: "stdout", text: "workspace parse failed" },
     ]);
+  });
+});
+
+describe("checkPackageManagerAvailability", () => {
+  test("uses the selected manager without project-scoping arguments", async () => {
+    await checkPackageManagerAvailability("pnpm", "/tmp/app");
+
+    expect(mockedSpawn).toHaveBeenCalledWith(
+      "pnpm",
+      ["--version"],
+      expect.objectContaining({ cwd: "/tmp/app" }),
+    );
   });
 });
 

--- a/packages/eve/src/setup/primitives/run-pnpm.ts
+++ b/packages/eve/src/setup/primitives/run-pnpm.ts
@@ -1,4 +1,5 @@
 export {
+  checkPackageManagerAvailability,
   eveDevArguments,
   runPackageManagerInstall,
   runPnpmInstall,


### PR DESCRIPTION
### Summary

Recent init telemetry shows that a meaningful share of install-phase failures occur because eve cannot start its selected package manager. This preflights that executable with `--version` after package-manager selection and before scaffolding or modifying an existing project, so users receive a direct recovery message without partially changing the target. Selection behavior remains unchanged, including workspace, launcher, and pnpm fallback precedence.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/setup/primitives/run-pnpm.test.ts src/internal/structural-tests/file-length.test.ts`
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/cli/commands/init.integration.test.ts`
- `pnpm --filter eve typecheck`
- `pnpm docs:check`
- `pnpm lint` (passed; two existing control-regex warnings)

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
