### PR TITLE
fix(eve): keep collision-suffixed OpenAPI tool names within 64 characters

### DIFF
--- a/.changeset/unique-tool-name-length.md
+++ b/.changeset/unique-tool-name-length.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Keep OpenAPI tool names within the 64-character provider limit when a collision suffix (`_2`, `_3`, …) is added: the base name is shortened to make room instead of the suffix pushing the name past the limit.

--- a/packages/eve/src/runtime/connections/openapi-operations.test.ts
+++ b/packages/eve/src/runtime/connections/openapi-operations.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { uniqueName } from "./openapi-operations.js";
+
+describe("uniqueName", () => {
+  it("returns the name unchanged when it is free", () => {
+    const used = new Set<string>();
+    expect(uniqueName("get_users", used)).toBe("get_users");
+    expect(used.has("get_users")).toBe(true);
+  });
+
+  it("appends an increasing suffix on collisions", () => {
+    const used = new Set<string>();
+    expect(uniqueName("get_users", used)).toBe("get_users");
+    expect(uniqueName("get_users", used)).toBe("get_users_2");
+    expect(uniqueName("get_users", used)).toBe("get_users_3");
+  });
+
+  it("keeps a colliding 64-character name within the provider limit", () => {
+    const base = "a".repeat(64);
+    const used = new Set([base]);
+    const result = uniqueName(base, used);
+    expect(result).toHaveLength(64);
+    expect(result).toBe(`${"a".repeat(62)}_2`);
+    expect(result).not.toBe(base);
+  });
+
+  it("stays within the limit and unique across repeated long collisions", () => {
+    const base = "b".repeat(63);
+    const used = new Set([base]);
+    const names = Array.from({ length: 10 }, () => uniqueName(base, used));
+    for (const name of names) {
+      expect(name.length).toBeLessThanOrEqual(64);
+    }
+    expect(new Set(names).size).toBe(names.length);
+    expect(names[8]).toBe(`${"b".repeat(61)}_10`);
+  });
+
+  it("does not shorten names that have room for the suffix", () => {
+    const base = "c".repeat(62);
+    const used = new Set([base]);
+    expect(uniqueName(base, used)).toBe(`${base}_2`);
+  });
+});

--- a/packages/eve/src/runtime/connections/openapi-operations.ts
+++ b/packages/eve/src/runtime/connections/openapi-operations.ts
@@ -44,20 +44,29 @@ export function operationName(
   return sanitizeToolName(`${method}_${sanitizedPath}`);
 }
 
+/** Longest tool name the model providers accept. */
+const MAX_TOOL_NAME_LENGTH = 64;
+
 /** Coerces an arbitrary string into a provider-legal tool name (`[a-zA-Z0-9_-]`, ≤64). */
 function sanitizeToolName(name: string): string {
   return name
     .replace(/[^a-zA-Z0-9_-]+/g, "_")
     .replace(/^[_-]+|[_-]+$/g, "")
-    .slice(0, 64);
+    .slice(0, MAX_TOOL_NAME_LENGTH);
 }
 
-/** Disambiguates a tool name against names already used in the same connection. */
+/**
+ * Disambiguates a tool name against names already used in the same connection.
+ *
+ * The `_N` suffix is applied within the provider limit: a name that already
+ * fills the 64 characters is shortened to make room for it.
+ */
 export function uniqueName(name: string, used: Set<string>): string {
   let candidate = name;
   let suffix = 2;
   while (used.has(candidate)) {
-    candidate = `${name}_${suffix}`;
+    const tail = `_${suffix}`;
+    candidate = `${name.slice(0, MAX_TOOL_NAME_LENGTH - tail.length)}${tail}`;
     suffix += 1;
   }
   used.add(candidate);


### PR DESCRIPTION
### Summary

Closes #3251.

`sanitizeToolName` truncates an OpenAPI operation's tool name to the 64-character provider limit, but `uniqueName` then appended `_2`, `_3`, … to that already-full name on a collision, producing 65+ character tool names that providers reject. The suffix is now applied within the limit: the base is shortened to make room for `_N`, repeated collisions stay unique and at most 64 characters, and names that have room for the suffix are unchanged (`get_users` → `get_users_2` as before).

### Validation

```
cd packages/eve && npx vitest run --config vitest.unit.config.ts src/runtime/connections/openapi-operations.test.ts
# 5 passed
npx oxlint packages/eve/src/runtime/connections/openapi-operations.ts packages/eve/src/runtime/connections/openapi-operations.test.ts
# 0 warnings, 0 errors
```

The new test file covers: a free name is returned unchanged; collisions append `_2`, `_3`; a colliding 64-character name comes back as 62 characters plus `_2`; ten collisions on a 63-character name all stay ≤ 64 and distinct (the tenth is `…_10`, trimmed by one more character); a 62-character name keeps its full base.

### Checklist

- [ ] This change was requested or approved by a maintainer (opened against the issue; not pre-approved)
- [x] I ran the relevant checks from `CONTRIBUTING.md` (unit tests and oxlint for the touched files; the full typecheck was not run)
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
