### PR TITLE
fix(eve): reconnect idle TUI session streams

### DIFF
--- a/.changeset/reconnect-idle-tui-streams.md
+++ b/.changeset/reconnect-idle-tui-streams.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+The local dev TUI now reconnects idle session streams, so approvals and questions from long-running background tasks still interrupt the prompt after an earlier transport stream closes.

--- a/packages/eve/src/cli/dev/tui/runner.test.ts
+++ b/packages/eve/src/cli/dev/tui/runner.test.ts
@@ -1025,6 +1025,106 @@ describe("EveTUIRunner idle session follow", () => {
     ]);
   });
 
+  it("reconnects idle following when a transport stream ends before an approval arrives", async () => {
+    const session = stubSession();
+    const prompt = createDeferred<string | undefined>();
+    const requestId = "task_123:approval-after-reconnect";
+    const firstWakeEvents = [
+      stampTestEvent({
+        type: "message.appended",
+        data: {
+          messageDelta: "Still working.",
+          sequence: 1,
+          stepIndex: 0,
+          turnId: "progress-turn",
+        },
+      } as UnstampedMessageStreamEvent),
+      stampTestEvent({
+        type: "session.waiting",
+        data: { continuationToken: "session-id", wait: "next-user-message" },
+      }),
+    ];
+    const wakeEvents = [
+      stampTestEvent({
+        type: "input.requested",
+        data: {
+          sequence: 1,
+          stepIndex: 0,
+          turnId: "wake-turn",
+          requests: [
+            {
+              action: {
+                callId: "call-1",
+                input: { address: "connection/linear" },
+                kind: "tool-call",
+                toolName: "selfmod__registry_add",
+              },
+              display: "confirmation",
+              kind: "tool-approval",
+              options: [
+                { id: "approve", label: "Approve" },
+                { id: "cancel", label: "Cancel" },
+              ],
+              prompt: "Approve tool call: selfmod__registry_add",
+              requestId,
+            },
+          ],
+        },
+      } as UnstampedMessageStreamEvent),
+      stampTestEvent({
+        type: "session.waiting",
+        data: { continuationToken: "session-id", wait: "next-user-message" },
+      }),
+    ];
+    let streamCalls = 0;
+    vi.spyOn(session, "stream").mockImplementation((options?: { signal?: AbortSignal }) => {
+      const call = ++streamCalls;
+      const events = call === 1 ? firstWakeEvents : call === 2 ? wakeEvents : [];
+      return {
+        async *[Symbol.asyncIterator]() {
+          for (const event of events) yield event;
+          if (call === 2) {
+            await new Promise<void>((resolve) => {
+              if (options?.signal?.aborted) resolve();
+              else options?.signal?.addEventListener("abort", () => resolve(), { once: true });
+            });
+          }
+        },
+      };
+    });
+    const idleEvents: AgentTUIStreamEvent[] = [];
+    const fallback = setTimeout(() => prompt.resolve(undefined), 1_000);
+    const renderer = fakeRenderer({
+      readPrompt: vi
+        .fn()
+        .mockImplementationOnce(() => prompt.promise)
+        .mockResolvedValueOnce(undefined),
+      readToolApproval: vi.fn(async () => ({ approved: false })),
+      renderIdleStream: vi.fn(async (result) => {
+        for await (const event of result.events) idleEvents.push(event);
+      }),
+      renderStream: vi.fn(async (result) => {
+        for await (const event of result.events) void event;
+      }),
+      suspendPromptForInput: vi.fn(() => prompt.reject(interruptedError())),
+    });
+
+    try {
+      await new EveTUIRunner({ session, renderer, name: "Task Agent" }).run();
+    } finally {
+      clearTimeout(fallback);
+    }
+
+    expect(streamCalls).toBeGreaterThanOrEqual(2);
+    expect(idleEvents.filter((event) => event.type === "assistant-delta")).toEqual([
+      { delta: "Still working.", id: "text:progress-turn:0", type: "assistant-delta" },
+    ]);
+    expect(renderer.readToolApproval).toHaveBeenCalledWith(
+      expect.objectContaining({ approvalId: requestId, toolName: "selfmod__registry_add" }),
+      { title: "Task Agent" },
+    );
+  });
+
   it("answers a background-task approval that arrives while the prompt is idle", async () => {
     const session = stubSession();
     const prompt = createDeferred<string | undefined>();

--- a/packages/eve/src/cli/dev/tui/runner.ts
+++ b/packages/eve/src/cli/dev/tui/runner.ts
@@ -118,6 +118,8 @@ export { parsePromptCommand, type PromptCommand } from "./prompt-commands.js";
 const defaultAssistantResponseStats: AssistantResponseStatsMode = "tokensPerSecond";
 const idleRuntimeArtifactPollMs = 500;
 const idleChatGptAuthPollMs = 5_000;
+const idleSessionReconnectBaseDelayMs = 100;
+const idleSessionReconnectMaxDelayMs = 2_000;
 /**
  * Cooperative-cancel retry cadence: 8 × 250ms covers the turn-dispatch
  * window (locally the cancel hook is claimed well under a second after the
@@ -130,6 +132,20 @@ async function delayMs(ms: number): Promise<void> {
   await new Promise<void>((resolve) => {
     const timer = setTimeout(resolve, ms);
     timer.unref?.();
+  });
+}
+
+async function abortableDelay(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return;
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(done, ms);
+    timer.unref?.();
+    signal.addEventListener("abort", done, { once: true });
+    function done() {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", done);
+      resolve();
+    }
   });
 }
 
@@ -1373,42 +1389,57 @@ export class EveTUIRunner {
   async #followIdleSession(signal: AbortSignal, options: AgentTUISessionOptions): Promise<void> {
     const sourceSession = this.#session;
     if (sourceSession === undefined) return;
-    const source = sourceSession.stream({ signal })[Symbol.asyncIterator]();
-    try {
-      while (!signal.aborted) {
-        let consumed = false;
-        const turn = {
-          async *[Symbol.asyncIterator]() {
-            while (!signal.aborted) {
-              const next = await source.next();
-              if (next.done === true) return;
-              consumed = true;
-              yield next.value;
-              if (isCurrentTurnBoundaryEvent(next.value)) return;
-            }
-          },
-        };
-        const result = this.#createTUIStreamResult(turn, () => {}, sourceSession);
-        await this.#renderer.renderIdleStream!(result, {
-          ...options,
-          continueSession: true,
-        });
-        this.#enterPendingConnectionAuthorization(result);
-        if (
-          (result.turnState?.pendingApprovals.length ?? 0) > 0 ||
-          (result.turnState?.pendingQuestions.length ?? 0) > 0
-        ) {
-          this.#idleInputResult = {
-            events: (async function* () {})(),
-            turnState: result.turnState,
+    let reconnectDelayMs = idleSessionReconnectBaseDelayMs;
+    while (!signal.aborted) {
+      const source = sourceSession.stream({ signal })[Symbol.asyncIterator]();
+      let deliveredEvent = false;
+      try {
+        while (!signal.aborted) {
+          let consumed = false;
+          const turn = {
+            async *[Symbol.asyncIterator]() {
+              while (!signal.aborted) {
+                const next = await source.next();
+                if (next.done === true) return;
+                consumed = true;
+                deliveredEvent = true;
+                yield next.value;
+                if (isCurrentTurnBoundaryEvent(next.value)) return;
+              }
+            },
           };
-          this.#renderer.suspendPromptForInput?.();
-          return;
+          const result = this.#createTUIStreamResult(turn, () => {}, sourceSession);
+          await this.#renderer.renderIdleStream!(result, {
+            ...options,
+            continueSession: true,
+          });
+          this.#enterPendingConnectionAuthorization(result);
+          if (
+            (result.turnState?.pendingApprovals.length ?? 0) > 0 ||
+            (result.turnState?.pendingQuestions.length ?? 0) > 0
+          ) {
+            this.#idleInputResult = {
+              events: (async function* () {})(),
+              turnState: result.turnState,
+            };
+            this.#renderer.suspendPromptForInput?.();
+            return;
+          }
+          if (
+            result.turnState?.boundaryEvent === "session.completed" ||
+            result.turnState?.boundaryEvent === "session.failed"
+          ) {
+            return;
+          }
+          if (!consumed) break;
         }
-        if (!consumed) return;
+      } finally {
+        await source.return?.();
       }
-    } finally {
-      await source.return?.();
+      reconnectDelayMs = deliveredEvent
+        ? idleSessionReconnectBaseDelayMs
+        : Math.min(reconnectDelayMs * 2, idleSessionReconnectMaxDelayMs);
+      if (!signal.aborted) await abortableDelay(reconnectDelayMs, signal);
     }
   }
 


### PR DESCRIPTION
### Summary

Fixes the dev TUI dropping late approvals and questions from long-running background tasks after its idle transport stream closes. Idle session following now reconnects from the retained client cursor with bounded backoff, while still stopping for terminal session boundaries.

Before (question ask is dropped):

<img width="1246" height="612" alt="Screenshot 2026-09-10 at 2 20 42 PM" src="https://github.com/user-attachments/assets/b90837c1-d36b-46d7-ab55-8b0eeaa9de29" />

### Validation

Adds a unit regression where one idle transport stream ends before the next delivers `selfmod__registry_add` approval. It fails against the parent commit and passes with this fix.
