### PR TITLE
fix(slack): hydrate copied message links

### DIFF
--- a/.changeset/fast-lions-unfurl.md
+++ b/.changeset/fast-lions-unfurl.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Refresh copied Slack message permalinks once so delayed message unfurls reach agents when available.

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -179,7 +179,7 @@ export default slackChannel({
 
 The model-visible `<slack_message>` includes `sender_id`, `bot_user_id` when available, and the `is_mentioned` value from `ctx.isBotMentioned()`. Its `<content>` keeps `<@USER_ID>` intact while converting other mrkdwn to Markdown; routing is unchanged.
 
-When a Slack message shares another Slack message, eve extracts the forwarded message body from Slack's message-unfurl attachment and includes it in `<content>`. The original top-level comment, when present, remains alongside the forwarded content.
+When a Slack message shares another Slack message, eve extracts the forwarded message body from Slack's message-unfurl attachment and includes it in `<content>`. The original top-level comment, when present, remains alongside the forwarded content. For a copied Slack permalink whose event initially contains only `:crosspost:` and the link, eve briefly waits and refreshes the destination conversation once so Slack's delayed unfurl can reach the agent. This is best effort: if the app cannot read the destination conversation or Slack has not attached the unfurl yet, eve preserves the original link.
 
 #### Restrict who can invoke the agent
 

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -1789,6 +1789,59 @@ describe("slackChannel() inbound mention pipeline", () => {
     });
   });
 
+  it("passes a delayed copied-message unfurl to the mention handler", async () => {
+    const ts = "1700000000.000100";
+    fetchMock.mockImplementation(async (request: string | URL | Request) => {
+      if (String(request).includes("conversations.replies")) {
+        return new Response(
+          JSON.stringify({
+            messages: [
+              {
+                attachments: [
+                  {
+                    is_msg_unfurl: true,
+                    message_blocks: [{ message: { text: "The copied report body" } }],
+                  },
+                ],
+                text: "<@U_BOT> :crosspost: <https://example.slack.com/archives/C012ABC/p1700000000000100>",
+                ts,
+              },
+            ],
+            ok: true,
+          }),
+          { headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(JSON.stringify({ ok: true }), {
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const onAppMention = vi.fn(() => null);
+    const channel = slackChannel({
+      credentials: { botToken: "xoxb-test" },
+      onAppMention,
+    });
+    const body = buildEventBody(
+      {
+        channel: "C01",
+        text: "<@U_BOT> :crosspost: <https://example.slack.com/archives/C012ABC/p1700000000000100>",
+        ts,
+        type: "app_mention",
+        user: "U01",
+      },
+      { authorizations: [{ is_bot: true, user_id: "U_BOT" }] },
+    );
+
+    await firePost(channel, buildSignedRequest({ body }));
+
+    expect(onAppMention).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        text: "<@U_BOT> :crosspost: <https://example.slack.com/archives/C012ABC/p1700000000000100>\nThe copied report body",
+      }),
+    );
+  });
+
   it("uses the app installation workspace for mention credentials", async () => {
     const botToken = vi.fn((_context: { readonly teamId?: string }) => "xoxb-test");
     const channel = slackChannel({

--- a/packages/eve/src/public/channels/slack/slackChannel.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.ts
@@ -56,6 +56,7 @@ import {
 } from "#public/channels/slack/model-context.js";
 import { isPrivateSlackConversation } from "#public/channels/slack/privacy.js";
 import {
+  hydrateCopiedSlackMessage,
   loadThreadContextMessages,
   type LoadThreadContextMessagesOptions,
 } from "#public/channels/slack/thread.js";
@@ -1309,7 +1310,8 @@ async function dispatchSlackMessage(input: {
     installationTeamId: input.installationTeamId,
     teamId: input.message.teamId,
   });
-  const author = input.message.author;
+  const message = await hydrateCopiedSlackMessage(thread, input.message);
+  const author = message.author;
   const channelState: SlackChannelState = {
     audience: "unknown",
     channelId: input.message.channelId,
@@ -1339,13 +1341,13 @@ async function dispatchSlackMessage(input: {
   let privateConversation: Promise<boolean> | undefined;
   const isDMOrPrivateChannel = () =>
     (privateConversation ??= isPrivateSlackConversation({
-      channelId: input.message.channelId,
-      raw: input.message.raw,
+      channelId: message.channelId,
+      raw: message.raw,
       request: slack.request,
     }));
   const isBotMentioned =
     input.kind === "app_mention" ||
-    (input.botUserId !== undefined && input.message.text.includes(`<@${input.botUserId}`));
+    (input.botUserId !== undefined && message.text.includes(`<@${input.botUserId}`));
   const ctx: SlackInboundMessageContext = {
     ...sessionOperations,
     isBotMentioned: () => isBotMentioned,
@@ -1357,7 +1359,7 @@ async function dispatchSlackMessage(input: {
 
   let result;
   try {
-    result = await input.handler(ctx, input.message);
+    result = await input.handler(ctx, message);
   } catch (error) {
     logError(log, `${input.kind} handler failed`, error, {
       channelId: input.message.channelId,
@@ -1375,7 +1377,7 @@ async function dispatchSlackMessage(input: {
     kind: input.kind,
     isPrivateConversation,
     isMentioned: isBotMentioned,
-    message: input.message,
+    message,
     result,
     sessionOperations,
     thread,

--- a/packages/eve/src/public/channels/slack/thread.test.ts
+++ b/packages/eve/src/public/channels/slack/thread.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { SlackThreadMessage } from "#public/channels/slack/api.js";
-import { loadThreadContextMessages } from "#public/channels/slack/thread.js";
+import type { SlackMessage } from "#public/channels/slack/inbound.js";
+import {
+  hydrateCopiedSlackMessage,
+  loadThreadContextMessages,
+} from "#public/channels/slack/thread.js";
 
 function threadMessage(input: {
   readonly isMe?: boolean;
@@ -20,6 +24,89 @@ function threadMessage(input: {
     user: "U01",
   };
 }
+
+function slackMessage(text: string): SlackMessage {
+  return {
+    attachments: [],
+    author: undefined,
+    channelId: "C_DESTINATION",
+    markdown: text,
+    raw: { channel_type: "channel", text },
+    teamId: "T01",
+    text,
+    threadTs: "1700000000.000001",
+    ts: "1700000000.000001",
+  };
+}
+
+describe("hydrateCopiedSlackMessage", () => {
+  it("waits for and uses a copied Slack message unfurl", async () => {
+    const initial = slackMessage(
+      ":crosspost: <https://example.slack.com/archives/C012ABC/p1700000000000100>",
+    );
+    const messages: SlackThreadMessage[] = [];
+    const refresh = vi.fn(async () => {
+      messages.push(
+        threadMessage({
+          text: ":crosspost:\nThe copied report body",
+          threadTs: initial.threadTs,
+          ts: initial.ts,
+        }),
+      );
+    });
+    const wait = vi.fn(async () => {});
+
+    await expect(
+      hydrateCopiedSlackMessage({ recentMessages: messages, refresh }, initial, wait),
+    ).resolves.toMatchObject({
+      markdown: ":crosspost:\nThe copied report body",
+      raw: { channel_type: "channel" },
+      text: ":crosspost:\nThe copied report body",
+    });
+    expect(wait).toHaveBeenCalledWith(500);
+    expect(refresh).toHaveBeenCalledOnce();
+  });
+
+  it("recognizes a copied permalink after a leading app mention", async () => {
+    const initial = slackMessage(
+      "<@U012BOT> :crosspost: <https://example.enterprise.slack.com/archives/C012ABC/p1700000000000100?thread_ts=1700000000.000100>",
+    );
+    const refresh = vi.fn(async () => {});
+
+    await hydrateCopiedSlackMessage({ recentMessages: [], refresh }, initial, async () => {});
+
+    expect(refresh).toHaveBeenCalledOnce();
+  });
+
+  it("does not refresh native forwards or ordinary Slack links", async () => {
+    const refresh = vi.fn(async () => {});
+    const wait = vi.fn(async () => {});
+
+    for (const text of [
+      ":crosspost:\nThe forwarded report body",
+      "Please review <https://example.slack.com/archives/C012ABC/p1700000000000100>",
+    ]) {
+      const message = slackMessage(text);
+      await expect(
+        hydrateCopiedSlackMessage({ recentMessages: [], refresh }, message, wait),
+      ).resolves.toBe(message);
+    }
+
+    expect(wait).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("preserves the original message when the unfurl is still unavailable", async () => {
+    const initial = slackMessage(
+      ":crosspost: <https://example.slack.com/archives/C012ABC/p1700000000000100>",
+    );
+    const refresh = vi.fn(async () => {});
+
+    await expect(
+      hydrateCopiedSlackMessage({ recentMessages: [], refresh }, initial, async () => {}),
+    ).resolves.toBe(initial);
+  });
+});
 
 describe("loadThreadContextMessages", () => {
   it("returns an empty array without refreshing when the message is the thread root", async () => {

--- a/packages/eve/src/public/channels/slack/thread.ts
+++ b/packages/eve/src/public/channels/slack/thread.ts
@@ -1,4 +1,46 @@
 import type { SlackThread, SlackThreadMessage } from "#public/channels/slack/api.js";
+import type { SlackMessage } from "#public/channels/slack/inbound.js";
+
+const COPIED_MESSAGE_UNFURL_DELAY_MS = 500;
+const SLACK_MESSAGE_PERMALINK =
+  /^:crosspost:\s*<https:\/\/[a-z0-9-]+(?:\.enterprise)?\.slack\.com\/archives\/[A-Z0-9]+\/p\d+(?:\?[^>]*)?(?:\|[^>]*)?>$/iu;
+
+/**
+ * Replaces a copied Slack permalink with the message unfurl Slack attaches
+ * shortly after delivery. Native forwards already contain their unfurl in the
+ * webhook and skip this path.
+ */
+export async function hydrateCopiedSlackMessage(
+  thread: Pick<SlackThread, "recentMessages" | "refresh">,
+  message: SlackMessage,
+  wait: (milliseconds: number) => Promise<void> = delay,
+): Promise<SlackMessage> {
+  if (!isCopiedSlackMessagePermalink(message.text)) return message;
+
+  await wait(COPIED_MESSAGE_UNFURL_DELAY_MS);
+  await thread.refresh();
+
+  const refreshed = thread.recentMessages.find((entry) => entry.ts === message.ts);
+  if (refreshed === undefined || isCopiedSlackMessagePermalink(refreshed.text)) {
+    return message;
+  }
+
+  return {
+    ...message,
+    text: refreshed.text,
+    markdown: refreshed.markdown,
+    raw: { ...message.raw, ...refreshed.raw },
+  };
+}
+
+function isCopiedSlackMessagePermalink(text: string): boolean {
+  const withoutLeadingMentions = text.trim().replace(/^(?:<@[^>\s]+>\s*)+/u, "");
+  return SLACK_MESSAGE_PERMALINK.test(withoutLeadingMentions);
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
 
 /**
  * Boundary for {@link loadThreadContextMessages}. `"thread-root"` returns all


### PR DESCRIPTION
### Summary

Copied Slack message links can reach an agent before Slack attaches the source-message unfurl, leaving the agent with only `:crosspost:` and a permalink. This change waits 500 ms and refreshes the destination conversation once for that narrow message shape, then passes the enriched message to the handler when available. Native forwards and ordinary links remain unchanged; failed or unavailable unfurls preserve the original message, and Eve does not fetch arbitrary source channels.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/channels/slack/thread.test.ts src/public/channels/slack/inbound-content.test.ts src/public/channels/slack/slackChannel.test.ts` — 180 tests passed
- `pnpm lint` — passed with two existing `no-control-regex` warnings in unrelated files
- `pnpm typecheck`
- `pnpm docs:check`
- `pnpm fmt --check`
- `git diff --check`

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
