### PR TITLE
fix(eve): enable Agent Runs for previews

### DIFF
--- a/.changeset/enable-preview-agent-runs.md
+++ b/.changeset/enable-preview-agent-runs.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Enable the built-in Vercel Agent Runs instrumentation for Preview deployments as well as Production deployments.

--- a/docs/guides/instrumentation-providers.md
+++ b/docs/guides/instrumentation-providers.md
@@ -217,7 +217,7 @@ Policies run in declaration order. A later policy sees the filtered span produce
 The provider layout adds two environment-specific defaults:
 
 - `local` records local traces during `eve dev`.
-- `agent-runs` exports to Vercel Agent Runs in production.
+- `agent-runs` exports to Vercel Agent Runs in preview and production deployments.
 
 Omitting these files preserves the defaults. Reconfigure a slot by exporting `localTraces()` or `agentRuns()` from the matching file. Disable one explicitly:
 

--- a/packages/eve/src/instrumentation/providers.test.ts
+++ b/packages/eve/src/instrumentation/providers.test.ts
@@ -141,13 +141,22 @@ describe("seedInstrumentationProviders", () => {
     expect(getInstrumentationProviders().map(({ slot }) => slot)).toEqual(["backend", "local"]);
   });
 
-  it("seeds Agent Runs only in Vercel production", () => {
+  it.each(["preview", "production"])("seeds Agent Runs in Vercel %s", (environment) => {
     vi.stubEnv(DEVELOPMENT_WORKER_APP_ROOT_ENV, undefined);
-    vi.stubEnv("VERCEL_ENV", "production");
+    vi.stubEnv("VERCEL_ENV", environment);
 
     seedInstrumentationProviders();
 
     expect(getInstrumentationProviders().map(({ slot }) => slot)).toEqual(["agent-runs"]);
+  });
+
+  it("does not seed Agent Runs in Vercel development", () => {
+    vi.stubEnv(DEVELOPMENT_WORKER_APP_ROOT_ENV, undefined);
+    vi.stubEnv("VERCEL_ENV", "development");
+
+    seedInstrumentationProviders();
+
+    expect(getInstrumentationProviders()).toEqual([]);
   });
 
   it("lets an authored reserved slot reconfigure or disable its default", async () => {
@@ -160,7 +169,7 @@ describe("seedInstrumentationProviders", () => {
     expect(getInstrumentationProviders()).toEqual([]);
   });
 
-  it("lets an authored Agent Runs slot reconfigure the production default", async () => {
+  it("lets an authored Agent Runs slot reconfigure the hosted default", async () => {
     vi.stubEnv(DEVELOPMENT_WORKER_APP_ROOT_ENV, undefined);
     vi.stubEnv("VERCEL_ENV", "production");
     seedInstrumentationProviders();

--- a/packages/eve/src/instrumentation/providers.ts
+++ b/packages/eve/src/instrumentation/providers.ts
@@ -52,7 +52,9 @@ function providerRegistry(): Map<string, InstrumentationProvider> {
 /** Fills reserved slots before authored files may reconfigure or disable them. */
 export function seedInstrumentationProviders(): void {
   const registry = providerRegistry();
-  if (process.env.VERCEL_ENV === "production") registry.set("agent-runs", agentRuns());
+  if (process.env.VERCEL_ENV === "preview" || process.env.VERCEL_ENV === "production") {
+    registry.set("agent-runs", agentRuns());
+  }
   if (process.env[DEVELOPMENT_WORKER_APP_ROOT_ENV] !== undefined) {
     registry.set("local", localTraces());
   }

--- a/packages/eve/src/public/instrumentation/otel.ts
+++ b/packages/eve/src/public/instrumentation/otel.ts
@@ -44,7 +44,7 @@ export {
 export type { SpanExporter, SpanProcessor } from "#compiled/@vercel/otel/index.js";
 
 /**
- * Vercel Agent Runs, enabled by default in production.
+ * Vercel Agent Runs, enabled by default in preview and production deployments.
  *
  * Export it from `agent/instrumentation/agent-runs.ts` to configure export, or
  * export `disableInstrumentation()` from that file to turn it off.

--- a/packages/eve/src/tracing/otel-declaration.ts
+++ b/packages/eve/src/tracing/otel-declaration.ts
@@ -222,7 +222,7 @@ function createOtelIntegration(
   };
 }
 
-/** Vercel Agent Runs through the production request-context transport. @internal */
+/** Vercel Agent Runs through the hosted request-context transport. @internal */
 export function agentRunsIntegration(options: ManagedTraceOptions = {}): OtelIntegration {
   return {
     [OTEL_INTEGRATION]: true,


### PR DESCRIPTION
### Summary

Preview deployments currently omit the built-in Agent Runs instrumentation, so preview traffic is not visible in Vercel Agent Runs unless the reserved slot is authored explicitly. Enable the default for both Preview and Production deployments while preserving local and Vercel development behavior.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/instrumentation/providers.test.ts` (24 tests passed)
- `pnpm --filter eve typecheck`
- `pnpm docs:check`
- `pnpm guard:invariants`
- `pnpm exec oxfmt --check packages/eve/src/instrumentation/providers.ts packages/eve/src/instrumentation/providers.test.ts packages/eve/src/public/instrumentation/otel.ts packages/eve/src/tracing/otel-declaration.ts docs/guides/instrumentation-providers.md .changeset/enable-preview-agent-runs.md`
- `pnpm exec oxlint packages/eve/src/instrumentation/providers.ts packages/eve/src/instrumentation/providers.test.ts packages/eve/src/public/instrumentation/otel.ts packages/eve/src/tracing/otel-declaration.ts`

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
