### PR TITLE
fix(eve): offer to repair failed self-modifications

### DIFF
--- a/.changeset/offer-self-mod-repairs.md
+++ b/.changeset/offer-self-mod-repairs.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+When a self-modification later fails or behaves incorrectly, agents now offer to send the issue back for repair instead of leaving users to discover the recovery path. Repairs still require user confirmation and do not start automatically.

--- a/packages/eve/src/self-modification/agent.test.ts
+++ b/packages/eve/src/self-modification/agent.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineSelfModificationAgent } from "./agent.js";
+
+const originalEveDev = process.env.EVE_DEV;
+
+afterEach(() => {
+  if (originalEveDev === undefined) delete process.env.EVE_DEV;
+  else process.env.EVE_DEV = originalEveDev;
+});
+
+describe("defineSelfModificationAgent", () => {
+  it("tells the parent to offer, but not automatically start, repairs", async () => {
+    process.env.EVE_DEV = "1";
+    const agent = defineSelfModificationAgent();
+    const resolved = await agent.events["session.started"]?.(
+      {},
+      {
+        channel: {},
+        messages: [],
+        session: { auth: { current: null, initiator: null }, id: "session-1" },
+      },
+    );
+
+    expect(resolved).toMatchObject({
+      description: expect.stringContaining(
+        "If a change made by this subagent later fails or behaves incorrectly",
+      ),
+    });
+    expect((resolved as { description: string }).description).toContain(
+      "Do not start the repair without user confirmation.",
+    );
+  });
+});

--- a/packages/eve/src/self-modification/agent.ts
+++ b/packages/eve/src/self-modification/agent.ts
@@ -38,6 +38,10 @@ const followUpDelegation =
   "Resolve short follow-ups such as “yes” or “do it” against the preceding conversation. " +
   "If whether the requested change should persist is genuinely ambiguous, ask one concise clarifying question.";
 
+const repairDelegation =
+  "If a change made by this subagent later fails or behaves incorrectly, explain the failure and offer to delegate a repair to this subagent. " +
+  "Do not start the repair without user confirmation.";
+
 const localIntegrationDelegation =
   "Delegate questions about which integrations, channels, connections, or capabilities are available to add: the subagent searches the eve registry and reports exact item addresses instead of guessing them.";
 
@@ -66,6 +70,7 @@ export function defineSelfModificationAgent(options: SelfModificationAgentOption
       mode === "local" ? localIntegrationDelegation : deployedIntegrationDelegation,
       mode === "local" ? localTraceDelegation : "",
       followUpDelegation,
+      repairDelegation,
       mode === "local" ? localEffectiveEdits : deployedEffectiveEdits,
     ]);
     if (mode === "local") return defineAgent({ description, model });


### PR DESCRIPTION
### Summary

When a self-modification later fails or behaves incorrectly, the parent now offers to send it back to self-mod for repair. For now this is conservative: it requires confirmation and only applies to failures tied to a prior self-modification. We may want to offer self-mod repair after any tool failure once we have a good way to avoid irrelevant suggestions.

### Validation

Adds a unit test for the repair offer and confirmation requirement.

🤖
