### PR TITLE
fix(eve): avoid rescanning durable session history

### DIFF
--- a/.changeset/avoid-legacy-history-rescan.md
+++ b/.changeset/avoid-legacy-history-rescan.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Avoid an extra full-history scan when restoring durable sessions. Legacy message classification now shares hydration's existing validation pass, while histories written by current versions remain strict.

--- a/packages/eve/src/execution/durable-session-migrations/snapshot.test.ts
+++ b/packages/eve/src/execution/durable-session-migrations/snapshot.test.ts
@@ -22,7 +22,8 @@ describe("migrateDurableSessionSnapshot", () => {
 
     const migrated = migrateDurableSessionSnapshot(snapshot);
 
-    expect(migrated).toEqual(snapshot);
+    expect(migrated).toBe(snapshot);
+    expect(migrated.session.history).toBe(snapshot.session.history);
     expect(migrated.version).toBe(DURABLE_SESSION_VERSION);
   });
 

--- a/packages/eve/src/execution/durable-session-migrations/snapshot.ts
+++ b/packages/eve/src/execution/durable-session-migrations/snapshot.ts
@@ -14,11 +14,8 @@
  * 4. Append the migration to {@link snapshotMigrations}.
  * 5. Cover it in `snapshot.test.ts`.
  */
-import type { ModelMessage } from "ai";
-
 import type { DurableSessionSnapshot } from "#execution/durable-session-store.js";
 import { DURABLE_SESSION_VERSION } from "#execution/durable-session-store.js";
-import { validateHarnessModelMessages } from "#harness/messages.js";
 
 import { runMigrationChain, type VersionMigration } from "./chain.js";
 
@@ -33,22 +30,10 @@ const snapshotMigrations: readonly VersionMigration[] = [];
  * {@link DURABLE_SESSION_VERSION}. Pure; safe to call inline.
  */
 export function migrateDurableSessionSnapshot(value: unknown): DurableSessionSnapshot {
-  const snapshot = runMigrationChain<DurableSessionSnapshot>({
+  return runMigrationChain<DurableSessionSnapshot>({
     label: "durable session snapshot",
     migrations: snapshotMigrations,
     targetVersion: DURABLE_SESSION_VERSION,
     value,
   });
-
-  // Pre-0.54 history used user-role messages for both human and framework input.
-  // Keep v1 so a pinned older driver can still forward the updated snapshot.
-  const history = snapshot.session.history.map((message: ModelMessage) =>
-    message.role === "user" && !("kind" in message)
-      ? { ...message, kind: "legacy.unknown" as const }
-      : message,
-  );
-  return {
-    ...snapshot,
-    session: { ...snapshot.session, history: validateHarnessModelMessages(history) },
-  };
 }

--- a/packages/eve/src/execution/durable-session-store.test.ts
+++ b/packages/eve/src/execution/durable-session-store.test.ts
@@ -11,9 +11,16 @@ import {
   replaceDurableSessionSnapshot,
 } from "#execution/durable-session-store.js";
 import type { NextDriverAction } from "#execution/next-driver-action.js";
-import { projectToDurableSession } from "#execution/session.js";
+import { hydrateDurableSession, projectToDurableSession } from "#execution/session.js";
 
 const getRunMock = vi.hoisted(() => vi.fn());
+const turnAgent = {
+  id: "test-agent",
+  instructions: ["Be concise."],
+  model: { id: "test-model" },
+  tools: [],
+  workspaceSpec: { rootEntries: [] },
+};
 
 vi.mock("#compiled/@workflow/core/runtime.js", () => ({
   getRun: (...args: unknown[]) => getRunMock(...args),
@@ -71,6 +78,7 @@ describe("durable-session-store cross-version contract", () => {
     expect(durable.sessionId).toBe(session.sessionId);
     expect(durable.continuationToken).toBe(session.continuationToken);
     expect(durable.history).toBe(session.history);
+    expect(durable.userMessageKindVersion).toBe(1);
     expect(durable.agent).toEqual({ system: session.agent.system });
     // turnAgent-derived fields are rebuilt every turn — not persisted.
     expect(durable.agent).not.toHaveProperty("modelReference");
@@ -202,16 +210,18 @@ describe("durable-session-store cross-version contract", () => {
     expect(getRunMock).not.toHaveBeenCalled();
   });
 
-  it("classifies unmarked legacy history in an embedded snapshot", async () => {
+  it("reads unmarked legacy history without normalizing the snapshot", async () => {
     const session = buildSession({
       continuationToken: "http:test",
       sessionId: "wrun_embedded_legacy",
     });
     const state = createDurableSessionState({ session });
+    const legacySession = { ...state.snapshot!.session };
+    delete legacySession.userMessageKindVersion;
     const legacySnapshot = {
       ...state.snapshot,
       session: {
-        ...state.snapshot!.session,
+        ...legacySession,
         history: [{ content: "Retained before eve 0.54.", role: "user" }],
       },
     } as DurableSessionSnapshot;
@@ -219,8 +229,9 @@ describe("durable-session-store cross-version contract", () => {
     const durableSession = await readDurableSession({ ...state, snapshot: legacySnapshot });
 
     expect(durableSession.history).toEqual([
-      { content: "Retained before eve 0.54.", kind: "legacy.unknown", role: "user" },
+      { content: "Retained before eve 0.54.", role: "user" },
     ]);
+    expect(durableSession.userMessageKindVersion).toBeUndefined();
     expect(getRunMock).not.toHaveBeenCalled();
   });
 
@@ -229,9 +240,11 @@ describe("durable-session-store cross-version contract", () => {
       continuationToken: "http:test",
       sessionId: "wrun_tail_cancel",
     });
+    const legacySession = { ...projectToDurableSession(session) };
+    delete legacySession.userMessageKindVersion;
     const snapshot = {
       session: {
-        ...projectToDurableSession(session),
+        ...legacySession,
         history: [{ content: "Retained before eve 0.54.", role: "user" }],
       },
       version: DURABLE_SESSION_VERSION,
@@ -248,10 +261,10 @@ describe("durable-session-store cross-version contract", () => {
 
     const durableSession = await readDurableSession(projectSessionState({ session }));
 
-    expect(durableSession).toEqual({
-      ...snapshot.session,
-      history: [{ content: "Retained before eve 0.54.", kind: "legacy.unknown", role: "user" }],
-    });
+    expect(durableSession).toEqual(snapshot.session);
+    expect(hydrateDurableSession({ durable: durableSession, turnAgent }).history).toEqual([
+      { content: "Retained before eve 0.54.", kind: "legacy.unknown", role: "user" },
+    ]);
     expect(getRunMock).toHaveBeenCalledWith("wrun_tail_cancel");
     expect(getReadable).toHaveBeenCalledWith({
       namespace: "eve.session",

--- a/packages/eve/src/execution/durable-session-store.ts
+++ b/packages/eve/src/execution/durable-session-store.ts
@@ -80,6 +80,8 @@ export interface DurableSession {
   readonly rootSessionId?: string;
   readonly continuationToken: string;
   readonly history: HarnessModelMessage[];
+  /** Message-kind schema version; absent on history persisted before eve 0.54. */
+  readonly userMessageKindVersion?: 1;
   readonly limits?: HarnessSession["limits"];
   readonly outputSchema?: JsonObject;
   readonly state?: SessionStateMap;

--- a/packages/eve/src/execution/legacy-session-history.integration.test.ts
+++ b/packages/eve/src/execution/legacy-session-history.integration.test.ts
@@ -1,3 +1,4 @@
+import type { ModelMessage } from "ai";
 import { describe, expect, it } from "vitest";
 
 import { migrateDurableSessionSnapshot } from "#execution/durable-session-migrations/snapshot.js";
@@ -43,13 +44,16 @@ describe("pre-0.54 durable history", () => {
       turnAgent,
     });
     const state = createDurableSessionState({ session: initial });
+    const legacySession = { ...projectToDurableSession(initial) };
+    delete legacySession.userMessageKindVersion;
     const legacySnapshot = {
       ...state.snapshot,
       retained: "snapshot field",
-      session: { ...projectToDurableSession(initial), history },
+      session: { ...legacySession, history },
     } as DurableSessionSnapshot;
 
     const durable = await readDurableSession({ ...state, snapshot: legacySnapshot });
+    expect(durable.history[0]).not.toHaveProperty("kind");
     const resumed = hydrateDurableSession({ durable, turnAgent });
 
     expect(resumed.history).toEqual([
@@ -62,9 +66,11 @@ describe("pre-0.54 durable history", () => {
     const saved = createDurableSessionState({ session: resumed });
     expect(saved.version).toBe(state.version);
     expect(saved.snapshot?.version).toBe(state.snapshot?.version);
-    expect(await readDurableSession(saved)).toEqual(durable);
+    expect(saved.snapshot?.session.userMessageKindVersion).toBe(1);
+    expect((await readDurableSession(saved)).history).toEqual(resumed.history);
 
     const migrated = migrateDurableSessionSnapshot(legacySnapshot);
+    expect(migrated).toBe(legacySnapshot);
     expect(migrated).toHaveProperty("retained", "snapshot field");
   });
 
@@ -72,12 +78,23 @@ describe("pre-0.54 durable history", () => {
     expect(() => validateHarnessModelMessages([{ content: "New input", role: "user" }])).toThrow(
       "Expected every user-role model message to have a kind.",
     );
+    const malformed: ModelMessage = { content: "Old input", role: "user" };
+    Reflect.set(malformed, "kind", "invalid");
     expect(() =>
-      migrateDurableSessionSnapshot({
-        session: {
-          history: [{ content: "Old input", kind: "invalid", role: "user" }],
-        },
-        version: 1,
+      validateHarnessModelMessages([malformed], { missingUserKind: "legacy.unknown" }),
+    ).toThrow("Expected every user-role model message to have a kind.");
+
+    const initial = createSession({
+      continuationToken: "test-token",
+      sessionId: "test-session",
+      turnAgent,
+    });
+    const durable = projectToDurableSession(initial);
+    Reflect.set(durable, "history", [{ content: "Current input", role: "user" }]);
+    expect(() =>
+      hydrateDurableSession({
+        durable,
+        turnAgent,
       }),
     ).toThrow("Expected every user-role model message to have a kind.");
   });

--- a/packages/eve/src/execution/session.ts
+++ b/packages/eve/src/execution/session.ts
@@ -201,12 +201,14 @@ export function projectToDurableSession(session: HarnessSession): DurableSession
     sessionId: string;
     state?: HarnessSession["state"];
     taskId?: string;
+    userMessageKindVersion: 1;
     workflowMaxSubagents?: number;
   } = {
     agent: { system: session.agent.system },
     continuationToken: session.continuationToken,
     history: session.history,
     sessionId: session.sessionId,
+    userMessageKindVersion: 1,
   };
 
   if (
@@ -268,7 +270,12 @@ export function hydrateDurableSession(input: {
       thresholdPercent: input.compactionOverrides?.thresholdPercent,
     }),
     continuationToken: durable.continuationToken,
-    history: validateHarnessModelMessages(durable.history),
+    history: validateHarnessModelMessages(
+      durable.history,
+      durable.userMessageKindVersion === undefined
+        ? { missingUserKind: "legacy.unknown" }
+        : undefined,
+    ),
     sessionId: durable.sessionId,
   };
 

--- a/packages/eve/src/harness/messages.test.ts
+++ b/packages/eve/src/harness/messages.test.ts
@@ -343,6 +343,27 @@ describe("createFrameworkUserMessage", () => {
       validateHarnessModelMessages([{ content: "A user message", role: "user" }]),
     ).toThrow("Expected every user-role model message to have a kind.");
   });
+
+  it("classifies only missing legacy kinds when explicitly requested", () => {
+    const legacy = { content: "A retained pre-0.54 message", role: "user" as const };
+    const classified = {
+      content: "A current framework message",
+      kind: "context.instruction" as const,
+      role: "user" as const,
+    };
+
+    expect(
+      validateHarnessModelMessages([legacy, classified], {
+        missingUserKind: "legacy.unknown",
+      }),
+    ).toEqual([{ ...legacy, kind: "legacy.unknown" }, classified]);
+    expect(legacy).not.toHaveProperty("kind");
+    const malformed: ModelMessage = { content: "Malformed input", role: "user" };
+    Reflect.set(malformed, "kind", undefined);
+    expect(() =>
+      validateHarnessModelMessages([malformed], { missingUserKind: "legacy.unknown" }),
+    ).toThrow("Expected every user-role model message to have a kind.");
+  });
 });
 
 describe("resolveAssistantStepText", () => {

--- a/packages/eve/src/harness/messages.ts
+++ b/packages/eve/src/harness/messages.ts
@@ -87,6 +87,10 @@ export function isFrameworkUserMessage(message: ModelMessage): message is Framew
 /** Validates that every user-role message is classified before history retains it. */
 export function validateHarnessModelMessages(
   messages: readonly ModelMessage[],
+  options?: {
+    /** Applied only when a user message has no `kind` property. */
+    readonly missingUserKind?: "legacy.unknown";
+  },
 ): HarnessModelMessage[] {
   const validated: HarnessModelMessage[] = [];
   for (const message of messages) {
@@ -95,6 +99,10 @@ export function validateHarnessModelMessages(
       continue;
     }
     if (!isUserModelMessage(message)) {
+      if (options?.missingUserKind !== undefined && !("kind" in message)) {
+        validated.push({ ...message, kind: options.missingUserKind });
+        continue;
+      }
       throw new TypeError("Expected every user-role model message to have a kind.");
     }
     validated.push(message);


### PR DESCRIPTION
### Summary

PR #3303 restored pre-0.54 sessions by traversing and rebuilding message history during every durable snapshot read. This follow-up stamps current durable sessions with a user-message-kind schema marker and repairs pre-marker history inside hydration's existing validation pass instead. Current snapshots remain strict, legacy snapshots preserve unknown provenance as `legacy.unknown`, and re-persisted sessions take the marked fast path. Follow-up to #3300.

### Validation

- `CI=true pnpm --filter eve run build:js`
- `node scripts/guard-invariants.mjs`
- `node_modules/.bin/tsc -p packages/eve/tsconfig.json --noEmit`
- `node_modules/.bin/oxlint packages/eve/src/harness/messages.ts packages/eve/src/execution/durable-session-store.ts packages/eve/src/execution/session.ts packages/eve/src/execution/durable-session-migrations/snapshot.ts packages/eve/src/harness/messages.test.ts packages/eve/src/execution/durable-session-migrations/snapshot.test.ts packages/eve/src/execution/durable-session-store.test.ts packages/eve/src/execution/legacy-session-history.integration.test.ts`
- `node_modules/.bin/oxfmt --check packages/eve/src/harness/messages.ts packages/eve/src/execution/durable-session-store.ts packages/eve/src/execution/session.ts packages/eve/src/execution/durable-session-migrations/snapshot.ts packages/eve/src/harness/messages.test.ts packages/eve/src/execution/durable-session-migrations/snapshot.test.ts packages/eve/src/execution/durable-session-store.test.ts packages/eve/src/execution/legacy-session-history.integration.test.ts .changeset/avoid-legacy-history-rescan.md`
- From `packages/eve`: `node_modules/.bin/vitest run --config vitest.unit.config.ts src/harness/messages.test.ts src/execution/durable-session-migrations/snapshot.test.ts src/execution/durable-session-store.test.ts src/execution/session.test.ts` — 86 tests passed.
- From `packages/eve`: `node_modules/.bin/vitest run --config vitest.integration.config.ts src/execution/legacy-session-history.integration.test.ts` — 2 tests passed.

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
