### PR TITLE
test(eve): cover subagent install approval timing

### DIFF
--- a/apps/fixtures/agent-tui-hot-add/agent/agent.ts
+++ b/apps/fixtures/agent-tui-hot-add/agent/agent.ts
@@ -1,0 +1,14 @@
+import { defineAgent } from "eve";
+import { mockModel, type MockModelRequest } from "eve/evals";
+
+function respond(request: MockModelRequest) {
+  if (request.lastUserMessage !== "HOT-ADD-APPROVAL") return "ready";
+  return request.toolResults.some((result) => result.name === "self-modification")
+    ? "completed"
+    : { toolCalls: [{ input: { message: "Call the gated tool." }, name: "self-modification" }] };
+}
+
+export default defineAgent({
+  model: mockModel(respond),
+  modelContextWindowTokens: 1_000_000,
+});

--- a/apps/fixtures/agent-tui-hot-add/agent/instructions.md
+++ b/apps/fixtures/agent-tui-hot-add/agent/instructions.md
@@ -1,0 +1,1 @@
+Follow the deterministic test model.

--- a/apps/fixtures/agent-tui-hot-add/package.json
+++ b/apps/fixtures/agent-tui-hot-add/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "agent-tui-hot-add",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "eve build",
+    "dev": "eve dev",
+    "start": "eve start",
+    "typecheck": "eve build && tsc"
+  },
+  "dependencies": {
+    "eve": "workspace:*",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/apps/fixtures/agent-tui-hot-add/tsconfig.json
+++ b/apps/fixtures/agent-tui-hot-add/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["agent/**/*.ts"]
+}

--- a/packages/eve/test/tui-client/hot-add-fixture.ts
+++ b/packages/eve/test/tui-client/hot-add-fixture.ts
@@ -1,0 +1,32 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const testRoot = dirname(fileURLToPath(import.meta.url));
+export const hotAddAppRoot = resolve(testRoot, "../../../../apps/fixtures/agent-tui-hot-add");
+const subagentRoot = resolve(hotAddAppRoot, "agent/subagents/self-modification");
+
+export async function removeApprovalSubagent(): Promise<void> {
+  await rm(subagentRoot, { force: true, recursive: true });
+}
+
+export async function installApprovalSubagent(): Promise<void> {
+  await mkdir(resolve(subagentRoot, "tools"), { recursive: true });
+  await Promise.all([
+    writeFile(
+      resolve(subagentRoot, "agent.ts"),
+      `import { defineAgent } from "eve";\nimport { mockModel, type MockModelRequest } from "eve/evals";\n\nfunction respond(request: MockModelRequest) {\n  return request.toolResults.some((result) => result.name === "selfmod__registry_add")\n    ? "installed"\n    : { toolCalls: [{ input: { address: "connection/linear" }, name: "selfmod__registry_add" }] };\n}\n\nexport default defineAgent({\n  description: "Install capabilities requested by the parent.",\n  model: mockModel(respond),\n  modelContextWindowTokens: 1_000_000,\n});\n`,
+      "utf8",
+    ),
+    writeFile(
+      resolve(subagentRoot, "instructions.md"),
+      "Call selfmod__registry_add exactly once.\n",
+      "utf8",
+    ),
+    writeFile(
+      resolve(subagentRoot, "tools/selfmod__registry_add.ts"),
+      `import { defineTool } from "eve/tools";\nimport { once } from "eve/tools/approval";\nimport { z } from "zod";\n\nexport default defineTool({\n  approval: once(),\n  description: "Approval-gated registry installation stand-in.",\n  inputSchema: z.object({ address: z.string() }),\n  execute: async ({ address }) => ({ address, status: "installed" }),\n});\n`,
+      "utf8",
+    ),
+  ]);
+}

--- a/packages/eve/test/tui-client/tui-hot-added-subagent-approval.ts
+++ b/packages/eve/test/tui-client/tui-hot-added-subagent-approval.ts
@@ -1,0 +1,113 @@
+import { Buffer } from "node:buffer";
+import { randomUUID } from "node:crypto";
+import { setTimeout as sleep } from "node:timers/promises";
+
+import { Client } from "eve/client";
+import {
+  resumeDevelopmentRuntimeArtifacts,
+  suspendDevelopmentRuntimeArtifacts,
+} from "../../src/services/dev-client/runtime-artifacts.ts";
+import { EveTUIRunner, MockScreen, MockUserInput } from "./lib/tui.ts";
+
+import {
+  hotAddAppRoot,
+  installApprovalSubagent,
+  removeApprovalSubagent,
+} from "./hot-add-fixture.ts";
+import { runEnvironment } from "./lib/run.ts";
+import { theme } from "./lib/theme.ts";
+
+/**
+ * Reproduces the fresh-onboarding path where `/add` installs a background
+ * subagent into the same live dev process that immediately delegates to it.
+ * The child's first approval must wake the idle parent TUI without a restart.
+ */
+
+process.env.EVE_TUI_UNICODE = "1";
+
+runEnvironment("hot-added subagent approval", async ({ cleanup, target }) => {
+  await removeApprovalSubagent();
+  cleanup(removeApprovalSubagent);
+
+  const resolvedTarget = await target({
+    app: "agent-tui-hot-add",
+    kind: "local-dev",
+    startEnv: { ...process.env, EVE_E2E_MODEL: "mock" },
+  });
+
+  const client = new Client({ host: resolvedTarget.baseUrl });
+  const screen = new MockScreen({ columns: 140, rows: 60 });
+  const input = new MockUserInput();
+  const runner = new EveTUIRunner({
+    appRoot: hotAddAppRoot,
+    bootDetections: [],
+    client,
+    name: "Hot-added subagent approval",
+    onboard: true,
+    promptCommandHandler: {
+      async handle(command, context) {
+        if (command.name === "model") return { message: "Model ready" };
+        if (command.name !== "add") return { message: `/${command.name} dismissed.` };
+        await context.withExclusiveTerminal?.(installApprovalSubagent);
+        return { message: "Added Self-modification", tone: "success" };
+      },
+    },
+    screen,
+    serverUrl: resolvedTarget.baseUrl,
+    userInput: input,
+    withExclusiveTerminal: (task) => withSuspendedRuntime(resolvedTarget.baseUrl, task),
+  });
+
+  const runPromise = runner.run().catch((error: unknown) => {
+    if (error instanceof Error && error.message === "Interrupted") return;
+    throw error;
+  });
+
+  try {
+    await screen.waitForIdlePrompt(30_000);
+    input.type("HOT-ADD-APPROVAL");
+    input.enter();
+
+    await screen.waitForText("Approve selfmod__registry_add?", 15_000);
+    await sleep(500);
+    input.emit("data", Buffer.from("n"));
+    await screen.waitForIdlePrompt(30_000);
+    console.log(theme.muted("[tui-hot-add] approval reached the parent TUI"));
+  } catch (error) {
+    throw new Error(`Hot-added child approval did not reach the TUI.\n\n${screen.snapshot()}`, {
+      cause: error,
+    });
+  } finally {
+    input.type("/exit");
+    input.enter();
+    await runPromise;
+    await resolvedTarget.stop();
+    await removeApprovalSubagent();
+  }
+});
+
+async function withSuspendedRuntime<T>(serverUrl: string, task: () => Promise<T>): Promise<T> {
+  const leaseId = randomUUID();
+  let suspended = false;
+  for (let attempt = 0; attempt < 20 && !suspended; attempt += 1) {
+    suspended = await suspendDevelopmentRuntimeArtifacts({ leaseId, serverUrl });
+    if (!suspended) await sleep(100);
+  }
+  if (!suspended) throw new Error("Could not suspend development runtime artifacts.");
+  let outcome: { ok: true; value: T } | { error: unknown; ok: false };
+  try {
+    outcome = { ok: true, value: await task() };
+  } catch (error) {
+    outcome = { error, ok: false };
+  }
+  const resumed =
+    (await resumeDevelopmentRuntimeArtifacts({ leaseId, serverUrl, silent: true })) ??
+    (await resumeDevelopmentRuntimeArtifacts({ leaseId, serverUrl, silent: true }));
+  if (resumed === undefined) {
+    throw new Error("Could not resume development runtime artifacts.", {
+      cause: outcome.ok ? undefined : outcome.error,
+    });
+  }
+  if (!outcome.ok) throw outcome.error;
+  return outcome.value;
+}

--- a/packages/eve/test/tui-client/tui-preinstalled-subagent-approval.ts
+++ b/packages/eve/test/tui-client/tui-preinstalled-subagent-approval.ts
@@ -1,0 +1,69 @@
+import { Buffer } from "node:buffer";
+import { setTimeout as sleep } from "node:timers/promises";
+
+import { Client } from "eve/client";
+import { EveTUIRunner, MockScreen, MockUserInput } from "./lib/tui.ts";
+
+import {
+  hotAddAppRoot,
+  installApprovalSubagent,
+  removeApprovalSubagent,
+} from "./hot-add-fixture.ts";
+import { runEnvironment } from "./lib/run.ts";
+import { theme } from "./lib/theme.ts";
+
+/** Control for the hot-add regression: the same child approval works when the
+ * subagent is present before `eve dev` starts. */
+
+process.env.EVE_TUI_UNICODE = "1";
+
+runEnvironment("preinstalled subagent approval", async ({ cleanup, target }) => {
+  await installApprovalSubagent();
+  cleanup(removeApprovalSubagent);
+
+  const resolvedTarget = await target({
+    app: "agent-tui-hot-add",
+    kind: "local-dev",
+    startEnv: { ...process.env, EVE_E2E_MODEL: "mock" },
+  });
+
+  const client = new Client({ host: resolvedTarget.baseUrl });
+  const screen = new MockScreen({ columns: 140, rows: 60 });
+  const input = new MockUserInput();
+  const runner = new EveTUIRunner({
+    appRoot: hotAddAppRoot,
+    client,
+    name: "Preinstalled subagent approval",
+    screen,
+    serverUrl: resolvedTarget.baseUrl,
+    userInput: input,
+  });
+
+  const runPromise = runner.run().catch((error: unknown) => {
+    if (error instanceof Error && error.message === "Interrupted") return;
+    throw error;
+  });
+
+  try {
+    await screen.waitForIdlePrompt(30_000);
+    input.type("HOT-ADD-APPROVAL");
+    input.enter();
+
+    await screen.waitForText("Approve selfmod__registry_add?", 15_000);
+    await sleep(500);
+    input.emit("data", Buffer.from("y"));
+    await screen.waitForText("installed", 30_000);
+    await screen.waitForIdlePrompt(30_000);
+    console.log(theme.muted("[tui-preinstalled] approval completed through the parent TUI"));
+  } catch (error) {
+    throw new Error(`Preinstalled child approval failed.\n\n${screen.snapshot()}`, {
+      cause: error,
+    });
+  } finally {
+    input.type("/exit");
+    input.enter();
+    await runPromise;
+    await resolvedTarget.stop();
+    await removeApprovalSubagent();
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -405,6 +405,22 @@ importers:
         specifier: 'catalog:'
         version: 7.0.2
 
+  apps/fixtures/agent-tui-hot-add:
+    dependencies:
+      eve:
+        specifier: workspace:*
+        version: link:../../../packages/eve
+      zod:
+        specifier: 'catalog:'
+        version: 4.5.4
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.3
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+
   apps/fixtures/datadog-eval-reporter:
     dependencies:
       '@eve-e2e/config':


### PR DESCRIPTION
### Summary

Adds TUI smoke controls for an approval-gated subagent installed before `eve dev` starts and during an active onboarding session. Both cases already pass on `main`; this captures the installation and approval-routing behavior separately from the idle-stream timeout fix in #3256.

### Validation

Both TUI smokes pass against `main`.

🤖
