### PR TITLE
fix(eve): propagate dynamic skill resolver failures

### DIFF
--- a/.changeset/propagate-dynamic-skill-errors.md
+++ b/.changeset/propagate-dynamic-skill-errors.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Propagate dynamic skill resolver errors instead of continuing with stale skills. A turn-start resolver failure now fails the conversation turn before model work and allows a later turn after the source is repaired.

--- a/.changeset/propagate-dynamic-skill-errors.md
+++ b/.changeset/propagate-dynamic-skill-errors.md
@@ -2,4 +2,4 @@
 "eve": patch
 ---
 
-Propagate dynamic skill resolver errors instead of continuing with stale skills. A turn-start resolver failure now fails the conversation turn before model work and allows a later turn after the source is repaired.
+Propagate dynamic skill resolver errors instead of continuing with stale skills. In an ordinary conversation turn, a turn-start resolver failure uses recoverable turn failure before the assistant model call. Session initialization and the separate authorization-callback preamble still propagate terminal failures.

--- a/docs/guides/dynamic-capabilities.md
+++ b/docs/guides/dynamic-capabilities.md
@@ -384,6 +384,8 @@ The caller's team gets its own playbook advertised as a loadable skill; everyone
 
 Skills follow the same naming rule as tools: a single `defineSkill(...)` is named after the file slug, while a map names each entry by its bare key (namespace the key yourself if it might collide). A dynamic skill overrides a same-named authored one; two dynamic resolvers emitting the same name throws.
 
+If a `turn.started` skill resolver throws, the current conversation turn fails before model work and the session stays available for a new turn. Repair the source before sending the next turn. Errors from `session.started` skill resolvers fail session initialization.
+
 ## Dynamic instructions
 
 A dynamic instructions file returns `defineInstructions({ content, role? })` built from the principal, tenant, channel, or external data. Omit `role` for system context:

--- a/docs/guides/dynamic-capabilities.md
+++ b/docs/guides/dynamic-capabilities.md
@@ -384,7 +384,7 @@ The caller's team gets its own playbook advertised as a loadable skill; everyone
 
 Skills follow the same naming rule as tools: a single `defineSkill(...)` is named after the file slug, while a map names each entry by its bare key (namespace the key yourself if it might collide). A dynamic skill overrides a same-named authored one; two dynamic resolvers emitting the same name throws.
 
-If a `turn.started` skill resolver throws, the current conversation turn fails before model work and the session stays available for a new turn. Repair the source before sending the next turn. Errors from `session.started` skill resolvers fail session initialization.
+For an ordinary conversation turn, a throwing `turn.started` skill resolver fails that turn before the assistant model call and leaves the session available for a later turn after repairing the source. Errors from `session.started` skill resolvers fail initialization. Resolver errors during the separate authorization-callback preamble currently terminate the session.
 
 ## Dynamic instructions
 

--- a/packages/eve/src/context/dynamic-skill-errors.integration.test.ts
+++ b/packages/eve/src/context/dynamic-skill-errors.integration.test.ts
@@ -1,0 +1,159 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it, onTestFinished } from "vitest";
+
+import { ContextContainer } from "#context/container.js";
+import {
+  dispatchDynamicSkillEvent,
+  PendingSkillAnnouncementKey,
+} from "#context/dynamic-skill-lifecycle.js";
+import { DynamicSkillManifestKey, SandboxKey, SessionIdKey } from "#context/keys.js";
+import { createJustBashSandboxBackend } from "#execution/sandbox/bindings/just-bash.js";
+import { createSessionStartedEvent, createTurnStartedEvent } from "#protocol/message.js";
+import { defineSkill } from "#public/definitions/skill.js";
+import type { ResolvedDynamicSkillResolver } from "#runtime/types.js";
+import { BoundaryHookError } from "#shared/boundary-hook-error.js";
+import { resolveSandboxSkillRoot } from "#shared/skill-paths.js";
+
+async function createSession() {
+  const appRoot = await mkdtemp(join(tmpdir(), "eve-dynamic-skill-errors-"));
+  onTestFinished(async () => await rm(appRoot, { recursive: true, force: true }));
+  const handle = await createJustBashSandboxBackend({
+    createOptions: { autoInstall: false },
+  }).create({
+    runtimeContext: { appRoot },
+    sessionKey: "skill-errors",
+    templateKey: null,
+  });
+  onTestFinished(async () => await handle.shutdown());
+  const ctx = new ContextContainer();
+  ctx.set(SessionIdKey, "skill-errors");
+  ctx.set(SandboxKey, {
+    async captureState() {
+      return { initialized: true, session: await handle.captureState() };
+    },
+    async get() {
+      return handle.session;
+    },
+    async stop() {
+      await handle.stop();
+    },
+  });
+  const skillRoot = await resolveSandboxSkillRoot({ sandbox: handle.session });
+  return { ctx, sandbox: handle.session, skillRoot, sourcePath: join(appRoot, "playbook.md") };
+}
+
+function createResolver(
+  slug: string,
+  handler: ResolvedDynamicSkillResolver["events"]["turn.started"],
+) {
+  return {
+    eventNames: ["session.started", "turn.started"],
+    events: { "session.started": handler, "turn.started": handler },
+    exportName: "default",
+    logicalPath: `skills/${slug}.ts`,
+    slug,
+    sourceId: `skills/${slug}.ts`,
+    sourceKind: "module",
+  } satisfies ResolvedDynamicSkillResolver;
+}
+
+describe("dynamic skill resolver errors", () => {
+  it("rejects a failed turn refresh and permits a later refresh in the same session", async () => {
+    const { ctx, sandbox, skillRoot, sourcePath } = await createSession();
+    await writeFile(sourcePath, "Original playbook");
+    const resolver = createResolver("playbook", async () =>
+      defineSkill({ description: "Playbook", markdown: await readFile(sourcePath, "utf8") }),
+    );
+    await dispatchDynamicSkillEvent({
+      ctx,
+      event: createTurnStartedEvent({ sequence: 0, turnId: "turn_0" }),
+      messages: [],
+      resolvers: [resolver],
+    });
+    await expect(sandbox.readTextFile({ path: `${skillRoot}/playbook/SKILL.md` })).resolves.toBe(
+      "Original playbook",
+    );
+
+    await rm(sourcePath);
+    ctx.clearVirtualContext();
+    const failedRefresh = dispatchDynamicSkillEvent({
+      ctx,
+      event: createTurnStartedEvent({ sequence: 1, turnId: "turn_1" }),
+      messages: [],
+      resolvers: [resolver],
+    });
+    await expect(failedRefresh).rejects.toBeInstanceOf(BoundaryHookError);
+    await expect(failedRefresh).rejects.toMatchObject({ cause: { code: "ENOENT" } });
+    expect(ctx.get(DynamicSkillManifestKey)).toEqual({
+      playbook: [{ description: "Playbook", name: "playbook" }],
+    });
+
+    await writeFile(sourcePath, "Repaired playbook");
+    ctx.clearVirtualContext();
+    await dispatchDynamicSkillEvent({
+      ctx,
+      event: createTurnStartedEvent({ sequence: 2, turnId: "turn_2" }),
+      messages: [],
+      resolvers: [resolver],
+    });
+    await expect(sandbox.readTextFile({ path: `${skillRoot}/playbook/SKILL.md` })).resolves.toBe(
+      "Repaired playbook",
+    );
+    expect(ctx.get(PendingSkillAnnouncementKey)).toContain("playbook: Playbook");
+  });
+
+  it("propagates session-start resolver failures", async () => {
+    const { ctx, sourcePath } = await createSession();
+    const resolver = createResolver("playbook", async () =>
+      defineSkill({ description: "Playbook", markdown: await readFile(sourcePath, "utf8") }),
+    );
+    await expect(
+      dispatchDynamicSkillEvent({
+        ctx,
+        event: createSessionStartedEvent(),
+        messages: [],
+        resolvers: [resolver],
+      }),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    expect(ctx.get(DynamicSkillManifestKey)).toBeUndefined();
+  });
+
+  it("does not apply another resolver's update when one resolver fails", async () => {
+    const { ctx, sandbox, skillRoot, sourcePath } = await createSession();
+    await writeFile(sourcePath, "Playbook instructions");
+    const playbook = createResolver("playbook", async () =>
+      defineSkill({ description: "Playbook", markdown: await readFile(sourcePath, "utf8") }),
+    );
+    let supportSkill = defineSkill({ description: "Original support", markdown: "Original" });
+    const support = createResolver("support", () => supportSkill);
+    await dispatchDynamicSkillEvent({
+      ctx,
+      event: createTurnStartedEvent({ sequence: 0, turnId: "turn_0" }),
+      messages: [],
+      resolvers: [support, playbook],
+    });
+
+    await rm(sourcePath);
+    supportSkill = defineSkill({ description: "Updated support", markdown: "Updated" });
+    await expect(
+      dispatchDynamicSkillEvent({
+        ctx,
+        event: createTurnStartedEvent({ sequence: 1, turnId: "turn_1" }),
+        messages: [],
+        resolvers: [support, playbook],
+      }),
+    ).rejects.toMatchObject({ name: "BoundaryHookError" });
+    await expect(sandbox.readTextFile({ path: `${skillRoot}/support/SKILL.md` })).resolves.toBe(
+      "Original",
+    );
+    expect(ctx.get(DynamicSkillManifestKey)).toEqual({
+      playbook: [{ description: "Playbook", name: "playbook" }],
+      support: [{ description: "Original support", name: "support" }],
+    });
+    expect(ctx.get(PendingSkillAnnouncementKey)).toContain("support: Original support");
+    expect(ctx.get(PendingSkillAnnouncementKey)).not.toContain("Updated support");
+  });
+});

--- a/packages/eve/src/context/dynamic-skill-lifecycle.ts
+++ b/packages/eve/src/context/dynamic-skill-lifecycle.ts
@@ -1,6 +1,7 @@
 import type { ModelMessage } from "ai";
 
 import { ALLOWED_DYNAMIC_SKILL_EVENTS } from "#dynamic/definition.js";
+import { BoundaryHookError } from "#shared/boundary-hook-error.js";
 import { isBrandedSkillEntry, type SkillPackageDefinition } from "#shared/skill-definition.js";
 import {
   type MaterializableSkillPackage,
@@ -11,8 +12,6 @@ import {
 import type { UnstampedMessageStreamEvent } from "#protocol/message.js";
 import type { ResolvedDynamicSkillResolver } from "#runtime/types.js";
 import { formatAvailableSkillsSection } from "#execution/skills/instructions.js";
-import { createLogger } from "#internal/logging.js";
-import { toErrorMessage } from "#shared/errors.js";
 import type { ContextContainer } from "#context/container.js";
 import {
   type DurableDynamicSkillMetadata,
@@ -21,8 +20,6 @@ import {
 } from "#context/keys.js";
 import { buildResolveContext } from "#context/dynamic-resolve-context.js";
 import { resolveSandboxSkillRoot } from "#shared/skill-paths.js";
-
-const log = createLogger("dynamic-skills");
 
 // ---------------------------------------------------------------------------
 // Name qualification
@@ -158,10 +155,10 @@ export async function dispatchDynamicSkillEvent(input: {
 
   for (const outcome of outcomes) {
     if (outcome.status === "rejected") {
-      log.error(`Dynamic skill resolver (${event.type}) threw — skipping.`, {
-        error: toErrorMessage(outcome.reason),
-      });
-      continue;
+      if (event.type === "turn.started") {
+        throw new BoundaryHookError(outcome.reason);
+      }
+      throw outcome.reason;
     }
     if (outcome.value === null) continue;
     updates.push({


### PR DESCRIPTION
### Summary

Closes #3288.

A rejected dynamic skill resolver currently logs an error and lets the turn continue with the previous skill package. Resolver rejections now propagate, preserving the original cause. During an ordinary conversation turn, a `turn.started` failure uses the existing recoverable turn-boundary path before the assistant model call; session-start failures stop initialization.

All resolver outcomes settle before materialization. When any resolver rejects, none of that dispatch's skill updates are materialized. A later ordinary turn can resolve the repaired source in the same session.

The separate authorization-callback preamble emits lifecycle events outside the harness recovery path and can still terminate the session on resolver or authored-hook errors. This existing exception is documented, not changed here; it was traced in source rather than reproduced in a new runtime test.

### Validation

- All three new real just-bash integration cases fail on the base implementation and pass with the fix: turn-boundary rejection and later refresh in the same context, session-start rejection, and no sibling update after a resolver rejects. Run with `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/context/dynamic-skill-errors.integration.test.ts`.
- Existing skill suites pass (22 tests), as do the seven focused turn-boundary recovery tests.
- Typecheck, lint, formatting, runtime invariants, and `git diff --check` pass. Lint retains two pre-existing warnings in unrelated files.
- Full documentation checks pass, including metadata, imports, snippets, and MDX for the final changed guide.

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)

### Diff size

**Docs** — 2 files · `+7 / -0`

A release note and the dynamic-skills guide describe resolver failures and the existing recovery boundaries.

**Implementation** — 1 file · `+5 / -8`

Routes rejected resolvers through the existing lifecycle error handling and removes the log-and-skip path.

**Tests** — 1 file · `+159 / -0`

Uses a real filesystem source, sandbox, and session context to cover errors, preserved state, and later refresh without mocked resolvers or sandbox operations.
