### PR TITLE
feat(eve): project connection tool results with toolCall.toModelOutput

### DIFF
--- a/.changeset/connection-tool-model-output.md
+++ b/.changeset/connection-tool-model-output.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add `toolCall.toModelOutput` to MCP and OpenAPI connections: a per-operation projection of the model-facing tool result, keyed by remote tool or operation name. It reuses the authored-tool `toModelOutput` contract, so `action.result`, channel events, and hooks still receive the complete remote result. Operations without an entry are unchanged.

--- a/docs/connections/mcp.mdx
+++ b/docs/connections/mcp.mdx
@@ -133,9 +133,28 @@ Return `"user-approval"` (or `true`) to pause for a person and `"not-applicable"
 
 ## Control result size
 
-eve sends an MCP tool's returned content to the model as the tool result. MCP connections do not expose a per-result transform equivalent to an authored tool's [`toModelOutput`](/docs/tools#shape-what-the-model-sees-with-tomodeloutput).
+eve sends an MCP tool's returned content to the model as the tool result. When a remote tool returns more data than the model needs, project the model-facing result with `toolCall.toModelOutput`, keyed by the bare remote tool name:
 
-When a remote tool returns more data than the model needs, narrow the result at the MCP server. Prefer a purpose-built search or summary tool, or return a stable handle that another call can use to fetch a smaller slice. If you do not control the server and an equivalent upstream API is available, replace only that operation with an authored tool that stores the full payload outside model context and projects the needed fields through `toModelOutput`. Block the original MCP operation through [`tools.block`](#tool-filters) so the model does not see duplicate tools.
+```ts title="agent/connections/docs.ts"
+import { defineMcpClientConnection } from "eve/connections";
+
+export default defineMcpClientConnection({
+  url: "https://docs.example.com/mcp",
+  description: "Product documentation search and retrieval.",
+  toolCall: {
+    toModelOutput: {
+      search_documents: (result: { documents: { id: string; title: string }[] }) => ({
+        type: "json",
+        value: { hits: result.documents.map(({ id, title }) => ({ id, title })) },
+      }),
+    },
+  },
+});
+```
+
+This is the same [`toModelOutput`](/docs/tools#shape-what-the-model-sees-with-tomodeloutput) contract authored tools use, and it has the same boundary: only the model sees the projection. `action.result`, channel events, and hooks still receive the complete remote result. Tools without an entry keep eve's default serialization. eve does not know the remote result shape, so `output` is unchecked — annotate it with the type the server returns.
+
+Narrowing at the server is still better when you control it: prefer a purpose-built search or summary tool, or return a stable handle that another call can use to fetch a smaller slice. Replacing an operation with an authored tool and blocking the original through [`tools.block`](#tool-filters) remains an option when you also need to change the operation's inputs or behavior, not just its result.
 
 ## Troubleshooting
 

--- a/docs/connections/openapi.mdx
+++ b/docs/connections/openapi.mdx
@@ -92,6 +92,34 @@ eve removes configured keys from every operation's model-facing input schema and
 
 Use `headers` for transport-wide headers that are not operation inputs. Use `providedArguments` when the OpenAPI document declares the value as an operation parameter and it should remain outside model control. Approval policies continue to receive only the model-authored input.
 
+## Control result size
+
+An operation tool returns `{ status, statusText, body }` to the model. When one endpoint answers with far more than the model needs, project its model-facing result with `toolCall.toModelOutput`, keyed by the generated operation name:
+
+```ts title="agent/connections/reports.ts"
+import { defineOpenAPIConnection } from "eve/connections";
+
+interface ReportResponse {
+  readonly status: number;
+  readonly body: { readonly id: string; readonly state: string; readonly rows: unknown[] };
+}
+
+export default defineOpenAPIConnection({
+  spec: "https://api.example.com/openapi.json",
+  description: "Reporting API.",
+  toolCall: {
+    toModelOutput: {
+      getReport: (result: ReportResponse) => ({
+        type: "json",
+        value: { id: result.body.id, rowCount: result.body.rows.length, state: result.body.state },
+      }),
+    },
+  },
+});
+```
+
+This is the same [`toModelOutput`](/docs/tools#shape-what-the-model-sees-with-tomodeloutput) contract authored tools use, and it has the same boundary: only the model sees the projection. `action.result`, channel events, and hooks still receive the complete response. Operations without an entry keep eve's default serialization. Keys are the same names [operation filters](#operation-filters) match — the `operationId`, or the deterministic name eve derives from the method and path.
+
 ## Operation filters
 
 Most OpenAPI specs describe far more than the model should use. Narrow generated tools with exactly one of `operations.allow` or `operations.block`:

--- a/packages/eve/extension-contracts/compatibility/connection/v15.ts
+++ b/packages/eve/extension-contracts/compatibility/connection/v15.ts
@@ -1,0 +1,11 @@
+import { defineMcpClientConnection } from "#public/connections/index.js";
+
+export default defineMcpClientConnection({
+  description: "Call-aware MCP service",
+  toolCall: {
+    providedArguments: {
+      requestId: ({ callId, session, toolName }) => `${session.id}:${toolName}:${callId}`,
+    },
+  },
+  url: "https://example.com/mcp",
+});

--- a/packages/eve/extension-contracts/compatibility/tool/v33.ts
+++ b/packages/eve/extension-contracts/compatibility/tool/v33.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+import { defineTool, defineWorkflowTool } from "#public/tools/index.js";
+
+export const write = defineTool({
+  description: "Write an approved message.",
+  inputSchema: z.object({ message: z.string() }),
+  outputSchema: z.object({ written: z.string() }),
+  approval: ({ toolInput }) => (toolInput?.message ? "user-approval" : "not-applicable"),
+  label: {
+    start: (input) => `Write ${input.message}`,
+    complete: (_input, output) => `Wrote ${output.written}`,
+  },
+  execute: (input) => ({ written: input.message }),
+  toModelOutput: (output) => ({ type: "text", value: output.written }),
+});
+
+export const workflow = defineWorkflowTool({
+  description: "Run a report workflow.",
+  inputSchema: z.object({ report: z.string() }),
+  async execute(input) {
+    "use workflow";
+    return { report: input.report };
+  },
+});

--- a/packages/eve/extension-contracts/reports/connection/v16.json
+++ b/packages/eve/extension-contracts/reports/connection/v16.json
@@ -1,0 +1,16 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "connection",
+  "epoch": 16,
+  "sha256": "cb79f3f34109758cab5048bfe9b7215e0f506c82fdbb18eb5f855ce532892e98",
+  "exports": [
+    "ConnectionAuthorizationFailedError",
+    "ConnectionAuthorizationRequiredError",
+    "defineDynamic",
+    "defineInteractiveAuthorization",
+    "defineMcpClientConnection",
+    "defineOpenAPIConnection",
+    "isConnectionAuthorizationFailedError",
+    "isConnectionAuthorizationRequiredError"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/tool/v34.json
+++ b/packages/eve/extension-contracts/reports/tool/v34.json
@@ -1,0 +1,20 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "tool",
+  "epoch": 34,
+  "sha256": "3b1830764e78ac454d505f6b65cfec35ec68d339b00be025ecb495066e4e8d8b",
+  "exports": [
+    "defaultWebSearch",
+    "defineTool",
+    "defineWorkflowTool",
+    "disableTool",
+    "experimental_workflow",
+    "isDisabledToolSentinel",
+    "isExperimentalWorkflowToolDefinition",
+    "isWebSearchToolDefinition",
+    "toolOutput",
+    "toolOutputPart",
+    "toolResultFrom",
+    "webSearch"
+  ]
+}

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -22,8 +22,8 @@ interface ExtensionCapabilityContract {
 const EXTENSION_CAPABILITY_CONTRACTS = {
   extension: { current: 1, supported: [1], dropped: {} },
   tool: {
-    current: 33,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 28, 29, 30, 31, 32, 33],
+    current: 34,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 28, 29, 30, 31, 32, 33, 34],
     dropped: {
       14: "TaskExec.delegated was removed; migrate to workflow-backed background tools",
       15: "TaskExec replaces stageEffect with send",
@@ -79,8 +79,8 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     },
   },
   connection: {
-    current: 15,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 13, 14, 15],
+    current: 16,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 13, 14, 15, 16],
     dropped: {
       9: "Dynamic connection resolvers no longer receive conversation or channel continuation data",
       10: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",

--- a/packages/eve/src/execution/tools/connection-search.test.ts
+++ b/packages/eve/src/execution/tools/connection-search.test.ts
@@ -20,6 +20,7 @@ import type { ResolvedConnectionDefinition } from "#runtime/types.js";
 import { isBrandedToolEntry, type DynamicToolSet } from "#tools/dynamic.js";
 import type { DynamicResolveContext } from "#dynamic/definition.js";
 import { readDurableDynamicToolCallbacks } from "#tools/durable-callbacks.js";
+import { createRuntimeToolResultFromValue } from "#harness/action-result-helpers.js";
 import { resolveHeaders } from "#runtime/connections/mcp-client.js";
 
 function connection(name: string): ResolvedConnectionDefinition {
@@ -199,7 +200,112 @@ describe("connection dynamic tools", () => {
       "call-1",
     ]);
   });
+
+  it("projects the model-facing result while action.result keeps the full payload", async () => {
+    const fullResult = {
+      issues: [
+        { body: "b".repeat(20_000), id: "ENG-1", title: "First" },
+        { body: "b".repeat(20_000), id: "ENG-2", title: "Second" },
+      ],
+    };
+    const linear: ResolvedConnectionDefinition = {
+      ...connection("linear"),
+      toolCall: {
+        toModelOutput: {
+          list_issues: (output: typeof fullResult) => ({
+            type: "json",
+            value: { ids: output.issues.map((issue) => issue.id) },
+          }),
+        },
+      },
+    };
+
+    await withDiscoveredTools(
+      linear,
+      async () => fullResult,
+      async (tools) => {
+        const discovered = tools["linear__list_issues"]!;
+        const output = await discovered.execute({}, { callId: "call-1" } as ToolContext);
+
+        expect(output).toEqual(fullResult);
+        expect(
+          createRuntimeToolResultFromValue({
+            callId: "call-1",
+            output,
+            toolName: "linear__list_issues",
+          }).output,
+        ).toEqual(fullResult);
+        await expect(discovered.toModelOutput!(output)).resolves.toEqual({
+          type: "json",
+          value: { ids: ["ENG-1", "ENG-2"] },
+        });
+        expect(readDurableDynamicToolCallbacks(discovered)?.toModelOutput?.closure).toEqual({
+          connectionName: "linear",
+          toolName: "list_issues",
+        });
+      },
+    );
+  });
+
+  it("leaves the discovered tool unprojected when no operation is configured", async () => {
+    const linear: ResolvedConnectionDefinition = {
+      ...connection("linear"),
+      toolCall: {
+        toModelOutput: {
+          create_issue: () => ({ type: "json", value: {} }),
+        },
+      },
+    };
+
+    await withDiscoveredTools(
+      linear,
+      async () => ({ ok: true }),
+      (tools) => {
+        const discovered = tools["linear__list_issues"]!;
+
+        expect(discovered.toModelOutput).toBeUndefined();
+        expect(readDurableDynamicToolCallbacks(discovered)?.toModelOutput).toBeUndefined();
+      },
+    );
+  });
 });
+
+async function withDiscoveredTools(
+  target: ResolvedConnectionDefinition,
+  executeTool: (
+    toolName: string,
+    args: unknown,
+    options: ConnectionToolExecuteOptions,
+  ) => Promise<unknown>,
+  assert: (tools: DynamicToolSet) => Promise<void> | void,
+): Promise<void> {
+  const baseRegistry = registry({
+    connections: [target],
+    loadTools: {
+      [target.connectionName]: async () => [
+        { description: "List issues", inputSchema: { type: "object" }, name: "list_issues" },
+      ],
+    },
+  });
+  const connectionRegistry: ConnectionRegistry = {
+    ...baseRegistry,
+    getClient: (name) => ({ ...baseRegistry.getClient(name), executeTool }),
+  };
+  const ctx = new ContextContainer();
+  ctx.set(ConnectionRegistryKey, connectionRegistry);
+
+  await contextStorage.run(ctx, async () => {
+    const resolve = getConnectionSearchResolver().events["step.started"]!;
+    const resolveContext = {
+      channel: {},
+      messages: [],
+      session: { auth: { current: null, initiator: null }, id: "test-session" },
+    } satisfies DynamicResolveContext;
+    const initial = (await resolve({}, resolveContext)) as DynamicToolSet;
+    await initial["connection_search"]!.execute({ keywords: "list issues" }, {} as ToolContext);
+    await assert((await resolve({}, resolveContext)) as DynamicToolSet);
+  });
+}
 
 describe("connection_search", () => {
   it("fails when every targeted connection fails to load", async () => {

--- a/packages/eve/src/execution/tools/connection-search.ts
+++ b/packages/eve/src/execution/tools/connection-search.ts
@@ -21,6 +21,8 @@ import {
 } from "#approval/definition.js";
 import type { JsonObject } from "#shared/json.js";
 import { stampDurableDynamicToolCallbacks } from "#tools/durable-callbacks.js";
+import type { ToolModelOutput } from "#tools/model-output.js";
+import type { ConnectionToolModelOutput } from "#public/definitions/connections/tool-call.js";
 import { resolveConnectionAuthorization } from "#runtime/connections/resolve-authorization.js";
 import {
   createAuthorizationExecution,
@@ -321,6 +323,36 @@ function readDiscoveredToolClosure(closure: JsonObject): {
   return { connectionName, toolName };
 }
 
+/**
+ * Applies the connection's per-operation projection to a result the model is
+ * about to see. `action.result`, channel events, and hooks are unaffected:
+ * they observe the executor output this receives.
+ */
+async function projectDiscoveredConnectionToolOutput(
+  closure: JsonObject,
+  output: unknown,
+): Promise<ToolModelOutput> {
+  const { connectionName, toolName } = readDiscoveredToolClosure(closure);
+  const project = readConnectionToolModelOutput(connectionName, toolName);
+  if (project === undefined) {
+    throw new Error(
+      `Connection "${connectionName}" no longer defines toolCall.toModelOutput for "${toolName}".`,
+    );
+  }
+  return await project(output);
+}
+
+function readConnectionToolModelOutput(
+  connectionName: string,
+  toolName: string,
+): ConnectionToolModelOutput | undefined {
+  const registry = loadContext().get(ConnectionRegistryKey);
+  const connection = registry
+    ?.getConnections()
+    .find((candidate) => candidate.connectionName === connectionName);
+  return connection?.toolCall?.toModelOutput?.[toolName];
+}
+
 async function executeDiscoveredConnectionTool(
   closure: JsonObject,
   input: Record<string, unknown>,
@@ -420,6 +452,8 @@ export async function resolveConnectionSearchDynamicTools() {
     const approval = registry.getConnectionApproval(connectionName);
 
     const closure = { connectionName, toolName };
+    const hasModelOutputProjection =
+      readConnectionToolModelOutput(connectionName, toolName) !== undefined;
     const discoveredTool = defineTool({
       description: result.description,
       inputSchema: (result.inputSchema ?? {
@@ -430,9 +464,23 @@ export async function resolveConnectionSearchDynamicTools() {
       async execute(input: Record<string, unknown>, executeCtx) {
         return await executeDiscoveredConnectionTool(closure, input, executeCtx);
       },
+      ...(hasModelOutputProjection
+        ? {
+            toModelOutput: async (output: unknown) =>
+              await projectDiscoveredConnectionToolOutput(closure, output),
+          }
+        : {}),
     });
     stampDurableDynamicToolCallbacks(discoveredTool, {
       execute: { callback: executeDiscoveredConnectionTool, closure },
+      ...(hasModelOutputProjection
+        ? {
+            toModelOutput: {
+              callback: projectDiscoveredConnectionToolOutput,
+              closure,
+            },
+          }
+        : {}),
       ...(approval === undefined
         ? {}
         : {

--- a/packages/eve/src/internal/authored-definition/connection.test.ts
+++ b/packages/eve/src/internal/authored-definition/connection.test.ts
@@ -512,6 +512,33 @@ describe("normalizeMcpClientConnectionDefinition", () => {
     });
   });
 
+  describe("toolCall.toModelOutput validation", () => {
+    it("keeps one projection per operation name", () => {
+      const getReport = () => ({ type: "json" as const, value: { status: "ready" } });
+      const result = normalizeMcpClientConnectionDefinition(
+        validInput({
+          toolCall: {
+            providedArguments: { tenantId: "acme" },
+            toModelOutput: { getReport },
+          },
+        }),
+        MSG,
+      );
+
+      expect(result.toolCall?.providedArguments).toEqual({ tenantId: "acme" });
+      expect(result.toolCall?.toModelOutput).toEqual({ getReport });
+    });
+
+    it("rejects a non-function projection", () => {
+      expect(() =>
+        normalizeMcpClientConnectionDefinition(
+          validInput({ toolCall: { toModelOutput: { getReport: "summary" } } }),
+          MSG,
+        ),
+      ).toThrow(/toolCall\.toModelOutput\.getReport.*must be a function/);
+    });
+  });
+
   describe("tools (tool filter) validation", () => {
     it("accepts an allow filter", () => {
       const result = normalizeMcpClientConnectionDefinition(

--- a/packages/eve/src/internal/authored-definition/connection.ts
+++ b/packages/eve/src/internal/authored-definition/connection.ts
@@ -2,6 +2,7 @@ import { normalizeApproval } from "#internal/authored-definition/approval.js";
 import type { McpClientConnectionDefinition } from "#public/definitions/connections/mcp.js";
 import type { OpenAPIConnectionDefinition } from "#public/definitions/connections/openapi.js";
 import type {
+  ConnectionToModelOutputDefinition,
   ConnectionToolCallDefinition,
   ProvidedArgumentsDefinition,
 } from "#public/definitions/connections/tool-call.js";
@@ -52,7 +53,7 @@ const KNOWN_AUTHORIZATION_KEYS = [
   // canonical producer.
   "vercelConnect",
 ] as const;
-const KNOWN_TOOL_CALL_KEYS = ["providedArguments"] as const;
+const KNOWN_TOOL_CALL_KEYS = ["providedArguments", "toModelOutput"] as const;
 
 /**
  * Validates one authored MCP client connection module export at build time
@@ -131,28 +132,39 @@ function normalizeConnectionToolCall(
   );
   expectOnlyKnownKeys(toolCall, KNOWN_TOOL_CALL_KEYS, `${message} The "toolCall" field`);
 
-  if (toolCall.providedArguments === undefined) {
-    return {};
+  const result: {
+    -readonly [K in keyof ConnectionToolCallDefinition]: ConnectionToolCallDefinition[K];
+  } = {};
+
+  if (toolCall.providedArguments !== undefined) {
+    result.providedArguments = normalizeProvidedArguments(toolCall.providedArguments, message);
+  }
+  if (toolCall.toModelOutput !== undefined) {
+    result.toModelOutput = normalizeConnectionToModelOutput(toolCall.toModelOutput, message);
   }
 
+  return result;
+}
+
+function normalizeProvidedArguments(value: unknown, message: string): ProvidedArgumentsDefinition {
   const providedArguments = expectObjectRecord(
-    toolCall.providedArguments,
+    value,
     `${message} The "toolCall.providedArguments" field must be a plain object.`,
   );
 
-  for (const [key, value] of Object.entries(providedArguments)) {
-    if (typeof value === "function") {
+  for (const [key, entry] of Object.entries(providedArguments)) {
+    if (typeof entry === "function") {
       continue;
     }
     if (
-      typeof value === "object" &&
-      value !== null &&
-      typeof (value as { then?: unknown }).then === "function"
+      typeof entry === "object" &&
+      entry !== null &&
+      typeof (entry as { then?: unknown }).then === "function"
     ) {
       continue;
     }
     try {
-      parseJsonValue(value);
+      parseJsonValue(entry);
     } catch {
       throw new Error(
         `${message} The "toolCall.providedArguments.${key}" value must be JSON-serializable, a Promise, or a function.`,
@@ -160,7 +172,25 @@ function normalizeConnectionToolCall(
     }
   }
 
-  return { providedArguments: providedArguments as ProvidedArgumentsDefinition };
+  return providedArguments as ProvidedArgumentsDefinition;
+}
+
+function normalizeConnectionToModelOutput(
+  value: unknown,
+  message: string,
+): ConnectionToModelOutputDefinition {
+  const toModelOutput = expectObjectRecord(
+    value,
+    `${message} The "toolCall.toModelOutput" field must be a plain object.`,
+  );
+
+  for (const [key, entry] of Object.entries(toModelOutput)) {
+    if (typeof entry !== "function") {
+      throw new Error(`${message} The "toolCall.toModelOutput.${key}" value must be a function.`);
+    }
+  }
+
+  return toModelOutput as ConnectionToModelOutputDefinition;
 }
 
 /**

--- a/packages/eve/src/internal/authored-definition/openapi-connection.test.ts
+++ b/packages/eve/src/internal/authored-definition/openapi-connection.test.ts
@@ -24,6 +24,16 @@ describe("normalizeOpenApiConnectionDefinition", () => {
     expect(result.toolCall?.providedArguments?.tenantId).toBe(tenantId);
   });
 
+  it("preserves per-operation model-output projections", () => {
+    const getReport = () => ({ type: "json" as const, value: { status: "ready" } });
+    const result = normalizeOpenApiConnectionDefinition(
+      validInput({ toolCall: { toModelOutput: { getReport } } }),
+      MSG,
+    );
+
+    expect(result.toolCall?.toModelOutput?.getReport).toBe(getReport);
+  });
+
   describe("happy path", () => {
     it("accepts a string spec URL and base URL", () => {
       const result = normalizeOpenApiConnectionDefinition(validInput(), MSG);

--- a/packages/eve/src/public/connections/index.ts
+++ b/packages/eve/src/public/connections/index.ts
@@ -31,7 +31,9 @@ export {
   type McpClientConnectionDefinition,
 } from "#public/definitions/connections/mcp.js";
 export type {
+  ConnectionToModelOutputDefinition,
   ConnectionToolCallDefinition,
+  ConnectionToolModelOutput,
   ProvidedArgumentContext,
   ProvidedArgumentsDefinition,
   ProvidedArgumentValue,

--- a/packages/eve/src/public/definitions/connections/mcp.ts
+++ b/packages/eve/src/public/definitions/connections/mcp.ts
@@ -87,6 +87,10 @@ export interface McpClientConnectionDefinition {
    * Use `providedArguments` for application-owned values that should not be
    * controlled by the model. eve removes configured keys from the model-facing
    * input schema and adds their resolved values immediately before execution.
+   *
+   * Use `toModelOutput`, keyed by remote tool name, to shrink what the model
+   * sees of a large result. `action.result`, channel events, and hooks keep
+   * the full remote result.
    */
   toolCall?: ConnectionToolCallDefinition;
   /**

--- a/packages/eve/src/public/definitions/connections/openapi.ts
+++ b/packages/eve/src/public/definitions/connections/openapi.ts
@@ -106,6 +106,10 @@ export interface OpenAPIConnectionDefinition {
    * Use `providedArguments` for application-owned operation parameters. eve
    * removes configured keys from the model-facing input schema and adds their
    * resolved values immediately before building the HTTP request.
+   *
+   * Use `toModelOutput`, keyed by operation name, to shrink what the model
+   * sees of a large response. `action.result`, channel events, and hooks keep
+   * the full `{ status, statusText, body }` result.
    */
   toolCall?: ConnectionToolCallDefinition;
   /**

--- a/packages/eve/src/public/definitions/connections/tool-call.ts
+++ b/packages/eve/src/public/definitions/connections/tool-call.ts
@@ -1,5 +1,6 @@
 import type { SessionContext } from "#public/definitions/callback-context.js";
 import type { JsonValue } from "#public/types/json.js";
+import type { ToolModelOutput } from "#tools/model-output.js";
 
 /** Context available while resolving an application-provided connection tool argument. */
 export type ProvidedArgumentContext = SessionContext & {
@@ -23,8 +24,35 @@ export type ProvidedArgumentValue =
  */
 export type ProvidedArgumentsDefinition = Readonly<Record<string, ProvidedArgumentValue>>;
 
+/**
+ * Projects one connection tool's execution result into the model-facing
+ * result, matching an authored tool's `toModelOutput`.
+ *
+ * The remote result shape belongs to the connection, not to eve, so `output`
+ * is unchecked: annotate it with the type the operation returns. An MCP
+ * operation receives the remote tool result; an OpenAPI operation receives
+ * `{ status, statusText, body }`.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ConnectionToolModelOutput = (output: any) => ToolModelOutput | Promise<ToolModelOutput>;
+
+/**
+ * Model-facing result projections keyed by the bare tool or operation name
+ * published by the remote connection.
+ *
+ * Operations without an entry keep eve's default serialization.
+ */
+export type ConnectionToModelOutputDefinition = Readonly<Record<string, ConnectionToolModelOutput>>;
+
 /** Per-call behavior shared by tools exposed through a connection. */
 export interface ConnectionToolCallDefinition {
   /** Application-owned arguments hidden from the model and added at execution time. */
   readonly providedArguments?: ProvidedArgumentsDefinition;
+  /**
+   * Per-operation projections of the result the model sees.
+   *
+   * Only the model-facing representation changes: `action.result`, channel
+   * events, and hooks keep the full result the connection returned.
+   */
+  readonly toModelOutput?: ConnectionToModelOutputDefinition;
 }


### PR DESCRIPTION
### Summary

Related to #905. Connection tool results enter model history verbatim and are re-sent on every subsequent model call in the turn, so one large OpenAPI operation (~40 KB per response) pushed a turn past 800k input tokens and a later run was rejected with `context_length_exceeded`. Authored tools solve this with `toModelOutput`; connections expose only `providedArguments`. This adds `toolCall.toModelOutput` to MCP and OpenAPI connections — projections keyed by remote tool or operation name, reusing the authored-tool contract. Only the model-facing representation changes: `action.result`, channel events, and hooks still receive the complete remote result, and an operation without an entry is byte-identical to today.

```ts
// before: block the operation, hand-reimplement it as an authored tool,
// and give up the connection's generated input schema
operations: { block: ["getReport"] },

// after
toolCall: {
  toModelOutput: {
    getReport: (result: ReportResponse) => ({
      type: "json",
      value: { id: result.body.id, rowCount: result.body.rows.length },
    }),
  },
},
```

Deliberately excluded: the agent-level output budget #905 opens with — no ceiling, no truncation, no new config surface, no compaction changes. A projection handles a *predictably* large, well-structured result and returns a valid smaller object; a ceiling is the backstop for an *unexpectedly* large one and would cut mid-payload. The two are complementary, and the ceiling is worth designing separately.

Two decisions worth review. **Unknown operation names are inert** — remote names are not known at build time (MCP publishes at runtime, an OpenAPI `spec` URL is fetched on first use), so a projection keyed to a nonexistent operation is unused, as a `providedArguments` key or `tools.allow` entry matching nothing is today; build-time validation checks shape only. **`output` is unchecked** — eve does not own the remote result shape, so the parameter is `any` and authors annotate it, mirroring `DynamicToolEntry`'s `TOutput`.

Offered for direction-setting on question 4, not as a claim on the issue. Happy to fold it into a `research/` proposal instead.

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
