### PR TITLE
feat(eve): configure MCP protocol discovery per connection

### DIFF
--- a/.changeset/quiet-mcp-handshake.md
+++ b/.changeset/quiet-mcp-handshake.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Add `protocolVersionDiscovery` to MCP client connections. Set it to `false` to use the initialization handshake for servers that reject modern discovery, while keeping discovery enabled by default.

--- a/docs/connections/mcp.mdx
+++ b/docs/connections/mcp.mdx
@@ -24,6 +24,20 @@ export default defineMcpClientConnection({
 
 The `url` must speak Streamable HTTP or SSE. Write the `description` for the model, not for yourself: it is the main signal `connection_search` uses when deciding which connection to query.
 
+## Configure protocol discovery
+
+eve discovers the server's MCP protocol by default. If a server requires the older `initialize` handshake, disable discovery for that connection:
+
+```ts
+export default defineMcpClientConnection({
+  url: "https://mcp.example.com/mcp",
+  description: "Search support cases",
+  protocolVersionDiscovery: false,
+});
+```
+
+With `protocolVersionDiscovery: false`, the client skips `server/discover` and starts with `initialize`, proposing `2025-11-25` and negotiating a supported handshake-based version. This is a per-connection setting; omitting it or setting it to `true` keeps discovery enabled. Remove the override when the server supports discovery. The setting also applies to connections returned by dynamic resolvers.
+
 ## Use Vercel Connect for OAuth
 
 For OAuth-backed MCP servers, use the shared [Vercel Connect flow](../connections#interactive-oauth-via-vercel-connect), then pass the returned connector UID to `connect()`. Keep the MCP runtime URL and Connect service identifier distinct. For example, Linear uses `https://mcp.linear.app/mcp` as the MCP endpoint and `mcp.linear.app` when creating the connector.

--- a/packages/eve/extension-contracts/compatibility/connection/v16.ts
+++ b/packages/eve/extension-contracts/compatibility/connection/v16.ts
@@ -1,0 +1,19 @@
+import { defineDynamic, defineMcpClientConnection } from "#public/connections/index.js";
+
+export const support = defineMcpClientConnection({
+  description: "Search support cases",
+  url: "https://support.example.com/mcp",
+  auth: { getToken: async () => ({ token: "fixture-token" }) },
+});
+
+export default defineDynamic({
+  events: {
+    "session.started": (_event, ctx) =>
+      defineMcpClientConnection({
+        description: "Search tenant support cases",
+        url: "https://support.example.com/mcp",
+        instanceKey: ctx.session.id,
+        headers: { "X-Session": ctx.session.id },
+      }),
+  },
+});

--- a/packages/eve/extension-contracts/compatibility/tool/v36.ts
+++ b/packages/eve/extension-contracts/compatibility/tool/v36.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+import { defineTool } from "#public/tools/index.js";
+
+export default defineTool({
+  description: "Report the active session.",
+  inputSchema: z.object({}),
+  outputSchema: z.object({
+    sessionId: z.string(),
+    turnId: z.string(),
+  }),
+  execute: (_input, ctx) => ({
+    sessionId: ctx.session.id,
+    turnId: ctx.session.turn.id,
+  }),
+});

--- a/packages/eve/extension-contracts/reports/connection/v17.json
+++ b/packages/eve/extension-contracts/reports/connection/v17.json
@@ -1,0 +1,16 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "connection",
+  "epoch": 17,
+  "sha256": "a717fb8c62d41e585ce53c75b5fdc04dec415cf711cac90aec35746a001308dd",
+  "exports": [
+    "ConnectionAuthorizationFailedError",
+    "ConnectionAuthorizationRequiredError",
+    "defineDynamic",
+    "defineInteractiveAuthorization",
+    "defineMcpClientConnection",
+    "defineOpenAPIConnection",
+    "isConnectionAuthorizationFailedError",
+    "isConnectionAuthorizationRequiredError"
+  ]
+}

--- a/packages/eve/extension-contracts/reports/tool/v37.json
+++ b/packages/eve/extension-contracts/reports/tool/v37.json
@@ -1,0 +1,20 @@
+{
+  "kind": "eve-extension-capability-contract",
+  "capability": "tool",
+  "epoch": 37,
+  "sha256": "db0fce19b4f0189a6d321c69235ce512fc92e1fd86659bb86fc09b3bc4caa9c2",
+  "exports": [
+    "defaultWebSearch",
+    "defineTool",
+    "defineWorkflowTool",
+    "disableTool",
+    "experimental_workflow",
+    "isDisabledToolSentinel",
+    "isExperimentalWorkflowToolDefinition",
+    "isWebSearchToolDefinition",
+    "toolOutput",
+    "toolOutputPart",
+    "toolResultFrom",
+    "webSearch"
+  ]
+}

--- a/packages/eve/src/compiler/extension-compatibility.ts
+++ b/packages/eve/src/compiler/extension-compatibility.ts
@@ -22,8 +22,8 @@ interface ExtensionCapabilityContract {
 const EXTENSION_CAPABILITY_CONTRACTS = {
   extension: { current: 1, supported: [1], dropped: {} },
   tool: {
-    current: 36,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 28, 29, 30, 31, 32, 34, 35, 36],
+    current: 37,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 28, 29, 30, 31, 32, 34, 35, 36, 37],
     dropped: {
       14: "TaskExec.delegated was removed; migrate to workflow-backed background tools",
       15: "TaskExec replaces stageEffect with send",
@@ -81,8 +81,8 @@ const EXTENSION_CAPABILITY_CONTRACTS = {
     },
   },
   connection: {
-    current: 16,
-    supported: [1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 13, 14, 15, 16],
+    current: 17,
+    supported: [1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 13, 14, 15, 16, 17],
     dropped: {
       9: "Dynamic connection resolvers no longer receive conversation or channel continuation data",
       10: "Message and reasoning append events now expose deltas instead of cumulative snapshots.",

--- a/packages/eve/src/internal/authored-definition/connection.test.ts
+++ b/packages/eve/src/internal/authored-definition/connection.test.ts
@@ -25,6 +25,20 @@ function authProvider(auth: ConnectionAuthDefinition | undefined): ConnectionAut
 }
 
 describe("normalizeMcpClientConnectionDefinition", () => {
+  it.each([undefined, true, false])("preserves protocolVersionDiscovery %s", (value) => {
+    const result = normalizeMcpClientConnectionDefinition(
+      validInput({ protocolVersionDiscovery: value }),
+      MSG,
+    );
+    expect(result.protocolVersionDiscovery).toBe(value);
+  });
+
+  it.each([null, "false", 0, {}])("rejects a non-boolean protocolVersionDiscovery: %j", (value) => {
+    expect(() =>
+      normalizeMcpClientConnectionDefinition(validInput({ protocolVersionDiscovery: value }), MSG),
+    ).toThrow('"protocolVersionDiscovery" must be a boolean.');
+  });
+
   describe("happy path", () => {
     it("accepts a valid definition with a getToken function", () => {
       const result = normalizeMcpClientConnectionDefinition(validInput(), MSG);

--- a/packages/eve/src/internal/authored-definition/connection.ts
+++ b/packages/eve/src/internal/authored-definition/connection.ts
@@ -20,6 +20,7 @@ const KNOWN_TOP_LEVEL_KEYS = [
   "description",
   "headers",
   "instanceKey",
+  "protocolVersionDiscovery",
   "toolCall",
   "tools",
   "url",
@@ -92,6 +93,13 @@ export function normalizeMcpClientConnectionDefinition(
     description: record.description as string,
     url: record.url as string,
   };
+
+  if (record.protocolVersionDiscovery !== undefined) {
+    if (typeof record.protocolVersionDiscovery !== "boolean") {
+      throw new Error(`${message} "protocolVersionDiscovery" must be a boolean.`);
+    }
+    result.protocolVersionDiscovery = record.protocolVersionDiscovery;
+  }
 
   if (record.instanceKey !== undefined) {
     result.instanceKey = record.instanceKey as string;

--- a/packages/eve/src/public/definitions/connections/mcp.ts
+++ b/packages/eve/src/public/definitions/connections/mcp.ts
@@ -29,6 +29,12 @@ export interface McpClientConnectionDefinition {
    */
   readonly url: string;
   /**
+   * Whether to discover the server's protocol before initialization.
+   * Defaults to enabled. Set to false for servers that require the older
+   * initialize handshake; that handshake still negotiates a supported version.
+   */
+  readonly protocolVersionDiscovery?: boolean;
+  /**
    * Human-readable summary of the connection and its tools.
    *
    * The system prompt layer uses it to describe the connection to

--- a/packages/eve/src/runtime/connections/mcp-client.integration.test.ts
+++ b/packages/eve/src/runtime/connections/mcp-client.integration.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ROOT_COMPILED_AGENT_NODE_ID,
+  type CompiledConnectionDefinition,
+} from "#compiler/manifest.js";
+import { normalizeMcpClientConnectionDefinition } from "#internal/authored-definition/connection.js";
+import { defineMcpClientConnection } from "#public/definitions/connections/mcp.js";
+import {
+  resolveConnectionDefinition,
+  resolveDynamicConnectionValue,
+} from "#runtime/resolve-connection.js";
+import { McpConnectionClient } from "#runtime/connections/mcp-client.js";
+
+describe.each(["static", "dynamic"] as const)(
+  "%s MCP protocol configuration with the bundled client",
+  (kind) => {
+    const requests: { method: string; protocolVersion: string | null }[] = [];
+    let client: McpConnectionClient;
+    let discoveryError: { code: number; message: string; data?: unknown } | undefined;
+    let initializeError: { code: number; message: string } | undefined;
+
+    async function createClient(protocolVersionDiscovery?: boolean) {
+      const authored = defineMcpClientConnection({
+        description: "Support cases",
+        headers: { Authorization: "Bearer fixture-token", "X-Workspace": "fixture-workspace" },
+        instanceKey: "fixture-workspace",
+        protocolVersionDiscovery,
+        url: "https://mcp.example.com/mcp",
+      });
+      const normalized = normalizeMcpClientConnectionDefinition(authored, "Invalid connection:");
+      const compiled: CompiledConnectionDefinition = {
+        connectionName: "plain",
+        description: normalized.description,
+        logicalPath: "connections/plain.ts",
+        protocol: "mcp",
+        sourceId: "connections/plain",
+        sourceKind: "module",
+        url: normalized.url,
+      };
+      const resolved =
+        kind === "dynamic"
+          ? resolveDynamicConnectionValue(authored, compiled)
+          : await resolveConnectionDefinition(
+              compiled,
+              {
+                nodes: {
+                  [ROOT_COMPILED_AGENT_NODE_ID]: {
+                    modules: { [compiled.sourceId]: { default: authored } },
+                  },
+                },
+              },
+              undefined,
+            );
+      client = new McpConnectionClient(resolved);
+      return client;
+    }
+
+    beforeEach(() => {
+      requests.length = 0;
+      discoveryError = {
+        code: -32022,
+        data: {
+          requested: "2026-07-28",
+          supported: ["2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"],
+        },
+        message: "Unsupported protocol version",
+      };
+      initializeError = undefined;
+
+      // Replace only HTTP I/O: eve's connection, bundled SDK, and protocol parsing stay real.
+      vi.stubGlobal("fetch", async (input: string | URL | Request, init?: RequestInit) => {
+        const request = new Request(input, init);
+        expect(request.url).toBe("https://mcp.example.com/mcp");
+        expect(request.headers.get("Authorization")).toBe("Bearer fixture-token");
+        expect(request.headers.get("X-Workspace")).toBe("fixture-workspace");
+        expect(request.method).toBe("POST");
+        const message = (await request.json()) as {
+          id?: number;
+          method: string;
+          params?: { name?: string; protocolVersion?: string };
+        };
+        const protocolVersion = request.headers.get("MCP-Protocol-Version");
+        requests.push({ method: message.method, protocolVersion });
+
+        let result: Record<string, unknown>;
+        switch (message.method) {
+          case "server/discover":
+            if (discoveryError !== undefined) {
+              return Response.json({ jsonrpc: "2.0", id: message.id, error: discoveryError });
+            }
+            result = { capabilities: { tools: {} }, supportedVersions: ["2026-07-28"] };
+            break;
+          case "initialize":
+            expect(protocolVersion).toBe("2025-11-25");
+            expect(message.params?.protocolVersion).toBe("2025-11-25");
+            if (initializeError !== undefined) {
+              return Response.json({ jsonrpc: "2.0", id: message.id, error: initializeError });
+            }
+            result = {
+              capabilities: { tools: {} },
+              protocolVersion: "2025-11-25",
+              serverInfo: { name: "support-fixture", version: "1.0.0" },
+            };
+            break;
+          case "notifications/initialized":
+            return new Response(null, { status: 202 });
+          case "tools/list":
+            result = {
+              tools: [{ name: "getMyUser", inputSchema: { type: "object", properties: {} } }],
+            };
+            break;
+          case "tools/call":
+            expect(message.params?.name).toBe("getMyUser");
+            result = { content: [{ type: "text", text: "fixture-user" }] };
+            break;
+          default:
+            throw new Error(`Unexpected MCP method: ${message.method}`);
+        }
+        return Response.json({
+          jsonrpc: "2.0",
+          id: message.id,
+          result: protocolVersion === "2026-07-28" ? { ...result, resultType: "complete" } : result,
+        });
+      });
+    });
+
+    afterEach(async () => {
+      await client?.close();
+      vi.unstubAllGlobals();
+    });
+
+    it("initializes and calls Plain-style tools with discovery disabled", async () => {
+      await createClient(false);
+      await expect(client.getToolMetadata()).resolves.toEqual([
+        expect.objectContaining({ name: "getMyUser" }),
+      ]);
+      await expect(client.executeTool("getMyUser", {}, { callId: "read-user" })).resolves.toEqual({
+        content: [{ type: "text", text: "fixture-user" }],
+        isError: false,
+      });
+      expect(requests).toEqual([
+        { method: "initialize", protocolVersion: "2025-11-25" },
+        { method: "notifications/initialized", protocolVersion: "2025-11-25" },
+        { method: "tools/list", protocolVersion: "2025-11-25" },
+        { method: "tools/call", protocolVersion: "2025-11-25" },
+      ]);
+    });
+
+    it.each([undefined, true])("keeps discovery enabled when the option is %s", async (option) => {
+      await createClient(option);
+      discoveryError = undefined;
+      await expect(client.getToolMetadata()).resolves.toEqual([
+        expect.objectContaining({ name: "getMyUser" }),
+      ]);
+      expect(requests).toEqual([
+        { method: "server/discover", protocolVersion: "2026-07-28" },
+        { method: "tools/list", protocolVersion: "2026-07-28" },
+      ]);
+    });
+
+    it("preserves Plain's version error when discovery is not disabled", async () => {
+      await createClient();
+      await expect(client.connect()).rejects.toMatchObject(discoveryError!);
+      expect(requests).toEqual([{ method: "server/discover", protocolVersion: "2026-07-28" }]);
+    });
+
+    it("propagates a failed handshake without retrying it or switching transports", async () => {
+      await createClient(false);
+      initializeError = { code: -32603, message: "Initialization failed" };
+      await expect(client.connect()).rejects.toMatchObject(initializeError);
+      expect(requests).toEqual([{ method: "initialize", protocolVersion: "2025-11-25" }]);
+    });
+  },
+);

--- a/packages/eve/src/runtime/connections/mcp-client.test.ts
+++ b/packages/eve/src/runtime/connections/mcp-client.test.ts
@@ -73,6 +73,31 @@ describe("McpConnectionClient", () => {
     createMCPClient.mockReset();
   });
 
+  it.each([false, true])(
+    "preserves protocol discovery %s when switching to SSE",
+    async (protocolVersionDiscovery) => {
+      createMCPClient.mockRejectedValueOnce({ response: { status: 405 } });
+      createMCPClient.mockResolvedValueOnce({ close: vi.fn() });
+      const client = new McpConnectionClient(makeConnection({ protocolVersionDiscovery }));
+      await client.connect();
+      expect(createMCPClient).toHaveBeenCalledTimes(2);
+      expect(createMCPClient).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          protocolVersionDiscovery,
+          transport: expect.objectContaining({ type: "http" }),
+        }),
+      );
+      expect(createMCPClient).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          protocolVersionDiscovery,
+          transport: expect.objectContaining({ type: "sse" }),
+        }),
+      );
+    },
+  );
+
   it("hides provided arguments from schemas and adds resolved values at execution", async () => {
     const execute = vi.fn().mockResolvedValue({ ok: true });
     const toolsFromDefinitions = vi.fn().mockReturnValue({ lookup: { execute } });
@@ -171,6 +196,7 @@ describe("McpConnectionClient", () => {
     await expect(mcpClient.connect()).resolves.toBe(client);
     expect(createMCPClient).toHaveBeenCalledTimes(1);
     expect(createMCPClient).toHaveBeenCalledWith({
+      protocolVersionDiscovery: undefined,
       transport: {
         headers: {
           Authorization: "Bearer test-token",
@@ -197,6 +223,7 @@ describe("McpConnectionClient", () => {
 
     await expect(mcpClient.connect()).resolves.toBe(client);
     expect(createMCPClient).toHaveBeenNthCalledWith(1, {
+      protocolVersionDiscovery: undefined,
       transport: {
         headers: { Authorization: "Bearer test-token" },
         type: "http",
@@ -204,6 +231,7 @@ describe("McpConnectionClient", () => {
       },
     });
     expect(createMCPClient).toHaveBeenNthCalledWith(2, {
+      protocolVersionDiscovery: undefined,
       transport: {
         headers: { Authorization: "Bearer test-token" },
         type: "sse",
@@ -228,6 +256,7 @@ describe("McpConnectionClient", () => {
     await expect(mcpClient.connect()).resolves.toBe(client);
     expect(createMCPClient).toHaveBeenCalledTimes(2);
     expect(createMCPClient).toHaveBeenNthCalledWith(2, {
+      protocolVersionDiscovery: undefined,
       transport: {
         headers: { Authorization: "Bearer test-token" },
         type: "sse",
@@ -250,6 +279,7 @@ describe("McpConnectionClient", () => {
     await expect(mcpClient.connect()).resolves.toBe(client);
     expect(createMCPClient).toHaveBeenCalledTimes(2);
     expect(createMCPClient).toHaveBeenNthCalledWith(2, {
+      protocolVersionDiscovery: undefined,
       transport: {
         headers: { Authorization: "Bearer test-token" },
         type: "sse",
@@ -274,6 +304,7 @@ describe("McpConnectionClient", () => {
     await expect(mcpClient.connect()).resolves.toBe(client);
     expect(createMCPClient).toHaveBeenCalledTimes(2);
     expect(createMCPClient).toHaveBeenNthCalledWith(2, {
+      protocolVersionDiscovery: undefined,
       transport: {
         headers: { Authorization: "Bearer test-token" },
         type: "sse",
@@ -293,6 +324,7 @@ describe("McpConnectionClient", () => {
     await expect(mcpClient.connect()).rejects.toBe(error);
     expect(createMCPClient).toHaveBeenCalledTimes(1);
     expect(createMCPClient).toHaveBeenCalledWith({
+      protocolVersionDiscovery: undefined,
       transport: {
         headers: { Authorization: "Bearer test-token" },
         type: "http",

--- a/packages/eve/src/runtime/connections/mcp-client.ts
+++ b/packages/eve/src/runtime/connections/mcp-client.ts
@@ -76,6 +76,7 @@ export class McpConnectionClient implements ConnectionClient {
 
     try {
       return await createMCPClient({
+        protocolVersionDiscovery: this.#connection.protocolVersionDiscovery,
         transport: { type: "http", url, headers },
       });
     } catch (error) {
@@ -83,6 +84,7 @@ export class McpConnectionClient implements ConnectionClient {
         throw error;
       }
       return await createMCPClient({
+        protocolVersionDiscovery: this.#connection.protocolVersionDiscovery,
         transport: { type: "sse", url, headers },
       });
     }

--- a/packages/eve/src/runtime/resolve-connection.ts
+++ b/packages/eve/src/runtime/resolve-connection.ts
@@ -83,6 +83,7 @@ export async function resolveConnectionDefinition(
       instanceId: string;
       logicalPath: string;
       protocol: ResolvedConnectionDefinition["protocol"];
+      protocolVersionDiscovery?: boolean;
       sourceId: string;
       sourceKind: "module";
       spec?: ResolvedConnectionDefinition["spec"];
@@ -124,6 +125,13 @@ export async function resolveConnectionDefinition(
           });
         }
       }
+    }
+
+    if (definition.protocol === "mcp" && resolvedRecord.protocolVersionDiscovery !== undefined) {
+      if (typeof resolvedRecord.protocolVersionDiscovery !== "boolean") {
+        throw new Error('"protocolVersionDiscovery" must be a boolean.');
+      }
+      result.protocolVersionDiscovery = resolvedRecord.protocolVersionDiscovery;
     }
 
     if (hasHeaders) {
@@ -232,6 +240,7 @@ export function resolveDynamicConnectionValue(
     sourceId: source.sourceId,
     sourceKind: "module" as const,
     toolCall: normalized.toolCall,
+    protocolVersionDiscovery: normalized.protocolVersionDiscovery,
     tools: normalized.tools,
     url: normalized.url,
   });

--- a/packages/eve/src/runtime/types.ts
+++ b/packages/eve/src/runtime/types.ts
@@ -101,6 +101,7 @@ export type ResolvedScheduleDefinition = Readonly<
  * server that requires no authentication (e.g. localhost) may omit both.
  */
 export interface ResolvedConnectionDefinition extends ResolvedModuleSourceRef {
+  readonly protocolVersionDiscovery?: boolean;
   readonly approval?: Approval;
   readonly authorization?: Readonly<AuthorizationDefinition> | ConnectionAuthResolver;
   readonly connectionName: string;


### PR DESCRIPTION
### Summary

Some MCP servers, including Plain, reject modern protocol discovery even though they support the older initialization handshake. Add an optional, per-connection `protocolVersionDiscovery` setting so authors can select that handshake explicitly, preserving the SDK's default discovery behavior and error handling for other connections. The setting is validated at build time, retained for static and dynamic connections, and forwarded to HTTP and SSE clients; regression tests exercise the bundled SDK through tool discovery and execution. This respects the intentional default introduced in https://github.com/vercel/ai/pull/19026 and enables the companion v change after an eve release.

### Validation

- `pnpm fmt`, `pnpm lint`, `pnpm typecheck`, `pnpm build`, `pnpm docs:check`, and `pnpm guard:invariants`: passed on the rebased change.
- `pnpm --filter eve exec vitest run --config vitest.unit.config.ts src/internal/authored-definition/connection.test.ts src/runtime/connections/mcp-client.test.ts src/runtime/resolve-connection.test.ts src/cli/run.test.ts src/instrumentation/config.test.ts`: 181 tests passed.
- `pnpm test:integration`: 808 tests passed across 106 files, including 10 tests of static/dynamic MCP configuration using the real bundled SDK.
- The earlier full `pnpm test` run reported 8,700 passes, one skip, three callback-log failures caused by matching `/private/tmp` in stack traces, and five failures in unchanged CLI/instrumentation tests. The latter tests all passed in the focused rerun above.
- API compatibility tooling classified both affected capabilities as structurally backward compatible; retained-authoring fixtures and new metadata are included.

Companion consumer PR: https://github.com/vercel/internal-agents/pull/2612 (requires an eve release).

### Checklist

- [x] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)


Linear: [AX-4884](https://linear.app/vercel/issue/AX-4884/feateve-configure-mcp-protocol-discovery-per-connection)

