### PR TITLE
chore: add chadhietala as CODEOWNER

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-/packages/*/package.json @andrewbarba @ctgowrie @ruiconti @ijjk @cmpadden @prha @OwenKephart @benpankow
+/packages/*/package.json @andrewbarba @ctgowrie @ruiconti @ijjk @cmpadden @prha @OwenKephart @benpankow @chadhietala


### PR DESCRIPTION
### Summary

The package manifest ownership rule needs to include @chadhietala so review requests reach the appropriate maintainer. This adds that handle to the existing rule only; runtime behavior and package contents are unchanged.

### Validation

- `git diff --check`

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
