### PR TITLE
fix(eve): accept input responses while observing a turn

### DIFF
--- a/.changeset/react-inflight-approvals.md
+++ b/.changeset/react-inflight-approvals.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Allow React input responses while a turn stream is still attached. Approval submissions now reach the server without steering or cancelling the observed turn.

--- a/docs/guides/client/messages.mdx
+++ b/docs/guides/client/messages.mdx
@@ -137,6 +137,11 @@ After eve accepts the reply, the durable stream emits `input.resolved`. Its `res
 
 `send(message, options)` and `respond(inputResponses, options)` are separate operations. Put `clientContext`, `outputSchema`, headers, or stream options in the second argument to either method.
 
+React's `useEveAgent().respond()` also accepts input responses while a turn stream
+is attached. It submits the response without steering or cancelling that turn,
+then follows the continuation. A rejected submission leaves the existing observer
+attached and rejects the returned promise so the UI can show the error beside the input.
+
 ## Single-use responses
 
 `MessageResponse` is single-use. Either aggregate it:

--- a/packages/eve/src/client/eve-agent-store.test.ts
+++ b/packages/eve/src/client/eve-agent-store.test.ts
@@ -6,6 +6,7 @@ import { stampTestEvents } from "#internal/testing/events.js";
 import {
   createAuthorizationCompletedEvent,
   createAuthorizationRequiredEvent,
+  createInputRequestedEvent,
   createMessageAppendedEvent,
   createMessageCompletedEvent,
   createMessageReceivedEvent,
@@ -817,6 +818,106 @@ describe("EveAgentStore session resume", () => {
     });
     expect(new URL(requests[0]!, "http://localhost").searchParams.get("startIndex")).toBeNull();
     expect(new URL(requests[1]!, "http://localhost").searchParams.get("startIndex")).toBe("2");
+  });
+});
+
+describe("EveAgentStore in-flight input responses", () => {
+  it.each(["send", "resume"] as const)(
+    "submits an approval during %s and replays the continuation",
+    async (mode) => {
+      const active = controlledStreamResponse();
+      const first = stampTestEvents([
+        createTurnStartedEvent({ sequence: 0, turnId: "turn_1" }),
+        createInputRequestedEvent({
+          requests: [
+            {
+              requestId: "approval_1",
+              kind: "tool-approval",
+              display: "confirmation",
+              prompt: "Approve tool call: publish",
+              action: { kind: "tool-call", toolName: "publish", callId: "call_1", input: {} },
+            },
+          ],
+          sequence: 1,
+          stepIndex: 0,
+          turnId: "turn_1",
+        }),
+        createSessionWaitingEvent(),
+      ]);
+      const continuation = stampTestEvents([
+        createTurnStartedEvent({ sequence: 0, turnId: "turn_2" }),
+        createMessageCompletedEvent({
+          finishReason: "stop",
+          message: "Published.",
+          sequence: 1,
+          stepIndex: 0,
+          turnId: "turn_2",
+        }),
+        createSessionWaitingEvent(),
+      ]).map((event) => ({
+        ...event,
+        meta: { ...event.meta, id: `${event.meta.id}_continuation` },
+      }));
+      const fetchMock = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(
+          mode === "send" ? startedResponse() : boundedStreamResponse(first.slice(0, -1)),
+        )
+        .mockResolvedValueOnce(active.response)
+        .mockResolvedValueOnce(startedResponse())
+        .mockResolvedValueOnce(
+          boundedStreamResponse(continuation, first.length + continuation.length - 1),
+        )
+        .mockResolvedValueOnce(boundedStreamResponse([], first.length + continuation.length - 1));
+      const store = new EveAgentStore({
+        reducer: defaultMessageReducer(),
+        ...(mode === "resume"
+          ? { initialSession: { sessionId: "session_1", streamIndex: 0 } }
+          : {}),
+      });
+      const sending = mode === "send" ? store.send({ message: "Prepare a PR" }) : store.resume();
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+      if (mode === "send") for (const event of first.slice(0, -1)) active.emit(event);
+      await vi.waitFor(() => expect(store.snapshot.status).toBe("streaming"));
+      const inputResponses = [{ requestId: "approval_1", optionId: "approve" }];
+      const approval = store.send({ inputResponses });
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+      expect(JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body))).toEqual({ inputResponses });
+      active.emit(first.at(-1)!);
+      active.close();
+      await Promise.all([sending, approval]);
+      expect(store.snapshot.status).toBe("ready");
+      expect(store.snapshot.events).toEqual([...first, ...continuation]);
+      expect(store.snapshot.data.messages.at(-1)?.parts).toContainEqual(
+        expect.objectContaining({ text: "Published." }),
+      );
+    },
+  );
+
+  it("preserves the active observer when an approval is rejected", async () => {
+    const active = controlledStreamResponse();
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(startedResponse())
+      .mockResolvedValueOnce(active.response)
+      .mockResolvedValueOnce(
+        Response.json(
+          { ok: false, error: "Approval is no longer pending.", code: "invalid_input_response" },
+          { status: 409 },
+        ),
+      );
+    const store = new EveAgentStore({ reducer: defaultMessageReducer() });
+    const sending = store.send({ message: "Prepare a PR" });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    await expect(
+      store.send({ inputResponses: [{ requestId: "old", optionId: "approve" }] }),
+    ).rejects.toThrow("Approval is no longer pending.");
+    for (const event of turnEvents()) active.emit(event);
+    active.close();
+    await sending;
+    expect(store.snapshot.status).toBe("ready");
+    expect(store.snapshot.error).toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 });
 

--- a/packages/eve/src/client/eve-agent-store.ts
+++ b/packages/eve/src/client/eve-agent-store.ts
@@ -198,6 +198,9 @@ export class EveAgentStore<TData> {
 
   async send<TOutput = unknown>(input: SendTurnPayload<TOutput>): Promise<void> {
     if (this.#activeTurn !== undefined) {
+      if (input.inputResponses !== undefined) {
+        return await this.#respondDuringTurn(this.#activeTurn, input);
+      }
       if (this.#status === "resuming") {
         throw new Error("eve session is resuming.");
       }
@@ -437,6 +440,36 @@ export class EveAgentStore<TData> {
     this.#status = "ready";
     this.#callbacks.onSessionChange?.(this.#session?.state);
     this.#publish();
+  }
+
+  async #respondDuringTurn<TOutput>(
+    turn: ActiveTurn,
+    input: SendTurnPayload<TOutput>,
+  ): Promise<void> {
+    const preparedInput = (await this.#callbacks.prepareSend?.(input)) ?? input;
+    assertExclusiveTurnInput(preparedInput);
+    if (preparedInput.inputResponses === undefined) {
+      throw new Error("An in-flight input response requires inputResponses.");
+    }
+    await turn.response;
+    if (!this.#isActiveTurn(turn)) return await this.send(preparedInput);
+    const session = this.#session;
+    if (session === undefined)
+      throw new Error("Cannot answer an input request before the session starts.");
+    const { inputResponses, ...options } = preparedInput;
+    const observing = this.#resumePromise;
+    await session.respond(inputResponses, options);
+
+    // Keep one stream owner. The existing observer may stop at the preceding
+    // turn's boundary; replay after it settles to follow the accepted response.
+    await turn.completion;
+    await observing;
+    if (
+      !turn.abortController.signal.aborted &&
+      this.#activeTurn === undefined &&
+      this.#session === session
+    )
+      await this.resume();
   }
 
   async #sendFollowUp<TOutput>(turn: ActiveTurn, input: SendTurnPayload<TOutput>): Promise<void> {

--- a/packages/eve/src/react/use-eve-agent.ts
+++ b/packages/eve/src/react/use-eve-agent.ts
@@ -58,7 +58,7 @@ export interface UseEveAgentHelpers<TData> extends UseEveAgentSnapshot<TData> {
     message: string | UserContent,
     options?: SendTurnOptions<TOutput>,
   ) => Promise<void>;
-  /** Answers pending HITL input requests. Rejects if a turn is already in flight. */
+  /** Answers pending HITL input requests, including while following an in-flight turn. */
   readonly respond: <TOutput = unknown>(
     inputResponses: Parameters<ClientSession["respond"]>[0],
     options?: RespondTurnOptions<TOutput>,


### PR DESCRIPTION
### Summary

A client can display a pending approval while its turn stream remains attached. `useEveAgent().respond()` currently rejects that response before HTTP dispatch because the store treats every in-flight submission as a steering message. Allow input responses through the native session API while preserving the existing observer, then replay and follow the continuation after that observer settles. Rejected responses leave the observer attached; message steering and server-side approval validation are unchanged.

### Reproduction

1. Start or resume a session containing a tool that requires approval, and keep the turn stream attached.
2. Call `await agent.respond([{ requestId, optionId: "approve" }])` using the displayed request ID.
3. Before this change, the promise rejects with `eve session is already processing a turn. Send a message with turnPolicy: "steer" to replace it.` No approval POST reaches the server.

The regression tests use synthetic in-memory responses. They reproduce the rejection against unmodified main and cover both initial sends and resumed sessions, continuation replay, and a rejected approval that must preserve the current observer.

### Validation

- From `packages/eve`: `./node_modules/.bin/vitest run --config vitest.unit.config.ts src/client/eve-agent-store.test.ts src/react/use-eve-agent.test.ts src/client/session.test.ts` — 86 tests passed.
- `./node_modules/.bin/tsc -p packages/eve/tsconfig.json --noEmit` — passed.
- Changed TypeScript files: `oxlint` and `oxfmt` passed.
- `node scripts/guard-invariants.mjs` and `node scripts/check-docs.mjs` — passed.
- No live model or deployed E2E run; reproduction exercises the actual client store with deterministic HTTP responses.

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
