### PR TITLE
feat(eve): classify HTTP session audiences

### DIFF
--- a/.changeset/classify-http-session-audience.md
+++ b/.changeset/classify-http-session-audience.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Let `eveChannel` set the tracing audience for each new HTTP session with an asynchronous `audience(ctx)` resolver over the verified caller and request. Attached local TUI sessions set the tracing audience to `private`, while zero-config local tracing retains private trace metadata without capturing model or tool content.

--- a/docs/channels/eve.mdx
+++ b/docs/channels/eve.mdx
@@ -157,6 +157,47 @@ Neither admits browser users or external clients in production. For a public app
 
 For the full auth model and helper list, see [Auth & route protection](../guides/auth-and-route-protection).
 
+## Audience classification
+
+Use `audience` to set the value passed to `tracePolicy` for a new HTTP session.
+The value is observability metadata; it does not change HTTP authorization.
+
+```ts title="agent/channels/eve.ts"
+import { eveChannel } from "eve/channels/eve";
+import { localDev, vercelOidc } from "eve/channels/auth";
+import { resolveTraceAudience } from "../lib/observability";
+
+export default eveChannel({
+  auth: [vercelOidc(), localDev()],
+  audience(ctx) {
+    return resolveTraceAudience(ctx.caller, ctx.request);
+  },
+});
+```
+
+`resolveTraceAudience` is application code. Return `public`, `private`, or
+`unknown` according to the audience classification your trace policy should
+use. A common mapping is `public` for an open or workspace-visible
+conversation, `private` for a conversation limited to specific people, and
+`unknown` when the application cannot establish either classification.
+
+The callback receives the verified `caller` and inbound `request`. eve does not
+add an audience field to `caller`; use a verified custom auth attribute or an
+application-owned lookup. Because the default trace policy may capture content
+for `public`, do not return it based on an unverified request header or body
+field.
+
+eve calls `audience` once, after authentication, when it creates a session.
+Follow-up messages keep the stored value. Omitting the callback or returning an
+unsupported value produces `unknown`; throwing rejects session creation with
+`500`.
+
+For the local `eve dev` TUI, eve sets the tracing audience to `private` and
+bypasses the callback. A remote TUI uses the configured callback like any other
+HTTP client. See
+[Observability](../guides/instrumentation#open-telemetry) for how audience
+controls trace capture.
+
 ## Customization
 
 Use `onMessage` to add request-specific context before the agent sees the user message, and `events` to observe stream events from sessions this channel created:

--- a/docs/guides/instrumentation.md
+++ b/docs/guides/instrumentation.md
@@ -60,7 +60,7 @@ You are responsible for ensuring any observability or eval provider is approved 
 
 The third configurable surface, [runtime context events](#runtime-context), attaches per-model-call values to these spans.
 
-Built-in messaging channels classify their instrumentation metadata with an `audience`: `public`, `private`, or `unknown`. Slack public channels and Chat SDK workspace-visible threads are public; direct and private conversations are private; platform surfaces without enough visibility evidence remain unknown. Proactive Slack `receive` / `ctx.send` handoffs stay `unknown` unless the caller passes `audience` on the target, for example when a webhook or schedule already knows the destination channel is public.
+Built-in messaging channels classify their instrumentation metadata with an `audience`: `public`, `private`, or `unknown`. Slack public channels and Chat SDK workspace-visible threads are public; direct and private conversations are private; platform surfaces without enough visibility evidence remain unknown. The [eve HTTP channel](../channels/eve#audience-classification) uses its `audience(ctx)` resolver for new sessions and sets the tracing audience of a parent-attested local TUI to `private`. Proactive Slack `receive` / `ctx.send` handoffs stay `unknown` unless the caller passes `audience` on the target, for example when a webhook or schedule already knows the destination channel is public.
 
 ## Channel delivery traces
 
@@ -238,12 +238,12 @@ These tags power the **Agent Runs** tab in the Vercel dashboard. When you deploy
 
 ## Local traces
 
-Without an `instrumentation.ts`, `eve dev` records spans to disk — one trace per session, with turns, model steps, and tool calls. Read them two ways:
+Without an `instrumentation.ts`, `eve dev` records spans to disk — one trace per session, with turns, model steps, and tool calls. It emits trace metadata for every audience, but its capture ceiling includes model and tool content only for `public` sessions. Read traces two ways:
 
 - [`/traces`](dev-tui#logs-and-traces) in the dev TUI: a live trace viewer that replays captured content as a conversation.
 - [`eve traces`](../reference/cli#eve-traces): a span tree in the terminal, `eve traces ls` to list. Works after `eve dev` exits.
 
-Local traces omit model and tool inputs and outputs by default. Set `EVE_TRACES_CONTENT=on` in `.env.local` to capture that content.
+Local traces omit model and tool inputs and outputs by default. Set `EVE_TRACES_CONTENT=on` in `.env.local` to capture content for `public` sessions. Private and unknown content remains excluded unless an authored trace policy explicitly admits it.
 
 Writing `instrumentation.ts` replaces this: your `setup` takes over and nothing is recorded locally. For span attributes, retention, and the `EVE_TRACES*` variables, see [`eve traces`](../reference/cli#eve-traces).
 

--- a/packages/eve/src/eve-channel/index.ts
+++ b/packages/eve/src/eve-channel/index.ts
@@ -77,6 +77,7 @@ import {
   findRemoteSubagentBinding,
   healthResponse,
   normalizeEveCors,
+  resolveEveAudience,
   resolveOnMessage,
 } from "#eve-channel/support.js";
 import type { EveChannel, EveChannelInput, EveEventContext } from "#eve-channel/types.js";
@@ -236,6 +237,12 @@ export function eveChannel(input: EveChannelInput): EveChannel {
           request: req,
         });
         if (messageResult instanceof Response) return messageResult;
+        const audience = await resolveEveAudience({
+          auth: forwarded.auth,
+          config: input,
+          request: req,
+        });
+        if (audience instanceof Response) return audience;
         const createSession = readRouteSessionCreator(args);
         if (createSession === undefined) {
           return Response.json(
@@ -252,6 +259,7 @@ export function eveChannel(input: EveChannelInput): EveChannel {
             capabilities:
               body.capabilities ?? (body.mode === "task" ? undefined : { requestInput: true }),
             callback: body.callback,
+            channelAudience: audience,
             continuationToken: operationToken,
             initiatorAuth: forwarded.accepted ? forwarded.initiatorAuth : undefined,
             input: attachClientContext(

--- a/packages/eve/src/eve-channel/support.test.ts
+++ b/packages/eve/src/eve-channel/support.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { SessionAuthContext } from "#channel/types.js";
+import { resolveEveAudience } from "#eve-channel/support.js";
+import { getLocalDevCapability } from "#runtime/local-dev-capability.js";
+
+vi.mock("#runtime/local-dev-capability.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("#runtime/local-dev-capability.js")>()),
+  getLocalDevCapability: vi.fn(),
+}));
+
+const AUTH: SessionAuthContext = {
+  attributes: {},
+  authenticator: "test",
+  principalId: "user-1",
+  principalType: "user",
+};
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("resolveEveAudience", () => {
+  it("classifies an attested local TUI as private without consulting authored policy", async () => {
+    vi.mocked(getLocalDevCapability).mockReturnValue({
+      appRoot: "/app",
+      interactiveClient: true,
+      async withSuspendedSource<T>(task: () => Promise<T>): Promise<T> {
+        return await task();
+      },
+    });
+    const audience = vi.fn(() => "public" as const);
+    const request = new Request("http://127.0.0.1:3000/eve/v1/session");
+
+    await expect(
+      resolveEveAudience({
+        auth: AUTH,
+        config: { audience, auth: () => AUTH },
+        request,
+      }),
+    ).resolves.toBe("private");
+    expect(audience).not.toHaveBeenCalled();
+  });
+
+  it("passes a flat context to authored policy outside a local TUI request", async () => {
+    vi.mocked(getLocalDevCapability).mockReturnValue(undefined);
+    const request = new Request("https://agent.example.com/eve/v1/session");
+    const audience = vi.fn((ctx) => {
+      expect(ctx).toEqual({ caller: AUTH, request });
+      return "public" as const;
+    });
+
+    await expect(
+      resolveEveAudience({
+        auth: AUTH,
+        config: { audience, auth: () => AUTH },
+        request,
+      }),
+    ).resolves.toBe("public");
+    expect(audience).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/eve/src/eve-channel/support.ts
+++ b/packages/eve/src/eve-channel/support.ts
@@ -5,8 +5,11 @@ import { workflowEntryReference } from "#execution/workflow-runtime.js";
 import { createLogger, logError } from "#internal/logging.js";
 import type { MessageStreamEvent, SubagentCalledStreamEvent } from "#protocol/message.js";
 import type { ChannelCors } from "#public/definitions/channel.js";
+import { getLocalDevCapability } from "#runtime/local-dev-capability.js";
+import { normalizeChannelAudience, type ChannelAudience } from "#shared/channel-audience.js";
 import {
   defaultEveAuth,
+  type EveAudienceContext,
   type EveChannelCors,
   type EveChannelCorsOptions,
   type EveChannelInput,
@@ -126,6 +129,25 @@ interface OnMessageOutcome {
   readonly title?: string;
 }
 
+export async function resolveEveAudience(input: {
+  readonly auth: SessionAuthContext | null;
+  readonly config: EveChannelInput;
+  readonly request: Request;
+}): Promise<ChannelAudience | Response> {
+  if (getLocalDevCapability()?.interactiveClient === true) return "private";
+  if (input.config.audience === undefined) return "unknown";
+
+  try {
+    return normalizeChannelAudience(await input.config.audience(createEveAudienceContext(input)));
+  } catch (error) {
+    const errorId = logError(log, "audience resolver failed", error);
+    return Response.json(
+      { error: "Audience resolver failed.", errorId, ok: false },
+      { status: 500 },
+    );
+  }
+}
+
 export async function resolveOnMessage(input: {
   readonly auth: SessionAuthContext | null;
   readonly config: EveChannelInput;
@@ -137,11 +159,7 @@ export async function resolveOnMessage(input: {
 
   let result: EveMessageResult;
   try {
-    const eve: EveHandle =
-      input.sessionId === undefined
-        ? { caller: input.auth, request: input.request }
-        : { caller: input.auth, request: input.request, sessionId: input.sessionId };
-    const ctx: EveMessageContext = { eve };
+    const ctx = createEveMessageContext(input);
     result = await handler(ctx, input.message);
     if (result === null || result === undefined) {
       throw new TypeError("eveChannel onMessage must return an auth result.");
@@ -161,4 +179,23 @@ export async function resolveOnMessage(input: {
 
 export function defaultOnMessage(ctx: EveMessageContext): EveMessageResult {
   return { auth: defaultEveAuth(ctx) };
+}
+
+function createEveAudienceContext(input: {
+  readonly auth: SessionAuthContext | null;
+  readonly request: Request;
+}): EveAudienceContext {
+  return { caller: input.auth, request: input.request };
+}
+
+function createEveMessageContext(input: {
+  readonly auth: SessionAuthContext | null;
+  readonly request: Request;
+  readonly sessionId?: string;
+}): EveMessageContext {
+  const eve: EveHandle =
+    input.sessionId === undefined
+      ? { caller: input.auth, request: input.request }
+      : { caller: input.auth, request: input.request, sessionId: input.sessionId };
+  return { eve };
 }

--- a/packages/eve/src/eve-channel/types.ts
+++ b/packages/eve/src/eve-channel/types.ts
@@ -4,6 +4,7 @@ import type { SessionAuthContext, TurnPolicy } from "#channel/types.js";
 import type { TrustedForwarders } from "#channel/forwarded-principal.js";
 import type { AuthFn } from "#public/channels/auth.js";
 import type { UploadPolicyInput } from "#public/channels/upload-policy.js";
+import type { ChannelAudience } from "#shared/channel-audience.js";
 import type {
   Channel,
   ChannelContinuationOps,
@@ -61,6 +62,13 @@ export interface EveMessageContext {
   readonly eve: EveHandle;
 }
 
+/** Context passed to `eveChannel({ audience })` when a new session is created. */
+export interface EveAudienceContext {
+  /** Verified route-auth caller, or the accepted forwarded caller. */
+  readonly caller: SessionAuthContext | null;
+  readonly request: Request;
+}
+
 /**
  * Result of `eveChannel({ onMessage })`. The object dispatches the inbound message,
  * optionally prepending `context` strings as user messages.
@@ -85,7 +93,8 @@ export function defaultEveAuth(ctx: EveMessageContext): SessionAuthContext | nul
 
 /**
  * Configuration for {@link eveChannel}. Only {@link auth} is required;
- * `uploadPolicy`, `onMessage`, and `events` refine the default HTTP behavior.
+ * `audience`, `uploadPolicy`, `onMessage`, and `events` refine the default HTTP
+ * behavior.
  */
 export interface EveChannelInput {
   /**
@@ -94,6 +103,13 @@ export interface EveChannelInput {
    * the next; exhaustion (including the empty array) rejects with 401. Include `none()` last for anonymous traffic.
    */
   readonly auth: AuthFn<Request> | readonly AuthFn<Request>[];
+  /**
+   * Sets the audience classification exposed to tracing for a newly created
+   * HTTP session. Runs after route authentication with the verified caller and
+   * request; the returned audience is pinned to the session. This is
+   * observability metadata and does not change HTTP authorization.
+   */
+  readonly audience?: (ctx: EveAudienceContext) => ChannelAudience | Promise<ChannelAudience>;
   /**
    * The trusted-forwarders policy: which transport-authenticated callers may
    * assert a forwarded principal or callback-marked public trace audience. The predicate

--- a/packages/eve/src/internal/nitro/routes/channel-dispatch.test.ts
+++ b/packages/eve/src/internal/nitro/routes/channel-dispatch.test.ts
@@ -35,6 +35,7 @@ import {
   dispatchChannelRequest,
   dispatchChannelWebSocketRequest,
 } from "#internal/nitro/routes/channel-dispatch.js";
+import { readRouteSessionCreator } from "#internal/nitro/routes/channel-route-context.js";
 import { resolveNitroChannelRuntimeBundle } from "#internal/nitro/routes/runtime-stack.js";
 
 vi.mock("#internal/nitro/routes/runtime-stack.js", () => ({
@@ -873,6 +874,59 @@ describe("dispatchChannelRequest tracing", () => {
 
     const [span] = await finishedSpans();
     expect(span!.attributes["eve.channel.kind"]).toBe("channel:support");
+  });
+
+  it("projects a route-resolved audience onto new session metadata", async () => {
+    const createSession = vi.fn().mockResolvedValue({
+      events: new ReadableStream(),
+      sessionId: "session-1",
+    });
+    const routedRuntime = createRuntime({ createSession });
+    mockedResolveNitroChannelRuntimeBundle.mockResolvedValue({
+      agentName: "test-agent",
+      channels: [
+        slackChannel(async () => new Response("unused"), {
+          adapter: {
+            kind: "http",
+            instrumentation: {
+              metadata: () => ({ audience: "unknown", workspaceId: "workspace-1" }),
+            },
+          },
+          handler: async (_request, args) => {
+            const create = readRouteSessionCreator(args);
+            if (create === undefined) throw new Error("Expected route session creator.");
+            await create({
+              auth: null,
+              channelAudience: "private",
+              input: { message: "hello" },
+              mode: "conversation",
+            });
+            return new Response("ok");
+          },
+        }),
+      ],
+      runtime: routedRuntime,
+    });
+
+    const response = await dispatchChannelRequest(
+      createEvent({ method: "POST", waitUntil: vi.fn() }),
+      "POST /slack",
+      {} as never,
+    );
+
+    expect(response.status).toBe(200);
+    expect(createSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelMetadata: {
+          channelType: "http",
+          kind: "channel:slack",
+          metadata: {
+            audience: "private",
+            workspaceId: "workspace-1",
+          },
+        },
+      }),
+    );
   });
 
   it("makes a span created inside the handler a child of the request span", async () => {

--- a/packages/eve/src/internal/nitro/routes/channel-dispatch.ts
+++ b/packages/eve/src/internal/nitro/routes/channel-dispatch.ts
@@ -6,6 +6,7 @@ import { createCrossChannelToFn, toCrossChannelTargets } from "#channel/cross-ch
 import type { RouteHandlerArgs, WebSocketRouteHooks } from "#channel/routes.js";
 import { createChannelOperations } from "#channel/channel-operations.js";
 import { createChannelDeliveryMetadata } from "#channel/delivery-metadata.js";
+import { buildChannelInstrumentationProjection } from "#channel/instrumentation.js";
 import { createAttachSessionFn } from "#channel/session.js";
 import { createLogger, logError } from "#internal/logging.js";
 import { readTrustedDevelopmentClientAddress } from "#internal/nitro/dev-client-address.js";
@@ -278,10 +279,20 @@ function buildRouteArgs(
       ),
       { agentName: bundle.agentName },
     ),
-    async (input) =>
-      await bundle.runtime.createSession({
+    async ({ channelAudience, ...input }) => {
+      let channelMetadata = input.channelMetadata;
+      if (channelAudience !== undefined) {
+        const projection =
+          channelMetadata ?? buildChannelInstrumentationProjection({ adapter, channelName });
+        channelMetadata = {
+          ...projection,
+          metadata: { ...projection.metadata, audience: channelAudience },
+        };
+      }
+      return await bundle.runtime.createSession({
         ...input,
         adapter,
+        channelMetadata,
         channelName,
         continuationToken:
           input.continuationToken === undefined
@@ -289,7 +300,8 @@ function buildRouteArgs(
             : `${channelName}:${input.continuationToken}`,
         delivery: createChannelDeliveryMetadata(deliverySource),
         requestId,
-      }),
+      });
+    },
   );
   if (bundle.resolveRemoteAgentStreamHeaders !== undefined) {
     attachRemoteAgentStreamHeadersResolver(args, bundle.resolveRemoteAgentStreamHeaders);

--- a/packages/eve/src/internal/nitro/routes/channel-route-context.ts
+++ b/packages/eve/src/internal/nitro/routes/channel-route-context.ts
@@ -1,5 +1,6 @@
 import type { RouteHandlerArgs } from "#channel/routes.js";
 import type { RunHandle, RunInput } from "#channel/types.js";
+import type { ChannelAudience } from "#shared/channel-audience.js";
 
 type AgentInfoRouteResponse = () => Promise<Response>;
 export interface HomeRouteMetadata {
@@ -11,7 +12,9 @@ export interface HomeRouteMetadata {
  * established here is visible to `resolveSession` on the same channel.
  */
 export type RouteSessionCreator = (
-  input: Omit<RunInput, "adapter" | "channelName" | "requestId">,
+  input: Omit<RunInput, "adapter" | "channelName" | "requestId"> & {
+    readonly channelAudience?: ChannelAudience;
+  },
 ) => Promise<RunHandle>;
 
 export type RemoteAgentStreamHeadersResolver = (input: {

--- a/packages/eve/src/public/channels/eve.test.ts
+++ b/packages/eve/src/public/channels/eve.test.ts
@@ -890,6 +890,85 @@ describe("eveChannel — onMessage", () => {
   });
 });
 
+describe("eveChannel — audience", () => {
+  it("classifies a new session after authentication", async () => {
+    const audience = vi.fn(async (ctx) => {
+      expect(ctx.caller).toEqual(ACCEPTED_AUTH);
+      expect(ctx.request.url).toBe("https://example.com/eve/v1/session");
+      return "private" as const;
+    });
+    const handler = createEveCreateHandler({
+      audience,
+      auth: () => ACCEPTED_AUTH,
+    });
+
+    const response = await handler.fetch(createJsonMessageRequest({ message: "hi" }));
+
+    expect(response.status).toBe(202);
+    expect(audience).toHaveBeenCalledOnce();
+    expect(handler.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ channelAudience: "private" }),
+    );
+  });
+
+  it("normalizes an unsupported audience to unknown", async () => {
+    const handler = createEveCreateHandler({
+      audience: (() => "workspace") as never,
+      auth: none(),
+    });
+
+    const response = await handler.fetch(createJsonMessageRequest({ message: "hi" }));
+
+    expect(response.status).toBe(202);
+    expect(handler.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ channelAudience: "unknown" }),
+    );
+  });
+
+  it("rejects session creation when the audience resolver throws", async () => {
+    const handler = createEveCreateHandler({
+      audience: () => {
+        throw new Error("visibility lookup failed");
+      },
+      auth: none(),
+    });
+
+    const response = await handler.fetch(createJsonMessageRequest({ message: "hi" }));
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Audience resolver failed.",
+      ok: false,
+    });
+    expect(handler.createSession).not.toHaveBeenCalled();
+  });
+
+  it("does not reclassify follow-up messages", async () => {
+    const audience = vi.fn(() => "public" as const);
+    const handler = createEveContinueHandler({ audience, auth: none() });
+
+    const response = await handler.fetch(createJsonMessageRequest({ message: "follow-up" }));
+
+    expect(response.status).toBe(202);
+    expect(audience).not.toHaveBeenCalled();
+  });
+
+  it("does not reclassify an existing idempotent session", async () => {
+    const audience = vi.fn(() => "public" as const);
+    const handler = createEveCreateHandler(
+      { audience, auth: () => ACCEPTED_AUTH },
+      { activeSessionId: "child-1" },
+    );
+
+    const response = await handler.fetch(
+      createJsonMessageRequest({ message: "hi", operationId: "operation-1" }),
+    );
+
+    expect(response.status).toBe(202);
+    expect(audience).not.toHaveBeenCalled();
+  });
+});
+
 describe("eveChannel — create session idempotency", () => {
   it("creates once for an operation id and uses it as the continuation token", async () => {
     const handler = createEveCreateHandler({ auth: () => ACCEPTED_AUTH });
@@ -2221,6 +2300,27 @@ describe("eveChannel — forwarded principal", () => {
     expect(onMessage).toHaveBeenCalledTimes(1);
     const options = handler.send.mock.calls[0]?.[1] as MockSendOptions;
     expect(options.auth?.principalId).toBe(FORWARDED_CURRENT.principalId);
+  });
+
+  it("exposes the stamped forwarded principal to the audience resolver", async () => {
+    const audience = vi.fn((ctx: Parameters<NonNullable<EveChannelInput["audience"]>>[0]) => {
+      expect(ctx.caller?.principalId).toBe(FORWARDED_CURRENT.principalId);
+      expect(ctx.caller?.attributes["eve:forwarded-by"]).toBe(ROUTER_CALLER.principalId);
+      return "private" as const;
+    });
+    const handler = createEveCreateHandler({
+      audience,
+      trustedForwarders: () => true,
+      auth: () => ROUTER_CALLER,
+    });
+
+    const response = await handler.fetch(forwardedRequest({ current: FORWARDED_CURRENT }));
+
+    expect(response.status).toBe(202);
+    expect(audience).toHaveBeenCalledOnce();
+    expect(handler.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ channelAudience: "private" }),
+    );
   });
 
   it("keeps the transport principal and omits initiatorAuth without a forwarded body", async () => {

--- a/packages/eve/src/tracing/local-instrumentation-runtime.ts
+++ b/packages/eve/src/tracing/local-instrumentation-runtime.ts
@@ -11,9 +11,12 @@ import {
   type TraceCapturePolicy,
 } from "#tracing/otel-declaration.js";
 
-/** Zero-config local tracing keeps unclassified HTTP/TUI sessions observable. @internal */
-export const localTracePolicy: TraceCapturePolicy = ({ audience }) =>
-  audience === "public" || audience === "unknown";
+/** Zero-config local tracing emits every audience but captures content only for public sessions. @internal */
+export const localTracePolicy: TraceCapturePolicy = ({ audience }) => ({
+  emit: true,
+  recordInputs: audience === "public",
+  recordOutputs: audience === "public",
+});
 
 /** Installs the zero-config local OTel runtime once in an `eve dev` worker. */
 export function installLocalInstrumentationRuntime(input: {

--- a/packages/eve/src/tracing/local-traces.test.ts
+++ b/packages/eve/src/tracing/local-traces.test.ts
@@ -102,14 +102,18 @@ describe("resolveLocalTracesContent", () => {
 describe("localTracePolicy", () => {
   it.each([
     ["public", true],
-    ["unknown", true],
+    ["unknown", false],
     ["private", false],
-  ] as const)("accepts the %s audience: %s", (audience, accepted) => {
+  ] as const)("captures content for the %s audience: %s", (audience, capturesContent) => {
     expect(
       localTracePolicy({
         agentName: "weather",
         audience,
       }),
-    ).toBe(accepted);
+    ).toEqual({
+      emit: true,
+      recordInputs: capturesContent,
+      recordOutputs: capturesContent,
+    });
   });
 });

--- a/research/channel-audience-content-policy.md
+++ b/research/channel-audience-content-policy.md
@@ -1,14 +1,14 @@
 ---
 issue: https://github.com/vercel/eve/issues/2331
 status: proposed
-last_updated: "2026-09-01"
+last_updated: "2026-09-10"
 ---
 
 # Audience-aware trace content policy
 
 ## Summary
 
-Messaging agents need different trace behavior for public and private conversations. Public messages may be traced with model and tool content; private conversations should not produce traces unless an author explicitly admits them. Zero-config local tracing additionally retains unclassified HTTP/TUI sessions for debugging.
+Messaging agents need different trace behavior for public and private conversations. Public messages may be traced with model and tool content; private and unknown conversations remain metadata-only unless an author explicitly admits their content. Zero-config local tracing retains metadata for every audience.
 
 This proposal adds a fail-closed audience classification to channel instrumentation metadata, classifies built-in messaging channels from durable platform state, and separates the process-wide trace gate from each destination's ordered export pipeline.
 
@@ -20,7 +20,7 @@ Channels may project one of three values from their existing synchronous `metada
 type ChannelAudience = "public" | "private" | "unknown";
 ```
 
-The field is optional for authored channels. Eve normalizes absent, malformed, and unsupported values to `unknown`. Built-in channel metadata interfaces require the field and classify only from platform evidence already captured during dispatch; ambiguous and proactive destinations remain `unknown` rather than performing observability-only network requests. Proactive Slack `receive` / `ctx.send` targets may optionally supply `audience` when the caller already knows channel visibility, for example a webhook that classified the Slack destination before handoff.
+The field is optional for authored channels. Eve normalizes absent, malformed, and unsupported values to `unknown`. Built-in channel metadata interfaces require the field and classify only from platform evidence already captured during dispatch; ambiguous and proactive destinations remain `unknown` rather than performing observability-only network requests. The eve HTTP channel may set the tracing audience for each new session with an asynchronous `audience(ctx)` resolver that runs after route authentication. Its flat context contains the verified caller and request; the result is persisted with the session, and omission remains `unknown`. A parent-attested local TUI sets the tracing audience to `private` and bypasses the authored resolver. Proactive Slack `receive` / `ctx.send` targets may optionally supply `audience` when the caller already knows channel visibility, for example a webhook that classified the Slack destination before handoff.
 
 The normalized audience is persisted with session trace state and exported as `agent.channel.audience` only on each `agent.session` window. Durable Eve state and an internal OpenTelemetry context key make the same value available to descendant export policies without duplicating a public attribute onto every span. Local subagents inherit the parent audience. A remote agent with principal forwarding propagates the immutable origin audience and the current hop's effective directional ceiling through one `eve.audience` W3C Baggage member. The receiver accepts it only with the same `trustedForwarders` decision that admitted the principal, then intersects it with its own process policy. Every later hop forwards that intersection; malformed and mixed-version assertions become metadata-only.
 
@@ -168,10 +168,14 @@ policy remains subject to its process-wide audience ceiling.
 The default policy for local tracing for `eve dev` is equivalent to:
 
 ```ts
-({ audience }) => audience === "public" || audience === "unknown";
+({ audience }) => ({
+  emit: true,
+  recordInputs: audience === "public",
+  recordOutputs: audience === "public",
+});
 ```
 
-This keeps unclassified local HTTP/TUI sessions observable while still rejecting channels classified as `private`.
+This keeps private TUI and messaging-channel trace metadata observable without capturing their content.
 
 The runtime order is:
 


### PR DESCRIPTION
### Summary

HTTP sessions currently reach audience-aware trace policy as `unknown`, even when an application can determine the tracing classification after route authentication. This adds an asynchronous `audience(ctx)` resolver with a flat verified `caller` and `request`, then persists the normalized result for follow-ups. A parent-attested local TUI sets the tracing audience to private, while zero-config local tracing retains metadata for every audience and captures content only for public sessions. The value is observability metadata and does not change HTTP authorization. Related to #2331.

### Validation

- `pnpm test:unit`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/eve-channel/support.test.ts src/public/channels/eve.test.ts src/internal/nitro/routes/channel-dispatch.test.ts src/tracing/local-traces.test.ts`
- `pnpm typecheck`
- `pnpm --filter eve typecheck`
- `pnpm lint` (passes with two existing `no-control-regex` warnings in unrelated files)
- `pnpm guard:invariants`
- `pnpm docs:check`
- `pnpm fmt`

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
