### PR TITLE
feat: add non-provisioning sandbox stop lifecycle

### DIFF
--- a/.changeset/stop-sandbox.md
+++ b/.changeset/stop-sandbox.md
@@ -1,0 +1,5 @@
+---
+"eve": minor
+---
+
+Add `ctx.stopSandbox()` for stopping durable sandbox compute without opening or resuming the sandbox first.

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -64,26 +64,27 @@ interface HookContext extends SessionContext {
 }
 ```
 
-That means a hook can access the current sandbox and release its backing
-compute at an application-defined boundary:
+That means a hook can release the current session's backing compute at a
+durable lifecycle boundary:
 
 ```ts title="agent/hooks/stop-after-turn.ts"
 import { defineHook } from "eve/hooks";
 
 export default defineHook({
   events: {
-    async "turn.completed"(_event, ctx) {
-      const sandbox = await ctx.getSandbox();
-      await sandbox.stop();
+    async "session.waiting"(_event, ctx) {
+      await ctx.stopSandbox();
     },
   },
 });
 ```
 
-Every built-in backend stops its underlying compute while preserving the
-durable session and filesystem for the next callback. On Vercel, the current
-handle can also automatically resume on later I/O. A hook failure, including a
-failed stop, follows the normal
+`ctx.stopSandbox()` never opens or resumes a sandbox that is not already live in
+the current callback. Every built-in backend that supports durable reconnect
+state stops its underlying compute while preserving the durable session and
+filesystem for the next callback. On Vercel, the next call to
+`ctx.getSandbox()` reopens the same persistent sandbox. A hook failure,
+including a failed stop, follows the normal
 [hook failure behavior](#what-happens-when-a-hook-throws).
 
 ### Narrowing tool results

--- a/docs/guides/session-context.md
+++ b/docs/guides/session-context.md
@@ -9,6 +9,7 @@ eve passes a runtime `ctx` to tool executors, hook handlers, channel event handl
 | ---------------------------- | --------------------------------------------------------- | ----------------------------------------------- |
 | `ctx.session`                | Session identity, turn metadata, auth, and parent lineage | This page                                       |
 | `ctx.getSandbox()`           | The current agent's live sandbox handle                   | [Sandbox](../sandbox)                           |
+| `ctx.stopSandbox()`          | Stop owned sandbox compute without opening it             | [Sandbox](../sandbox#lifecycle)                 |
 | `ctx.getSkill(identifier)`   | A handle for a skill visible to the current agent         | [Skills](../skills#read-skill-files-at-runtime) |
 | `defineState(name, initial)` | Durable typed state shared by runtime code in one session | [State](../concepts/state)                      |
 
@@ -60,6 +61,30 @@ const result = await sandbox.run({ command: "npm test" });
 ```
 
 The accessor is asynchronous because eve may need to bind or restore the sandbox. A subagent sees its own sandbox, not its parent's. The returned handle also exposes `stop()` and `delete()`; see [Sandbox lifecycle](../sandbox#lifecycle) for their behavior.
+
+## `ctx.stopSandbox()`
+
+Call `ctx.stopSandbox()` from a lifecycle hook when the session reaches a
+durable boundary and you want to release compute without opening the sandbox:
+
+```ts title="agent/hooks/stop-after-turn.ts"
+import { defineHook } from "eve/hooks";
+
+export default defineHook({
+  events: {
+    async "session.waiting"(_event, ctx) {
+      await ctx.stopSandbox();
+    },
+  },
+});
+```
+
+The method stops compute owned by the current durable session and preserves its
+filesystem and reconnect state. It is safe to call when the session has no
+sandbox, when the sandbox is already stopped, or when a lifecycle event is
+replayed. It does not call `ctx.getSandbox()` and therefore does not provision
+or resume a sandbox just to stop it. A shared child session does not stop its
+parent's sandbox.
 
 ## `ctx.getSkill(identifier)`
 

--- a/docs/reference/typescript-api.md
+++ b/docs/reference/typescript-api.md
@@ -103,6 +103,7 @@ import template from "../../prompts/template.txt?raw";
 | --------------------------- | ---------------------------------------------------------------------------- |
 | `ctx.session`               | Current session, turn, auth, and optional parent lineage (read-only)         |
 | `ctx.getSandbox()`          | Live sandbox handle; `stop()` releases compute but preserves durable state   |
+| `ctx.stopSandbox()`         | Release owned compute without opening or resuming a sandbox                  |
 | `ctx.getSkill(identifier)`  | Handle for a named skill visible to the current agent                        |
 | `ctx.getToken(provider)`    | Resolve a bearer token for an inline auth provider such as `connect("...")`  |
 | `ctx.requireAuth(provider)` | Evict and re-authorize an inline provider, commonly after a downstream `401` |

--- a/docs/sandbox.mdx
+++ b/docs/sandbox.mdx
@@ -264,6 +264,26 @@ stop-specific state is needed. Lifecycle `use()` calls return the I/O-only
 `SandboxSession` because bootstrap and session initialization do not own runtime
 teardown.
 
+Lifecycle hooks can stop an existing durable sandbox without opening it first:
+
+```ts
+import { defineHook } from "eve/hooks";
+
+export default defineHook({
+  events: {
+    async "session.waiting"(_event, ctx) {
+      await ctx.stopSandbox();
+    },
+  },
+});
+```
+
+`ctx.stopSandbox()` is safe for repeated lifecycle events and for sessions that
+did not use a sandbox. It preserves the sandbox filesystem and reconnect state,
+and the next call to `ctx.getSandbox()` reopens the existing sandbox. It does
+not call `ctx.getSandbox()` internally, so it cannot provision or resume a
+sandbox only to stop it.
+
 ### Delete a sandbox
 
 Permanently delete the current session sandbox from an authored runtime callback:

--- a/packages/eve/src/context/accessors.integration.test.ts
+++ b/packages/eve/src/context/accessors.integration.test.ts
@@ -140,6 +140,30 @@ describe("buildCallbackContext – getSandbox", () => {
     expect(stops).toBe(1);
   });
 
+  it("stops persisted sandbox compute without opening a sandbox", async () => {
+    let stops = 0;
+    const sandbox = mockSandbox({
+      stop: () => {
+        stops += 1;
+      },
+    });
+    const runtime = await createTestRuntime();
+
+    await runtime.runAsSession({ sandbox }, async () => {
+      await buildCallbackContext().stopSandbox();
+    });
+
+    expect(stops).toBe(1);
+  });
+
+  it("does nothing when the session has no sandbox", async () => {
+    const runtime = await createTestRuntime();
+
+    await expect(
+      runtime.runAsSession({}, () => buildCallbackContext().stopSandbox()),
+    ).resolves.toBe(undefined);
+  });
+
   it("deletes the active sandbox through the runtime session", async () => {
     let deletions = 0;
     const sandbox = mockSandbox({

--- a/packages/eve/src/context/build-callback-context.ts
+++ b/packages/eve/src/context/build-callback-context.ts
@@ -48,6 +48,12 @@ export function buildCallbackContext(): SessionContext {
       });
     },
 
+    stopSandbox(): Promise<void> {
+      const access = ctx.get(SandboxKey);
+      if (access === undefined) return Promise.resolve();
+      return access.stopExisting?.() ?? Promise.resolve();
+    },
+
     getSkill(identifier: string): SkillHandle {
       const access = ctx.get(SandboxKey);
       if (access === undefined) {

--- a/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
+++ b/packages/eve/src/context/dynamic-tool-lifecycle.test.ts
@@ -416,6 +416,7 @@ function createApprovalContext(input: {
     callId: "call_1",
     getSandbox: vi.fn(),
     getSkill: vi.fn(),
+    stopSandbox: vi.fn(),
     session: {
       auth: { current: null, initiator: null },
       id: "test-session",

--- a/packages/eve/src/context/session-context.ts
+++ b/packages/eve/src/context/session-context.ts
@@ -30,6 +30,16 @@ export interface SessionContext {
   getSandbox(): Promise<RuntimeSandboxSession>;
 
   /**
+   * Stops this session's sandbox compute without opening or resuming a
+   * sandbox that is not already live in the current callback.
+   *
+   * The durable sandbox state remains available for the next callback. This
+   * method is safe to call when the session has no sandbox, when its sandbox
+   * is already stopped, and from repeated lifecycle events.
+   */
+  stopSandbox(): Promise<void>;
+
+  /**
    * Returns a {@link SkillHandle} for the named authored skill.
    */
   getSkill(identifier: string): SkillHandle;

--- a/packages/eve/src/execution/sandbox/bindings/vercel-lifecycle.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel-lifecycle.ts
@@ -7,8 +7,11 @@ import type {
   VercelCreateOptions,
   VercelDeleteGetOptions,
   VercelDeleteModule,
+  VercelModule,
   VercelSandbox,
 } from "#execution/sandbox/bindings/vercel-sdk-types.js";
+import type { SandboxBackendSessionState } from "#public/definitions/sandbox-backend.js";
+import { getNamedVercelSandbox } from "#execution/sandbox/bindings/vercel-lookup.js";
 
 export async function deleteVercelSandbox(input: {
   readonly createOptions: VercelCreateOptions;
@@ -54,6 +57,39 @@ export async function stopVercelSandbox(sandbox: VercelSandbox): Promise<void> {
     return;
   }
   await sandbox.stop();
+}
+
+export type VercelSandboxStopExistingResult = "stopped" | "not-running" | "not-found";
+
+/**
+ * Stops a persisted Vercel sandbox without resuming or initializing it.
+ *
+ * Durable lifecycle hooks use this path when they run in a later step than
+ * the one that opened the sandbox. It must never call the backend's normal
+ * create path because that path can resume the VM and run framework setup.
+ */
+export async function stopExistingVercelSandbox(input: {
+  readonly createOptions: VercelCreateOptions;
+  readonly loadSandboxModule: () => Promise<VercelModule>;
+  readonly state: SandboxBackendSessionState;
+}): Promise<VercelSandboxStopExistingResult> {
+  const sandboxName = input.state.metadata.sandboxName;
+  if (typeof sandboxName !== "string" || sandboxName.length === 0) {
+    return "not-found";
+  }
+
+  const sandbox = await getNamedVercelSandbox({
+    createOptions: input.createOptions,
+    sandboxModule: await input.loadSandboxModule(),
+    sandboxName,
+  });
+  if (sandbox === null) return "not-found";
+  if (sandbox.status !== "running" && sandbox.status !== "pending") {
+    return "not-running";
+  }
+
+  await sandbox.stop();
+  return "stopped";
 }
 
 async function resolveVercelSandboxCredentials(

--- a/packages/eve/src/execution/sandbox/bindings/vercel.test.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel.test.ts
@@ -155,6 +155,122 @@ afterEach(() => {
 });
 
 describe("createVercelSandbox", () => {
+  it("stops an existing sandbox without resuming or creating it", async () => {
+    const sandbox = createMockSandbox({ name: "session", status: "running" });
+    const sandboxModule = {
+      Sandbox: {
+        create: vi.fn(),
+        get: vi.fn().mockResolvedValue(sandbox),
+      },
+    };
+    const backend = createVercelSandbox({
+      createOptions: { fetch: vi.fn() } as never,
+      loadSandboxModule: async () => sandboxModule as never,
+    });
+
+    await expect(
+      backend.stopExisting?.({
+        existingState: {
+          backendName: "vercel",
+          metadata: { sandboxName: "session" },
+          sessionKey: "session-key",
+        },
+        runtimeContext: { appRoot: "/tmp/test-app-root" },
+      }),
+    ).resolves.toBe("stopped");
+
+    expect(sandboxModule.Sandbox.create).not.toHaveBeenCalled();
+    expect(sandboxModule.Sandbox.get).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "session", resume: false }),
+    );
+    expect(sandbox.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not stop a sandbox that is already stopped", async () => {
+    const sandbox = createMockSandbox({ name: "session", status: "stopped" });
+    const sandboxModule = {
+      Sandbox: {
+        create: vi.fn(),
+        get: vi.fn().mockResolvedValue(sandbox),
+      },
+    };
+    const backend = createVercelSandbox({
+      loadSandboxModule: async () => sandboxModule as never,
+    });
+
+    await expect(
+      backend.stopExisting?.({
+        existingState: {
+          backendName: "vercel",
+          metadata: { sandboxName: "session" },
+          sessionKey: "session-key",
+        },
+        runtimeContext: { appRoot: "/tmp/test-app-root" },
+      }),
+    ).resolves.toBe("not-running");
+
+    expect(sandbox.stop).not.toHaveBeenCalled();
+  });
+
+  it("treats a missing sandbox as an idempotent no-op", async () => {
+    const sandboxModule = {
+      Sandbox: {
+        create: vi.fn(),
+        get: vi.fn().mockResolvedValue(null),
+      },
+    };
+    const backend = createVercelSandbox({
+      loadSandboxModule: async () => sandboxModule as never,
+    });
+
+    await expect(
+      backend.stopExisting?.({
+        existingState: {
+          backendName: "vercel",
+          metadata: { sandboxName: "missing" },
+          sessionKey: "session-key",
+        },
+        runtimeContext: { appRoot: "/tmp/test-app-root" },
+      }),
+    ).resolves.toBe("not-found");
+
+    expect(sandboxModule.Sandbox.create).not.toHaveBeenCalled();
+  });
+
+  it("propagates provider lookup failures without creating or clearing state", async () => {
+    const failure = Object.assign(new Error("provider unavailable"), {
+      response: { status: 503 },
+    });
+    const sandboxModule = {
+      Sandbox: {
+        create: vi.fn(),
+        get: vi.fn().mockRejectedValue(failure),
+      },
+    };
+    const backend = createVercelSandbox({
+      loadSandboxModule: async () => sandboxModule as never,
+    });
+    const existingState = {
+      backendName: "vercel",
+      metadata: { sandboxName: "preserved" },
+      sessionKey: "session-key",
+    } as const;
+
+    await expect(
+      backend.stopExisting?.({
+        existingState,
+        runtimeContext: { appRoot: "/tmp/test-app-root" },
+      }),
+    ).rejects.toThrow(/provider unavailable/u);
+
+    expect(sandboxModule.Sandbox.create).not.toHaveBeenCalled();
+    expect(existingState).toEqual({
+      backendName: "vercel",
+      metadata: { sandboxName: "preserved" },
+      sessionKey: "session-key",
+    });
+  });
+
   it("creates fresh Vercel sandboxes with eve's shared base image", async () => {
     const templateSandbox = createMockSandbox({ name: "template-key" });
     const fetch = vi.fn();

--- a/packages/eve/src/execution/sandbox/bindings/vercel.ts
+++ b/packages/eve/src/execution/sandbox/bindings/vercel.ts
@@ -22,6 +22,7 @@ import type {
   SandboxBackendPrewarmResult,
   SandboxBackendTags,
   SandboxSeedFile,
+  SandboxBackendStopExistingInput,
 } from "#public/definitions/sandbox-backend.js";
 import { SandboxTemplateNotProvisionedError } from "#public/definitions/sandbox-backend.js";
 import type {
@@ -53,6 +54,7 @@ import { getNamedVercelSandbox } from "#execution/sandbox/bindings/vercel-lookup
 import {
   deleteUnusableVercelSandbox,
   deleteVercelSandbox,
+  stopExistingVercelSandbox,
   stopVercelSandbox,
 } from "#execution/sandbox/bindings/vercel-lifecycle.js";
 import { normalizeVercelReadStream } from "#execution/sandbox/bindings/vercel-read-stream.js";
@@ -172,6 +174,13 @@ export function createVercelSandbox(
         loadDeleteSandboxModule,
         sandbox: session.sandbox,
         sessionKey: createInput.sessionKey,
+      });
+    },
+    async stopExisting(stopInput: SandboxBackendStopExistingInput) {
+      return await stopExistingVercelSandbox({
+        createOptions,
+        loadSandboxModule,
+        state: stopInput.existingState,
       });
     },
     async prewarm(

--- a/packages/eve/src/execution/sandbox/ensure.test.ts
+++ b/packages/eve/src/execution/sandbox/ensure.test.ts
@@ -434,6 +434,77 @@ describe("ensureSandboxAccess", () => {
     expect(handle?.stop).toHaveBeenCalledTimes(1);
   });
 
+  it("stops persisted compute without creating or reattaching a handle", async () => {
+    const backend = createBackend();
+    const stopExisting = vi.fn(async () => "stopped" as const);
+    const lifecycleBackend: SandboxBackend = { ...backend, stopExisting };
+    const registry = createTestRegistry({}, lifecycleBackend);
+
+    const first = await ensure({ registry });
+    await first.get();
+    const state = await first.captureState();
+
+    const second = await ensure({ registry, state });
+    await second.stopExisting!();
+
+    expect(backend.create).toHaveBeenCalledTimes(1);
+    expect(stopExisting).toHaveBeenCalledWith({
+      existingState: state.session,
+      runtimeContext: { appRoot: process.cwd() },
+    });
+  });
+
+  it("does not create a sandbox when stopping an unused session", async () => {
+    const backend = createBackend();
+    const stopExisting = vi.fn(async () => "stopped" as const);
+    const access = await ensure({
+      registry: createTestRegistry({}, { ...backend, stopExisting }),
+    });
+
+    await access.stopExisting!();
+
+    expect(backend.create).not.toHaveBeenCalled();
+    expect(stopExisting).not.toHaveBeenCalled();
+  });
+
+  it("coalesces concurrent persisted stop requests", async () => {
+    const backend = createBackend();
+    const deferred = createDeferred<"stopped">();
+    const stopExisting = vi.fn(() => deferred.promise);
+    const lifecycleBackend: SandboxBackend = { ...backend, stopExisting };
+    const first = await ensure({ registry: createTestRegistry({}, lifecycleBackend) });
+    await first.get();
+    const state = await first.captureState();
+    const second = await ensure({
+      registry: createTestRegistry({}, lifecycleBackend),
+      state,
+    });
+
+    const firstStop = second.stopExisting!();
+    const secondStop = second.stopExisting!();
+    expect(stopExisting).toHaveBeenCalledTimes(1);
+    deferred.resolve("stopped");
+    await Promise.all([firstStop, secondStop]);
+  });
+
+  it("does not stop a shared sandbox from a child session", async () => {
+    const backend = createBackend();
+    const stopExisting = vi.fn(async () => "stopped" as const);
+    const access = await ensure({
+      ownsSandbox: false,
+      registry: createTestRegistry({}, { ...backend, stopExisting }),
+      state: {
+        initialized: true,
+        session: { backendName: "test", metadata: {}, sessionKey: "session_1" },
+      },
+    });
+
+    await access.stopExisting!();
+
+    expect(backend.create).not.toHaveBeenCalled();
+    expect(stopExisting).not.toHaveBeenCalled();
+  });
+
   it("deletes the sandbox and reprovisions a fresh handle on the next access", async () => {
     const ctx = new ContextContainer();
     ctx.set(SessionKey, createSession());

--- a/packages/eve/src/execution/sandbox/ensure.ts
+++ b/packages/eve/src/execution/sandbox/ensure.ts
@@ -54,6 +54,7 @@ export async function ensureSandboxAccess(input: EnsureSandboxAccessInput): Prom
 
   const registered = input.registry.sandbox;
   let handlePromise: Promise<SandboxBackendHandle | null> | undefined;
+  let stopExistingPromise: Promise<void> | undefined;
 
   function getHandle(): Promise<SandboxBackendHandle | null> {
     if (handlePromise !== undefined) {
@@ -168,6 +169,49 @@ export async function ensureSandboxAccess(input: EnsureSandboxAccessInput): Prom
     await callback();
   }
 
+  async function stopExisting(): Promise<void> {
+    if (input.ownsSandbox === false) return;
+
+    if (stopExistingPromise !== undefined) {
+      return await stopExistingPromise;
+    }
+
+    stopExistingPromise = stopExistingOnce();
+    try {
+      await stopExistingPromise;
+    } finally {
+      stopExistingPromise = undefined;
+    }
+  }
+
+  async function stopExistingOnce(): Promise<void> {
+    // A live handle is already available in this authored step. Reuse it so
+    // the backend can stop the exact resource it opened, but never invoke
+    // createHandle solely to perform teardown.
+    if (handlePromise !== undefined) {
+      const handle = await handlePromise;
+      if (handle !== null) {
+        await handle.stop();
+        return;
+      }
+    }
+
+    if (!initialized || persistedSession === null) return;
+
+    const registered = input.registry.sandbox;
+    if (registered === null) return;
+
+    const inheritance = registered.inheritance;
+    const definition = inheritance?.definition ?? registered.definition;
+    const backend = definition.backend;
+    if (persistedSession.backendName !== backend.name) return;
+
+    await backend.stopExisting?.({
+      existingState: persistedSession,
+      runtimeContext: { appRoot },
+    });
+  }
+
   return {
     async captureState() {
       if (handlePromise !== undefined) {
@@ -209,6 +253,7 @@ export async function ensureSandboxAccess(input: EnsureSandboxAccessInput): Prom
       }
       await handle.stop();
     },
+    stopExisting,
   };
 }
 

--- a/packages/eve/src/execution/sandbox/lazy-backend.ts
+++ b/packages/eve/src/execution/sandbox/lazy-backend.ts
@@ -33,5 +33,8 @@ export function lazyBackend<BO, SO>(factory: () => SandboxBackend<BO, SO>): Sand
     prewarm(input) {
       return resolve().prewarm(input);
     },
+    stopExisting(input) {
+      return resolve().stopExisting?.(input) ?? Promise.resolve("not-running");
+    },
   };
 }

--- a/packages/eve/src/execution/tools/workflow/body.ts
+++ b/packages/eve/src/execution/tools/workflow/body.ts
@@ -148,6 +148,7 @@ function createWorkflowBodyContext(
     callId: input.callId,
     getSandbox: () => unavailable("getSandbox()", "the session sandbox belongs to the turn"),
     getSkill: () => unavailable("getSkill()", "skills are read through the session sandbox"),
+    stopSandbox: () => unavailable("stopSandbox()", "the session sandbox belongs to the turn"),
     getToken: () =>
       unavailable("getToken()", 'pass ctx directly to a "use step" helper to resolve credentials'),
     requireAuth: () =>

--- a/packages/eve/src/internal/testing/app-harness.ts
+++ b/packages/eve/src/internal/testing/app-harness.ts
@@ -159,6 +159,7 @@ const TEST_SANDBOX_BACKEND: SandboxBackend = {
       delete: async (options) => await sandbox.access.delete?.(options),
       shutdown: async () => undefined,
       stop: async () => undefined,
+      stopExisting: async () => "not-running",
     };
   },
   prewarm: async () => ({ reused: true }),

--- a/packages/eve/src/internal/testing/mocks/mock-sandbox.ts
+++ b/packages/eve/src/internal/testing/mocks/mock-sandbox.ts
@@ -263,6 +263,9 @@ export function mockSandbox(input: MockSandboxInput = {}): MockSandbox {
     async stop(): Promise<void> {
       await input.stop?.();
     },
+    async stopExisting(): Promise<void> {
+      await input.stop?.();
+    },
   };
 
   return {

--- a/packages/eve/src/public/channels/linear/defaults.test.ts
+++ b/packages/eve/src/public/channels/linear/defaults.test.ts
@@ -11,6 +11,7 @@ function sessionContext(): SessionContext {
   return {
     getSandbox: vi.fn(),
     getSkill: vi.fn(),
+    stopSandbox: vi.fn(),
     session: {
       auth: {
         current: {

--- a/packages/eve/src/public/channels/slack/defaults.test.ts
+++ b/packages/eve/src/public/channels/slack/defaults.test.ts
@@ -10,6 +10,7 @@ function sessionContext(
   return {
     getSandbox: vi.fn(),
     getSkill: vi.fn(),
+    stopSandbox: vi.fn(),
     session: {
       auth: { current, initiator: null },
       id: "test-session",

--- a/packages/eve/src/public/definitions/sandbox-backend.ts
+++ b/packages/eve/src/public/definitions/sandbox-backend.ts
@@ -6,6 +6,8 @@ export type {
   SandboxBackendTags,
   SandboxBackendRuntimeContext,
   SandboxBackendCreateInput,
+  SandboxBackendStopExistingInput,
+  SandboxBackendStopExistingResult,
   SandboxBackendPrewarmInput,
   SandboxBackendPrewarmResult,
   SandboxBackend,

--- a/packages/eve/src/public/memory/file/provider.test.ts
+++ b/packages/eve/src/public/memory/file/provider.test.ts
@@ -403,6 +403,7 @@ function toolsContext(): MemoryToolsContext {
 function operationContext() {
   return {
     abortSignal: signal,
+    stopSandbox: async () => undefined,
     getSandbox: async () => {
       throw new Error("not available");
     },

--- a/packages/eve/src/public/sandbox/index.ts
+++ b/packages/eve/src/public/sandbox/index.ts
@@ -34,6 +34,8 @@ export type {
   SandboxBackendPrewarmInput,
   SandboxBackendRuntimeContext,
   SandboxBackendSessionState,
+  SandboxBackendStopExistingInput,
+  SandboxBackendStopExistingResult,
   SandboxDeleteOptions,
   SandboxSeedFile,
 } from "#public/definitions/sandbox-backend.js";

--- a/packages/eve/src/sandbox/state.ts
+++ b/packages/eve/src/sandbox/state.ts
@@ -35,4 +35,5 @@ export interface SandboxAccess {
   delete?(options?: SandboxDeleteOptions): Promise<void>;
   get(): Promise<SandboxSession | null>;
   stop(): Promise<void>;
+  stopExisting?(): Promise<void>;
 }

--- a/packages/eve/src/shared/sandbox-backend.ts
+++ b/packages/eve/src/shared/sandbox-backend.ts
@@ -52,6 +52,20 @@ export interface SandboxBackendSessionState {
 }
 
 /**
+ * Input passed to a backend when eve needs to stop an existing durable
+ * sandbox without opening it first.
+ */
+export interface SandboxBackendStopExistingInput {
+  readonly existingState: SandboxBackendSessionState;
+  readonly runtimeContext: SandboxBackendRuntimeContext;
+}
+
+/**
+ * Result of a non-provisioning stop request.
+ */
+export type SandboxBackendStopExistingResult = "stopped" | "not-running" | "not-found";
+
+/**
  * One file written into a sandbox template before template state capture.
  */
 export interface SandboxSeedFile {
@@ -173,6 +187,14 @@ export interface SandboxBackend<BO = Record<string, never>, SO = Record<string, 
    * template is missing.
    */
   create(input: SandboxBackendCreateInput): Promise<SandboxBackendHandle<SO>>;
+  /**
+   * Stops an existing durable session without creating or resuming it.
+   *
+   * Backends that cannot address a persisted session without opening it may
+   * omit this capability. eve then leaves the provider-side lifecycle to the
+   * backend's normal timeout or shutdown behavior.
+   */
+  stopExisting?(input: SandboxBackendStopExistingInput): Promise<SandboxBackendStopExistingResult>;
   /**
    * Build-time prewarm hook. eve invokes this for every authored
    * sandbox in the compiled graph before serving traffic so the backend


### PR DESCRIPTION
## Summary

Add a non-provisioning `SessionContext.stopSandbox()` lifecycle API for durable session boundaries.

The API stops the current session's owned compute without calling `getSandbox()`, creating a provider resource, resuming a stopped resource, running `onSession`, or running base-runtime initialization. Persisted session metadata remains available for the next callback.

## Implementation

- Add `SessionContext.stopSandbox()` with idempotent and ownership-aware behavior.
- Add the optional backend `stopExisting` primitive and public input/result types.
- Coalesce concurrent stop requests within one access and tolerate replayed requests.
- Add the Vercel implementation using `Sandbox.get({ resume: false })` and stop only running or pending resources.
- Preserve the existing explicit live-handle `getSandbox().stop()` behavior.
- Document the lifecycle API and add unit and integration coverage for unused, persisted, concurrent, shared, missing, already-stopped, and provider-failure cases.

## Verification

- `pnpm exec oxfmt --check .`
- `pnpm --filter eve typecheck`
- `pnpm --filter eve build:js`
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/execution/sandbox/ensure.test.ts src/execution/sandbox/bindings/vercel.test.ts`
- `pnpm --filter eve exec vitest run --config vitest.integration.config.ts src/context/accessors.integration.test.ts`

The full unit suite currently has four environment-sensitive failures unrelated to this change: three existing redaction assertions include the checkout's `/private` path, and one existing production-server test cannot bind loopback in the restricted test environment. The focused lifecycle and Vercel suites pass.
