### PR TITLE
[3/3] feat(slack): route application input requests

### DIFF
--- a/.changeset/private-slack-approvals.md
+++ b/.changeset/private-slack-approvals.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Slack channels can route each input request, including tool approvals and `ctx.ask()` questions, to the shared thread or the triggering user's direct messages with the `approvalChannel` callback. Direct-message requests include a preview of the Slack message that triggered the turn, while the original thread names the reviewer without exposing the request.
+Slack channels can route each input request, including tool approvals and `ctx.ask()` questions, to the shared thread or the triggering user's direct messages with the `approvalChannel` callback. Custom input renderers can also render questions or approvals outside the session thread with an authenticated return route, and `ctx.ask()` now carries bounded application metadata through durable `input.requested` events.

--- a/docs/channels/slack.mdx
+++ b/docs/channels/slack.mdx
@@ -453,6 +453,30 @@ export default slackChannel({
 
 The callback receives the `InputRequest` and current `SessionContext`, so it can switch on `kind`, `action`, or presentation properties. Omit it to keep every request in the thread, or return `"direct-message"` unconditionally to make every request private. If eve cannot resolve the triggering Slack user for a direct message, it logs the undelivered request and posts no fallback, so private delivery fails closed. The existing `onInputResponse` or tool approval response policy still decides whether the person who clicks may respond.
 
+For application-owned delivery, override `events["input.requested"]` and use `renderInputRequestBlocks(request, { returnTo })` when you post a question or tool approval outside its session thread. The encoded return route sends a button, select, or freeform-modal answer back to the original continuation. eve still runs `onInputResponse` with auth derived from the Slack user who submitted the signed interaction before delivering the answer. Metadata on a `ctx.ask()` request is available to this trusted event handler but is not included in the rendered blocks.
+
+```ts title="agent/channels/slack.ts"
+import { renderInputRequestBlocks, slackChannel } from "eve/channels/slack";
+
+export default slackChannel({
+  events: {
+    async "input.requested"({ requests }, channel) {
+      for (const request of requests) {
+        const blocks = renderInputRequestBlocks(request, {
+          returnTo: {
+            channelId: channel.slack.channelId,
+            threadTs: channel.slack.threadTs,
+          },
+        });
+        // Post `blocks` to the application-selected Slack conversation.
+      }
+    },
+  },
+});
+```
+
+Use the `returnTo` values from `channel.slack`, not request metadata or other client-provided data. Omitting `returnTo` preserves normal thread behavior.
+
 Authorization prompts split public status from private credentials. A sign-in challenge (OAuth URL, device code) is a credential. Anyone who completes it binds their identity to the session's connection. The default `authorization.required` handler posts a public, link-free status in the thread, delivers the actual challenge ephemerally to the triggering user, device code included, and then updates that public status when `authorization.completed` fires. The handler receives a private-delivery context with `postEphemeral`, `postDirectMessage` (needs the `im:write` scope), and `state`. There is, intentionally, no public `post` and no raw API access.
 
 ```ts

--- a/docs/tools/workflows.mdx
+++ b/docs/tools/workflows.mdx
@@ -216,16 +216,21 @@ Blocking workflows and background workflows without auth are unaffected.
 ## Ask a human: `ctx.ask`
 
 ```ts
+type JSONValue = null | boolean | number | string | JSONValue[] | { [key: string]: JSONValue };
+
 const answer = await ctx.ask({
   prompt: string,
   display?: "confirmation" | "select" | "text",
   options?: { id: string; label: string; description?: string; style?: "primary" | "danger" | "default" }[],
   allowFreeform?: boolean,
+  metadata?: Record<string, JSONValue>,
 }); // { optionId?: string; text?: string }
 ```
 
 `ctx.ask` publishes an `input.requested` event on the session — rendered the way channels render
 `ask_question` and tool approvals — and returns an awaitable answer. Awaiting it suspends the run until a response arrives.
+
+Use `metadata` to identify an application-specific request in a custom `input.requested` renderer. eve passes the metadata through unchanged, does not render it automatically, and preserves it when the workflow suspends and replays. Metadata must be a JSON-serializable object whose serialized form is at most 16 KiB. Treat it as application data, not responder identity or authorization evidence.
 It composes with the SDK's own constructs; race it against a deadline:
 
 ```ts

--- a/packages/eve/extension-contracts/compatibility/channel/v19.ts
+++ b/packages/eve/extension-contracts/compatibility/channel/v19.ts
@@ -1,0 +1,10 @@
+import { defineChannel, POST } from "#public/channels/index.js";
+
+export default defineChannel({
+  routes: [
+    POST("/continue/:sessionId", async (_request, { attachSession, params }) => {
+      const result = await attachSession(params.sessionId!).send("Continue.", { auth: null });
+      return Response.json({ accepted: result.status === "accepted" });
+    }),
+  ],
+});

--- a/packages/eve/extension-contracts/compatibility/connection/v15.ts
+++ b/packages/eve/extension-contracts/compatibility/connection/v15.ts
@@ -1,0 +1,6 @@
+import { defineMcpClientConnection } from "#public/connections/index.js";
+
+export default defineMcpClientConnection({
+  description: "Call-aware MCP service",
+  url: "https://example.com/mcp",
+});

--- a/packages/eve/extension-contracts/compatibility/dynamicInstructions/v18.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicInstructions/v18.ts
@@ -1,0 +1,8 @@
+import { defineDynamic, defineInstructions } from "#public/instructions/index.js";
+
+export default defineDynamic({
+  events: {
+    "session.started": (_event, ctx) =>
+      defineInstructions({ markdown: `Use session ${ctx.session.id} for correlation.` }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/dynamicSkill/v17.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicSkill/v17.ts
@@ -1,0 +1,11 @@
+import { defineDynamic, defineSkill } from "#public/skills/index.js";
+
+export default defineDynamic({
+  events: {
+    "turn.started": (_event, ctx) =>
+      defineSkill({
+        description: `Review session ${ctx.session.id}.`,
+        markdown: "# Review\n\nCheck each claim.",
+      }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/dynamicTool/v34.ts
+++ b/packages/eve/extension-contracts/compatibility/dynamicTool/v34.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+import { defineDynamic, defineTool } from "#public/tools/index.js";
+
+export default defineDynamic({
+  events: {
+    "session.started": () =>
+      defineTool({
+        description: "Report deployment progress.",
+        inputSchema: z.object({ service: z.string() }),
+        outputSchema: z.object({ url: z.string() }),
+        execute: async ({ service }) => ({ url: `https://${service}.example.com` }),
+      }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/hook/v22.ts
+++ b/packages/eve/extension-contracts/compatibility/hook/v22.ts
@@ -1,0 +1,9 @@
+import { defineHook } from "#public/hooks/index.js";
+
+export default defineHook({
+  events: {
+    "turn.started"(event, ctx) {
+      console.info(event.meta.id, event.data.turnId, ctx.session.id);
+    },
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/schedule/v11.ts
+++ b/packages/eve/extension-contracts/compatibility/schedule/v11.ts
@@ -1,0 +1,8 @@
+import { defineSchedule } from "#public/schedules/index.js";
+
+export default defineSchedule({
+  cron: "0 9 * * *",
+  run({ waitUntil, appAuth }) {
+    waitUntil(Promise.resolve(appAuth.principalId));
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/subagent/v12.ts
+++ b/packages/eve/extension-contracts/compatibility/subagent/v12.ts
@@ -1,0 +1,7 @@
+import { defineAgent } from "#public/index.js";
+
+export default defineAgent({
+  description: "Delegate research tasks.",
+  experimental: { workflow: { modelCallsPerStep: 4 } },
+  model: "anthropic/claude-sonnet-5",
+});

--- a/packages/eve/extension-contracts/compatibility/tool/v36.ts
+++ b/packages/eve/extension-contracts/compatibility/tool/v36.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+import { defineTool } from "#public/tools/index.js";
+
+export default defineTool({
+  description: "Report the active session.",
+  inputSchema: z.object({}),
+  outputSchema: z.object({ sessionId: z.string() }),
+  execute: (_input, ctx) => ({ sessionId: ctx.session.id }),
+});

--- a/packages/eve/extension-contracts/reports/channel/v20.json
+++ b/packages/eve/extension-contracts/reports/channel/v20.json
@@ -1,0 +1,21 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "channel",
+  "epoch": 20,
+  "sha256": "a7b9d6ce65f8934c9a0e8b6e33f5fb208dd49f053163b67de26155b9028f2d78",
+  "exports": [
+    "DELETE",
+    "GET",
+    "HEAD",
+    "OPTIONS",
+    "PATCH",
+    "POST",
+    "PUT",
+    "WS",
+    "createWebSocketUpgradeServer",
+    "defineChannel",
+    "disableRoute",
+    "isChannel",
+    "isDisabledRouteSentinel"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/connection/v16.json
+++ b/packages/eve/extension-contracts/reports/connection/v16.json
@@ -1,0 +1,16 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "connection",
+  "epoch": 16,
+  "sha256": "b0cb855d061c666b9cda4af7fcd5d60eb57f516614bac124b1ec4cc7e341cf21",
+  "exports": [
+    "ConnectionAuthorizationFailedError",
+    "ConnectionAuthorizationRequiredError",
+    "defineDynamic",
+    "defineInteractiveAuthorization",
+    "defineMcpClientConnection",
+    "defineOpenAPIConnection",
+    "isConnectionAuthorizationFailedError",
+    "isConnectionAuthorizationRequiredError"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/dynamicInstructions/v19.json
+++ b/packages/eve/extension-contracts/reports/dynamicInstructions/v19.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicInstructions",
+  "epoch": 19,
+  "sha256": "1e027859d76eb55dfa7f42b5e52cffcce5f8274a0398b9434c9d6d6c5eb9bab8",
+  "exports": ["defineDynamic"]
+}

--- a/packages/eve/extension-contracts/reports/dynamicSkill/v18.json
+++ b/packages/eve/extension-contracts/reports/dynamicSkill/v18.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicSkill",
+  "epoch": 18,
+  "sha256": "10746b19e9ea5acd3c4e0747100f4e59b32132d752ac12dea5f2ad5555f40d40",
+  "exports": ["defineDynamic"]
+}

--- a/packages/eve/extension-contracts/reports/dynamicTool/v35.json
+++ b/packages/eve/extension-contracts/reports/dynamicTool/v35.json
@@ -1,0 +1,14 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "dynamicTool",
+  "epoch": 35,
+  "sha256": "e3935b54511cf3a97d0f812461e5b8495a0a352373db16f618e2746c1e814179",
+  "exports": [
+    "DynamicToolEntry",
+    "DynamicToolEvents",
+    "DynamicToolResult",
+    "DynamicToolSet",
+    "defineDurableCallback",
+    "defineDynamic"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/hook/v23.json
+++ b/packages/eve/extension-contracts/reports/hook/v23.json
@@ -1,0 +1,7 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "hook",
+  "epoch": 23,
+  "sha256": "021ea342105091577d54cd414e26e55cfbdae38510f73802865bbb2a8a9a7961",
+  "exports": ["defineHook"]
+}

--- a/packages/eve/extension-contracts/reports/schedule/v12.json
+++ b/packages/eve/extension-contracts/reports/schedule/v12.json
@@ -1,0 +1,14 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "schedule",
+  "epoch": 12,
+  "sha256": "c559304ce592f2ca6520788596e61dc4ac2685f1673abc6ea7350e666ae501a7",
+  "exports": [
+    "ScheduleDefinition",
+    "ScheduleHandlerArgs",
+    "ScheduleRunHandler",
+    "ScheduleToFn",
+    "TypedReceiveTarget",
+    "defineSchedule"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/subagent/v13.json
+++ b/packages/eve/extension-contracts/reports/subagent/v13.json
@@ -1,0 +1,20 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "subagent",
+  "epoch": 13,
+  "sha256": "ccd138820c431b9ad19791125c7e722b378685947626bd74b08e73d67eeda41a",
+  "exports": [
+    "AgentCompactionDefinition",
+    "AgentDefinition",
+    "AgentModelDefinition",
+    "AgentStaticModelDefinition",
+    "DefinedAgent",
+    "DynamicLocalSubagentDefinition",
+    "DynamicSubagentDefinition",
+    "RemoteAgentDefinition",
+    "RemoteAgentDefinitionInput",
+    "defineAgent",
+    "defineDynamic",
+    "defineRemoteAgent"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/tool/v37.json
+++ b/packages/eve/extension-contracts/reports/tool/v37.json
@@ -1,0 +1,20 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "tool",
+  "epoch": 37,
+  "sha256": "e3d6507c8b9bc09d6969147ac1b53850eae4ab1be9adc1de194444342f2bb46a",
+  "exports": [
+    "defaultWebSearch",
+    "defineTool",
+    "defineWorkflowTool",
+    "disableTool",
+    "experimental_workflow",
+    "isDisabledToolSentinel",
+    "isExperimentalWorkflowToolDefinition",
+    "isWebSearchToolDefinition",
+    "toolOutput",
+    "toolOutputPart",
+    "toolResultFrom",
+    "webSearch"
+  ]
+}

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -22,8 +22,8 @@ interface ExtensionCapabilityContract {
 const EXTENSION_CAPABILITY_CONTRACTS = {
   extension: { current: 1, supported: [1], dropped: {} },
   tool: {
-    current: 36,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 28, 29, 30, 31, 32, 34, 35, 36],
+    current: 37,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 28, 29, 30, 31, 32, 34, 35, 36, 37],
     dropped: {
       14: "TaskExec.delegated was removed; migrate to workflow-backed background tools",
       15: "TaskExec replaces stageEffect with send",
@@ -43,10 +43,10 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     },
   },
   dynamicTool: {
-    current: 34,
+    current: 35,
     supported: [
       1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 28, 29, 30, 31, 32,
-      33, 34,
+      33, 34, 35,
     ],
     dropped: {
       21: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",
@@ -58,22 +58,22 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     },
   },
   channel: {
-    current: 19,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19],
+    current: 20,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19, 20],
     dropped: {
       12: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",
     },
   },
   schedule: {
-    current: 11,
-    supported: [1, 2, 3, 4, 6, 7, 8, 9, 10, 11],
+    current: 12,
+    supported: [1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12],
     dropped: {
       5: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",
     },
   },
   subagent: {
-    current: 12,
-    supported: [3, 4, 6, 7, 8, 9, 10, 11, 12],
+    current: 13,
+    supported: [3, 4, 6, 7, 8, 9, 10, 11, 12, 13],
     dropped: {
       1: "Persistent subagent sessions are now the default and the experimental opt-in was removed",
       2: "Persistent subagent sessions are now the default and the experimental opt-in was removed",
@@ -81,16 +81,16 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     },
   },
   connection: {
-    current: 15,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 13, 14, 15],
+    current: 16,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 13, 14, 15, 16],
     dropped: {
       9: "Dynamic connection resolvers no longer receive conversation or channel continuation data",
       10: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",
     },
   },
   hook: {
-    current: 22,
-    supported: [10, 11, 12, 13, 14, 15, 17, 18, 19, 20, 21, 22],
+    current: 23,
+    supported: [10, 11, 12, 13, 14, 15, 17, 18, 19, 20, 21, 22, 23],
     dropped: {
       1: "Model identity moved from session.started runtime metadata to step.started call attribution.",
       2: "Model identity moved from session.started runtime metadata to step.started call attribution.",
@@ -106,16 +106,16 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
   },
   skill: { current: 1, supported: [1], dropped: {} },
   dynamicSkill: {
-    current: 17,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 15, 16, 17],
+    current: 18,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 15, 16, 17, 18],
     dropped: {
       13: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",
     },
   },
   instructions: { current: 2, supported: [1, 2], dropped: {} },
   dynamicInstructions: {
-    current: 18,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 16, 17, 18],
+    current: 19,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 16, 17, 18, 19],
     dropped: {
       14: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",
     },

--- a/packages/eve/src/execution/tools/workflow/ask.ts
+++ b/packages/eve/src/execution/tools/workflow/ask.ts
@@ -6,6 +6,7 @@ import type {
 } from "#execution/tools/workflow/messages.js";
 import { resumeHookStep } from "#execution/tools/workflow/resume-hook-step.js";
 import type { ToolContext, ToolInputRequest, ToolInputResponse } from "#tools/definition.js";
+import { parseInputRequestMetadata } from "#shared/input.js";
 import { workflowToolContextErrorMessage } from "#shared/workflow-tool-context.js";
 
 // `Symbol.for`, not a module-local WeakMap: workflow helpers and body setup may
@@ -70,12 +71,16 @@ export function readWorkflowToolRunAdmission(
 /** Returns an answer hook which may be awaited or raced with another workflow operation. */
 export function ask(ctx: ToolContext, request: ToolInputRequest): Hook<ToolInputResponse> {
   const context = readWorkflowToolRunContext(ctx, "ask");
+  const normalizedRequest =
+    request.metadata === undefined
+      ? request
+      : { ...request, metadata: parseInputRequestMetadata(request.metadata) };
   const answer = createHook<ToolInputResponse>();
   void resumeHookStep(context.owner.inbox, {
     kind: "request",
     from: context.from,
     replyTo: answer.token,
-    request: { kind: "ask", request },
+    request: { kind: "ask", request: normalizedRequest },
   });
   return answer;
 }

--- a/packages/eve/src/execution/tools/workflow/owner-inbox.test.ts
+++ b/packages/eve/src/execution/tools/workflow/owner-inbox.test.ts
@@ -18,6 +18,39 @@ const from = {
 };
 
 describe("workflow-tool task input", () => {
+  it("preserves workflow ask metadata by value during normalization", () => {
+    const metadata = { source: "customer", nested: { priority: 2 }, enabled: true };
+    const request = {
+      kind: "ask" as const,
+      request: {
+        metadata,
+        prompt: "Choose a priority",
+      },
+    };
+
+    const normalized = workflowToolRunRequestToTaskInputRequest({
+      from,
+      replyTo: "subagent:parent:call-1",
+      request,
+    });
+
+    expect(normalized.request).toMatchObject({ metadata });
+    expect(JSON.parse(JSON.stringify(normalized))).toMatchObject({ request: { metadata } });
+  });
+
+  it.each([
+    ["non-JSON metadata", { invalid: new Date() }],
+    ["oversized metadata", { value: "x".repeat(16 * 1024) }],
+  ])("rejects %s at the workflow input boundary", (_name, metadata) => {
+    expect(() =>
+      workflowToolRunRequestToTaskInputRequest({
+        from,
+        replyTo: "subagent:parent:call-1",
+        request: { kind: "ask", request: { metadata: metadata as never, prompt: "Choose" } },
+      }),
+    ).toThrow();
+  });
+
   it("preserves a forwarded child request id independently of its session route", () => {
     const request = {
       action: {

--- a/packages/eve/src/execution/tools/workflow/owner-inbox.ts
+++ b/packages/eve/src/execution/tools/workflow/owner-inbox.ts
@@ -10,6 +10,7 @@ import type {
 import type { RuntimeToolResultActionResult } from "#shared/action-types.js";
 import type { RuntimeSubagentResult } from "#shared/action-types.js";
 import type { InputRequest } from "#shared/input.js";
+import { parseInputRequestMetadata } from "#shared/input.js";
 import type { ToolInputRequest } from "#tools/definition.js";
 import type { WorkflowToolRunTaskInputRequest } from "#execution/tasks/child/workflow.js";
 import type { TaskCommand, TaskInboundMessage, TaskInboundUpdate } from "#tasks/types.js";
@@ -219,6 +220,9 @@ function normalizeAskRequest(
   };
   if (authored.allowFreeform !== undefined) normalized.allowFreeform = authored.allowFreeform;
   if (authored.display !== undefined) normalized.display = authored.display;
+  if (authored.metadata !== undefined) {
+    normalized.metadata = parseInputRequestMetadata(authored.metadata);
+  }
   if (authored.options !== undefined) normalized.options = [...authored.options];
   return normalized;
 }

--- a/packages/eve/src/public/channels/slack/hitl.test.ts
+++ b/packages/eve/src/public/channels/slack/hitl.test.ts
@@ -4,6 +4,7 @@ import type { InputRequest } from "#shared/input.js";
 import {
   buildAnsweredBlocks,
   buildFreeformModalView,
+  decodeFreeformActionId,
   decodeHitlActionId,
   deriveHitlResponse,
   formatInputRequestFallbackText,
@@ -43,7 +44,7 @@ describe("private HITL routes", () => {
         ],
         requestId: "approval_abc123",
       }),
-      { channelId: "C123", threadTs: "111.222" },
+      { returnTo: { channelId: "C123", threadTs: "111.222" } },
     );
     const actionId = (blocks[0] as { actions: Array<{ action_id: string }> }).actions[0]!.action_id;
 
@@ -51,17 +52,45 @@ describe("private HITL routes", () => {
       button: true,
       kind: "tool-approval",
       requestId: "approval_abc123",
-      route: { channelId: "C123", threadTs: "111.222" },
+      returnTo: { channelId: "C123", threadTs: "111.222" },
     });
     expect(deriveHitlResponse({ actionId, value: "approve" })).toMatchObject({
       kind: "tool-approval",
       response: { optionId: "approve", requestId: "approval_abc123" },
-      route: { channelId: "C123", threadTs: "111.222" },
+      returnTo: { channelId: "C123", threadTs: "111.222" },
     });
   });
 });
 
 describe("deriveHitlResponse", () => {
+  it("decodes routed question button actions with the question kind", () => {
+    const actionId = (
+      renderInputRequestBlocks(
+        makeRequest({
+          options: [{ id: "yes", label: "Yes" }],
+          requestId: "question_123",
+        }),
+        { returnTo: { channelId: "C999", threadTs: "9.9" } },
+      )[0] as { actions: Array<{ action_id: string }> }
+    ).actions[0]!.action_id;
+
+    expect(actionId).toBe("eve_input:route:C999:9.9:question:question_123:button:0");
+    expect(decodeHitlActionId(actionId)).toEqual({
+      button: true,
+      kind: "question",
+      requestId: "question_123",
+      returnTo: { channelId: "C999", threadTs: "9.9" },
+    });
+  });
+
+  it("keeps normal non-routed question button action ids unchanged", () => {
+    const blocks = renderInputRequestBlocks(
+      makeRequest({ options: [{ id: "yes", label: "Yes" }] }),
+    );
+    expect((blocks[0] as { actions: Array<{ action_id: string }> }).actions[0]!.action_id).toBe(
+      `${HITL_ACTION_PREFIX}call_abc123:button:0`,
+    );
+  });
   it("keeps Slack classification outside the durable input response type", () => {
     const derived: NonNullable<ReturnType<typeof deriveHitlResponse>> = {
       kind: "tool-approval",
@@ -433,16 +462,21 @@ describe("renderInputRequestBlocks", () => {
     expect(freeformRequestIdFromActionId(HITL_FREEFORM_ACTION_PREFIX)).toBeUndefined();
   });
 
-  it("preserves the return route on a freeform question", () => {
+  it("decodes a routed freeform question while preserving its return route", () => {
     const blocks = renderInputRequestBlocks(
       makeRequest({ requestId: "question_freeform", options: undefined }),
-      { channelId: "C777", threadTs: "7.7" },
+      { returnTo: { channelId: "C777", threadTs: "7.7" } },
     );
     const actionId = (blocks[1] as { elements: Array<{ action_id: string }> }).elements[0]!
       .action_id;
 
-    expect(actionId).toBe("eve_input_freeform:route:C777:7.7:question_freeform");
-    expect(freeformRequestIdFromActionId(actionId)).toBe("question_freeform");
+    expect(decodeFreeformActionId(actionId)).toEqual({
+      button: false,
+      kind: "question",
+      requestId: "question_freeform",
+      returnTo: { channelId: "C777", threadTs: "7.7" },
+    });
+    expect(decodeFreeformActionId(`${HITL_FREEFORM_ACTION_PREFIX}route:missing`)).toBeNull();
   });
 
   it("truncates section-block prompts past the Slack 3000-char cap", () => {

--- a/packages/eve/src/public/channels/slack/hitl.ts
+++ b/packages/eve/src/public/channels/slack/hitl.ts
@@ -21,6 +21,7 @@ import {
 } from "#public/channels/slack/limits.js";
 import {
   type InputRequest,
+  type InputRequestKind,
   parseInputResponse,
   type ValidatedInputResponse,
 } from "#shared/input.js";
@@ -60,9 +61,15 @@ export const HITL_FREEFORM_MODAL_ACTION_ID = "eve_freeform_text";
 
 const HITL_ROUTE_PREFIX = `${HITL_ACTION_PREFIX}route:`;
 
-export interface SlackHitlRoute {
+export interface SlackInputRequestRoute {
   readonly channelId: string;
   readonly threadTs: string;
+}
+
+/** Options for rendering an input request outside its session thread. */
+export interface SlackInputRequestRenderOptions {
+  /** Session thread that owns the pending request and must receive its answer. */
+  readonly returnTo?: SlackInputRequestRoute;
 }
 
 /**
@@ -71,7 +78,7 @@ export interface SlackHitlRoute {
  * groups stay readable up to ~6 items).
  */
 const RADIO_SELECT_OPTION_LIMIT = 6;
-const BUTTON_ACTION_ID_RE = /^(?:(?<kind>tool-approval):)?(?<requestId>.+):button:\d+$/u;
+const BUTTON_ACTION_ID_RE = /^(?:(?<kind>question|tool-approval):)?(?<requestId>.+):button:\d+$/u;
 const TOOL_INPUT_PREFIX = "*Tool input*\n```\n";
 const TOOL_INPUT_CODE_PREFIX = "```\n";
 const TOOL_INPUT_SUFFIX = "\n```";
@@ -98,17 +105,18 @@ interface SlackHitlAction {
  * Slack-local classification stays beside the typed eve input response so
  * presentation metadata cannot cross the durable session-inbox boundary.
  */
-interface DerivedHitlResponse {
-  kind?: "tool-approval";
-  response: ValidatedInputResponse;
-  route?: SlackHitlRoute;
+export interface DecodedSlackInputInteraction {
+  readonly button: boolean;
+  readonly kind?: Extract<InputRequestKind, "question" | "tool-approval">;
+  readonly requestId: string;
+  readonly returnTo?: SlackInputRequestRoute;
 }
 
-interface DecodedHitlActionId {
-  button: boolean;
-  kind?: "tool-approval";
-  requestId: string;
-  route?: SlackHitlRoute;
+/** Input response and routing data decoded from a framework-owned Slack action. */
+export interface DerivedHitlResponse {
+  readonly kind?: Extract<InputRequestKind, "question" | "tool-approval">;
+  readonly response: ValidatedInputResponse;
+  readonly returnTo?: SlackInputRequestRoute;
 }
 
 /**
@@ -123,22 +131,27 @@ export function deriveHitlResponse(action: SlackHitlAction): DerivedHitlResponse
   if (decoded === null) return null;
   const optionId = action.selectedOptionValue ?? action.value;
   if (optionId === undefined || (action.value !== undefined && !decoded.button)) return null;
-  const derived: DerivedHitlResponse = {
+  const derived: {
+    kind?: DerivedHitlResponse["kind"];
+    response: ValidatedInputResponse;
+    returnTo?: SlackInputRequestRoute;
+  } = {
     response: parseInputResponse({ optionId, requestId: decoded.requestId }),
   };
   if (decoded.kind !== undefined) derived.kind = decoded.kind;
-  if (decoded.route !== undefined) derived.route = decoded.route;
+  if (decoded.returnTo !== undefined) derived.returnTo = decoded.returnTo;
   return derived;
 }
 
 function splitEncodedRequest(value: string): {
-  readonly kind?: "tool-approval";
+  readonly kind?: Extract<InputRequestKind, "question" | "tool-approval">;
   readonly requestId: string;
 } {
-  const prefix = "tool-approval:";
-  return value.startsWith(prefix)
-    ? { kind: "tool-approval", requestId: value.slice(prefix.length) }
-    : { requestId: value };
+  for (const kind of ["question", "tool-approval"] as const) {
+    const prefix = `${kind}:`;
+    if (value.startsWith(prefix)) return { kind, requestId: value.slice(prefix.length) };
+  }
+  return { requestId: value };
 }
 
 /**
@@ -151,36 +164,53 @@ export function isHitlAction(actionId: string): boolean {
 }
 
 /** Decodes the framework-owned identity and optional return route from one action id. */
-export function decodeHitlActionId(actionId: string): DecodedHitlActionId | null {
+export function decodeHitlActionId(actionId: string): DecodedSlackInputInteraction | null {
   if (!actionId.startsWith(HITL_ACTION_PREFIX)) return null;
-  let encoded = actionId.slice(HITL_ACTION_PREFIX.length);
-  let route: SlackHitlRoute | undefined;
+  return decodeInputActionPayload(actionId.slice(HITL_ACTION_PREFIX.length));
+}
+
+function decodeInputActionPayload(payload: string): DecodedSlackInputInteraction | null {
+  let encoded = payload;
+  let returnTo: SlackInputRequestRoute | undefined;
   if (encoded.startsWith("route:")) {
     encoded = encoded.slice("route:".length);
     const first = encoded.indexOf(":");
     const second = encoded.indexOf(":", first + 1);
     if (first <= 0 || second <= first + 1) return null;
-    route = { channelId: encoded.slice(0, first), threadTs: encoded.slice(first + 1, second) };
+    returnTo = { channelId: encoded.slice(0, first), threadTs: encoded.slice(first + 1, second) };
     encoded = encoded.slice(second + 1);
   }
   const button = BUTTON_ACTION_ID_RE.exec(encoded);
   const request = splitEncodedRequest(button?.groups?.requestId ?? encoded);
   if (!request.requestId) return null;
-  const kind = button?.groups?.kind === "tool-approval" ? "tool-approval" : request.kind;
-  const decoded: DecodedHitlActionId = {
+  const encodedKind = button?.groups?.kind;
+  const kind =
+    encodedKind === "question" || encodedKind === "tool-approval" ? encodedKind : request.kind;
+  const decoded: {
+    button: boolean;
+    kind?: DecodedSlackInputInteraction["kind"];
+    requestId: string;
+    returnTo?: SlackInputRequestRoute;
+  } = {
     button: button !== null,
     requestId: request.requestId,
   };
   if (kind !== undefined) decoded.kind = kind;
-  if (route !== undefined) decoded.route = route;
+  if (returnTo !== undefined) decoded.returnTo = returnTo;
   return decoded;
 }
 
-function encodeHitlActionId(request: InputRequest, route?: SlackHitlRoute): string {
-  const requestIdentity = `${request.kind === "tool-approval" ? "tool-approval:" : ""}${request.requestId}`;
-  return route === undefined
+function encodeHitlActionId(
+  request: InputRequest,
+  options?: SlackInputRequestRenderOptions,
+): string {
+  const kind =
+    request.kind === "question" || request.kind === "tool-approval" ? request.kind : undefined;
+  const requestIdentity = `${kind === "tool-approval" || options?.returnTo !== undefined ? `${kind ?? request.kind}:` : ""}${request.requestId}`;
+  const returnTo = options?.returnTo;
+  return returnTo === undefined
     ? `${HITL_ACTION_PREFIX}${requestIdentity}`
-    : `${HITL_ROUTE_PREFIX}${route.channelId}:${route.threadTs}:${requestIdentity}`;
+    : `${HITL_ROUTE_PREFIX}${returnTo.channelId}:${returnTo.threadTs}:${requestIdentity}`;
 }
 
 /**
@@ -201,13 +231,16 @@ function encodeHitlActionId(request: InputRequest, route?: SlackHitlRoute): stri
  *
  * Always emits at least the prompt section.
  */
-export function renderInputRequestBlocks(request: InputRequest, route?: SlackHitlRoute): unknown[] {
+export function renderInputRequestBlocks(
+  request: InputRequest,
+  renderOptions?: SlackInputRequestRenderOptions,
+): unknown[] {
   const prompt = {
     text: { text: truncateSectionText(request.prompt), type: "mrkdwn" },
     type: "section",
   };
   const details = renderInputRequestDetailBlocks(request);
-  const actionId = encodeHitlActionId(request, route);
+  const actionId = encodeHitlActionId(request, renderOptions);
 
   const options = request.options;
   const acceptsFreeform = request.allowFreeform === true || !options || options.length === 0;
@@ -266,12 +299,12 @@ export interface SlackInputRequestPostPart {
  */
 export function renderInputRequestPostParts(
   request: InputRequest,
-  route?: SlackHitlRoute,
+  options?: SlackInputRequestRenderOptions,
 ): {
   readonly controls: SlackInputRequestPostPart;
   readonly details?: SlackInputRequestPostPart;
 } {
-  const blocks = renderInputRequestBlocks(request, route);
+  const blocks = renderInputRequestBlocks(request, options);
   const firstBlock = blocks[0];
   if (!isApprovalRequest(request) || !isBlockType(firstBlock, "card") || blocks.length === 1) {
     return {
@@ -366,15 +399,14 @@ export function isFreeformAction(actionId: string): boolean {
 /**
  * Extracts the requestId from a freeform-answer button's `action_id`.
  */
-export function freeformRequestIdFromActionId(actionId: string): string | undefined {
-  return decodeFreeformHitlActionId(actionId)?.requestId;
+export function decodeFreeformActionId(actionId: string): DecodedSlackInputInteraction | null {
+  if (!isFreeformAction(actionId)) return null;
+  return decodeInputActionPayload(actionId.slice(HITL_FREEFORM_ACTION_PREFIX.length));
 }
 
-export function decodeFreeformHitlActionId(actionId: string): DecodedHitlActionId | null {
-  if (!isFreeformAction(actionId)) return null;
-  return decodeHitlActionId(
-    `${HITL_ACTION_PREFIX}${actionId.slice(HITL_FREEFORM_ACTION_PREFIX.length)}`,
-  );
+/** Extracts the requestId from a freeform-answer button's `action_id`. */
+export function freeformRequestIdFromActionId(actionId: string): string | undefined {
+  return decodeFreeformActionId(actionId)?.requestId;
 }
 
 function buildCardButton(

--- a/packages/eve/src/public/channels/slack/index.ts
+++ b/packages/eve/src/public/channels/slack/index.ts
@@ -76,6 +76,19 @@ export {
 export { defaultSlackAuth } from "#public/channels/slack/defaults.js";
 
 export {
+  decodeFreeformActionId,
+  decodeHitlActionId,
+  renderInputRequestBlocks,
+  renderInputRequestPostParts,
+  type DecodedSlackInputInteraction,
+  type SlackInputRequestPostPart,
+  type SlackInputRequestRenderOptions,
+  type SlackInputRequestRoute,
+} from "#public/channels/slack/hitl.js";
+
+export type { InputRequest, InputRequestMetadata, InputOption } from "#shared/input.js";
+
+export {
   experimental_slackActivityPlan,
   experimental_slackActivityRenderer,
   experimental_slackActivityTree,

--- a/packages/eve/src/public/channels/slack/input-response.ts
+++ b/packages/eve/src/public/channels/slack/input-response.ts
@@ -1,6 +1,7 @@
+import type { ChannelFrom } from "#channel/channel-operations.js";
 import type { SessionAuthContext } from "#channel/types.js";
 import { createLogger } from "#internal/logging.js";
-import { buildSlackBinding } from "#public/channels/slack/api.js";
+import { buildSlackBinding, slackContinuationToken } from "#public/channels/slack/api.js";
 import { buildSlackAuthContext } from "#public/channels/slack/auth.js";
 import { deriveHitlResponse } from "#public/channels/slack/hitl.js";
 import type {
@@ -10,6 +11,7 @@ import type {
   SlackInputResponseSubmission,
   SlackChannelState,
 } from "#public/channels/slack/slackChannel.js";
+import type { ValidatedInputResponse } from "#shared/input.js";
 
 const log = createLogger("slack.interactions");
 
@@ -24,6 +26,19 @@ export function approvalResponderStatePatch(
     return undefined;
   }
   return { approvalResponderUsers: { [auth.principalId]: submission.user.id } };
+}
+
+/** Delivers an admitted response to the session that owns the routed request. */
+export async function deliverAuthenticatedInputResponse(input: {
+  readonly auth: SessionAuthContext | null;
+  readonly from: ChannelFrom<SlackChannelState>;
+  readonly inputResponses: readonly ValidatedInputResponse[];
+  readonly returnTo: { readonly channelId: string; readonly threadTs: string };
+  readonly state?: Partial<SlackChannelState>;
+}): Promise<void> {
+  await input
+    .from(slackContinuationToken(input.returnTo.channelId, input.returnTo.threadTs))
+    .respond(input.inputResponses, { auth: input.auth, state: input.state });
 }
 
 export async function authorizeInputResponse(input: {

--- a/packages/eve/src/public/channels/slack/interactions.ts
+++ b/packages/eve/src/public/channels/slack/interactions.ts
@@ -20,7 +20,7 @@ import {
 import { buildSlackAuthContext } from "#public/channels/slack/auth.js";
 import {
   buildFreeformModalView,
-  decodeFreeformHitlActionId,
+  decodeFreeformActionId,
   deriveHitlResponse,
   HITL_FREEFORM_MODAL_ACTION_ID,
   HITL_FREEFORM_MODAL_BLOCK_ID,
@@ -37,6 +37,7 @@ import {
 import {
   approvalResponderStatePatch,
   authorizeInputResponse,
+  deliverAuthenticatedInputResponse,
 } from "#public/channels/slack/input-response.js";
 import type {
   SlackChannelConfig,
@@ -306,13 +307,13 @@ export async function handleInteractionPost(
 
   if (hitlActions.length > 0) {
     const user = hitlActions[0]!.action.user;
-    const route = hitlActions[0]!.derived.route;
+    const returnTo = hitlActions[0]!.derived.returnTo;
     ctx.waitUntil(
       dispatchBlockInputResponses({
         ctx,
         deps,
         interaction,
-        route,
+        returnTo,
         submission: {
           type: "block_actions",
           actions: hitlActions.map(({ action }) => action),
@@ -483,11 +484,11 @@ async function dispatchBlockInputResponses(input: {
   };
   readonly deps: InteractionHandlerDeps;
   readonly interaction: ParsedBlockActionsPayload;
-  readonly route?: { readonly channelId: string; readonly threadTs: string };
+  readonly returnTo?: { readonly channelId: string; readonly threadTs: string };
   readonly submission: Extract<SlackInputResponseSubmission, { type: "block_actions" }>;
 }): Promise<void> {
-  const channelId = input.route?.channelId ?? input.interaction.channelId;
-  const threadTs = input.route?.threadTs ?? input.interaction.threadTs;
+  const channelId = input.returnTo?.channelId ?? input.interaction.channelId;
+  const threadTs = input.returnTo?.threadTs ?? input.interaction.threadTs;
   const result = await authorizeInputResponse({
     channelId,
     deps: input.deps,
@@ -499,12 +500,13 @@ async function dispatchBlockInputResponses(input: {
   if (result === null) return;
 
   try {
-    await input.ctx
-      .from(slackContinuationToken(channelId, threadTs))
-      .respond(input.submission.inputResponses, {
-        auth: result.auth,
-        state: approvalResponderStatePatch(input.submission, result.auth),
-      });
+    await deliverAuthenticatedInputResponse({
+      auth: result.auth,
+      from: input.ctx.from,
+      inputResponses: input.submission.inputResponses,
+      returnTo: { channelId, threadTs },
+      state: approvalResponderStatePatch(input.submission, result.auth),
+    });
   } catch (error) {
     log.error("HITL interaction delivery failed", { error });
     return;
@@ -535,11 +537,8 @@ async function openFreeformModal(input: {
     return;
   }
 
-  const decoded = decodeFreeformHitlActionId(input.freeformAction.actionId);
-  if (decoded === null) {
-    log.warn("freeform button click carries invalid metadata");
-    return;
-  }
+  const decoded = decodeFreeformActionId(input.freeformAction.actionId);
+  if (decoded === null) return log.warn("freeform button click carries invalid metadata");
   const requestId = decoded.requestId;
   if (!requestId) {
     log.warn("freeform button click missing requestId");
@@ -552,8 +551,8 @@ async function openFreeformModal(input: {
     return;
   }
 
-  const channelId = decoded?.route?.channelId ?? input.interaction.channelId;
-  const threadTs = decoded?.route?.threadTs ?? input.interaction.threadTs;
+  const channelId = decoded?.returnTo?.channelId ?? input.interaction.channelId;
+  const threadTs = decoded?.returnTo?.threadTs ?? input.interaction.threadTs;
   const metadata: HitlFreeformModalMetadata = {
     continuationToken: slackContinuationToken(channelId, threadTs),
     channelId,
@@ -607,7 +606,8 @@ async function handleViewSubmission(
     !metadata.requestId ||
     !metadata.messageTs ||
     !metadata.channelId ||
-    !metadata.threadTs
+    !metadata.threadTs ||
+    metadata.continuationToken !== slackContinuationToken(metadata.channelId, metadata.threadTs)
   ) {
     return ack;
   }
@@ -672,11 +672,12 @@ async function dispatchViewInputResponse(input: {
   if (result === null) return;
 
   try {
-    await input.ctx
-      .from(input.metadata.continuationToken)
-      .respond(input.submission.inputResponses, {
-        auth: result.auth,
-      });
+    await deliverAuthenticatedInputResponse({
+      auth: result.auth,
+      from: input.ctx.from,
+      inputResponses: input.submission.inputResponses,
+      returnTo: { channelId: input.metadata.channelId, threadTs: input.metadata.threadTs },
+    });
   } catch (error) {
     log.error("freeform answer delivery failed", { error });
     return;

--- a/packages/eve/src/public/channels/slack/private-approval-delivery.ts
+++ b/packages/eve/src/public/channels/slack/private-approval-delivery.ts
@@ -1,6 +1,6 @@
 import { createLogger, logError } from "#internal/logging.js";
 import type { SlackHandle } from "#public/channels/slack/api.js";
-import { renderInputRequestPostParts, type SlackHitlRoute } from "#public/channels/slack/hitl.js";
+import { renderInputRequestPostParts } from "#public/channels/slack/hitl.js";
 import type { SlackPendingApprovalCard } from "#public/channels/slack/slackChannel.js";
 import type { InputRequest } from "#shared/input.js";
 
@@ -20,11 +20,12 @@ export async function deliverPrivateInputRequest(input: {
     throw new Error(`Slack conversations.open failed: ${open.error ?? "unknown_error"}`);
   }
 
-  const route: SlackHitlRoute = {
-    channelId: input.slack.channelId,
-    threadTs: input.slack.threadTs,
-  };
-  const parts = renderInputRequestPostParts(input.request, route);
+  const parts = renderInputRequestPostParts(input.request, {
+    returnTo: {
+      channelId: input.slack.channelId,
+      threadTs: input.slack.threadTs,
+    },
+  });
   const postedMessageIds: string[] = [];
 
   try {

--- a/packages/eve/src/public/channels/slack/slackChannel.test.ts
+++ b/packages/eve/src/public/channels/slack/slackChannel.test.ts
@@ -3402,7 +3402,7 @@ describe("slackChannel() HITL interaction pipeline", () => {
         },
         actions: [
           {
-            action_id: `${HITL_FREEFORM_ACTION_PREFIX}route:C_ORIGINAL:1700000000.000001:call_abc123`,
+            action_id: `${HITL_FREEFORM_ACTION_PREFIX}route:C_ORIGINAL:1700000000.000001:question:call_abc123`,
             text: { type: "plain_text", text: "Type your answer" },
             value: "call_abc123",
           },
@@ -3425,6 +3425,35 @@ describe("slackChannel() HITL interaction pipeline", () => {
       messageChannelId: "C01",
       requestId: "call_abc123",
       threadTs: "1700000000.000001",
+    });
+  });
+
+  it("routes a question answer back to its original thread", async () => {
+    const channel = slackChannel({ credentials: { botToken: "xoxb-test" } });
+    const { send } = await firePost(
+      channel,
+      buildSignedInteractionRequest({
+        type: "block_actions",
+        team: { id: "T01" },
+        user: { id: "U_REVIEWER", username: "ada", team_id: "T01" },
+        channel: { id: "D_REVIEW" },
+        message: { ts: "1700000000.000010", blocks: [] },
+        actions: [
+          {
+            action_id:
+              "eve_input:route:C_ORIGINAL:1700000000.000001:question:question_abc:button:0",
+            text: { type: "plain_text", text: "Approve" },
+            value: "approve",
+          },
+        ],
+      }),
+    );
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0]?.[0]).toBe("C_ORIGINAL:1700000000.000001");
+    expect(send.mock.calls[0]?.[1]).toMatchObject({
+      auth: { principalId: "slack:T01:U_REVIEWER" },
+      inputResponses: [{ optionId: "approve", requestId: "question_abc" }],
     });
   });
 

--- a/packages/eve/src/shared/input.ts
+++ b/packages/eve/src/shared/input.ts
@@ -1,6 +1,26 @@
 import { z } from "#compiled/zod/index.js";
 
 import { runtimeToolCallActionRequestSchema } from "#shared/action-types.js";
+import { jsonObjectSchema } from "#shared/json-schemas.js";
+import type { JsonObject } from "#shared/json.js";
+
+/** Maximum serialized size of application-authored input request metadata. */
+export const INPUT_REQUEST_METADATA_MAX_BYTES = 16 * 1024;
+
+const inputRequestMetadataSchema = jsonObjectSchema.refine(
+  (metadata) =>
+    new TextEncoder().encode(JSON.stringify(metadata)).byteLength <=
+    INPUT_REQUEST_METADATA_MAX_BYTES,
+  `Input request metadata exceeds ${INPUT_REQUEST_METADATA_MAX_BYTES} UTF-8 bytes.`,
+);
+
+/** Bounded application metadata carried with an input request. */
+export type InputRequestMetadata = JsonObject;
+
+/** Validates application-authored input request metadata at the durable boundary. */
+export function parseInputRequestMetadata(value: unknown): InputRequestMetadata {
+  return inputRequestMetadataSchema.parse(value);
+}
 
 /**
  * One selectable option presented to the user in an input request.
@@ -58,6 +78,9 @@ export const inputRequestSchema = z
     kind: inputRequestKindSchema.describe(
       "Framework-owned request source used to resolve, route, and render the response.",
     ),
+    metadata: inputRequestMetadataSchema
+      .describe("Application-authored metadata passed unchanged to input request renderers.")
+      .optional(),
     options: z
       .array(inputOptionSchema)
       .describe("Selectable answer options to present to the user.")

--- a/packages/eve/src/tools/definition.ts
+++ b/packages/eve/src/tools/definition.ts
@@ -10,7 +10,7 @@ import { stampDefinitionKey } from "#internal/authored-definition/source-identit
 import type { JsonObject } from "#shared/json.js";
 import type { TokenResult } from "#shared/connection-types.js";
 import type { ToolAuthOptions, ToolAuthProvider } from "#tools/auth.js";
-import type { InputOption } from "#shared/input.js";
+import type { InputOption, InputRequestMetadata } from "#shared/input.js";
 import {
   collectDurableDynamicToolCallbacks,
   stampDurableDynamicToolCallbacks,
@@ -139,6 +139,8 @@ export interface ToolInputRequest {
   readonly allowFreeform?: boolean;
   /** Rendering hint: confirmation buttons, a selection list, or a text field. */
   readonly display?: "confirmation" | "select" | "text";
+  /** Bounded JSON metadata passed unchanged to the channel's input request renderer. */
+  readonly metadata?: InputRequestMetadata;
   /** Selectable answers. */
   readonly options?: readonly InputOption[];
   readonly prompt: string;

--- a/packages/eve/src/tools/framework/ask-question.ts
+++ b/packages/eve/src/tools/framework/ask-question.ts
@@ -6,6 +6,7 @@ export const ASK_QUESTION_INPUT_SCHEMA = inputRequestSchema.omit({
   action: true,
   display: true,
   kind: true,
+  metadata: true,
   requestId: true,
 });
 export const ASK_QUESTION_OUTPUT_SCHEMA = z


### PR DESCRIPTION
### Summary

Application-owned Slack renderers need a durable way to identify input requests and return responses to the originating session. This adds typed `ctx.ask()` metadata and authenticated return routes for routed questions and approvals, while preserving normal thread rendering and the `onInputResponse` lifecycle. This is PR 3 in the stack, on top of #3145 and #3061.

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/public/channels/slack/defaults.test.ts src/public/channels/slack/hitl.test.ts src/public/channels/slack/slackChannel.test.ts src/execution/tools/workflow/owner-inbox.test.ts src/context/dynamic-tool-lifecycle.test.ts src/harness/input-extraction.test.ts src/internal/authored-definition/schema-backed.test.ts` — 307 tests passed after `pnpm typecheck` built compiled assets; the initial run had 229 passing tests and one suite unable to resolve a missing compiled vendor module.
- `pnpm typecheck`
- `pnpm docs:check`
- `pnpm guard:invariants` — fails on #3145's pre-existing modifications to published `dynamicTool/v31` and `tool/v32` contract reports.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
