### PR TITLE
scaffold local self-modification configuration by default

### DIFF
--- a/apps/docs/registry/experimental/self-modification/config.ts
+++ b/apps/docs/registry/experimental/self-modification/config.ts
@@ -1,3 +1,5 @@
 import { defineSelfModificationConfig } from "eve/self-modification/config";
 
-export default defineSelfModificationConfig({});
+export default defineSelfModificationConfig({
+  local: { enabled: true },
+});

--- a/packages/eve/src/self-modification/setup.test.ts
+++ b/packages/eve/src/self-modification/setup.test.ts
@@ -14,9 +14,14 @@ import {
 } from "./setup.js";
 
 describe("self-modification setup", () => {
-  it("renders an explicitly enabled local configuration", () => {
+  it("recognizes default local configurations", () => {
     expect(renderSelfModificationConfig()).toContain("local: { enabled: true }");
     expect(classifySelfModificationConfig(renderSelfModificationConfig())).toBe("local");
+    expect(
+      classifySelfModificationConfig(
+        'import { defineSelfModificationConfig } from "eve/self-modification/config";\n\nexport default defineSelfModificationConfig({});\n',
+      ),
+    ).toBe("local");
   });
 
   it("renders a generated Connect-backed deployed configuration", () => {

--- a/packages/eve/src/self-modification/setup.test.ts
+++ b/packages/eve/src/self-modification/setup.test.ts
@@ -14,6 +14,11 @@ import {
 } from "./setup.js";
 
 describe("self-modification setup", () => {
+  it("renders an explicitly enabled local configuration", () => {
+    expect(renderSelfModificationConfig()).toContain("local: { enabled: true }");
+    expect(classifySelfModificationConfig(renderSelfModificationConfig())).toBe("local");
+  });
+
   it("renders a generated Connect-backed deployed configuration", () => {
     const source = renderSelfModificationConfig({
       branch: "release/production",

--- a/packages/eve/src/self-modification/setup.ts
+++ b/packages/eve/src/self-modification/setup.ts
@@ -42,7 +42,7 @@ export function connectorName(owner: string, repo: string): string {
 
 export function renderSelfModificationConfig(values?: SelfModificationSetupValues): string {
   if (values === undefined) {
-    return `import { defineSelfModificationConfig } from "eve/self-modification/config";\n\nexport default defineSelfModificationConfig({});\n`;
+    return `import { defineSelfModificationConfig } from "eve/self-modification/config";\n\nexport default defineSelfModificationConfig({\n  local: { enabled: true },\n});\n`;
   }
   const channelNames = [...new Set(values.channelNames)].filter((name) => name !== "eve").sort();
   const channelCases = (values.vercelBackend ? channelNames : [])

--- a/packages/eve/src/self-modification/setup.ts
+++ b/packages/eve/src/self-modification/setup.ts
@@ -11,6 +11,8 @@ import { SELF_MODIFICATION_CONFIG_PATH } from "./git-workspace.js";
 
 const runFile = promisify(execFile);
 const GENERATED_MARKER = "// eve-self-modification: generated-v1";
+const LEGACY_LOCAL_CONFIG =
+  'import { defineSelfModificationConfig } from "eve/self-modification/config";\n\nexport default defineSelfModificationConfig({});\n';
 
 export interface SelfModificationSetupValues {
   readonly branch: string;
@@ -99,7 +101,7 @@ export function classifySelfModificationConfig(
   source: string | undefined,
 ): "missing" | "local" | "generated" | "authored" {
   if (source === undefined) return "missing";
-  if (source === renderSelfModificationConfig()) return "local";
+  if (source === renderSelfModificationConfig() || source === LEGACY_LOCAL_CONFIG) return "local";
   const [marker, ...body] = source.split("\n");
   const match = /^\/\/ eve-self-modification: generated-v1 digest:([a-f0-9]{64})$/u.exec(
     marker ?? "",


### PR DESCRIPTION
### Summary

New self-modification scaffolds defaulted to an empty configuration, so locally runnable agents did not get an explicit local setup. Enable the local configuration by default and mirror that setting in the experimental registry example. The generated config remains classified as local, with coverage for the default render path.

### Validation

Not run (not requested).

### Checklist

- [ ] This change was requested or approved by a maintainer
- [ ] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [ ] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
