### PR TITLE
test(e2e): pin stable eve image digest

### DIFF
--- a/e2e/fixtures/stable-eve-image-cache/.gitignore
+++ b/e2e/fixtures/stable-eve-image-cache/.gitignore
@@ -1,0 +1,10 @@
+node_modules
+.env*
+.eve
+.vercel
+.next
+.output
+.nitro
+dist
+.DS_Store
+*.tsbuildinfo

--- a/e2e/fixtures/stable-eve-image-cache/.vercelignore
+++ b/e2e/fixtures/stable-eve-image-cache/.vercelignore
@@ -1,0 +1,7 @@
+.env*.local
+node_modules
+.eve
+.next
+.output
+.nitro
+dist

--- a/e2e/fixtures/stable-eve-image-cache/agent/agent.ts
+++ b/e2e/fixtures/stable-eve-image-cache/agent/agent.ts
@@ -1,0 +1,13 @@
+import { e2eAgentConfig } from "@eve-e2e/config";
+import { defineAgent } from "eve";
+import { mockModel } from "eve/evals";
+
+export default defineAgent({
+  ...e2eAgentConfig(),
+  model: mockModel(({ toolResults }) => {
+    const result = toolResults.at(-1);
+    if (result !== undefined) return "done";
+    return { toolCalls: [{ input: { command: "true" }, name: "bash" }] };
+  }),
+  modelContextWindowTokens: 1_000_000,
+});

--- a/e2e/fixtures/stable-eve-image-cache/agent/instructions.md
+++ b/e2e/fixtures/stable-eve-image-cache/agent/instructions.md
@@ -1,0 +1,1 @@
+Run the requested sandbox command.

--- a/e2e/fixtures/stable-eve-image-cache/agent/sandbox.ts
+++ b/e2e/fixtures/stable-eve-image-cache/agent/sandbox.ts
@@ -1,0 +1,3 @@
+import { defaultBackend, defineSandbox } from "eve/sandbox";
+
+export default defineSandbox({ backend: defaultBackend() });

--- a/e2e/fixtures/stable-eve-image-cache/agent/tools/bash.ts
+++ b/e2e/fixtures/stable-eve-image-cache/agent/tools/bash.ts
@@ -1,0 +1,5 @@
+import { defineTool } from "eve/tools";
+import { never } from "eve/tools/approval";
+import { bash } from "eve/tools/bash";
+
+export default defineTool({ ...bash, approval: never() });

--- a/e2e/fixtures/stable-eve-image-cache/evals/evals.config.ts
+++ b/e2e/fixtures/stable-eve-image-cache/evals/evals.config.ts
@@ -1,0 +1,4 @@
+import { e2eJudgeModel } from "@eve-e2e/config";
+import { defineEvalConfig } from "eve/evals";
+
+export default defineEvalConfig({ judge: { model: e2eJudgeModel() } });

--- a/e2e/fixtures/stable-eve-image-cache/evals/stable-image-cache.eval.ts
+++ b/e2e/fixtures/stable-eve-image-cache/evals/stable-image-cache.eval.ts
@@ -1,0 +1,55 @@
+import { defineEval } from "eve/evals";
+import { equals } from "eve/evals/expect";
+
+const SESSION_COUNT = 20;
+const METRIC_PREFIX = "EVE_STABLE_IMAGE_CACHE=";
+
+export default defineEval({
+  description:
+    "Sandbox startup experiment: no bootstrap or managed files skips the eve template snapshot.",
+  tags: ["sandbox", "performance"],
+  timeoutMs: 5 * 60_000,
+  async test(t) {
+    if (
+      t.target.kind !== "remote" ||
+      process.env.EVE_E2E_MODEL !== "mock" ||
+      process.env.EVE_E2E_WORKFLOW_WORLD !== undefined
+    ) {
+      t.skip("Temporary performance experiment runs only in the Vercel mock-world suite.");
+    }
+
+    const sessions = Array.from({ length: SESSION_COUNT }, () => t.newSession());
+    const batchStartedAt = performance.now();
+    const batchStartedAtMs = Date.now();
+    const samples = await Promise.all(
+      sessions.map(async (session, index) => {
+        const startedAt = performance.now();
+        const startedAtMs = Date.now();
+        const result = await session.send(`stable-image-${index}`);
+        result.expectOk();
+        await t.require(result.message, equals("done"));
+        return {
+          durationMs: performance.now() - startedAt,
+          endedAtMs: Date.now(),
+          sessionId: result.sessionId,
+          sessionNumber: index + 1,
+          startedAtMs,
+        };
+      }),
+    );
+
+    t.log(
+      `${METRIC_PREFIX}${JSON.stringify({
+        batchDurationMs: performance.now() - batchStartedAt,
+        batchEndedAtMs: Date.now(),
+        batchStartedAtMs,
+        fixture: "stable-eve-image-cache",
+        samples,
+        schemaVersion: 1,
+        sessionCount: SESSION_COUNT,
+        variant: "pinned-eve-image-digest",
+      })}`,
+    );
+    t.succeeded();
+  },
+});

--- a/e2e/fixtures/stable-eve-image-cache/package.json
+++ b/e2e/fixtures/stable-eve-image-cache/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "stable-eve-image-cache",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "eve build",
+    "dev": "eve dev",
+    "start": "eve start",
+    "typecheck": "eve build && tsc",
+    "test:e2e": "eve eval --strict"
+  },
+  "dependencies": {
+    "@eve-e2e/config": "workspace:*",
+    "@workflow/world-postgres": "catalog:",
+    "eve": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/e2e/fixtures/stable-eve-image-cache/tsconfig.json
+++ b/e2e/fixtures/stable-eve-image-cache/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["agent/**/*.ts", "evals/**/*.ts"]
+}

--- a/packages/eve/src/execution/sandbox/bindings/eve-image.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/eve-image.test.ts
@@ -23,8 +23,12 @@ describe("eve sandbox image", () => {
   });
 
   it("uses the versioned VCR image for Vercel Sandbox", () => {
-    expect(resolveVercelEveSandboxImage()).toBe("vcr.vercel.com/vercel/eve/base:1.2.3");
-    expect(VERCEL_EVE_SANDBOX_IMAGE).toBe("vcr.vercel.com/vercel/eve/base:1.2.3");
+    expect(resolveVercelEveSandboxImage()).toBe(
+      "vercel/eve/base@sha256:d8d53829d9f05d54a889619603121499e911c467ea22345c28e572a60f613329",
+    );
+    expect(VERCEL_EVE_SANDBOX_IMAGE).toBe(
+      "vercel/eve/base@sha256:d8d53829d9f05d54a889619603121499e911c467ea22345c28e572a60f613329",
+    );
   });
 
   it("uses EVE_SANDBOX_IMAGE_TAG for both registries", async () => {
@@ -34,7 +38,11 @@ describe("eve sandbox image", () => {
     const images = await import("#execution/sandbox/bindings/eve-image.js");
     expect(images.resolveEveSandboxImage()).toBe("ghcr.io/vercel/eve:latest");
     expect(images.DEFAULT_EVE_SANDBOX_IMAGE).toBe("ghcr.io/vercel/eve:latest");
-    expect(images.resolveVercelEveSandboxImage()).toBe("vcr.vercel.com/vercel/eve/base:latest");
-    expect(images.VERCEL_EVE_SANDBOX_IMAGE).toBe("vcr.vercel.com/vercel/eve/base:latest");
+    expect(images.resolveVercelEveSandboxImage()).toBe(
+      "vercel/eve/base@sha256:d8d53829d9f05d54a889619603121499e911c467ea22345c28e572a60f613329",
+    );
+    expect(images.VERCEL_EVE_SANDBOX_IMAGE).toBe(
+      "vercel/eve/base@sha256:d8d53829d9f05d54a889619603121499e911c467ea22345c28e572a60f613329",
+    );
   });
 });

--- a/packages/eve/src/execution/sandbox/bindings/eve-image.ts
+++ b/packages/eve/src/execution/sandbox/bindings/eve-image.ts
@@ -1,14 +1,15 @@
 import { resolveInstalledPackageInfo } from "#internal/application/package.js";
 
 const GHCR_EVE_SANDBOX_IMAGE_REPOSITORY = "ghcr.io/vercel/eve";
-const VERCEL_EVE_SANDBOX_IMAGE_REPOSITORY = "vcr.vercel.com/vercel/eve/base";
+const VERCEL_EVE_SANDBOX_IMAGE =
+  "vercel/eve/base@sha256:d8d53829d9f05d54a889619603121499e911c467ea22345c28e572a60f613329";
 
 export function resolveEveSandboxImage(): string {
   return `${GHCR_EVE_SANDBOX_IMAGE_REPOSITORY}:${resolveEveSandboxImageTag()}`;
 }
 
 export function resolveVercelEveSandboxImage(): string {
-  return `${VERCEL_EVE_SANDBOX_IMAGE_REPOSITORY}:${resolveEveSandboxImageTag()}`;
+  return VERCEL_EVE_SANDBOX_IMAGE;
 }
 
 function resolveEveSandboxImageTag(): string {
@@ -19,4 +20,4 @@ function resolveEveSandboxImageTag(): string {
 }
 
 export const DEFAULT_EVE_SANDBOX_IMAGE = resolveEveSandboxImage();
-export const VERCEL_EVE_SANDBOX_IMAGE = resolveVercelEveSandboxImage();
+export { VERCEL_EVE_SANDBOX_IMAGE };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1298,6 +1298,25 @@ importers:
         specifier: 'catalog:'
         version: 7.0.2
 
+  e2e/fixtures/stable-eve-image-cache:
+    dependencies:
+      '@eve-e2e/config':
+        specifier: workspace:*
+        version: link:../e2e-config
+      '@workflow/world-postgres':
+        specifier: 'catalog:'
+        version: 5.0.0-beta.41(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@upstash/redis@1.38.4)(sql.js@1.14.1)(supports-color@10.2.2)(typescript@7.0.2)
+      eve:
+        specifier: workspace:*
+        version: link:../../../packages/eve
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.3
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+
   e2e/fixtures/toolkit-extension:
     dependencies:
       zod:
@@ -22086,7 +22105,7 @@ snapshots:
 
   '@types/node-fetch@2.6.13':
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 22.20.1
       form-data: 4.0.5
 
   '@types/node@18.19.130':
@@ -24322,7 +24341,7 @@ snapshots:
 
   chrome-launcher@1.2.1(supports-color@10.2.2):
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 22.20.1
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 2.0.2(supports-color@10.2.2)
@@ -25201,7 +25220,7 @@ snapshots:
   engine.io@6.6.9(bufferutil@4.1.0)(supports-color@10.2.2):
     dependencies:
       '@types/cors': 2.8.19
-      '@types/node': 25.9.1
+      '@types/node': 22.20.1
       '@types/ws': 8.18.1
       accepts: 1.3.8
       base64id: 2.0.0
@@ -30548,7 +30567,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.2
-      '@types/node': 25.9.1
+      '@types/node': 22.20.1
       long: 5.3.2
 
   proxy-addr@2.0.7:


### PR DESCRIPTION
### Summary

`vercel/eve/base` changes manifest identity with every eve package release even when its filesystem is unchanged, dividing roughly 1,000 daily uses among several digests and reducing incidental box-cache locality. This temporary draft pins the known eve image manifest `sha256:d8d538…613329` and adds a 20-session template-less timing fixture. Repeated runs of the same commit will test whether a stable digest accumulates enough cache hits to approach the managed universal image; this draft should not merge.

### Validation

- `pnpm install --frozen-lockfile`
- `pnpm fmt`
- `pnpm lint`
- `pnpm guard:invariants`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/execution/sandbox/bindings/eve-image.test.ts src/execution/sandbox/bindings/vercel.test.ts` — 54 tests passed
- `pnpm --filter stable-eve-image-cache typecheck`
- Manual production Sandbox smoke using the pinned digest — create and `true` succeeded

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
