### PR TITLE
fix(eve): use GenAI input messages for traces

### DIFF
--- a/.changeset/compact-binary-traces.md
+++ b/.changeset/compact-binary-traces.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Record model input once using the OpenTelemetry `gen_ai.input.messages` schema. Local traces no longer serialize the duplicate `ai.prompt.messages` payload, avoiding binary attachment traversal.

--- a/packages/eve/src/cli/dev/tui/traces/trace-content.test.ts
+++ b/packages/eve/src/cli/dev/tui/traces/trace-content.test.ts
@@ -44,27 +44,21 @@ describe("formatAttributeContent", () => {
 
   it("renders prompt messages as role-prefixed blocks", () => {
     const messages = JSON.stringify([
-      { role: "user", content: "test" },
+      { role: "user", parts: [{ type: "text", content: "test" }] },
       {
         role: "assistant",
-        content: [
-          { type: "reasoning", text: "" },
-          { type: "text", text: "Hi! What city?" },
-          { type: "tool-call", toolName: "get_weather", input: { city: "nyc" } },
+        parts: [
+          { type: "reasoning", content: "" },
+          { type: "text", content: "Hi! What city?" },
+          { type: "tool_call", id: "call-1", name: "get_weather", arguments: { city: "nyc" } },
         ],
       },
       {
         role: "tool",
-        content: [
-          {
-            type: "tool-result",
-            toolName: "get_weather",
-            output: { type: "text", value: "sunny, 72F" },
-          },
-        ],
+        parts: [{ type: "tool_call_response", id: "call-1", response: "sunny, 72F" }],
       },
     ]);
-    expect(format("ai.prompt.messages", messages)).toEqual([
+    expect(format("gen_ai.input.messages", messages)).toEqual([
       "user: test",
       "assistant: ⟨reasoning⟩",
       "  Hi! What city?",
@@ -75,8 +69,10 @@ describe("formatAttributeContent", () => {
 
   it("keeps wrapped continuations indented under their block", () => {
     const longText = "word ".repeat(30).trim();
-    const messages = JSON.stringify([{ role: "assistant", content: longText }]);
-    const lines = format("ai.prompt.messages", messages, 40);
+    const messages = JSON.stringify([
+      { role: "assistant", parts: [{ type: "text", content: longText }] },
+    ]);
+    const lines = format("gen_ai.input.messages", messages, 40);
     expect(lines[0]).toMatch(/^assistant: /);
     for (const line of lines.slice(1)) expect(line).toMatch(/^ {2}\S/);
     for (const line of lines) expect(visibleLength(line)).toBeLessThanOrEqual(40);
@@ -84,27 +80,27 @@ describe("formatAttributeContent", () => {
     expect(lines.join(" ").match(/word/g)).toHaveLength(30);
   });
 
-  it("unwraps typed tool output envelopes", () => {
+  it("renders structured tool responses", () => {
     const messages = JSON.stringify([
       {
         role: "tool",
-        content: [
+        parts: [
           {
-            type: "tool-result",
-            toolName: "get_weather",
-            output: { type: "json", value: { city: "nyc", temperatureF: 72 } },
+            type: "tool_call_response",
+            id: "call-1",
+            response: { city: "nyc", temperatureF: 72 },
           },
         ],
       },
     ]);
-    expect(format("ai.prompt.messages", messages)).toEqual([
-      'tool get_weather: {"city":"nyc","temperatureF":72}',
+    expect(format("gen_ai.input.messages", messages)).toEqual([
+      'tool: {"city":"nyc","temperatureF":72}',
     ]);
   });
 
   it("falls back to pretty JSON for non-message payloads", () => {
     const notMessages = JSON.stringify([{ notARole: true }]);
-    expect(format("ai.prompt.messages", notMessages)).toEqual([
+    expect(format("gen_ai.input.messages", notMessages)).toEqual([
       "[",
       "  {",
       '    "notARole": true',
@@ -114,35 +110,24 @@ describe("formatAttributeContent", () => {
   });
 
   it("keeps unparseable strings raw", () => {
-    expect(format("ai.prompt.messages", "not json at all")).toEqual(["not json at all"]);
-  });
-
-  it("renders the truncation marker as a notice before the kept messages", () => {
-    const messages = JSON.stringify([
-      { "eve.truncated": { omittedMessages: 47 } },
-      { role: "user", content: "latest question" },
-    ]);
-    expect(format("ai.prompt.messages", messages)).toEqual([
-      "… 47 earlier messages omitted (long context)",
-      "user: latest question",
-    ]);
+    expect(format("gen_ai.input.messages", "not json at all")).toEqual(["not json at all"]);
   });
 
   it("splits embedded newlines in payload text into separate lines", () => {
     const messages = JSON.stringify([
       {
         role: "tool",
-        content: [
+        parts: [
           {
-            type: "tool-result",
-            toolName: "load_skill",
-            output: { type: "text", value: "line one.\nline two.\n" },
+            type: "tool_call_response",
+            id: "call-1",
+            response: "line one.\nline two.\n",
           },
         ],
       },
     ]);
-    const lines = format("ai.prompt.messages", messages);
-    expect(lines).toEqual(["tool load_skill: line one.", "  line two."]);
+    const lines = format("gen_ai.input.messages", messages);
+    expect(lines).toEqual(["tool: line one.", "  line two."]);
     for (const line of lines) expect(line).not.toContain("\n");
   });
 
@@ -156,26 +141,29 @@ describe("formatAttributeContent", () => {
 
   it("strips terminal escape sequences from roles, content, and tool names", () => {
     const messages = JSON.stringify([
-      { role: "user", content: "hello\x1b[31mred\x1b[0m world" },
+      {
+        role: "user",
+        parts: [{ type: "text", content: "hello\x1b[31mred\x1b[0m world" }],
+      },
       {
         role: "assistant",
-        content: [
-          { type: "text", text: "safe\x1b[2Jtext" },
-          { type: "tool-call", toolName: "evil\x1b[?1000h", input: {} },
+        parts: [
+          { type: "text", content: "safe\x1b[2Jtext" },
+          { type: "tool_call", id: "call-1", name: "evil\x1b[?1000h", arguments: {} },
         ],
       },
       {
         role: "tool",
-        content: [
+        parts: [
           {
-            type: "tool-result",
-            toolName: "evil\x1b[?1000h",
-            output: { type: "text", value: "r\x1besult" },
+            type: "tool_call_response",
+            id: "call-1",
+            response: "r\x1besult",
           },
         ],
       },
     ]);
-    const lines = format("ai.prompt.messages", messages);
+    const lines = format("gen_ai.input.messages", messages);
     const joined = lines.join("\n");
     expect(joined).not.toContain("\x1b");
     expect(joined).toContain("hello");

--- a/packages/eve/src/cli/dev/tui/traces/trace-content.ts
+++ b/packages/eve/src/cli/dev/tui/traces/trace-content.ts
@@ -2,9 +2,7 @@
  * Formats span attribute values for the `/traces` detail panel. Payload
  * attributes render as readable structure — prompt messages as a chat-like
  * transcript with role-prefixed blocks and hanging indents, JSON as
- * pretty-printed blocks — instead of one wrapped blob. Provider transport
- * noise was already stripped at capture time (see `agent-otel-provider.ts`),
- * so what remains here is presentation only.
+ * pretty-printed blocks — instead of one wrapped blob.
  *
  * Every returned line fits the given width; wrapped continuations keep a
  * two-space hanging indent so they read as part of their block.
@@ -35,8 +33,8 @@ export function formatAttributeContent(
     if (Array.isArray(value)) return prettyJson(value, width);
     return [stripTerminalControls(shortJson(value))];
   }
-  if (key === "ai.prompt.messages") {
-    const transcript = messageTranscript(value, dim, width);
+  if (key === "gen_ai.input.messages") {
+    const transcript = genAiMessageTranscript(value, dim, width);
     if (transcript !== undefined) return transcript;
   }
   return formatPayloadContent(value, width);
@@ -61,38 +59,18 @@ export function formatPayloadContent(text: string, width: number): string[] {
   return wrapPlainText(text, width);
 }
 
-function messageTranscript(
+function genAiMessageTranscript(
   raw: string,
   dim: (text: string) => string,
   width: number,
 ): string[] | undefined {
   const parsed = parseJson(raw);
   if (!Array.isArray(parsed)) return undefined;
-  // Long conversations are front-truncated at capture time with an
-  // `eve.truncated` marker; it renders as a notice, not a message.
-  let omitted = 0;
-  const messages: Record<string, unknown>[] = [];
-  for (const item of parsed) {
-    if (isRecord(item) && isRecord(item["eve.truncated"])) {
-      const count = item["eve.truncated"].omittedMessages;
-      if (typeof count === "number") {
-        omitted += count;
-        continue;
-      }
-    }
-    messages.push(item);
-  }
-  if (!messages.every((message) => typeof message.role === "string")) {
-    return undefined;
-  }
+  if (!parsed.every(isGenAiMessage)) return undefined;
   const lines: string[] = [];
-  if (omitted > 0) {
-    lines.push(
-      dim(`… ${omitted} earlier message${omitted === 1 ? "" : "s"} omitted (long context)`),
-    );
-  }
-  for (const message of messages) {
-    const parts = messageContentParts(message.content);
+  const toolNames = new Map<string, string>();
+  for (const message of parsed) {
+    const parts = genAiMessageParts(message.parts, toolNames);
     const role =
       message.role === "tool" ? toolRoleLabel(parts) : stripTerminalControls(String(message.role));
     // The first part sits beside the role prefix; the rest hang underneath.
@@ -116,46 +94,37 @@ interface MessageContentPart {
   readonly name?: string;
 }
 
-function messageContentParts(content: unknown): MessageContentPart[] {
-  if (typeof content === "string") return [{ text: stripTerminalControls(content) }];
-  if (!Array.isArray(content)) return [{ text: shortJson(content) }];
+function genAiMessageParts(value: unknown, toolNames: Map<string, string>): MessageContentPart[] {
+  if (!Array.isArray(value)) return [{ text: shortJson(value) }];
   const parts: MessageContentPart[] = [];
-  for (const part of content) {
+  for (const part of value) {
     if (!isRecord(part) || typeof part.type !== "string") {
       parts.push({ text: shortJson(part) });
       continue;
     }
-    if (part.type === "text" && typeof part.text === "string") {
-      parts.push({ text: stripTerminalControls(part.text) });
+    if (part.type === "text" && typeof part.content === "string") {
+      parts.push({ text: stripTerminalControls(part.content) });
     } else if (part.type === "reasoning") {
-      const text = typeof part.text === "string" ? stripTerminalControls(part.text.trim()) : "";
+      const text =
+        typeof part.content === "string" ? stripTerminalControls(part.content.trim()) : "";
       parts.push({ dim: true, text: text.length > 0 ? `⟨reasoning⟩ ${text}` : "⟨reasoning⟩" });
-    } else if (part.type === "tool-call" && typeof part.toolName === "string") {
-      const name = stripTerminalControls(part.toolName);
-      parts.push({ name, text: `→ ${name}(${shortJson(part.input)})` });
-    } else if (part.type === "tool-result" && typeof part.toolName === "string") {
-      const name = stripTerminalControls(part.toolName);
-      parts.push({ name, text: toolOutputText(part.output) });
+    } else if (part.type === "tool_call" && typeof part.name === "string") {
+      const name = stripTerminalControls(part.name);
+      if (typeof part.id === "string") toolNames.set(part.id, name);
+      parts.push({ name, text: `→ ${name}(${shortJson(part.arguments)})` });
+    } else if (part.type === "tool_call_response") {
+      const name = typeof part.id === "string" ? toolNames.get(part.id) : undefined;
+      parts.push({ name, text: toolResponseText(part.response) });
     } else {
       parts.push({ text: shortJson(part) });
     }
   }
-  if (parts.length === 0) parts.push({ text: shortJson(content) });
+  if (parts.length === 0) parts.push({ text: shortJson(value) });
   return parts;
 }
 
-/**
- * Unwraps the AI SDK's typed output envelopes: `{"type":"text","value":"…"}`
- * renders as the text, `{"type":"json","value":{…}}` as the inner payload's
- * compact JSON. Everything else renders as compact JSON.
- */
-function toolOutputText(output: unknown): string {
-  if (isRecord(output) && typeof output.type === "string" && "value" in output) {
-    if (output.type === "text" && typeof output.value === "string")
-      return stripTerminalControls(output.value);
-    return shortJson(output.value);
-  }
-  return shortJson(output);
+function toolResponseText(response: unknown): string {
+  return typeof response === "string" ? stripTerminalControls(response) : shortJson(response);
 }
 
 /** Pretty-prints a JSON value with two-space indents, wrapped to `width`. */
@@ -225,6 +194,12 @@ function parseJson(value: string): unknown {
   } catch {
     return undefined;
   }
+}
+
+function isGenAiMessage(
+  value: unknown,
+): value is Record<string, unknown> & { readonly role: string } {
+  return isRecord(value) && typeof value.role === "string";
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/eve/src/cli/dev/tui/traces/trace-conversation.test.ts
+++ b/packages/eve/src/cli/dev/tui/traces/trace-conversation.test.ts
@@ -50,13 +50,13 @@ function weatherTurn(): LocalTraceSpan[] {
   });
   const step = span("b".repeat(16), "agent.step", 10, 5000, turn.spanId, {});
   const messages = JSON.stringify([
-    { role: "user", content: "weather in nyc?" },
-    { role: "assistant", content: "hi" },
-    { role: "user", content: "weather in sf?" },
+    { role: "user", parts: [{ type: "text", content: "weather in nyc?" }] },
+    { role: "assistant", parts: [{ type: "text", content: "hi" }] },
+    { role: "user", parts: [{ type: "text", content: "weather in sf?" }] },
   ]);
   const model = span("c".repeat(16), "ai.streamText.doStream", 20, 2000, step.spanId, {
     "gen_ai.request.model": "claude-test",
-    "ai.prompt.messages": messages,
+    "gen_ai.input.messages": messages,
     "ai.response.text": "Let me check.",
     "agent.usage.input_tokens": 6200,
     "agent.usage.output_tokens": 50,
@@ -176,7 +176,9 @@ describe("buildConversationItems", () => {
       7000,
       childStep.spanId,
       {
-        "ai.prompt.messages": JSON.stringify([{ role: "user", content: "delegated task" }]),
+        "gen_ai.input.messages": JSON.stringify([
+          { parts: [{ content: "delegated task", type: "text" }], role: "user" },
+        ]),
         "ai.response.text": "delegated reply",
       },
     );
@@ -222,7 +224,9 @@ describe("buildConversationItems", () => {
     });
     const step1 = span("b".repeat(16), "agent.step", 10, 20, turn.spanId, {});
     const dispatch = span("c".repeat(16), "ai.streamText.doStream", 12, 18, step1.spanId, {
-      "ai.prompt.messages": JSON.stringify([{ role: "user", content: "run the subagent" }]),
+      "gen_ai.input.messages": JSON.stringify([
+        { parts: [{ content: "run the subagent", type: "text" }], role: "user" },
+      ]),
       "ai.response.text": "Dispatching.",
     });
     const parentAction = span("e".repeat(16), "agent.action", 20, 30, step1.spanId, {
@@ -245,7 +249,9 @@ describe("buildConversationItems", () => {
     );
     const childStep = span("1".repeat(16), "agent.step", 32, 40, childTurn.spanId, {});
     const childModel = span("2".repeat(16), "ai.streamText.doStream", 34, 38, childStep.spanId, {
-      "ai.prompt.messages": JSON.stringify([{ role: "user", content: "delegated task" }]),
+      "gen_ai.input.messages": JSON.stringify([
+        { parts: [{ content: "delegated task", type: "text" }], role: "user" },
+      ]),
       "ai.response.text": "delegated reply",
     });
     const step2 = span("3".repeat(16), "agent.step", 50, 60, turn.spanId, {});
@@ -269,7 +275,9 @@ describe("buildConversationItems", () => {
     const turn = span("a".repeat(16), "agent.turn", 0, 0, undefined, {});
     const step = span("b".repeat(16), "agent.step", 10, 5000, turn.spanId, {});
     const model = span("c".repeat(16), "ai.streamText.doStream", 20, 2000, step.spanId, {
-      "ai.prompt.messages": JSON.stringify([{ role: "user", content: "hi" }]),
+      "gen_ai.input.messages": JSON.stringify([
+        { parts: [{ content: "hi", type: "text" }], role: "user" },
+      ]),
     });
     const items = buildConversationItems(trace([turn, step, model]));
     expect(items).toEqual([]);
@@ -284,7 +292,11 @@ describe("buildConversationItems", () => {
       20,
       2000,
       step.spanId,
-      { "ai.prompt.messages": JSON.stringify([{ role: "user", content: "hi" }]) },
+      {
+        "gen_ai.input.messages": JSON.stringify([
+          { parts: [{ content: "hi", type: "text" }], role: "user" },
+        ]),
+      },
       2,
     );
     const items = buildConversationItems(trace([turn, step, model]));
@@ -296,7 +308,9 @@ describe("buildConversationItems", () => {
     const turn = span("a".repeat(16), "agent.turn", 0, 0, undefined, {});
     const step = span("b".repeat(16), "agent.step", 10, 5000, turn.spanId, {});
     const model = span("c".repeat(16), "ai.streamText.doStream", 20, 2000, step.spanId, {
-      "ai.prompt.messages": JSON.stringify([{ role: "user", content: "hi" }]),
+      "gen_ai.input.messages": JSON.stringify([
+        { parts: [{ content: "hi", type: "text" }], role: "user" },
+      ]),
       "agent.usage.input_tokens": 100,
       "agent.usage.output_tokens": 10,
     });
@@ -309,7 +323,9 @@ describe("buildConversationItems", () => {
     const turn = span("a".repeat(16), "agent.turn", 0, 0, undefined, {});
     const step = span("b".repeat(16), "agent.step", 10, 100, turn.spanId, {});
     const model = span("c".repeat(16), "ai.streamText.doStream", 20, 50, step.spanId, {
-      "ai.prompt.messages": JSON.stringify([{ role: "user", content: "hi" }]),
+      "gen_ai.input.messages": JSON.stringify([
+        { parts: [{ content: "hi", type: "text" }], role: "user" },
+      ]),
       "agent.usage.input_tokens": 10,
     });
     const action = span(
@@ -395,7 +411,9 @@ describe("renderConversationItem", () => {
     });
     const model = span("c".repeat(16), "ai.streamText.doStream", 20, 2000, step.spanId, {
       "gen_ai.request.model": "claude-test",
-      "ai.prompt.messages": JSON.stringify([{ role: "user", content: "hi" }]),
+      "gen_ai.input.messages": JSON.stringify([
+        { parts: [{ content: "hi", type: "text" }], role: "user" },
+      ]),
       "ai.response.text": "reply",
       "agent.usage.input_tokens": 100,
     });
@@ -425,7 +443,9 @@ describe("renderConversationItem", () => {
     const step = span("b".repeat(16), "agent.step", 10, 100, turn.spanId, {});
     const model = span("c".repeat(16), "ai.streamText.doStream", 20, 50, step.spanId, {
       "ai.prompt.system": "You are a test assistant. Be brief.",
-      "ai.prompt.messages": JSON.stringify([{ role: "user", content: "hi" }]),
+      "gen_ai.input.messages": JSON.stringify([
+        { parts: [{ content: "hi", type: "text" }], role: "user" },
+      ]),
     });
     const items = buildConversationItems(trace([turn, step, model]));
     expect(items[0]?.kind).toBe("system");
@@ -453,7 +473,9 @@ describe("renderConversationItem", () => {
     const turn = span("a".repeat(16), "agent.turn", 0, 0, undefined, {});
     const step = span("b".repeat(16), "agent.step", 10, 100, turn.spanId, {});
     const model = span("c".repeat(16), "ai.streamText.doStream", 20, 50, step.spanId, {
-      "ai.prompt.messages": JSON.stringify([{ role: "user", content: "hi" }]),
+      "gen_ai.input.messages": JSON.stringify([
+        { parts: [{ content: "hi", type: "text" }], role: "user" },
+      ]),
       "ai.response.reasoning": "let me think about this",
       "ai.response.text": "here is my answer",
     });

--- a/packages/eve/src/cli/dev/tui/traces/trace-view.test.ts
+++ b/packages/eve/src/cli/dev/tui/traces/trace-view.test.ts
@@ -51,7 +51,9 @@ function conversationSpans(): LocalTraceSpan[] {
   const model = span("c".repeat(16), "ai.streamText.doStream", 20, 2000, step.spanId, {
     "gen_ai.request.model": "gpt-5",
     "agent.usage.input_tokens": 1234,
-    "ai.prompt.messages": JSON.stringify([{ role: "user", content: "hi" }]),
+    "gen_ai.input.messages": JSON.stringify([
+      { parts: [{ content: "hi", type: "text" }], role: "user" },
+    ]),
     "ai.prompt.system": "You are a test assistant.",
     "ai.response.text": "reply",
   });
@@ -207,7 +209,9 @@ describe("renderTraceViewer", () => {
     const turn = span("a".repeat(16), "agent.turn", 0, 0);
     const step = span("b".repeat(16), "agent.step", 10, 300, turn.spanId, {});
     const model = span("c".repeat(16), "ai.streamText.doStream", 20, 100, step.spanId, {
-      "ai.prompt.messages": JSON.stringify([{ role: "user", content: "hi" }]),
+      "gen_ai.input.messages": JSON.stringify([
+        { parts: [{ content: "hi", type: "text" }], role: "user" },
+      ]),
       "ai.response.text": "reply",
       "agent.usage.input_tokens": 10,
     });
@@ -250,7 +254,7 @@ describe("renderTraceViewer", () => {
   it("skips payload keys in the drawer since the cards already carry them", () => {
     const frame = render(viewerState(conversationSpans(), { panelOpen: true, selectedRow: 2 }));
     const body = frame.rows.map(stripAnsi).join("\n");
-    expect(body).not.toContain("ai.prompt.messages");
+    expect(body).not.toContain("gen_ai.input.messages");
     expect(body).not.toContain("ai.response.text");
     expect(body).toContain("agent.usage.input_tokens 1234");
   });

--- a/packages/eve/src/cli/dev/tui/traces/trace-view.ts
+++ b/packages/eve/src/cli/dev/tui/traces/trace-view.ts
@@ -191,7 +191,7 @@ function overlayRight(row: string, segment: string, width: number, margin: numbe
  * them in conversation mode so it stays metadata-focused.
  */
 const CONVERSATION_CONTENT_KEYS: ReadonlySet<string> = new Set([
-  "ai.prompt.messages",
+  "gen_ai.input.messages",
   "ai.prompt.system",
   "ai.response.reasoning",
   "ai.response.text",

--- a/packages/eve/src/cli/dev/tui/traces/trace-viewer-session.test.ts
+++ b/packages/eve/src/cli/dev/tui/traces/trace-viewer-session.test.ts
@@ -84,7 +84,9 @@ describe("TraceViewerSession drag copy", () => {
       name: "ai.streamText.doStream",
       parentSpanId: turn.spanId,
       attributes: {
-        "ai.prompt.messages": JSON.stringify([{ role: "user", content: "copy me please" }]),
+        "gen_ai.input.messages": JSON.stringify([
+          { parts: [{ content: "copy me please", type: "text" }], role: "user" },
+        ]),
         "ai.response.text": "reply",
       },
     };
@@ -151,7 +153,9 @@ describe("TraceViewerSession background surfaces", () => {
       name: "ai.streamText.doStream",
       parentSpanId: turn.spanId,
       attributes: {
-        "ai.prompt.messages": JSON.stringify([{ role: "user", content: "hi" }]),
+        "gen_ai.input.messages": JSON.stringify([
+          { parts: [{ content: "hi", type: "text" }], role: "user" },
+        ]),
         "ai.response.text": "reply",
       },
     };
@@ -194,7 +198,9 @@ describe("TraceViewerSession background surfaces", () => {
       name: "ai.streamText.doStream",
       parentSpanId: turn.spanId,
       attributes: {
-        "ai.prompt.messages": JSON.stringify([{ role: "user", content: "hi" }]),
+        "gen_ai.input.messages": JSON.stringify([
+          { parts: [{ content: "hi", type: "text" }], role: "user" },
+        ]),
         "ai.response.text": "reply",
       },
     };

--- a/packages/eve/src/cli/dev/tui/traces/trace-viewer-state.test.ts
+++ b/packages/eve/src/cli/dev/tui/traces/trace-viewer-state.test.ts
@@ -62,7 +62,9 @@ function conversationTrace(options: { readonly longReply?: boolean } = {}): Loca
     spanId: "c".repeat(16),
     parentSpanId: step.spanId,
     attributes: {
-      "ai.prompt.messages": JSON.stringify([{ role: "user", content: "hi" }]),
+      "gen_ai.input.messages": JSON.stringify([
+        { parts: [{ content: "hi", type: "text" }], role: "user" },
+      ]),
       "ai.response.text": options.longReply === true ? "a long reply. ".repeat(60) : "reply",
     },
   });
@@ -543,7 +545,9 @@ describe("applyLoadedTrace", () => {
           spanId: "c".repeat(16),
           parentSpanId: "b".repeat(16),
           attributes: {
-            "ai.prompt.messages": JSON.stringify([{ role: "user", content: "hi" }]),
+            "gen_ai.input.messages": JSON.stringify([
+              { parts: [{ content: "hi", type: "text" }], role: "user" },
+            ]),
             "ai.prompt.system": "system prompt",
             "ai.response.text": "reply",
           },

--- a/packages/eve/src/tracing/agent-action-instrumentation.ts
+++ b/packages/eve/src/tracing/agent-action-instrumentation.ts
@@ -78,7 +78,7 @@ export function createAgentActionInstrumentation(input: {
       attemptIndex: event.scope.attemptIndex,
       callId: event.callId,
       channelAudience: normalizeChannelAudience(event.scope.channelAudience),
-      inputAttribute: input.recordInputs ? contentAttribute(event.input, false) : undefined,
+      inputAttribute: input.recordInputs ? contentAttribute(event.input) : undefined,
       kind: event.kind,
       name: event.name,
       parent: {
@@ -234,7 +234,7 @@ export function createAgentActionInstrumentation(input: {
         setAgentUsage(span, event.usage);
       }
       if (input.recordOutputs && !isAgentInvocation(state.kind)) {
-        const result = contentAttribute(event.output.output, false);
+        const result = contentAttribute(event.output.output);
         if (result !== undefined) span.setAttribute("gen_ai.tool.call.result", result);
       }
     }
@@ -304,7 +304,7 @@ function recordActionError(span: Span, error: unknown, errorType?: string): void
 
 function serializedErrorDetail(error: unknown): string | undefined {
   if (typeof error === "string") return textContentAttribute(error);
-  const serialized = contentAttribute(error, false);
+  const serialized = contentAttribute(error);
   if (typeof error !== "object" || error === null || Array.isArray(error)) return serialized;
   const message = Reflect.get(error, "message");
   if (typeof message !== "string") return serialized;

--- a/packages/eve/src/tracing/agent-approval-instrumentation.ts
+++ b/packages/eve/src/tracing/agent-approval-instrumentation.ts
@@ -79,7 +79,7 @@ export function createAgentApprovalInstrumentation(input: {
       stepIndex: event.scope.stepIndex,
       turnId: event.scope.turnId,
     };
-    const requestAttribute = contentAttribute(event.request, false);
+    const requestAttribute = contentAttribute(event.request);
     if (requestAttribute !== undefined) state["requestAttribute"] = requestAttribute;
     ctx.state.set(state);
   };
@@ -128,7 +128,7 @@ export function createAgentApprovalInstrumentation(input: {
       span.setAttribute("agent.approval.request", state.requestAttribute);
     }
     if (event.response !== undefined) {
-      const response = contentAttribute(event.response, false);
+      const response = contentAttribute(event.response);
       if (response !== undefined) span.setAttribute("agent.approval.response", response);
     }
     if (event.outcome === "failed") recordError(span, event.error);

--- a/packages/eve/src/tracing/agent-channel-delivery-instrumentation.ts
+++ b/packages/eve/src/tracing/agent-channel-delivery-instrumentation.ts
@@ -54,7 +54,7 @@ export function createAgentChannelDeliveryInstrumentation(input: {
         ? undefined
         : await input.stateStore.getTurn(event.sessionId, event.turnId);
     if (!isSampledTrace(turn?.context ?? session.context)) return;
-    const inputAttribute = input.recordInputs ? contentAttribute(event.input, false) : undefined;
+    const inputAttribute = input.recordInputs ? contentAttribute(event.input) : undefined;
     const state: Record<string, JsonValue> = {};
     if (inputAttribute !== undefined) state.inputAttribute = inputAttribute;
     if (event.delivery.requestTraceContext !== undefined) {

--- a/packages/eve/src/tracing/agent-otel-content.test.ts
+++ b/packages/eve/src/tracing/agent-otel-content.test.ts
@@ -84,6 +84,35 @@ describe("GenAI message attributes", () => {
     ]);
   });
 
+  it.each([
+    ["only", [{ content: "x".repeat(CONTENT_ATTRIBUTE_LIMIT + 1), role: "user" }], undefined],
+    [
+      "newest",
+      [
+        { content: "older message", role: "assistant" },
+        {
+          content: "x".repeat(CONTENT_ATTRIBUTE_LIMIT * 2),
+          kind: "context.state",
+          role: "user",
+        },
+      ],
+      "context.state",
+    ],
+  ] as const)("keeps a truncated %s message when it alone exceeds the cap", (_, messages, kind) => {
+    const attribute = genAiInputMessagesAttribute(messages);
+
+    expect(attribute).toBeDefined();
+    expect(attribute!.length).toBeLessThanOrEqual(CONTENT_ATTRIBUTE_LIMIT);
+    const parsed = JSON.parse(attribute!) as Array<Record<string, unknown>>;
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]).toMatchObject({
+      ...(kind === undefined ? {} : { kind }),
+      parts: [{ content: expect.stringMatching(/… \[truncated\]$/u), type: "text" }],
+      role: "user",
+    });
+    expect(attribute).not.toContain("older message");
+  });
+
   it("formats model input, output, and system instructions for inspectors", () => {
     expect(
       genAiInputMessagesAttribute([

--- a/packages/eve/src/tracing/agent-otel-content.test.ts
+++ b/packages/eve/src/tracing/agent-otel-content.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { FrameworkMessageKind } from "#harness/messages.js";
 import {
@@ -20,6 +20,41 @@ const FRAMEWORK_MESSAGE_KINDS = [
 ] as const satisfies readonly FrameworkMessageKind[];
 
 describe("GenAI message attributes", () => {
+  it.each([
+    ["Buffer", () => Buffer.alloc(64, 97)],
+    ["Uint8Array", () => new Uint8Array(64).fill(97)],
+    ["base64", () => "a".repeat(CONTENT_ATTRIBUTE_LIMIT * 2)],
+    ["data URL", () => `data:image/png;base64,${"a".repeat(CONTENT_ATTRIBUTE_LIMIT * 2)}`],
+  ] as const)("omits %s attachment payloads", (_, createData) => {
+    const data = createData();
+    const entries = Object.entries;
+    let binaryEnumerations = 0;
+    const spy = vi.spyOn(Object, "entries").mockImplementation((value) => {
+      if (value === data) binaryEnumerations += 1;
+      return entries(value);
+    });
+
+    let attribute: string | undefined;
+    try {
+      attribute = genAiInputMessagesAttribute([
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Summarize file." },
+            { type: "file", mediaType: "application/octet-stream", filename: "test.bin", data },
+          ],
+        },
+      ]);
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(binaryEnumerations).toBe(0);
+    expect(attribute).toBe(
+      '[{"parts":[{"content":"Summarize file.","type":"text"},{"type":"file"}],"role":"user"}]',
+    );
+  });
+
   it("preserves every user-message kind in the GenAI input attribute", () => {
     expect(
       genAiInputMessagesAttribute([

--- a/packages/eve/src/tracing/agent-otel-content.test.ts
+++ b/packages/eve/src/tracing/agent-otel-content.test.ts
@@ -106,10 +106,10 @@ describe("GenAI message attributes", () => {
     const parsed = JSON.parse(attribute!) as Array<Record<string, unknown>>;
     expect(parsed).toHaveLength(1);
     expect(parsed[0]).toMatchObject({
-      ...(kind === undefined ? {} : { kind }),
       parts: [{ content: expect.stringMatching(/… \[truncated\]$/u), type: "text" }],
       role: "user",
     });
+    expect(parsed[0]?.kind).toBe(kind);
     expect(attribute).not.toContain("older message");
   });
 

--- a/packages/eve/src/tracing/agent-otel-content.ts
+++ b/packages/eve/src/tracing/agent-otel-content.ts
@@ -11,48 +11,17 @@ import { isUserMessageKind } from "#harness/messages.js";
 /** Content attributes are capped so a giant payload cannot bloat a span segment. */
 export const CONTENT_ATTRIBUTE_LIMIT = 32 * 1024;
 
-/** Provider transport noise stripped from messages (not tool data). */
-const CONTENT_NOISE_KEYS = new Set(["providerOptions", "providerMetadata"]);
-
-/** Marker prepended when oldest messages are dropped to fit the content cap. */
-const TRUNCATED_MESSAGES_KEY = "eve.truncated";
-
-/**
- * Serializes one payload value. `strip` removes {@link CONTENT_NOISE_KEYS};
- * pass `false` for tool data, where those keys may be legitimate domain
- * fields the user authored or the tool returned.
- */
-export function contentAttribute(value: unknown, strip = true): string | undefined {
+/** Serializes one payload value as capped JSON. */
+export function contentAttribute(value: unknown): string | undefined {
   if (value === undefined) return undefined;
-  const prepared = strip ? stripContentNoise(value, 0) : value;
   let json: string | undefined;
   try {
-    json = JSON.stringify(prepared);
+    json = JSON.stringify(value);
   } catch {
     return undefined;
   }
   if (json === undefined) return undefined;
   return textContentAttribute(json);
-}
-
-/**
- * Serializes the prompt messages, keeping the result parseable: oldest
- * messages drop first behind an omission marker, and a single message over
- * the cap is truncated at the text level rather than the JSON level.
- */
-export function messagesContentAttribute(messages: unknown): string | undefined {
-  if (!Array.isArray(messages)) return contentAttribute(messages);
-  const stripped = stripContentNoise(messages, 0) as unknown[];
-  const full = stringifyContent(stripped);
-  if (full !== undefined && full.length <= CONTENT_ATTRIBUTE_LIMIT) return full;
-  for (let omitted = 1; omitted < stripped.length; omitted += 1) {
-    const json = stringifyContent([
-      { [TRUNCATED_MESSAGES_KEY]: { omittedMessages: omitted } },
-      ...stripped.slice(omitted),
-    ]);
-    if (json !== undefined && json.length <= CONTENT_ATTRIBUTE_LIMIT) return json;
-  }
-  return truncateSingleMessage(stripped);
 }
 
 /** Serializes model messages using the OpenTelemetry GenAI message schema. */
@@ -152,35 +121,6 @@ export function textContentAttribute(text: string): string | undefined {
   return text.length <= CONTENT_ATTRIBUTE_LIMIT
     ? text
     : `${text.slice(0, CONTENT_ATTRIBUTE_LIMIT)}… [truncated]`;
-}
-
-function stripContentNoise(value: unknown, depth: number): unknown {
-  if (depth > 32 || value === null || typeof value !== "object") return value;
-  if (Array.isArray(value)) return value.map((e) => stripContentNoise(e, depth + 1));
-  const out: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(value))
-    if (!CONTENT_NOISE_KEYS.has(k)) out[k] = stripContentNoise(v, depth + 1);
-  return out;
-}
-
-function truncateSingleMessage(messages: unknown[]): string | undefined {
-  if (messages.length === 0) return undefined;
-  const last = messages[messages.length - 1];
-  if (!isRecord(last)) return undefined;
-  const marker = { [TRUNCATED_MESSAGES_KEY]: { omittedMessages: messages.length - 1 } };
-  const role = typeof last.role === "string" ? last.role : "user";
-  let text = "";
-  if (typeof last.content === "string") text = last.content;
-  else if (Array.isArray(last.content))
-    for (const part of last.content)
-      if (isRecord(part) && part.type === "text" && typeof part.text === "string")
-        text += (text ? "\n" : "") + part.text;
-  for (let len = Math.min(text.length, CONTENT_ATTRIBUTE_LIMIT); len > 0; len -= 256) {
-    const cut = len >= text.length ? text : `${text.slice(0, len)}… [truncated]`;
-    const json = stringifyContent([marker, { role, content: cut }]);
-    if (json !== undefined && json.length <= CONTENT_ATTRIBUTE_LIMIT) return json;
-  }
-  return stringifyContent([marker, { role, content: "" }]);
 }
 
 function stringifyContent(value: unknown): string | undefined {

--- a/packages/eve/src/tracing/agent-otel-content.ts
+++ b/packages/eve/src/tracing/agent-otel-content.ts
@@ -43,7 +43,7 @@ export function genAiInputMessagesAttribute(messages: unknown): string | undefin
     const json = semanticJsonAttribute(formatted.slice(start));
     if (json !== undefined) return json;
   }
-  return semanticJsonAttribute([]);
+  return truncateSingleSemanticMessage(formatted) ?? semanticJsonAttribute([]);
 }
 
 /** Serializes the system prompt using the OpenTelemetry GenAI instruction schema. */
@@ -134,6 +134,41 @@ function stringifyContent(value: unknown): string | undefined {
 function semanticJsonAttribute(value: unknown): string | undefined {
   const json = stringifyContent(value);
   return json !== undefined && json.length <= CONTENT_ATTRIBUTE_LIMIT ? json : undefined;
+}
+
+function truncateSingleSemanticMessage(
+  messages: readonly Record<string, unknown>[],
+): string | undefined {
+  const message = messages.at(-1);
+  if (message === undefined || typeof message.role !== "string") return undefined;
+  const text = semanticMessageText(message.parts);
+  const base =
+    typeof message.kind === "string"
+      ? { kind: message.kind, role: message.role }
+      : { role: message.role };
+  for (let length = Math.min(text.length, CONTENT_ATTRIBUTE_LIMIT); length > 0; length -= 256) {
+    const json = semanticJsonAttribute([
+      {
+        ...base,
+        parts: [{ content: `${text.slice(0, length)}… [truncated]`, type: "text" }],
+      },
+    ]);
+    if (json !== undefined) return json;
+  }
+  return semanticJsonAttribute([{ ...base, parts: [{ content: "… [truncated]", type: "text" }] }]);
+}
+
+function semanticMessageText(parts: unknown): string {
+  if (!Array.isArray(parts)) return "";
+  let text = "";
+  for (const part of parts) {
+    if (!isRecord(part) || part.type !== "text" || typeof part.content !== "string") continue;
+    const separator = text.length === 0 ? "" : "\n";
+    const remaining = CONTENT_ATTRIBUTE_LIMIT + 1 - text.length - separator.length;
+    if (remaining <= 0) break;
+    text += separator + part.content.slice(0, remaining);
+  }
+  return text;
 }
 
 function semanticParts(content: unknown): Record<string, unknown>[] {

--- a/packages/eve/src/tracing/agent-otel-provider.test.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.test.ts
@@ -2344,10 +2344,6 @@ describe("createAgentOtelInstrumentation", () => {
     const spans = runtime.exporter.getFinishedSpans();
     const model = byName(spans, "chat claude-test")[0]!;
     const tool = byName(spans, "execute_tool weather")[0]!;
-    // Provider transport noise (signatures et al.) is stripped at capture time.
-    expect(model.attributes["ai.prompt.messages"]).toBe(
-      '[{"content":"real user text","role":"user"}]',
-    );
     expect(model.attributes["ai.prompt.system"]).toBe(
       "You are a weather assistant (system prompt).",
     );
@@ -2472,14 +2468,11 @@ describe("createAgentOtelInstrumentation", () => {
     await runtime.provider.forceFlush();
 
     const model = byName(runtime.exporter.getFinishedSpans(), "chat claude-test")[0]!;
-    const raw = model.attributes["ai.prompt.messages"];
+    const raw = model.attributes["gen_ai.input.messages"];
     expect(typeof raw).toBe("string");
     expect((raw as string).length).toBeLessThanOrEqual(32 * 1024);
     const parsed = JSON.parse(raw as string) as Array<Record<string, unknown>>;
     expect(parsed.length).toBeGreaterThan(1);
-    expect(parsed[0]).toMatchObject({
-      "eve.truncated": { omittedMessages: expect.any(Number) },
-    });
     expect(JSON.stringify(parsed)).toContain("message 199");
     expect(JSON.stringify(parsed)).not.toContain("message 0 ");
     expect(model.attributes["agent.input.messages.delta"]).toBeUndefined();
@@ -2665,8 +2658,8 @@ describe("createAgentOtelInstrumentation", () => {
       '[{"content":"You are a weather assistant (system prompt).","type":"text"}]',
     );
     expect(secondModel.attributes["agent.input.messages.delta"]).toBeUndefined();
-    expect(secondModel.attributes["ai.prompt.messages"]).toBe(
-      '[{"content":"real user text","role":"user"}]',
+    expect(secondModel.attributes["gen_ai.input.messages"]).toBe(
+      '[{"parts":[{"content":"real user text","type":"text"}],"role":"user"}]',
     );
     expect([
       ...byName(firstRuntime.exporter.getFinishedSpans(), "agent.session"),

--- a/packages/eve/src/tracing/agent-otel-provider.ts
+++ b/packages/eve/src/tracing/agent-otel-provider.ts
@@ -20,7 +20,6 @@ import {
   genAiInputMessagesAttribute,
   genAiOutputMessagesAttribute,
   genAiSystemInstructionsAttribute,
-  messagesContentAttribute,
   systemPromptAttribute,
   textContentAttribute,
   toolResultsContentAttribute,
@@ -382,8 +381,6 @@ export function createAgentOtelInstrumentation(
       attempt.context,
     );
     if (recordInputs && event.input !== undefined) {
-      const messages = messagesContentAttribute(event.input.messages);
-      if (messages !== undefined) span.setAttribute("ai.prompt.messages", messages);
       const genAiMessages = genAiInputMessagesAttribute(event.input.messages);
       if (genAiMessages !== undefined) span.setAttribute("gen_ai.input.messages", genAiMessages);
       const system = systemPromptAttribute(event.input.instructions);
@@ -445,7 +442,7 @@ export function createAgentOtelInstrumentation(
           .filter((part) => part.type === "tool-call")
           .map((part) => ({ callId: part.callId, input: part.input, toolName: part.toolName }));
         if (toolCalls.length > 0) {
-          const json = contentAttribute(toolCalls, false);
+          const json = contentAttribute(toolCalls);
           if (json !== undefined) state.span.setAttribute("ai.response.tool_calls", json);
         }
         // Provider-executed tools (e.g. web_search) run inside the model call,

--- a/packages/eve/src/tracing/agent-tool-instrumentation.ts
+++ b/packages/eve/src/tracing/agent-tool-instrumentation.ts
@@ -181,7 +181,7 @@ export function createAgentToolInstrumentation(input: {
       ),
     );
     if (input.recordInputs) {
-      const args = contentAttribute(state.event.input, false);
+      const args = contentAttribute(state.event.input);
       if (args !== undefined) state.span.setAttribute("gen_ai.tool.call.arguments", args);
     }
   }
@@ -203,7 +203,7 @@ export function createAgentToolInstrumentation(input: {
     } else if (terminal?.output.type === "error") {
       recordError(span, terminal.output.error);
     } else if (terminal !== undefined && input.recordOutputs) {
-      const result = contentAttribute(terminal.output.output, false);
+      const result = contentAttribute(terminal.output.output);
       if (result !== undefined) span.setAttribute("gen_ai.tool.call.result", result);
     }
     span.end();

--- a/packages/eve/src/tracing/content-attributes.test.ts
+++ b/packages/eve/src/tracing/content-attributes.test.ts
@@ -4,7 +4,7 @@ import { withoutDeclinedContent } from "#tracing/content-attributes.js";
 
 const ATTRIBUTES = {
   "agent.channel.delivery.input": '{"message":"private"}',
-  "ai.prompt.messages": "what the user said",
+  "gen_ai.input.messages": "what the user said",
   "ai.response.finish_reason": "stop",
   "ai.response.text": "what the model said",
   "gen_ai.request.model": "test-model",
@@ -46,7 +46,7 @@ describe("withoutDeclinedContent", () => {
       withoutDeclinedContent(ATTRIBUTES, { recordInputs: true, recordOutputs: false }),
     ).toEqual({
       "agent.channel.delivery.input": '{"message":"private"}',
-      "ai.prompt.messages": "what the user said",
+      "gen_ai.input.messages": "what the user said",
       "ai.response.finish_reason": "stop",
       "gen_ai.request.model": "test-model",
       "gen_ai.tool.call.arguments": "{}",

--- a/packages/eve/src/tracing/content-attributes.ts
+++ b/packages/eve/src/tracing/content-attributes.ts
@@ -19,7 +19,6 @@ const INPUT_CONTENT_ATTRIBUTES: ReadonlySet<string> = new Set([
   "agent.approval.request",
   "ai.documents",
   "ai.prompt",
-  "ai.prompt.messages",
   "ai.prompt.system",
   "ai.prompt.toolChoice",
   "ai.prompt.tools",

--- a/packages/eve/src/tracing/content-span-processor.test.ts
+++ b/packages/eve/src/tracing/content-span-processor.test.ts
@@ -43,7 +43,7 @@ function span(attributes: Record<string, unknown>): unknown {
 describe("contentFilteringProcessor", () => {
   it("forwards the span untouched when the destination declined nothing", () => {
     const downstream = recordingProcessor();
-    const original = span({ "ai.prompt.messages": "what the user said" });
+    const original = span({ "gen_ai.input.messages": "what the user said" });
 
     contentFilteringProcessor(downstream).onEnd(original as never);
 
@@ -55,7 +55,7 @@ describe("contentFilteringProcessor", () => {
 
     contentFilteringProcessor(downstream, redactSpanInputs()).onEnd(
       span({
-        "ai.prompt.messages": "what the user said",
+        "gen_ai.input.messages": "what the user said",
         "ai.response.text": "what the model said",
       }) as never,
     );
@@ -68,7 +68,7 @@ describe("contentFilteringProcessor", () => {
   it("leaves the original span's attributes in place for the other destinations", () => {
     const kept = recordingProcessor();
     const declined = recordingProcessor();
-    const original = span({ "ai.prompt.messages": "what the user said" });
+    const original = span({ "gen_ai.input.messages": "what the user said" });
 
     contentFilteringProcessor(
       declined,
@@ -78,7 +78,7 @@ describe("contentFilteringProcessor", () => {
 
     expect((declined.ended[0] as { attributes: unknown }).attributes).toEqual({});
     expect((kept.ended[0] as { attributes: unknown }).attributes).toEqual({
-      "ai.prompt.messages": "what the user said",
+      "gen_ai.input.messages": "what the user said",
     });
   });
 
@@ -88,7 +88,7 @@ describe("contentFilteringProcessor", () => {
     contentFilteringProcessor(
       downstream,
       composeSpanExportPolicies(redactSpanInputs(), redactSpanOutputs()),
-    ).onEnd(span({ "ai.prompt.messages": "what the user said" }) as never);
+    ).onEnd(span({ "gen_ai.input.messages": "what the user said" }) as never);
 
     expect((downstream.ended[0] as { spanContext: () => unknown }).spanContext()).toEqual({
       spanId: "span",
@@ -122,7 +122,7 @@ describe("contentFilteringProcessor", () => {
   it("redacts initial attributes before onStart without exposing the original", () => {
     const downstream = recordingProcessor();
     const original = span({
-      "ai.prompt.messages": "what the user said",
+      "gen_ai.input.messages": "what the user said",
       "service.name": "weather",
     });
 
@@ -136,7 +136,7 @@ describe("contentFilteringProcessor", () => {
       "service.name": "weather",
     });
     expect((original as { attributes: unknown }).attributes).toHaveProperty(
-      "ai.prompt.messages",
+      "gen_ai.input.messages",
       "what the user said",
     );
   });
@@ -144,7 +144,7 @@ describe("contentFilteringProcessor", () => {
   it("reuses and refreshes one facade from onStart through onEnd", () => {
     const downstream = recordingProcessor();
     const original = span({
-      "ai.prompt.messages": "what the user said",
+      "gen_ai.input.messages": "what the user said",
       "service.name": "weather",
     }) as { attributes: Record<string, unknown> };
     const processor = contentFilteringProcessor(downstream, redactSpanInputs());
@@ -170,7 +170,7 @@ describe("contentFilteringProcessor", () => {
       spanContext(): unknown;
     };
     original = {
-      attributes: { "ai.prompt.messages": "what the user said" },
+      attributes: { "gen_ai.input.messages": "what the user said" },
       fluent() {
         return this;
       },
@@ -204,7 +204,7 @@ describe("contentFilteringProcessor", () => {
 
   it("continues refreshing after a processor freezes the facade", () => {
     const downstream = recordingProcessor();
-    const original = span({ "ai.prompt.messages": "what the user said" }) as {
+    const original = span({ "gen_ai.input.messages": "what the user said" }) as {
       attributes: Record<string, unknown>;
     };
     const processor = contentFilteringProcessor(downstream, redactSpanInputs());
@@ -226,7 +226,7 @@ describe("contentFilteringProcessor", () => {
       spanProcessors: [filtering as OpenTelemetrySpanProcessor],
     });
     const span = provider.getTracer("test").startSpan("test", {
-      attributes: { "ai.prompt.messages": "what the user said" },
+      attributes: { "gen_ai.input.messages": "what the user said" },
     });
 
     span.setAttribute("ai.response.text", "what the model said");
@@ -256,14 +256,14 @@ describe("contentFilteringProcessor", () => {
     ).onEnd(
       span({
         "agent.channel.audience": audience,
-        "ai.prompt.messages": "input",
+        "gen_ai.input.messages": "input",
         "ai.response.text": "output",
       }) as never,
     );
 
     const expected: Record<string, unknown> = { "agent.channel.audience": audience };
     if (retained) {
-      expected["ai.prompt.messages"] = "input";
+      expected["gen_ai.input.messages"] = "input";
       expected["ai.response.text"] = "output";
     }
     expect((downstream.ended[0] as { attributes: Record<string, unknown> }).attributes).toEqual(
@@ -282,14 +282,14 @@ describe("contentFilteringProcessor", () => {
     ).onEnd(
       span({
         "agent.channel.audience": "public",
-        "ai.prompt.messages": "private",
+        "gen_ai.input.messages": "private",
         "ai.settings.context.eve.channel.audience": "private",
       }) as never,
     );
 
     expect(
       (downstream.ended[0] as { attributes: Record<string, unknown> }).attributes,
-    ).not.toHaveProperty("ai.prompt.messages");
+    ).not.toHaveProperty("gen_ai.input.messages");
   });
 
   it("can drop an individual span", () => {

--- a/packages/eve/src/tracing/otel-declaration.test.ts
+++ b/packages/eve/src/tracing/otel-declaration.test.ts
@@ -105,11 +105,11 @@ describe("managed export policy", () => {
     spanProcessor.onEnd(
       testSpan({
         "agent.channel.audience": "private",
-        "ai.prompt.messages": "private input",
+        "gen_ai.input.messages": "private input",
       }),
     );
 
-    expect(visibleAttributes).toHaveProperty("ai.prompt.messages", "private input");
+    expect(visibleAttributes).toHaveProperty("gen_ai.input.messages", "private input");
   });
 
   it("runs composed export policies in declaration order", () => {
@@ -132,7 +132,7 @@ describe("managed export policy", () => {
     spanProcessor.onEnd(
       testSpan({
         "agent.channel.audience": "private",
-        "ai.prompt.messages": "private input",
+        "gen_ai.input.messages": "private input",
       }),
     );
 
@@ -154,7 +154,7 @@ describe("managed export policy", () => {
 
     const spanProcessor = integration.spanProcessors[0];
     if (spanProcessor === undefined || spanProcessor === "auto") throw new Error("Expected policy");
-    spanProcessor.onEnd(testSpan({ "ai.prompt.messages": "private input" }));
+    spanProcessor.onEnd(testSpan({ "gen_ai.input.messages": "private input" }));
 
     expect(visibleAttributes).toEqual({});
   });


### PR DESCRIPTION
### Summary

Model input tracing records messages twice, and the legacy `ai.prompt.messages` path recursively enumerates binary attachments before enforcing the 32 KB content limit. That produces the memory growth reproduced in #3272. This removes the duplicate attribute, keeps `gen_ai.input.messages` as the single model-input representation, and updates the local trace viewer to render the standard GenAI parts schema. When no whole-message suffix fits, the serializer retains a bounded truncated version of the latest message instead of reporting empty input.

Related to #3272.

### Validation

- `pnpm --filter eve typecheck`
- `pnpm --filter eve build`
- `pnpm guard:invariants`
- `pnpm --filter eve test:unit` — 796 files passed; 8,653 tests passed and 1 skipped
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/tracing/agent-otel-content.test.ts src/tracing/agent-otel-provider.test.ts src/tracing/content-attributes.test.ts src/tracing/content-span-processor.test.ts src/tracing/otel-declaration.test.ts src/cli/dev/tui/traces/trace-content.test.ts src/cli/dev/tui/traces/trace-conversation.test.ts src/cli/dev/tui/traces/trace-view.test.ts src/cli/dev/tui/traces/trace-viewer-session.test.ts src/cli/dev/tui/traces/trace-viewer-state.test.ts` — 10 files and 223 tests passed

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
