### PR TITLE
fix(compiler): reject dot-prefixed and dot-suffixed Git ref components

### DIFF
--- a/.changeset/reject-dot-git-refs.md
+++ b/.changeset/reject-dot-git-refs.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Reject Git refs containing dot-prefixed or dot-suffixed path components, matching Git's ref format rules.

--- a/packages/eve/src/self-modification/identifiers.test.ts
+++ b/packages/eve/src/self-modification/identifiers.test.ts
@@ -16,5 +16,7 @@ describe("Git identifiers", () => {
   it("rejects Git lock refs", () => {
     expect(() => assertGitRef("main.lock")).toThrow(/valid Git ref/u);
     expect(() => assertGitRef("heads/main.lock/next")).toThrow(/valid Git ref/u);
+    expect(() => assertGitRef(".hidden")).toThrow(/valid Git ref/u);
+    expect(() => assertGitRef("feature/.hidden")).toThrow(/valid Git ref/u);
   });
 });

--- a/packages/eve/src/shared/git.test.ts
+++ b/packages/eve/src/shared/git.test.ts
@@ -14,9 +14,20 @@ describe("Git helpers", () => {
   });
 
   it("rejects unsafe Git refs", () => {
+    expect(isValidGitRef("main")).toBe(true);
     expect(isValidGitRef("feature/self-modification")).toBe(true);
+    expect(isValidGitRef("release/v1.0.0")).toBe(true);
+    expect(isValidGitRef(".hidden")).toBe(false);
+    expect(isValidGitRef("feature/.hidden")).toBe(false);
+    expect(isValidGitRef("feature/hidden.")).toBe(false);
     expect(isValidGitRef("main.lock")).toBe(false);
+    expect(isValidGitRef("feature/main.lock")).toBe(false);
+    expect(isValidGitRef("@")).toBe(false);
+    expect(isValidGitRef("-branch")).toBe(false);
     expect(isValidGitRef("main; curl example.com")).toBe(false);
+    expect(isValidGitRef("feature//branch")).toBe(false);
+    expect(isValidGitRef("/feature/branch")).toBe(false);
+    expect(isValidGitRef("feature/branch/")).toBe(false);
   });
 
   it("uses a clean GitHub remote and brokers credentials only at the firewall", () => {

--- a/packages/eve/src/shared/git.ts
+++ b/packages/eve/src/shared/git.ts
@@ -11,15 +11,19 @@ export function isFullGitSha(value: string): boolean {
 export function isValidGitRef(value: string): boolean {
   return !(
     value.length === 0 ||
+    value === "@" ||
     value.startsWith("-") ||
-    value.endsWith(".") ||
-    value.endsWith("/") ||
     value.includes("..") ||
-    value.includes("//") ||
     value.includes("@{") ||
     value.includes("\\") ||
-    value.split("/").some((part) => part.length === 0 || part.endsWith(".lock")) ||
-    /[\x00-\x20~^:?*[]/u.test(value)
+    value
+      .split("/")
+      .some(
+        (part) =>
+          part.length === 0 || part.startsWith(".") || part.endsWith(".") || part.endsWith(".lock"),
+      ) ||
+    // oxlint-disable-next-line no-control-regex -- Git refs must not contain ASCII control characters or whitespace.
+    /[\x00-\x20\x7f~^:?*[]/u.test(value)
   );
 }
 


### PR DESCRIPTION
Closes #3252

### Summary
`isValidGitRef` allowed Git branch and ref path components that begin or end with a dot (`.`), as well as `@`, which Git rejects via `git check-ref-format --branch`. This could cause self-modification operations targeting branches like `.hidden` or `feature/.hidden` to pass initial validation but fail downstream in Git CLI execution.

This change updates `isValidGitRef` in `packages/eve/src/shared/git.ts` to inspect slash-separated path components, ensuring no component begins or ends with `.`, rejects standalone `@`, and adds the ASCII DEL character (`\x7f`) to control character checks.

### Validation
- Ran unit tests covering invalid dot-prefixed/suffixed refs, `@`, lock extensions, and empty parts:
  `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/shared/git.test.ts src/self-modification/identifiers.test.ts` (6/6 passed)
- Verified workspace TypeScript invariants:
  `pnpm --filter eve exec tsc -p tsconfig.json --noEmit` (0 errors)
- Verified linter and formatter:
  `pnpm lint` and `pnpm fmt` passed cleanly.
- Added a patch changeset under `.changeset/reject-dot-git-refs.md`.

### Checklist
- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)