### PR TITLE
Simplify workflow agent calls

### DIFF
--- a/.changeset/clean-workflow-agent-api.md
+++ b/.changeset/clean-workflow-agent-api.md
@@ -1,0 +1,5 @@
+---
+"eve": minor
+---
+
+Simplify workflow-tool delegation to `ctx.agent(target, input)`. eve now derives replay-stable invocation identities, so workflow authors no longer provide separate `key` and `target` fields, and inline output schemas infer the structured result type.

--- a/docs/tools/workflows.mdx
+++ b/docs/tools/workflows.mdx
@@ -102,9 +102,9 @@ the build with the missing import in the error.
 ### Migrate an existing workflow tool
 
 Replace `defineTool` with `defineWorkflowTool`, keep the executor's `"use workflow"` directive,
-and replace `agent(ctx, input)` and `ask(ctx, request)` with `ctx.agent(input)` and `ctx.ask(request)`.
-The `eve/workflow` entry point has been removed. Import `WorkflowToolContext`, `AgentInput`,
-`ToolInputRequest`, and `ToolInputResponse` from `eve/tools` when you need explicit types.
+and replace `agent(ctx, input)` and `ask(ctx, request)` with `ctx.agent(target, input)` and
+`ctx.ask(request)`. The `eve/workflow` entry point has been removed. Import `WorkflowToolContext`,
+`AgentInput`, `ToolInputRequest`, and `ToolInputResponse` from `eve/tools` when you need explicit types.
 
 ## Wait or run in the background
 
@@ -250,17 +250,22 @@ and can only show the model's input. Both compose: `approval` before the run, `c
 Workflow tools can call a visible subagent and wait for its result:
 
 ```ts
-const result = await ctx.agent({
-  key: "security-review",
-  target: "reviewer",
+const result = await ctx.agent("reviewer", {
   message: "Review the deployment plan for security risks.",
+  outputSchema: {
+    type: "object",
+    properties: {
+      findings: { type: "array", items: { type: "string" } },
+    },
+    required: ["findings"],
+  },
 });
 ```
 
-`key` is required, non-empty, and unique within the workflow run. It makes the invocation identity
-stable across replay, so use a fixed key for each logical call site. Parallel calls must use distinct
-keys. `target` is the model-visible subagent name; pass `agentId` to continue an existing child and
-`outputSchema` to require structured output.
+The first argument is the model-visible subagent name. eve assigns each call a replay-stable
+invocation identity, including repeated and parallel calls to the same subagent. Pass `agentId` to
+continue an existing child. An inline `outputSchema` requires structured output and determines the
+return type, so `result` in the example is typed as `{ findings: string[] }`.
 
 ## Report progress: `yield`
 

--- a/e2e/fixtures/agent-workflow-tools/agent/lib/workflow-agent-probe.ts
+++ b/e2e/fixtures/agent-workflow-tools/agent/lib/workflow-agent-probe.ts
@@ -9,9 +9,7 @@ export async function executeWorkflowAgentProbe(
   input: z.infer<typeof workflowAgentProbeInputSchema>,
   ctx: WorkflowToolContext,
 ): Promise<unknown> {
-  return await ctx.agent({
-    key: `local-${input.kind}`,
+  return await ctx.agent(input.kind === "hitl" ? "workflow-hitl" : "workflow-auth", {
     message: `Run the ${input.kind} probe.`,
-    target: input.kind === "hitl" ? "workflow-hitl" : "workflow-auth",
   });
 }

--- a/e2e/fixtures/agent-workflow-tools/agent/tools/background_agent.ts
+++ b/e2e/fixtures/agent-workflow-tools/agent/tools/background_agent.ts
@@ -8,10 +8,8 @@ export default defineWorkflowTool({
   async execute({ service }, ctx) {
     "use workflow";
 
-    return await ctx.agent({
-      key: "background-child",
+    return await ctx.agent("workflow-marker", {
       message: `${service}:background`,
-      target: "workflow-marker",
     });
   },
 });

--- a/e2e/fixtures/agent-workflow-tools/agent/tools/blocking_agent.ts
+++ b/e2e/fixtures/agent-workflow-tools/agent/tools/blocking_agent.ts
@@ -7,10 +7,8 @@ export default defineWorkflowTool({
   async execute({ service }, ctx) {
     "use workflow";
 
-    return await ctx.agent({
-      key: "blocking-child",
+    return await ctx.agent("workflow-marker", {
       message: `${service}:blocking`,
-      target: "workflow-marker",
     });
   },
 });

--- a/e2e/fixtures/agent-workflow-tools/agent/tools/fanout_agents.ts
+++ b/e2e/fixtures/agent-workflow-tools/agent/tools/fanout_agents.ts
@@ -8,15 +8,11 @@ export default defineWorkflowTool({
     "use workflow";
 
     return await Promise.all([
-      ctx.agent({
-        key: "replica-0",
+      ctx.agent("workflow-marker", {
         message: `${service}:replica-0`,
-        target: "workflow-marker",
       }),
-      ctx.agent({
-        key: "replica-1",
+      ctx.agent("workflow-marker", {
         message: `${service}:replica-1`,
-        target: "workflow-marker",
       }),
     ]);
   },

--- a/packages/eve/extension-contracts/reports/tool/v34.json
+++ b/packages/eve/extension-contracts/reports/tool/v34.json
@@ -1,0 +1,20 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "tool",
+  "epoch": 34,
+  "sha256": "a975670cb03255f7436f841adaa20ee8ba7e6ae2bdfc9ed6eb3ba55a7669d666",
+  "exports": [
+    "defaultWebSearch",
+    "defineTool",
+    "defineWorkflowTool",
+    "disableTool",
+    "experimental_workflow",
+    "isDisabledToolSentinel",
+    "isExperimentalWorkflowToolDefinition",
+    "isWebSearchToolDefinition",
+    "toolOutput",
+    "toolOutputPart",
+    "toolResultFrom",
+    "webSearch"
+  ]
+}

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -22,8 +22,8 @@ interface ExtensionCapabilityContract {
 const EXTENSION_CAPABILITY_CONTRACTS = {
   extension: { current: 1, supported: [1], dropped: {} },
   tool: {
-    current: 33,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 28, 29, 30, 31, 32, 33],
+    current: 34,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 28, 29, 30, 31, 32, 34],
     dropped: {
       14: "TaskExec.delegated was removed; migrate to workflow-backed background tools",
       15: "TaskExec replaces stageEffect with send",
@@ -39,6 +39,7 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
       25: "TaskExec.delegated was removed; migrate to workflow-backed background tools",
       26: "Background tools now use task yield descriptors",
       27: "TaskExec.delegated was removed; migrate to workflow-backed background tools",
+      33: "ctx.agent now accepts the subagent name as its first argument, derives invocation identity internally, and infers structured output types",
     },
   },
   dynamicTool: {

--- a/packages/eve/src/execution/tools/subagent/invoke-agent.test.ts
+++ b/packages/eve/src/execution/tools/subagent/invoke-agent.test.ts
@@ -2,7 +2,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ask, attachWorkflowToolRunContext } from "#execution/tools/workflow/ask.js";
 import type { WorkflowToolRunRef } from "#execution/tools/workflow/messages.js";
-import { agent, type AgentInvocationReply } from "#execution/tools/subagent/invoke-agent.js";
+import {
+  agent,
+  type AgentInvocationReply,
+  validateAgentInput,
+} from "#execution/tools/subagent/invoke-agent.js";
 import type { ToolContext } from "#tools/definition.js";
 
 const mocks = vi.hoisted(() => ({
@@ -32,14 +36,22 @@ describe("workflow helper context errors", () => {
     ["null context", null],
   ])("rejects %s before creating hooks or dispatching work", async (_name, context) => {
     const ctx = context as ToolContext;
-    await expect(
-      agent(ctx, { key: "review", target: "reviewer", message: "Review" }),
-    ).rejects.toThrow("ctx.agent() requires a defineWorkflowTool() executor context.");
+    await expect(agent(ctx, "reviewer", { message: "Review" })).rejects.toThrow(
+      "ctx.agent() requires a defineWorkflowTool() executor context.",
+    );
     expect(() => ask(ctx, { prompt: "Continue?" })).toThrow(
       "ctx.ask() requires a defineWorkflowTool() executor context.",
     );
     expect(mocks.createHook).not.toHaveBeenCalled();
     expect(mocks.resumeHook).not.toHaveBeenCalled();
+  });
+});
+
+describe("agent invocation input", () => {
+  it("requires a non-empty positional agent name", () => {
+    expect(() => validateAgentInput({ message: "Review", target: "" })).toThrow(
+      "agent() requires a non-empty agent name as its first argument.",
+    );
   });
 });
 
@@ -68,7 +80,7 @@ describe("background agent invocation routing", () => {
       },
     });
 
-    const result = agent(ctx, { key: "research", message: "Find it", target: "research" });
+    const result = agent(ctx, "research", { message: "Find it" });
     await vi.waitFor(() => expect(mocks.resumeHook).toHaveBeenCalledOnce());
     controller.abort(new Error("task cancelled"));
 
@@ -78,12 +90,12 @@ describe("background agent invocation routing", () => {
 
   it("sends the invocation through the task owner after admission", async () => {
     const result = {
-      callId: "call-1:research",
+      callId: "call-1:agent-reply",
       kind: "subagent-result" as const,
       origin: "child" as const,
       outcome: {
         kind: "parked" as const,
-        result: { kind: "succeeded" as const, output: "available" },
+        result: { kind: "succeeded" as const, output: { findings: ["available"] } },
         usageDelta: {
           cacheReadTokens: 0,
           cacheWriteTokens: 0,
@@ -91,7 +103,7 @@ describe("background agent invocation routing", () => {
           outputTokens: 0,
         },
       },
-      output: "available",
+      output: { findings: ["available"] },
       subagentName: "research",
     };
     const replies: AgentInvocationReply[] = [{ kind: "runtime-action-result", results: [result] }];
@@ -124,20 +136,83 @@ describe("background agent invocation routing", () => {
       },
     });
 
-    await expect(
-      agent(ctx, { key: "research", message: "Find it", target: "research" }),
-    ).resolves.toBe("available");
+    const outputSchema = {
+      properties: { findings: { items: { type: "string" }, type: "array" } },
+      required: ["findings"],
+      type: "object",
+    };
+    await expect(agent(ctx, "research", { message: "Find it", outputSchema })).resolves.toEqual({
+      findings: ["available"],
+    });
 
     expect(mocks.resumeHook).toHaveBeenCalledWith("owner-inbox", {
       kind: "request",
       from,
       replyTo: "agent-reply",
       request: {
-        input: { message: "Find it", target: "research" },
-        invocationId: "call-1:research",
+        input: { message: "Find it", outputSchema, target: "research" },
+        invocationId: "call-1:agent-reply",
         kind: "agent-invoke",
       },
     });
+  });
+
+  it("derives unique invocation ids for repeated parallel calls", async () => {
+    for (const token of ["reply-1", "reply-2"]) {
+      const replies: AgentInvocationReply[] = [
+        {
+          kind: "runtime-action-result",
+          results: [
+            {
+              callId: `call-1:${token}`,
+              kind: "subagent-result",
+              origin: "child",
+              output: token,
+              subagentName: "research",
+            } as never,
+          ],
+        },
+      ];
+      mocks.createHook.mockReturnValueOnce({
+        [Symbol.asyncIterator]: () => ({
+          next: async () =>
+            replies.length > 0
+              ? { done: false as const, value: replies.shift()! }
+              : { done: true as const, value: undefined },
+        }),
+        token,
+      });
+    }
+    mocks.resumeHook.mockImplementation(async () => undefined);
+    const ctx = { callId: "call-1" } as ToolContext;
+    attachWorkflowToolRunContext(ctx, {
+      from: {
+        callId: "call-1",
+        execution: "blocking",
+        input: {},
+        runId: "run-1",
+        sequence: 0,
+        stepIndex: 0,
+        toolName: "research",
+        turnId: "turn-1",
+      },
+      owner: { inbox: "owner-inbox" },
+    });
+
+    await expect(
+      Promise.all([
+        agent(ctx, "research", { message: "First" }),
+        agent(ctx, "research", { message: "Second" }),
+      ]),
+    ).resolves.toEqual(["reply-1", "reply-2"]);
+
+    const requests = mocks.resumeHook.mock.calls
+      .map(([, message]) => message.request)
+      .filter((request) => request.kind === "agent-invoke");
+    expect(requests.map((request) => request.invocationId)).toEqual([
+      "call-1:reply-1",
+      "call-1:reply-2",
+    ]);
   });
 
   it("does not send the invocation before the owning task is admitted", async () => {
@@ -147,7 +222,7 @@ describe("background agent invocation routing", () => {
         kind: "runtime-action-result",
         results: [
           {
-            callId: "call-1:research",
+            callId: "call-1:agent-reply",
             kind: "subagent-result",
             origin: "child",
             output: "done",
@@ -183,7 +258,7 @@ describe("background agent invocation routing", () => {
       },
     });
 
-    const result = agent(ctx, { key: "research", message: "Find it", target: "research" });
+    const result = agent(ctx, "research", { message: "Find it" });
     await Promise.resolve();
     expect(mocks.createHook).not.toHaveBeenCalled();
     expect(mocks.resumeHook).not.toHaveBeenCalled();
@@ -195,7 +270,7 @@ describe("background agent invocation routing", () => {
 
   it("waits for agent calls inside a blocking workflow tool", async () => {
     const result = {
-      callId: "call-1:research",
+      callId: "call-1:agent-reply",
       kind: "subagent-result" as const,
       origin: "child" as const,
       outcome: {
@@ -240,9 +315,7 @@ describe("background agent invocation routing", () => {
       },
     });
 
-    await expect(
-      agent(ctx, { key: "research", message: "Find it", target: "research" }),
-    ).resolves.toBe("inline");
+    await expect(agent(ctx, "research", { message: "Find it" })).resolves.toBe("inline");
     expect(mocks.resumeHook).toHaveBeenCalledTimes(2);
     expect(mocks.resumeHook).toHaveBeenNthCalledWith(1, "owner-inbox", {
       kind: "request",
@@ -250,7 +323,7 @@ describe("background agent invocation routing", () => {
       replyTo: "agent-reply",
       request: {
         input: { message: "Find it", target: "research" },
-        invocationId: "call-1:research",
+        invocationId: "call-1:agent-reply",
         kind: "agent-invoke",
       },
     });
@@ -258,7 +331,7 @@ describe("background agent invocation routing", () => {
 
   it("rejects dispatch failures without reporting a child settlement", async () => {
     const failure = {
-      callId: "call-1:research",
+      callId: "call-1:agent-reply",
       isError: true as const,
       kind: "subagent-result" as const,
       origin: "dispatch" as const,
@@ -297,9 +370,7 @@ describe("background agent invocation routing", () => {
       },
     });
 
-    await expect(
-      agent(ctx, { key: "research", message: "Find it", target: "research" }),
-    ).rejects.toEqual(failure.output);
+    await expect(agent(ctx, "research", { message: "Find it" })).rejects.toEqual(failure.output);
     expect(mocks.resumeHook).toHaveBeenCalledTimes(1);
     expect(mocks.resumeHook).not.toHaveBeenCalledWith(
       "owner-inbox",
@@ -346,7 +417,7 @@ describe("background agent invocation routing", () => {
           kind: "runtime-action-result",
           results: [
             {
-              callId: "call-1:research",
+              callId: "call-1:agent-reply",
               kind: "subagent-result",
               origin: "child",
               output: "done",
@@ -384,9 +455,7 @@ describe("background agent invocation routing", () => {
         },
       });
 
-      await expect(
-        agent(ctx, { key: "research", message: "Find it", target: "research" }),
-      ).resolves.toBe("done");
+      await expect(agent(ctx, "research", { message: "Find it" })).resolves.toBe("done");
 
       expect(mocks.resumeHook).toHaveBeenNthCalledWith(2, "owner-inbox", {
         kind: "request",
@@ -433,7 +502,7 @@ describe("background agent invocation routing", () => {
         kind: "runtime-action-result",
         results: [
           {
-            callId: "call-1:research",
+            callId: "call-1:agent-reply",
             kind: "subagent-result",
             origin: "child",
             output: "done",
@@ -471,9 +540,7 @@ describe("background agent invocation routing", () => {
       },
     });
 
-    await expect(
-      agent(ctx, { key: "research", message: "Find it", target: "research" }),
-    ).resolves.toBe("done");
+    await expect(agent(ctx, "research", { message: "Find it" })).resolves.toBe("done");
 
     expect(mocks.resumeHook).toHaveBeenCalledWith("owner-inbox", {
       kind: "request",
@@ -503,7 +570,7 @@ describe("background agent invocation routing", () => {
         kind: "runtime-action-result",
         results: [
           {
-            callId: "call-1:research",
+            callId: "call-1:agent-reply",
             kind: "subagent-result",
             origin: "child",
             output: "done",
@@ -541,9 +608,7 @@ describe("background agent invocation routing", () => {
       },
     });
 
-    await expect(
-      agent(ctx, { key: "research", message: "Find it", target: "research" }),
-    ).resolves.toBe("done");
+    await expect(agent(ctx, "research", { message: "Find it" })).resolves.toBe("done");
 
     expect(mocks.resumeHook).toHaveBeenCalledWith("owner-inbox", {
       kind: "report",

--- a/packages/eve/src/execution/tools/subagent/invoke-agent.ts
+++ b/packages/eve/src/execution/tools/subagent/invoke-agent.ts
@@ -56,22 +56,20 @@ export type AgentInvocationReply =
   | RuntimeActionResultHookPayload
   | TaskInboundUpdate;
 
-const AGENT_INVOCATION_IDS = Symbol.for("eve.workflow-tool-run.agent-invocation-ids");
-
-/** Invokes an agent from a task-owned background workflow tool. */
-export async function agent(ctx: ToolContext, input: AgentInput): Promise<JsonValue> {
-  validateAgentInput(input, true);
+/** Invokes an agent from a workflow tool. */
+export async function agent(
+  ctx: ToolContext,
+  target: string,
+  input: AgentInput,
+): Promise<JsonValue> {
   readWorkflowToolRunRef(ctx);
-  return await invokeAgent(
-    ctx,
-    {
-      agentId: input.agentId,
-      message: input.message,
-      outputSchema: input.outputSchema,
-      target: input.target,
-    },
-    { invocationId: `${ctx.callId}:${input.key}` },
-  );
+  validateAgentInput({ ...input, target });
+  return await invokeAgent(ctx, {
+    agentId: input.agentId,
+    message: input.message,
+    outputSchema: input.outputSchema,
+    target,
+  });
 }
 
 /** Invokes an agent with a framework-selected replay-stable invocation id. */
@@ -83,29 +81,29 @@ export async function invokeAgent(
 export async function invokeAgent(
   ctx: ToolContext,
   input: InternalAgentInput,
-  options: { readonly invocationId: string; readonly returnResult?: false },
+  options?: { readonly invocationId?: string; readonly returnResult?: false },
 ): Promise<JsonValue>;
 export async function invokeAgent(
   ctx: ToolContext,
   input: InternalAgentInput,
-  options: { readonly invocationId: string; readonly returnResult?: boolean },
+  options: { readonly invocationId?: string; readonly returnResult?: boolean } = {},
 ): Promise<JsonValue | RuntimeSubagentResult> {
-  validateAgentInput(input, false);
+  validateAgentInput(input);
   const run = readWorkflowToolRunRef(ctx);
   const owner = readWorkflowToolRunOwner(ctx);
   const admission = readWorkflowToolRunAdmission(ctx);
-  claimInvocationId(ctx, options.invocationId);
   if (admission !== undefined) {
     const admitted = await admission;
     if (admitted.status === "rejected") throw new Error(admitted.reason);
   }
   const replies = createHook<AgentInvocationReply>();
+  const invocationId = options.invocationId ?? `${ctx.callId}:${replies.token}`;
   try {
     await resumeHookStep(owner.inbox, {
       kind: "request",
       from: run,
       replyTo: replies.token,
-      request: { input, invocationId: options.invocationId, kind: "agent-invoke" },
+      request: { input, invocationId, kind: "agent-invoke" },
     });
 
     const iterator = replies[Symbol.asyncIterator]();
@@ -116,7 +114,7 @@ export async function invokeAgent(
       if (reply.kind === "runtime-action-result") {
         const result = reply.results.find(
           (candidate): candidate is RuntimeSubagentResult =>
-            candidate.kind === "subagent-result" && candidate.callId === options.invocationId,
+            candidate.kind === "subagent-result" && candidate.callId === invocationId,
         );
         if (result !== undefined) {
           if (result.origin === "child") {
@@ -197,36 +195,11 @@ async function nextAgentReply(
   }
 }
 
-export function validateAgentInput(
-  input: InternalAgentInput | AgentInput,
-  requireKey: boolean,
-): void {
-  if (
-    requireKey &&
-    (typeof (input as AgentInput).key !== "string" || (input as AgentInput).key.trim() === "")
-  ) {
-    throw new TypeError("agent() requires a non-empty `key`.");
-  }
+export function validateAgentInput(input: InternalAgentInput): void {
   if (typeof input.target !== "string" || input.target.trim() === "") {
-    throw new TypeError("agent() requires a non-empty `target`.");
+    throw new TypeError("agent() requires a non-empty agent name as its first argument.");
   }
   if (typeof input.message !== "string" || input.message.trim() === "") {
     throw new TypeError("agent() requires a non-empty `message`.");
-  }
-}
-
-function claimInvocationId(ctx: ToolContext, invocationId: string): void {
-  const holder = ctx as ToolContext & { [AGENT_INVOCATION_IDS]?: Set<string> };
-  const ids = holder[AGENT_INVOCATION_IDS] ?? new Set<string>();
-  if (ids.has(invocationId)) {
-    const separator = invocationId.lastIndexOf(":");
-    const key = separator < 0 ? invocationId : invocationId.slice(separator + 1);
-    throw new TypeError(
-      `agent() invocation key "${key}" was already used in this run; keys must be unique per run.`,
-    );
-  }
-  ids.add(invocationId);
-  if (holder[AGENT_INVOCATION_IDS] === undefined) {
-    Object.defineProperty(holder, AGENT_INVOCATION_IDS, { enumerable: false, value: ids });
   }
 }

--- a/packages/eve/src/execution/tools/workflow/body.test.ts
+++ b/packages/eve/src/execution/tools/workflow/body.test.ts
@@ -29,16 +29,17 @@ it("binds workflow-only methods to the run context", async () => {
     runId: "run",
   } as WorkflowBodyInput & { execution: "blocking"; runId: string };
   const question = { prompt: "Continue?" };
-  const invocation = { key: "review", target: "reviewer", message: "Review" };
+  const target = "reviewer";
+  const invocation = { message: "Review" };
   mocks.ask.mockResolvedValue({ optionId: "yes" });
   mocks.agent.mockResolvedValue("reviewed");
   mocks.execute.mockImplementation(async (_input, ctx: WorkflowToolContext & ToolContext) => {
     expect(readWorkflowToolRunRef(ctx).runId).toBe("run");
     expect(ctx.abortSignal).toBe(signal);
     const answer = await ctx.ask(question);
-    const result = await ctx.agent(invocation);
+    const result = await ctx.agent(target, invocation);
     expect(mocks.ask).toHaveBeenCalledWith(ctx, question);
-    expect(mocks.agent).toHaveBeenCalledWith(ctx, invocation);
+    expect(mocks.agent).toHaveBeenCalledWith(ctx, target, invocation);
     return { answer, result };
   });
   await expect(executeWorkflowBody(input, signal)).resolves.toEqual({

--- a/packages/eve/src/execution/tools/workflow/body.ts
+++ b/packages/eve/src/execution/tools/workflow/body.ts
@@ -2,7 +2,7 @@ import { getWorkflowMetadata } from "#compiled/@workflow/core/index.js";
 
 import type { SessionContext } from "#context/session-context.js";
 import { agent } from "#execution/tools/subagent/invoke-agent.js";
-import type { WorkflowToolContext } from "#tools/workflow-definition.js";
+import type { AgentInput, WorkflowToolContext } from "#tools/workflow-definition.js";
 import { ask, attachWorkflowToolRunContext } from "#execution/tools/workflow/ask.js";
 import {
   type WorkflowToolRunOutcome,
@@ -141,7 +141,8 @@ function createWorkflowBodyContext(
     );
   };
   const ctx: ToolContext & WorkflowToolContext = {
-    agent: (input) => agent(ctx, input),
+    agent: ((target: string, agentInput: AgentInput) =>
+      agent(ctx, target, agentInput)) as WorkflowToolContext["agent"],
     ask: (request) => ask(ctx, request),
     abortSignal: signal,
     callId: input.callId,

--- a/packages/eve/src/internal/authored-module-loader.scenario.test.ts
+++ b/packages/eve/src/internal/authored-module-loader.scenario.test.ts
@@ -171,7 +171,7 @@ export default defineWorkflowTool({ description: "Probe", inputSchema: { type: "
   "use workflow";
   return delegate(ctx, input);
 } });`,
-        "agent/lib/delegate.ts": `export async function delegate(ctx, input) { return ctx.agent(input); }`,
+        "agent/lib/delegate.ts": `export async function delegate(ctx, input) { return ctx.agent("researcher", input); }`,
       },
       installDependencies: true,
       name: "valid-workflow-helper",

--- a/packages/eve/src/internal/workflow-bundle/authored-workflow-directives.ts
+++ b/packages/eve/src/internal/workflow-bundle/authored-workflow-directives.ts
@@ -59,7 +59,7 @@ export async function prepareAuthoredWorkflowDirectives(input: {
   const body = program.body ?? [];
   if (body.some((node) => node.source?.value === "eve/workflow")) {
     throw new Error(
-      `${input.filePath}: "eve/workflow" has been removed. Use defineWorkflowTool() from "eve/tools" and call ctx.agent(input) or ctx.ask(request) in its executor.`,
+      `${input.filePath}: "eve/workflow" has been removed. Use defineWorkflowTool() from "eve/tools" and call ctx.agent(target, input) or ctx.ask(request) in its executor.`,
     );
   }
   for (const statement of body) {

--- a/packages/eve/src/tools/workflow-definition.test.ts
+++ b/packages/eve/src/tools/workflow-definition.test.ts
@@ -17,6 +17,20 @@ describe("defineWorkflowTool", () => {
       async execute(input, ctx) {
         expectTypeOf(input).toEqualTypeOf<{ service: string }>();
         expectTypeOf(ctx).toEqualTypeOf<WorkflowToolContext>();
+        const review = ctx.agent("researcher", {
+          message: "Review the deployment.",
+          outputSchema: {
+            properties: {
+              findings: { items: { type: "string" }, type: "array" },
+              score: { type: "number" },
+            },
+            required: ["findings"],
+            type: "object",
+          },
+        });
+        expectTypeOf(review).toEqualTypeOf<Promise<{ findings: string[]; score?: number }>>();
+        // @ts-expect-error The subagent name is the first argument, not part of the input.
+        void ctx.agent({ message: "Review the deployment.", target: "researcher" });
         // Token capabilities are available when this context is passed into a step.
         void ctx.getToken;
         // @ts-expect-error Workflow bodies do not have a session sandbox.

--- a/packages/eve/src/tools/workflow-definition.ts
+++ b/packages/eve/src/tools/workflow-definition.ts
@@ -17,10 +17,59 @@ import type { ToolModelOutput } from "#tools/model-output.js";
 
 export interface AgentInput {
   readonly agentId?: string;
-  readonly key: string;
   readonly message: string;
   readonly outputSchema?: JsonObject;
-  readonly target: string;
+}
+
+type JsonSchemaProperties = Readonly<Record<string, JsonObject>>;
+type JsonSchemaRequiredKeys<
+  TProperties extends JsonSchemaProperties,
+  TRequired,
+> = TRequired extends readonly string[] ? Extract<TRequired[number], keyof TProperties> : never;
+type Simplify<TValue> = { [TKey in keyof TValue]: TValue[TKey] };
+type JsonSchemaObjectOutput<TProperties extends JsonSchemaProperties, TRequired> = Simplify<
+  {
+    -readonly [TKey in JsonSchemaRequiredKeys<TProperties, TRequired>]-?: JsonSchemaOutput<
+      TProperties[TKey]
+    >;
+  } & {
+    -readonly [
+      TKey in Exclude<keyof TProperties, JsonSchemaRequiredKeys<TProperties, TRequired>>
+    ]?: JsonSchemaOutput<TProperties[TKey]>;
+  }
+>;
+
+type JsonSchemaOutput<TSchema> = TSchema extends { readonly const: infer TValue }
+  ? Extract<TValue, JsonValue>
+  : TSchema extends { readonly enum: readonly (infer TValue)[] }
+    ? Extract<TValue, JsonValue>
+    : TSchema extends {
+          readonly type: "object";
+          readonly properties: infer TProperties extends JsonSchemaProperties;
+          readonly required?: infer TRequired;
+        }
+      ? JsonSchemaObjectOutput<TProperties, TRequired>
+      : TSchema extends {
+            readonly type: "array";
+            readonly items: infer TItems extends JsonObject;
+          }
+        ? JsonSchemaOutput<TItems>[]
+        : TSchema extends { readonly type: "string" }
+          ? string
+          : TSchema extends { readonly type: "integer" | "number" }
+            ? number
+            : TSchema extends { readonly type: "boolean" }
+              ? boolean
+              : TSchema extends { readonly type: "null" }
+                ? null
+                : JsonValue;
+
+interface WorkflowAgent {
+  <const TOutputSchema extends JsonObject>(
+    target: string,
+    input: AgentInput & { readonly outputSchema: TOutputSchema },
+  ): Promise<JsonSchemaOutput<TOutputSchema>>;
+  (target: string, input: AgentInput): Promise<JsonValue>;
 }
 
 /**
@@ -31,8 +80,8 @@ export type WorkflowToolContext = Pick<
   ToolContext,
   "abortSignal" | "callId" | "session" | "toolName" | "getToken" | "requireAuth"
 > & {
-  /** Invoke a visible subagent. The key must be unique within this workflow run. */
-  agent(input: AgentInput): Promise<JsonValue>;
+  /** Invoke a visible subagent by its model-visible name. */
+  agent: WorkflowAgent;
   /** Ask the human on the session's channel; awaiting the answer suspends the run. */
   ask(request: ToolInputRequest): PromiseLike<ToolInputResponse>;
 };

--- a/research/tools-as-workflows.md
+++ b/research/tools-as-workflows.md
@@ -1,7 +1,7 @@
 ---
 issue: https://github.com/vercel/eve/issues/1084
 status: implemented
-last_updated: "2026-09-04"
+last_updated: "2026-09-10"
 ---
 
 # Tools as workflows
@@ -21,9 +21,7 @@ export default defineWorkflowTool({
   inputSchema: z.object({ service: z.string() }),
   async execute({ service }, ctx) {
     "use workflow";
-    const review = await ctx.agent({
-      key: "review",
-      target: "reviewer",
+    const review = await ctx.agent("reviewer", {
       message: `Review ${service} for deployment.`,
     });
     const answer = await ctx.ask({
@@ -41,7 +39,7 @@ export default defineWorkflowTool({
 ```
 
 The executor receives `WorkflowToolContext`: `session`, `callId`, `toolName`, `abortSignal`,
-`agent(input)`, and `ask(request)`. Ordinary `ToolContext`, channel contexts, and schedule contexts
+`agent(target, input)`, and `ask(request)`. Ordinary `ToolContext`, channel contexts, and schedule contexts
 have no `agent` or `ask` methods. Shared helpers can accept `WorkflowToolContext` explicitly.
 The turn-owned `getSandbox`, `getSkill`, `getToken`, and `requireAuth` methods are absent from this
 public type. Side effects and credential reads belong in top-level `"use step"` helpers.
@@ -80,9 +78,10 @@ error, or cancellation resolves the model's tool call. With `execution: "backgro
 receives a task receipt. Ordinary yields are stream-only progress; yielding
 `task.postMessage(message)` wakes the owning agent, as does completion.
 
-`ctx.agent` delegates to a visible subagent. Its required `key` is unique within the run and keeps
-invocation identity stable across replay. `ctx.ask` publishes an input request on the session's
-channel and returns an awaitable answer. It can be raced against `sleep`; finishing or cancelling
+`ctx.agent` delegates to the visible subagent named by its first argument. eve derives a unique,
+replay-stable invocation identity for each call from its durable reply hook, including repeated and
+parallel calls to the same subagent. `ctx.ask` publishes an input request on the session's channel
+and returns an awaitable answer. It can be raced against `sleep`; finishing or cancelling
 the run withdraws pending requests. The existing owner hooks and message protocol stay internal.
 
 An async generator's `yield` reports progress. `ctx.abortSignal` remains durable and supports
@@ -93,7 +92,7 @@ their existing behavior.
 
 - Replace `defineTool` with `defineWorkflowTool` for workflow tools and keep the executor's
   `"use workflow"` directive.
-- Replace `agent(ctx, input)` with `ctx.agent(input)` and `ask(ctx, request)` with `ctx.ask(request)`.
+- Replace `agent(ctx, input)` with `ctx.agent(target, input)` and `ask(ctx, request)` with `ctx.ask(request)`.
 - Remove imports from `eve/workflow`; that entry point is removed. Import `WorkflowToolContext`,
   `AgentInput`, `ToolInputRequest`, and `ToolInputResponse` from `eve/tools` when needed.
 


### PR DESCRIPTION
### Summary

Related to #1084. `ctx.agent` currently makes workflow authors provide both a replay key and a target name, even though the replay key is framework bookkeeping. This changes the API to `ctx.agent(target, input)` and derives each invocation identity from its durable reply hook, including repeated and parallel calls to the same subagent. Inline `outputSchema` values now infer the returned structured type.

This is a breaking pre-1.0 API change. Tool extension epoch 33 is dropped, the workflow-tool fixture and docs use the new form, and a minor changeset records the migration.

### Validation

Focused coverage verifies the positional API, runtime validation, output-schema forwarding and inference, hook-derived invocation IDs, and repeated parallel calls. The full unit suite passed with 8,481 tests and one skip; the workflow-tools fixture is migrated for CI e2e coverage.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 3 files · `+28 / -19`

Updates the workflow guide and implemented research plan, with release metadata for the breaking API change and typed structured results.

**Implementation** — 6 files · `+101 / -57`

Removes authored invocation-key handling, derives identity from the durable reply hook, infers inline JSON Schema output types, and records the required tool contract epoch.

**Tests** — 8 files · `+125 / -55`

Adds regression coverage for generated identities and structured outputs, and migrates unit, scenario, and e2e fixture call sites to the positional API.
