### PR TITLE
feat(evals): report Datadog experiment runtime links

### DIFF
--- a/.changeset/report-datadog-runtime-trace-links.md
+++ b/.changeset/report-datadog-runtime-trace-links.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Attach deduplicated Eve runtime trace references to Datadog Experiment rows so the LLM Observability UI can resolve and display each eval's related runtime traces.

--- a/packages/eve/src/evals/runner/reporters/datadog.test.ts
+++ b/packages/eve/src/evals/runner/reporters/datadog.test.ts
@@ -460,7 +460,20 @@ describe("Datadog", () => {
       recordExpectedOutputs: true,
     });
     const reporter = Datadog(config);
-    const result = makeEvalResult();
+    const result = makeEvalResult({
+      result: {
+        ...makeEvalResult().result,
+        traceContexts: [
+          {
+            traceId: "0123456789abcdef0123456789abcdef",
+            spanId: "0123456789abcdef",
+            traceFlags: 1,
+            sessionId: "session-123",
+            primary: true,
+          },
+        ],
+      },
+    });
 
     await reporter.onRunStart([makeEval()], makeTarget());
     await reporter.onEvalComplete(result);
@@ -499,6 +512,14 @@ describe("Datadog", () => {
         output: "actual output",
         expectedOutput: "helpful onboarding answer",
         datasetRecordId: "record-1",
+        metadata: expect.objectContaining({
+          eveRuntimeTraceLinks: [
+            expect.objectContaining({
+              traceId: "0123456789abcdef0123456789abcdef",
+              spanId: "0123456789abcdef",
+            }),
+          ],
+        }),
       }),
     );
     expect(lines.join("\n")).toContain("Datadog dataset URL: https://dd.test/dataset");

--- a/packages/eve/src/evals/runner/reporters/datadog.test.ts
+++ b/packages/eve/src/evals/runner/reporters/datadog.test.ts
@@ -201,6 +201,7 @@ describe("Datadog", () => {
     expect(submittedSpan).not.toHaveProperty("metadata.expectedOutput");
     expect(submittedSpan).not.toHaveProperty("metadata.expected");
     expect(submittedSpan).not.toHaveProperty("metadata.expected_output");
+    expect(submittedSpan).not.toHaveProperty("metadata.eveRuntimeTraceLinks");
     expect(experiment.submitEvaluationMetrics).toHaveBeenCalledWith(span, [
       expect.objectContaining({ label: "gate_succeeded", value: 1 }),
       expect.objectContaining({ label: "similarity", value: 0.9 }),
@@ -218,6 +219,102 @@ describe("Datadog", () => {
       ]),
     );
   });
+
+  it("records deduplicated runtime trace links across sessions", async () => {
+    const { config, experiment } = makeConfig();
+    const reporter = Datadog(config);
+    const evaluation = makeEval();
+    const result = makeEvalResult({
+      result: {
+        ...makeEvalResult().result,
+        traceContexts: [
+          {
+            traceId: "0123456789abcdef0123456789abcdef",
+            spanId: "0123456789abcdef",
+            traceFlags: 1,
+            sessionId: "secondary-session",
+            primary: false,
+          },
+          {
+            traceId: "0123456789abcdef0123456789abcdef",
+            spanId: "0123456789abcdef",
+            traceFlags: 1,
+            sessionId: "primary-session",
+            primary: true,
+          },
+          {
+            traceId: "fedcba9876543210fedcba9876543210",
+            spanId: "fedcba9876543210",
+            traceFlags: 1,
+            sessionId: "secondary-session",
+            primary: false,
+          },
+        ],
+      },
+    });
+
+    await reporter.onRunStart([evaluation], makeTarget());
+    await reporter.onEvalComplete(result);
+
+    expect(experiment.submitSpan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          eveRuntimeTraceLinks: [
+            {
+              relation: "eve_runtime",
+              traceId: "0123456789abcdef0123456789abcdef",
+              spanId: "0123456789abcdef",
+              sessionId: "primary-session",
+              primary: true,
+            },
+            {
+              relation: "eve_runtime",
+              traceId: "fedcba9876543210fedcba9876543210",
+              spanId: "fedcba9876543210",
+              sessionId: "secondary-session",
+              primary: false,
+            },
+          ],
+        }),
+      }),
+    );
+  });
+
+  it.each(["failed", "waiting"] as const)(
+    "records runtime trace links for %s evals",
+    async (status) => {
+      const { config, experiment } = makeConfig();
+      const reporter = Datadog(config);
+      const result = makeEvalResult({
+        result: {
+          ...makeEvalResult().result,
+          status,
+          traceContexts: [
+            {
+              traceId: "0123456789abcdef0123456789abcdef",
+              spanId: "0123456789abcdef",
+              traceFlags: 1,
+              sessionId: "session-123",
+              primary: true,
+            },
+          ],
+        },
+      });
+
+      await reporter.onRunStart([makeEval()], makeTarget());
+      await reporter.onEvalComplete(result);
+
+      expect(experiment.submitSpan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            eveRuntimeTraceLinks: [
+              expect.objectContaining({ relation: "eve_runtime", primary: true }),
+            ],
+          }),
+        }),
+      );
+    },
+  );
 
   it("redacts target URL secrets and execution errors by default", async () => {
     const { client, config, experiment } = makeConfig();

--- a/packages/eve/src/evals/runner/reporters/datadog.ts
+++ b/packages/eve/src/evals/runner/reporters/datadog.ts
@@ -521,6 +521,10 @@ function resolveResultMetadata(
     eveSubagentCalls: result.result.derived.subagentCalls.map((call) => call.name),
     eveParked: result.result.derived.parked,
   });
+  const runtimeTraceLinks = resolveRuntimeTraceLinks(result.result.traceContexts);
+  if (runtimeTraceLinks.length > 0) {
+    metadata.eveRuntimeTraceLinks = runtimeTraceLinks;
+  }
   if (recordAssertionDetails) {
     const failedAssertions = result.assertions
       .filter((assertion) => !assertion.passed)
@@ -533,6 +537,35 @@ function resolveResultMetadata(
     metadata.eveFailureCode = result.result.derived.failureCode;
   }
   return metadata;
+}
+
+function resolveRuntimeTraceLinks(traceContexts: EveEvalResult["result"]["traceContexts"]) {
+  const links = new Map<
+    string,
+    {
+      relation: "eve_runtime";
+      traceId: string;
+      spanId: string;
+      sessionId: string;
+      primary: boolean;
+    }
+  >();
+
+  for (const traceContext of traceContexts) {
+    const key = `${traceContext.traceId}:${traceContext.spanId}`;
+    const existing = links.get(key);
+    if (existing?.primary || (existing && !traceContext.primary)) continue;
+
+    links.set(key, {
+      relation: "eve_runtime",
+      traceId: traceContext.traceId,
+      spanId: traceContext.spanId,
+      sessionId: traceContext.sessionId,
+      primary: traceContext.primary,
+    });
+  }
+
+  return [...links.values()];
 }
 
 function resolveEvaluationMetrics(


### PR DESCRIPTION
### Summary

Attach independently emitted runtime trace references to Datadog Experiment rows produced by the Eve eval reporter.

The reporter writes the reusable metadata contract:

```json
{
  "experimentRuntimeTraceLinks": [
    {
      "relation": "experiment_runtime",
      "traceId": "<32-char trace id>",
      "spanId": "<16-char span id>",
      "sessionId": "<runtime session id>",
      "primary": true
    }
  ]
}
```

Links are deduplicated by trace/span ID, primary links win duplicates, and dataset-backed Experiment rows receive the same metadata. The field and relation are intentionally provider-neutral so non-Eve services can publish the same contract when their Experiment row and runtime spans cannot share trace parentage.

This is a hard rename from the earlier draft-only `eveRuntimeTraceLinks` / `eve_runtime` contract; legacy names are not emitted.

Related draft PRs:

- Datadog API: https://github.com/ddoghq/dd-source/pull/89477
- Datadog UI: https://github.com/ddoghq/web-ui/pull/12362
- Node tracer track selection: https://github.com/DataDog/dd-trace-js/pull/10352

### Validation

- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/evals/runner/reporters/datadog.test.ts --reporter=verbose` — 14 tests passed
- `pnpm exec oxlint packages/eve/src/evals/runner/reporters/datadog.ts packages/eve/src/evals/runner/reporters/datadog.test.ts` — no warnings or errors
- `pnpm --filter eve typecheck`
- `pnpm --filter eve build`
- GitHub core CI previously passed lint, typecheck, unit, integration (Ubuntu/Windows), and scenario checks. Secret-backed TUI/E2E/Vercel jobs on the fork require repository credentials unavailable to fork PRs.

### Checklist

- [x] Added reporter tests for empty, deduplicated, primary, failed, waiting, and dataset-backed links
- [x] Added a patch changeset
- [x] Preserved canonical runtime trace IDs and parentage
