### PR TITLE
fix(eve): keep deeply nested OpenAPI schema alternatives intact

### DIFF
--- a/.changeset/deep-openapi-alternatives.md
+++ b/.changeset/deep-openapi-alternatives.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Raise the OpenAPI schema dereference depth limit from 12 to 32 keyword levels. Deeply nested request bodies such as Notion's page properties were truncated to `{}` below the old limit, which turned the alternatives of a nested `oneOf` into indistinguishable empty schemas and made the generated tool validator reject valid input with "more than one option matched".

--- a/packages/eve/src/runtime/connections/openapi-schema.test.ts
+++ b/packages/eve/src/runtime/connections/openapi-schema.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { derefSchema } from "./openapi-schema.js";
+
+const richText = {
+  oneOf: [
+    {
+      type: "object",
+      properties: {
+        type: { type: "string", enum: ["text"] },
+        text: {
+          type: "object",
+          properties: { content: { type: "string" } },
+          required: ["content"],
+        },
+      },
+      required: ["text"],
+    },
+    {
+      type: "object",
+      properties: {
+        type: { type: "string", enum: ["mention"] },
+        mention: {
+          type: "object",
+          properties: { page: { type: "object" } },
+          required: ["page"],
+        },
+      },
+      required: ["mention"],
+    },
+  ],
+};
+
+/** The shape of Notion's `createPage` request body, inlined as the API serves it. */
+const createPageBody = {
+  type: "object",
+  properties: {
+    properties: {
+      type: "object",
+      additionalProperties: {
+        oneOf: [
+          {
+            type: "object",
+            properties: { title: { type: "array", items: richText } },
+            required: ["title"],
+          },
+          {
+            type: "object",
+            properties: { number: { type: "number" } },
+            required: ["number"],
+          },
+        ],
+      },
+    },
+  },
+};
+
+function nest(levels: number): Record<string, unknown> {
+  let schema: Record<string, unknown> = { type: "string" };
+  for (let i = 0; i < levels; i += 1) {
+    schema = { type: "object", properties: { child: schema } };
+  }
+  return schema;
+}
+
+describe("derefSchema", () => {
+  it("keeps the constraints of alternatives nested deep inside a request body (#3267)", () => {
+    const result = derefSchema({}, createPageBody) as Record<string, unknown>;
+    const titleItems = (
+      (
+        (
+          ((result.properties as Record<string, unknown>).properties as Record<string, unknown>)
+            .additionalProperties as { oneOf: Record<string, unknown>[] }
+        ).oneOf[0].properties as Record<string, unknown>
+      ).title as { items: { oneOf: Record<string, unknown>[] } }
+    ).items;
+    // Both rich-text alternatives survive with their own `required` and nested
+    // `text.content` / `mention.page` constraints, so a validator can still
+    // tell them apart instead of matching every value against both.
+    expect(titleItems.oneOf).toHaveLength(2);
+    expect(titleItems.oneOf[0]).toMatchObject({
+      required: ["text"],
+      properties: { text: { properties: { content: { type: "string" } } } },
+    });
+    expect(titleItems.oneOf[1]).toMatchObject({
+      required: ["mention"],
+      properties: { mention: { properties: { page: { type: "object" } } } },
+    });
+  });
+
+  it("still truncates inline nesting past the limit", () => {
+    const result = derefSchema({}, nest(40));
+    let node = result as Record<string, unknown>;
+    let levels = 0;
+    while (node.properties !== undefined) {
+      node = (node.properties as Record<string, unknown>).child as Record<string, unknown>;
+      levels += 1;
+    }
+    expect(levels).toBeGreaterThan(12);
+    expect(levels).toBeLessThan(40);
+    expect(node).toEqual({});
+  });
+
+  it("cuts reference cycles regardless of depth", () => {
+    const document = {
+      components: {
+        schemas: {
+          Node: {
+            type: "object",
+            properties: { next: { $ref: "#/components/schemas/Node" } },
+          },
+        },
+      },
+    };
+    const result = derefSchema(document, { $ref: "#/components/schemas/Node" }) as Record<
+      string,
+      unknown
+    >;
+    expect((result.properties as Record<string, unknown>).next).toEqual({});
+  });
+});

--- a/packages/eve/src/runtime/connections/openapi-schema.ts
+++ b/packages/eve/src/runtime/connections/openapi-schema.ts
@@ -1,7 +1,15 @@
 import { isObject } from "#shared/guards.js";
 
-/** Max structural depth the schema dereferencer descends before truncating. */
-const MAX_DEREF_DEPTH = 12;
+/**
+ * Max structural depth the schema dereferencer descends before truncating.
+ *
+ * Every keyword level counts and a `properties` hop counts twice, so real
+ * API schemas run deep quickly: Notion's page properties reach the
+ * `title[].text.content` constraint at depth 14, and truncating alternatives
+ * of a `oneOf` there to `{}` makes every value match all of them (#3267).
+ * Reference cycles are cut by `seen`, so this only bounds inline nesting.
+ */
+const MAX_DEREF_DEPTH = 32;
 
 /** A path, query, header, or cookie parameter resolved from an operation. */
 export interface OpenApiParameter {


### PR DESCRIPTION
Fixes #3267.

## Summary

The OpenAPI schema dereferencer truncated any node deeper than 12 keyword levels to `{}`. Every keyword level counts and a `properties` hop counts twice, so real request bodies run out of budget quickly: Notion's `createPage` body reaches the `title[].text.content` constraint at depth 14. Both alternatives of the nested rich-text `oneOf` became `{}`, every value matched both, and the generated tool validator rejected a valid page title with `Invalid input: more than one option matched` before any HTTP request was made, exactly as the reproduction in the issue shows.

Reference cycles are already cut by the `seen` set, so the depth limit only bounds inline nesting. This raises it to 32, the same bound the MCP channel applies to output schemas, and documents why in the source.

## Test plan

New `openapi-schema.test.ts` with three cases:

- The Notion `createPage` body shape (inlined as the API serves it): both rich-text alternatives keep their own `required` and nested `text.content` / `mention.page` constraints. Fails on `main` (the alternatives come back as `{}`), passes with this change.
- 40 levels of inline nesting are still truncated past the limit.
- A self-referencing `$ref` is still cut regardless of depth.

```
packages/eve: npx vitest run --config vitest.unit.config.ts src/runtime/connections/openapi-schema.test.ts   # 3 passed
packages/eve: npx oxlint src/runtime/connections/openapi-schema.ts src/runtime/connections/openapi-schema.test.ts   # clean
```

Changeset added (`"eve": patch`). Commit is signed and signed off.