### PR TITLE
fix(eve): classify recalled memory as input

### DIFF
--- a/.changeset/memory-record-input-policy.md
+++ b/.changeset/memory-record-input-policy.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Treat recalled memory records as model input content when applying instrumentation trace policies.

--- a/docs/guides/instrumentation.md
+++ b/docs/guides/instrumentation.md
@@ -50,8 +50,8 @@ Any OTel-compatible backend works (Braintrust, PostHog, Sentry, Raindrop, Arize,
 
 Three more fields control what eve and the AI SDK record inside those spans (see the AI SDK's [telemetry reference](https://ai-sdk.dev/docs/ai-sdk-core/telemetry)):
 
-- `recordInputs` records full message history on each step span. It defaults to `false`; set it to `true` to include input content.
-- `recordOutputs` records model outputs and recalled memory records. It defaults to `false`; set it to `true` to include output content.
+- `recordInputs` records full message history on each step span and recalled records on memory spans. It defaults to `false`; set it to `true` to include input content.
+- `recordOutputs` records model outputs. It defaults to `false`; set it to `true` to include output content.
 - `functionId` overrides the function name on spans (defaults to the agent name).
 
 eve records metadata without model, tool, or memory-record content by default. Enable either content category only after reviewing the exporter and its data-retention path.
@@ -144,7 +144,7 @@ eve records [OpenTelemetry GenAI memory spans](https://opentelemetry.io/docs/spe
 
 Every memory span includes `gen_ai.operation.name` and `gen_ai.memory.store.id`. The store ID is eve's opaque `memory.scope.key`, which identifies the resolved scope without exposing the namespace or scope values. Recall spans set `gen_ai.memory.record.count` to their result count.
 
-`gen_ai.memory.records` contains recalled record content only when `recordOutputs` is enabled. eve does not set `gen_ai.memory.query.text` because a memory provider receives structured conversation messages, not a standalone search-query string. The `agent.memory.slot` and `agent.memory.phase` attributes identify the eve slot and lifecycle boundary without adding either to the span name.
+`gen_ai.memory.records` contains recalled record content only when `recordInputs` is enabled. eve classifies recalled records as input content because they become part of the model context. eve does not set `gen_ai.memory.query.text` because a memory provider receives structured conversation messages, not a standalone search-query string. The `agent.memory.slot` and `agent.memory.phase` attributes identify the eve slot and lifecycle boundary without adding either to the span name.
 
 ## Agent trace contract
 

--- a/packages/eve/src/instrumentation/content.test.ts
+++ b/packages/eve/src/instrumentation/content.test.ts
@@ -77,6 +77,37 @@ describe("withInstrumentationDecision", () => {
     );
   });
 
+  it("treats recalled memory records as inputs", () => {
+    const completed = {
+      idempotencyKey: "memory-1",
+      operationName: "search_memory",
+      outputRecords: [{ content: "The user prefers dark mode.", id: "preference" }],
+      phase: "turn.started",
+      recordCount: 1,
+      rootSessionId: "session-1",
+      sessionId: "session-1",
+      slot: "profile",
+      storeId: "memscope1_scope",
+      turnId: "turn-1",
+      type: "memory.operation.completed",
+    } as const;
+
+    expect(
+      withInstrumentationDecision(completed, {
+        action: "record",
+        recordInputs: true,
+        recordOutputs: false,
+      }),
+    ).toBe(completed);
+    expect(
+      withInstrumentationDecision(completed, {
+        action: "record",
+        recordInputs: false,
+        recordOutputs: true,
+      }),
+    ).toEqual(expect.objectContaining({ outputRecords: undefined }));
+  });
+
   it("reduces provider metadata to structural output when outputs are disabled", () => {
     const projected = withInstrumentationDecision(
       {

--- a/packages/eve/src/instrumentation/content.ts
+++ b/packages/eve/src/instrumentation/content.ts
@@ -51,7 +51,7 @@ export function withInstrumentationDecision(
     case "model.call.completed":
       return decision.recordOutputs ? event : Object.freeze({ ...event, content: undefined });
     case "memory.operation.completed":
-      return decision.recordOutputs ? event : Object.freeze({ ...event, outputRecords: undefined });
+      return decision.recordInputs ? event : Object.freeze({ ...event, outputRecords: undefined });
     case "step.attempt.metadata":
       return decision.recordOutputs
         ? event

--- a/packages/eve/src/instrumentation/memory.ts
+++ b/packages/eve/src/instrumentation/memory.ts
@@ -44,7 +44,7 @@ export interface InstrumentationMemoryOperationCompletedEvent extends Instrument
   readonly type: "memory.operation.completed";
   /** The number of records the operation returned or changed, when known. */
   readonly recordCount?: number;
-  /** Content. Absent unless this provider's trace policy records outputs. */
+  /** Content. Absent unless this provider's trace policy records inputs. */
   readonly outputRecords?: readonly InstrumentationMemoryRecord[];
 }
 

--- a/packages/eve/src/tracing/content-attributes.test.ts
+++ b/packages/eve/src/tracing/content-attributes.test.ts
@@ -73,17 +73,17 @@ describe("withoutDeclinedContent", () => {
     expect(attributes).toEqual(ATTRIBUTES);
   });
 
-  it("redacts recalled memory records as output content", () => {
+  it("redacts recalled memory records as input content", () => {
     const searched = {
       "gen_ai.memory.records": '[{"content":"Private preference"}]',
       "gen_ai.operation.name": "search_memory",
     };
 
-    expect(
-      withoutDeclinedContent(searched, { recordInputs: false, recordOutputs: true }),
-    ).toBeUndefined();
-    expect(withoutDeclinedContent(searched, { recordInputs: true, recordOutputs: false })).toEqual({
+    expect(withoutDeclinedContent(searched, { recordInputs: false, recordOutputs: true })).toEqual({
       "gen_ai.operation.name": "search_memory",
     });
+    expect(
+      withoutDeclinedContent(searched, { recordInputs: true, recordOutputs: false }),
+    ).toBeUndefined();
   });
 });

--- a/packages/eve/src/tracing/content-attributes.ts
+++ b/packages/eve/src/tracing/content-attributes.ts
@@ -26,6 +26,7 @@ const INPUT_CONTENT_ATTRIBUTES: ReadonlySet<string> = new Set([
   "ai.value",
   "ai.values",
   "gen_ai.input.messages",
+  "gen_ai.memory.records",
   "gen_ai.system_instructions",
   "gen_ai.tool.call.arguments",
   "gen_ai.tool.definitions",
@@ -51,7 +52,6 @@ const OUTPUT_CONTENT_ATTRIBUTES: ReadonlySet<string> = new Set([
   "ai.response.tool_results",
   "ai.toolCall.args",
   "ai.toolCall.result",
-  "gen_ai.memory.records",
   "gen_ai.output.messages",
   "gen_ai.tool.call.result",
 ]);


### PR DESCRIPTION
### Summary

Recalled memory records are consumed as context by the model, but instrumentation policies classified them as output content. This changes lifecycle projection and OpenTelemetry span redaction to honor `recordInputs`, keeping provider events and exported spans aligned. The observability guide now documents the same privacy contract.

### Validation

- `./node_modules/.bin/vitest run --config vitest.unit.config.ts src/instrumentation/content.test.ts src/tracing/content-attributes.test.ts` (`11` tests passed)
- `./node_modules/.bin/tsc -p packages/eve/tsconfig.json --noEmit`
- `./node_modules/.bin/oxlint packages/eve/src/instrumentation/content.ts packages/eve/src/instrumentation/content.test.ts packages/eve/src/instrumentation/memory.ts packages/eve/src/tracing/content-attributes.ts packages/eve/src/tracing/content-attributes.test.ts`
- `./node_modules/.bin/oxfmt --check packages/eve/src/instrumentation/content.ts packages/eve/src/instrumentation/content.test.ts packages/eve/src/instrumentation/memory.ts packages/eve/src/tracing/content-attributes.ts packages/eve/src/tracing/content-attributes.test.ts .changeset/memory-record-input-policy.md`
- `pnpm_config_verify_deps_before_run=false pnpm docs:check`

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
