### PR TITLE
fix(eve): replace refreshed dynamic skill packages

### DIFF
--- a/.changeset/replace-dynamic-skill-packages.md
+++ b/.changeset/replace-dynamic-skill-packages.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Replace dynamic skill package contents on refresh so omitted supporting files are removed and file/directory changes can be applied.

--- a/docs/guides/dynamic-capabilities.md
+++ b/docs/guides/dynamic-capabilities.md
@@ -384,6 +384,8 @@ The caller's team gets its own playbook advertised as a loadable skill; everyone
 
 Skills follow the same naming rule as tools: a single `defineSkill(...)` is named after the file slug, while a map names each entry by its bare key (namespace the key yourself if it might collide). A dynamic skill overrides a same-named authored one; two dynamic resolvers emitting the same name throws.
 
+Each resolved skill replaces its sandbox package directory, so supporting files omitted from the new result are removed. Store session output outside these managed directories. Package refreshes are not atomic for concurrent readers of a shared sandbox.
+
 ## Dynamic instructions
 
 A dynamic instructions file returns `defineInstructions({ content, role? })` built from the principal, tenant, channel, or external data. Omit `role` for system context:

--- a/packages/eve/src/context/dynamic-skill-lifecycle.test.ts
+++ b/packages/eve/src/context/dynamic-skill-lifecycle.test.ts
@@ -110,7 +110,10 @@ describe("dispatchDynamicSkillEvent", () => {
 
     expect(ctx.get(DynamicSkillManifestKey)).toEqual({});
     expect(ctx.get(PendingSkillAnnouncementKey)).toBe("");
-    expect(sandbox.removedPaths).toEqual(["/home/agent/.agents/skills/tenant"]);
+    expect(sandbox.removedPaths).toEqual([
+      "/home/agent/.agents/skills/tenant",
+      "/home/agent/.agents/skills/tenant",
+    ]);
   });
 
   it("keeps remaining dynamic skills in the announcement when one resolver removes its skill", async () => {

--- a/packages/eve/src/context/dynamic-skill-lifecycle.ts
+++ b/packages/eve/src/context/dynamic-skill-lifecycle.ts
@@ -227,6 +227,7 @@ export async function dispatchDynamicSkillEvent(input: {
 
     for (const { skills } of updates) {
       for (const skill of skills) {
+        await removeSkillPackageFromSandbox({ name: skill.name, sandbox });
         await writeSkillPackageToSandbox({ sandbox, skill });
       }
     }

--- a/packages/eve/src/context/dynamic-skill-refresh.integration.test.ts
+++ b/packages/eve/src/context/dynamic-skill-refresh.integration.test.ts
@@ -1,0 +1,192 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it, onTestFinished } from "vitest";
+
+import { ContextContainer } from "#context/container.js";
+import { dispatchDynamicSkillEvent } from "#context/dynamic-skill-lifecycle.js";
+import { DynamicSkillManifestKey, SandboxKey, SessionIdKey } from "#context/keys.js";
+import { createJustBashSandboxBackend } from "#execution/sandbox/bindings/just-bash.js";
+import { createTurnStartedEvent } from "#protocol/message.js";
+import { defineSkill } from "#public/definitions/skill.js";
+import type { ResolvedDynamicSkillResolver } from "#runtime/types.js";
+import type { SkillPackageDefinition } from "#shared/skill-definition.js";
+import { resolveSandboxSkillRoot } from "#shared/skill-paths.js";
+
+async function createSession() {
+  const appRoot = await mkdtemp(join(tmpdir(), "eve-dynamic-skill-refresh-"));
+  onTestFinished(async () => await rm(appRoot, { recursive: true, force: true }));
+  const handle = await createJustBashSandboxBackend({
+    createOptions: { autoInstall: false },
+  }).create({
+    runtimeContext: { appRoot },
+    sessionKey: "skill-refresh",
+    templateKey: null,
+  });
+  onTestFinished(async () => await handle.shutdown());
+  const ctx = new ContextContainer();
+  ctx.set(SessionIdKey, "skill-refresh");
+  ctx.set(SandboxKey, {
+    async captureState() {
+      return { initialized: true, session: await handle.captureState() };
+    },
+    async get() {
+      return handle.session;
+    },
+    async stop() {
+      await handle.stop();
+    },
+  });
+  const skillRoot = await resolveSandboxSkillRoot({ sandbox: handle.session });
+  return { ctx, sandbox: handle.session, skillRoot };
+}
+
+function resolverFor(handler: ResolvedDynamicSkillResolver["events"]["turn.started"]) {
+  return {
+    eventNames: ["turn.started"],
+    events: { "turn.started": handler },
+    exportName: "default",
+    logicalPath: "skills/playbook.ts",
+    slug: "playbook",
+    sourceId: "skills/playbook.ts",
+    sourceKind: "module",
+  } satisfies ResolvedDynamicSkillResolver;
+}
+
+describe("dynamic skill package refresh", () => {
+  it("removes omitted siblings while refreshing text and binary files in the same sandbox", async () => {
+    const { ctx, sandbox, skillRoot } = await createSession();
+    let skill: SkillPackageDefinition = defineSkill({
+      description: "Team playbook",
+      markdown: "Revision one",
+      files: {
+        "references/obsolete.txt": "Retired instructions",
+        "references/current.txt": "Old instructions",
+        "assets/data.bin": new Uint8Array([0, 128, 255]),
+      },
+    });
+    const resolver = resolverFor(() => skill);
+    await sandbox.writeTextFile({
+      content: "Unrelated skill",
+      path: `${skillRoot}/other/SKILL.md`,
+    });
+
+    await dispatchDynamicSkillEvent({
+      ctx,
+      event: createTurnStartedEvent({ sequence: 0, turnId: "turn_0" }),
+      messages: [],
+      resolvers: [resolver],
+    });
+    await expect(
+      sandbox.readTextFile({ path: `${skillRoot}/playbook/references/obsolete.txt` }),
+    ).resolves.toBe("Retired instructions");
+
+    skill = defineSkill({
+      description: "Updated team playbook",
+      markdown: "Revision two",
+      files: {
+        "references/current.txt": "Current instructions",
+        "assets/data.bin": new Uint8Array([255, 0, 129, 10]),
+      },
+    });
+    await dispatchDynamicSkillEvent({
+      ctx,
+      event: createTurnStartedEvent({ sequence: 1, turnId: "turn_1" }),
+      messages: [],
+      resolvers: [resolver],
+    });
+
+    const listing = await sandbox.run({
+      command: "find . -type f",
+      workingDirectory: `${skillRoot}/playbook`,
+    });
+    expect(listing.exitCode).toBe(0);
+    expect(listing.stdout.trim().split("\n").sort()).toEqual([
+      "./SKILL.md",
+      "./assets/data.bin",
+      "./references/current.txt",
+    ]);
+    await expect(sandbox.readTextFile({ path: `${skillRoot}/playbook/SKILL.md` })).resolves.toBe(
+      "Revision two",
+    );
+    await expect(
+      sandbox.readTextFile({ path: `${skillRoot}/playbook/references/current.txt` }),
+    ).resolves.toBe("Current instructions");
+    const bytes = await sandbox.readBinaryFile({ path: `${skillRoot}/playbook/assets/data.bin` });
+    expect(bytes).toEqual(Buffer.from([255, 0, 129, 10]));
+    await expect(sandbox.readTextFile({ path: `${skillRoot}/other/SKILL.md` })).resolves.toBe(
+      "Unrelated skill",
+    );
+    expect(ctx.get(DynamicSkillManifestKey)).toEqual({
+      playbook: [{ description: "Updated team playbook", name: "playbook" }],
+    });
+  });
+
+  it.each([
+    { beforePath: "reference", afterPath: "reference/guide.txt" },
+    { beforePath: "reference/guide.txt", afterPath: "reference" },
+  ])("replaces $beforePath with $afterPath", async ({ beforePath, afterPath }) => {
+    const { ctx, sandbox, skillRoot } = await createSession();
+    let files = { [beforePath]: "Old file" };
+    const resolver = resolverFor(() =>
+      defineSkill({ description: "Playbook", markdown: "Instructions", files }),
+    );
+    await dispatchDynamicSkillEvent({
+      ctx,
+      event: createTurnStartedEvent({ sequence: 0, turnId: "turn_0" }),
+      messages: [],
+      resolvers: [resolver],
+    });
+    files = { [afterPath]: "New file" };
+    await dispatchDynamicSkillEvent({
+      ctx,
+      event: createTurnStartedEvent({ sequence: 1, turnId: "turn_1" }),
+      messages: [],
+      resolvers: [resolver],
+    });
+    await expect(
+      sandbox.readTextFile({ path: `${skillRoot}/playbook/${afterPath}` }),
+    ).resolves.toBe("New file");
+  });
+
+  it("propagates a write failure without publishing a successful refresh", async () => {
+    const { ctx, sandbox, skillRoot } = await createSession();
+    let skill = defineSkill({ description: "Original playbook", markdown: "Original" });
+    const resolver = resolverFor(() => skill);
+    await dispatchDynamicSkillEvent({
+      ctx,
+      event: createTurnStartedEvent({ sequence: 0, turnId: "turn_0" }),
+      messages: [],
+      resolvers: [resolver],
+    });
+
+    skill = defineSkill({
+      description: "Broken playbook",
+      markdown: "Broken",
+      files: { reference: "File", "reference/guide.txt": "Cannot be written below a file" },
+    });
+    await expect(
+      dispatchDynamicSkillEvent({
+        ctx,
+        event: createTurnStartedEvent({ sequence: 1, turnId: "turn_1" }),
+        messages: [],
+        resolvers: [resolver],
+      }),
+    ).rejects.toThrow();
+    expect(ctx.get(DynamicSkillManifestKey)).toEqual({
+      playbook: [{ description: "Original playbook", name: "playbook" }],
+    });
+
+    skill = defineSkill({ description: "Repaired playbook", markdown: "Repaired" });
+    await dispatchDynamicSkillEvent({
+      ctx,
+      event: createTurnStartedEvent({ sequence: 2, turnId: "turn_2" }),
+      messages: [],
+      resolvers: [resolver],
+    });
+    await expect(sandbox.readTextFile({ path: `${skillRoot}/playbook/SKILL.md` })).resolves.toBe(
+      "Repaired",
+    );
+  });
+});


### PR DESCRIPTION
### Summary

Closes #3284.

A dynamic skill refresh that drops a supporting file currently leaves that file readable in the sandbox. The refresh now replaces the package directory before writing the current revision, including file/directory topology changes.

Concurrent refreshes in a shared sandbox are not serialized. The remove/write sequence is not atomic: another session sharing the sandbox can observe missing or partial files during the update. The refreshing lifecycle awaits the writes, propagates filesystem errors, and only publishes the new manifest after materialization completes; this does not add rollback or concurrent-reader isolation.

### Validation

The real just-bash regression suite reproduced three failures on the base implementation and passes all four cases with the fix: omitted siblings, exact text/binary updates, both topology changes, and explicit write failure. Ran `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/context/dynamic-skill-refresh.integration.test.ts`; the three existing focused skill suites also pass (22 tests).

`pnpm docs:check` passes for the changed guide: 88 documents, 349 import paths, and 88 MDX compilations. Package typecheck, lint, and invariants also pass.

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+7 / -0`

A release note and the dynamic-skills guide explain complete package replacement and the shared-sandbox limit.

**Implementation** — 1 file · `+1 / -0`

Reuses the existing package-removal operation at the dynamic materialization boundary.

**Tests** — 2 files · `+196 / -1`

A real sandbox fixture covers removed files, binary contents, topology changes, and write failures. The existing lifecycle trace now includes the preceding package removal.
