### PR TITLE
fix(eve): release startup output after readiness

### DIFF
--- a/.changeset/clear-production-startup-output.md
+++ b/.changeset/clear-production-startup-output.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Stop retaining server output in `eve start` after the server is ready, preventing memory growth as a long-running server writes logs. stdout and stderr continue to stream to the host's log collector.

--- a/docs/guides/deployment/self-hosting.md
+++ b/docs/guides/deployment/self-hosting.md
@@ -18,6 +18,8 @@ The build writes the Nitro server under `.output/`. `eve start` serves that outp
 
 Run this process under the same process manager or container platform you use for other Node web services. Configure Transport Layer Security (TLS), scaling, restarts, and log collection in that platform.
 
+`eve start` forwards the server's stdout and stderr throughout its lifetime. Once the server is ready, `eve start` releases its startup output buffer and stops retaining subsequent logs in memory.
+
 ## Configure model access and route auth
 
 Set `AI_GATEWAY_API_KEY` to use a string model ID through the Vercel AI Gateway from a non-Vercel host. To call a provider directly, install its [AI SDK provider package](https://ai-sdk.dev/docs/foundations/providers-and-models). Then pass its model object in `agent.ts` and set its API key. See [Agent configuration](../../agent-config#set-the-model) for examples.

--- a/packages/eve/src/internal/nitro/host/start-production-server.scenario.test.ts
+++ b/packages/eve/src/internal/nitro/host/start-production-server.scenario.test.ts
@@ -1,0 +1,53 @@
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { compileAgentInWorkspace } from "#compiler/compile-agent.js";
+import { useTemporaryAppRoots } from "#internal/testing/use-temporary-app-roots.js";
+import { startProductionServer } from "./start-production-server.js";
+
+describe("production server output", () => {
+  const createApp = useTemporaryAppRoots();
+
+  it.each(["stdout", "stderr"] as const)(
+    "releases startup %s and stops retaining output after readiness",
+    async (stream) => {
+      const { appRoot } = await createApp("eve-production-output-", {
+        files: {
+          "agent/agent.ts": 'export default { model: "openai/gpt-5.4" };',
+          "agent/instructions.md": "Help with the user's requests.",
+          ".output/server/index.mjs": [
+            'import { createServer } from "node:http";',
+            "const server = createServer((_request, response) => {",
+            '  response.end("done", () => {',
+            `    process.${stream}.write("runtime-output-marker\\n", () => {`,
+            "      server.close(() => { process.exitCode = 23; });",
+            "    });",
+            "  });",
+            "});",
+            "server.listen(Number(process.env.PORT), process.env.HOST, () => {",
+            `  process.${stream}.write("startup-output-marker\\n");`,
+            "  console.log(`Listening on http://${process.env.HOST}:${process.env.PORT}/`);",
+            "});",
+          ].join("\n"),
+        },
+      });
+      const artifactsRoot = join(appRoot, ".output", ".eve");
+      await compileAgentInWorkspace({
+        artifactLocations: { publishedRoot: artifactsRoot, writeRoot: artifactsRoot },
+        startPath: appRoot,
+      });
+
+      const server = await startProductionServer(appRoot, { host: "127.0.0.1", port: 0 });
+      try {
+        const response = await fetch(server.url);
+        expect(await response.text()).toBe("done");
+        await expect(server.wait()).rejects.toThrow("code=23");
+        await expect.soft(server.wait()).rejects.not.toThrow("startup-output-marker");
+        await expect.soft(server.wait()).rejects.not.toThrow("runtime-output-marker");
+      } finally {
+        await server.close();
+      }
+    },
+  );
+});

--- a/packages/eve/src/internal/nitro/host/start-production-server.ts
+++ b/packages/eve/src/internal/nitro/host/start-production-server.ts
@@ -220,6 +220,7 @@ export async function startProductionServer(
     port,
   });
   let output = "";
+  let captureStartupOutput = true;
   let closing = false;
   let startError: unknown;
 
@@ -236,11 +237,15 @@ export async function startProductionServer(
   });
 
   child.stdout?.on("data", (chunk: Buffer) => {
-    output += chunk.toString("utf8");
+    if (captureStartupOutput) {
+      output += chunk.toString("utf8");
+    }
     process.stdout.write(chunk);
   });
   child.stderr?.on("data", (chunk: Buffer) => {
-    output += chunk.toString("utf8");
+    if (captureStartupOutput) {
+      output += chunk.toString("utf8");
+    }
     process.stderr.write(chunk);
   });
 
@@ -274,6 +279,8 @@ export async function startProductionServer(
       getOutput: () => output,
       knownUrl,
     });
+    captureStartupOutput = false;
+    output = "";
 
     return {
       async close() {


### PR DESCRIPTION
### Summary

Closes #3282.

`eve start` retains the server's entire stdout/stderr history after readiness, so a long-running server's logs keep growing the parent process's memory. Capture now ends at readiness and releases the startup buffer, while stdout and stderr continue to stream normally.

### Validation

Both real subprocess scenarios fail on the original implementation and pass with the fix: startup and runtime log markers no longer appear in the later process-exit error. The four existing startup tests also pass. `pnpm docs:check` passes: 88 documents, 349 import paths, and all 88 MDX compilations.

Additional checks passed: `pnpm exec turbo run build --filter='eve...'`, `pnpm --filter eve typecheck`, targeted `oxlint`, and `pnpm guard:invariants`.

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+7 / -0`

Documents the logging lifetime for self-hosted services and includes a patch release note.

**Implementation** — 1 file · `+9 / -2`

Limits the existing output buffer to startup and releases it once readiness succeeds.

**Tests** — 1 file · `+53 / -0`

Uses real HTTP subprocesses to cover stdout and stderr before and after readiness.
