### PR TITLE
fix(eve): paginate all mcp tools

### DIFF
--- a/.changeset/seven-doors-grow.md
+++ b/.changeset/seven-doors-grow.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Paginate all MCP tools to make sure agent can discover beyond the first 50 tools

--- a/packages/eve/src/runtime/connections/mcp-client.test.ts
+++ b/packages/eve/src/runtime/connections/mcp-client.test.ts
@@ -73,6 +73,40 @@ describe("McpConnectionClient", () => {
     createMCPClient.mockReset();
   });
 
+  it("paginates tool list", async () => {
+    const listTools = vi
+      .fn()
+      .mockResolvedValueOnce({
+        nextCursor: "page-2",
+        tools: [{ description: "First tool", inputSchema: {}, name: "first" }],
+      })
+      .mockResolvedValueOnce({
+        tools: [{ description: "Second tool", inputSchema: {}, name: "second" }],
+      });
+    const toolsFromDefinitions = vi.fn().mockReturnValue({});
+    createMCPClient.mockResolvedValue({
+      close: vi.fn(),
+      listTools,
+      toolsFromDefinitions,
+    });
+
+    const mcpClient = new McpConnectionClient(makeConnection());
+
+    await expect(mcpClient.getToolMetadata()).resolves.toEqual([
+      expect.objectContaining({ name: "first" }),
+      expect.objectContaining({ name: "second" }),
+    ]);
+    expect(listTools).toHaveBeenNthCalledWith(1, { params: { cursor: undefined } });
+    expect(listTools).toHaveBeenNthCalledWith(2, { params: { cursor: "page-2" } });
+    expect(listTools).toHaveBeenCalledTimes(2);
+    expect(toolsFromDefinitions).toHaveBeenCalledWith({
+      tools: [
+        expect.objectContaining({ name: "first" }),
+        expect.objectContaining({ name: "second" }),
+      ],
+    });
+  });
+
   it("hides provided arguments from schemas and adds resolved values at execution", async () => {
     const execute = vi.fn().mockResolvedValue({ ok: true });
     const toolsFromDefinitions = vi.fn().mockReturnValue({ lookup: { execute } });

--- a/packages/eve/src/runtime/connections/mcp-client.ts
+++ b/packages/eve/src/runtime/connections/mcp-client.ts
@@ -27,6 +27,8 @@ interface McpToolCache {
   readonly tools: ToolSet;
 }
 
+type MCPToolDefinition = Awaited<ReturnType<MCPClient["listTools"]>>["tools"][number];
+
 /**
  * Wraps one `MCPClient` from `@ai-sdk/mcp` for a single connection.
  *
@@ -178,13 +180,18 @@ export class McpConnectionClient implements ConnectionClient {
 
   async #fetchToolsInner(): Promise<McpToolCache> {
     const client = await this.connect();
-    const listResult = await client.listTools();
+    const allTools: MCPToolDefinition[] = [];
+    let cursor: string | undefined;
+
+    do {
+      const page = await client.listTools({ params: { cursor } });
+      allTools.push(...page.tools);
+      cursor = page.nextCursor;
+    } while (cursor);
 
     const filter = this.#connection.tools;
     const filteredTools =
-      filter !== undefined
-        ? listResult.tools.filter((t) => passesToolFilter(t.name, filter))
-        : listResult.tools;
+      filter !== undefined ? allTools.filter((t) => passesToolFilter(t.name, filter)) : allTools;
 
     // `toolsFromDefinitions` returns `McpToolSet<"automatic">`, whose
     // elements are `Tool<unknown, CallToolResult>`. The AI SDK's


### PR DESCRIPTION
### Summary

Currently, MCP tools discovery only sees the first 50 tools per connection

### Validation

Add a connection with 50+ tools (e.g. Atlassian MCP w/ `?tools=all`) and ask agent to find one at the end of the list before vs after

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
