### PR TITLE
fix(eve): preserve ChatGPT cache identity with session header

### DIFF
--- a/.changeset/chatgpt-session-cache-affinity.md
+++ b/.changeset/chatgpt-session-cache-affinity.md
@@ -1,0 +1,5 @@
+---
+"eve": patch
+---
+
+Send a stable session identity with ChatGPT subscription requests, including context compaction, so the backend can reuse cached prompt prefixes across turns instead of assigning a new cache key on each request.

--- a/docs/reference/typescript-api.md
+++ b/docs/reference/typescript-api.md
@@ -186,6 +186,8 @@ Pass another bare OpenAI model slug to override the default. `experimental_chatg
 
 `chatgpt()` uses stateless requests (`store: false`). eve retains reasoning summaries and encrypted reasoning in session history and replays them after tool calls and on later turns. You do not need to configure `reasoning.encrypted_content` explicitly.
 
+eve sends a stable session identity with ChatGPT subscription requests, including context compaction, so requests from the same eve session can reuse cached prompt prefixes. Cache reuse still depends on the backend and the prompt; a stable session identity does not guarantee a cache hit.
+
 Sign in directly from eve; the Codex CLI is not required:
 
 1. Run `eve dev`, open `/model`, and select **Provider** → **ChatGPT subscription**.

--- a/packages/eve/src/harness/tool-loop.test.ts
+++ b/packages/eve/src/harness/tool-loop.test.ts
@@ -10964,7 +10964,7 @@ describe("createToolLoopHarness", () => {
     });
   });
 
-  describe("gateway app attribution headers", () => {
+  describe("model request headers", () => {
     function setupStopResultForAttribution(): void {
       setupMockAgent({
         finishReason: "stop",
@@ -10974,6 +10974,80 @@ describe("createToolLoopHarness", () => {
         toolResults: [],
       });
     }
+
+    it("keeps ChatGPT cache identity stable across turns and separate across sessions", async () => {
+      setupStopResultForAttribution();
+      const runStep = createToolLoopHarness(
+        createTestConfig("conversation", undefined, {
+          resolveModel: vi.fn().mockResolvedValue(
+            new MockLanguageModelV3({
+              provider: "codex.responses",
+              modelId: "gpt-5.6-luna",
+            }),
+          ),
+        }),
+      );
+      const first = await runStep(createTestSession({ sessionId: "session-a" }), { message: "Hi" });
+      await runStep(first.session, { message: "Continue" });
+      await runStep(createTestSession({ sessionId: "session-b" }), {
+        message: "Hi",
+      });
+
+      expect(vi.mocked(ToolLoopAgent).mock.calls.map(([settings]) => settings.headers)).toEqual([
+        { "session-id": "session-a" },
+        { "session-id": "session-a" },
+        { "session-id": "session-b" },
+      ]);
+    });
+
+    it.each([
+      ["codex.responses", "codex.responses"],
+      ["openai.responses", "codex.responses"],
+      ["codex.responses", "openai.responses"],
+      ["openai.responses", "openai.responses"],
+    ])(
+      "uses each request's provider for %s replies and %s compaction",
+      async (provider, compactionProvider) => {
+        setupStopResultForAttribution();
+        vi.mocked(shouldCompact).mockReturnValueOnce(true);
+        vi.mocked(compactMessages).mockResolvedValueOnce([
+          createFrameworkUserMessage("context.compaction", "Summary of our conversation so far:"),
+          { content: "summary", role: "assistant" },
+        ]);
+        const runStep = createToolLoopHarness(
+          createTestConfig("conversation", undefined, {
+            resolveModel: vi.fn().mockImplementation(
+              async (reference) =>
+                new MockLanguageModelV3({
+                  provider: reference.id === "compaction-model" ? compactionProvider : provider,
+                  modelId: "gpt-5.6-luna",
+                }),
+            ),
+          }),
+        );
+        const session = createTestSession();
+        await runStep(
+          {
+            ...session,
+            agent: {
+              ...session.agent,
+              compactionModelReference: { id: "compaction-model" },
+            },
+          },
+          { message: "Hi" },
+        );
+
+        expect(vi.mocked(ToolLoopAgent).mock.calls[0]?.[0].headers).toEqual(
+          provider === "codex.responses" ? { "session-id": session.sessionId } : undefined,
+        );
+        expect(compactMessages).toHaveBeenCalledOnce();
+        expect(vi.mocked(compactMessages).mock.calls[0]?.[5]).toEqual(
+          compactionProvider === "codex.responses"
+            ? { "session-id": session.sessionId }
+            : undefined,
+        );
+      },
+    );
 
     it("sets x-title and http-referer headers for gateway-routed string models", async () => {
       setupStopResultForAttribution();

--- a/packages/eve/src/harness/tool-loop.ts
+++ b/packages/eve/src/harness/tool-loop.ts
@@ -346,15 +346,19 @@ function mergeSystemInstructions(
 }
 
 /**
- * Builds AI Gateway app attribution headers when the model is gateway-routed.
- *
- * Bare model ids and `gateway.*` model instances route through AI Gateway.
- * Direct-provider model instances receive no Gateway-specific headers.
+ * Builds provider-specific request headers for the active session.
  */
-function buildGatewayAttributionHeaders(
+function buildModelRequestHeaders(
   model: LanguageModel,
   runtimeIdentity: ToolLoopHarnessConfig["runtimeIdentity"],
+  sessionId: string,
 ): Record<string, string> | undefined {
+  if (typeof model !== "string" && model.provider === "codex.responses") {
+    // ChatGPT derives cache identity from this header, overriding the body's
+    // prompt_cache_key. Without it, the backend assigns a new key per request.
+    return { "session-id": sessionId };
+  }
+
   const providerHeaders = resolveProviderHeaders(model);
   if (providerHeaders === undefined) return undefined;
 
@@ -1183,7 +1187,11 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
     //
     // Runs before `agent.stream()` so the compacted messages flow through
     // `messages` (which the harness uses to rebuild session history).
-    const attributionHeaders = buildGatewayAttributionHeaders(model, config.runtimeIdentity);
+    const requestHeaders = buildModelRequestHeaders(
+      model,
+      config.runtimeIdentity,
+      session.sessionId,
+    );
 
     const clientContextTailLength =
       turnClientContext === undefined
@@ -1440,7 +1448,7 @@ export function createToolLoopHarness(config: ToolLoopHarnessConfig): StepFn {
       });
 
       const agentSettings = {
-        headers: attributionHeaders,
+        headers: requestHeaders,
         instructions,
         model,
         onLanguageModelCallEnd(event: LanguageModelCallEndEvent) {
@@ -3273,7 +3281,7 @@ async function maybeCompact(input: {
         session.compaction,
         providerOptions,
         input.telemetry,
-        buildGatewayAttributionHeaders(compaction.model, input.runtimeIdentity),
+        buildModelRequestHeaders(compaction.model, input.runtimeIdentity, session.sessionId),
         input.abortSignal,
         input.force === true,
       )

--- a/packages/eve/src/public/models/openai/chatgpt/model.integration.test.ts
+++ b/packages/eve/src/public/models/openai/chatgpt/model.integration.test.ts
@@ -18,6 +18,7 @@ describe("ChatGPT streamed reasoning replay", () => {
   it("preserves all summaries and encrypted reasoning through a tool and durable history", async () => {
     const warnings = vi.spyOn(process, "emitWarning").mockImplementation(() => {});
     const requests: RecordedRequest[] = [];
+    const sessionHeaders: (string | null)[] = [];
     const model = createCodexSubscriptionModel(
       { model: "gpt-5.6-luna" },
       {
@@ -27,6 +28,7 @@ describe("ChatGPT streamed reasoning replay", () => {
           state: () => ({ kind: "ready" }),
         },
         fetch: async (_input, init) => {
+          sessionHeaders.push(new Headers(init?.headers).get("session-id"));
           requests.push(JSON.parse(String(init?.body)));
           return sseResponse(requests.length === 1 ? reasoningAndToolEvents() : answerEvents());
         },
@@ -123,6 +125,16 @@ describe("ChatGPT streamed reasoning replay", () => {
     const replayedReasoning = (request: RecordedRequest | undefined) =>
       request?.input.filter((item) => item.type === "reasoning");
     expect(replayedReasoning(requests[2])).toEqual(replayedReasoning(requests[1]));
+
+    expect(sessionHeaders).toEqual(Array(3).fill(session.sessionId));
+
+    await runStep({ ...session, sessionId: "another-chatgpt-session" }, { message: "Hello." });
+    expect(sessionHeaders).toEqual([
+      session.sessionId,
+      session.sessionId,
+      session.sessionId,
+      "another-chatgpt-session",
+    ]);
 
     for (const request of requests) {
       expect(request.store).toBe(false);


### PR DESCRIPTION
### Summary

`chatgpt()` omits the HTTP `session-id` header, causing the backend to assign a new cache identity per request.  This is bad because cache misses burn tokens significantly faster.

This PR forwards the durable eve session ID for ChatGPT calls, including compaction. Other providers are unchanged.

Related to #3239. Corrects the approach in #3240: the backend uses the session header in preference to the JSON `prompt_cache_key`.

### Validation

- 332 focused unit tests and the HTTP adapter integration test pass. Regressions cover conversation continuity, separate sessions, and compaction with different providers.
- Type checking, lint, formatting, docs, and invariant checks pass. Full-suite/e2e checks remain for CI.
- Prior controlled tests on eve 0.52.3 with `gpt-5.6-luna` raised reported warm cache reuse from **0% to 94.3%** by adding only this header. This does not guarantee hits or establish physical recomputation.

### Checklist

- [ ] This change was requested or approved by a maintainer
- [x] I ran the relevant checks from `CONTRIBUTING.md`
- [x] I added tests and documentation where relevant
- [x] I added a changeset if this touches the published `eve` package
- [x] DCO sign-off passes for every commit (`git commit --signoff`)
