### PR TITLE
test: reproduce binary attachment enumeration in tracing

### DIFF
--- a/packages/eve/src/tracing/agent-otel-content.test.ts
+++ b/packages/eve/src/tracing/agent-otel-content.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { FrameworkMessageKind } from "#harness/messages.js";
 import {
@@ -6,6 +6,7 @@ import {
   genAiInputMessagesAttribute,
   genAiOutputMessagesAttribute,
   genAiSystemInstructionsAttribute,
+  messagesContentAttribute,
   toolResultsContentAttribute,
 } from "#tracing/agent-otel-content.js";
 
@@ -18,6 +19,51 @@ const FRAMEWORK_MESSAGE_KINDS = [
   "execution.continuation",
   "execution.retry",
 ] as const satisfies readonly FrameworkMessageKind[];
+
+describe("messagesContentAttribute", () => {
+  it.each([
+    ["Buffer", () => Buffer.alloc(64, 97)],
+    ["Uint8Array", () => new Uint8Array(64).fill(97)],
+  ] as const)(
+    "does not enumerate %s attachment bytes before applying the trace limit",
+    (_, createData) => {
+      // A small attachment takes the same traversal path as a multi-MiB file,
+      // without making the regression test depend on RSS or GC behavior.
+      const data = createData();
+      const entries = Object.entries;
+      let binaryEnumerations = 0;
+      const spy = vi.spyOn(Object, "entries").mockImplementation((value) => {
+        if (value === data) binaryEnumerations += 1;
+        return entries(value);
+      });
+
+      let attribute: string | undefined;
+      try {
+        attribute = messagesContentAttribute([
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "Summarize file." },
+              { type: "file", mediaType: "application/octet-stream", filename: "test.bin", data },
+            ],
+          },
+        ]);
+      } finally {
+        spy.mockRestore();
+      }
+
+      expect(binaryEnumerations).toBe(0);
+      expect(attribute).toBeDefined();
+      expect(attribute!.length).toBeLessThanOrEqual(CONTENT_ATTRIBUTE_LIMIT);
+      expect(JSON.parse(attribute!)).toEqual([
+        expect.objectContaining({
+          role: "user",
+          content: expect.arrayContaining([{ type: "text", text: "Summarize file." }]),
+        }),
+      ]);
+    },
+  );
+});
 
 describe("GenAI message attributes", () => {
   it("preserves every user-message kind in the GenAI input attribute", () => {


### PR DESCRIPTION
### Summary

Tracing currently calls `Object.entries()` on binary attachments before enforcing the content limit, so a small final trace can still require substantial intermediate allocation. This adds deterministic regression cases for Buffer and Uint8Array attachments, using 64-byte inputs to detect the same enumeration path without RSS thresholds or large allocations. Both tests intentionally fail against the current implementation; this draft is a test-only reproduction, and the tracing fix is still needed before merge.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/tracing/agent-otel-content.test.ts` — 14 passed, 2 expected failures: each attachment is enumerated once instead of zero times.
- `./node_modules/.bin/oxfmt --check packages/eve/src/tracing/agent-otel-content.test.ts` — passed.
- `./node_modules/.bin/oxlint packages/eve/src/tracing/agent-otel-content.test.ts` — passed.
- `git diff --cached --check` — passed.
- No runtime changes or release notes; no changeset added for this test-only reproduction. Workspace typecheck and the full test suite were not run.

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
