### PR TITLE
Add durable Slack admission and idempotent session sends

### DIFF
--- a/.changeset/durable-channel-admission.md
+++ b/.changeset/durable-channel-admission.md
@@ -1,0 +1,7 @@
+---
+"eve": patch
+---
+
+Open idle channel sessions before dispatching work and retry fixed-session sends with authenticated operation IDs. Updated session drivers suppress replayed operations; older pinned drivers reject idempotent sends before accepting them.
+
+Slack channels can persist verified mentions and DMs before acknowledgement and prepare stored input for a trusted worker.

--- a/docs/channels/custom.mdx
+++ b/docs/channels/custom.mdx
@@ -78,6 +78,35 @@ contains `sessionId` directly.
 `from()`, `resolveSession()`, and `rekey()`. Framework namespace prefixes are not
 part of the authored channel API.
 
+## Durable application inboxes
+
+When an application owns a durable incoming-event queue, allocate the session before sending
+work. `from(address).open(options)` opens an idle conversation and waits 100 times with 100 ms between attempts for
+the canonical owner. It creates no model turn. Persist the returned session ID with the verified
+event, then use `attachSession(sessionId).send(message, { auth, operationId })` for each retry.
+
+```ts
+const session = await from(threadId).open({ auth });
+// Persist session.id with the event before the first send.
+const result = await attachSession(session.id).send(message, {
+  auth,
+  operationId: eventId,
+  turnPolicy: "queue",
+});
+```
+
+Operation IDs require an authenticated principal and contain 1–512 characters. They are scoped
+to the immutable session and principal. The first payload wins; retries return the same delivery
+identity and cannot start another turn. Events carry that delivery ID for result reconciliation.
+The guarantee lasts for the session's retained workflow history. A driver started by an older
+deployment rejects idempotent sends before accepting them.
+
+If a send returns `session_not_active`, inspect the recorded session's transcript or surface an
+unresolved delivery. Keep the recorded session ID: resolving the channel address again could
+select a replacement session and execute the work twice. `open()` can be retried after timeout;
+startup candidates are idle, and only the canonical owner is returned. A durable inbox still
+owns verified-event persistence before acknowledgement, retry scheduling, and reply reconciliation.
+
 ## Channel operations and session handles
 
 Channel operations are dynamic: every call targets whichever session currently

--- a/docs/channels/custom.mdx
+++ b/docs/channels/custom.mdx
@@ -451,3 +451,9 @@ The framework handles staging bytes to the sandbox, enforcing upload policy, hyd
 - [Auth & route protection](../guides/auth-and-route-protection)
 - [Durable cross-channel notifications](../patterns/durable-cross-channel-notifications): deliver a provider message without starting an agent turn
 - [Universal Commerce Protocol (UCP)](../protocols/ucp): serve a UCP profile from a custom channel
+
+`Session.getStreamTailIndex()` throws `SessionHistoryUnavailableError` (from `eve/channels`)
+when the provider reports the exact run missing or expired. Keep that admission unresolved and
+surface its reference; do not create a replacement to replay it. Transient provider read failures
+remain retryable errors. An admitted operation can also be safely retried with the same exact
+session, principal and `operationId` to detect `session_not_active` without executing another turn.

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -473,3 +473,40 @@ Staged files live in the session sandbox under `/workspace/attachments`. Session
 
 - [Channels overview](./overview): the channel contract and every built-in channel
 - [Auth & route protection](../guides/auth-and-route-protection): authenticating inbound traffic
+
+## Durable incoming requests
+
+Use `admitMessage` when the application must retain mentions and DMs before acknowledgement:
+
+```ts
+const slack = slackChannel({
+  credentials,
+  async admitMessage(message, { waitUntil }) {
+    const record = await inbox.persist(message);
+    waitUntil(wakeWorker(record.id));
+  },
+  onAppMention: authorizeMessage,
+  onDirectMessage: authorizeMessage,
+});
+```
+
+The hook receives a verified, normalized `SlackAdmittedMessage`, without verification headers
+or bot credentials. It is awaited before HTTP 200; a thrown error returns HTTP 503 so the
+provider can retry. Persist by workspace and event ID. HTTP-timeout retries reach the hook too.
+The hook replaces automatic dispatch for mentions and DMs. Other events and interactive
+callbacks retain their existing handlers. Without this option, acknowledgement remains asynchronous.
+
+From an authenticated worker in the same channel, call `slack.prepareMessage(record.message, { from, resolveSession })`. This runs the authored admission hook and prepares attribution,
+context, attachments and audience without opening a session or sending input. Hooks used with
+preparation must not send messages themselves. A `null` result means the application intentionally
+ignored the input; failures propagate for retry. Persist the JSON-safe prepared result before
+opening a session, so later retries reuse the same authorized payload.
+
+Open with `from(address).open({ auth: prepared.options.auth ?? null, state: prepared.state })`,
+persist the returned exact session ID, then send using `attachSession(id).send(prepared.message, { ...prepared.options, auth: prepared.options.auth ?? null, operationId })`. Keep the thread
+address from `slackContinuationToken(message.channelId, message.threadTs)`.
+
+Compute and persist correlation before the send using `getSessionOperationDeliveryId({ sessionId, operationId, auth })` from `eve/channels`. It returns the same ID as accepted sends and lets
+maintenance find a completed turn even when the send response was lost. The application owns
+retry scheduling, trusted storage, expiry handling and reply recovery. See
+[durable application inboxes](./custom#durable-application-inboxes) for identity and retention limits.

--- a/e2e/fixtures/agent-channels/agent/channels/admission.ts
+++ b/e2e/fixtures/agent-channels/agent/channels/admission.ts
@@ -1,0 +1,35 @@
+import { defineChannel, POST } from "eve/channels";
+
+const auth = {
+  attributes: {},
+  authenticator: "admission-eval",
+  principalId: "eval",
+  principalType: "service",
+} as const;
+
+export default defineChannel({
+  routes: [
+    POST("/admission", async (request, ctx) => {
+      const body = (await request.json()) as {
+        address: string;
+        sessionId?: string;
+        operationId?: string;
+        message?: string;
+      };
+      if (body.sessionId === undefined) {
+        const session = await ctx.from(body.address).open({ auth });
+        return Response.json({ sessionId: session.id });
+      }
+      const session = await ctx.resolveSession(body.address);
+      if (session?.id !== body.sessionId)
+        return new Response("Session does not own this address", { status: 409 });
+      return Response.json(
+        await ctx.attachSession(body.sessionId).send(body.message ?? "", {
+          auth,
+          operationId: body.operationId,
+          turnPolicy: "queue",
+        }),
+      );
+    }),
+  ],
+});

--- a/e2e/fixtures/agent-channels/agent/channels/admission.ts
+++ b/e2e/fixtures/agent-channels/agent/channels/admission.ts
@@ -15,14 +15,14 @@ export default defineChannel({
         sessionId?: string;
         operationId?: string;
         message?: string;
+        action?: "reset";
       };
       if (body.sessionId === undefined) {
         const session = await ctx.from(body.address).open({ auth });
         return Response.json({ sessionId: session.id });
       }
-      const session = await ctx.resolveSession(body.address);
-      if (session?.id !== body.sessionId)
-        return new Response("Session does not own this address", { status: 409 });
+      if (body.action === "reset")
+        return Response.json(await ctx.attachSession(body.sessionId).reset());
       return Response.json(
         await ctx.attachSession(body.sessionId).send(body.message ?? "", {
           auth,

--- a/e2e/fixtures/agent-channels/evals/custom-channels/durable-admission.eval.ts
+++ b/e2e/fixtures/agent-channels/evals/custom-channels/durable-admission.eval.ts
@@ -36,5 +36,28 @@ export default defineEval({
       count: 1,
       data: { message: "Reply with exactly: second-operation" },
     });
+    await postChannel(t.target, "/admission", { ...request, action: "reset" });
+    const retired = await postChannel<{ status: string }>(t.target, "/admission", request);
+    await t.require(retired.status, equals("session_not_active"));
+    const replacement = await postChannel<{ sessionId: string }>(t.target, "/admission", {
+      address,
+    });
+    await t.require(replacement.sessionId === first.sessionId, equals(false));
+    const afterReplacement = await postChannel<{ status: string }>(t.target, "/admission", request);
+    await t.require(afterReplacement.status, equals("session_not_active"));
+    await postChannel(t.target, "/admission", {
+      address,
+      sessionId: replacement.sessionId,
+      operationId: "new-request",
+      message: "Alice opened a new conversation. Reply with exactly: replacement-ready",
+    });
+    const replacementTurn = await t.target.watchTurn(replacement.sessionId).result();
+    replacementTurn.expectOk();
+    replacementTurn.event("message.received", {
+      count: 1,
+      data: {
+        message: "Alice opened a new conversation. Reply with exactly: replacement-ready",
+      },
+    });
   },
 });

--- a/e2e/fixtures/agent-channels/evals/custom-channels/durable-admission.eval.ts
+++ b/e2e/fixtures/agent-channels/evals/custom-channels/durable-admission.eval.ts
@@ -1,0 +1,40 @@
+import { defineEval } from "eve/evals";
+import { equals } from "eve/evals/expect";
+import { postChannel } from "./shared";
+
+export default defineEval({
+  description:
+    "Idle session allocation and replayed fixed-session admission produce one turn per operation.",
+  async test(t) {
+    const address = `admission-${crypto.randomUUID()}`;
+    const [first, concurrent] = await Promise.all([
+      postChannel<{ sessionId: string }>(t.target, "/admission", { address }),
+      postChannel<{ sessionId: string }>(t.target, "/admission", { address }),
+    ]);
+    await t.require(first.sessionId, equals(concurrent.sessionId));
+    const request = {
+      address,
+      sessionId: first.sessionId,
+      operationId: "one",
+      message: "Reply with exactly: admitted-once",
+    };
+    const accepted = await postChannel<{ deliveryId: string }>(t.target, "/admission", request);
+    const turn = await t.target.watchTurn(first.sessionId).result();
+    turn.expectOk();
+    turn.event("message.received", { count: 1, data: { message: request.message } });
+    const replay = await postChannel<{ deliveryId: string }>(t.target, "/admission", request);
+    await t.require(replay.deliveryId, equals(accepted.deliveryId));
+    const next = t.target.watchTurn(first.sessionId, { startIndex: turn.events.length });
+    await postChannel(t.target, "/admission", {
+      ...request,
+      operationId: "two",
+      message: "Reply with exactly: second-operation",
+    });
+    const second = await next.result();
+    second.expectOk();
+    second.event("message.received", {
+      count: 1,
+      data: { message: "Reply with exactly: second-operation" },
+    });
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/channel/v19.ts
+++ b/packages/eve/extension-contracts/compatibility/channel/v19.ts
@@ -1,0 +1,14 @@
+import { defineChannel, POST } from "#public/channels/index.js";
+
+export default defineChannel({
+  routes: [
+    POST("/message", async (_request, { from }) => {
+      const session = await from("shared-thread").send("Hello", {
+        auth: null,
+        turnPolicy: "queue",
+      });
+      await session.send("Follow up", { auth: null, turnPolicy: "queue" });
+      return Response.json({ sessionId: session.id });
+    }),
+  ],
+});

--- a/packages/eve/extension-contracts/compatibility/schedule/v11.ts
+++ b/packages/eve/extension-contracts/compatibility/schedule/v11.ts
@@ -1,0 +1,8 @@
+import { defineSchedule } from "#public/schedules/index.js";
+
+export default defineSchedule({
+  cron: "0 9 * * *",
+  run({ waitUntil, appAuth }) {
+    waitUntil(Promise.resolve(appAuth.principalId));
+  },
+});

--- a/packages/eve/extension-contracts/entrypoints/channel.ts
+++ b/packages/eve/extension-contracts/entrypoints/channel.ts
@@ -9,6 +9,7 @@ export {
   WS,
   createWebSocketUpgradeServer,
   defineChannel,
+  getSessionOperationDeliveryId,
   disableRoute,
   isChannel,
   isDisabledRouteSentinel,

--- a/packages/eve/extension-contracts/entrypoints/channel.ts
+++ b/packages/eve/extension-contracts/entrypoints/channel.ts
@@ -5,6 +5,7 @@ export {
   OPTIONS,
   PATCH,
   POST,
+  SessionHistoryUnavailableError,
   PUT,
   WS,
   createWebSocketUpgradeServer,

--- a/packages/eve/extension-contracts/reports/channel/v20.json
+++ b/packages/eve/extension-contracts/reports/channel/v20.json
@@ -1,0 +1,22 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "channel",
+  "epoch": 20,
+  "sha256": "4dd310ef5ae69a81f80326508d4a4ccffeae6254713b2b5fc9d3e0ea550a2d6a",
+  "exports": [
+    "DELETE",
+    "GET",
+    "HEAD",
+    "OPTIONS",
+    "PATCH",
+    "POST",
+    "PUT",
+    "WS",
+    "createWebSocketUpgradeServer",
+    "defineChannel",
+    "disableRoute",
+    "getSessionOperationDeliveryId",
+    "isChannel",
+    "isDisabledRouteSentinel"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/channel/v20.json
+++ b/packages/eve/extension-contracts/reports/channel/v20.json
@@ -2,7 +2,7 @@
   "kind": "eve-extension-capability-contract",
   "capability": "channel",
   "epoch": 20,
-  "sha256": "4dd310ef5ae69a81f80326508d4a4ccffeae6254713b2b5fc9d3e0ea550a2d6a",
+  "sha256": "8bc482f793ab409f67a46e2e1740faa30b510ed4789a6683d05ec490dd483b10",
   "exports": [
     "DELETE",
     "GET",
@@ -11,6 +11,7 @@
     "PATCH",
     "POST",
     "PUT",
+    "SessionHistoryUnavailableError",
     "WS",
     "createWebSocketUpgradeServer",
     "defineChannel",

--- a/packages/eve/extension-contracts/reports/schedule/v12.json
+++ b/packages/eve/extension-contracts/reports/schedule/v12.json
@@ -1,0 +1,14 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "schedule",
+  "epoch": 12,
+  "sha256": "75307e94f5d7286b9e7dc9e6fa2e576e315d83035638637d935262bef797348b",
+  "exports": [
+    "ScheduleDefinition",
+    "ScheduleHandlerArgs",
+    "ScheduleRunHandler",
+    "ScheduleToFn",
+    "TypedReceiveTarget",
+    "defineSchedule"
+  ]
+}

--- a/packages/eve/src/channel/channel-address.test.ts
+++ b/packages/eve/src/channel/channel-address.test.ts
@@ -30,6 +30,30 @@ describe("createChannelAddress", () => {
     ).toThrow("reserved session namespace");
   });
 
+  it("opens the canonical idle owner without delivering a message", async () => {
+    const runtime = createRuntime();
+    vi.mocked(runtime.resolveContinuation)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({ sessionId: "canonical" });
+    const address = createChannelAddress({
+      adapter: { kind: "slack" },
+      channelName: "slack",
+      continuationToken: "C1:T1",
+      runtime,
+    });
+    const session = await address.open({ auth: null });
+    expect(session.id).toBe("canonical");
+    expect(runtime.dispatchContinuation).not.toHaveBeenCalled();
+    expect(runtime.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        continuationToken: "slack:C1:T1",
+        startPaused: true,
+        mode: "conversation",
+        input: { message: "" },
+      }),
+    );
+  });
+
   it("sends directly through the address and returns a fixed session handle", async () => {
     const runtime = createRuntime();
     const address = createChannelAddress({

--- a/packages/eve/src/channel/channel-address.test.ts
+++ b/packages/eve/src/channel/channel-address.test.ts
@@ -34,7 +34,8 @@ describe("createChannelAddress", () => {
     const runtime = createRuntime();
     vi.mocked(runtime.resolveContinuation)
       .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce({ sessionId: "canonical" });
+      .mockResolvedValueOnce({ sessionId: "canonical" })
+      .mockResolvedValue({ sessionId: "canonical" });
     const address = createChannelAddress({
       adapter: { kind: "slack" },
       channelName: "slack",
@@ -238,3 +239,43 @@ describe("createChannelAddress", () => {
     });
   });
 });
+
+it.each([false, true])(
+  "waits for the exact owner's send inbox when the alias already exists: %s",
+  async (exists) => {
+    const runtime = createRuntime();
+    let aliasCalls = 0;
+    let stableCalls = 0;
+    let release!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    vi.mocked(runtime.resolveContinuation).mockImplementation(async (token) => {
+      if (token === "eve:session:canonical:inbox") {
+        stableCalls += 1;
+        if (stableCalls === 1) return undefined;
+        await ready;
+        return { sessionId: "canonical" };
+      }
+      aliasCalls += 1;
+      return !exists && aliasCalls === 1 ? undefined : { sessionId: "canonical" };
+    });
+    const address = createChannelAddress({
+      adapter: { kind: "slack" },
+      channelName: "slack",
+      continuationToken: "C:T",
+      runtime,
+    });
+    let returned = false;
+    const pending = address.open({ auth: null }).then((session) => {
+      returned = true;
+      return session;
+    });
+    await vi.waitFor(() => expect(stableCalls).toBe(2));
+    expect(returned).toBe(false);
+    release();
+    expect((await pending).id).toBe("canonical");
+    expect(runtime.createSession).toHaveBeenCalledTimes(exists ? 0 : 1);
+    expect(runtime.dispatchSession).not.toHaveBeenCalled();
+  },
+);

--- a/packages/eve/src/channel/channel-address.ts
+++ b/packages/eve/src/channel/channel-address.ts
@@ -23,7 +23,10 @@ import type {
   TurnPolicy,
 } from "#channel/types.js";
 import { DEFAULT_TURN_POLICY } from "#channel/types.js";
-import { isReservedSessionCommandToken } from "#execution/session-command-token.js";
+import {
+  isReservedSessionCommandToken,
+  sessionCommandHookToken,
+} from "#execution/session-command-token.js";
 import type { RunMode } from "#shared/run-mode.js";
 
 interface BaseChannelAddressDeliveryOptions {
@@ -90,27 +93,32 @@ export function createChannelAddress<TState = undefined>(input: {
         throw new Error("open() requires conversation mode.");
       }
       const existing = await this.resolveSession();
-      if (existing !== undefined) return existing;
-      const adapter = adapterWithState(
-        input.adapter,
-        (options as { readonly state?: TState }).state,
-      );
-      await input.runtime.createSession({
-        adapter,
-        auth: options.auth,
-        capabilities: { requestInput: true },
-        channelName: input.channelName,
-        continuationToken: namespacedToken,
-        initiatorAuth: options.initiatorAuth,
-        input: { message: "" },
-        mode: "conversation",
-        startPaused: true,
-        requestId: metadata.requestId,
-        title: options.title,
-      });
+      if (existing === undefined) {
+        const adapter = adapterWithState(
+          input.adapter,
+          (options as { readonly state?: TState }).state,
+        );
+        await input.runtime.createSession({
+          adapter,
+          auth: options.auth,
+          capabilities: { requestInput: true },
+          channelName: input.channelName,
+          continuationToken: namespacedToken,
+          initiatorAuth: options.initiatorAuth,
+          input: { message: "" },
+          mode: "conversation",
+          startPaused: true,
+          requestId: metadata.requestId,
+          title: options.title,
+        });
+      }
       for (let attempt = 0; attempt < 100; attempt += 1) {
-        const owner = await this.resolveSession();
-        if (owner !== undefined) return owner;
+        const owner =
+          attempt === 0 && existing !== undefined ? existing : await this.resolveSession();
+        if (owner !== undefined) {
+          const inbox = await input.runtime.resolveContinuation(sessionCommandHookToken(owner.id));
+          if (inbox?.sessionId === owner.id) return owner;
+        }
         await setTimeout(100);
       }
       throw new Error(

--- a/packages/eve/src/channel/channel-address.ts
+++ b/packages/eve/src/channel/channel-address.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from "node:timers/promises";
 import type { UserContent } from "ai";
 
 import type { ChannelAdapter } from "#channel/adapter.js";
@@ -45,6 +46,7 @@ export type ChannelAddressDeliveryOptions<TState = undefined> = [TState] extends
  */
 export interface ChannelAddress<TState = undefined> {
   readonly continuationToken: string;
+  open(options: ChannelAddressDeliveryOptions<TState>): Promise<Session>;
   deliver(input: SendPayload, options: ChannelAddressDeliveryOptions<TState>): Promise<Session>;
   send(
     message: string | UserContent,
@@ -83,6 +85,43 @@ export function createChannelAddress<TState = undefined>(input: {
 
   return {
     continuationToken: input.continuationToken,
+    async open(options) {
+      if (options.mode !== undefined && options.mode !== "conversation") {
+        throw new Error("open() requires conversation mode.");
+      }
+      const existing = await this.resolveSession();
+      if (existing !== undefined) return existing;
+      const state = (options as { readonly state?: TState }).state;
+      const adapter =
+        state === undefined
+          ? input.adapter
+          : {
+              ...input.adapter,
+              state: { ...input.adapter.state, ...(state as Record<string, unknown>) },
+            };
+      if (adapter !== input.adapter) copyChannelActivityPresentation(input.adapter, adapter);
+      await input.runtime.createSession({
+        adapter,
+        auth: options.auth,
+        capabilities: { requestInput: true },
+        channelName: input.channelName,
+        continuationToken: namespacedToken,
+        initiatorAuth: options.initiatorAuth,
+        input: { message: "" },
+        mode: "conversation",
+        startPaused: true,
+        requestId: metadata.requestId,
+        title: options.title,
+      });
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        const owner = await this.resolveSession();
+        if (owner !== undefined) return owner;
+        await setTimeout(100);
+      }
+      throw new Error(
+        "Session ownership is not available yet. Retry open() without sending a message.",
+      );
+    },
     async deliver(sendInput, options) {
       const delivery =
         metadata.channelKind !== undefined && metadata.channelName !== undefined

--- a/packages/eve/src/channel/channel-address.ts
+++ b/packages/eve/src/channel/channel-address.ts
@@ -91,15 +91,10 @@ export function createChannelAddress<TState = undefined>(input: {
       }
       const existing = await this.resolveSession();
       if (existing !== undefined) return existing;
-      const state = (options as { readonly state?: TState }).state;
-      const adapter =
-        state === undefined
-          ? input.adapter
-          : {
-              ...input.adapter,
-              state: { ...input.adapter.state, ...(state as Record<string, unknown>) },
-            };
-      if (adapter !== input.adapter) copyChannelActivityPresentation(input.adapter, adapter);
+      const adapter = adapterWithState(
+        input.adapter,
+        (options as { readonly state?: TState }).state,
+      );
       await input.runtime.createSession({
         adapter,
         auth: options.auth,
@@ -166,15 +161,10 @@ export function createChannelAddress<TState = undefined>(input: {
         );
       }
 
-      const state = (options as { readonly state?: TState }).state;
-      const adapter =
-        state === undefined
-          ? input.adapter
-          : {
-              ...input.adapter,
-              state: { ...input.adapter.state, ...(state as Record<string, unknown>) },
-            };
-      if (adapter !== input.adapter) copyChannelActivityPresentation(input.adapter, adapter);
+      const adapter = adapterWithState(
+        input.adapter,
+        (options as { readonly state?: TState }).state,
+      );
       const capabilities: RunInput["capabilities"] =
         options.mode === "task" ? undefined : { requestInput: true };
       const runInput: RunInput = {
@@ -256,4 +246,14 @@ export function createChannelAddressFn<TState = undefined>(input: {
   readonly turnPolicy?: TurnPolicy;
 }): ChannelAddressFn<TState> {
   return (continuationToken) => createChannelAddress({ ...input, continuationToken });
+}
+
+function adapterWithState<TState>(
+  adapter: ChannelAdapter<any>,
+  state: TState | undefined,
+): ChannelAdapter<any> {
+  if (state === undefined) return adapter;
+  const merged = { ...adapter, state: { ...adapter.state, ...(state as Record<string, unknown>) } };
+  copyChannelActivityPresentation(adapter, merged);
+  return merged;
 }

--- a/packages/eve/src/channel/channel-operations.ts
+++ b/packages/eve/src/channel/channel-operations.ts
@@ -52,8 +52,16 @@ interface BaseChannelRespondOptions<TState = undefined> {
 /** Options for answering pending input requests at an existing continuation address. */
 export type ChannelRespondOptions<TState = undefined> = BaseChannelRespondOptions<TState>;
 
+/** Session allocation options; messages and turn callbacks belong to a later send. */
+export type ChannelOpenOptions<TState = undefined> = Omit<
+  ChannelSendOptions<TState>,
+  "callback" | "context" | "mode" | "outputSchema" | "turnPolicy"
+>;
+
 /** Dynamic handle for whichever session currently owns one channel-local address. */
 export interface ChannelSource<TState = undefined> {
+  /** Opens an idle conversation, returning its canonical owner without starting a turn. */
+  open(options: ChannelOpenOptions<TState>): Promise<Session>;
   /** Starts or resumes a turn with a user message. May create a session. */
   send(message: string | UserContent, options: ChannelSendOptions<TState>): Promise<Session>;
   /** Answers pending input requests. Never creates a session. */
@@ -107,6 +115,7 @@ export function createChannelOperations<TState = undefined>(input: {
     from(address) {
       const bound = channelAddress(address);
       const source: InternalChannelSource<TState> = {
+        open: (options) => bound.open(options),
         async send(message, options) {
           return await bound.deliver(
             {

--- a/packages/eve/src/channel/delivery-metadata.ts
+++ b/packages/eve/src/channel/delivery-metadata.ts
@@ -1,4 +1,8 @@
-import type { ChannelDeliveryMetadata, SessionTraceContext } from "#channel/types.js";
+import type {
+  ChannelDeliveryMetadata,
+  SessionAuthContext,
+  SessionTraceContext,
+} from "#channel/types.js";
 
 export interface ChannelDeliverySource {
   readonly acceptedDeploymentId?: string;
@@ -32,4 +36,51 @@ export function createChannelDeliveryMetadata(
     metadata.requestTraceContext = source.requestTraceContext;
   }
   return metadata;
+}
+
+/** Binds a caller-owned operation to one immutable session and authenticated principal. */
+export async function createSessionOperationDelivery(input: {
+  readonly auth: SessionAuthContext | null;
+  readonly operationId: string;
+  readonly sessionId: string;
+  readonly source?: Partial<ChannelDeliverySource>;
+}): Promise<ChannelDeliveryMetadata> {
+  const deliveryId = await getSessionOperationDeliveryId(input);
+  return {
+    ...createChannelDeliveryMetadata({
+      ...input.source,
+      channelKind: input.source?.channelKind ?? "session",
+      channelName: input.source?.channelName ?? "session",
+    }),
+    deliveryId,
+  };
+}
+
+/** Computes correlation before sending, including when an accepted send response is lost.
+ * Persist this with the exact session ID; never reuse the operation in a replacement session. */
+export async function getSessionOperationDeliveryId(input: {
+  readonly auth: SessionAuthContext | null;
+  readonly operationId: string;
+  readonly sessionId: string;
+}): Promise<string> {
+  if (input.auth === null || input.auth.principalType === "anonymous") {
+    throw new Error("operationId requires an authenticated principal.");
+  }
+  if (input.operationId.length === 0 || input.operationId.length > 512) {
+    throw new Error("operationId must contain between 1 and 512 characters.");
+  }
+  const identity = JSON.stringify([
+    "eve:session-send:v1",
+    input.sessionId,
+    input.auth.authenticator,
+    input.auth.issuer ?? null,
+    input.auth.principalType,
+    input.auth.principalId,
+    input.operationId,
+  ]);
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(identity));
+  const hex = Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join(
+    "",
+  );
+  return `operation:${hex}`;
 }

--- a/packages/eve/src/channel/session-history.ts
+++ b/packages/eve/src/channel/session-history.ts
@@ -1,0 +1,11 @@
+/** The provider no longer retains this exact session's history. Transient read failures use their original errors. */
+export class SessionHistoryUnavailableError extends Error {
+  readonly sessionId: string;
+  constructor(sessionId: string) {
+    super(
+      `History for session ${JSON.stringify(sessionId)} is no longer available. Preserve its admission as unresolved; do not resend it to a replacement session.`,
+    );
+    this.sessionId = sessionId;
+    this.name = "SessionHistoryUnavailableError";
+  }
+}

--- a/packages/eve/src/channel/session.test.ts
+++ b/packages/eve/src/channel/session.test.ts
@@ -84,6 +84,60 @@ describe("createSession#cancel", () => {
   });
 });
 
+describe("idempotent fixed-session sends", () => {
+  it("retains a caller's operation identity after reconstructing the session handle", async () => {
+    const runtime = createRuntime();
+    const auth = {
+      attributes: {},
+      authenticator: "slack-webhook",
+      principalId: "slack:T1:U1",
+      principalType: "user",
+    };
+    const options = { auth, operationId: "slack:Ev1" };
+    await createSession("sess_1", runtime).send("hello", options);
+    await createSession("sess_1", runtime).send("hello", options);
+    const calls = vi.mocked(runtime.dispatchSession).mock.calls;
+    const deliveries = calls.map(([input]) =>
+      input.command.kind === "send" ? input.command.delivery : undefined,
+    );
+    expect(deliveries[0]?.deliveryId).toEqual(expect.any(String));
+    expect(deliveries[1]?.deliveryId).toBe(deliveries[0]?.deliveryId);
+  });
+});
+
+describe("session operation identity", () => {
+  it("separates principals, sessions, and operation ids", async () => {
+    const runtime = createRuntime();
+    const auth = {
+      attributes: {},
+      authenticator: "slack-webhook",
+      principalId: "slack:T1:U1",
+      principalType: "user",
+    };
+    await createSession("s1", runtime).send("one", { auth, operationId: "one" });
+    await createSession("s1", runtime).send("one", {
+      auth: { ...auth, principalId: "slack:T1:U2" },
+      operationId: "one",
+    });
+    await createSession("s2", runtime).send("one", { auth, operationId: "one" });
+    await createSession("s1", runtime).send("two", { auth, operationId: "two" });
+    const ids = vi
+      .mocked(runtime.dispatchSession)
+      .mock.calls.map(([input]) =>
+        input.command.kind === "send" ? input.command.delivery?.deliveryId : undefined,
+      );
+    expect(new Set(ids).size).toBe(4);
+  });
+
+  it("rejects unauthenticated operation ids before dispatch", async () => {
+    const runtime = createRuntime();
+    await expect(
+      createSession("s1", runtime).send("one", { auth: null, operationId: "one" }),
+    ).rejects.toThrow("authenticated principal");
+    expect(runtime.dispatchSession).not.toHaveBeenCalled();
+  });
+});
+
 describe("fixed session operations", () => {
   it("dispatches ephemeral context separately from durable channel context", async () => {
     const runtime = createRuntime();

--- a/packages/eve/src/channel/session.ts
+++ b/packages/eve/src/channel/session.ts
@@ -1,6 +1,7 @@
 import type { ContextAccessor } from "#context/key.js";
 import {
   createChannelDeliveryMetadata,
+  createSessionOperationDelivery,
   type ChannelDeliverySource,
 } from "#channel/delivery-metadata.js";
 import type { MessageStreamEvent } from "#protocol/message.js";
@@ -70,7 +71,11 @@ interface SessionDeliveryOptions {
 }
 
 /** Options for sending a message through a fixed session handle. */
-export type SessionSendOptions = SessionDeliveryOptions & { readonly turnPolicy?: TurnPolicy };
+export type SessionSendOptions = SessionDeliveryOptions & {
+  /** Replay-stable identity scoped to this exact session and authenticated principal. */
+  readonly operationId?: string;
+  readonly turnPolicy?: TurnPolicy;
+};
 
 /** Options for answering pending input requests through a fixed session handle. */
 export type SessionRespondOptions = SessionDeliveryOptions;
@@ -99,7 +104,15 @@ export function createSession(
   return {
     id,
     async send(message, options) {
-      const delivery = createDelivery(metadata);
+      const delivery =
+        options.operationId === undefined
+          ? createDelivery(metadata)
+          : await createSessionOperationDelivery({
+              auth: options.auth,
+              operationId: options.operationId,
+              sessionId: id,
+              source: metadata,
+            });
       const caller = sessionCallbackToTurnCaller(options.callback, options.activityObserver);
       const payload = attachClientContext<{
         context?: readonly string[];

--- a/packages/eve/src/channel/types.ts
+++ b/packages/eve/src/channel/types.ts
@@ -453,6 +453,8 @@ export interface SessionCapabilities {
  * subagent tool wrapper).
  */
 export interface RunInput {
+  /** Create an idle conversation that waits for its first explicit send. */
+  readonly startPaused?: boolean;
   readonly adapter: ChannelAdapter<any>;
   /** Framework task that owns this run, when the run is a task executor. */
   readonly taskId?: string;

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -56,15 +56,15 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     },
   },
   channel: {
-    current: 19,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19],
+    current: 20,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19, 20],
     dropped: {
       12: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",
     },
   },
   schedule: {
-    current: 11,
-    supported: [1, 2, 3, 4, 6, 7, 8, 9, 10, 11],
+    current: 12,
+    supported: [1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12],
     dropped: {
       5: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",
     },

--- a/packages/eve/src/execution/channel-delivery-dedup.ts
+++ b/packages/eve/src/execution/channel-delivery-dedup.ts
@@ -1,0 +1,14 @@
+import type { DeliverHookPayload } from "#channel/types.js";
+
+/** Channel operations and task deliveries occupy distinct identities in the driver's replay ledger. */
+export function acceptChannelOperation(
+  delivery: Pick<DeliverHookPayload, "deliveryMetadata">,
+  seen: Set<string>,
+): boolean {
+  const keys = (delivery.deliveryMetadata ?? [])
+    .filter((entry) => entry.deliveryId.startsWith("operation:"))
+    .map((entry) => `channel:${entry.deliveryId}`);
+  if (keys.some((key) => seen.has(key))) return false;
+  for (const key of keys) seen.add(key);
+  return true;
+}

--- a/packages/eve/src/execution/inline-turn.ts
+++ b/packages/eve/src/execution/inline-turn.ts
@@ -1,3 +1,4 @@
+import { acceptChannelOperation } from "#execution/channel-delivery-dedup.js";
 import type { DeliverHookPayload, HookPayload, SessionCapabilities } from "#channel/types.js";
 import { readAcceptedDeploymentId } from "#execution/accepted-delivery-deployment.js";
 import { cancelAllIndexedSessionTasksStep } from "#execution/cancel-indexed-session-tasks-step.js";
@@ -39,7 +40,7 @@ export async function runInlineTurn(input: {
   readonly delivery: HookPayload;
   readonly mode: RunMode;
   readonly parentWritable: WritableStream<Uint8Array>;
-  readonly seenTaskDeliveries?: Set<string>;
+  readonly seenDeliveries?: Set<string>;
   readonly serializedContext: Record<string, unknown>;
   readonly sessionState: DurableSessionState;
   readonly stateCursor?: SessionStateCursor;
@@ -59,7 +60,7 @@ export async function runInlineTurn(input: {
     cancelledTaskIds: input.cancelledTaskIds,
     commandInbox: input.commandInbox,
     expectedTurnId: activeTurnId(input.sessionState.emissionState),
-    seenTaskDeliveries: input.seenTaskDeliveries,
+    seenDeliveries: input.seenDeliveries,
     stateCursor: cursor,
   });
   let nextStepInput: TurnStepPayload | undefined = input.delivery;
@@ -164,7 +165,7 @@ class InlineTurnControl {
   private readonly commandInbox: SessionCommandInbox;
   private readonly controller = new AbortController();
   private readonly expectedTurnId: string;
-  private readonly seenTaskDeliveries: Set<string>;
+  private readonly seenDeliveries: Set<string>;
   private readonly stateCursor: SessionStateCursor;
   private cancellation: TurnCancelPayload | undefined;
 
@@ -174,7 +175,7 @@ class InlineTurnControl {
     readonly cancelledTaskIds?: Set<string>;
     readonly commandInbox: SessionCommandInbox;
     readonly expectedTurnId: string;
-    readonly seenTaskDeliveries?: Set<string>;
+    readonly seenDeliveries?: Set<string>;
     readonly stateCursor: SessionStateCursor;
   }) {
     this.bufferedDeliveries = input.bufferedDeliveries;
@@ -182,7 +183,7 @@ class InlineTurnControl {
     this.cancelledTaskIds = input.cancelledTaskIds ?? new Set();
     this.commandInbox = input.commandInbox;
     this.expectedTurnId = input.expectedTurnId;
-    this.seenTaskDeliveries = input.seenTaskDeliveries ?? new Set();
+    this.seenDeliveries = input.seenDeliveries ?? new Set();
     this.stateCursor = input.stateCursor;
   }
 
@@ -217,11 +218,12 @@ class InlineTurnControl {
   }
 
   private acceptTaskDelivery(command: DeliverHookPayload): boolean {
+    if (!acceptChannelOperation(command, this.seenDeliveries)) return false;
     const deliveryId = command.taskDeliveryId ?? command.caller?.taskId;
     if (deliveryId === undefined) return true;
     if (this.originatesFromCancelledTask(deliveryId)) return false;
-    if (this.seenTaskDeliveries.has(deliveryId)) return false;
-    this.seenTaskDeliveries.add(deliveryId);
+    if (this.seenDeliveries.has(deliveryId)) return false;
+    this.seenDeliveries.add(deliveryId);
     return true;
   }
 

--- a/packages/eve/src/execution/parked-delivery-wait.ts
+++ b/packages/eve/src/execution/parked-delivery-wait.ts
@@ -1,3 +1,4 @@
+import { acceptChannelOperation } from "#execution/channel-delivery-dedup.js";
 import type { DeliverHookPayload, DeliverPayload } from "#channel/types.js";
 import { jsonValuesEqual } from "#shared/json.js";
 import { cancelAllIndexedSessionTasksStep } from "#execution/cancel-indexed-session-tasks-step.js";
@@ -70,7 +71,7 @@ export async function nextTurnDelivery(input: {
   readonly commandInbox: SessionCommandInbox;
   readonly deferDeliveries?: boolean;
   readonly driverWritable: WritableStream<Uint8Array>;
-  readonly seenTaskDeliveries?: Set<string>;
+  readonly seenDeliveries?: Set<string>;
   readonly stateCursor: SessionStateCursor;
 }): Promise<NextTurnInstruction> {
   if (input.awaitAuthorizationCallbacks !== true) {
@@ -92,11 +93,11 @@ async function awaitNextTurnDelivery(input: {
   readonly commandInbox: SessionCommandInbox;
   readonly deferDeliveries?: boolean;
   readonly driverWritable: WritableStream<Uint8Array>;
-  readonly seenTaskDeliveries?: Set<string>;
+  readonly seenDeliveries?: Set<string>;
   readonly stateCursor: SessionStateCursor;
 }): Promise<NextTurnInstruction> {
   const cancelledTaskIds = input.cancelledTaskIds ?? new Set<string>();
-  const seenTaskDeliveries = input.seenTaskDeliveries ?? new Set<string>();
+  const seenDeliveries = input.seenDeliveries ?? new Set<string>();
   while (true) {
     const nextAction = await waitForNextSessionAction({
       bufferedDeliveries: input.bufferedDeliveries,
@@ -104,7 +105,7 @@ async function awaitNextTurnDelivery(input: {
       cancelledTaskIds,
       commandInbox: input.commandInbox,
       deferDeliveries: input.deferDeliveries,
-      seenTaskDeliveries,
+      seenDeliveries,
       stateCursor: input.stateCursor,
     });
 
@@ -148,7 +149,7 @@ async function waitForNextSessionAction(input: {
   readonly cancelledTaskIds: Set<string>;
   readonly commandInbox: SessionCommandInbox;
   readonly deferDeliveries?: boolean;
-  readonly seenTaskDeliveries: Set<string>;
+  readonly seenDeliveries: Set<string>;
   readonly stateCursor: SessionStateCursor;
 }): Promise<NextSessionAction> {
   const pendingSessionControl = input.bufferedSessionControls.shift();
@@ -238,13 +239,15 @@ async function waitForNextSessionAction(input: {
       continue;
     }
 
+    if (!acceptChannelOperation(decoded, input.seenDeliveries)) continue;
+
     const deliveryId = decoded.taskDeliveryId ?? decoded.caller?.taskId;
     if (deliveryId !== undefined && isCancelledTaskDeliveryId(deliveryId, input.cancelledTaskIds)) {
       continue;
     }
     if (deliveryId !== undefined) {
-      if (input.seenTaskDeliveries.has(deliveryId)) continue;
-      input.seenTaskDeliveries.add(deliveryId);
+      if (input.seenDeliveries.has(deliveryId)) continue;
+      input.seenDeliveries.add(deliveryId);
     }
 
     if (input.deferDeliveries === true) {

--- a/packages/eve/src/execution/session-callback-request.test.ts
+++ b/packages/eve/src/execution/session-callback-request.test.ts
@@ -59,7 +59,18 @@ describe("postSessionCallbackRequest", () => {
         }),
       );
       const logged = JSON.stringify(errorSpy.mock.calls);
-      for (const secret of ["private", "password", "user:", "secret=query", "fragment"]) {
+      for (const secret of [
+        "private response body",
+        "private update",
+        "private result",
+        "private failure",
+        "private-body-token",
+        "private-token",
+        "password",
+        "user:",
+        "secret=query",
+        "fragment",
+      ]) {
         expect(logged).not.toContain(secret);
       }
     },

--- a/packages/eve/src/execution/session-command-inbox.test.ts
+++ b/packages/eve/src/execution/session-command-inbox.test.ts
@@ -123,7 +123,11 @@ describe("createSessionCommandInbox", () => {
     );
     expect(createHookMock).toHaveBeenCalledOnce();
     expect(createHookMock).toHaveBeenCalledWith({
-      metadata: { sessionInboxWireVersion: 6, workflowTaskAuthorization: true },
+      metadata: {
+        idempotentSessionSend: true,
+        sessionInboxWireVersion: 6,
+        workflowTaskAuthorization: true,
+      },
       token: "stable",
     });
     await inbox.dispose();

--- a/packages/eve/src/execution/session-command-inbox.ts
+++ b/packages/eve/src/execution/session-command-inbox.ts
@@ -8,6 +8,7 @@ import type {
 } from "#channel/types.js";
 import { claimHookOwnership, disposeHook } from "#execution/hook-ownership.js";
 import {
+  IDEMPOTENT_SESSION_SEND_METADATA_KEY,
   SESSION_INBOX_WIRE_VERSION,
   SESSION_INBOX_WIRE_VERSION_METADATA_KEY,
   WORKFLOW_TASK_AUTHORIZATION_METADATA_KEY,
@@ -138,6 +139,7 @@ export function createSessionCommandInbox(): SessionCommandInboxHandle {
     // legacy shape.
     const hook = createHook<SessionInboxPayload>({
       metadata: {
+        [IDEMPOTENT_SESSION_SEND_METADATA_KEY]: true,
         [SESSION_INBOX_WIRE_VERSION_METADATA_KEY]: SESSION_INBOX_WIRE_VERSION,
         [WORKFLOW_TASK_AUTHORIZATION_METADATA_KEY]: true,
       },

--- a/packages/eve/src/execution/turn-control-receiver.test.ts
+++ b/packages/eve/src/execution/turn-control-receiver.test.ts
@@ -172,7 +172,7 @@ describe("TurnControlReceiver", () => {
         { caller, kind: "send", payload: { message: "once" } },
         { caller, kind: "send", payload: { message: "duplicate" } },
       ]),
-      seenTaskDeliveries: new Set(),
+      seenDeliveries: new Set(),
     });
 
     expect(bufferedDeliveries.map((delivery) => delivery.payloads[0]?.message)).toEqual(["once"]);
@@ -200,12 +200,31 @@ describe("TurnControlReceiver", () => {
           taskDeliveryId: "task-1:q2",
         },
       ]),
-      seenTaskDeliveries: new Set(),
+      seenDeliveries: new Set(),
     });
 
     expect(
       bufferedDeliveries.map((delivery) => delivery.payloads[0]?.inputResponses?.[0]?.requestId),
     ).toEqual(["q1", "q2"]);
+  });
+
+  it("deduplicates retried channel operations while accepting distinct requests", async () => {
+    installControlHook([parkResult()], true);
+    const bufferedDeliveries: DeliverHookPayload[] = [];
+    await runReceiver(bufferedDeliveries, {
+      commandInbox: createCommandInbox(
+        ["operation:one", "operation:one", "operation:two"].map((deliveryId) => ({
+          kind: "send" as const,
+          payload: { message: deliveryId },
+          delivery: { channelKind: "slack", channelName: "slack", deliveryId },
+        })),
+      ),
+      seenDeliveries: new Set(),
+    });
+    expect(bufferedDeliveries.map((delivery) => delivery.payloads[0]?.message)).toEqual([
+      "operation:one",
+      "operation:two",
+    ]);
   });
 
   it("discards queued deliveries when their task is cancelled", async () => {
@@ -221,7 +240,7 @@ describe("TurnControlReceiver", () => {
         },
         { kind: "cancel", taskId: "task-1", turnId: "turn_3" },
       ]),
-      seenTaskDeliveries: new Set(),
+      seenDeliveries: new Set(),
     });
 
     expect(bufferedDeliveries).toEqual([]);
@@ -303,7 +322,7 @@ function runReceiver(
   options: {
     readonly bufferedSessionControls?: Array<"clear" | "compact" | "expired" | "reset">;
     readonly commandInbox?: SessionCommandInbox;
-    readonly seenTaskDeliveries?: Set<string>;
+    readonly seenDeliveries?: Set<string>;
   } = {},
 ): ReturnType<TurnControlReceiver["waitForAction"]> {
   const receiver = new TurnControlReceiver({
@@ -311,7 +330,7 @@ function runReceiver(
     bufferedSessionControls: options.bufferedSessionControls ?? [],
     commandInbox: options.commandInbox ?? createCommandInbox(),
     expectedTurnId: "turn_0",
-    seenTaskDeliveries: options.seenTaskDeliveries,
+    seenDeliveries: options.seenDeliveries,
     stateCursor: new SessionStateCursor({ serializedContext: {}, sessionState: createState() }),
     token: "turn-control",
   });

--- a/packages/eve/src/execution/turn-control-receiver.ts
+++ b/packages/eve/src/execution/turn-control-receiver.ts
@@ -1,3 +1,4 @@
+import { acceptChannelOperation } from "#execution/channel-delivery-dedup.js";
 import { createHook, type Hook } from "#compiled/@workflow/core/index.js";
 
 import type { DeliverHookPayload } from "#channel/types.js";
@@ -31,7 +32,7 @@ export class TurnControlReceiver {
   private readonly controlIterator: AsyncIterator<TurnControlPayload>;
   private readonly expectedTurnId: string;
   private readonly cancelledTaskIds: Set<string>;
-  private readonly seenTaskDeliveries: Set<string>;
+  private readonly seenDeliveries: Set<string>;
   private readonly stateCursor: SessionStateCursor;
   private pendingControl: Promise<IteratorResult<TurnControlPayload>> | null = null;
 
@@ -41,7 +42,7 @@ export class TurnControlReceiver {
     readonly cancelledTaskIds?: Set<string>;
     readonly commandInbox: SessionCommandInbox;
     readonly expectedTurnId: string;
-    readonly seenTaskDeliveries?: Set<string>;
+    readonly seenDeliveries?: Set<string>;
     readonly stateCursor: SessionStateCursor;
     readonly token: string;
   }) {
@@ -49,7 +50,7 @@ export class TurnControlReceiver {
     this.bufferedSessionControls = input.bufferedSessionControls;
     this.cancelledTaskIds = input.cancelledTaskIds ?? new Set();
     this.commandInbox = input.commandInbox;
-    this.seenTaskDeliveries = input.seenTaskDeliveries ?? new Set();
+    this.seenDeliveries = input.seenDeliveries ?? new Set();
     this.stateCursor = input.stateCursor;
     this.control = createHook<TurnControlPayload>({ token: input.token });
     this.controlIterator = this.control[Symbol.asyncIterator]();
@@ -345,11 +346,12 @@ export class TurnControlReceiver {
   }
 
   private acceptTaskDelivery(command: DeliverHookPayload): boolean {
+    if (!acceptChannelOperation(command, this.seenDeliveries)) return false;
     const deliveryId = command.taskDeliveryId ?? command.caller?.taskId;
     if (deliveryId === undefined) return true;
     if (this.originatesFromCancelledTask(deliveryId)) return false;
-    if (this.seenTaskDeliveries.has(deliveryId)) return false;
-    this.seenTaskDeliveries.add(deliveryId);
+    if (this.seenDeliveries.has(deliveryId)) return false;
+    this.seenDeliveries.add(deliveryId);
     return true;
   }
 

--- a/packages/eve/src/execution/turn-dispatch.ts
+++ b/packages/eve/src/execution/turn-dispatch.ts
@@ -42,7 +42,7 @@ interface TurnDispatchInput {
   readonly mode: RunMode;
   readonly parentWritable: WritableStream<Uint8Array>;
   readonly serializedContext: Record<string, unknown>;
-  readonly seenTaskDeliveries?: Set<string>;
+  readonly seenDeliveries?: Set<string>;
   readonly sessionState: DurableSessionState;
   readonly stateCursor?: SessionStateCursor;
 }
@@ -80,7 +80,7 @@ async function runAndAwaitTurn(
     cancelledTaskIds: input.cancelledTaskIds,
     commandInbox: input.commandInbox,
     expectedTurnId: activeTurnId(input.sessionState.emissionState),
-    seenTaskDeliveries: input.seenTaskDeliveries ?? new Set(),
+    seenDeliveries: input.seenDeliveries ?? new Set(),
     stateCursor: input.stateCursor!,
     token: input.controlToken,
   });

--- a/packages/eve/src/execution/wire/session-inbox-contract.ts
+++ b/packages/eve/src/execution/wire/session-inbox-contract.ts
@@ -16,6 +16,8 @@ export const SESSION_INBOX_WIRE_VERSION_METADATA_KEY = "sessionInboxWireVersion"
  * drop those events, so producers fail fast instead of waiting on a callback
  * no channel will render.
  */
+export const IDEMPOTENT_SESSION_SEND_METADATA_KEY = "idempotentSessionSend";
+
 export const WORKFLOW_TASK_AUTHORIZATION_METADATA_KEY = "workflowTaskAuthorization";
 
 export const SESSION_INBOX_CONTEXT_KEY = "eve.sessionInbox";

--- a/packages/eve/src/execution/wire/session-inbox-resume.test.ts
+++ b/packages/eve/src/execution/wire/session-inbox-resume.test.ts
@@ -88,6 +88,34 @@ describe("session inbox target resolution", () => {
 });
 
 describe("resumeSessionInbox", () => {
+  it("refuses idempotent sends to a pinned driver without deduplication support", async () => {
+    getHookByTokenMock.mockResolvedValue(
+      sessionHook("session-1", "token", { sessionInboxWireVersion: 6 }),
+    );
+    await expect(
+      resumeSessionInbox("token", {
+        kind: "send",
+        payload: { message: "hello" },
+        delivery: { channelKind: "slack", channelName: "slack", deliveryId: "operation:stable" },
+      }),
+    ).rejects.toThrow("does not support idempotent sends");
+    expect(resumeHookMock).not.toHaveBeenCalled();
+  });
+
+  it("persists an idempotent send only after checking the exact target's capability", async () => {
+    const hook = sessionHook("session-1", "token", {
+      sessionInboxWireVersion: 6,
+      idempotentSessionSend: true,
+    });
+    getHookByTokenMock.mockResolvedValue(hook);
+    await resumeSessionInbox("token", {
+      kind: "send",
+      payload: { message: "hello" },
+      delivery: { channelKind: "slack", channelName: "slack", deliveryId: "operation:stable" },
+    });
+    expect(resumeHookMock).toHaveBeenCalledWith(hook, expect.any(Object));
+  });
+
   it.each(SESSION_INBOX_WIRE_VERSIONS)(
     "uses the persisted consumer version %i without reading hook metadata",
     async (version) => {

--- a/packages/eve/src/execution/wire/session-inbox-resume.ts
+++ b/packages/eve/src/execution/wire/session-inbox-resume.ts
@@ -10,6 +10,7 @@ import {
   sessionCommandHookToken,
 } from "#execution/session-command-token.js";
 import {
+  IDEMPOTENT_SESSION_SEND_METADATA_KEY,
   SESSION_INBOX_WIRE_VERSION_METADATA_KEY,
   WORKFLOW_TASK_AUTHORIZATION_METADATA_KEY,
   isSessionInboxAddress,
@@ -38,9 +39,26 @@ export async function resumeSessionInbox(
         `Session inbox target declares unsupported wire version ${JSON.stringify(address.version)}.`,
       );
     }
+  }
+  if (command.kind === "send" && command.delivery?.deliveryId.startsWith("operation:")) {
+    const hook = await getHookByToken(
+      typeof address === "string" ? address : sessionCommandHookToken(address.sessionId),
+    );
+    if (!isObject(hook.metadata) || hook.metadata[IDEMPOTENT_SESSION_SEND_METADATA_KEY] !== true) {
+      throw new SessionInboxWireError(
+        "This session's driver does not support idempotent sends. Open a new session on an updated deployment.",
+      );
+    }
+    const target = await resolveSessionInboxWireTarget(hook);
+    return await resumeHook(hook, sessionInboxWire.encode(command, target));
+  }
+  if (typeof address !== "string") {
+    const version = address.version;
+    if (!isSessionInboxWireVersion(version))
+      throw new SessionInboxWireError("Unsupported session inbox version.");
     return await resumeHook(
       sessionCommandHookToken(address.sessionId),
-      sessionInboxWire.encode(command, { version: address.version }),
+      sessionInboxWire.encode(command, { version }),
     );
   }
 

--- a/packages/eve/src/execution/workflow-entry.integration.test.ts
+++ b/packages/eve/src/execution/workflow-entry.integration.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { getWorld, resumeHook, start } from "#internal/workflow/runtime.js";
 import { hydrateWorkflowArguments } from "@workflow/core/serialization";
 
+import { createSession } from "#channel/session.js";
 import { createChannelAddress } from "#channel/channel-address.js";
 import { captureTurnEvents, filterEventsByType } from "#internal/testing/events.js";
 import { createTestRuntime } from "#internal/testing/app-harness.js";
@@ -688,6 +689,81 @@ describe("workflowEntry integration", () => {
           outcome: "authorized",
         });
         expect(filterEventsByType(callbackTurn, "turn.cancelled")).toHaveLength(0);
+      } finally {
+        stream.dispose();
+        await run.cancel();
+      }
+    });
+  });
+
+  it("opens idle and deduplicates reconstructed fixed-session sends across turns", async () => {
+    const runtime = await createTestRuntime({ agent: { name: "idempotent-admission" } });
+    await runtime.run(async () => {
+      const run = await start(workflowEntry, [
+        {
+          startPaused: true,
+          input: { message: "must never reach the model" },
+          serializedContext: buildSerializedContext({
+            channelKind: "http",
+            continuationToken: "http:idle-admission",
+            mode: "conversation",
+          }),
+        },
+      ]);
+      const stream = captureTurnEvents(run);
+      await waitForHook({ runId: run.runId }, { token: "http:idle-admission" });
+      const provider = createWorkflowRuntime({
+        compiledArtifactsSource: createBundledRuntimeCompiledArtifactsSource(),
+      });
+      const auth = {
+        attributes: {},
+        authenticator: "slack-webhook",
+        principalId: "slack:T1:U1",
+        principalType: "user",
+      };
+      try {
+        const first = await createSession(run.runId, provider).send("first request", {
+          auth,
+          operationId: "event-1",
+          turnPolicy: "queue",
+        });
+        const events = await stream.nextTurn();
+        expect(
+          events.some(
+            (event) =>
+              event.type === "message.completed" && event.data.message?.includes("first request"),
+          ),
+        ).toBe(true);
+        expect(
+          events.some(
+            (event) =>
+              event.type === "message.completed" && event.data.message?.includes("must never"),
+          ),
+        ).toBe(false);
+        const replay = await createSession(run.runId, provider).send("first request", {
+          auth,
+          operationId: "event-1",
+          turnPolicy: "queue",
+        });
+        expect(replay).toEqual(first);
+        await createSession(run.runId, provider).send("second request", {
+          auth,
+          operationId: "event-2",
+          turnPolicy: "queue",
+        });
+        const second = await stream.nextTurn();
+        expect(
+          second.some(
+            (event) =>
+              event.type === "message.completed" && event.data.message?.includes("second request"),
+          ),
+        ).toBe(true);
+        expect(
+          second.some(
+            (event) =>
+              event.type === "message.completed" && event.data.message?.includes("first request"),
+          ),
+        ).toBe(false);
       } finally {
         stream.dispose();
         await run.cancel();

--- a/packages/eve/src/execution/workflow-entry.ts
+++ b/packages/eve/src/execution/workflow-entry.ts
@@ -1,3 +1,4 @@
+import { acceptChannelOperation } from "#execution/channel-delivery-dedup.js";
 import { getWorkflowMetadata, getWritable } from "#compiled/@workflow/core/index.js";
 
 import type {
@@ -27,7 +28,10 @@ import { rebaseTaskAgentHandleMutations } from "#subagents/handles/rebase.js";
 import { cancelDescendantTurnsStep } from "#execution/cancel-descendant-turns-step.js";
 import { dispatchAndAwaitTurn } from "#execution/turn-dispatch.js";
 import type { TurnDriverAction } from "#execution/turn-control-receiver.js";
-import { normalizeSerializableError } from "#execution/workflow-errors.js";
+import {
+  createSafeOuterWorkflowError,
+  normalizeSerializableError,
+} from "#execution/workflow-errors.js";
 import { createSessionStep } from "#execution/create-session-step.js";
 import { settleCancelledTurnStep } from "#execution/settle-cancelled-turn-step.js";
 import { emitTerminalSessionFailureStep } from "#execution/terminal-session-failure-step.js";
@@ -50,9 +54,6 @@ import {
   SESSION_INBOX_WIRE_VERSION,
 } from "#execution/wire/session-inbox-contract.js";
 
-const SAFE_OUTER_WORKFLOW_FAILURE_MESSAGE =
-  "Agent workflow failed. Inspect the private session trace for details.";
-
 // workflow-entry.ts is the durable workflow body — the bundler rejects
 // node built-ins here, so `internal/logging.ts` cannot be imported.
 // Error logging happens inside `emitTerminalSessionFailureStep`.
@@ -63,6 +64,7 @@ const SAFE_OUTER_WORKFLOW_FAILURE_MESSAGE =
  * and deserialized at each `"use step"` boundary.
  */
 export interface WorkflowEntryInput {
+  readonly startPaused?: boolean;
   readonly activityCollectorRunId?: string;
   readonly continuationConflictCommand?: Extract<SessionCommand, { readonly kind: "send" }>;
   readonly input: RunInput["input"];
@@ -247,6 +249,7 @@ export async function workflowEntry(input: WorkflowEntryInput): Promise<Workflow
       crashCleanupState.callerResolved = true;
 
       outcome = await runDriverLoop({
+        startPaused: input.startPaused,
         capabilities,
         commandInbox,
         driverWritable,
@@ -354,16 +357,8 @@ function hasDelegatedCallerContext(serializedContext: Record<string, unknown>): 
   );
 }
 
-/**
- * Caller to reject from the crash path. Normally the resolved cell value —
- * including `undefined` after a settled reply cleared it, when there is
- * nothing left to notify. When the crash happened before
- * `resolveInitialTurnCallerStep` ever ran (e.g. `createSessionStep` threw),
- * the cell is empty even though a delegated caller may be parked on this
- * session's reply, so the caller is re-resolved from the serialized context
- * — which needs nothing from the failed steps. Best-effort: when resolution
- * fails again there is no reachable caller to notify.
- */
+/** A crash before caller resolution must still notify the delegated caller. Resolution
+ * is best effort because the same dependency may fail again during cleanup. */
 async function resolveCallerForCrash(
   state: CrashCleanupState,
   serializedContext: Record<string, unknown>,
@@ -378,13 +373,8 @@ async function resolveCallerForCrash(
   }
 }
 
-function createSafeOuterWorkflowError(): Error {
-  const error = new Error(SAFE_OUTER_WORKFLOW_FAILURE_MESSAGE);
-  error.name = "EveWorkflowFailure";
-  return error;
-}
-
 async function runDriverLoop(input: {
+  readonly startPaused?: boolean;
   readonly capabilities?: SessionCapabilities;
   readonly commandInbox: SessionCommandInbox;
   readonly driverWritable: WritableStream<Uint8Array>;
@@ -441,7 +431,7 @@ async function runDriverLoop(input: {
         commandInbox,
         deferDeliveries: input.mode === "task" && expectedAttemptIds.size > 0,
         driverWritable: input.driverWritable,
-        seenTaskDeliveries,
+        seenDeliveries,
         stateCursor,
       });
       if (next.kind !== "authorization") return next;
@@ -475,7 +465,9 @@ async function runDriverLoop(input: {
   const bufferedDeliveries: DeliverHookPayload[] = [];
   const bufferedSessionControls: Array<"clear" | "compact" | "expired" | "reset"> = [];
   const cancelledTaskIds = new Set<string>();
-  const seenTaskDeliveries = new Set<string>();
+  const seenDeliveries = new Set<string>();
+  if (input.initialInput.kind === "deliver")
+    acceptChannelOperation(input.initialInput, seenDeliveries);
   const stateCursor = new SessionStateCursor({
     serializedContext: input.serializedContext,
     sessionState: input.sessionState,
@@ -494,7 +486,7 @@ async function runDriverLoop(input: {
     const dispatchedSessionState = stateCursor.sessionState;
     const caller = input.crashCleanupState.caller;
     if (caller?.taskId !== undefined) {
-      seenTaskDeliveries.add(caller.taskId);
+      seenDeliveries.add(caller.taskId);
     }
     const serializedContext =
       caller === undefined
@@ -515,7 +507,7 @@ async function runDriverLoop(input: {
       mode: input.mode,
       parentWritable: input.driverWritable,
       serializedContext,
-      seenTaskDeliveries,
+      seenDeliveries,
       sessionState: stateCursor.sessionState,
       stateCursor,
     });
@@ -538,7 +530,13 @@ async function runDriverLoop(input: {
   try {
     await sessionTimeout?.start();
 
-    let action: TurnDriverAction = await runTurn(input.initialInput);
+    let action: TurnDriverAction = input.startPaused
+      ? {
+          kind: "park",
+          sessionState: stateCursor.sessionState,
+          serializedContext: stateCursor.serializedContext,
+        }
+      : await runTurn(input.initialInput);
 
     while (true) {
       if (action.kind === "done") {

--- a/packages/eve/src/execution/workflow-errors.ts
+++ b/packages/eve/src/execution/workflow-errors.ts
@@ -63,3 +63,9 @@ export function rebuildSerializableError(error: unknown): Error {
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object";
 }
+
+export function createSafeOuterWorkflowError(): Error {
+  const error = new Error("Agent workflow failed. Inspect the private session trace for details.");
+  error.name = "EveWorkflowFailure";
+  return error;
+}

--- a/packages/eve/src/execution/workflow-runtime.test.ts
+++ b/packages/eve/src/execution/workflow-runtime.test.ts
@@ -1,3 +1,4 @@
+import { SessionHistoryUnavailableError } from "#channel/session-history.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { context as apiContext } from "@opentelemetry/api";
 import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
@@ -1175,4 +1176,22 @@ describe("createWorkflowRuntime#createSession trace seed allocation", () => {
     expect(serialized["eve.otelTraceEnabled"]).toBe(false);
     expect(startMock.mock.calls[0]?.[2].attributes["$eve.is_otel_trace_enabled"]).toBe("false");
   });
+});
+
+it("distinguishes retired session history from transient read failures", async () => {
+  const { WorkflowRunNotFoundError } = await import("#compiled/@workflow/errors/index.js");
+  const getTailIndex = vi
+    .fn()
+    .mockRejectedValueOnce(new WorkflowRunNotFoundError("lost-session"))
+    .mockRejectedValueOnce(new Error("temporary outage"));
+  const cancel = vi.fn().mockResolvedValue(undefined);
+  getRunMock.mockReturnValue({ getReadable: () => ({ getTailIndex, cancel }) });
+  const runtime = createWorkflowRuntime({
+    compiledArtifactsSource: {} as RuntimeCompiledArtifactsSource,
+  });
+  await expect(runtime.getStreamTailIndex("lost-session")).rejects.toBeInstanceOf(
+    SessionHistoryUnavailableError,
+  );
+  await expect(runtime.getStreamTailIndex("live-session")).rejects.toThrow("temporary outage");
+  expect(cancel).toHaveBeenCalledTimes(2);
 });

--- a/packages/eve/src/execution/workflow-runtime.test.ts
+++ b/packages/eve/src/execution/workflow-runtime.test.ts
@@ -1179,10 +1179,19 @@ describe("createWorkflowRuntime#createSession trace seed allocation", () => {
 });
 
 it("distinguishes retired session history from transient read failures", async () => {
-  const { WorkflowRunNotFoundError } = await import("#compiled/@workflow/errors/index.js");
+  const { RunExpiredError, StreamExpiredError, WorkflowRunNotFoundError, WorkflowWorldError } =
+    await import("#compiled/@workflow/errors/index.js");
+  const missingStream = new WorkflowWorldError("Stream not found", { status: 404 });
   const getTailIndex = vi
     .fn()
     .mockRejectedValueOnce(new WorkflowRunNotFoundError("lost-session"))
+    .mockRejectedValueOnce(new RunExpiredError("Run expired"))
+    .mockRejectedValueOnce(
+      new Error("Stream info unavailable", {
+        cause: new StreamExpiredError("Stream expired", "expired-session", "default"),
+      }),
+    )
+    .mockRejectedValueOnce(missingStream)
     .mockRejectedValueOnce(new Error("temporary outage"));
   const cancel = vi.fn().mockResolvedValue(undefined);
   getRunMock.mockReturnValue({ getReadable: () => ({ getTailIndex, cancel }) });
@@ -1192,6 +1201,13 @@ it("distinguishes retired session history from transient read failures", async (
   await expect(runtime.getStreamTailIndex("lost-session")).rejects.toBeInstanceOf(
     SessionHistoryUnavailableError,
   );
+  await expect(runtime.getStreamTailIndex("expired-session")).rejects.toBeInstanceOf(
+    SessionHistoryUnavailableError,
+  );
+  await expect(runtime.getStreamTailIndex("expired-session")).rejects.toBeInstanceOf(
+    SessionHistoryUnavailableError,
+  );
+  await expect(runtime.getStreamTailIndex("starting-session")).rejects.toBe(missingStream);
   await expect(runtime.getStreamTailIndex("live-session")).rejects.toThrow("temporary outage");
-  expect(cancel).toHaveBeenCalledTimes(2);
+  expect(cancel).toHaveBeenCalledTimes(5);
 });

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -6,6 +6,7 @@ import {
   EntityConflictError,
   HookNotFoundError,
   RunExpiredError,
+  StreamExpiredError,
   WorkflowRunNotFoundError,
 } from "#compiled/@workflow/errors/index.js";
 
@@ -304,7 +305,10 @@ export function createWorkflowRuntime(config: {
       } catch (error) {
         if (
           [...walkCauseChain(error)].some(
-            (cause) => WorkflowRunNotFoundError.is(cause) || RunExpiredError.is(cause),
+            (cause) =>
+              WorkflowRunNotFoundError.is(cause) ||
+              RunExpiredError.is(cause) ||
+              StreamExpiredError.is(cause),
           )
         ) {
           throw new SessionHistoryUnavailableError(sessionId);

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -139,6 +139,9 @@ export function createWorkflowRuntime(config: {
 }): Runtime {
   return {
     async createSession(input: RunInput): Promise<RunHandle> {
+      if (input.startPaused && input.mode !== "conversation") {
+        throw new Error("Idle sessions require conversation mode.");
+      }
       const bundle = await getCompiledRuntimeAgentBundle({
         compiledArtifactsSource: config.compiledArtifactsSource,
         nodeId: config.nodeId,
@@ -206,6 +209,7 @@ export function createWorkflowRuntime(config: {
         limits: input.limits,
         serializedContext,
       };
+      if (input.startPaused === true) workflowInput.startPaused = true;
       const taskId = input.taskId ?? input.callback?.taskId;
       if (taskId !== undefined) workflowInput.taskId = taskId;
       if (collectorRunId !== undefined) {

--- a/packages/eve/src/execution/workflow-runtime.ts
+++ b/packages/eve/src/execution/workflow-runtime.ts
@@ -1,3 +1,4 @@
+import { SessionHistoryUnavailableError } from "#channel/session-history.js";
 import { randomBytes } from "node:crypto";
 
 import { context, trace } from "#compiled/@opentelemetry/api/index.js";
@@ -300,6 +301,15 @@ export function createWorkflowRuntime(config: {
       const readable = getRun(sessionId).getReadable();
       try {
         return await readable.getTailIndex();
+      } catch (error) {
+        if (
+          [...walkCauseChain(error)].some(
+            (cause) => WorkflowRunNotFoundError.is(cause) || RunExpiredError.is(cause),
+          )
+        ) {
+          throw new SessionHistoryUnavailableError(sessionId);
+        }
+        throw error;
       } finally {
         await readable.cancel().catch(() => {});
       }

--- a/packages/eve/src/internal/testing/mocks/mock-channel-operations.ts
+++ b/packages/eve/src/internal/testing/mocks/mock-channel-operations.ts
@@ -25,6 +25,9 @@ export function mockChannelContext<TState = undefined>(
   return {
     from(continuationToken) {
       const source: InternalChannelSource<TState> = {
+        async open() {
+          throw new Error("Mock channel open is not configured.");
+        },
         async send(message, options) {
           return (await observeDelivery(continuationToken, { ...options, message })) as never;
         },

--- a/packages/eve/src/public/channels/index.ts
+++ b/packages/eve/src/public/channels/index.ts
@@ -1,3 +1,4 @@
+export { getSessionOperationDeliveryId } from "#channel/delivery-metadata.js";
 export {
   defineChannel,
   disableRoute,
@@ -21,6 +22,7 @@ export {
   type ChannelReceiveContext,
   type ChannelResolveSession,
   type ChannelRespondOptions,
+  type ChannelOpenOptions,
   type ChannelSendOptions,
   type ChannelSource,
   type ChannelCors,

--- a/packages/eve/src/public/channels/index.ts
+++ b/packages/eve/src/public/channels/index.ts
@@ -1,3 +1,4 @@
+export { SessionHistoryUnavailableError } from "#channel/session-history.js";
 export { getSessionOperationDeliveryId } from "#channel/delivery-metadata.js";
 export {
   defineChannel,

--- a/packages/eve/src/public/channels/slack/index.ts
+++ b/packages/eve/src/public/channels/slack/index.ts
@@ -8,6 +8,8 @@ export type { ModelMessage } from "ai";
 
 export {
   slackChannel,
+  type SlackAdmittedMessage,
+  type SlackPreparedMessage,
   type SlackApiResponse,
   type SlackAuthorizationEventContext,
   type SlackAuthorizationRequiredHandler,
@@ -45,6 +47,7 @@ export {
   type SlackReceiveTarget,
   type SlackSessionTarget,
   type SlackRespondOptions,
+  type SlackOpenOptions,
   type SlackSendOptions,
   type SlackSessionOperations,
   type SlackThread,

--- a/packages/eve/src/public/channels/slack/session-operations.ts
+++ b/packages/eve/src/public/channels/slack/session-operations.ts
@@ -1,5 +1,6 @@
 import type {
   ChannelFrom,
+  ChannelOpenOptions,
   ChannelResolveSession,
   ChannelRespondOptions,
   ChannelSendOptions,
@@ -11,6 +12,11 @@ import type { UserContent } from "ai";
 import type { SlackChannelState } from "#public/channels/slack/slackChannel.js";
 
 type SlackSource = ChannelSource<SlackChannelState>;
+
+/** Options for opening an idle Slack thread session. */
+export type SlackOpenOptions = Omit<ChannelOpenOptions<SlackChannelState>, "auth" | "state"> & {
+  readonly auth?: SessionAuthContext | null;
+};
 
 /** Options for a message send already bound to one Slack thread. */
 export type SlackSendOptions = Omit<ChannelSendOptions<SlackChannelState>, "auth" | "state"> & {
@@ -24,6 +30,8 @@ export type SlackRespondOptions = Omit<ChannelRespondOptions<SlackChannelState>,
 
 /** Current-owner operations already bound to one Slack thread. */
 export interface SlackSessionOperations {
+  /** Opens an idle thread session without starting a turn. */
+  open(options?: SlackOpenOptions): ReturnType<SlackSource["open"]>;
   send(message: string | UserContent, options?: SlackSendOptions): ReturnType<SlackSource["send"]>;
   respond<const TResponses extends readonly InputResponse[]>(
     inputResponses: StrictInputResponses<TResponses>,
@@ -49,6 +57,8 @@ export function bindSlackSessionOperations(input: {
     value === undefined ? input.defaultAuth : value;
 
   return {
+    open: (options = {}) =>
+      source.open({ ...options, auth: auth(options.auth), state: input.state }),
     async send(message, options = {}) {
       return await source.send(message, {
         ...options,

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -4147,6 +4147,7 @@ describe("durable Slack admission", () => {
     const body = buildMentionBody().body;
     expect((await firePost(channel, buildSignedRequest({ body }))).response.status).toBe(503);
     const retry = buildSignedRequest({ body });
+    retry.headers.set("x-slack-retry-num", "1");
     retry.headers.set("x-slack-retry-reason", "http_timeout");
     expect((await firePost(channel, retry)).response.status).toBe(200);
     expect(admitMessage).toHaveBeenCalledTimes(2);
@@ -4209,4 +4210,20 @@ it("prepares admitted Slack input without execution and preserves auth, context,
   } finally {
     vi.unstubAllGlobals();
   }
+});
+
+it("retains timeout-retry suppression for interactive callbacks with durable message admission", async () => {
+  const onSlashCommand = vi.fn();
+  const channel = slackChannel({
+    credentials: { signingSecret: SIGNING_SECRET },
+    admitMessage: vi.fn(),
+    onSlashCommand,
+  });
+  const request = buildSignedSlashCommandRequest();
+  request.headers.set("x-slack-retry-num", "1");
+  request.headers.set("x-slack-retry-reason", "http_timeout");
+  const result = await firePost(channel, request);
+  expect(result.response.status).toBe(200);
+  expect(result.waitUntil).not.toHaveBeenCalled();
+  expect(onSlashCommand).not.toHaveBeenCalled();
 });

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -4107,3 +4107,106 @@ describe("constrainAuthorizationRequired", () => {
     expect(handler.mock.calls[0]?.[2]).toBe(sessionCtx);
   });
 });
+
+describe("durable Slack admission", () => {
+  it("awaits persistence before acknowledgement and never dispatches the admitted message", async () => {
+    let release!: () => void;
+    const stored = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const admitMessage = vi.fn(() => stored);
+    const onAppMention = vi.fn(() => ({ auth: null }));
+    const channel = slackChannel({
+      credentials: { signingSecret: SIGNING_SECRET },
+      admitMessage,
+      onAppMention,
+    });
+    let acknowledged = false;
+    const pending = firePost(channel, buildSignedRequest({ body: buildMentionBody().body })).then(
+      (result) => {
+        acknowledged = true;
+        return result;
+      },
+    );
+    await vi.waitFor(() => expect(admitMessage).toHaveBeenCalledOnce());
+    expect(acknowledged).toBe(false);
+    release();
+    const result = await pending;
+    expect(result.response.status).toBe(200);
+    expect(result.waitUntil).not.toHaveBeenCalled();
+    expect(result.send).not.toHaveBeenCalled();
+    expect(onAppMention).not.toHaveBeenCalled();
+  });
+
+  it("retries failed storage and HTTP timeout redeliveries instead of swallowing them", async () => {
+    const admitMessage = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("storage unavailable"))
+      .mockResolvedValue(undefined);
+    const channel = slackChannel({ credentials: { signingSecret: SIGNING_SECRET }, admitMessage });
+    const body = buildMentionBody().body;
+    expect((await firePost(channel, buildSignedRequest({ body }))).response.status).toBe(503);
+    const retry = buildSignedRequest({ body });
+    retry.headers.set("x-slack-retry-reason", "http_timeout");
+    expect((await firePost(channel, retry)).response.status).toBe(200);
+    expect(admitMessage).toHaveBeenCalledTimes(2);
+    expect(admitMessage.mock.calls[0]?.[0]).toEqual(admitMessage.mock.calls[1]?.[0]);
+  });
+
+  it("does not persist unverified events", async () => {
+    const admitMessage = vi.fn();
+    const channel = slackChannel({ credentials: { signingSecret: SIGNING_SECRET }, admitMessage });
+    const request = buildSignedRequest({ body: buildMentionBody().body });
+    request.headers.set("x-slack-signature", "v0=invalid");
+    expect((await firePost(channel, request)).response.status).toBe(401);
+    expect(admitMessage).not.toHaveBeenCalled();
+  });
+});
+
+it("prepares admitted Slack input without execution and preserves auth, context, and durable attachment URLs", async () => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(Response.json({ ok: true, messages: [] })));
+  try {
+    const admitted: import("./slackChannel.js").SlackAdmittedMessage[] = [];
+    const channel = slackChannel({
+      credentials: { signingSecret: SIGNING_SECRET },
+      admitMessage: async (message) => {
+        admitted.push(message);
+      },
+      onDirectMessage: (ctx, message) => ({
+        auth: defaultSlackAuth(message, ctx),
+        context: ["Only configured repositories"],
+      }),
+    });
+    await firePost(channel, buildSignedRequest({ body: buildDirectMessageBody().body }));
+    const message = admitted[0]!;
+    const send = vi.fn();
+    const context = mockChannelContext<SlackChannelState>(send);
+    const prepared = await channel.prepareMessage(
+      {
+        ...message,
+        message: {
+          ...message.message,
+          attachments: [
+            {
+              id: "F1",
+              type: "file",
+              url: "https://files.slack.com/file.pdf",
+              name: "file.pdf",
+              mimeType: "application/pdf",
+              size: 42,
+            },
+          ],
+        },
+      },
+      context,
+    );
+    expect(prepared?.state.audience).toBe("private");
+    expect(prepared?.options.context).toEqual(["Only configured repositories"]);
+    expect(prepared?.options.auth?.principalId).toContain("U01");
+    expect(JSON.parse(JSON.stringify(prepared))).toEqual(prepared);
+    expect(JSON.stringify(prepared?.message)).toContain("files.slack.com");
+    expect(send).not.toHaveBeenCalled();
+  } finally {
+    vi.unstubAllGlobals();
+  }
+});

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -1,3 +1,4 @@
+import { serializeUrlFilePartsInMessage } from "#channel/send-input.js";
 import { parseSlackWebhookBody } from "#compiled/@chat-adapter/slack/webhook.js";
 
 import type { UserContent } from "ai";
@@ -84,6 +85,7 @@ import {
 export type {
   SlackRespondOptions,
   SlackSendOptions,
+  SlackOpenOptions,
   SlackSessionOperations,
 } from "#public/channels/slack/session-operations.js";
 
@@ -604,6 +606,12 @@ export interface SlackChannelInternalEvents extends Omit<
 }
 
 export interface SlackChannelConfig {
+  /** Persist verified mention/DM messages before acknowledgement. Throw to return 503 for retry.
+   * When configured, this replaces automatic dispatch for these messages. */
+  readonly admitMessage?: (
+    message: SlackAdmittedMessage,
+    context: { readonly waitUntil: (task: Promise<unknown>) => void },
+  ) => Promise<void>;
   readonly credentials?: SlackChannelCredentials;
   readonly botName?: string;
 
@@ -810,7 +818,36 @@ export interface SlackChannel extends Channel<
   SlackChannelState,
   SlackReceiveTarget,
   SlackInstrumentationMetadata
-> {}
+> {
+  /** Prepare a previously admitted message using current credentials and authored admission hooks.
+   * Call only with messages from admitMessage retained in trusted application storage.
+   * This does not send or create a session. Persist the result before opening/sending. */
+  prepareMessage(
+    message: SlackAdmittedMessage,
+    context: {
+      readonly from: ChannelFrom<SlackChannelState>;
+      readonly resolveSession: ChannelResolveSession;
+    },
+  ): Promise<SlackPreparedMessage | null>;
+}
+
+/** Verified, serializable message input. Contains no verification headers or bot credentials. */
+export interface SlackAdmittedMessage {
+  readonly eventId: string;
+  readonly kind: "app_mention" | "direct_message";
+  readonly appId?: string;
+  readonly botUserId?: string;
+  readonly receivingBotUserId?: string;
+  readonly installationTeamId?: string;
+  readonly message: SlackMessage;
+}
+
+/** JSON-serializable prepared input; URL attachments retain eve's durable file references. */
+export interface SlackPreparedMessage {
+  readonly message: string | UserContent;
+  readonly state: SlackChannelState;
+  readonly options: SlackSendOptions;
+}
 
 /**
  * Slack channel factory. Wires up the webhook route, mention dispatch,
@@ -948,7 +985,7 @@ export function slackChannel(config: SlackChannelConfig = {}): SlackChannel {
         const body = await verifyInbound(req, config.credentials);
         if (body === null) return new Response("unauthorized", { status: 401 });
 
-        if (shouldDropSlackHttpTimeoutRetry(req.headers)) {
+        if (config.admitMessage === undefined && shouldDropSlackHttpTimeoutRetry(req.headers)) {
           return new Response("ok");
         }
 
@@ -992,7 +1029,31 @@ export function slackChannel(config: SlackChannelConfig = {}): SlackChannel {
     },
     renderers: activityRenderers,
   });
-  return channel;
+  return Object.assign(channel, {
+    prepareMessage(
+      message: SlackAdmittedMessage,
+      context: {
+        readonly from: ChannelFrom<SlackChannelState>;
+        readonly resolveSession: ChannelResolveSession;
+      },
+    ) {
+      return prepareSlackMessage({
+        ...message,
+        ...context,
+        appId: message.appId,
+        botUserId: message.botUserId,
+        receivingBotUserId: message.receivingBotUserId,
+        installationTeamId: message.installationTeamId,
+        credentials: config.credentials,
+        handler:
+          message.kind === "app_mention"
+            ? (config.onAppMention ?? config.onMessage ?? defaultOnAppMention)
+            : (config.onDirectMessage ?? config.onMessage ?? defaultOnDirectMessage),
+        threadContext: config.threadContext,
+        uploadPolicy,
+      });
+    },
+  });
 }
 
 function defaultOnInputResponse(ctx: SlackInputResponseContext): SlackInputResponseResult {
@@ -1168,6 +1229,27 @@ async function handleEventPost(input: {
     const kind = payload.kind;
     const message = slackMessageFromWebhookPayload(payload);
     if (message !== null && !isSelfAuthoredSlackMessage({ appId, botUserId }, message)) {
+      if (config.admitMessage !== undefined) {
+        if (!envelope.event_id) return new Response("event_id required", { status: 400 });
+        try {
+          await config.admitMessage(
+            {
+              eventId: envelope.event_id,
+              kind,
+              appId,
+              botUserId,
+              receivingBotUserId,
+              installationTeamId,
+              message,
+            },
+            { waitUntil: input.waitUntil },
+          );
+          return new Response("ok");
+        } catch (error) {
+          logError(log, "durable message admission failed", error, { eventId: envelope.event_id });
+          return new Response("admission unavailable", { status: 503 });
+        }
+      }
       const dispatchMessageWith =
         (handler: NonNullable<SlackChannelConfig["onAppMention"]>) => () =>
           dispatchSlackMessage({
@@ -1284,7 +1366,27 @@ function isSelfAuthoredSlackMessage(
   return identity.appId !== undefined && message.raw.app_id === identity.appId;
 }
 
-async function dispatchSlackMessage(input: {
+async function dispatchSlackMessage(
+  input: Parameters<typeof prepareSlackMessage>[0],
+): Promise<void> {
+  try {
+    const prepared = await prepareSlackMessage(input);
+    if (prepared === null) return;
+    await input
+      .from(slackContinuationToken(input.message.channelId, input.message.threadTs))
+      .send(prepared.message, {
+        ...prepared.options,
+        auth: prepared.options.auth ?? null,
+        state: prepared.state,
+      });
+  } catch (error) {
+    logError(log, `${input.kind} handler or delivery failed`, error, {
+      channelId: input.message.channelId,
+    });
+  }
+}
+
+async function prepareSlackMessage(input: {
   readonly appId: string | undefined;
   readonly botUserId: string | undefined;
   readonly receivingBotUserId: string | undefined;
@@ -1297,7 +1399,7 @@ async function dispatchSlackMessage(input: {
   readonly message: SlackMessage;
   readonly threadContext: LoadThreadContextMessagesOptions | undefined;
   readonly uploadPolicy: UploadPolicy;
-}): Promise<void> {
+}): Promise<SlackPreparedMessage | null> {
   const continuationToken = slackContinuationToken(input.message.channelId, input.message.threadTs);
   const { thread, slack } = buildSlackBinding({
     appId: input.appId,
@@ -1354,33 +1456,27 @@ async function dispatchSlackMessage(input: {
     thread,
   };
 
-  let result;
-  try {
-    result = await input.handler(ctx, input.message);
-  } catch (error) {
-    logError(log, `${input.kind} handler failed`, error, {
-      channelId: input.message.channelId,
-    });
-    return;
-  }
-  if (result === null || result === undefined) return;
+  const result = await input.handler(ctx, input.message);
+  if (result === null || result === undefined) return null;
 
   const isPrivateConversation = await isDMOrPrivateChannel();
   channelState.audience =
     input.kind === "direct_message" || isPrivateConversation ? "private" : "public";
-  await deliverSlackMessage({
-    botUserId: input.receivingBotUserId,
-    credentials: input.credentials,
-    kind: input.kind,
-    isPrivateConversation,
-    isMentioned: isBotMentioned,
-    message: input.message,
-    result,
-    sessionOperations,
-    thread,
-    threadContext: input.threadContext,
-    uploadPolicy: input.uploadPolicy,
-  });
+  return {
+    state: channelState,
+    ...(await prepareSlackDelivery({
+      botUserId: input.receivingBotUserId,
+      credentials: input.credentials,
+      kind: input.kind,
+      isPrivateConversation,
+      isMentioned: isBotMentioned,
+      message: input.message,
+      result,
+      thread,
+      threadContext: input.threadContext,
+      uploadPolicy: input.uploadPolicy,
+    })),
+  };
 }
 
 /** Runs a generic Events API handler with an imperative Slack operation surface. */
@@ -1469,9 +1565,8 @@ async function verifyInbound(
   }
 }
 
-async function deliverSlackMessage(input: {
+async function prepareSlackDelivery(input: {
   readonly botUserId: string | undefined;
-  readonly sessionOperations: SlackSessionOperations;
   readonly credentials: SlackChannelCredentials | undefined;
   readonly isPrivateConversation: boolean;
   readonly isMentioned: boolean;
@@ -1481,48 +1576,42 @@ async function deliverSlackMessage(input: {
   readonly thread: SlackThread;
   readonly threadContext: LoadThreadContextMessagesOptions | undefined;
   readonly uploadPolicy: UploadPolicy;
-}): Promise<void> {
+}): Promise<Omit<SlackPreparedMessage, "state">> {
   const { message, thread } = input;
-  // This runs in the webhook's `waitUntil` task; an unguarded throw would
-  // reject silently into the dispatch `allSettled` ("no response, no logs").
-  try {
-    const priorMessages =
-      input.threadContext === undefined
-        ? []
-        : await loadThreadContextMessages(thread, message, input.threadContext);
-    const threadContext = formatSlackThreadContext(priorMessages);
-    const fileParts = await collectInboundFileParts({
-      mention: message,
-      thread,
-      policy: input.uploadPolicy,
-    });
-    const inboundContext: SlackInboundContext = {
-      botUserId: input.botUserId,
-      channelId: message.channelId,
-      fullName: message.author?.fullName,
-      isMentioned: input.isMentioned,
-      teamId: message.teamId,
-      threadTs: message.threadTs,
-      userId: message.author?.userId ?? "",
-      userName: message.author?.userName,
-    };
-    const attributedMessage = formatSlackInboundMessage(inboundContext, message);
-    const turnMessage = buildSlackTurnMessage(
-      threadContext === undefined ? attributedMessage : `${threadContext}\n\n${attributedMessage}`,
-      fileParts,
-    );
+  const priorMessages =
+    input.threadContext === undefined
+      ? []
+      : await loadThreadContextMessages(thread, message, input.threadContext);
+  const threadContext = formatSlackThreadContext(priorMessages);
+  const fileParts = await collectInboundFileParts({
+    mention: message,
+    thread,
+    policy: input.uploadPolicy,
+  });
+  const inboundContext: SlackInboundContext = {
+    botUserId: input.botUserId,
+    channelId: message.channelId,
+    fullName: message.author?.fullName,
+    isMentioned: input.isMentioned,
+    teamId: message.teamId,
+    threadTs: message.threadTs,
+    userId: message.author?.userId ?? "",
+    userName: message.author?.userName,
+  };
+  const attributedMessage = formatSlackInboundMessage(inboundContext, message);
+  const turnMessage = buildSlackTurnMessage(
+    threadContext === undefined ? attributedMessage : `${threadContext}\n\n${attributedMessage}`,
+    fileParts,
+  );
 
-    const channelContext = input.result.context ?? [];
-    const title = input.isPrivateConversation
-      ? PRIVATE_SLACK_RUN_TITLE
-      : (input.result.title ?? message.markdown);
-    const sendOptions: SlackSendOptions =
-      channelContext.length === 0
-        ? { auth: input.result.auth, title }
-        : { auth: input.result.auth, context: channelContext, title };
+  const channelContext = input.result.context ?? [];
+  const title = input.isPrivateConversation
+    ? PRIVATE_SLACK_RUN_TITLE
+    : (input.result.title ?? message.markdown);
+  const sendOptions: SlackSendOptions =
+    channelContext.length === 0
+      ? { auth: input.result.auth, title }
+      : { auth: input.result.auth, context: channelContext, title };
 
-    await input.sessionOperations.send(turnMessage, sendOptions);
-  } catch (error) {
-    logError(log, `${input.kind} delivery failed`, error, { channelId: message.channelId });
-  }
+  return { message: serializeUrlFilePartsInMessage(turnMessage)!, options: sendOptions };
 }

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -985,12 +985,9 @@ export function slackChannel(config: SlackChannelConfig = {}): SlackChannel {
         const body = await verifyInbound(req, config.credentials);
         if (body === null) return new Response("unauthorized", { status: 401 });
 
-        if (config.admitMessage === undefined && shouldDropSlackHttpTimeoutRetry(req.headers)) {
-          return new Response("ok");
-        }
-
         const contentType = req.headers.get("content-type") ?? "";
         if (contentType.includes("application/x-www-form-urlencoded")) {
+          if (shouldDropSlackHttpTimeoutRetry(req.headers)) return new Response("ok");
           return handleInteractionPost(
             body,
             { from, resolveSession, waitUntil },
@@ -1213,6 +1210,10 @@ async function handleEventPost(input: {
   }
 
   if (envelope === null) return new Response("ok");
+  const durableMessage =
+    config.admitMessage !== undefined &&
+    (payload.kind === "app_mention" || payload.kind === "direct_message");
+  if (!durableMessage && shouldDropSlackHttpTimeoutRetry(input.headers)) return new Response("ok");
   const appId = typeof envelope.api_app_id === "string" ? envelope.api_app_id : undefined;
   const botUserId = slackEventBotUserId(envelope);
   const receivingBotUserId = slackEventReceivingBotUserId(envelope);

--- a/packages/eve/src/public/definitions/channel.ts
+++ b/packages/eve/src/public/definitions/channel.ts
@@ -12,6 +12,7 @@ import type {
   ChannelReceiveContext,
   ChannelResolveSession,
   ChannelRespondOptions,
+  ChannelOpenOptions,
   ChannelSendOptions,
   ChannelSource,
 } from "#channel/channel-operations.js";
@@ -42,6 +43,7 @@ export type {
   ChannelReceiveContext,
   ChannelResolveSession,
   ChannelRespondOptions,
+  ChannelOpenOptions,
   ChannelSendOptions,
   ChannelSource,
 };

--- a/research/durable-channel-admission.md
+++ b/research/durable-channel-admission.md
@@ -1,0 +1,37 @@
+---
+issue: https://github.com/vercel-labs/agent-factory/pull/392
+status: proposed
+last_updated: "2026-09-10"
+---
+
+# Durable channel admission
+
+Factory acknowledges Slack events before the asynchronous channel send finishes. An application
+inbox can retry those events, but a lost send response currently risks another turn. Channel
+startup may also return a provisional session that loses continuation ownership.
+
+Add `from(address).open({ auth, state })` to open an idle conversation and return its canonical
+owner. It starts no model turn. The application persists the returned session ID alongside its
+verified event before calling `attachSession(id).send(message, { auth, operationId })`.
+Operation identity is scoped to the immutable session and authenticated principal. Repeated
+operations are consumed once by the durable driver; the first payload wins. Responses expose the
+stable delivery ID, which correlates with turn events. Public calls require a driver capability
+marker so existing pinned sessions reject unsupported guarantees before accepting input.
+
+An application owns persistence before webhook acknowledgement, replay scheduling, and retention.
+It must retain the chosen session ID, never re-resolve an old operation to a replacement session.
+An inactive target returns `session_not_active`; the owner reconciles its retained transcript or
+surfaces an unresolved delivery. Session reset does not silently send accepted work elsewhere.
+Idempotency lasts for the target session's retained workflow history.
+
+Slack channels can opt into `admitMessage(message, { waitUntil })`, awaited after verification
+and before acknowledgement. A failed persistence call returns HTTP 503. The application stores
+the normalized message, then calls `channel.prepareMessage(storedMessage, routeContext)` from a
+trusted worker. Preparation retains the authored auth hooks, attribution, upload policy and
+private-channel classification without creating or sending to a session. Persist its JSON-safe
+result before opening an idle session. This opt-in covers mentions and DMs; interactivity and
+other event handlers retain their existing behavior.
+
+`getSessionOperationDeliveryId({ sessionId, operationId, auth })` exposes correlation before
+sending so a lost response followed by session retirement can still be reconciled. The
+application owns the inbox store and maintenance; eve does not supply an application queue.

--- a/research/durable-channel-admission.md
+++ b/research/durable-channel-admission.md
@@ -35,3 +35,6 @@ other event handlers retain their existing behavior.
 `getSessionOperationDeliveryId({ sessionId, operationId, auth })` exposes correlation before
 sending so a lost response followed by session retirement can still be reconciled. The
 application owns the inbox store and maintenance; eve does not supply an application queue.
+
+`SessionHistoryUnavailableError` distinguishes provider-reported missing/expired history from
+transient stream-tail read failures, so maintenance can surface permanently unresolved admissions.


### PR DESCRIPTION
### Summary

Slack messages can be acknowledged before delivery succeeds, while retrying an ambiguous send can create duplicate turns. Add awaited admission, idle session creation, and idempotent sends to an exact session, enabling [Factory's durable inbox](https://github.com/vercel-labs/agent-factory/pull/394). Applications own persistence and recovery; deduplication lasts while workflow history is retained.

### Validation

- Focused unit/integration tests, workspace typechecks, `pnpm lint`, `pnpm guard:invariants`, `pnpm docs:check`, and package build/pack passed.
- Factory checks passed against the local provider package.
- Full unit runs encountered timeouts. Added e2e coverage is CI-only; clean CI remains required.

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
