### PR TITLE
feat(eve): offer self-modification during local init

### DIFF
--- a/.changeset/brief-selfmod-reports.md
+++ b/.changeset/brief-selfmod-reports.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Guide self-modification agents to return concise source-change handoffs with changed paths, validation status, and required follow-up, while preserving detailed reports for investigation tasks.

--- a/.changeset/brief-selfmod-reports.md
+++ b/.changeset/brief-selfmod-reports.md
@@ -1,5 +1,0 @@
----
-"eve": patch
----
-
-Guide self-modification agents to return concise source-change handoffs with changed paths, validation status, and required follow-up, while preserving detailed reports for investigation tasks.

--- a/.changeset/gentle-eves-self-modify.md
+++ b/.changeset/gentle-eves-self-modify.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add a self-modification option to the interactive `eve init` flow. Selecting it scaffolds the self-modification subagent and continues to `eve dev` without offering an external coding-agent handoff.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -56,7 +56,7 @@ Creates a new agent app or adds an agent to an existing app. Always installs dep
 
 Coding-agent launches and non-interactive terminals cannot answer the location prompt and fail before writing. Pass a new directory name, such as `eve init my-agent`, in those environments.
 
-After scaffolding, a human terminal usually continues into `eve dev`. If a coding-agent REPL is on `PATH`, the handoff menu can open it instead or exit without starting either process. Coding-agent launches print the next steps instead of opening the TUI, so the session does not get stuck. Fresh projects use the parent workspace's package manager when there is one; otherwise they use the manager that launched `eve init`.
+After scaffolding, a human terminal usually continues into `eve dev`. Enable the self-modification subagent to edit your agent from the dev session. Otherwise, if a coding-agent REPL is on `PATH`, you can launch it to make changes instead of opening the TUI. Fresh projects use the parent workspace's package manager when there is one; otherwise they use the manager that launched `eve init`.
 
 | Flag                   | Type   | Default                    | Description                                                                                                              |
 | ---------------------- | ------ | -------------------------- | ------------------------------------------------------------------------------------------------------------------------ |

--- a/packages/eve/src/cli/commands/init-project.ts
+++ b/packages/eve/src/cli/commands/init-project.ts
@@ -1,0 +1,74 @@
+import { relative } from "node:path";
+
+import pc from "#compiled/picocolors/index.js";
+
+import { formatNodeEngineOverrideWarning, type NodeEngineOverride } from "#setup/node-engine.js";
+import type { PackageManagerKind } from "#setup/package-manager.js";
+import type { WorkspaceRootMutation } from "#setup/scaffold/workspace-root.js";
+
+import type { GitInitResult } from "./init-git.js";
+import type { InitCliLogger } from "./init-agent-workspace.js";
+import type { InitFailurePolicy } from "./init-recovery.js";
+
+export type PreparedInitProject =
+  | {
+      configurationFilesChanged: string[];
+      dependenciesAdded: string[];
+      failurePolicy: "preserve";
+      filesWritten: string[];
+      kind: "added";
+      nodeEngineOverride?: NodeEngineOverride;
+      packageManager: PackageManagerKind;
+      projectPath: string;
+    }
+  | {
+      failurePolicy: InitFailurePolicy;
+      kind: "created";
+      packageManager: PackageManagerKind;
+      preservedTargetEntries: readonly string[];
+      projectPath: string;
+      retryCommand: string;
+      workspaceMember: boolean;
+      workspaceRootMutations: WorkspaceRootMutation[];
+    };
+
+export type InitResult = {
+  agentElapsedMs: number;
+  agentLaunched: boolean;
+  installElapsedMs: number;
+  packageManager: PackageManagerKind;
+  projectPath: string;
+  selfModificationEnabled: boolean;
+} & (
+  | {
+      configurationFilesChanged: string[];
+      dependenciesAdded: string[];
+      filesWritten: string[];
+      kind: "added";
+      nodeEngineOverride?: NodeEngineOverride;
+    }
+  | {
+      gitResult: GitInitResult;
+      kind: "created";
+      workspaceRootMutations: WorkspaceRootMutation[];
+    }
+);
+
+export function reportExistingProjectChanges(
+  logger: InitCliLogger,
+  project: Extract<PreparedInitProject, { kind: "added" }>,
+): void {
+  logger.log("Updated existing project:");
+  for (const path of project.filesWritten) {
+    logger.log(`  Created ${relative(project.projectPath, path).replaceAll("\\", "/")}`);
+  }
+  if (project.dependenciesAdded.length > 0) {
+    logger.log(`  Added dependencies: ${project.dependenciesAdded.join(", ")}`);
+  }
+  for (const path of project.configurationFilesChanged) {
+    logger.log(`  Updated ${path}`);
+  }
+  if (project.nodeEngineOverride !== undefined) {
+    logger.log(pc.yellow(`  ⚠ ${formatNodeEngineOverrideWarning(project.nodeEngineOverride)}`));
+  }
+}

--- a/packages/eve/src/cli/commands/init-self-modification.ts
+++ b/packages/eve/src/cli/commands/init-self-modification.ts
@@ -1,0 +1,39 @@
+import { createPrompter, type Prompter } from "#setup/prompter.js";
+
+import { hasInteractiveTerminal } from "./preconditions.js";
+
+export interface InitSelfModificationDependencies {
+  createPrompter(): Prompter;
+  hasInteractiveTerminal(): boolean;
+}
+
+const defaultDependencies: InitSelfModificationDependencies = {
+  createPrompter,
+  hasInteractiveTerminal,
+};
+
+/** Offers eve's self-modification subagent before the external coding-agent handoff. */
+export async function selectInitSelfModification(
+  dependencies: InitSelfModificationDependencies = defaultDependencies,
+): Promise<boolean> {
+  if (!dependencies.hasInteractiveTerminal()) return false;
+
+  return dependencies.createPrompter().select({
+    message: "Enable local self-modification?",
+    description:
+      "Self-modification adds a subagent that can edit your agent's source during local development.",
+    options: [
+      {
+        value: true,
+        label: "Enable self-modification",
+        focusHint: "let your eve agent make source changes in dev",
+      },
+      {
+        value: false,
+        label: "Not now",
+        focusHint: "continue with eve dev or an external coding agent",
+      },
+    ],
+    initialValue: false,
+  });
+}

--- a/packages/eve/src/cli/commands/init.integration.test.ts
+++ b/packages/eve/src/cli/commands/init.integration.test.ts
@@ -71,7 +71,13 @@ function dependencies(
   runPackageManagerInstall: ReturnType<
     typeof vi.fn<InitCommandDependencies["runPackageManagerInstall"]>
   >;
+  installSelfModification: ReturnType<
+    typeof vi.fn<InitCommandDependencies["installSelfModification"]>
+  >;
   selectInitHandoff: ReturnType<typeof vi.fn<InitCommandDependencies["selectInitHandoff"]>>;
+  selectInitSelfModification: ReturnType<
+    typeof vi.fn<InitCommandDependencies["selectInitSelfModification"]>
+  >;
   spawnCodingAgentRepl: ReturnType<typeof vi.fn<InitCommandDependencies["spawnCodingAgentRepl"]>>;
   spawnPackageManager: ReturnType<typeof vi.fn<InitCommandDependencies["spawnPackageManager"]>>;
   tryInitializeGit: ReturnType<typeof vi.fn<InitCommandDependencies["tryInitializeGit"]>>;
@@ -106,7 +112,9 @@ function dependencies(
         webPackageVersions: { ...WEB_VERSIONS, ...options.webPackageVersions },
       }),
     runPackageManagerInstall: vi.fn(async () => packageInstallResult()),
+    installSelfModification: vi.fn(async () => {}),
     selectInitHandoff: vi.fn(async () => "eve-dev"),
+    selectInitSelfModification: vi.fn(async () => false),
     spawnCodingAgentRepl: vi.fn(async () => true),
     spawnPackageManager: vi.fn(async () => packageProcessResult()),
     tryInitializeGit: vi.fn(async () => gitResult),
@@ -335,6 +343,42 @@ describe("runInitCommand", () => {
 
     await expect(pathExists(join(parentDirectory, "my-agent"))).resolves.toBe(false);
     expect(deps.runPackageManagerInstall).not.toHaveBeenCalled();
+  });
+
+  it("installs self-modification before Git initialization and skips the coding-agent handoff", async () => {
+    const parentDirectory = await mkdtemp(join(tmpdir(), "eve-init-self-modification-"));
+    const output = logger();
+    const deps = dependencies();
+    deps.selectInitSelfModification.mockResolvedValue(true);
+
+    await runInitCommand(output, parentDirectory, "my-agent", {}, deps);
+
+    const projectPath = join(parentDirectory, "my-agent");
+    expect(deps.installSelfModification).toHaveBeenCalledWith(projectPath);
+    expect(deps.installSelfModification.mock.invocationCallOrder[0]).toBeLessThan(
+      deps.tryInitializeGit.mock.invocationCallOrder[0]!,
+    );
+    expect(deps.selectInitHandoff).not.toHaveBeenCalled();
+    expect(deps.spawnCodingAgentRepl).not.toHaveBeenCalled();
+    expect(deps.spawnPackageManager).toHaveBeenCalledWith("pnpm", projectPath, [
+      "exec",
+      "eve",
+      "dev",
+      "--onboard",
+    ]);
+    expect(stripAnsi(output.messages.join("\n"))).toContain("✓ Enabled self-modification");
+  });
+
+  it("does not offer self-modification when init was launched by a coding agent", async () => {
+    const parentDirectory = await mkdtemp(join(tmpdir(), "eve-init-agent-launched-selfmod-"));
+    const output = logger();
+    const deps = dependencies();
+    deps.isCodingAgentLaunch.mockResolvedValue(true);
+
+    await runInitCommand(output, parentDirectory, "my-agent", {}, deps);
+
+    expect(deps.selectInitSelfModification).not.toHaveBeenCalled();
+    expect(deps.installSelfModification).not.toHaveBeenCalled();
   });
 
   it("opens the selected coding-agent REPL instead of starting eve dev", async () => {

--- a/packages/eve/src/cli/commands/init.ts
+++ b/packages/eve/src/cli/commands/init.ts
@@ -1,5 +1,5 @@
 import { mkdtemp, readdir, rename, rm } from "node:fs/promises";
-import { basename, join, relative, resolve } from "node:path";
+import { basename, join, resolve } from "node:path";
 import { performance } from "node:perf_hooks";
 
 import pc from "#compiled/picocolors/index.js";
@@ -15,7 +15,7 @@ import { formatElapsed } from "#cli/format-elapsed.js";
 import { startCliLiveRow } from "#cli/ui/live-row.js";
 import { createLogger, isLogLevelEnabled } from "#internal/logging.js";
 import { DEFAULT_AGENT_MODEL_ID } from "#shared/default-agent-model.js";
-import { formatNodeEngineOverrideWarning, type NodeEngineOverride } from "#setup/node-engine.js";
+import type { NodeEngineOverride } from "#setup/node-engine.js";
 import {
   detectInvokingPackageManager,
   detectPackageManager,
@@ -58,13 +58,15 @@ import {
   type InitCommandOptions,
 } from "./init-agent-workspace.js";
 import { initAgentReadySummary } from "./agent-instructions.js";
+import { tryInitializeGit } from "./init-git.js";
 import { InitTargetError } from "./init-telemetry.js";
 import {
-  cleanupFreshInitTarget,
-  workspaceFailureNote,
-  type InitFailurePolicy,
-} from "./init-recovery.js";
-import { tryInitializeGit, type GitInitResult } from "./init-git.js";
+  reportExistingProjectChanges,
+  type InitResult,
+  type PreparedInitProject,
+} from "./init-project.js";
+import { cleanupFreshInitTarget, workspaceFailureNote } from "./init-recovery.js";
+import { selectInitSelfModification } from "./init-self-modification.js";
 import { selectInitHandoff, spawnCodingAgentRepl, type InitHandoff } from "./init-repl.js";
 import { resolveInitTarget } from "./init-target.js";
 
@@ -80,6 +82,8 @@ export interface InitCommandDependencies {
   runPackageManagerInstall: typeof runPackageManagerInstall;
   scaffoldBaseProject: typeof scaffoldBaseProject;
   selectInitHandoff: typeof selectInitHandoff;
+  selectInitSelfModification: typeof selectInitSelfModification;
+  installSelfModification(appRoot: string): Promise<void>;
   spawnCodingAgentRepl: typeof spawnCodingAgentRepl;
   spawnPackageManager: typeof spawnPackageManager;
   tryInitializeGit: typeof tryInitializeGit;
@@ -96,6 +100,11 @@ const defaultDependencies: InitCommandDependencies = {
   runPackageManagerInstall,
   scaffoldBaseProject,
   selectInitHandoff,
+  selectInitSelfModification,
+  installSelfModification: async (appRoot) => {
+    const { installRegistryItem } = await import("./registry.js");
+    await installRegistryItem(appRoot, "experimental/self-modification", { silent: true });
+  },
   spawnCodingAgentRepl,
   spawnPackageManager,
   tryInitializeGit,
@@ -262,73 +271,11 @@ async function scaffoldProject(
   }
 }
 
-type PreparedInitProject =
-  | {
-      configurationFilesChanged: string[];
-      dependenciesAdded: string[];
-      failurePolicy: "preserve";
-      filesWritten: string[];
-      kind: "added";
-      nodeEngineOverride?: NodeEngineOverride;
-      packageManager: PackageManagerKind;
-      projectPath: string;
-    }
-  | {
-      failurePolicy: InitFailurePolicy;
-      kind: "created";
-      packageManager: PackageManagerKind;
-      preservedTargetEntries: readonly string[];
-      projectPath: string;
-      retryCommand: string;
-      workspaceMember: boolean;
-      workspaceRootMutations: WorkspaceRootMutation[];
-    };
-
 type InitTerminalTracker = (
   step: EveCliSetupStep,
   result: EveCliSetupTerminalResult,
   failureCode?: EveCliSetupFailureCode,
 ) => void;
-
-type InitResult = {
-  agentElapsedMs: number;
-  agentLaunched: boolean;
-  installElapsedMs: number;
-  packageManager: PackageManagerKind;
-  projectPath: string;
-} & (
-  | {
-      configurationFilesChanged: string[];
-      dependenciesAdded: string[];
-      filesWritten: string[];
-      kind: "added";
-      nodeEngineOverride?: NodeEngineOverride;
-    }
-  | {
-      gitResult: GitInitResult;
-      kind: "created";
-      workspaceRootMutations: WorkspaceRootMutation[];
-    }
-);
-
-function reportExistingProjectChanges(
-  logger: InitCliLogger,
-  project: Extract<PreparedInitProject, { kind: "added" }>,
-): void {
-  logger.log("Updated existing project:");
-  for (const path of project.filesWritten) {
-    logger.log(`  Created ${relative(project.projectPath, path).replaceAll("\\", "/")}`);
-  }
-  if (project.dependenciesAdded.length > 0) {
-    logger.log(`  Added dependencies: ${project.dependenciesAdded.join(", ")}`);
-  }
-  for (const path of project.configurationFilesChanged) {
-    logger.log(`  Updated ${path}`);
-  }
-  if (project.nodeEngineOverride !== undefined) {
-    logger.log(pc.yellow(`  ⚠ ${formatNodeEngineOverrideWarning(project.nodeEngineOverride)}`));
-  }
-}
 
 async function runInitSteps(input: {
   dependencies: InitCommandDependencies;
@@ -336,15 +283,27 @@ async function runInitSteps(input: {
   options: InitCommandOptions;
   parentDirectory: string;
   target: string | undefined;
+  agentLaunched: boolean;
   trackStep?: (step: EveCliSetupStep) => void;
   trackTerminal?: InitTerminalTracker;
 }): Promise<InitResult> {
-  const { dependencies, logger, options, parentDirectory, target, trackStep, trackTerminal } =
-    input;
+  const {
+    agentLaunched,
+    dependencies,
+    logger,
+    options,
+    parentDirectory,
+    target,
+    trackStep,
+    trackTerminal,
+  } = input;
   const debug = isLogLevelEnabled("debug");
-  const agentLaunched = await dependencies.isCodingAgentLaunch();
   const initTarget = await resolveInitTarget({ parentDirectory, target });
   const evePackage = resolveInitEvePackageOverride();
+  const selfModificationEnabled =
+    !agentLaunched && options.agents === undefined
+      ? await dependencies.selectInitSelfModification()
+      : false;
 
   let progress = startCliLiveRow(logger);
   let activeInitStep: EveCliSetupStep = "scaffold";
@@ -516,6 +475,13 @@ async function runInitSteps(input: {
     }
     initLog.debug("dependencies installed", { ms: installElapsedMs });
 
+    if (selfModificationEnabled) {
+      activeInitStep = "registry_install";
+      trackStep?.(activeInitStep);
+      progress.update("Enabling self-modification");
+      await dependencies.installSelfModification(project.projectPath);
+    }
+
     if (project.kind === "created") {
       activeInitStep = "initialize_git";
       trackStep?.(activeInitStep);
@@ -527,10 +493,17 @@ async function runInitSteps(input: {
         agentLaunched,
         gitResult: await dependencies.tryInitializeGit(project.projectPath),
         installElapsedMs,
+        selfModificationEnabled,
       };
     }
 
-    return { ...project, agentElapsedMs, agentLaunched, installElapsedMs };
+    return {
+      ...project,
+      agentElapsedMs,
+      agentLaunched,
+      installElapsedMs,
+      selfModificationEnabled,
+    };
   } catch (error) {
     trackTerminal?.(
       activeInitStep,
@@ -570,6 +543,7 @@ export async function runInitCommand(
     }
 
     result = await runInitSteps({
+      agentLaunched: await dependencies.isCodingAgentLaunch(),
       dependencies,
       logger,
       options,
@@ -605,6 +579,9 @@ export async function runInitCommand(
   logger.log(
     `${pc.green("✓")} Installed dependencies ${pc.dim(`in ${formatElapsed(result.installElapsedMs)}`)}`,
   );
+  if (result.selfModificationEnabled) {
+    logger.log(`${pc.green("✓")} Enabled self-modification`);
+  }
 
   if (result.kind === "created" && result.gitResult.kind === "failed") {
     logger.error(
@@ -639,11 +616,15 @@ export async function runInitCommand(
   }
 
   let handoff: InitHandoff;
-  try {
-    handoff = await dependencies.selectInitHandoff({ agentName: basename(result.projectPath) });
-  } catch (error) {
-    if (error instanceof WizardCancelledError) return;
-    throw error;
+  if (result.selfModificationEnabled) {
+    handoff = "eve-dev";
+  } else {
+    try {
+      handoff = await dependencies.selectInitHandoff({ agentName: basename(result.projectPath) });
+    } catch (error) {
+      if (error instanceof WizardCancelledError) return;
+      throw error;
+    }
   }
   if (handoff === "exit") return;
   if (handoff !== "eve-dev") {


### PR DESCRIPTION
### Summary

Local users currently have to discover and install eve's self-modification subagent after scaffolding an agent. This adds an opt-in prompt to interactive `eve init` runs, installs the registry item when selected, and continues directly into `eve dev` so self-modification is available in the first session. Coding-agent launches and explicit agent selections preserve their existing non-interactive behavior.

### Validation

- Not run locally; this draft includes focused unit and integration coverage for the new prompt and init flow.

### Checklist

- [ ] This change was requested or approved by a maintainer
- [ ] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [ ] DCO sign-off passes for every commit (`git commit --signoff`)
